### PR TITLE
Update Buildkite tooling and configs to fix cache re-builder pipeline

### DIFF
--- a/.buildkite/cache_builder.yml
+++ b/.buildkite/cache_builder.yml
@@ -7,10 +7,8 @@
 common_params:
   - &common_plugins
     - automattic/bash-cache#2.6.0
-    - automattic/git-s3-cache#fix-cache-key-comparison:
+    - automattic/git-s3-cache#v1.1.3:
         bucket: a8c-repo-mirrors
-        # This is not the name of the repo but the key used in the bucket,
-        # which is set based on the Buildkite pipeline slug
         repo: automattic/pocket-casts-ios/
 
 steps:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,10 +3,8 @@ common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
     - automattic/bash-cache#2.6.0
-    - automattic/git-s3-cache#fix-cache-key-comparison:
+    - automattic/git-s3-cache#v1.1.3:
         bucket: a8c-repo-mirrors
-        # This is not the name of the repo but the key used in the bucket,
-        # which is set based on the Buildkite pipeline slug
         repo: automattic/pocket-casts-ios/
   # Common environment values to use with the `env` key.
   - &common_env


### PR DESCRIPTION
**Update:** Finally got to the bottom of the caching issues, as you can see from both the default `pipeline.yml` build and a [manual `cache_builder.yml` build](https://buildkite.com/automattic/pocket-casts-ios/builds/91) being green and _without any warning_.

<img width="1211" alt="image" src="https://user-images.githubusercontent.com/1218433/179688831-c3327054-75a4-4584-b48f-2bce7a987996.png">

<img width="1287" alt="image" src="https://user-images.githubusercontent.com/1218433/179685145-408ee6ed-d37f-4241-96ef-97cc536817bf.png">

I left a version of the original PR description with the issues I found in the `<details>` node below. 



<details>
<summary>Original description with the details of the issues we were experiencing</summary>

These are all the tweaks I could think of, and yet the caching still doesn't seem to work 🤔

<img width="1197" alt="image" src="https://user-images.githubusercontent.com/1218433/178666506-f34ee291-6d35-4b41-a5af-108162e0d94f.png">

The output I'm getting in CI is

```
📦 Restoring cache for automattic/pocket-casts-ios/ from a8c-repo-mirrors | 0s
-- | --
  | Git mirror found, attempting download. | 0s
  | Using Git Mirror Server at http://192.168.130.34:41362
  | % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
  | Dload  Upload   Total   Spent    Left  Speed
  | 100   380  100   380    0     0  24667      0 --:--:-- --:--:-- --:--:-- 42222
  | ↳ WARNING: No snapshots found in http://192.168.130.34:41362. Will attempt s3.
  | ⚠️ Git Mirror download failed, attempting download from s3.... | 1s
  | ↳ WARNING: Nothing downloaded. automattic/pocket-casts-ios/2022-07-13.git.tar is not the same as automattic/pocket-casts-ios/ (comparison used automattic/pocket-casts-ios)
  | ⚠️ S3 Download failed. This probably means the cache may not exist yet. | 0s
  | ↳ Full error:
``` 

But the tasks that uploads the cache seems fine 🤔 

```
[2022-07-13T06:30:21Z] $ trap 'kill -- $' INT TERM QUIT; cache_repo a8c-repo-mirrors
--
  | [2022-07-13T06:30:21Z] Cloning into bare repository '/tmp/2022-07-13/pocket-casts-ios.git'...
  | [2022-07-13T06:30:21Z] remote: Enumerating objects: 5099, done.
  | remote: Counting objects: 100% (5099/5099), done.
  | remote: Compressing objects: 100% (3750/3750), done.
  | remote: Total 5099 (delta 1344), reused 5053 (delta 1302), pack-reused 0
  | Receiving objects: 100% (5099/5099), 40.43 MiB \| 45.79 MiB/s, done.iB \| 42.12 MiB/s
  | Resolving deltas: 100% (1344/1344), done.  0% (0/1344)
  | [2022-07-13T06:30:22Z] pocket-casts-ios.git/
  | [2022-07-13T06:30:22Z] pocket-casts-ios.git/branches/
  | [2022-07-13T06:30:22Z] pocket-casts-ios.git/description
  | [2022-07-13T06:30:22Z] pocket-casts-ios.git/hooks/
  | [2022-07-13T06:30:22Z] pocket-casts-ios.git/hooks/applypatch-msg.sample
  | [2022-07-13T06:30:22Z] pocket-casts-ios.git/hooks/commit-msg.sample
  | [2022-07-13T06:30:22Z] pocket-casts-ios.git/hooks/post-update.sample
  | [2022-07-13T06:30:22Z] pocket-casts-ios.git/hooks/pre-applypatch.sample
  | [2022-07-13T06:30:22Z] pocket-casts-ios.git/hooks/pre-commit.sample
  | [2022-07-13T06:30:22Z] pocket-casts-ios.git/hooks/pre-merge-commit.sample
  | [2022-07-13T06:30:22Z] pocket-casts-ios.git/hooks/pre-push.sample
  | [2022-07-13T06:30:22Z] pocket-casts-ios.git/hooks/pre-receive.sample
  | [2022-07-13T06:30:22Z] pocket-casts-ios.git/hooks/push-to-checkout.sample
  | [2022-07-13T06:30:22Z] pocket-casts-ios.git/hooks/update.sample
  | [2022-07-13T06:30:22Z] pocket-casts-ios.git/hooks/fsmonitor-watchman.sample
  | [2022-07-13T06:30:22Z] pocket-casts-ios.git/hooks/pre-rebase.sample
  | [2022-07-13T06:30:22Z] pocket-casts-ios.git/hooks/prepare-commit-msg.sample
  | [2022-07-13T06:30:22Z] pocket-casts-ios.git/info/
  | [2022-07-13T06:30:22Z] pocket-casts-ios.git/info/exclude
  | [2022-07-13T06:30:22Z] pocket-casts-ios.git/refs/
  | [2022-07-13T06:30:22Z] pocket-casts-ios.git/refs/heads/
  | [2022-07-13T06:30:22Z] pocket-casts-ios.git/refs/tags/
  | [2022-07-13T06:30:22Z] pocket-casts-ios.git/HEAD
  | [2022-07-13T06:30:22Z] pocket-casts-ios.git/config
  | [2022-07-13T06:30:22Z] pocket-casts-ios.git/objects/
  | [2022-07-13T06:30:22Z] pocket-casts-ios.git/objects/pack/
  | [2022-07-13T06:30:22Z] pocket-casts-ios.git/objects/pack/pack-c3af5cd56302bb2f5c46b81237a5b5d7ed5169e4.pack
  | [2022-07-13T06:30:22Z] pocket-casts-ios.git/objects/pack/pack-c3af5cd56302bb2f5c46b81237a5b5d7ed5169e4.idx
  | [2022-07-13T06:30:22Z] pocket-casts-ios.git/objects/info/
  | [2022-07-13T06:30:22Z] pocket-casts-ios.git/packed-refs
  | upload: ./2022-07-13.git.tar to s3://a8c-repo-mirrors/automattic/pocket-casts-ios/2022-07-13.git.tar
```

Ping @jkmassel. I'm close to EOD so I won't be able to do any further experiments. My next step would be to look at the Git S3 cache plugin source, and maybe add some logging there to use here for further debugging.


</details>