### PR TITLE
Open Source: add code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @yaelirub @emilylaguna @leandroalonso
+* @Automattic/pocket-casts-ios


### PR DESCRIPTION
This PR adds @yaelirub, @emilylaguna, and me (@leandroalonso) as code owners.

When a PR is opened it will automatically add them as reviewers.