### PR TITLE
Makefile: fix excluding Protobuffer models from swiftformat

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ generate_colors: ## Generate colors and themes based on themes.csv
 	swiftformat --commas inline --stripunusedargs closure-only --elseposition next-line --trimwhitespace nonblank-lines ./podcasts/ThemeColor.swift ./podcasts/ThemeStyle.swift
 
 swiftformat: ## Run swiftformat
-	./Pods/SwiftFormat/CommandLineTool/swiftformat --commas inline --stripunusedargs closure-only --elseposition next-line --trimwhitespace nonblank-lines --swiftversion 5 podcasts PodcastsIntents Modules fastlane "Pocket Casts Watch App Extension" "WidgetExtension" PocketCastsTests --exclude podcasts/Strings+Generated.swift --exclude fastlane/SnapshotHelper.swift --exclude **/**/*.pb.swift
+	./Pods/SwiftFormat/CommandLineTool/swiftformat --commas inline --stripunusedargs closure-only --elseposition next-line --trimwhitespace nonblank-lines --swiftversion 5 podcasts PodcastsIntents Modules fastlane "Pocket Casts Watch App Extension" "WidgetExtension" PocketCastsTests --exclude podcasts/Strings+Generated.swift --exclude fastlane/SnapshotHelper.swift --exclude **/Protobuffer/*.swift
 
 upload_dsyms: ## Upload dSYMs
 	./scripts/upload-symbols -gsp ./podcasts/GoogleService-Info.plist -p ios ./podcasts.app.dSYM.zip


### PR DESCRIPTION
Whenever `swiftformat` fails you can use `make swiftformat` to fix everything.

However, `api.pb.swift` and `files.pb.swift` were fixed when the command was used. These files are auto-generated and should be excluded, this PR fix this behavior.

### How to test

1. Run `make swiftformat`
2. ✅ Make sure `api.pb.swift` and `files.pb.swift` weren't changed