### PR TITLE
Folders: increase the deadline to focus on text field

### DIFF
--- a/podcasts/NameFolderView.swift
+++ b/podcasts/NameFolderView.swift
@@ -38,7 +38,7 @@ struct NameFolderView: View {
         .navigationTitle(L10n.folderNameTitle)
         .onAppear {
             // this appears to be a known issue with SwiftUI, in that it just passes this onto UIKit which can't set focus while a view is appearing, so here we artificially delay it
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
                 focusOnTextField = true
             }
         }


### PR DESCRIPTION
Fixes #72 

This PR increase the deadline to focus on a text field from `0.5` to `0.6`. `0.5` works consistently on the simulator but not on devices.

If you're wondering why the heck a delay is needed is because `@FocusState` has an issue when used when a view is appearing (see [here](https://developer.apple.com/forums/thread/681941) and [here](https://stackoverflow.com/questions/70221722/swiftui-focusstate-when-view-appears)).

Also, [given Woo uses](https://github.com/woocommerce/woocommerce-ios/blob/81ed7b18078c58d3337f53a91d0f09c802bf3c3f/WooCommerce/Classes/View%20Modifiers/View%2BAutofocusTextModifier.swift#L15) `0.6` I think we're safe with this value.

### To test

1. Build the app to your device
2. Tap the folder icon (top left under "Podcasts")
3. Tap the bottom button
4. ✅ Make sure the text field is selected
5. Play with it: tap back, then go to the folder name screen again, etc