### PR TITLE
Adds some underlaying helper functions for tracking of Firebase promotions

### DIFF
--- a/podcasts/AnalyticsHelper.swift
+++ b/podcasts/AnalyticsHelper.swift
@@ -254,41 +254,43 @@ class AnalyticsHelper {
 }
 
 // MARK: - Plus Upgrades
+
 #if os(iOS)
-extension AnalyticsHelper {
-    static func plusUpgradeViewed(source: PlusUpgradeViewSource) {
-        logPromotionEvent(AnalyticsEventViewPromotion,
-                          promotionId: source.promotionId(),
-                          promotionName: source.promotionName())
+    extension AnalyticsHelper {
+        static func plusUpgradeViewed(source: PlusUpgradeViewSource) {
+            logPromotionEvent(AnalyticsEventViewPromotion,
+                              promotionId: source.promotionId(),
+                              promotionName: source.promotionName())
+        }
+
+        static func plusUpgradeConfirmed(source: PlusUpgradeViewSource) {
+            logPromotionEvent(AnalyticsEventSelectPromotion,
+                              promotionId: source.promotionId(),
+                              promotionName: source.promotionName())
+        }
     }
 
-    static func plusUpgradeConfirmed(source: PlusUpgradeViewSource) {
-        logPromotionEvent(AnalyticsEventSelectPromotion,
-                          promotionId: source.promotionId(),
-                          promotionName: source.promotionName())
+    // MARK: - Folders
+
+    extension AnalyticsHelper {
+        static func folderCreated() {
+            logEvent("folder_created")
+        }
     }
-}
 
-// MARK: - Folders
+    // MARK: - Promotion Events
 
-extension AnalyticsHelper {
-    static func folderCreated() {
-        logEvent("folder_created")
+    private extension AnalyticsHelper {
+        // Helper method to log a Firebase promotion event
+        static func logPromotionEvent(_ name: String, promotionId: String, promotionName: String) {
+            let parameters = [
+                AnalyticsParameterPromotionID: promotionId,
+                AnalyticsParameterPromotionName: promotionName
+            ]
+
+            logEvent(name, parameters: parameters)
+        }
     }
-}
-
-// MARK: - Promotion Events
-private extension AnalyticsHelper {
-    // Helper method to log a Firebase promotion event
-    static func logPromotionEvent(_ name: String, promotionId: String, promotionName: String) {
-        let parameters = [
-            AnalyticsParameterPromotionID: promotionId,
-            AnalyticsParameterPromotionName: promotionName
-        ]
-
-        logEvent(name, parameters: parameters)
-    }
-}
 #endif // End iOS Only Check
 
 // MARK: - Private

--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -240,7 +240,7 @@ enum PlusUpgradeViewSource: String {
 
     /// Converts the enum into a Firebase promotionId, this matches the values set on Android
     func promotionId() -> String {
-        return self.rawValue.uppercased()
+        return rawValue.uppercased()
     }
 
     /// Converts the enum into a Firebase promotion name, this matches the values set on Android
@@ -250,9 +250,9 @@ enum PlusUpgradeViewSource: String {
         }
 
         if self == .profile {
-            return "Upgrade to Plus from \(self.rawValue)"
+            return "Upgrade to Plus from \(rawValue)"
         }
 
-        return "Upgrade to Plus for \(self.rawValue)"
+        return "Upgrade to Plus for \(rawValue)"
     }
 }


### PR DESCRIPTION
Part of #68 

## Description

This adds a few items that will be used in later PRs to support Firebase promotions:
- `logPromotionEvent` to the AnalyticsHelpers that crafts the required parameters to track a promotion in Firebase
    - This mirrors the [Android setup](https://github.com/Automattic/pocket-casts-android/pull/13/files#diff-ed1f55f538001cfe568ddd97b4ec601c81e4bb938ed6f58d19e1088c226a53acR201)
- To allow for easier tracking I added a new enum called `PlusUpgradeViewSource` that also has some helper methods to extract the promotion ID and promotion Name. 
    - This mirrors the [values from Android](https://github.com/Automattic/pocket-casts-android/pull/13/files#diff-b9307bc43f79967348a0eb4081c66527314339811adadd950ca2d81f070692acR27)
- Adds 2 more tracking methods to the AnalyticsHelper to track the plus upgrades, the implementation will come in a later PR

## To test

There are no testable changes in this PR, so make sure the code looks good, and the app builds.

## Checklist

- [x]  I have considered if this change warrants user-facing release notes and have added them to `docs/change_log.txt` if necessary.
- [x]  I have considered adding unit tests for my changes.
