### PR TITLE
Free Trials: Update the Plus detail view in settings

### DIFF
--- a/podcasts/PlusDetailsViewController.swift
+++ b/podcasts/PlusDetailsViewController.swift
@@ -175,6 +175,7 @@ class PlusDetailsViewController: PCViewController {
 private extension PlusDetailsViewController {
     private func loadPrices() {
         guard let trialDetails = IapHelper.shared.getFirstFreeTrialDetails() else {
+            updatePricingLabels()
             return
         }
 


### PR DESCRIPTION
Project: #111 
Depends on: #122 

## Screenshots
| Before | After No Trial | After With Trial Top | After With Trial Bottom |
|:---:|:---:|:---:|:---:|
|<img width="487" alt="Screen Shot 2022-07-29 at 11 41 41 AM" src="https://user-images.githubusercontent.com/793774/181795324-7c0181b6-0983-4d47-b610-931074b41b0a.png">|<img width="487" alt="Screen Shot 2022-07-29 at 11 43 25 AM" src="https://user-images.githubusercontent.com/793774/181795631-a3b375c4-7375-4787-a240-4bcbbeeae34d.png">|<img width="487" alt="Screen Shot 2022-07-29 at 11 40 02 AM" src="https://user-images.githubusercontent.com/793774/181795661-ccc7c1c5-5471-484a-9008-6df346694fa5.png">|<img width="487" alt="Screen Shot 2022-07-29 at 11 40 07 AM" src="https://user-images.githubusercontent.com/793774/181795686-c294ec2e-2076-4887-923f-d56a99b97fb6.png">|
## Description

Please include a summary of the changes and the related issue.

## To test

1. Setup the StoreKit config from #111 
2. Setup the IAP subscriptions with no trials
3. Launch the app
4. Tap the Profile tab
5. Tap the Cog in the top right corner to open the settings
6. Tap the "Pocket Casts Plus" item
7. ✅ The Button says "Upgrade To Plus" 
8. ✅ The pricing label below the button says "$0.99 per month / $9.99 per year" 
9. Swipe down to the bottom and verify the button and label says the same thing
10. Setup a trial for any of the subscriptions
11. Relaunch the app 
12. Go back to the Pocket Casts Plus view
13. ✅ The button now says "Start Free Trial"
14. ✅ The pricing label below says the free trial duration and pricing
15. Swipe down to the bottom and verify the button and label there say the same thing

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE_NOTES.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
