### PR TITLE
Make the plus account type default when creating a new account

### DIFF
--- a/podcasts/SelectAccountTypeViewController.swift
+++ b/podcasts/SelectAccountTypeViewController.swift
@@ -143,7 +143,7 @@ class SelectAccountTypeViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         title = L10n.accountSelectType
-        isFreeAccount = true
+        isFreeAccount = false
         configureLabels()
         let closeButton = UIBarButtonItem(image: UIImage(named: "cancel"), style: .done, target: self, action: #selector(closeTapped(_:)))
         closeButton.accessibilityLabel = L10n.accessibilityCloseDialog


### PR DESCRIPTION
## Description
Make the plus account type default when creating a new account

## To test

1. Launch the app
2. Sign out if you're signed in
3. Tap the podcasts tab
4. Tap the add folder button
5. Tap the Upgrade button
6. Tap the Create Account button
7. ✅ Verify the plus option is selected by default

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE_NOTES.md` if necessary.
- [x] I have considered adding unit tests for my changes.
