### PR TITLE
Removed the `dc_location` value from the Buildkite pipelines

### DIFF
--- a/.buildkite/cache_builder.yml
+++ b/.buildkite/cache_builder.yml
@@ -28,7 +28,6 @@ steps:
     plugins: *common_plugins
     agents:
       queue: mac
-      dc_location: mke
     env:
       IMAGE_ID: xcode-13.4.1
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -12,7 +12,6 @@ common_params:
   # Common agents values to use with the `agents` key.
   - &common_agents
     queue: mac
-    dc_location: mke
 
 steps:
   - label: Build and Test


### PR DESCRIPTION
## Description

This PR removes the `dc_location` value from the `pipeline.yml` and `cache_builder.yml` pipelines. `dc_location` is used to specify which data center to run the build on. It was necessary when Automattic used multiple data centers. Because there is only one data center now, this value isn't needed anymore. 

## To test

This PR can be verified by checking that CI passed. 

## Checklist

- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE_NOTES.md` if necessary.
- [X] I have considered adding unit tests for my changes.
