### PR TITLE
Update versioning setup to work with integer build number

### DIFF
--- a/config/PocketCasts.base.xcconfig
+++ b/config/PocketCasts.base.xcconfig
@@ -3,4 +3,4 @@
 // Map our custom version values (used by the automation tooling) to the values
 // Xcode uses
 MARKETING_VERSION=$(VERSION_SHORT)
-CURRENT_PROJECT_VERSION=$(VERSION_LONG)
+CURRENT_PROJECT_VERSION=$(BUILD_NUMBER)

--- a/config/Version.xcconfig
+++ b/config/Version.xcconfig
@@ -1,2 +1,12 @@
-VERSION_LONG=887
+// Should be used for `MARKETING_VERSION`, what Xcode version prior to 11
+// called `CFBundleShortVersionString`.
 VERSION_SHORT=7.20.2
+
+// Should be use for `CURRENT_PROJECT_VERSION`, what Xcode versions prior to 11
+// called `CFBundleVersion`.
+BUILD_NUMBER=887
+
+// This is not used in the project but needs to be defined because of the
+// inflexible versioning setup in the release toolkit version at the time of
+// writing.
+VERSION_LONG=7.20.2.0

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -83,6 +83,9 @@ platform :ios do
     save_ci_spm_cache
   end
 
+  # FIXME: This whole lane should no longer be neccessary, but I'm reluctant to
+  # remove it now because of the `ENV` setup it does. We might want to refer to
+  # that code soon.
   desc 'Submit a new Beta Build to Apple TestFlight'
   lane :beta do
     ENV['DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS'] = '-t Aspera'
@@ -145,16 +148,18 @@ platform :ios do
     )
   end
 
-  # Increment the value of `VERSION_LONG` from the `Version.xcconfig` file
+  # Increment the value of `BUILD_NUMBER` from the `Version.xcconfig` file
   #
+  # Note that this is currently only used in the `:beta` lane, which we may be
+  # able to remove in favor of `build_and_upload_app_store_connect`.
   def increment_version_on_config
     fastlane_require 'Xcodeproj'
 
     # Get the current build version, and update it if needed
     versions = Xcodeproj::Config.new(File.new(VERSION_XCCONFIG_PATH)).to_hash
-    build_number = versions['VERSION_LONG'].to_i + 1
-    UI.message("Updating build version to #{build_number}")
-    versions['VERSION_LONG'] = build_number
+    build_number = versions['BUILD_NUMBER'].to_i + 1
+    UI.message("Updating build number (`BUILD_NUMBER`, `CURRENT_PROJECT_VERSION`) to #{build_number}")
+    versions['BUILD_NUMBER'] = build_number
     new_config = Xcodeproj::Config.new(versions)
     new_config.save_as(Pathname.new(VERSION_XCCONFIG_PATH))
   end


### PR DESCRIPTION
By default, the release toolkit expect `VERSION_SHORT` to be in the `3.2` (or `3.2.1` for hotfix) format and `VERSION_LONG`, `3.2.0.0` (or `3.2.1.0` for hotfix).

This project uses a more convention (or old school?) build number (`VERSION_LONG`) approach where the value is an increasing integer.

To account for this setup, we need to add a new version property, `BUILD_NUMBER`.

Notice that the resulting setup is a bit unclear but that's an issue at the release toolkit side.

I verified the changes by creating [`mokagio/test-104`](https://github.com/Automattic/pocket-casts-ios/compare/mokagio/test-104) which is based off #104 and adds some hacks to test the code freeze lane without updating the GitHub milestones. Running `bundle exec code freeze` generates `release/887.1`.

I then created [`mokagio/test-146`](https://github.com/Automattic/pocket-casts-ios/compare/mokagio/test-146) which is a on top of this PR and run `bundle exec code freeze` there. It generated the desired `release/7.21`

![image](https://user-images.githubusercontent.com/1218433/183349396-b9a2666d-4e67-478b-84f5-3a6f08563cd6.png)
