### PR TITLE
Change the user key to pocketcasts:user_id

### DIFF
--- a/podcasts/Analytics/Adapters/Tracks/TracksAdapter.swift
+++ b/podcasts/Analytics/Adapters/Tracks/TracksAdapter.swift
@@ -15,7 +15,7 @@ class TracksAdapter: AnalyticsAdapter {
 
     private enum TracksConfig {
         static let prefix = "pcios"
-        static let userKey = "pc:user_id"
+        static let userKey = "pocketcasts:user_id"
         static let anonymousUUIDKey = "TracksAnonymousUUID"
     }
 


### PR DESCRIPTION
| 📘 Project: #154 | 
|:---:|

## Description
Updates the user key to `pocketcasts:user_id` to improve clarity

## To test

1. Open the project in Xcode
2. Open the AppDelegate+Analytics file
3. Under line 3 (the Analytics.register) line
4. Add Analytics.track(.applicationOpened)
5. Launch the app
6. Sign in if you're signed out
7. Relaunch the app
8. ✅ Verify you see ` 🔵 Tracked: application_opened`
9. Open the Tracks Live view, filter for rejects only, and search for `pcios_application_opened`
10. Once the event appears, click it to expand the eventprops
11. Verify the event's userid property is now your PC user id and the useridtype is `pocketcasts:user_id`

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE_NOTES.md` if necessary.
- [x] I have considered adding unit tests for my changes.
