### PR TITLE
Add lane to upload metadata to ASC via Fastlane `deliver`

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -6,7 +6,8 @@ default_platform :ios
 
 # Paths that are re-used across multiple lanes
 PROJECT_ROOT_FOLDER = File.dirname(File.expand_path(__dir__))
-APP_STORE_METADATA_FOLDER = File.join(PROJECT_ROOT_FOLDER, 'fastlane', 'metadata')
+FASTLANE_FOLDER = File.join(PROJECT_ROOT_FOLDER, 'fastlane')
+APP_STORE_METADATA_FOLDER = File.join(FASTLANE_FOLDER, 'metadata')
 SECRETS_FOLDER = File.join(Dir.home, '.configure', 'pocketcasts-ios', 'secrets')
 ASC_KEY_PATH = File.join(SECRETS_FOLDER, 'app_store_connect_fastlane_api_key.json')
 VERSION_XCCONFIG_PATH = File.join(PROJECT_ROOT_FOLDER, 'config', 'Version.xcconfig')
@@ -19,8 +20,9 @@ GHHELPER_REPO = 'Automattic/pocket-casts-ios'
 
 TEAM_ID = 'PZYM8XX95Q'
 
+APP_STORE_VERSION_BUNDLE_IDENTIFIER = 'au.com.shiftyjelly.podcasts'
 MAIN_BUNDLE_IDENTIFIERS = [
-  'au.com.shiftyjelly.podcasts',
+  APP_STORE_VERSION_BUNDLE_IDENTIFIER,
   'au.com.shiftyjelly.podcasts.NotificationExtension',
   'au.com.shiftyjelly.podcasts.NotificationContent',
   'au.com.shiftyjelly.podcasts.watchkitapp',
@@ -476,6 +478,31 @@ inal copy, and try again.")
       language_codes: GLOTPRESS_TO_ASC_METADATA_LOCALE_CODES.keys,
       abort_on_violations: abort_on_violations,
       skip_confirm: skip_confirm
+    )
+  end
+
+  # Upload the localized metadata (from `fastlane/metadata/`) to App Store Connect
+  #
+  # @option [Boolean] with_screenshots (default: false) If true, will also upload the latest screenshot files to ASC
+  #
+  desc 'Upload the localized metadata to App Store Connect, optionally including screenshots.'
+  lane :update_metadata_on_app_store_connect do |options|
+    # Skip screenshots by default. The naming is "with" to make it clear that
+    # callers need to opt-in to adding screenshots. The naming of the deliver
+    # (upload_to_app_store) parameter, on the other hand, uses the skip verb.
+    with_screenshots = options.fetch(:with_screenshots, false)
+    skip_screenshots = with_screenshots == false
+
+    upload_to_app_store(
+      app_identifier: APP_STORE_VERSION_BUNDLE_IDENTIFIER,
+      app_version: ios_get_app_version,
+      skip_binary_upload: true,
+      screenshots_path: File.join(FASTLANE_FOLDER, 'screenshots'),
+      skip_screenshots: skip_screenshots,
+      overwrite_screenshots: true, # won't have effect if `skip_screenshots` is true
+      phased_release: true,
+      precheck_include_in_app_purchases: false,
+      api_key_path: ASC_KEY_PATH
     )
   end
 


### PR DESCRIPTION
## Description

What is says in the title. We prefer to have a lane to call rather than using `bundle exec fastlane deliver` because:

- It's consistent with how we run the rest of our release process automation.
- It allows us to computed parameters (`version: ios_get_app_version` wouldn't work otherwise).
- We don't have to spread configuration across multiple files, and keep everything in `Fastfile` instead.

## To test

Run `bundle exec fastlane update_metadata_on_app_store_connect` and checked the preview 

<img width="3200" alt="Screen Shot 2022-08-26 at 3 35 48 pm" src="https://user-images.githubusercontent.com/1218433/186838394-28add291-4059-48e6-8fff-b69a0c42d945.png">


## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE_NOTES.md` if necessary. – N.A.
- [x] I have considered adding unit tests for my changes. – N.A.
