### PR TITLE
Update `SnapshotHelper.swift` to latest version, 1.28

### DIFF
--- a/fastlane/SnapshotHelper.swift
+++ b/fastlane/SnapshotHelper.swift
@@ -165,7 +165,7 @@ open class Snapshot: NSObject {
             }
 
             let screenshot = XCUIScreen.main.screenshot()
-            #if os(iOS)
+            #if os(iOS) && !targetEnvironment(macCatalyst)
             let image = XCUIDevice.shared.orientation.isLandscape ?  fixLandscapeOrientation(image: screenshot.image) : screenshot.image
             #else
             let image = screenshot.image
@@ -306,4 +306,4 @@ private extension CGFloat {
 
 // Please don't remove the lines below
 // They are used to detect outdated configuration files
-// SnapshotHelperVersion [1.27]
+// SnapshotHelperVersion [1.28]


### PR DESCRIPTION
## Description

While working on https://github.com/Automattic/pocket-casts-ios/pull/172, I tried to run the screenshots automation, which failed because of an out-of-date `SnapshotHelper`. This PR updates it, with `bundle exec fastlane snapshot update`.

After the update, the screenshots automation still fails, but that's out of scope for the moment and something we should address only when we'll need new screenshots.

## To test

I run `bundle exec fastlane snapshot update` twice and verified it didn't update the diff.

I also checked with the latest version of Fastlane, no changes. I decided not to include the Fastlane upgrade here to keep things focused.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE_NOTES.md` if necessary.
- [x] I have considered adding unit tests for my changes.