### PR TITLE
Remove `MacroExpansion` from Watch automation xcscheme

### DIFF
--- a/podcasts.xcodeproj/xcshareddata/xcschemes/Screenshot Automation Watch.xcscheme
+++ b/podcasts.xcodeproj/xcshareddata/xcschemes/Screenshot Automation Watch.xcscheme
@@ -92,15 +92,6 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "46AFC23327AB19CE004B026F"
-            BuildableName = "Screenshot Automation Watch.xctest"
-            BlueprintName = "Screenshot Automation Watch"
-            ReferencedContainer = "container:podcasts.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">


### PR DESCRIPTION
This wasn't removed in #156

## To test

1. Open the project on Xcode
2. Check that the `xcscheme` doesn't change

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE_NOTES.md` if necessary.
- [x] I have considered adding unit tests for my changes.
