### PR TITLE
Classify `podcasts/Strings+Generated.swift` as `linguist-generated`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 CHANGELOG.md merge=union
+podcasts/Strings+Generated.swift linguist-generated


### PR DESCRIPTION

## Description

Follows up on a suggestion by @AliSoftware [from here](https://github.com/Automattic/pocket-casts-ios/pull/174#pullrequestreview-1081886625).

This will result in the file being "Excluded from stats and hidden in diffs", as per
https://github.com/github/linguist/blob/1f65799270b46a0bd1d4a62ea5734a1117f45e61/docs/overrides.md?rgh-link-date=2022-08-23T10%3A36%3A05Z#summary

The change is appropriate because the file is code-generated by SwiftGen and any diff in it will depend entirely on changes made in other files.

Please include a summary of the changes and the related issue.

## To test

Nothing to tests.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE_NOTES.md` if necessary.
- [x] I have considered adding unit tests for my changes.

---

Note: I asked @Automattic/owl-team for a review for visibility. [`linguist-generated`](https://github.com/github/linguist/blob/1f65799270b46a0bd1d4a62ea5734a1117f45e61/docs/overrides.md?rgh-link-date=2022-08-23T10%3A36%3A05Z#generated-code) was a TIL for me. I think it's worth knowing about it and consider in other repos, too.
