### PR TITLE
Track `.xcscheme` updates made by Xcode 13.4.1

### DIFF
--- a/podcasts.xcodeproj/xcshareddata/xcschemes/Pocket Casts Watch App (Complication).xcscheme
+++ b/podcasts.xcodeproj/xcshareddata/xcschemes/Pocket Casts Watch App (Complication).xcscheme
@@ -84,8 +84,10 @@
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES"
       launchAutomaticallySubstyle = "32">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <RemoteRunnable
+         runnableDebuggingMode = "2"
+         BundleIdentifier = "com.apple.Carousel"
+         RemotePath = "/Pocket Casts">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "BDD301631EFB9356004A9972"
@@ -93,7 +95,7 @@
             BlueprintName = "Pocket Casts Watch App"
             ReferencedContainer = "container:podcasts.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </RemoteRunnable>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -102,8 +104,10 @@
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES"
       launchAutomaticallySubstyle = "32">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <RemoteRunnable
+         runnableDebuggingMode = "2"
+         BundleIdentifier = "com.apple.Carousel"
+         RemotePath = "/Pocket Casts">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "BDD301631EFB9356004A9972"
@@ -111,7 +115,16 @@
             BlueprintName = "Pocket Casts Watch App"
             ReferencedContainer = "container:podcasts.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </RemoteRunnable>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "BDD301631EFB9356004A9972"
+            BuildableName = "Pocket Casts Watch App.app"
+            BlueprintName = "Pocket Casts Watch App"
+            ReferencedContainer = "container:podcasts.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/podcasts.xcodeproj/xcshareddata/xcschemes/Pocket Casts Watch App (Notification).xcscheme
+++ b/podcasts.xcodeproj/xcshareddata/xcschemes/Pocket Casts Watch App (Notification).xcscheme
@@ -85,8 +85,10 @@
       allowLocationSimulation = "YES"
       launchAutomaticallySubstyle = "8"
       notificationPayloadFile = "Pocket Casts Watch App Extension/PushNotificationPayload.apns">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <RemoteRunnable
+         runnableDebuggingMode = "2"
+         BundleIdentifier = "com.apple.Carousel"
+         RemotePath = "/Pocket Casts">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "BDD301631EFB9356004A9972"
@@ -94,7 +96,7 @@
             BlueprintName = "Pocket Casts Watch App"
             ReferencedContainer = "container:podcasts.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </RemoteRunnable>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -104,8 +106,10 @@
       debugDocumentVersioning = "YES"
       launchAutomaticallySubstyle = "8"
       notificationPayloadFile = "Pocket Casts Watch App Extension/PushNotificationPayload.apns">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <RemoteRunnable
+         runnableDebuggingMode = "2"
+         BundleIdentifier = "com.apple.Carousel"
+         RemotePath = "/Pocket Casts">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "BDD301631EFB9356004A9972"
@@ -113,7 +117,16 @@
             BlueprintName = "Pocket Casts Watch App"
             ReferencedContainer = "container:podcasts.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </RemoteRunnable>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "BDD301631EFB9356004A9972"
+            BuildableName = "Pocket Casts Watch App.app"
+            BlueprintName = "Pocket Casts Watch App"
+            ReferencedContainer = "container:podcasts.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/podcasts.xcodeproj/xcshareddata/xcschemes/Pocket Casts Watch App.xcscheme
+++ b/podcasts.xcodeproj/xcshareddata/xcschemes/Pocket Casts Watch App.xcscheme
@@ -84,8 +84,10 @@
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES"
       notificationPayloadFile = "Pocket Casts Watch App Extension/PushNotificationPayload.apns">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <RemoteRunnable
+         runnableDebuggingMode = "2"
+         BundleIdentifier = "com.apple.Carousel"
+         RemotePath = "/Pocket Casts">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "BDD301631EFB9356004A9972"
@@ -93,7 +95,7 @@
             BlueprintName = "Pocket Casts Watch App"
             ReferencedContainer = "container:podcasts.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </RemoteRunnable>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -101,8 +103,10 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <RemoteRunnable
+         runnableDebuggingMode = "2"
+         BundleIdentifier = "com.apple.Carousel"
+         RemotePath = "/Pocket Casts">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "BDD301631EFB9356004A9972"
@@ -110,7 +114,16 @@
             BlueprintName = "Pocket Casts Watch App"
             ReferencedContainer = "container:podcasts.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </RemoteRunnable>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "BDD301631EFB9356004A9972"
+            BuildableName = "Pocket Casts Watch App.app"
+            BlueprintName = "Pocket Casts Watch App"
+            ReferencedContainer = "container:podcasts.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/podcasts.xcodeproj/xcshareddata/xcschemes/Screenshot Automation Watch.xcscheme
+++ b/podcasts.xcodeproj/xcshareddata/xcschemes/Screenshot Automation Watch.xcscheme
@@ -75,8 +75,10 @@
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES"
       notificationPayloadFile = "Pocket Casts Watch App Extension/PushNotificationPayload.apns">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <RemoteRunnable
+         runnableDebuggingMode = "2"
+         BundleIdentifier = "com.apple.Carousel"
+         RemotePath = "/Pocket Casts">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "BDD301631EFB9356004A9972"
@@ -84,7 +86,7 @@
             BlueprintName = "Pocket Casts Watch App"
             ReferencedContainer = "container:podcasts.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </RemoteRunnable>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"


### PR DESCRIPTION
## Description

My Xcode keeps touching these files. I'm running the latest stable,  "Version 13.4.1 (13F100)".

## To test

You can verify this behavior (which I assume is correct?) by adding a new file in the project from `trunk`. You should see these files changing, too.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE_NOTES.md` if necessary.
- [x] I have considered adding unit tests for my changes.
