### PR TITLE
Make `register_new_device` ask for the user email only once

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -614,6 +614,17 @@ inal copy, and try again.")
       )
     end
 
+    # We're about to use `add_development_certificates_to_provisioning_profiles` and `add_all_devices_to_provisioning_profiles`.
+    # These actions use Developer Portal APIs that don't yet support authentication via API key (-.-').
+    # Let's preemptively ask for and set the email here to avoid being asked twice for it if not set.
+
+    require 'credentials_manager'
+
+    # If Fastlane cannot instantiate a user, it will ask the caller for the email.
+    # Once we have it, we can set it as `FASTLANE_USER` in the environment (which has lifecycle limited to this call) so that the next commands will already have access to it.
+    # Note that if the user is already available to `AccountManager`, setting it in the environment is redundant, but Fastlane doesn't provide a way to check it so we have to do it anyway.
+    ENV['FASTLANE_USER'] = CredentialsManager::AccountManager.new.user
+
     # Add all development certificates to the provisioning profiles (just in case – this is an easy step to miss)
     add_development_certificates_to_provisioning_profiles(
       team_id: TEAM_ID,


### PR DESCRIPTION
Same as https://github.com/woocommerce/woocommerce-ios/pull/7522. Refer to its description for details.

I used this to add @emilylaguna's iOS 16 device to our Developer Portal.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary. – N.A.
- [x] I have considered adding unit tests for my changes. – N.A.
