### PR TITLE
Tracks: Add user_is_logged_in to the global properties

### DIFF
--- a/podcasts/Analytics/Adapters/Tracks/TracksAdapter.swift
+++ b/podcasts/Analytics/Adapters/Tracks/TracksAdapter.swift
@@ -82,6 +82,9 @@ class TracksAdapter: AnalyticsAdapter {
         let hasLifetime = subscriptionData.hasLifetimeGift()
 
         return [
+            // General keys
+            "user_is_logged_in": SyncManager.isUserLoggedIn(),
+            
             // Subscription Keys
             "plus_has_subscription": hasSubscription,
             "plus_has_lifetime": hasLifetime,
@@ -91,6 +94,7 @@ class TracksAdapter: AnalyticsAdapter {
             
             // Accessibility
             "is_rtl_language": UIApplication.shared.userInterfaceLayoutDirection == .rightToLeft,
+            
             // Large is the default size
             "has_dynamic_font_size": UIApplication.shared.preferredContentSizeCategory != .large
         ]


### PR DESCRIPTION
| 📘 Project: #154 |
|:---:|

This makes changed based on a discussion (pdeCcb-ZZ-p2) with the Android team:
- Adds `user_is_logged_in` to the global properties

## To test

1. Open TracksAdapter in Xcode
2. Add the following on line 119: `print("🔵 Default: \(key) = \(value)")`
3. Launch the app
4. ✅ The `user_is_logged_in` value that is logged reflects your current state
5. If you're logged in, sign out
6. ✅ `user_is_logged_in` is now `false`
7. If you're logged out, sign in
8. ✅ `user_is_logged_in` is now `true`

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
