### PR TITLE
Tracks: Update the purchase events to include is_free_trial_eligible and is_free_trial_available

### DIFF
--- a/podcasts/IapHelper.swift
+++ b/podcasts/IapHelper.swift
@@ -227,21 +227,15 @@ private extension IapHelper {
 
 extension IapHelper: SKPaymentTransactionObserver {
     func purchaseWasSuccessful(_ productId: String) {
-        let product = getProductWithIdentifier(identifier: productId)
-        let isFreeTrial = product?.introductoryPrice?.paymentMode == .freeTrial
-        let isEligible = isEligibleForFreeTrial()
-        
-        Analytics.track(.purchaseSuccessful, properties: ["product": productId,
-                                                          "is_free_trial_available": isFreeTrial,
-                                                          "is_free_trial_eligible": isEligible])
+        trackPaymentEvent(.purchaseSuccessful, productId: productId)
     }
 
     func purchaseWasCancelled(_ productId: String, error: NSError) {
-        Analytics.track(.purchaseCancelled, properties: ["error_code": error.code])
+        trackPaymentEvent(.purchaseCancelled, productId: productId, error: error)
     }
 
     func purchaseFailed(_ productId: String, error: NSError) {
-        Analytics.track(.purchaseFailed, properties: ["error_code": error.code])
+        trackPaymentEvent(.purchaseFailed, productId: productId, error: error)
     }
 
     func paymentQueue(_ queue: SKPaymentQueue, updatedTransactions transactions: [SKPaymentTransaction]) {
@@ -331,5 +325,23 @@ private extension SKProductSubscriptionPeriod {
         }
 
         return TimePeriodFormatter.format(numberOfUnits: numberOfUnits, unit: calendarUnit)
+    }
+}
+
+private extension IapHelper {
+    func trackPaymentEvent(_ event: AnalyticsEvent, productId: String, error: NSError? = nil) {
+        let product = getProductWithIdentifier(identifier: productId)
+        let isFreeTrial = product?.introductoryPrice?.paymentMode == .freeTrial
+        let isEligible = isEligibleForFreeTrial()
+
+        var properties: [AnyHashable: Any] = ["product": productId,
+                                              "is_free_trial_available": isFreeTrial,
+                                              "is_free_trial_eligible": isEligible]
+
+        if let error = error {
+            properties["error_code"] = error.code
+        }
+
+        Analytics.track(event, properties: properties)
     }
 }


### PR DESCRIPTION
| 📘 Project: #154 |
|:---:|

After a discussion with Android we're adding the `is_free_trial_eligible` and `is_free_trial_available` to all the purchase events. This updates the code to include that.

## To test

Before testing, Enable the StoreKit testing configuration on the scheme and set feature flag `tracksEnabled` and `freeTrialsEnabled` to `true`.

#### payment_failed
1. Open the `Pocket Casts Configuration.storekit` file in Xcode
2. Click on Editor in the top menubar
3. Hover over the 'Fail Transactions' option, and select any of them
4. Sign into an account without plus
5. Tap the podcast tab, then tap the folder button to open the upsell
6. Go through the flow until you get to the confirm payment view
7. Tap the Confirm button
8. Tap the pay button in the Apple dialog
9. ✅ Verify you see `🔵 Tracked: purchase_failed ["error_code": ERROR_CODE, "is_free_trial_eligible": false, "is_free_trial_available": false]` where the ERROR_CODE is a number
10. Change the failure error type in the storekit and confirm the error_code changes

#### payment_cancelled
1. Go through the flow to get to the payment confirm screen again
2. Tap the confirm button
3. When the Apple dialog pops up, tap the cancel button
4. ✅ Verify you see `🔵 Tracked: purchase_cancelled ["error_code": 2, "is_free_trial_eligible": false, "is_free_trial_available": false]`

#### payment_successful - without free trial
1. Disable the StoreKit failure state
1. Go through the flow to get to the payment confirm screen again
2. Tap the confirm button
3. Tap the subscribe button
4. ✅ Verify you see: `🔵 Tracked: purchase_successful ["product": "PRODUCT_ID", "is_free_trial_eligible": false, "is_free_trial_available": false]`
   - Verify the PRODUCT_ID is set to the product you selected


#### payment_successful - with free trial
1. Disable the StoreKit failure state
2. Enable the Free Trial in StoreKit config
1. Go through the flow to get to the payment confirm screen again
3. Tap the confirm button
4. Tap the subscribe button
5. ✅ Verify you see: `🔵 Tracked: purchase_successful ["product": "PRODUCT_ID", "is_free_trial_eligible": false, "is_free_trial_available": false]`
   - Verify the PRODUCT_ID is set to the product you selected


## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
