### PR TITLE
Tooling: skip Deliverfile

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -338,7 +338,7 @@ platform :ios do
   desc 'Creates a new hotfix branch for the given `version:x.y.z`. The branch will be cut from the `x.y` tag.'
   lane :new_hotfix_release do |options|
     prev_ver = ios_hotfix_prechecks(options)
-    ios_bump_version_hotfix(previous_version: prev_ver, version: options[:version])
+    ios_bump_version_hotfix(previous_version: prev_ver, version: options[:version], skip_deliver: true)
   end
 
   # Finalizes a hotfix, by triggering a release build on CI


### PR DESCRIPTION
Add an option to skip changing `Deliverfile` when hotfixing.

## To test

Green CI.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
