### PR TITLE
Tooling: fix Danger errors on Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'danger'
 gem 'danger-rubocop', '~> 0.10'
 gem 'danger-swiftformat', git: 'https://github.com/shiftyjelly/danger-ruby-swiftformat.git'
 gem 'danger-swiftlint'
-gem "fastlane", :git => "https://github.com/freddi-kit/fastlane.git", :branch => "altool-upload"
+gem 'fastlane', git: 'https://github.com/freddi-kit/fastlane.git', branch: 'altool-upload'
 gem 'fastlane-plugin-wpmreleasetoolkit', '~> 5.4'
 gem 'rubocop', '~> 1.30'
 gem 'watchbuild'


### PR DESCRIPTION
On https://github.com/Automattic/pocket-casts-ios/pull/232 we didn't wait for CI to complete, and Danger yelled at us. This PR fixes that.

## To test

Wait for Danger to finish.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
