### PR TITLE
Release: merge changes from 7.22 code freeze into `trunk`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 -----
 
 - Add a pull to refresh to the podcast list and profile view (#239)
+- Testing
 
 7.22
 -----


### PR DESCRIPTION
Merge changes from 7.22 to `trunk`.

## To test

- Ensure the build is 🟢
- The code changes here were tested in their own PRs