### PR TITLE
Change podcastTabOpened to podcastsTabOpened

### DIFF
--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -144,7 +144,7 @@ enum AnalyticsEvent: String {
 
     // MARK: - Tab Bar Items
 
-    case podcastTabOpened
+    case podcastsTabOpened
     case filtersTabOpened
     case discoverTabOpened
     case profileTabOpened

--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -462,7 +462,7 @@ private extension MainTabBarController {
         let event: AnalyticsEvent
         switch tab {
         case .podcasts:
-            event = .podcastTabOpened
+            event = .podcastsTabOpened
         case .filter:
             event = .filtersTabOpened
         case .discover:


### PR DESCRIPTION
This changes podcastTabOpened to podcastsTabOpened

## To test

1. Launch the app
2. Tap on the Podcasts tab
3. ✅ Verify you see `🔵 Tracked: podcasts_tab_opened ["initial": INITIAL]` in console
   - Where initial is true or false depending on whether the tab was the active one when you launched the app

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
