### PR TITLE
Tooling: automate release tasks

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -323,20 +323,8 @@ platform :ios do
     ios_completecodefreeze_prechecks(options)
     generate_strings_file_for_glotpress
 
-    create_merge_release_branch(build_version: ios_get_build_version)
-
-    after_confirming_push_release_branches do
+    after_confirming_push do
       trigger_beta_build(branch_to_build: release_branch_name)
-    end
-  end
-
-  def create_merge_release_branch(build_version:)
-    Fastlane::Helper::GitHelper.create_branch("merge/release-#{build_version}-into-trunk", from: release_branch_name)
-  end
-
-  def push_release_branches(build_version:)
-    ["merge/release-#{build_version}-into-trunk", release_branch_name].each do |branch_name|
-      push_to_git_remote(local_branch: branch_name, remote_branch: branch_name, tags: false)
     end
   end
 
@@ -388,11 +376,6 @@ platform :ios do
     setfrozentag(repository: GHHELPER_REPO, milestone: version, freeze: false)
     create_new_milestone(repository: GHHELPER_REPO)
     close_milestone(repository: GHHELPER_REPO, milestone: version)
-
-    # Set up branches to merge
-    build_version = ios_get_build_version
-    create_merge_release_branch(build_version: build_version)
-    push_release_branches(build_version: build_version)
 
     # Start the build
     trigger_release_build(branch_to_build: release_branch_name)
@@ -465,7 +448,7 @@ platform :ios do
       body: {
         title: "#{ios_get_app_version} Release: Merge changes from #{ios_get_build_version} into `trunk`",
         body: "Merge changes from #{ios_get_app_version} (#{ios_get_build_version}) to `trunk`.\n\n## To test\n\n- Ensure the build is 🟢\n- The code changes here were tested in their own PRs",
-        head: "merge/release-#{ios_get_app_version}-into-trunk",
+        head: release_branch_name,
         base: 'trunk'
       },
       error_handlers: {
@@ -504,8 +487,7 @@ platform :ios do
     lint_localizations
 
     ios_bump_version_beta
-    create_merge_release_branch(build_version: ios_get_build_version)
-    push_release_branches(build_version: ios_get_build_version)
+
     trigger_beta_build(branch_to_build: release_branch_name)
   end
 
@@ -529,12 +511,8 @@ platform :ios do
   #
   desc 'Performs the final checks and triggers a release build for the hotfix in the current branch'
   lane :finalize_hotfix_release do |options|
-    # Set up branches to merge
-    build_version = ios_get_build_version
-    create_merge_release_branch(build_version: build_version)
-
     # Push and trigger build
-    after_confirming_push_release_branches do
+    after_confirming_push do
       ios_finalize_prechecks(options)
       trigger_release_build(branch_to_build: release_branch_name)
     end
@@ -955,9 +933,9 @@ inal copy, and try again.")
     "$BUILDKITE_PIPELINE_SLUG-spm-cache-#{hash}"
   end
 
-  def after_confirming_push_release_branches(message: 'Push changes to the remote and trigger the build?')
+  def after_confirming_push(message: 'Push changes to the remote and trigger the build?')
     if ENV.fetch('RELEASE_TOOLKIT_SKIP_PUSH_CONFIRM', false) || UI.confirm(message)
-      push_release_branches(build_version: ios_get_build_version)
+      push_to_git_remote(tags: false)
       yield
     else
       UI.message('Aborting push as requested.')


### PR DESCRIPTION
Disclaimer: I know some changes on this PR can go as actions on the `release-toolkit`. However, I wanna make sure the new automation works well before migrating some of this code there.

The intent of this PR is to simplify and automate some release tasks such as:

- Simplify code freeze to be executed in one single step (no start/finish)
- Create pre-release for betas (instead of draft releases that need to be manually published) ([example](https://github.com/Automattic/pocket-casts-ios/releases/tag/7.23.0.0))
- Automatically leave a message on PRs targeting the frozen milestone ([example](https://github.com/Automattic/pocket-casts-ios/pull/259#issuecomment-1254061047))
- Automatically open PRs after each build (no need to manually open a PR) ([example](https://github.com/Automattic/pocket-casts-ios/pull/261))
- Automatically notifies the iOS team with messages on Slack ([example](https://a8c.slack.com/archives/C029BMLUGRX/p1663794904003009))

## The changes in the current flow

There are changes on the developer's machine and o CI:

1. Code changes and branch creation are done on the developer's machine, not on the CI.
2. Opening a PR, creating a release, and sending Slack messages happens on CI

## To test

The code freeze flow and the intermediate beta build have been tested for the current release.

If you want to test the flow, you can edit `Fastfile` removing the action that sends the app to TestFlight:

```ruby
    secrets_dir = File.join(Dir.home, '.configure', 'pocketcasts-ios', 'secrets')
    testflight(
      skip_waiting_for_build_processing: true,
      team_id: TEAM_ID,
      api_key_path: File.join(secrets_dir, 'app_store_connect_fastlane_api_key.json')
    )

    sh 'cd .. && make upload_dsyms'
```

Create a new branch, commit this change and then merge it into your local trunk. Then you'll be able to test it without actually submitting the app to Apple.

However, this will send messages, create branches, etc. So if you do this remember to:

1. Delete the pre-release [here](https://github.com/Automattic/pocket-casts-ios/releases) and [its tag here](https://github.com/Automattic/pocket-casts-ios/tags)
2. Close the open PR and delete the `merge/...` branch
3. Go to the repository Settings and remove the `release/VERSION` protection, then delete it
4. Delete the `release/VERSION` and `merge/...` branches from your machine
5. Remove the code freeze from the milestone [here](https://github.com/Automattic/pocket-casts-ios/milestones)

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
