### PR TITLE
Tracks: Update playback event names

### DIFF
--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -208,10 +208,10 @@ enum AnalyticsEvent: String {
 
     // MARK: - Playback
 
-    case play
-    case pause
-    case skipBack
-    case skipForward
+    case playbackPlay
+    case playbackPause
+    case playbackSkipBack
+    case playbackSkipForward
 
     // MARK: - Filters
 

--- a/podcasts/Analytics/AnalyticsPlaybackHelper.swift
+++ b/podcasts/Analytics/AnalyticsPlaybackHelper.swift
@@ -25,19 +25,19 @@ class AnalyticsPlaybackHelper {
         }
 
         func play() {
-            track(.play)
+            track(.playbackPlay)
         }
 
         func pause() {
-            track(.pause)
+            track(.playbackPause)
         }
 
         func skipBack() {
-            track(.skipBack)
+            track(.playbackSkipBack)
         }
 
         func skipForward() {
-            track(.skipForward)
+            track(.playbackSkipForward)
         }
 
         private func track(_ event: AnalyticsEvent) {


### PR DESCRIPTION
| 📘 Project: #154 |
|:---:|

Turns out Tracks rejects events that don't contain 2 underscores. This updates the playback events to be prefixed with `playback`

## To test

1. Launch the app
2. Tap Play on the player
3. ✅ Verify you see `🔵 Tracked: playback_play ["source": "SOURCE"]`
4. Tap Pause on the player
5. ✅ Verify you see `🔵 Tracked: playback_pause ["source": "SOURCE"]`
6. Tap the skip forward button
7. ✅ Verify you see `🔵 Tracked: playback_skip_forward ["source": "SOURCE"]`
8. Tap the skip back button
9. ✅ Verify you see `🔵 Tracked: playback_skip_back ["source": "SOURCE"]`

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
