### PR TITLE
Centralize scheme definition and remove unused `build` lane in `Fastfile`

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -344,7 +344,11 @@ platform :ios do
     sentry_check_cli_installed
     configure_code_signing
 
-    build_pocketcasts(
+    build_app(
+      scheme: SCHEME,
+      include_bitcode: false,
+      include_symbols: true,
+      clean: true,
       export_options: {
         method: 'app-store',
         manageAppVersionAndBuildNumber: false
@@ -413,17 +417,6 @@ platform :ios do
     )
 
     FileUtils.rm_rf(archive_zip_path)
-  end
-
-  def build_pocketcasts(additional_options = {})
-    build_app(
-      scheme: SCHEME,
-      include_bitcode: false,
-      include_symbols: true,
-      clean: true,
-      # Double splat additional options at the end to override existing ones, if any
-      **additional_options
-    )
   end
 
   # Creates a new beta by bumping the app version appropriately then triggering a beta build on CI

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -138,11 +138,8 @@ platform :ios do
 
     configure_code_signing
 
-    gym(
-      scheme: SCHEME,
-      include_bitcode: false,
-      clean: true
-    )
+    build_pocketcasts
+
     clean_build_artifacts
     sh(command: 'rm -fr ~/Library/Developer/Xcode/Archives/*')
   end
@@ -363,12 +360,11 @@ platform :ios do
     sentry_check_cli_installed
     configure_code_signing
 
-    gym(
-      scheme: SCHEME,
-      include_bitcode: false,
-      include_symbols: true,
-      clean: true,
-      export_options: { method: 'app-store', manageAppVersionAndBuildNumber: false }
+    build_pocketcasts(
+      export_options: {
+        method: 'app-store',
+        manageAppVersionAndBuildNumber: false
+      }
     )
 
     secrets_dir = File.join(Dir.home, '.configure', 'pocketcasts-ios', 'secrets')
@@ -433,6 +429,17 @@ platform :ios do
     )
 
     FileUtils.rm_rf(archive_zip_path)
+  end
+
+  def build_pocketcasts(additional_options = {})
+    gym(
+      scheme: SCHEME,
+      include_bitcode: false,
+      include_symbols: true,
+      clean: true,
+      # Double splat additional options at the end to override existing ones, if any
+      **additional_options
+    )
   end
 
   # Creates a new beta by bumping the app version appropriately then triggering a beta build on CI

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -432,7 +432,7 @@ platform :ios do
   end
 
   def build_pocketcasts(additional_options = {})
-    gym(
+    build_app(
       scheme: SCHEME,
       include_bitcode: false,
       include_symbols: true,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -128,22 +128,6 @@ platform :ios do
     )
   end
 
-  desc 'Build the project only'
-  lane :build do
-    # CI has its own mechanism to setup the Ruby gems and CocoaPods
-    unless is_ci
-      bundle_install
-      cocoapods
-    end
-
-    configure_code_signing
-
-    build_pocketcasts
-
-    clean_build_artifacts
-    sh(command: 'rm -fr ~/Library/Developer/Xcode/Archives/*')
-  end
-
   desc 'This lane downloads and configures the code signing certificates and profiles.'
   lane :configure_code_signing do |options|
     match(

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -19,6 +19,8 @@ SENTRY_PROJECT_SLUG = 'pocket-casts-ios'
 
 GHHELPER_REPO = 'Automattic/pocket-casts-ios'
 
+SCHEME = 'pocketcasts'
+
 TEAM_ID = 'PZYM8XX95Q'
 
 APP_STORE_VERSION_BUNDLE_IDENTIFIER = 'au.com.shiftyjelly.podcasts'
@@ -122,7 +124,7 @@ platform :ios do
   desc 'Run the unit tests'
   lane :test do
     run_tests(
-      scheme: 'pocketcasts'
+      scheme: SCHEME
     )
   end
 
@@ -137,7 +139,7 @@ platform :ios do
     configure_code_signing
 
     gym(
-      scheme: 'pocketcasts',
+      scheme: SCHEME,
       include_bitcode: false,
       clean: true
     )
@@ -362,7 +364,7 @@ platform :ios do
     configure_code_signing
 
     gym(
-      scheme: 'pocketcasts',
+      scheme: SCHEME,
       include_bitcode: false,
       include_symbols: true,
       clean: true,


### PR DESCRIPTION
Refactors `Fastfile` to:

1. Remove a couple of unused lanes, `:beta` and `:build`—At least, I assume they're unused because no code runs them and they're outside of the automation work that we've been working on recently
2. Ensures the step that builds the app for deployment in CI uses the SPM cache, as a followup to 9176e3d9bd253c382c3ca3f76d344bd8bd497315.

## To test

_TBD_

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary. – N.A.
- [x] I have considered adding unit tests for my changes. – N.A.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics. – N.A.
