### PR TITLE
DRY Slack message root generation 

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -267,18 +267,18 @@ platform :ios do
     appstoreconnect_url = 'https://appstoreconnect.apple.com/apps/414834813'
     testflight_submit_link = "<#{appstoreconnect_url}/testflight/ios|App Store Connect>"
     appstore_submit_link = "<#{appstoreconnect_url}/versions/deliverable|App Store Connect>"
-    pull_requests_list_link = "<https://github.com/Automattic/pocket-casts-ios/pulls?q=is%3Apr+is%3Aopen+#{build_number}+into|merge the PR>"
+    merge_pr_link = "<https://github.com/Automattic/pocket-casts-ios/pulls?q=is%3Apr+is%3Aopen+#{build_number}+into|merge the PR>"
 
     if is_beta
       if (build_number_split[3] || '0') == '0'
-        "#{message_root.call(build_number, version)} code freeze is completed.\nPlease submit #{build_number} for testers on #{testflight_submit_link} and #{pull_requests_list_link}."
+        "#{message_root.call(build_number, version)} code freeze is completed.\nPlease submit #{build_number} for testers on #{testflight_submit_link} and #{merge_pr_link}."
       else
-        "#{message_root.call(build_number, build_number)} beta has been submitted to Apple.\nPlease distribute #{build_number} to testers on #{testflight_submit_link} and #{pull_requests_list_link}."
+        "#{message_root.call(build_number, build_number)} beta has been submitted to Apple.\nPlease distribute #{build_number} to testers on #{testflight_submit_link} and #{merge_pr_link}."
       end
     elsif (build_number_split[2] || '0').to_i.positive?
-      "#{message_root.call(version, version)} hotfix has been uploaded to Apple.\nPlease submit it for review on #{appstore_submit_link} and #{pull_requests_list_link}."
+      "#{message_root.call(version, version)} hotfix has been uploaded to Apple.\nPlease submit it for review on #{appstore_submit_link} and #{merge_pr_link}."
     else
-      "#{message_root.call(version, version)} final build has been uploaded to Apple.\nPlease submit it for review on #{appstore_submit_link} and #{pull_requests_list_link}."
+      "#{message_root.call(version, version)} final build has been uploaded to Apple.\nPlease submit it for review on #{appstore_submit_link} and #{merge_pr_link}."
     end
   end
   # rubocop:enable Metrics/MethodLength


### PR DESCRIPTION
See discussion [here](https://github.com/Automattic/pocket-casts-ios/pull/270#discussion_r980246555).

Whether or not this makes the code more readable might be questionable. But at least it makes it easier to change because by removing most duplication.

## To test

I tested this with a dedicate lane

```diff
diff --git a/fastlane/Fastfile b/fastlane/Fastfile
index bccd24fa9..f8555d215 100644
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -281,6 +281,32 @@ platform :ios do
       "#{message_root.call(version, version)} final build has been uploaded to Apple.\nPlease submit it for review on #{appstore_submit_link} and #{pull_requests_list_link}."
     end
   end
+
+  lane :slack_test do
+    UI.message "slack_message(version: '1.2.0', build_number: '1.2.0.0', is_beta: true)"
+    puts slack_message(version: '1.2.0', build_number: '1.2.0.0', is_beta: true)
+
+    UI.message "slack_message(version: '1.2.0', build_number: '1.2.0.0', is_beta: false)"
+    puts slack_message(version: '1.2.0', build_number: '1.2.0.0', is_beta: false)
+
+    UI.message "slack_message(version: '1.2.0', build_number: '1.2.0.1', is_beta: true)"
+    puts slack_message(version: '1.2.0', build_number: '1.2.0.1', is_beta: true)
+
+    UI.message "slack_message(version: '1.2.0', build_number: '1.2.0.1', is_beta: false)"
+    puts slack_message(version: '1.2.0', build_number: '1.2.0.1', is_beta: false)
+
+    UI.message "slack_message(version: '1.2.1', build_number: '1.2.0.0', is_beta: true)"
+    puts slack_message(version: '1.2.1', build_number: '1.2.0.0', is_beta: true)
+
+    UI.message "slack_message(version: '1.2.1', build_number: '1.2.0.0', is_beta: false)"
+    puts slack_message(version: '1.2.1', build_number: '1.2.0.0', is_beta: false)
+
+    UI.message "slack_message(version: '1.2.1', build_number: '1.2.0.1', is_beta: true)"
+    puts slack_message(version: '1.2.1', build_number: '1.2.0.1', is_beta: true)
+
+    UI.message "slack_message(version: '1.2.1', build_number: '1.2.0.1', is_beta: false)"
+    puts slack_message(version: '1.2.1', build_number: '1.2.0.1', is_beta: false)
+  end
   # rubocop:enable Metrics/MethodLength
 
   # Executes the initial steps of the code freeze
```

The result was

```
[13:31:29]: slack_message(version: '1.2.0', build_number: '1.2.0.0', is_beta: true)
[13:31:29]: :announcement: <https://github.com/Automattic/pocket-casts-ios/releases/tag/1.2.0.0|*1.2.0*> code freeze is completed.
Please submit 1.2.0.0 for testers on <https://appstoreconnect.apple.com/apps/414834813/testflight/ios|App Store Connect> and <https://github.com/Automattic/pocket-casts-ios/pulls?q=is%3Apr+is%3Aopen+1.2.0.0+into|merge the PR>.
[13:31:29]: slack_message(version: '1.2.0', build_number: '1.2.0.0', is_beta: false)
[13:31:29]: :announcement: <https://github.com/Automattic/pocket-casts-ios/releases/tag/1.2.0|*1.2.0*> final build has been uploaded to Apple.
Please submit it for review on <https://appstoreconnect.apple.com/apps/414834813/versions/deliverable|App Store Connect> and <https://github.com/Automattic/pocket-casts-ios/pulls?q=is%3Apr+is%3Aopen+1.2.0.0+into|merge the PR>.
[13:31:29]: slack_message(version: '1.2.0', build_number: '1.2.0.1', is_beta: true)
[13:31:29]: :announcement: <https://github.com/Automattic/pocket-casts-ios/releases/tag/1.2.0.1|*1.2.0.1*> beta has been submitted to Apple.
Please distribute 1.2.0.1 to testers on <https://appstoreconnect.apple.com/apps/414834813/testflight/ios|App Store Connect> and <https://github.com/Automattic/pocket-casts-ios/pulls?q=is%3Apr+is%3Aopen+1.2.0.1+into|merge the PR>.
[13:31:29]: slack_message(version: '1.2.0', build_number: '1.2.0.1', is_beta: false)
[13:31:29]: :announcement: <https://github.com/Automattic/pocket-casts-ios/releases/tag/1.2.0|*1.2.0*> final build has been uploaded to Apple.
Please submit it for review on <https://appstoreconnect.apple.com/apps/414834813/versions/deliverable|App Store Connect> and <https://github.com/Automattic/pocket-casts-ios/pulls?q=is%3Apr+is%3Aopen+1.2.0.1+into|merge the PR>.
[13:31:29]: slack_message(version: '1.2.1', build_number: '1.2.0.0', is_beta: true)
[13:31:29]: :announcement: <https://github.com/Automattic/pocket-casts-ios/releases/tag/1.2.0.0|*1.2.1*> code freeze is completed.
Please submit 1.2.0.0 for testers on <https://appstoreconnect.apple.com/apps/414834813/testflight/ios|App Store Connect> and <https://github.com/Automattic/pocket-casts-ios/pulls?q=is%3Apr+is%3Aopen+1.2.0.0+into|merge the PR>.
[13:31:29]: slack_message(version: '1.2.1', build_number: '1.2.0.0', is_beta: false)
[13:31:29]: :announcement: <https://github.com/Automattic/pocket-casts-ios/releases/tag/1.2.1|*1.2.1*> final build has been uploaded to Apple.
Please submit it for review on <https://appstoreconnect.apple.com/apps/414834813/versions/deliverable|App Store Connect> and <https://github.com/Automattic/pocket-casts-ios/pulls?q=is%3Apr+is%3Aopen+1.2.0.0+into|merge the PR>.
[13:31:29]: slack_message(version: '1.2.1', build_number: '1.2.0.1', is_beta: true)
[13:31:29]: :announcement: <https://github.com/Automattic/pocket-casts-ios/releases/tag/1.2.0.1|*1.2.0.1*> beta has been submitted to Apple.
Please distribute 1.2.0.1 to testers on <https://appstoreconnect.apple.com/apps/414834813/testflight/ios|App Store Connect> and <https://github.com/Automattic/pocket-casts-ios/pulls?q=is%3Apr+is%3Aopen+1.2.0.1+into|merge the PR>.
[13:31:29]: slack_message(version: '1.2.1', build_number: '1.2.0.1', is_beta: false)
[13:31:29]: :announcement: <https://github.com/Automattic/pocket-casts-ios/releases/tag/1.2.1|*1.2.1*> final build has been uploaded to Apple.
Please submit it for review on <https://appstoreconnect.apple.com/apps/414834813/versions/deliverable|App Store Connect> and <https://github.com/Automattic/pocket-casts-ios/pulls?q=is%3Apr+is%3Aopen+1.2.0.1+into|merge the PR>.
```

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary. – N.A.
- [x] I have considered adding unit tests for my changes. – N.A.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics. – N.A.
