### PR TITLE
Remove left over Fieldguide message

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,6 @@ Next you'll need to install all the dependencies needed for CocoaPods and FastLa
 
 `make install_dependencies`
 
-Then you'll need to install secret config values. [Follow this guide to get access to the shared Mobile Secrets](https://fieldguide.automattic.com/mobile-native-development/updating-mobile-secrets/) and then:
-
 ## External contributors
 
 If you're an external contributor run `make external_contributor`. After that you should be able to build and run the project.


### PR DESCRIPTION
Fixes N/A

Dropping a lingering reference to the Fieldguide. 

## To test

N/A

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
