### PR TITLE
Tracks: Add in the playback source for the extended episode list

### DIFF
--- a/podcasts/ExpandedEpisodeListViewController.swift
+++ b/podcasts/ExpandedEpisodeListViewController.swift
@@ -115,3 +115,9 @@ class ExpandedEpisodeListViewController: PCViewController, UITableViewDelegate, 
         }
     }
 }
+
+extension ExpandedEpisodeListViewController: PlaybackSource {
+    var playbackSource: String {
+        "discover_episode_list"
+    }
+}


### PR DESCRIPTION
| 📘 Project: #154 |
|:---:|

Adds in a missing playback source for the extended episode list.

## To test

1. Change to the staging setup
2. Launch the app
3. Go to the Discover tab
4. Locate the Featuring Keanu Reeves section
5. Tap on it
6. Tap on the play item on one of the episodes
7. ✅ `🔵 Tracked: playback_play ["source": "discover_episode_list"]`
8. Tap on the pause button
9. ✅ `🔵 Tracked: playback_pause ["source": "discover_episode_list"]`


## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
