### PR TITLE
Tooling: submit beta release with the contents of changelog

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -410,7 +410,7 @@ platform :ios do
       skip_waiting_for_build_processing: true,
       team_id: TEAM_ID,
       api_key_path: File.join(secrets_dir, 'app_store_connect_fastlane_api_key.json'),
-      changelog: changelog
+      changelog: changelog.gsub(/\s*\(#.+\)$/, '')
     )
 
     sh 'cd .. && make upload_dsyms'


### PR DESCRIPTION
Changes the lane to submit the contents of changelog instead of doing manually each time we release a new beta.

We may want to do more fancy stuff in the future such as removing internal items and stuff but I believe that's enough for now.

## To test

1. Green build
2. Just review the code

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
