### PR TITLE
Tooling: fix the called action when releasing a new beta

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -486,9 +486,10 @@ platform :ios do
     # localization fixes.
     generate_strings_file_for_glotpress
 
-    ios_update_release_notes(
-      new_version: new_version,
-      release_notes_file_path: RELEASE_NOTES_SOURCE_PATH
+    extract_release_notes_for_version(
+      version: ios_get_app_version,
+      release_notes_file_path: RELEASE_NOTES_SOURCE_PATH,
+      extracted_notes_file_path: EXTRACTED_RELEASE_NOTES_PATH
     )
 
     download_localized_strings_and_metadata_from_glotpress


### PR DESCRIPTION
This fixes the command called when releasing a new beta.

We want to create new release notes, not to create a new entry on `CHANGELOG.md`.

## To test

- Just code review

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
