### PR TITLE
Tooling: remove submitting changelog and fix a wrong method name

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -460,7 +460,7 @@ platform :ios do
 
     UI.message('Sending message to Slack...')
     slack(
-      pretext: message(version: ios_get_app_version, build_number: ios_get_build_version, is_beta: options[:beta_release]),
+      pretext: slack_message(version: ios_get_app_version, build_number: ios_get_build_version, is_beta: options[:beta_release]),
       default_payloads: [],
       slack_url: ENV.fetch('SLACK_WEBHOOK'),
       fail_on_error: false


### PR DESCRIPTION
Unfortunately, if we want to submit the changelog when submitting a new Testflight version the build waits for it to appear. This makes the build take longer so I think we should not use this for now — even though we need to go there and manually submit the build for our beta testers.

This also fixes a wrong method name when sending a message to Slack.

## To test

- Green build is enough

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
