### PR TITLE
Tracks: Enable the analytics feature flag

### DIFF
--- a/podcasts/Analytics/Adapters/AnalyticsLoggingAdapter.swift
+++ b/podcasts/Analytics/Adapters/AnalyticsLoggingAdapter.swift
@@ -4,6 +4,8 @@ import PocketCastsUtils
 /// Simple tracking adapter that just logs the event
 struct AnalyticsLoggingAdapter: AnalyticsAdapter {
     func track(name: String, properties: [AnyHashable: Any]?) {
+        guard FeatureFlag.tracksLoggingEnabled else { return }
+
         guard let properties = properties as? [String: Any] else {
             log("🔵 Tracked: \(name)")
             return

--- a/podcasts/FeatureFlag.swift
+++ b/podcasts/FeatureFlag.swift
@@ -7,6 +7,9 @@ enum FeatureFlag {
     /// Whether the Tracks analytics are enabled
     static let tracksEnabled = true
 
-    /// Whether logging of Firebase events in console is enabled
+    /// Whether logging of Tracks events in console are enabled
+    static let tracksLoggingEnabled = false
+
+    /// Whether logging of Firebase events in console are enabled
     static let firebaseLoggingEnabled = false
 }


### PR DESCRIPTION
| 📘 Project: #154 |
|:---:|

Enables the analytics Feature Flag

## To test

1. Launch the app
2. Tap around a verify you don't see any `🔵 Tracked` logs in console
3. Enable the `tracksLoggingEnabled` Feature Flag and relaunch the app
4. Tap around and verify you see `🔵 Tracked` logs in console

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
