### PR TITLE
Adjust padding to exclude the scrollbar in folders

### DIFF
--- a/podcasts/CreateFolderView.swift
+++ b/podcasts/CreateFolderView.swift
@@ -36,8 +36,9 @@ struct CreateFolderView: View {
                 Text(addButtonTitle)
                     .textStyle(RoundedButton())
             }
+            .padding(.horizontal)
         }
-        .padding()
+        .padding(.vertical)
         .navigationTitle(L10n.folderCreate)
         .onAppear {
             pickerModel.setup()

--- a/podcasts/EditFolderPodcastsView.swift
+++ b/podcasts/EditFolderPodcastsView.swift
@@ -9,11 +9,8 @@ struct EditFolderPodcastsView: View {
     
     var body: some View {
         NavigationView {
-            VStack(alignment: .leading) {
-                PodcastPickerView(pickerModel: pickerModel)
-            }
+            PodcastPickerView(pickerModel: pickerModel)
             .navigationTitle(L10n.folderChoosePodcasts)
-            .padding()
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
                     Button {

--- a/podcasts/EditFolderPodcastsView.swift
+++ b/podcasts/EditFolderPodcastsView.swift
@@ -10,19 +10,19 @@ struct EditFolderPodcastsView: View {
     var body: some View {
         NavigationView {
             PodcastPickerView(pickerModel: pickerModel)
-            .navigationTitle(L10n.folderChoosePodcasts)
-            .toolbar {
-                ToolbarItem(placement: .navigationBarLeading) {
-                    Button {
-                        dismissAction()
-                    } label: {
-                        Image("close")
-                            .foregroundColor(ThemeColor.secondaryIcon01(for: theme.activeTheme).color)
+                .navigationTitle(L10n.folderChoosePodcasts)
+                .toolbar {
+                    ToolbarItem(placement: .navigationBarLeading) {
+                        Button {
+                            dismissAction()
+                        } label: {
+                            Image("close")
+                                .foregroundColor(ThemeColor.secondaryIcon01(for: theme.activeTheme).color)
+                        }
+                        .accessibilityLabel(L10n.close)
                     }
-                    .accessibilityLabel(L10n.close)
                 }
-            }
-            .applyDefaultThemeOptions()
+                .applyDefaultThemeOptions()
         }
         .navigationViewStyle(StackNavigationViewStyle())
         .onAppear {

--- a/podcasts/PodcastPickerRow.swift
+++ b/podcasts/PodcastPickerRow.swift
@@ -56,6 +56,7 @@ struct PodcastPickerRow: View {
                 }
             }
         }
+        .padding(.horizontal)
     }
 }
 

--- a/podcasts/PodcastPickerView.swift
+++ b/podcasts/PodcastPickerView.swift
@@ -9,34 +9,38 @@ struct PodcastPickerView: View {
     
     var body: some View {
         VStack(alignment: .leading) {
-            HStack {
-                PCSearchView(searchTerm: $pickerModel.searchTerm)
-                    .frame(height: PCSearchView.defaultHeight)
-                    .padding(.top, -10)
-                    .padding(.leading, -PCSearchView.defaultIndenting)
-                Spacer()
-                Menu {
-                    SortByView(sortType: .titleAtoZ, pickerModel: pickerModel)
-                    SortByView(sortType: .episodeDateNewestToOldest, pickerModel: pickerModel)
-                    SortByView(sortType: .dateAddedNewestToOldest, pickerModel: pickerModel)
-                } label: {
-                    Image("podcast-sort")
-                        .accessibilityLabel(L10n.podcastsSort)
-                        .foregroundColor(ThemeColor.primaryInteractive01(for: theme.activeTheme).color)
-                        .frame(width: 32, height: 32)
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 10)
-                                .stroke(ThemeColor.primaryInteractive01(for: theme.activeTheme).color, lineWidth: 2)
-                        )
+            Group {
+                HStack {
+                    PCSearchView(searchTerm: $pickerModel.searchTerm)
+                        .frame(height: PCSearchView.defaultHeight)
+                        .padding(.top, -10)
+                        .padding(.leading, -PCSearchView.defaultIndenting)
+                    Spacer()
+                    Menu {
+                        SortByView(sortType: .titleAtoZ, pickerModel: pickerModel)
+                        SortByView(sortType: .episodeDateNewestToOldest, pickerModel: pickerModel)
+                        SortByView(sortType: .dateAddedNewestToOldest, pickerModel: pickerModel)
+                    } label: {
+                        Image("podcast-sort")
+                            .accessibilityLabel(L10n.podcastsSort)
+                            .foregroundColor(ThemeColor.primaryInteractive01(for: theme.activeTheme).color)
+                            .frame(width: 32, height: 32)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 10)
+                                    .stroke(ThemeColor.primaryInteractive01(for: theme.activeTheme).color, lineWidth: 2)
+                            )
+                    }
+                    .padding(.top, -20)
                 }
-                .padding(.top, -20)
+                ThemedDivider()
+                Text(L10n.selectedPodcastCount(pickerModel.selectedPodcastUuids.count, capitalized: true))
+                    .font(.subheadline)
+                    .textStyle(PrimaryText())
+                    .padding(.top, 3)
+                ThemedDivider()
             }
-            ThemedDivider()
-            Text(L10n.selectedPodcastCount(pickerModel.selectedPodcastUuids.count, capitalized: true))
-                .font(.subheadline)
-                .textStyle(PrimaryText())
-                .padding(.top, 3)
-            ThemedDivider()
+            .padding(.horizontal)
+            
             List(pickerModel.filteredPodcasts) { podcast in
                 Button {
                     pickerModel.togglePodcastSelected(podcast)


### PR DESCRIPTION
Fixes #144 

Moves the padding from being globally applied to all elements and adds it to the subgroups that need it

## To test

Create a folder or edit and folder check to make the scroll indicator doesn't overlap the ☑️ 

<img width="300" src="https://user-images.githubusercontent.com/3384451/193356343-c8f7a557-d16b-422a-831a-5187ded350ab.png">

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
