### PR TITLE
Setup analytics after protected data is available

### DIFF
--- a/podcasts/AppDelegate+Analytics.swift
+++ b/podcasts/AppDelegate+Analytics.swift
@@ -7,9 +7,16 @@ extension AppDelegate {
             return
         }
 
-        Analytics.register(adapters: [AnalyticsLoggingAdapter(), TracksAdapter()])
-
         addAnalyticsObservers()
+
+        // Check if we're able to write to protected data
+        if UIApplication.shared.isProtectedDataAvailable {
+            setupAdapters()
+        }
+    }
+
+    private func setupAdapters() {
+        Analytics.register(adapters: [AnalyticsLoggingAdapter(), TracksAdapter()])
     }
 
     private func addAnalyticsObservers() {
@@ -20,6 +27,11 @@ extension AppDelegate {
             }
 
             Analytics.track(.userSignedOut, properties: ["user_initiated": userIniated])
+        }
+
+        // Setup adapters if needed after protected data becomes available
+        NotificationCenter.default.addObserver(forName: UIApplication.protectedDataDidBecomeAvailableNotification, object: nil, queue: .main) { [weak self] _ in
+            self?.setupAdapters()
         }
     }
 


### PR DESCRIPTION
Ref: paNNhX-AX-p2

This applies a potential fix for a crash that can occur when setting up the analytics databases. I suspect one of the reasons this crash occurs is because of the default value for the default data protection and some backgrounding events. 

This adds a check when the app is launched to only setup the database when protected files are enabled, if they aren't we'll listen for the `UIApplication.protectedDataDidBecomeAvailableNotification` notification and then configure them then.

## To test

> **Warning**
> This is a bit difficult to reproduce, and requires running on a real device, and using AirPods


1. Clone a local copy of: https://github.com/Automattic/Automattic-Tracks-iOS
2. Drag the folder into the Pocketcasts project and wait for Xcode to update the packages
3. Open TracksContextManager.m
4. Go to line 45, and add the following: `NSDictionary *options = @{ NSPersistentStoreFileProtectionKey: NSFileProtectionComplete };`
5. Then replace `options:nil` on lines 49 and 53 with `options: options`
6. In Xcode, go to: Window > Devices and Simulators > Open Console
7. Click the Start Streaming action
8. In the search field in the top right corner search for `terminating`
9. Click the Clear button
10. Run the app on your phone. 
11. Play any episode
12. Quit the app, and remove it from your background apps
13. Lock your device
14. Wait about 10 seconds, this step is required because the data protection expires after about 7 - 10 seconds
15. Cover your FaceID if you have it, to prevent unlocking the device
16. Use the play action on your AirPods
    - This forces the app to open in the background while the device is locked
17. In Console.app on your Mac
18. ✅ Verify you don't see any logs "terminating"

If you want to reproduce the crash:
1. Open AppDelegate+Analytics
2. Comment out lines 13, 15, and 34
3. Repeat the steps above



## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
