### PR TITLE
Set the data protection to none when connecting to the database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 7.25
 -----
-
+- Fixed a crash that could happen when playing an episode while the app is in the background (#345)
 
 7.24
 -----

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -1,5 +1,6 @@
 import FMDB
 import PocketCastsUtils
+import SQLite3
 
 public class DataManager {
     public static let podcastTableName = "SJPodcast"
@@ -27,7 +28,8 @@ public class DataManager {
     public init() {
         DataManager.ensureDbFolderExists()
 
-        dbQueue = FMDatabaseQueue(path: DataManager.pathToDb())!
+        let flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FILEPROTECTION_NONE
+        dbQueue = FMDatabaseQueue(path: DataManager.pathToDb(), flags: flags)!
         dbQueue.inDatabase { db in
             DatabaseHelper.setup(db: db)
         }


### PR DESCRIPTION
Fixes: https://github.com/Automattic/pocket-casts-ios/issues/346


This attempts to fix the DataManager crash that happens early in the app lifecycle. This is a different crash than: https://github.com/Automattic/pocket-casts-ios/issues/34

This is a similar fix to: https://github.com/Automattic/pocket-casts-ios/pull/344

## To test
> **Warning**
> This is a bit difficult to reproduce, and requires running on a real device, and using AirPods

### Verify the database data is the same:
1. Launch the app 
2. Tap around to your subscribed Podcasts and verify they are all there, and you are able to interact / play them, etc
3. Verify your filters are all still there

### Reproducing the crash and verifying the fix
1. Open DataManager.swift
5. Go to Line 31 and replace `SQLITE_OPEN_FILEPROTECTION_NONE` with `SQLITE_OPEN_FILEPROTECTION_COMPLETE`
6. In Xcode, go to: Window > Devices and Simulators > Open Console
7. Click the Start Streaming action
8. In the search field in the top right corner search for `EXC_BREAKPOINT`
9. Click the Clear button
10. Run the app on your phone. 
11. Play any episode
12. Quit the app, and remove it from your background apps
13. Lock your device
14. Wait about 10 seconds, this step is required because the data protection expires after about 7 - 10 seconds
15. Cover your FaceID if you have it, to prevent unlocking the device
16. Use the play action on your AirPods
    - This forces the app to open in the background while the device is locked
17. In Console.app on your Mac
18. You should see a few new logs appear, clicking on one you should see something like:

```Aggregated. Transform: StabilityCrashNumerator3 Dirty: 1 Event: com.apple.stability.crash {"appVersion":"7.24","bundleID":"au.com.shiftyjelly.podcasts","bundleVersion":"7.24.0.0","exceptionCodes":"0x0000000000000001, 0x00000001c793df54(\n    1,\n    7643324244\n)EXC_BREAKPOINTSIGTRAP","incidentID":"EC1655FC-23B6-4D1D-ACF7-12791D370D4F","logwritten":0,"process":"podcasts","terminationReasonExceptionCode":"0x5","terminationReasonNamespace":"SIGNAL","timestamp":1664838276464015}```


19. This is the same error that appears in the crash logs
20. Replace `SQLITE_OPEN_FILEPROTECTION_COMPLETE` with `SQLITE_OPEN_FILEPROTECTION_NONE`
21. Relaunch the app and repeats the steps
22. Verify you don't see any crash logs appear in console

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
