### PR TITLE
Configure Danger to run SwiftLint

### DIFF
--- a/.buildkite/commands/danger.sh
+++ b/.buildkite/commands/danger.sh
@@ -5,7 +5,6 @@ install_gems
 
 echo "--- Install Pods"
 # We need the pods because that's where SwiftLint (used by Danger) comes from
-# FIXME: SwiftLint is not used in Danger yet, but we aim to get it there soon.
 install_cocoapods
 
 echo "--- :warning: Run Danger"

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,2 +1,9 @@
 parent_config: https://raw.githubusercontent.com/Automattic/swiftlint-config/0f8ab6388bd8d15a04391825ab125f80cfb90704/.swiftlint.yml
 remote_timeout: 10.0
+
+disabled_rules:
+  # FIXME: The following three rules have been disabled so that CI doesn't fail
+  # the build because of them. They ought to be addressed ASAP.
+  - inverse_text_alignment
+  - natural_content_alignment
+  - natural_text_alignment

--- a/Dangerfile
+++ b/Dangerfile
@@ -6,3 +6,8 @@ github.dismiss_out_of_range_messages
 warn('PR is classed as Work in Progress') if github.pr_title.include? '[WIP]'
 
 rubocop.lint inline_comment: true, fail_on_inline_comment: true
+
+swiftlint.binary_path = './Pods/SwiftLint/swiftlint'
+# Lint all files to ensure maximum coverage.
+swiftlint.lint_all_files = true
+swiftlint.lint_files


### PR DESCRIPTION
~~**Update**: Still a draft. For some reason, the plugin is linting files from the Pods. I haven't figured out how to prevent this.~~ Solved via https://github.com/Automattic/pocket-casts-ios/pull/349#issuecomment-1267815239.

We already have Danger setup here, and as you can see making it run SwiftLint was straightforward.

However, I do wonder if this is worth doing at all. It's nice to have Danger comment on the PR, but, as of #349, CI is already running SwiftLint as part of the build process. I wonder if it would be better to augment the `make lint` so that it can fail the build or what not if in CI.

The conversation about the extent to which to run SwiftLint and other tools in CI and whether to include them in Danger is one that span across all our mobile projects. My suggestion here  is  to adopt the setup from this PR for the time being.

## To test

See #357, which shows Danger leaving a comment:

<img width="1024" alt="image" src="https://user-images.githubusercontent.com/1218433/193969039-b2f671ac-ffe4-4290-896c-78bd8dad6282.png">


## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary. – N.A.
- [x] I have considered adding unit tests for my changes. – N.A.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics. – N.A.