### PR TITLE
Run SwiftLint as part of the PreBuildActions target

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,2 +1,2 @@
-parent_config: https://raw.githubusercontent.com/Automattic/swiftlint-config/16560cc1db19447a7cd9ddf268b5e8290f153a6c/.swiftlint.yml
+parent_config: https://raw.githubusercontent.com/Automattic/swiftlint-config/0f8ab6388bd8d15a04391825ab125f80cfb90704/.swiftlint.yml
 remote_timeout: 10.0

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,2 +1,2 @@
-parent_config: https://raw.githubusercontent.com/Automattic/swiftlint-config/37b80c60da84780a5780749e6af72bcde4fd1705/.swiftlint.yml
+parent_config: https://raw.githubusercontent.com/Automattic/swiftlint-config/16560cc1db19447a7cd9ddf268b5e8290f153a6c/.swiftlint.yml
 remote_timeout: 10.0

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 			buildPhases = (
 				462EE0C527025346003D67DC /* GenerateCredentials */,
 				462F3AA2274EB4C3005FEB1F /* L10n */,
+				3F407FBC28EC30B800818E41 /* SwiftLint */,
 			);
 			dependencies = (
 			);
@@ -6756,6 +6757,26 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		3F407FBC28EC30B800818E41 /* SwiftLint */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = SwiftLint;
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "make lint\n";
+			showEnvVarsInLog = 0;
+		};
 		462EE0C527025346003D67DC /* GenerateCredentials */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;


### PR DESCRIPTION
This is neat because it runs SwiftLint _before_ building the app, delivering fast feedback and, if/when there'll be `--strict` mode, even faster build failures.

I decided to split this PR from the one that runs SwiftLint via Danger in CI, #348, so that changes in one won't block the other.

The setup I propose is to run SwiftLint on every build but without the `--autocorrect` (`make format`) mode. Running the tool to also reformat the entire source code would _flush the Xcode undo history_. A possible semi-workaround is to run it with the unit tests, which reduces the reformat occurrences but does not address the undo history loss.

Keen to hear what @Automattic/pocket-casts-ios think about this and keen to iterate.

## To test

You can test this by checking out this branch and building the app:

![image](https://user-images.githubusercontent.com/1218433/193785125-39d0e154-feec-4fee-8c6d-3ddfccf0b2ea.png)

Notice that those warnings will go away when #348 lands in `trunk`. In there, I disabled them via the config file `disabled_rule` option. 

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary. – N.A.
- [x] I have considered adding unit tests for my changes. – N.A.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics. – N.A.