### PR TITLE
Adds pull to refresh haptic feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fixed an iOS 16 issue where a feedback text field had a light background for a dark theme or vice versa. (#301)
 - Fixed an issue where the keyboard would dismiss when resetting search text on discover. (#321)
 - Fixed an issue where the support feedback box would be unusable on smaller devices (#330)
+- Add haptic feedback when the user pulls to refresh (#TBD)
 
 7.23
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Fixed an iOS 16 issue where a feedback text field had a light background for a dark theme or vice versa. (#301)
 - Fixed an issue where the keyboard would dismiss when resetting search text on discover. (#321)
 - Fixed an issue where the support feedback box would be unusable on smaller devices (#330)
-- Add haptic feedback when the user pulls to refresh (#TBD)
+- Add haptic feedback when the user pulls to refresh (#351)
 
 7.23
 -----

--- a/podcasts/HapticsHelper.swift
+++ b/podcasts/HapticsHelper.swift
@@ -21,6 +21,10 @@ class HapticsHelper {
         triggerImpactOccurredHaptic(style: .light)
     }
 
+    class func triggerPullToRefreshHaptic() {
+        triggerImpactOccurredHaptic(style: .heavy)
+    }
+
     private class func triggerImpactOccurredHaptic(style: UIImpactFeedbackGenerator.FeedbackStyle) {
         let feedbackGenerator = UIImpactFeedbackGenerator(style: style)
         feedbackGenerator.impactOccurred()

--- a/podcasts/PCRefreshControl.swift
+++ b/podcasts/PCRefreshControl.swift
@@ -204,6 +204,11 @@ class PCRefreshControl: UIView {
 
     // MARK: - Scroll Events
 
+
+    /// Track whether we've triggered the haptic.
+    /// Defaults to true to prevent the haptic from being fired when the refresh control is initially created
+    private var didTriggerHaptic = true
+
     func didPullDown(_ amount: CGFloat) {
         if refreshing {
             return
@@ -212,8 +217,16 @@ class PCRefreshControl: UIView {
         let adjustedAmount = min(pullDownAmountForRefresh, amount)
         if adjustedAmount < pullDownAmountForRefresh {
             refreshLabel.text = L10n.refreshControlPullToRefresh
+            didTriggerHaptic = false
         } else {
             refreshLabel.text = L10n.refreshControlReleaseToRefresh
+
+            // Only fire the haptic once per "release" state
+            if !didTriggerHaptic {
+                didTriggerHaptic = true
+
+                HapticsHelper.triggerPullToRefreshHaptic()
+            }
         }
 
         innerRotationAngle = (amount * 4).degreesToRadians

--- a/podcasts/PCRefreshControl.swift
+++ b/podcasts/PCRefreshControl.swift
@@ -204,7 +204,6 @@ class PCRefreshControl: UIView {
 
     // MARK: - Scroll Events
 
-
     /// Track whether we've triggered the haptic.
     /// Defaults to true to prevent the haptic from being fired when the refresh control is initially created
     private var didTriggerHaptic = true


### PR DESCRIPTION
Fixes #350

Adds haptic feedback when the user swipes down enough to trigger a pull to refresh.

## To test

> **Warning** 
> This requires a real device to test

1. Launch the app
2. Go to the Podcasts tab
3. Swipe down to pull to refresh
4. Once the label displays "release to refresh"
5. Verify that you feel the haptic feedback, just once
6. Swipe your finger up to leave the "release to refresh" state then swipe back down 
7. ✅ Verify you feel the haptic feedback, just once
8. Release to perform a refresh, then swipe down again and verify the haptic happens again
9. Repeat the steps in the following places:
    - Filters
    - Profile Tab
    - Profile > Files

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
