### PR TITLE
Tooling: revert translation tooling

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -561,8 +561,25 @@ platform :ios do
 
   desc 'Downloads localized strings and App Store Connect metadata from GlotPress'
   lane :download_localized_strings_and_metadata_from_glotpress do
-    download_localized_strings_from_glotpress
+    download_localized_strings_and_metadata
     download_localized_app_store_metadata_from_glotpress
+  end
+
+  # Downloads the localized app strings and App Store Connect metadata from GlotPress.
+  #
+  desc 'Downloads localized metadata for App Store Connect from GlotPress'
+  lane :download_localized_strings_and_metadata do
+    # FIXME: This is a copy of what the release toolkit `ios_update_metadata` action does.
+    # We'll soon replace this with the new `ios_download_strings_files_from_glotpress`-based workflow.
+    sh("cd #{PROJECT_ROOT_FOLDER} && ./scripts/update-translations.rb")
+
+    files_to_commit = Dir.glob(File.join(PROJECT_ROOT_FOLDER, 'podcasts', '**', '*.strings'))
+    git_add(path: files_to_commit, shell_escape: false)
+    git_commit(
+      path: files_to_commit,
+      message: 'Update translations',
+      allow_nothing_to_commit: true
+    )
   end
 
   desc 'Lint the `.strings` files'


### PR DESCRIPTION
While releasing 7.24.0.1 we receive a communication from Apple with a lot of "ITMS-90626: Invalid Siri Support" due to localization strings missing.

This seems to be caused by the new way we get the translations.

In this PR I'm reverting that until we fix this issue.

## To test

1. Just check the changes, you can compare them to the Fastfile on the latest 7.23 release: https://github.com/Automattic/pocket-casts-ios/blob/7.23/fastlane/Fastfile#L572

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
