### PR TITLE
Fix the readme Pocket Casts logo in the dark theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 <p align="center">
-    <img src="https://user-images.githubusercontent.com/7040243/190481901-1b47101c-da98-400f-b92b-bca9e66f4c8c.svg" />
+    <img src="https://user-images.githubusercontent.com/308331/194037473-41ad7eba-8602-4be5-be73-49e3c0c48c12.svg#gh-light-mode-only" />
+    <img src="https://user-images.githubusercontent.com/308331/194041226-4c6d8181-cafa-4ea8-8735-1d8106f5e5f6.svg#gh-dark-mode-only" />
 </p>
 
 <p align="center">


### PR DESCRIPTION
This change adds a readme Pocket Casts logo that works on the dark theme.

Before
<img width="961" alt="Screen Shot 2022-10-05 at 9 16 37 pm" src="https://user-images.githubusercontent.com/308331/194043689-c2d42ff2-a15a-442e-84eb-7e9dcbd44644.png">

After on the dark theme
<img width="1021" alt="Screen Shot 2022-10-05 at 9 16 26 pm" src="https://user-images.githubusercontent.com/308331/194043738-045de39e-63b0-455d-b382-957f8dc03f63.png">

After on the light theme
<img width="942" alt="Screen Shot 2022-10-05 at 9 16 19 pm" src="https://user-images.githubusercontent.com/308331/194043712-894dc289-ebab-4b6e-bdd5-9a134d5f80ac.png">
