### PR TITLE
Tracks: Fix some events being fired on app launch/install

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncManager.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncManager.swift
@@ -58,6 +58,7 @@ public class SyncManager {
     }
 
     public class func clearTokensFromKeyChain() {
+        KeychainHelper.removeKey(ServerConstants.Values.syncingEmailKey)
         KeychainHelper.removeKey(ServerConstants.Values.syncingPasswordKey)
         KeychainHelper.removeKey(ServerConstants.Values.syncingV2TokenKey)
     }

--- a/podcasts/AppDelegate+Defaults.swift
+++ b/podcasts/AppDelegate+Defaults.swift
@@ -16,7 +16,7 @@ extension AppDelegate {
 
             Settings.setShouldDeleteWhenPlayed(true)
             Settings.setHomeFolderSortOrder(order: .dateAddedNewestToOldest)
-            Settings.setMobileDataAllowed(true, userInitiated: false)
+            Settings.setMobileDataAllowed(true)
             setWhatsNewAcknowledgeToLatest()
         }
 
@@ -24,7 +24,7 @@ extension AppDelegate {
             let query = "SELECT COUNT(*) FROM \(DataManager.podcastTableName) WHERE autoDownloadSetting == 1 AND subscribed == 1"
             let podcastsWithAutoDownloadOn = dataManager.count(query: query, values: nil)
             let autoDownloadEnabled = podcastsWithAutoDownloadOn > 0
-            Settings.setAutoDownloadEnabled(autoDownloadEnabled, userInitiated: false)
+            Settings.setAutoDownloadEnabled(autoDownloadEnabled)
         }
 
         performUpdateIfRequired(updateKey: "v6_5Run") {
@@ -39,13 +39,13 @@ extension AppDelegate {
         }
 
         performUpdateIfRequired(updateKey: "v7bRun") {
-            Settings.setAutoDownloadMobileDataAllowed(false, userInitiated: false)
+            Settings.setAutoDownloadMobileDataAllowed(false)
         }
 
         performUpdateIfRequired(updateKey: "v7cRun") {
-            Settings.setAutoArchivePlayedAfter(0, userInitiated: false)
-            Settings.setAutoArchiveInactiveAfter(-1, userInitiated: false)
-            Settings.setArchiveStarredEpisodes(false, userInitiated: false)
+            Settings.setAutoArchivePlayedAfter(0)
+            Settings.setAutoArchiveInactiveAfter(-1)
+            Settings.setArchiveStarredEpisodes(false)
         }
 
         performUpdateIfRequired(updateKey: "v7_3Run") {
@@ -66,7 +66,7 @@ extension AppDelegate {
             }
         }
         performUpdateIfRequired(updateKey: "v7_12Run") {
-            Settings.setMultiSelectGestureEnabled(true, userInitiated: false)
+            Settings.setMultiSelectGestureEnabled(true)
         }
         performUpdateIfRequired(updateKey: "v7_15Run") {
             defaults.setValue(true, forKey: Constants.UserDefaults.intelligentPlaybackResumption)
@@ -78,7 +78,7 @@ extension AppDelegate {
             // we didn't previously need a default value for this key, but due to changes in this release we do, otherwise it will default to the first item in the ThemeType enum
             let preferredDarkTheme = Theme.preferredDarkTheme()
             if preferredDarkTheme.rawValue == 0 {
-                Theme.setPreferredDarkTheme(.dark, systemIsDark: false, userInitiated: false)
+                Theme.setPreferredDarkTheme(.dark, systemIsDark: false)
             }
         }
         performUpdateIfRequired(updateKey: "FoldersInitialRun") {

--- a/podcasts/AppDelegate+Defaults.swift
+++ b/podcasts/AppDelegate+Defaults.swift
@@ -16,7 +16,7 @@ extension AppDelegate {
 
             Settings.setShouldDeleteWhenPlayed(true)
             Settings.setHomeFolderSortOrder(order: .dateAddedNewestToOldest)
-            Settings.setMobileDataAllowed(true)
+            Settings.setMobileDataAllowed(true, userInitiated: false)
             setWhatsNewAcknowledgeToLatest()
         }
 
@@ -24,7 +24,7 @@ extension AppDelegate {
             let query = "SELECT COUNT(*) FROM \(DataManager.podcastTableName) WHERE autoDownloadSetting == 1 AND subscribed == 1"
             let podcastsWithAutoDownloadOn = dataManager.count(query: query, values: nil)
             let autoDownloadEnabled = podcastsWithAutoDownloadOn > 0
-            Settings.setAutoDownloadEnabled(autoDownloadEnabled)
+            Settings.setAutoDownloadEnabled(autoDownloadEnabled, userInitiated: false)
         }
 
         performUpdateIfRequired(updateKey: "v6_5Run") {
@@ -39,13 +39,13 @@ extension AppDelegate {
         }
 
         performUpdateIfRequired(updateKey: "v7bRun") {
-            Settings.setAutoDownloadMobileDataAllowed(false)
+            Settings.setAutoDownloadMobileDataAllowed(false, userInitiated: false)
         }
 
         performUpdateIfRequired(updateKey: "v7cRun") {
-            Settings.setAutoArchivePlayedAfter(0)
-            Settings.setAutoArchiveInactiveAfter(-1)
-            Settings.setArchiveStarredEpisodes(false)
+            Settings.setAutoArchivePlayedAfter(0, userInitiated: false)
+            Settings.setAutoArchiveInactiveAfter(-1, userInitiated: false)
+            Settings.setArchiveStarredEpisodes(false, userInitiated: false)
         }
 
         performUpdateIfRequired(updateKey: "v7_3Run") {
@@ -66,7 +66,7 @@ extension AppDelegate {
             }
         }
         performUpdateIfRequired(updateKey: "v7_12Run") {
-            Settings.setMultiSelectGestureEnabled(true)
+            Settings.setMultiSelectGestureEnabled(true, userInitiated: false)
         }
         performUpdateIfRequired(updateKey: "v7_15Run") {
             defaults.setValue(true, forKey: Constants.UserDefaults.intelligentPlaybackResumption)
@@ -78,7 +78,7 @@ extension AppDelegate {
             // we didn't previously need a default value for this key, but due to changes in this release we do, otherwise it will default to the first item in the ThemeType enum
             let preferredDarkTheme = Theme.preferredDarkTheme()
             if preferredDarkTheme.rawValue == 0 {
-                Theme.setPreferredDarkTheme(.dark, systemIsDark: false)
+                Theme.setPreferredDarkTheme(.dark, systemIsDark: false, userInitiated: false)
             }
         }
         performUpdateIfRequired(updateKey: "FoldersInitialRun") {

--- a/podcasts/AppearanceViewController.swift
+++ b/podcasts/AppearanceViewController.swift
@@ -159,7 +159,7 @@ class AppearanceViewController: SimpleNotificationsViewController, UITableViewDa
             }
         } else if row == .darkTheme {
             presentThemePicker(selectedTheme: Theme.preferredDarkTheme()) { [weak self] theme in
-                Theme.setPreferredDarkTheme(theme, systemIsDark: self?.traitCollection.userInterfaceStyle == .dark)
+                Theme.setPreferredDarkTheme(theme, systemIsDark: self?.traitCollection.userInterfaceStyle == .dark, userInitiated: true)
             }
         }
     }

--- a/podcasts/AutoArchiveViewController.swift
+++ b/podcasts/AutoArchiveViewController.swift
@@ -128,14 +128,14 @@ class AutoArchiveViewController: PCViewController, UITableViewDelegate, UITableV
     private func addArchiveInactiveAction(time: TimeInterval, to: OptionsPicker) {
         let selectedSetting = Settings.autoArchiveInactiveAfter()
         let action = OptionAction(label: ArchiveHelper.archiveTimeToText(time), selected: selectedSetting == time) { [weak self] in
-            Settings.setAutoArchiveInactiveAfter(time)
+            Settings.setAutoArchiveInactiveAfter(time, userInitiated: true)
             self?.archiveTable.reloadData()
         }
         to.addAction(action: action)
     }
 
     @objc private func archiveStarredChanged(_ sender: UISwitch) {
-        Settings.setArchiveStarredEpisodes(sender.isOn)
+        Settings.setArchiveStarredEpisodes(sender.isOn, userInitiated: true)
 
         archiveTable.beginUpdates()
         if let containerView = archiveTable.footerView(forSection: starredSection) {

--- a/podcasts/DownloadSettingsViewController.swift
+++ b/podcasts/DownloadSettingsViewController.swift
@@ -202,7 +202,7 @@ class DownloadSettingsViewController: PCViewController, UITableViewDataSource, U
     // MARK: - Switch Settings
 
     @objc private func automaticDownloadToggled(_ slider: UISwitch) {
-        Settings.setAutoDownloadEnabled(slider.isOn)
+        Settings.setAutoDownloadEnabled(slider.isOn, userInitiated: true)
         settingsTable.reloadData()
     }
 
@@ -213,7 +213,7 @@ class DownloadSettingsViewController: PCViewController, UITableViewDataSource, U
     }
 
     @objc private func useMobileDataToggled(_ slider: UISwitch) {
-        Settings.setAutoDownloadMobileDataAllowed(!slider.isOn)
+        Settings.setAutoDownloadMobileDataAllowed(!slider.isOn, userInitiated: true)
     }
 
     private func tableRows() -> [[TableRow]] {

--- a/podcasts/GeneralSettingsViewController.swift
+++ b/podcasts/GeneralSettingsViewController.swift
@@ -418,7 +418,7 @@ class GeneralSettingsViewController: UIViewController, UITableViewDelegate, UITa
     }
 
     @objc private func multiSelectGestureToggled(_ sender: UISwitch) {
-        Settings.setMultiSelectGestureEnabled(sender.isOn)
+        Settings.setMultiSelectGestureEnabled(sender.isOn, userInitiated: true)
     }
 
     @objc private func extraMediaSessionActionsToggled(_ sender: UISwitch) {

--- a/podcasts/IapHelper.swift
+++ b/podcasts/IapHelper.swift
@@ -254,20 +254,17 @@ extension IapHelper: SKPaymentTransactionObserver {
                     hasNewPurchasedReceipt = true
                     queue.finishTransaction(transaction)
                     FileLog.shared.addMessage("IAPHelper Purchase successful for \(product) ")
-                    AnalyticsHelper.plusPlanPurchased()
-
-                    purchaseWasSuccessful(product)
                 case .failed:
                     let e = transaction.error! as NSError
                     FileLog.shared.addMessage("IAPHelper Purchase FAILED for \(product), code=\(e.code) msg= \(e.localizedDescription)/")
                     queue.finishTransaction(transaction)
 
+                    let userInfo = ["error": e]
+
                     if e.code == 0 || e.code == 2 { // app store couldn't be connected or user cancelled
-                        NotificationCenter.postOnMainThread(notification: ServerNotifications.iapPurchaseCancelled)
-                        purchaseWasCancelled(product, error: e)
+                        NotificationCenter.postOnMainThread(notification: ServerNotifications.iapPurchaseCancelled, userInfo: userInfo)
                     } else { // report error to user
-                        NotificationCenter.postOnMainThread(notification: ServerNotifications.iapPurchaseFailed)
-                        purchaseFailed(product, error: e)
+                        NotificationCenter.postOnMainThread(notification: ServerNotifications.iapPurchaseFailed, userInfo: userInfo)
                     }
                 case .deferred:
                     FileLog.shared.addMessage("IAPHelper Purchase deferred for \(product)")

--- a/podcasts/PodcastSettingsViewController+Table.swift
+++ b/podcasts/PodcastSettingsViewController+Table.swift
@@ -337,7 +337,7 @@ extension PodcastSettingsViewController: UITableViewDataSource, UITableViewDeleg
     @objc private func autoDownloadChanged(_ sender: UISwitch) {
         if sender.isOn {
             podcast.autoDownloadSetting = AutoDownloadSetting.latest.rawValue
-            Settings.setAutoDownloadEnabled(true)
+            Settings.setAutoDownloadEnabled(true, userInitiated: true)
         } else {
             podcast.autoDownloadSetting = AutoDownloadSetting.off.rawValue
         }

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -78,7 +78,7 @@ class Settings: NSObject {
         UserDefaults.standard.bool(forKey: Settings.allowCellularDownloadKey)
     }
 
-    class func setMobileDataAllowed(_ allow: Bool, userInitiated: Bool = true) {
+    class func setMobileDataAllowed(_ allow: Bool, userInitiated: Bool = false) {
         UserDefaults.standard.set(allow, forKey: Settings.allowCellularDownloadKey)
 
         guard userInitiated else { return }
@@ -92,7 +92,7 @@ class Settings: NSObject {
         UserDefaults.standard.bool(forKey: Settings.allowCellularAutoDownloadKey)
     }
 
-    class func setAutoDownloadMobileDataAllowed(_ allow: Bool, userInitiated: Bool = true) {
+    class func setAutoDownloadMobileDataAllowed(_ allow: Bool, userInitiated: Bool = false) {
         UserDefaults.standard.set(allow, forKey: Settings.allowCellularAutoDownloadKey)
 
         guard userInitiated else { return }
@@ -106,7 +106,7 @@ class Settings: NSObject {
         UserDefaults.standard.bool(forKey: Settings.autoDownloadEnabledKey)
     }
 
-    class func setAutoDownloadEnabled(_ allow: Bool, userInitiated: Bool = true) {
+    class func setAutoDownloadEnabled(_ allow: Bool, userInitiated: Bool = false) {
         UserDefaults.standard.set(allow, forKey: Settings.autoDownloadEnabledKey)
 
         guard userInitiated else { return }
@@ -265,7 +265,7 @@ class Settings: NSObject {
         UserDefaults.standard.double(forKey: Settings.autoArchivePlayedAfterKey)
     }
 
-    class func setAutoArchivePlayedAfter(_ after: TimeInterval, userInitiated: Bool = true) {
+    class func setAutoArchivePlayedAfter(_ after: TimeInterval, userInitiated: Bool = false) {
         UserDefaults.standard.set(after, forKey: Settings.autoArchivePlayedAfterKey)
 
         guard userInitiated else { return }
@@ -279,7 +279,7 @@ class Settings: NSObject {
         UserDefaults.standard.double(forKey: Settings.autoArchiveInactiveAfterKey)
     }
 
-    class func setAutoArchiveInactiveAfter(_ after: TimeInterval, userInitiated: Bool = true) {
+    class func setAutoArchiveInactiveAfter(_ after: TimeInterval, userInitiated: Bool = false) {
         UserDefaults.standard.set(after, forKey: Settings.autoArchiveInactiveAfterKey)
 
         guard userInitiated else { return }
@@ -293,7 +293,7 @@ class Settings: NSObject {
         UserDefaults.standard.bool(forKey: Settings.archiveStarredEpisodesKey)
     }
 
-    class func setArchiveStarredEpisodes(_ archive: Bool, userInitiated: Bool = true) {
+    class func setArchiveStarredEpisodes(_ archive: Bool, userInitiated: Bool = false) {
         UserDefaults.standard.set(archive, forKey: Settings.archiveStarredEpisodesKey)
 
         guard userInitiated else { return }
@@ -584,7 +584,7 @@ class Settings: NSObject {
         UserDefaults.standard.bool(forKey: multiSelectGestureKey)
     }
 
-    class func setMultiSelectGestureEnabled(_ enabled: Bool, userInitiated: Bool = true) {
+    class func setMultiSelectGestureEnabled(_ enabled: Bool, userInitiated: Bool = false) {
         UserDefaults.standard.set(enabled, forKey: multiSelectGestureKey)
 
         guard userInitiated else { return }

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -78,8 +78,10 @@ class Settings: NSObject {
         UserDefaults.standard.bool(forKey: Settings.allowCellularDownloadKey)
     }
 
-    class func setMobileDataAllowed(_ allow: Bool) {
+    class func setMobileDataAllowed(_ allow: Bool, userInitiated: Bool = true) {
         UserDefaults.standard.set(allow, forKey: Settings.allowCellularDownloadKey)
+
+        guard userInitiated else { return }
         trackValueToggled(.settingsStorageWarnBeforeUsingDataToggled, enabled: allow)
     }
 
@@ -90,8 +92,10 @@ class Settings: NSObject {
         UserDefaults.standard.bool(forKey: Settings.allowCellularAutoDownloadKey)
     }
 
-    class func setAutoDownloadMobileDataAllowed(_ allow: Bool) {
+    class func setAutoDownloadMobileDataAllowed(_ allow: Bool, userInitiated: Bool = true) {
         UserDefaults.standard.set(allow, forKey: Settings.allowCellularAutoDownloadKey)
+
+        guard userInitiated else { return }
         trackValueToggled(.settingsAutoDownloadOnlyOnWifiToggled, enabled: !allow)
     }
 
@@ -102,8 +106,10 @@ class Settings: NSObject {
         UserDefaults.standard.bool(forKey: Settings.autoDownloadEnabledKey)
     }
 
-    class func setAutoDownloadEnabled(_ allow: Bool) {
+    class func setAutoDownloadEnabled(_ allow: Bool, userInitiated: Bool = true) {
         UserDefaults.standard.set(allow, forKey: Settings.autoDownloadEnabledKey)
+
+        guard userInitiated else { return }
         trackValueToggled(.settingsAutoDownloadNewEpisodesToggled, enabled: allow)
     }
 
@@ -259,9 +265,10 @@ class Settings: NSObject {
         UserDefaults.standard.double(forKey: Settings.autoArchivePlayedAfterKey)
     }
 
-    class func setAutoArchivePlayedAfter(_ after: TimeInterval) {
+    class func setAutoArchivePlayedAfter(_ after: TimeInterval, userInitiated: Bool = true) {
         UserDefaults.standard.set(after, forKey: Settings.autoArchivePlayedAfterKey)
 
+        guard userInitiated else { return }
         if let archiveTime = AutoArchiveAfterTime(rawValue: after) {
             trackValueChanged(.settingsAutoArchivePlayedChanged, value: archiveTime)
         }
@@ -272,9 +279,10 @@ class Settings: NSObject {
         UserDefaults.standard.double(forKey: Settings.autoArchiveInactiveAfterKey)
     }
 
-    class func setAutoArchiveInactiveAfter(_ after: TimeInterval) {
+    class func setAutoArchiveInactiveAfter(_ after: TimeInterval, userInitiated: Bool = true) {
         UserDefaults.standard.set(after, forKey: Settings.autoArchiveInactiveAfterKey)
 
+        guard userInitiated else { return }
         if let archiveTime = AutoArchiveAfterTime(rawValue: after) {
             trackValueChanged(.settingsAutoArchiveInactiveChanged, value: archiveTime)
         }
@@ -285,8 +293,10 @@ class Settings: NSObject {
         UserDefaults.standard.bool(forKey: Settings.archiveStarredEpisodesKey)
     }
 
-    class func setArchiveStarredEpisodes(_ archive: Bool) {
+    class func setArchiveStarredEpisodes(_ archive: Bool, userInitiated: Bool = true) {
         UserDefaults.standard.set(archive, forKey: Settings.archiveStarredEpisodesKey)
+
+        guard userInitiated else { return }
         trackValueToggled(.settingsAutoArchiveIncludeStarredToggled, enabled: archive)
     }
 
@@ -574,8 +584,10 @@ class Settings: NSObject {
         UserDefaults.standard.bool(forKey: multiSelectGestureKey)
     }
 
-    class func setMultiSelectGestureEnabled(_ enabled: Bool) {
+    class func setMultiSelectGestureEnabled(_ enabled: Bool, userInitiated: Bool = true) {
         UserDefaults.standard.set(enabled, forKey: multiSelectGestureKey)
+
+        guard userInitiated else { return }
         Settings.trackValueToggled(.settingsGeneralMultiSelectGestureToggled, enabled: enabled)
     }
 

--- a/podcasts/StorageAndDataUseViewController.swift
+++ b/podcasts/StorageAndDataUseViewController.swift
@@ -83,6 +83,6 @@ class StorageAndDataUseViewController: PCViewController, UITableViewDelegate, UI
     }
 
     @objc private func warnWhenNotOnWifiToggled(_ sender: UISwitch) {
-        Settings.setMobileDataAllowed(!sender.isOn)
+        Settings.setMobileDataAllowed(!sender.isOn, userInitiated: true)
     }
 }

--- a/podcasts/Theme.swift
+++ b/podcasts/Theme.swift
@@ -168,7 +168,7 @@ class Theme: ObservableObject {
         return themeType
     }
 
-    class func setPreferredDarkTheme(_ preferredType: ThemeType, systemIsDark: Bool) {
+    class func setPreferredDarkTheme(_ preferredType: ThemeType, systemIsDark: Bool, userInitiated: Bool = true) {
         UserDefaults.standard.setValue(preferredType.rawValue, forKey: preferredDarkThemeKey)
 
         // change the active theme if it needs to change
@@ -176,6 +176,7 @@ class Theme: ObservableObject {
             Theme.sharedTheme.activeTheme = preferredType
         }
 
+        guard userInitiated else { return }
         Settings.trackValueChanged(.settingsAppearanceDarkThemeChanged, value: preferredType)
     }
 

--- a/podcasts/Theme.swift
+++ b/podcasts/Theme.swift
@@ -168,7 +168,7 @@ class Theme: ObservableObject {
         return themeType
     }
 
-    class func setPreferredDarkTheme(_ preferredType: ThemeType, systemIsDark: Bool, userInitiated: Bool = true) {
+    class func setPreferredDarkTheme(_ preferredType: ThemeType, systemIsDark: Bool, userInitiated: Bool = false) {
         UserDefaults.standard.setValue(preferredType.rawValue, forKey: preferredDarkThemeKey)
 
         // change the active theme if it needs to change


### PR DESCRIPTION
This fixes:
- Some settings changed events being triggered on app install
- Some payment events being triggered when there is a renewal
- On reinstall the email was not being removed from the keychain which resulted in the "weird state" logs

## To test

### Settings changed
1. Enable the `tracksLoggingEnabled` feature flag
2. Delete the app
3. Launch it
4. ✅ Verify you do not see the `Sync account is in a weird state, logging user out` log in console
5. ✅ Verify you do not see any settings changed events
6. Go to the General Settings and change the Multi Select gesture enabled and verify you see the event in console
7. Go to the Appearance settings and change the "Use iOS Light/Dark Mode" and verify you see the event in console
8. Go to the Auto Archive settings and change the Starred/Inactive after and verify you see the event in console
9. Go to the Download settings and change the Up Next and Only on Wifi option
10. Go to the Storate and Data use and toggle the warn before using mobile data option 
11. Go to the settings for a Podcast and toggle the auto download enabled option

### Payment
1. Enable the `tracksLoggingEnabled` feature flag
2. Launch the app
3. Sign into an account without plus
4. Purchase the Monthly version of plus using your sandbox account
12. ✅ Verify after purchasing you see the `purchase_successful` event in console
13. Go back to the main app
14. Wait 5 minutes
15. ✅ Verify you do not see any purchase_successful events being fired again

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
