### PR TITLE
Tracks: Fix some "unknown" playback sources

### DIFF
--- a/Pocket Casts Watch App Extension/WatchSourceViewModel.swift
+++ b/Pocket Casts Watch App Extension/WatchSourceViewModel.swift
@@ -55,8 +55,6 @@ class WatchSourceViewModel: PlaySourceViewModel {
     }
 
     func playPauseTapped(withEpisode episode: BaseEpisode) {
-        AnalyticsPlaybackHelper.shared.currentSource = "watch"
-
         if PlaybackManager.shared.isNowPlayingEpisode(episodeUuid: episode.uuid) {
             PlaybackManager.shared.playPause()
         } else {
@@ -65,7 +63,6 @@ class WatchSourceViewModel: PlaySourceViewModel {
     }
 
     func skip(forward: Bool) {
-        AnalyticsPlaybackHelper.shared.currentSource = "watch"
         if forward {
             PlaybackManager.shared.skipForward()
         } else {
@@ -74,7 +71,6 @@ class WatchSourceViewModel: PlaySourceViewModel {
     }
 
     func changeChapter(next: Bool) {
-        AnalyticsPlaybackHelper.shared.currentSource = "watch"
         if next {
             PlaybackManager.shared.skipToNextChapter()
         } else {

--- a/Pocket Casts Watch App Extension/WatchSourceViewModel.swift
+++ b/Pocket Casts Watch App Extension/WatchSourceViewModel.swift
@@ -55,6 +55,8 @@ class WatchSourceViewModel: PlaySourceViewModel {
     }
 
     func playPauseTapped(withEpisode episode: BaseEpisode) {
+        AnalyticsPlaybackHelper.shared.currentSource = "watch"
+
         if PlaybackManager.shared.isNowPlayingEpisode(episodeUuid: episode.uuid) {
             PlaybackManager.shared.playPause()
         } else {
@@ -63,6 +65,7 @@ class WatchSourceViewModel: PlaySourceViewModel {
     }
 
     func skip(forward: Bool) {
+        AnalyticsPlaybackHelper.shared.currentSource = "watch"
         if forward {
             PlaybackManager.shared.skipForward()
         } else {
@@ -71,6 +74,7 @@ class WatchSourceViewModel: PlaySourceViewModel {
     }
 
     func changeChapter(next: Bool) {
+        AnalyticsPlaybackHelper.shared.currentSource = "watch"
         if next {
             PlaybackManager.shared.skipToNextChapter()
         } else {

--- a/podcasts/Analytics/Helpers/AnalyticsCoordinator.swift
+++ b/podcasts/Analytics/Helpers/AnalyticsCoordinator.swift
@@ -20,15 +20,17 @@ class AnalyticsCoordinator {
         }
 
         func track(_ event: AnalyticsEvent, properties: [String: Any]? = nil) {
-            DispatchQueue.main.async { [weak self] in
-                guard let self = self else {
-                    return
+            // Only dispatch async on the main thread if needed
+            guard Thread.isMainThread else {
+                DispatchQueue.main.async {
+                    self.track(event, properties: properties)
                 }
-
-                let defaultProperties: [String: Any] = ["source": self.currentPlaybackSource]
-                let mergedProperties = defaultProperties.merging(properties ?? [:]) { current, _ in current }
-                Analytics.track(event, properties: mergedProperties)
+                return
             }
+
+            let defaultProperties: [String: Any] = ["source": currentPlaybackSource]
+            let mergedProperties = defaultProperties.merging(properties ?? [:]) { current, _ in current }
+            Analytics.track(event, properties: mergedProperties)
         }
 
         func getTopViewController(base: UIViewController? = UIApplication.shared.windows.first { $0.isKeyWindow }?.rootViewController) -> UIViewController? {

--- a/podcasts/CarPlaySceneDelegate+Interaction.swift
+++ b/podcasts/CarPlaySceneDelegate+Interaction.swift
@@ -31,6 +31,8 @@ extension CarPlaySceneDelegate {
     }
 
     func episodeTapped(_ episode: BaseEpisode, closeListOnTap: Bool) {
+        AnalyticsPlaybackHelper.shared.currentSource = "carplay"
+
         if PlaybackManager.shared.isNowPlayingEpisode(episodeUuid: episode.uuid) {
             PlaybackManager.shared.playPause()
         } else {
@@ -57,6 +59,8 @@ extension CarPlaySceneDelegate {
     }
 
     func chaptersTapped() {
+        AnalyticsPlaybackHelper.shared.currentSource = "carplay"
+
         let chapterCount = PlaybackManager.shared.chapterCount()
         guard chapterCount > 0 else { return }
 

--- a/podcasts/CastToViewController.swift
+++ b/podcasts/CastToViewController.swift
@@ -91,6 +91,7 @@ class CastToViewController: PCViewController {
     }
 
     @IBAction func playPauseTapped(_ sender: Any) {
+        AnalyticsPlaybackHelper.shared.currentSource = "chromecast"
         PlaybackManager.shared.playPause()
     }
 

--- a/podcasts/DefaultPlayer.swift
+++ b/podcasts/DefaultPlayer.swift
@@ -192,7 +192,7 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
 
     func routeDidChange(shouldPause: Bool) {
         if shouldPause {
-            PlaybackManager.shared.pause()
+            PlaybackManager.shared.pause(userInitiated: false)
         }
     }
 

--- a/podcasts/EffectsPlayer.swift
+++ b/podcasts/EffectsPlayer.swift
@@ -304,10 +304,10 @@ class EffectsPlayer: PlaybackProtocol, Hashable {
         // when this is called, the engine has detected an interruption like a route change. Because this happens on things like bluetooth connect, and not just disconnect, we deal with it here.
         // The audio engine has shut down at this point, so we call pause to destroy all our current state and play to restore it all if we should still be playing
         if shouldKeepPlaying.value, !PlaybackManager.shared.interruptionInProgress() {
-            PlaybackManager.shared.pause()
-            PlaybackManager.shared.play()
+            PlaybackManager.shared.pause(userInitiated: false)
+            PlaybackManager.shared.play(userInitiated: false)
         } else if !shouldKeepPlaying.value {
-            PlaybackManager.shared.pause()
+            PlaybackManager.shared.pause(userInitiated: false)
         }
     }
 

--- a/podcasts/GoogleCastManager.swift
+++ b/podcasts/GoogleCastManager.swift
@@ -285,6 +285,7 @@ class GoogleCastManager: NSObject, GCKRemoteMediaClientListener, GCKSessionManag
 
     func remoteMediaClient(_ client: GCKRemoteMediaClient, didUpdate mediaStatus: GCKMediaStatus?) {
         guard let mediaStatus = mediaStatus else { return }
+        AnalyticsPlaybackHelper.shared.currentSource = "chromecast"
 
         if mediaStatus.playerState == .playing {
             if bufferingInitialPartOfEpisode {
@@ -305,6 +306,7 @@ class GoogleCastManager: NSObject, GCKRemoteMediaClientListener, GCKSessionManag
 
             if let playingEpisodeUuid = customData[episodeUuidKey] {
                 episodeUuidLoadedOnConnect = playingEpisodeUuid
+                AnalyticsPlaybackHelper.shared.currentSource = "chromecast"
                 PlaybackManager.shared.remoteDeviceAutoConnected(episodeUuidLoadedOnConnect)
             }
         }

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -807,7 +807,8 @@ class PlaybackManager: ServerPlaybackDelegate {
 
     func playbackDidFail(logMessage: String?, userMessage: String?) {
         FileLog.shared.addMessage("playbackDidFail: \(logMessage ?? "No error provided")")
-
+        AnalyticsPlaybackHelper.shared.currentSource = "playback_failed"
+        
         guard let episode = currentEpisode() else {
             endPlayback()
 

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -184,10 +184,12 @@ class PlaybackManager: ServerPlaybackDelegate {
         }
     }
 
-    func play(completion: (() -> Void)? = nil) {
+    func play(completion: (() -> Void)? = nil, userInitiated: Bool = true) {
         guard let currEpisode = currentEpisode() else { return }
 
-        analyticsPlaybackHelper.play()
+        if userInitiated {
+            analyticsPlaybackHelper.play()
+        }
 
         aboutToPlay.value = true
 
@@ -221,11 +223,11 @@ class PlaybackManager: ServerPlaybackDelegate {
         })
     }
 
-    func pause() {
+    func pause(userInitiated: Bool = true) {
         guard let episode = currentEpisode() else { return }
 
         // Only trigger the event if we are already playing
-        if playing() {
+        if playing(), userInitiated == true {
             analyticsPlaybackHelper.pause()
         }
 
@@ -378,7 +380,7 @@ class PlaybackManager: ServerPlaybackDelegate {
             }
 
             if startPlaybackAfterSeek, !playing() {
-                play()
+                play(userInitiated: false)
             }
         }
 
@@ -523,7 +525,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         DataManager.sharedManager.saveEpisode(playbackError: nil, episode: nextEpisode)
 
         if autoPlay {
-            play()
+            play(userInitiated: false)
         } else {
             NotificationCenter.postOnMainThread(notification: Constants.Notifications.upNextQueueChanged)
         }
@@ -1685,7 +1687,7 @@ class PlaybackManager: ServerPlaybackDelegate {
             let interruptionOption = userInfo[AVAudioSessionInterruptionOptionKey] as! NSNumber
             FileLog.shared.addMessage("PlaybackManager handleAudioInterrupt ended, should attempt to restart audio = \(interruptionOption) )")
             if interruptionOption.uintValue == AVAudioSession.InterruptionOptions.shouldResume.rawValue, wasPlayingBeforeInterruption {
-                play()
+                play(userInitiated: false)
                 wasPlayingBeforeInterruption = false
             }
         } else if interruptionType.uintValue == AVAudioSession.InterruptionType.began.rawValue {
@@ -1717,7 +1719,10 @@ class PlaybackManager: ServerPlaybackDelegate {
         AnalyticsHelper.didConnectToChromecast()
         if let episode = currentEpisode() {
             if playerSwitchRequired() {
+                AnalyticsPlaybackHelper.shared.currentSource = "chromecast"
                 pause()
+
+                AnalyticsPlaybackHelper.shared.currentSource = "chromecast"
                 load(episode: episode, autoPlay: true, overrideUpNext: false)
             }
         }

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -808,7 +808,7 @@ class PlaybackManager: ServerPlaybackDelegate {
     func playbackDidFail(logMessage: String?, userMessage: String?) {
         FileLog.shared.addMessage("playbackDidFail: \(logMessage ?? "No error provided")")
         AnalyticsPlaybackHelper.shared.currentSource = "playback_failed"
-        
+
         guard let episode = currentEpisode() else {
             endPlayback()
 

--- a/podcasts/WatchManager.swift
+++ b/podcasts/WatchManager.swift
@@ -66,14 +66,17 @@ class WatchManager: NSObject, WCSessionDelegate {
                 handlePlayRequest(episodeUuid: episodeUuid)
             }
         } else if WatchConstants.Messages.PlayPauseRequest.type == messageType {
+            AnalyticsPlaybackHelper.shared.currentSource = "watch"
             if PlaybackManager.shared.playing() {
                 PlaybackManager.shared.pause()
             } else {
                 PlaybackManager.shared.play()
             }
         } else if WatchConstants.Messages.SkipBackRequest.type == messageType {
+            AnalyticsPlaybackHelper.shared.currentSource = "watch"
             PlaybackManager.shared.skipBack()
         } else if WatchConstants.Messages.SkipForwardRequest.type == messageType {
+            AnalyticsPlaybackHelper.shared.currentSource = "watch"
             PlaybackManager.shared.skipForward()
         } else if WatchConstants.Messages.StarRequest.type == messageType {
             if let starred = message[WatchConstants.Messages.StarRequest.star] as? Bool, let uuid = message[WatchConstants.Messages.StarRequest.episodeUuid] as? String {


### PR DESCRIPTION
This adds some more playback sources for CarPlay, Chromecast, Watch, and a playback failed source.

## To test

### CarPlay
1. Enable the `tracksLoggingEnabled` feature flag
1. Launch the app
2. Connect to CarPlay
3. Tap on an episode to play it
4. ✅ Verify you see `🔵 Tracked: playback_play ["source": "carplay"]`
5. Tap on the episode again to pause it
6. ✅ Verify you see `🔵 Tracked: playback_pause ["source": "carplay"]`

### Chromecast
1. Enable the `tracksLoggingEnabled` feature flag
2. Launch the app
3. Play an episode
4. Cast to Chromecast
5. ✅ Verify you see `🔵 Tracked: playback_pause ["source": "chromecast"]`
5. ✅ Verify you see `🔵 Tracked: playback_play ["source": "chromecast"]`
6. Restart the app (the episode should continue to play on Chromecast)
7. ✅  Verify on app launch you see: `🔵 Tracked: playback_play ["source": "chromecast"]`

### Playback failed
1. Launch the app
2. Play an episode
3. On your Mac open Activity monitor
4. Search for coreaudiod
5. Force quit it
6. The audio in the simulator should stop
7. Tap the play button to play it again
8. ✅ Verify you see `🔵 Tracked: playback_pause ["source": "playback_failed"]`
9. Restart your simulator to fix it10. 

### Apple Watch
1. Launch the app on your device
2. Put it on background
3. On your Apple Watch tap play/pause/skip forward/skip back
8. ✅ Verify you see playback events tracked with `["source": "watch"]`


## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
