### PR TITLE
Save and restore SPM cache in CI from project root

### DIFF
--- a/.buildkite/commands/build.sh
+++ b/.buildkite/commands/build.sh
@@ -35,4 +35,21 @@ echo "--- Install Pods"
 install_cocoapods # see bash-cache Automattic's Buildkite plugin
 
 echo "--- Build & Test"
+
+set +e
 bundle exec fastlane test
+TESTS_EXIT_STATUS=$?
+set -e
+
+if [[ $TESTS_EXIT_STATUS -ne 0 ]]; then
+  # Keep the (otherwise collapsed) current "Testing" section open in Buildkite logs on error. See https://buildkite.com/docs/pipelines/managing-log-output#collapsing-output
+  echo "^^^ +++"
+  echo "Unit Tests failed!"
+fi
+
+echo "--- 📦 Zipping test results"
+zip -rq spm_cache.zip vendor/spm/
+
+buildkite-agent artifact upload spm_cache.zip
+
+exit $TESTS_EXIT_STATUS

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -936,17 +936,44 @@ inal copy, and try again.")
     # truth for what the cache key is. The alternative would be to call the
     # save and restore cache commands in the CI pipeline and then duplicate the
     # logic to get the key here.
-    sh(command: %(restore_cache "#{ci_spm_cache_key}")) if is_ci
+    return unless is_ci
+
+    # Need to cd into the project root otherwise Fastlane will run the command
+    # in its own project folder, `./fastlane`
+    Dir.chdir(PROJECT_ROOT_FOLDER) do
+      sh(command: %(restore_cache "#{ci_spm_cache_key}"))
+    end
   end
 
   def save_ci_spm_cache
-    sh(command: %(save_cache #{SPM_CACHE_FOLDER} "#{ci_spm_cache_key}")) if is_ci
+    return unless is_ci
+
+    # Need to cd into the project root otherwise Fastlane will run the command
+    # in its own project folder, ./fastlane
+    Dir.chdir(PROJECT_ROOT_FOLDER) do
+      # We need to make the SPM path relative, otherwise the tar will include
+      # nested folders starting from the machines `/Users`, which is not
+      # deterministic and would not be able to be referenced when needed.
+
+      require 'pathname'
+
+      project_root = Pathname.new(PROJECT_ROOT_FOLDER)
+      spm_cache = Pathname.new(SPM_CACHE_FOLDER)
+      spm_cache_relative_path = spm_cache.relative_path_from(project_root)
+
+      sh(command: %(save_cache #{spm_cache_relative_path} "#{ci_spm_cache_key}"))
+    end
   end
 
   def ci_spm_cache_key
     UI.user_error! 'This function should be called from the Buildkite CI only!' unless is_ci
 
-    hash = sh(command: 'hash_file "../podcasts.xcworkspace/xcshareddata/swiftpm/Package.resolved"').rstrip
+    # Use absolute path to insulate from the runtime location Fastlane might be
+    # executing the command
+    package_resolved_path = File.expand_path(
+      File.join(PROJECT_ROOT_FOLDER, 'podcasts.xcworkspace', 'xcshareddata', 'swiftpm', 'Package.resolved')
+    )
+    hash = sh(command: "hash_file #{package_resolved_path}").rstrip
     "$BUILDKITE_PIPELINE_SLUG-spm-cache-#{hash}"
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -942,6 +942,11 @@ inal copy, and try again.")
     # in its own project folder, `./fastlane`
     Dir.chdir(PROJECT_ROOT_FOLDER) do
       sh(command: %(restore_cache "#{ci_spm_cache_key}"))
+      sh(command: "ls #{PROJECT_ROOT_FOLDER}")
+      sh(command: "ls #{PROJECT_ROOT_FOLDER}/vendor")
+      sh(command: "ls #{PROJECT_ROOT_FOLDER}/vendor/spm")
+      sh(command: "ls #{PROJECT_ROOT_FOLDER}/vendor/spm/artifacts")
+      sh(command: "ls #{PROJECT_ROOT_FOLDER}/vendor/spm/artifacts/firebase-ios-sdk")
     end
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -944,9 +944,9 @@ inal copy, and try again.")
       sh(command: %(restore_cache "#{ci_spm_cache_key}"))
       sh(command: "ls #{PROJECT_ROOT_FOLDER}")
       sh(command: "ls #{PROJECT_ROOT_FOLDER}/vendor")
-      # sh(command: "ls #{PROJECT_ROOT_FOLDER}/vendor/spm")
-      # sh(command: "ls #{PROJECT_ROOT_FOLDER}/vendor/spm/artifacts")
-      # sh(command: "ls #{PROJECT_ROOT_FOLDER}/vendor/spm/artifacts/firebase-ios-sdk")
+      sh(command: "ls #{PROJECT_ROOT_FOLDER}/vendor/spm")
+      sh(command: "ls #{PROJECT_ROOT_FOLDER}/vendor/spm/artifacts")
+      sh(command: "ls #{PROJECT_ROOT_FOLDER}/vendor/spm/artifacts/firebase-ios-sdk")
     end
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -944,9 +944,9 @@ inal copy, and try again.")
       sh(command: %(restore_cache "#{ci_spm_cache_key}"))
       sh(command: "ls #{PROJECT_ROOT_FOLDER}")
       sh(command: "ls #{PROJECT_ROOT_FOLDER}/vendor")
-      sh(command: "ls #{PROJECT_ROOT_FOLDER}/vendor/spm")
-      sh(command: "ls #{PROJECT_ROOT_FOLDER}/vendor/spm/artifacts")
-      sh(command: "ls #{PROJECT_ROOT_FOLDER}/vendor/spm/artifacts/firebase-ios-sdk")
+      # sh(command: "ls #{PROJECT_ROOT_FOLDER}/vendor/spm")
+      # sh(command: "ls #{PROJECT_ROOT_FOLDER}/vendor/spm/artifacts")
+      # sh(command: "ls #{PROJECT_ROOT_FOLDER}/vendor/spm/artifacts/firebase-ios-sdk")
     end
   end
 


### PR DESCRIPTION
All this time, we've been restoring the SPM cache in `./fastlane/vendor/spm` because that is the location from where Fastlane runs commands via `sh`.

That was of course incorrect, because the SPM cache path passed to `xcodebuild` via Fastlane `run_tests` and `build_app` was relative to the project root, `./vendor/spm/`.

Fixes #

Please include a summary of the changes and the related issue.

## To test

1. Run the build once to generated the cache
2. Run the build again to verify the cache is used — `xcodebuild` should no go an re-fetch all the packages like it does on `trunk`.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
