### PR TITLE
Fix episode count label display issue in iOS 14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 7.25
 -----
 - Fixed a crash that could happen when playing an episode while the app is in the background (#345)
+- Fixed an issue where the episode totals would not display above the podcast episode list in iOS 14 (#287)
 
 7.24
 -----

--- a/podcasts/EpisodeListSearchController.xib
+++ b/podcasts/EpisodeListSearchController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -107,28 +107,28 @@
                             </constraints>
                         </view>
                         <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="center" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="YwF-Gn-bkb">
-                            <rect key="frame" x="16" y="69" width="232" height="18"/>
+                            <rect key="frame" x="16" y="69" width="228.5" height="18"/>
                             <subviews>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="23 episodes " textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wNf-rq-iBx" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                                    <rect key="frame" x="0.0" y="0.0" width="58.5" height="18"/>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="23 episodes " textAlignment="center" lineBreakMode="wordWrap" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wNf-rq-iBx" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
+                                    <rect key="frame" x="0.0" y="0.5" width="83" height="17"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                     <nil key="textColor"/>
                                     <nil key="highlightedColor"/>
                                 </label>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="•" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HMd-Rg-WEW" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                                    <rect key="frame" x="89.5" y="0.5" width="6.5" height="17"/>
+                                    <rect key="frame" x="88" y="0.5" width="6.5" height="17"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                     <nil key="textColor"/>
                                     <nil key="highlightedColor"/>
                                 </label>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="13 archived" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="J57-7s-Hfz" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                                    <rect key="frame" x="127" y="0.5" width="74" height="17"/>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="13 archived" textAlignment="center" lineBreakMode="wordWrap" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="J57-7s-Hfz" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
+                                    <rect key="frame" x="99.5" y="0.5" width="74" height="17"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                     <nil key="textColor"/>
                                     <nil key="highlightedColor"/>
                                 </label>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lbQ-Z6-M40" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                                    <rect key="frame" x="232" y="9" width="0.0" height="0.0"/>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="wordWrap" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lbQ-Z6-M40" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
+                                    <rect key="frame" x="178.5" y="0.0" width="50" height="18"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                     <nil key="textColor"/>
                                     <nil key="highlightedColor"/>

--- a/podcasts/EpisodeListSearchController.xib
+++ b/podcasts/EpisodeListSearchController.xib
@@ -127,7 +127,7 @@
                                     <nil key="textColor"/>
                                     <nil key="highlightedColor"/>
                                 </label>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="wordWrap" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lbQ-Z6-M40" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lbQ-Z6-M40" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
                                     <rect key="frame" x="178.5" y="0.0" width="50" height="18"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                     <nil key="textColor"/>


### PR DESCRIPTION
Fixes #287

This PR provides the labels in the labels in the Episode List Search Controller with a non-zero lines value to help UIStackView better resize itself in iOS 14

**Before (iOS 14)**

<img width="239" alt="Screen Shot 2022-10-06 at 4 46 08 PM" src="https://user-images.githubusercontent.com/4081020/194415367-4849a785-ea84-49d2-b2ae-c8a9e16d9bcc.png">

**After**
| iOS 14 | iOS 15/16 |
|--------|----------|
| ![Simulator Screen Shot - iPhone 12 mini - 2022-10-06 at 15 32 11](https://user-images.githubusercontent.com/4081020/194405286-3d18832f-acf2-44e0-8e68-11b49f71df18.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2022-10-06 at 15 35 51](https://user-images.githubusercontent.com/4081020/194405392-29f7bd14-0e73-414a-9d5e-66751e833f6c.png) |
| ![Simulator Screen Shot - iPhone 12 mini - 2022-10-06 at 15 32 18](https://user-images.githubusercontent.com/4081020/194405291-64efcd9a-1a24-4e60-99a6-3640fbc53b1a.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2022-10-06 at 15 36 12](https://user-images.githubusercontent.com/4081020/194405400-7003b725-5720-464f-ba84-08fa0cd66dea.png) |
| ![Simulator Screen Shot - iPhone 12 mini - 2022-10-06 at 15 32 43](https://user-images.githubusercontent.com/4081020/194405292-a66e8621-7522-4a2a-8ca4-12864a3bed6f.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2022-10-06 at 15 36 25](https://user-images.githubusercontent.com/4081020/194405407-1af32047-51df-4c6d-8847-4266a5660313.png) |


XCode XIB change to `lines`
| before | after |
|--------|----------|
| <img width="259" alt="Screen Shot 2022-10-06 at 3 58 31 PM" src="https://user-images.githubusercontent.com/4081020/194406923-20a35ddc-e53a-4730-9e8f-a2783978e154.png"> | <img width="265" alt="Screen Shot 2022-10-06 at 3 42 17 PM" src="https://user-images.githubusercontent.com/4081020/194406786-149375ef-cbe3-4ccb-95d3-f3d73225f0c3.png"> |

## To test

1. In an iOS 14 
2. Open a non-subscribed to podcast from Discover, the episode count and archived/limited text should appear with appropriate spacing
3. Open a subscribed to podcast, and set the episode limit (Gear icon -> `Auto Archive` -> set `Custom for this Podcast` -> Select an episode limit)
4. Return to the episode list, the episode count and archived text should appear with appropriate spacing
5. Repeat the above for iOS 15 and/or 16 simulator/device to ensure they continue to work as expected

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
