### PR TITLE
Add support for OPML import using poll uuids.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fixed a crash where a sync account has started listening to a local file on one device and visits the up next queue on a different device. (#371)
 - Fixed an issue where the episode totals would not display above the podcast episode list in iOS 14 (#287)
 - Fixed an issue where the Up Next queue wouldn't reset when playing all items from a filter. (#375)
+- Improved OPML import to support poll uuids (#367)
 
 7.24
 -----

--- a/Modules/Server/Sources/PocketCastsServer/Public/Refresh/MainServerHandler.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Refresh/MainServerHandler.swift
@@ -85,6 +85,7 @@ public class MainServerHandler {
 
     private struct UploadOpmlRequest: BaseRequest {
         var urls: [String]?
+        var pollUuids: [String]?
         var device: String?
         var m: String?
         var av: String?
@@ -92,9 +93,13 @@ public class MainServerHandler {
         var c: String?
         var dt: String?
         var v: String?
+
+        public enum CodingKeys: String, CodingKey {
+            case urls, pollUuids = "poll_uuids", device, m, av, l, c, dt, v
+        }
     }
 
-    public func sendOpmlChunk(feedUrls: [String], completion: @escaping (ImportOpmlResponse?) -> Void) {
+    public func sendOpmlChunk(feedUrls: [String] = [], pollUuids: [String] = [], completion: @escaping (ImportOpmlResponse?) -> Void) {
         guard let uniqueId = ServerConfig.shared.syncDelegate?.uniqueAppId() else {
             completion(ImportOpmlResponse.failedResponse())
             return
@@ -105,6 +110,7 @@ public class MainServerHandler {
 
         var uploadRequest = baseRequest as! UploadOpmlRequest
         uploadRequest.urls = feedUrls
+        uploadRequest.pollUuids = pollUuids
 
         let url = ServerHelper.asUrl(ServerConstants.Urls.main() + "import/opml")
         guard let request = ServerHelper.createJsonRequest(url: url, params: uploadRequest, timeout: MainServerHandler.callTimeout, cachePolicy: .reloadIgnoringCacheData) else {


### PR DESCRIPTION
The OPML import call to the server needs to send the poll UUIDs in a separate parameter called `poll_uuids`.

Please review this extra carefully as I'm an Android developer! Also, feel free to merge changes into my branch, I won't be offended. I'm surprised I even managed to get the project to compile. 

## To test

1. Point to our staging servers by switching to `Staging` in Product -> Scheme -> Edit Scheme...
2. Create an OPML test file `test.opml` using this template. Use a new podcast feed URL from production that isn't yet in our staging database.

```
<?xml version="1.0" encoding="utf-8" standalone="no"?>
<opml version="1.0">
	<head>
		<title>Pocket Casts Feeds</title>
	</head>
	<body>
		<outline text="feeds">
                    <outline type="rss" xmlUrl="https://anchor.fm/s/b5f4b5b8/podcast/rss" text="" />
		</outline>
	</body>
</opml>
```

3. Drag the OPML file onto the Simulator

The new podcast should be added to the database and appear on the podcasts page.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
