### PR TITLE
Tracks: Fixes bulk archive and adds some events to the podcast menu

### DIFF
--- a/PocketCastsTests/Tests/Analytics/AnalyticsPlaybackHelperTests.swift
+++ b/PocketCastsTests/Tests/Analytics/AnalyticsPlaybackHelperTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 class AnalyticsPlaybackHelperTests: XCTestCase {
     func testCurrentSourceIsRemovedAfterEventIsTriggered() {
-        AnalyticsPlaybackHelper.shared.currentSource = "test"
+        AnalyticsPlaybackHelper.shared.currentSource = .unknown
 
         AnalyticsPlaybackHelper.shared.play()
 

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -260,6 +260,8 @@ enum AnalyticsEvent: String {
     case podcastScreenToggleArchived
     case podcastScreenShareTapped
     case podcastScreenToggleSummary
+    case podcastsScreenSortOrderChanged
+    case podcastsScreenEpisodeGroupingChanged
 
     // MARK: - App Store Review Request
 

--- a/podcasts/Enumerations.swift
+++ b/podcasts/Enumerations.swift
@@ -53,7 +53,7 @@ enum PodcastLicensing: Int32 {
     case keepEpisodesAfterExpiry = 0, deleteEpisodesAfterExpiry = 1
 }
 
-enum PodcastEpisodeSortOrder: Int32, CaseIterable {
+enum PodcastEpisodeSortOrder: Int32, CaseIterable, AnalyticsDescribable {
     case newestToOldest = 1, oldestToNewest, shortestToLongest, longestToShortest
 
     var description: String {
@@ -66,6 +66,20 @@ enum PodcastEpisodeSortOrder: Int32, CaseIterable {
             return L10n.podcastsEpisodeSortShortestToLongest
         case .longestToShortest:
             return L10n.podcastsEpisodeSortLongestToShortest
+        }
+    }
+
+    var analyticsDescription: String {
+        switch self {
+
+        case .newestToOldest:
+            return "newest_to_oldest"
+        case .oldestToNewest:
+            return "oldest_to_newest"
+        case .shortestToLongest:
+            return "shortest_to_longest"
+        case .longestToShortest:
+            return "longest_to_shortest"
         }
     }
 }

--- a/podcasts/EpisodeListSearchController.swift
+++ b/podcasts/EpisodeListSearchController.swift
@@ -282,35 +282,35 @@ class EpisodeListSearchController: SimpleNotificationsViewController, UISearchBa
 
         let noneAction = OptionAction(label: L10n.none, selected: podcast.episodeGrouping == PodcastGrouping.none.rawValue) { [weak self] in
             self?.setGroupingSetting(.none)
-            Analytics.track(.podcastsScreenEpisodeGroupingChanged, properties: ["grouping": PodcastGrouping.none])
+            Analytics.track(.podcastsScreenEpisodeGroupingChanged, properties: ["value": PodcastGrouping.none])
 
         }
         optionPicker.addAction(action: noneAction)
 
         let downloadedAction = OptionAction(label: L10n.statusDownloaded, selected: podcast.episodeGrouping == PodcastGrouping.downloaded.rawValue) { [weak self] in
             self?.setGroupingSetting(.downloaded)
-            Analytics.track(.podcastsScreenEpisodeGroupingChanged, properties: ["grouping": PodcastGrouping.downloaded])
+            Analytics.track(.podcastsScreenEpisodeGroupingChanged, properties: ["value": PodcastGrouping.downloaded])
 
         }
         optionPicker.addAction(action: downloadedAction)
 
         let unplayedAction = OptionAction(label: L10n.statusUnplayed, selected: podcast.episodeGrouping == PodcastGrouping.unplayed.rawValue) { [weak self] in
             self?.setGroupingSetting(.unplayed)
-            Analytics.track(.podcastsScreenEpisodeGroupingChanged, properties: ["grouping": PodcastGrouping.unplayed])
+            Analytics.track(.podcastsScreenEpisodeGroupingChanged, properties: ["value": PodcastGrouping.unplayed])
 
         }
         optionPicker.addAction(action: unplayedAction)
 
         let seasonAction = OptionAction(label: L10n.season, selected: podcast.episodeGrouping == PodcastGrouping.season.rawValue) { [weak self] in
             self?.setGroupingSetting(.season)
-            Analytics.track(.podcastsScreenEpisodeGroupingChanged, properties: ["grouping": PodcastGrouping.season])
+            Analytics.track(.podcastsScreenEpisodeGroupingChanged, properties: ["value": PodcastGrouping.season])
 
         }
         optionPicker.addAction(action: seasonAction)
 
         let starAction = OptionAction(label: L10n.statusStarred, selected: podcast.episodeGrouping == PodcastGrouping.starred.rawValue) { [weak self] in
             self?.setGroupingSetting(.starred)
-            Analytics.track(.podcastsScreenEpisodeGroupingChanged, properties: ["grouping": PodcastGrouping.starred])
+            Analytics.track(.podcastsScreenEpisodeGroupingChanged, properties: ["value": PodcastGrouping.starred])
 
         }
         optionPicker.addAction(action: starAction)

--- a/podcasts/EpisodeListSearchController.swift
+++ b/podcasts/EpisodeListSearchController.swift
@@ -247,22 +247,28 @@ class EpisodeListSearchController: SimpleNotificationsViewController, UISearchBa
 
         let newestToOldestAction = OptionAction(label: PodcastEpisodeSortOrder.newestToOldest.description, selected: podcast.episodeSortOrder == PodcastEpisodeSortOrder.newestToOldest.rawValue) { [weak self] in
             self?.setSortSetting(.newestToOldest)
+            Analytics.track(.podcastsScreenSortOrderChanged, properties: ["sort_by": PodcastEpisodeSortOrder.newestToOldest])
         }
 
         optionPicker.addAction(action: newestToOldestAction)
 
         let oldestToNewestAction = OptionAction(label: PodcastEpisodeSortOrder.oldestToNewest.description, selected: podcast.episodeSortOrder == PodcastEpisodeSortOrder.oldestToNewest.rawValue) { [weak self] in
             self?.setSortSetting(.oldestToNewest)
+            Analytics.track(.podcastsScreenSortOrderChanged, properties: ["sort_by": PodcastEpisodeSortOrder.oldestToNewest])
         }
         optionPicker.addAction(action: oldestToNewestAction)
 
         let shortestToLongestAction = OptionAction(label: PodcastEpisodeSortOrder.shortestToLongest.description, selected: podcast.episodeSortOrder == PodcastEpisodeSortOrder.shortestToLongest.rawValue) { [weak self] in
             self?.setSortSetting(.shortestToLongest)
+            Analytics.track(.podcastsScreenSortOrderChanged, properties: ["sort_by": PodcastEpisodeSortOrder.shortestToLongest])
+
         }
         optionPicker.addAction(action: shortestToLongestAction)
 
         let longestToShortestAction = OptionAction(label: PodcastEpisodeSortOrder.longestToShortest.description, selected: podcast.episodeSortOrder == PodcastEpisodeSortOrder.longestToShortest.rawValue) { [weak self] in
             self?.setSortSetting(.longestToShortest)
+            Analytics.track(.podcastsScreenSortOrderChanged, properties: ["sort_by": PodcastEpisodeSortOrder.longestToShortest])
+
         }
         optionPicker.addAction(action: longestToShortestAction)
 
@@ -276,26 +282,36 @@ class EpisodeListSearchController: SimpleNotificationsViewController, UISearchBa
 
         let noneAction = OptionAction(label: L10n.none, selected: podcast.episodeGrouping == PodcastGrouping.none.rawValue) { [weak self] in
             self?.setGroupingSetting(.none)
+            Analytics.track(.podcastsScreenEpisodeGroupingChanged, properties: ["sort_by": PodcastGrouping.none])
+
         }
         optionPicker.addAction(action: noneAction)
 
         let downloadedAction = OptionAction(label: L10n.statusDownloaded, selected: podcast.episodeGrouping == PodcastGrouping.downloaded.rawValue) { [weak self] in
             self?.setGroupingSetting(.downloaded)
+            Analytics.track(.podcastsScreenEpisodeGroupingChanged, properties: ["sort_by": PodcastGrouping.downloaded])
+
         }
         optionPicker.addAction(action: downloadedAction)
 
         let unplayedAction = OptionAction(label: L10n.statusUnplayed, selected: podcast.episodeGrouping == PodcastGrouping.unplayed.rawValue) { [weak self] in
             self?.setGroupingSetting(.unplayed)
+            Analytics.track(.podcastsScreenEpisodeGroupingChanged, properties: ["sort_by": PodcastGrouping.unplayed])
+
         }
         optionPicker.addAction(action: unplayedAction)
 
         let seasonAction = OptionAction(label: L10n.season, selected: podcast.episodeGrouping == PodcastGrouping.season.rawValue) { [weak self] in
             self?.setGroupingSetting(.season)
+            Analytics.track(.podcastsScreenEpisodeGroupingChanged, properties: ["sort_by": PodcastGrouping.season])
+
         }
         optionPicker.addAction(action: seasonAction)
 
         let starAction = OptionAction(label: L10n.statusStarred, selected: podcast.episodeGrouping == PodcastGrouping.starred.rawValue) { [weak self] in
             self?.setGroupingSetting(.starred)
+            Analytics.track(.podcastsScreenEpisodeGroupingChanged, properties: ["sort_by": PodcastGrouping.starred])
+
         }
         optionPicker.addAction(action: starAction)
 

--- a/podcasts/EpisodeListSearchController.swift
+++ b/podcasts/EpisodeListSearchController.swift
@@ -282,35 +282,35 @@ class EpisodeListSearchController: SimpleNotificationsViewController, UISearchBa
 
         let noneAction = OptionAction(label: L10n.none, selected: podcast.episodeGrouping == PodcastGrouping.none.rawValue) { [weak self] in
             self?.setGroupingSetting(.none)
-            Analytics.track(.podcastsScreenEpisodeGroupingChanged, properties: ["sort_by": PodcastGrouping.none])
+            Analytics.track(.podcastsScreenEpisodeGroupingChanged, properties: ["grouping": PodcastGrouping.none])
 
         }
         optionPicker.addAction(action: noneAction)
 
         let downloadedAction = OptionAction(label: L10n.statusDownloaded, selected: podcast.episodeGrouping == PodcastGrouping.downloaded.rawValue) { [weak self] in
             self?.setGroupingSetting(.downloaded)
-            Analytics.track(.podcastsScreenEpisodeGroupingChanged, properties: ["sort_by": PodcastGrouping.downloaded])
+            Analytics.track(.podcastsScreenEpisodeGroupingChanged, properties: ["grouping": PodcastGrouping.downloaded])
 
         }
         optionPicker.addAction(action: downloadedAction)
 
         let unplayedAction = OptionAction(label: L10n.statusUnplayed, selected: podcast.episodeGrouping == PodcastGrouping.unplayed.rawValue) { [weak self] in
             self?.setGroupingSetting(.unplayed)
-            Analytics.track(.podcastsScreenEpisodeGroupingChanged, properties: ["sort_by": PodcastGrouping.unplayed])
+            Analytics.track(.podcastsScreenEpisodeGroupingChanged, properties: ["grouping": PodcastGrouping.unplayed])
 
         }
         optionPicker.addAction(action: unplayedAction)
 
         let seasonAction = OptionAction(label: L10n.season, selected: podcast.episodeGrouping == PodcastGrouping.season.rawValue) { [weak self] in
             self?.setGroupingSetting(.season)
-            Analytics.track(.podcastsScreenEpisodeGroupingChanged, properties: ["sort_by": PodcastGrouping.season])
+            Analytics.track(.podcastsScreenEpisodeGroupingChanged, properties: ["grouping": PodcastGrouping.season])
 
         }
         optionPicker.addAction(action: seasonAction)
 
         let starAction = OptionAction(label: L10n.statusStarred, selected: podcast.episodeGrouping == PodcastGrouping.starred.rawValue) { [weak self] in
             self?.setGroupingSetting(.starred)
-            Analytics.track(.podcastsScreenEpisodeGroupingChanged, properties: ["sort_by": PodcastGrouping.starred])
+            Analytics.track(.podcastsScreenEpisodeGroupingChanged, properties: ["grouping": PodcastGrouping.starred])
 
         }
         optionPicker.addAction(action: starAction)

--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -697,12 +697,17 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
         DispatchQueue.global().async { [weak self] in
             guard let allObjects = self?.episodeInfo[safe: 1]?.elements, allObjects.count > 0 else { return }
 
+            var count = 0
             for object in allObjects {
                 guard let listEpisode = object as? ListEpisode else { continue }
                 if listEpisode.episode.archived || (playedOnly && !listEpisode.episode.played()) { continue }
 
                 EpisodeManager.archiveEpisode(episode: listEpisode.episode, fireNotification: false, userInitiated: false)
+                count += 1
             }
+
+            AnalyticsEpisodeHelper.shared.currentSource = .podcastScreen
+            AnalyticsEpisodeHelper.shared.bulkArchiveEpisodes(count: count)
 
             DispatchQueue.main.async { [weak self] in
                 guard let strongSelf = self else { return }

--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -698,7 +698,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
                 guard let listEpisode = object as? ListEpisode else { continue }
                 if listEpisode.episode.archived || (playedOnly && !listEpisode.episode.played()) { continue }
 
-                EpisodeManager.archiveEpisode(episode: listEpisode.episode, fireNotification: false)
+                EpisodeManager.archiveEpisode(episode: listEpisode.episode, fireNotification: false, userInitiated: false)
             }
 
             DispatchQueue.main.async { [weak self] in

--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -680,6 +680,9 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
         DispatchQueue.global().async {
             DataManager.sharedManager.markAllUnarchivedForPodcast(id: podcast.id)
 
+            AnalyticsEpisodeHelper.shared.currentSource = .podcastScreen
+            AnalyticsEpisodeHelper.shared.bulkUnarchiveEpisodes(count: self.episodeCount())
+
             DispatchQueue.main.async { [weak self] in
                 guard let strongSelf = self else { return }
 
@@ -712,6 +715,11 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
     func downloadAllTapped() {
         DispatchQueue.global().async { [weak self] in
             guard let self = self, let allObjects = self.episodeInfo[safe: 1]?.elements, allObjects.count > 0 else { return }
+
+            let episodes = allObjects.compactMap { ($0 as? ListEpisode)?.episode }
+            AnalyticsEpisodeHelper.shared.currentSource = .podcastScreen
+            AnalyticsEpisodeHelper.shared.bulkDownloadEpisodes(episodes: episodes)
+
             self.downloadItems(allObjects: allObjects)
         }
     }


### PR DESCRIPTION
This fixes an issue where performing an archive from the podcast ... menu would result in an archive event per episode. Also Adds some extra events to the podcast menu options

- `podcasts_screen_sort_order_changed`: When the sort order of the episodes list changes
- `podcasts_screen_episode_grouping_changed`: When the layout of the podcasts list is changed

## To test

1. Launch the app
2. Go to the Podcasts tab
3. Tap on the ... button next to the search field
4. Tap on Archive All
5. ✅ Verify you see: `🔵 Tracked: episode_bulk_archived ["episode_count": COUNT, "source": "podcast_screen"]` - Where COUNT is the number of episodes that were archived
6. Tap on the ... button again and tap on the Unarchive all item
7. ✅ Verify you see `🔵 Tracked: episode_bulk_unarchived ["episode_count": COUNT, "source": "podcast_screen"]` - Where COUNT is the number of episodes the podcast has
8. Tap the ... again and change the Sort Episodes option
9. ✅ `🔵 Tracked: podcasts_screen_sort_order_changed ["sort_by": "OPTION"]` - Where OPTION is the item you selected
10. Tap the ... again and change the Group Episodes option
11. ✅ `🔵 Tracked: podcasts_screen_episode_grouping_changed ["value": "GROUP"]` - Where GROUP is the name of the grouping you selected
12. Tap the Download All option
13. ✅ `🔵 Tracked: episode_bulk_download_queued ["episode_count": COUNT, "source": "podcast_screen"]` - Where COUNT is the number of episodes the podcast has


## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
