### PR TITLE
Enable the free trial feature flag

### DIFF
--- a/podcasts/FeatureFlag.swift
+++ b/podcasts/FeatureFlag.swift
@@ -2,7 +2,7 @@ import Foundation
 
 enum FeatureFlag {
     /// Whether we should detect and show the free trial UI
-    static let freeTrialsEnabled = false
+    static let freeTrialsEnabled = true
 
     /// Whether the Tracks analytics are enabled
     static let tracksEnabled = true


### PR DESCRIPTION
Enables the Free Trial feature flag

## To test

- You can follow the steps from here: https://github.com/Automattic/pocket-casts-ios/pull/171#issue-1345037050

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
