### PR TITLE
Tighten up the widget letter spacing.

### DIFF
--- a/WidgetExtension/Now Playing/NowPlayingLockScreenWidget.swift
+++ b/WidgetExtension/Now Playing/NowPlayingLockScreenWidget.swift
@@ -37,7 +37,7 @@ struct NowPlayingLockscreenWidgetEntryView: View {
 
     var body: some View {
         HStack {
-            VStack(alignment: .leading, spacing: 3) {
+            VStack(alignment: .leading, spacing: 2) {
                 HStack {
                     Image("logo-transparent")
                         .resizable()


### PR DESCRIPTION
Fixes #356 

Tightens up the spacing on the new now playing widget

## To test

1. Add the now playing widget to your iOS 16 lock screen. 
2. Play a Podcast where the title has a character with a tail. g, q, p, j, y
3. Expect that the top of the Podcast logo and bottom of the character are no longer cut off.

| Before | After |
| --- | --- |
| <img width=300 src="https://user-images.githubusercontent.com/24919469/193919590-be02975e-fa7e-4a8f-b282-722c8338f3bc.png" /> | <img width=300 src="https://user-images.githubusercontent.com/3384451/194638323-d12061cb-6dd0-4d92-8f8f-c4de470d393e.jpg" /> |


## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
