### PR TITLE
Remove force unwrap on missing episode.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 7.25
 -----
 - Fixed a crash that could happen when playing an episode while the app is in the background (#345)
+- Fixed a crash where a sync account has started listening to a local file on one device and visits the up next queue on a different device. (#371)
 
 7.24
 -----

--- a/podcasts/UpNextNowPlayingCell.swift
+++ b/podcasts/UpNextNowPlayingCell.swift
@@ -61,7 +61,7 @@ class UpNextNowPlayingCell: ThemeableCell {
 
     @IBOutlet var progressViewWidthConstraint: NSLayoutConstraint!
 
-    private var episode: BaseEpisode!
+    private var episode: BaseEpisode? = nil
 
     override func awakeFromNib() {
         super.awakeFromNib()
@@ -99,8 +99,17 @@ class UpNextNowPlayingCell: ThemeableCell {
     @objc func progressUpdated(animated: Bool = true) {
         layoutIfNeeded()
 
-        let duration = episode.duration
-        let currentTime = PlaybackManager.shared.currentTime()
+        let duration: Double
+        let currentTime: TimeInterval
+
+        if let episode = episode {
+            duration = episode.duration
+            currentTime = PlaybackManager.shared.currentTime()
+        }
+        else {
+            duration = 1
+            currentTime = 1
+        }
 
         guard duration > 0, currentTime.isFinite else { return }
 
@@ -136,6 +145,11 @@ class UpNextNowPlayingCell: ThemeableCell {
     }
 
     func updateDownloadStatus() {
+        guard let episode = episode else {
+            downloadingIndicator.isHidden = true
+            downloadedIndicator.isHidden = true
+            return
+        }
         if let episode = episode as? UserEpisode, episode.uploadStatus == UploadStatus.missing.rawValue {
             downloadingIndicator.isHidden = true
             downloadedIndicator.isHidden = true


### PR DESCRIPTION
Fixes #331 

The crash mentioned in the ticket was caused by a force unwrap of the missing episode.

## To test

1. On a different device, add a local file (not available in the cloud) to the Up Next Queue
2. Sync the device with a Pocket Casts account
3. On the test device that's using the same sync account
4. Open the Up Next queue
5. Dismiss the up Next queue
6. Swipe up to open the full-screen player
7. Swipe up again to open the Up Next Queue

Ensure that the Now Playing cell isn't showing any download indicators and the duration defaults to 0 seconds. 

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
