### PR TITLE
Tooling: Cherry picks bat-cache and CI Xcode version updates from #347

### DIFF
--- a/.buildkite/cache_builder.yml
+++ b/.buildkite/cache_builder.yml
@@ -6,7 +6,7 @@
 # Nodes with values to reuse in the pipeline.
 common_params:
   - &common_plugins
-    - automattic/bash-cache#2.6.0
+    - automattic/bash-cache#2.8.0
     - automattic/git-s3-cache#v1.1.3:
         bucket: a8c-repo-mirrors
         repo: automattic/pocket-casts-ios/
@@ -17,9 +17,6 @@ steps:
   # every pod we've ever used
   - label: ":cocoapods: Rebuild CocoaPods cache"
     command: |
-      # Fix for https://github.com/Automattic/bash-cache-buildkite-plugin/issues/16
-      gem install bundler
-
       echo "--- :rubygems: Setting up Gems"
       install_gems
 
@@ -29,7 +26,7 @@ steps:
     agents:
       queue: mac
     env:
-      IMAGE_ID: xcode-13.4.1
+      IMAGE_ID: xcode-14
 
   # Because this repo is large (~2m 20s to checkout), we periodically create a
   # Git Mirror and copy it to S3, from where it can be fetched by agents more

--- a/.buildkite/commands/build.sh
+++ b/.buildkite/commands/build.sh
@@ -28,8 +28,7 @@ echo "--- Setup Ruby tooling"
 
 export LANG=en_US.UTF-8
 export LC_ALL=en_US.UTF-8
-# Workaround for https://github.com/Automattic/buildkite-ci/issues/79
-gem install bundler
+
 install_gems # see bash-cache Automattic's Buildkite plugin
 
 echo "--- Install Pods"

--- a/.buildkite/commands/danger.sh
+++ b/.buildkite/commands/danger.sh
@@ -1,9 +1,5 @@
 #!/bin/bash -eu
 
-# Workaround for https://github.com/Automattic/buildkite-ci/issues/79
-echo "--- :rubygems: Fix Ruby Setup"
-gem install bundler
-
 echo "--- :rubygems: Set up Gems"
 install_gems
 

--- a/.buildkite/commands/release-build.sh
+++ b/.buildkite/commands/release-build.sh
@@ -1,9 +1,5 @@
 #!/bin/bash -eu
 
-# Workaround for https://github.com/Automattic/buildkite-ci/issues/79
-echo "--- :rubygems: Fixing Ruby Setup"
-gem install bundler
-
 echo "--- :rubygems: Setting up Gems"
 install_gems
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,14 +2,14 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/bash-cache#2.6.0
+    - automattic/bash-cache#2.8.0
     - automattic/git-s3-cache#v1.1.3:
         bucket: a8c-repo-mirrors
         repo: automattic/pocket-casts-ios/
   # Common environment values to use with the `env` key.
   - &common_env
     # If you update the image to a newer Xcode version, don't forget to also update the badge in the README.md file accordingly for consistency
-    IMAGE_ID: xcode-14.rc
+    IMAGE_ID: xcode-14
   # Common agents values to use with the `agents` key.
   - &common_agents
     queue: mac

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -4,13 +4,13 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/bash-cache#2.7.0
+    - automattic/bash-cache#2.8.0
     - automattic/git-s3-cache#v1.1.3:
         bucket: "a8c-repo-mirrors"
         repo: "automattic/pocket-casts-ios/"
   # Common environment values to use with the `env` key.
   - &common_env
-    IMAGE_ID: xcode-14.rc
+    IMAGE_ID: xcode-14
 
 steps:
 


### PR DESCRIPTION
CI Builds are failing for the release branch: https://buildkite.com/automattic/pocket-casts-ios/builds/1524

This cherry-picks the commit that updates the bat-cache and CI Xcode version updates from here: https://github.com/Automattic/pocket-casts-ios/pull/347

## To test

This is a pure tooling change, a 🟢 Green CI should be all that's needed

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
