### PR TITLE
Honor the clear up next command when the episode isn't changing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Fixed a crash that could happen when playing an episode while the app is in the background (#345)
 - Fixed a crash where a sync account has started listening to a local file on one device and visits the up next queue on a different device. (#371)
 - Fixed an issue where the episode totals would not display above the podcast episode list in iOS 14 (#287)
+- Fixed an issue where the Up Next queue wouldn't reset when playing all items from a filter. (#375)
 
 7.24
 -----

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -159,6 +159,10 @@ class PlaybackManager: ServerPlaybackDelegate {
         } else {
             // even if the episode isn't changing, we might have a stale copy of it, so update ours
             queue.nowPlayingEpisodeChanged()
+
+            if overrideUpNext {
+                queue.clearUpNextList()
+            }
         }
         uuidOfPlayingList = ""
 


### PR DESCRIPTION
Fixes #254

When selecting to play all from a new filter the app will skip clearing the playback queue if the episode isn't changing. The inline comment hints that this is because this method is called multiple times by the effects player, which hints that maybe there is a possibility to reduce those repeated calls. Instead, I decided to honor clearing the queue when directed. 

## To test
1. Set up an Up Next queue where the active item is at the top of one of your filters.
2. Select to Play All from the filter mentioned above.

Expect your queue to be reset with the new filter's content.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
