### PR TITLE
End of Year: add stories initial screen

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -459,6 +459,7 @@
 		8B71828D28CF68E800B98F04 /* AppIconWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B71828C28CF68E800B98F04 /* AppIconWidget.swift */; };
 		8B71828F28CF6ED900B98F04 /* StaticWidgetProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B71828E28CF6ED900B98F04 /* StaticWidgetProvider.swift */; };
 		8B71829128CF755D00B98F04 /* UpNextLockScreenWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B71829028CF755D00B98F04 /* UpNextLockScreenWidget.swift */; };
+		8B738F3128F5CBE0004E7526 /* StoriesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B738F3028F5CBE0004E7526 /* StoriesView.swift */; };
 		8BA55A0D28CA4540002BECC5 /* AnalyticsPlaybackHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA55A0C28CA4540002BECC5 /* AnalyticsPlaybackHelper.swift */; };
 		8BA55A0E28CA46E4002BECC5 /* AnalyticsPlaybackHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA55A0C28CA4540002BECC5 /* AnalyticsPlaybackHelper.swift */; };
 		8BA55A1028CA6843002BECC5 /* AnalyticsPlaybackHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA55A0F28CA6843002BECC5 /* AnalyticsPlaybackHelperTests.swift */; };
@@ -1970,6 +1971,7 @@
 		8B71828C28CF68E800B98F04 /* AppIconWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconWidget.swift; sourceTree = "<group>"; };
 		8B71828E28CF6ED900B98F04 /* StaticWidgetProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaticWidgetProvider.swift; sourceTree = "<group>"; };
 		8B71829028CF755D00B98F04 /* UpNextLockScreenWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpNextLockScreenWidget.swift; sourceTree = "<group>"; };
+		8B738F3028F5CBE0004E7526 /* StoriesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoriesView.swift; sourceTree = "<group>"; };
 		8BA55A0C28CA4540002BECC5 /* AnalyticsPlaybackHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsPlaybackHelper.swift; sourceTree = "<group>"; };
 		8BA55A0F28CA6843002BECC5 /* AnalyticsPlaybackHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsPlaybackHelperTests.swift; sourceTree = "<group>"; };
 		8BA55A1228CA7425002BECC5 /* XCTestCase+eventually.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+eventually.swift"; sourceTree = "<group>"; };
@@ -3631,6 +3633,7 @@
 			isa = PBXGroup;
 			children = (
 				8BCB22B128F47F44001A0315 /* EndOfYearModal.swift */,
+				8B738F3028F5CBE0004E7526 /* StoriesView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -7135,6 +7138,7 @@
 				40C2188122C44D1F005B8367 /* UploadedRefreshControl.swift in Sources */,
 				BDD5CA022303EB95005E133C /* ThemeableCollectionCell.swift in Sources */,
 				BD874EEE1C9A373C00F5B2A5 /* SettingsViewController.swift in Sources */,
+				8B738F3128F5CBE0004E7526 /* StoriesView.swift in Sources */,
 				BDDA14DC219B021A0066441E /* SearchLoadingCell.swift in Sources */,
 				BD16385A27B0FC5A00F24A39 /* PodcastPickerView.swift in Sources */,
 				408B932C216EFD9B00B57B78 /* TextEntryCell.swift in Sources */,

--- a/podcasts/End of Year/EndOfYear.swift
+++ b/podcasts/End of Year/EndOfYear.swift
@@ -17,9 +17,15 @@ struct EndOfYear {
             return
         }
 
-        let storiesViewController = UIViewController()
-        storiesViewController.view.backgroundColor = .systemBackground
+        let storiesViewController = StoriesHostingController(rootView: StoriesView())
+        storiesViewController.view.backgroundColor = .black
         storiesViewController.modalPresentationStyle = .fullScreen
         viewController.present(storiesViewController, animated: true, completion: nil)
+    }
+}
+
+class StoriesHostingController<ContentView: View>: UIHostingController<ContentView> {
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        return .lightContent
     }
 }

--- a/podcasts/End of Year/Views/StoriesView.swift
+++ b/podcasts/End of Year/Views/StoriesView.swift
@@ -8,12 +8,13 @@ struct StoriesView: View {
             ZStack {
                 Spacer()
                 fakeStory
-                header
+                    .cornerRadius(Constants.storyCornerRadius)
                 storySwitcher
+                header
             }
 
             ZStack {}
-                .frame(height: 15)
+                .frame(height: Constants.spaceBetweenShareAndStory)
 
             shareButton
         }
@@ -28,22 +29,21 @@ struct StoriesView: View {
                     storyIndicator
                     storyIndicator
                 }
-                .frame(height: 2)
+                .frame(height: Constants.storyIndicatorHeight)
                 Spacer()
             }
-            .padding(.leading, 13)
-            .padding(.trailing, 13)
+            .padding(.leading, Constants.storyIndicatorVerticalPadding)
+            .padding(.trailing, Constants.storyIndicatorVerticalPadding)
 
             closeButton
         }
-        .padding(.top, 5)
+        .padding(.top, Constants.headerTopPadding)
     }
 
     var fakeStory: some View {
         ZStack {
             Color.purple
         }
-        .cornerRadius(15)
     }
 
     var closeButton: some View {
@@ -55,10 +55,10 @@ struct StoriesView: View {
                     }) {
                         Image(systemName: "xmark")
                             .foregroundColor(.white)
-                            .padding(13)
+                            .padding(Constants.closeButtonPadding)
                     }
                 }
-                .padding(.top, 5)
+                .padding(.top, Constants.closeButtonTopPadding)
                 Spacer()
             }
         }
@@ -67,19 +67,19 @@ struct StoriesView: View {
         GeometryReader { geometry in
                 ZStack(alignment: .leading) {
                     Rectangle()
-                        .foregroundColor(Color.white.opacity(0.3))
-                        .cornerRadius(5)
+                        .foregroundColor(Color.white.opacity(Constants.storyIndicatorBackgroundOpacity))
+                        .cornerRadius(Constants.storyIndicatorBorderRadius)
 
                     Rectangle()
-                        .foregroundColor(Color.white.opacity(0.9))
-                        .cornerRadius(5)
+                        .foregroundColor(Color.white.opacity(Constants.storyIndicatorForegroundOpacity))
+                        .cornerRadius(Constants.storyIndicatorBorderRadius)
                 }
             }
     }
 
     // Invisible component to go to the next/prev story
     var storySwitcher: some View {
-        HStack(alignment: .center, spacing: 0) {
+        HStack(alignment: .center, spacing: Constants.storySwitcherSpacing) {
             Rectangle()
                 .foregroundColor(.clear)
                 .contentShape(Rectangle())
@@ -109,16 +109,46 @@ struct StoriesView: View {
             }
         }
         .contentShape(Rectangle())
-        .padding(.top, 10)
-        .padding(.bottom, 10)
+        .padding(.top, Constants.shareButtonVerticalPadding)
+        .padding(.bottom, Constants.shareButtonVerticalPadding)
         .overlay(
-            RoundedRectangle(cornerRadius: 10)
-                .stroke(.white, style: StrokeStyle(lineWidth: 1))
+            RoundedRectangle(cornerRadius: Constants.shareButtonCornerRadius)
+                .stroke(.white, style: StrokeStyle(lineWidth: Constants.shareButtonBorderSize))
         )
-        .padding(.leading, 5)
-        .padding(.trailing, 5)
+        .padding(.leading, Constants.shareButtonHorizontalPadding)
+        .padding(.trailing, Constants.shareButtonHorizontalPadding)
     }
 }
+
+// MARK: - Constants
+
+private extension StoriesView {
+    struct Constants {
+        static let storyIndicatorHeight: CGFloat = 2
+        static let storyIndicatorVerticalPadding: CGFloat = 13
+        static let headerTopPadding: CGFloat = 5
+
+        static let closeButtonPadding: CGFloat = 13
+        static let closeButtonTopPadding: CGFloat = 5
+
+        static let storyIndicatorBorderRadius: CGFloat = 5
+        static let storyIndicatorBackgroundOpacity: CGFloat = 0.3
+        static let storyIndicatorForegroundOpacity: CGFloat = 0.9
+
+        static let storySwitcherSpacing: CGFloat = 0
+
+        static let shareButtonVerticalPadding: CGFloat = 10
+        static let shareButtonHorizontalPadding: CGFloat = 5
+        static let shareButtonCornerRadius: CGFloat = 10
+        static let shareButtonBorderSize: CGFloat = 1
+
+        static let spaceBetweenShareAndStory: CGFloat = 15
+
+        static let storyCornerRadius: CGFloat = 15
+    }
+}
+
+// MARK: - Preview Provider
 
 struct StoriesView_Previews: PreviewProvider {
     static var previews: some View {

--- a/podcasts/End of Year/Views/StoriesView.swift
+++ b/podcasts/End of Year/Views/StoriesView.swift
@@ -1,0 +1,86 @@
+import SwiftUI
+
+struct StoriesView: View {
+    @Environment(\.presentationMode) var presentationMode
+
+    var body: some View {
+        VStack {
+            ZStack {
+
+                VStack {
+                    HStack {
+                        storyIndicator
+                        storyIndicator
+                    }
+                    .frame(height: 2)
+                    Spacer()
+                }
+                .padding(.leading, 5)
+                .padding(.trailing, 5)
+
+                closeButton
+                Spacer()
+            }
+
+            Button(action: {
+
+            }) {
+                HStack {
+                    Spacer()
+                    Image(systemName: "square.and.arrow.up")
+                        .foregroundColor(.white)
+                    Text("Share")
+                        .foregroundColor(.white)
+                    Spacer()
+                }
+            }
+            .contentShape(Rectangle())
+            .padding(.top, 10)
+            .padding(.bottom, 10)
+            .overlay(
+                RoundedRectangle(cornerRadius: 10)
+                    .stroke(.white, style: StrokeStyle(lineWidth: 1))
+            )
+            .padding(.leading, 5)
+            .padding(.trailing, 5)
+        }
+        .background(Color.black)
+    }
+
+    var closeButton: some View {
+            VStack {
+                HStack {
+                    Spacer()
+                    Button(action: {
+                        presentationMode.wrappedValue.dismiss()
+                    }) {
+                        Image(systemName: "xmark")
+                            .foregroundColor(.white)
+                            .padding(13)
+                    }
+                }
+                .padding(.top, 5)
+                Spacer()
+            }
+        }
+
+    var storyIndicator: some View {
+        GeometryReader { geometry in
+                ZStack(alignment: .leading) {
+                    Rectangle()
+                        .foregroundColor(Color.white.opacity(0.3))
+                        .cornerRadius(5)
+
+                    Rectangle()
+                        .foregroundColor(Color.white.opacity(0.9))
+                        .cornerRadius(5)
+                }
+            }
+    }
+}
+
+struct StoriesView_Previews: PreviewProvider {
+    static var previews: some View {
+        StoriesView()
+    }
+}

--- a/podcasts/End of Year/Views/StoriesView.swift
+++ b/podcasts/End of Year/Views/StoriesView.swift
@@ -6,45 +6,43 @@ struct StoriesView: View {
     var body: some View {
         VStack {
             ZStack {
-
-                VStack {
-                    HStack {
-                        storyIndicator
-                        storyIndicator
-                    }
-                    .frame(height: 2)
-                    Spacer()
-                }
-                .padding(.leading, 5)
-                .padding(.trailing, 5)
-
-                closeButton
+                fakeStory
+                header
                 Spacer()
             }
 
-            Button(action: {
+            ZStack {}
+                .frame(height: 15)
 
-            }) {
-                HStack {
-                    Spacer()
-                    Image(systemName: "square.and.arrow.up")
-                        .foregroundColor(.white)
-                    Text("Share")
-                        .foregroundColor(.white)
-                    Spacer()
-                }
-            }
-            .contentShape(Rectangle())
-            .padding(.top, 10)
-            .padding(.bottom, 10)
-            .overlay(
-                RoundedRectangle(cornerRadius: 10)
-                    .stroke(.white, style: StrokeStyle(lineWidth: 1))
-            )
-            .padding(.leading, 5)
-            .padding(.trailing, 5)
+            shareButton
         }
         .background(Color.black)
+    }
+
+    // Header containing the close button and the rectangles
+    var header: some View {
+        ZStack {
+            VStack {
+                HStack {
+                    storyIndicator
+                    storyIndicator
+                }
+                .frame(height: 2)
+                Spacer()
+            }
+            .padding(.leading, 13)
+            .padding(.trailing, 13)
+
+            closeButton
+        }
+        .padding(.top, 5)
+    }
+
+    var fakeStory: some View {
+        ZStack {
+            Color.purple
+        }
+        .cornerRadius(15)
     }
 
     var closeButton: some View {
@@ -76,6 +74,30 @@ struct StoriesView: View {
                         .cornerRadius(5)
                 }
             }
+    }
+
+    var shareButton: some View {
+        Button(action: {
+
+        }) {
+            HStack {
+                Spacer()
+                Image(systemName: "square.and.arrow.up")
+                    .foregroundColor(.white)
+                Text("Share")
+                    .foregroundColor(.white)
+                Spacer()
+            }
+        }
+        .contentShape(Rectangle())
+        .padding(.top, 10)
+        .padding(.bottom, 10)
+        .overlay(
+            RoundedRectangle(cornerRadius: 10)
+                .stroke(.white, style: StrokeStyle(lineWidth: 1))
+        )
+        .padding(.leading, 5)
+        .padding(.trailing, 5)
     }
 }
 

--- a/podcasts/End of Year/Views/StoriesView.swift
+++ b/podcasts/End of Year/Views/StoriesView.swift
@@ -6,9 +6,10 @@ struct StoriesView: View {
     var body: some View {
         VStack {
             ZStack {
+                Spacer()
                 fakeStory
                 header
-                Spacer()
+                storySwitcher
             }
 
             ZStack {}
@@ -74,6 +75,24 @@ struct StoriesView: View {
                         .cornerRadius(5)
                 }
             }
+    }
+
+    // Invisible component to go to the next/prev story
+    var storySwitcher: some View {
+        HStack(alignment: .center, spacing: 0) {
+            Rectangle()
+                .foregroundColor(.clear)
+                .contentShape(Rectangle())
+                .onTapGesture {
+                    print("Previous")
+            }
+            Rectangle()
+                .foregroundColor(.clear)
+                .contentShape(Rectangle())
+                .onTapGesture {
+                    print("Next")
+            }
+        }
     }
 
     var shareButton: some View {


### PR DESCRIPTION
| 📘 Project: #376 |
|:---:|

Adds the initial stories screen. No functionality is built on this PR, just the view.

<img src="https://user-images.githubusercontent.com/7040243/195399967-af898c1b-0cf0-4d06-bff6-bbd698c36d51.png" width="300">

## To test

1. Enable the `endOfYear` flag in `FeatureFlag.swift`
2. Run the app
3. When the prompt appears, tap "View My 2022"
4. ✅ Check that the stories view appear
5. Tap close
6. ✅ Check that the stories view is dismissed
7. Open the stories view again
8. Change the device/simulator orientation to landscape
9. ✅ Check that the view remains in portrait mode

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
