### PR TITLE
Apple SSO: Setup

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -362,6 +362,7 @@
 		463D169E27CE7E5C008FA135 /* EpisodeDetailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 463D169D27CE7E5C008FA135 /* EpisodeDetailsViewModel.swift */; };
 		463FCE7D27BEA90B00E5AF89 /* WatchInterfaceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 463FCE7C27BEA90B00E5AF89 /* WatchInterfaceType.swift */; };
 		463FCE7F27BEAE6400E5AF89 /* WatchHostingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 463FCE7E27BEAE6400E5AF89 /* WatchHostingController.swift */; };
+		4647623328F733D4006D005A /* AuthenticationServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4647623228F733D3006D005A /* AuthenticationServices.framework */; };
 		4649404327D94757007F29C8 /* EpisodeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4649404227D94757007F29C8 /* EpisodeViewModel.swift */; };
 		464B481F27E8FC7E00107CBF /* NowPlayingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 464B481E27E8FC7E00107CBF /* NowPlayingViewModel.swift */; };
 		4650F5C128ECC6D1006A5704 /* CrashLoggingDataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4650F5C028ECC6D1006A5704 /* CrashLoggingDataProvider.swift */; };
@@ -1853,6 +1854,7 @@
 		463D169D27CE7E5C008FA135 /* EpisodeDetailsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EpisodeDetailsViewModel.swift; sourceTree = "<group>"; };
 		463FCE7C27BEA90B00E5AF89 /* WatchInterfaceType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchInterfaceType.swift; sourceTree = "<group>"; };
 		463FCE7E27BEAE6400E5AF89 /* WatchHostingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchHostingController.swift; sourceTree = "<group>"; };
+		4647623228F733D3006D005A /* AuthenticationServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AuthenticationServices.framework; path = System/Library/Frameworks/AuthenticationServices.framework; sourceTree = SDKROOT; };
 		4649404227D94757007F29C8 /* EpisodeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EpisodeViewModel.swift; sourceTree = "<group>"; };
 		464B481E27E8FC7E00107CBF /* NowPlayingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowPlayingViewModel.swift; sourceTree = "<group>"; };
 		4650F5C028ECC6D1006A5704 /* CrashLoggingDataProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashLoggingDataProvider.swift; sourceTree = "<group>"; };
@@ -2909,6 +2911,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4647623328F733D4006D005A /* AuthenticationServices.framework in Frameworks */,
 				468F00D327CD575C00FFAAAA /* FirebasePerformance in Frameworks */,
 				BD11C41D2524741C00E308E6 /* CarPlay.framework in Frameworks */,
 				BD44F750267C850000810148 /* DifferenceKit in Frameworks */,
@@ -5214,6 +5217,7 @@
 		BDBD53EE17019B2A0048C8C5 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				4647623228F733D3006D005A /* AuthenticationServices.framework */,
 				BD11C41C2524741C00E308E6 /* CarPlay.framework */,
 				BD3C61A5221A91150061341D /* liblottie-ios.a */,
 				BD3C61A3221A90EA0061341D /* liblottie-ios.a */,

--- a/podcasts/FeatureFlag.swift
+++ b/podcasts/FeatureFlag.swift
@@ -15,4 +15,7 @@ enum FeatureFlag {
 
     /// Whether End Of Year feature is enabled
     static let endOfYear = false
+
+    /// Adds the Sign In With Apple options to the login flow
+    static let signInWithApple = false
 }

--- a/podcasts/ProfileIntroViewController.swift
+++ b/podcasts/ProfileIntroViewController.swift
@@ -4,10 +4,14 @@ import AuthenticationServices
 class ProfileIntroViewController: PCViewController, SyncSigninDelegate {
     weak var upgradeRootViewController: UIViewController?
 
+    private var buttonFont: UIFont {
+        .systemFont(ofSize: 18, weight: .semibold)
+    }
+
     @IBOutlet var createAccountBtn: ThemeableRoundedButton! {
         didSet {
             createAccountBtn.setTitle(L10n.createAccount, for: .normal)
-            createAccountBtn.titleLabel?.font = UIFont.systemFont(ofSize: 18, weight: UIFont.Weight.semibold)
+            createAccountBtn.titleLabel?.font = buttonFont
         }
     }
 
@@ -17,7 +21,7 @@ class ProfileIntroViewController: PCViewController, SyncSigninDelegate {
             signInBtn.isHidden = FeatureFlag.signInWithApple
             signInBtn.setTitle(L10n.signIn, for: .normal)
             signInBtn.shouldFill = false
-            signInBtn.titleLabel?.font = UIFont.systemFont(ofSize: 18, weight: UIFont.Weight.semibold)
+            signInBtn.titleLabel?.font = buttonFont
         }
     }
 
@@ -25,7 +29,7 @@ class ProfileIntroViewController: PCViewController, SyncSigninDelegate {
         didSet {
             passwordAuthOption.isHidden = !FeatureFlag.signInWithApple
             passwordAuthOption.setTitle(L10n.accountLogin, for: .normal)
-            passwordAuthOption.titleLabel?.font = UIFont.systemFont(ofSize: 18, weight: UIFont.Weight.semibold)
+            passwordAuthOption.titleLabel?.font = buttonFont
         }
     }
 

--- a/podcasts/ProfileIntroViewController.swift
+++ b/podcasts/ProfileIntroViewController.swift
@@ -1,4 +1,5 @@
 import UIKit
+import AuthenticationServices
 
 class ProfileIntroViewController: PCViewController, SyncSigninDelegate {
     weak var upgradeRootViewController: UIViewController?
@@ -10,11 +11,21 @@ class ProfileIntroViewController: PCViewController, SyncSigninDelegate {
         }
     }
 
+    @IBOutlet var authenticationProviders: UIStackView!
     @IBOutlet var signInBtn: ThemeableRoundedButton! {
         didSet {
+            signInBtn.isHidden = FeatureFlag.signInWithApple
             signInBtn.setTitle(L10n.signIn, for: .normal)
             signInBtn.shouldFill = false
             signInBtn.titleLabel?.font = UIFont.systemFont(ofSize: 18, weight: UIFont.Weight.semibold)
+        }
+    }
+
+    @IBOutlet var passwordAuthOption: ThemeableUIButton! {
+        didSet {
+            passwordAuthOption.isHidden = !FeatureFlag.signInWithApple
+            passwordAuthOption.setTitle(L10n.accountLogin, for: .normal)
+            passwordAuthOption.titleLabel?.font = UIFont.systemFont(ofSize: 18, weight: UIFont.Weight.semibold)
         }
     }
 
@@ -51,6 +62,8 @@ class ProfileIntroViewController: PCViewController, SyncSigninDelegate {
         let doneButton = UIBarButtonItem(image: UIImage(named: "cancel"), style: .done, target: self, action: #selector(doneTapped))
         doneButton.accessibilityLabel = L10n.accessibilityCloseDialog
         navigationController?.navigationBar.setValue(true, forKey: "hidesShadow")
+
+        setupProviderLoginView()
 
         Analytics.track(.setupAccountShown)
     }
@@ -107,5 +120,22 @@ class ProfileIntroViewController: PCViewController, SyncSigninDelegate {
 
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         .portrait // since this controller is presented modally it needs to tell iOS it only goes portrait
+    }
+}
+
+// MARK: - Apple Auth
+extension ProfileIntroViewController {
+    func setupProviderLoginView() {
+        guard FeatureFlag.signInWithApple else { return }
+
+        let authorizationButton = ASAuthorizationAppleIDButton(type: .continue, style: .whiteOutline)
+        authorizationButton.cornerRadius = createAccountBtn.cornerRadius
+        authorizationButton.addTarget(self, action: #selector(handleAppleAuthButtonPress), for: .touchUpInside)
+        authorizationButton.heightAnchor.constraint(equalToConstant: 56).isActive = true
+        authenticationProviders.insertArrangedSubview(authorizationButton, at: 0)
+      }
+
+    @objc
+    func handleAppleAuthButtonPress() {
     }
 }

--- a/podcasts/ProfileIntroViewController.xib
+++ b/podcasts/ProfileIntroViewController.xib
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ProfileIntroViewController" customModule="podcasts" customModuleProvider="target">
             <connections>
+                <outlet property="authenticationProviders" destination="GOk-uO-NBJ" id="rsi-Es-uga"/>
                 <outlet property="createAccountBtn" destination="J6c-um-8gq" id="ZGj-eX-TLF"/>
                 <outlet property="infoLabel" destination="xRp-Cs-cvI" id="jkd-bO-uIj"/>
+                <outlet property="passwordAuthOption" destination="1kp-ow-mWD" id="dKY-GU-hSm"/>
                 <outlet property="profileIllustration" destination="nY7-Sl-Gxg" id="FSe-pS-xhJ"/>
                 <outlet property="signInBtn" destination="f5E-dc-t9b" id="Lko-Ln-Je0"/>
                 <outlet property="signOrCreateLabel" destination="oOL-Vb-lE7" id="fqK-o7-urx"/>
@@ -22,7 +22,7 @@
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT" customClass="ThemeableView" customModule="podcasts" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
+            <rect key="frame" x="0.0" y="0.0" width="375" height="623"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="nY7-Sl-Gxg">
@@ -48,45 +48,57 @@
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
-                <view contentMode="scaleToFill" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="J6c-um-8gq" customClass="ThemeableRoundedButton" customModule="podcasts" customModuleProvider="target">
-                    <rect key="frame" x="16" y="459" width="343" height="56"/>
-                    <constraints>
-                        <constraint firstAttribute="height" constant="56" id="mFU-rA-l1k"/>
-                    </constraints>
-                    <connections>
-                        <action selector="createTapped" destination="-1" eventType="touchUpInside" id="diI-CU-FCd"/>
-                    </connections>
-                </view>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="f5E-dc-t9b" customClass="ThemeableRoundedButton" customModule="podcasts" customModuleProvider="target">
-                    <rect key="frame" x="16" y="531" width="343" height="56"/>
-                    <constraints>
-                        <constraint firstAttribute="height" constant="56" id="y0c-mx-CdK"/>
-                    </constraints>
-                    <connections>
-                        <action selector="signInTapped" destination="-1" eventType="touchUpInside" id="oSv-QU-2xj"/>
-                    </connections>
-                </view>
+                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="GOk-uO-NBJ">
+                    <rect key="frame" x="16" y="407" width="343" height="200"/>
+                    <subviews>
+                        <view contentMode="scaleToFill" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="J6c-um-8gq" customClass="ThemeableRoundedButton" customModule="podcasts" customModuleProvider="target">
+                            <rect key="frame" x="0.0" y="0.0" width="343" height="56"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="56" id="mFU-rA-l1k"/>
+                            </constraints>
+                            <connections>
+                                <action selector="createTapped" destination="-1" eventType="touchUpInside" id="diI-CU-FCd"/>
+                            </connections>
+                        </view>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="f5E-dc-t9b" customClass="ThemeableRoundedButton" customModule="podcasts" customModuleProvider="target">
+                            <rect key="frame" x="0.0" y="72" width="343" height="56"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="56" id="y0c-mx-CdK"/>
+                            </constraints>
+                            <connections>
+                                <action selector="signInTapped" destination="-1" eventType="touchUpInside" id="oSv-QU-2xj"/>
+                            </connections>
+                        </view>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1kp-ow-mWD" customClass="ThemeableUIButton" customModule="podcasts" customModuleProvider="target">
+                            <rect key="frame" x="0.0" y="144" width="343" height="56"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="56" id="5rj-H8-ZjM"/>
+                            </constraints>
+                            <connections>
+                                <action selector="signInTapped" destination="-1" eventType="touchUpInside" id="lnA-eY-y3l"/>
+                            </connections>
+                        </view>
+                    </subviews>
+                </stackView>
             </subviews>
+            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
-                <constraint firstItem="f5E-dc-t9b" firstAttribute="trailing" secondItem="fnl-2z-Ty3" secondAttribute="trailing" constant="-16" id="0At-13-V11"/>
                 <constraint firstItem="nY7-Sl-Gxg" firstAttribute="centerX" secondItem="fnl-2z-Ty3" secondAttribute="centerX" id="2XD-1P-gsU"/>
-                <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="f5E-dc-t9b" secondAttribute="bottom" constant="16" id="4jE-Ap-ezm"/>
-                <constraint firstItem="f5E-dc-t9b" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="16" id="5XY-G3-NA6"/>
                 <constraint firstItem="xRp-Cs-cvI" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="23" id="63H-tj-FKR"/>
                 <constraint firstItem="oOL-Vb-lE7" firstAttribute="trailing" secondItem="fnl-2z-Ty3" secondAttribute="trailing" constant="8" id="BUi-ih-aEw"/>
                 <constraint firstItem="xRp-Cs-cvI" firstAttribute="top" secondItem="oOL-Vb-lE7" secondAttribute="bottom" constant="8" id="E6A-ke-Zci"/>
-                <constraint firstItem="J6c-um-8gq" firstAttribute="trailing" secondItem="fnl-2z-Ty3" secondAttribute="trailing" constant="-16" id="GQE-fm-2Sd"/>
-                <constraint firstItem="f5E-dc-t9b" firstAttribute="top" secondItem="J6c-um-8gq" secondAttribute="bottom" constant="16" id="Vsr-xK-2Lf"/>
-                <constraint firstItem="J6c-um-8gq" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="16" id="bV0-M1-iE8"/>
                 <constraint firstItem="xRp-Cs-cvI" firstAttribute="trailing" secondItem="fnl-2z-Ty3" secondAttribute="trailing" constant="-23" id="fQl-mz-Q3W"/>
                 <constraint firstItem="nY7-Sl-Gxg" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" priority="750" constant="60" id="gLh-ll-owx"/>
+                <constraint firstItem="GOk-uO-NBJ" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="16" id="hFj-W6-qY2"/>
                 <constraint firstItem="oOL-Vb-lE7" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="8" id="hjW-93-fBF"/>
                 <constraint firstItem="oOL-Vb-lE7" firstAttribute="top" secondItem="nY7-Sl-Gxg" secondAttribute="bottom" constant="14" id="kb6-5O-kH3"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="GOk-uO-NBJ" secondAttribute="trailing" constant="16" id="o5m-vl-ZJ4"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="GOk-uO-NBJ" secondAttribute="bottom" constant="16" id="oV3-Ch-3vg"/>
                 <constraint firstItem="xRp-Cs-cvI" firstAttribute="centerX" secondItem="fnl-2z-Ty3" secondAttribute="centerX" id="qa1-DW-bMa"/>
+                <constraint firstItem="GOk-uO-NBJ" firstAttribute="top" relation="greaterThanOrEqual" secondItem="xRp-Cs-cvI" secondAttribute="bottom" constant="8" id="sNp-lB-e79"/>
             </constraints>
             <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" translucent="NO" prompted="NO"/>
-            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <point key="canvasLocation" x="-816.79999999999995" y="23.838080959520241"/>
         </view>
     </objects>

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -96,6 +96,8 @@ internal enum L10n {
   internal static var accountDeleteAccountFirstAlertMsg: String { return L10n.tr("Localizable", "account_delete_account_first_alert_msg") }
   /// Delete Account?
   internal static var accountDeleteAccountTitle: String { return L10n.tr("Localizable", "account_delete_account_title") }
+  /// Log in
+  internal static var accountLogin: String { return L10n.tr("Localizable", "account_login") }
   /// Renews automatically monthly
   internal static var accountPaymentRenewsMonthly: String { return L10n.tr("Localizable", "account_payment_renews_monthly") }
   /// Renews automatically yearly

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -88,6 +88,9 @@
 /* Title for the confirmation dialog asking the user to confirm they want to delete their account. */
 "account_delete_account_title" = "Delete Account?";
 
+/* Button title to prompt a user to login. */
+"account_login" = "Log in";
+
 /* Informs the user that their purchase will be automatically renewed monthly */
 "account_payment_renews_monthly" = "Renews automatically monthly";
 

--- a/podcasts/podcasts.entitlements
+++ b/podcasts/podcasts.entitlements
@@ -6,6 +6,10 @@
 	<string>production</string>
 	<key>beta-reports-active</key>
 	<true/>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>webcredentials:www.pocketcasts.com</string>

--- a/podcasts/podcastsDebug.entitlements
+++ b/podcasts/podcastsDebug.entitlements
@@ -4,6 +4,10 @@
 <dict>
 	<key>aps-environment</key>
 	<string>development</string>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>webcredentials:www.pocketcasts.com</string>


### PR DESCRIPTION
| 📘 Project: #381 |
|:---:|

Adds the baseline for the Sign in with Apple Flow by exposing the Sign In with Apple Button when the feature is enabled. 

We're using the standard Sign In with Apple button, so some design details differ from what's in Figma. 

## To test
- Enable the Feature Flag `signInWithApple`
- Navigate to the Log in screen
- Look for a continue with Apple Button
- Check that Login takes you to the Password Login flow
- Disabling the Feature should show the same options as prod. 
<img width="300" src="https://user-images.githubusercontent.com/3384451/195415306-6cb302c8-ddd5-4a09-b341-26aac18cd5ad.png">

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
