### PR TITLE
Apple SSO: Happy Path

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Private/Protobuffer/api.pb.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Private/Protobuffer/api.pb.swift
@@ -200,6 +200,8 @@ struct Api_UserLoginResponse {
 
   var uuid: String = String()
 
+  var email: String = String()
+
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
@@ -4956,6 +4958,7 @@ extension Api_UserLoginResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageIm
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .same(proto: "token"),
     2: .same(proto: "uuid"),
+    3: .same(proto: "email"),
   ]
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -4966,6 +4969,7 @@ extension Api_UserLoginResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageIm
       switch fieldNumber {
       case 1: try { try decoder.decodeSingularStringField(value: &self.token) }()
       case 2: try { try decoder.decodeSingularStringField(value: &self.uuid) }()
+      case 3: try { try decoder.decodeSingularStringField(value: &self.email) }()
       default: break
       }
     }
@@ -4978,12 +4982,16 @@ extension Api_UserLoginResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageIm
     if !self.uuid.isEmpty {
       try visitor.visitSingularStringField(value: self.uuid, fieldNumber: 2)
     }
+    if !self.email.isEmpty {
+      try visitor.visitSingularStringField(value: self.email, fieldNumber: 3)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: Api_UserLoginResponse, rhs: Api_UserLoginResponse) -> Bool {
     if lhs.token != rhs.token {return false}
     if lhs.uuid != rhs.uuid {return false}
+    if lhs.email != rhs.email {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+Account.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+Account.swift
@@ -124,8 +124,8 @@ public extension ApiServerHandler {
         }
     }
 
-    internal func obtainToken(request: URLRequest, completion: @escaping (Result<AuthenticationResponse, APIError>) -> Void) {
-        urlSession.dataTask(with: request) { data, response, error in
+    func obtainToken(request: URLRequest, completion: @escaping (Result<AuthenticationResponse, APIError>) -> Void) {
+        URLSession.shared.dataTask(with: request) { data, response, error in
             guard let responseData = data, error == nil, response?.extractStatusCode() == ServerConstants.HttpConstants.ok else {
                 let errorResponse = ApiServerHandler.extractErrorResponse(data: data, error: error)
                 FileLog.shared.addMessage("Unable to obtain token, status code: \(response?.extractStatusCode() ?? -1), server error: \(errorResponse?.rawValue ?? "none")")
@@ -144,7 +144,7 @@ public extension ApiServerHandler {
         }.resume()
     }
 
-    internal class func extractErrorResponse(data: Data?, error: Error? = nil) -> APIError? {
+    class func extractErrorResponse(data: Data?, error: Error? = nil) -> APIError? {
         if let data = data {
             do {
                 let errorJson = try JSON(data: data)

--- a/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+SocialAuth.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+SocialAuth.swift
@@ -1,0 +1,20 @@
+import Foundation
+import PocketCastsDataModel
+import PocketCastsUtils
+
+public extension ApiServerHandler {
+    func validateLogin(identityToken: Data?, completion: @escaping (Result<AuthenticationResponse, APIError>) -> Void) {
+        let url = ServerHelper.asUrl(ServerConstants.Urls.api() + "user/login_apple")
+        guard var request = ServerHelper.createEmptyProtoRequest(url: url),
+              let identityToken = identityToken,
+              let token = String(data: identityToken, encoding: .utf8)
+        else {
+            FileLog.shared.addMessage("Unable to create protobuffer request to obtain token")
+            completion(.failure(.UNKNOWN))
+            return
+        }
+
+        request.setValue("Bearer \(token)", forHTTPHeaderField: ServerConstants.HttpHeaders.authorization)
+        obtainToken(request: request, completion: completion)
+    }
+}

--- a/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+SocialAuth.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+SocialAuth.swift
@@ -9,7 +9,7 @@ public extension ApiServerHandler {
               let identityToken = identityToken,
               let token = String(data: identityToken, encoding: .utf8)
         else {
-            FileLog.shared.addMessage("Unable to create protobuffer request to obtain token")
+            FileLog.shared.addMessage("Unable to create protobuffer request to obtain token via Apple SSO")
             completion(.failure(.UNKNOWN))
             return
         }

--- a/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler.swift
@@ -5,6 +5,11 @@ import SwiftProtobuf
 
 public class ApiServerHandler {
     public static let shared = ApiServerHandler()
+    internal let urlSession: URLSession
+
+    init(urlSession: URLSession = URLSession.shared) {
+        self.urlSession = urlSession
+    }
 
     lazy var apiQueue: OperationQueue = {
         let queue = OperationQueue()

--- a/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler.swift
@@ -5,11 +5,6 @@ import SwiftProtobuf
 
 public class ApiServerHandler {
     public static let shared = ApiServerHandler()
-    internal let urlSession: URLSession
-
-    init(urlSession: URLSession = URLSession.shared) {
-        self.urlSession = urlSession
-    }
 
     lazy var apiQueue: OperationQueue = {
         let queue = OperationQueue()

--- a/Modules/Server/Sources/PocketCastsServer/Public/Models/AuthenticationResponse.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Models/AuthenticationResponse.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+public struct AuthenticationResponse: Codable {
+    public let token: String?
+    public let uuid: String?
+    public let email: String?
+
+    internal init(from apiResponse: Api_UserLoginResponse) {
+        token = apiResponse.token.isEmpty ? nil : apiResponse.token
+        uuid = apiResponse.uuid.isEmpty ? nil : apiResponse.uuid
+        email = apiResponse.email.isEmpty ? nil : apiResponse.email
+    }
+}

--- a/Modules/Server/Sources/PocketCastsServer/Public/ServerHelper.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/ServerHelper.swift
@@ -112,12 +112,18 @@ public class ServerHelper: NSObject {
     }
 
     class func createProtoRequest(url: URL, data: Data) -> URLRequest? {
+        var request = createEmptyProtoRequest(url: url)
+        request?.httpBody = data
+
+        return request
+    }
+
+    class func createEmptyProtoRequest(url: URL) -> URLRequest? {
         var request = URLRequest(url: url, cachePolicy: .useProtocolCachePolicy, timeoutInterval: 15.seconds)
         request.httpMethod = "POST"
         request.addValue("application/octet-stream", forHTTPHeaderField: ServerConstants.HttpHeaders.accept)
         request.setValue("application/octet-stream", forHTTPHeaderField: ServerConstants.HttpHeaders.contentType)
         request.setValue(ServerConfig.shared.syncDelegate?.privateUserAgent(), forHTTPHeaderField: ServerConstants.HttpHeaders.userAgent)
-        request.httpBody = data
 
         return request
     }

--- a/Modules/Server/Sources/PocketCastsServer/Public/ServerSettings.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/ServerSettings.swift
@@ -306,11 +306,6 @@ public class ServerSettings {
         UserDefaults.standard.setValue(action.rawValue, forKey: onAutoAddLimitReachedKey)
     }
 
-    // Sync Token
-    public class func syncingV2Token() -> String? {
-        KeychainHelper.string(for: ServerConstants.Values.syncingV2TokenKey)
-    }
-
     public class func syncSettings() {
         guard SyncManager.isUserLoggedIn(), ServerSettings.marketingOptInNeedsSyncing() || SubscriptionHelper.subscriptionGiftAcknowledgementNeedsSyncing() else { return }
 
@@ -318,7 +313,7 @@ public class ServerSettings {
     }
 }
 
-// MARK: - User ID Support
+// MARK: - Authentication Support
 
 public extension ServerSettings {
     class var userId: String? {
@@ -328,6 +323,16 @@ public extension ServerSettings {
 
         set {
             UserDefaults.standard.set(newValue, forKey: ServerConstants.UserDefaults.userId)
+        }
+    }
+
+    class var syncingV2Token: String? {
+        get {
+            KeychainHelper.string(for: ServerConstants.Values.syncingV2TokenKey)
+        }
+
+        set {
+            KeychainHelper.save(string: newValue, key: ServerConstants.Values.syncingV2TokenKey, accessibility: kSecAttrAccessibleAfterFirstUnlock)
         }
     }
 }

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -362,7 +362,7 @@
 		463D169E27CE7E5C008FA135 /* EpisodeDetailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 463D169D27CE7E5C008FA135 /* EpisodeDetailsViewModel.swift */; };
 		463FCE7D27BEA90B00E5AF89 /* WatchInterfaceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 463FCE7C27BEA90B00E5AF89 /* WatchInterfaceType.swift */; };
 		463FCE7F27BEAE6400E5AF89 /* WatchHostingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 463FCE7E27BEAE6400E5AF89 /* WatchHostingController.swift */; };
-		4647623328F733D4006D005A /* AuthenticationServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4647623228F733D3006D005A /* AuthenticationServices.framework */; };
+		4647623128F70CD0006D005A /* AuthenticationHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4647623028F70CD0006D005A /* AuthenticationHelper.swift */; };
 		4649404327D94757007F29C8 /* EpisodeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4649404227D94757007F29C8 /* EpisodeViewModel.swift */; };
 		464B481F27E8FC7E00107CBF /* NowPlayingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 464B481E27E8FC7E00107CBF /* NowPlayingViewModel.swift */; };
 		4650F5C128ECC6D1006A5704 /* CrashLoggingDataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4650F5C028ECC6D1006A5704 /* CrashLoggingDataProvider.swift */; };
@@ -415,6 +415,7 @@
 		46B5DFD427EA2739006FC2ED /* NowPlayingContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46B5DFD327EA2739006FC2ED /* NowPlayingContainerView.swift */; };
 		46B5DFD827EA2A80006FC2ED /* NowPlayingOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46B5DFD727EA2A80006FC2ED /* NowPlayingOptions.swift */; };
 		46B5DFDA27EA4F12006FC2ED /* VolumeControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46B5DFD927EA4F12006FC2ED /* VolumeControl.swift */; };
+		46C22EE028F73D9A00F4173B /* AuthenticationServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 46C22EDF28F73D9900F4173B /* AuthenticationServices.framework */; };
 		46C3D552275EA16200DDE116 /* SingleEpisodeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46C3D551275EA16200DDE116 /* SingleEpisodeViewController.swift */; };
 		46C3D554275EA19B00DDE116 /* SingleEpisodeViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 46C3D553275EA19B00DDE116 /* SingleEpisodeViewController.xib */; };
 		46C3D556275EA6C400DDE116 /* DiscoverEpisodeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46C3D555275EA6C400DDE116 /* DiscoverEpisodeViewModel.swift */; };
@@ -1854,7 +1855,7 @@
 		463D169D27CE7E5C008FA135 /* EpisodeDetailsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EpisodeDetailsViewModel.swift; sourceTree = "<group>"; };
 		463FCE7C27BEA90B00E5AF89 /* WatchInterfaceType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchInterfaceType.swift; sourceTree = "<group>"; };
 		463FCE7E27BEAE6400E5AF89 /* WatchHostingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchHostingController.swift; sourceTree = "<group>"; };
-		4647623228F733D3006D005A /* AuthenticationServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AuthenticationServices.framework; path = System/Library/Frameworks/AuthenticationServices.framework; sourceTree = SDKROOT; };
+		4647623028F70CD0006D005A /* AuthenticationHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationHelper.swift; sourceTree = "<group>"; };
 		4649404227D94757007F29C8 /* EpisodeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EpisodeViewModel.swift; sourceTree = "<group>"; };
 		464B481E27E8FC7E00107CBF /* NowPlayingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowPlayingViewModel.swift; sourceTree = "<group>"; };
 		4650F5C028ECC6D1006A5704 /* CrashLoggingDataProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashLoggingDataProvider.swift; sourceTree = "<group>"; };
@@ -1920,6 +1921,7 @@
 		46B5DFD927EA4F12006FC2ED /* VolumeControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolumeControl.swift; sourceTree = "<group>"; };
 		46B867C227A08C35006CDBA0 /* ScreenshotAutomation_iPhone_Light_Interface.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = ScreenshotAutomation_iPhone_Light_Interface.xctestplan; sourceTree = "<group>"; };
 		46B867C327A08C85006CDBA0 /* ScreenshotAutomation_iPhone_Dark_Interface.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = ScreenshotAutomation_iPhone_Dark_Interface.xctestplan; sourceTree = "<group>"; };
+		46C22EDF28F73D9900F4173B /* AuthenticationServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AuthenticationServices.framework; path = System/Library/Frameworks/AuthenticationServices.framework; sourceTree = SDKROOT; };
 		46C3D551275EA16200DDE116 /* SingleEpisodeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleEpisodeViewController.swift; sourceTree = "<group>"; };
 		46C3D553275EA19B00DDE116 /* SingleEpisodeViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SingleEpisodeViewController.xib; sourceTree = "<group>"; };
 		46C3D555275EA6C400DDE116 /* DiscoverEpisodeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverEpisodeViewModel.swift; sourceTree = "<group>"; };
@@ -2911,7 +2913,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4647623328F733D4006D005A /* AuthenticationServices.framework in Frameworks */,
+				46C22EE028F73D9A00F4173B /* AuthenticationServices.framework in Frameworks */,
 				468F00D327CD575C00FFAAAA /* FirebasePerformance in Frameworks */,
 				BD11C41D2524741C00E308E6 /* CarPlay.framework in Frameworks */,
 				BD44F750267C850000810148 /* DifferenceKit in Frameworks */,
@@ -4441,6 +4443,7 @@
 				BDDAE72B27F2E76B003741A1 /* FileTypeUtil.swift */,
 				8B484EF428D23BEF001AFA97 /* PlaybackTimeHelper.swift */,
 				C7F4BAB428DA6BBB001C9785 /* BackgroundSignOutListener.swift */,
+				4647623028F70CD0006D005A /* AuthenticationHelper.swift */,
 			);
 			name = "Managers and Helpers";
 			sourceTree = "<group>";
@@ -5217,7 +5220,7 @@
 		BDBD53EE17019B2A0048C8C5 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				4647623228F733D3006D005A /* AuthenticationServices.framework */,
+				46C22EDF28F73D9900F4173B /* AuthenticationServices.framework */,
 				BD11C41C2524741C00E308E6 /* CarPlay.framework */,
 				BD3C61A5221A91150061341D /* liblottie-ios.a */,
 				BD3C61A3221A90EA0061341D /* liblottie-ios.a */,
@@ -7564,6 +7567,7 @@
 				BDED9312251DD5EB000BF622 /* CarPlayImageHelper.swift in Sources */,
 				BDB206AA2191734D00C1E456 /* NowPlayingHelper.swift in Sources */,
 				400AB301220BA8DC0003EE21 /* UploadedViewController+Table.swift in Sources */,
+				4647623128F70CD0006D005A /* AuthenticationHelper.swift in Sources */,
 				BDDF8AA2240CE240009BA263 /* PlaylistViewController+Swipe.swift in Sources */,
 				BD9324742398BB6B004F19A1 /* TourViewController.swift in Sources */,
 				BD2B6DCB231FD9A800E76FF7 /* DiscoverPodcastSearchResultsController.swift in Sources */,

--- a/podcasts/AuthenticationHelper.swift
+++ b/podcasts/AuthenticationHelper.swift
@@ -1,0 +1,39 @@
+import Foundation
+import PocketCastsDataModel
+import PocketCastsServer
+import AuthenticationServices
+
+class AuthenticationHelper {
+    static func processAppleIDCredential(_ appleIDCredential: ASAuthorizationAppleIDCredential, _ completion: @escaping (Result<Bool, Error>) -> Void) {
+        ApiServerHandler.shared.validateLogin(identityToken: appleIDCredential.identityToken) { result in
+            switch result {
+            case .success(let response):
+                handleSuccessfulSignIn(response)
+                completion(.success(true))
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
+    }
+
+    private static func handleSuccessfulSignIn(_ response: AuthenticationResponse) {
+        SyncManager.clearTokensFromKeyChain()
+
+        ServerSettings.userId = response.uuid
+        ServerSettings.syncingV2Token = response.token
+
+        // we've signed in, set all our existing podcasts to be non synced
+        DataManager.sharedManager.markAllPodcastsUnsynced()
+
+        ServerSettings.clearLastSyncTime()
+        ServerSettings.setSyncingEmail(email: response.email)
+
+        NotificationCenter.default.post(name: .userLoginDidChange, object: nil)
+        // TODO: Track login source details
+//        Analytics.track(.userSignedIn)
+
+        RefreshManager.shared.refreshPodcasts(forceEvenIfRefreshedRecently: true)
+        Settings.setPromotionFinishedAcknowledged(true)
+        Settings.setLoginDetailsUpdated()
+    }
+}

--- a/podcasts/EpisodeManager.swift
+++ b/podcasts/EpisodeManager.swift
@@ -372,7 +372,7 @@ class EpisodeManager: NSObject {
         } else if let episode = episode as? Episode, let url = episode.downloadUrl {
             return URL(string: url)
         } else if let episode = episode as? UserEpisode {
-            if let token = ServerSettings.syncingV2Token(), episode.uploadStatus != UploadStatus.missing.rawValue {
+            if let token = ServerSettings.syncingV2Token, episode.uploadStatus != UploadStatus.missing.rawValue {
                 return URL(string: "\(ServerConstants.Urls.api())files/url/\(episode.uuid)?token=\(token)")
             }
         }


### PR DESCRIPTION
| 📘 Project: #381 | Depends on: https://github.com/Automattic/pocket-casts-ios/pull/387 |
|:---:|:---:|

Connects the Continue with Apple Button to the login flow for connecting an Apple ID to an existing Sync Account.

📓 This doesn't handle Errors yet and will need to handle [Token refreshes](https://github.com/Automattic/pocket-casts-ios/blob/33a541ed0af33691a6d1b462dc84a1a1956ad0c0/Modules/Server/Sources/PocketCastsServer/Private/TokenHelper.swift#L53) still those will come in a follow-up PR. 

📓 You'll need a Sync account with the same email address as your Apple ID in the Staging environment to test this.

## To test
1. Enable the Feature Flag `signInWithApple`
2. Switch your Scheme to `Staging`
3. Navigate to the Log in screen
4. Complete the Login flow and select to Share your email (hiding email will fail)

Expect to:
- Be logged in
- The log in screen to dismiss
- Your podcasts to sync to the device. 

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
