### PR TITLE
Manually update fr-CA strings

### DIFF
--- a/podcasts/fr-CA.lproj/Localizable.strings
+++ b/podcasts/fr-CA.lproj/Localizable.strings
@@ -1,10 +1,10 @@
-/* Translation-Revision-Date: 2022-08-01 16:48:27+0000 */
-/* Plural-Forms: nplurals=2; plural=n != 1; */
+/* Translation-Revision-Date: 2022-10-04 11:54:03+0000 */
+/* Plural-Forms: nplurals=2; plural=n > 1; */
 /* Generator: GlotPress/2.4.0-alpha */
 /* Language: fr_CA */
 
 /* Subtitle for the toggle to auto add new files to the Up Next Queue. */
-"Settings_files_add_up_next_subtitle" = "Ajouter automatiquement de nouveaux fichiers aux Prochains épisodes";
+"Settings_files_add_up_next_subtitle" = "Ajouter automatiquement les nouveaux fichiers à la file d’attente";
 
 /* Button that takes you to other Automattic apps, eg: our Automattic family of apps */
 "about_a8c_family" = "Famille Automattic";
@@ -13,7 +13,7 @@
 "about_acknowledgements" = "Remerciements";
 
 /* Secondary text on our come with with us call out */
-"about_join_from_anywhere" = "Inscrivez-vous de partout";
+"about_join_from_anywhere" = "Rejoignez-nous, où que vous soyez";
 
 /* Button that takes the user to legal and more screen */
 "about_legal_and_more" = "Droit et divers";
@@ -22,10 +22,10 @@
 "about_privacy_policy" = "Politique de confidentialité";
 
 /* About page text to ask the user to rate our app in the App Store */
-"about_rate_us" = "Évaluez-nous";
+"about_rate_us" = "Donnez-nous votre avis";
 
 /* About page text to ask the user to share a link to our app with friends */
-"about_share_friends" = "Partager avec des amis";
+"about_share_friends" = "Partagez l’application avec vos amis";
 
 /* Button that takes the user to terms of service screen */
 "about_terms_of_service" = "Conditions d’utilisation";
@@ -34,16 +34,16 @@
 "about_website" = "Site Web";
 
 /* Main callout to come get a job with Automattic */
-"about_work_with_us" = "Travaillez avec nous";
+"about_work_with_us" = "Rejoignez-nous";
 
 /* A common string used throughout the app. An accessibility label to direct the user to turn off the multi-select mode. */
 "accessibility_cancel_multiselect" = "Annuler la sélection multiple";
 
 /* A common string used throughout the app. Accessibility hint to inform that the control closes the current dialog window. */
-"accessibility_close_dialog" = "Fermer la boîte";
+"accessibility_close_dialog" = "Fermer la boîte de dialogue";
 
 /* A common string used throughout the app. Accessibility hint to inform the user that this control will deselect the episode. */
-"accessibility_deselect_episode" = "Désélectionner un épisode";
+"accessibility_deselect_episode" = "Désélectionner l’épisode";
 
 /* A common string used throughout the app. Accessibility hint to inform that the control is disabled. */
 "accessibility_disabled" = "Désactivé";
@@ -55,7 +55,7 @@
 "accessibility_hide_filter_details" = "Appuyer pour masquer les détails du filtre";
 
 /* Accessibility hint to inform the user how to star (favorite) for an episode. */
-"accessibility_hint_star" = "Appuyer deux fois pour ajouter l’épisode dans les favoris";
+"accessibility_hint_star" = "Appuyer deux fois pour ajouter l’épisode aux favoris";
 
 /* Accessibility hint to inform the user how to un-star (remove favorite) for an episode. */
 "accessibility_hint_unstar" = "Appuyer deux fois pour retirer l’épisode des favoris";
@@ -64,10 +64,10 @@
 "accessibility_more_actions" = "Plus d’actions";
 
 /* A common string used throughout the app. An accessibility label to inform the user the completed percentage of a given task. '%1$@' is a placeholder for the localized spelled out number for Voice Over */
-"accessibility_percent_complete_format" = "%1$@ pour cent terminé";
+"accessibility_percent_complete_format" = "%1$@ pour cent effectué";
 
 /* Accessibility text listing the current value for the playback speed. '%1$@' is a placeholder for the playback speed. */
-"accessibility_player_effects_playback_speed" = "Vitesse de lecture %1$@ fois";
+"accessibility_player_effects_playback_speed" = "Vitesse de lecture %1$@ fois";
 
 /* Accessibility hint to inform the user which filter color flag is being used. '%1$@' is a placeholder for the filter color number. */
 "accessibility_playlist_color" = "Couleur de la playlist %1$@";
@@ -79,7 +79,7 @@
 "accessibility_profile_settings" = "Réglages de Pocket Casts";
 
 /* A common string used throughout the app. Accessibility hint to inform the user that this control will select the episode. */
-"accessibility_select_episode" = "Sélectionner un épisode";
+"accessibility_select_episode" = "Sélectionner l’épisode";
 
 /* An accessibility label to direct the user tap to get access to filter details. */
 "accessibility_show_filter_details" = "Appuyer pour afficher les détails du filtre";
@@ -91,25 +91,25 @@
 "accessibility_sort_and_options" = "Tri et options";
 
 /* Prompt to allow the user to update the email associated to their account. */
-"account_change_email" = "Changer l’adresse courriel";
+"account_change_email" = "Changer d’adresse e-mail";
 
 /* Nudge to inform the user that they are nearly done with the account set up steps. */
-"account_completion_nudge" = "Vous y êtes presque!";
+"account_completion_nudge" = "Vous y êtes presque !";
 
 /* Message portion of the nudge to inform the user that they are nearly done with the account set up steps. */
-"account_completion_nudge_msg" = "Terminez votre paiement pour achever la mise à niveau de votre compte.";
+"account_completion_nudge_msg" = "Finalisez votre paiement pour terminer la mise à niveau de votre compte.";
 
 /* Title informing the user that their account has been successfully created */
 "account_created" = "Compte créé";
 
 /* Title for the final screen in the account creation flow. */
-"account_creation_complete" = "Terminer le compte";
+"account_creation_complete" = "Compte finalisé";
 
 /* Prompt to allow the user to delete their account. */
 "account_delete_account" = "Supprimer le compte";
 
 /* Confirmation option for deleting the user account. */
-"account_delete_account_conf" = "Oui, je veux le supprimer";
+"account_delete_account_conf" = "Oui, supprimez-le";
 
 /* Error title for when the delete account process has failed. */
 "account_delete_account_error" = "Échec de la suppression du compte";
@@ -118,37 +118,37 @@
 "account_delete_account_error_msg" = "Impossible de supprimer le compte.";
 
 /* The final alert message for the confirmation dialog asking the user to confirm they want to delete their account. */
-"account_delete_account_final_alert_msg" = "Dernière chance : voulez-vous définitivement supprimer votre compte? Vous perdrez tous vos abonnements et votre historique de lecture de façon permanente!";
+"account_delete_account_final_alert_msg" = "Dernière chance, vous voulez vraiment supprimer votre compte ? Vous perdrez définitivement tous vos abonnements et votre historique de lecture !";
 
 /* The first message for the confirmation dialog asking the user to confirm they want to delete their account. */
-"account_delete_account_first_alert_msg" = "Voulez-vous vraiment supprimer votre compte? Il n’y a rien à faire pour revenir en arrière par la suite.";
+"account_delete_account_first_alert_msg" = "Êtes-vous sûr de vouloir supprimer votre compte, il n’y a aucun moyen d’annuler cette action !";
 
 /* Title for the confirmation dialog asking the user to confirm they want to delete their account. */
-"account_delete_account_title" = "Supprimer le compte?";
+"account_delete_account_title" = "Supprimer le compte ?";
 
 /* Informs the user that their purchase will be automatically renewed monthly */
-"account_payment_renews_monthly" = "Se renouvelle automatiquement chaque mois";
+"account_payment_renews_monthly" = "Renouvellement mensuel automatique";
 
 /* Informs the user that their purchase will be automatically renewed yearly */
-"account_payment_renews_yearly" = "Se renouvelle automatiquement chaque année";
+"account_payment_renews_yearly" = "Renouvellement annuel automatique";
 
 /* Allows the user to ope a screen to review the Privacy Policy */
 "account_privacy_policy" = "Politique de confidentialité";
 
 /* Error message for when the account registration request has failed. */
-"account_registration_failed" = "Échec de l’inscription. Veuillez réessayer plus tard.";
+"account_registration_failed" = "L’enregistrement a échoué, veuillez réessayer plus tard";
 
 /* Prompt to allow the user to choose their account time when setting up their account. */
 "account_select_type" = "Sélectionner le type de compte";
 
 /* Prompt to allow the user to sign out of their account. */
-"account_sign_out" = "Se déconnecter";
+"account_sign_out" = "Déconnexion";
 
 /* Confirmation dialog informing the user that signing out will remove the given number of supported podcasts. '%1$@' is a placeholder for the number of supported podcasts. */
-"account_sign_out_supporter_prompt" = "En vous déconnectant, les %1$@ balados que vous soutenez seront supprimés de cet appareil. Êtes-vous certain(e)?";
+"account_sign_out_supporter_prompt" = "En vous déconnectant, vous supprimez %1$@ podcasts pris en charge sur cet appareil. Confirmez-vous ?";
 
 /* Subtitle to the Confirmation dialog informing the user that signing out will remove the given number of supported podcasts. */
-"account_sign_out_supporter_subtitle" = "Vous pouvez vous connecter de nouveau pour récupérer l’accès.";
+"account_sign_out_supporter_subtitle" = "Vous pouvez vous reconnecter pour récupérer l’accès.";
 
 /* Message/Body of an alert that explains that the user should tap a button and sign in again */
 "account_signed_out_alert_message" = "Turns out, if you type Google into Google, you can break the internet. 🫢 \n\nTap the button below to sign into your Pocket Casts account again.";
@@ -163,13 +163,13 @@
 "account_upgraded" = "Compte mis à niveau";
 
 /* Welcome message presented after a user has signed up for Pocket Casts */
-"account_welcome" = "Bienvenue à Pocket Casts!";
+"account_welcome" = "Bienvenue sur Pocket Casts !";
 
 /* Welcome message presented after a user has signed up for Pocket Casts Plus */
-"account_welcome_plus" = "Bienvenue à Pocket Casts Plus!";
+"account_welcome_plus" = "Bienvenue sur Pocket Casts Plus !";
 
 /* A common string used throughout the app. Title for the prompt to add an episode to the up next queue. */
-"add_to_up_next" = "Ajouter à la file d’attente Prochains épisodes";
+"add_to_up_next" = "Ajouter à la file d'attente";
 
 /* A common string used throughout the app. Option that determines the behavior of the app after playing an item. */
 "after_playing" = "Après la lecture";
@@ -184,7 +184,7 @@
 "app_icon_dark" = "Sombre";
 
 /* The name for the Default App Icon */
-"app_icon_default" = "Par défaut";
+"app_icon_default" = "Valeur par défaut";
 
 /* The name for the Electric Blue App Icon */
 "app_icon_electric_blue" = "Bleu électrique";
@@ -199,43 +199,43 @@
 "app_icon_plus" = "Plus";
 
 /* The name for the Pocket Cats App Icon. The name for this one is meant to be a play on the App name Pocket Casts and the icon includes a cat image. */
-"app_icon_pocket_cats" = "Chats Pocket";
+"app_icon_pocket_cats" = "Pocket Cats";
 
 /* The name for the Radioactivity App Icon */
 "app_icon_radioactivity" = "Radioactivité";
 
 /* The name for the Red Velvet App Icon */
-"app_icon_red_velvet" = "Rouge velours";
+"app_icon_red_velvet" = "Velours rouge";
 
 /* The name for the Rosé App Icon */
 "app_icon_rose" = "Rosé";
 
 /* The name for the Round Dark App Icon */
-"app_icon_round_dark" = "Cercle sombre";
+"app_icon_round_dark" = "Ronde sombre";
 
 /* The name for the Round Light App Icon */
-"app_icon_round_light" = "Cercle clair";
+"app_icon_round_light" = "Ronde claire";
 
 /* Text sent when sharing a link to our app with other people */
-"app_share_text" = "Hé! Voici un lien pour télécharger l’application Pocket Casts. Je l’aime beaucoup et je pense que tu l’aimeras aussi.";
+"app_share_text" = "Salut, Voici un lien pour télécharger l’application Pocket Casts. Je la trouve super et je me suis dit qu’elle pourrait aussi te plaire.";
 
 /* App version label in the about controller. `%1$@` is a placeholder for the version number and %2$@ is a placeholder for the build number */
 "app_version" = "Version %1$@ (%2$@)";
 
 /* Section header for the appearance settings related to app icons. */
-"appearance_app_icon_header" = "Icône de l’application";
+"appearance_app_icon_header" = "Icône de l’app";
 
 /* Section header for the appearance settings related to artwork. */
-"appearance_artwork_header" = "Illustration du balado";
+"appearance_artwork_header" = "Illustration du podcast";
 
 /* Label for letting the user choose a theme for iOS dark mode. */
 "appearance_dark_theme" = "Thème sombre";
 
 /* Prompt to toggle on the use of artwork that's embedded in the episode download files. */
-"appearance_embedded_artwork" = "Utiliser l’illustration intégrée";
+"appearance_embedded_artwork" = "Utiliser les illustrations intégrées";
 
 /* Subtitle explaining embedded artwork in the episode download files. */
-"appearance_embedded_artwork_subtitle" = "Affiche l’illustration des émissions du fichier téléchargé (s’il existe) dans le lecteur plutôt que d’utiliser l’illustration de l’émission.";
+"appearance_embedded_artwork_subtitle" = "Affiche l’illustration du fichier téléchargé (si elle existe) dans le lecteur au lieu d’utiliser l’illustration de l’émission.";
 
 /* Label for letting the user choose a theme for iOS light mode. */
 "appearance_light_theme" = "Thème clair";
@@ -244,67 +244,67 @@
 "appearance_match_device_theme" = "Utiliser le mode clair\/sombre d’iOS";
 
 /* Prompt to refresh the artwork for all podcasts. */
-"appearance_refresh_all_artwork" = "Actualiser l’illustration de tous les balados";
+"appearance_refresh_all_artwork" = "Actualiser toutes les illustrations de podcast";
 
 /* Confirmation message used to inform the user that the refresh has been successfully triggered. */
-"appearance_refresh_all_artwork_conf_msg" = "Actualisation de votre illustration";
+"appearance_refresh_all_artwork_conf_msg" = "Actualiser votre illustration maintenant";
 
 /* Confirmation title used to inform the user that the refresh has been successfully triggered. */
-"appearance_refresh_all_artwork_conf_title" = "Oui, oui, Capitaine";
+"appearance_refresh_all_artwork_conf_title" = "Oui oui, mon capitaine";
 
 /* Section header for the appearance settings related to themes. */
 "appearance_theme_header" = "Thème";
 
 /* Header for asking the user to select a theme. */
-"appearance_theme_select" = "Sélectionner le thème";
+"appearance_theme_select" = "Sélectionner un thème";
 
 /* A common string used throughout the app. Prompt to archive the selected item(s). */
 "archive" = "Archiver";
 
 /* A common string used throughout the app. Confirmation prompt before moving forward. */
-"are_you_sure" = "Êtes-vous certain(e)?";
+"are_you_sure" = "Confirmez-vous ?";
 
 /* A common string used throughout the app. Prompt to configure the auto add options for a podcast. */
 "auto_add" = "Ajout automatique à";
 
 /* Option in the auto add dialog to add the items to the bottom of the queue. */
-"auto_add_to_bottom" = "Au bas";
+"auto_add_to_bottom" = "Vers le bas";
 
 /* Option in the auto add dialog to add the items to the top of the queue. */
-"auto_add_to_top" = "Au haut";
+"auto_add_to_top" = "Vers le haut";
 
 /* Option in the auto add settings to stop adding options once the limit is reached. This option won't add new episodes. */
-"auto_add_to_up_next_stop" = "Arrêter l’ajout de nouveaux épisodes";
+"auto_add_to_up_next_stop" = "Arrêter d’ajouter de nouveaux épisodes";
 
 /* Option in the auto add settings to stop adding options once the limit is reached. This option won't add new episodes. To conserve space this should be a more concise version of 'Stop Adding New Episodes' */
-"auto_add_to_up_next_stop_short" = "Arrêter l’ajout";
+"auto_add_to_up_next_stop_short" = "Arrêter d’ajouter";
 
 /* Option in the auto add settings to stop adding options once the limit is reached. This option will add the podcast to the top top the queue and drop the bottom. */
-"auto_add_to_up_next_top_only" = "Ajouter uniquement au haut de la liste";
+"auto_add_to_up_next_top_only" = "Ajouter uniquement au début";
 
 /* Option in the auto add settings to stop adding options once the limit is reached. This option will add the podcast to the top top the queue and drop the bottom. To conserve space this shouldn't be longer than the English string. If needed "Add To Top" or "To Top" can be translated instead */
 "auto_add_to_up_next_top_only_short" = "Ajouter uniquement au début de la file d’attente";
 
 /* Title for the dialog box that presents the available options for how many episodes for auto download from a filter. */
-"auto_download_first" = "Téléchargement automatique du premier épisode";
+"auto_download_first" = "Télécharger automatiquement les premiers";
 
 /* Subtitle for the auto download setting. This is displayed when the option is turned off. */
-"auto_download_off_subtitle" = "Activer le téléchargement automatique des épisodes dans ce filtre";
+"auto_download_off_subtitle" = "Activer pour télécharger automatiquement les épisodes dans ce filtre";
 
 /* Subtitle for the auto download setting. This is displayed when the option is turned on. '%1$@' is a placeholder for the number of episodes, this will be more than one. */
-"auto_download_on_plural_format" = "Les %1$@ premiers épisodes dans ce filtre seront automatiquement téléchargés.";
+"auto_download_on_plural_format" = "Les %1$@ premiers épisodes de ce filtre seront automatiquement téléchargés.";
 
 /* Provides hint text to auto download the a the first of a configurable amount of episodes. Accompanied by a label indicating how many episodes will be auto downloaded. */
 "auto_download_prompt_first" = "Premiers";
 
 /* A common string used throughout the app. Title for the back button. Used with the accessibility settings. */
-"back" = "Revenir";
+"back" = "Retour";
 
 /* A common string used throughout the app. Title option to place the item at the bottom of the queue. */
 "bottom" = "Bas";
 
 /* A common string used throughout the app. Informs the user of the maximum amount of bulk downloads. '%1$@' is a placeholder for maximum amount of bulk downloads. */
-"bulk_download_max_format" = "Les téléchargements en lot sont limités à %1$@.";
+"bulk_download_max_format" = "Les téléchargements en masse sont limités à %1$@.";
 
 /* A common string used throughout the app. Prompt to cancel the current flow. */
 "cancel" = "Annuler";
@@ -322,7 +322,7 @@
 "canceling" = "Annulation...";
 
 /* CarPlay subtitle information label that includes the current chapter and total chapter count and the current chapter length. '%1$@' is a placeholder for the current chapter. '%2$@' is a placeholder for the total chapters. '%3$@' is a placeholder for the length of the current chapter. */
-"carplay_chapter_count" = "%1$@ de %2$@. %3$@";
+"carplay_chapter_count" = "%1$@ sur %2$@. %3$@";
 
 /* Provides a link to the menu to present more options. */
 "carplay_more" = "Plus";
@@ -331,55 +331,55 @@
 "carplay_playback_speed" = "Vitesse de lecture";
 
 /* CarPlay prompt to navigate to the up next Queue. */
-"carplay_up_next_queue" = "File d’attente Prochains épisodes";
+"carplay_up_next_queue" = "File d’attente";
 
 /* Prompt to allow the user to update their email address. */
-"change_email" = "Changer d’adresse courriel";
+"change_email" = "Changer d’adresse e-mail";
 
 /* Confirmation message title informing the user that their email has been successfully updated. */
-"change_email_conf" = "Adresse courriel modifiée";
+"change_email_conf" = "Adresse e-mail modifiée";
 
 /* Prompt to allow the user to Update their password. */
 "change_password" = "Changer le mot de passe";
 
 /* Confirmation message title informing the user that their password has been successfully updated. */
-"change_password_conf" = "Mot de passe changé";
+"change_password_conf" = "Mot de passe modifié";
 
 /* Error message informing the user that the change password process failed. */
-"change_password_error" = "Impossible de changer le mot de passe. Mot de passe non valide.";
+"change_password_error" = "Impossible de changer le mot de passe. Mot de passe invalide.";
 
 /* Error message informing the user that the change password process failed because they failed to enter matching passwords. */
-"change_password_error_mismatch" = "Les mots de passe ne sont pas identiques";
+"change_password_error_mismatch" = "Les mots de passe ne correspondent pas";
 
 /* Error message informing the user that they need to choose a longer password. */
-"change_password_length_error" = "Doit contenir au moins 6 caractères";
+"change_password_length_error" = "Doit comporter au moins 6 caractères";
 
 /* A common string used throughout the app. Often refers to the Chapters list or Chapters tab in the player. */
 "chapters" = "Chapitres";
 
 /* A common string used throughout the app. Informs the user how many podcasts have been chosen. '%1$@' is a placeholder for the number of podcasts, this will be more than one. */
-"chosen_podcasts_plural_format" = "%1$@ balados choisis";
+"chosen_podcasts_plural_format" = "%1$@ podcasts sélectionnés";
 
 /* A common string used throughout the app. Informs the user how many podcasts have been chosen. This is the singular format for an accompanying plural option. */
-"chosen_podcasts_singular" = "1 balado choisi";
+"chosen_podcasts_singular" = "1 podcast sélectionné";
 
 /* Title for the screen that provides the list of available ChromeCast devices. */
-"chromecast_cast_to" = "Diffuser sur";
+"chromecast_cast_to" = "Diffuser vers";
 
 /* Informs the user that ChromeCast has connected. */
 "chromecast_connected" = "Connecté";
 
 /* Informs the user that ChromeCast has connected to the device. Used as a title when no episode is playing. */
-"chromecast_connected_to_device" = "Connecté à l’appareil";
+"chromecast_connected_to_device" = "Connecté au périphérique";
 
 /* Error message informing the user that the app is unable to Cast local files in ChromeCast. */
-"chromecast_error" = "Impossible de diffuser le fichier local";
+"chromecast_error" = "Impossible de diffuser un fichier local";
 
 /* Informs the user that ChromeCast has connected to the device but no episode is playing. */
 "chromecast_nothing_playing" = "Aucun épisode en cours de lecture";
 
 /* Placeholder name for when ChromeCast doesn't have a device name. */
-"chromecast_unnamed_device" = "Appareil sans nom";
+"chromecast_unnamed_device" = "Périphérique inconnu";
 
 /* A common string used throughout the app. Prompt to perform a clean up operation on the selected items. */
 "clean_up" = "Nettoyer";
@@ -388,10 +388,10 @@
 "clear" = "Supprimer";
 
 /* A common string used throughout the app. Prompt to clear the up next queue. */
-"clear_up_next" = "Effacer la file d’attente Prochains épisodes";
+"clear_up_next" = "Supprimer la file d'attente";
 
 /* A common string used throughout the app. Message to clear the up next queue. */
-"clear_up_next_message" = "Voulez-vous vraiment effacer votre file d’attente Prochains épisodes?";
+"clear_up_next_message" = "Êtes-vous sûr de vouloir supprimer votre file d’attente ?";
 
 /* A common string used throughout the app. Prompt to close the current screen. */
 "close" = "Fermer";
@@ -409,19 +409,19 @@
 "continue" = "Continuer";
 
 /* Prompt to open the create account options. */
-"create_account" = "Créer un compte";
+"create_account" = "Créer compte";
 
 /* Error message shown when Pocket Casts can't connect to the App Store to retrieve in app purchase details */
-"create_account_app_store_error_message" = "Pocket Casts a de la difficulté à se connecter à l’App Store. Veuillez vérifier votre connexion Internet et réessayez.";
+"create_account_app_store_error_message" = "Pocket Casts a des difficultés à se connecter à l’App Store. Veuillez vérifier votre connexion et réessayer.";
 
 /* Error title shown when Pocket Casts can't connect to the App Store to retrieve in app purchase details */
 "create_account_app_store_error_title" = "Impossible de communiquer avec l’App Store";
 
 /* Button title to find out more about Pocket Casts Plus. Note that "Pocket Casts Plus" shouldn't be translated as it's a product name */
-"create_account_find_out_more_plus" = "Découvrez-en plus à propos de Pocket Casts Plus";
+"create_account_find_out_more_plus" = "En savoir plus sur Pocket Casts Plus";
 
 /* Account type shown on the select account page. Regular as in the normal or default option */
-"create_account_free_account_type" = "Courant";
+"create_account_free_account_type" = "Normal";
 
 /* Shown under the create account type to indicate what you get with a free Pocket Casts account */
 "create_account_free_details" = "Presque tout";
@@ -436,7 +436,7 @@
 "create_filter" = "Créer un filtre";
 
 /* Email change form current email label */
-"current_email_prompt" = "Adresse courriel actuelle";
+"current_email_prompt" = "Adresse e-mail actuelle";
 
 /* Password change form current password field prompt */
 "current_password_prompt" = "Mot de passe actuel";
@@ -445,13 +445,13 @@
 "custom_episode" = "Épisode personnalisé";
 
 /* Prompt to cancel an active upload of a file. */
-"custom_episode_cancel_upload" = "Annuler le téléversement";
+"custom_episode_cancel_upload" = "Annuler le chargement";
 
 /* Prompt to delete an uploaded file from the cloud. */
-"custom_episode_remove_upload" = "Supprimer du nuage";
+"custom_episode_remove_upload" = "Supprimer du Cloud";
 
 /* Prompt to upload a file to the cloud. */
-"custom_episode_upload" = "Téléverser dans le nuage";
+"custom_episode_upload" = "Télécharger vers le Cloud";
 
 /* Label shown for days listened when it's singular, eg: 1 day listened. */
 "day_listened" = "Jour écouté";
@@ -469,10 +469,10 @@
 "delete" = "Supprimer";
 
 /* A prompt to delete the downloaded file */
-"delete_download" = "Supprimer le téléchargement";
+"delete_download" = "Supprimer le fichier téléchargé";
 
 /* Prompt to delete the selected item(s) from the device storage and the cloud. */
-"delete_everywhere" = "Supprimer de partout";
+"delete_everywhere" = "Supprimer partout";
 
 /* Prompt to delete the selected item(s) from the device storage and the cloud. */
 "delete_everywhere_short" = "Supprimer partout";
@@ -481,19 +481,19 @@
 "delete_file" = "Supprimer le fichier";
 
 /* A common string used throughout the app. Message portion of the prompt to delete the selected file. */
-"delete_file_message" = "Voulez-vous vraiment supprimer ce fichier?";
+"delete_file_message" = "Êtes-vous sûr de vouloir supprimer ce fichier ?";
 
 /* A common string used throughout the app. Prompt to delete the selected item(s) from the cloud storage. */
-"delete_from_cloud" = "Supprimer du nuage";
+"delete_from_cloud" = "Supprimer du Cloud";
 
 /* A common string used throughout the app. Prompt to delete the selected item(s) from the device storage. */
-"delete_from_device" = "Supprimer de l’appareil";
+"delete_from_device" = "Supprimer de cet appareil";
 
 /* A common string used throughout the app. Prompt to delete the selected item(s) from the device storage. 'Only' is used to emphasize that the item is also stored in the cloud and that file won't be deleted. */
 "delete_from_device_only" = "Supprimer de l’appareil uniquement";
 
 /* A common string used throughout the app. Prompt to deselect all items in the presented list. */
-"deselect_all" = "Désélectionner tout";
+"deselect_all" = "Tout désélectionner";
 
 /* A common string used throughout the app. Refers to the Discover tab. */
 "discover" = "Découvrir";
@@ -505,31 +505,31 @@
 "discover_browse_by_category_art" = "Arts";
 
 /* Title for the podcast category Business */
-"discover_browse_by_category_business" = "Affaires";
+"discover_browse_by_category_business" = "Business";
 
 /* Title for the podcast category Comedy */
 "discover_browse_by_category_comedy" = "Comédie";
 
 /* Title for the podcast category Education */
-"discover_browse_by_category_education" = "Éducation";
+"discover_browse_by_category_education" = "Enseignement";
 
 /* Title for the podcast category Fiction */
 "discover_browse_by_category_fiction" = "Fiction";
 
 /* Title for the podcast category Games & Hobbies */
-"discover_browse_by_category_games_and_hobbies" = "Jeux et passe-temps";
+"discover_browse_by_category_games_and_hobbies" = "Jeux et loisirs";
 
 /* Title for the podcast category Government */
 "discover_browse_by_category_government" = "Gouvernement";
 
 /* Title for the podcast category Government & Organizations */
-"discover_browse_by_category_government_and_organizations" = "Gouvernements et organismes";
+"discover_browse_by_category_government_and_organizations" = "Gouvernement et organisations";
 
 /* Title for the podcast category Health */
 "discover_browse_by_category_health" = "Santé";
 
 /* Title for the podcast category Health & Fitness */
-"discover_browse_by_category_health_and_fitness" = "Santé et forme physique";
+"discover_browse_by_category_health_and_fitness" = "Santé et remise en forme";
 
 /* Title for the podcast category History */
 "discover_browse_by_category_history" = "Histoire";
@@ -538,7 +538,7 @@
 "discover_browse_by_category_kids_and_family" = "Enfants et famille";
 
 /* Title for the podcast category Leisure */
-"discover_browse_by_category_leisure" = "Loisir";
+"discover_browse_by_category_leisure" = "Loisirs";
 
 /* Title for the podcast category Music */
 "discover_browse_by_category_music" = "Musique";
@@ -547,16 +547,16 @@
 "discover_browse_by_category_news" = "Actualités";
 
 /* Title for the podcast category News & Politics */
-"discover_browse_by_category_news_and_politics" = "Actualités et politique";
+"discover_browse_by_category_news_and_politics" = "Actualité et politique";
 
 /* Title for the podcast category Religion & Spirituality */
 "discover_browse_by_category_religion_and_spirituality" = "Religion et spiritualité";
 
 /* Title for the podcast category Science */
-"discover_browse_by_category_science" = "Sciences";
+"discover_browse_by_category_science" = "Science";
 
 /* Title for the podcast category Science & Medicine */
-"discover_browse_by_category_science_and_medicine" = "Sciences et médecine";
+"discover_browse_by_category_science_and_medicine" = "Science et médecine";
 
 /* Title for the podcast category Society */
 "discover_browse_by_category_society" = "Société";
@@ -577,25 +577,25 @@
 "discover_browse_by_category_true_crime" = "Documentaires criminels";
 
 /* Title for the podcast category TV & Film */
-"discover_browse_by_category_tv_and_film" = "Télé et films";
+"discover_browse_by_category_tv_and_film" = "TV et films";
 
 /* Prompt to allow the user to manually change the regional information for the Discover tab. '%1$@' is a placeholder for the current region. */
 "discover_change_region" = "Changer la région, actuellement %1$@";
 
 /* Badge used to mark featured podcasts. */
-"discover_featured" = "En vedette";
+"discover_featured" = "À la Une";
 
 /* Informative label letting the users know that the displayed episode is a featured episode. */
-"discover_featured_episode" = "ÉPISODE EN VEDETTE";
+"discover_featured_episode" = "ÉPISODE À LA UNE";
 
 /* Informative label letting the users know that the displayed podcast is a featured new podcast. */
-"discover_fresh_pick" = "NOUVELLE SUGGESTION";
+"discover_fresh_pick" = "NOUVELLE SÉLECTION";
 
 /* Informational title when the search succeeds but returns no results. */
-"discover_no_podcasts_found" = "Aucun balado trouvé";
+"discover_no_podcasts_found" = "Aucun podcast trouvé";
 
 /* Informational title when the search succeeds but returns no results. */
-"discover_no_podcasts_found_msg" = "Essayez d’autres mots-clés ou des termes plus généraux";
+"discover_no_podcasts_found_msg" = "Essayez des mots-clés plus généraux ou différents.";
 
 /* Button prompt on the discover page to play the featured episode. */
 "discover_play_episode" = "Lire l’épisode";
@@ -604,13 +604,13 @@
 "discover_play_trailer" = "Lire la bande-annonce";
 
 /* Display title for calling out a podcast network on the discover tab. '%1$@' is a placeholder for the podcast's network title. */
-"discover_podcast_network" = "Réseau de %1$@";
+"discover_podcast_network" = "Réseau %1$@";
 
 /* Title used for promotional purposes to highlight podcasts that are popular worldwide. */
 "discover_popular" = "Populaire";
 
 /* Title used for promotional purposes to highlight podcasts that are popular in a specific region. '%1$@' is a placeholder for the region's name. */
-"discover_popular_in" = "Populaire dans le pays suivant : %1$@";
+"discover_popular_in" = "Populaire en %1$@";
 
 /* Region name for Australia used in the Discover Section */
 "discover_region_australia" = "Australie";
@@ -724,13 +724,13 @@
 "discover_region_united_states" = "États-Unis";
 
 /* Region name used in the Discover Section for a genreic global setting instead of a specific region. */
-"discover_region_worldwide" = "International";
+"discover_region_worldwide" = "Mondial";
 
 /* Error message when a user performs a search using a search term that's too short. */
-"discover_search_error_msg" = "Veuillez entrer au moins 2 caractères.";
+"discover_search_error_msg" = "Veuillez saisir au moins 2 caractères.";
 
 /* Error title when a user performs a search using a search term that's too short. */
-"discover_search_error_title" = "Longueur contestée";
+"discover_search_error_title" = "Longueur insuffisante";
 
 /* Informational title informing the users that the search has failed. */
 "discover_search_failed" = "Échec de la recherche";
@@ -745,43 +745,43 @@
 "discover_show_all" = "AFFICHER TOUT";
 
 /* Informative label letting the users know that the displayed podcast is a paid placement ad. */
-"discover_sponsored" = "COMMANDITÉ";
+"discover_sponsored" = "SPONSORISÉ";
 
 /* Title used for promotional purposes to highlight trending podcasts. */
-"discover_trending" = "Tendance";
+"discover_trending" = "Tendances";
 
 /* A common string used throughout the app. Confirmation text. */
-"done" = "Terminer";
+"done" = "Terminé";
 
 /* A common string used throughout the app. Prompt to download the selected item(s). */
 "download" = "Télécharger";
 
 /* A common string used throughout the app. Prompt to download all of the selected item(s). */
-"download_all" = "Télécharger tout";
+"download_all" = "Tout télécharger";
 
 /* A common string used throughout the app. Prompt to warn the user that continuing with the download will consume data. Used in tandem with a notice that the user is not on WiFi. */
-"download_data_warning" = "Le téléchargement utilisera des données.";
+"download_data_warning" = "Le téléchargement consommera des données.";
 
 /* A common string used throughout the app. Prompts the user that they have selected multiple episodes to download. '%1$@' is a placeholder for the count of the selected items, will be more than one. */
-"download_episode_plural_format" = "Télécharger %1$@ épisodes";
+"download_episode_plural_format" = "Télécharger %1$@ épisodes";
 
 /* A common string used throughout the app. Prompts the user that they have selected one episode to download. */
-"download_episode_singular" = "Télécharge 1 épisode";
+"download_episode_singular" = "Télécharger 1 épisode";
 
 /* The episode failed to download due to an issue with the feed. Suggesting the user reaches out to the Podcast Author. */
-"download_error_contact_author" = "L’épisode n’est pas disponible, car une erreur s’est produite dans le flux du balado. Communiquez avec l’auteur du balado.";
+"download_error_contact_author" = "L’épisode n’est pas disponible en raison d’une erreur dans le flux du podcast. Contactez l’auteur du podcast.";
 
 /* The episode failed to download due to an issue with the feed. Suggesting the user reaches out to the Podcast Author. */
-"download_error_contact_author_version_2" = "Cet épisode a peut-être été déplacée ou supprimée. Communiquez avec l’auteur du balado.";
+"download_error_contact_author_version_2" = "Cet épisode a peut-être été déplacé ou supprimé. Contactez l’auteur du podcast.";
 
 /* The episode failed to download due to the user running out of storage space. */
-"download_error_not_enough_space" = "Impossible d’enregistrer l’épisode. Avez-vous suffisamment d’espace?";
+"download_error_not_enough_space" = "Impossible d’enregistrer l’épisode, manquez-vous d’espace ?";
 
 /* The episode failed to download because the file wasn't available on the server */
-"download_error_not_uploaded" = "Fichier non téléversé, lecture impossible";
+"download_error_not_uploaded" = "Fichier non téléchargé, impossible de le lire";
 
 /* The episode failed to download due to an issue with the feed. Suggesting the user reaches out to the Podcast Author. '%1$@' is a placeholder for the status code that the app received. */
-"download_error_status_code" = "Échec du téléchargement, code d’erreur %1$@. Communiquez avec l’auteur du balado.";
+"download_error_status_code" = "Échec du téléchargement, code d’erreur %1$@. Contactez l’auteur du podcast.";
 
 /* The episode failed to download but the app wasn't able to determine why. Suggesting to try again after waiting for a bit. */
 "download_error_try_again" = "Impossible de télécharger l’épisode. Veuillez réessayer plus tard.";
@@ -793,13 +793,13 @@
 "downloaded_files" = "Fichiers téléchargés";
 
 /* Confirmation message when you choose to delete a set of downloaded files */
-"downloaded_files_cleanup_confirmation" = "Voulez-vous vraiment supprimer ces fichiers téléchargés?";
+"downloaded_files_cleanup_confirmation" = "Voulez-vous vraiment supprimer ces fichiers téléchargés ?";
 
 /* Message for an unsubscribe message box that informs the user that unsubscribing will remove downloaded files. */
-"downloaded_files_conf_message" = "En vous désabonnant, tous les fichiers téléchargés de balado seront supprimés? Voulez-vous vraiment vous désabonner?";
+"downloaded_files_conf_message" = "Le désabonnement supprimera tous les fichiers téléchargés dans ce podcast, confirmez-vous ?";
 
 /* Title for an unsubscribe message box that informs the user that unsubscribing will remove downloaded files. Informs the user how many files have been downloaded. '%1$@' is a placeholder for the number of downloaded files, will be more than one. */
-"downloaded_files_conf_plural_format" = "%1$@ fichiers téléchargés";
+"downloaded_files_conf_plural_format" = "%1$@ fichiers téléchargés";
 
 /* Title for an unsubscribe message box that informs the user that unsubscribing will remove downloaded files. Informs the user one file has been downloaded. Singular version of an accompanying plural message. */
 "downloaded_files_conf_singular" = "1 fichier téléchargé";
@@ -808,16 +808,16 @@
 "downloads" = "Téléchargements";
 
 /* Prompt to navigate the user to the Auto Downloads settings menu. */
-"downloads_auto_download" = "Paramètres du téléchargement automatique";
+"downloads_auto_download" = "Réglages de téléchargement automatique";
 
 /* The description for the empty state when there are no downloads available */
-"downloads_no_downloads_desc" = "Oh non! Vous n’avez plus de téléchargements. Téléchargez des fichiers et ils seront affichés ici.";
+"downloads_no_downloads_desc" = "Oh non ! Vous n’avez plus de téléchargements. Téléchargez quelques épisodes et ils apparaîtront ici.";
 
 /* Title for the empty state when there are no downloads available */
 "downloads_no_downloads_title" = "Aucun épisode téléchargé";
 
 /* Prompt to allow the user to retry failed downloads. */
-"downloads_retry_failed_downloads" = "Réessayer les téléchargements échoués";
+"downloads_retry_failed_downloads" = "Relancer les téléchargements échoués";
 
 /* Prompt to allow the user to stop active downloads. */
 "downloads_stop_all_downloads" = "Arrêter tous les téléchargements";
@@ -829,7 +829,7 @@
 "episode" = "Épisode";
 
 /* A common string used throughout the app. Display configurable options related to a number of episodes. '%1$@' is a placeholder for the number of episodes, the value will be more than one. */
-"episode_count_plural_format" = "%1$@ épisodes";
+"episode_count_plural_format" = "%1$@ épisodes";
 
 /* Label for adding duration filtering to an episode filter, eg: filter by the duration of an episode */
 "episode_filter_by_duration_label" = "Filtrer par durée";
@@ -841,52 +841,52 @@
 "episode_filter_no_episodes_title" = "Aucun épisode";
 
 /* Episode indicator that the current episode is a bonus episode. */
-"episode_indicator_bonus" = "Extra";
+"episode_indicator_bonus" = "Bonus";
 
 /* Episode indicator that the current episode is a trailer for an upcoming season of the podcast. '%1$@' is a placeholder for the season number. */
-"episode_indicator_season_trailer" = "Bande-annonce de la saison %1$@";
+"episode_indicator_season_trailer" = "Bande-annonce de la saison %1$@";
 
 /* Episode indicator that the current episode is a trailer. */
 "episode_indicator_trailer" = "Bande-annonce";
 
 /* Shorthand format used to show the Episode number of a podcast. '%1$@' is a placeholder for the episode number. */
-"episode_shorthand_format" = "ÉPISODE %1$@";
+"episode_shorthand_format" = "ÉPISODE %1$@";
 
 /* Shorthand format used to show the Episode number of a podcast. 'EP' is short for Episode. '%1$@' is a placeholder for the episode number. */
-"episode_shorthand_format_short" = "Épisode %1$@";
+"episode_shorthand_format_short" = "EP %1$@";
 
 /* A common string used throughout the app. Generic title informing the user of an Error. Accompanied with an error message. */
 "error" = "Erreur";
 
 /* A common string used throughout the app. Generic title informing the user of an Error. General error message used when the app is unable to locate the podcast that was selected. This usually comes from a sharing or import feature. */
-"error_general_podcast_not_found" = "Impossible de trouver le balado. Veuillez communiquer avec l’auteur du balado.";
+"error_general_podcast_not_found" = "Impossible de trouver le podcast. Veuillez contacter l’auteur du podcast.";
 
 /* Describes how the process to export podcasts from Pocket Casts works. */
-"export_podcasts_description" = "Cette fonctionnalité vous permet d’exporter tous vos balados en tant que fichier OPML que vous pouvez importer dans d’autres applications de balados.";
+"export_podcasts_description" = "Exporte tous vos podcasts sous forme de fichier OPML, que vous pouvez importer dans d’autres applications de podcast.";
 
 /* Title for the button that allows the user to export podcasts from Pocket Casts */
-"export_podcasts_option" = "Exporter des balados";
+"export_podcasts_option" = "Exporter des podcasts";
 
 /* Title for the section that provides information on how to export podcasts from Pocket Casts */
 "export_podcasts_title" = "EXPORTER";
 
 /* Indicator during the new feature tour serves as a prompt to end the tour. */
-"feature_tour_end_tour" = "Terminer la visite";
+"feature_tour_end_tour" = "Fin de la visite";
 
 /* Indicator during the new feature tour. Used as a navigation indicator when the tour is on the first step. This is replaced with 'position of total' as the user progresses. */
 "feature_tour_new" = "NOUVEAU";
 
 /* Indicator during the new feature tour. Used as a navigation indicator as the user progresses through the tour. '%1$@' is a placeholder for the current position. '%2$@' is a placeholder for the total number of steps. */
-"feature_tour_step_format" = "%1$@ de %2$@";
+"feature_tour_step_format" = "%1$@ sur %2$@";
 
 /* Option to continue with a Third-Party Mail app when the default Apple mail app isn't available. */
-"feedback_continue_with_mail" = "Ouvrir l’application de courriel par défaut";
+"feedback_continue_with_mail" = "Ouvrir l’application de messagerie par défaut";
 
 /* Error message for when the user has a mail app configured that's not the default mail app. */
-"feedback_mail_not_configured_msg" = "Pour envoyer une pièce jointe de débogage, l’application Mail d’Apple doit être configurée sur votre téléphone. Que voulez-vous faire?";
+"feedback_mail_not_configured_msg" = "Pour envoyer une pièce jointe de débogage, l’application Apple Mail doit être configurée sur votre téléphone. Que voulez-vous faire ?";
 
 /* Error title for when the user has a mail app configured that's not the default mail app. */
-"feedback_mail_not_configured_title" = "Application Mail non configurée";
+"feedback_mail_not_configured_title" = "Messagerie non configurée";
 
 /* Title for the file upload settings screen. This is used when a user is uploading a new file. */
 "file_upload_add_file" = "Ajouter un fichier";
@@ -898,41 +898,41 @@
 "file_upload_choose_image" = "Choisir une image";
 
 /* Option for selecting the image source for an uploaded image. */
-"file_upload_choose_image_camera" = "Caméra";
+"file_upload_choose_image_camera" = "Appareil photo";
 
 /* Option for selecting the image source for an uploaded image. */
-"file_upload_choose_image_photo_Library" = "Galerie de photos";
+"file_upload_choose_image_photo_Library" = "Bibliothèque photo";
 
 /* Title for the file upload settings screen. This is used when a user is editing an uploaded file. */
 "file_upload_edit_file" = "Modifier le fichier";
 
 /* Error message displayed when the user has used all of their storage space. */
-"file_upload_error" = "L’espace est insuffisant pour téléverser ce fichier.";
+"file_upload_error" = "Espace insuffisant pour télécharger ce fichier";
 
 /* Subtitle for the error message displayed when the user has used all of their storage space. Instructs the user to try freeing up space. */
-"file_upload_error_subtitle" = "Retirez certains fichiers et réessayez.";
+"file_upload_error_subtitle" = "Supprimer des fichiers et réessayer.";
 
 /* Prompt indicating that the user needs to name the file in order to upload it. */
-"file_upload_name_required" = "Nom obligatoire";
+"file_upload_name_required" = "Nom (obligatoire)";
 
 /* The description for the screen when there are no files currently uploaded. '
 ' is a line break format to allow a clean wrapping of text */
-"file_upload_no_files_description" = "Voulez-vous écouter vos propres fichiers?\nPartagez-les avec Pocket Casts et ils seront affichés ici.";
+"file_upload_no_files_description" = "Vous souhaitez écouter vos propres fichiers ?\nPartagez-les avec Pocket Casts, ils apparaîtront ici";
 
 /* The helper link describing how to add files to Pocket Casts. */
-"file_upload_no_files_helper" = "Comment dois-je m’y prendre?";
+"file_upload_no_files_helper" = "Comment faire ?";
 
 /* Title for the screen when there are no files currently uploaded */
 "file_upload_no_files_title" = "Aucun fichier";
 
 /* Prompt to remove the image from the uploaded file. */
-"file_upload_remove_image" = "Retirer l’image";
+"file_upload_remove_image" = "Supprimer l’image";
 
 /* Prompt to save the changes to an edited file. */
 "file_upload_save" = "Enregistrer";
 
 /* Error message displayed when the user has attempted to upload an unsupported file type. */
-"file_upload_support_error" = "Ce type de fichier n’est pas pris en charge.";
+"file_upload_support_error" = "Ce type de fichier n’est pas pris en charge";
 
 /* A common string used throughout the app. Refers to the Files settings menu */
 "files" = "Fichiers";
@@ -944,37 +944,37 @@
 "files_sort" = "Trier les fichiers";
 
 /* Subtitle informing the user that new podcasts will be automatically added to this filter. */
-"filter_auto_add_subtitle" = "Les nouveaux balados auxquels vous vous abonnez seront automatiquement ajoutés.";
+"filter_auto_add_subtitle" = "Les nouveaux podcasts auxquels vous êtes abonné seront ajoutés automatiquement.";
 
 /* Title for the filter option that indicates all podcasts will be included. */
-"filter_chips_all_podcasts" = "Tous vos balados";
+"filter_chips_all_podcasts" = "Tous vos podcasts";
 
 /* Title for the filter option that that opens the episode duration options. */
 "filter_chips_duration" = "Durée";
 
 /* Filter option to select podcasts that will be included in the filter. */
-"filter_choose_podcasts" = "Choisir des balados";
+"filter_choose_podcasts" = "Sélectionner les podcasts";
 
 /* Used on the screen to create a new filter. Provides a prompt to continue refining the filter selections. */
-"filter_create_add_more" = "Ajoutez d’autres critères pour terminer d’affiner votre filtre.";
+"filter_create_add_more" = "Ajoutez plus de critères pour affiner votre filtre.";
 
 /* Used on the screen to create a new filter. The section header for the list of options to use with the filter. */
 "filter_create_filter_by" = "FILTRER PAR";
 
 /* Used on the screen to create a new filter. Provides instructions on how to set up a new filter. */
-"filter_create_instructions" = "Sélectionnez les critères de votre filtre à l’aide de ces boutons pour créer une liste de lecture intelligente d’épisodes.";
+"filter_create_instructions" = "Sélectionnez vos critères de filtre à l’aide de ces boutons pour créer une playlist intelligente d’épisodes à jour.";
 
 /* Used on the screen to create a new filter. Title for the state where their selection doesn't include any content. */
 "filter_create_no_episodes" = "Aucun épisode correspondant";
 
 /* Used on the screen to create a new filter. The description about why the list of filtered episodes is empty. */
-"filter_create_no_episodes_description_explanation" = "Les critères que vous avez sélectionnés ne correspondent à aucun épisode dans vos abonnements.";
+"filter_create_no_episodes_description_explanation" = "Les critères que vous avez sélectionnés ne correspondent à aucun épisode actuel de vos abonnements";
 
 /* Used on the screen to create a new filter. The prompt about what they can do in order to make sure their filter returns results. */
-"filter_create_no_episodes_description_prompt" = "Choisissez d’autres critères ou enregistrez ce filtre si vous croyez qu’il correspondra à des épisodes plus tard.";
+"filter_create_no_episodes_description_prompt" = "Choisissez des critères différents ou enregistrez ce filtre si vous pensez qu’il correspondra à des épisodes ultérieurement.";
 
 /* Used on the screen to create a new filter. Title for the toggle to include all podcasts in the filter. */
-"filter_create_podcasts_all_podcasts" = "Tous les balados";
+"filter_create_podcasts_all_podcasts" = "Tous les podcasts";
 
 /* Used on the screen to create a new filter. The section that shows a preview of waht podcast episodes will be included in the filter. */
 "filter_create_preview" = "APERÇU";
@@ -992,25 +992,25 @@
 "filter_details_color_selection" = "Sélecteur de couleur";
 
 /* Accessibility hint text for icon selection on filters. */
-"filter_details_icon_selection" = "Sélecteur d’icône";
+"filter_details_icon_selection" = "Sélecteur d’icônes";
 
 /* Hint text above the dialog box to enter the filter's name. */
 "filter_details_name" = "NOM";
 
 /* Title for filter options related to Download Status. */
-"filter_download_status" = "État du téléchargement";
+"filter_download_status" = "Statut du téléchargement";
 
 /* Title for filter sections that relate to episode status. */
-"filter_episode_status" = "État de l’épisode";
+"filter_episode_status" = "Statut de l’épisode";
 
 /* Label for the longer than duration filter time */
 "filter_longer_than_label" = "Plus de";
 
 /* Subtitle informing the user that new podcasts will not be automatically added to this filter. */
-"filter_manual_add_subtitle" = "Les nouveaux balados auxquels vous vous abonnez ne seront pas automatiquement ajoutés.";
+"filter_manual_add_subtitle" = "Les nouveaux podcasts auxquels vous êtes abonné ne seront pas ajoutés automatiquement.";
 
 /* Title for filter options related to media type settings. */
-"filter_media_type" = "Type de contenu multimédia";
+"filter_media_type" = "Type de média";
 
 /* Media Type filter option for audio media types. */
 "filter_media_type_audio" = "Son";
@@ -1022,19 +1022,19 @@
 "filter_option_episode_duration" = "Durée de l’épisode";
 
 /* Error message for when the user attempts to set a filter where the minimal duration is higher than the max duration. Meant to be a fun/funny message. '%1$@' and '%2$@' are placeholders for the configured minimum and maximum times, respectively. */
-"filter_option_episode_duration_error_msg_format" = "Le filtrage des épisodes plus longs que %1$@, mais plus courts que %2$@ provoquerait une faille dans notre continuum espace-temps. Désolés.";
+"filter_option_episode_duration_error_msg_format" = "Le filtrage des épisodes d’une durée supérieure à %1$@ mais inférieure à %2$@ provoquerait une faille dans notre continuum espace-temps Désolé.";
 
 /* Error title for when the user attempts to set a filter where the minimal duration is higher than the max duration. Meant to be a fun/funny message. */
 "filter_option_episode_duration_error_title" = "Oui, mais non";
 
 /* Menu prompt to open the Filter options. Also used for the title of the filter options screen. */
-"filter_options" = "Options du filtre";
+"filter_options" = "Options de filtre";
 
 /* Title for filter options related to release date settings. */
-"filter_release_date" = "Date de sortie";
+"filter_release_date" = "Date de diffusion";
 
 /* Release Date filter option for any release date. */
-"filter_release_date_anytime" = "N’importe quand";
+"filter_release_date_anytime" = "Date indifférente";
 
 /* Release Date filter option for episodes with a release date with in the last day. */
 "filter_release_date_last_24_hours" = "24 dernières heures";
@@ -1046,10 +1046,10 @@
 "filter_release_date_last_3_days" = "3 derniers jours";
 
 /* Release Date filter option for episodes with a release date with in the last month. */
-"filter_release_date_last_month" = "Mois dernier";
+"filter_release_date_last_month" = "Le mois dernier";
 
 /* Release Date filter option for episodes with a release date with in the last week. */
-"filter_release_date_last_week" = "Semaine dernière";
+"filter_release_date_last_week" = "La semaine dernière";
 
 /* Label for the shorter than duration filter time */
 "filter_shorter_than_label" = "Moins de";
@@ -1058,7 +1058,7 @@
 "filter_update" = "Mettre à jour le filtre";
 
 /* A common string used throughout the app. Filter option for the default setting on multiple filters. */
-"filter_value_all" = "Tout";
+"filter_value_all" = "Tous";
 
 /* A common string used throughout the app. Often refers to the Filters screen. */
 "filters" = "Filtres";
@@ -1067,22 +1067,22 @@
 "filters_default_new_filter" = "Nouveau filtre";
 
 /* The title for the auto generated 'New Release' filter. */
-"filters_default_new_releases" = "Nouvelles sorties";
+"filters_default_new_releases" = "Nouvelles versions";
 
 /* Button title for adding a new filter. */
-"filters_new_filter_button" = "+ nouveau filtre";
+"filters_new_filter_button" = "+ Nouveau filtre";
 
 /* Common word used as in the app to denote a folder of items */
 "folder" = "Dossier";
 
 /* A common string used throughout the app. Informs the user how many podcasts are being added. '%1$@' is a placeholder for the number of podcasts, this will be more than one. */
-"folder_add_podcasts_plural_format" = "Ajouter %1$@ balados";
+"folder_add_podcasts_plural_format" = "Ajouter %1$@ podcasts";
 
 /* A common string used throughout the app. Informs the user how many podcasts have been chosen. This is the singular format for an accompanying plural option. */
-"folder_add_podcasts_singular" = "Ajouter 1 balado";
+"folder_add_podcasts_singular" = "Ajouter 1 podcast";
 
 /* Label for the option to add and remove podcasts from a folder */
-"folder_add_remove_podcasts" = "Ajouter ou supprimer des balados";
+"folder_add_remove_podcasts" = "Ajouter ou supprimer des podcasts";
 
 /* Text shown on button to change the folder a podcast is in */
 "folder_change" = "Modifier le dossier";
@@ -1106,10 +1106,10 @@
 "folder_delete" = "Supprimer le dossier";
 
 /* Confirmation prompt message after you try to delete a folder */
-"folder_delete_prompt_msg" = "Ce dossier sera supprimé, et son contenu sera retransféré vers l’écran Balados.";
+"folder_delete_prompt_msg" = "Ce dossier sera supprimé, et son contenu sera retransféré vers l’écran Podcasts.";
 
 /* Confirmation prompt title after you try to delete a folder */
-"folder_delete_prompt_title" = "Êtes-vous certain(e)?";
+"folder_delete_prompt_title" = "Confirmez-vous ?";
 
 /* Label for the option that lets you edit a folder */
 "folder_edit" = "Modifier le dossier";
@@ -1166,58 +1166,58 @@
 "free_trial_title_label" = "Essayez Plus avec une période de gratuité de %1$@";
 
 /* Funny confirmation message accompanying several descriptive dialogs */
-"funny_conf_msg" = "Ça va vraiment bien avec la couleur de vos yeux ✨";
+"funny_conf_msg" = "C’est bien assorti à vos yeux ✨";
 
 /* The default value when the user has listened for under one minute. */
-"funny_time_not_enough" = "Vous n’écoutez pas beaucoup, n’est-ce pas?";
+"funny_time_not_enough" = "Vous n’écoutez vraiment pas longtemps, n’est-ce pas ?";
 
 /* A funny time unit used in stats comparing the listening time to the number of times an airplane has taken off. '%1$@' is a placeholder for the amount of time listened compared to the stat. */
-"funny_time_unit_airplane_takeoffs" = "Temps pendant lequel %1$@ avions ont décollés. Veuillez attacher votre ceinture! 🛫";
+"funny_time_unit_airplane_takeoffs" = "Pendant ce temps, %1$@ avions ont décollé. Attachez votre ceinture. 🛫";
 
 /* A funny time unit used in stats comparing the listening time to the number of times an astronaut has sneezed. '%1$@' is a placeholder for the amount of time listened compared to the stat. */
-"funny_time_unit_astronaut_sneezes" = "Temps pendant lequel un astronaute a éternué %1$@ fois. Atchoum! 😤";
+"funny_time_unit_astronaut_sneezes" = "Pendant ce temps, un astronaute a éternué %1$@ fois. Atchoum ! 😤";
 
 /* A funny time unit used in stats comparing the listening time to the number of times you could have traveled around the world. '%1$@' is a placeholder for the amount of time listened compared to the stat. */
-"funny_time_unit_balloon_travel" = "Temps pendant lequel vous auriez pu faire %1$@ fois le tour de la terre dans une montgolfière. 🌏";
+"funny_time_unit_balloon_travel" = "Pendant ce temps, vous auriez pu faire %1$@ fois le tour du monde en ballon. 🌏";
 
 /* A funny time unit used in stats comparing the listening time to the number of births that have happened. '%1$@' is a placeholder for the amount of time listened compared to the stat. */
-"funny_time_unit_births" = "Temps pendant lequel %1$@ bébés sont nés. Wahhh! 🍼";
+"funny_time_unit_births" = "Pendant ce temps, %1$@ bébés sont nés. waouhh ! 🍼";
 
 /* A funny time unit used in stats comparing the listening time to the number of times you've blinked. '%1$@' is a placeholder for the amount of time listened compared to the stat. */
-"funny_time_unit_blinks" = "Temps pendant lequel vous avez cligné des yeux %1$@ fois. Impressionnant! 👀";
+"funny_time_unit_blinks" = "Pendant ce temps, vous avez cligné des yeux %1$@ fois. Hé hé ! 👀";
 
 /* A funny time unit used in stats comparing the listening time to the number of emails that have been sent. '%1$@' is a placeholder for the amount of time listened compared to the stat. */
-"funny_time_unit_emails" = "Temps pendant lequel %1$@ courriels ont été envoyés. 💌";
+"funny_time_unit_emails" = "Pendant ce temps, %1$@ e-mails ont été envoyés. 💌";
 
 /* A funny time unit used in stats comparing the listening time to the number of times you farted. '%1$@' is a placeholder for the amount of time listened compared to the stat. */
-"funny_time_unit_farts" = "Temps pendant lequel vous avez relâché %1$@ oz de gaz. Dégoûtant! 💨";
+"funny_time_unit_farts" = "Pendant ce temps, vous avez libéré %1$@ g de gaz. Dégoûtant ! 💨";
 
 /* A funny time unit used in stats comparing the listening time to the number of times a Google search was performed. '%1$@' is a placeholder for the amount of time listened compared to the stat. */
-"funny_time_unit_google" = "Temps pendant lequel %1$@ recherches Google ont été effectuées. Bazinga. 🔎";
+"funny_time_unit_google" = "Pendant ce temps, %1$@ recherches Google ont été effectuées. Stupéfiant. 🔎";
 
 /* A funny time unit used in stats comparing the listening time to the number of times lightning has struck. '%1$@' is a placeholder for the amount of time listened compared to the stat. */
-"funny_time_unit_lightning" = "Temps pendant lequel la foudre a frappé %1$@ fois. Boum. ⚡️";
+"funny_time_unit_lightning" = "Pendant ce temps, la foudre a frappé %1$@ fois. Boum. ⚡️";
 
 /* A funny time unit used in stats comparing the listening time to the number of phones that have been produced. '%1$@' is a placeholder for the amount of time listened compared to the stat. */
-"funny_time_unit_phone_production" = "Temps pendant lequel un certain vendeur de fruits a gagné %1$@ $ 🍏";
+"funny_time_unit_phone_production" = "Pendant ce temps, un marchand de fruits a vendu $%1$@ 🍏";
 
 /* A funny time unit used in stats comparing the listening time to the amount of skin cells you've shed. '%1$@' is a placeholder for the amount of time listened compared to the stat. */
-"funny_time_unit_shed_skin" = "Temps pendant lequel vous perdez %1$@ cellules de peau. Beurk? 😅";
+"funny_time_unit_shed_skin" = "Pendant ce temps, vous avez perdu %1$@ cellules cutanées. Bah ? 😅";
 
 /* A funny time unit used in stats comparing the listening time to the number of times you tied your shoes. '%1$@' is a placeholder for the amount of time listened compared to the stat. */
-"funny_time_unit_tied_shoes" = "Temps pendant lequel vous auriez pu attacher %1$@ lacets de chaussure. Peut-être. 👟";
+"funny_time_unit_tied_shoes" = "Pendant ce temps, vous auriez pu lacer vos chaussures %1$@ fois. Sans doute. 👟";
 
 /* A funny time unit used in stats comparing the listening time to the number of tweets that have been sent. '%1$@' is a placeholder for the amount of time listened compared to the stat. */
-"funny_time_unit_tweets" = "Pendant lequel %1$@ gazouillis ont été publiés. Cui! Cui! 🐣";
+"funny_time_unit_tweets" = "Pendant ce temps, %1$@ tweets ont été envoyés. Tût ! Tût ! 🐣";
 
 /* A common string used throughout the app. Title for the prompt to navigate the user to the podcast associated to the selected item. */
-"go_to_podcast" = "Accéder au balado";
+"go_to_podcast" = "Accéder au podcast";
 
 /* A common string used throughout the app. Title accompanying the group option setting. */
-"group_episodes" = "Regrouper des épisodes";
+"group_episodes" = "Grouper des épisodes";
 
 /* Prompt to clear the full listening history for the user. */
-"history_clear_all" = "Effacer tout";
+"history_clear_all" = "Tout supprimer";
 
 /* Title for the details prompt to confirm the user wants to clear their listening history. */
 "history_clear_all_details" = "Supprimer l’historique d’écoute";
@@ -1235,27 +1235,27 @@
 "hours_listened" = "Heures écoutées";
 
 /* Time format to display a set number of hours. '%1$@' is a placeholder for a number of hours, this value will be more than one. */
-"hours_plural_format" = "%1$@ heures";
+"hours_plural_format" = "%1$@ heures";
 
 /* Label shown for hours saved when it's plural, eg: 1 hours saved. */
 "hours_saved" = "Heures économisées";
 
 /* The initial informational text explaining how to upload a file */
-"how_to_upload_explanation" = "Ouvrez d’abord une application qui a les fichiers audio que vous souhaitez enregistrer.";
+"how_to_upload_explanation" = "Tout d’abord, ouvrez une application contenant les fichiers audio que vous souhaitez enregistrer";
 
 /* The title for the first instructional image that explains how to upload a file */
-"how_to_upload_first_instruction" = "Choisissez de partager ce fichier.";
+"how_to_upload_first_instruction" = "Choisissez de partager ce fichier";
 
 /* The title for the second instructional image that explains how to upload a file */
-"how_to_upload_second_instruction" = "Dans le menu, appuyez sur « Copier vers Pocket Casts ».";
+"how_to_upload_second_instruction" = "Dans le menu, appuyez sur « Copier vers Pocket Casts »";
 
 /* The summary text at the end of the screen explaining how to upload a file */
-"how_to_upload_summary" = "Voilà! C’est fait. Changez les renseignements de votre choix, appuyez sur Enregistrer et écoutez des balados!";
+"how_to_upload_summary" = "Voilà, vous avez terminé. Modifiez les détails que vous souhaitez, appuyez sur Enregistrer et écoutez !";
 
 /* Describes the process about how to import podcasts to Pocket Casts. '\
 \
 ' Is a line break format to separate the description from the following note. */
-"import_podcasts_description" = "Vous pouvez importer vos abonnements à des balados dans Pocket Casts en utilisant le format OPML, largement répandu. Exportez le fichier d’une autre application et choisissez de l’ouvrir dans Pocket Casts.\n\nRemarque : Vous devrez peut-être vous envoyer le fichier OPML par courriel, appuyer longuement sur la pièce jointe et sélectionner Pocket Casts.";
+"import_podcasts_description" = "Vous pouvez importer vos abonnements à des podcasts dans Pocket Casts en utilisant le format OPML largement pris en charge. Exportez le fichier depuis une autre application et choisissez Ouvrir dans Pocket Casts.\n\nRemarque : vous devrez peut-être vous envoyer le fichier OPML par e-mail, appuyer longuement sur la pièce jointe et sélectionner Pocket Casts.";
 
 /* Title for the section that provides information on how to import podcasts to Pocket Casts */
 "import_podcasts_title" = "IMPORTER DANS POCKET CASTS";
@@ -1276,7 +1276,7 @@
 "keycommand_open_player" = "Ouvrir le lecteur";
 
 /* Title for the hardware keyboard command that toggles play and pause of playback. */
-"keycommand_play_pause" = "Lire\/Suspendre";
+"keycommand_play_pause" = "Lecture\/Pause";
 
 /* Text for a button where you learn more about a feature */
 "learn_more" = "En savoir plus";
@@ -1285,19 +1285,19 @@
 "listening_history" = "Historique d’écoute";
 
 /* Progress indicator informing the user that the selected item is still loading. */
-"loading" = "Chargement...";
+"loading" = "Chargement en cours…";
 
 /* A common string used throughout the app. Prompt to mark the selected item(s) as played. */
-"mark_played" = "Marquer comme lu(s)";
+"mark_played" = "Marquer comme lu";
 
 /* A common string used throughout the app. Prompt to mark the selected item(s) as played. Similar to 'Mark as Played' but more concise. */
-"mark_played_short" = "Marquer lu(s)";
+"mark_played_short" = "Marquer comme lu";
 
 /* A common string used throughout the app. Prompt to mark the selected item(s) as not played. */
-"mark_unplayed_short" = "Marquer non lu(s)";
+"mark_unplayed_short" = "Marquer comme non lu";
 
 /* Prompt to close the mini player and clear the queue. */
-"mini_player_close" = "Fermer et effacer la file d’attente Prochains épisodes";
+"mini_player_close" = "Fermer et supprimer la file d’attente";
 
 /* Label shown for minutes listened when it's singular, eg: 1 minute listened. */
 "minute_listened" = "Minute écoutée";
@@ -1315,64 +1315,64 @@
 "month" = "mois";
 
 /* Basic string used to callout payment intervals like yearly vs monthly */
-"monthly" = "Mensuel";
+"monthly" = "Mensuellement";
 
 /* A common string used throughout the app. Prompt to move the selected item(s) to the end of the up next queue. */
-"move_to_bottom" = "Déplacer au bas";
+"move_to_bottom" = "Déplacer vers le bas";
 
 /* A common string used throughout the app. Prompt to move the selected item(s) to the top of the up next queue. */
-"move_to_top" = "Déplacer au haut";
+"move_to_top" = "Déplacer vers le haut";
 
 /* Multi-select status message for adding multiple episodes. Notifies that the selected list exceeds the bulk limit so only the first set up to the limit will be added. '%1$@' is a placeholder for the max amount of episodes to add. */
-"multi_select_add_episodes_max_format" = "Ajout d’un maximum de %1$@ épisodes.";
+"multi_select_add_episodes_max_format" = "Ajouter un maximum de %1$@ épisodes.";
 
 /* Multi-select status message for adding multiple episodes. '%1$@' is a placeholder for the amount of episodes to add. */
-"multi_select_adding_episodes_plural_format" = "Ajout de %1$@ épisodes.";
+"multi_select_adding_episodes_plural_format" = "Ajouter %1$@ épisodes.";
 
 /* Multi-select status message for adding an episode. '%1$@' is a placeholder for the amount of episodes to add. */
-"multi_select_adding_episodes_singular" = "Ajout de 1 épisode.";
+"multi_select_adding_episodes_singular" = "Ajouter 1 épisode.";
 
 /* Multi-select status message for archiving multiple episodes. '%1$@' is a placeholder for the count of files to be archived (the number will be more than one). */
-"multi_select_archiving_episodes_plural_format" = "Archivage de %1$@ épisodes";
+"multi_select_archiving_episodes_plural_format" = "Archiver %1$@ épisodes";
 
 /* Multi-select status message for archiving one episode. */
-"multi_select_archiving_episodes_singular" = "Archivage de 1 épisode";
+"multi_select_archiving_episodes_singular" = "Archiver 1 épisode";
 
 /* Message portion of the prompt to delete the selected files on the multi select UI. '%1$@' is a placeholder for the count of files to be deleted (the number will be more than one). */
-"multi_select_delete_file_message_plural" = "Voulez-vous vraiment supprimer %1$@ fichiers?";
+"multi_select_delete_file_message_plural" = "Êtes-vous sûr de vouloir supprimer %1$@ fichiers ?";
 
 /* Message portion of the prompt to delete a selected file on the multi select UI. */
-"multi_select_delete_file_message_singular" = "Voulez-vous vraiment supprimer 1 fichier?";
+"multi_select_delete_file_message_singular" = "Êtes-vous sûr de vouloir supprimer 1 fichier ?";
 
 /* Multi-select status message informing the user that downloads have begun. '%1$@' is a placeholder for the count of the selected items being downloaded. */
-"multi_select_downloading_episodes_format" = "Téléchargement de %1$@";
+"multi_select_downloading_episodes_format" = "En cours de téléchargement %1$@";
 
 /* Multi-select status message for marking multiple episodes as played. '%1$@' is a placeholder for the count of episodes to be marked played (the number will be more than one). */
-"multi_select_mark_episodes_played_plural_format" = "Marquage de %1$@ épisodes comme lus.";
+"multi_select_mark_episodes_played_plural_format" = "Marquer %1$@ épisodes comme lus.";
 
 /* Multi-select status message for marking one episode as played. */
-"multi_select_mark_episodes_played_singular" = "Marquage de 1 épisode comme lu.";
+"multi_select_mark_episodes_played_singular" = "Marquer 1 épisode comme lu.";
 
 /* Multi-select status message for marking multiple episodes as not played. '%1$@' is a placeholder for the count of episodes to be marked not played (the number will be more than one). */
-"multi_select_mark_episodes_unplayed_plural_format" = "Marquage de %1$@ épisodes comme non lus.";
+"multi_select_mark_episodes_unplayed_plural_format" = "Marquer %1$@ épisodes comme non lus.";
 
 /* Multi-select status message for marking one episode as not played. */
-"multi_select_mark_episodes_unplayed_singular" = "Marquage de 1 épisode comme non lu.";
+"multi_select_mark_episodes_unplayed_singular" = "Marquer 1 épisode comme non lu.";
 
 /* Multi-select status message informing the user how many episodes have been queued for download. '%1$@' is a placeholder for the count of the selected items be queued for download. */
-"multi_select_queuing_episodes_format" = "Ajout de %1$@ à la file d’attente";
+"multi_select_queuing_episodes_format" = "%1$@ épisodes en file d’attente";
 
 /* Multi-select status message informing the user one episode download is being removed. */
-"multi_select_remove_download_singular" = "Retrait de 1 téléchargement.";
+"multi_select_remove_download_singular" = "Suppression d’1 téléchargement.";
 
 /* Multi-select status message informing the user how many episodes downloads are being removed. '%1$@' is a placeholder for the count of the selected items be removed for download. */
-"multi_select_remove_downloads_plural_format" = "Retrait de %1$@ téléchargements.";
+"multi_select_remove_downloads_plural_format" = "Suppression de %1$@ téléchargements.";
 
 /* Title for the prompt to mark the selected items as not having been played. */
-"multi_select_remove_mark_unplayed" = "Marquer comme non lu(s)";
+"multi_select_remove_mark_unplayed" = "Marquer comme non lu";
 
 /* Multi-select label indicating the number of selected items. '%1$@' is a placeholder for the number of selected items, this will be more than one. */
-"multi_select_selected_count_plural" = "%1$@ ÉPISODES SÉLECTIONNÉS";
+"multi_select_selected_count_plural" = "%1$@ ÉPISODES SÉLECTIONNÉS";
 
 /* Multi-select label indicating that there is one item selected. */
 "multi_select_selected_count_singular" = "1 ÉPISODE SÉLECTIONNÉ";
@@ -1381,34 +1381,34 @@
 "multi_select_shortcut_in_action_bar" = "RACCOURCI DANS LA BARRE D’ACTIONS";
 
 /* Title for the prompt to mark the selected items as stared (favorited). */
-"multi_select_star" = "Ajouter les épisodes aux favoris";
+"multi_select_star" = "Épisodes favoris";
 
 /* Multi-select status message for marking multiple episodes as favorited (starred). '%1$@' is a placeholder for the count of episodes to be starred (the number will be more than one). */
-"multi_select_starring_episodes_plural_format" = "Ajout de %1$@ épisodes aux favoris.";
+"multi_select_starring_episodes_plural_format" = "Mettre %1$@ épisodes en favori.";
 
 /* Multi-select status message for marking one episode as favorited (starred). */
-"multi_select_starring_episodes_singular" = "Ajout de 1 épisode aux favoris.";
+"multi_select_starring_episodes_singular" = "Mettre 1 épisode en favori.";
 
 /* Multi-select status message for unarchiving multiple episodes. '%1$@' is a placeholder for the count of files to be unarchived (the number will be more than one). */
-"multi_select_unarchiving_episodes_plural_format" = "Désarchivage de %1$@ épisodes.";
+"multi_select_unarchiving_episodes_plural_format" = "Désarchiver %1$@ épisodes";
 
 /* Multi-select status message for unarchiving one episode. */
-"multi_select_unarchiving_episodes_singular" = "Désarchivage de 1 épisode.";
+"multi_select_unarchiving_episodes_singular" = "Désarchiver 1 épisode";
 
 /* Title for the prompt to remove the selected items from being stared (favorited). */
-"multi_select_unstar" = "Retirer des épisodes des favoris";
+"multi_select_unstar" = "Retirer les épisodes des favoris";
 
 /* Multi-select status message for marking multiple episodes as not favorited (un-starred). '%1$@' is a placeholder for the count of episodes to be un-starred (the number will be more than one). */
-"multi_select_unstarring_episodes_plural_format" = "Retrait de %1$@ épisodes des favoris.";
+"multi_select_unstarring_episodes_plural_format" = "Retirer %1$@ épisodes des favoris";
 
 /* Multi-select status message for marking one episode as not favorited (un-starred). */
-"multi_select_unstarring_episodes_singular" = "Retrait de 1 épisode des favoris.";
+"multi_select_unstarring_episodes_singular" = "Retirer 1 épisode des favoris";
 
 /* Common word used as a title when asking the user to name something */
 "name" = "Nom";
 
 /* Email change form new email address field prompt */
-"new_email_address_prompt" = "Nouvelle adresse courriel";
+"new_email_address_prompt" = "Nouvelle adresse e-mail";
 
 /* A common string used throughout the app. References to new episodes. */
 "new_episodes" = "Nouveaux épisodes";
@@ -1420,16 +1420,16 @@
 "next" = "Suivant";
 
 /* A common string used throughout the app. Prompt to move to the next episode. */
-"next_episode" = "Prochain épisode";
+"next_episode" = "Épisode suivant";
 
 /* A common string used throughout the app. Format used to call out when the associated subscription will be renewed. '%1$@' is a placeholder for a localized date indicating when the renewal will process. */
-"next_payment_format" = "Prochain paiement : %1$@";
+"next_payment_format" = "Prochain paiement le %1$@";
 
 /* A common string used throughout the app. Default 'not set' option mostly used with group settings. */
 "none" = "Aucun";
 
 /* A common string used throughout the app. Informs the user that they are not on WiFi and the action they're about to take will use data. Used for downloads and uploads. */
-"not_on_wifi" = "Vous n’êtes pas sur Wi-Fi";
+"not_on_wifi" = "Vous n’êtes pas connecté au WiFi";
 
 /* Prompt to play the selected item now. */
 "notifications_play_now" = "Lire maintenant";
@@ -1438,10 +1438,10 @@
 "now_playing" = "En cours de lecture";
 
 /* A common string used throughout the app. Specifically calls out the item that is currently being played. '%1$@' is a placeholder for the item'r name that is being played. */
-"now_playing_item" = "%1$@ en cours de lecture";
+"now_playing_item" = "%1$@ En cours de lecture";
 
 /* A common string used throughout the app. Refers to the Now Playing tab in the player. Removes 'Now' to conserve space. */
-"now_playing_short_title" = "Lecture en cours";
+"now_playing_short_title" = "En lecture";
 
 /* A common string used throughout the app. Indicates that the feature is not enabled. */
 "off" = "Désactivé";
@@ -1450,80 +1450,80 @@
 "ok" = "OK";
 
 /* A common string used throughout the app. Often used as a toggle to enable a feature only when the user is on Wifi. */
-"only_on_wifi" = "Uniquement sur Wi-Fi";
+"only_on_wifi" = "Uniquement sur le WiFi";
 
 /* Message for the dialog box informing the user that the podcast import from the provided OPML file has failed. */
-"opml_import_failed_message" = "Impossible d’importer les balados du fichier OPML que vous avez fourni. Veuillez vérifier qu’il est valide.";
+"opml_import_failed_message" = "Impossible d’importer des podcasts à partir du fichier OPML indiqué. Veuillez vérifier qu’il est valide.";
 
 /* Title for the dialog box informing the user that the podcast import from the provided OPML file has failed. */
-"opml_import_failed_title" = "Échec de l’importation du fichier OPML";
+"opml_import_failed_title" = "Échec de l’importation OPML";
 
 /* Progress message indicating the total number of podcasts imported from an OPML file. '%1$@' serves as a placeholder for the current number of imported podcasts. '%2$@' serves as a placeholder for the total number of podcasts to import. */
-"opml_import_progress_format" = "Importation %1$@ de %2$@";
+"opml_import_progress_format" = "Importation de %1$@ sur %2$@";
 
 /* Progress message indicating that the import process of an OPML file is running. */
-"opml_importing" = "Importation des balados...";
+"opml_importing" = "Importation de podcasts...";
 
 /* Format used to indicate the current page and total in a custom page control. '%1$@' is a placeholder for the current page. '%2$@' is a placeholder for the total pages. */
 "page_control_page_progress_format" = "Page %1$@ de %2$@";
 
 /* A label indicating the number of podcasts the user has subscribed to compared to the total number of podcasts in the bundle. '%1$@' is a placeholder for the number of subscribed podcasts. '%2$@' is a placeholder for the number of podcasts in the bundle. */
-"paid_podcast_bundled_subscriptions" = "%1$@\/%2$@ ABONNÉS";
+"paid_podcast_bundled_subscriptions" = "%1$@ \/ %2$@ SOUSCRITS";
 
 /* Option to allow the user to cancel their subscription to a paid podcast feed. */
 "paid_podcast_cancel" = "Annuler la contribution";
 
 /* Message displayed when the user selects to cancel their paid podcast subscription. This message is used when the user is canceling multiple subscriptions. '%1$@' is a placeholder for the last date that the current subscriptions will remain active. */
-"paid_podcast_cancel_msg_plural" = "L’état de partisan demeurera actif jusqu’au %1$@. Après cette date, vous ne pourrez plus écouter ces balados.";
+"paid_podcast_cancel_msg_plural" = "Le statut de l’abonné restera actif jusqu’au %1$@. Après cette date, vous ne pourrez plus écouter ces podcasts.";
 
 /* Message displayed when the user selects to cancel their paid podcast subscription. This message is used when the podcast allows the user to access episodes that were available to them during their subscription window. '%1$@' is a placeholder for the last date that the current subscription will remain active. */
-"paid_podcast_cancel_msg_retain_access" = "L’état de partisan demeurera actif jusqu’au %1$@. Vous pourrez uniquement écouter des épisodes publiés avant cette date.";
+"paid_podcast_cancel_msg_retain_access" = "Le statut de l’abonné restera actif jusqu’au %1$@. Vous ne pourrez écouter que les épisodes diffusés avant cette date.";
 
 /* Message displayed when the user selects to cancel their paid podcast subscription. This message is used when the user is only canceling a singular subscription. '%1$@' is a placeholder for the last date that the current subscription will remain active. */
-"paid_podcast_cancel_msg_singular" = "L’état de partisan demeurera actif jusqu’au %1$@. Après cette date, vous ne pourrez plus écouter ce balado.";
+"paid_podcast_cancel_msg_singular" = "Le statut de l’abonné restera actif jusqu’au %1$@. Après cette date, vous ne pourrez plus écouter ce podcast.";
 
 /* A generic error indicating that the app failed to load information about the paid feed. */
-"paid_podcast_generic_error" = "Impossible de charger l’information";
+"paid_podcast_generic_error" = "Impossible de charger les informations";
 
 /* Prompt to open settings to adjust settings for a paid feed. */
-"paid_podcast_manage" = "Gérer";
+"paid_podcast_manage" = "Organiser";
 
 /* Informational label informing the user when to expect the next episode. '%1$@' is a placeholder for the next upcoming release date. */
 "paid_podcast_next_episode_format" = "Prochain épisode le %1$@";
 
 /* Informational label informing the user when the latest episode was released. '%1$@' is a placeholder for the latest release date. */
-"paid_podcast_release_frequency_format" = "Publié le %1$@";
+"paid_podcast_release_frequency_format" = "Diffusé %1$@";
 
 /* Prompt to get the user to sign in to see updates. This acts as the details message for a section. '
 ' is the new line character to cause a line wrap. */
-"paid_podcast_signin_prompt_msg" = "CONNECTEZ-VOUS POUR\nMISES À JOUR";
+"paid_podcast_signin_prompt_msg" = "SE CONNECTER POUR\nMISES À JOUR";
 
 /* Prompt to get the user to sign in to see updates. This acts as the title for a section. */
-"paid_podcast_signin_prompt_title" = "Connectez-vous pour de nouveaux épisodes";
+"paid_podcast_signin_prompt_title" = "Se connecter pour les nouveaux épisodes";
 
 /* Format used to indicate the subscription for the paid podcast has ended. '%1$@' is a placeholder for the date that the subscription ended on. */
-"paid_podcast_subscription_ended" = "TERMINÉ : %1$@";
+"paid_podcast_subscription_ended" = "A EXPIRÉ LE %1$@";
 
 /* Format used to indicate the subscription for the paid podcast will end on the specified date. '%1$@' is a placeholder for the date that the subscription will end. */
-"paid_podcast_subscription_ends" = "SE TERMINE : %1$@";
+"paid_podcast_subscription_ends" = "EXPIRE LE %1$@";
 
 /* A label used to inform the user that the selected podcast feed is for paid supporters only. */
-"paid_podcast_supporter_only_msg" = "Flux pour les partisans uniquement";
+"paid_podcast_supporter_only_msg" = "Flux réservé aux abonnés";
 
 /* A confirmation message for when a user has selected too unsubscribe and has downloaded files. */
-"paid_podcast_unsubscribe_msg" = "En vous désabonnant de tous ces balados, tous les fichiers téléchargés de ceux-ci seront supprimés? Voulez-vous vraiment vous désabonner?";
+"paid_podcast_unsubscribe_msg" = "Se désabonner de tous ces podcasts supprimera tous les fichiers téléchargés qu’ils contiennent, confirmez-vous ?";
 
 /* A common string used throughout the app. Prompt to pause the playback. */
-"pause" = "Suspendre";
+"pause" = "Pause";
 
 /* A common string used throughout the app. Used to reference the Phone as the playing source with in the Apple Watch App (Watch is the other option for this use case) */
 "phone" = "Téléphone";
 
 /* A common string used throughout the app. Prompt to start playback. */
-"play" = "Lire";
+"play" = "Lecture";
 
 /* A common string used throughout the app. Prompt to start playback and add the remaining selected items to the queue. */
-"play_all" = "Lire tout";
+"play_all" = "Tout lire";
 
 /* A common string used throughout the app. Prompt to add the selected item(s) to the end of the queue. */
 "play_last" = "Lire dernier";
@@ -1532,13 +1532,13 @@
 "play_next" = "Lire suivant";
 
 /* One of the options for how aggressive to be in trimming silence. Sets it to max the highest setting. */
-"playback_effect_trim_silence_max" = "Max";
+"playback_effect_trim_silence_max" = "Maximum";
 
 /* One of the options for how aggressive to be in trimming silence. Sets it to medium the middle setting. */
 "playback_effect_trim_silence_medium" = "Moyen";
 
 /* One of the options for how aggressive to be in trimming silence. Sets it to mild the lowest setting. */
-"playback_effect_trim_silence_mild" = "Faible";
+"playback_effect_trim_silence_mild" = "Léger";
 
 /* Used in the player to describe effects you can use to change audio playback. Things like speed, volume, etc. */
 "playback_effects" = "Effets de lecture";
@@ -1547,13 +1547,13 @@
 "playback_failed" = "Échec de la lecture";
 
 /* Label indicating the current value for the playback speed. '%1$@' is a placeholder for the playback speed and 'x' is meant to read as 'times' as in '1.1 times' for '1.1x' */
-"playback_speed" = "%1$@x";
+"playback_speed" = "%1$@ x";
 
 /* Accessibility hint text informing the user that the Sleep timer is enabled. */
-"player_accessibility_sleep_timer_on" = "Minuterie de veille activée";
+"player_accessibility_sleep_timer_on" = "Mise en veille activée";
 
 /* Subtitle for settings indicating this item operates as delete for files. */
-"player_action_subtitle_delete" = "Affiché en tant que Supprimer pour les épisodes personnalisés";
+"player_action_subtitle_delete" = "Fonctionne comme une suppression des épisodes personnalisés";
 
 /* Subtitle for settings indicating this item is hidden for files. */
 "player_action_subtitle_hidden" = "Masqué pour les épisodes personnalisés";
@@ -1562,13 +1562,13 @@
 "player_action_title_effects" = "Effets de lecture";
 
 /* Title for the prompt to navigate the user to the files section of the app. */
-"player_action_title_go_to_file" = "Accéder aux fichiers";
+"player_action_title_go_to_file" = "Accéder à Fichiers";
 
 /* Title for the available output device options. */
 "player_action_title_output_options" = "Périphérique de sortie";
 
 /* Header for the available timer options for auto-pausing playback. */
-"player_action_title_sleep_timer" = "Minuterie de veille";
+"player_action_title_sleep_timer" = "Mise en veille";
 
 /* Title for the prompt to remove an episode from the favorites. */
 "player_action_title_unstar_episode" = "Retirer l’épisode des favoris";
@@ -1577,61 +1577,61 @@
 "player_actions_rearrange_title" = "Réorganiser les actions";
 
 /* Confirmation prompt for archiving an episode. */
-"player_archived_confirmation" = "Archiver cet épisode?";
+"player_archived_confirmation" = "Archiver cet épisode ?";
 
 /* Accessibility label calling out the current artwork that's being displayed. '%1$@' is a placeholder for either the episode name or the chapter title. */
-"player_artwork" = "Illustration de %1$@";
+"player_artwork" = "Illustration %1$@";
 
 /* Information label that includes the current chapter and total chapter count example '1 of 3'. '%1$@' is a placeholder for the current chapter. '%2$@' is a placeholder for the total chapters. */
-"player_chapter_count" = "%1$@ de %2$@";
+"player_chapter_count" = "%1$@ sur %2$@";
 
 /* Accessibility label for the player control that rewinds the current playback position by a customizable time. */
 "player_decrement_time" = "Réduire le temps";
 
 /* Detail text explaining that trim silence feature. */
-"player_effects_trim_silence_details" = "Cette fonctionnalité réduit la durée d’un épisode en coupant le silence dans les conversations.";
+"player_effects_trim_silence_details" = "Réduit la longueur d’un épisode en coupant les silences dans les conversations.";
 
 /* Detail text celebrating how much time has been saved using the trim silence feature. '%1$@' is a placeholder for the amount of time saved using the feature. */
-"player_effects_trim_silence_progress" = "Au total, vous avez gagné %1$@ à l’aide de cette fonctionnalité.";
+"player_effects_trim_silence_progress" = "Au total, vous avez économisé %1$@ en utilisant cette fonction.";
 
 /* Generic error used when playback fails but the episode has a downloaded file. Warns the user that playback is failing because the associated file likely has been corrupted. */
-"player_error_corrupted_file" = "L’épisode est peut-être corrompu, mais vous pouvez essayer de l’écouter de nouveau.";
+"player_error_corrupted_file" = "L’épisode peut être corrompu, mais vous pouvez essayer de le lire à nouveau.";
 
 /* Generic error used when playback fails while streaming. Asks the user to verify their internet connection. */
 "player_error_internet_connection" = "Vérifiez votre connexion Internet et réessayez.";
 
 /* Accessibility label for the player control that fast-forwards the current playback position by a customizable time. */
-"player_increment_time" = "Augmenter le temps";
+"player_increment_time" = "Incrémenter le temps";
 
 /* Confirmation prompt for marking an episode as played. */
-"player_mark_as_played_confirmation" = "Marquer cet épisode comme étant lu?";
+"player_mark_as_played_confirmation" = "Marquer cet épisode comme lu ?";
 
 /* Warning that comes along with selecting to play all. Informs the user that their queue will be cleared. */
-"player_options_play_all_message" = "Votre file d’attente Prochains épisodes actuelle sera effacée.";
+"player_options_play_all_message" = "Ceci supprimera la file d’attente actuelle.";
 
 /* Prompt to play a single episode from a multi-select screen. */
 "player_options_play_episode_singular" = "Lire 1 épisode";
 
 /* Prompt to play a multiple episodes from a multi-select screen. '%1$@' is a placeholder for the number of episodes; the value will be more than one. */
-"player_options_play_episodes_plural" = "Lire %1$@ épisodes";
+"player_options_play_episodes_plural" = "Lire %1$@ épisodes";
 
 /* Section header for organizing which options will show in the player vs in the menu. */
 "player_options_shortcut_on_player" = "RACCOURCI SUR LE LECTEUR";
 
 /* Accessibility label for the Route selector control. Opens the Apple menu for selecting the playback device such as headphones or a Bluetooth speaker. */
-"player_route_selection" = "Sélecteur de chemin";
+"player_route_selection" = "Sélecteur de canal de diffusion";
 
 /* Header for the share menu where the user selects to share the podcast, episode, or episode at the current position */
-"player_share_header" = "PARTAGER LE LIEN DANS";
+"player_share_header" = "PARTAGER LE LIEN VERS";
 
 /* Error title when there is a download error. */
-"player_user_episode_download_error" = "Erreur lors du téléchargement";
+"player_user_episode_download_error" = "Erreur de téléchargement";
 
 /* Error title when there is a playback error. */
-"player_user_episode_playback_error" = "Erreur lors de la lecture";
+"player_user_episode_playback_error" = "Erreur de lecture";
 
 /* Error title when there is an upload error. */
-"player_user_episode_upload_error" = "Erreur lors du téléversement";
+"player_user_episode_upload_error" = "Erreur de chargement";
 
 /* A common string used throughout the app. Catch all prompt to suggest to the user to try the task again. */
 "please_try_again" = "Veuillez réessayer";
@@ -1640,61 +1640,61 @@
 "please_try_again_later" = "Veuillez réessayer plus tard.";
 
 /* Prompt informing the user that an account is required in order to sign up for Pocket Casts Plus */
-"plus_account_required_prompt" = "Un compte Pocket Casts est requis pour Pocket Casts Plus. Vous pourrez ainsi facilement écouter vos balados sur tous vos appareils.";
+"plus_account_required_prompt" = "Un compte Pocket Casts est nécessaire pour accéder à Pocket Casts Plus. Cela garantit une écoute parfaite sur tous vos appareils.";
 
 /* Details prompt informing the user that an account is required in order to sign up for Pocket Casts Plus */
 "plus_account_required_prompt_details" = "Créez un compte ou connectez-vous pour profiter de votre accès à Pocket Casts Plus.";
 
 /* Details message informing the user that they'll return to a free account at the end of their trial */
-"plus_account_trial_details" = "Lorsque votre période d’essai sera terminée, vous pourrez encore profiter des excellents avantages de votre compte normal. Joyeuse baladodiffusion!";
+"plus_account_trial_details" = "À la fin de votre essai, vous bénéficierez toujours de tous les avantages de votre compte classique. Bon podcasting !";
 
 /* The available cloud storage limit available to Pocket Casts Plus Subscribers. '%1$@' is a placeholder for the available storage. */
-"plus_cloud_storage_limit_format" = "%1$@ Go de stockage infonuagique";
+"plus_cloud_storage_limit_format" = "%1$@ Go de stockage Cloud";
 
 /* Error message informing the user that they have already signed up for plus with this account. */
 "plus_error_already_registered" = "Vous avez déjà un compte Pocket Casts Plus";
 
 /* Error message details informing the user that they have already signed up for plus with this account so they can't take advantage of the entered promotion. */
-"plus_error_already_registered_details" = "Merci de votre soutien, mais malheureusement, cela signifie que vous ne pouvez pas profiter de cette promotion.";
+"plus_error_already_registered_details" = "Merci pour votre confiance, mais malheureusement cela signifie que vous ne pouvez pas participer à cette promotion.";
 
 /* Account detail message informing the user when their Plus account will expire. '%1$@' is a placeholder for when the account will expire. */
 "plus_expiration_format" = "Expire le %1$@";
 
 /* Feature of Pocket Casts plus, Cloud Storage. Being able to upload your files to the Pocket Casts servers */
-"plus_feature_cloud_storage" = "Stockage infonuagique";
+"plus_feature_cloud_storage" = "Stockage Cloud";
 
 /* Feature of Pocket Casts plus, Themes and icons. Themes for changing the way the app looks, icons to change the icon shown on your home screen */
-"plus_feature_themes_icons" = "Thèmes et icônes supplémentaires";
+"plus_feature_themes_icons" = "Thèmes et icônes d’applications supplémentaires";
 
 /* Feature of Pocket Casts plus, Apple Watch app. Standalone meaning it can run with your iPhone */
-"plus_feature_watch_app" = "Lecture autonome sur Watch";
+"plus_feature_watch_app" = "Lecture autonome sur la montre";
 
 /* Feature of Pocket Casts plus, Web Player. As in our web based version capable of playing podcasts */
 "plus_feature_web_player" = "Lecteur Web";
 
 /* A common string used throughout the app. often used as a section header to divide settings related to Pocket Casts Plus vs free features. 'PLUS' refers to Pocket Casts Plus. */
-"plus_features" = "FONCTIONNALITÉS PLUS";
+"plus_features" = "FONCTIONNALITÉS EXCLUSIVES PLUS";
 
 /* Account detail message informing the user that they have been granted a limited free membership. '%1$@' is a placeholder for a localized string for the free time period. */
-"plus_free_membership_format" = "%1$@ gratuit";
+"plus_free_membership_format" = "Période de gratuité : %1$@";
 
 /* Account detail message informing the user that they have been granted a lifetime membership. */
 "plus_lifetime_membership" = "Membre à vie";
 
 /* Pocket Casts Plus marketing page, description of the Cloud Storage feature */
-"plus_marketing_cloud_storage_description" = "Accélérer vos conférences. Passez en revue les autres contenus. Soyez votre propre DJ de balados.";
+"plus_marketing_cloud_storage_description" = "Accélérez vos présentations. Conservez d’autres contenus. Devenez votre propre DJ de podcast.";
 
 /* Pocket Casts Plus marketing page, title of the Cloud Storage feature */
-"plus_marketing_cloud_storage_title" = "Stockage infonuagique";
+"plus_marketing_cloud_storage_title" = "Stockage Cloud";
 
 /* Pocket Casts Plus marketing page, description of the Desktop Apps feature */
-"plus_marketing_desktop_apps_description" = "Apportez vos balados à plus d’endroits avec nos applications Windows, macOS et Web.";
+"plus_marketing_desktop_apps_description" = "Diffusez vos podcasts partout grâce à nos applications Windows, macOS et Web.";
 
 /* Pocket Casts Plus marketing page, title of the Desktop Apps feature */
 "plus_marketing_desktop_apps_title" = "Applications de bureau";
 
 /* Pocket Casts Plus marketing page, the final call to action to get people to upgrade */
-"plus_marketing_final_call_to_action" = "Il est temps d’améliorer votre jeu de baladodiffusion?\nObtenez des applications de bureau, apportez vos propres fichiers et donnez un coup de jeune à vos applications avec de nouveaux thèmes, exclusifs aux membres Plus.";
+"plus_marketing_final_call_to_action" = "Il est temps de passer à la vitesse supérieure pour vos podcasts ?\nProfitez des applications de bureau, transférez vos propres fichiers et ajoutez une touche de fraîcheur avec de nouveaux thèmes, réservés exclusivement aux membres Plus.";
 
 /* Pocket Casts Plus marketing page, description of the Folders feature */
 "plus_marketing_folders_description" = "Créez des dossiers pour organiser votre collection de podcasts.";
@@ -1703,82 +1703,82 @@
 "plus_marketing_learn_more_button" = "En savoir plus sur Pocket Casts Plus";
 
 /* Pocket Casts Plus marketing page, the main description of Pocket Casts Plus */
-"plus_marketing_main_description" = "Faites-en une affaire personnelle et écoutez votre contenu partout. Téléversez vos fichiers audio personnels dans nos serveurs infonuagiques, accédez à votre compte dans notre lecteur Web et appropriez-vous notre application.";
+"plus_marketing_main_description" = "Soyez vous-même tout en bénéficiant de la diffusion. Téléchargez vos fichiers audio personnels sur nos serveurs Cloud, accédez à votre compte via notre lecteur web, et appropriez-vous l’application.";
 
 /* Pocket Casts Plus marketing page, the main title */
-"plus_marketing_main_title" = "Des fonctionnalités améliorées pour les auditeurs expérimentés";
+"plus_marketing_main_title" = "Des fonctionnalités optimisées pour les auditeurs exigeants.";
 
 /* Pocket Casts Plus marketing page, description of the Themes & Icons feature */
-"plus_marketing_themes_icons_description" = "Affichez vos vraies couleurs. Des icônes et des thèmes exclusifs uniquement pour le club plus.";
+"plus_marketing_themes_icons_description" = "Affichez vos véritables couleurs. Des icônes et des thèmes exclusifs pour le club Plus uniquement.";
 
 /* Pocket Casts Plus marketing page, title of the Themes & Icons feature */
 "plus_marketing_themes_icons_title" = "Thèmes et icônes";
 
 /* Pocket Casts Plus marketing page, the text on the upgrade button */
-"plus_marketing_upgrade_button" = "Mettre à niveau à Plus";
+"plus_marketing_upgrade_button" = "Mise à niveau vers Plus";
 
 /* Pocket Casts Plus marketing page, description of the Watch Playback feature */
-"plus_marketing_watch_playback_description" = "Sortez courir en laissant votre téléphone à la maison, sans rien manquer. L’Apple Watch est autonome.";
+"plus_marketing_watch_playback_description" = "Abandonnez votre téléphone et partez courir - sans perdre un instant. L’Apple Watch est autonome.";
 
 /* Pocket Casts Plus marketing page, title of the Watch Playback feature */
-"plus_marketing_watch_playback_title" = "Lecture sur Watch";
+"plus_marketing_watch_playback_title" = "Lecture sur la montre";
 
 /* Informational message informing the user that their recurring payments for Plus have been canceled. */
 "plus_payment_canceled" = "Paiement annulé";
 
 /* Label that goes along with the yearly subscription used to indicate that the yearly plan is the best overall value. */
-"plus_payment_frequency_best_value" = "Valeur optimale";
+"plus_payment_frequency_best_value" = "Meilleur Prix";
 
 /* Informational label that's below the monthly price of Pocket Casts Plus. This label sits below a localized price. */
 "plus_per_month" = "par mois";
 
 /* The price of Pocket Casts Plus per month. '%1$@' is a localized monthly price. */
-"plus_price_per_month" = "%1$@\/mois";
+"plus_price_per_month" = "%1$@ \/ mois";
 
 /* Promotional information for Pocket Casts Plus. Please note that "Pocket Casts Plus" should not be translated because it's a product name */
-"plus_promo_paragraph" = "Obtenez Pocket Casts Plus pour déverrouiller cette fonctionnalité et beaucoup d’autres!";
+"plus_promo_paragraph" = "Obtenez Pocket Casts Plus pour débloquer cette fonctionnalité, et bien plus encore !";
 
 /* Error message informing the user the promotion code has expired */
-"plus_promotion_expired" = "Offre expirée ou non valide";
+"plus_promotion_expired" = "Promotion expirée ou invalide";
 
 /* A nudge to ask the user to continue the sign up process even though they encountered an error. */
-"plus_promotion_expired_nudge" = "Vous pouvez tout de même vous inscrire à Pocket Casts Plus, créer un compte normal, ou simplement vous lancer dans les balados.";
+"plus_promotion_expired_nudge" = "Vous êtes de toutes façons bienvenu pour vous inscrire à Pocket Casts Plus, pour créer un compte classique ou plonger directement.";
 
 /* Error message informing the user the promotion code has already been used */
 "plus_promotion_used" = "Code déjà utilisé";
 
 /* Heading for things that require Pocket Casts Plus to work. Please note that "Pocket Casts Plus" should not be translated because it's a product name */
-"plus_required_feature" = "Cette fonctionnalité nécessite Pocket Casts Plus";
+"plus_required_feature" = "Cette fonctionnalité nécessite Pocket Casts Plus";
 
 /* Title for the screen to allow the user to choose between a monthly or yearly subscription. */
-"plus_select_payment_frequency" = "Sélectionner la fréquence de paiement";
+"plus_select_payment_frequency" = "Sélectionner une fréquence de paiement";
 
 /* Message informing the user that their Pocket Casts Plus subscription is managed by Apple's system and needs to be managed there. */
-"plus_subscription_apple" = "Votre abonnement est géré par l’App Store d’Apple.";
+"plus_subscription_apple" = "Votre abonnement est géré par l’Apple App Store";
 
 /* Message informing the user where to manage their Pocket Casts Plus subscription managed by Apple. */
-"plus_subscription_apple_details" = "Pour annuler votre abonnement, vous devrez le faire dans les Paramètres.";
+"plus_subscription_apple_details" = "Pour annuler votre abonnement, accédez à Réglages.";
 
 /* Message informing the user when their Pocket Casts Plus subscription will expire. %1$@ is a placeholder for the expiration date. */
-"plus_subscription_expiration" = "PLUS EXPIRE DANS %1$@";
+"plus_subscription_expiration" = "PLUS EXPIRE LE %1$@";
 
 /* Message informing the user that their Pocket Casts Plus subscription is managed by Google's system and needs to be managed there. */
-"plus_subscription_google" = "Vous vous êtes abonné(e) à Pocket Casts Plus sur un appareil Android.";
+"plus_subscription_google" = "Il semble que vous vous soyez abonné à Pocket Casts Plus depuis un périphérique Android.";
 
 /* Message informing the user where to manage their Pocket Casts Plus subscription managed by Google. */
-"plus_subscription_google_details" = "Pour annuler votre abonnement, vous devrez le faire dans les Paramètres.";
+"plus_subscription_google_details" = "Pour annuler votre abonnement, accédez à Réglages.";
 
 /* Message informing the user that their Pocket Casts Plus subscription is managed by Web's system and needs to be managed there. */
-"plus_subscription_web" = "Vous vous êtes abonné(e) à Pocket Casts Plus sur le Web.";
+"plus_subscription_web" = "Il semble que vous vous soyez abonné à Pocket Casts Plus depuis le Web.";
 
 /* Message informing the user where to manage their Pocket Casts Plus subscription managed by Web. */
-"plus_subscription_web_details" = "Pour annuler votre abonnement, vous devrez le faire sur Pocketcasts.com.";
+"plus_subscription_web_details" = "Pour annuler votre abonnement, connectez-vous sur le site Pocketcasts.com.";
 
 /* The heading shown for the Pocket Casts Newsletter */
-"pocket_casts_newsletter" = "Bulletin d’information Pocket Casts";
+"pocket_casts_newsletter" = "Newsletter Pocket Casts";
 
 /* The description for the Pocket Casts Newsletter */
-"pocket_casts_newsletter_description" = "Recevez des nouvelles, des mises à jour de l’application, des listes de lecture thématiques, des entrevues et plus encore.";
+"pocket_casts_newsletter_description" = "Recevez des actualités, des mises à jour d’applications, des playlists thématiques, des interviews et plus encore.";
 
 /* A common string used throughout the app. Refers to the subscription program Pocket Casts Plus subscription. 'Pocket Casts' as a proper noun should not be localized. */
 "pocket_casts_plus" = "Pocket Casts Plus";
@@ -1787,13 +1787,13 @@
 "pocket_casts_plus_short" = "Plus";
 
 /* Indicates that the access to the podcast has ended on the specified date. '%1$@' is a placeholder for date that the access expired. */
-"podcast_access_ended" = "L’accès a pris fin : %1$@";
+"podcast_access_ended" = "Accès au podcast expiré le %1$@";
 
 /* Indicates that the access to the podcast will end on the specified date. '%1$@' is a placeholder for date that the access will end. */
-"podcast_access_ends" = "Fin de l’accès : %1$@";
+"podcast_access_ends" = "Expiration de l’accès au podcast le %1$@";
 
 /* Prompt to archive all of the selected items. */
-"podcast_archive_all" = "Archiver tous les épisodes";
+"podcast_archive_all" = "Tout archiver";
 
 /* Prompt to archive all played episodes of the current podcast. */
 "podcast_archive_all_played" = "Archiver tous les épisodes lus";
@@ -1802,46 +1802,46 @@
 "podcast_archive_episode_count_singular" = "Archiver 1 épisode";
 
 /* Confirmation to archive a certain number of podcast episodes. '%1$@' is a placeholder for the number of episodes. */
-"podcast_archive_episodes_count_plural_format" = "Archiver %1$@ épisodes";
+"podcast_archive_episodes_count_plural_format" = "Archiver %1$@ épisodes";
 
 /* Confirmation message that appears alongside the various bulk archive prompts. */
-"podcast_archive_prompt_msg" = "Vous devriez les archiver seulement si vous ne voulez plus les voir.";
+"podcast_archive_prompt_msg" = "Effectuez cette action uniquement si vous ne souhaitez plus les afficher.";
 
 /* Indicates that the episode has been archived. */
-"podcast_archived" = "Épisodes archivés";
+"podcast_archived" = "Archivé";
 
 /* Label used to display the number or archived episodes in a podcast. '%1$@' is a placeholder for the archived episode number. */
-"podcast_archived_count_format" = "%1$@ épisodes archivés";
+"podcast_archived_count_format" = "%1$@ épisodes archivés";
 
 /* Informational message informing the user that no episodes are being displayed because they're all archived. '%1$@' is a placeholder for the number of episodes. */
-"podcast_archived_msg" = "Tous les %1$@ épisodes de ce balado ont été archivés.";
+"podcast_archived_msg" = "Les %1$@ épisodes de ce podcast ont tous été archivés.";
 
 /* A common string used throughout the app. Displays the count of selected podcasts. '%1$@' is a placeholder for the number of podcasts, the value will be more than one. */
-"podcast_count_plural_format" = "%1$@ balados";
+"podcast_count_plural_format" = "%1$@ podcasts";
 
 /* A common string used throughout the app. Displays the count of selected podcasts. This is the singular version of an accompanying plural format. */
-"podcast_count_singular" = "1 balado";
+"podcast_count_singular" = "1 podcast";
 
 /* Error message informing the user that the episode encountered a download error. */
-"podcast_details_download_error" = "Le téléchargement de l’épisode a échoué.";
+"podcast_details_download_error" = "Le téléchargement de l’épisode a échoué";
 
 /* Message informing the user that the episode will download once the device restores a WiFi connection. */
-"podcast_details_download_wifi_queue" = "Cet épisode sera automatiquement téléchargé lorsque vous serez de nouveau connecté à un réseau Wi-Fi.";
+"podcast_details_download_wifi_queue" = "Cet épisode sera automatiquement téléchargé lorsque vous serez à nouveau connecté au WiFi.";
 
 /* Message details informing the user that the episode has been unarchived manually and won't be archived when the episode limit is reached. '%1$@' is a placeholder for the episode limit. */
-"podcast_details_manual_unarchive_msg" = "Il ne sera pas automatiquement archivé en raison de votre limite de %1$@ nouveaux épisodes.";
+"podcast_details_manual_unarchive_msg" = "Il ne sera pas archivé automatiquement lorsque la nouvelle limite de %1$@ épisodes sera atteinte.";
 
 /* Message informing the user that the episode has been unarchived manually. Used with episode limits. */
 "podcast_details_manual_unarchive_title" = "Épisode désarchivé manuellement";
 
 /* Error message informing the user that the episode encountered a playback error. */
-"podcast_details_playback_error" = "Lecture de l’épisode impossible";
+"podcast_details_playback_error" = "Impossible de lire l’épisode";
 
 /* Indicates that the episode is queued for download. */
 "podcast_details_queued" = "En file d’attente";
 
 /* Confirmation prompt to remove the episode file for the selected podcast episode. */
-"podcast_details_remove_download" = "RETIRER LE FICHIER TÉLÉCHARGÉ?";
+"podcast_details_remove_download" = "SUPPRIMER LE FICHIER TÉLÉCHARGÉ ?";
 
 /* Prompt to download the selected podcast now. */
 "podcast_download_now" = "Télécharger maintenant";
@@ -1850,61 +1850,61 @@
 "podcast_downloading" = "Téléchargement... %1$@";
 
 /* Label used to display the number of episodes in a podcast. '%1$@' is a placeholder for the number of episodes. */
-"podcast_episode_count_plural_format" = "%1$@ épisodes";
+"podcast_episode_count_plural_format" = "%1$@ épisodes";
 
 /* Label used to display the number of episodes in a podcast. This is the singular form of an accompanying plural form. */
 "podcast_episode_count_singular" = "1 épisode";
 
 /* Label used to display the episode limit for a podcast. '%1$@' is a placeholder for the episode limit. */
-"podcast_episode_limit_count_format" = "Limité à %1$@";
+"podcast_episode_limit_count_format" = "Limité à %1$@ épisodes";
 
 /* Message for a generic error used when a podcast fails to load without a more detailed reason why. ':(' is meant to be ASCII art for a sad face. */
-"podcast_error_message" = "Impossible de charger les renseignements sur le balado :(";
+"podcast_error_message" = "Impossible de charger les données du podcast :(";
 
 /* Title for a generic error used when a podcast fails to load without a more detailed reason why. Meant to be a fun cultural reference. */
-"podcast_error_title" = "Je ne peux littéralement même pas";
+"podcast_error_title" = "Il n’y a absolument rien à faire";
 
 /* Indicates that a file has failed to download. */
 "podcast_failed_download" = "Le téléchargement de l’épisode a échoué.";
 
 /* Indicates that a file has failed to upload. */
-"podcast_failed_upload" = "Échec du téléversement";
+"podcast_failed_upload" = "Échec du chargement";
 
 /* Button text shown on the podcast grid when you have no podcasts, takes you to the Discover section of the app */
-"podcast_grid_discover_podcasts" = "Découvrir des balados";
+"podcast_grid_discover_podcasts" = "Découvrir des podcasts";
 
 /* Description shown when you have no podcasts on the podcast grid */
-"podcast_grid_no_podcasts_msg" = "Proviennent-ils d’une autre application? Importez vos balados en accédant à Profil > Paramètres > Importer et exporter.\n\n\nSi vous voulez obtenir des suggestions, essayez l’onglet Découvertes.";
+"podcast_grid_no_podcasts_msg" = "Vous arrivez d’une autre application ? Importez vos podcasts via Profil > Réglages > Importer et exporter.\n\n\nSi vous cherchez de l’inspiration, consultez l’onglet Découvrir.";
 
 /* Title of the message on the podcast grid when you have no podcasts */
-"podcast_grid_no_podcasts_title" = "Le temps est venu d’ajouter des balados!";
+"podcast_grid_no_podcasts_title" = "Il est temps d’ajouter des podcasts !";
 
 /* Title for the options box that allows the user to pick from the various grouping options. */
-"podcast_group_options_title" = "REGROUPER PAR";
+"podcast_group_options_title" = "GROUPER PAR";
 
 /* Prompt to hide archived episodes from the episode list. */
 "podcast_hide_archived" = "Masquer les épisodes archivés";
 
 /* Longer form informational label informing users that this podcast is limited to a configured set of episodes. '%1$@' is a placeholder for the number of episodes. */
-"podcast_limit_plural_format" = "Limité à %1$@ épisodes les plus récents";
+"podcast_limit_plural_format" = "Limité aux %1$@ épisodes les plus récents";
 
 /* Longer form informational label informing users that this podcast is limited to one episode. Singular version of an accompanying plural format. */
 "podcast_limit_singular" = "Limité à 1 épisode le plus récent";
 
 /* Progress indicator informing the user that the podcasts that have been shared or imported are currently loading. */
-"podcast_loading" = "Chargement du balado...";
+"podcast_loading" = "Chargement podcast...";
 
 /* Used to indicate no date was provided. */
-"podcast_no_date" = "Aucune date définie";
+"podcast_no_date" = "Date non définie";
 
 /* Label used to indicate that the podcast episode isn't grouped into a season. */
-"podcast_no_season" = "Aucune saison";
+"podcast_no_season" = "Hors saison";
 
 /* Accessibility label to prompt to pause an active download. */
 "podcast_pause_download" = "Suspendre le téléchargement";
 
 /* Accessibility label to prompt to pause a playback. */
-"podcast_pause_playback" = "Suspendre la lecture";
+"podcast_pause_playback" = "Mettre la lecture en pause";
 
 /* Indicates that a file is queued for download and includes the estimated size. */
 "podcast_queued" = "En file d’attente";
@@ -1922,19 +1922,19 @@
 "podcast_share_episode" = "Partager le lien vers l’épisode";
 
 /* Error message used when there are no available apps that can accept the podcast file. */
-"podcast_share_episode_error_msg" = "Vous n’avez aucun application installée qui acceptera ce fichier.";
+"podcast_share_episode_error_msg" = "Aucune application installée ne peut accepter ce fichier.";
 
 /* Error message for when a podcast can't be found after it has been shared. */
-"podcast_share_error_msg" = "L’auteur du balado pourrait l’avoir retiré après le partage du lien.";
+"podcast_share_error_msg" = "L’auteur du podcast a pu le supprimer depuis que ce lien a été partagé.";
 
 /* Error title for when a podcast can't be found after it has been shared. */
-"podcast_share_error_title" = "Épisode introuvable";
+"podcast_share_error_title" = "Impossible de trouver l’épisode";
 
 /* Progress message shown while the users curated list is being synced to the server. */
 "podcast_share_list_creating" = "Création de la liste...";
 
 /* Placeholder for the description of the podcast list. Used when users create a curated list of podcasts. This item is optional. */
-"podcast_share_list_description" = "Description (facultatif)";
+"podcast_share_list_description" = "Description (facultative)";
 
 /* Placeholder for the name of the podcast list. Used when users create a curated list of podcasts. */
 "podcast_share_list_name" = "Nom de la liste";
@@ -1946,55 +1946,55 @@
 "podcast_show_archived" = "Afficher les épisodes archivés";
 
 /* A common string used throughout the app. Refers to Podcasts in the singular form. */
-"podcast_singular" = "Balado";
+"podcast_singular" = "Podcast";
 
 /* Used to reference that a new podcast episode will be available in the near future. */
 "podcast_soon" = "D’un jour à l’autre";
 
 /* Title for the options box that allows the user to pick from the various sort options. */
-"podcast_sort_order_title" = "TRIER L’ORDRE";
+"podcast_sort_order_title" = "ORDRE DE TRI";
 
 /* Confirmation option to stream the selected episode. Used in tandem with a notice that the user is not on WiFi. */
-"podcast_stream_confirmation" = "Lire tout de même";
+"podcast_stream_confirmation" = "Diffuser quand même en streaming";
 
 /* Prompt to warn the user that continuing with the option to stream will consume data. Used in tandem with a notice that the user is not on WiFi. */
-"podcast_stream_data_warning" = "La lecture en continu de cet épisode utilisera des données.";
+"podcast_stream_data_warning" = "La diffusion en streaming de cet épisode va consommer des données";
 
 /* Used to reference the episode was published this month. */
 "podcast_this_month" = "Ce mois-ci";
 
 /* Indicates the remaining amount of time left in the episode. '%1$@' is a placeholder for the remaining time. */
-"podcast_time_left" = "Il reste %1$@";
+"podcast_time_left" = "Temps restant : %1$@";
 
 /* Used to reference tomorrow in terms of when the next episode will be available. */
 "podcast_tomorrow" = "Demain";
 
 /* Prompt to unarchive all of the selected items. */
-"podcast_unarchive_all" = "Désarchiver tout";
+"podcast_unarchive_all" = "Tout désarchiver";
 
 /* Indicates that the updates to the podcast has ended on the specified date. '%1$@' is a placeholder for date that the updates ended. */
-"podcast_updates_ended" = "Les mises à jour se sont terminées le : %1$@";
+"podcast_updates_ended" = "Mises à jour terminées le %1$@";
 
 /* Indicates that the updates to the podcast will end on the specified date. '%1$@' is a placeholder for date that the updates will end. */
-"podcast_updates_ends" = "Les mises à jour se terminent le : %1$@";
+"podcast_updates_ends" = "Fin des mises à jour le %1$@";
 
 /* Confirmation option to upload the selected file. Used in tandem with a notice that the user is not on WiFi. */
-"podcast_upload_confirmation" = "Téléverser maintenant";
+"podcast_upload_confirmation" = "Télécharger maintenant";
 
 /* Indicates that a file is being uploaded and includes the completed percentage. '%1$@' is a placeholder for a localized percentage that has been uploaded so far. */
-"podcast_uploading" = "Téléversement... %1$@";
+"podcast_uploading" = "Téléchargement... %1$@";
 
 /* Indicates that a file is queued to be uploaded but hasn't started yet. */
-"podcast_waiting_upload" = "En attente du téléversement";
+"podcast_waiting_upload" = "En attente de téléchargement";
 
 /* Used to reference yesterday. */
 "podcast_yesterday" = "Hier";
 
 /* The badge feature is set to show the number of unplayed episodes. */
-"podcasts_badge_all_unplayed" = "Épisodes non terminés";
+"podcasts_badge_all_unplayed" = "Épisodes non lus";
 
 /* The badge feature is set to show an indicator if an unplayed episode exists. */
-"podcasts_badge_latest_episode" = "Uniquement le plus récent épisode";
+"podcasts_badge_latest_episode" = "Seulement le dernier épisode";
 
 /* Title for the options to configure badge display options. */
 "podcasts_badges" = "Badges";
@@ -2021,10 +2021,10 @@
 "podcasts_library_sort_custom" = "Glisser-déposer";
 
 /* Grid Items will be sorted based on the date the user subscribed to them. Newest to oldest. */
-"podcasts_library_sort_date_added" = "Date ajoutée";
+"podcasts_library_sort_date_added" = "Date d’ajout";
 
 /* Grid Items will be sorted based on the date of their newest episode. Newest to oldest. */
-"podcasts_library_sort_episode_release_date" = "Date de sortie de l’épisode";
+"podcasts_library_sort_episode_release_date" = "Date de diffusion de l’épisode";
 
 /* Grid Items will be sorted alphabetically based on name. */
 "podcasts_library_sort_title" = "Nom";
@@ -2033,16 +2033,16 @@
 "podcasts_list" = "Liste";
 
 /* A common string used throughout the app. Refers to Podcasts in the plural form as well as the Podcasts screen. */
-"podcasts_plural" = "Balados";
+"podcasts_plural" = "Podcasts";
 
 /* Prompt to open the menu to share your podcasts list. */
-"podcasts_share" = "Partager des balados";
+"podcasts_share" = "Partager des podcasts";
 
 /* Presents the podcasts with small podcast artwork tiles. */
 "podcasts_small_grid" = "Petite grille";
 
 /* Prompt to open the menu to allow the user to sort their podcasts. */
-"podcasts_sort" = "Trier les balados";
+"podcasts_sort" = "Trier les podcasts";
 
 /* Common word to denote a preview of something is being shown */
 "preview" = "Prévisualisation";
@@ -2057,61 +2057,61 @@
 "profile_help_support" = "Soutenez Pocket Casts en mettant à niveau votre compte";
 
 /* Informational label indicating the last time the app was refreshed. '%1$@' is a placeholder for a date string indicating when the last refresh occurred. */
-"profile_last_app_refresh" = "Dernière actualisation de l’application %1$@";
+"profile_last_app_refresh" = "Dernière actualisation de l’application : %1$@";
 
 /* Displays the number of files for when there are multiple files. '%1$@' is a placeholder for the number of files. */
-"profile_number_of_files" = "%1$@ fichiers";
+"profile_number_of_files" = "%1$@ fichiers";
 
 /* The percentage of file storage space that is currently being used. '%1$@' is a placeholder for a localized percentage. */
-"profile_percent_full" = "%1$@ plein";
+"profile_percent_full" = "Occupé à %1$@";
 
 /* Prompt to allow the user to reset their account password. */
-"profile_reset_password" = "Réinitialisation du mot de passe";
+"profile_reset_password" = "Réinitialiser le mot de passe";
 
 /* Notice informing the user that the email to reset their password is being prepared to be sent. */
-"profile_sending_reset_email" = "Envoi du courriel de réinitialisation";
+"profile_sending_reset_email" = "Envoi de l’e-mail de réinitialisation";
 
 /* Notice informing the user that the email to reset their password has been successfully sent. This serves as the message body for an alert accompanied with a title. ':)' is meant to be ASCII art for a happy face. */
-"profile_sending_reset_email_conf_msg" = "Consultez vos courriels ;)";
+"profile_sending_reset_email_conf_msg" = "Vérifiez vos e-mails !";
 
 /* Notice informing the user that the email to reset their password has been successfully sent. This serves as the title for an alert. */
-"profile_sending_reset_email_conf_title" = "Lien de réinitialisation du mot de passe envoyé";
+"profile_sending_reset_email_conf_title" = "Lien de réinitialisation du mot de passe envoyé avec succès";
 
 /* Notice informing the user that the attempt to send the password reset email has failed. */
-"profile_sending_reset_email_failed" = "Échec de l’envoi du courriel de réinitialisation. Veuillez réessayer plus tard.";
+"profile_sending_reset_email_failed" = "L’envoi de l’e-mail de réinitialisation a échoué, veuillez réessayer plus tard.";
 
 /* Displays the number of files for when there is a single file. */
 "profile_single_file" = "1 fichier";
 
 /* Description for the empty state on screen where the user can review their starred (favorited) podcast epsiodes */
-"profile_starred_no_episodes_desc" = "Vous n’avez ajouté aucun épisode à vos favoris pour le moment.";
+"profile_starred_no_episodes_desc" = "Vous n’avez encore mis aucun épisode en favori.";
 
 /* Title for the empty state on screen where the user can review their starred (favorited) podcast epsiodes */
-"profile_starred_no_episodes_title" = "Aucun épisode favori";
+"profile_starred_no_episodes_title" = "Aucun favori";
 
 /* Confirmation message to clear the give number of episodes from the queue. '%1$@' is a placeholder for the number of episodes, this will be more than one. */
-"queue_clear_episode_queue_plural" = "Effacer %1$@ épisodes";
+"queue_clear_episode_queue_plural" = "Supprimer %1$@ épisodes";
 
 /* Prompt to allow the user to clear their queue. */
-"queue_clear_queue" = "EFFACER LA FILE D’ATTENTE";
+"queue_clear_queue" = "SUPPRIMER LA FILE D’ATTENTE";
 
 /* A common string used throughout the app. Provides an option to add the selected item(s) to a queue instead of performing the action now. Used for downloads and uploads. */
-"queue_for_later" = "Ajouter à la file d’attente";
+"queue_for_later" = "Ajouter plus tard à la file d’attente";
 
 /* Accessibility label indicating the current podcast is playing and it's episode date. '%1$@' is a placeholder for the episode date. */
 "queue_now_playing_accessibility" = "En cours de lecture. %1$@";
 
 /* Label indicating the amount of time remains on an episode. '%1$@' is a placeholder for a localized time format for the remaining time. */
-"queue_time_remaining" = "Il reste %1$@";
+"queue_time_remaining" = "Temps restant : %1$@";
 
 /* Information label indication the total time remaining in the queue. This is a total across all episodes in the up next queue. '%1$@' is a placeholder for the total time remaining in the queue. */
-"queue_total_time_remaining" = "Il reste %1$@ au total";
+"queue_total_time_remaining" = "Temps total restant : %1$@";
 
 /* Hint text in the pull to refresh custom control. Provides a notice that new Podcast episodes are being fetched. */
-"refresh_control_fetching_episodes" = "RECHERCHE DE NOUVEAUX ÉPISODES DE BALADOS";
+"refresh_control_fetching_episodes" = "RECHERCHE DE NOUVEAUX ÉPISODES DE PODCAST";
 
 /* Hint text in the pull to refresh custom control. */
-"refresh_control_pull_to_refresh" = "TIRER POUR ACTUALISER";
+"refresh_control_pull_to_refresh" = "EXTRAIRE POUR ACTUALISER";
 
 /* Hint text in the pull to refresh custom control. Informs the user that the refresh has finished successfully. */
 "refresh_control_refresh_complete" = "ACTUALISATION TERMINÉE";
@@ -2129,7 +2129,7 @@
 "refresh_control_sync_failed" = "ÉCHEC DE LA SYNCHRONISATION :(";
 
 /* Hint text in the pull to refresh custom control. Provides a notice that Podcasts are being synced with the server. */
-"refresh_control_syncing_podcasts" = "SYNCHRONISATION DES BALADOS ET DU PROGRÈS";
+"refresh_control_syncing_podcasts" = "SYNCHRONISATION DES PODCASTS ET PROGRESSION";
 
 /* A common string used throughout the app. Error title indicating that the refresh process has failed. */
 "refresh_failed" = "Échec de l’actualisation";
@@ -2159,28 +2159,28 @@
 "release_frequency_weekly" = "Hebdomadaire";
 
 /* A common string used throughout the app. Prompt to remove the selected item(s). */
-"remove" = "Retirer";
+"remove" = "Supprimer";
 
 /* A common string used throughout the app. Prompt to remove all of the selected item(s). */
-"remove_all" = "Retirer tout";
+"remove_all" = "Tout supprimer";
 
 /* A common string used throughout the app. Prompt to delete the selected item(s) local file download. */
-"remove_download" = "Retirer le téléchargement";
+"remove_download" = "Supprimer le téléchargement";
 
 /* A common string used throughout the app. Prompt to remove the selected item(s) from the up next queue. */
-"remove_from_up_next" = "Supprimer de la file d’attente Prochains épisodes";
+"remove_from_up_next" = "Supprimer de la file d'attente";
 
 /* A common string used throughout the app. Prompt to remove the selected item(s) from the up next queue. Shorter form of 'Remove From Up Next' to conserve space on the Apple Watch. */
-"remove_up_next" = "Supprimer la file d’attente Prochains épisodes";
+"remove_up_next" = "Supprimer la file d'attente";
 
 /* A common string used throughout the app. Prompt to retry the recent request. */
 "retry" = "Réessayer";
 
 /* A common string used throughout the app. Placeholder text used in search boxes. */
-"search" = "Rechercher";
+"search" = "Recherche";
 
 /* A common string used throughout the app when searching podcasts. Placeholder text used in search boxes. */
-"search_podcasts" = "Rechercher des balados";
+"search_podcasts" = "Rechercher des podcasts";
 
 /* A common string used throughout the app. Refers to the season a podcast episode is in. */
 "season" = "Saison";
@@ -2201,88 +2201,88 @@
 "select" = "Sélectionner";
 
 /* A common string used throughout the app. Prompt to select all items in the presented list. */
-"select_all" = "Sélectionner tout";
+"select_all" = "Tout sélectionner";
 
 /* A common string used throughout the app. Prompt to select all items above the currently selected item. */
-"select_all_above" = "Sélectionner tout ci-dessus";
+"select_all_above" = "Sélectionner tous les éléments au-dessus";
 
 /* A common string used throughout the app. Prompt to select all items below the currently selected item. */
-"select_all_below" = "Sélectionner tout ci-dessous";
+"select_all_below" = "Sélectionner tous les éléments en dessous";
 
 /* A common string used throughout the app. Prompt to select episodes in the presented list. */
 "select_episodes" = "Sélectionner des épisodes";
 
 /* A common string used throughout the app. Indicates the number of selected items. '%1$@' is a placeholder for the selected items. */
-"selected_count_format" = "%1$@ épisodes sélectionnés";
+"selected_count_format" = "%1$@ sélectionné(s)";
 
 /* Server error message for when the user tries to upload a file that is too large. */
-"server_error_files_file_too_large" = "Ce fichier est trop volumineux pour le téléversement.";
+"server_error_files_file_too_large" = "Ce fichier est trop volumineux pour être téléchargé.";
 
 /* Server error message for when the user tries to upload a file with an invalid file type. */
-"server_error_files_invalid_content_type" = "Impossible de téléverser le fichier, car nous n’avons pas pu déterminer le type du contenu de ce fichier.";
+"server_error_files_invalid_content_type" = "Impossible de télécharger, car nous ne sommes pas en mesure de déterminer le type de contenu de ce fichier.";
 
 /* Server error message for when the user tries to upload a file while not logged in. */
 "server_error_files_invalid_user" = "L’utilisateur n’est pas connecté.";
 
 /* Server error message for when the user tries to upload a file but doesn't have sufficient space remaining. */
-"server_error_files_storage_limit_exceeded" = "Vous avez atteint la limite de stockage pour votre compte.";
+"server_error_files_storage_limit_exceeded" = "Vous avez dépassé la limite de stockage de votre compte.";
 
 /* Server error message for when the user tries to upload a file without a title. */
 "server_error_files_title_required" = "Le titre est obligatoire.";
 
 /* Server error message indicating a generic error for when the file uploads fail. */
-"server_error_files_upload_failed_generic" = "Impossible de téléverser le fichier. Veuillez réessayer plus tard.";
+"server_error_files_upload_failed_generic" = "Impossible de télécharger le fichier, veuillez réessayer plus tard.";
 
 /* Server error message for when a file upload files because a unique identifier failed wasn't created. */
-"server_error_files_uuid_required" = "Le fichier uuid est obligatoire.";
+"server_error_files_uuid_required" = "L’identifiant unique de l’utilisateur du fichier est requis";
 
 /* Server error message for when the user account has been locked. */
-"server_error_login_account_locked" = "Votre compte a été verrouillé en raison d’un trop grand nombre de tentatives de connexion. Veuillez réessayer plus tard.";
+"server_error_login_account_locked" = "Votre compte a été bloqué en raison de trop nombreuses tentatives de connexion, veuillez réessayer plus tard.";
 
 /* Server error message for when the user attempted to login without their email. */
-"server_error_login_email_blank" = "Entrer une adresse courriel.";
+"server_error_login_email_blank" = "Entrer une adresse e-mail.";
 
 /* Server error message for when the user enters an invalid email. */
-"server_error_login_email_invalid" = "Adresse courriel non valide";
+"server_error_login_email_invalid" = "E-mail non valide";
 
 /* Server error message for when the user's email couldn't be identified on the server . */
-"server_error_login_email_not_found" = "Adresse courriel introuvable";
+"server_error_login_email_not_found" = "E-mail non trouvé";
 
 /* Server error message for when the user tries to create an account for an email tied to an existing account. */
-"server_error_login_email_taken" = "Adresse courriel déjà utilisée";
+"server_error_login_email_taken" = "E-mail utilisé";
 
 /* Server error message for when the user attempted to login without their password. */
-"server_error_login_password_blank" = "Entrez un mot de passe.";
+"server_error_login_password_blank" = "Saisir un mot de passe";
 
 /* Server error message for when the user enters an invalid password. */
-"server_error_login_password_incorrect" = "Mot de passe incorrect";
+"server_error_login_password_incorrect" = "Mot de passe incorrect.";
 
 /* Server error message for when the user enters an invalid password. */
-"server_error_login_password_invalid" = "Mot de passe non valide";
+"server_error_login_password_invalid" = "Mot de passe invalide";
 
 /* Server error message for when the user tries to access a feature they don't have access to. */
-"server_error_login_permission_denied_not_admin" = "Autorisation refusée";
+"server_error_login_permission_denied_not_admin" = "Permission refusée";
 
 /* Server error message for when the server failed to create the account fro the user. */
-"server_error_login_unable_to_create_account" = "Désolés, nous n’avons pas pu configurer ce compte.";
+"server_error_login_unable_to_create_account" = "Nous n’avons pas pu créer ce compte, désolé.";
 
 /* Server error message for when the server failed to create the account fro the user. */
-"server_error_login_user_register_failed" = "Nous n’avons pas pu créer le compte. Veuillez réessayer plus tard.";
+"server_error_login_user_register_failed" = "Impossible de créer un compte, veuillez réessayer plus tard.";
 
 /* Server error message for when the user tries to redeem a promo when they are already a plus subscriber. */
-"server_error_promo_already_plus" = "Vous êtes déjà abonné(e) à Pocket Casts Plus. Il est inutile d’utiliser des codes.";
+"server_error_promo_already_plus" = "Vous êtes déjà un abonné Pocket Casts Plus, il n’est pas nécessaire d’utiliser des codes.";
 
 /* Server error message for when the user tries to redeem a promo code that has already been used. */
-"server_error_promo_already_redeemed" = "Vous avez déjà utilisé ce code promotionnel. Ça valait la peine d’essayer!";
+"server_error_promo_already_redeemed" = "Vous avez déjà utilisé ce code promotionnel. Mais ça valait le coup d’essayer !";
 
 /* Server error message for when the user attempts to redeem a promo code that is no longer active. */
 "server_error_promo_code_expired_or_invalid" = "Ce code promotionnel a expiré ou n’est pas valide.";
 
 /* Generic server error message for when an unexpected or unhandled issue occurred. */
-"server_error_unknown" = "Un problème est survenu.";
+"server_error_unknown" = "Un problème est survenu…";
 
 /* Server message thanking the user for signing up to the service. */
-"server_message_login_thanks_signing_up" = "Merci de votre inscription!";
+"server_message_login_thanks_signing_up" = "Merci pour votre inscription !";
 
 /* A common string used throughout the app. Reference to the settings menus. */
 "settings" = "Réglages";
@@ -2306,25 +2306,25 @@
 "settings_archive_played_title" = "Archiver les épisodes lus";
 
 /* A common string used throughout the app. Refers to the Auto Add to Up Next settings menu */
-"settings_auto_add" = "Ajout automatique à la file d’attente Prochains épisodes";
+"settings_auto_add" = "Ajout automatique à la file d'attente";
 
 /* Prompt to select the episode limit for auto adding podcasts to the Up Next Queue. */
-"settings_auto_add_limit" = "Limite de l’ajout automatique";
+"settings_auto_add_limit" = "Limite d’ajout automatique";
 
 /* Prompt to select the behavior of the app if the auto add limit has been reached. */
 "settings_auto_add_limit_reached" = "Si la limite est atteinte";
 
 /* Subtitle explaining the app's behavior when the episode limit is reached and new episodes are not add to the Up Next Queue. '%1$@' is a placeholder for the auto add limit. */
-"settings_auto_add_limit_subtitle_stop" = "Les nouveaux épisodes ne seront plus ajoutés lorsque la file d’attente Prochains épisodes atteindra %1$@ épisodes.";
+"settings_auto_add_limit_subtitle_stop" = "Les nouveaux épisodes ne seront plus ajoutés dès que la file d'attente atteindra %1$@ épisodes.";
 
 /* Subtitle explaining the app's behavior when the episode limit is reached and new episodes are added to the top of the Up Next Queue. '%1$@' is a placeholder for the auto add limit. */
-"settings_auto_add_limit_subtitle_top" = "Lorsque la file d’attente Prochains épisodes atteint %1$@, l’ajout automatique de nouveaux épisodes au haut de la liste supprimera le dernier épisode dans la file d’attente. Aucun nouvel épisode ne sera ajouté au bas.";
+"settings_auto_add_limit_subtitle_top" = "Lorsque la file d'attente atteint %1$@, chaque nouvel épisode ajouté automatiquement au début de la file d’attente supprimera le dernier épisode de celle-ci. Aucun nouvel épisode ne sera ajouté en bas de la file d’attente.";
 
 /* Section header that displays all of the Podcasts that will automatically add new episodes to the Up Next Queue. */
-"settings_auto_add_podcasts" = "Ajout automatique de balados";
+"settings_auto_add_podcasts" = "Ajout automatique des podcasts";
 
 /* A common string used throughout the app. Refers to the Auto Archive settings menu */
-"settings_auto_archive" = "Archivage automatique";
+"settings_auto_archive" = "Archiver automatiquement";
 
 /* Setting to auto archive a podcast episode. This value will auto archive the episode after 1 Week has passed. */
 "settings_auto_archive_1_week" = "Après 1 semaine";
@@ -2345,16 +2345,16 @@
 "settings_auto_archive_3_months" = "Après 3 mois";
 
 /* Prompt for the toggle to include starred episodes when auto archiving. */
-"settings_auto_archive_include_starred" = "Inclure les épisodes favoris";
+"settings_auto_archive_include_starred" = "Inclure les épisodes marqués d’une étoile";
 
 /* Subtitle for the toggle to include starred episodes when auto archiving. This is the text that will be shown when the toggle is on. */
-"settings_auto_archive_include_starred_off_subtitle" = "Les épisodes ajoutés aux favoris ne seront pas automatiquement archivés.";
+"settings_auto_archive_include_starred_off_subtitle" = "Les épisodes marqués d’une étoile ne seront pas archivés automatiquement.";
 
 /* Subtitle for the toggle to include starred episodes when auto archiving. This is the text that will be shown when the toggle is on. */
-"settings_auto_archive_include_starred_on_subtitle" = "Les épisodes favoris seront automatiquement archivés.";
+"settings_auto_archive_include_starred_on_subtitle" = "Les épisodes marqués d’une étoile seront archivés automatiquement";
 
 /* Subtitle for the main section of auto archive settings. This section sets the time limits or event triggers for when episodes are auto archived. */
-"settings_auto_archive_subtitle" = "Archivez les épisodes après le délai défini. Les téléchargements sont retirés lorsque l’épisode est archivé.";
+"settings_auto_archive_subtitle" = "Archiver les épisodes après les délais définis. Les téléchargements sont supprimés lorsque l’épisode est archivé.";
 
 /* A common string used throughout the app. Refers to the Auto Download settings menu */
 "settings_auto_download" = "Téléchargement automatique";
@@ -2369,31 +2369,31 @@
 "settings_auto_downloads_no_filters_selected" = "Aucun filtre sélectionné";
 
 /* Label indicating no podcasts have been selected. */
-"settings_auto_downloads_no_podcasts_selected" = "Aucun balado sélectionné";
+"settings_auto_downloads_no_podcasts_selected" = "Aucun podcast sélectionné";
 
 /* Label indicating the number of selected podcasts. '%1$@' is a placeholder for the number of podcasts selected. */
-"settings_auto_downloads_podcasts_selected_format" = "%1$@ balados sélectionnés";
+"settings_auto_downloads_podcasts_selected_format" = "%1$@ podcasts sélectionnés";
 
 /* Label indicating the number of selected podcasts. This is the singular form for an accompanying plural option. */
-"settings_auto_downloads_podcasts_selected_singular" = "1 balado sélectionné";
+"settings_auto_downloads_podcasts_selected_singular" = "1 podcast sélectionné";
 
 /* Subtitle explaining the toggle to auto download the top episodes of a filter. */
-"settings_auto_downloads_subtitle_filters" = "Téléchargez les épisodes du haut de la liste dans un filtre.";
+"settings_auto_downloads_subtitle_filters" = "Télécharger les premiers épisodes dans un filtre.";
 
 /* Subtitle explaining the toggle to auto download New Episodes. */
-"settings_auto_downloads_subtitle_new_episodes" = "Téléchargez les nouveaux épisodes lorsqu’ils sont publiés.";
+"settings_auto_downloads_subtitle_new_episodes" = "Télécharger les nouveaux épisodes lorsqu’ils sont diffusés.";
 
 /* Subtitle explaining the toggle to auto download items in the Up Next Queue. */
-"settings_auto_downloads_subtitle_up_next" = "Téléchargez les épisodes ajoutés aux Prochains épisodes.";
+"settings_auto_downloads_subtitle_up_next" = "Télécharger les épisodes ajoutés à la file d'attente.";
 
 /* Section Header for selecting the options for setting the app badge based on the user's filters. */
 "settings_badge_filter_header" = "NOMBRE DE FILTRES D’ÉPISODES";
 
 /* Option for setting the app badge based on the new episodes since the app opened. */
-"settings_badge_new_since_opened" = "Nouveau depuis l’ouverture de l’application";
+"settings_badge_new_since_opened" = "Nouveaux épisodes depuis l’ouverture de l’application";
 
 /* Option for setting the app badge based on the total unplayed episodes. */
-"settings_badge_total_unplayed" = "Total non lus";
+"settings_badge_total_unplayed" = "Nombre total d’épisodes non lus";
 
 /* Label displayed right next the button to opt-in/out for Analytics tracking */
 "settings_collect_information" = "Collecter des informations";
@@ -2405,58 +2405,58 @@
 "settings_create_siri_shortcut" = "Créer un raccourci Siri";
 
 /* Informational message to accompany a prompt to create a Siri Shortcut. 'Siri' refers to Apple's voice assistant. '%1$@' is a placeholder for the podcasts name. */
-"settings_create_siri_shortcut_msg" = "Créez un raccourci Siri pour lire le plus récent épisode de %1$@";
+"settings_create_siri_shortcut_msg" = "Créer un raccourci Siri pour lire le dernier épisode de %1$@";
 
 /* A common string used throughout the app. Indicates an option(s) to customize the settings for this podcast. */
-"settings_custom" = "Personnaliser pour ce balado";
+"settings_custom" = "Personnaliser les paramètres de ce podcast";
 
 /* A message accompanying the toggle to enable auto archive settings that are specific to the selected podcast. */
-"settings_custom_auto_archive_msg" = "Voulez-vous un contrôle plus poussé? Activer les paramètres d’archivage automatique pour ce balado";
+"settings_custom_auto_archive_msg" = "Vous souhaitez un contrôle plus précis ? Activer les réglages d’archivage automatique pour ce podcast.";
 
 /* A message accompanying the toggle to set custom settings for a particular podcast. */
-"settings_custom_msg" = "Pocket Casts enregistrera vos derniers effets de lecture et les utilisera pour tous les balados. Vous pouvez activer cette fonctionnalité si vous voulez créer des effets personnalisés uniquement pour ce balado.";
+"settings_custom_msg" = "Pocket Casts se souviendra de vos derniers effets de lecture et les utilisera pour tous les podcasts. Vous pouvez activer cette option si vous souhaitez créer des effets personnalisés pour ce podcast uniquement.";
 
 /* Provides a prompt for the user to configure the settings related to episode limits. This controls how many episodes will be preserved before auto archiving them. */
-"settings_episode_limit" = "Limite d’épisodes";
+"settings_episode_limit" = "Nombre limite d’épisodes";
 
 /* Informs the user of max episode count for the up next queue. This value is configurable. '%1$@' is a placeholder for the current value as set by the user. */
-"settings_episode_limit_format" = "Limite de %1$@ épisodes";
+"settings_episode_limit_format" = "Nombre limite d’épisodes %1$@";
 
 /* A format for values accompanying the setting to auto archive based on a set limit. '%1$@' is a placeholder for the number of episodes that will be saved before auto archiving the oldest ones. */
-"settings_episode_limit_limit_format" = "%1$@ épisodes les plus récents";
+"settings_episode_limit_limit_format" = "les %1$@ plus récents";
 
 /* A message accompanying the episode limit settings providing a hint towards one use case for this feature. */
-"settings_episode_limit_msg" = "Pour les émissions qui diffusent des épisodes toutes les heures ou tous les jours, établir une limite d’épisodes peut aider à ne conserver que les plus récents, tout en archivant les plus anciens.";
+"settings_episode_limit_msg" = "Pour les émissions diffusant des épisodes toutes les heures ou quotidiennement, définir une limite d’épisodes peut aider à ne conserver que les plus récents, tout en archivant les plus anciens.";
 
 /* A value accompanying the setting to auto archive based on a set limit. This value disables the feature. */
-"settings_episode_limit_no_limit" = "Aucune limite";
+"settings_episode_limit_no_limit" = "Pas de limite";
 
 /* Alert title informing the user that the OPML export has encountered an error. 'OPML' refers to the file type that will be exported. */
-"settings_export_error" = "Erreur lors de l’exportation";
+"settings_export_error" = "Erreur d’export";
 
 /* Alert message informing the user that the OPML export has encountered an error. 'OPML' refers to the file type that will be exported. */
-"settings_export_error_msg" = "Impossible d’exporter le fichier OPML. Veuillez réessayer plus tard.";
+"settings_export_error_msg" = "Export OPML impossible, veuillez réessayer plus tard.";
 
 /* Alert title informing the user that the OPML export is processing. 'OPML' refers to the file type that will be exported. */
-"settings_export_opml" = "Exportation du fichier OPML";
+"settings_export_opml" = "Export OPML";
 
 /* Informs the user that Pocket Casts has dedicated an issue with this podcasts feed. */
 "settings_feed_error" = "Erreur de flux";
 
 /* Informs the user that Pocket Casts has stopped updating this feed due to too many errors. Provides a prompt to tap the refresh button that is presented above this message box. */
-"settings_feed_error_msg" = "Le flux de ce balado a cessé d’être mis à jour, car il contient trop d’erreurs. Appuyez ci-dessus pour régler ce problème.";
+"settings_feed_error_msg" = "La mise à jour du flux de ce podcast a été interrompue car il contenait trop d’erreurs. Appuyez sur le bouton ci-dessus pour résoudre ce problème.";
 
 /* Title used in a dialog box. Prompt user to try refreshing the feed after encountering an error. */
-"settings_feed_fix_refresh" = "Essayer de le mettre à jour";
+"settings_feed_fix_refresh" = "Essayer de mettre à jour";
 
 /* The message body for a dialog box used to inform the user the request to update the feed has failed. */
-"settings_feed_fix_refresh_failed_msg" = "Impossible de mettre à jour ce flux. Veuillez réessayer plus tard.";
+"settings_feed_fix_refresh_failed_msg" = "Impossible de mettre à jour ce flux, veuillez réessayer plus tard.";
 
 /* The title for a dialog box used to inform the user that the request to update the feed has failed. */
-"settings_feed_fix_refresh_failed_title" = "Échec de la mise à jour";
+"settings_feed_fix_refresh_failed_title" = "Échec de la mise à jour !";
 
 /* The message body for a dialog box used to inform the user that the an update to the feed has been queued. */
-"settings_feed_fix_refresh_success_msg" = "Nous avons mis en attente une mise à jour pour ce balado. Notre serveur la revérifiera et si elle fonctionne, vous aurez de nouveaux épisodes bientôt. Veuillez revenir dans environ une heure.";
+"settings_feed_fix_refresh_success_msg" = "Nous avons ajouté une mise à jour en attente pour ce podcast. Notre serveur va la revérifier et si cela fonctionne, vous devriez bientôt profiter de nouveaux épisodes. Veuillez revenir dans une heure environ.";
 
 /* The title for a dialog box used to inform the user that the an update to the feed has been queued. */
 "settings_feed_fix_refresh_success_title" = "Mise à jour en attente";
@@ -2465,88 +2465,88 @@
 "settings_feed_issue" = "Problème de flux";
 
 /* Informs the user that Pocket Casts has stopped updating this feed due to too many errors. */
-"settings_feed_issue_msg" = "Le flux de ce balado a cessé d’être mis à jour, car il contient trop d’erreurs.";
+"settings_feed_issue_msg" = "La mise à jour du flux de ce podcast a été interrompue car il contenait trop d’erreurs.";
 
 /* Prompt to navigate the user to the files setting screen. */
 "settings_files" = "Réglages des fichiers";
 
 /* Prompt for the toggle to enable auto downloads for uploaded files. */
-"settings_files_auto_download" = "Téléchargement automatique à partir du nuage";
+"settings_files_auto_download" = "Télécharger automatiquement depuis le Cloud";
 
 /* Subtitle explaining the app behavior when the toggle to for auto downloads for uploaded files is off. */
-"settings_files_auto_download_subtitle_off" = "Les fichiers ajoutés au nuage à partir d’autres appareils ne seront pas automatiquement téléchargés.";
+"settings_files_auto_download_subtitle_off" = "Les fichiers ajoutés au Cloud depuis d’autres appareils ne seront pas automatiquement téléchargés.";
 
 /* Subtitle explaining the app behavior when the toggle to for auto downloads for uploaded files is on. */
-"settings_files_auto_download_subtitle_on" = "Les fichiers ajoutés au nuage à partir d’autres appareils seront automatiquement téléchargés.";
+"settings_files_auto_download_subtitle_on" = "Les fichiers ajoutés au Cloud depuis d’autres appareils seront automatiquement téléchargés.";
 
 /* Prompt for the toggle to enable auto uploads for uploaded files. */
-"settings_files_auto_upload" = "Téléversement automatique dans le nuage";
+"settings_files_auto_upload" = "Téléchargement automatique vers le Cloud";
 
 /* Subtitle explaining the app behavior when the toggle to for auto uploads is off. */
-"settings_files_auto_upload_subtitle_off" = "Les fichiers ajoutés à cet appareil ne seront pas automatiquement téléversés dans le nuage.";
+"settings_files_auto_upload_subtitle_off" = "Les fichiers ajoutés sur cet appareil ne seront pas automatiquement téléchargés vers le Cloud.";
 
 /* Subtitle explaining the app behavior when the toggle to for auto uploads is on. */
-"settings_files_auto_upload_subtitle_on" = "Les fichiers ajoutés à cet appareil seront automatiquement téléversés dans le nuage.";
+"settings_files_auto_upload_subtitle_on" = "Les fichiers ajoutés sur cet appareil seront automatiquement téléchargés vers le Cloud.";
 
 /* Prompt for the toggle to enable the option to delete the cloud file after playing. */
-"settings_files_delete_cloud_file" = "Supprimer le fichier infonuagique";
+"settings_files_delete_cloud_file" = "Supprimer le fichier du Cloud";
 
 /* Prompt for the toggle to enable the option to delete the local file after playing. */
 "settings_files_delete_local_file" = "Supprimer le fichier local";
 
 /* A common string used throughout the app. Reference to the General settings menu. */
-"settings_general" = "Généralités";
+"settings_general" = "Général";
 
 /* Confirmation to apply a setting change to all podcasts. */
-"settings_general_apply_all_conf" = "Appliquer";
+"settings_general_apply_all_conf" = "Appliquer aux podcasts existants";
 
 /* Prompt to apply a setting change to all podcasts. */
-"settings_general_apply_all_title" = "Appliquer aux balados existants?";
+"settings_general_apply_all_title" = "Appliquer aux podcasts existants ?";
 
 /* Setting option to choose the default display archived episodes. */
 "settings_general_archived_episodes" = "Épisodes archivés";
 
 /* Prompt to ask the user if they'd like to show/hide archived episodes for all podcasts. '%1$@' is a placeholder for a localized string 'show' or 'hide' based on the current setting. */
-"settings_general_archived_episodes_prompt_format" = "Voulez-vous changer tous vos balados existants par %1$@ épisodes archivés?";
+"settings_general_archived_episodes_prompt_format" = "Souhaitez-vous basculer tous vos podcasts existants pour %1$@ les épisodes archivés ?";
 
 /* Setting toggle to enable the feature to automatically open the player when playback starts. */
-"settings_general_auto_open_player" = "Ouvrir automatiquement le lecteur";
+"settings_general_auto_open_player" = "Ouvrir le lecteur automatiquement";
 
 /* Section header for the general settings that are more general app related. */
 "settings_general_defaults_header" = "PAR DÉFAUT";
 
 /* Setting option to choose the primary way in which episodes are grouped. */
-"settings_general_episode_groups" = "Groupement d’épisodes de balados";
+"settings_general_episode_groups" = "Groupement des épisodes";
 
 /* Setting option to choose to hide archived episodes. */
 "settings_general_hide" = "Masquer";
 
 /* Setting toggle to enable the app to keep your screen awake. */
-"settings_general_keep_screen_awake" = "Garder l’écran activé";
+"settings_general_keep_screen_awake" = "Garder l’écran actif";
 
 /* Setting toggle to modify which bluetooth protocol to use. */
-"settings_general_legacy_bluetooth" = "Prise en charge de l’ancien système Bluetooth";
+"settings_general_legacy_bluetooth" = "Prise en charge de l’ancien protocole Bluetooth";
 
 /* Subtitle explaining the toggle to modify which bluetooth protocol to use. */
-"settings_general_legacy_bluetooth_subtitle" = "Si vous avez un appareil Bluetooth ou une chaîne stéréo de voiture qui suspend la lecture de Pocket Casts, ou qui réinitialise la lecture à la position 0, activez ce paramètre pour régler le problème.";
+"settings_general_legacy_bluetooth_subtitle" = "Si un périphérique Bluetooth ou un autoradio semble mettre Pocket Casts en pause pendant la lecture, ou remettre la position de lecture à 0, essayez d’activer ce paramètre pour résoudre le problème.";
 
 /* Setting toggle to enable the gesture for multi-select. */
-"settings_general_multi_select_gesture" = "Geste de sélection multiple";
+"settings_general_multi_select_gesture" = "Commande tactile pour la multi-sélection";
 
 /* Subtitle explaining the toggle to enable the gesture for multi-select. */
-"settings_general_multi_select_gesture_subtitle" = "Sélectionnez plusieurs épisodes en glissant deux doigts vers le bas dans une liste d’épisodes. Désactivez cette fonctionnalité si vous déclenchez cette action accidentellement ou si cela vous empêche d’utiliser des fonctionnalités d’accessibilité.";
+"settings_general_multi_select_gesture_subtitle" = "Multi-sélection en faisant glisser 2 doigts vers le bas sur une liste d’épisodes. Désactivez cette fonction si vous la déclenchez accidentellement ou si elle interfère avec les fonctions d’accessibilité que vous utilisez.";
 
 /* Option to not move forward with a prompt to apply to all podcasts. */
 "settings_general_no_thanks" = "Non merci";
 
 /* Setting toggle to enable the app to open the links in an external browser. */
-"settings_general_open_in_browser" = "Ouvrir les liens dans un navigateur";
+"settings_general_open_in_browser" = "Ouvrir les liens dans le navigateur";
 
 /* Setting toggle to modify what controls are available on the lock screen. */
 "settings_general_play_back_actions" = "Actions de lecture supplémentaires";
 
 /* Subtitle explaining the toggle to modify what controls are available on the lock screen. */
-"settings_general_play_back_actions_subtitle" = "Ajoute une marque « lu » et une option « favori » à l’écran de verrouillage de votre téléphone ou à CarPlay. Remarque : cela remplacera le bouton Saut vers l’arrière sur votre écran de verrouillage.";
+"settings_general_play_back_actions_subtitle" = "Ajoute une option de marquage de lecture et de favori (étoile) à l’écran de verrouillage de votre téléphone et à CarPlay. Remarque : sur l’écran de verrouillage, ce bouton remplacera le bouton de retour rapide.";
 
 /* Section header for the general settings that are more player related. */
 "settings_general_player_header" = "LECTEUR";
@@ -2558,19 +2558,19 @@
 "settings_general_publish_chapter_titles_subtitle" = "Activez cette option pour envoyer les titres des chapitres par Bluetooth et autres appareils connectés au lieu du titre de l’épisode.";
 
 /* Setting toggle to change the behavior of the skip button on external devices. */
-"settings_general_remote_skips_chapters" = "Passer les chapitres à distance";
+"settings_general_remote_skips_chapters" = "Ignorer des chapitres à distance";
 
 /* Subtitle explaining the toggle to change the behavior of the skip button on external devices. */
-"settings_general_remote_skips_chapters_subtitle" = "Lorsque cette fonctionnalité est activée et qu’un épisode a des chapitres, vous passerez au prochain chapitre en appuyant sur le bouton Passer dans votre voiture ou sur votre casque d’écoute.";
+"settings_general_remote_skips_chapters_subtitle" = "Lorsqu’il est activé et qu’un épisode comporte des chapitres, appuyer sur le bouton Ignorer dans votre voiture ou sur vos écouteurs vous permettra de passer au chapitre suivant.";
 
 /* Prompt to ask the user if they'd like to remove the grouping from all podcasts. */
-"settings_general_remove_groups_apply_all" = "Voulez-vous changer tous vos balados existants pour qu’ils ne soient également plus regroupés?";
+"settings_general_remove_groups_apply_all" = "Souhaitez-vous modifier tous vos podcasts existants pour qu’ils ne soient plus groupés ?";
 
 /* Setting option to choose the default action when selecting an episode row. */
-"settings_general_row_action" = "Action de la ligne";
+"settings_general_row_action" = "Action de la série";
 
 /* Prompt to ask the user if they'd like to apply the grouping to all podcasts. '%1$@' is a placeholder for a localized name for the grouping type. */
-"settings_general_selected_group_apply_all" = "Voulez-vous changer tous vos balados existants pour les regrouper par %1$@?";
+"settings_general_selected_group_apply_all" = "Souhaitez-vous que tous vos podcasts existants soient groupés par %1$@ ?";
 
 /* Setting option to choose to show archived episodes. */
 "settings_general_show" = "Afficher";
@@ -2579,31 +2579,31 @@
 "settings_general_smart_playback" = "Reprise intelligente de la lecture";
 
 /* Subtitle explaining the feature that adjusts the playback position when resuming. */
-"settings_general_smart_playback_subtitle" = "Si la fonctionnalité est activée, Pocket Casts reculera un peu dans les épisodes dont vous reprenez la lecture afin de mieux vous remettre dans le contexte.";
+"settings_general_smart_playback_subtitle" = "Si cette fonction est activée, Pocket Casts reviendra un peu en arrière dans les épisodes que vous reprenez afin que vous puissiez combler votre retard plus confortablement.";
 
 /* Setting option to choose how to handle swiping to add something to the queue. */
-"settings_general_up_next_swipe" = "Balayage Prochains épisodes";
+"settings_general_up_next_swipe" = "Balayage file d'attente";
 
 /* Setting toggle to modify how a tap is handled in the up next queue. */
-"settings_general_up_next_tap" = "Lire le prochain épisode en appuyant";
+"settings_general_up_next_tap" = "Lire la file d'attente par une pression";
 
 /* Subtitle explaining the toggle to modify how a tap is handled in the up next queue. This is used when the toggle is off. */
-"settings_general_up_next_tap_off_subtitle" = "Appuyer sur un épisode dans Prochains épisodes fait afficher la page d’actions. L’épisode est lorsque vous appuyez longuement. Activez cette fonctionnalité pour les changer place.";
+"settings_general_up_next_tap_off_subtitle" = "Un appui sur un épisode dans la file d’attente affiche la page des actions. Une pression prolongée permet de lire l’épisode. Activer pour permuter.";
 
 /* Subtitle explaining the toggle to modify how a tap is handled in the up next queue. This is used when the toggle is on. */
-"settings_general_up_next_tap_on_subtitle" = "Appuyer sur un épisode dans Prochains épisodes le fera démarrer. Les options de l’épisode sont affichées lorsque vous appuyez longuement. Désactivez cette fonctionnalité pour les changer de place.";
+"settings_general_up_next_tap_on_subtitle" = "Un appui sur un épisode dans la file d’attente déclenche sa lecture. Une pression prolongée affiche les options de l’épisode. Désactiver pour permuter.";
 
 /* Title for the menu that takes you to the global up next queue settings */
-"settings_global_settings" = "Paramètres généraux";
+"settings_global_settings" = "Réglages globaux";
 
 /* A common string used throughout the app. Refers to the Help & Feedback settings menu */
 "settings_help" = "Aide et commentaires";
 
 /* Title for the screen that manages the importing and exporting of podcasts. */
-"settings_import_export" = "Importer\/exporter";
+"settings_import_export" = "Importer \/ Exporter";
 
 /* Informs the user that the current podcast is included in one filter. '%1$@' is a placeholder for the number of filters this podcast is included in. */
-"settings_in_filters_plural_format" = "Inclus dans %1$@ filtres";
+"settings_in_filters_plural_format" = "Inclus dans %1$@ filtres";
 
 /* Informs the user that the current podcast is included in one filter. This is the singular form of an accompanying plural string. */
 "settings_in_filters_singular" = "Inclus dans 1 filtre";
@@ -2612,10 +2612,10 @@
 "settings_in_menu" = "DANS LE MENU";
 
 /* A message accompanying the settings for inactive episodes explaining what is considered an inactive episode. */
-"settings_inactive_episodes_msg" = "Des épisodes inactifs sont des épisodes que vous n’avez pas écoutés ni téléchargés dans le délai que vous spécifiez ci-dessus. Les téléchargements sont retirés lorsque l’épisode est archivé.";
+"settings_inactive_episodes_msg" = "Les épisodes inactifs sont des épisodes que vous n’avez pas lus ou téléchargés dans la période que vous avez indiquée ci-dessus. Les téléchargements sont supprimés lorsque l’épisode est archivé.";
 
 /* Informs the user that the current podcast isn't included in any filters. */
-"settings_not_in_filters" = "Non inclus dans aucun filtre";
+"settings_not_in_filters" = "Inclus dans aucun filtre";
 
 /* A common string used throughout the app. Refers to the Notifications settings menu. */
 "settings_notifications" = "Notifications";
@@ -2624,22 +2624,22 @@
 "settings_notifications_filter_count" = "Nombre de filtres";
 
 /* Subtitle explaining what notifications to expect when you enable notifications. */
-"settings_notifications_subtitle" = "Recevez une notification lorsqu’un nouvel épisode est disponible. Également utile pour améliorer la fiabilité des téléchargements automatiques.";
+"settings_notifications_subtitle" = "Vous avertit lorsqu’un nouvel épisode est disponible. Également utile pour améliorer la fiabilité des téléchargements automatiques.";
 
 /* A common string used throughout the app. Refers to the Import/Export OPML settings menu */
-"settings_opml" = "Importer\/exporter OPML";
+"settings_opml" = "Importation\/Exportation OPML";
 
 /* Provides a prompt for the user to configure the playback speed options. */
 "settings_play_speed" = "Vitesse de lecture";
 
 /* Informational label breaking down the pricing structure for Pocket Casts Plus. '%1$@' is a placeholder for the localized price if paid per month, '%2$@' is a placeholder for the localized price if paid per year */
-"settings_plus_pricing_format" = "%1$@ par mois ou %2$@ par année";
+"settings_plus_pricing_format" = "%1$@ par mois \/ %2$@ par an";
 
 /* A common string used throughout the app. Refers to the Privacy settings menu */
 "settings_privacy" = "Confidentialité";
 
 /* Title for the options to configure the queue position when a podcast is set to be auto added to the up next queue. */
-"settings_queue_position" = "Placer dans la file d’attente";
+"settings_queue_position" = "Position dans la file d’attente";
 
 /* Label for an input that takes the user to the privacy policy */
 "settings_read_privacy_policy" = "Lire notre politique de confidentialité";
@@ -2657,13 +2657,13 @@
 "settings_shortcuts_filter_play_all_episodes" = "Lire tous les épisodes";
 
 /* Option for the filter Siri Shortcut. This sets the filter to play the top episode in the filter when the shortcut is triggered. */
-"settings_shortcuts_filter_play_top_episode" = "Lire l’épisode au haut de la liste";
+"settings_shortcuts_filter_play_top_episode" = "Lire le premier épisode";
 
 /* Prompt to open the menu to interact with a pre-configured Siri shortcut. 'Siri' refers to Apple's voice assistant. */
 "settings_siri_shortcut" = "Raccourci Siri";
 
 /* Informational message that accompanies an existing Siri shortcut for a particular podcast. 'Siri' refers to Apple's voice assistant. '%1$@' is a placeholder for the podcasts name. */
-"settings_siri_shortcut_msg" = "Un raccourci Siri pour faire jouer l’épisode du haut de la liste dans %1$@";
+"settings_siri_shortcut_msg" = "Raccourci Siri pour lire le premier épisode de %1$@";
 
 /* A common string used throughout the app. Refers to the Siri Shortcuts settings menu. 'Siri' refers to Apple's voice assistant. */
 "settings_siri_shortcuts" = "Raccourcis Siri";
@@ -2675,19 +2675,19 @@
 "settings_siri_shortcuts_enabled" = "Raccourcis activés";
 
 /* Option to create a Siri Shortcut to a specific filter. */
-"settings_siri_shortcuts_specific_filter" = "Raccourci vers un filtre particulier";
+"settings_siri_shortcuts_specific_filter" = "Raccourci vers un filtre spécifique";
 
 /* Option to create a Siri Shortcut to a specific podcast. */
-"settings_siri_shortcuts_specific_podcast" = "Raccourci vers un balado particulier";
+"settings_siri_shortcuts_specific_podcast" = "Raccourci vers un podcast spécifique";
 
 /* Prompt to open the configurable options to have the podcast skip an initial portion of the selected podcast. */
-"settings_skip_first" = "Passer le premier";
+"settings_skip_first" = "Ignorer le début";
 
 /* Prompt to open the configurable options to have the podcast skip the final portion of the selected podcast. */
-"settings_skip_last" = "Passer le dernier";
+"settings_skip_last" = "Ignorer la fin";
 
 /* Fun informational message about the skip options available in the settings. */
-"settings_skip_msg" = "Passer la musique du générique du début et de fin tel le puissant utilisateur que vous avez toujours rêvé d’être.";
+"settings_skip_msg" = "Ignorez la musique d’intro et de fin comme l’utilisateur chevronné que vous êtes depuis toujours.";
 
 /* A common string used throughout the app. Refers to the Stats settings menu */
 "settings_stats" = "Statistiques";
@@ -2708,49 +2708,49 @@
 "settings_storage_usage" = "UTILISATION";
 
 /* Title for the settings screen */
-"settings_title" = "Paramètres du balado";
+"settings_title" = "Réglages de podcast";
 
 /* Provides a prompt for the user to configure the sensitivity associated to the auto trimming silence setting. */
-"settings_trim_level" = "Degré de coupure";
+"settings_trim_level" = "Sensibilité de coupe";
 
 /* Provides a prompt for the user to configure the trim silence options. */
-"settings_trim_silence" = "Couper le silence";
+"settings_trim_silence" = "Couper les silences";
 
 /* Informs the user about how the Queue will be adjusted when the episode limit is reached. '%1$@' is a placeholder for the current queue limit. */
-"settings_up_next_limit" = "Ajout automatique des nouveaux épisodes à la liste Prochains épisodes Les nouveaux épisodes ne seront plus ajoutés lorsque la file d’attente Prochains épisodes atteindra %1$@.";
+"settings_up_next_limit" = "Ajoute automatiquement les nouveaux épisodes à la file d'attente. Les nouveaux épisodes ne seront plus ajoutés lorsque la file d'attente aura atteint %1$@.";
 
 /* Informs the user about how the Queue will be adjusted when the episode limit is reached. '%1$@' is a placeholder for the current queue limit. */
-"settings_up_next_limit_add_to_top" = "Ajout automatique des nouveaux épisodes à la file d’attente Prochains épisodes Lorsque la file d’attente Prochains épisodes atteint %1$@, l’ajout automatique de nouveaux épisodes au haut de la liste supprimera le dernier épisode dans la file d’attente.";
+"settings_up_next_limit_add_to_top" = "Ajoute automatiquement les nouveaux épisodes à la file d'attente. Lorsque la file d'attente atteint %1$@, chaque nouvel épisode ajouté automatiquement au début de la file d’attente supprimera le dernier épisode de celle-ci.";
 
 /* Provides a prompt for the user to toggle on the volume boosting setting. */
-"settings_volume_boost" = "Amplification du volume";
+"settings_volume_boost" = "Augmenter le volume";
 
 /* Prompt for the toggle that enables auto downloads for the Apple Watch app. */
-"settings_watch_auto_download" = "Téléchargement automatique de la file d’attente";
+"settings_watch_auto_download" = "Téléchargement auto de la file d'attente";
 
 /* Subtitle for the toggle that explains the behavior for the auto download feature for the Apple Watch app. */
-"settings_watch_auto_download_off_subtitle" = "Définissez le nombre d’épisodes de votre file d’attente Prochains épisodes de Pocket Casts qui seront téléchargés pour une écoute hors ligne.";
+"settings_watch_auto_download_off_subtitle" = "Définir le nombre d’épisodes de votre file d’attente que Pocket Casts téléchargera sur votre montre pour une lecture hors ligne.";
 
 /* Prompt for the toggle that enables the feature to delete auto downloads that fall outside episode limit for the Apple Watch app. */
-"settings_watch_delete_downloads" = "Supprimer les téléchargements en dehors de cette limite";
+"settings_watch_delete_downloads" = "Supprimer les téléchargements hors limite";
 
 /* Subtitle explaining the behavior of the app for when the toggle to delete auto downloads is turned off. */
-"settings_watch_delete_downloads_off_subtitle" = "Pour conserver de l’espace de stockage d’écoute, un maximum de 25 épisodes dans votre file d’attente Prochains épisodes seront téléchargés. Les fichiers de téléchargement plus anciens qui sont en dehors de cette limite seront automatiquement supprimés.";
+"settings_watch_delete_downloads_off_subtitle" = "Pour économiser l’espace de stockage de la montre, un maximum de 25 épisodes dans votre file d’attente sera téléchargé automatiquement. Les anciens fichiers téléchargés en dehors de cette limite seront automatiquement supprimés.";
 
 /* Subtitle explaining the behavior of the app for when the toggle to delete auto downloads is turned on. */
-"settings_watch_delete_downloads_on_subtitle" = "Tous les fichiers de téléchargement dans votre file d’attente Prochains épisodes qui sont en dehors de cette limite seront automatiquement supprimés. Ces paramètres ne s’appliquent pas aux téléchargements manuels.";
+"settings_watch_delete_downloads_on_subtitle" = "Tous les fichiers téléchargés dans votre file d’attente qui dépassent cette limite seront automatiquement supprimés. Les téléchargements manuels ne sont pas gérés par ces réglages.";
 
 /* Prompt for the option to select the number of episodes to auto downloads for the Apple Watch app. */
 "settings_watch_episode_limit" = "Nombre d’épisodes";
 
 /* Subtitle explaining for the option to select the number of episodes to auto downloads for the Apple Watch app. '%1$@' is a placeholder for the number of items to download. */
-"settings_watch_episode_limit_subtitle" = "Pocket Casts téléchargera les %1$@ épisodes dans le haut de votre file d’attente pour que vous puissiez les écouter hors ligne.";
+"settings_watch_episode_limit_subtitle" = "Pocket Casts téléchargera les %1$@ premiers épisodes de votre file d’attente sur votre montre pour une lecture hors ligne.";
 
 /* Prompt for the option format to select the number of episodes to auto downloads for the Apple Watch app. '%1$@' is a placeholder for the number of items to download */
-"settings_watch_episode_number_option_format" = "%1$@ épisodes du haut";
+"settings_watch_episode_number_option_format" = "Les %1$@ premiers";
 
 /* Title for the options for the user to configure their account. */
-"setup_account" = "Configurer le compte";
+"setup_account" = "Créer un compte";
 
 /* A common string used throughout the app. Prompt to open the share settings for the selected item(s). */
 "share" = "Partager";
@@ -2762,7 +2762,7 @@
 "share_list_subscribing" = "Abonnement...";
 
 /* Message indicating that all of the podcasts have been selected. */
-"share_podcasts_all_selected" = "TOUS LES ÉLÉMENTS SÉLECTIONNÉS";
+"share_podcasts_all_selected" = "TOUS SÉLECTIONNÉS";
 
 /* Title for the screen to finalize options to create a list of podcasts to share. */
 "share_podcasts_create_list" = "Créer une liste";
@@ -2771,13 +2771,13 @@
 "share_podcasts_sharing" = "Partage...";
 
 /* Error message for when sharing fails. */
-"share_podcasts_sharing_failed_msg" = "Une erreur s’est produite lors de la création de votre page de partage.";
+"share_podcasts_sharing_failed_msg" = "Un problème est survenu lors de la création de votre page de partage";
 
 /* Title indicating that sharing has failed. */
 "share_podcasts_sharing_failed_title" = "Échec du partage";
 
 /* A common string used throughout the app. Title for the screen to select multiple podcasts to share. */
-"share_select_podcasts" = "Sélectionner des balados";
+"share_select_podcasts" = "Sélectionner les podcasts";
 
 /* Progress indicator informing the user that the item that has been sent to them via share is loading. */
 "shared_item_loading" = "Chargement de l’élément partagé...";
@@ -2786,28 +2786,28 @@
 "shared_list" = "Liste partagée";
 
 /* Confirmation option presented when a user selects to subscribe to all podcasts in a list. */
-"shared_list_subscribe_conf_action" = "Certainement!";
+"shared_list_subscribe_conf_action" = "Oui, bien sûr !";
 
 /* Message for a dialog presented when a user selects to subscribe to all podcasts in a list. '%1$@' is a placeholder for the number of podcasts that will be subscribed to. */
-"shared_list_subscribe_conf_msg" = "Voulez-vous vraiment vous abonner à %1$@ balados?";
+"shared_list_subscribe_conf_msg" = "Êtes-vous sûr de vouloir vous abonner à %1$@ podcasts ?";
 
 /* Title for a dialog presented when a user selects to subscribe to all podcasts in a list. */
-"shared_list_subscribe_conf_title" = "C’est beaucoup de balados!";
+"shared_list_subscribe_conf_title" = "Ça fait beaucoup de podcasts !";
 
 /* A common string used throughout the app. Refers to the Notes (show notes) tab in the player. */
-"show_notes" = "Notes";
+"show_notes" = "Commentaires";
 
 /* A common string used throughout the app. Prompt for the user to sign into their account. */
 "sign_in" = "Se connecter";
 
 /* Email address field prompt */
-"sign_in_email_address_prompt" = "Adresse courriel";
+"sign_in_email_address_prompt" = "Adresse e-mail";
 
 /* Button text to go to the forgot password page */
 "sign_in_forgot_password" = "J’ai oublié mon mot de passe";
 
 /* Message shown below the sign in prompt to give users more details about what it does */
-"sign_in_message" = "Enregistrez vos abonnements à des balados dans le nuage et synchronisez votre progrès dans vos autres appareils.";
+"sign_in_message" = "Enregistrez vos abonnements aux podcasts dans le cloud et synchronisez votre progression avec d’autres appareils.";
 
 /* Password field prompt */
 "sign_in_password_prompt" = "Mot de passe";
@@ -2816,16 +2816,16 @@
 "sign_in_prompt" = "Se connecter ou créer un compte";
 
 /* Label indicating which account the user is signed into. The accounts email address is displayed in close proximity to this label. */
-"signed_in_as" = "CONNECTÉ(E) EN TANT QUE";
+"signed_in_as" = "CONNECTÉ EN TANT QUE";
 
 /* Label indicating which account is not signed in. */
-"signed_out" = "Non connecté(e)";
+"signed_out" = "Non connecté";
 
 /* Siri shortcut title for increasing the sleep timer by a specified amount. '%1$@' is the placeholder for the time specified amount or time. */
-"siri_shortcut_extend_sleep_timer" = "Régler la minuterie de veille à %1$@";
+"siri_shortcut_extend_sleep_timer" = "Définir la mise en veille sur %1$@";
 
 /* Siri shortcut phrase for increasing the sleep timer by a specified amount. */
-"siri_shortcut_extend_sleep_timer_five_min" = "Prolonger la minuterie de veille de 5 minutes";
+"siri_shortcut_extend_sleep_timer_five_min" = "Retarder la mise en veille de 5 minutes";
 
 /* Siri shortcut title and phrase for having siri skip to the next chapter of a podcast */
 "siri_shortcut_next_chapter" = "Chapitre suivant";
@@ -2834,10 +2834,10 @@
 "siri_shortcut_open_filter_phrase" = "Ouvrir %1$@";
 
 /* Siri shortcut invocation phrase for pausing the current episode */
-"siri_shortcut_pause_phrase" = "Suspendre";
+"siri_shortcut_pause_phrase" = "Pause";
 
 /* Siri shortcut title for pausing the current episode */
-"siri_shortcut_pause_title" = "Suspendre l’épisode actuel";
+"siri_shortcut_pause_title" = "Mettre l’épisode actuel en pause";
 
 /* Siri shortcut invocation phrase for playing all episodes of a particular filter. '%1$@' is a placeholder for the name of the filter to play from */
 "siri_shortcut_play_all_phrase" = "Lire tous les %1$@";
@@ -2846,10 +2846,10 @@
 "siri_shortcut_play_all_title" = "Lecture de tous les épisodes";
 
 /* Siri shortcut title for playing the top episode of a particular podcast or filter */
-"siri_shortcut_play_episode_title" = "Lecture de l’épisode au haut de la liste";
+"siri_shortcut_play_episode_title" = "Lecture du meilleur épisode";
 
 /* Siri shortcut invocation phrase for playing the specified filter. '%1$@' is a placeholder for the name of the filter to play from */
-"siri_shortcut_play_filter_phrase" = "Lire les %1$@ épisodes du haut de la liste";
+"siri_shortcut_play_filter_phrase" = "Lire le meilleur %1$@";
 
 /* Siri shortcut invocation phrase for playing the specified podcast. '%1$@' is a placeholder for the name of the podcast */
 "siri_shortcut_play_podcast_phrase" = "Lire %1$@";
@@ -2858,13 +2858,13 @@
 "siri_shortcut_play_suggested_podcast_phrase" = "Lire un épisode suggéré";
 
 /* Siri shortcut suggested title for playing a suggested podcast */
-"siri_shortcut_play_suggested_podcast_suggested_title" = "Surprenez-moi!";
+"siri_shortcut_play_suggested_podcast_suggested_title" = "Surprise !";
 
 /* Siri shortcut title for playing a suggested podcast */
 "siri_shortcut_play_suggested_podcast_title" = "Lecture d’un épisode suggéré";
 
 /* Siri shortcut invocation phrase for playing the next episode in the queue. */
-"siri_shortcut_play_up_next_phrase" = "Prochains épisodes";
+"siri_shortcut_play_up_next_phrase" = "File d’attente";
 
 /* Siri shortcut title for playing the next episode in the queue */
 "siri_shortcut_play_up_next_title" = "Lecture du prochain épisode";
@@ -2876,34 +2876,34 @@
 "siri_shortcut_resume_phrase" = "Reprendre";
 
 /* Siri shortcut title for resuming the current episode */
-"siri_shortcut_resume_title" = "Reprise de l’épisode actuel";
+"siri_shortcut_resume_title" = "Reprise de l’épisode en cours";
 
 /* Title for the siri shortcuts page to create a shortcut to a podcast */
 "siri_shortcut_to_podcast" = "Créer un raccourci vers le podcast";
 
 /* A common string used throughout the app. Prompt to rewind the playback by a configurable amount. */
-"skip_back" = "Saut vers l’arrière";
+"skip_back" = "Retour rapide";
 
 /* A common string used throughout the app. Prompt to fast-forward the playback by a configurable amount. */
-"skip_forward" = "Saut vers l’avant";
+"skip_forward" = "Avance rapide";
 
 /* The Sleep Timer feature. */
-"sleep_timer" = "Minuterie de veille";
+"sleep_timer" = "Mise en veille";
 
 /* Prompt to add five minutes to an active timer. */
 "sleep_timer_add_5_mins" = "+ 5 minutes";
 
 /* Prompt to cancel the active sleep timer. */
-"sleep_timer_cancel" = "Annuler la minuterie";
+"sleep_timer_cancel" = "Annuler la mise en veille";
 
 /* Prompt to change the active sleep timer to be end of episode. */
 "sleep_timer_end_of_episode" = "Fin de l’épisode";
 
 /* Accessibility hint that displays the remaining amount of time for the sleep timer. '%1$@' is a placeholder for the remaining time. */
-"sleep_timer_time_remaining" = "Minuterie de veille activée, il reste %1$@";
+"sleep_timer_time_remaining" = "Mise en veille activée, temps restant : %1$@";
 
 /* Prompt to confirm when presented with a connection prompt. Used when connecting to a Sonos speaker. */
-"sonos_connect_action" = "SE CONNECTER";
+"sonos_connect_action" = "CONNECTER";
 
 /* Prompt to connect to a Sonos speaker. 'Sonos' refers the the speaker manufacturer. */
 "sonos_connect_prompt" = "Se connecter à Sonos";
@@ -2912,19 +2912,19 @@
 "sonos_connecting" = "CONNEXION...";
 
 /* Notice indicating that the app failed to make a connection to a Sonos device because the accounts weren't successfully linked. 'Sonos' refers the the speaker manufacturer. */
-"sonos_connection_failed_account_link" = "Impossible d’associer le compte Pocket Casts pour le moment. Veuillez réessayer plus tard.";
+"sonos_connection_failed_account_link" = "Impossible de connecter le compte Pocket Casts pour le moment. Veuillez réessayer plus tard.";
 
 /* Notice indicating that the app failed to make a connection to a Sonos device because because it couldn't detect the Sonos App. 'Sonos' refers the the speaker manufacturer. */
-"sonos_connection_failed_app_missing" = "Impossible d’ouvrir l’application Sonos pour terminer le processus d’association.";
+"sonos_connection_failed_app_missing" = "Impossible d’ouvrir l’application Sonos pour finaliser le processus de connexion.";
 
 /* Notice indicating that the app failed to make a connection to a Sonos device. 'Sonos' refers the the speaker manufacturer. */
-"sonos_connection_failed_title" = "Échec de l’association";
+"sonos_connection_failed_title" = "Échec de la connexion";
 
 /* Notice informing the users about what data will be provided to the Sonos speaker upon connection. 'Sonos' refers the the speaker manufacturer. */
-"sonos_connection_privacy_notice" = "La connexion à Sonos permettra à l’application Sonos d’accéder aux informations de l’épisode.\n\nVotre adresse courriel, votre mot de passe et d’autres éléments sensibles ne sont jamais partagés.";
+"sonos_connection_privacy_notice" = "La connexion à Sonos permettra à l’application Sonos d’accéder aux informations de l’épisode.\n\nVotre adresse e-mail, votre mot de passe et d’autres éléments sensibles ne sont jamais partagés.";
 
 /* Notice informing the users they need Pocket Casts account and need to sign in before connecting to the Sonos speaker. 'Sonos' refers the the speaker manufacturer. */
-"sonos_connection_sign_in_prompt" = "Vous devez avoir un compte Pocket Casts pour vous connecter avec Sonos.";
+"sonos_connection_sign_in_prompt" = "Vous devez avoir un compte Pocket Casts pour pouvoir vous connecter à Sonos.";
 
 /* A common string used throughout the app. Prompt for the sort option menus. */
 "sort_by" = "Trier par";
@@ -2936,37 +2936,37 @@
 "speed" = "Vitesse";
 
 /* A common string used throughout the app. Prompt to mark an episode(s) as favorited. */
-"star_episode" = "Ajouter l’épisode aux favoris";
+"star_episode" = "Épisode favori";
 
 /* A common string used throughout the app. Prompt to mark an episode(s) as favorited. Similar to 'Star Episode' but more concise. */
 "star_episode_short" = "Favori";
 
 /* Accessibility message for the cell displaying the time for how long they've listened to Pocket Casts. '%1$@' is a placeholder for how long they've listened and '%2$@' is a placeholder for a localized funny stat related to their listening history. */
-"stats_accessibility_listen_history_format" = "Vous avez écouté des balados pendant %1$@. %2$@";
+"stats_accessibility_listen_history_format" = "Votre durée d’écoute est de %1$@. %2$@";
 
 /* Row header that displays the amount of time saved from Auto skipping episode parts. */
 "stats_auto_skip" = "Saut automatique";
 
 /* Error message for when stats fail to load due to internet connection error. */
-"stats_error" = "Impossible de charger les statistiques. Vérifiez votre connexion Internet.";
+"stats_error" = "Impossible de charger les statistiques, vérifiez votre connexion Internet.";
 
 /* Message informing the user how long they've been a user. '%1$@' is a placeholder for the date for when they created their account. */
-"stats_listen_history_format" = "Depuis le %1$@, vous avez écouté des balados pendant";
+"stats_listen_history_format" = "Depuis le %1$@, votre durée d’écoute est de";
 
 /* Loading message displayed while stats are being pulled. */
-"stats_listen_history_loading" = "Vous avez écouté des balados pendant";
+"stats_listen_history_loading" = "Votre durée d’écoute est de";
 
 /* Header for the cell displaying the time for how long they've listened to Pocket Casts. */
-"stats_listen_history_no_date" = "Vous avez écouté des balados pendant";
+"stats_listen_history_no_date" = "Votre durée d’écoute est de";
 
 /* Row header that displays the amount of time saved from the Skip forward feature. */
-"stats_skipping" = "Saut";
+"stats_skipping" = "Ignorer";
 
 /* Section header that breaks down how much listening time has been saved across a variety of features. */
 "stats_time_saved" = "TEMPS ÉCONOMISÉ PAR";
 
 /* A placeholder string for when the app fails to generate a time from the given inputs. */
-"stats_time_zero_seconds" = "0 seconde";
+"stats_time_zero_seconds" = "0 secondes";
 
 /* A common string used throughout the app. Status header showing the totals for accumulated stat numbers. */
 "stats_total" = "Total";
@@ -2975,34 +2975,34 @@
 "stats_variable_speed" = "Vitesse variable";
 
 /* A common string used throughout the app. Status message informing the user that the episode has been downloaded. */
-"status_downloaded" = "Téléchargés";
+"status_downloaded" = "Téléchargé(s)";
 
 /* A common string used throughout the app. Status message informing the user that the episode is downloading. */
-"status_downloading" = "Téléchargement";
+"status_downloading" = "En cours de téléchargement";
 
 /* A common string used throughout the app. Status message informing the user that the episode has not been downloaded. */
-"status_not_downloaded" = "Non téléchargés";
+"status_not_downloaded" = "Non téléchargé(s)";
 
 /* A common string used throughout the app. Status message informing the user that the episode is currently not selected. Used with accessibility. */
-"status_not_selected" = "Non sélectionnés";
+"status_not_selected" = "Non sélectionné";
 
 /* A common string used throughout the app. Status message informing the user that the episode has not been starred (favorited). */
-"status_not_starred" = "Non ajoutés aux favoris";
+"status_not_starred" = "Non favori";
 
 /* A common string used throughout the app. Status message informing the user that the episode has been played. */
-"status_played" = "Lus";
+"status_played" = "Lu(s)";
 
 /* A common string used throughout the app. Status message informing the user that the episode is currently selected. Used with accessibility. */
-"status_selected" = "Sélectionnés";
+"status_selected" = "Sélectionné";
 
 /* A common string used throughout the app. Status message informing the user that the episode has been starred (favorited). */
-"status_starred" = "Favoris";
+"status_starred" = "Favori";
 
 /* A common string used throughout the app. Status message informing the user that the episode has not been played. */
-"status_unplayed" = "Non lus";
+"status_unplayed" = "Non lu(s)";
 
 /* A common string used throughout the app. Status message informing the user that the episode has been uploaded. */
-"status_uploaded" = "Téléversés";
+"status_uploaded" = "Chargé";
 
 /* A common string used throughout the app. Prompt to cancel the download for the selected item(s). */
 "stop_download" = "Arrêter le téléchargement";
@@ -3011,34 +3011,34 @@
 "subscribe" = "S’abonner";
 
 /* Prompt to subscribe to all of the selected podcast. */
-"subscribe_all" = "S’abonner à tout";
+"subscribe_all" = "S’abonner à tous les podcasts";
 
 /* Label indicating that the user is currently subscribed to the selected podcast. */
-"subscribed" = "Abonné(e)";
+"subscribed" = "Abonné";
 
 /* Title for the subscription details page informing the users that the selected subscription has been canceled. */
 "subscription_cancelled" = "Abonnement annulé";
 
 /* Message on the subscription details page informing the users when the canceled subscription will officially end. '%1$@' is a placeholder for the date in which the subscription expires. */
-"subscription_cancelled_msg" = "Abonnement annulé %1$@ ";
+"subscription_cancelled_msg" = "Abonnement résilié le %1$@ ";
 
 /* A common string used throughout the app. Thanks the user for their support. Used for paid feeds and Pocket Casts Plus. */
-"subscriptions_thank_you" = "Merci de votre soutien!";
+"subscriptions_thank_you" = "Merci pour votre soutien !";
 
 /* A label used to identify that a user is a supporter of the selected podcast. */
-"supporter" = "Partisan";
+"supporter" = "Abonné";
 
 /* Menu option to open details on available podcast supporter contribution options. */
-"supporter_contributions" = "Contributions des partisans";
+"supporter_contributions" = "Contributions abonnés";
 
 /* Subtitle to prompt the user to review their supports contribution details for more information. */
-"supporter_contributions_subtitle" = "Consulter les contributions pour obtenir des renseignements détaillés";
+"supporter_contributions_subtitle" = "Vérifier les détails des contributions";
 
 /* Informational message informing the user that their recurring payments for supporter contributions have been canceled. */
-"supporter_payment_canceled" = "Partisan : annulé";
+"supporter_payment_canceled" = "Abonné : Annulé";
 
 /* Notice the sync failed due to an account error. */
-"sync_account_error" = "Vérifiez votre nom d’utilisateur et votre mot de passe.";
+"sync_account_error" = "Vérifiez votre identifiant et votre mot de passe.";
 
 /* Sync status update notifying the user that the app is logged in. */
 "sync_account_login" = "Connecté...";
@@ -3047,16 +3047,16 @@
 "sync_failed" = "Échec de la synchronisation";
 
 /* Notice that the app is syncing the up next and history for the account. */
-"sync_in_progress" = "Synchronisation des prochains épisodes et de l’historique";
+"sync_in_progress" = "Synchronisation file d’attente et historique";
 
 /* Progress message indicating the total number of podcasts being synced. '%1$@' serves as a placeholder for the current number of synced podcasts. '%2$@' serves as a placeholder for the total number of podcasts to sync. */
-"sync_progress" = "%1$@ de %2$@ balado(s)";
+"sync_progress" = "Podcast %1$@ sur %2$@";
 
 /* Progress message indicating the total number of podcasts that have been synced. '%1$@' serves as a placeholder for the current number of synced podcasts, will be more than one. */
-"sync_progress_unknown_count_plural_format" = "%1$@ balados synchronisés";
+"sync_progress_unknown_count_plural_format" = "%1$@ podcasts synchronisés";
 
 /* Progress message indicating the total number of podcasts that have been synced. Used in the singular case. */
-"sync_progress_unknown_count_singular" = "1 balado synchronisé";
+"sync_progress_unknown_count_singular" = "1 podcast synchronisé";
 
 /* A common string used throughout the app. Used to indicate that the sync process in running. */
 "syncing" = "Synchronisation...";
@@ -3071,7 +3071,7 @@
 "theme_dark" = "Sombre par défaut";
 
 /* Theme name for the Dark Contrast theme. */
-"theme_dark_contrast" = "Contraste sombre";
+"theme_dark_contrast" = "Contraste foncé";
 
 /* Theme name for the Electricity theme. */
 "theme_electricity" = "Électricité";
@@ -3086,7 +3086,7 @@
 "theme_light" = "Clair par défaut";
 
 /* Theme name for the Light Contrast theme. */
-"theme_light_contrast" = "Contraste clair";
+"theme_light_contrast" = "Léger contraste";
 
 /* Theme name for the Radioactivity theme. */
 "theme_radioactivity" = "Radioactivité";
@@ -3098,61 +3098,61 @@
 "time_format_never" = "jamais";
 
 /* A placeholder when time conversions fail. Sets the value to zero seconds */
-"time_placeholder" = "0 s";
+"time_placeholder" = "0 s";
 
 /* A common string used throughout the app. Used to reference today. */
-"today" = "Aujourd’hui";
+"today" = "Aujourd'hui";
 
 /* A common string used throughout the app. Title option to place the item at the top of the queue. */
 "top" = "Haut";
 
 /* Label indicating that the trial period for the subscription or promotion has ended. */
-"trial_finished" = "Période d’essai terminée";
+"trial_finished" = "Essai terminé";
 
 /* The Trim Silence feature, removes silence from podcasts to make them shorter. */
-"trim_silence" = "Couper le silence";
+"trim_silence" = "Couper les silences";
 
 /* A common string used throughout the app. Catch all prompt to suggest to the user to try the the task again. */
-"try_again" = "Réessayer";
+"try_again" = "Recommencer";
 
 /* A common string used throughout the app. Prompt to restore the selected item(s) from an archived state. */
 "unarchive" = "Désarchiver";
 
 /* A common string used throughout the app. Used to reference an unknown duration '?' is an indicator that the amount of time isn't known and 'm' is a reference for minutes. */
-"unknown_duration" = "? min";
+"unknown_duration" = "? min";
 
 /* A common string used throughout the app. Prompt to un-star the selected item (remove from favorited). */
 "unstar" = "Retirer des favoris";
 
 /* A common string used throughout the app. Prompt to unsubscribe from the selected podcast(s). */
-"unsubscribe" = "Se désabonner";
+"unsubscribe" = "Résilier";
 
 /* A common string used throughout the app. Prompt to unsubscribe from all of the selected podcast. */
-"unsubscribe_all" = "Se désabonner de tout";
+"unsubscribe_all" = "Résilier tous";
 
 /* A common string used throughout the app. Title for the prompt to display the queue of episodes to play next. */
-"up_next" = "Prochains épisodes";
+"up_next" = "File d’attente";
 
 /* Description shown when your Up Next list is empty. Note that for non right to left languages "right" should be change to "left" (and translated) */
-"up_next_empty_description" = "Vous pouvez mettre des épisodes dans la file d’attente de lecture en balayant la ligne de l’épisode vers la droite ou en appuyant sur l’icône dans la fiche d’un épisode.";
+"up_next_empty_description" = "Vous pouvez mettre en file d’attente des épisodes à lire par la suite en faisant glisser les lignes d’épisodes vers la droite ou en appuyant sur l’icône d’une carte d’épisode.";
 
 /* Heading shown when your Up Next list is empty */
-"up_next_empty_title" = "Aucun épisode dans Prochains épisodes";
+"up_next_empty_title" = "File d’attente vide";
 
 /* An alphabetical sort option for uploaded files. */
-"upload_sort_alpha" = "Titre (A à Z)";
+"upload_sort_alpha" = "Titre (A-Z)";
 
 /* The Volume Boost feature. Makes voices louder. */
-"volume_boost" = "Amplification du volume";
+"volume_boost" = "Augmenter le volume";
 
 /* A short description of what the Volume Boost feature does */
-"volume_boost_description" = "Le volume des voix est plus élevé";
+"volume_boost_description" = "Les voix sont plus fortes";
 
 /* A common string used throughout the app. Informs the user that the app is waiting for wifi to reconnect. */
-"wait_for_wifi" = "En attente de réseau Wi-Fi";
+"wait_for_wifi" = "En attente de WiFi";
 
 /* A common string used throughout the app. Used to reference the Watch as the playing source with in the Apple Watch App (Phone is the other option for this use case) */
-"watch" = "Regarder";
+"watch" = "Montre";
 
 /* Indicates that the episode is being played is currently buffering to download more content for playback. */
 "watch_buffering" = "Mise en tampon...";
@@ -3167,7 +3167,7 @@
 "watch_effects" = "Effets";
 
 /* Prompt in the Apple Watch App to open episode details. */
-"watch_episode_details" = "Renseignements sur l’épisode";
+"watch_episode_details" = "Détails de l’épisode";
 
 /* Prompt in the Apple Watch app to return to the Main Menu */
 "watch_main_menu" = "Menu principal";
@@ -3179,7 +3179,7 @@
 "watch_no_filters" = "Aucun filtre";
 
 /* Label in the Apple Watch app informing the user that they haven't subscribed to podcasts. */
-"watch_no_podcasts" = "Aucun balado";
+"watch_no_podcasts" = "Aucun Podcast";
 
 /* Subtitle text used on the now playing screen in the Watch App. Indicates there is nothing palying or paused in the app. Please leave the "\
 \
@@ -3190,10 +3190,10 @@
 "watch_nothing_playing_title" = "Aucune lecture en cours";
 
 /* Message detailing where the audio will play from when selecting the source on the Apple Watch */
-"watch_source_msg" = "Le son des balados sortira du haut-parleur auquel est connecté l’appareil choisi.";
+"watch_source_msg" = "Les podcasts seront diffusés sur l’enceinte à laquelle le périphérique choisi est connecté.";
 
 /* Information label providing a brief explanation of Pocket Casts Plus. */
-"watch_source_plus_info" = "Téléchargez des balados directement sur votre montre et écoutez-les sans votre téléphone. Découvrez Pocket Casts Plus sur l’application mobile ou sur le Web.";
+"watch_source_plus_info" = "Téléchargez des podcasts directement sur votre montre et écoutez-les sans votre téléphone. Découvrez Pocket Casts Plus sur l’application mobile ou sur le Web.";
 
 /* Button that allows the user to manually trigger a refresh of their profile from the watch app. */
 "watch_source_refresh_account" = "Actualiser le compte";
@@ -3208,7 +3208,7 @@
 "watch_source_sign_in_info" = "Connectez-vous ou créez un compte depuis votre téléphone";
 
 /* Apple Watch complication prompt to tap the control to open the watch app. */
-"watch_tap_to_open" = "Appuyez pour ouvrir";
+"watch_tap_to_open" = "Appuyer pour ouvrir";
 
 /* Subtitle for the up next screen when a user has no episode queued up to play. */
 "watch_up_next_no_items_subtitle" = "Vous pouvez mettre en file d’attente des épisodes à lire ensuite depuis l’écran de détails de ces derniers, ou les ajouter sur votre téléphone.";
@@ -3217,7 +3217,7 @@
 "watch_up_next_no_items_title" = "Rien dans Up Next";
 
 /* Title for the announcement screen that calls out new features. */
-"whats_new" = "Nouveautés";
+"whats_new" = "Quoi de neuf";
 
 /* Text for a link that goes to our blog where people can read more about the current update */
 "whats_new_blog_more_link_text" = "Lire la suite sur cette mise à jour sur notre blog";
@@ -3248,13 +3248,13 @@
 "widgets_app_icon_name" = "Icône";
 
 /* Widget prompt message to direct the user to the discover tab to add new podcasts to their queue */
-"widgets_discover_prompt_msg" = "Consultez l’onglet Découvertes";
+"widgets_discover_prompt_msg" = "Consulter l’onglet Découvrir";
 
 /* Widget prompt title to direct the user to the discover tab to add new podcasts to their queue */
-"widgets_discover_prompt_title" = "Vos oreilles en demande plus?";
+"widgets_discover_prompt_title" = "Vos oreilles en redemandent ?";
 
 /* Widget label informing the user that nothing is currently being played. */
-"widgets_nothing_playing" = "Aucun épisode en cours de lecture";
+"widgets_nothing_playing" = "Aucune lecture en cours";
 
 /* Description for the now playing widget. */
 "widgets_now_playing_desc" = "Accédez rapidement à l’épisode en cours de lecture.";


### PR DESCRIPTION
Related to #390 

This PR manually updates the `fr-CA` strings to reflect the contents of `fr`.

It looks like our tooling has stopped picking up those changes for `fr-CA`. The fix for that will be addressed in another PR.

## To test

1. Just check the code changes (you can compare them with the `fr` localization file)
2. Green build

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
