### PR TITLE
Apple SSO: Corrupt Token Failure

### DIFF
--- a/Modules/Server/Package.swift
+++ b/Modules/Server/Package.swift
@@ -30,7 +30,10 @@ let package = Package(
                 "SwiftyJSON"
             ],
             path: "Sources",
-            linkerSettings: [.linkedFramework("CFNetwork", .when(platforms: [.iOS]))]
+            linkerSettings: [
+                .linkedFramework("CFNetwork", .when(platforms: [.iOS])),
+                .linkedFramework("AuthenticationServices", .when(platforms: [.iOS, .watchOS]))
+            ]
         ),
         .testTarget(
             name: "PocketCastsServerTests",

--- a/Modules/Server/Sources/PocketCastsServer/Private/TokenHelper.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Private/TokenHelper.swift
@@ -52,6 +52,7 @@ class TokenHelper {
 
     class func acquireToken() -> String? {
         if let token = acquirePasswordToken() ?? acquireIdentityToken() {
+            KeychainHelper.save(string: token, key: ServerConstants.Values.syncingV2TokenKey, accessibility: kSecAttrAccessibleAfterFirstUnlock)
             return token
         }
         else {
@@ -94,8 +95,6 @@ class TokenHelper {
 
             if httpResponse.statusCode == ServerConstants.HttpConstants.ok {
                 let token = try Api_UserLoginResponse(serializedData: validData).token
-                KeychainHelper.save(string: token, key: ServerConstants.Values.syncingV2TokenKey, accessibility: kSecAttrAccessibleAfterFirstUnlock)
-
                 return token
             }
 

--- a/Modules/Server/Sources/PocketCastsServer/Private/TokenHelper.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Private/TokenHelper.swift
@@ -111,6 +111,7 @@ class TokenHelper {
     }
 
     // MARK: - SSO Identity Token
+
     private class func acquireIdentityToken() -> String? {
         let semaphore = DispatchSemaphore(value: 0)
         var refreshedToken: String? = nil

--- a/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+Account.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+Account.swift
@@ -125,23 +125,36 @@ public extension ApiServerHandler {
     }
 
     func obtainToken(request: URLRequest, completion: @escaping (Result<AuthenticationResponse, APIError>) -> Void) {
-        URLSession.shared.dataTask(with: request) { data, response, error in
-            guard let responseData = data, error == nil, response?.extractStatusCode() == ServerConstants.HttpConstants.ok else {
-                let errorResponse = ApiServerHandler.extractErrorResponse(data: data, error: error)
-                FileLog.shared.addMessage("Unable to obtain token, status code: \(response?.extractStatusCode() ?? -1), server error: \(errorResponse?.rawValue ?? "none")")
-                completion(.failure(errorResponse ?? .UNKNOWN))
-                return
-            }
-
+        Task {
             do {
-                let response = try Api_UserLoginResponse(serializedData: responseData)
-                completion(.success(AuthenticationResponse(from: response)))
+                let response = try await obtainToken(request: request)
+                completion(.success(response))
             } catch {
-                FileLog.shared.addMessage("Error occurred while trying to unpack token request \(error.localizedDescription)")
-                completion(.failure(.UNKNOWN))
+                completion(.failure((error as? APIError) ?? .UNKNOWN))
             }
+        }
+    }
 
-        }.resume()
+    func obtainToken(request: URLRequest) async throws -> AuthenticationResponse {
+        try await withUnsafeThrowingContinuation { continuation in
+            URLSession.shared.dataTask(with: request) { data, response, error in
+                guard let responseData = data, error == nil, response?.extractStatusCode() == ServerConstants.HttpConstants.ok else {
+                    let errorResponse = ApiServerHandler.extractErrorResponse(data: data, error: error)
+                    FileLog.shared.addMessage("Unable to obtain token, status code: \(response?.extractStatusCode() ?? -1), server error: \(errorResponse?.rawValue ?? "none")")
+                    continuation.resume(throwing: errorResponse ?? .UNKNOWN)
+                    return
+                }
+
+                do {
+                    let response = try Api_UserLoginResponse(serializedData: responseData)
+                    continuation.resume(returning: AuthenticationResponse(from: response))
+                } catch {
+                    FileLog.shared.addMessage("Error occurred while trying to unpack token request \(error.localizedDescription)")
+                    continuation.resume(throwing: APIError.UNKNOWN)
+                }
+
+            }.resume()
+        }
     }
 
     class func extractErrorResponse(data: Data?, error: Error? = nil) -> APIError? {

--- a/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+Account.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+Account.swift
@@ -144,31 +144,6 @@ public extension ApiServerHandler {
         }.resume()
     }
 
-    func syncObtainToken(request: URLRequest) -> String? {
-        do {
-            let (responseData, response) = try URLConnection.sendSynchronousRequest(with: request)
-            guard let validData = responseData, let httpResponse = response as? HTTPURLResponse else {
-                FileLog.shared.addMessage("TokenHelper: Unable to acquire token")
-                return nil
-            }
-
-            if httpResponse.statusCode == ServerConstants.HttpConstants.ok {
-                let token = try Api_UserLoginResponse(serializedData: validData).token
-                ServerSettings.syncingV2Token = token
-                return token
-            }
-
-            if httpResponse.statusCode == ServerConstants.HttpConstants.unauthorized {
-                FileLog.shared.addMessage("TokenHelper logging user out, invalid password")
-                SyncManager.signout()
-            }
-        } catch {
-            FileLog.shared.addMessage("TokenHelper acquireToken failed \(error.localizedDescription)")
-        }
-
-        return nil
-    }
-
     class func extractErrorResponse(data: Data?, error: Error? = nil) -> APIError? {
         if let data = data {
             do {

--- a/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+SocialAuth.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+SocialAuth.swift
@@ -4,17 +4,36 @@ import PocketCastsUtils
 
 public extension ApiServerHandler {
     func validateLogin(identityToken: Data?, completion: @escaping (Result<AuthenticationResponse, APIError>) -> Void) {
-        let url = ServerHelper.asUrl(ServerConstants.Urls.api() + "user/login_apple")
-        guard var request = ServerHelper.createEmptyProtoRequest(url: url),
-              let identityToken = identityToken,
-              let token = String(data: identityToken, encoding: .utf8)
+        guard let identityToken = identityToken,
+              let token = String(data: identityToken, encoding: .utf8),
+              let request = tokenRequest(identityToken: token)
         else {
             FileLog.shared.addMessage("Unable to create protobuffer request to obtain token via Apple SSO")
             completion(.failure(.UNKNOWN))
             return
         }
 
-        request.setValue("Bearer \(token)", forHTTPHeaderField: ServerConstants.HttpHeaders.authorization)
         obtainToken(request: request, completion: completion)
+    }
+
+    func refreshIdentityToken() -> String? {
+        guard
+            let identityToken = ServerSettings.appleAuthIdentityToken,
+            let request = tokenRequest(identityToken: identityToken, cachePolicy: .reloadIgnoringLocalCacheData, timeoutInterval: 30.seconds)
+        else {
+            return nil
+        }
+
+        return syncObtainToken(request: request)
+    }
+
+    private func tokenRequest(identityToken: String?, cachePolicy: URLRequest.CachePolicy = .useProtocolCachePolicy, timeoutInterval: TimeInterval = 15.seconds) -> URLRequest? {
+        let url = ServerHelper.asUrl(ServerConstants.Urls.api() + "user/login_apple")
+        guard let identityToken = identityToken,
+            var request = ServerHelper.createEmptyProtoRequest(url: url, cachePolicy: cachePolicy, timeoutInterval: timeoutInterval)
+        else { return nil }
+
+        request.setValue("Bearer \(identityToken)", forHTTPHeaderField: ServerConstants.HttpHeaders.authorization)
+        return request
     }
 }

--- a/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+SocialAuth.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+SocialAuth.swift
@@ -49,7 +49,7 @@ public extension ApiServerHandler {
         guard let userID = ServerSettings.appleAuthUserID else { return .notFound }
         return try await ASAuthorizationAppleIDProvider().credentialState(forUserID: userID)
     }
-    
+
     func hasValidSSOToken() async throws -> Bool {
         let tokenState = try await ssoCredentialState()
 

--- a/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+SocialAuth.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+SocialAuth.swift
@@ -1,6 +1,7 @@
 import Foundation
 import PocketCastsDataModel
 import PocketCastsUtils
+import AuthenticationServices
 
 public extension ApiServerHandler {
     func validateLogin(identityToken: Data?, completion: @escaping (Result<AuthenticationResponse, APIError>) -> Void) {
@@ -17,29 +18,54 @@ public extension ApiServerHandler {
     }
 
     func refreshIdentityToken(completion: @escaping (Result<String?, APIError>) -> Void) {
+        Task {
+            do {
+                let token = try await refreshIdentityToken()
+                completion(.success(token))
+            } catch {
+                completion(.failure((error as? APIError) ?? .UNKNOWN))
+            }
+        }
+    }
+
+    func refreshIdentityToken() async throws -> String? {
         guard
             let identityToken = ServerSettings.appleAuthIdentityToken,
             let request = tokenRequest(identityToken: identityToken, cachePolicy: .reloadIgnoringLocalCacheData, timeoutInterval: 30.seconds)
         else {
             FileLog.shared.addMessage("Unable to locate Apple SSO token in Keychain")
-            completion(.failure(.UNKNOWN))
-            return
+            throw APIError.UNKNOWN
         }
 
-        obtainToken(request: request) { result in
-            switch result {
-            case .success(let response):
-                completion(.success(response.token))
-            case .failure(let error):
-                completion(.failure(error))
-            }
+        if try await hasValidSSOToken() {
+            let response = try await obtainToken(request: request)
+            return response.token
+        } else {
+            return nil
+        }
+    }
+
+    func ssoCredentialState() async throws -> ASAuthorizationAppleIDProvider.CredentialState {
+        guard let userID = ServerSettings.appleAuthUserID else { return .notFound }
+        return try await ASAuthorizationAppleIDProvider().credentialState(forUserID: userID)
+    }
+    
+    func hasValidSSOToken() async throws -> Bool {
+        let tokenState = try await ssoCredentialState()
+
+        switch tokenState {
+        case .authorized:
+            return true
+        default:
+            FileLog.shared.addMessage("Apple SSO token has been revoked")
+            return false
         }
     }
 
     private func tokenRequest(identityToken: String?, cachePolicy: URLRequest.CachePolicy = .useProtocolCachePolicy, timeoutInterval: TimeInterval = 15.seconds) -> URLRequest? {
         let url = ServerHelper.asUrl(ServerConstants.Urls.api() + "user/login_apple")
         guard let identityToken = identityToken,
-            var request = ServerHelper.createEmptyProtoRequest(url: url, cachePolicy: cachePolicy, timeoutInterval: timeoutInterval)
+              var request = ServerHelper.createEmptyProtoRequest(url: url, cachePolicy: cachePolicy, timeoutInterval: timeoutInterval)
         else { return nil }
 
         request.setValue("Bearer \(identityToken)", forHTTPHeaderField: ServerConstants.HttpHeaders.authorization)

--- a/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+SocialAuth.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+SocialAuth.swift
@@ -3,6 +3,23 @@ import PocketCastsDataModel
 import PocketCastsUtils
 import AuthenticationServices
 
+public extension ASAuthorizationAppleIDProvider.CredentialState {
+    var loggingValue: String {
+        switch self {
+        case .revoked:
+            return "revoked (\(rawValue))"
+        case .authorized:
+            return "authorized (\(rawValue))"
+        case .notFound:
+            return "notFound (\(rawValue))"
+        case .transferred:
+            return "transferred (\(rawValue))"
+        default:
+            return "unknown raw value: \(rawValue)}"
+        }
+    }
+}
+
 public extension ApiServerHandler {
     func validateLogin(identityToken: Data?) async throws -> AuthenticationResponse {
         guard let identityToken = identityToken,
@@ -40,6 +57,7 @@ public extension ApiServerHandler {
 
     func hasValidSSOToken() async throws -> Bool {
         let tokenState = try await ssoCredentialState()
+        FileLog.shared.addMessage("Validated Apple SSO token state: \(tokenState.loggingValue)")
 
         switch tokenState {
         case .authorized:

--- a/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+SocialAuth.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+SocialAuth.swift
@@ -4,28 +4,16 @@ import PocketCastsUtils
 import AuthenticationServices
 
 public extension ApiServerHandler {
-    func validateLogin(identityToken: Data?, completion: @escaping (Result<AuthenticationResponse, APIError>) -> Void) {
+    func validateLogin(identityToken: Data?) async throws -> AuthenticationResponse {
         guard let identityToken = identityToken,
               let token = String(data: identityToken, encoding: .utf8),
               let request = tokenRequest(identityToken: token)
         else {
             FileLog.shared.addMessage("Unable to create protobuffer request to obtain token via Apple SSO")
-            completion(.failure(.UNKNOWN))
-            return
+            throw APIError.UNKNOWN
         }
 
-        obtainToken(request: request, completion: completion)
-    }
-
-    func refreshIdentityToken(completion: @escaping (Result<String?, APIError>) -> Void) {
-        Task {
-            do {
-                let token = try await refreshIdentityToken()
-                completion(.success(token))
-            } catch {
-                completion(.failure((error as? APIError) ?? .UNKNOWN))
-            }
-        }
+        return try await obtainToken(request: request)
     }
 
     func refreshIdentityToken() async throws -> String? {

--- a/Modules/Server/Sources/PocketCastsServer/Public/ServerHelper.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/ServerHelper.swift
@@ -118,8 +118,8 @@ public class ServerHelper: NSObject {
         return request
     }
 
-    class func createEmptyProtoRequest(url: URL) -> URLRequest? {
-        var request = URLRequest(url: url, cachePolicy: .useProtocolCachePolicy, timeoutInterval: 15.seconds)
+    class func createEmptyProtoRequest(url: URL, cachePolicy: URLRequest.CachePolicy = .useProtocolCachePolicy, timeoutInterval: TimeInterval = 15.seconds) -> URLRequest? {
+        var request = URLRequest(url: url, cachePolicy: cachePolicy, timeoutInterval: timeoutInterval)
         request.httpMethod = "POST"
         request.addValue("application/octet-stream", forHTTPHeaderField: ServerConstants.HttpHeaders.accept)
         request.setValue("application/octet-stream", forHTTPHeaderField: ServerConstants.HttpHeaders.contentType)

--- a/Modules/Server/Sources/PocketCastsServer/Public/ServerSettings.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/ServerSettings.swift
@@ -335,4 +335,14 @@ public extension ServerSettings {
             KeychainHelper.save(string: newValue, key: ServerConstants.Values.syncingV2TokenKey, accessibility: kSecAttrAccessibleAfterFirstUnlock)
         }
     }
+
+    class var appleAuthIdentityToken: String? {
+        get {
+            KeychainHelper.string(for: ServerConstants.Values.appleAuthIdentityTokenKey)
+        }
+
+        set {
+            KeychainHelper.save(string: newValue, key: ServerConstants.Values.appleAuthIdentityTokenKey, accessibility: kSecAttrAccessibleAfterFirstUnlock)
+        }
+    }
 }

--- a/Modules/Server/Sources/PocketCastsServer/Public/ServerSettings.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/ServerSettings.swift
@@ -345,4 +345,14 @@ public extension ServerSettings {
             KeychainHelper.save(string: newValue, key: ServerConstants.Values.appleAuthIdentityTokenKey, accessibility: kSecAttrAccessibleAfterFirstUnlock)
         }
     }
+
+    class var appleAuthUserID: String? {
+        get {
+            KeychainHelper.string(for: ServerConstants.Values.appleAuthUserIDKey)
+        }
+
+        set {
+            KeychainHelper.save(string: newValue, key: ServerConstants.Values.appleAuthUserIDKey, accessibility: kSecAttrAccessibleAfterFirstUnlock)
+        }
+    }
 }

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerConstants.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerConstants.swift
@@ -89,6 +89,7 @@ public enum ServerConstants {
         static let syncingEmailKey = "SJSyncingEmail"
         static let syncingPasswordKey = "SJSyncingPwd"
         static let syncingV2TokenKey = "SJSyncV2Token"
+        static let appleAuthIdentityTokenKey = "SJAppleAuthIdentityToken"
         public static let appUserAgent = "Pocket Casts"
         static let customStorageUsed = "SJCustomStorageUsed"
         static let customStorageNumFiles = "SJCustomStorageNumFiles"

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerConstants.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerConstants.swift
@@ -90,6 +90,7 @@ public enum ServerConstants {
         static let syncingPasswordKey = "SJSyncingPwd"
         static let syncingV2TokenKey = "SJSyncV2Token"
         static let appleAuthIdentityTokenKey = "SJAppleAuthIdentityToken"
+        static let appleAuthUserIDKey = "SJAppleAuthUserID"
         public static let appUserAgent = "Pocket Casts"
         static let customStorageUsed = "SJCustomStorageUsed"
         static let customStorageNumFiles = "SJCustomStorageNumFiles"

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncManager.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncManager.swift
@@ -62,5 +62,6 @@ public class SyncManager {
         KeychainHelper.removeKey(ServerConstants.Values.syncingPasswordKey)
         KeychainHelper.removeKey(ServerConstants.Values.syncingV2TokenKey)
         KeychainHelper.removeKey(ServerConstants.Values.appleAuthIdentityTokenKey)
+        KeychainHelper.removeKey(ServerConstants.Values.appleAuthUserIDKey)
     }
 }

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncManager.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncManager.swift
@@ -61,5 +61,6 @@ public class SyncManager {
         KeychainHelper.removeKey(ServerConstants.Values.syncingEmailKey)
         KeychainHelper.removeKey(ServerConstants.Values.syncingPasswordKey)
         KeychainHelper.removeKey(ServerConstants.Values.syncingV2TokenKey)
+        KeychainHelper.removeKey(ServerConstants.Values.appleAuthIdentityTokenKey)
     }
 }

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -416,6 +416,7 @@
 		46B5DFD827EA2A80006FC2ED /* NowPlayingOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46B5DFD727EA2A80006FC2ED /* NowPlayingOptions.swift */; };
 		46B5DFDA27EA4F12006FC2ED /* VolumeControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46B5DFD927EA4F12006FC2ED /* VolumeControl.swift */; };
 		46C22EE028F73D9A00F4173B /* AuthenticationServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 46C22EDF28F73D9900F4173B /* AuthenticationServices.framework */; };
+		46C22EE328F7497300F4173B /* DeveloperMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46C22EE228F7497300F4173B /* DeveloperMenu.swift */; };
 		46C3D552275EA16200DDE116 /* SingleEpisodeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46C3D551275EA16200DDE116 /* SingleEpisodeViewController.swift */; };
 		46C3D554275EA19B00DDE116 /* SingleEpisodeViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 46C3D553275EA19B00DDE116 /* SingleEpisodeViewController.xib */; };
 		46C3D556275EA6C400DDE116 /* DiscoverEpisodeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46C3D555275EA6C400DDE116 /* DiscoverEpisodeViewModel.swift */; };
@@ -1922,6 +1923,7 @@
 		46B867C227A08C35006CDBA0 /* ScreenshotAutomation_iPhone_Light_Interface.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = ScreenshotAutomation_iPhone_Light_Interface.xctestplan; sourceTree = "<group>"; };
 		46B867C327A08C85006CDBA0 /* ScreenshotAutomation_iPhone_Dark_Interface.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = ScreenshotAutomation_iPhone_Dark_Interface.xctestplan; sourceTree = "<group>"; };
 		46C22EDF28F73D9900F4173B /* AuthenticationServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AuthenticationServices.framework; path = System/Library/Frameworks/AuthenticationServices.framework; sourceTree = SDKROOT; };
+		46C22EE228F7497300F4173B /* DeveloperMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperMenu.swift; sourceTree = "<group>"; };
 		46C3D551275EA16200DDE116 /* SingleEpisodeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleEpisodeViewController.swift; sourceTree = "<group>"; };
 		46C3D553275EA19B00DDE116 /* SingleEpisodeViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SingleEpisodeViewController.xib; sourceTree = "<group>"; };
 		46C3D555275EA6C400DDE116 /* DiscoverEpisodeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverEpisodeViewModel.swift; sourceTree = "<group>"; };
@@ -3531,6 +3533,14 @@
 			name = Interface;
 			sourceTree = "<group>";
 		};
+		46C22EE128F7496000F4173B /* Developer Menu */ = {
+			isa = PBXGroup;
+			children = (
+				46C22EE228F7497300F4173B /* DeveloperMenu.swift */,
+			);
+			name = "Developer Menu";
+			sourceTree = "<group>";
+		};
 		46C3D550275EA0E400DDE116 /* Single Episode */ = {
 			isa = PBXGroup;
 			children = (
@@ -4360,6 +4370,7 @@
 		BD5B79191783F9CF00A0F407 /* Settings */ = {
 			isa = PBXGroup;
 			children = (
+				46C22EE128F7496000F4173B /* Developer Menu */,
 				BD69EBBD1CD1D39F007F273B /* Helpers */,
 				BD69EBB61CD1C7EE007F273B /* Support */,
 				BDFB26E41CD08AB900787B7E /* About */,
@@ -7479,6 +7490,7 @@
 				BDF7BDD51CA24F5C0045AB6D /* FunnyTimeConverter.swift in Sources */,
 				4006E31723AC935700174DEB /* DescriptiveCollectionCell.swift in Sources */,
 				BD90134F275F3346004AC104 /* ThemeSelectorView.swift in Sources */,
+				46C22EE328F7497300F4173B /* DeveloperMenu.swift in Sources */,
 				BD2219F1253EAEAF000025BE /* PlaybackCatchUpHelper.swift in Sources */,
 				BD1BA4191D07EED9001383F0 /* ActionSheetRootViewController.swift in Sources */,
 				BD2D0AD7243C506C000B313A /* AnimatedImageButton+Pointer.swift in Sources */,

--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -83,6 +83,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         NotificationCenter.default.addObserver(self, selector: #selector(showOverlays), name: Constants.Notifications.closedNonOverlayableWindow, object: nil)
 
         setupSignOutListener()
+        AuthenticationHelper.validateAppleSSOCredentials()
+        AuthenticationHelper.observeAppleSSOEvents()
+
         return true
     }
 

--- a/podcasts/AuthenticationHelper.swift
+++ b/podcasts/AuthenticationHelper.swift
@@ -20,6 +20,7 @@ class AuthenticationHelper {
         handleSuccessfulSignIn(response)
         if let identityToken = appleIDCredential.identityToken {
             ServerSettings.appleAuthIdentityToken = String(data: identityToken, encoding: .utf8)
+            ServerSettings.appleAuthUserID = appleIDCredential.user
         }
     }
 

--- a/podcasts/AuthenticationHelper.swift
+++ b/podcasts/AuthenticationHelper.swift
@@ -8,11 +8,18 @@ class AuthenticationHelper {
         ApiServerHandler.shared.validateLogin(identityToken: appleIDCredential.identityToken) { result in
             switch result {
             case .success(let response):
-                handleSuccessfulSignIn(response)
+                handleSSO(appleIDCredential, response)
                 completion(.success(true))
             case .failure(let error):
                 completion(.failure(error))
             }
+        }
+    }
+
+    private static func handleSSO(_ appleIDCredential: ASAuthorizationAppleIDCredential, _ response: AuthenticationResponse) {
+        handleSuccessfulSignIn(response)
+        if let identityToken = appleIDCredential.identityToken {
+            ServerSettings.appleAuthIdentityToken = String(data: identityToken, encoding: .utf8)
         }
     }
 

--- a/podcasts/DeveloperMenu.swift
+++ b/podcasts/DeveloperMenu.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+import PocketCastsServer
+
+struct DeveloperMenu: View {
+    var body: some View {
+        VStack {
+            Button {
+                ServerSettings.syncingV2Token = "badToken"
+            } label: {
+                Text("Corrupt Sync Login Token")
+                    .padding()
+                    .overlay(
+                          RoundedRectangle(cornerRadius: 8)
+                            .stroke(Color.accentColor, lineWidth: 2)
+                      )
+            }
+        }
+        .padding()
+    }
+}
+
+struct DeveloperMenu_Previews: PreviewProvider {
+    static var previews: some View {
+        DeveloperMenu()
+    }
+}

--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -308,13 +308,19 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
 
     func showSignInPage() {
         switchToTab(.profile)
+        guard !SyncManager.isUserLoggedIn() else { return }
 
-        if !SyncManager.isUserLoggedIn() {
-            let signInController = SyncSigninViewController()
-            signInController.dismissOnCancel = true
-            let navController = SJUIUtils.popupNavController(for: signInController)
-            present(navController, animated: true, completion: nil)
+        let signInController: UIViewController
+        if FeatureFlag.signInWithApple {
+            signInController = ProfileIntroViewController()
         }
+        else {
+            signInController = SyncSigninViewController()
+            (signInController as! SyncSigninViewController).dismissOnCancel = true
+        }
+
+        let navController = SJUIUtils.popupNavController(for: signInController)
+        present(navController, animated: true, completion: nil)
     }
 
     func showSupporterSignIn(podcastInfo: PodcastInfo) {

--- a/podcasts/SettingsViewController.swift
+++ b/podcasts/SettingsViewController.swift
@@ -5,7 +5,7 @@ import WatchConnectivity
 
 class SettingsViewController: PCViewController, UITableViewDataSource, UITableViewDelegate {
     private enum TableRow: String {
-        case general, notifications, appearance, storageAndDataUse, autoArchive, autoDownload, autoAddToUpNext, siriShortcuts, watch, customFiles, help, opml, about, pocketCastsPlus, privacy
+        case general, notifications, appearance, storageAndDataUse, autoArchive, autoDownload, autoAddToUpNext, siriShortcuts, watch, customFiles, help, opml, about, pocketCastsPlus, privacy, developer
 
         var display: (text: String, image: UIImage?) {
             switch self {
@@ -39,6 +39,8 @@ class SettingsViewController: PCViewController, UITableViewDataSource, UITableVi
                 return (L10n.pocketCastsPlus, UIImage(named: "plusGold24"))
             case .privacy:
                 return (L10n.settingsPrivacy, UIImage(systemName: "lock.fill"))
+            case .developer:
+                return ("Developer", UIImage(systemName: "ladybug.fill"))
             }
         }
     }
@@ -137,6 +139,9 @@ class SettingsViewController: PCViewController, UITableViewDataSource, UITableVi
             navigationController?.pushViewController(PlusDetailsViewController(), animated: true)
         case .privacy:
             navigationController?.pushViewController(PrivacySettingsViewController(), animated: true)
+        case .developer:
+            let hostingController = UIHostingController(rootView: DeveloperMenu())
+            navigationController?.pushViewController(hostingController, animated: true)
         }
     }
 
@@ -154,6 +159,10 @@ class SettingsViewController: PCViewController, UITableViewDataSource, UITableVi
         if !SubscriptionHelper.hasActiveSubscription() {
             tableData.insert([.pocketCastsPlus], at: 0)
         }
+
+        #if DEBUG
+        tableData.append([.developer])
+        #endif
 
         settingsTable.reloadData()
     }


### PR DESCRIPTION
| 📘 Project: #381 | Depends on: https://github.com/Automattic/pocket-casts-ios/pull/388 |
|:---:|:---:|

This handles the path for when a user's Auth token has been revoked, and the app cannot log them in again. Previously the app navigated the user to the Password login flow. Now, it will take the user to the start of the login flow so they can select their social login provider again. 

## To test

📓  The simulator doesn't always return the email address so please test with a physical device to ensure every thing works as expected 

1. Enable the Feature Flag `signInWithApple`
2. Switch your Scheme to `Staging`
3. Login with SSO 
4. Navigate to the new developer menu
    - Profile > Settings > Developer
    - 🗒️ This Menu will only appear in Debug and Staging
5. Select "Corrupt Sync Login Token" 
6. Trigger an Authenticated request like Refresh
7. Expect the Token to be restored.
8. Corrupt your token again
9. Remove Apple Sign-In from the app.
    - Apple Settings App > Your Name > Password & Security > Apps Using Apple ID > Pocket Casts > Stop Using Apple ID
10. Return to the App 
11. Expect to see the logged out message with the prompt to sign in
<img width="300" src="https://user-images.githubusercontent.com/3384451/195666396-54fa72f1-c856-46d6-bcc8-8f044b3c065e.png">

12. Tapping Sign-In should take you to step 1 of the authentication flow

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
