### PR TITLE
End of Year: add badge and card to Profile

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -444,6 +444,8 @@
 		8B10E78828D9094500702C54 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 8B10E78528D908A900702C54 /* GoogleService-Info.plist */; };
 		8B10E78928D9094900702C54 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 8B10E78528D908A900702C54 /* GoogleService-Info.plist */; };
 		8B10E78A28D9094A00702C54 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 8B10E78528D908A900702C54 /* GoogleService-Info.plist */; };
+		8B2E055228F88D7300C2DBDE /* EndOfYearPromptCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B2E055128F88D7300C2DBDE /* EndOfYearPromptCell.swift */; };
+		8B2E055428F891F900C2DBDE /* EndOfYearCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B2E055328F891F900C2DBDE /* EndOfYearCard.swift */; };
 		8B2FEA8D28F5A2E200A10DAE /* AppIcon-Halloween@2x~ipad.png in Resources */ = {isa = PBXBuildFile; fileRef = 8B2FEA8C28F5A2E200A10DAE /* AppIcon-Halloween@2x~ipad.png */; };
 		8B317BA028906A8900A26A13 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B317B9F28906A8900A26A13 /* main.swift */; };
 		8B317BA328906C8100A26A13 /* TestingAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B317BA228906C8100A26A13 /* TestingAppDelegate.swift */; };
@@ -469,9 +471,9 @@
 		8BA55A1328CA7425002BECC5 /* XCTestCase+eventually.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA55A1228CA7425002BECC5 /* XCTestCase+eventually.swift */; };
 		8BA55A1528CA8FEB002BECC5 /* PrivacySettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA55A1428CA8FEB002BECC5 /* PrivacySettingsViewController.swift */; };
 		8BA55A1728CA92A7002BECC5 /* PrivacySettingsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8BA55A1628CA92A7002BECC5 /* PrivacySettingsViewController.xib */; };
-		8BDEBC0F28F6F82A00A1B03C /* AppIcon-Halloween-152@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 8BDEBC0E28F6F82A00A1B03C /* AppIcon-Halloween-152@2x.png */; };
 		8BCB22B228F47F44001A0315 /* EndOfYearModal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BCB22B128F47F44001A0315 /* EndOfYearModal.swift */; };
 		8BCB22B428F48282001A0315 /* EndOfYear.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BCB22B328F48282001A0315 /* EndOfYear.swift */; };
+		8BDEBC0F28F6F82A00A1B03C /* AppIcon-Halloween-152@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 8BDEBC0E28F6F82A00A1B03C /* AppIcon-Halloween-152@2x.png */; };
 		8BE36DE8287352A100E35313 /* PocketCastsServer in Frameworks */ = {isa = PBXBuildFile; productRef = 8BE36DE7287352A100E35313 /* PocketCastsServer */; };
 		8BE36DEB287352F200E35313 /* PocketCastsDataModel in Frameworks */ = {isa = PBXBuildFile; productRef = 8BE36DEA287352F200E35313 /* PocketCastsDataModel */; };
 		8BE36DEC287352F200E35313 /* PocketCastsDataModel in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 8BE36DEA287352F200E35313 /* PocketCastsDataModel */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
@@ -1961,6 +1963,8 @@
 		7E84A6B7056C4797BAD62A1F /* Pods-Pocket Casts Watch App Extension.staging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Pocket Casts Watch App Extension.staging.xcconfig"; path = "Pods/Target Support Files/Pods-Pocket Casts Watch App Extension/Pods-Pocket Casts Watch App Extension.staging.xcconfig"; sourceTree = "<group>"; };
 		8229174E612BC7BAC6F63274 /* Pods-Pocket Casts Watch App Extension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Pocket Casts Watch App Extension.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Pocket Casts Watch App Extension/Pods-Pocket Casts Watch App Extension.debug.xcconfig"; sourceTree = "<group>"; };
 		8B10E78528D908A900702C54 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
+		8B2E055128F88D7300C2DBDE /* EndOfYearPromptCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndOfYearPromptCell.swift; sourceTree = "<group>"; };
+		8B2E055328F891F900C2DBDE /* EndOfYearCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndOfYearCard.swift; sourceTree = "<group>"; };
 		8B2FEA8C28F5A2E200A10DAE /* AppIcon-Halloween@2x~ipad.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "AppIcon-Halloween@2x~ipad.png"; sourceTree = "<group>"; };
 		8B317B9F28906A8900A26A13 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		8B317BA228906C8100A26A13 /* TestingAppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestingAppDelegate.swift; sourceTree = "<group>"; };
@@ -1985,9 +1989,9 @@
 		8BA55A1228CA7425002BECC5 /* XCTestCase+eventually.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+eventually.swift"; sourceTree = "<group>"; };
 		8BA55A1428CA8FEB002BECC5 /* PrivacySettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacySettingsViewController.swift; sourceTree = "<group>"; };
 		8BA55A1628CA92A7002BECC5 /* PrivacySettingsViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = PrivacySettingsViewController.xib; sourceTree = "<group>"; };
-		8BDEBC0E28F6F82A00A1B03C /* AppIcon-Halloween-152@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "AppIcon-Halloween-152@2x.png"; sourceTree = "<group>"; };
 		8BCB22B128F47F44001A0315 /* EndOfYearModal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndOfYearModal.swift; sourceTree = "<group>"; };
 		8BCB22B328F48282001A0315 /* EndOfYear.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndOfYear.swift; sourceTree = "<group>"; };
+		8BDEBC0E28F6F82A00A1B03C /* AppIcon-Halloween-152@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "AppIcon-Halloween-152@2x.png"; sourceTree = "<group>"; };
 		8BE36DCA28734F7000E35313 /* DataModel */ = {isa = PBXFileReference; lastKnownFileType = text; name = DataModel; path = Modules/DataModel; sourceTree = SOURCE_ROOT; };
 		8BE36DCB28734F7000E35313 /* Utils */ = {isa = PBXFileReference; lastKnownFileType = text; name = Utils; path = Modules/Utils; sourceTree = SOURCE_ROOT; };
 		8BE36DCC28734F7000E35313 /* Server */ = {isa = PBXFileReference; lastKnownFileType = text; name = Server; path = Modules/Server; sourceTree = SOURCE_ROOT; };
@@ -3650,6 +3654,8 @@
 			isa = PBXGroup;
 			children = (
 				8BCB22B128F47F44001A0315 /* EndOfYearModal.swift */,
+				8B2E055128F88D7300C2DBDE /* EndOfYearPromptCell.swift */,
+				8B2E055328F891F900C2DBDE /* EndOfYearCard.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -7187,6 +7193,7 @@
 				BDD5253A20477E4400AAD211 /* NSObject+AppDelegate.swift in Sources */,
 				46305CED272AFA5F003AC87B /* UserDefaults+Helpers.swift in Sources */,
 				BD2F3BA22366C0DA00416633 /* PlayerContainerViewController+Update.swift in Sources */,
+				8B2E055228F88D7300C2DBDE /* EndOfYearPromptCell.swift in Sources */,
 				4034503324BF33B6001265E2 /* ListeningHistoryViewController+MultiSelect.swift in Sources */,
 				BD40987A1B9ECA5F007F36BD /* AudioReadTask.swift in Sources */,
 				BDA42B6B21B794B9003919CB /* AnimatedImageButton.swift in Sources */,
@@ -7389,6 +7396,7 @@
 				BD874EFB1C9A637200F5B2A5 /* NotificationsViewController.swift in Sources */,
 				BD424AFC2575EBF900C9447B /* AutoAddToUpNextViewController+PodcastSelect.swift in Sources */,
 				463538AB26E814B300BA9D35 /* DataModel+Strings.swift in Sources */,
+				8B2E055428F891F900C2DBDE /* EndOfYearCard.swift in Sources */,
 				BDDF8AA8240CEBF9009BA263 /* DownloadsViewController+Swipe.swift in Sources */,
 				BDF0507C1FBA65ED00194D68 /* ListeningHistoryViewController.swift in Sources */,
 				BD6C3EFF2378EC5900C01403 /* NowPlayingPlayerItemViewController+Shelf.swift in Sources */,

--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -88,6 +88,9 @@ struct Constants {
         // folders
         static let folderChanged = NSNotification.Name(rawValue: "SJFolderChanged")
         static let folderDeleted = NSNotification.Name(rawValue: "SJFolderDeleted")
+
+        // End of Year
+        static let profileSeen = NSNotification.Name(rawValue: "profileSeen")
     }
 
     enum UserDefaults {
@@ -140,6 +143,8 @@ struct Constants {
         static let lastRunVersion = "lastRunVersion"
 
         static let reviewRequestDates = "reviewRequestDates"
+
+        static let showBadgeFor2022EndOfYear = "showBadgeFor2022EndOfYear"
     }
 
     enum Values {

--- a/podcasts/End of Year/Views/EndOfYearCard.swift
+++ b/podcasts/End of Year/Views/EndOfYearCard.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+
+struct EndOfYearCard: View {
+    var body: some View {
+        ZStack {
+            HStack {
+                VStack(alignment: .leading) {
+                    Text("Your Year in Podcasts")
+                        .foregroundColor(.white)
+                    Text("See your top podcasts, categories, listening stats and more.")
+                        .foregroundColor(.white)
+                }
+                .padding()
+                Spacer()
+            }
+            .background(Color.black)
+            .cornerRadius(15)
+        }
+        .padding()
+    }
+}
+
+struct EndOfYearCard_Previews: PreviewProvider {
+    static var previews: some View {
+        EndOfYearCard()
+    }
+}

--- a/podcasts/End of Year/Views/EndOfYearPromptCell.swift
+++ b/podcasts/End of Year/Views/EndOfYearPromptCell.swift
@@ -1,0 +1,23 @@
+import Foundation
+import SwiftUI
+
+class EndOfYearPromptCell: ThemeableCell {
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+
+        let childView = UIHostingController(rootView: EndOfYearCard())
+        contentView.addSubview(childView.view)
+
+        childView.view.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            childView.view.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            childView.view.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            childView.view.topAnchor.constraint(equalTo: contentView.topAnchor),
+            childView.view.bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
+        ])
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -12,6 +12,8 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
 
     private lazy var endOfYear = EndOfYear()
 
+    private lazy var profileTabBarItem = UITabBarItem(title: L10n.profile, image: UIImage(named: "profile_tab"), tag: tabs.firstIndex(of: .profile)!)
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -25,7 +27,11 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
         discoverViewController.tabBarItem = UITabBarItem(title: L10n.discover, image: UIImage(named: "discover_tab"), tag: tabs.firstIndex(of: .discover)!)
 
         let profileViewController = ProfileViewController()
-        profileViewController.tabBarItem = UITabBarItem(title: L10n.profile, image: UIImage(named: "profile_tab"), tag: tabs.firstIndex(of: .profile)!)
+        profileViewController.tabBarItem = profileTabBarItem
+
+        if FeatureFlag.endOfYear && Settings.showBadgeFor2022EndOfYear {
+            profileTabBarItem.badgeValue = ""
+        }
 
         viewControllers = [podcastsController, filtersViewController, discoverViewController, profileViewController].map { SJUIUtils.navController(for: $0) }
         selectedIndex = UserDefaults.standard.integer(forKey: Constants.UserDefaults.lastTabOpened)
@@ -44,6 +50,7 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
         NotificationCenter.default.addObserver(self, selector: #selector(handleFollowSystemThemeTurnedOn), name: Constants.Notifications.followSystemThemeTurnedOn, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(willEnterForeground), name: UIApplication.willEnterForegroundNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(unhideNavBar), name: Constants.Notifications.unhideNavBarRequested, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(profileSeen), name: Constants.Notifications.profileSeen, object: nil)
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -368,6 +375,13 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
         selectedIndex = tabs.firstIndex(of: tab)!
 
         return true
+    }
+
+    // MARK: - End of Year badge
+
+    @objc private func profileSeen() {
+        profileTabBarItem.badgeValue = nil
+        Settings.showBadgeFor2022EndOfYear = false
     }
 
     // MARK: - Orientation

--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -30,7 +30,7 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
         profileViewController.tabBarItem = profileTabBarItem
 
         if FeatureFlag.endOfYear && Settings.showBadgeFor2022EndOfYear {
-            profileTabBarItem.badgeValue = ""
+            profileTabBarItem.badgeValue = "●"
         }
 
         viewControllers = [podcastsController, filtersViewController, discoverViewController, profileViewController].map { SJUIUtils.navController(for: $0) }
@@ -395,6 +395,17 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
         let appearance = UITabBarAppearance()
         appearance.configureWithOpaqueBackground()
         appearance.backgroundColor = AppTheme.tabBarBackgroundColor()
+
+        if FeatureFlag.endOfYear {
+            // Change badge colors
+            [appearance.stackedLayoutAppearance,
+             appearance.inlineLayoutAppearance,
+             appearance.compactInlineLayoutAppearance]
+                .forEach {
+                    $0.normal.badgeBackgroundColor = .clear
+                    $0.normal.badgeTextAttributes = [NSAttributedString.Key.foregroundColor: UIColor.systemRed]
+                }
+        }
 
         tabBar.standardAppearance = appearance
         if #available(iOS 15.0, *) {

--- a/podcasts/ProfileViewController.swift
+++ b/podcasts/ProfileViewController.swift
@@ -412,6 +412,14 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
         return cell
     }
 
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        if FeatureFlag.endOfYear && indexPath.row == 0 {
+            return UITableView.automaticDimension
+        } else {
+            return 70
+        }
+    }
+
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
 

--- a/podcasts/ProfileViewController.swift
+++ b/podcasts/ProfileViewController.swift
@@ -113,12 +113,14 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
 
     var promoRedeemedMessage: String?
     private let settingsCellId = "SettingsCell"
+    private let endOfYearPromptCell = "EndOfYearPromptCell"
 
     private enum TableRow { case allStats, downloaded, starred, listeningHistory, uploadedFiles, endOfYearPrompt }
 
     @IBOutlet var profileTable: UITableView! {
         didSet {
             profileTable.register(UINib(nibName: "TopLevelSettingsCell", bundle: nil), forCellReuseIdentifier: settingsCellId)
+            profileTable.register(EndOfYearPromptCell.self, forCellReuseIdentifier: endOfYearPromptCell)
             profileTable.applyInsetForMiniPlayer()
         }
     }
@@ -384,11 +386,16 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let row = tableData()[indexPath.section][indexPath.row]
+
+        guard row != .endOfYearPrompt else {
+            return tableView.dequeueReusableCell(withIdentifier: endOfYearPromptCell, for: indexPath) as! EndOfYearPromptCell
+        }
+
         let cell = tableView.dequeueReusableCell(withIdentifier: settingsCellId, for: indexPath) as! TopLevelSettingsCell
 
         cell.settingsImage.tintColor = ThemeColor.primaryIcon01()
         cell.settingsLabel.setLetterSpacing(-0.01)
-        let row = tableData()[indexPath.section][indexPath.row]
         switch row {
         case .allStats:
             cell.settingsImage.image = UIImage(named: "profile-stats")

--- a/podcasts/ProfileViewController.swift
+++ b/podcasts/ProfileViewController.swift
@@ -169,6 +169,10 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
             showPromotionRedeemedAcknowledgement()
             promoRedeemedMessage = nil
         }
+
+        if FeatureFlag.endOfYear {
+            NotificationCenter.postOnMainThread(notification: Constants.Notifications.profileSeen)
+        }
     }
 
     override func viewDidDisappear(_ animated: Bool) {

--- a/podcasts/ProfileViewController.swift
+++ b/podcasts/ProfileViewController.swift
@@ -114,7 +114,7 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
     var promoRedeemedMessage: String?
     private let settingsCellId = "SettingsCell"
 
-    private enum TableRow { case allStats, downloaded, starred, listeningHistory, uploadedFiles }
+    private enum TableRow { case allStats, downloaded, starred, listeningHistory, uploadedFiles, endOfYearPrompt }
 
     @IBOutlet var profileTable: UITableView! {
         didSet {
@@ -405,6 +405,8 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
         case .listeningHistory:
             cell.settingsImage.image = UIImage(named: "profile-history")
             cell.settingsLabel.text = L10n.listeningHistory
+        case .endOfYearPrompt:
+            return UITableViewCell()
         }
 
         return cell
@@ -430,6 +432,8 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
         case .listeningHistory:
             let historyController = ListeningHistoryViewController()
             navigationController?.pushViewController(historyController, animated: true)
+        case .endOfYearPrompt:
+            EndOfYear().showStories(in: self)
         }
     }
 
@@ -442,11 +446,18 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
     }
 
     private func tableData() -> [[ProfileViewController.TableRow]] {
+        var data: [[ProfileViewController.TableRow]]
         if !SyncManager.isUserLoggedIn() {
-            return [[.allStats, .downloaded, .uploadedFiles, .listeningHistory]]
+            data = [[.allStats, .downloaded, .uploadedFiles, .listeningHistory]]
         } else {
-            return [[.allStats, .downloaded, .uploadedFiles, .starred, .listeningHistory]]
+            data = [[.allStats, .downloaded, .uploadedFiles, .starred, .listeningHistory]]
         }
+
+        if FeatureFlag.endOfYear {
+            data[0].insert(.endOfYearPrompt, at: 0)
+        }
+
+        return data
     }
 
     private func updateFooterFrame() {

--- a/podcasts/ProfileViewController.swift
+++ b/podcasts/ProfileViewController.swift
@@ -406,7 +406,7 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
             cell.settingsImage.image = UIImage(named: "profile-history")
             cell.settingsLabel.text = L10n.listeningHistory
         case .endOfYearPrompt:
-            return UITableViewCell()
+            return EndOfYearPromptCell()
         }
 
         return cell

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -719,6 +719,18 @@ class Settings: NSObject {
         UserDefaults.standard.bool(forKey: Constants.UserDefaults.analyticsOptOut)
     }
 
+    // MARK: - Profile Badge for End of Year 2022
+
+    class var showBadgeFor2022EndOfYear: Bool {
+        set {
+            UserDefaults.standard.set(newValue, forKey: Constants.UserDefaults.showBadgeFor2022EndOfYear)
+        }
+
+        get {
+            (UserDefaults.standard.value(forKey: Constants.UserDefaults.showBadgeFor2022EndOfYear) as? Bool) ?? true
+        }
+    }
+
     // MARK: - Variables that are loaded/changed through Firebase
 
     #if !os(watchOS)


### PR DESCRIPTION
| 📘 Project: #376 |
|:---:|

Add a badge and the End of Year card structure to the Profile screen.

| Card | Badge |
| ---- | ------- |
| <img src="https://user-images.githubusercontent.com/7040243/195703076-449fc50c-f8ed-4b00-903f-e716ec161338.png"> | ![Simulator Screen Shot - iPhone 14 - 2022-10-14 at 10 06 27](https://user-images.githubusercontent.com/7040243/195854527-9f44eb43-a873-43d6-aa18-d0b8d0872907.png) |


Design is not on the scope of this task.

## To test

### Badge

1. Enable the `endOfYear` flag in `FeatureFlag.swift`
2. Run the app
3. ✅ Check that there's a badge on the Profile icon at the tab bar
4. Tap Profile
5. ✅ Check that the badge disappears
6. Re-run the app
7. ✅ Check that the badge doesn't appear anymore

### Card

1. Enable the `endOfYear` flag in `FeatureFlag.swift`
2. Run the app
3. ✅ Check that there's a card at the top of Stats about the End of Year
4. Tap it
5. ✅ Check that the stories screen is shown

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
