### PR TITLE
Tooling: update the translation tooling

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -552,7 +552,11 @@ platform :ios do
 
   desc 'Lint the `.strings` files'
   lane :lint_localizations do
-    ios_lint_localizations(input_dir: File.join(PROJECT_ROOT_FOLDER, 'podcasts'), allow_retry: true)
+    ios_lint_localizations(
+      input_dir: File.join(PROJECT_ROOT_FOLDER, 'podcasts'),
+      allow_retry: true,
+      check_duplicate_keys: false
+    )
   end
 
   # This lane updates the `AppStoreStrings.po` file for the Pocket Casts app

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -529,8 +529,8 @@ platform :ios do
 
   desc 'Downloads localized strings and App Store Connect metadata from GlotPress'
   lane :download_localized_strings_and_metadata_from_glotpress do
-    # download_localized_strings_and_metadata
-    # download_localized_app_store_metadata_from_glotpress
+    download_localized_strings_from_glotpress
+    download_localized_app_store_metadata_from_glotpress
   end
 
   # Downloads the localized app strings and App Store Connect metadata from GlotPress.


### PR DESCRIPTION
During the last code freeze, we disabled the new translation tooling.

This PR enables it again for the next code freeze.

## To test

Not much to test, you can compare the changes here with #353

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
