### PR TITLE
Apple SSO: Analytics - Sign in flow

### DIFF
--- a/podcasts/ProfileIntroViewController.swift
+++ b/podcasts/ProfileIntroViewController.swift
@@ -1,6 +1,8 @@
 import UIKit
 import PocketCastsUtils
 import AuthenticationServices
+import PocketCastsUtils
+import PocketCastsServer
 
 class ProfileIntroViewController: PCViewController, SyncSigninDelegate {
     weak var upgradeRootViewController: UIViewController?
@@ -134,7 +136,7 @@ extension ProfileIntroViewController {
         authorizationButton.addTarget(self, action: #selector(handleAppleAuthButtonPress), for: .touchUpInside)
         authorizationButton.heightAnchor.constraint(equalToConstant: 56).isActive = true
         authenticationProviders.insertArrangedSubview(authorizationButton, at: 0)
-      }
+    }
 
     @objc
     func handleAppleAuthButtonPress() {
@@ -177,7 +179,7 @@ extension ProfileIntroViewController: ASAuthorizationControllerDelegate {
                     try await AuthenticationHelper.validateLogin(appleIDCredential)
                     success = true
                 } catch {
-                    FileLog.shared.addMessage("Failed to connect SSO account: \(error.localizedDescription)")
+                    self.showError(error)
                 }
 
                 DispatchQueue.main.async {
@@ -188,5 +190,13 @@ extension ProfileIntroViewController: ASAuthorizationControllerDelegate {
                 }
             }
         })
+    }
+
+    func showError(_ error: Error) {
+        FileLog.shared.addMessage("Failed to connect SSO account: \(error.localizedDescription)")
+        let error = (error as? APIError) ?? .UNKNOWN
+        Analytics.track(.userSignInFailed, properties: ["source": AuthenticationSource.ssoApple.rawValue, "error_code": error.rawValue])
+
+        // TODO: Present Error
     }
 }

--- a/podcasts/SyncSigninViewController.swift
+++ b/podcasts/SyncSigninViewController.swift
@@ -8,6 +8,7 @@ protocol SyncSigninDelegate: AnyObject {
 }
 
 class SyncSigninViewController: PCViewController, UITextFieldDelegate {
+    private let authSource = AuthenticationSource.password.rawValue
     @IBOutlet var emailField: ThemeableTextField! {
         didSet {
             emailField.placeholder = L10n.signInEmailAddressPrompt
@@ -273,7 +274,7 @@ class SyncSigninViewController: PCViewController, UITextFieldDelegate {
         ApiServerHandler.shared.validateLogin(username: username, password: password) { success, userId, error in
             DispatchQueue.main.async {
                 if !success {
-                    Analytics.track(.userSignInFailed, properties: ["error_code": (error ?? .UNKNOWN).rawValue])
+                    Analytics.track(.userSignInFailed, properties: ["source": self.authSource, "error_code": (error ?? .UNKNOWN).rawValue])
 
                     if error != .UNKNOWN, let message = error?.localizedDescription, !message.isEmpty {
                         self.showErrorMessage(message)
@@ -335,7 +336,7 @@ class SyncSigninViewController: PCViewController, UITextFieldDelegate {
 
         NotificationCenter.default.post(name: .userLoginDidChange, object: nil)
 
-        Analytics.track(.userSignedIn)
+        Analytics.track(.userSignedIn, properties: ["source": authSource])
     }
 
     private func showErrorMessage(_ message: String) {


### PR DESCRIPTION
| 📘 Project: #381 | Depends on: https://github.com/Automattic/pocket-casts-ios/pull/392 |
|:---:|:---:|

Adds analytic events for sign-in flow for apple SSO by adding a `source` field with options:
- `password` 
- `sso_apple`

## To test
1. Enable the Feature Flag `signInWithApple` and `tracksLoggingEnabled`
2. Switch your Scheme to `Staging`
3. Login with SSO 
4. Expect to see log: `🔵 Tracked: user_signed_in ["source": "sso_apple"]`
5. Sign out
6. Log in with password: 
7. Expect to see log: `🔵 Tracked: user_signed_in ["source": "password"]`
8. Sign out
9. Switch your Scheme to `Debug`
10. Try to log in with SSO (This will trigger an error)
11. Expect to see log: `🔵 Tracked: user_sign_in_failed ["source": "sso_apple", "error_code": "unknown"]`
12. Try to log in with Password using a bad email or passowrd
13. Expect to see log: `🔵 Tracked: user_sign_in_failed ["source": "password", "error_code": --Depends On Error--]`

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
