### PR TITLE
Tooling: for beta and code freeze, submit the PR using a "merge branch"

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -299,6 +299,10 @@ platform :ios do
     "release/#{ios_get_app_version}"
   end
 
+  def merge_branch_name
+    "merge/release-#{build_version}-into-trunk"
+  end
+
   # Triggers a beta build on CI
   #
   # @option [String] branch_to_build The name of the branch we want the CI to build, e.g. `release/19.3`

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -956,6 +956,8 @@ inal copy, and try again.")
   def push_release_branches
     [merge_branch_name, release_branch_name].each do |branch_name|
       push_to_git_remote(local_branch: branch_name, remote_branch: branch_name, tags: false)
+    rescue StandardError
+      UI.message("#{branch_name} doesn't exist. Skip pushing it.")
     end
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -460,6 +460,8 @@ platform :ios do
     lint_localizations
 
     ios_bump_version_beta
+    create_merge_release_branch
+    push_release_branches
 
     trigger_beta_build(branch_to_build: release_branch_name)
   end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -421,7 +421,7 @@ platform :ios do
       body: {
         title: "#{ios_get_app_version} Release: Merge changes from #{ios_get_build_version} into `trunk`",
         body: "Merge changes from #{ios_get_app_version} (#{ios_get_build_version}) to `trunk`.\n\n## To test\n\n- Ensure the build is 🟢\n- The code changes here were tested in their own PRs",
-        head: release_branch_name,
+        head: options[:beta_release] ? merge_branch_name : release_branch_name,
         base: 'trunk'
       },
       error_handlers: {

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -487,7 +487,7 @@ platform :ios do
   desc 'Performs the final checks and triggers a release build for the hotfix in the current branch'
   lane :finalize_hotfix_release do |options|
     # Push and trigger build
-    after_confirming_push do
+    after_confirming_push(push_merge_branch: false) do
       ios_finalize_prechecks(options)
       trigger_release_build(branch_to_build: release_branch_name)
     end
@@ -944,9 +944,9 @@ inal copy, and try again.")
     Fastlane::Helper::GitHelper.create_branch(merge_branch_name, from: release_branch_name)
   end
 
-  def after_confirming_push(message: 'Push changes to the remote and trigger the build?')
+  def after_confirming_push(push_merge_branch:, message: 'Push changes to the remote and trigger the build?')
     if ENV.fetch('RELEASE_TOOLKIT_SKIP_PUSH_CONFIRM', false) || UI.confirm(message)
-      push_release_branches
+      push_merge_branch ? push_release_branches : push_to_git_remote(tags: false)
       yield
     else
       UI.message('Aborting push as requested.')
@@ -956,8 +956,6 @@ inal copy, and try again.")
   def push_release_branches
     [merge_branch_name, release_branch_name].each do |branch_name|
       push_to_git_remote(local_branch: branch_name, remote_branch: branch_name, tags: false)
-    rescue StandardError
-      UI.message("#{branch_name} doesn't exist. Skip pushing it.")
     end
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -301,7 +301,7 @@ platform :ios do
   end
 
   def merge_branch_name
-    "merge/release-#{build_version}-into-trunk"
+    "merge/release-#{ios_get_build_version}-into-trunk"
   end
 
   # Triggers a beta build on CI

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -937,12 +937,22 @@ inal copy, and try again.")
     "$BUILDKITE_PIPELINE_SLUG-spm-cache-#{hash}"
   end
 
+  def create_merge_release_branch
+    Fastlane::Helper::GitHelper.create_branch(merge_branch_name, from: release_branch_name)
+  end
+
   def after_confirming_push(message: 'Push changes to the remote and trigger the build?')
     if ENV.fetch('RELEASE_TOOLKIT_SKIP_PUSH_CONFIRM', false) || UI.confirm(message)
-      push_to_git_remote(tags: false)
+      push_release_branches
       yield
     else
       UI.message('Aborting push as requested.')
+    end
+  end
+
+  def push_release_branches
+    [merge_branch_name, release_branch_name].each do |branch_name|
+      push_to_git_remote(local_branch: branch_name, remote_branch: branch_name, tags: false)
     end
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -289,6 +289,7 @@ platform :ios do
   lane :complete_code_freeze do |options|
     ios_completecodefreeze_prechecks(options)
     generate_strings_file_for_glotpress
+    create_merge_release_branch
 
     after_confirming_push do
       trigger_beta_build(branch_to_build: release_branch_name)


### PR DESCRIPTION
During the release of 7.24, we ran into an issue where the release branch conflicted with `trunk`.

The conflict was somewhat simple and I solved it using GitHub until I realized this led to a mistake: `trunk` had been merged into the release branch.

We want the release process to be able to avoid such mistakes, so I changed the release process to do this:

* For the final release and hotfix: the PR will be created from the release branch. Eg.: `release/7.25` or `release/7.25.1`
* For intermediate beta and code freeze: the PR will be created from a "merge release branch". Eg.: `merge/release-7.25-into-trunk`

In this case, if a conflict appears, we can easily fix it and not run into the issue we had last week.

## To test

Not much to test, just check the code.

Steps to test your PR.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
