### PR TITLE
Apple SSO: Create Flow

### DIFF
--- a/podcasts/NewEmailViewController.swift
+++ b/podcasts/NewEmailViewController.swift
@@ -4,6 +4,7 @@ import PocketCastsUtils
 import UIKit
 
 class NewEmailViewController: UIViewController, UITextFieldDelegate {
+    private let authSource = AuthenticationSource.password.rawValue
     @IBOutlet var emailField: ThemeableTextField! {
         didSet {
             emailField.delegate = self
@@ -171,7 +172,7 @@ class NewEmailViewController: UIViewController, UITextFieldDelegate {
                 self.activityIndicator.stopAnimating()
 
                 if !success {
-                    Analytics.track(.userAccountCreationFailed, properties: ["error_code": (error ?? .UNKNOWN).rawValue])
+                    Analytics.track(.userAccountCreationFailed, properties: ["error_code": (error ?? .UNKNOWN).rawValue, "source": self.authSource])
 
                     FileLog.shared.addMessage("Failed to register new account")
                     if error != .UNKNOWN, let message = error?.localizedDescription, !message.isEmpty {
@@ -242,7 +243,7 @@ class NewEmailViewController: UIViewController, UITextFieldDelegate {
 
         NotificationCenter.default.post(name: .userLoginDidChange, object: nil)
 
-        Analytics.track(.userAccountCreated)
+        Analytics.track(.userAccountCreated, properties: ["source": authSource])
     }
 
     // MARK: - UITextField Methods

--- a/podcasts/SelectAccountTypeViewController.swift
+++ b/podcasts/SelectAccountTypeViewController.swift
@@ -172,11 +172,10 @@ class SelectAccountTypeViewController: UIViewController {
     // MARK: - Actions
 
     @IBAction func nextTapped(_ sender: Any) {
-        let newSubscription = NewSubscription(isNewAccount: true, iap_identifier: "")
         if isFreeAccount {
-            let enailVC = NewEmailViewController(newSubscription: newSubscription)
-            navigationController?.pushViewController(enailVC, animated: true)
+            handleNextForFreeAccount()
         } else {
+            let newSubscription = NewSubscription(isNewAccount: true, iap_identifier: "")
             let termsOfUseVC = TermsViewController(newSubscription: newSubscription)
             navigationController?.pushViewController(termsOfUseVC, animated: true)
         }
@@ -228,6 +227,31 @@ class SelectAccountTypeViewController: UIViewController {
         freeRadioButton.setImage(UIImage(named: "radio-unselected")?.tintedImage(ThemeColor.primaryField03()), for: .normal)
         freeRadioButton.setImage(UIImage(named: "radio-selected")?.tintedImage(ThemeColor.primaryField03Active()), for: .selected)
         learnMoreButton.setTitleColor(ThemeColor.primaryInteractive01(), for: .normal)
+    }
+
+    // MARK: Free Account Selected
+
+    private func handleNextForFreeAccount() {
+        if SyncManager.isUserLoggedIn() {
+            presentWeclome()
+        }
+        else {
+            presentNewEmailPrompt()
+        }
+    }
+    private func presentNewEmailPrompt() {
+        let newSubscription = NewSubscription(isNewAccount: true, iap_identifier: "")
+        let emailVC = NewEmailViewController(newSubscription: newSubscription)
+        navigationController?.pushViewController(emailVC, animated: true)
+    }
+
+    private func presentWeclome() {
+        let accountCreatedVC = AccountUpdatedViewController()
+        accountCreatedVC.titleText = L10n.accountCreated
+        accountCreatedVC.detailText = L10n.accountWelcome
+        accountCreatedVC.imageName = AppTheme.accountCreatedImageName
+        accountCreatedVC.hideNewsletter = false
+        navigationController?.pushViewController(accountCreatedVC, animated: true)
     }
 }
 

--- a/podcasts/SelectAccountTypeViewController.swift
+++ b/podcasts/SelectAccountTypeViewController.swift
@@ -233,7 +233,7 @@ class SelectAccountTypeViewController: UIViewController {
 
     private func handleNextForFreeAccount() {
         if SyncManager.isUserLoggedIn() {
-            presentWeclome()
+            presentWelcome()
         }
         else {
             presentNewEmailPrompt()
@@ -245,7 +245,7 @@ class SelectAccountTypeViewController: UIViewController {
         navigationController?.pushViewController(emailVC, animated: true)
     }
 
-    private func presentWeclome() {
+    private func presentWelcome() {
         let accountCreatedVC = AccountUpdatedViewController()
         accountCreatedVC.titleText = L10n.accountCreated
         accountCreatedVC.detailText = L10n.accountWelcome

--- a/podcasts/SelectAccountTypeViewController.swift
+++ b/podcasts/SelectAccountTypeViewController.swift
@@ -175,7 +175,7 @@ class SelectAccountTypeViewController: UIViewController {
         if isFreeAccount {
             handleNextForFreeAccount()
         } else {
-            let newSubscription = NewSubscription(isNewAccount: true, iap_identifier: "")
+            let newSubscription = NewSubscription(isNewAccount: !SyncManager.isUserLoggedIn(), iap_identifier: "")
             let termsOfUseVC = TermsViewController(newSubscription: newSubscription)
             navigationController?.pushViewController(termsOfUseVC, animated: true)
         }


### PR DESCRIPTION
| 📘 Project: #381 | Depends on: https://github.com/Automattic/pocket-casts-ios/pull/394 |
|:---:|:---:|

Adds the upsell flow to the account creation process. 

📓 In my testing, Apple SSO didn't always return the email in the simulator, so testing with a physical device is recommended. 

## To test

1. Enable the Feature Flag `signInWithApple`
2. Set your scheme to `Staging` 
3. Login with SSO using an account that isn't in Staging (you can also use hide my email to create a new account)
    - **TODO:** The endpoint doesn't handle new accounts yet. 
4. Expect to see the upsell flow.
5. Complete the flow for a Free Account and again for a Paid. 
    - **TODO:** I wasn't sure yet how to handle payment methods in Staging using IAP.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
