### PR TITLE
Updates the method of detecting the iPhone 14 to reuse the UIDeviceIdentifier module

### DIFF
--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -3,6 +3,7 @@ import PocketCastsDataModel
 import PocketCastsServer
 import PocketCastsUtils
 import UIKit
+import UIDeviceIdentifier
 
 protocol PodcastActionsDelegate: AnyObject {
     func isSummaryExpanded() -> Bool
@@ -214,12 +215,17 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
     }
 
     private func updateTopConstraintForiPhone14Pro() {
-        guard let window = UIApplication.shared.windows.filter({ $0.isKeyWindow }).first else {
-            return
-        }
+        // Retrieve the name of the device
+        var deviceName = UIDeviceHardware.platformString()
 
-        let statusBarHeight = UIUtil.statusBarHeight(in: window)
-        if statusBarHeight > 50 {
+        #if targetEnvironment(simulator)
+        // If we're running in the simulator, grab the model that we're simulating
+        if let simulatorIdentifier = ProcessInfo.processInfo.environment["SIMULATOR_MODEL_IDENTIFIER"] {
+            deviceName = UIDeviceHardware.platformString(forType: simulatorIdentifier)
+        }
+        #endif
+
+        if deviceName.startsWith(string: "iPhone 14 Pro") {
             // On iPhone 14 Pro and iPhone 14 Pro Max there's a space
             // between the nav bar and the content
             // Here we change the table top constraint to take into account that


### PR DESCRIPTION
Fixes #327

There is a strange issue where the iPhone 14 Pro fix is applied to the release and debug versions but not the TestFlight version. So instead of relying on the status bar height we'll instead detect the model of the device starts with iPhone 14 Pro. 

This also reuses the UIDeviceIdentifier module that has been bundled in the app.

I also added some simulator model detection to allow this to be tested in the simulator.

## To test

### On iPhone 14 Pro and iPhone 14 Pro Max (devices with Dynamic Island)

1. Run the app
2. Open any podcast screen
3. Toggle the header
4. ✅ Check that the top doesn't have a white line blinking
5. Scroll down
6. ✅ Check that there isn't a space between the search bar and the nav bar

### Other devices
1. Repeat the steps above and make sure everything works as it was.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
