### PR TITLE
Apple SSO: Login Consolidate

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+Account.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+Account.swift
@@ -23,20 +23,6 @@ public extension ApiServerHandler {
         return try await obtainToken(request: request)
     }
 
-    func validateLogin(username: String, password: String, completion: @escaping (_ success: Bool, _ userId: String?, _ error: APIError?) -> Void) {
-        Task {
-            do {
-                let response = try await validateLogin(username: username, password: password, scope: ServerConstants.Values.apiScope)
-                completion(response.token != nil, response.uuid, nil)
-            }
-            catch {
-                let err = (error as? APIError) ?? APIError.UNKNOWN
-                completion(false, nil, err)
-
-            }
-        }
-    }
-
     func forgotPassword(email: String, completion: @escaping (_ success: Bool, _ error: APIError?) -> Void) {
         var request = Api_EmailRequest()
         request.email = email

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -384,6 +384,7 @@
 		46737E6A272B2EEC00739C3E /* ReadOnlyTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46737E69272B2EEC00739C3E /* ReadOnlyTextView.swift */; };
 		46737E6C2730400500739C3E /* ThemedSwitchToggleStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46737E6B2730400500739C3E /* ThemedSwitchToggleStyle.swift */; };
 		46741E4F28FDE12700CC962E /* AuthenticationHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4647623028F70CD0006D005A /* AuthenticationHelper.swift */; };
+		46741E5128FF353400CC962E /* SyncLoadingAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46741E5028FF353400CC962E /* SyncLoadingAlert.swift */; };
 		467BB04726CC07C900A73BAF /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF15A4D1B54E8F0000EC323 /* Constants.swift */; };
 		467DF6E926E1093A00AC290C /* Strings+Generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 467DF6E826E1093A00AC290C /* Strings+Generated.swift */; };
 		467DF6EA26E10AFB00AC290C /* Strings+Generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 467DF6E826E1093A00AC290C /* Strings+Generated.swift */; };
@@ -1879,6 +1880,7 @@
 		46703E1327BEF79C00DD7998 /* PreviewHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewHelpers.swift; sourceTree = "<group>"; };
 		46737E69272B2EEC00739C3E /* ReadOnlyTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadOnlyTextView.swift; sourceTree = "<group>"; };
 		46737E6B2730400500739C3E /* ThemedSwitchToggleStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemedSwitchToggleStyle.swift; sourceTree = "<group>"; };
+		46741E5028FF353400CC962E /* SyncLoadingAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncLoadingAlert.swift; sourceTree = "<group>"; };
 		467DF6E626E107A000AC290C /* swiftgen.yml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.yaml; path = swiftgen.yml; sourceTree = "<group>"; };
 		467DF6E826E1093A00AC290C /* Strings+Generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Strings+Generated.swift"; sourceTree = "<group>"; };
 		4680CBF6271F5DEB00391AB8 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -4061,6 +4063,7 @@
 				BD4D91741B9933A800B62FD2 /* AngularActivityIndicator.swift */,
 				BD77E9021B9D2CF600DC4ADF /* AngularProgressIndicator.swift */,
 				BD5C39531B5E0A2A00C3A499 /* ShiftyLoadingAlert.swift */,
+				46741E5028FF353400CC962E /* SyncLoadingAlert.swift */,
 				BDC692821BA7B0B70023B9F2 /* TinyPageControl.swift */,
 				BD4DB9941CAB8CFF009E512F /* PCRefreshControl.swift */,
 				BDC6DEBB1CBCD6C80030491D /* ReorderableFlowLayout.swift */,
@@ -7693,6 +7696,7 @@
 				BD965761246906C900873BB5 /* CastDevicesManager.swift in Sources */,
 				BD561031200DADA0002F2D53 /* Episode+Formatting.swift in Sources */,
 				BD57646A17E140BE0039CF8B /* NSNull+Length.m in Sources */,
+				46741E5128FF353400CC962E /* SyncLoadingAlert.swift in Sources */,
 				BD7BCF151F6A5C510006E008 /* VideoPlayerView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/podcasts/AppDelegate+Analytics.swift
+++ b/podcasts/AppDelegate+Analytics.swift
@@ -39,23 +39,15 @@ extension AppDelegate {
     /// This should only need to be ran once.
     func retrieveUserIdIfNeeded() {
         guard
-            let username = ServerSettings.syncingEmail(),
-            let password = ServerSettings.syncingPassword(),
+            ServerSettings.syncingEmail() != nil,
             ServerSettings.userId == nil
         else {
             return
         }
 
         FileLog.shared.addMessage("Missing User ID - Retrieving from the server")
-
-        // Refresh the login, but only retrieve the userId
-        ApiServerHandler.shared.validateLogin(username: username, password: password) { success, userId, _ in
-            guard success, let userId else {
-                return
-            }
-
-            ServerSettings.userId = userId
-            NotificationCenter.default.post(name: .userLoginDidChange, object: nil)
+        Task {
+            try? await AuthenticationHelper.refreshLogin()
         }
     }
 }

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -2308,6 +2308,8 @@ internal enum L10n {
   internal static var supporterPaymentCanceled: String { return L10n.tr("Localizable", "supporter_payment_canceled") }
   /// Check your username and password.
   internal static var syncAccountError: String { return L10n.tr("Localizable", "sync_account_error") }
+  /// Logging in...
+  internal static var syncAccountLoggingIn: String { return L10n.tr("Localizable", "sync_account_logging_in") }
   /// Logged in...
   internal static var syncAccountLogin: String { return L10n.tr("Localizable", "sync_account_login") }
   /// Sync failed

--- a/podcasts/SyncLoadingAlert.swift
+++ b/podcasts/SyncLoadingAlert.swift
@@ -5,7 +5,7 @@ class SyncLoadingAlert: ShiftyLoadingAlert {
     private var totalPodcastsToImport: Int = 0
 
     init() {
-        super.init(title: L10n.syncAccountLogin)
+        super.init(title: L10n.syncAccountLoggingIn)
     }
 
     override func showAlert(_ presentingController: UIViewController, hasProgress: Bool, completion: (() -> Void)?) {
@@ -22,10 +22,17 @@ class SyncLoadingAlert: ShiftyLoadingAlert {
         NotificationCenter.default.addObserver(self, selector: #selector(syncProgressCountKnown(_:)), name: ServerNotifications.syncProgressPodcastCount, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(syncUpToChanged(_:)), name: ServerNotifications.syncProgressPodcastUpto, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(podcastsImported), name: ServerNotifications.syncProgressImportedPodcasts, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(loggedIn), name: .userLoginDidChange, object: nil)
     }
 
     private func unSubscribeToSyncChanges() {
         NotificationCenter.default.removeObserver(self)
+    }
+
+    @objc private func loggedIn() {
+        DispatchQueue.main.async {
+            self.title = L10n.syncAccountLogin
+        }
     }
 
     @objc private func syncProgressCountKnown(_ notification: Notification) {
@@ -37,9 +44,7 @@ class SyncLoadingAlert: ShiftyLoadingAlert {
     @objc private func syncUpToChanged(_ notification: Notification) {
         guard let number = notification.object as? NSNumber else { return }
 
-        DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
-
+        DispatchQueue.main.async {
             let upTo = number.intValue
             if self.totalPodcastsToImport > 0 {
                 self.title = L10n.syncProgress(upTo.localized(), self.totalPodcastsToImport.localized())

--- a/podcasts/SyncLoadingAlert.swift
+++ b/podcasts/SyncLoadingAlert.swift
@@ -1,0 +1,59 @@
+import UIKit
+import PocketCastsServer
+
+class SyncLoadingAlert: ShiftyLoadingAlert {
+    private var totalPodcastsToImport: Int = 0
+
+    init() {
+        super.init(title: L10n.syncAccountLogin)
+    }
+
+    override func showAlert(_ presentingController: UIViewController, hasProgress: Bool, completion: (() -> Void)?) {
+        super.showAlert(presentingController, hasProgress: hasProgress, completion: completion)
+        subscribeToSyncChanges()
+    }
+
+    override func hideAlert(_ animated: Bool) {
+        super.hideAlert(animated)
+        unSubscribeToSyncChanges()
+    }
+
+    private func subscribeToSyncChanges() {
+        NotificationCenter.default.addObserver(self, selector: #selector(syncProgressCountKnown(_:)), name: ServerNotifications.syncProgressPodcastCount, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(syncUpToChanged(_:)), name: ServerNotifications.syncProgressPodcastUpto, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(podcastsImported), name: ServerNotifications.syncProgressImportedPodcasts, object: nil)
+    }
+
+    private func unSubscribeToSyncChanges() {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    @objc private func syncProgressCountKnown(_ notification: Notification) {
+        if let number = notification.object as? NSNumber {
+            totalPodcastsToImport = number.intValue
+        }
+    }
+
+    @objc private func syncUpToChanged(_ notification: Notification) {
+        guard let number = notification.object as? NSNumber else { return }
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+
+            let upTo = number.intValue
+            if self.totalPodcastsToImport > 0 {
+                self.title = L10n.syncProgress(upTo.localized(), self.totalPodcastsToImport.localized())
+                self.progress = CGFloat(upTo / self.totalPodcastsToImport)
+            } else {
+                // Used when the total number of podcasts to sync isn't known.
+                self.title = upTo == 1 ? L10n.syncProgressUnknownCountSingular : L10n.syncProgressUnknownCountPluralFormat(upTo.localized())
+            }
+        }
+    }
+
+    @objc private func podcastsImported() {
+        DispatchQueue.main.async {
+            self.title = L10n.syncInProgress
+        }
+    }
+}

--- a/podcasts/SyncSigninViewController.swift
+++ b/podcasts/SyncSigninViewController.swift
@@ -255,7 +255,7 @@ class SyncSigninViewController: PCViewController, UITextFieldDelegate {
 
     private func handleError(_ error: Error) {
         let error = (error as? APIError) ?? APIError.UNKNOWN
-        Analytics.track(.userSignInFailed, properties: ["source": self.authSource, "error_code": error.rawValue])
+        Analytics.track(.userSignInFailed, properties: ["source": authSource, "error_code": error.rawValue])
 
         var message = L10n.syncAccountError
         if error != .UNKNOWN, !error.localizedDescription.isEmpty {

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -2819,6 +2819,9 @@
 /* Notice the sync failed due to an account error. */
 "sync_account_error" = "Check your username and password.";
 
+/* Sync status update notifying the user that the app is logging the user in. */
+"sync_account_logging_in" = "Logging in...";
+
 /* Sync status update notifying the user that the app is logged in. */
 "sync_account_login" = "Logged in...";
 


### PR DESCRIPTION
| 📘 Project: #381 | Depends on #408 |
|:---:|:---:|

| 📓 For Apple SSO testing: In my testing, Apple SSO didn't always return the email in the simulator, so testing with a physical device is recommended. |
|:---:|

Consolidates some code paths when using the Password Auth:
- Reduces duplicated code in the obtain Token flow to use the paths created for Apple Watch and Sonos
- Moves Sync Progress updates to a shared view.

## To test
1. Log into an account with Username and Password with the `signInWithApple` feature flag enabled and disabled to ensure prod is fine.
2. ✅ Validate you are logged in successfully and the Sync Progress indicator updates with sync status changes.
3. Enable `signInWithApple`  switch to `Staging` use Apple SSO to login 
4. ✅ Validate you are logged in successfully, and the Sync Progress indicator updates with sync status changes.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
