### PR TITLE
Apple SSO: Consolidate Token Refresh paths

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Private/TokenHelper.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Private/TokenHelper.swift
@@ -80,7 +80,10 @@ class TokenHelper {
 
     private class func asyncAcquireToken(completion: @escaping (Result<String?, APIError>) -> Void) {
         Task {
-            if async let token = await acquirePasswordToken() ?? await acquireIdentityToken() {
+            if let token = await acquirePasswordToken() {
+                completion(.success(token))
+            }
+            else if let token = await acquireIdentityToken() {
                 completion(.success(token))
             }
             else {
@@ -99,7 +102,7 @@ class TokenHelper {
         }
 
         do {
-            return try await ApiServerHandler.shared.validateLogin(username: email, password: password, scope: ServerConstants.Values.apiScope)
+            return try await ApiServerHandler.shared.validateLogin(username: email, password: password, scope: ServerConstants.Values.apiScope).token
         }
         catch {
             FileLog.shared.addMessage("TokenHelper Password acquireToken failed \(error.localizedDescription)")

--- a/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+Account.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+Account.swift
@@ -15,7 +15,7 @@ public extension ApiServerHandler {
 
         let url = ServerHelper.asUrl(ServerConstants.Urls.api() + "user/login")
         let data = try loginRequest.serializedData()
-        guard let request = ServerHelper.createProtoRequest(url: url, data: data) else {
+        guard let request = ServerHelper.createProtoRequest(url: url, data: data, cachePolicy: .reloadIgnoringCacheData) else {
             FileLog.shared.addMessage("Unable to create protobuffer request to obtain token")
             throw APIError.UNKNOWN
         }

--- a/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+SocialAuth.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+SocialAuth.swift
@@ -35,7 +35,7 @@ public extension ApiServerHandler {
     func refreshIdentityToken() async throws -> String? {
         guard
             let identityToken = ServerSettings.appleAuthIdentityToken,
-            let request = tokenRequest(identityToken: identityToken, cachePolicy: .reloadIgnoringLocalCacheData, timeoutInterval: 30.seconds)
+            let request = tokenRequest(identityToken: identityToken)
         else {
             FileLog.shared.addMessage("Unable to locate Apple SSO token in Keychain")
             throw APIError.UNKNOWN
@@ -67,10 +67,10 @@ public extension ApiServerHandler {
         }
     }
 
-    private func tokenRequest(identityToken: String?, cachePolicy: URLRequest.CachePolicy = .useProtocolCachePolicy, timeoutInterval: TimeInterval = 15.seconds) -> URLRequest? {
+    private func tokenRequest(identityToken: String?) -> URLRequest? {
         let url = ServerHelper.asUrl(ServerConstants.Urls.api() + "user/login_apple")
         guard let identityToken = identityToken,
-              var request = ServerHelper.createEmptyProtoRequest(url: url, cachePolicy: cachePolicy, timeoutInterval: timeoutInterval)
+              var request = ServerHelper.createEmptyProtoRequest(url: url, cachePolicy: .reloadIgnoringLocalCacheData)
         else { return nil }
 
         request.setValue("Bearer \(identityToken)", forHTTPHeaderField: ServerConstants.HttpHeaders.authorization)

--- a/Modules/Server/Sources/PocketCastsServer/Public/ServerHelper.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/ServerHelper.swift
@@ -111,15 +111,15 @@ public class ServerHelper: NSObject {
         return request
     }
 
-    class func createProtoRequest(url: URL, data: Data) -> URLRequest? {
-        var request = createEmptyProtoRequest(url: url)
+    class func createProtoRequest(url: URL, data: Data, cachePolicy: URLRequest.CachePolicy = .useProtocolCachePolicy) -> URLRequest? {
+        var request = createEmptyProtoRequest(url: url, cachePolicy: cachePolicy)
         request?.httpBody = data
 
         return request
     }
 
-    class func createEmptyProtoRequest(url: URL, cachePolicy: URLRequest.CachePolicy = .useProtocolCachePolicy, timeoutInterval: TimeInterval = 15.seconds) -> URLRequest? {
-        var request = URLRequest(url: url, cachePolicy: cachePolicy, timeoutInterval: timeoutInterval)
+    class func createEmptyProtoRequest(url: URL, cachePolicy: URLRequest.CachePolicy = .useProtocolCachePolicy) -> URLRequest? {
+        var request = URLRequest(url: url, cachePolicy: cachePolicy, timeoutInterval: 15.seconds)
         request.httpMethod = "POST"
         request.addValue("application/octet-stream", forHTTPHeaderField: ServerConstants.HttpHeaders.accept)
         request.setValue("application/octet-stream", forHTTPHeaderField: ServerConstants.HttpHeaders.contentType)


### PR DESCRIPTION
| 📘 Project: #381 | Depends on #409 |
|:---:|:---:|

| 📓 For Apple SSO testing: In my testing, Apple SSO didn't always return the email in the simulator, so testing with a physical device is recommended. |
|:---:|

Consolidates the refresh password token flow to use the existing API methods.

The token refresh methods have a `30.seconds` timeout which seems very long, especially when the default is already `15.seconds`, so I didn't maintain the `30.seconds` period when porting to the existing methods. 

I did, however, modify the login paths (SSO and Username/Password) to use the `.reloadIgnoringLocalCacheData` policy, as that just seems wise for auth calls. 

## To test

This can be tested with the same process as https://github.com/Automattic/pocket-casts-ios/pull/392 but using Username and Password log in instead of SSO

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
