### PR TITLE
End of Year: show total listening time for the year

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
@@ -4,4 +4,26 @@ import PocketCastsUtils
 /// Calculates user End of Year stats
 class EndOfYearDataManager {
 
+    /// Returns 5 random podcasts from the DB
+    /// This is here for development purposes.
+    func listeningTime(dbQueue: FMDatabaseQueue) -> Double? {
+        var listeningTime: Double?
+
+        dbQueue.inDatabase { db in
+            do {
+                let query = "SELECT SUM(playedUpTo) as totalPlayedTime from SJEpisode WHERE lastPlaybackInteractionDate IS NOT NULL AND lastPlaybackInteractionDate BETWEEN strftime('%s', date('now','start of year')) and strftime('%s', 'now')"
+                let resultSet = try db.executeQuery(query, values: nil)
+                defer { resultSet.close() }
+
+                while resultSet.next() {
+                    listeningTime = resultSet.double(forColumn: "totalPlayedTime")
+                }
+            } catch {
+                FileLog.shared.addMessage("PodcastDataManager.listeningTime error: \(error)")
+            }
+        }
+
+        return listeningTime
+    }
+
 }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
@@ -11,7 +11,7 @@ class EndOfYearDataManager {
 
         dbQueue.inDatabase { db in
             do {
-                let query = "SELECT SUM(playedUpTo) as totalPlayedTime from SJEpisode WHERE lastPlaybackInteractionDate IS NOT NULL AND lastPlaybackInteractionDate BETWEEN strftime('%s', date('now','start of year')) and strftime('%s', 'now')"
+                let query = "SELECT SUM(playedUpTo) as totalPlayedTime from \(DataManager.episodeTableName) WHERE lastPlaybackInteractionDate IS NOT NULL AND lastPlaybackInteractionDate BETWEEN strftime('%s', date('now','start of year')) and strftime('%s', 'now')"
                 let resultSet = try db.executeQuery(query, values: nil)
                 defer { resultSet.close() }
 

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
@@ -5,7 +5,7 @@ import PocketCastsUtils
 class EndOfYearDataManager {
     private let endPeriod = "2022-12-01"
 
-    /// Returns the aproximately listening time for the current year
+    /// Returns the approximate listening time for the current year
     func listeningTime(dbQueue: FMDatabaseQueue) -> Double? {
         var listeningTime: Double?
 

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
@@ -4,8 +4,7 @@ import PocketCastsUtils
 /// Calculates user End of Year stats
 class EndOfYearDataManager {
 
-    /// Returns 5 random podcasts from the DB
-    /// This is here for development purposes.
+    /// Returns the aproximately listening time for the current year
     func listeningTime(dbQueue: FMDatabaseQueue) -> Double? {
         var listeningTime: Double?
 

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
@@ -15,7 +15,7 @@ class EndOfYearDataManager {
                 let resultSet = try db.executeQuery(query, values: nil)
                 defer { resultSet.close() }
 
-                while resultSet.next() {
+                if resultSet.next() {
                     listeningTime = resultSet.double(forColumn: "totalPlayedTime")
                 }
             } catch {

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
@@ -1,0 +1,7 @@
+import FMDB
+import PocketCastsUtils
+
+/// Calculates user End of Year stats
+class EndOfYearDataManager {
+
+}

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
@@ -3,6 +3,7 @@ import PocketCastsUtils
 
 /// Calculates user End of Year stats
 class EndOfYearDataManager {
+    private let endPeriod = "2022-12-01"
 
     /// Returns the aproximately listening time for the current year
     func listeningTime(dbQueue: FMDatabaseQueue) -> Double? {
@@ -10,7 +11,7 @@ class EndOfYearDataManager {
 
         dbQueue.inDatabase { db in
             do {
-                let query = "SELECT SUM(playedUpTo) as totalPlayedTime from \(DataManager.episodeTableName) WHERE lastPlaybackInteractionDate IS NOT NULL AND lastPlaybackInteractionDate BETWEEN strftime('%s', date('now','start of year')) and strftime('%s', 'now')"
+                let query = "SELECT SUM(playedUpTo) as totalPlayedTime from \(DataManager.episodeTableName) WHERE lastPlaybackInteractionDate IS NOT NULL AND lastPlaybackInteractionDate BETWEEN strftime('%s', '2022-01-01') and strftime('%s', '\(endPeriod)')"
                 let resultSet = try db.executeQuery(query, values: nil)
                 defer { resultSet.close() }
 

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -893,3 +893,11 @@ public extension DataManager {
         }
     }
 }
+
+// MARK: - End of Year stats
+
+public extension DataManager {
+    func listeningTime() -> Double? {
+        endOfYearManager.listeningTime(dbQueue: dbQueue)
+    }
+}

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -20,6 +20,7 @@ public class DataManager {
     private let userEpisodeManager = UserEpisodeDataManager()
     private let settingsManager = UserSettingsManager()
     private let folderManager = FolderDataManager()
+    private lazy var endOfYearManager = EndOfYearDataManager()
 
     private let dbQueue: FMDatabaseQueue
 

--- a/Modules/Utils/Sources/PocketCastsUtils/Extensions/Double+formatTime.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Extensions/Double+formatTime.swift
@@ -1,7 +1,10 @@
 import Foundation
 
 extension Double {
-    public func formatStat() -> String? {
+    /// Returns a localized time description
+    ///
+    /// Eg.: 5400 will return "1 hour 30 min"
+    public var localizedTimeDescription: String? {
         let days = Int(safeDouble: self / 86400)
         let hours = Int(safeDouble: self / 3600) - (days * 24)
         let mins = Int(safeDouble: self / 60) - (hours * 60) - (days * 24 * 60)

--- a/Modules/Utils/Sources/PocketCastsUtils/Extensions/Double+formatTime.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Extensions/Double+formatTime.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+extension Double {
+    public func formatStat() -> String? {
+        let days = Int(safeDouble: self / 86400)
+        let hours = Int(safeDouble: self / 3600) - (days * 24)
+        let mins = Int(safeDouble: self / 60) - (hours * 60) - (days * 24 * 60)
+        let secs = Int(safeDouble: self.truncatingRemainder(dividingBy: 60))
+        var output = [String]()
+
+        if let daysHours = formatDaysHours(days: days, hours: hours) {
+            output.append(daysHours)
+        }
+
+        if days > 0, hours > 0 {
+            return output.first ?? ""
+        }
+
+        let secondsForDisplay = hours < 1 ? secs : 0
+        if let minsSeconds = formatMinsSeconds(mins: mins, secs: secondsForDisplay) {
+            output.append(minsSeconds)
+        }
+
+        if output.count == 0 {
+            let components = DateComponents(calendar: Calendar.current, second: secs)
+            return DateComponentsFormatter.localizedString(from: components, unitsStyle: .full)
+        }
+
+        return output.joined(separator: " ")
+    }
+
+    func formatDaysHours(days: Int, hours: Int) -> String? {
+        guard days > 0 || hours > 0 else { return nil }
+        let components = DateComponents(calendar: Calendar.current, day: days, hour: hours)
+        return DateComponentsFormatter.localizedString(from: components, unitsStyle: .full)?.replacingOccurrences(of: ",", with: "")
+    }
+
+    func formatMinsSeconds(mins: Int, secs: Int) -> String? {
+        guard mins > 0 else { return nil }
+        let components = DateComponents(calendar: Calendar.current, minute: mins, second: secs)
+        return DateComponentsFormatter.localizedString(from: components, unitsStyle: .short)?.replacingOccurrences(of: ",", with: "")
+    }
+}

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -442,6 +442,7 @@
 		46FBD8B6276A874F00867746 /* Intents.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = 46FBD8B9276A874F00867746 /* Intents.intentdefinition */; settings = {ATTRIBUTES = (codegen, ); }; };
 		46FBD8B7276A874F00867746 /* Intents.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = 46FBD8B9276A874F00867746 /* Intents.intentdefinition */; settings = {ATTRIBUTES = (codegen, ); }; };
 		4A3C19F543779593E98EDA3C /* libPods-Pocket Casts Watch App Extension.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C7C2391BA608F0CAB6E1D038 /* libPods-Pocket Casts Watch App Extension.a */; };
+		8B0EEDE029003E8D00075772 /* ListeningTimeStory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B0EEDDF29003E8D00075772 /* ListeningTimeStory.swift */; };
 		8B10E78628D9093E00702C54 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 8B10E78528D908A900702C54 /* GoogleService-Info.plist */; };
 		8B10E78728D9093F00702C54 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 8B10E78528D908A900702C54 /* GoogleService-Info.plist */; };
 		8B10E78828D9094500702C54 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 8B10E78528D908A900702C54 /* GoogleService-Info.plist */; };
@@ -1978,6 +1979,7 @@
 		779DF889D4A7C56C0935B7A7 /* Pods-podcasts.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-podcasts.debug.xcconfig"; path = "Pods/Target Support Files/Pods-podcasts/Pods-podcasts.debug.xcconfig"; sourceTree = "<group>"; };
 		7E84A6B7056C4797BAD62A1F /* Pods-Pocket Casts Watch App Extension.staging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Pocket Casts Watch App Extension.staging.xcconfig"; path = "Pods/Target Support Files/Pods-Pocket Casts Watch App Extension/Pods-Pocket Casts Watch App Extension.staging.xcconfig"; sourceTree = "<group>"; };
 		8229174E612BC7BAC6F63274 /* Pods-Pocket Casts Watch App Extension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Pocket Casts Watch App Extension.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Pocket Casts Watch App Extension/Pods-Pocket Casts Watch App Extension.debug.xcconfig"; sourceTree = "<group>"; };
+		8B0EEDDF29003E8D00075772 /* ListeningTimeStory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListeningTimeStory.swift; sourceTree = "<group>"; };
 		8B10E78528D908A900702C54 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		8B1C974528FE1C7E00BD5EB9 /* ImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageView.swift; sourceTree = "<group>"; };
 		8B1C974728FE234B00BD5EB9 /* View+Snapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Snapshot.swift"; sourceTree = "<group>"; };
@@ -3680,6 +3682,7 @@
 			children = (
 				8B9D459B28F9A6260034219E /* DummyStory.swift */,
 				8B9D459E28F9AD3F0034219E /* EndOfYearStoriesDataSource.swift */,
+				8B0EEDDF29003E8D00075772 /* ListeningTimeStory.swift */,
 			);
 			path = Stories;
 			sourceTree = "<group>";
@@ -7584,6 +7587,7 @@
 				408529A3247C9A53007FE8AA /* PodcastSupporterCell.swift in Sources */,
 				BDCD1E82244D636D00B83602 /* LenticularFilter.swift in Sources */,
 				4006E31423AC453700174DEB /* ExpandedCollectionViewController+CollectionView.swift in Sources */,
+				8B0EEDE029003E8D00075772 /* ListeningTimeStory.swift in Sources */,
 				BD27B8C92756FA20007A0EA7 /* ModalCloseButton.swift in Sources */,
 				462EE0AF26FCCF97003D67DC /* PCMessageSupportViewModel.swift in Sources */,
 				4036B0A425240F5D00AE08E6 /* WidgetHelper.swift in Sources */,

--- a/podcasts/End of Year/Stories/EndOfYearStoriesDataSource.swift
+++ b/podcasts/End of Year/Stories/EndOfYearStoriesDataSource.swift
@@ -16,7 +16,11 @@ struct EndOfYearStoriesDataSource: StoriesDataSource {
     }
 
     func isReady() async -> Bool {
-        true
+        await withCheckedContinuation { continuation in
+            let listeningTime = DataManager.sharedManager.listeningTime()
+
+            continuation.resume(returning: true)
+        }
     }
 }
 

--- a/podcasts/End of Year/Stories/EndOfYearStoriesDataSource.swift
+++ b/podcasts/End of Year/Stories/EndOfYearStoriesDataSource.swift
@@ -1,10 +1,12 @@
 import SwiftUI
 import PocketCastsDataModel
 
-struct EndOfYearStoriesDataSource: StoriesDataSource {
+class EndOfYearStoriesDataSource: StoriesDataSource {
     var numberOfStories: Int = 2
 
     let randomPodcasts = DataManager.sharedManager.randomPodcasts()
+
+    var listeningTime: Double?
 
     func story(for storyNumber: Int) -> any StoryView {
         switch storyNumber {
@@ -17,7 +19,7 @@ struct EndOfYearStoriesDataSource: StoriesDataSource {
 
     func isReady() async -> Bool {
         await withCheckedContinuation { continuation in
-            let listeningTime = DataManager.sharedManager.listeningTime()
+            self.listeningTime = DataManager.sharedManager.listeningTime()
 
             continuation.resume(returning: true)
         }

--- a/podcasts/End of Year/Stories/EndOfYearStoriesDataSource.swift
+++ b/podcasts/End of Year/Stories/EndOfYearStoriesDataSource.swift
@@ -11,9 +11,9 @@ class EndOfYearStoriesDataSource: StoriesDataSource {
     func story(for storyNumber: Int) -> any StoryView {
         switch storyNumber {
         case 0:
-            return DummyStory(podcasts: randomPodcasts)
+            return ListeningTimeStory(listeningTime: listeningTime!)
         default:
-            return FakeStory()
+            return DummyStory(podcasts: randomPodcasts)
         }
     }
 
@@ -22,16 +22,6 @@ class EndOfYearStoriesDataSource: StoriesDataSource {
             self.listeningTime = DataManager.sharedManager.listeningTime()
 
             continuation.resume(returning: true)
-        }
-    }
-}
-
-struct FakeStory: StoryView {
-    var duration: TimeInterval = 5.seconds
-
-    var body: some View {
-        ZStack {
-            Color.yellow
         }
     }
 }

--- a/podcasts/End of Year/Stories/ListeningTimeStory.swift
+++ b/podcasts/End of Year/Stories/ListeningTimeStory.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+struct ListeningTimeStory: StoryView {
+    var duration: TimeInterval = 5.seconds
+
+    let listeningTime: Double
+
+    var body: some View {
+        VStack {
+            Text("In 2022, you spent \(listeningTime.localizedTimeDescription ?? "") listening to podcasts")
+                .foregroundColor(.white)
+            Text(FunnyTimeConverter.timeSecsToFunnyText(listeningTime))
+                .foregroundColor(.white)
+        }
+    }
+}
+
+struct ListeningTimeStory_Previews: PreviewProvider {
+    static var previews: some View {
+        ListeningTimeStory(listeningTime: 100)
+    }
+}

--- a/podcasts/End of Year/Stories/ListeningTimeStory.swift
+++ b/podcasts/End of Year/Stories/ListeningTimeStory.swift
@@ -6,11 +6,16 @@ struct ListeningTimeStory: StoryView {
     let listeningTime: Double
 
     var body: some View {
-        VStack {
-            Text("In 2022, you spent \(listeningTime.localizedTimeDescription ?? "") listening to podcasts")
-                .foregroundColor(.white)
-            Text(FunnyTimeConverter.timeSecsToFunnyText(listeningTime))
-                .foregroundColor(.white)
+        ZStack {
+            Color.black
+
+            VStack {
+                Text("In 2022, you spent \(listeningTime.localizedTimeDescription ?? "") listening to podcasts")
+                    .foregroundColor(.white)
+                Text(FunnyTimeConverter.timeSecsToFunnyText(listeningTime))
+                    .foregroundColor(.white)
+            }
+            .padding()
         }
     }
 }

--- a/podcasts/StatsViewController.swift
+++ b/podcasts/StatsViewController.swift
@@ -183,43 +183,7 @@ class StatsViewController: UIViewController, UITableViewDelegate, UITableViewDat
     }
 
     private func formatStat(_ stat: Double) -> String {
-        let days = Int(safeDouble: stat / 86400)
-        let hours = Int(safeDouble: stat / 3600) - (days * 24)
-        let mins = Int(safeDouble: stat / 60) - (hours * 60) - (days * 24 * 60)
-        let secs = Int(safeDouble: stat.truncatingRemainder(dividingBy: 60))
-        var output = [String]()
-
-        if let daysHours = formatDaysHours(days: days, hours: hours) {
-            output.append(daysHours)
-        }
-
-        if days > 0, hours > 0 {
-            return output.first ?? ""
-        }
-
-        let secondsForDisplay = hours < 1 ? secs : 0
-        if let minsSeconds = formatMinsSeconds(mins: mins, secs: secondsForDisplay) {
-            output.append(minsSeconds)
-        }
-
-        if output.count == 0 {
-            let components = DateComponents(calendar: Calendar.current, second: secs)
-            return DateComponentsFormatter.localizedString(from: components, unitsStyle: .full) ?? L10n.statsTimeZeroSeconds
-        }
-
-        return output.joined(separator: " ")
-    }
-
-    private func formatDaysHours(days: Int, hours: Int) -> String? {
-        guard days > 0 || hours > 0 else { return nil }
-        let components = DateComponents(calendar: Calendar.current, day: days, hour: hours)
-        return DateComponentsFormatter.localizedString(from: components, unitsStyle: .full)?.replacingOccurrences(of: ",", with: "")
-    }
-
-    private func formatMinsSeconds(mins: Int, secs: Int) -> String? {
-        guard mins > 0 else { return nil }
-        let components = DateComponents(calendar: Calendar.current, minute: mins, second: secs)
-        return DateComponentsFormatter.localizedString(from: components, unitsStyle: .short)?.replacingOccurrences(of: ",", with: "")
+        stat.localizedTimeDescription ?? L10n.statsTimeZeroSeconds
     }
 
     private func requestReviewIfPossible() {


### PR DESCRIPTION
| 📘 Project: #376 |
|:---:|

Show the approximately total listening time in 2022.

<img src="https://user-images.githubusercontent.com/7040243/196740289-8da8e538-8fad-45e8-9dca-7c655d9c6ac9.png" width="300">

It also includes a small refactor on the Stats screen.

Like the PRs before, designs are gonna be done in another task.

## To test

### Listening time

1. Enable the `endOfYear` flag in `FeatureFlag.swift`
1. Login to an existing account
2. Run the app
3. When the prompt appears, tap "View My 2022"
4. ✅ Check that your total listening time in 2022 is shown

### Stats

1. Open the stats screen
2. ✅ Check that all your data is shown correctly

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
