### PR TITLE
End of Year: show total categories listened and top categories

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
@@ -26,4 +26,46 @@ class EndOfYearDataManager {
         return listeningTime
     }
 
+    /// Returns all the categories the user has listened to podcasts
+    ///
+    /// The returned array is ordered from the most listened to the least
+    func listenedCategories(dbQueue: FMDatabaseQueue) -> [ListenedCategory] {
+        var listenedCategories: [ListenedCategory] = []
+
+        dbQueue.inDatabase { db in
+            do {
+                let query = """
+                            SELECT COUNT(DISTINCT podcastUuid) as numberOfPodcasts,
+                                SUM(playedUpTo) as totalPlayedTime,
+                                replace(IFNULL( nullif(substr(\(DataManager.podcastTableName).podcastCategory, 0, INSTR(\(DataManager.podcastTableName).podcastCategory, char(10))), '') , \(DataManager.podcastTableName).podcastCategory), CHAR(10), '') as category
+                            FROM \(DataManager.episodeTableName), \(DataManager.podcastTableName)
+                            WHERE \(DataManager.podcastTableName).uuid = \(DataManager.episodeTableName).podcastUuid and
+                                lastPlaybackInteractionDate IS NOT NULL AND
+                                lastPlaybackInteractionDate BETWEEN strftime('%s', '2022-01-01') and strftime('%s', '\(endPeriod)')
+                            GROUP BY category
+                            ORDER BY totalPlayedTime DESC
+"""
+
+                let resultSet = try db.executeQuery(query, values: nil)
+                defer { resultSet.close() }
+
+                while resultSet.next() {
+                    let numberOfPodcasts = Int(resultSet.int(forColumn: "numberOfPodcasts"))
+                    if let categoryTitle = resultSet.string(forColumn: "category") {
+                        listenedCategories.append(ListenedCategory(numberOfPodcasts: numberOfPodcasts, categoryTitle: categoryTitle))
+                    }
+                }
+            } catch {
+                FileLog.shared.addMessage("PodcastDataManager.listenedCategories error: \(error)")
+            }
+        }
+
+        return listenedCategories
+    }
+
+}
+
+public struct ListenedCategory {
+    let numberOfPodcasts: Int
+    let categoryTitle: String
 }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
@@ -66,6 +66,6 @@ class EndOfYearDataManager {
 }
 
 public struct ListenedCategory {
-    let numberOfPodcasts: Int
-    let categoryTitle: String
+    public let numberOfPodcasts: Int
+    public let categoryTitle: String
 }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -900,4 +900,8 @@ public extension DataManager {
     func listeningTime() -> Double? {
         endOfYearManager.listeningTime(dbQueue: dbQueue)
     }
+
+    func listenedCategories() -> [ListenedCategory] {
+        endOfYearManager.listenedCategories(dbQueue: dbQueue)
+    }
 }

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -444,6 +444,7 @@
 		4A3C19F543779593E98EDA3C /* libPods-Pocket Casts Watch App Extension.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C7C2391BA608F0CAB6E1D038 /* libPods-Pocket Casts Watch App Extension.a */; };
 		8B0EEDE029003E8D00075772 /* ListeningTimeStory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B0EEDDF29003E8D00075772 /* ListeningTimeStory.swift */; };
 		8B0EEDE2290065C100075772 /* ListenedCategoriesStory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B0EEDE1290065C000075772 /* ListenedCategoriesStory.swift */; };
+		8B0EEDE429006C9B00075772 /* TopListenedCategories.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B0EEDE329006C9B00075772 /* TopListenedCategories.swift */; };
 		8B10E78628D9093E00702C54 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 8B10E78528D908A900702C54 /* GoogleService-Info.plist */; };
 		8B10E78728D9093F00702C54 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 8B10E78528D908A900702C54 /* GoogleService-Info.plist */; };
 		8B10E78828D9094500702C54 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 8B10E78528D908A900702C54 /* GoogleService-Info.plist */; };
@@ -1982,6 +1983,7 @@
 		8229174E612BC7BAC6F63274 /* Pods-Pocket Casts Watch App Extension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Pocket Casts Watch App Extension.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Pocket Casts Watch App Extension/Pods-Pocket Casts Watch App Extension.debug.xcconfig"; sourceTree = "<group>"; };
 		8B0EEDDF29003E8D00075772 /* ListeningTimeStory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListeningTimeStory.swift; sourceTree = "<group>"; };
 		8B0EEDE1290065C000075772 /* ListenedCategoriesStory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListenedCategoriesStory.swift; sourceTree = "<group>"; };
+		8B0EEDE329006C9B00075772 /* TopListenedCategories.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopListenedCategories.swift; sourceTree = "<group>"; };
 		8B10E78528D908A900702C54 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		8B1C974528FE1C7E00BD5EB9 /* ImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageView.swift; sourceTree = "<group>"; };
 		8B1C974728FE234B00BD5EB9 /* View+Snapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Snapshot.swift"; sourceTree = "<group>"; };
@@ -3686,6 +3688,7 @@
 				8B9D459E28F9AD3F0034219E /* EndOfYearStoriesDataSource.swift */,
 				8B0EEDDF29003E8D00075772 /* ListeningTimeStory.swift */,
 				8B0EEDE1290065C000075772 /* ListenedCategoriesStory.swift */,
+				8B0EEDE329006C9B00075772 /* TopListenedCategories.swift */,
 			);
 			path = Stories;
 			sourceTree = "<group>";
@@ -7257,6 +7260,7 @@
 				BDB9E7101FD655240091F8A7 /* UpNextButton.swift in Sources */,
 				BD93FDA620159A9A00F6EF55 /* PlaylistsViewController.swift in Sources */,
 				BD023C642251BCE1008A9C6F /* ListItem.swift in Sources */,
+				8B0EEDE429006C9B00075772 /* TopListenedCategories.swift in Sources */,
 				BD16385C27B101F300F24A39 /* PCSearchView.swift in Sources */,
 				BDB5F0C52045036200437669 /* OptionAction.swift in Sources */,
 				40FFAD93214A170200024FCF /* FilterSettingsOverlayController.swift in Sources */,

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -443,6 +443,7 @@
 		46FBD8B7276A874F00867746 /* Intents.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = 46FBD8B9276A874F00867746 /* Intents.intentdefinition */; settings = {ATTRIBUTES = (codegen, ); }; };
 		4A3C19F543779593E98EDA3C /* libPods-Pocket Casts Watch App Extension.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C7C2391BA608F0CAB6E1D038 /* libPods-Pocket Casts Watch App Extension.a */; };
 		8B0EEDE029003E8D00075772 /* ListeningTimeStory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B0EEDDF29003E8D00075772 /* ListeningTimeStory.swift */; };
+		8B0EEDE2290065C100075772 /* ListenedCategoriesStory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B0EEDE1290065C000075772 /* ListenedCategoriesStory.swift */; };
 		8B10E78628D9093E00702C54 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 8B10E78528D908A900702C54 /* GoogleService-Info.plist */; };
 		8B10E78728D9093F00702C54 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 8B10E78528D908A900702C54 /* GoogleService-Info.plist */; };
 		8B10E78828D9094500702C54 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 8B10E78528D908A900702C54 /* GoogleService-Info.plist */; };
@@ -1980,6 +1981,7 @@
 		7E84A6B7056C4797BAD62A1F /* Pods-Pocket Casts Watch App Extension.staging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Pocket Casts Watch App Extension.staging.xcconfig"; path = "Pods/Target Support Files/Pods-Pocket Casts Watch App Extension/Pods-Pocket Casts Watch App Extension.staging.xcconfig"; sourceTree = "<group>"; };
 		8229174E612BC7BAC6F63274 /* Pods-Pocket Casts Watch App Extension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Pocket Casts Watch App Extension.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Pocket Casts Watch App Extension/Pods-Pocket Casts Watch App Extension.debug.xcconfig"; sourceTree = "<group>"; };
 		8B0EEDDF29003E8D00075772 /* ListeningTimeStory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListeningTimeStory.swift; sourceTree = "<group>"; };
+		8B0EEDE1290065C000075772 /* ListenedCategoriesStory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListenedCategoriesStory.swift; sourceTree = "<group>"; };
 		8B10E78528D908A900702C54 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		8B1C974528FE1C7E00BD5EB9 /* ImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageView.swift; sourceTree = "<group>"; };
 		8B1C974728FE234B00BD5EB9 /* View+Snapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Snapshot.swift"; sourceTree = "<group>"; };
@@ -3683,6 +3685,7 @@
 				8B9D459B28F9A6260034219E /* DummyStory.swift */,
 				8B9D459E28F9AD3F0034219E /* EndOfYearStoriesDataSource.swift */,
 				8B0EEDDF29003E8D00075772 /* ListeningTimeStory.swift */,
+				8B0EEDE1290065C000075772 /* ListenedCategoriesStory.swift */,
 			);
 			path = Stories;
 			sourceTree = "<group>";
@@ -7668,6 +7671,7 @@
 				BDCCBC8824BC444F009B4D1D /* CustomTimeStepper.swift in Sources */,
 				BDFB53CB2362B9080001806E /* UpNextViewController.swift in Sources */,
 				BD240C3F231E8BE000FB2CDD /* PCSearchBarController.swift in Sources */,
+				8B0EEDE2290065C100075772 /* ListenedCategoriesStory.swift in Sources */,
 				BD9FF61C1B8EDDBB009F075E /* NetworkCell.swift in Sources */,
 				C7C4CAF328ABFD0900CFC8CF /* Notifications.swift in Sources */,
 				461C46C7274D80990003D3A9 /* LocalizationHelpers.swift in Sources */,

--- a/podcasts/End of Year/Stories/EndOfYearStoriesDataSource.swift
+++ b/podcasts/End of Year/Stories/EndOfYearStoriesDataSource.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import PocketCastsDataModel
 
 class EndOfYearStoriesDataSource: StoriesDataSource {
-    var numberOfStories: Int = 3
+    var numberOfStories: Int = 4
 
     let randomPodcasts = DataManager.sharedManager.randomPodcasts()
 
@@ -16,6 +16,8 @@ class EndOfYearStoriesDataSource: StoriesDataSource {
             return ListeningTimeStory(listeningTime: listeningTime!)
         case 1:
             return ListenedCategoriesStory(listenedCategories: listenedCategories)
+        case 2:
+            return TopListenedCategories(listenedCategories: listenedCategories)
         default:
             return DummyStory(podcasts: randomPodcasts)
         }

--- a/podcasts/End of Year/Stories/EndOfYearStoriesDataSource.swift
+++ b/podcasts/End of Year/Stories/EndOfYearStoriesDataSource.swift
@@ -8,6 +8,8 @@ class EndOfYearStoriesDataSource: StoriesDataSource {
 
     var listeningTime: Double?
 
+    var listenedCategories: [ListenedCategory] = []
+
     func story(for storyNumber: Int) -> any StoryView {
         switch storyNumber {
         case 0:
@@ -20,6 +22,8 @@ class EndOfYearStoriesDataSource: StoriesDataSource {
     func isReady() async -> Bool {
         await withCheckedContinuation { continuation in
             self.listeningTime = DataManager.sharedManager.listeningTime()
+
+            self.listenedCategories = DataManager.sharedManager.listenedCategories()
 
             continuation.resume(returning: true)
         }

--- a/podcasts/End of Year/Stories/EndOfYearStoriesDataSource.swift
+++ b/podcasts/End of Year/Stories/EndOfYearStoriesDataSource.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import PocketCastsDataModel
 
 class EndOfYearStoriesDataSource: StoriesDataSource {
-    var numberOfStories: Int = 2
+    var numberOfStories: Int = 3
 
     let randomPodcasts = DataManager.sharedManager.randomPodcasts()
 
@@ -14,6 +14,8 @@ class EndOfYearStoriesDataSource: StoriesDataSource {
         switch storyNumber {
         case 0:
             return ListeningTimeStory(listeningTime: listeningTime!)
+        case 1:
+            return ListenedCategoriesStory(listenedCategories: listenedCategories)
         default:
             return DummyStory(podcasts: randomPodcasts)
         }

--- a/podcasts/End of Year/Stories/ListenedCategoriesStory.swift
+++ b/podcasts/End of Year/Stories/ListenedCategoriesStory.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+import PocketCastsDataModel
+
+struct ListenedCategoriesStory: StoryView {
+    var duration: TimeInterval = 5.seconds
+
+    let listenedCategories: [ListenedCategory]
+
+    var body: some View {
+        ZStack {
+            Color.purple
+            VStack {
+                Text("You listened to \(listenedCategories.count) different categories this year")
+                Text("Let's take a look at some of your favourites..")
+            }
+        }
+    }
+}
+
+struct ListenedCategoriesStory_Previews: PreviewProvider {
+    static var previews: some View {
+        ListenedCategoriesStory(listenedCategories: [])
+    }
+}

--- a/podcasts/End of Year/Stories/TopListenedCategories.swift
+++ b/podcasts/End of Year/Stories/TopListenedCategories.swift
@@ -26,7 +26,7 @@ struct TopListenedCategories: StoryView {
                                 .resizable()
                                 .frame(width: 40, height: 40)
                                 .foregroundColor(.white)
-                            Text(listenedCategories[x].categoryTitle ?? "")
+                            Text(listenedCategories[x].categoryTitle.localized ?? "")
                                 .lineLimit(2)
                                 .font(.system(size: 22, weight: .bold))
                                 .foregroundColor(.white)

--- a/podcasts/End of Year/Stories/TopListenedCategories.swift
+++ b/podcasts/End of Year/Stories/TopListenedCategories.swift
@@ -7,7 +7,44 @@ struct TopListenedCategories: StoryView {
     let listenedCategories: [ListenedCategory]
 
     var body: some View {
-        Text("Hello, World!")
+        ZStack {
+            Color.purple
+
+            VStack {
+                Text("Your Top Categories")
+                    .font(.system(size: 22, weight: .bold))
+                    .foregroundColor(.white)
+                    .padding(.bottom)
+                VStack {
+                    ForEach(0 ..< min(listenedCategories.count, 5), id: \.self) { x in
+                        HStack(spacing: 16) {
+                            Text("\(x + 1).")
+                                .font(.system(size: 32, weight: .bold))
+                                .foregroundColor(.white)
+                            Image("discover_cat_1")
+                                .renderingMode(.template)
+                                .resizable()
+                                .frame(width: 40, height: 40)
+                                .foregroundColor(.white)
+                            Text(listenedCategories[x].categoryTitle ?? "")
+                                .lineLimit(2)
+                                .font(.system(size: 22, weight: .bold))
+                                .foregroundColor(.white)
+                            VStack(alignment: .trailing) {
+                                Text("\(listenedCategories[x].numberOfPodcasts)").font(.system(size: 22, weight: .bold))
+                                    .foregroundColor(.white)
+                                Text("Podcasts")
+                                    .font(.system(size: 12, weight: .semibold))
+                                        .foregroundColor(.white)
+                            }
+                            Spacer()
+                        }
+                    }
+                }
+                .padding(.leading, 40)
+                .padding(.trailing, 40)
+            }
+        }
     }
 }
 

--- a/podcasts/End of Year/Stories/TopListenedCategories.swift
+++ b/podcasts/End of Year/Stories/TopListenedCategories.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+import PocketCastsDataModel
+
+struct TopListenedCategories: StoryView {
+    var duration: TimeInterval = 5.seconds
+
+    let listenedCategories: [ListenedCategory]
+
+    var body: some View {
+        Text("Hello, World!")
+    }
+}
+
+struct TopListenedCategories_Previews: PreviewProvider {
+    static var previews: some View {
+        TopListenedCategories(listenedCategories: [])
+    }
+}


### PR DESCRIPTION
| 📘 Project: #376 |
|:---:|

Adds two new stories:

* Total categories listened
* Top 5 categories listened

| Total categories | Top 5 categories |
| ---------------- | ---------------- |
| ![Simulator Screen Shot - iPhone 14 - 2022-10-19 at 15 01 35](https://user-images.githubusercontent.com/7040243/196769439-dc0c4bce-5ee0-4f22-95bb-a52bc86cc1b4.png) | ![Simulator Screen Shot - iPhone 14 - 2022-10-19 at 15 01 44](https://user-images.githubusercontent.com/7040243/196769472-8279fe97-2c36-4616-82b1-5714fc4be3d8.png) |

As you already know, design is gonna be tackled in another PR.

## To discuss

The list is being ordered by total time listened in each category. However, I wonder if the user might find it strange that maybe they have a top 1 category that has fewer podcasts than the top 2, for example.

We can either change the design to show the listening time, change the query (to order by the number of podcasts) or do nothing.

## To test

1. Enable the `endOfYear` flag in `FeatureFlag.swift`
2. Run the app and login with an account that has a Listening History with at least a few items
3. When the prompt appears, tap "View My 2022"
4. Skip the first story
5. ✅ Check that the second story shows the total number of categories you listened to
6. ✅ Check that the third story shows the top 5 categories you listened to with the number of different podcasts for each one

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
