### PR TITLE
End of Year: show number of listened podcasts and episodes

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
@@ -105,4 +105,9 @@ public struct ListenedCategory {
 public struct ListenedNumbers {
     public let numberOfPodcasts: Int
     public let numberOfEpisodes: Int
+
+    public init(numberOfPodcasts: Int, numberOfEpisodes: Int) {
+        self.numberOfPodcasts = numberOfPodcasts
+        self.numberOfEpisodes = numberOfEpisodes
+    }
 }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -904,4 +904,8 @@ public extension DataManager {
     func listenedCategories() -> [ListenedCategory] {
         endOfYearManager.listenedCategories(dbQueue: dbQueue)
     }
+
+    func listenedNumbers() -> ListenedNumbers {
+        endOfYearManager.listenedNumbers(dbQueue: dbQueue)
+    }
 }

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -445,6 +445,7 @@
 		8B0EEDE029003E8D00075772 /* ListeningTimeStory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B0EEDDF29003E8D00075772 /* ListeningTimeStory.swift */; };
 		8B0EEDE2290065C100075772 /* ListenedCategoriesStory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B0EEDE1290065C000075772 /* ListenedCategoriesStory.swift */; };
 		8B0EEDE429006C9B00075772 /* TopListenedCategories.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B0EEDE329006C9B00075772 /* TopListenedCategories.swift */; };
+		8B0EEDE6290081E400075772 /* ListenedNumbersStory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B0EEDE5290081E400075772 /* ListenedNumbersStory.swift */; };
 		8B10E78628D9093E00702C54 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 8B10E78528D908A900702C54 /* GoogleService-Info.plist */; };
 		8B10E78728D9093F00702C54 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 8B10E78528D908A900702C54 /* GoogleService-Info.plist */; };
 		8B10E78828D9094500702C54 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 8B10E78528D908A900702C54 /* GoogleService-Info.plist */; };
@@ -1984,6 +1985,7 @@
 		8B0EEDDF29003E8D00075772 /* ListeningTimeStory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListeningTimeStory.swift; sourceTree = "<group>"; };
 		8B0EEDE1290065C000075772 /* ListenedCategoriesStory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListenedCategoriesStory.swift; sourceTree = "<group>"; };
 		8B0EEDE329006C9B00075772 /* TopListenedCategories.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopListenedCategories.swift; sourceTree = "<group>"; };
+		8B0EEDE5290081E400075772 /* ListenedNumbersStory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListenedNumbersStory.swift; sourceTree = "<group>"; };
 		8B10E78528D908A900702C54 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		8B1C974528FE1C7E00BD5EB9 /* ImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageView.swift; sourceTree = "<group>"; };
 		8B1C974728FE234B00BD5EB9 /* View+Snapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Snapshot.swift"; sourceTree = "<group>"; };
@@ -3688,6 +3690,7 @@
 				8B9D459E28F9AD3F0034219E /* EndOfYearStoriesDataSource.swift */,
 				8B0EEDDF29003E8D00075772 /* ListeningTimeStory.swift */,
 				8B0EEDE1290065C000075772 /* ListenedCategoriesStory.swift */,
+				8B0EEDE5290081E400075772 /* ListenedNumbersStory.swift */,
 				8B0EEDE329006C9B00075772 /* TopListenedCategories.swift */,
 			);
 			path = Stories;
@@ -7450,6 +7453,7 @@
 				403946E9228587FC00F55162 /* AddCustomViewController+CollectionView.swift in Sources */,
 				BDB4E7D2240E3134005770E3 /* String+Differentiable.swift in Sources */,
 				BD2BE6791C5B11C20087EE1E /* ShiftyRoundButton.swift in Sources */,
+				8B0EEDE6290081E400075772 /* ListenedNumbersStory.swift in Sources */,
 				4007B04C230E1FB4008DDCF5 /* WhatsNewViewController.swift in Sources */,
 				BDB002C1211A9EDD00224A55 /* ProgressLineLayer.swift in Sources */,
 				BD4D91751B9933A800B62FD2 /* AngularActivityIndicator.swift in Sources */,

--- a/podcasts/End of Year/Stories/EndOfYearStoriesDataSource.swift
+++ b/podcasts/End of Year/Stories/EndOfYearStoriesDataSource.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import PocketCastsDataModel
 
 class EndOfYearStoriesDataSource: StoriesDataSource {
-    var numberOfStories: Int = 4
+    var numberOfStories: Int = 5
 
     let randomPodcasts = DataManager.sharedManager.randomPodcasts()
 
@@ -20,6 +20,8 @@ class EndOfYearStoriesDataSource: StoriesDataSource {
             return ListenedCategoriesStory(listenedCategories: listenedCategories)
         case 2:
             return TopListenedCategories(listenedCategories: listenedCategories)
+        case 3:
+            return ListenedNumbersStory(listenedNumbers: listenedNumbers!)
         default:
             return DummyStory(podcasts: randomPodcasts)
         }

--- a/podcasts/End of Year/Stories/EndOfYearStoriesDataSource.swift
+++ b/podcasts/End of Year/Stories/EndOfYearStoriesDataSource.swift
@@ -10,6 +10,8 @@ class EndOfYearStoriesDataSource: StoriesDataSource {
 
     var listenedCategories: [ListenedCategory] = []
 
+    var listenedNumbers: ListenedNumbers?
+
     func story(for storyNumber: Int) -> any StoryView {
         switch storyNumber {
         case 0:
@@ -28,6 +30,8 @@ class EndOfYearStoriesDataSource: StoriesDataSource {
             self.listeningTime = DataManager.sharedManager.listeningTime()
 
             self.listenedCategories = DataManager.sharedManager.listenedCategories()
+
+            self.listenedNumbers = DataManager.sharedManager.listenedNumbers()
 
             continuation.resume(returning: true)
         }

--- a/podcasts/End of Year/Stories/ListenedNumbersStory.swift
+++ b/podcasts/End of Year/Stories/ListenedNumbersStory.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+import PocketCastsDataModel
+
+struct ListenedNumbersStory: StoryView {
+    var duration: TimeInterval = 5.seconds
+
+    let listenedNumbers: ListenedNumbers
+
+    var body: some View {
+        ZStack {
+            Color.orange
+
+            Text("You listened to \(listenedNumbers.numberOfPodcasts) different podcasts and \(listenedNumbers.numberOfEpisodes) episodes, but there was one that you kept coming back to...")
+                .foregroundColor(.white)
+                .padding()
+        }
+    }
+}
+
+struct ListenedNumbersStory_Previews: PreviewProvider {
+    static var previews: some View {
+        ListenedNumbersStory(listenedNumbers: ListenedNumbers(numberOfPodcasts: 5, numberOfEpisodes: 10))
+    }
+}


### PR DESCRIPTION
| 📘 Project: #376 |
|:---:|

Adds a story that shows the number of listened podcasts and episodes. Designs are not contemplated in this task.

<img src="https://user-images.githubusercontent.com/7040243/196783390-f8f63c9c-4281-423e-a1db-abc0c798b4a0.png" width="300">

## To test

1. Enable the `endOfYear` flag in `FeatureFlag.swift`
2. Run the app and make sure you're logged in to an account with a few items on Listening History
3. When the prompt appears, tap "View My 2022"
4. Skip to the fourth story
5. ✅ Check that the number of played podcasts and episodes is shown

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
