### PR TITLE
Folders: Choose Podcasts UI is cut off at the top fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 7.26
 -----
-
+- Fixed a search bar layout issue when adding/removing podcasts to folder (#378)
 
 7.25
 -----

--- a/podcasts/PodcastPickerView.swift
+++ b/podcasts/PodcastPickerView.swift
@@ -13,7 +13,7 @@ struct PodcastPickerView: View {
                 HStack {
                     PCSearchView(searchTerm: $pickerModel.searchTerm)
                         .frame(height: PCSearchView.defaultHeight)
-                        .padding(.top, -10)
+                        .padding(.top, -6)
                         .padding(.leading, -PCSearchView.defaultIndenting)
                     Spacer()
                     Menu {
@@ -30,7 +30,7 @@ struct PodcastPickerView: View {
                                     .stroke(ThemeColor.primaryInteractive01(for: theme.activeTheme).color, lineWidth: 2)
                             )
                     }
-                    .padding(.top, -20)
+                    .padding(.top, -14)
                 }
                 ThemedDivider()
                 Text(L10n.selectedPodcastCount(pickerModel.selectedPodcastUuids.count, capitalized: true))


### PR DESCRIPTION
Fixes #378 

## To test
 - Open up a folder
 - Click the ellipsis, then select "Add or remove podcasts"
 - Search bar top margin should be correct

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
