### PR TITLE
End of Year: show first and last story

### DIFF
--- a/PocketCastsTests/Tests/End of Year/StoriesModelTests.swift
+++ b/PocketCastsTests/Tests/End of Year/StoriesModelTests.swift
@@ -6,20 +6,23 @@ import SwiftUI
 @MainActor
 class StoriesModelTests: XCTestCase {
     func testCurrentStoryAndProgressStartsInZero() {
-        let model = StoriesModel(dataSource: MockStoriesDataSource())
+        let model = StoriesModel(dataSource: MockStoriesDataSource(),
+                                 configuration: StoriesConfiguration())
 
         XCTAssertEqual(model.currentStory, 0)
         XCTAssertEqual(model.progress, 0)
     }
 
     func testNumberOfStoriesReflectDataSourceValue() {
-        let model = StoriesModel(dataSource: MockStoriesDataSource())
+        let model = StoriesModel(dataSource: MockStoriesDataSource(),
+                                 configuration: StoriesConfiguration())
 
         XCTAssertEqual(model.numberOfStories, 2)
     }
 
     func testProgressChangesAfterStart() {
-        let model = StoriesModel(dataSource: MockStoriesDataSource())
+        let model = StoriesModel(dataSource: MockStoriesDataSource(),
+                                 configuration: StoriesConfiguration())
 
         model.start()
 
@@ -29,7 +32,8 @@ class StoriesModelTests: XCTestCase {
     }
 
     func testNext() {
-        let model = StoriesModel(dataSource: MockStoriesDataSource())
+        let model = StoriesModel(dataSource: MockStoriesDataSource(),
+                                 configuration: StoriesConfiguration())
         model.start()
 
         model.next()
@@ -40,7 +44,8 @@ class StoriesModelTests: XCTestCase {
     }
 
     func testPrevious() {
-        let model = StoriesModel(dataSource: MockStoriesDataSource())
+        let model = StoriesModel(dataSource: MockStoriesDataSource(),
+                                 configuration: StoriesConfiguration())
         model.start()
         model.next()
 
@@ -53,7 +58,8 @@ class StoriesModelTests: XCTestCase {
 
     func testWhenCallingStoryTheDataSourceIsCalledForTheView() {
         let dataSource = MockStoriesDataSource()
-        let model = StoriesModel(dataSource: dataSource)
+        let model = StoriesModel(dataSource: dataSource,
+                                 configuration: StoriesConfiguration())
 
         _ = model.story(index: 0)
 

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -473,6 +473,7 @@
 		8B484F0228D25DB5001AFA97 /* UIViewController+requestReview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B484F0028D25D1E001AFA97 /* UIViewController+requestReview.swift */; };
 		8B5AB488290188F30018C637 /* IntroStory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B5AB487290188F30018C637 /* IntroStory.swift */; };
 		8B5AB48A29018A950018C637 /* EpilogueStory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B5AB48929018A950018C637 /* EpilogueStory.swift */; };
+		8B5AB48C29018EFA0018C637 /* StoriesConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B5AB48B29018EFA0018C637 /* StoriesConfiguration.swift */; };
 		8B5F9A6728EFBB9800DE1C12 /* AppIcon-Halloween@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 8B5F9A6528EFBB9700DE1C12 /* AppIcon-Halloween@2x.png */; };
 		8B5F9A6828EFBB9800DE1C12 /* AppIcon-Halloween@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = 8B5F9A6628EFBB9800DE1C12 /* AppIcon-Halloween@3x.png */; };
 		8B6B68E528F744520032BFFF /* StoriesDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6B68E428F744520032BFFF /* StoriesDataSource.swift */; };
@@ -2013,6 +2014,7 @@
 		8B484F0028D25D1E001AFA97 /* UIViewController+requestReview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+requestReview.swift"; sourceTree = "<group>"; };
 		8B5AB487290188F30018C637 /* IntroStory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroStory.swift; sourceTree = "<group>"; };
 		8B5AB48929018A950018C637 /* EpilogueStory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EpilogueStory.swift; sourceTree = "<group>"; };
+		8B5AB48B29018EFA0018C637 /* StoriesConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoriesConfiguration.swift; sourceTree = "<group>"; };
 		8B5F9A6528EFBB9700DE1C12 /* AppIcon-Halloween@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "AppIcon-Halloween@2x.png"; sourceTree = "<group>"; };
 		8B5F9A6628EFBB9800DE1C12 /* AppIcon-Halloween@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "AppIcon-Halloween@3x.png"; sourceTree = "<group>"; };
 		8B6B68E428F744520032BFFF /* StoriesDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoriesDataSource.swift; sourceTree = "<group>"; };
@@ -3724,6 +3726,7 @@
 				8BCB22B528F48A4E001A0315 /* Views */,
 				8B9D459D28F9ACFB0034219E /* Stories */,
 				8BCB22B328F48282001A0315 /* EndOfYear.swift */,
+				8B5AB48B29018EFA0018C637 /* StoriesConfiguration.swift */,
 				8B6B68E428F744520032BFFF /* StoriesDataSource.swift */,
 				8B6B68E628F74A010032BFFF /* StoriesModel.swift */,
 				8BB55E3928FEEE99001D1766 /* StoryShareableProvider.swift */,
@@ -7308,6 +7311,7 @@
 				BDC86830238251B0004C998F /* NowPlayingPlayerItemViewController+UpNextPan.swift in Sources */,
 				BD7BCF131F6A4F920006E008 /* SharingItemProvider.swift in Sources */,
 				BD21D4A722DEDAE700D5888B /* ThemeableCollectionView.swift in Sources */,
+				8B5AB48C29018EFA0018C637 /* StoriesConfiguration.swift in Sources */,
 				C7AF5791289D87CF0089E435 /* Analytics.swift in Sources */,
 				BDE7409A2060CE1B00FB22C7 /* EpisodeManager.swift in Sources */,
 				BD240C43231F46F400FB2CDD /* PCSearchBarController+TextFieldDelegate.swift in Sources */,

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -471,6 +471,7 @@
 		8B484EFD28D2574D001AFA97 /* EpisodeBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B484EFC28D2574D001AFA97 /* EpisodeBuilder.swift */; };
 		8B484EFF28D257E2001AFA97 /* DataManagerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B484EFE28D257E2001AFA97 /* DataManagerMock.swift */; };
 		8B484F0228D25DB5001AFA97 /* UIViewController+requestReview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B484F0028D25D1E001AFA97 /* UIViewController+requestReview.swift */; };
+		8B5AB488290188F30018C637 /* IntroStory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B5AB487290188F30018C637 /* IntroStory.swift */; };
 		8B5F9A6728EFBB9800DE1C12 /* AppIcon-Halloween@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 8B5F9A6528EFBB9700DE1C12 /* AppIcon-Halloween@2x.png */; };
 		8B5F9A6828EFBB9800DE1C12 /* AppIcon-Halloween@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = 8B5F9A6628EFBB9800DE1C12 /* AppIcon-Halloween@3x.png */; };
 		8B6B68E528F744520032BFFF /* StoriesDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6B68E428F744520032BFFF /* StoriesDataSource.swift */; };
@@ -2009,6 +2010,7 @@
 		8B484EFC28D2574D001AFA97 /* EpisodeBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EpisodeBuilder.swift; sourceTree = "<group>"; };
 		8B484EFE28D257E2001AFA97 /* DataManagerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataManagerMock.swift; sourceTree = "<group>"; };
 		8B484F0028D25D1E001AFA97 /* UIViewController+requestReview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+requestReview.swift"; sourceTree = "<group>"; };
+		8B5AB487290188F30018C637 /* IntroStory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroStory.swift; sourceTree = "<group>"; };
 		8B5F9A6528EFBB9700DE1C12 /* AppIcon-Halloween@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "AppIcon-Halloween@2x.png"; sourceTree = "<group>"; };
 		8B5F9A6628EFBB9800DE1C12 /* AppIcon-Halloween@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "AppIcon-Halloween@3x.png"; sourceTree = "<group>"; };
 		8B6B68E428F744520032BFFF /* StoriesDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoriesDataSource.swift; sourceTree = "<group>"; };
@@ -3691,6 +3693,7 @@
 			isa = PBXGroup;
 			children = (
 				8B9D459E28F9AD3F0034219E /* EndOfYearStoriesDataSource.swift */,
+				8B5AB487290188F30018C637 /* IntroStory.swift */,
 				8B0EEDDF29003E8D00075772 /* ListeningTimeStory.swift */,
 				8B0EEDE1290065C000075772 /* ListenedCategoriesStory.swift */,
 				8B0EEDE5290081E400075772 /* ListenedNumbersStory.swift */,
@@ -7606,6 +7609,7 @@
 				4006E31423AC453700174DEB /* ExpandedCollectionViewController+CollectionView.swift in Sources */,
 				8B0EEDE029003E8D00075772 /* ListeningTimeStory.swift in Sources */,
 				BD27B8C92756FA20007A0EA7 /* ModalCloseButton.swift in Sources */,
+				8B5AB488290188F30018C637 /* IntroStory.swift in Sources */,
 				462EE0AF26FCCF97003D67DC /* PCMessageSupportViewModel.swift in Sources */,
 				4036B0A425240F5D00AE08E6 /* WidgetHelper.swift in Sources */,
 				BD92323823629FAA00C1E118 /* ShowNotesPlayerItemViewController.swift in Sources */,

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -472,6 +472,7 @@
 		8B484EFF28D257E2001AFA97 /* DataManagerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B484EFE28D257E2001AFA97 /* DataManagerMock.swift */; };
 		8B484F0228D25DB5001AFA97 /* UIViewController+requestReview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B484F0028D25D1E001AFA97 /* UIViewController+requestReview.swift */; };
 		8B5AB488290188F30018C637 /* IntroStory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B5AB487290188F30018C637 /* IntroStory.swift */; };
+		8B5AB48A29018A950018C637 /* EpilogueStory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B5AB48929018A950018C637 /* EpilogueStory.swift */; };
 		8B5F9A6728EFBB9800DE1C12 /* AppIcon-Halloween@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 8B5F9A6528EFBB9700DE1C12 /* AppIcon-Halloween@2x.png */; };
 		8B5F9A6828EFBB9800DE1C12 /* AppIcon-Halloween@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = 8B5F9A6628EFBB9800DE1C12 /* AppIcon-Halloween@3x.png */; };
 		8B6B68E528F744520032BFFF /* StoriesDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6B68E428F744520032BFFF /* StoriesDataSource.swift */; };
@@ -2011,6 +2012,7 @@
 		8B484EFE28D257E2001AFA97 /* DataManagerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataManagerMock.swift; sourceTree = "<group>"; };
 		8B484F0028D25D1E001AFA97 /* UIViewController+requestReview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+requestReview.swift"; sourceTree = "<group>"; };
 		8B5AB487290188F30018C637 /* IntroStory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroStory.swift; sourceTree = "<group>"; };
+		8B5AB48929018A950018C637 /* EpilogueStory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EpilogueStory.swift; sourceTree = "<group>"; };
 		8B5F9A6528EFBB9700DE1C12 /* AppIcon-Halloween@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "AppIcon-Halloween@2x.png"; sourceTree = "<group>"; };
 		8B5F9A6628EFBB9800DE1C12 /* AppIcon-Halloween@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "AppIcon-Halloween@3x.png"; sourceTree = "<group>"; };
 		8B6B68E428F744520032BFFF /* StoriesDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoriesDataSource.swift; sourceTree = "<group>"; };
@@ -3701,6 +3703,7 @@
 				8B9D459B28F9A6260034219E /* TopFivePodcastsStory.swift */,
 				8B0EEDE329006C9B00075772 /* TopListenedCategories.swift */,
 				8B0EEDE729008B6300075772 /* TopOnePodcastStory.swift */,
+				8B5AB48929018A950018C637 /* EpilogueStory.swift */,
 			);
 			path = Stories;
 			sourceTree = "<group>";
@@ -7195,6 +7198,7 @@
 				BDA0E29F22DDB2DC0029EBEB /* ThemeableLabel.swift in Sources */,
 				BD3FD738202A85E900A7F609 /* ListeningHistoryViewController+Table.swift in Sources */,
 				BD2B50AD201076310099B79D /* PodcastSettingsViewController.swift in Sources */,
+				8B5AB48A29018A950018C637 /* EpilogueStory.swift in Sources */,
 				8BB55E3A28FEEE99001D1766 /* StoryShareableProvider.swift in Sources */,
 				408426322134CBE60076D82E /* SmallPagedListSummaryViewController.swift in Sources */,
 				BD4098801B9EFE3C007F36BD /* AudioPlayTask.swift in Sources */,

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -474,6 +474,7 @@
 		8B5AB488290188F30018C637 /* IntroStory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B5AB487290188F30018C637 /* IntroStory.swift */; };
 		8B5AB48A29018A950018C637 /* EpilogueStory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B5AB48929018A950018C637 /* EpilogueStory.swift */; };
 		8B5AB48C29018EFA0018C637 /* StoriesConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B5AB48B29018EFA0018C637 /* StoriesConfiguration.swift */; };
+		8B5AB48E2901A8BD0018C637 /* StoriesController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B5AB48D2901A8BD0018C637 /* StoriesController.swift */; };
 		8B5F9A6728EFBB9800DE1C12 /* AppIcon-Halloween@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 8B5F9A6528EFBB9700DE1C12 /* AppIcon-Halloween@2x.png */; };
 		8B5F9A6828EFBB9800DE1C12 /* AppIcon-Halloween@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = 8B5F9A6628EFBB9800DE1C12 /* AppIcon-Halloween@3x.png */; };
 		8B6B68E528F744520032BFFF /* StoriesDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6B68E428F744520032BFFF /* StoriesDataSource.swift */; };
@@ -2015,6 +2016,7 @@
 		8B5AB487290188F30018C637 /* IntroStory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroStory.swift; sourceTree = "<group>"; };
 		8B5AB48929018A950018C637 /* EpilogueStory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EpilogueStory.swift; sourceTree = "<group>"; };
 		8B5AB48B29018EFA0018C637 /* StoriesConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoriesConfiguration.swift; sourceTree = "<group>"; };
+		8B5AB48D2901A8BD0018C637 /* StoriesController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoriesController.swift; sourceTree = "<group>"; };
 		8B5F9A6528EFBB9700DE1C12 /* AppIcon-Halloween@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "AppIcon-Halloween@2x.png"; sourceTree = "<group>"; };
 		8B5F9A6628EFBB9800DE1C12 /* AppIcon-Halloween@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "AppIcon-Halloween@3x.png"; sourceTree = "<group>"; };
 		8B6B68E428F744520032BFFF /* StoriesDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoriesDataSource.swift; sourceTree = "<group>"; };
@@ -3728,6 +3730,7 @@
 				8BCB22B328F48282001A0315 /* EndOfYear.swift */,
 				8B5AB48B29018EFA0018C637 /* StoriesConfiguration.swift */,
 				8B6B68E428F744520032BFFF /* StoriesDataSource.swift */,
+				8B5AB48D2901A8BD0018C637 /* StoriesController.swift */,
 				8B6B68E628F74A010032BFFF /* StoriesModel.swift */,
 				8BB55E3928FEEE99001D1766 /* StoryShareableProvider.swift */,
 			);
@@ -7260,6 +7263,7 @@
 				BD7C1FFD237D16C600B3353B /* PCAlwaysVisibleCastBtn.swift in Sources */,
 				BD9324712398BB50004F19A1 /* TourView.swift in Sources */,
 				BDC5360A27C88A5700EFCF31 /* FolderPreviewWrapper.swift in Sources */,
+				8B5AB48E2901A8BD0018C637 /* StoriesController.swift in Sources */,
 				BD6D4187200C802900CA8993 /* PodcastViewController+NetworkLoad.swift in Sources */,
 				40C2188122C44D1F005B8367 /* UploadedRefreshControl.swift in Sources */,
 				BDD5CA022303EB95005E133C /* ThemeableCollectionCell.swift in Sources */,

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -3697,6 +3697,7 @@
 			isa = PBXGroup;
 			children = (
 				8B9D459E28F9AD3F0034219E /* EndOfYearStoriesDataSource.swift */,
+				8B5AB48929018A950018C637 /* EpilogueStory.swift */,
 				8B5AB487290188F30018C637 /* IntroStory.swift */,
 				8B0EEDDF29003E8D00075772 /* ListeningTimeStory.swift */,
 				8B0EEDE1290065C000075772 /* ListenedCategoriesStory.swift */,
@@ -3705,7 +3706,6 @@
 				8B9D459B28F9A6260034219E /* TopFivePodcastsStory.swift */,
 				8B0EEDE329006C9B00075772 /* TopListenedCategories.swift */,
 				8B0EEDE729008B6300075772 /* TopOnePodcastStory.swift */,
-				8B5AB48929018A950018C637 /* EpilogueStory.swift */,
 			);
 			path = Stories;
 			sourceTree = "<group>";

--- a/podcasts/End of Year/Stories/EndOfYearStoriesDataSource.swift
+++ b/podcasts/End of Year/Stories/EndOfYearStoriesDataSource.swift
@@ -37,6 +37,11 @@ class EndOfYearStoriesDataSource: StoriesDataSource {
         }
     }
 
+    /// The only interactive view we have is the last one, with the replay button
+    func interactiveView(for storyNumber: Int) -> AnyView {
+        storyNumber == 8 ? AnyView(EpilogueStory()) : AnyView(EmptyView())
+    }
+
     func isReady() async -> Bool {
         await withCheckedContinuation { continuation in
             self.listeningTime = DataManager.sharedManager.listeningTime()

--- a/podcasts/End of Year/Stories/EndOfYearStoriesDataSource.swift
+++ b/podcasts/End of Year/Stories/EndOfYearStoriesDataSource.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import PocketCastsDataModel
 
 class EndOfYearStoriesDataSource: StoriesDataSource {
-    var numberOfStories: Int = 7
+    var numberOfStories: Int = 9
 
     var listeningTime: Double?
 
@@ -30,8 +30,10 @@ class EndOfYearStoriesDataSource: StoriesDataSource {
             return TopOnePodcastStory(topPodcast: topPodcasts[0])
         case 6:
             return TopFivePodcastsStory(podcasts: topPodcasts.map { $0.podcast })
-        default:
+        case 7:
             return LongestEpisodeStory(episode: longestEpisode!, podcast: longestEpisode!.parentPodcast()!)
+        default:
+            return EpilogueStory()
         }
     }
 

--- a/podcasts/End of Year/Stories/EndOfYearStoriesDataSource.swift
+++ b/podcasts/End of Year/Stories/EndOfYearStoriesDataSource.swift
@@ -17,16 +17,18 @@ class EndOfYearStoriesDataSource: StoriesDataSource {
     func story(for storyNumber: Int) -> any StoryView {
         switch storyNumber {
         case 0:
-            return ListeningTimeStory(listeningTime: listeningTime!)
+            return IntroStory()
         case 1:
-            return ListenedCategoriesStory(listenedCategories: listenedCategories)
+            return ListeningTimeStory(listeningTime: listeningTime!)
         case 2:
-            return TopListenedCategories(listenedCategories: listenedCategories)
+            return ListenedCategoriesStory(listenedCategories: listenedCategories)
         case 3:
-            return ListenedNumbersStory(listenedNumbers: listenedNumbers!)
+            return TopListenedCategories(listenedCategories: listenedCategories)
         case 4:
-            return TopOnePodcastStory(topPodcast: topPodcasts[0])
+            return ListenedNumbersStory(listenedNumbers: listenedNumbers!)
         case 5:
+            return TopOnePodcastStory(topPodcast: topPodcasts[0])
+        case 6:
             return TopFivePodcastsStory(podcasts: topPodcasts.map { $0.podcast })
         default:
             return LongestEpisodeStory(episode: longestEpisode!, podcast: longestEpisode!.parentPodcast()!)

--- a/podcasts/End of Year/Stories/EpilogueStory.swift
+++ b/podcasts/End of Year/Stories/EpilogueStory.swift
@@ -6,12 +6,25 @@ struct EpilogueStory: StoryView {
     var body: some View {
         ZStack {
             Color.orange
+                .allowsHitTesting(false)
 
             VStack {
-                Text("Thank you for letting Pocket Casts be apart of your listening experience in 2022")
+                Text("Thank you for letting Pocket Casts be a part of your listening experience in 2022")
                     .foregroundColor(.white)
                 Text("Don't forget to share with your friends and give a shout out to your favorite podcasts creators")
                     .foregroundColor(.white)
+                Button(action: {
+                    StoriesController.shared.replay()
+                }) {
+                    HStack {
+                        Spacer()
+                        Image(systemName: "arrow.clockwise")
+                            .foregroundColor(.white)
+                        Text("Replay")
+                            .foregroundColor(.white)
+                        Spacer()
+                    }
+                }
             }
             .padding()
         }

--- a/podcasts/End of Year/Stories/EpilogueStory.swift
+++ b/podcasts/End of Year/Stories/EpilogueStory.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+struct EpilogueStory: StoryView {
+    var duration: TimeInterval = 5.seconds
+
+    var body: some View {
+        ZStack {
+            Color.orange
+
+            VStack {
+                Text("Thank you for letting Pocket Casts be apart of your listening experience in 2022")
+                    .foregroundColor(.white)
+                Text("Don't forget to share with your friends and give a shout out to your favorite podcasts creators")
+                    .foregroundColor(.white)
+            }
+            .padding()
+        }
+    }
+}
+
+struct EpilogueStory_Previews: PreviewProvider {
+    static var previews: some View {
+        EpilogueStory()
+    }
+}

--- a/podcasts/End of Year/Stories/IntroStory.swift
+++ b/podcasts/End of Year/Stories/IntroStory.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+struct IntroStory: StoryView {
+    var duration: TimeInterval = 5.seconds
+
+    var body: some View {
+        Text("Let's celebrate your year of listening...")
+            .foregroundColor(.white)
+    }
+}
+
+struct IntroStory_Previews: PreviewProvider {
+    static var previews: some View {
+        IntroStory()
+    }
+}

--- a/podcasts/End of Year/StoriesConfiguration.swift
+++ b/podcasts/End of Year/StoriesConfiguration.swift
@@ -1,8 +1,10 @@
 import Foundation
 
 /// Used to configure how Stories are presented
-struct StoriesConfiguration {
+class StoriesConfiguration {
     /// If set to `true` it will replay the stories after the last one finished
     /// Otherwise, it will just pause on the last one.
-    let startOverFromBeginningAfterFinished: Bool
+    ///
+    /// Default value is `false`
+    var startOverFromBeginningAfterFinished: Bool = false
 }

--- a/podcasts/End of Year/StoriesConfiguration.swift
+++ b/podcasts/End of Year/StoriesConfiguration.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+/// Used to configure how Stories are presented
+struct StoriesConfiguration {
+    /// If set to `true` it will replay the stories after the last one finished
+    /// Otherwise, it will just pause on the last one.
+    let startOverFromBeginningAfterFinished: Bool
+}

--- a/podcasts/End of Year/StoriesController.swift
+++ b/podcasts/End of Year/StoriesController.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// Control the presentation of the stories
+class StoriesController {
+    static var shared = StoriesController()
+
+    enum Notifications: String, CaseIterable {
+        case replay
+    }
+
+    private init() { }
+
+    /// Start the stories from the beginning
+    func replay() {
+        NotificationCenter.default.post(name: NSNotification.Name(rawValue: Notifications.replay.rawValue), object: nil)
+    }
+}

--- a/podcasts/End of Year/StoriesDataSource.swift
+++ b/podcasts/End of Year/StoriesDataSource.swift
@@ -6,6 +6,13 @@ protocol StoriesDataSource {
     func story(for: Int) -> any StoryView
     func storyView(for: Int) -> AnyView
 
+    /// An interactive view that is put on top of the Stories control
+    ///
+    /// This allows having interactive elements, such as buttons.
+    /// It's up to the view to control `allowsHitTesting`. So make
+    /// sure that your story doesn't entirely block user interactions.
+    func interactiveView(for: Int) -> AnyView
+
     /// Whether the data source is ready to be used.
     ///
     /// You may want to make a request, or preload images/video.
@@ -17,6 +24,10 @@ protocol StoriesDataSource {
 extension StoriesDataSource {
     func storyView(for storyNumber: Int) -> AnyView {
         return AnyView(story(for: storyNumber))
+    }
+
+    func interactiveView(for: Int) -> AnyView {
+        return AnyView(EmptyView())
     }
 
     func shareableAsset(for storyNumber: Int) -> Any {

--- a/podcasts/End of Year/StoriesModel.swift
+++ b/podcasts/End of Year/StoriesModel.swift
@@ -11,6 +11,8 @@ class StoriesModel: ObservableObject {
 
     private let dataSource: StoriesDataSource
     private let publisher: Timer.TimerPublisher
+    private let configuration: StoriesConfiguration
+
     private var cancellable: Cancellable?
     private var interval: TimeInterval {
         dataSource.story(for: currentStory).duration
@@ -20,8 +22,9 @@ class StoriesModel: ObservableObject {
         dataSource.numberOfStories
     }
 
-    init(dataSource: StoriesDataSource) {
+    init(dataSource: StoriesDataSource, configuration: StoriesConfiguration) {
         self.dataSource = dataSource
+        self.configuration = configuration
         self.progress = 0
         self.publisher = Timer.publish(every: 0.01, on: .main, in: .default)
         Task.init {

--- a/podcasts/End of Year/StoriesModel.swift
+++ b/podcasts/End of Year/StoriesModel.swift
@@ -70,11 +70,11 @@ class StoriesModel: ObservableObject {
     }
 
     func next() {
-        progress = Double(Int(progress) + 1)
+        progress = min(Double(numberOfStories), Double(Int(progress) + 1))
     }
 
     func previous() {
-        progress = Double(Int(progress) - 1)
+        progress = max(0, Double(Int(progress) - 1))
     }
 
     func pause() {

--- a/podcasts/End of Year/StoriesModel.swift
+++ b/podcasts/End of Year/StoriesModel.swift
@@ -58,6 +58,10 @@ class StoriesModel: ObservableObject {
         dataSource.storyView(for: index)
     }
 
+    func interactive(index: Int) -> AnyView {
+        dataSource.interactiveView(for: index)
+    }
+
     func shareableAsset(index: Int) -> Any {
         dataSource.shareableAsset(for: index)
     }

--- a/podcasts/End of Year/StoriesModel.swift
+++ b/podcasts/End of Year/StoriesModel.swift
@@ -39,8 +39,13 @@ class StoriesModel: ObservableObject {
             let currentStory = Int(newProgress)
 
             if currentStory >= self.numberOfStories || newProgress < 0 {
-                newProgress = 0
-                self.currentStory = 0
+                if self.configuration.startOverFromBeginningAfterFinished {
+                    newProgress = 0
+                    self.currentStory = 0
+                }
+                else {
+                    self.pause()
+                }
             } else if currentStory != self.currentStory {
                 self.currentStory = currentStory
             }

--- a/podcasts/End of Year/StoriesModel.swift
+++ b/podcasts/End of Year/StoriesModel.swift
@@ -27,9 +27,12 @@ class StoriesModel: ObservableObject {
         self.configuration = configuration
         self.progress = 0
         self.publisher = Timer.publish(every: 0.01, on: .main, in: .default)
+
         Task.init {
             await isReady = dataSource.isReady()
         }
+
+        subscribeToNotifications()
     }
 
     func start() {
@@ -76,5 +79,25 @@ class StoriesModel: ObservableObject {
 
     func pause() {
         cancellable?.cancel()
+    }
+
+    func replay() {
+        progress = 0
+        currentStory = 0
+        pause()
+        start()
+    }
+}
+
+private extension StoriesModel {
+    func subscribeToNotifications() {
+        StoriesController.Notifications.allCases.forEach { controller in
+            switch controller {
+            case .replay:
+                NotificationCenter.default.addObserver(forName: NSNotification.Name(rawValue: controller.rawValue), object: nil, queue: .main) { _ in
+                    self.replay()
+                }
+            }
+        }
     }
 }

--- a/podcasts/End of Year/Views/StoriesView.swift
+++ b/podcasts/End of Year/Views/StoriesView.swift
@@ -32,6 +32,12 @@ struct StoriesView: View {
                 .cornerRadius(Constants.storyCornerRadius)
 
                 storySwitcher
+
+                ZStack {
+                    model.interactive(index: model.currentStory)
+                }
+                .cornerRadius(Constants.storyCornerRadius)
+
                 header
             }
 

--- a/podcasts/End of Year/Views/StoriesView.swift
+++ b/podcasts/End of Year/Views/StoriesView.swift
@@ -5,8 +5,8 @@ struct StoriesView: View {
 
     @ObservedObject private var model: StoriesModel
 
-    init(dataSource: StoriesDataSource) {
-        model = StoriesModel(dataSource: dataSource)
+    init(dataSource: StoriesDataSource, configuration: StoriesConfiguration = StoriesConfiguration()) {
+        model = StoriesModel(dataSource: dataSource, configuration: configuration)
     }
 
     @ViewBuilder


### PR DESCRIPTION
| 📘 Project: #376 |
|:---:|

Adds the first and last story. The last story also adds a new concept to our Stories: interactive views.

This layer is added on top of the Stories control (the view that handles tap to next/previous and swipes to dismiss). It's useful when you have something that is interactive: a button, or something else.

Right now, it is used to allow the "Replay" button to work properly, but in the future, we can use this for more advanced stuff. 

| First story | Last story |
| ---------- | ---------- |
| ![Simulator Screen Shot - iPhone 14 - 2022-10-20 at 13 24 47](https://user-images.githubusercontent.com/7040243/197005196-9f481447-6671-48ea-9cfa-51cb9735d9f2.png) | ![Simulator Screen Shot - iPhone 14 - 2022-10-20 at 13 24 53](https://user-images.githubusercontent.com/7040243/197005222-0d9d2e3c-d7be-436f-a94d-e66f11aa7301.png) |

## To test

1. Enable the `endOfYear` flag in `FeatureFlag.swift`
2. Run the app and make sure you're logged in to an account with a few items on Listening History
3. When the prompt appears, tap "View My 2022"
4. ✅ Check that the first story contains a "Let's celebrate..." string
5. Tap next to go to the next story
6. ✅ Check that it works
7. Advance to the last story
8. ✅ Wait for it to end, notice that the stories won't start over
9. Tap the "Replay" button
10. ✅ Check that the stories start again
11. Go back to the last story
12. ✅ Perform a swipe down in any part of the story except where the Replay button is and the stories view should be dismissed

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
