### PR TITLE
Apple SSO: Adds a Specific Error Type for token failures

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Private/TokenHelper.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Private/TokenHelper.swift
@@ -87,7 +87,7 @@ class TokenHelper {
                 completion(.success(token))
             }
             else {
-                completion(.failure(.UNKNOWN))
+                completion(.failure(.TOKEN_REFRESH_FAILED))
             }
         }
     }

--- a/Modules/Server/Sources/PocketCastsServer/Public/API/ErrorResponse.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/API/ErrorResponse.swift
@@ -25,4 +25,5 @@ public enum APIError: String, Error {
     case PROMO_CODE_EXPIRED_OR_INVALID = "promo_code_expired_or_invalid"
     case PROMO_ALREADY_REDEEMED = "promo_already_redeemed"
     case NO_CONNECTION = "no_connection" // This error doesn't map to a code provided by the API but is added locallay for client errors.
+    case TOKEN_REFRESH_FAILED = "token_refresh_failed"
 }

--- a/podcasts/ForgotPasswordViewController.swift
+++ b/podcasts/ForgotPasswordViewController.swift
@@ -106,8 +106,8 @@ class ForgotPasswordViewController: PCViewController, UITextFieldDelegate {
                 self.progressAlert = nil
 
                 if !success {
-                    if error != .UNKNOWN, let message = error?.localizedDescription, !message.isEmpty {
-                        self.showErrorMessage(message)
+                    if let error = error, !error.isGenericError, !error.localizedDescription.isEmpty {
+                        self.showErrorMessage(error.localizedDescription)
                     } else {
                         self.showErrorMessage(L10n.profileSendingResetEmailFailed)
                     }

--- a/podcasts/NewEmailViewController.swift
+++ b/podcasts/NewEmailViewController.swift
@@ -173,10 +173,10 @@ class NewEmailViewController: UIViewController, UITextFieldDelegate {
                 if !success {
                     Analytics.track(.userAccountCreationFailed, properties: ["error_code": (error ?? .UNKNOWN).rawValue])
 
-                    FileLog.shared.addMessage("Failed to register new account")
-                    if error != .UNKNOWN, let message = error?.localizedDescription, !message.isEmpty {
-                        FileLog.shared.addMessage(message)
-                        self.showErrorMessage(message)
+                    FileLog.shared.addMessage("Failed to register new account. error \(error?.description ?? "unknown")")
+                    if let error = error, !error.isGenericError, !error.localizedDescription.isEmpty {
+                        FileLog.shared.addMessage(error.localizedDescription)
+                        self.showErrorMessage(error.localizedDescription)
                     } else {
                         self.showErrorMessage(L10n.accountRegistrationFailed)
                     }

--- a/podcasts/Server+Strings.swift
+++ b/podcasts/Server+Strings.swift
@@ -22,7 +22,7 @@ public extension SubscriptionHelper {
 public extension APIError {
     var localizedDescription: String {
         switch self {
-        case .UNKNOWN: return L10n.serverErrorUnknown
+        case .UNKNOWN, .TOKEN_REFRESH_FAILED: return L10n.serverErrorUnknown
         case .INCORRECT_PASSWORD: return L10n.serverErrorLoginPasswordIncorrect
         case .PERMISSION_DENIED: return L10n.serverErrorLoginPermissionDeniedNotAdmin
         case .ACCOUNT_LOCKED: return L10n.serverErrorLoginAccountLocked
@@ -46,6 +46,15 @@ public extension APIError {
         case .PROMO_CODE_EXPIRED_OR_INVALID: return L10n.serverErrorPromoCodeExpiredOrInvalid
         case .PROMO_ALREADY_REDEEMED: return L10n.serverErrorPromoAlreadyRedeemed
         case .NO_CONNECTION: return L10n.playerErrorInternetConnection
+        }
+    }
+
+    var isGenericError: Bool {
+        switch self {
+        case .UNKNOWN, .TOKEN_REFRESH_FAILED:
+            return true
+        default:
+            return false
         }
     }
 }

--- a/podcasts/SyncSigninViewController.swift
+++ b/podcasts/SyncSigninViewController.swift
@@ -258,7 +258,7 @@ class SyncSigninViewController: PCViewController, UITextFieldDelegate {
         Analytics.track(.userSignInFailed, properties: ["source": self.authSource, "error_code": error.rawValue])
 
         var message = L10n.syncAccountError
-        if error != .UNKNOWN, !error.localizedDescription.isEmpty {
+        if !error.isGenericError, !error.localizedDescription.isEmpty {
             message = error.localizedDescription
         }
 


### PR DESCRIPTION
| 📘 Project: #381 | Depends on #410 |
|:---:|:---:|

| 📓 For Apple SSO testing: In my testing, Apple SSO didn't always return the email in the simulator, so testing with a physical device is recommended. |
|:---:|

Captures the suggestions in https://github.com/Automattic/pocket-casts-ios/pull/410#discussion_r999700174 to add a specific token error type. 

## To test

This can be tested with the steps in #410

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
