### PR TITLE
Address a couple of warnings

### DIFF
--- a/podcasts/End of Year/Stories/TopFivePodcastsStory.swift
+++ b/podcasts/End of Year/Stories/TopFivePodcastsStory.swift
@@ -57,7 +57,6 @@ struct TopFivePodcastsStory: StoryView {
 
 struct DummyStory_Previews: PreviewProvider {
     static var previews: some View {
-        let podcast = Podcast()
         TopFivePodcastsStory(podcasts: [Podcast.previewPodcast()])
     }
 }

--- a/podcasts/End of Year/Stories/TopListenedCategories.swift
+++ b/podcasts/End of Year/Stories/TopListenedCategories.swift
@@ -26,7 +26,7 @@ struct TopListenedCategories: StoryView {
                                 .resizable()
                                 .frame(width: 40, height: 40)
                                 .foregroundColor(.white)
-                            Text(listenedCategories[x].categoryTitle.localized ?? "")
+                            Text(listenedCategories[x].categoryTitle.localized)
                                 .lineLimit(2)
                                 .font(.system(size: 22, weight: .bold))
                                 .foregroundColor(.white)


### PR DESCRIPTION
Removes an unused variable and a nil-coalescing for a non-optional value.

## To test

If CI is green, this is safe to merge.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary. – N.A.
- [x] I have considered adding unit tests for my changes. – N.A.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics. – N.A.

---

Notice this PR comes from [a fork](https://github.com/mokagio/pocket-casts-ios/) of the repo. The purpose of this PR is to verify my assumption that Buildkite won't run on this PR, because we don't run it (or can't run it?) against external contributor PR.

One tell tale is that there are no "Details" links in the GitHub checks. Usually, when we create a PR, a Buildkite build starts as well and, even if the build doesn't run for a while in cases where the queue is full, we always have a link to the build in there.

<img width="1056" alt="image" src="https://user-images.githubusercontent.com/1218433/197089058-695dcfc8-3af2-4d69-aaad-59d1be9c2b13.png">
