### PR TITLE
Project member PR to run CI checks against #422

### DIFF
--- a/podcasts/End of Year/Stories/TopFivePodcastsStory.swift
+++ b/podcasts/End of Year/Stories/TopFivePodcastsStory.swift
@@ -57,7 +57,6 @@ struct TopFivePodcastsStory: StoryView {
 
 struct DummyStory_Previews: PreviewProvider {
     static var previews: some View {
-        let podcast = Podcast()
         TopFivePodcastsStory(podcasts: [Podcast.previewPodcast()])
     }
 }

--- a/podcasts/End of Year/Stories/TopListenedCategories.swift
+++ b/podcasts/End of Year/Stories/TopListenedCategories.swift
@@ -26,7 +26,7 @@ struct TopListenedCategories: StoryView {
                                 .resizable()
                                 .frame(width: 40, height: 40)
                                 .foregroundColor(.white)
-                            Text(listenedCategories[x].categoryTitle.localized ?? "")
+                            Text(listenedCategories[x].categoryTitle.localized)
                                 .lineLimit(2)
                                 .font(.system(size: 22, weight: .bold))
                                 .foregroundColor(.white)


### PR DESCRIPTION
#422 is an external contributor PR. As such, our CI doesn't run against it. To make sure all the tests and checks pass, we need to open a PR _from this repo_.

We can do that by:

1. Checking out the external contributor's repository and branch. `git remote add mokagio git@github.com:mokagio/pocket-casts-ios && git fetch mokagio && git checkout -b address-a-couple-of-warnings`
2. Creating a new branch from the external contributor one. `git checkout -b mokagio/pr-to-run-ci-in-422`
3. Pushing the new branch to this remote. `git push -u origin/mokagio/pr-to-run-ci-in-422` (assuming the name of the project's main remote is `origin` your machine)
4. Opening a PR for it

In this PR, unlike when I created #422, I can see the "Details" link to the Buildkite build:

<img width="1025" alt="image" src="https://user-images.githubusercontent.com/1218433/197090142-c640bd05-fb2d-45be-8994-3938c4c0cb18.png">

The cool thing about this approach is that, since the GitHub checks are bound to _the commit_, the checks are now listed in #422 as well, as you can see in the screenshot below where the Buildkite build number is the same as for this PR:

![image](https://user-images.githubusercontent.com/1218433/197090340-16679a70-34d5-40b2-9aa1-591a6fd7f675.png)

That means that, once CI has completed, we can safely close this PR and merge the other one, which is a nice way to give credit to external contributors. The checks status will be retained.