### PR TITLE
Modify accessibility label of ThemeableSelectionView based on its selection state

### DIFF
--- a/podcasts/ThemeableSelectionView.swift
+++ b/podcasts/ThemeableSelectionView.swift
@@ -70,11 +70,6 @@ class ThemeableSelectionView: UIView {
     }
 
     private func updateAccessibilityLabel() {
-        if unselectedAccessibilityLabel == nil {
-            unselectedAccessibilityLabel = accessibilityLabel
-        }
-        let unselectedAccessibilityLabel = self.unselectedAccessibilityLabel ?? ""
-        let selectedAccessibilityLabel = "\(L10n.statusSelected), \(unselectedAccessibilityLabel)"
-        accessibilityLabel = isSelected ? selectedAccessibilityLabel : unselectedAccessibilityLabel
+        accessibilityValue = isSelected ? L10n.statusSelected : ""
     }
 }

--- a/podcasts/ThemeableSelectionView.swift
+++ b/podcasts/ThemeableSelectionView.swift
@@ -16,7 +16,7 @@ class ThemeableSelectionView: UIView {
     var isSelected: Bool = false {
         didSet {
             updateColor()
-            updateAccessibilityLabel()
+            updateAccessibilityTraits()
         }
     }
 
@@ -67,7 +67,11 @@ class ThemeableSelectionView: UIView {
         layer.borderColor = isSelected ? AppTheme.colorForStyle(selectedStyle, themeOverride: themeOverride).cgColor : AppTheme.colorForStyle(unselectedStyle, themeOverride: themeOverride).cgColor
     }
 
-    private func updateAccessibilityLabel() {
-        accessibilityValue = isSelected ? L10n.statusSelected : ""
+    private func updateAccessibilityTraits() {
+        if isSelected {
+            accessibilityTraits.insert(.selected)
+        } else {
+            accessibilityTraits.remove(.selected)
+        }
     }
 }

--- a/podcasts/ThemeableSelectionView.swift
+++ b/podcasts/ThemeableSelectionView.swift
@@ -32,8 +32,6 @@ class ThemeableSelectionView: UIView {
         }
     }
 
-    private var unselectedAccessibilityLabel: String?
-
     override init(frame: CGRect) {
         super.init(frame: frame)
 

--- a/podcasts/ThemeableSelectionView.swift
+++ b/podcasts/ThemeableSelectionView.swift
@@ -16,6 +16,7 @@ class ThemeableSelectionView: UIView {
     var isSelected: Bool = false {
         didSet {
             updateColor()
+            updateAccessibilityLabel()
         }
     }
 
@@ -30,6 +31,8 @@ class ThemeableSelectionView: UIView {
             updateColor()
         }
     }
+
+    private var unselectedAccessibilityLabel: String?
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -64,5 +67,14 @@ class ThemeableSelectionView: UIView {
     private func updateColor() {
         backgroundColor = AppTheme.colorForStyle(style, themeOverride: themeOverride)
         layer.borderColor = isSelected ? AppTheme.colorForStyle(selectedStyle, themeOverride: themeOverride).cgColor : AppTheme.colorForStyle(unselectedStyle, themeOverride: themeOverride).cgColor
+    }
+
+    private func updateAccessibilityLabel() {
+        if unselectedAccessibilityLabel == nil {
+            unselectedAccessibilityLabel = accessibilityLabel
+        }
+        let unselectedAccessibilityLabel = self.unselectedAccessibilityLabel ?? ""
+        let selectedAccessibilityLabel = "\(L10n.statusSelected), \(unselectedAccessibilityLabel)"
+        accessibilityLabel = isSelected ? selectedAccessibilityLabel : unselectedAccessibilityLabel
     }
 }


### PR DESCRIPTION
When user was creating a new account, plan selection was not indicated to VoiceOver users. When user taps "regular" or "plus" account, VoiceOver now  prefixes with word "selected" if that plan is selected. This is inspired by UIButton selection state.

## To test
1. Turn voiceover on
2. Go to profile
3. Tap create account
4. Navigate with voiceover

If selected plan is regular, voiceover should say "Selected, Regular". If regular is not selected, voiceover should just read the accessibility label "regular". Same of course applies for the plus plan.

