### PR TITLE
End of Year: refactor data source

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -43,6 +43,11 @@ public class DataManager {
         upNextManager.setup(dbQueue: dbQueue)
     }
 
+    convenience init(endOfYearManager: EndOfYearDataManager) {
+        self.init()
+        self.endOfYearManager = endOfYearManager
+    }
+
     // MARK: - Up Next
 
     public func allUpNextPlaylistEpisodes() -> [PlaylistEpisode] {

--- a/PocketCastsTests/Mocks/EndOfYearManagerMock.swift
+++ b/PocketCastsTests/Mocks/EndOfYearManagerMock.swift
@@ -12,6 +12,8 @@ class EndOfYearManagerMock: EndOfYearDataManager {
 
     var topPodcastsToReturn: [TopPodcast] = []
 
+    var longestEpisodeToReturn: Episode?
+
     override func listeningTime(dbQueue: FMDatabaseQueue) -> Double? {
         listeningTimeToReturn
     }
@@ -26,5 +28,9 @@ class EndOfYearManagerMock: EndOfYearDataManager {
 
     override func topPodcasts(dbQueue: FMDatabaseQueue, limit: Int = 5) -> [TopPodcast] {
         topPodcastsToReturn
+    }
+
+    override func longestEpisode(dbQueue: FMDatabaseQueue) -> Episode? {
+        return longestEpisodeToReturn
     }
 }

--- a/PocketCastsTests/Mocks/EndOfYearManagerMock.swift
+++ b/PocketCastsTests/Mocks/EndOfYearManagerMock.swift
@@ -8,11 +8,17 @@ class EndOfYearManagerMock: EndOfYearDataManager {
 
     var listenedCategoriesToReturn: [ListenedCategory] = []
 
+    var listenedNumbersToReturn: ListenedNumbers?
+
     override func listeningTime(dbQueue: FMDatabaseQueue) -> Double? {
         return listeningTimeToReturn
     }
 
     override func listenedCategories(dbQueue: FMDatabaseQueue) -> [ListenedCategory] {
         return listenedCategoriesToReturn
+    }
+
+    override func listenedNumbers(dbQueue: FMDatabaseQueue) -> ListenedNumbers {
+        return listenedNumbersToReturn!
     }
 }

--- a/PocketCastsTests/Mocks/EndOfYearManagerMock.swift
+++ b/PocketCastsTests/Mocks/EndOfYearManagerMock.swift
@@ -10,15 +10,21 @@ class EndOfYearManagerMock: EndOfYearDataManager {
 
     var listenedNumbersToReturn: ListenedNumbers?
 
+    var topPodcastsToReturn: [TopPodcast] = []
+
     override func listeningTime(dbQueue: FMDatabaseQueue) -> Double? {
-        return listeningTimeToReturn
+        listeningTimeToReturn
     }
 
     override func listenedCategories(dbQueue: FMDatabaseQueue) -> [ListenedCategory] {
-        return listenedCategoriesToReturn
+        listenedCategoriesToReturn
     }
 
     override func listenedNumbers(dbQueue: FMDatabaseQueue) -> ListenedNumbers {
-        return listenedNumbersToReturn ?? ListenedNumbers(numberOfPodcasts: 0, numberOfEpisodes: 0)
+        listenedNumbersToReturn ?? ListenedNumbers(numberOfPodcasts: 0, numberOfEpisodes: 0)
+    }
+
+    override func topPodcasts(dbQueue: FMDatabaseQueue, limit: Int = 5) -> [TopPodcast] {
+        topPodcastsToReturn
     }
 }

--- a/PocketCastsTests/Mocks/EndOfYearManagerMock.swift
+++ b/PocketCastsTests/Mocks/EndOfYearManagerMock.swift
@@ -19,6 +19,6 @@ class EndOfYearManagerMock: EndOfYearDataManager {
     }
 
     override func listenedNumbers(dbQueue: FMDatabaseQueue) -> ListenedNumbers {
-        return listenedNumbersToReturn!
+        return listenedNumbersToReturn ?? ListenedNumbers(numberOfPodcasts: 0, numberOfEpisodes: 0)
     }
 }

--- a/PocketCastsTests/Mocks/EndOfYearManagerMock.swift
+++ b/PocketCastsTests/Mocks/EndOfYearManagerMock.swift
@@ -1,0 +1,12 @@
+import Foundation
+import FMDB
+
+@testable import PocketCastsDataModel
+
+class EndOfYearManagerMock: EndOfYearDataManager {
+    var listeningTimeToReturn: Double = 0
+
+    override func listeningTime(dbQueue: FMDatabaseQueue) -> Double? {
+        return listeningTimeToReturn
+    }
+}

--- a/PocketCastsTests/Mocks/EndOfYearManagerMock.swift
+++ b/PocketCastsTests/Mocks/EndOfYearManagerMock.swift
@@ -6,7 +6,13 @@ import FMDB
 class EndOfYearManagerMock: EndOfYearDataManager {
     var listeningTimeToReturn: Double = 0
 
+    var listenedCategoriesToReturn: [ListenedCategory] = []
+
     override func listeningTime(dbQueue: FMDatabaseQueue) -> Double? {
         return listeningTimeToReturn
+    }
+
+    override func listenedCategories(dbQueue: FMDatabaseQueue) -> [ListenedCategory] {
+        return listenedCategoriesToReturn
     }
 }

--- a/PocketCastsTests/Tests/End of Year/EndOfYearStoriesBuilderTests.swift
+++ b/PocketCastsTests/Tests/End of Year/EndOfYearStoriesBuilderTests.swift
@@ -1,9 +1,18 @@
 import XCTest
 
 @testable import podcasts
+@testable import PocketCastsDataModel
 
 class EndOfYearStoriesBuilderTests: XCTestCase {
-    func testSomething() {
-        let builder = EndOfYearStoriesBuilder(dataManager: DataManagerMock())
+    func testReturnListeningTimeStoryIfBiggerThanZero() async {
+        let endOfYearManager = EndOfYearManagerMock()
+        let dataManager = DataManagerMock(endOfYearManager: endOfYearManager)
+        let builder = EndOfYearStoriesBuilder(dataManager: dataManager)
+
+        endOfYearManager.listeningTimeToReturn = 3000
+        let stories = await builder.build()
+
+        XCTAssertEqual(stories.0.first, EndOfYearStory.listeningTime)
+        XCTAssertEqual(stories.1.listeningTime, 3000)
     }
 }

--- a/PocketCastsTests/Tests/End of Year/EndOfYearStoriesBuilderTests.swift
+++ b/PocketCastsTests/Tests/End of Year/EndOfYearStoriesBuilderTests.swift
@@ -1,0 +1,9 @@
+import XCTest
+
+@testable import podcasts
+
+class EndOfYearStoriesBuilderTests: XCTestCase {
+    func testSomething() {
+        let builder = EndOfYearStoriesBuilder(dataManager: DataManagerMock())
+    }
+}

--- a/PocketCastsTests/Tests/End of Year/EndOfYearStoriesBuilderTests.swift
+++ b/PocketCastsTests/Tests/End of Year/EndOfYearStoriesBuilderTests.swift
@@ -81,4 +81,35 @@ class EndOfYearStoriesBuilderTests: XCTestCase {
         XCTAssertFalse(stories.0.contains(.listenedNumbers))
         XCTAssertNil(stories.1.listenedNumbers)
     }
+
+    func testReturnTopOnePodcast() async {
+        let endOfYearManager = EndOfYearManagerMock()
+        let dataManager = DataManagerMock(endOfYearManager: endOfYearManager)
+        let builder = EndOfYearStoriesBuilder(dataManager: dataManager)
+
+        endOfYearManager.topPodcastsToReturn = [
+            TopPodcast(podcast: Podcast.previewPodcast(),
+                       numberOfPlayedEpisodes: 3,
+                       totalPlayedTime: 3000)
+        ]
+        let stories = await builder.build()
+
+        XCTAssertEqual(stories.0.first, EndOfYearStory.topOnePodcast)
+        XCTAssertEqual(stories.1.topPodcasts.count, 1)
+        XCTAssertNotNil(stories.1.topPodcasts.first?.podcast)
+        XCTAssertEqual(stories.1.topPodcasts.first?.numberOfPlayedEpisodes, 3)
+        XCTAssertEqual(stories.1.topPodcasts.first?.totalPlayedTime, 3000)
+    }
+
+    func testDontReturnTopOnePodcast() async {
+        let endOfYearManager = EndOfYearManagerMock()
+        let dataManager = DataManagerMock(endOfYearManager: endOfYearManager)
+        let builder = EndOfYearStoriesBuilder(dataManager: dataManager)
+
+        endOfYearManager.topPodcastsToReturn = []
+        let stories = await builder.build()
+
+        XCTAssertFalse(stories.0.contains(.topOnePodcast))
+        XCTAssertEqual(stories.1.topPodcasts.count, 0)
+    }
 }

--- a/PocketCastsTests/Tests/End of Year/EndOfYearStoriesBuilderTests.swift
+++ b/PocketCastsTests/Tests/End of Year/EndOfYearStoriesBuilderTests.swift
@@ -69,4 +69,16 @@ class EndOfYearStoriesBuilderTests: XCTestCase {
         XCTAssertEqual(stories.1.listenedNumbers.numberOfPodcasts, 3)
         XCTAssertEqual(stories.1.listenedNumbers.numberOfEpisodes, 10)
     }
+
+    func testDontReturnListenedPodcastsAndEpisodes() async {
+        let endOfYearManager = EndOfYearManagerMock()
+        let dataManager = DataManagerMock(endOfYearManager: endOfYearManager)
+        let builder = EndOfYearStoriesBuilder(dataManager: dataManager)
+
+        endOfYearManager.listenedNumbersToReturn = ListenedNumbers(numberOfPodcasts: 0, numberOfEpisodes: 0)
+        let stories = await builder.build()
+
+        XCTAssertFalse(stories.0.contains(.listenedNumbers))
+        XCTAssertNil(stories.1.listenedNumbers)
+    }
 }

--- a/PocketCastsTests/Tests/End of Year/EndOfYearStoriesBuilderTests.swift
+++ b/PocketCastsTests/Tests/End of Year/EndOfYearStoriesBuilderTests.swift
@@ -145,6 +145,20 @@ class EndOfYearStoriesBuilderTests: XCTestCase {
         XCTAssertNotNil(stories.1.longestEpisode)
         XCTAssertNotNil(stories.1.longestEpisodePodcast)
     }
+
+    func testDontReturnLongestEpisode() async {
+        let endOfYearManager = EndOfYearManagerMock()
+        let dataManager = DataManagerMock(endOfYearManager: endOfYearManager)
+        let builder = EndOfYearStoriesBuilder(dataManager: dataManager)
+
+        let episode = EpisodeMock()
+        endOfYearManager.longestEpisodeToReturn = nil
+        let stories = await builder.build()
+
+        XCTAssertFalse(stories.0.contains(.longestEpisode))
+        XCTAssertNil(stories.1.longestEpisode)
+        XCTAssertNil(stories.1.longestEpisodePodcast)
+    }
 }
 
 private class EpisodeMock: Episode {

--- a/PocketCastsTests/Tests/End of Year/EndOfYearStoriesBuilderTests.swift
+++ b/PocketCastsTests/Tests/End of Year/EndOfYearStoriesBuilderTests.swift
@@ -12,7 +12,7 @@ class EndOfYearStoriesBuilderTests: XCTestCase {
         endOfYearManager.listeningTimeToReturn = 3000
         let stories = await builder.build()
 
-        XCTAssertFalse(stories.0.contains(.listeningTime))
+        XCTAssertTrue(stories.0.contains(.listeningTime))
         XCTAssertEqual(stories.1.listeningTime, 3000)
     }
 
@@ -42,5 +42,18 @@ class EndOfYearStoriesBuilderTests: XCTestCase {
         XCTAssertEqual(stories.0[1], EndOfYearStory.topFiveCategories)
         XCTAssertEqual(stories.1.listenedCategories.first?.numberOfPodcasts, 1)
         XCTAssertEqual(stories.1.listenedCategories.first?.numberOfPodcasts, 1)
+    }
+
+    func testDontReturnListenedCategoriesIfEmpty() async {
+        let endOfYearManager = EndOfYearManagerMock()
+        let dataManager = DataManagerMock(endOfYearManager: endOfYearManager)
+        let builder = EndOfYearStoriesBuilder(dataManager: dataManager)
+
+        endOfYearManager.listenedCategoriesToReturn = []
+        let stories = await builder.build()
+
+        XCTAssertFalse(stories.0.contains(.listenedCategories))
+        XCTAssertFalse(stories.0.contains(.topFiveCategories))
+        XCTAssertTrue(stories.1.listenedCategories.isEmpty)
     }
 }

--- a/PocketCastsTests/Tests/End of Year/EndOfYearStoriesBuilderTests.swift
+++ b/PocketCastsTests/Tests/End of Year/EndOfYearStoriesBuilderTests.swift
@@ -112,4 +112,23 @@ class EndOfYearStoriesBuilderTests: XCTestCase {
         XCTAssertFalse(stories.0.contains(.topOnePodcast))
         XCTAssertEqual(stories.1.topPodcasts.count, 0)
     }
+
+    func testReturnTopFivePodcasts() async {
+        let endOfYearManager = EndOfYearManagerMock()
+        let dataManager = DataManagerMock(endOfYearManager: endOfYearManager)
+        let builder = EndOfYearStoriesBuilder(dataManager: dataManager)
+
+        endOfYearManager.topPodcastsToReturn = [
+            TopPodcast(podcast: Podcast.previewPodcast(),
+                       numberOfPlayedEpisodes: 3,
+                       totalPlayedTime: 3000),
+            TopPodcast(podcast: Podcast.previewPodcast(),
+                       numberOfPlayedEpisodes: 10,
+                       totalPlayedTime: 4000)
+        ]
+        let stories = await builder.build()
+
+        XCTAssertEqual(stories.0[1], EndOfYearStory.topFivePodcasts)
+        XCTAssertEqual(stories.1.topPodcasts.count, 2)
+    }
 }

--- a/PocketCastsTests/Tests/End of Year/EndOfYearStoriesBuilderTests.swift
+++ b/PocketCastsTests/Tests/End of Year/EndOfYearStoriesBuilderTests.swift
@@ -131,4 +131,24 @@ class EndOfYearStoriesBuilderTests: XCTestCase {
         XCTAssertEqual(stories.0[1], EndOfYearStory.topFivePodcasts)
         XCTAssertEqual(stories.1.topPodcasts.count, 2)
     }
+
+    func testReturnLongestEpisode() async {
+        let endOfYearManager = EndOfYearManagerMock()
+        let dataManager = DataManagerMock(endOfYearManager: endOfYearManager)
+        let builder = EndOfYearStoriesBuilder(dataManager: dataManager)
+
+        let episode = EpisodeMock()
+        endOfYearManager.longestEpisodeToReturn = episode
+        let stories = await builder.build()
+
+        XCTAssertEqual(stories.0.first, EndOfYearStory.longestEpisode)
+        XCTAssertNotNil(stories.1.longestEpisode)
+        XCTAssertNotNil(stories.1.longestEpisodePodcast)
+    }
+}
+
+private class EpisodeMock: Episode {
+    override func parentPodcast() -> Podcast? {
+        return Podcast.previewPodcast()
+    }
 }

--- a/PocketCastsTests/Tests/End of Year/EndOfYearStoriesBuilderTests.swift
+++ b/PocketCastsTests/Tests/End of Year/EndOfYearStoriesBuilderTests.swift
@@ -12,7 +12,7 @@ class EndOfYearStoriesBuilderTests: XCTestCase {
         endOfYearManager.listeningTimeToReturn = 3000
         let stories = await builder.build()
 
-        XCTAssertEqual(stories.0.first, EndOfYearStory.listeningTime)
+        XCTAssertFalse(stories.0.contains(.listeningTime))
         XCTAssertEqual(stories.1.listeningTime, 3000)
     }
 
@@ -26,5 +26,21 @@ class EndOfYearStoriesBuilderTests: XCTestCase {
 
         XCTAssertFalse(stories.0.contains(.listeningTime))
         XCTAssertEqual(stories.1.listeningTime, 0)
+    }
+
+    func testReturnListenedCategories() async {
+        let endOfYearManager = EndOfYearManagerMock()
+        let dataManager = DataManagerMock(endOfYearManager: endOfYearManager)
+        let builder = EndOfYearStoriesBuilder(dataManager: dataManager)
+
+        endOfYearManager.listenedCategoriesToReturn = [
+            ListenedCategory(numberOfPodcasts: 1, categoryTitle: "title")
+        ]
+        let stories = await builder.build()
+
+        XCTAssertEqual(stories.0.first, EndOfYearStory.listenedCategories)
+        XCTAssertEqual(stories.0[1], EndOfYearStory.topFiveCategories)
+        XCTAssertEqual(stories.1.listenedCategories.first?.numberOfPodcasts, 1)
+        XCTAssertEqual(stories.1.listenedCategories.first?.numberOfPodcasts, 1)
     }
 }

--- a/PocketCastsTests/Tests/End of Year/EndOfYearStoriesBuilderTests.swift
+++ b/PocketCastsTests/Tests/End of Year/EndOfYearStoriesBuilderTests.swift
@@ -56,4 +56,17 @@ class EndOfYearStoriesBuilderTests: XCTestCase {
         XCTAssertFalse(stories.0.contains(.topFiveCategories))
         XCTAssertTrue(stories.1.listenedCategories.isEmpty)
     }
+
+    func testReturnListenedPodcastsAndEpisodes() async {
+        let endOfYearManager = EndOfYearManagerMock()
+        let dataManager = DataManagerMock(endOfYearManager: endOfYearManager)
+        let builder = EndOfYearStoriesBuilder(dataManager: dataManager)
+
+        endOfYearManager.listenedNumbersToReturn = ListenedNumbers(numberOfPodcasts: 3, numberOfEpisodes: 10)
+        let stories = await builder.build()
+
+        XCTAssertEqual(stories.0.first, EndOfYearStory.listenedNumbers)
+        XCTAssertEqual(stories.1.listenedNumbers.numberOfPodcasts, 3)
+        XCTAssertEqual(stories.1.listenedNumbers.numberOfEpisodes, 10)
+    }
 }

--- a/PocketCastsTests/Tests/End of Year/EndOfYearStoriesBuilderTests.swift
+++ b/PocketCastsTests/Tests/End of Year/EndOfYearStoriesBuilderTests.swift
@@ -15,4 +15,16 @@ class EndOfYearStoriesBuilderTests: XCTestCase {
         XCTAssertEqual(stories.0.first, EndOfYearStory.listeningTime)
         XCTAssertEqual(stories.1.listeningTime, 3000)
     }
+
+    func testDontReturnListeningTimeStoryIfZero() async {
+        let endOfYearManager = EndOfYearManagerMock()
+        let dataManager = DataManagerMock(endOfYearManager: endOfYearManager)
+        let builder = EndOfYearStoriesBuilder(dataManager: dataManager)
+
+        endOfYearManager.listeningTimeToReturn = 0
+        let stories = await builder.build()
+
+        XCTAssertFalse(stories.0.contains(.listeningTime))
+        XCTAssertEqual(stories.1.listeningTime, 0)
+    }
 }

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -456,6 +456,7 @@
 		8B1C974628FE1C7E00BD5EB9 /* ImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B1C974528FE1C7E00BD5EB9 /* ImageView.swift */; };
 		8B1C974828FE234B00BD5EB9 /* View+Snapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B1C974728FE234B00BD5EB9 /* View+Snapshot.swift */; };
 		8B23193F2902C84A0001C3DE /* EndOfYearStoriesBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B23193E2902C84A0001C3DE /* EndOfYearStoriesBuilder.swift */; };
+		8B2319412902C8FE0001C3DE /* EndOfYearStoriesBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B2319402902C8FE0001C3DE /* EndOfYearStoriesBuilderTests.swift */; };
 		8B2E055028F8579700C2DBDE /* StoriesModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B2E054F28F8579700C2DBDE /* StoriesModelTests.swift */; };
 		8B2E055228F88D7300C2DBDE /* EndOfYearPromptCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B2E055128F88D7300C2DBDE /* EndOfYearPromptCell.swift */; };
 		8B2E055428F891F900C2DBDE /* EndOfYearCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B2E055328F891F900C2DBDE /* EndOfYearCard.swift */; };
@@ -1999,6 +2000,7 @@
 		8B1C974528FE1C7E00BD5EB9 /* ImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageView.swift; sourceTree = "<group>"; };
 		8B1C974728FE234B00BD5EB9 /* View+Snapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Snapshot.swift"; sourceTree = "<group>"; };
 		8B23193E2902C84A0001C3DE /* EndOfYearStoriesBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndOfYearStoriesBuilder.swift; sourceTree = "<group>"; };
+		8B2319402902C8FE0001C3DE /* EndOfYearStoriesBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndOfYearStoriesBuilderTests.swift; sourceTree = "<group>"; };
 		8B2E054F28F8579700C2DBDE /* StoriesModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoriesModelTests.swift; sourceTree = "<group>"; };
 		8B2E055128F88D7300C2DBDE /* EndOfYearPromptCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndOfYearPromptCell.swift; sourceTree = "<group>"; };
 		8B2E055328F891F900C2DBDE /* EndOfYearCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndOfYearCard.swift; sourceTree = "<group>"; };
@@ -3658,6 +3660,7 @@
 			isa = PBXGroup;
 			children = (
 				8B2E054F28F8579700C2DBDE /* StoriesModelTests.swift */,
+				8B2319402902C8FE0001C3DE /* EndOfYearStoriesBuilderTests.swift */,
 			);
 			path = "End of Year";
 			sourceTree = "<group>";
@@ -7149,6 +7152,7 @@
 				8BA55A1328CA7425002BECC5 /* XCTestCase+eventually.swift in Sources */,
 				C7D854F328ADD98700877E87 /* AppLifecyleAnalyticsTests.swift in Sources */,
 				C79E1E4028887549008524CB /* PlusUpgradeViewSourceTests.swift in Sources */,
+				8B2319412902C8FE0001C3DE /* EndOfYearStoriesBuilderTests.swift in Sources */,
 				8BF0BBD92891AFB5006BBECF /* PodcastBuilder.swift in Sources */,
 				8B2E055028F8579700C2DBDE /* StoriesModelTests.swift in Sources */,
 				C7F4BAB728DA8666001C9785 /* BackgroundSignOutListenerTests.swift in Sources */,

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -457,6 +457,7 @@
 		8B1C974828FE234B00BD5EB9 /* View+Snapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B1C974728FE234B00BD5EB9 /* View+Snapshot.swift */; };
 		8B23193F2902C84A0001C3DE /* EndOfYearStoriesBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B23193E2902C84A0001C3DE /* EndOfYearStoriesBuilder.swift */; };
 		8B2319412902C8FE0001C3DE /* EndOfYearStoriesBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B2319402902C8FE0001C3DE /* EndOfYearStoriesBuilderTests.swift */; };
+		8B2319432902CF170001C3DE /* EndOfYearManagerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B2319422902CF170001C3DE /* EndOfYearManagerMock.swift */; };
 		8B2E055028F8579700C2DBDE /* StoriesModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B2E054F28F8579700C2DBDE /* StoriesModelTests.swift */; };
 		8B2E055228F88D7300C2DBDE /* EndOfYearPromptCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B2E055128F88D7300C2DBDE /* EndOfYearPromptCell.swift */; };
 		8B2E055428F891F900C2DBDE /* EndOfYearCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B2E055328F891F900C2DBDE /* EndOfYearCard.swift */; };
@@ -2001,6 +2002,7 @@
 		8B1C974728FE234B00BD5EB9 /* View+Snapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Snapshot.swift"; sourceTree = "<group>"; };
 		8B23193E2902C84A0001C3DE /* EndOfYearStoriesBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndOfYearStoriesBuilder.swift; sourceTree = "<group>"; };
 		8B2319402902C8FE0001C3DE /* EndOfYearStoriesBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndOfYearStoriesBuilderTests.swift; sourceTree = "<group>"; };
+		8B2319422902CF170001C3DE /* EndOfYearManagerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndOfYearManagerMock.swift; sourceTree = "<group>"; };
 		8B2E054F28F8579700C2DBDE /* StoriesModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoriesModelTests.swift; sourceTree = "<group>"; };
 		8B2E055128F88D7300C2DBDE /* EndOfYearPromptCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndOfYearPromptCell.swift; sourceTree = "<group>"; };
 		8B2E055328F891F900C2DBDE /* EndOfYearCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndOfYearCard.swift; sourceTree = "<group>"; };
@@ -3799,6 +3801,7 @@
 				8BF0BBDA2891B038006BBECF /* FolderBuilder.swift */,
 				8BF0BBD82891AFB5006BBECF /* PodcastBuilder.swift */,
 				8B484EFE28D257E2001AFA97 /* DataManagerMock.swift */,
+				8B2319422902CF170001C3DE /* EndOfYearManagerMock.swift */,
 				8B484EFC28D2574D001AFA97 /* EpisodeBuilder.swift */,
 			);
 			path = Mocks;
@@ -7143,6 +7146,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				8B317BA528906CAB00A26A13 /* TestingSceneDelegate.swift in Sources */,
+				8B2319432902CF170001C3DE /* EndOfYearManagerMock.swift in Sources */,
 				8B317BA328906C8100A26A13 /* TestingAppDelegate.swift in Sources */,
 				8B484EFD28D2574D001AFA97 /* EpisodeBuilder.swift in Sources */,
 				8B484EFB28D25719001AFA97 /* Double+Ext.swift in Sources */,

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -455,6 +455,7 @@
 		8B10E78A28D9094A00702C54 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 8B10E78528D908A900702C54 /* GoogleService-Info.plist */; };
 		8B1C974628FE1C7E00BD5EB9 /* ImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B1C974528FE1C7E00BD5EB9 /* ImageView.swift */; };
 		8B1C974828FE234B00BD5EB9 /* View+Snapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B1C974728FE234B00BD5EB9 /* View+Snapshot.swift */; };
+		8B23193F2902C84A0001C3DE /* EndOfYearStoriesBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B23193E2902C84A0001C3DE /* EndOfYearStoriesBuilder.swift */; };
 		8B2E055028F8579700C2DBDE /* StoriesModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B2E054F28F8579700C2DBDE /* StoriesModelTests.swift */; };
 		8B2E055228F88D7300C2DBDE /* EndOfYearPromptCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B2E055128F88D7300C2DBDE /* EndOfYearPromptCell.swift */; };
 		8B2E055428F891F900C2DBDE /* EndOfYearCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B2E055328F891F900C2DBDE /* EndOfYearCard.swift */; };
@@ -1997,6 +1998,7 @@
 		8B10E78528D908A900702C54 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		8B1C974528FE1C7E00BD5EB9 /* ImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageView.swift; sourceTree = "<group>"; };
 		8B1C974728FE234B00BD5EB9 /* View+Snapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Snapshot.swift"; sourceTree = "<group>"; };
+		8B23193E2902C84A0001C3DE /* EndOfYearStoriesBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndOfYearStoriesBuilder.swift; sourceTree = "<group>"; };
 		8B2E054F28F8579700C2DBDE /* StoriesModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoriesModelTests.swift; sourceTree = "<group>"; };
 		8B2E055128F88D7300C2DBDE /* EndOfYearPromptCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndOfYearPromptCell.swift; sourceTree = "<group>"; };
 		8B2E055328F891F900C2DBDE /* EndOfYearCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndOfYearCard.swift; sourceTree = "<group>"; };
@@ -3728,6 +3730,7 @@
 				8BCB22B528F48A4E001A0315 /* Views */,
 				8B9D459D28F9ACFB0034219E /* Stories */,
 				8BCB22B328F48282001A0315 /* EndOfYear.swift */,
+				8B23193E2902C84A0001C3DE /* EndOfYearStoriesBuilder.swift */,
 				8B5AB48B29018EFA0018C637 /* StoriesConfiguration.swift */,
 				8B6B68E428F744520032BFFF /* StoriesDataSource.swift */,
 				8B5AB48D2901A8BD0018C637 /* StoriesController.swift */,
@@ -7391,6 +7394,7 @@
 				46851BB72790D5E00065C8B2 /* PodcastCollectionColors+Helpers.swift in Sources */,
 				C72CED2F289DA1650017883A /* String+Analytics.swift in Sources */,
 				BD0B68742203EFCC002CCE3F /* EpisodeLimitCell.swift in Sources */,
+				8B23193F2902C84A0001C3DE /* EndOfYearStoriesBuilder.swift in Sources */,
 				C7AF5789289C60B70089E435 /* FeatureFlag.swift in Sources */,
 				BD36F3CE21882B87005E0BB2 /* ThemeSecondaryIcon.swift in Sources */,
 				BDC692831BA7B0B70023B9F2 /* TinyPageControl.swift in Sources */,

--- a/podcasts/End of Year/EndOfYearStoriesBuilder.swift
+++ b/podcasts/End of Year/EndOfYearStoriesBuilder.swift
@@ -59,6 +59,11 @@ class EndOfYearStoriesBuilder {
                 stories.append(.topOnePodcast)
             }
 
+            // Top 5 podcasts
+            if topPodcasts.count > 1 {
+                stories.append(.topFivePodcasts)
+            }
+
             continuation.resume(returning: (stories, data))
         }
     }

--- a/podcasts/End of Year/EndOfYearStoriesBuilder.swift
+++ b/podcasts/End of Year/EndOfYearStoriesBuilder.swift
@@ -29,10 +29,19 @@ class EndOfYearStoriesBuilder {
     // Call this method to build the list of stories and the data provider
     func build() async -> ([EndOfYearStory], EndOfYearStoriesData) {
         await withCheckedContinuation { continuation in
+            // Listening time
             if let listeningTime = dataManager.listeningTime(),
                 listeningTime > 0 {
                 stories.append(.listeningTime)
                 data.listeningTime = listeningTime
+            }
+
+            // Listened categories
+            let listenedCategories = dataManager.listenedCategories()
+            if !listenedCategories.isEmpty {
+                data.listenedCategories = listenedCategories
+                stories.append(.listenedCategories)
+                stories.append(.topFiveCategories)
             }
 
             continuation.resume(returning: (stories, data))
@@ -43,4 +52,6 @@ class EndOfYearStoriesBuilder {
 /// An entity that holds data to present EoY stories
 class EndOfYearStoriesData {
     var listeningTime: Double = 0
+
+    var listenedCategories: [ListenedCategory] = []
 }

--- a/podcasts/End of Year/EndOfYearStoriesBuilder.swift
+++ b/podcasts/End of Year/EndOfYearStoriesBuilder.swift
@@ -1,6 +1,19 @@
 import Foundation
 import PocketCastsDataModel
 
+/// The available stories for EoY
+enum EndOfYearStory {
+    case intro
+    case listeningTime
+    case listenedCategories
+    case topFiveCategories
+    case listenedNumbers
+    case topOnePodcast
+    case topFivePodcasts
+    case longestEpisode
+    case epilogue
+}
+
 /// Build the list of stories for End of Year alongside the data
 class EndOfYearStoriesBuilder {
     private let dataManager: DataManager

--- a/podcasts/End of Year/EndOfYearStoriesBuilder.swift
+++ b/podcasts/End of Year/EndOfYearStoriesBuilder.swift
@@ -64,6 +64,13 @@ class EndOfYearStoriesBuilder {
                 stories.append(.topFivePodcasts)
             }
 
+            if let longestEpisode = dataManager.longestEpisode(),
+               let podcast = longestEpisode.parentPodcast() {
+                data.longestEpisode = longestEpisode
+                data.longestEpisodePodcast = podcast
+                stories.append(.longestEpisode)
+            }
+
             continuation.resume(returning: (stories, data))
         }
     }
@@ -78,4 +85,8 @@ class EndOfYearStoriesData {
     var listenedNumbers: ListenedNumbers!
 
     var topPodcasts: [TopPodcast] = []
+
+    var longestEpisode: Episode!
+
+    var longestEpisodePodcast: Podcast!
 }

--- a/podcasts/End of Year/EndOfYearStoriesBuilder.swift
+++ b/podcasts/End of Year/EndOfYearStoriesBuilder.swift
@@ -26,7 +26,7 @@ class EndOfYearStoriesBuilder {
         self.dataManager = dataManager
     }
 
-    // Call this method to build the list of stories and the data provider
+    /// Call this method to build the list of stories and the data provider
     func build() async -> ([EndOfYearStory], EndOfYearStoriesData) {
         await withCheckedContinuation { continuation in
             // Listening time

--- a/podcasts/End of Year/EndOfYearStoriesBuilder.swift
+++ b/podcasts/End of Year/EndOfYearStoriesBuilder.swift
@@ -64,6 +64,7 @@ class EndOfYearStoriesBuilder {
                 stories.append(.topFivePodcasts)
             }
 
+            // Longest episode
             if let longestEpisode = dataManager.longestEpisode(),
                let podcast = longestEpisode.parentPodcast() {
                 data.longestEpisode = longestEpisode

--- a/podcasts/End of Year/EndOfYearStoriesBuilder.swift
+++ b/podcasts/End of Year/EndOfYearStoriesBuilder.swift
@@ -52,6 +52,13 @@ class EndOfYearStoriesBuilder {
                 stories.append(.listenedNumbers)
             }
 
+            // Top podcasts
+            let topPodcasts = dataManager.topPodcasts()
+            if !topPodcasts.isEmpty {
+                data.topPodcasts = topPodcasts
+                stories.append(.topOnePodcast)
+            }
+
             continuation.resume(returning: (stories, data))
         }
     }
@@ -64,4 +71,6 @@ class EndOfYearStoriesData {
     var listenedCategories: [ListenedCategory] = []
 
     var listenedNumbers: ListenedNumbers!
+
+    var topPodcasts: [TopPodcast] = []
 }

--- a/podcasts/End of Year/EndOfYearStoriesBuilder.swift
+++ b/podcasts/End of Year/EndOfYearStoriesBuilder.swift
@@ -18,13 +18,25 @@ enum EndOfYearStory {
 class EndOfYearStoriesBuilder {
     private let dataManager: DataManager
 
+    private var stories: [EndOfYearStory] = []
+
+    private let data = EndOfYearStoriesData()
+
     init(dataManager: DataManager = DataManager.sharedManager) {
         self.dataManager = dataManager
     }
 
     // Call this method to build the list of stories and the data provider
-    func build() async {
+    func build() async -> ([EndOfYearStory], EndOfYearStoriesData) {
+        await withCheckedContinuation { continuation in
+            if let listeningTime = dataManager.listeningTime(),
+                listeningTime > 0 {
+                stories.append(.listeningTime)
+                data.listeningTime = listeningTime
+            }
 
+            continuation.resume(returning: (stories, data))
+        }
     }
 }
 

--- a/podcasts/End of Year/EndOfYearStoriesBuilder.swift
+++ b/podcasts/End of Year/EndOfYearStoriesBuilder.swift
@@ -27,3 +27,8 @@ class EndOfYearStoriesBuilder {
 
     }
 }
+
+/// An entity that holds data to present EoY stories
+class EndOfYearStoriesData {
+    var listeningTime: Double = 0
+}

--- a/podcasts/End of Year/EndOfYearStoriesBuilder.swift
+++ b/podcasts/End of Year/EndOfYearStoriesBuilder.swift
@@ -1,6 +1,16 @@
 import Foundation
+import PocketCastsDataModel
 
 /// Build the list of stories for End of Year alongside the data
 class EndOfYearStoriesBuilder {
-    
+    private let dataManager: DataManager
+
+    init(dataManager: DataManager = DataManager.sharedManager) {
+        self.dataManager = dataManager
+    }
+
+    // Call this method to build the list of stories and the data provider
+    func build() async {
+
+    }
 }

--- a/podcasts/End of Year/EndOfYearStoriesBuilder.swift
+++ b/podcasts/End of Year/EndOfYearStoriesBuilder.swift
@@ -44,6 +44,14 @@ class EndOfYearStoriesBuilder {
                 stories.append(.topFiveCategories)
             }
 
+            // Listened podcasts and episodes
+            let listenedNumbers = dataManager.listenedNumbers()
+            if listenedNumbers.numberOfEpisodes > 0
+                && listenedNumbers.numberOfPodcasts > 0 {
+                data.listenedNumbers = listenedNumbers
+                stories.append(.listenedNumbers)
+            }
+
             continuation.resume(returning: (stories, data))
         }
     }
@@ -54,4 +62,6 @@ class EndOfYearStoriesData {
     var listeningTime: Double = 0
 
     var listenedCategories: [ListenedCategory] = []
+
+    var listenedNumbers: ListenedNumbers!
 }

--- a/podcasts/End of Year/EndOfYearStoriesBuilder.swift
+++ b/podcasts/End of Year/EndOfYearStoriesBuilder.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+/// Build the list of stories for End of Year alongside the data
+class EndOfYearStoriesBuilder {
+    
+}

--- a/podcasts/End of Year/Stories/EndOfYearStoriesDataSource.swift
+++ b/podcasts/End of Year/Stories/EndOfYearStoriesDataSource.swift
@@ -51,8 +51,8 @@ class EndOfYearStoriesDataSource: StoriesDataSource {
             stories.append(.epilogue)
 
             return true
-        } else {
-            return false
         }
+
+        return false
     }
 }

--- a/podcasts/End of Year/Stories/EndOfYearStoriesDataSource.swift
+++ b/podcasts/End of Year/Stories/EndOfYearStoriesDataSource.swift
@@ -2,59 +2,57 @@ import SwiftUI
 import PocketCastsDataModel
 
 class EndOfYearStoriesDataSource: StoriesDataSource {
-    var numberOfStories: Int = 9
+    var numberOfStories: Int {
+        stories.count
+    }
 
-    var listeningTime: Double?
+    var stories: [EndOfYearStory] = []
 
-    var listenedCategories: [ListenedCategory] = []
-
-    var listenedNumbers: ListenedNumbers?
-
-    var topPodcasts: [TopPodcast] = []
-
-    var longestEpisode: Episode?
+    var data: EndOfYearStoriesData!
 
     func story(for storyNumber: Int) -> any StoryView {
-        switch storyNumber {
-        case 0:
+        switch stories[storyNumber] {
+        case .intro:
             return IntroStory()
-        case 1:
-            return ListeningTimeStory(listeningTime: listeningTime!)
-        case 2:
-            return ListenedCategoriesStory(listenedCategories: listenedCategories)
-        case 3:
-            return TopListenedCategories(listenedCategories: listenedCategories)
-        case 4:
-            return ListenedNumbersStory(listenedNumbers: listenedNumbers!)
-        case 5:
-            return TopOnePodcastStory(topPodcast: topPodcasts[0])
-        case 6:
-            return TopFivePodcastsStory(podcasts: topPodcasts.map { $0.podcast })
-        case 7:
-            return LongestEpisodeStory(episode: longestEpisode!, podcast: longestEpisode!.parentPodcast()!)
-        default:
+        case .listeningTime:
+            return ListeningTimeStory(listeningTime: data.listeningTime)
+        case .listenedCategories:
+            return ListenedCategoriesStory(listenedCategories: data.listenedCategories)
+        case .topFiveCategories:
+            return TopListenedCategories(listenedCategories: data.listenedCategories)
+        case .listenedNumbers:
+            return ListenedNumbersStory(listenedNumbers: data.listenedNumbers)
+        case .topOnePodcast:
+            return TopOnePodcastStory(topPodcast: data.topPodcasts[0])
+        case .topFivePodcasts:
+            return TopFivePodcastsStory(podcasts: data.topPodcasts.map { $0.podcast })
+        case .longestEpisode:
+            return LongestEpisodeStory(episode: data.longestEpisode, podcast: data.longestEpisodePodcast)
+        case .epilogue:
             return EpilogueStory()
         }
     }
 
     /// The only interactive view we have is the last one, with the replay button
     func interactiveView(for storyNumber: Int) -> AnyView {
-        storyNumber == 8 ? AnyView(EpilogueStory()) : AnyView(EmptyView())
+        switch stories[storyNumber] {
+        case .epilogue:
+            return AnyView(EpilogueStory())
+        default:
+            return AnyView(EmptyView())
+        }
     }
 
     func isReady() async -> Bool {
-        await withCheckedContinuation { continuation in
-            self.listeningTime = DataManager.sharedManager.listeningTime()
+        (stories, data) = await EndOfYearStoriesBuilder().build()
 
-            self.listenedCategories = DataManager.sharedManager.listenedCategories()
+        if !stories.isEmpty {
+            stories.insert(.intro, at: 0)
+            stories.append(.epilogue)
 
-            self.listenedNumbers = DataManager.sharedManager.listenedNumbers()
-
-            self.topPodcasts = DataManager.sharedManager.topPodcasts()
-
-            self.longestEpisode = DataManager.sharedManager.longestEpisode()
-
-            continuation.resume(returning: true)
+            return true
+        } else {
+            return false
         }
     }
 }

--- a/podcasts/End of Year/Stories/TopFivePodcastsStory.swift
+++ b/podcasts/End of Year/Stories/TopFivePodcastsStory.swift
@@ -57,7 +57,6 @@ struct TopFivePodcastsStory: StoryView {
 
 struct DummyStory_Previews: PreviewProvider {
     static var previews: some View {
-        let podcast = Podcast()
         TopFivePodcastsStory(podcasts: [Podcast.previewPodcast()])
     }
 }

--- a/podcasts/End of Year/StoriesModel.swift
+++ b/podcasts/End of Year/StoriesModel.swift
@@ -9,6 +9,8 @@ class StoriesModel: ObservableObject {
 
     @Published var isReady: Bool = false
 
+    @Published var failed: Bool = false
+
     private let dataSource: StoriesDataSource
     private let publisher: Timer.TimerPublisher
     private let configuration: StoriesConfiguration
@@ -30,6 +32,7 @@ class StoriesModel: ObservableObject {
 
         Task.init {
             await isReady = dataSource.isReady()
+            failed = !isReady
         }
 
         subscribeToNotifications()

--- a/podcasts/End of Year/Views/StoriesView.swift
+++ b/podcasts/End of Year/Views/StoriesView.swift
@@ -16,6 +16,8 @@ struct StoriesView: View {
             .onAppear {
                 model.start()
             }
+        } else if model.failed {
+            failed
         } else {
             loading
         }
@@ -59,6 +61,18 @@ struct StoriesView: View {
                 .brightness(1)
                 .padding()
                 .background(Color.black)
+
+            storySwitcher
+            header
+        }
+    }
+
+    var failed: some View {
+        ZStack {
+            Spacer()
+
+            Text("Failed to load stories.")
+                .foregroundColor(.white)
 
             storySwitcher
             header


### PR DESCRIPTION
| 📘 Project: #376 |
|:---:|

Refactor the data source to move data initialization to another entity and also add handling failure in the process:

<img src="https://user-images.githubusercontent.com/7040243/197217456-b9283412-3a30-467d-8a88-dfdb84ddc80b.png" width="300">

Most of the changes are merely changes in the code though.

## To test

### Stories hasn't changed

1. Enable the `endOfYear` flag in `FeatureFlag.swift`
2. Run the app and make sure you're logged in to an account with a few items on Listening History
3. When the prompt appears, tap "View My 2022"
4. ✅ Check that the stories are presented correctly (there are no changes)

### Forcing error

We might run into an error when loading stories. This is now handled, first, change `EndOfYearStoriesDataSource.isReady()` to just `return false`. Then:

1. Run the app
3. When the prompt appears, tap "View My 2022"
4. ✅ Check that you see a "Failed to load stories" error

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
