### PR TITLE
Fix localization link in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Open the .xcworkspace file, select the Pocket Casts project and the Simulator De
 
 ## Localization
 
-You can learn more about localization at [docs/Localization.md](./documentation/localization.md)
+You can learn more about localization at [docs/Localization.md](./docs/localization.md)
 
 ## Protocol Buffers
 


### PR DESCRIPTION
The localization link currently links to the wrong file. This updates the link.

## To test

1. Code review and verify the link points to the right file

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
