### PR TITLE
About screen dark theme background in light mode fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 7.26
 -----
 - Fixed a search bar layout issue when adding/removing podcasts to folder (#378)
+- Fixed About screen dark theme background in light mode (#339)
 
 7.25
 -----

--- a/podcasts/AboutView.swift
+++ b/podcasts/AboutView.swift
@@ -18,7 +18,6 @@ struct AboutView: View {
 
     init(dismissAction: @escaping (() -> Void)) {
         self.dismissAction = dismissAction
-        UITableView.appearance().backgroundColor = .clear
     }
 
     var body: some View {
@@ -37,7 +36,7 @@ struct AboutView: View {
                             .padding(.top, 5)
                     }
                     .padding(.top, 30)
-                    List {
+                    Form {
                         if model.shouldShowWhatsNew, let whatsNewInfo = model.whatsNewInfo {
                             Section {
                                 AboutRow(mainText: model.whatsNewText) {
@@ -104,7 +103,7 @@ struct AboutView: View {
                         }
                         .listRowBackground(ThemeColor.primaryUi02(for: theme.activeTheme).color)
                     }
-                    .listStyle(.insetGrouped)
+                    .colorScheme(theme.activeTheme.isDark ? .dark : .light)
                 }
                 NavigationLink(destination: LegalAndMore(), isActive: $showLegalAndMore) {}
             }
@@ -200,5 +199,6 @@ struct AboutRow: View {
 struct AboutView_Previews: PreviewProvider {
     static var previews: some View {
         AboutView {}
+            .environmentObject(Theme(previewTheme: .dark))
     }
 }


### PR DESCRIPTION
Fixes #339 

## To test
- Set your app to use a dark theme (Default Dark is good) regardless of the system theme
- Set your system to use Light Interface
- Open the About screen.


Steps to test your PR.

## Checklist

- [X] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [X] I have considered adding unit tests for my changes.
- [X] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
