### PR TITLE
End of Year: check eligibility and listening history

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
@@ -64,7 +64,7 @@ class EndOfYearDataManager {
                 if resultSet.next() {
                     isFullListeningHistory = true
                 } else {
-                    isFullListeningHistory = numberOfItemsInListeningHistory(dbQueue: dbQueue) >= 100
+                    isFullListeningHistory = numberOfItemsInListeningHistory(db: db) <= 100
                 }
             } catch {
                 FileLog.shared.addMessage("EndOfYearDataManager.isFullListeningHistory error: \(error)")
@@ -72,33 +72,6 @@ class EndOfYearDataManager {
         }
 
         return isFullListeningHistory
-    }
-
-    private func numberOfItemsInListeningHistory(dbQueue: FMDatabaseQueue) -> Int {
-        var numberOfItemsInListeningHistory = 0
-
-        dbQueue.inDatabase { db in
-            do {
-                let query = """
-                            SELECT COUNT(*) as total from \(DataManager.episodeTableName)
-                            WHERE
-                            \(listenedEpisodesThisYear)
-                            LIMIT 1
-                            """
-                let resultSet = try db.executeQuery(query, values: nil)
-                defer { resultSet.close() }
-
-                if resultSet.next() {
-                    numberOfItemsInListeningHistory = Int(resultSet.int(forColumn: "total"))
-                } else {
-
-                }
-            } catch {
-                FileLog.shared.addMessage("EndOfYearDataManager.numberOfItemsInListeningHistory error: \(error)")
-            }
-        }
-
-        return numberOfItemsInListeningHistory
     }
 
     /// Returns the approximate listening time for the current year
@@ -251,6 +224,31 @@ class EndOfYearDataManager {
         }
 
         return episode
+    }
+
+    private func numberOfItemsInListeningHistory(db: FMDatabase) -> Int {
+        var numberOfItemsInListeningHistory = 0
+
+        do {
+            let query = """
+                        SELECT COUNT(*) as total from \(DataManager.episodeTableName)
+                        WHERE
+                        \(listenedEpisodesThisYear)
+                        LIMIT 1
+                        """
+            let resultSet = try db.executeQuery(query, values: nil)
+            defer { resultSet.close() }
+
+            if resultSet.next() {
+                numberOfItemsInListeningHistory = Int(resultSet.int(forColumn: "total"))
+            } else {
+
+            }
+        } catch {
+            FileLog.shared.addMessage("EndOfYearDataManager.numberOfItemsInListeningHistory error: \(error)")
+        }
+
+        return numberOfItemsInListeningHistory
     }
 
 }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
@@ -40,7 +40,7 @@ class EndOfYearDataManager {
 
     /// Check if the user has the full listening history or not.
     ///
-    /// This is not 100% accurated. In order to determine if the user
+    /// This is not 100% accurate. In order to determine if the user
     /// has the full history we check for their latest episode listened.
     /// If this episode was interacted in 2021 or before, we assume they
     /// have the full history.

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
@@ -45,7 +45,7 @@ class EndOfYearDataManager {
     /// If this episode was interacted in 2021 or before, we assume they
     /// have the full history.
     /// If this is not true, we check for the total number of items of
-    /// this year. If the number is small or equal 100, we assume they
+    /// this year. If the number is less than or equal 100, we assume they
     /// have the full history.
     func isFullListeningHistory(dbQueue: FMDatabaseQueue) -> Bool {
         var isFullListeningHistory = false

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
@@ -53,7 +53,7 @@ class EndOfYearDataManager {
         dbQueue.inDatabase { db in
             do {
                 let query = """
-                            SELECT * from SJEpisode
+                            SELECT * from \(DataManager.episodeTableName)
                             WHERE
                             lastPlaybackInteractionDate IS NOT NULL AND lastPlaybackInteractionDate < strftime('%s', '2022-01-01')
                             LIMIT 1
@@ -80,9 +80,9 @@ class EndOfYearDataManager {
         dbQueue.inDatabase { db in
             do {
                 let query = """
-                            SELECT COUNT(*) as total from SJEpisode
+                            SELECT COUNT(*) as total from \(DataManager.episodeTableName)
                             WHERE
-                            lastPlaybackInteractionDate IS NOT NULL AND lastPlaybackInteractionDate BETWEEN strftime('%s', '2022-01-01') and strftime('%s', '2022-12-01')
+                            \(listenedEpisodesThisYear)
                             LIMIT 1
                             """
                 let resultSet = try db.executeQuery(query, values: nil)

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -906,6 +906,10 @@ public extension DataManager {
         endOfYearManager.isEligible(dbQueue: dbQueue)
     }
 
+    func isFullListeningHistory() -> Bool {
+        endOfYearManager.isFullListeningHistory(dbQueue: dbQueue)
+    }
+
     func listeningTime() -> Double? {
         endOfYearManager.listeningTime(dbQueue: dbQueue)
     }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -902,6 +902,10 @@ public extension DataManager {
 // MARK: - End of Year stats
 
 public extension DataManager {
+    func isEligibleForEndOfYearStories() -> Bool {
+        endOfYearManager.isEligible(dbQueue: dbQueue)
+    }
+
     func listeningTime() -> Double? {
         endOfYearManager.listeningTime(dbQueue: dbQueue)
     }

--- a/PocketCastsTests/Mocks/EndOfYearManagerMock.swift
+++ b/PocketCastsTests/Mocks/EndOfYearManagerMock.swift
@@ -14,6 +14,8 @@ class EndOfYearManagerMock: EndOfYearDataManager {
 
     var longestEpisodeToReturn: Episode?
 
+    var isFullListeningHistoryToReturn = false
+
     override func listeningTime(dbQueue: FMDatabaseQueue) -> Double? {
         listeningTimeToReturn
     }
@@ -32,5 +34,9 @@ class EndOfYearManagerMock: EndOfYearDataManager {
 
     override func longestEpisode(dbQueue: FMDatabaseQueue) -> Episode? {
         return longestEpisodeToReturn
+    }
+
+    override func isFullListeningHistory(dbQueue: FMDatabaseQueue) -> Bool {
+        return isFullListeningHistoryToReturn
     }
 }

--- a/PocketCastsTests/Tests/End of Year/EndOfYearStoriesBuilderTests.swift
+++ b/PocketCastsTests/Tests/End of Year/EndOfYearStoriesBuilderTests.swift
@@ -151,7 +151,6 @@ class EndOfYearStoriesBuilderTests: XCTestCase {
         let dataManager = DataManagerMock(endOfYearManager: endOfYearManager)
         let builder = EndOfYearStoriesBuilder(dataManager: dataManager)
 
-        let episode = EpisodeMock()
         endOfYearManager.longestEpisodeToReturn = nil
         let stories = await builder.build()
 

--- a/PocketCastsTests/Tests/End of Year/EndOfYearStoriesBuilderTests.swift
+++ b/PocketCastsTests/Tests/End of Year/EndOfYearStoriesBuilderTests.swift
@@ -170,6 +170,18 @@ class EndOfYearStoriesBuilderTests: XCTestCase {
 
         XCTAssertTrue(syncCalled)
     }
+
+    func testDontSyncWhenNotNeeded() async {
+        var syncCalled = false
+        let endOfYearManager = EndOfYearManagerMock()
+        let dataManager = DataManagerMock(endOfYearManager: endOfYearManager)
+        let builder = EndOfYearStoriesBuilder(dataManager: dataManager, sync: { syncCalled = true })
+
+        endOfYearManager.isFullListeningHistoryToReturn = true
+        let stories = await builder.build()
+
+        XCTAssertFalse(syncCalled)
+    }
 }
 
 private class EpisodeMock: Episode {

--- a/PocketCastsTests/Tests/End of Year/EndOfYearStoriesBuilderTests.swift
+++ b/PocketCastsTests/Tests/End of Year/EndOfYearStoriesBuilderTests.swift
@@ -158,6 +158,18 @@ class EndOfYearStoriesBuilderTests: XCTestCase {
         XCTAssertNil(stories.1.longestEpisode)
         XCTAssertNil(stories.1.longestEpisodePodcast)
     }
+
+    func testSyncWhenNeeded() async {
+        var syncCalled = false
+        let endOfYearManager = EndOfYearManagerMock()
+        let dataManager = DataManagerMock(endOfYearManager: endOfYearManager)
+        let builder = EndOfYearStoriesBuilder(dataManager: dataManager, sync: { syncCalled = true })
+
+        endOfYearManager.isFullListeningHistoryToReturn = false
+        let stories = await builder.build()
+
+        XCTAssertTrue(syncCalled)
+    }
 }
 
 private class EpisodeMock: Episode {

--- a/podcasts/End of Year/EndOfYear.swift
+++ b/podcasts/End of Year/EndOfYear.swift
@@ -1,11 +1,15 @@
 import SwiftUI
 import MaterialComponents.MaterialBottomSheet
+import PocketCastsDataModel
 
 struct EndOfYear {
-    static var finishedImage: UIImage?
+    // We'll calculate this just once
+    static var isEligible: Bool = {
+        FeatureFlag.endOfYear && DataManager.sharedManager.isEligibleForEndOfYearStories()
+    }()
 
     func showPrompt(in viewController: UIViewController) {
-        guard FeatureFlag.endOfYear else {
+        guard Self.isEligible else {
             return
         }
 

--- a/podcasts/End of Year/EndOfYear.swift
+++ b/podcasts/End of Year/EndOfYear.swift
@@ -4,9 +4,9 @@ import PocketCastsDataModel
 
 struct EndOfYear {
     // We'll calculate this just once
-    static var isEligible: Bool = {
+    static var isEligible: Bool {
         FeatureFlag.endOfYear && DataManager.sharedManager.isEligibleForEndOfYearStories()
-    }()
+    }
 
     func showPrompt(in viewController: UIViewController) {
         guard Self.isEligible else {

--- a/podcasts/End of Year/EndOfYearStoriesBuilder.swift
+++ b/podcasts/End of Year/EndOfYearStoriesBuilder.swift
@@ -22,13 +22,22 @@ class EndOfYearStoriesBuilder {
 
     private let data = EndOfYearStoriesData()
 
-    init(dataManager: DataManager = DataManager.sharedManager) {
+    private let sync: (() -> Void)?
+
+    init(dataManager: DataManager = DataManager.sharedManager, sync: (() -> Void)? = nil) {
         self.dataManager = dataManager
+        self.sync = sync
     }
 
     // Call this method to build the list of stories and the data provider
     func build() async -> ([EndOfYearStory], EndOfYearStoriesData) {
         await withCheckedContinuation { continuation in
+            // Check if the user has the full listening history for this year
+            if !dataManager.isFullListeningHistory() {
+                // TODO: update with the correct endpoint to sync history (eoy-todo)
+                sync?()
+            }
+
             // Listening time
             if let listeningTime = dataManager.listeningTime(),
                 listeningTime > 0 {

--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -29,7 +29,7 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
         let profileViewController = ProfileViewController()
         profileViewController.tabBarItem = profileTabBarItem
 
-        if FeatureFlag.endOfYear && Settings.showBadgeFor2022EndOfYear {
+        if EndOfYear.isEligible && Settings.showBadgeFor2022EndOfYear {
             profileTabBarItem.badgeValue = "●"
         }
 
@@ -402,7 +402,7 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
         appearance.configureWithOpaqueBackground()
         appearance.backgroundColor = AppTheme.tabBarBackgroundColor()
 
-        if FeatureFlag.endOfYear {
+        if EndOfYear.isEligible {
             // Change badge colors
             [appearance.stackedLayoutAppearance,
              appearance.inlineLayoutAppearance,

--- a/podcasts/ProfileViewController.swift
+++ b/podcasts/ProfileViewController.swift
@@ -172,7 +172,7 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
             promoRedeemedMessage = nil
         }
 
-        if FeatureFlag.endOfYear {
+        if EndOfYear.isEligible {
             NotificationCenter.postOnMainThread(notification: Constants.Notifications.profileSeen)
         }
     }
@@ -420,7 +420,7 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
     }
 
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        if FeatureFlag.endOfYear && indexPath.row == 0 {
+        if EndOfYear.isEligible && indexPath.row == 0 {
             return UITableView.automaticDimension
         } else {
             return 70
@@ -468,7 +468,7 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
             data = [[.allStats, .downloaded, .uploadedFiles, .starred, .listeningHistory]]
         }
 
-        if FeatureFlag.endOfYear {
+        if EndOfYear.isEligible {
             data[0].insert(.endOfYearPrompt, at: 0)
         }
 


### PR DESCRIPTION
| 📘 Project: #376 |
|:---:|

* Check if a user is eligible to see their EoY stats (aka they listened to at least one episode for more than 30 minutes this year)
* Check user Listening History, if their history is not complete, call a block to sync it

## Checking Listening History

Right now, the app assumes that the user has the full listening history based on:

1. If their oldest item on Listening History is from a previous year
2. If the above is false check if their total number of episodes in Listening History is smaller or equal to 100 (the server limit)

Conversations about this is ongoing in pdeCcb-1mZ-p2#comment-1325

Note that we also still don't have the "listening history" sync endpoint, so there's no sync happening yet. However, everything is in place for doing so.

## To test

1. Enable the `endOfYear` flag in `FeatureFlag.swift`
2. Do a clean install of the app and run it
3. ✅ Check that nothing happens, no modal is shown and there's no card under Profile
4. Login to account in which you have a Listening History with a few episodes
5. ✅ Check that as soon as you logged in the modal is shown and the card is now visible on Profile

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
