### PR TITLE
Folders: Select all action is missing fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 -----
 - Fixed a search bar layout issue when adding/removing podcasts to folder (#378)
 - Fixed About screen dark theme background in light mode (#339)
-- Adding select/deselect all podcasts in folder creation (#143)
+- Adding select/deselect all podcasts button to folder creation (#143)
 
 7.25
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 -----
 - Fixed a search bar layout issue when adding/removing podcasts to folder (#378)
 - Fixed About screen dark theme background in light mode (#339)
+- Adding select/deselect all podcasts in folder creation (#143)
 
 7.25
 -----

--- a/podcasts/CreateFolderView.swift
+++ b/podcasts/CreateFolderView.swift
@@ -64,6 +64,14 @@ struct CreateFolderView: View {
                         }
                         .accessibilityLabel(L10n.close)
                     }
+                    
+                    ToolbarItem(placement: .navigationBarTrailing) {
+                        Button {
+                            pickerModel.toggleSelectAll()
+                        } label: {
+                            Text(pickerModel.hasSelectedAll ? L10n.deselectAll : L10n.selectAll)
+                        }
+                    }
                 }
         }
         .navigationViewStyle(StackNavigationViewStyle())

--- a/podcasts/CreateFolderView.swift
+++ b/podcasts/CreateFolderView.swift
@@ -64,13 +64,13 @@ struct CreateFolderView: View {
                         }
                         .accessibilityLabel(L10n.close)
                     }
-                    
                     ToolbarItem(placement: .navigationBarTrailing) {
                         Button {
                             pickerModel.toggleSelectAll()
                         } label: {
                             Text(pickerModel.hasSelectedAll ? L10n.deselectAll : L10n.selectAll)
                         }
+                        .foregroundColor(ThemeColor.secondaryIcon01(for: theme.activeTheme).color)
                     }
                 }
         }

--- a/podcasts/PodcastPickerModel.swift
+++ b/podcasts/PodcastPickerModel.swift
@@ -1,6 +1,7 @@
 import Foundation
 import PocketCastsDataModel
 
+@MainActor
 class PodcastPickerModel: ObservableObject {
     @Published var selectedPodcastUuids: [String] = []
     @Published var allPodcasts: [Podcast] = []
@@ -28,6 +29,10 @@ class PodcastPickerModel: ObservableObject {
         didSet {
             filterPodcasts()
         }
+    }
+    
+    var hasSelectedAll: Bool {
+        selectedPodcastUuids.count == allPodcasts.count
     }
 
     func setup() {
@@ -58,6 +63,14 @@ class PodcastPickerModel: ObservableObject {
             selectedPodcastUuids.remove(at: selectedIndex)
         } else {
             selectedPodcastUuids.append(podcast.uuid)
+        }
+    }
+    
+    func toggleSelectAll() {
+        if selectedPodcastUuids.count == allPodcasts.count {
+            selectedPodcastUuids = []
+        } else {
+            selectedPodcastUuids = allPodcasts.map { $0.uuid }
         }
     }
 

--- a/podcasts/PodcastPickerModel.swift
+++ b/podcasts/PodcastPickerModel.swift
@@ -1,7 +1,6 @@
 import Foundation
 import PocketCastsDataModel
 
-@MainActor
 class PodcastPickerModel: ObservableObject {
     @Published var selectedPodcastUuids: [String] = []
     @Published var allPodcasts: [Podcast] = []
@@ -30,7 +29,7 @@ class PodcastPickerModel: ObservableObject {
             filterPodcasts()
         }
     }
-    
+
     var hasSelectedAll: Bool {
         selectedPodcastUuids.count == allPodcasts.count
     }
@@ -65,10 +64,10 @@ class PodcastPickerModel: ObservableObject {
             selectedPodcastUuids.append(podcast.uuid)
         }
     }
-    
+
     func toggleSelectAll() {
-        if selectedPodcastUuids.count == allPodcasts.count {
-            selectedPodcastUuids = []
+        if hasSelectedAll {
+            selectedPodcastUuids.removeAll()
         } else {
             selectedPodcastUuids = allPodcasts.map { $0.uuid }
         }


### PR DESCRIPTION
Fixes #143

## To test
- Create a new folder
- It should show the select/deselect all button

## Video
https://user-images.githubusercontent.com/7861088/197297636-1303a775-a0cb-4c58-8777-7b151d20eaab.mp4

## Checklist

- [X] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [X] I have considered adding unit tests for my changes.
- [X] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
