### PR TITLE
Fix Discover sponsors displaying incorrectly for cancelled Plus subscribers

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/ServerEnums.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/ServerEnums.swift
@@ -6,6 +6,13 @@ public enum SubscriptionStatus: Int {
 
 public enum SubscriptionPlatform: Int {
     case none = 0, iOS = 1, android = 2, web = 3, gift = 4
+
+    public var isPaidSubscriptionPlatform: Bool {
+        switch self {
+            case .iOS, .android, .web: return true
+            default: return false
+        }
+    }
 }
 
 public enum SubscriptionFrequency: Int {

--- a/PocketCastsTests/Tests/Discover/DiscoverCoordinatorTests.swift
+++ b/PocketCastsTests/Tests/Discover/DiscoverCoordinatorTests.swift
@@ -12,8 +12,8 @@ final class DiscoverCoordinatorTests: XCTestCase {
         coordinator = DiscoverCoordinator(subscriptionData: subscriptionData)
     }
 
-    func testDoesNotDisplayWithPaidPlatforms() throws {
-        let item = try DiscoverItem.make(isSponsored: true)
+    func testDoesNotDisplayWithPaidPlatforms() {
+        let item = DiscoverItem.make(isSponsored: true)
         subscriptionData.mockHasActiveSubscription = true
 
         subscriptionData.mocksubscriptionPlatform = .iOS
@@ -26,24 +26,16 @@ final class DiscoverCoordinatorTests: XCTestCase {
         XCTAssertFalse(coordinator.shouldDisplay(item))
     }
 
-    func testDoesNotDisplayWithActiveSubscription() throws {
-        let item = try DiscoverItem.make(isSponsored: true)
-        subscriptionData.mockHasActiveSubscription = true
-        subscriptionData.mocksubscriptionPlatform = .iOS
-
-        XCTAssertFalse(coordinator.shouldDisplay(item))
-    }
-
-    func testDisplaysWithoutActiveSubscription() throws {
-        let item = try DiscoverItem.make(isSponsored: true)
+    func testDisplaysWithoutActiveSubscription() {
+        let item = DiscoverItem.make(isSponsored: true)
         subscriptionData.mockHasActiveSubscription = false
         subscriptionData.mocksubscriptionPlatform = .none
 
         XCTAssertTrue(coordinator.shouldDisplay(item))
     }
 
-    func testDisplaysNormalDiscoverItem() throws {
-        let item = try DiscoverItem.make(isSponsored: false)
+    func testDisplaysNormalDiscoverItem() {
+        let item = DiscoverItem.make(isSponsored: false)
         subscriptionData.mockHasActiveSubscription = true
         subscriptionData.mocksubscriptionPlatform = .web
 
@@ -66,10 +58,10 @@ private class MockSubscriptionHelper: SubscriptionHelper {
 }
 
 private extension DiscoverItem {
-    static func make(isSponsored: Bool) throws -> DiscoverItem {
+    static func make(isSponsored: Bool) -> DiscoverItem {
         let decoder = JSONDecoder()
 
         let data = Data("{\"sponsored\": \(isSponsored), \"regions\": [\"us\"]}".utf8)
-        return try decoder.decode(DiscoverItem.self, from: data)
+        return try! decoder.decode(DiscoverItem.self, from: data)
     }
 }

--- a/PocketCastsTests/Tests/Discover/DiscoverCoordinatorTests.swift
+++ b/PocketCastsTests/Tests/Discover/DiscoverCoordinatorTests.swift
@@ -1,0 +1,75 @@
+import Foundation
+@testable import podcasts
+@testable import PocketCastsServer
+import XCTest
+
+final class DiscoverCoordinatorTests: XCTestCase {
+    private var coordinator: DiscoverCoordinator!
+    private var subscriptionData: MockSubscriptionHelper.Type!
+
+    override func setUp() {
+        subscriptionData = MockSubscriptionHelper.self
+        coordinator = DiscoverCoordinator(subscriptionData: subscriptionData)
+    }
+
+    func testDoesNotDisplayWithPaidPlatforms() throws {
+        let item = try DiscoverItem.make(isSponsored: true)
+        subscriptionData.mockHasActiveSubscription = true
+
+        subscriptionData.mocksubscriptionPlatform = .iOS
+        XCTAssertFalse(coordinator.shouldDisplay(item))
+
+        subscriptionData.mocksubscriptionPlatform = .web
+        XCTAssertFalse(coordinator.shouldDisplay(item))
+
+        subscriptionData.mocksubscriptionPlatform = .android
+        XCTAssertFalse(coordinator.shouldDisplay(item))
+    }
+
+    func testDoesNotDisplayWithActiveSubscription() throws {
+        let item = try DiscoverItem.make(isSponsored: true)
+        subscriptionData.mockHasActiveSubscription = true
+        subscriptionData.mocksubscriptionPlatform = .iOS
+
+        XCTAssertFalse(coordinator.shouldDisplay(item))
+    }
+
+    func testDisplaysWithoutActiveSubscription() throws {
+        let item = try DiscoverItem.make(isSponsored: true)
+        subscriptionData.mockHasActiveSubscription = false
+        subscriptionData.mocksubscriptionPlatform = .none
+
+        XCTAssertTrue(coordinator.shouldDisplay(item))
+    }
+
+    func testDisplaysNormalDiscoverItem() throws {
+        let item = try DiscoverItem.make(isSponsored: false)
+        subscriptionData.mockHasActiveSubscription = true
+        subscriptionData.mocksubscriptionPlatform = .web
+
+        XCTAssertTrue(coordinator.shouldDisplay(item))
+    }
+}
+
+// MARK: - Mocks
+private class MockSubscriptionHelper: SubscriptionHelper {
+    static var mockHasActiveSubscription: Bool = false
+    static var mocksubscriptionPlatform: SubscriptionPlatform = .none
+
+    override class func hasActiveSubscription() -> Bool {
+        return mockHasActiveSubscription
+    }
+
+    override class func subscriptionPlatform() -> SubscriptionPlatform {
+        return mocksubscriptionPlatform
+    }
+}
+
+private extension DiscoverItem {
+    static func make(isSponsored: Bool) throws -> DiscoverItem {
+        let decoder = JSONDecoder()
+
+        let data = Data("{\"sponsored\": \(isSponsored), \"regions\": [\"us\"]}".utf8)
+        return try decoder.decode(DiscoverItem.self, from: data)
+    }
+}

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1346,6 +1346,9 @@
 		C7AF578E289C60CD0089E435 /* FeatureFlag.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7AF5788289C60B70089E435 /* FeatureFlag.swift */; };
 		C7AF5791289D87CF0089E435 /* Analytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7AF5790289D87CF0089E435 /* Analytics.swift */; };
 		C7BF5E47290832FD00733C1E /* DiscoverCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7BF5E46290832FD00733C1E /* DiscoverCoordinator.swift */; };
+		C7BF5E4A29083B5300733C1E /* DiscoverCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7BF5E4929083B5300733C1E /* DiscoverCoordinatorTests.swift */; };
+		C7BF5E4D29083E2100733C1E /* PocketCastsServer in Frameworks */ = {isa = PBXBuildFile; productRef = C7BF5E4C29083E2100733C1E /* PocketCastsServer */; };
+		C7BF5E4E29083E2100733C1E /* PocketCastsServer in Embed Frameworks */ = {isa = PBXBuildFile; productRef = C7BF5E4C29083E2100733C1E /* PocketCastsServer */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		C7C4CAEB28AB05A800CFC8CF /* AnalyticsLoggingAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7C4CAEA28AB05A800CFC8CF /* AnalyticsLoggingAdapter.swift */; };
 		C7C4CAEE28AB0BF200CFC8CF /* TracksSubscriptionData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7C4CAED28AB0BF200CFC8CF /* TracksSubscriptionData.swift */; };
 		C7C4CAF328ABFD0900CFC8CF /* Notifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7C4CAF228ABFD0900CFC8CF /* Notifications.swift */; };
@@ -1475,6 +1478,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				C7BF5E4E29083E2100733C1E /* PocketCastsServer in Embed Frameworks */,
 				8BF0BBD6289199D2006BBECF /* PocketCastsDataModel in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
@@ -2873,6 +2877,7 @@
 		C7AF5788289C60B70089E435 /* FeatureFlag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlag.swift; sourceTree = "<group>"; };
 		C7AF5790289D87CF0089E435 /* Analytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Analytics.swift; sourceTree = "<group>"; };
 		C7BF5E46290832FD00733C1E /* DiscoverCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverCoordinator.swift; sourceTree = "<group>"; };
+		C7BF5E4929083B5300733C1E /* DiscoverCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverCoordinatorTests.swift; sourceTree = "<group>"; };
 		C7C2391BA608F0CAB6E1D038 /* libPods-Pocket Casts Watch App Extension.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Pocket Casts Watch App Extension.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		C7C4CAEA28AB05A800CFC8CF /* AnalyticsLoggingAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsLoggingAdapter.swift; sourceTree = "<group>"; };
 		C7C4CAED28AB0BF200CFC8CF /* TracksSubscriptionData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracksSubscriptionData.swift; sourceTree = "<group>"; };
@@ -2931,6 +2936,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C7BF5E4D29083E2100733C1E /* PocketCastsServer in Frameworks */,
 				3FB8643028896539003A86BE /* BuildkiteTestCollector in Frameworks */,
 				3AAC732D703CDCF4C0F06E10 /* libPods-PocketCastsTests.a in Frameworks */,
 				8BF0BBD4289199D2006BBECF /* PocketCastsDataModel in Frameworks */,
@@ -3676,6 +3682,7 @@
 		8B47542C28D36D5800BC89F7 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				C7BF5E4829083B3F00733C1E /* Discover */,
 				8B2E054E28F8577200C2DBDE /* End of Year */,
 				C7D854F128ADD97700877E87 /* Analytics */,
 				8BF0BBCF28918B36006BBECF /* Podcasts */,
@@ -5931,6 +5938,14 @@
 			path = Analytics;
 			sourceTree = "<group>";
 		};
+		C7BF5E4829083B3F00733C1E /* Discover */ = {
+			isa = PBXGroup;
+			children = (
+				C7BF5E4929083B5300733C1E /* DiscoverCoordinatorTests.swift */,
+			);
+			path = Discover;
+			sourceTree = "<group>";
+		};
 		C7C4CAEC28AB0BE300CFC8CF /* Tracks */ = {
 			isa = PBXGroup;
 			children = (
@@ -6052,6 +6067,7 @@
 			packageProductDependencies = (
 				8BF0BBD3289199D2006BBECF /* PocketCastsDataModel */,
 				3FB8642F28896539003A86BE /* BuildkiteTestCollector */,
+				C7BF5E4C29083E2100733C1E /* PocketCastsServer */,
 			);
 			productName = PocketCastsTests;
 			productReference = 45ECEF7B27E910E300C65030 /* PocketCastsTests.xctest */;
@@ -7148,6 +7164,7 @@
 				8BF1C61D2881F05D007E80BF /* FolderModelTests.swift in Sources */,
 				8BA55A1328CA7425002BECC5 /* XCTestCase+eventually.swift in Sources */,
 				C7D854F328ADD98700877E87 /* AppLifecyleAnalyticsTests.swift in Sources */,
+				C7BF5E4A29083B5300733C1E /* DiscoverCoordinatorTests.swift in Sources */,
 				C79E1E4028887549008524CB /* PlusUpgradeViewSourceTests.swift in Sources */,
 				8BF0BBD92891AFB5006BBECF /* PodcastBuilder.swift in Sources */,
 				8B2E055028F8579700C2DBDE /* StoriesModelTests.swift in Sources */,
@@ -9783,6 +9800,10 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 46305CEE272B082C003AC87B /* XCRemoteSwiftPackageReference "Automattic-Tracks-iOS" */;
 			productName = AutomatticTracks;
+		};
+		C7BF5E4C29083E2100733C1E /* PocketCastsServer */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = PocketCastsServer;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1345,6 +1345,7 @@
 		C7AF578D289C60CA0089E435 /* FeatureFlag.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7AF5788289C60B70089E435 /* FeatureFlag.swift */; };
 		C7AF578E289C60CD0089E435 /* FeatureFlag.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7AF5788289C60B70089E435 /* FeatureFlag.swift */; };
 		C7AF5791289D87CF0089E435 /* Analytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7AF5790289D87CF0089E435 /* Analytics.swift */; };
+		C7BF5E47290832FD00733C1E /* DiscoverCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7BF5E46290832FD00733C1E /* DiscoverCoordinator.swift */; };
 		C7C4CAEB28AB05A800CFC8CF /* AnalyticsLoggingAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7C4CAEA28AB05A800CFC8CF /* AnalyticsLoggingAdapter.swift */; };
 		C7C4CAEE28AB0BF200CFC8CF /* TracksSubscriptionData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7C4CAED28AB0BF200CFC8CF /* TracksSubscriptionData.swift */; };
 		C7C4CAF328ABFD0900CFC8CF /* Notifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7C4CAF228ABFD0900CFC8CF /* Notifications.swift */; };
@@ -2871,6 +2872,7 @@
 		C79E1E3F28887549008524CB /* PlusUpgradeViewSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlusUpgradeViewSourceTests.swift; sourceTree = "<group>"; };
 		C7AF5788289C60B70089E435 /* FeatureFlag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlag.swift; sourceTree = "<group>"; };
 		C7AF5790289D87CF0089E435 /* Analytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Analytics.swift; sourceTree = "<group>"; };
+		C7BF5E46290832FD00733C1E /* DiscoverCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverCoordinator.swift; sourceTree = "<group>"; };
 		C7C2391BA608F0CAB6E1D038 /* libPods-Pocket Casts Watch App Extension.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Pocket Casts Watch App Extension.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		C7C4CAEA28AB05A800CFC8CF /* AnalyticsLoggingAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsLoggingAdapter.swift; sourceTree = "<group>"; };
 		C7C4CAED28AB0BF200CFC8CF /* TracksSubscriptionData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracksSubscriptionData.swift; sourceTree = "<group>"; };
@@ -5961,6 +5963,7 @@
 				BDB1E4DC1B8C5998009AD30F /* DiscoverViewController.xib */,
 				BD9FF6281B8EFC6F009F075E /* DiscoverSummaryProtocol.swift */,
 				40B26AC6213FED4300386173 /* DiscoverPeekViewController.swift */,
+				C7BF5E46290832FD00733C1E /* DiscoverCoordinator.swift */,
 			);
 			name = Discovery;
 			sourceTree = "<group>";
@@ -7376,6 +7379,7 @@
 				BD96575E2469053600873BB5 /* GoogleCastCell.swift in Sources */,
 				8B9D459C28F9A6260034219E /* TopFivePodcastsStory.swift in Sources */,
 				BDD3018C1EFB94C9004A9972 /* WatchManager.swift in Sources */,
+				C7BF5E47290832FD00733C1E /* DiscoverCoordinator.swift in Sources */,
 				BDD40A181FA1ABF500A53AE1 /* PCNavigationController.swift in Sources */,
 				40B1613822F3B66900759E41 /* ThemeableTextField.swift in Sources */,
 				407CD7292266DF510033C18E /* CancelInfoViewController.swift in Sources */,

--- a/podcasts/DeveloperMenu.swift
+++ b/podcasts/DeveloperMenu.swift
@@ -3,19 +3,84 @@ import PocketCastsServer
 
 struct DeveloperMenu: View {
     var body: some View {
-        VStack {
-            Button {
-                ServerSettings.syncingV2Token = "badToken"
-            } label: {
-                Text("Corrupt Sync Login Token")
-                    .padding()
-                    .overlay(
-                          RoundedRectangle(cornerRadius: 8)
-                            .stroke(Color.accentColor, lineWidth: 2)
-                      )
+        List {
+            Section {
+                Button("Corrupt Sync Login Token") {
+                    ServerSettings.syncingV2Token = "badToken"
+                }
+
+                Button("Force Reload Discover") {
+                    NotificationCenter.postOnMainThread(notification: Constants.Notifications.chartRegionChanged)
+                }
+            }
+
+            Section {
+                Button("Set to No Plus") {
+                    SubscriptionHelper.setSubscriptionPaid(Int(0))
+                    SubscriptionHelper.setSubscriptionPlatform(Int(0))
+                    SubscriptionHelper.setSubscriptionExpiryDate(Date(timeIntervalSinceNow: 30.days).timeIntervalSince1970)
+                    SubscriptionHelper.setSubscriptionAutoRenewing(false)
+                    SubscriptionHelper.setSubscriptionGiftDays(Int(0))
+                    SubscriptionHelper.setSubscriptionFrequency(Int(0))
+                    SubscriptionHelper.setSubscriptionType(Int(0))
+
+                    NotificationCenter.postOnMainThread(notification: ServerNotifications.subscriptionStatusChanged)
+                    HapticsHelper.triggerSubscribedHaptic()
+                }
+
+                Button("Set to Paid") {
+                    SubscriptionHelper.setSubscriptionPaid(Int(1))
+                    SubscriptionHelper.setSubscriptionPlatform(Int(1))
+                    SubscriptionHelper.setSubscriptionExpiryDate(Date(timeIntervalSinceNow: 30.days).timeIntervalSince1970)
+                    SubscriptionHelper.setSubscriptionAutoRenewing(true)
+                    SubscriptionHelper.setSubscriptionGiftDays(Int(0))
+                    SubscriptionHelper.setSubscriptionFrequency(Int(2))
+                    SubscriptionHelper.setSubscriptionType(Int(1))
+
+                    NotificationCenter.postOnMainThread(notification: ServerNotifications.subscriptionStatusChanged)
+                    HapticsHelper.triggerSubscribedHaptic()
+                }
+
+                VStack(alignment: .leading, spacing: 5) {
+                    Button("Set to Active but Cancelled") {
+                        SubscriptionHelper.setSubscriptionPaid(Int(1))
+                        SubscriptionHelper.setSubscriptionPlatform(Int(1))
+                        SubscriptionHelper.setSubscriptionExpiryDate(Date(timeIntervalSinceNow: 3.days).timeIntervalSince1970)
+                        SubscriptionHelper.setSubscriptionAutoRenewing(false)
+                        SubscriptionHelper.setSubscriptionGiftDays(Int(0))
+                        SubscriptionHelper.setSubscriptionFrequency(Int(0))
+                        SubscriptionHelper.setSubscriptionType(Int(1))
+
+                        NotificationCenter.postOnMainThread(notification: ServerNotifications.subscriptionStatusChanged)
+                        HapticsHelper.triggerSubscribedHaptic()
+                    }
+                    Text("Expiring in 2 days")
+                        .font(Font.footnote)
+                }
+
+                VStack(alignment: .leading, spacing: 5) {
+                    Button("Set Cancelled and Expired") {
+                        SubscriptionHelper.setSubscriptionPaid(Int(0))
+                        SubscriptionHelper.setSubscriptionPlatform(Int(1))
+                        SubscriptionHelper.setSubscriptionExpiryDate(Date(timeIntervalSinceNow: (1.days * -1)).timeIntervalSince1970)
+                        SubscriptionHelper.setSubscriptionAutoRenewing(false)
+                        SubscriptionHelper.setSubscriptionGiftDays(Int(0))
+                        SubscriptionHelper.setSubscriptionFrequency(Int(0))
+                        SubscriptionHelper.setSubscriptionType(Int(0))
+
+                        NotificationCenter.postOnMainThread(notification: ServerNotifications.subscriptionStatusChanged)
+                        HapticsHelper.triggerSubscribedHaptic()
+                    }
+                    Text("Cancelled subscription, but has passed expiration date")
+                        .font(Font.footnote)
+                }
+
+            } header: {
+                Text("Subscription Testing")
+            } footer: {
+                Text("⚠️ Temporary items only, the changes will only be active until the next server sync.")
             }
         }
-        .padding()
     }
 }
 

--- a/podcasts/DiscoverCoordinator.swift
+++ b/podcasts/DiscoverCoordinator.swift
@@ -12,7 +12,6 @@ class DiscoverCoordinator {
         let platform = subscriptionData.subscriptionPlatform()
         let isSponsored = item.isSponsored ?? false
 
-        print("Should Display?", isSponsored, subscriptionData.hasActiveSubscription(), platform.isPaidSubscriptionPlatform)
         // don't show sponsored items to active plus subscribers. Those who don't have a subscription, or have a gift (lifetime or otherwise) will still get them
         if isSponsored, subscriptionData.hasActiveSubscription(), platform.isPaidSubscriptionPlatform {
             return false

--- a/podcasts/DiscoverCoordinator.swift
+++ b/podcasts/DiscoverCoordinator.swift
@@ -1,0 +1,23 @@
+import Foundation
+import PocketCastsServer
+
+class DiscoverCoordinator {
+    private let subscriptionData: SubscriptionHelper.Type
+
+    init(subscriptionData: SubscriptionHelper.Type = SubscriptionHelper.self) {
+        self.subscriptionData = subscriptionData
+    }
+
+    func shouldDisplay(_ item: DiscoverItem) -> Bool {
+        let platform = subscriptionData.subscriptionPlatform()
+        let isSponsored = item.isSponsored ?? false
+
+        print("Should Display?", isSponsored, subscriptionData.hasActiveSubscription(), platform.isPaidSubscriptionPlatform)
+        // don't show sponsored items to active plus subscribers. Those who don't have a subscription, or have a gift (lifetime or otherwise) will still get them
+        if isSponsored, subscriptionData.hasActiveSubscription(), platform.isPaidSubscriptionPlatform {
+            return false
+        }
+
+        return true
+    }
+}

--- a/podcasts/DiscoverViewController.swift
+++ b/podcasts/DiscoverViewController.swift
@@ -24,6 +24,18 @@ class DiscoverViewController: PCViewController {
 
     var discoverLayout: DiscoverLayout?
 
+    private let coordinator: DiscoverCoordinator
+
+    init(coordinator: DiscoverCoordinator) {
+        self.coordinator = coordinator
+
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -157,8 +169,8 @@ class DiscoverViewController: PCViewController {
         for discoverItem in items {
             guard let type = discoverItem.type, let summaryStyle = discoverItem.summaryStyle, discoverItem.regions.contains(currentRegion) else { continue }
             let expandedStyle = discoverItem.expandedStyle ?? ""
-            // don't show sponsored items to active plus subscribers. Those who don't have a subscription, or have a gift (lifetime or otherwise) will still get them
-            if discoverItem.isSponsored ?? false, SubscriptionHelper.hasActiveSubscription(), SubscriptionHelper.hasRenewingSubscription() { continue }
+
+            guard coordinator.shouldDisplay(discoverItem) else { continue }
 
             switch (type, summaryStyle, expandedStyle) {
             case ("podcast_list", "carousel", _):

--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -23,7 +23,7 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
         let filtersViewController = PlaylistsViewController()
         filtersViewController.tabBarItem = UITabBarItem(title: L10n.filters, image: UIImage(named: "filters_tab"), tag: tabs.firstIndex(of: .filter)!)
 
-        let discoverViewController = DiscoverViewController()
+        let discoverViewController = DiscoverViewController(coordinator: DiscoverCoordinator())
         discoverViewController.tabBarItem = UITabBarItem(title: L10n.discover, image: UIImage(named: "discover_tab"), tag: tabs.firstIndex(of: .discover)!)
 
         let profileViewController = ProfileViewController()


### PR DESCRIPTION
This applies the same logic as [Android](https://github.com/Automattic/pocket-casts-android/pull/484). 

This fixes the issue where Discover sponsors are shown when a user a non-expired Plus subscription but has cancelled it. 

Since testing this is a bit difficult, I also updated the developer menu with some extra items to make it easier.

## To test

### Signed out user
1. Launch the app
2. Sign out if you're signed in
3. Go to Profile Tab > Settings> Developer and tap: Force Reload Discover
4. Go to the Discover tab
9. ✅ Verify the sponsored item appears

### Signed in and no plus
1. Launch the app
2. Sign into an account without plus active
3. Go to Profile Tab > Settings> Developer, and tap: Force Reload Discover
4. Go to the Discover tab
9. ✅ Verify the sponsored item appears

## Non-gifted, non-cancelled, unexpired, paid plus subscription
1. Launch the app
2. Sign into a Non-gifted, non-cancelled, unexpired, paid plus subscription
3. Or.... Sign into any account, and Go to Profile Tab > Settings > Developer
7. Tap on the Set to Paid item
8. Tap on the Force Reload Discover item
9. Tap on the Discover tab
10. ✅ Verify the sponsored item does not appear

## Non-gifted, canceled, unexpired paid plus subscription
1. Launch the app
2. Sign into a Non-gifted, cancelled, unexpired, paid plus subscription
3. Or.... Sign into any account, and Go to Profile Tab > Settings > Developer
7. Tap on the Set to Active but Cancelled item
8. Tap on the Force Reload Discover item
9. Tap on the Discover tab
10. ✅ Verify the sponsored item does not appear

## Non-gifted, canceled, expired paid plus subscription
1. Launch the app
2. Sign into a Non-gifted, cancelled, expired, paid plus subscription
3. Or.... Sign into any account, and Go to Profile Tab > Settings> Developer
6. Tap on the Set to cancelled and expired item
7. Tap on the Force Reload Discover item
8. Tap on the Discover tab
9. ✅ Verify the sponsored item appears

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
