### PR TITLE
Apple SSO: Fixes Watch app token refreshing issues

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+Account.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+Account.swift
@@ -7,11 +7,11 @@ import PocketCastsUtils
 import SwiftyJSON
 
 public extension ApiServerHandler {
-    func validateLogin(username: String, password: String) async throws -> AuthenticationResponse {
+    func validateLogin(username: String, password: String, scope: String) async throws -> AuthenticationResponse {
         var loginRequest = Api_UserLoginRequest()
         loginRequest.email = username
         loginRequest.password = password
-        loginRequest.scope = ServerConstants.Values.apiScope
+        loginRequest.scope = scope
 
         let url = ServerHelper.asUrl(ServerConstants.Urls.api() + "user/login")
         let data = try loginRequest.serializedData()

--- a/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+SocialAuth.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+SocialAuth.swift
@@ -4,12 +4,12 @@ import PocketCastsUtils
 
 /**
  * The Watch app and the iOS app don't share SIWA credentials, so if we try to do an "Credentials State" check from SIWA
- * from the watch, it will fail regardless. So, instead we will rely on the server to validate the identity token and fail
- * there if needed.
+ * from the watch, it will fail regardless. So, instead we will rely on the server to validate the identity token and fail there if needed. If not, then the watch will check the login state next time the user is connected to the main app on their phone.
  *
- * We will still do the credential state check in the main app, since it's better to fail early if possible.
+ * We will still do the credential state check in the main app since it's recommended by Apple.
  *
  */
+
 #if !os(watchOS)
 import AuthenticationServices
 

--- a/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+SocialAuth.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+SocialAuth.swift
@@ -1,6 +1,16 @@
 import Foundation
 import PocketCastsDataModel
 import PocketCastsUtils
+
+/**
+ * The Watch app and the iOS app don't share SIWA credentials, so if we try to do an "Credentials State" check from SIWA
+ * from the watch, it will fail regardless. So, instead we will rely on the server to validate the identity token and fail
+ * there if needed.
+ *
+ * We will still do the credential state check in the main app, since it's better to fail early if possible.
+ *
+ */
+#if !os(watchOS)
 import AuthenticationServices
 
 public extension ASAuthorizationAppleIDProvider.CredentialState {
@@ -19,6 +29,7 @@ public extension ASAuthorizationAppleIDProvider.CredentialState {
         }
     }
 }
+#endif
 
 public extension ApiServerHandler {
     func validateLogin(identityToken: String?) async throws -> AuthenticationResponse {
@@ -49,12 +60,26 @@ public extension ApiServerHandler {
         }
     }
 
-    func ssoCredentialState() async throws -> ASAuthorizationAppleIDProvider.CredentialState {
+    private func tokenRequest(identityToken: String?, cachePolicy: URLRequest.CachePolicy = .useProtocolCachePolicy, timeoutInterval: TimeInterval = 15.seconds) -> URLRequest? {
+        let url = ServerHelper.asUrl(ServerConstants.Urls.api() + "user/login_apple")
+        guard let identityToken = identityToken,
+              var request = ServerHelper.createEmptyProtoRequest(url: url, cachePolicy: cachePolicy, timeoutInterval: timeoutInterval)
+        else { return nil }
+
+        request.setValue("Bearer \(identityToken)", forHTTPHeaderField: ServerConstants.HttpHeaders.authorization)
+        return request
+    }
+}
+
+// MARK: - Only available to the main app, not the watch app
+#if !os(watchOS)
+extension ApiServerHandler {
+    public func ssoCredentialState() async throws -> ASAuthorizationAppleIDProvider.CredentialState {
         guard let userID = ServerSettings.appleAuthUserID else { return .notFound }
         return try await ASAuthorizationAppleIDProvider().credentialState(forUserID: userID)
     }
 
-    func hasValidSSOToken() async throws -> Bool {
+    private func hasValidSSOToken() async throws -> Bool {
         let tokenState = try await ssoCredentialState()
         FileLog.shared.addMessage("Validated Apple SSO token state: \(tokenState.loggingValue)")
 
@@ -66,14 +91,9 @@ public extension ApiServerHandler {
             return false
         }
     }
+}
+#else
 
-    private func tokenRequest(identityToken: String?, cachePolicy: URLRequest.CachePolicy = .useProtocolCachePolicy, timeoutInterval: TimeInterval = 15.seconds) -> URLRequest? {
-        let url = ServerHelper.asUrl(ServerConstants.Urls.api() + "user/login_apple")
-        guard let identityToken = identityToken,
-              var request = ServerHelper.createEmptyProtoRequest(url: url, cachePolicy: cachePolicy, timeoutInterval: timeoutInterval)
-        else { return nil }
-
-        request.setValue("Bearer \(identityToken)", forHTTPHeaderField: ServerConstants.HttpHeaders.authorization)
-        return request
     }
 }
+#endif

--- a/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+SocialAuth.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+SocialAuth.swift
@@ -95,7 +95,7 @@ extension ApiServerHandler {
 #else
 
 extension ApiServerHandler {
-    func hasValidSSOToken() async throws -> Bool {
+    private func hasValidSSOToken() async throws -> Bool {
         return true
     }
 }

--- a/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+SocialAuth.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+SocialAuth.swift
@@ -94,6 +94,9 @@ extension ApiServerHandler {
 }
 #else
 
+extension ApiServerHandler {
+    func hasValidSSOToken() async throws -> Bool {
+        return true
     }
 }
 #endif

--- a/Pocket Casts Watch App Extension/WatchSyncManager.swift
+++ b/Pocket Casts Watch App Extension/WatchSyncManager.swift
@@ -105,10 +105,13 @@ class WatchSyncManager {
             SessionManager.shared.requestLoginDetails(replyHandler: { response in
                 let username = response[WatchConstants.Messages.LoginDetailsResponse.username] as? String ?? ""
                 let password = response[WatchConstants.Messages.LoginDetailsResponse.password] as? String ?? ""
+                let appleAuthToken = response[WatchConstants.Messages.LoginDetailsResponse.appleAuthToken] as? String
+                let appleUserId = response[WatchConstants.Messages.LoginDetailsResponse.appleAuthUserID] as? String
+
                 ServerSettings.setSyncingEmail(email: username)
                 ServerSettings.saveSyncingPassword(password)
-                ServerSettings.appleAuthIdentityToken = response[WatchConstants.Messages.LoginDetailsResponse.appleAuthToken] as? String
-                ServerSettings.appleAuthUserID = response[WatchConstants.Messages.LoginDetailsResponse.appleAuthToken] as? String
+                ServerSettings.appleAuthIdentityToken = appleAuthToken
+                ServerSettings.appleAuthUserID = appleUserId
 
                 if !username.isEmpty {
                     self.login()
@@ -170,10 +173,13 @@ class WatchSyncManager {
         SessionManager.shared.requestLoginDetails(replyHandler: { response in
             let username = response[WatchConstants.Messages.LoginDetailsResponse.username] as? String ?? ""
             let password = response[WatchConstants.Messages.LoginDetailsResponse.password] as? String ?? ""
+            let appleAuthToken = response[WatchConstants.Messages.LoginDetailsResponse.appleAuthToken] as? String
+            let appleUserId = response[WatchConstants.Messages.LoginDetailsResponse.appleAuthUserID] as? String
+
             ServerSettings.setSyncingEmail(email: username)
             ServerSettings.saveSyncingPassword(password)
-
-            ServerSettings.appleAuthIdentityToken = response[WatchConstants.Messages.LoginDetailsResponse.appleAuthToken] as? String
+            ServerSettings.appleAuthIdentityToken = appleAuthToken
+            ServerSettings.appleAuthUserID = appleUserId
 
             if SyncManager.isUserLoggedIn(), username.isEmpty {
                 FileLog.shared.addMessage("Logging out as phone has logged out ")

--- a/podcasts/AuthenticationHelper.swift
+++ b/podcasts/AuthenticationHelper.swift
@@ -6,16 +6,6 @@ import PocketCastsUtils
 import AuthenticationServices
 #endif
 
-enum AuthenticationSource: String {
-    case password = "password"
-    case ssoApple = "sso_apple"
-}
-
-enum AuthenticationScope: String {
-    case mobile
-    case sonos
-}
-
 class AuthenticationHelper {
 
     @discardableResult
@@ -78,7 +68,7 @@ class AuthenticationHelper {
         }
 
         NotificationCenter.default.post(name: .userLoginDidChange, object: nil)
-        Analytics.track(.userSignedIn, properties: ["source": source.rawValue])
+        Analytics.track(.userSignedIn, properties: ["source": source])
 
         RefreshManager.shared.refreshPodcasts(forceEvenIfRefreshedRecently: true)
         Settings.setPromotionFinishedAcknowledged(true)
@@ -130,3 +120,17 @@ extension AuthenticationHelper {
     }
 }
 #endif
+
+// MARK: - Enums
+enum AuthenticationSource: String, AnalyticsDescribable {
+    case password = "password"
+    case ssoApple = "sso_apple"
+
+    var analyticsDescription: String { rawValue }
+}
+
+enum AuthenticationScope: String {
+    case mobile
+    case sonos
+}
+

--- a/podcasts/AuthenticationHelper.swift
+++ b/podcasts/AuthenticationHelper.swift
@@ -15,8 +15,8 @@ class AuthenticationHelper {
         if let username = ServerSettings.syncingEmail(), let password = ServerSettings.syncingPassword(), !password.isEmpty {
             try await validateLogin(username: username, password: password)
         }
-        else if FeatureFlag.signInWithApple, let token = ServerSettings.appleAuthIdentityToken {
-            try await validateLogin(identityToken: token)
+        else if FeatureFlag.signInWithApple, let token = ServerSettings.appleAuthIdentityToken, let userID = ServerSettings.appleAuthUserID {
+            try await validateLogin(identityToken: token, userID: userID)
         }
     }
 
@@ -45,15 +45,15 @@ class AuthenticationHelper {
             throw APIError.UNKNOWN
         }
 
-        try await validateLogin(identityToken: token)
-
-        ServerSettings.appleAuthIdentityToken = String(data: identityToken, encoding: .utf8)
-        ServerSettings.appleAuthUserID = appleIDCredential.user
+        try await validateLogin(identityToken: token, userID: appleIDCredential.user)
     }
 
-    static func validateLogin(identityToken: String) async throws {
+    static func validateLogin(identityToken: String, userID: String) async throws {
         let response = try await ApiServerHandler.shared.validateLogin(identityToken: identityToken)
         handleSuccessfulSignIn(response, .ssoApple)
+
+        ServerSettings.appleAuthIdentityToken = identityToken
+        ServerSettings.appleAuthUserID = userID
     }
 
     static func validateAppleSSOCredentials() {

--- a/podcasts/AuthenticationHelper.swift
+++ b/podcasts/AuthenticationHelper.swift
@@ -133,4 +133,3 @@ enum AuthenticationScope: String {
     case mobile
     case sonos
 }
-

--- a/podcasts/AuthenticationHelper.swift
+++ b/podcasts/AuthenticationHelper.swift
@@ -25,6 +25,13 @@ class AuthenticationHelper {
     static func validateLogin(username: String, password: String) async throws {
         let response = try await ApiServerHandler.shared.validateLogin(username: username, password: password)
         handleSuccessfulSignIn(response, .password)
+
+        // If the server didn't return a new email, and the call was successful, then reset the email to the one used to
+        // validate the login
+        if ServerSettings.syncingEmail() == nil {
+            ServerSettings.setSyncingEmail(email: username)
+        }
+
         ServerSettings.saveSyncingPassword(password)
     }
 

--- a/podcasts/AuthenticationHelper.swift
+++ b/podcasts/AuthenticationHelper.swift
@@ -114,6 +114,7 @@ extension AuthenticationHelper {
     private static func handleSSOTokenRevoked() {
         FileLog.shared.addMessage("Apple SSO token has been revoked. Signing user out.")
         SyncManager.signout()
+        Settings.setLoginDetailsUpdated()
     }
 }
 #endif

--- a/podcasts/AuthenticationHelper.swift
+++ b/podcasts/AuthenticationHelper.swift
@@ -24,7 +24,7 @@ class AuthenticationHelper {
             return try await validateLogin(username: username, password: password, scope: scope).token
         }
         else if FeatureFlag.signInWithApple, let token = ServerSettings.appleAuthIdentityToken, let userID = ServerSettings.appleAuthUserID {
-            return try await validateLogin(identityToken: token, userID: userID)
+            return try await validateLogin(identityToken: token, userID: userID).token
         }
 
         return nil
@@ -55,6 +55,8 @@ class AuthenticationHelper {
 
         ServerSettings.appleAuthIdentityToken = identityToken
         ServerSettings.appleAuthUserID = userID
+
+        return response
     }
 
     // MARK: Common

--- a/podcasts/ProfileIntroViewController.swift
+++ b/podcasts/ProfileIntroViewController.swift
@@ -62,8 +62,6 @@ class ProfileIntroViewController: PCViewController, SyncSigninDelegate {
         navigationItem.leftBarButtonItem = closeButton
 
         handleThemeChanged()
-        let doneButton = UIBarButtonItem(image: UIImage(named: "cancel"), style: .done, target: self, action: #selector(doneTapped))
-        doneButton.accessibilityLabel = L10n.accessibilityCloseDialog
         navigationController?.navigationBar.setValue(true, forKey: "hidesShadow")
 
         setupProviderLoginView()

--- a/podcasts/ProfileIntroViewController.xib
+++ b/podcasts/ProfileIntroViewController.xib
@@ -85,10 +85,10 @@
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="nY7-Sl-Gxg" firstAttribute="centerX" secondItem="fnl-2z-Ty3" secondAttribute="centerX" id="2XD-1P-gsU"/>
-                <constraint firstItem="xRp-Cs-cvI" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="23" id="63H-tj-FKR"/>
                 <constraint firstItem="oOL-Vb-lE7" firstAttribute="trailing" secondItem="fnl-2z-Ty3" secondAttribute="trailing" constant="8" id="BUi-ih-aEw"/>
                 <constraint firstItem="xRp-Cs-cvI" firstAttribute="top" secondItem="oOL-Vb-lE7" secondAttribute="bottom" constant="8" id="E6A-ke-Zci"/>
-                <constraint firstItem="xRp-Cs-cvI" firstAttribute="trailing" secondItem="fnl-2z-Ty3" secondAttribute="trailing" constant="-23" id="fQl-mz-Q3W"/>
+                <constraint firstItem="xRp-Cs-cvI" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" constant="23" id="Tr8-SU-rJw"/>
+                <constraint firstAttribute="trailing" secondItem="xRp-Cs-cvI" secondAttribute="trailing" constant="23" id="bnN-4t-F3S"/>
                 <constraint firstItem="nY7-Sl-Gxg" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" priority="750" constant="60" id="gLh-ll-owx"/>
                 <constraint firstItem="GOk-uO-NBJ" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="16" id="hFj-W6-qY2"/>
                 <constraint firstItem="oOL-Vb-lE7" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="8" id="hjW-93-fBF"/>

--- a/podcasts/SonosLinkController.swift
+++ b/podcasts/SonosLinkController.swift
@@ -90,15 +90,25 @@ class SonosLinkController: PCViewController {
         let signinPage = SyncSigninViewController()
         signinPage.delegate = self
         navigationController?.pushViewController(signinPage, animated: true)
+/// This is a small subclass of the ProfileIntroViewController to allow overriding a few features to allow it to work with the Sonos login.
+private class SonosLoginIntroViewController: ProfileIntroViewController {
+    /// Reuse the super class xib
+    override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
+        super.init(nibName: "ProfileIntroViewController", bundle: nil)
     }
 
-    @objc func cancelTapped() {
-        dismiss(animated: true, completion: nil)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
 
-    // MARK: - Sign In Delegate
+    override func viewDidLoad() {
+        super.viewDidLoad()
 
-    func signingProcessCompleted() {
-        navigationController?.popViewController(animated: true)
+        navigationItem.leftBarButtonItem = nil
+        navigationItem.hidesBackButton = false
+    }
+
+    override func signingProcessCompleted() {
+        navigationController?.popToRootViewController(animated: true)
     }
 }

--- a/podcasts/SonosLinkController.swift
+++ b/podcasts/SonosLinkController.swift
@@ -74,6 +74,8 @@ class SonosLinkController: PCViewController, SyncSigninDelegate {
                     SJUIUtils.showAlert(title: L10n.sonosConnectionFailedTitle, message: L10n.sonosConnectionFailedAccountLink, from: self)
                     return
                 }
+
+                FileLog.shared.addMessage("Sync Token refreshed source: Sonos")
                 guard let strongSelf = self else { return }
 
                 let fullUrl = strongSelf.callbackUri + "&code=" + token.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!

--- a/podcasts/SonosLinkController.swift
+++ b/podcasts/SonosLinkController.swift
@@ -56,6 +56,15 @@ class SonosLinkController: PCViewController {
     }
 }
 
+private extension SonosLinkController {
+    func updateConnectButtonTitle(_ title: String) {
+        connectBtn.setTitle(title, for: .normal)
+    }
+
+    func signIntoPocketCasts() {
+        navigationController?.pushViewController(SonosLoginIntroViewController(), animated: true)
+    }
+
     func connectWithSonos() {
         guard ServerSettings.syncingEmail() != nil else {
             updateConnectButtonTitle(L10n.retry.localizedUppercase)
@@ -78,18 +87,17 @@ class SonosLinkController: PCViewController {
                 let fullUrl = strongSelf.callbackUri + "&code=" + token.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!
                 if let url = URL(string: fullUrl) {
                     UIApplication.shared.open(url, options: [:], completionHandler: nil)
+                    strongSelf.dismiss(animated: true)
                 } else {
-                    strongSelf.connectBtn.buttonTitle = L10n.retry.localizedUppercase
+                    strongSelf.updateConnectButtonTitle(L10n.retry.localizedUppercase)
                     SJUIUtils.showAlert(title: L10n.sonosConnectionFailedTitle, message: L10n.sonosConnectionFailedAppMissing, from: self)
                 }
             }
         }
     }
+}
 
-    func signIntoPocketCasts(signInMode: Bool) {
-        let signinPage = SyncSigninViewController()
-        signinPage.delegate = self
-        navigationController?.pushViewController(signinPage, animated: true)
+
 /// This is a small subclass of the ProfileIntroViewController to allow overriding a few features to allow it to work with the Sonos login.
 private class SonosLoginIntroViewController: ProfileIntroViewController {
     /// Reuse the super class xib

--- a/podcasts/SonosLinkController.swift
+++ b/podcasts/SonosLinkController.swift
@@ -2,10 +2,6 @@ import PocketCastsServer
 import PocketCastsUtils
 import UIKit
 
-class SonosLinkController: PCViewController, SyncSigninDelegate {
-    private let accountBtnTag = 1
-    private let signinBtnTag = 2
-
     @IBOutlet var sonosImage: UIImageView! {
         didSet {
             sonosImage.image = Theme.isDarkTheme() ? UIImage(named: "sonos-dark") : UIImage(named: "sonos-light")

--- a/podcasts/SonosLinkController.xib
+++ b/podcasts/SonosLinkController.xib
@@ -1,17 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="SonosLinkController" customModule="podcasts" customModuleProvider="target">
             <connections>
                 <outlet property="connectBtn" destination="eq6-1h-j1k" id="Pu1-9e-8zp"/>
-                <outlet property="createBtn" destination="Xvs-nu-x8L" id="gsn-i6-tu2"/>
                 <outlet property="mainMessage" destination="Cob-KJ-KeT" id="c0U-ca-nqL"/>
                 <outlet property="sonosImage" destination="Yqf-gE-xPX" id="c33-dQ-xvT"/>
+                <outlet property="titleLabel" destination="6AL-1l-kSE" id="NDZ-Uv-6mI"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
             </connections>
         </placeholder>
@@ -24,7 +25,7 @@
                     <rect key="frame" x="0.0" y="0.0" width="375" height="623"/>
                     <subviews>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Hyf-AM-sbM">
-                            <rect key="frame" x="0.0" y="0.0" width="375" height="435"/>
+                            <rect key="frame" x="0.0" y="0.0" width="375" height="444"/>
                             <subviews>
                                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="sonos-light" translatesAutoresizingMaskIntoConstraints="NO" id="Yqf-gE-xPX">
                                     <rect key="frame" x="45.5" y="19" width="244" height="137"/>
@@ -36,10 +37,7 @@
                                     <nil key="highlightedColor"/>
                                 </label>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Cob-KJ-KeT" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                                    <rect key="frame" x="45" y="212" width="285" height="90"/>
-                                    <constraints>
-                                        <constraint firstAttribute="width" relation="lessThanOrEqual" constant="300" id="UT6-Ly-pu7"/>
-                                    </constraints>
+                                    <rect key="frame" x="15" y="203" width="345" height="90"/>
                                     <string key="text">Connecting to Sonos will allow the Sonos app to access your episode information.
 
 Your email address, password and other sensitive items are never shared.</string>
@@ -47,60 +45,32 @@ Your email address, password and other sensitive items are never shared.</string
                                     <nil key="textColor"/>
                                     <nil key="highlightedColor"/>
                                 </label>
-                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="eq6-1h-j1k" customClass="ShiftyRoundButton" customModule="podcasts" customModuleProvider="target">
-                                    <rect key="frame" x="37.5" y="316" width="300" height="44"/>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="eq6-1h-j1k" customClass="ThemeableRoundedButton" customModule="podcasts" customModuleProvider="target">
+                                    <rect key="frame" x="37.5" y="313" width="300" height="56"/>
                                     <accessibility key="accessibilityConfiguration">
                                         <accessibilityTraits key="traits" button="YES"/>
                                         <bool key="isElement" value="YES"/>
                                     </accessibility>
                                     <constraints>
                                         <constraint firstAttribute="width" constant="300" id="IRL-oz-zOr"/>
-                                        <constraint firstAttribute="height" constant="44" id="v3q-91-rut"/>
+                                        <constraint firstAttribute="height" constant="56" id="v3q-91-rut"/>
                                     </constraints>
-                                    <userDefinedRuntimeAttributes>
-                                        <userDefinedRuntimeAttribute type="color" keyPath="strokeColor">
-                                            <color key="value" red="0.47058823529999999" green="0.83529411760000005" blue="0.28627450980000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                        </userDefinedRuntimeAttribute>
-                                        <userDefinedRuntimeAttribute type="boolean" keyPath="isOn" value="YES"/>
-                                        <userDefinedRuntimeAttribute type="color" keyPath="fillColor">
-                                            <color key="value" red="0.47058823529999999" green="0.83529411760000005" blue="0.28627450980000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                        </userDefinedRuntimeAttribute>
-                                    </userDefinedRuntimeAttributes>
-                                </view>
-                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Xvs-nu-x8L" userLabel="Create Btn" customClass="ShiftyRoundButton" customModule="podcasts" customModuleProvider="target">
-                                    <rect key="frame" x="37.5" y="371" width="300" height="44"/>
-                                    <accessibility key="accessibilityConfiguration" label="Create Account">
-                                        <accessibilityTraits key="traits" button="YES"/>
-                                        <bool key="isElement" value="YES"/>
-                                    </accessibility>
-                                    <constraints>
-                                        <constraint firstAttribute="width" constant="300" id="IGr-8j-gXn"/>
-                                        <constraint firstAttribute="height" constant="44" id="NpY-bX-zw2"/>
-                                    </constraints>
-                                    <userDefinedRuntimeAttributes>
-                                        <userDefinedRuntimeAttribute type="color" keyPath="strokeColor">
-                                            <color key="value" red="0.076461829250000002" green="0.59036862850000005" blue="0.94450449940000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                        </userDefinedRuntimeAttribute>
-                                        <userDefinedRuntimeAttribute type="color" keyPath="fillColor">
-                                            <color key="value" red="0.076461829250000002" green="0.59036862850000005" blue="0.94450449940000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                        </userDefinedRuntimeAttribute>
-                                        <userDefinedRuntimeAttribute type="boolean" keyPath="isOn" value="YES"/>
-                                    </userDefinedRuntimeAttributes>
+                                    <connections>
+                                        <action selector="connect:" destination="-1" eventType="touchUpInside" id="dtx-o4-Phh"/>
+                                    </connections>
                                 </view>
                             </subviews>
                             <constraints>
                                 <constraint firstItem="6AL-1l-kSE" firstAttribute="centerX" secondItem="Hyf-AM-sbM" secondAttribute="centerX" id="F8U-Ue-Kza"/>
-                                <constraint firstItem="Xvs-nu-x8L" firstAttribute="centerX" secondItem="Hyf-AM-sbM" secondAttribute="centerX" id="ODH-c8-C54"/>
                                 <constraint firstItem="Yqf-gE-xPX" firstAttribute="top" secondItem="Hyf-AM-sbM" secondAttribute="top" constant="19" id="Ont-2D-Zpb"/>
                                 <constraint firstAttribute="bottom" secondItem="eq6-1h-j1k" secondAttribute="bottom" constant="75" id="PVt-ES-b5t"/>
-                                <constraint firstItem="Cob-KJ-KeT" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Hyf-AM-sbM" secondAttribute="leading" priority="750" constant="20" id="Plo-Qr-b1C"/>
+                                <constraint firstItem="Cob-KJ-KeT" firstAttribute="leading" secondItem="Hyf-AM-sbM" secondAttribute="leading" priority="750" constant="15" id="Plo-Qr-b1C"/>
                                 <constraint firstItem="Cob-KJ-KeT" firstAttribute="centerX" secondItem="Hyf-AM-sbM" secondAttribute="centerX" id="Tbr-O3-Tce"/>
                                 <constraint firstItem="eq6-1h-j1k" firstAttribute="centerX" secondItem="Hyf-AM-sbM" secondAttribute="centerX" id="WPw-8Q-Kw1"/>
-                                <constraint firstItem="eq6-1h-j1k" firstAttribute="top" secondItem="Cob-KJ-KeT" secondAttribute="bottom" constant="14" id="XIk-YQ-niV"/>
+                                <constraint firstItem="eq6-1h-j1k" firstAttribute="top" secondItem="Cob-KJ-KeT" secondAttribute="bottom" constant="20" id="XIk-YQ-niV"/>
                                 <constraint firstItem="6AL-1l-kSE" firstAttribute="top" secondItem="Yqf-gE-xPX" secondAttribute="bottom" constant="16" id="gIk-3f-HQh"/>
-                                <constraint firstItem="Xvs-nu-x8L" firstAttribute="top" secondItem="eq6-1h-j1k" secondAttribute="bottom" constant="11" id="jws-ab-nIO"/>
-                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="Cob-KJ-KeT" secondAttribute="trailing" priority="750" constant="20" id="kNZ-pq-vNl"/>
-                                <constraint firstItem="Cob-KJ-KeT" firstAttribute="top" secondItem="6AL-1l-kSE" secondAttribute="bottom" constant="19" id="onF-c6-O3F"/>
+                                <constraint firstAttribute="trailing" secondItem="Cob-KJ-KeT" secondAttribute="trailing" priority="750" constant="15" id="kNZ-pq-vNl"/>
+                                <constraint firstItem="Cob-KJ-KeT" firstAttribute="top" secondItem="6AL-1l-kSE" secondAttribute="bottom" constant="10" id="onF-c6-O3F"/>
                                 <constraint firstItem="Yqf-gE-xPX" firstAttribute="centerX" secondItem="Hyf-AM-sbM" secondAttribute="centerX" constant="-20" id="y4d-Jt-4Y1"/>
                             </constraints>
                         </view>

--- a/podcasts/WatchConstants.swift
+++ b/podcasts/WatchConstants.swift
@@ -230,6 +230,7 @@ public enum WatchConstants {
             public static let username = "username"
             public static let password = "password"
             public static let appleAuthToken = "appleAuthToken"
+            public static let appleAuthUserID = "appleAuthUserID"
         }
     }
 }

--- a/podcasts/WatchManager.swift
+++ b/podcasts/WatchManager.swift
@@ -334,8 +334,9 @@ class WatchManager: NSObject, WCSessionDelegate {
         if let password = ServerSettings.syncingPassword() {
             response[WatchConstants.Messages.LoginDetailsResponse.password] = password
         }
-        else if let authToken = ServerSettings.appleAuthIdentityToken {
+        else if let authToken = ServerSettings.appleAuthIdentityToken, let appleUserId = ServerSettings.appleAuthUserID {
             response[WatchConstants.Messages.LoginDetailsResponse.appleAuthToken] = authToken
+            response[WatchConstants.Messages.LoginDetailsResponse.appleAuthUserID] = appleUserId
         }
 
         Settings.clearLoginDetailsUpdated()


### PR DESCRIPTION
| 📘 Project: #381 |
|:---:|

This fixes a few issues:

1. When performing a token refresh the some of the required information (email, auth tokens) would be deleted and never restored when a successful refresh occurred.  To fix this I moved when the info is stored to after `handleSuccessfulSignIn` is called ensuring the information is set. If the endpoint doesn't return an email then we manually set our previously stored email again. 

2. If the user revoked the Sign in With Apple the app would be logged out, but the watch wouldn't. This is calling `setLoginDetailsUpdated` in `handleSSOTokenRevoked`

**3. Apple Watch and Apple SSO token refreshes**

If the stored `SJSyncV2Token` is invalid or needs to be refreshed, and the user has signed in with Apple, the code previously would try to do the following to refresh the token

1.  On Failure, it determined the user used Apple SSO
2. It calls `ApiServerHandler.shared.refreshIdentityToken` from `TokenHelper.acquireIdentityToken`
3. `refreshIdentityToken` calls `hasValidSSOToken`
4. Which calls `ssoCredentialState`
5. Which tries to retrieve the current Apple credential state (revoked, authorized, etc) using `ASAuthorizationAppleIDProvider`

The problem with this is that it assumes that:
1. The iOS and Watch apps are able to **share** the Apple SSO login information and check it
    -  The apps don't share this info, and in order for this to work we would need the user to sign in to Apple directly on their watch in the app
2. The Watch app has the correct entitlement for SIWA
   - It's currently not enabled, so it's not able to perform ANY SIWA code so the check will always fail

The change I made in this PR is to completely disable the SIWA checks on the Watch app and rely on the server to refresh, and then a connection with the app 

## To test

> **Note**
> Make sure you enabled the `signInWithApple` FeatureFlag, and switch to the Staging Build Configuration. 
> You can however test the email/password steps without the flag enabled. 

### Email/Password token Refresh
#### Main App
1. Launch the app
2. Sign into an existing account with email/password
3. Go to Profile Tab > Settings > Developer > Corrupt Sync Token
4. Perform a sync
5. ✅ The sync succeeds and you are not logged out

#### Watch App
1. Launch the app and the watch app
7. Sign into an existing account with Plus with email/password on the app
8. Sync the account with the watch
9. In Xcode open KeychainHelper.swift
10. Replace the first 2 methods with the contents of the `KeychainHelper Code` section at the bottom of this PR
    - This will log out any keychain changes making debugging easier
11. in Xcode open: `SourceInterfaceController`
12. Go to line 80 (`override func awake(withContext context: Any?)` method)
13. Add a new line with: `KeychainHelper.save(string: "invalid", key: "SJSyncV2Token", accessibility: kSecAttrAccessibleAfterFirstUnlock)`
    - 👆Upon relaunch of the Watch app this will force the login token to be invalid forcing the token refresh
14. Relaunch the Watch app
15. Once it's launched, tap the `Refresh Data` button
16. ✅ The refresh works correctly
17. ✅ Verify you see `🔐 Removing SJSyncingEmail`,  `🔐 Removing SJSyncingPwd`, and `🔐 Removing SJSyncV2Token`
18. ✅ Verify after all the removals you also see and `🔐 Saving:` log for each of the items above
    - If you were to reproduce the issue you would not see these

### Sign in With Apple Token Refresh
#### Main App
1. Launch the app
2. Sign using SIWA
3. Go to Profile Tab > Settings > Developer > Corrupt Sync Token
4. Perform a sync
5. ✅ The sync succeeds and you are not logged out

#### Watch App
1. Launch the app and the watch app
7. Sign into an existing account with Plus using SIWA on the app
8. Sync the account with the watch
9. In Xcode open KeychainHelper.swift
10. Replace the first 2 methods with the contents of the `KeychainHelper Code` section at the bottom of this PR
    - This will log out any keychain changes making debugging easier
11. in Xcode open: `SourceInterfaceController`
12. Go to line 80 (`override func awake(withContext context: Any?)` method)
13. Add a new line with: `KeychainHelper.save(string: "invalid", key: "SJSyncV2Token", accessibility: kSecAttrAccessibleAfterFirstUnlock)`
    - 👆Upon relaunch of the Watch app this will force the login token to be invalid forcing the token refresh
14. Relaunch the Watch app
15. Once it's launched, tap the `Refresh Data` button
16. ✅ The refresh works correctly
18. ✅ Verify you also see and `🔐 Saving: SJSyncV2Token` log with a large value


#### Revoking the login

1. Launch the app
2. Sign in with Apple
3. Sync the account to the watch
4. Go to Settings.app
5. Tap your name at the top of the view
6. Tap on Password & Security
7. Tap on Apps using Apple ID
8. Locate Pocket Casts
9. Tap Stop using Apple ID
10. Go back to the main app
11. ✅ Verify you are signed out
12. Open the Watch app
13. Tap Refresh Data
14. ✅ Verify you are signed out

----

#### KeychainHelper Code
```    @discardableResult
    public class func save(string: String?, key: String, accessibility: CFTypeRef) -> Bool {
        print("🔐 Saving: \(key): \(string ?? "<empty>")")
        return KeychainHelper.shared.save(value: string, key: key, accessibility: accessibility)
    }

    @discardableResult
    public class func removeKey(_ key: String) -> Bool {
        print("🔐 Removing: \(key)")
        // the accessibility flag is ignored on saving a nil value, so it's safe for this helper to put whatever in that field
        return KeychainHelper.shared.save(value: nil, key: key, accessibility: kSecAttrAccessibleAfterFirstUnlock)
    }
```


## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
