### PR TITLE
End of Year: add strings

### DIFF
--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -598,14 +598,58 @@ internal enum L10n {
   internal static var edit: String { return L10n.tr("Localizable", "edit") }
   /// See your top podcasts, categories, listening stats and more.
   internal static var eoyCardDescription: String { return L10n.tr("Localizable", "eoy_card_description") }
+  /// Save your podcasts in the cloud, get your end of year review and sync your progress with other devices.
+  internal static var eoyCreateAccountToSee: String { return L10n.tr("Localizable", "eoy_create_account_to_see") }
   /// See your top podcasts, categories, listening stats, and more. Share with friends and shout out your favorite creators!
   internal static var eoyDescription: String { return L10n.tr("Localizable", "eoy_description") }
   /// Not Now
   internal static var eoyNotNow: String { return L10n.tr("Localizable", "eoy_not_now") }
   /// Year in Podcasts
   internal static var eoySmallTitle: String { return L10n.tr("Localizable", "eoy_small_title") }
+  /// Don't forget to share with your friends and give a shout out to your favorite podcasts creators
+  internal static var eoyStoryEpilogueSubtitle: String { return L10n.tr("Localizable", "eoy_story_epilogue_subtitle") }
+  /// Thank you for letting Pocket Casts be a part of your listening experience in 2022
+  internal static var eoyStoryEpilogueTitle: String { return L10n.tr("Localizable", "eoy_story_epilogue_title") }
   /// Let's celebrate your year of listening...
   internal static var eoyStoryIntroTitle: String { return L10n.tr("Localizable", "eoy_story_intro_title") }
+  /// In 2022, you spent %1$@ listening to podcasts
+  internal static func eoyStoryListenedTo(_ p1: Any) -> String {
+    return L10n.tr("Localizable", "eoy_story_listened_to", String(describing: p1))
+  }
+  /// You listened to %1$@ different categories this year
+  internal static func eoyStoryListenedToCategories(_ p1: Any) -> String {
+    return L10n.tr("Localizable", "eoy_story_listened_to_categories", String(describing: p1))
+  }
+  /// Let's take a look at some of your favorites...
+  internal static var eoyStoryListenedToCategoriesSubtitle: String { return L10n.tr("Localizable", "eoy_story_listened_to_categories_subtitle") }
+  /// You listened to %1$@ different podcasts and %2$@ episodes
+  internal static func eoyStoryListenedToNumbers(_ p1: Any, _ p2: Any) -> String {
+    return L10n.tr("Localizable", "eoy_story_listened_to_numbers", String(describing: p1), String(describing: p2))
+  }
+  /// But there was one that you kept coming back to...
+  internal static var eoyStoryListenedToNumbersSubtitle: String { return L10n.tr("Localizable", "eoy_story_listened_to_numbers_subtitle") }
+  /// The longest episode you listened to was %1$@ from the podcast %2$@
+  internal static func eoyStoryLongestEpisode(_ p1: Any, _ p2: Any) -> String {
+    return L10n.tr("Localizable", "eoy_story_longest_episode", String(describing: p1), String(describing: p2))
+  }
+  /// This episode was %1$@ long
+  internal static func eoyStoryLongestEpisodeDuration(_ p1: Any) -> String {
+    return L10n.tr("Localizable", "eoy_story_longest_episode_duration", String(describing: p1))
+  }
+  /// Replay
+  internal static var eoyStoryReplay: String { return L10n.tr("Localizable", "eoy_story_replay") }
+  /// Your Top Categories
+  internal static var eoyStoryTopCategories: String { return L10n.tr("Localizable", "eoy_story_top_categories") }
+  /// Your top podcast was %1$@ by %2$@
+  internal static func eoyStoryTopPodcast(_ p1: Any, _ p2: Any) -> String {
+    return L10n.tr("Localizable", "eoy_story_top_podcast", String(describing: p1), String(describing: p2))
+  }
+  /// You listened to %1$@ episodes for a total of %2$@
+  internal static func eoyStoryTopPodcastSubtitle(_ p1: Any, _ p2: Any) -> String {
+    return L10n.tr("Localizable", "eoy_story_top_podcast_subtitle", String(describing: p1), String(describing: p2))
+  }
+  /// Your Top Podcasts
+  internal static var eoyStoryTopPodcasts: String { return L10n.tr("Localizable", "eoy_story_top_podcasts") }
   /// Your Year in Podcasts
   internal static var eoyTitle: String { return L10n.tr("Localizable", "eoy_title") }
   /// View My 2022

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -3276,9 +3276,6 @@
 /* Title for the End of Year feature */
 "eoy_title" = "Your Year in Podcasts";
 
-/* Title for the End of Year feature */
-"eoy_title" = "Your Year in Podcasts";
-
 /* A smaller title for the End of Year feature */
 "eoy_small_title" = "Year in Podcasts";
 

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -3331,7 +3331,7 @@
 "eoy_story_epilogue_title" = "Thank you for letting Pocket Casts be a part of your listening experience in 2022";
 
 /* Subtitle for the epilogue story */
-"eoy_story_epilogue_subtitle" = "Don't forget to share with your friends and give a shout out to your favorite podcasts creators";
+"eoy_story_epilogue_subtitle" = "Don't forget to share with your friends and give a shout out to your favorite podcast creators";
 
 /* Label for the replay button, which when tapped started the end of year stories from the first one. */
 "eoy_story_replay" = "Replay";

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -3276,6 +3276,9 @@
 /* Title for the End of Year feature */
 "eoy_title" = "Your Year in Podcasts";
 
+/* Title for the End of Year feature */
+"eoy_title" = "Your Year in Podcasts";
+
 /* A smaller title for the End of Year feature */
 "eoy_small_title" = "Year in Podcasts";
 
@@ -3293,3 +3296,48 @@
 
 /* Description that appears on the first story of the 2022 Pocket Casts wrap up (End of Year) */
 "eoy_story_intro_title" = "Let's celebrate your year of listening...";
+
+/* String telling the user how much time they listened to podcasts in 2022, %1$@ is a placeholder for the amount of time. */
+"eoy_story_listened_to" = "In 2022, you spent %1$@ listening to podcasts";
+
+/* String telling the user how much podcast categories they listened to podcasts in 2022, %1$@ is a placeholder for the number of categories. */
+"eoy_story_listened_to_categories" = "You listened to %1$@ different categories this year";
+
+/* String prompting the user for the next story to check the most listened categories. */
+"eoy_story_listened_to_categories_subtitle" = "Let's take a look at some of your favorites...";
+
+/* String telling the user how much podcasts and episodes they listened to this year, %1$@ is a placeholder for the number of podcasts and %2$@ is a placeholder fot eh number of episodes. */
+"eoy_story_listened_to_numbers" = "You listened to %1$@ different podcasts and %2$@ episodes";
+
+/* Subtitle for the story containing number of podcasts and episodes played this year. Segway for the next story. */
+"eoy_story_listened_to_numbers_subtitle" = "But there was one that you kept coming back to...";
+
+/* Title for the story that display the most listened podcast by the user this year. %1$@ is a placeholder for the podcast title and %2$@ is a placeholder for the author. */
+"eoy_story_top_podcast" = "Your top podcast was %1$@ by %2$@";
+
+/* Subtitle for the story that display the most listened podcast by the user this year. %1$@ is a placeholder for the number of episodes and %2$@ is a placeholder for the listened time. */
+"eoy_story_top_podcast_subtitle" = "You listened to %1$@ episodes for a total of %2$@";
+
+/* Title for the story showing the top podcasts for the user in the current year. */
+"eoy_story_top_podcasts" = "Your Top Podcasts";
+
+/* Title for the story showing the longest episode listened for the user in the current year. %1$@ is a placeholder for the episode title and %2$@ is a placeholder for the podcast title. */
+"eoy_story_longest_episode" = "The longest episode you listened to was %1$@ from the podcast %2$@";
+
+/* Subtitle for the story showing the longest episode listened for the user in the current year. %1$@ is a placeholder for the episode length. */
+"eoy_story_longest_episode_duration" = "This episode was %1$@ long";
+
+/* Title for the epilogue story */
+"eoy_story_epilogue_title" = "Thank you for letting Pocket Casts be a part of your listening experience in 2022";
+
+/* Subtitle for the epilogue story */
+"eoy_story_epilogue_subtitle" = "Don't forget to share with your friends and give a shout out to your favorite podcasts creators";
+
+/* Label for the replay button, which when tapped started the end of year stories from the first one. */
+"eoy_story_replay" = "Replay";
+
+/* Title of the top categories story. */
+"eoy_story_top_categories" = "Your Top Categories";
+
+/* Description to why the user needs to create an account to see their end of year stats. */
+"eoy_create_account_to_see" = "Save your podcasts in the cloud, get your end of year review and sync your progress with other devices.";


### PR DESCRIPTION
Adds strings needed for the upcoming EoY.

The reason to add those strings right now is so we're able to have enough time to review them in advance.

## To test

1. Green CI is enough
2. Just review the descriptions and strings

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
