### PR TITLE
Apple SSO: Updates the SonosLinkController to allow signing in the common intro view

### DIFF
--- a/podcasts/AuthenticationHelper.swift
+++ b/podcasts/AuthenticationHelper.swift
@@ -6,16 +6,6 @@ import PocketCastsUtils
 import AuthenticationServices
 #endif
 
-enum AuthenticationSource: String {
-    case password = "password"
-    case ssoApple = "sso_apple"
-}
-
-enum AuthenticationScope: String {
-    case mobile
-    case sonos
-}
-
 class AuthenticationHelper {
 
     @discardableResult
@@ -78,7 +68,7 @@ class AuthenticationHelper {
         }
 
         NotificationCenter.default.post(name: .userLoginDidChange, object: nil)
-        Analytics.track(.userSignedIn, properties: ["source": source.rawValue])
+        Analytics.track(.userSignedIn, properties: ["source": source])
 
         RefreshManager.shared.refreshPodcasts(forceEvenIfRefreshedRecently: true)
         Settings.setPromotionFinishedAcknowledged(true)
@@ -130,3 +120,17 @@ extension AuthenticationHelper {
     }
 }
 #endif
+
+// MARK: - Enums
+enum AuthenticationSource: String, AnalyticsDescribable {
+    case password = "password"
+    case ssoApple = "sso_apple"
+
+    var analyticsDescription: String { rawValue }
+}
+
+enum AuthenticationScope: String {
+    case mobile
+    case sonos
+}
+

--- a/podcasts/AuthenticationHelper.swift
+++ b/podcasts/AuthenticationHelper.swift
@@ -133,4 +133,3 @@ enum AuthenticationScope: String {
     case mobile
     case sonos
 }
-

--- a/podcasts/ProfileIntroViewController.swift
+++ b/podcasts/ProfileIntroViewController.swift
@@ -62,8 +62,6 @@ class ProfileIntroViewController: PCViewController, SyncSigninDelegate {
         navigationItem.leftBarButtonItem = closeButton
 
         handleThemeChanged()
-        let doneButton = UIBarButtonItem(image: UIImage(named: "cancel"), style: .done, target: self, action: #selector(doneTapped))
-        doneButton.accessibilityLabel = L10n.accessibilityCloseDialog
         navigationController?.navigationBar.setValue(true, forKey: "hidesShadow")
 
         setupProviderLoginView()

--- a/podcasts/ProfileIntroViewController.xib
+++ b/podcasts/ProfileIntroViewController.xib
@@ -85,10 +85,10 @@
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="nY7-Sl-Gxg" firstAttribute="centerX" secondItem="fnl-2z-Ty3" secondAttribute="centerX" id="2XD-1P-gsU"/>
-                <constraint firstItem="xRp-Cs-cvI" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="23" id="63H-tj-FKR"/>
                 <constraint firstItem="oOL-Vb-lE7" firstAttribute="trailing" secondItem="fnl-2z-Ty3" secondAttribute="trailing" constant="8" id="BUi-ih-aEw"/>
                 <constraint firstItem="xRp-Cs-cvI" firstAttribute="top" secondItem="oOL-Vb-lE7" secondAttribute="bottom" constant="8" id="E6A-ke-Zci"/>
-                <constraint firstItem="xRp-Cs-cvI" firstAttribute="trailing" secondItem="fnl-2z-Ty3" secondAttribute="trailing" constant="-23" id="fQl-mz-Q3W"/>
+                <constraint firstItem="xRp-Cs-cvI" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" constant="23" id="Tr8-SU-rJw"/>
+                <constraint firstAttribute="trailing" secondItem="xRp-Cs-cvI" secondAttribute="trailing" constant="23" id="bnN-4t-F3S"/>
                 <constraint firstItem="nY7-Sl-Gxg" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" priority="750" constant="60" id="gLh-ll-owx"/>
                 <constraint firstItem="GOk-uO-NBJ" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="16" id="hFj-W6-qY2"/>
                 <constraint firstItem="oOL-Vb-lE7" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="8" id="hjW-93-fBF"/>

--- a/podcasts/SonosLinkController.swift
+++ b/podcasts/SonosLinkController.swift
@@ -90,15 +90,25 @@ class SonosLinkController: PCViewController {
         let signinPage = SyncSigninViewController()
         signinPage.delegate = self
         navigationController?.pushViewController(signinPage, animated: true)
+/// This is a small subclass of the ProfileIntroViewController to allow overriding a few features to allow it to work with the Sonos login.
+private class SonosLoginIntroViewController: ProfileIntroViewController {
+    /// Reuse the super class xib
+    override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
+        super.init(nibName: "ProfileIntroViewController", bundle: nil)
     }
 
-    @objc func cancelTapped() {
-        dismiss(animated: true, completion: nil)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
 
-    // MARK: - Sign In Delegate
+    override func viewDidLoad() {
+        super.viewDidLoad()
 
-    func signingProcessCompleted() {
-        navigationController?.popViewController(animated: true)
+        navigationItem.leftBarButtonItem = nil
+        navigationItem.hidesBackButton = false
+    }
+
+    override func signingProcessCompleted() {
+        navigationController?.popToRootViewController(animated: true)
     }
 }

--- a/podcasts/SonosLinkController.swift
+++ b/podcasts/SonosLinkController.swift
@@ -56,6 +56,15 @@ class SonosLinkController: PCViewController {
     }
 }
 
+private extension SonosLinkController {
+    func updateConnectButtonTitle(_ title: String) {
+        connectBtn.setTitle(title, for: .normal)
+    }
+
+    func signIntoPocketCasts() {
+        navigationController?.pushViewController(SonosLoginIntroViewController(), animated: true)
+    }
+
     func connectWithSonos() {
         guard ServerSettings.syncingEmail() != nil else {
             updateConnectButtonTitle(L10n.retry.localizedUppercase)
@@ -78,18 +87,17 @@ class SonosLinkController: PCViewController {
                 let fullUrl = strongSelf.callbackUri + "&code=" + token.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!
                 if let url = URL(string: fullUrl) {
                     UIApplication.shared.open(url, options: [:], completionHandler: nil)
+                    strongSelf.dismiss(animated: true)
                 } else {
-                    strongSelf.connectBtn.buttonTitle = L10n.retry.localizedUppercase
+                    strongSelf.updateConnectButtonTitle(L10n.retry.localizedUppercase)
                     SJUIUtils.showAlert(title: L10n.sonosConnectionFailedTitle, message: L10n.sonosConnectionFailedAppMissing, from: self)
                 }
             }
         }
     }
+}
 
-    func signIntoPocketCasts(signInMode: Bool) {
-        let signinPage = SyncSigninViewController()
-        signinPage.delegate = self
-        navigationController?.pushViewController(signinPage, animated: true)
+
 /// This is a small subclass of the ProfileIntroViewController to allow overriding a few features to allow it to work with the Sonos login.
 private class SonosLoginIntroViewController: ProfileIntroViewController {
     /// Reuse the super class xib

--- a/podcasts/SonosLinkController.swift
+++ b/podcasts/SonosLinkController.swift
@@ -2,10 +2,6 @@ import PocketCastsServer
 import PocketCastsUtils
 import UIKit
 
-class SonosLinkController: PCViewController, SyncSigninDelegate {
-    private let accountBtnTag = 1
-    private let signinBtnTag = 2
-
     @IBOutlet var sonosImage: UIImageView! {
         didSet {
             sonosImage.image = Theme.isDarkTheme() ? UIImage(named: "sonos-dark") : UIImage(named: "sonos-light")

--- a/podcasts/SonosLinkController.xib
+++ b/podcasts/SonosLinkController.xib
@@ -1,17 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="SonosLinkController" customModule="podcasts" customModuleProvider="target">
             <connections>
                 <outlet property="connectBtn" destination="eq6-1h-j1k" id="Pu1-9e-8zp"/>
-                <outlet property="createBtn" destination="Xvs-nu-x8L" id="gsn-i6-tu2"/>
                 <outlet property="mainMessage" destination="Cob-KJ-KeT" id="c0U-ca-nqL"/>
                 <outlet property="sonosImage" destination="Yqf-gE-xPX" id="c33-dQ-xvT"/>
+                <outlet property="titleLabel" destination="6AL-1l-kSE" id="NDZ-Uv-6mI"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
             </connections>
         </placeholder>
@@ -24,7 +25,7 @@
                     <rect key="frame" x="0.0" y="0.0" width="375" height="623"/>
                     <subviews>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Hyf-AM-sbM">
-                            <rect key="frame" x="0.0" y="0.0" width="375" height="435"/>
+                            <rect key="frame" x="0.0" y="0.0" width="375" height="444"/>
                             <subviews>
                                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="sonos-light" translatesAutoresizingMaskIntoConstraints="NO" id="Yqf-gE-xPX">
                                     <rect key="frame" x="45.5" y="19" width="244" height="137"/>
@@ -36,10 +37,7 @@
                                     <nil key="highlightedColor"/>
                                 </label>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Cob-KJ-KeT" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                                    <rect key="frame" x="45" y="212" width="285" height="90"/>
-                                    <constraints>
-                                        <constraint firstAttribute="width" relation="lessThanOrEqual" constant="300" id="UT6-Ly-pu7"/>
-                                    </constraints>
+                                    <rect key="frame" x="15" y="203" width="345" height="90"/>
                                     <string key="text">Connecting to Sonos will allow the Sonos app to access your episode information.
 
 Your email address, password and other sensitive items are never shared.</string>
@@ -47,60 +45,32 @@ Your email address, password and other sensitive items are never shared.</string
                                     <nil key="textColor"/>
                                     <nil key="highlightedColor"/>
                                 </label>
-                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="eq6-1h-j1k" customClass="ShiftyRoundButton" customModule="podcasts" customModuleProvider="target">
-                                    <rect key="frame" x="37.5" y="316" width="300" height="44"/>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="eq6-1h-j1k" customClass="ThemeableRoundedButton" customModule="podcasts" customModuleProvider="target">
+                                    <rect key="frame" x="37.5" y="313" width="300" height="56"/>
                                     <accessibility key="accessibilityConfiguration">
                                         <accessibilityTraits key="traits" button="YES"/>
                                         <bool key="isElement" value="YES"/>
                                     </accessibility>
                                     <constraints>
                                         <constraint firstAttribute="width" constant="300" id="IRL-oz-zOr"/>
-                                        <constraint firstAttribute="height" constant="44" id="v3q-91-rut"/>
+                                        <constraint firstAttribute="height" constant="56" id="v3q-91-rut"/>
                                     </constraints>
-                                    <userDefinedRuntimeAttributes>
-                                        <userDefinedRuntimeAttribute type="color" keyPath="strokeColor">
-                                            <color key="value" red="0.47058823529999999" green="0.83529411760000005" blue="0.28627450980000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                        </userDefinedRuntimeAttribute>
-                                        <userDefinedRuntimeAttribute type="boolean" keyPath="isOn" value="YES"/>
-                                        <userDefinedRuntimeAttribute type="color" keyPath="fillColor">
-                                            <color key="value" red="0.47058823529999999" green="0.83529411760000005" blue="0.28627450980000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                        </userDefinedRuntimeAttribute>
-                                    </userDefinedRuntimeAttributes>
-                                </view>
-                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Xvs-nu-x8L" userLabel="Create Btn" customClass="ShiftyRoundButton" customModule="podcasts" customModuleProvider="target">
-                                    <rect key="frame" x="37.5" y="371" width="300" height="44"/>
-                                    <accessibility key="accessibilityConfiguration" label="Create Account">
-                                        <accessibilityTraits key="traits" button="YES"/>
-                                        <bool key="isElement" value="YES"/>
-                                    </accessibility>
-                                    <constraints>
-                                        <constraint firstAttribute="width" constant="300" id="IGr-8j-gXn"/>
-                                        <constraint firstAttribute="height" constant="44" id="NpY-bX-zw2"/>
-                                    </constraints>
-                                    <userDefinedRuntimeAttributes>
-                                        <userDefinedRuntimeAttribute type="color" keyPath="strokeColor">
-                                            <color key="value" red="0.076461829250000002" green="0.59036862850000005" blue="0.94450449940000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                        </userDefinedRuntimeAttribute>
-                                        <userDefinedRuntimeAttribute type="color" keyPath="fillColor">
-                                            <color key="value" red="0.076461829250000002" green="0.59036862850000005" blue="0.94450449940000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                        </userDefinedRuntimeAttribute>
-                                        <userDefinedRuntimeAttribute type="boolean" keyPath="isOn" value="YES"/>
-                                    </userDefinedRuntimeAttributes>
+                                    <connections>
+                                        <action selector="connect:" destination="-1" eventType="touchUpInside" id="dtx-o4-Phh"/>
+                                    </connections>
                                 </view>
                             </subviews>
                             <constraints>
                                 <constraint firstItem="6AL-1l-kSE" firstAttribute="centerX" secondItem="Hyf-AM-sbM" secondAttribute="centerX" id="F8U-Ue-Kza"/>
-                                <constraint firstItem="Xvs-nu-x8L" firstAttribute="centerX" secondItem="Hyf-AM-sbM" secondAttribute="centerX" id="ODH-c8-C54"/>
                                 <constraint firstItem="Yqf-gE-xPX" firstAttribute="top" secondItem="Hyf-AM-sbM" secondAttribute="top" constant="19" id="Ont-2D-Zpb"/>
                                 <constraint firstAttribute="bottom" secondItem="eq6-1h-j1k" secondAttribute="bottom" constant="75" id="PVt-ES-b5t"/>
-                                <constraint firstItem="Cob-KJ-KeT" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Hyf-AM-sbM" secondAttribute="leading" priority="750" constant="20" id="Plo-Qr-b1C"/>
+                                <constraint firstItem="Cob-KJ-KeT" firstAttribute="leading" secondItem="Hyf-AM-sbM" secondAttribute="leading" priority="750" constant="15" id="Plo-Qr-b1C"/>
                                 <constraint firstItem="Cob-KJ-KeT" firstAttribute="centerX" secondItem="Hyf-AM-sbM" secondAttribute="centerX" id="Tbr-O3-Tce"/>
                                 <constraint firstItem="eq6-1h-j1k" firstAttribute="centerX" secondItem="Hyf-AM-sbM" secondAttribute="centerX" id="WPw-8Q-Kw1"/>
-                                <constraint firstItem="eq6-1h-j1k" firstAttribute="top" secondItem="Cob-KJ-KeT" secondAttribute="bottom" constant="14" id="XIk-YQ-niV"/>
+                                <constraint firstItem="eq6-1h-j1k" firstAttribute="top" secondItem="Cob-KJ-KeT" secondAttribute="bottom" constant="20" id="XIk-YQ-niV"/>
                                 <constraint firstItem="6AL-1l-kSE" firstAttribute="top" secondItem="Yqf-gE-xPX" secondAttribute="bottom" constant="16" id="gIk-3f-HQh"/>
-                                <constraint firstItem="Xvs-nu-x8L" firstAttribute="top" secondItem="eq6-1h-j1k" secondAttribute="bottom" constant="11" id="jws-ab-nIO"/>
-                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="Cob-KJ-KeT" secondAttribute="trailing" priority="750" constant="20" id="kNZ-pq-vNl"/>
-                                <constraint firstItem="Cob-KJ-KeT" firstAttribute="top" secondItem="6AL-1l-kSE" secondAttribute="bottom" constant="19" id="onF-c6-O3F"/>
+                                <constraint firstAttribute="trailing" secondItem="Cob-KJ-KeT" secondAttribute="trailing" priority="750" constant="15" id="kNZ-pq-vNl"/>
+                                <constraint firstItem="Cob-KJ-KeT" firstAttribute="top" secondItem="6AL-1l-kSE" secondAttribute="bottom" constant="10" id="onF-c6-O3F"/>
                                 <constraint firstItem="Yqf-gE-xPX" firstAttribute="centerX" secondItem="Hyf-AM-sbM" secondAttribute="centerX" constant="-20" id="y4d-Jt-4Y1"/>
                             </constraints>
                         </view>


### PR DESCRIPTION
This adds the ability to sign in using SSO by pushing to the ProfileIntroViewController instead of directly to the SyncSignIn.

This also does a small UI update so the view style matches the rest of the app.

**Note** I spent some time trying to modify the registration flow so the user wouldn't get kicked out and have to restart the Sonos process, but the registration flow is a bit too complex to modify so I opted to ignore it for now. 

I also have installed the Sonos app (without any devices setup) and can confirm that I am correctly redirected into it after signing in and tapping the CONNECT button. We will still need to test on a real Sonos account in the future.

## Screenshots
| Before | After |
|:---:|:---:|
|<img width="320" alt="Screen Shot 2022-10-31 at 10 45 16 PM" src="https://user-images.githubusercontent.com/793774/199147406-ca8a40da-3f74-41f9-9d1c-0bdc127ca9de.png">|<img width="320" alt="Screen Shot 2022-10-31 at 10 45 10 PM" src="https://user-images.githubusercontent.com/793774/199147412-6bdbc4eb-f238-4af6-8e4f-24dfb6405f6b.png">|


## To test

1. Enable the `signInWithApple` FeatureFlag, and switch to the Staging config
2. Launch the app
3. Sign out if you're signed in
4. In Safari go to: `pktc://applink/sonos/sonos://`
5. Open the link in the app
6. ✅ Verify the view appears and looks good
7. Tap the Continue button
8. Log in with an existing email/password account
9. ✅ Verify after logging in you are returned to the Sonos view and the button says "CONNECT"
10. Dismiss the view
11. Log out
12. Open the app link in Safari again
13. Tap Continue
14. Log in using an existing account with Apple SIWA
15. ✅ Verify after you are signed in you are returned to the Sonos view and the button says "CONNECT"

Please also disable the feature flag and test to make sure the email/password sign in still works correctly.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
