### PR TITLE
Use the official, working way of setting user-agent in iOS16+

### DIFF
--- a/podcasts/PlaybackItem.swift
+++ b/podcasts/PlaybackItem.swift
@@ -15,7 +15,7 @@ class PlaybackItem: NSObject {
 
     func createPlayerItem() -> AVPlayerItem? {
         guard let url = EpisodeManager.urlForEpisode(episode) else { return nil }
-        var options = [String : Any]()
+        var options: [String: Any] = [:]
         if #available(iOS 16, *), #available(watchOSApplicationExtension 9.0, *) {
             // there is now an official, working way to set the user-agent for every request
             // https://developer.apple.com/documentation/avfoundation/avurlassethttpuseragentkey

--- a/podcasts/PlaybackItem.swift
+++ b/podcasts/PlaybackItem.swift
@@ -24,7 +24,6 @@ class PlaybackItem: NSObject {
             let customHeaders = [ServerConstants.HttpHeaders.userAgent: ServerConstants.Values.appUserAgent]
             options["AVURLAssetHTTPHeaderFieldsKey"] = customHeaders
         }
-        
         let asset = AVURLAsset(url: url, options: options)
 
         return AVPlayerItem(asset: asset)

--- a/podcasts/PlaybackItem.swift
+++ b/podcasts/PlaybackItem.swift
@@ -15,9 +15,17 @@ class PlaybackItem: NSObject {
 
     func createPlayerItem() -> AVPlayerItem? {
         guard let url = EpisodeManager.urlForEpisode(episode) else { return nil }
-
-        let customHeaders = [ServerConstants.HttpHeaders.userAgent: ServerConstants.Values.appUserAgent]
-        let asset = AVURLAsset(url: url, options: ["AVURLAssetHTTPHeaderFieldsKey": customHeaders])
+        var options = [String : Any]()
+        if #available(iOS 16, *) {
+            // there is now an official, working way to set the user-agent for every request
+            // https://developer.apple.com/documentation/avfoundation/avurlassethttpuseragentkey
+            options[AVURLAssetHTTPUserAgentKey] = ServerConstants.Values.appUserAgent
+        } else {
+            let customHeaders = [ServerConstants.HttpHeaders.userAgent: ServerConstants.Values.appUserAgent]
+            options["AVURLAssetHTTPHeaderFieldsKey"] = customHeaders
+        }
+        
+        let asset = AVURLAsset(url: url, options: options)
 
         return AVPlayerItem(asset: asset)
     }

--- a/podcasts/PlaybackItem.swift
+++ b/podcasts/PlaybackItem.swift
@@ -16,7 +16,7 @@ class PlaybackItem: NSObject {
     func createPlayerItem() -> AVPlayerItem? {
         guard let url = EpisodeManager.urlForEpisode(episode) else { return nil }
         var options = [String : Any]()
-        if #available(iOS 16, *) {
+        if #available(iOS 16, *), #available(watchOSApplicationExtension 9.0, *) {
             // there is now an official, working way to set the user-agent for every request
             // https://developer.apple.com/documentation/avfoundation/avurlassethttpuseragentkey
             options[AVURLAssetHTTPUserAgentKey] = ServerConstants.Values.appUserAgent


### PR DESCRIPTION
> As we’ve documented in the past, [many different apps use a useragent called AppleCoreMedia to request podcasts](https://podnews.net/article/applecoremedia-user-agent), making it hard for podcasters, and podcast hosting companies, to know which app is really downloading them. iOS 16 will fix that: [AVURLAssetHTTPUserAgentKey has just appeared in Apple’s documentation](https://developer.apple.com/documentation/avfoundation/avurlassethttpuseragentkey?utm_source=podnews.net&utm_medium=web&utm_campaign=podnews.net:2022-06-07) for the next version of iOS, allowing all podcast apps to correctly state their user agent.
>
> — https://podnews.net/update/applecoremedia-gone-off

Apple doc: https://developer.apple.com/documentation/avfoundation/avurlassethttpuseragentkey

This will ensure Pocket Casts is properly credited for all requests it makes when folks are analyzing backend server logs for app attribution.

## To test

1. Use a tool like Charles proxy (or any other proxy tool)
2. Run Pocket Casts
3. Check the requests for the asset
4. ✅ Ensure they have "Pocket Casts" as the user-agent:

<img width="512" alt="Screen Shot 2022-11-02 at 09 25 12" src="https://user-images.githubusercontent.com/7040243/199488989-b9aa6402-2fd6-4b73-a8c9-500a15b34146.png">

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
