### PR TITLE
End of Year: require account

### DIFF
--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -268,7 +268,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             Constants.RemoteParams.periodicSaveTimeMs: NSNumber(value: Constants.RemoteParams.periodicSaveTimeMsDefault),
             Constants.RemoteParams.episodeSearchDebounceMs: NSNumber(value: Constants.RemoteParams.episodeSearchDebounceMsDefault),
             Constants.RemoteParams.podcastSearchDebounceMs: NSNumber(value: Constants.RemoteParams.podcastSearchDebounceMsDefault),
-            Constants.RemoteParams.customStorageLimitGB: NSNumber(value: Constants.RemoteParams.customStorageLimitGBDefault)
+            Constants.RemoteParams.customStorageLimitGB: NSNumber(value: Constants.RemoteParams.customStorageLimitGBDefault),
+            Constants.RemoteParams.endOfYearRequireAccount: NSNumber(value: Constants.RemoteParams.endOfYearRequireAccountDefault)
         ])
 
         remoteConfig.fetch(withExpirationDuration: 2.hour) { status, _ in

--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -272,11 +272,18 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             Constants.RemoteParams.endOfYearRequireAccount: NSNumber(value: Constants.RemoteParams.endOfYearRequireAccountDefault)
         ])
 
-        remoteConfig.fetch(withExpirationDuration: 2.hour) { status, _ in
+        remoteConfig.fetch(withExpirationDuration: 2.hour) { [weak self] status, _ in
             if status == .success {
                 remoteConfig.activate(completion: nil)
+
+                self?.updateEndOfYearRemoteValue()
             }
         }
+    }
+
+    private func updateEndOfYearRemoteValue() {
+        // Update if EOY requires an account to be seen
+        EndOfYear.requireAccount = Settings.endOfYearRequireAccount
     }
 
     private func postLaunchSetup() {

--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -145,6 +145,7 @@ struct Constants {
         static let reviewRequestDates = "reviewRequestDates"
 
         static let showBadgeFor2022EndOfYear = "showBadgeFor2022EndOfYear"
+        static let modal2022HasBeenShown = "modal2022HasBeenShown"
     }
 
     enum Values {

--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -243,6 +243,9 @@ struct Constants {
 
         static let customStorageLimitGB = "custom_storage_limit_gb"
         static let customStorageLimitGBDefault: Int = 10
+
+        static let endOfYearRequireAccount = "end_of_year_require_account"
+        static let endOfYearRequireAccountDefault: Bool = true
     }
 
     static let defaultDebounceTime: TimeInterval = 0.5

--- a/podcasts/End of Year/EndOfYear.swift
+++ b/podcasts/End of Year/EndOfYear.swift
@@ -32,6 +32,7 @@ struct EndOfYear {
 
         if Settings.endOfYearRequireAccount && !SyncManager.isUserLoggedIn() {
             let controller = ProfileIntroViewController()
+            controller.infoLabelText = L10n.eoyCreateAccountToSee
             viewController.present(controller, animated: true)
             return
         }

--- a/podcasts/End of Year/EndOfYear.swift
+++ b/podcasts/End of Year/EndOfYear.swift
@@ -49,6 +49,7 @@ struct EndOfYear {
             let profileIntroController = ProfileIntroViewController()
             profileIntroController.infoLabelText = L10n.eoyCreateAccountToSee
             let navigationController = UINavigationController(rootViewController: profileIntroController)
+            navigationController.modalPresentationStyle = .fullScreen
             viewController.present(navigationController, animated: true)
             return
         }

--- a/podcasts/End of Year/EndOfYear.swift
+++ b/podcasts/End of Year/EndOfYear.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import PocketCastsServer
 import MaterialComponents.MaterialBottomSheet
 import PocketCastsDataModel
 
@@ -26,6 +27,12 @@ struct EndOfYear {
 
     func showStories(in viewController: UIViewController) {
         guard FeatureFlag.endOfYear else {
+            return
+        }
+
+        if Settings.endOfYearRequireAccount && !SyncManager.isUserLoggedIn() {
+            let controller = ProfileIntroViewController()
+            viewController.present(controller, animated: true)
             return
         }
 

--- a/podcasts/End of Year/EndOfYear.swift
+++ b/podcasts/End of Year/EndOfYear.swift
@@ -9,6 +9,10 @@ struct EndOfYear {
         FeatureFlag.endOfYear && DataManager.sharedManager.isEligibleForEndOfYearStories()
     }
 
+    /// Internal state machine to determine how we should react to login changes
+    /// and when to show the modal vs go directly to the stories
+    private static var state: EndOfYearState = .showModalIfNeeded
+
     static var requireAccount: Bool = Settings.endOfYearRequireAccount {
         didSet {
             // If registration is not needed anymore and this user is logged out
@@ -94,4 +98,8 @@ class StoriesHostingController<ContentView: View>: UIHostingController<ContentVi
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         .portrait
     }
+}
+
+private enum EndOfYearState {
+    case showModalIfNeeded, waitingForLogin, loggedIn
 }

--- a/podcasts/End of Year/EndOfYear.swift
+++ b/podcasts/End of Year/EndOfYear.swift
@@ -44,6 +44,26 @@ struct EndOfYear {
         MDCSwiftUIWrapper.present(EndOfYearModal(), in: viewController)
     }
 
+    func showPromptBasedOnState(in viewController: UIViewController) {
+        switch Self.state {
+
+        // If we're in the default state, then check to see if we should show the prompt
+        case .showModalIfNeeded:
+            showPrompt(in: viewController)
+
+        // If we were in the waiting state, but the user has logged in, then show stories
+        case .loggedIn:
+            Self.state = .showModalIfNeeded
+            showStories(in: viewController)
+
+        // If the user has seen the prompt, and chosen to login, but then has cancelled out of the flow without logging in,
+        // When this code is ran from MainTabController viewDidAppear we will still be in the waiting state
+        // reset the state to the default to restart the process over again
+        case .waitingForLogin:
+            Self.state = .showModalIfNeeded
+        }
+    }
+
     func showStories(in viewController: UIViewController) {
         guard FeatureFlag.endOfYear else {
             return

--- a/podcasts/End of Year/EndOfYear.swift
+++ b/podcasts/End of Year/EndOfYear.swift
@@ -46,9 +46,10 @@ struct EndOfYear {
         }
 
         if Self.requireAccount && !SyncManager.isUserLoggedIn() {
-            let controller = ProfileIntroViewController()
-            controller.infoLabelText = L10n.eoyCreateAccountToSee
-            viewController.present(controller, animated: true)
+            let profileIntroController = ProfileIntroViewController()
+            profileIntroController.infoLabelText = L10n.eoyCreateAccountToSee
+            let navigationController = UINavigationController(rootViewController: profileIntroController)
+            viewController.present(navigationController, animated: true)
             return
         }
 

--- a/podcasts/End of Year/EndOfYear.swift
+++ b/podcasts/End of Year/EndOfYear.swift
@@ -9,12 +9,27 @@ struct EndOfYear {
         FeatureFlag.endOfYear && DataManager.sharedManager.isEligibleForEndOfYearStories()
     }
 
+    static var requireAccount: Bool = Settings.endOfYearRequireAccount {
+        didSet {
+            // If registration is not needed anymore and this user is logged out
+            // Show the prompt again.
+            if oldValue && !requireAccount && !SyncManager.isUserLoggedIn() {
+                Settings.endOfYearModalHasBeenShown = false
+                NotificationCenter.postOnMainThread(notification: .eoyRegistrationNotRequired, object: nil)
+            }
+        }
+    }
+
     var presentationMode: UIModalPresentationStyle {
         UIDevice.current.isiPad() ? .formSheet : .fullScreen
     }
 
     var storiesPadding: EdgeInsets {
         .init(top: 0, leading: 0, bottom: UIDevice.current.isiPad() ? 5 : 0, trailing: 0)
+    }
+
+    init() {
+        Self.requireAccount = Settings.endOfYearRequireAccount
     }
 
     func showPrompt(in viewController: UIViewController) {
@@ -30,7 +45,7 @@ struct EndOfYear {
             return
         }
 
-        if Settings.endOfYearRequireAccount && !SyncManager.isUserLoggedIn() {
+        if Self.requireAccount && !SyncManager.isUserLoggedIn() {
             let controller = ProfileIntroViewController()
             controller.infoLabelText = L10n.eoyCreateAccountToSee
             viewController.present(controller, animated: true)

--- a/podcasts/End of Year/EndOfYear.swift
+++ b/podcasts/End of Year/EndOfYear.swift
@@ -70,6 +70,8 @@ struct EndOfYear {
         }
 
         if Self.requireAccount && !SyncManager.isUserLoggedIn() {
+            Self.state = .waitingForLogin
+
             let profileIntroController = ProfileIntroViewController()
             profileIntroController.infoLabelText = L10n.eoyCreateAccountToSee
             let navigationController = UINavigationController(rootViewController: profileIntroController)

--- a/podcasts/End of Year/EndOfYear.swift
+++ b/podcasts/End of Year/EndOfYear.swift
@@ -110,6 +110,22 @@ struct EndOfYear {
             StoryShareableProvider.generatedItem = asset() as? UIImage
         }
     }
+
+    func resetStateIfNeeded() {
+        // When a user logs in (or creates an account) we mark the EOY modal as not
+        // shown to show it again.
+        if Self.state == .showModalIfNeeded {
+            Settings.endOfYearModalHasBeenShown = false
+            return
+        }
+
+        guard Self.state == .waitingForLogin else { return }
+
+        // If we're in the waiting for login state (the user has seen the prompt, and chosen to login)
+        // Update the current state based on whether the user is logged in or not
+        // If the user did not login, then just reset the state to the default showModalIfNeeded
+        Self.state = SyncManager.isUserLoggedIn() ? .loggedIn : .showModalIfNeeded
+    }
 }
 
 class StoriesHostingController<ContentView: View>: UIHostingController<ContentView> {

--- a/podcasts/End of Year/EndOfYear.swift
+++ b/podcasts/End of Year/EndOfYear.swift
@@ -18,7 +18,7 @@ struct EndOfYear {
     }
 
     func showPrompt(in viewController: UIViewController) {
-        guard Self.isEligible else {
+        guard Self.isEligible, !Settings.endOfYearModalHasBeenShown else {
             return
         }
 

--- a/podcasts/End of Year/Views/EndOfYearModal.swift
+++ b/podcasts/End of Year/Views/EndOfYearModal.swift
@@ -28,6 +28,9 @@ struct EndOfYearModal: View {
         }
         .frame(maxWidth: Constants.maxWidth)
         .applyDefaultThemeOptions()
+        .onAppear {
+            Settings.endOfYearModalHasBeenShown = true
+        }
     }
 
     var pill: some View {

--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -51,6 +51,19 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
         NotificationCenter.default.addObserver(self, selector: #selector(willEnterForeground), name: UIApplication.willEnterForegroundNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(unhideNavBar), name: Constants.Notifications.unhideNavBarRequested, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(profileSeen), name: Constants.Notifications.profileSeen, object: nil)
+
+        observeLoginForEndOfYearStats()
+    }
+
+    func observeLoginForEndOfYearStats() {
+        guard FeatureFlag.endOfYear else {
+            return
+        }
+
+        NotificationCenter.default.addObserver(forName: .userLoginDidChange, object: nil, queue: .main) { _ in
+            // When a user login (or create an account) we show the modal again
+            Settings.endOfYearModalHasBeenShown = false
+        }
     }
 
     override func viewDidAppear(_ animated: Bool) {

--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -407,7 +407,7 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
         guard FeatureFlag.endOfYear else {
             return
         }
-        
+
         NotificationCenter.default.addObserver(forName: .userSignedIn, object: nil, queue: .main) { notification in
             self.endOfYear.resetStateIfNeeded()
         }

--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -63,7 +63,7 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
         checkPromotionFinishedAcknowledged()
         checkWhatsNewAcknowledged()
 
-        endOfYear.showPrompt(in: self)
+        endOfYear.showPromptBasedOnState(in: self)
     }
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
@@ -407,11 +407,9 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
         guard FeatureFlag.endOfYear else {
             return
         }
-
-        // When a user login (or create an account) we mark the EOY modal as not
-        // shown to show it again.
-        NotificationCenter.default.addObserver(forName: .userLoginDidChange, object: nil, queue: .main) { _ in
-            Settings.endOfYearModalHasBeenShown = false
+        
+        NotificationCenter.default.addObserver(forName: .userSignedIn, object: nil, queue: .main) { notification in
+            self.endOfYear.resetStateIfNeeded()
         }
 
         // If the requirement for EOY changes and registration is not required anymore

--- a/podcasts/NewEmailViewController.swift
+++ b/podcasts/NewEmailViewController.swift
@@ -241,6 +241,7 @@ class NewEmailViewController: UIViewController, UITextFieldDelegate {
         ServerSettings.setSyncingEmail(email: username)
 
         NotificationCenter.default.post(name: .userLoginDidChange, object: nil)
+        NotificationCenter.postOnMainThread(notification: .userSignedIn)
 
         Analytics.track(.userAccountCreated)
     }

--- a/podcasts/Notifications.swift
+++ b/podcasts/Notifications.swift
@@ -3,4 +3,7 @@ import Foundation
 extension NSNotification.Name {
     /// When a user has signed in, signed out, or been signed in during account creation
     static let userLoginDidChange = NSNotification.Name("User.LoginChanged")
+
+    /// When the requirement for having an account or not to see End Of Year Stats changes
+    static let eoyRegistrationNotRequired = NSNotification.Name("EOY.RegistrationNotRequired")
 }

--- a/podcasts/Notifications.swift
+++ b/podcasts/Notifications.swift
@@ -4,6 +4,9 @@ extension NSNotification.Name {
     /// When a user has signed in, signed out, or been signed in during account creation
     static let userLoginDidChange = NSNotification.Name("User.LoginChanged")
 
+    /// When a user logs via login or account creation
+    static let userSignedIn = NSNotification.Name("User.SignedOrCreatedAccount")
+
     /// When the requirement for having an account or not to see End Of Year Stats changes
     static let eoyRegistrationNotRequired = NSNotification.Name("EOY.RegistrationNotRequired")
 }

--- a/podcasts/ProfileIntroViewController.swift
+++ b/podcasts/ProfileIntroViewController.swift
@@ -57,10 +57,12 @@ class ProfileIntroViewController: PCViewController, SyncSigninDelegate {
 
     @IBOutlet var infoLabel: ThemeableLabel! {
         didSet {
-            infoLabel.text = L10n.signInMessage
+            infoLabel.text = infoLabelText ?? L10n.signInMessage
             infoLabel.style = .primaryText02
         }
     }
+
+    var infoLabelText: String?
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -746,6 +746,11 @@ class Settings: NSObject {
             remoteMsToTime(key: Constants.RemoteParams.episodeSearchDebounceMs)
         }
 
+        static var endOfYearRequireAccount: Bool {
+            let remote = RemoteConfig.remoteConfig().configValue(forKey: Constants.RemoteParams.endOfYearRequireAccount)
+            return remote.boolValue
+        }
+
         private class func remoteMsToTime(key: String) -> TimeInterval {
             let remoteMs = RemoteConfig.remoteConfig().configValue(forKey: key)
 

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -719,7 +719,7 @@ class Settings: NSObject {
         UserDefaults.standard.bool(forKey: Constants.UserDefaults.analyticsOptOut)
     }
 
-    // MARK: - Profile Badge for End of Year 2022
+    // MARK: - End of Year 2022
 
     class var showBadgeFor2022EndOfYear: Bool {
         set {
@@ -728,6 +728,16 @@ class Settings: NSObject {
 
         get {
             (UserDefaults.standard.value(forKey: Constants.UserDefaults.showBadgeFor2022EndOfYear) as? Bool) ?? true
+        }
+    }
+
+    class var endOfYearModalHasBeenShown: Bool {
+        set {
+            UserDefaults.standard.set(newValue, forKey: Constants.UserDefaults.modal2022HasBeenShown)
+        }
+
+        get {
+            UserDefaults.standard.bool(forKey: Constants.UserDefaults.modal2022HasBeenShown)
         }
     }
 

--- a/podcasts/SyncSigninViewController.swift
+++ b/podcasts/SyncSigninViewController.swift
@@ -299,6 +299,8 @@ class SyncSigninViewController: PCViewController, UITextFieldDelegate {
                     RefreshManager.shared.refreshPodcasts(forceEvenIfRefreshedRecently: true)
                     Settings.setPromotionFinishedAcknowledged(true)
                     Settings.setLoginDetailsUpdated()
+
+                    NotificationCenter.postOnMainThread(notification: .userSignedIn)
                 })
             }
         }


### PR DESCRIPTION
| 📘 Project: #376 |
|:---:|

In order to provide better End of Year stats next year, it's required to create an account to see 2022 End of Year stats.

## To test

On `AppDelegate.didFinishLaunchingWithOptions` add (before `return true`):

```swift
Settings.endOfYearModalHasBeenShown = false
```

1. Enable the `endOfYear` flag in `FeatureFlag.swift`
2. Run the app and make sure you're logged in to an account with a few items on Listening History
3. Logout
4. Re-run the app
5. ✅ The 2022 prompt should appear, even though you're logged out
6. Tap "View my 2022"
7. You should be prompted to login or create an account
8. Login (or create an account)
11. ✅ The stories should appear
12. Remove that you added on `AppDelegate` and re-run the app, the prompt should not appear anymore

You should see the same behavior when tapping the card under Profile. If you're logged in, the stories should appear. If not, the login/sign up screen should appear.

### Remote flag

There's a remote flag that dictates if an account is required or not to see the stories.

On `AppDelegate.didFinishLaunchingWithOptions` add (before `return true`):

```swift
Settings.endOfYearModalHasBeenShown = false
```

And on `configureFirebase` change `2.hour` to `30.seconds`. Then:

1. Enable the `endOfYear` flag in `FeatureFlag.swift`
2. Run the app and make sure you're logged in to an account with a few items on Listening History
3. Logout
4. Re-run the app
5. ✅ The 2022 prompt should appear, even though you're logged out
6. Go to Firebase Console > Remote Config
7. Change `end_of_year_require_account` from `true` to `false`
8. Publish the changes
9. Remove `Settings.endOfYearModalHasBeenShown = false` from `AppDelegate`
10. Re-run the app
11. ✅ The prompt should appear again
12. Tap "View my 2022"
13. Stories should appear even though you're logged out
14. Change `end_of_year_require_account` from `false` to `true` 
15. Publish the changes

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
