### PR TITLE
End of Year: tracks

### DIFF
--- a/PocketCastsTests/Tests/End of Year/EndOfYearStoriesBuilderTests.swift
+++ b/PocketCastsTests/Tests/End of Year/EndOfYearStoriesBuilderTests.swift
@@ -39,7 +39,7 @@ class EndOfYearStoriesBuilderTests: XCTestCase {
         let stories = await builder.build()
 
         XCTAssertEqual(stories.0.first, EndOfYearStory.listenedCategories)
-        XCTAssertEqual(stories.0[1], EndOfYearStory.topFiveCategories)
+        XCTAssertEqual(stories.0[1], EndOfYearStory.topCategories)
         XCTAssertEqual(stories.1.listenedCategories.first?.numberOfPodcasts, 1)
         XCTAssertEqual(stories.1.listenedCategories.first?.numberOfPodcasts, 1)
     }
@@ -53,7 +53,7 @@ class EndOfYearStoriesBuilderTests: XCTestCase {
         let stories = await builder.build()
 
         XCTAssertFalse(stories.0.contains(.listenedCategories))
-        XCTAssertFalse(stories.0.contains(.topFiveCategories))
+        XCTAssertFalse(stories.0.contains(.topCategories))
         XCTAssertTrue(stories.1.listenedCategories.isEmpty)
     }
 
@@ -65,7 +65,7 @@ class EndOfYearStoriesBuilderTests: XCTestCase {
         endOfYearManager.listenedNumbersToReturn = ListenedNumbers(numberOfPodcasts: 3, numberOfEpisodes: 10)
         let stories = await builder.build()
 
-        XCTAssertEqual(stories.0.first, EndOfYearStory.listenedNumbers)
+        XCTAssertEqual(stories.0.first, EndOfYearStory.numberOfPodcastsAndEpisodesListened)
         XCTAssertEqual(stories.1.listenedNumbers.numberOfPodcasts, 3)
         XCTAssertEqual(stories.1.listenedNumbers.numberOfEpisodes, 10)
     }
@@ -78,7 +78,7 @@ class EndOfYearStoriesBuilderTests: XCTestCase {
         endOfYearManager.listenedNumbersToReturn = ListenedNumbers(numberOfPodcasts: 0, numberOfEpisodes: 0)
         let stories = await builder.build()
 
-        XCTAssertFalse(stories.0.contains(.listenedNumbers))
+        XCTAssertFalse(stories.0.contains(.numberOfPodcastsAndEpisodesListened))
         XCTAssertNil(stories.1.listenedNumbers)
     }
 

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -488,6 +488,7 @@
 		8B71828D28CF68E800B98F04 /* AppIconWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B71828C28CF68E800B98F04 /* AppIconWidget.swift */; };
 		8B71828F28CF6ED900B98F04 /* StaticWidgetProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B71828E28CF6ED900B98F04 /* StaticWidgetProvider.swift */; };
 		8B71829128CF755D00B98F04 /* UpNextLockScreenWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B71829028CF755D00B98F04 /* UpNextLockScreenWidget.swift */; };
+		8B723755291185B300FA8219 /* Analytics+story.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B723754291185B300FA8219 /* Analytics+story.swift */; };
 		8B738F3128F5CBE0004E7526 /* StoriesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B738F3028F5CBE0004E7526 /* StoriesView.swift */; };
 		8B9D459C28F9A6260034219E /* TopFivePodcastsStory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B9D459B28F9A6260034219E /* TopFivePodcastsStory.swift */; };
 		8B9D459F28F9AD3F0034219E /* EndOfYearStoriesDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B9D459E28F9AD3F0034219E /* EndOfYearStoriesDataSource.swift */; };
@@ -2044,6 +2045,7 @@
 		8B71828C28CF68E800B98F04 /* AppIconWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconWidget.swift; sourceTree = "<group>"; };
 		8B71828E28CF6ED900B98F04 /* StaticWidgetProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaticWidgetProvider.swift; sourceTree = "<group>"; };
 		8B71829028CF755D00B98F04 /* UpNextLockScreenWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpNextLockScreenWidget.swift; sourceTree = "<group>"; };
+		8B723754291185B300FA8219 /* Analytics+story.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Analytics+story.swift"; sourceTree = "<group>"; };
 		8B738F3028F5CBE0004E7526 /* StoriesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoriesView.swift; sourceTree = "<group>"; };
 		8B9D459B28F9A6260034219E /* TopFivePodcastsStory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopFivePodcastsStory.swift; sourceTree = "<group>"; };
 		8B9D459E28F9AD3F0034219E /* EndOfYearStoriesDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndOfYearStoriesDataSource.swift; sourceTree = "<group>"; };
@@ -3767,6 +3769,7 @@
 			children = (
 				8BCB22B528F48A4E001A0315 /* Views */,
 				8B9D459D28F9ACFB0034219E /* Stories */,
+				8B723754291185B300FA8219 /* Analytics+story.swift */,
 				8BCB22B328F48282001A0315 /* EndOfYear.swift */,
 				8B23193E2902C84A0001C3DE /* EndOfYearStoriesBuilder.swift */,
 				8B5AB48B29018EFA0018C637 /* StoriesConfiguration.swift */,
@@ -7845,6 +7848,7 @@
 				BD3334521FC67FBB0017C3A8 /* PlaylistRefreshOperation.swift in Sources */,
 				BDD3579027BCD33D0000D155 /* FolderViewController.swift in Sources */,
 				BDD71CF41BA935E8006D2CE3 /* NetworkViewController.swift in Sources */,
+				8B723755291185B300FA8219 /* Analytics+story.swift in Sources */,
 				BD44A4452302DAC6004F55B2 /* CommonUpNextItem.swift in Sources */,
 				BDA2065D1BB3AF5D00D38389 /* DownloadProgress.swift in Sources */,
 				407083C625423F0A002FC9F8 /* EpisodePreviewCell.swift in Sources */,

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -588,4 +588,5 @@ enum AnalyticsEvent: String {
     case endOfYearModalShown
     case endOfYearStoriesShown
     case endOfYearStoryShown
+    case endOfYearStoryShare
 }

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -582,4 +582,9 @@ enum AnalyticsEvent: String {
 
     case incomingShareListShown
     case incomingShareListSubscribedAll
+
+    // MARK: - End of Year stats
+
+    case endOfYearModalShown
+    case endOfYearStoriesShown
 }

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -587,4 +587,5 @@ enum AnalyticsEvent: String {
 
     case endOfYearModalShown
     case endOfYearStoriesShown
+    case endOfYearStoryShown
 }

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -587,6 +587,7 @@ enum AnalyticsEvent: String {
 
     case endOfYearModalShown
     case endOfYearStoriesShown
+    case endOfYearStoriesDismissed
     case endOfYearStoryShown
     case endOfYearStoryShare
 }

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -588,6 +588,7 @@ enum AnalyticsEvent: String {
     case endOfYearModalShown
     case endOfYearStoriesShown
     case endOfYearStoriesDismissed
+    case endOfYearStoryReplayButtonTapped
     case endOfYearStoryShown
     case endOfYearStoryShare
 }

--- a/podcasts/End of Year/Analytics+story.swift
+++ b/podcasts/End of Year/Analytics+story.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+extension Analytics {
+    static func track(_ event: AnalyticsEvent, story: EndOfYearStory) {
+        Analytics.track(event, properties: ["story": story.rawValue])
+    }
+}

--- a/podcasts/End of Year/EndOfYear.swift
+++ b/podcasts/End of Year/EndOfYear.swift
@@ -3,6 +3,11 @@ import PocketCastsServer
 import MaterialComponents.MaterialBottomSheet
 import PocketCastsDataModel
 
+enum EndOfYearPresentationSource: String {
+    case modal = "modal"
+    case profile = "profile"
+}
+
 struct EndOfYear {
     // We'll calculate this just once
     static var isEligible: Bool {
@@ -40,7 +45,7 @@ struct EndOfYear {
         MDCSwiftUIWrapper.present(EndOfYearModal(), in: viewController)
     }
 
-    func showStories(in viewController: UIViewController) {
+    func showStories(in viewController: UIViewController, from source: EndOfYearPresentationSource) {
         guard FeatureFlag.endOfYear else {
             return
         }
@@ -62,6 +67,7 @@ struct EndOfYear {
         }
 
         viewController.present(storiesViewController, animated: true, completion: nil)
+        Analytics.track(.endOfYearStoriesShown, properties: ["source": source.rawValue])
     }
 
     func share(asset: @escaping () -> Any, onDismiss: (() -> Void)? = nil) {

--- a/podcasts/End of Year/EndOfYearStoriesBuilder.swift
+++ b/podcasts/End of Year/EndOfYearStoriesBuilder.swift
@@ -6,8 +6,8 @@ enum EndOfYearStory {
     case intro
     case listeningTime
     case listenedCategories
-    case topFiveCategories
-    case listenedNumbers
+    case topCategories
+    case numberOfPodcastsAndEpisodesListened
     case topOnePodcast
     case topFivePodcasts
     case longestEpisode
@@ -50,7 +50,7 @@ class EndOfYearStoriesBuilder {
             if !listenedCategories.isEmpty {
                 data.listenedCategories = listenedCategories
                 stories.append(.listenedCategories)
-                stories.append(.topFiveCategories)
+                stories.append(.topCategories)
             }
 
             // Listened podcasts and episodes
@@ -58,7 +58,7 @@ class EndOfYearStoriesBuilder {
             if listenedNumbers.numberOfEpisodes > 0
                 && listenedNumbers.numberOfPodcasts > 0 {
                 data.listenedNumbers = listenedNumbers
-                stories.append(.listenedNumbers)
+                stories.append(.numberOfPodcastsAndEpisodesListened)
             }
 
             // Top podcasts

--- a/podcasts/End of Year/EndOfYearStoriesBuilder.swift
+++ b/podcasts/End of Year/EndOfYearStoriesBuilder.swift
@@ -2,16 +2,16 @@ import Foundation
 import PocketCastsDataModel
 
 /// The available stories for EoY
-enum EndOfYearStory {
-    case intro
-    case listeningTime
-    case listenedCategories
-    case topCategories
-    case numberOfPodcastsAndEpisodesListened
-    case topOnePodcast
-    case topFivePodcasts
-    case longestEpisode
-    case epilogue
+enum EndOfYearStory: String {
+    case intro = "intro"
+    case listeningTime = "listening_time"
+    case listenedCategories = "listened_categories"
+    case topCategories = "top_categories"
+    case numberOfPodcastsAndEpisodesListened = "number_of_podcasts_and_episodes_listened"
+    case topOnePodcast = "top_one_podcast"
+    case topFivePodcasts = "top_five_podcast"
+    case longestEpisode = "longest_episode"
+    case epilogue = "epilogue"
 }
 
 /// Build the list of stories for End of Year alongside the data

--- a/podcasts/End of Year/Stories/EndOfYearStoriesDataSource.swift
+++ b/podcasts/End of Year/Stories/EndOfYearStoriesDataSource.swift
@@ -18,9 +18,9 @@ class EndOfYearStoriesDataSource: StoriesDataSource {
             return ListeningTimeStory(listeningTime: data.listeningTime, podcasts: data.randomPodcasts)
         case .listenedCategories:
             return ListenedCategoriesStory(listenedCategories: data.listenedCategories.reversed())
-        case .topFiveCategories:
+        case .topCategories:
             return TopListenedCategories(listenedCategories: data.listenedCategories)
-        case .listenedNumbers:
+        case .numberOfPodcastsAndEpisodesListened:
             return ListenedNumbersStory(listenedNumbers: data.listenedNumbers, podcasts: data.randomPodcasts)
         case .topOnePodcast:
             return TopOnePodcastStory(topPodcast: data.topPodcasts[0])

--- a/podcasts/End of Year/Stories/EpilogueStory.swift
+++ b/podcasts/End of Year/Stories/EpilogueStory.swift
@@ -63,7 +63,11 @@ struct EpilogueStory: StoryView {
     }
 
     func onAppear() {
-        Analytics.track(.endOfYearStoryShown, properties: ["story": EndOfYearStory.epilogue.rawValue])
+        Analytics.track(.endOfYearStoryShown, story: .epilogue)
+    }
+
+    func willShare() {
+        Analytics.track(.endOfYearStoryShare, story: .epilogue)
     }
 }
 

--- a/podcasts/End of Year/Stories/EpilogueStory.swift
+++ b/podcasts/End of Year/Stories/EpilogueStory.swift
@@ -32,6 +32,7 @@ struct EpilogueStory: StoryView {
 
                     Button(action: {
                         StoriesController.shared.replay()
+                        Analytics.track(.endOfYearStoryReplayButtonTapped)
                     }) {
                         HStack {
                             Image(systemName: "arrow.clockwise")

--- a/podcasts/End of Year/Stories/EpilogueStory.swift
+++ b/podcasts/End of Year/Stories/EpilogueStory.swift
@@ -61,6 +61,10 @@ struct EpilogueStory: StoryView {
             }
         }
     }
+
+    func onAppear() {
+        Analytics.track(.endOfYearStoryShown, properties: ["story": EndOfYearStory.epilogue.rawValue])
+    }
 }
 
 struct EpilogueStory_Previews: PreviewProvider {

--- a/podcasts/End of Year/Stories/IntroStory.swift
+++ b/podcasts/End of Year/Stories/IntroStory.swift
@@ -34,6 +34,10 @@ struct IntroStory: StoryView {
         Analytics.track(.endOfYearStoryShown, properties: ["story": EndOfYearStory.intro.rawValue])
     }
 
+    func willShare() {
+        Analytics.track(.endOfYearStoryShare, properties: ["story": EndOfYearStory.intro.rawValue])
+    }
+
     private struct Constants {
         static let imageVerticalPadding: CGFloat = 60
         static let imageHeightInPercentage: CGFloat = 0.54

--- a/podcasts/End of Year/Stories/IntroStory.swift
+++ b/podcasts/End of Year/Stories/IntroStory.swift
@@ -31,11 +31,11 @@ struct IntroStory: StoryView {
     }
 
     func onAppear() {
-        Analytics.track(.endOfYearStoryShown, properties: ["story": EndOfYearStory.intro.rawValue])
+        Analytics.track(.endOfYearStoryShown, story: .intro)
     }
 
     func willShare() {
-        Analytics.track(.endOfYearStoryShare, properties: ["story": EndOfYearStory.intro.rawValue])
+        Analytics.track(.endOfYearStoryShare, story: .intro)
     }
 
     private struct Constants {

--- a/podcasts/End of Year/Stories/IntroStory.swift
+++ b/podcasts/End of Year/Stories/IntroStory.swift
@@ -30,6 +30,10 @@ struct IntroStory: StoryView {
         }
     }
 
+    func onAppear() {
+        Analytics.track(.endOfYearStoryShown, properties: ["story": EndOfYearStory.intro.rawValue])
+    }
+
     private struct Constants {
         static let imageVerticalPadding: CGFloat = 60
         static let imageHeightInPercentage: CGFloat = 0.54

--- a/podcasts/End of Year/Stories/ListenedCategoriesStory.swift
+++ b/podcasts/End of Year/Stories/ListenedCategoriesStory.swift
@@ -73,7 +73,11 @@ struct ListenedCategoriesStory: StoryView {
     }
 
     func onAppear() {
-        Analytics.track(.endOfYearStoryShown, properties: ["story": EndOfYearStory.listenedCategories.rawValue])
+        Analytics.track(.endOfYearStoryShown, story: .listenedCategories)
+    }
+
+    func willShare() {
+        Analytics.track(.endOfYearStoryShare, story: .listenedCategories)
     }
 }
 

--- a/podcasts/End of Year/Stories/ListenedCategoriesStory.swift
+++ b/podcasts/End of Year/Stories/ListenedCategoriesStory.swift
@@ -71,6 +71,10 @@ struct ListenedCategoriesStory: StoryView {
         }
         .modifier(PodcastCover())
     }
+
+    func onAppear() {
+        Analytics.track(.endOfYearStoryShown, properties: ["story": EndOfYearStory.listenedCategories.rawValue])
+    }
 }
 
 struct ListenedCategoriesStory_Previews: PreviewProvider {

--- a/podcasts/End of Year/Stories/ListenedNumbersStory.swift
+++ b/podcasts/End of Year/Stories/ListenedNumbersStory.swift
@@ -98,6 +98,10 @@ struct ListenedNumbersStory: StoryView {
         }
         .modifier(PodcastCover())
     }
+
+    func onAppear() {
+        Analytics.track(.endOfYearStoryShown, properties: ["story": EndOfYearStory.numberOfPodcastsAndEpisodesListened.rawValue])
+    }
 }
 
 struct ListenedNumbersStory_Previews: PreviewProvider {

--- a/podcasts/End of Year/Stories/ListenedNumbersStory.swift
+++ b/podcasts/End of Year/Stories/ListenedNumbersStory.swift
@@ -100,7 +100,11 @@ struct ListenedNumbersStory: StoryView {
     }
 
     func onAppear() {
-        Analytics.track(.endOfYearStoryShown, properties: ["story": EndOfYearStory.numberOfPodcastsAndEpisodesListened.rawValue])
+        Analytics.track(.endOfYearStoryShown, story: .numberOfPodcastsAndEpisodesListened)
+    }
+
+    func willShare() {
+        Analytics.track(.endOfYearStoryShare, story: .numberOfPodcastsAndEpisodesListened)
     }
 }
 

--- a/podcasts/End of Year/Stories/ListeningTimeStory.swift
+++ b/podcasts/End of Year/Stories/ListeningTimeStory.swift
@@ -75,7 +75,11 @@ struct ListeningTimeStory: StoryView {
     }
 
     func onAppear() {
-        Analytics.track(.endOfYearStoryShown, properties: ["story": EndOfYearStory.listeningTime.rawValue])
+        Analytics.track(.endOfYearStoryShown, story: .listeningTime)
+    }
+
+    func willShare() {
+        Analytics.track(.endOfYearStoryShare, story: .listeningTime)
     }
 }
 

--- a/podcasts/End of Year/Stories/ListeningTimeStory.swift
+++ b/podcasts/End of Year/Stories/ListeningTimeStory.swift
@@ -73,6 +73,10 @@ struct ListeningTimeStory: StoryView {
         .modifier(PodcastCover())
         .frame(width: 140, height: 140)
     }
+
+    func onAppear() {
+        Analytics.track(.endOfYearStoryShown, properties: ["story": EndOfYearStory.listeningTime.rawValue])
+    }
 }
 
 /// Apply a perspective to the podcasts cover

--- a/podcasts/End of Year/Stories/LongestEpisodeStory.swift
+++ b/podcasts/End of Year/Stories/LongestEpisodeStory.swift
@@ -82,7 +82,11 @@ struct LongestEpisodeStory: StoryView {
     }
 
     func onAppear() {
-        Analytics.track(.endOfYearStoryShown, properties: ["story": EndOfYearStory.longestEpisode.rawValue])
+        Analytics.track(.endOfYearStoryShown, story: .longestEpisode)
+    }
+
+    func willShare() {
+        Analytics.track(.endOfYearStoryShare, story: .longestEpisode)
     }
 }
 

--- a/podcasts/End of Year/Stories/LongestEpisodeStory.swift
+++ b/podcasts/End of Year/Stories/LongestEpisodeStory.swift
@@ -80,6 +80,10 @@ struct LongestEpisodeStory: StoryView {
             }
         }
     }
+
+    func onAppear() {
+        Analytics.track(.endOfYearStoryShown, properties: ["story": EndOfYearStory.longestEpisode.rawValue])
+    }
 }
 
 struct LongestEpisodeStory_Previews: PreviewProvider {

--- a/podcasts/End of Year/Stories/TopCategoriesStory/TopListenedCategoriesStory.swift
+++ b/podcasts/End of Year/Stories/TopCategoriesStory/TopListenedCategoriesStory.swift
@@ -60,6 +60,10 @@ struct TopListenedCategoriesStory: StoryView {
                 .opacity(0)
         }
     }
+
+    func onAppear() {
+            Analytics.track(.endOfYearStoryShown, properties: ["story": EndOfYearStory.topCategories.rawValue])
+        }
 }
 
 #if DEBUG

--- a/podcasts/End of Year/Stories/TopCategoriesStory/TopListenedCategoriesStory.swift
+++ b/podcasts/End of Year/Stories/TopCategoriesStory/TopListenedCategoriesStory.swift
@@ -62,8 +62,12 @@ struct TopListenedCategoriesStory: StoryView {
     }
 
     func onAppear() {
-            Analytics.track(.endOfYearStoryShown, properties: ["story": EndOfYearStory.topCategories.rawValue])
-        }
+        Analytics.track(.endOfYearStoryShown, story: .topCategories)
+    }
+
+    func willShare() {
+        Analytics.track(.endOfYearStoryShare, story: .topCategories)
+    }
 }
 
 #if DEBUG

--- a/podcasts/End of Year/Stories/TopFivePodcastsStory.swift
+++ b/podcasts/End of Year/Stories/TopFivePodcastsStory.swift
@@ -79,7 +79,11 @@ struct TopFivePodcastsStory: StoryView {
     }
 
     func onAppear() {
-        Analytics.track(.endOfYearStoryShown, properties: ["story": EndOfYearStory.topFivePodcasts.rawValue])
+        Analytics.track(.endOfYearStoryShown, story: .topFivePodcasts)
+    }
+
+    func willShare() {
+        Analytics.track(.endOfYearStoryShare, story: .topFivePodcasts)
     }
 }
 

--- a/podcasts/End of Year/Stories/TopFivePodcastsStory.swift
+++ b/podcasts/End of Year/Stories/TopFivePodcastsStory.swift
@@ -77,6 +77,10 @@ struct TopFivePodcastsStory: StoryView {
         }
         .opacity(podcasts[safe: index] != nil ? 1 : 0)
     }
+
+    func onAppear() {
+        Analytics.track(.endOfYearStoryShown, properties: ["story": EndOfYearStory.topFivePodcasts.rawValue])
+    }
 }
 
 struct DummyStory_Previews: PreviewProvider {

--- a/podcasts/End of Year/Stories/TopOnePodcastStory.swift
+++ b/podcasts/End of Year/Stories/TopOnePodcastStory.swift
@@ -77,6 +77,10 @@ struct TopOnePodcastStory: StoryView {
             }
         }
     }
+
+    func onAppear() {
+        Analytics.track(.endOfYearStoryShown, properties: ["story": EndOfYearStory.topOnePodcast.rawValue])
+    }
 }
 
 struct TopOnePodcastStory_Previews: PreviewProvider {

--- a/podcasts/End of Year/Stories/TopOnePodcastStory.swift
+++ b/podcasts/End of Year/Stories/TopOnePodcastStory.swift
@@ -79,7 +79,11 @@ struct TopOnePodcastStory: StoryView {
     }
 
     func onAppear() {
-        Analytics.track(.endOfYearStoryShown, properties: ["story": EndOfYearStory.topOnePodcast.rawValue])
+        Analytics.track(.endOfYearStoryShown, story: .topOnePodcast)
+    }
+
+    func willShare() {
+        Analytics.track(.endOfYearStoryShare, story: .topOnePodcast)
     }
 }
 

--- a/podcasts/End of Year/StoriesDataSource.swift
+++ b/podcasts/End of Year/StoriesDataSource.swift
@@ -33,8 +33,11 @@ extension StoriesDataSource {
     }
 
     func shareableAsset(for storyNumber: Int) -> Any {
-        ZStack {
-            storyView(for: storyNumber)
+        let story = story(for: storyNumber)
+        story.willShare()
+
+        return ZStack {
+            AnyView(story)
         }
         .frame(width: 370, height: 693)
         .snapshot()
@@ -55,8 +58,13 @@ protocol Story {
     /// This method instead will only be called when the story
     /// is being presented.
     func onAppear()
+
+    /// Called when the story will be shared
+    func willShare()
 }
 
 extension Story {
-    func onAppear() {  }
+    func onAppear() {}
+
+    func willShare() {}
 }

--- a/podcasts/End of Year/StoriesDataSource.swift
+++ b/podcasts/End of Year/StoriesDataSource.swift
@@ -23,7 +23,9 @@ protocol StoriesDataSource {
 
 extension StoriesDataSource {
     func storyView(for storyNumber: Int) -> AnyView {
-        return AnyView(story(for: storyNumber))
+        let story = story(for: storyNumber)
+        story.onAppear()
+        return AnyView(story)
     }
 
     func interactiveView(for: Int) -> AnyView {
@@ -44,4 +46,17 @@ typealias StoryView = Story & View
 protocol Story {
     /// The amount of time this story should be show
     var duration: TimeInterval { get }
+
+    /// Called when the story actually appears.
+    ///
+    /// If you use SwiftUI `onAppear` together with preload
+    /// you might run into `onAppear` being called while the view
+    /// is not actually being displayed.
+    /// This method instead will only be called when the story
+    /// is being presented.
+    func onAppear()
+}
+
+extension Story {
+    func onAppear() {  }
 }

--- a/podcasts/End of Year/StoriesModel.swift
+++ b/podcasts/End of Year/StoriesModel.swift
@@ -107,11 +107,11 @@ class StoriesModel: ObservableObject {
 
 private extension StoriesModel {
     func subscribeToNotifications() {
-        StoriesController.Notifications.allCases.forEach { controller in
+        StoriesController.Notifications.allCases.forEach { [weak self] controller in
             switch controller {
             case .replay:
-                NotificationCenter.default.addObserver(forName: NSNotification.Name(rawValue: controller.rawValue), object: nil, queue: .main) { _ in
-                    self.replay()
+                NotificationCenter.default.addObserver(forName: NSNotification.Name(rawValue: controller.rawValue), object: nil, queue: .main) { [weak self] _ in
+                    self?.replay()
                 }
             }
         }

--- a/podcasts/End of Year/StoriesModel.swift
+++ b/podcasts/End of Year/StoriesModel.swift
@@ -71,7 +71,7 @@ class StoriesModel: ObservableObject {
 
     func preload(index: Int) -> AnyView {
         if index < numberOfStories {
-            return story(index: index)
+            return AnyView(dataSource.story(for: index))
         }
 
         return AnyView(EmptyView())

--- a/podcasts/End of Year/Views/EndOfYearModal.swift
+++ b/podcasts/End of Year/Views/EndOfYearModal.swift
@@ -30,6 +30,7 @@ struct EndOfYearModal: View {
         .applyDefaultThemeOptions()
         .onAppear {
             Settings.endOfYearModalHasBeenShown = true
+            Analytics.track(.endOfYearModalShown)
         }
     }
 

--- a/podcasts/End of Year/Views/StoriesView.swift
+++ b/podcasts/End of Year/Views/StoriesView.swift
@@ -104,6 +104,7 @@ struct StoriesView: View {
                 HStack {
                     Spacer()
                     Button(action: {
+                        Analytics.track(.endOfYearStoriesDismissed, properties: ["source": "close_button"])
                         NavigationManager.sharedManager.dismissPresentedViewController()
                     }) {
                         Image(systemName: "xmark")
@@ -145,6 +146,7 @@ struct StoriesView: View {
 
                     // If a quick swipe down is performed, dismiss the view
                     if velocity.height > 200 {
+                        Analytics.track(.endOfYearStoriesDismissed, properties: ["source": "swipe_down"])
                         NavigationManager.sharedManager.dismissPresentedViewController()
                     } else {
                         model.start()

--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -357,12 +357,12 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
 
     func showEndOfYearStories() {
         guard let presentedViewController else {
-            endOfYear.showStories(in: self)
+            endOfYear.showStories(in: self, from: .modal)
             return
         }
 
         presentedViewController.dismiss(animated: true) {
-            self.endOfYear.showStories(in: self)
+            self.endOfYear.showStories(in: self, from: .modal)
         }
     }
 

--- a/podcasts/ProfileViewController.swift
+++ b/podcasts/ProfileViewController.swift
@@ -448,7 +448,7 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
             let historyController = ListeningHistoryViewController()
             navigationController?.pushViewController(historyController, animated: true)
         case .endOfYearPrompt:
-            EndOfYear().showStories(in: self)
+            EndOfYear().showStories(in: self, from: .profile)
         }
     }
 


### PR DESCRIPTION
| 📘 Project: #376 |
|:---:|

Adds tracking for EoY feature.

## To test

To force the prompt to show, on `AppDelegate.didFinishLaunchingWithOptions` add (before `return true`):

```swift
Settings.endOfYearModalHasBeenShown = false
```

1. Enable the `endOfYear` and `tracksLoggingEnabled` flags in `FeatureFlag.swift`
2. Run the app and make sure you're logged in to an account with a few items on Listening History
3. ✅ When the prompt appears ensure `end_of_year_modal_shown` is tracked
4. Tap "View My 2022"
5. ✅ Ensure `end_of_year_stories_shown` is tracked with `source: modal`
6. Tap the upper-right "X" button
7. ✅ Ensure `end_of_year_stories_dismissed ["source": "close_button"]` is tracked
8. Go to Profile and tap the "Your Year in Podcasts" card
9. ✅ Ensure `end_of_year_stories_shown ["source": "profile"]` is tracked
10. ✅  For each story, check that `end_of_year_story_shown` is tracked and that the `story` parameter is correct
11. Swipe down to dismiss stories
12. ✅ Ensure `end_of_year_stories_dismissed ["source": "swipe_down"]` is tracked
13. Open the stories and navigate to the last one
14. Tap "Replay"
15. ✅ Ensure `end_of_year_story_replay_button_tapped` is tracked
16. Logout
17. Re-run the app
18. Login or create an account
19. ✅ Stories should appear and `end_of_year_stories_shown` is tracked with `source: user_login`

In this PR it was also added the `endOfYearStoryShare` event. The next PR will tackle sharing it, so it can be tested there.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
