### PR TITLE
End of Year: sharing

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1370,6 +1370,7 @@
 		C7D6551528E5153200AD7174 /* Debounce.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D6551328E5153200AD7174 /* Debounce.swift */; };
 		C7D6551628E5450600AD7174 /* AnalyticsDescribable+Modules.swift in Sources */ = {isa = PBXBuildFile; fileRef = C750EF7E28E3475600E06BA9 /* AnalyticsDescribable+Modules.swift */; };
 		C7D854F328ADD98700877E87 /* AppLifecyleAnalyticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D854F228ADD98700877E87 /* AppLifecyleAnalyticsTests.swift */; };
+		C7F2257F29145988001E4547 /* TumblrShareableMetadataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F2257E29145988001E4547 /* TumblrShareableMetadataProvider.swift */; };
 		C7F4BAB528DA6BBB001C9785 /* BackgroundSignOutListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F4BAB428DA6BBB001C9785 /* BackgroundSignOutListener.swift */; };
 		C7F4BAB728DA8666001C9785 /* BackgroundSignOutListenerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F4BAB628DA8666001C9785 /* BackgroundSignOutListenerTests.swift */; };
 		C7F4BABF28DB7F7C001C9785 /* DiscoverItem+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F4BABE28DB7F7C001C9785 /* DiscoverItem+Helper.swift */; };
@@ -2906,6 +2907,7 @@
 		C7C4CAF228ABFD0900CFC8CF /* Notifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Notifications.swift; sourceTree = "<group>"; };
 		C7D6551328E5153200AD7174 /* Debounce.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Debounce.swift; sourceTree = "<group>"; };
 		C7D854F228ADD98700877E87 /* AppLifecyleAnalyticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLifecyleAnalyticsTests.swift; sourceTree = "<group>"; };
+		C7F2257E29145988001E4547 /* TumblrShareableMetadataProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TumblrShareableMetadataProvider.swift; sourceTree = "<group>"; };
 		C7F4BAB428DA6BBB001C9785 /* BackgroundSignOutListener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundSignOutListener.swift; sourceTree = "<group>"; };
 		C7F4BAB628DA8666001C9785 /* BackgroundSignOutListenerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundSignOutListenerTests.swift; sourceTree = "<group>"; };
 		C7F4BABE28DB7F7C001C9785 /* DiscoverItem+Helper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DiscoverItem+Helper.swift"; sourceTree = "<group>"; };
@@ -3781,6 +3783,7 @@
 				8BC7FF54290FF92400017779 /* StoriesProgressModel.swift */,
 				8BB55E3928FEEE99001D1766 /* StoryShareableProvider.swift */,
 				8B0125672912A7AB00EC427A /* StoryShareableText.swift */,
+				C7F2257E29145988001E4547 /* TumblrShareableMetadataProvider.swift */,
 			);
 			path = "End of Year";
 			sourceTree = "<group>";
@@ -7445,6 +7448,7 @@
 				BDD40A181FA1ABF500A53AE1 /* PCNavigationController.swift in Sources */,
 				40B1613822F3B66900759E41 /* ThemeableTextField.swift in Sources */,
 				407CD7292266DF510033C18E /* CancelInfoViewController.swift in Sources */,
+				C7F2257F29145988001E4547 /* TumblrShareableMetadataProvider.swift in Sources */,
 				BD6D417E200C557A00CA8993 /* PodcastHeadingTableCell.swift in Sources */,
 				BD585C21204794AE00AC842C /* IncomingShareItem.swift in Sources */,
 				BD542C222403845500F35D26 /* PlaylistEpisode+Formatting.swift in Sources */,

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1370,7 +1370,7 @@
 		C7D6551528E5153200AD7174 /* Debounce.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D6551328E5153200AD7174 /* Debounce.swift */; };
 		C7D6551628E5450600AD7174 /* AnalyticsDescribable+Modules.swift in Sources */ = {isa = PBXBuildFile; fileRef = C750EF7E28E3475600E06BA9 /* AnalyticsDescribable+Modules.swift */; };
 		C7D854F328ADD98700877E87 /* AppLifecyleAnalyticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D854F228ADD98700877E87 /* AppLifecyleAnalyticsTests.swift */; };
-		C7F2257F29145988001E4547 /* TumblrShareableMetadataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F2257E29145988001E4547 /* TumblrShareableMetadataProvider.swift */; };
+		C7F2257F29145988001E4547 /* ShareableMetadataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F2257E29145988001E4547 /* ShareableMetadataProvider.swift */; };
 		C7F4BAB528DA6BBB001C9785 /* BackgroundSignOutListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F4BAB428DA6BBB001C9785 /* BackgroundSignOutListener.swift */; };
 		C7F4BAB728DA8666001C9785 /* BackgroundSignOutListenerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F4BAB628DA8666001C9785 /* BackgroundSignOutListenerTests.swift */; };
 		C7F4BABF28DB7F7C001C9785 /* DiscoverItem+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F4BABE28DB7F7C001C9785 /* DiscoverItem+Helper.swift */; };
@@ -2907,7 +2907,7 @@
 		C7C4CAF228ABFD0900CFC8CF /* Notifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Notifications.swift; sourceTree = "<group>"; };
 		C7D6551328E5153200AD7174 /* Debounce.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Debounce.swift; sourceTree = "<group>"; };
 		C7D854F228ADD98700877E87 /* AppLifecyleAnalyticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLifecyleAnalyticsTests.swift; sourceTree = "<group>"; };
-		C7F2257E29145988001E4547 /* TumblrShareableMetadataProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TumblrShareableMetadataProvider.swift; sourceTree = "<group>"; };
+		C7F2257E29145988001E4547 /* ShareableMetadataProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareableMetadataProvider.swift; sourceTree = "<group>"; };
 		C7F4BAB428DA6BBB001C9785 /* BackgroundSignOutListener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundSignOutListener.swift; sourceTree = "<group>"; };
 		C7F4BAB628DA8666001C9785 /* BackgroundSignOutListenerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundSignOutListenerTests.swift; sourceTree = "<group>"; };
 		C7F4BABE28DB7F7C001C9785 /* DiscoverItem+Helper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DiscoverItem+Helper.swift"; sourceTree = "<group>"; };
@@ -3783,7 +3783,7 @@
 				8BC7FF54290FF92400017779 /* StoriesProgressModel.swift */,
 				8BB55E3928FEEE99001D1766 /* StoryShareableProvider.swift */,
 				8B0125672912A7AB00EC427A /* StoryShareableText.swift */,
-				C7F2257E29145988001E4547 /* TumblrShareableMetadataProvider.swift */,
+				C7F2257E29145988001E4547 /* ShareableMetadataProvider.swift */,
 			);
 			path = "End of Year";
 			sourceTree = "<group>";
@@ -7448,7 +7448,7 @@
 				BDD40A181FA1ABF500A53AE1 /* PCNavigationController.swift in Sources */,
 				40B1613822F3B66900759E41 /* ThemeableTextField.swift in Sources */,
 				407CD7292266DF510033C18E /* CancelInfoViewController.swift in Sources */,
-				C7F2257F29145988001E4547 /* TumblrShareableMetadataProvider.swift in Sources */,
+				C7F2257F29145988001E4547 /* ShareableMetadataProvider.swift in Sources */,
 				BD6D417E200C557A00CA8993 /* PodcastHeadingTableCell.swift in Sources */,
 				BD585C21204794AE00AC842C /* IncomingShareItem.swift in Sources */,
 				BD542C222403845500F35D26 /* PlaylistEpisode+Formatting.swift in Sources */,

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -442,6 +442,7 @@
 		46FBD8B6276A874F00867746 /* Intents.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = 46FBD8B9276A874F00867746 /* Intents.intentdefinition */; settings = {ATTRIBUTES = (codegen, ); }; };
 		46FBD8B7276A874F00867746 /* Intents.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = 46FBD8B9276A874F00867746 /* Intents.intentdefinition */; settings = {ATTRIBUTES = (codegen, ); }; };
 		4A3C19F543779593E98EDA3C /* libPods-Pocket Casts Watch App Extension.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C7C2391BA608F0CAB6E1D038 /* libPods-Pocket Casts Watch App Extension.a */; };
+		8B0125682912A7AB00EC427A /* StoryShareableText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B0125672912A7AB00EC427A /* StoryShareableText.swift */; };
 		8B0EEDE029003E8D00075772 /* ListeningTimeStory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B0EEDDF29003E8D00075772 /* ListeningTimeStory.swift */; };
 		8B0EEDE2290065C100075772 /* ListenedCategoriesStory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B0EEDE1290065C000075772 /* ListenedCategoriesStory.swift */; };
 		8B0EEDE429006C9B00075772 /* TopListenedCategoriesStory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B0EEDE329006C9B00075772 /* TopListenedCategoriesStory.swift */; };
@@ -2003,6 +2004,7 @@
 		779DF889D4A7C56C0935B7A7 /* Pods-podcasts.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-podcasts.debug.xcconfig"; path = "Pods/Target Support Files/Pods-podcasts/Pods-podcasts.debug.xcconfig"; sourceTree = "<group>"; };
 		7E84A6B7056C4797BAD62A1F /* Pods-Pocket Casts Watch App Extension.staging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Pocket Casts Watch App Extension.staging.xcconfig"; path = "Pods/Target Support Files/Pods-Pocket Casts Watch App Extension/Pods-Pocket Casts Watch App Extension.staging.xcconfig"; sourceTree = "<group>"; };
 		8229174E612BC7BAC6F63274 /* Pods-Pocket Casts Watch App Extension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Pocket Casts Watch App Extension.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Pocket Casts Watch App Extension/Pods-Pocket Casts Watch App Extension.debug.xcconfig"; sourceTree = "<group>"; };
+		8B0125672912A7AB00EC427A /* StoryShareableText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoryShareableText.swift; sourceTree = "<group>"; };
 		8B0EEDDF29003E8D00075772 /* ListeningTimeStory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListeningTimeStory.swift; sourceTree = "<group>"; };
 		8B0EEDE1290065C000075772 /* ListenedCategoriesStory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListenedCategoriesStory.swift; sourceTree = "<group>"; };
 		8B0EEDE329006C9B00075772 /* TopListenedCategoriesStory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopListenedCategoriesStory.swift; sourceTree = "<group>"; };
@@ -3778,6 +3780,7 @@
 				8B6B68E628F74A010032BFFF /* StoriesModel.swift */,
 				8BC7FF54290FF92400017779 /* StoriesProgressModel.swift */,
 				8BB55E3928FEEE99001D1766 /* StoryShareableProvider.swift */,
+				8B0125672912A7AB00EC427A /* StoryShareableText.swift */,
 			);
 			path = "End of Year";
 			sourceTree = "<group>";
@@ -7687,6 +7690,7 @@
 				4006E31423AC453700174DEB /* ExpandedCollectionViewController+CollectionView.swift in Sources */,
 				8B0EEDE029003E8D00075772 /* ListeningTimeStory.swift in Sources */,
 				BD27B8C92756FA20007A0EA7 /* ModalCloseButton.swift in Sources */,
+				8B0125682912A7AB00EC427A /* StoryShareableText.swift in Sources */,
 				8B5AB488290188F30018C637 /* IntroStory.swift in Sources */,
 				462EE0AF26FCCF97003D67DC /* PCMessageSupportViewModel.swift in Sources */,
 				4036B0A425240F5D00AE08E6 /* WidgetHelper.swift in Sources */,

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -590,4 +590,5 @@ enum AnalyticsEvent: String {
     case endOfYearStoriesDismissed
     case endOfYearStoryShown
     case endOfYearStoryShare
+    case endOfYearStoryShared
 }

--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -146,6 +146,7 @@ struct Constants {
 
         static let showBadgeFor2022EndOfYear = "showBadgeFor2022EndOfYear"
         static let modal2022HasBeenShown = "modal2022HasBeenShown"
+        static let top5PodcastsListLink = "top5PodcastsListLink"
     }
 
     enum Values {

--- a/podcasts/End of Year/Analytics+story.swift
+++ b/podcasts/End of Year/Analytics+story.swift
@@ -4,4 +4,8 @@ extension Analytics {
     static func track(_ event: AnalyticsEvent, story: EndOfYearStory) {
         Analytics.track(event, properties: ["story": story.rawValue])
     }
+
+    static func track(_ event: AnalyticsEvent, story: String) {
+        Analytics.track(event, properties: ["story": story])
+    }
 }

--- a/podcasts/End of Year/Analytics+story.swift
+++ b/podcasts/End of Year/Analytics+story.swift
@@ -1,10 +1,6 @@
 import Foundation
 
 extension Analytics {
-    static func track(_ event: AnalyticsEvent, story: EndOfYearStory) {
-        Analytics.track(event, properties: ["story": story.rawValue])
-    }
-
     static func track(_ event: AnalyticsEvent, story: String) {
         Analytics.track(event, properties: ["story": story])
     }

--- a/podcasts/End of Year/EndOfYear.swift
+++ b/podcasts/End of Year/EndOfYear.swift
@@ -70,11 +70,10 @@ struct EndOfYear {
         Analytics.track(.endOfYearStoriesShown, properties: ["source": source.rawValue])
     }
 
-    func share(asset: @escaping () -> Any, onDismiss: (() -> Void)? = nil) {
+    func share(assets: [Any], onDismiss: (() -> Void)? = nil) {
         let presenter = SceneHelper.rootViewController()?.presentedViewController
 
-        let imageToShare = [StoryShareableProvider()]
-        let activityViewController = UIActivityViewController(activityItems: imageToShare, applicationActivities: nil)
+        let activityViewController = UIActivityViewController(activityItems: assets, applicationActivities: nil)
         activityViewController.popoverPresentationController?.sourceView = presenter?.view
 
         activityViewController.completionWithItemsHandler = { _, _, _, _ in
@@ -85,7 +84,7 @@ struct EndOfYear {
             // After the share sheet is presented we take the snapshot
             // This action needs to happen on the main thread because
             // the view needs to be rendered.
-            StoryShareableProvider.generatedItem = asset() as? UIImage
+//            StoryShareableProvider.generatedItem = asset() as? UIImage
         }
     }
 }

--- a/podcasts/End of Year/EndOfYear.swift
+++ b/podcasts/End of Year/EndOfYear.swift
@@ -70,14 +70,21 @@ struct EndOfYear {
         Analytics.track(.endOfYearStoriesShown, properties: ["source": source.rawValue])
     }
 
-    func share(assets: [Any], onDismiss: (() -> Void)? = nil) {
+    func share(assets: [Any], storyIdentifier: String = "unknown", onDismiss: (() -> Void)? = nil) {
         let presenter = SceneHelper.rootViewController()?.presentedViewController
 
         let activityViewController = UIActivityViewController(activityItems: assets, applicationActivities: nil)
         activityViewController.popoverPresentationController?.sourceView = presenter?.view
 
-        activityViewController.completionWithItemsHandler = { _, _, _, _ in
-            onDismiss?()
+        activityViewController.completionWithItemsHandler = { activity, success, _, _ in
+            if !success {
+                onDismiss?()
+            }
+
+            if let activity, success {
+                Analytics.track(.endOfYearStoryShared, properties: ["activity": activity.rawValue, "story": storyIdentifier])
+                onDismiss?()
+            }
         }
 
         presenter?.present(activityViewController, animated: true) {

--- a/podcasts/End of Year/EndOfYear.swift
+++ b/podcasts/End of Year/EndOfYear.swift
@@ -77,7 +77,7 @@ struct EndOfYear {
         activityViewController.popoverPresentationController?.sourceView = presenter?.view
 
         activityViewController.completionWithItemsHandler = { activity, success, _, _ in
-            if !success {
+            if !success && activity == nil {
                 onDismiss?()
             }
 

--- a/podcasts/End of Year/EndOfYear.swift
+++ b/podcasts/End of Year/EndOfYear.swift
@@ -84,7 +84,7 @@ struct EndOfYear {
             // After the share sheet is presented we take the snapshot
             // This action needs to happen on the main thread because
             // the view needs to be rendered.
-//            StoryShareableProvider.generatedItem = asset() as? UIImage
+            StoryShareableProvider.shared.snapshot()
         }
     }
 }

--- a/podcasts/End of Year/EndOfYearStoriesBuilder.swift
+++ b/podcasts/End of Year/EndOfYearStoriesBuilder.swift
@@ -2,16 +2,16 @@ import Foundation
 import PocketCastsDataModel
 
 /// The available stories for EoY
-enum EndOfYearStory: String {
-    case intro = "intro"
-    case listeningTime = "listening_time"
-    case listenedCategories = "listened_categories"
-    case topCategories = "top_categories"
-    case numberOfPodcastsAndEpisodesListened = "number_of_podcasts_and_episodes_listened"
-    case topOnePodcast = "top_one_podcast"
-    case topFivePodcasts = "top_five_podcast"
-    case longestEpisode = "longest_episode"
-    case epilogue = "epilogue"
+enum EndOfYearStory {
+    case intro
+    case listeningTime
+    case listenedCategories
+    case topCategories
+    case numberOfPodcastsAndEpisodesListened
+    case topOnePodcast
+    case topFivePodcasts
+    case longestEpisode
+    case epilogue
 }
 
 /// Build the list of stories for End of Year alongside the data

--- a/podcasts/End of Year/ShareableMetadataProvider.swift
+++ b/podcasts/End of Year/ShareableMetadataProvider.swift
@@ -24,7 +24,7 @@ class ShareableMetadataProvider: UIActivityItemProvider {
         guard let dataSource, let activityType, activityType.supportsShareableMetadata else { return nil }
 
         let item = NSExtensionItem()
-        
+
         // Provide tags using the x-extension format
         // Ref: https://github.com/tumblr/XExtensionItem
         // We don't need the entire library so we're just including what we need

--- a/podcasts/End of Year/Stories/EpilogueStory.swift
+++ b/podcasts/End of Year/Stories/EpilogueStory.swift
@@ -69,6 +69,13 @@ struct EpilogueStory: StoryView {
     func willShare() {
         Analytics.track(.endOfYearStoryShare, story: .epilogue)
     }
+
+    func sharingAssets() -> [Any] {
+            [
+                StoryShareableProvider.new(AnyView(self)),
+                StoryShareableText("")
+            ]
+    }
 }
 
 struct EpilogueStory_Previews: PreviewProvider {

--- a/podcasts/End of Year/Stories/EpilogueStory.swift
+++ b/podcasts/End of Year/Stories/EpilogueStory.swift
@@ -71,10 +71,10 @@ struct EpilogueStory: StoryView {
     }
 
     func sharingAssets() -> [Any] {
-            [
-                StoryShareableProvider.new(AnyView(self)),
-                StoryShareableText("")
-            ]
+        [
+            StoryShareableProvider.new(AnyView(self)),
+            StoryShareableText("")
+        ]
     }
 }
 

--- a/podcasts/End of Year/Stories/EpilogueStory.swift
+++ b/podcasts/End of Year/Stories/EpilogueStory.swift
@@ -3,6 +3,8 @@ import SwiftUI
 struct EpilogueStory: StoryView {
     var duration: TimeInterval = 5.seconds
 
+    var identifier: String = "epilogue"
+
     var body: some View {
         GeometryReader { geometry in
             ZStack {
@@ -63,11 +65,11 @@ struct EpilogueStory: StoryView {
     }
 
     func onAppear() {
-        Analytics.track(.endOfYearStoryShown, story: .epilogue)
+        Analytics.track(.endOfYearStoryShown, story: identifier)
     }
 
     func willShare() {
-        Analytics.track(.endOfYearStoryShare, story: .epilogue)
+        Analytics.track(.endOfYearStoryShare, story: identifier)
     }
 
     func sharingAssets() -> [Any] {

--- a/podcasts/End of Year/Stories/IntroStory.swift
+++ b/podcasts/End of Year/Stories/IntroStory.swift
@@ -39,7 +39,7 @@ struct IntroStory: StoryView {
     }
 
     func sharingAssets() -> [Any] {
-        [StoryShareableProvider.new(AnyView(self)), "Testing"]
+        [StoryShareableProvider.new(AnyView(self)), "#pocketcasts #endofyear2022"]
     }
 
     private struct Constants {

--- a/podcasts/End of Year/Stories/IntroStory.swift
+++ b/podcasts/End of Year/Stories/IntroStory.swift
@@ -3,6 +3,8 @@ import SwiftUI
 struct IntroStory: StoryView {
     var duration: TimeInterval = 5.seconds
 
+    let identifier: String? = "intro"
+
     var body: some View {
         GeometryReader { geometry in
             ZStack {

--- a/podcasts/End of Year/Stories/IntroStory.swift
+++ b/podcasts/End of Year/Stories/IntroStory.swift
@@ -39,7 +39,7 @@ struct IntroStory: StoryView {
     }
 
     func sharingAssets() -> [Any] {
-        ["Testing"]
+        [StoryShareableProvider.new(AnyView(self)), "Testing"]
     }
 
     private struct Constants {

--- a/podcasts/End of Year/Stories/IntroStory.swift
+++ b/podcasts/End of Year/Stories/IntroStory.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct IntroStory: StoryView {
     var duration: TimeInterval = 5.seconds
 
-    let identifier: String? = "intro"
+    let identifier: String = "intro"
 
     var body: some View {
         GeometryReader { geometry in
@@ -33,11 +33,11 @@ struct IntroStory: StoryView {
     }
 
     func onAppear() {
-        Analytics.track(.endOfYearStoryShown, story: .intro)
+        Analytics.track(.endOfYearStoryShown, story: identifier)
     }
 
     func willShare() {
-        Analytics.track(.endOfYearStoryShare, story: .intro)
+        Analytics.track(.endOfYearStoryShare, story: identifier)
     }
 
     func sharingAssets() -> [Any] {

--- a/podcasts/End of Year/Stories/IntroStory.swift
+++ b/podcasts/End of Year/Stories/IntroStory.swift
@@ -38,6 +38,10 @@ struct IntroStory: StoryView {
         Analytics.track(.endOfYearStoryShare, story: .intro)
     }
 
+    func sharingAssets() -> [Any] {
+        ["Testing"]
+    }
+
     private struct Constants {
         static let imageVerticalPadding: CGFloat = 60
         static let imageHeightInPercentage: CGFloat = 0.54

--- a/podcasts/End of Year/Stories/IntroStory.swift
+++ b/podcasts/End of Year/Stories/IntroStory.swift
@@ -39,7 +39,10 @@ struct IntroStory: StoryView {
     }
 
     func sharingAssets() -> [Any] {
-        [StoryShareableProvider.new(AnyView(self)), "#pocketcasts #endofyear2022"]
+        [
+            StoryShareableProvider.new(AnyView(self)),
+            StoryShareableText("")
+        ]
     }
 
     private struct Constants {

--- a/podcasts/End of Year/Stories/ListenedCategoriesStory.swift
+++ b/podcasts/End of Year/Stories/ListenedCategoriesStory.swift
@@ -7,6 +7,8 @@ struct ListenedCategoriesStory: StoryView {
 
     let listenedCategories: [ListenedCategory]
 
+    let identifier: String = "listened_categories"
+
     var body: some View {
         GeometryReader { geometry in
             ZStack {
@@ -73,11 +75,11 @@ struct ListenedCategoriesStory: StoryView {
     }
 
     func onAppear() {
-        Analytics.track(.endOfYearStoryShown, story: .listenedCategories)
+        Analytics.track(.endOfYearStoryShown, story: identifier)
     }
 
     func willShare() {
-        Analytics.track(.endOfYearStoryShare, story: .listenedCategories)
+        Analytics.track(.endOfYearStoryShare, story: identifier)
     }
 
     func sharingAssets() -> [Any] {

--- a/podcasts/End of Year/Stories/ListenedCategoriesStory.swift
+++ b/podcasts/End of Year/Stories/ListenedCategoriesStory.swift
@@ -79,6 +79,13 @@ struct ListenedCategoriesStory: StoryView {
     func willShare() {
         Analytics.track(.endOfYearStoryShare, story: .listenedCategories)
     }
+
+    func sharingAssets() -> [Any] {
+        [
+            StoryShareableProvider.new(AnyView(self)),
+            StoryShareableText(L10n.eoyStoryListenedToCategoriesShareText(listenedCategories.count))
+        ]
+    }
 }
 
 struct ListenedCategoriesStory_Previews: PreviewProvider {

--- a/podcasts/End of Year/Stories/ListenedNumbersStory.swift
+++ b/podcasts/End of Year/Stories/ListenedNumbersStory.swift
@@ -106,6 +106,13 @@ struct ListenedNumbersStory: StoryView {
     func willShare() {
         Analytics.track(.endOfYearStoryShare, story: .numberOfPodcastsAndEpisodesListened)
     }
+
+    func sharingAssets() -> [Any] {
+            [
+                StoryShareableProvider.new(AnyView(self)),
+                StoryShareableText(L10n.eoyStoryListenedToNumbersShareText(listenedNumbers.numberOfPodcasts, listenedNumbers.numberOfEpisodes))
+            ]
+        }
 }
 
 struct ListenedNumbersStory_Previews: PreviewProvider {

--- a/podcasts/End of Year/Stories/ListenedNumbersStory.swift
+++ b/podcasts/End of Year/Stories/ListenedNumbersStory.swift
@@ -112,7 +112,7 @@ struct ListenedNumbersStory: StoryView {
                 StoryShareableProvider.new(AnyView(self)),
                 StoryShareableText(L10n.eoyStoryListenedToNumbersShareText(listenedNumbers.numberOfPodcasts, listenedNumbers.numberOfEpisodes))
             ]
-        }
+    }
 }
 
 struct ListenedNumbersStory_Previews: PreviewProvider {

--- a/podcasts/End of Year/Stories/ListenedNumbersStory.swift
+++ b/podcasts/End of Year/Stories/ListenedNumbersStory.swift
@@ -5,6 +5,8 @@ import PocketCastsDataModel
 struct ListenedNumbersStory: StoryView {
     var duration: TimeInterval = 5.seconds
 
+    let identifier: String = "number_of_podcasts_and_episodes_listened"
+
     let listenedNumbers: ListenedNumbers
 
     let podcasts: [Podcast]
@@ -100,11 +102,11 @@ struct ListenedNumbersStory: StoryView {
     }
 
     func onAppear() {
-        Analytics.track(.endOfYearStoryShown, story: .numberOfPodcastsAndEpisodesListened)
+        Analytics.track(.endOfYearStoryShown, story: identifier)
     }
 
     func willShare() {
-        Analytics.track(.endOfYearStoryShare, story: .numberOfPodcastsAndEpisodesListened)
+        Analytics.track(.endOfYearStoryShare, story: identifier)
     }
 
     func sharingAssets() -> [Any] {

--- a/podcasts/End of Year/Stories/ListenedNumbersStory.swift
+++ b/podcasts/End of Year/Stories/ListenedNumbersStory.swift
@@ -108,10 +108,10 @@ struct ListenedNumbersStory: StoryView {
     }
 
     func sharingAssets() -> [Any] {
-            [
-                StoryShareableProvider.new(AnyView(self)),
-                StoryShareableText(L10n.eoyStoryListenedToNumbersShareText(listenedNumbers.numberOfPodcasts, listenedNumbers.numberOfEpisodes))
-            ]
+        [
+            StoryShareableProvider.new(AnyView(self)),
+            StoryShareableText(L10n.eoyStoryListenedToNumbersShareText(listenedNumbers.numberOfPodcasts, listenedNumbers.numberOfEpisodes))
+        ]
     }
 }
 

--- a/podcasts/End of Year/Stories/ListeningTimeStory.swift
+++ b/podcasts/End of Year/Stories/ListeningTimeStory.swift
@@ -83,7 +83,10 @@ struct ListeningTimeStory: StoryView {
     }
 
     func sharingAssets() -> [Any] {
-        [StoryShareableProvider.new(AnyView(self)), StoryShareableText(L10n.eoyStoryListenedToShareText(listeningTime.localizedTimeDescription ?? ""))]
+        [
+            StoryShareableProvider.new(AnyView(self)),
+            StoryShareableText(L10n.eoyStoryListenedToShareText(listeningTime.localizedTimeDescription ?? ""))
+        ]
     }
 }
 

--- a/podcasts/End of Year/Stories/ListeningTimeStory.swift
+++ b/podcasts/End of Year/Stories/ListeningTimeStory.swift
@@ -5,6 +5,8 @@ import PocketCastsDataModel
 struct ListeningTimeStory: StoryView {
     var duration: TimeInterval = 5.seconds
 
+    let identifier: String = "listening_time"
+
     let listeningTime: Double
 
     let podcasts: [Podcast]
@@ -75,11 +77,11 @@ struct ListeningTimeStory: StoryView {
     }
 
     func onAppear() {
-        Analytics.track(.endOfYearStoryShown, story: .listeningTime)
+        Analytics.track(.endOfYearStoryShown, story: identifier)
     }
 
     func willShare() {
-        Analytics.track(.endOfYearStoryShare, story: .listeningTime)
+        Analytics.track(.endOfYearStoryShare, story: identifier)
     }
 
     func sharingAssets() -> [Any] {

--- a/podcasts/End of Year/Stories/ListeningTimeStory.swift
+++ b/podcasts/End of Year/Stories/ListeningTimeStory.swift
@@ -81,6 +81,10 @@ struct ListeningTimeStory: StoryView {
     func willShare() {
         Analytics.track(.endOfYearStoryShare, story: .listeningTime)
     }
+
+    func sharingAssets() -> [Any] {
+        [StoryShareableProvider.new(AnyView(self)), StoryShareableText(L10n.eoyStoryListenedToShareText(listeningTime.localizedTimeDescription ?? ""))]
+    }
 }
 
 /// Apply a perspective to the podcasts cover

--- a/podcasts/End of Year/Stories/LongestEpisodeStory.swift
+++ b/podcasts/End of Year/Stories/LongestEpisodeStory.swift
@@ -88,6 +88,13 @@ struct LongestEpisodeStory: StoryView {
     func willShare() {
         Analytics.track(.endOfYearStoryShare, story: .longestEpisode)
     }
+
+    func sharingAssets() -> [Any] {
+            [
+                StoryShareableProvider.new(AnyView(self)),
+                StoryShareableText(L10n.eoyStoryLongestEpisodeShareText)
+            ]
+    }
 }
 
 struct LongestEpisodeStory_Previews: PreviewProvider {

--- a/podcasts/End of Year/Stories/LongestEpisodeStory.swift
+++ b/podcasts/End of Year/Stories/LongestEpisodeStory.swift
@@ -5,6 +5,8 @@ import PocketCastsDataModel
 struct LongestEpisodeStory: StoryView {
     let duration: TimeInterval = 5.seconds
 
+    var identifier: String = "longest_episode"
+
     let episode: Episode
 
     let podcast: Podcast
@@ -82,11 +84,11 @@ struct LongestEpisodeStory: StoryView {
     }
 
     func onAppear() {
-        Analytics.track(.endOfYearStoryShown, story: .longestEpisode)
+        Analytics.track(.endOfYearStoryShown, story: identifier)
     }
 
     func willShare() {
-        Analytics.track(.endOfYearStoryShare, story: .longestEpisode)
+        Analytics.track(.endOfYearStoryShare, story: identifier)
     }
 
     func sharingAssets() -> [Any] {

--- a/podcasts/End of Year/Stories/LongestEpisodeStory.swift
+++ b/podcasts/End of Year/Stories/LongestEpisodeStory.swift
@@ -92,7 +92,7 @@ struct LongestEpisodeStory: StoryView {
     func sharingAssets() -> [Any] {
         [
             StoryShareableProvider.new(AnyView(self)),
-            StoryShareableText(L10n.eoyStoryLongestEpisodeShareText)
+            StoryShareableText(L10n.eoyStoryLongestEpisodeShareText("%1$@"), episode: episode)
         ]
     }
 }

--- a/podcasts/End of Year/Stories/LongestEpisodeStory.swift
+++ b/podcasts/End of Year/Stories/LongestEpisodeStory.swift
@@ -90,10 +90,10 @@ struct LongestEpisodeStory: StoryView {
     }
 
     func sharingAssets() -> [Any] {
-            [
-                StoryShareableProvider.new(AnyView(self)),
-                StoryShareableText(L10n.eoyStoryLongestEpisodeShareText)
-            ]
+        [
+            StoryShareableProvider.new(AnyView(self)),
+            StoryShareableText(L10n.eoyStoryLongestEpisodeShareText)
+        ]
     }
 }
 

--- a/podcasts/End of Year/Stories/TopCategoriesStory/TopListenedCategoriesStory.swift
+++ b/podcasts/End of Year/Stories/TopCategoriesStory/TopListenedCategoriesStory.swift
@@ -68,6 +68,13 @@ struct TopListenedCategoriesStory: StoryView {
     func willShare() {
         Analytics.track(.endOfYearStoryShare, story: .topCategories)
     }
+
+    func sharingAssets() -> [Any] {
+        [
+            StoryShareableProvider.new(AnyView(self)),
+            StoryShareableText(L10n.eoyStoryTopCategoriesShareText)
+        ]
+    }
 }
 
 #if DEBUG

--- a/podcasts/End of Year/Stories/TopCategoriesStory/TopListenedCategoriesStory.swift
+++ b/podcasts/End of Year/Stories/TopCategoriesStory/TopListenedCategoriesStory.swift
@@ -4,6 +4,8 @@ import PocketCastsDataModel
 struct TopListenedCategoriesStory: StoryView {
     var duration: TimeInterval = 5.seconds
 
+    let identifier: String = "top_categories"
+
     let listenedCategories: [ListenedCategory]
 
     let contrastColor: CategoriesContrastingColors
@@ -62,11 +64,11 @@ struct TopListenedCategoriesStory: StoryView {
     }
 
     func onAppear() {
-        Analytics.track(.endOfYearStoryShown, story: .topCategories)
+        Analytics.track(.endOfYearStoryShown, story: identifier)
     }
 
     func willShare() {
-        Analytics.track(.endOfYearStoryShare, story: .topCategories)
+        Analytics.track(.endOfYearStoryShare, story: identifier)
     }
 
     func sharingAssets() -> [Any] {

--- a/podcasts/End of Year/Stories/TopFivePodcastsStory.swift
+++ b/podcasts/End of Year/Stories/TopFivePodcastsStory.swift
@@ -91,7 +91,7 @@ struct TopFivePodcastsStory: StoryView {
     func sharingAssets() -> [Any] {
         [
             StoryShareableProvider.new(AnyView(self)),
-            StoryShareableText(L10n.eoyStoryTopPodcastsShareText)
+            StoryShareableText(L10n.eoyStoryTopPodcastsShareText("%1$@"), podcasts: podcasts)
         ]
     }
 }

--- a/podcasts/End of Year/Stories/TopFivePodcastsStory.swift
+++ b/podcasts/End of Year/Stories/TopFivePodcastsStory.swift
@@ -85,6 +85,13 @@ struct TopFivePodcastsStory: StoryView {
     func willShare() {
         Analytics.track(.endOfYearStoryShare, story: .topFivePodcasts)
     }
+
+    func sharingAssets() -> [Any] {
+            [
+                StoryShareableProvider.new(AnyView(self)),
+                StoryShareableText(L10n.eoyStoryTopPodcastsShareText)
+            ]
+    }
 }
 
 struct DummyStory_Previews: PreviewProvider {

--- a/podcasts/End of Year/Stories/TopFivePodcastsStory.swift
+++ b/podcasts/End of Year/Stories/TopFivePodcastsStory.swift
@@ -87,10 +87,10 @@ struct TopFivePodcastsStory: StoryView {
     }
 
     func sharingAssets() -> [Any] {
-            [
-                StoryShareableProvider.new(AnyView(self)),
-                StoryShareableText(L10n.eoyStoryTopPodcastsShareText)
-            ]
+        [
+            StoryShareableProvider.new(AnyView(self)),
+            StoryShareableText(L10n.eoyStoryTopPodcastsShareText)
+        ]
     }
 }
 

--- a/podcasts/End of Year/Stories/TopFivePodcastsStory.swift
+++ b/podcasts/End of Year/Stories/TopFivePodcastsStory.swift
@@ -5,6 +5,8 @@ import PocketCastsDataModel
 struct TopFivePodcastsStory: StoryView {
     let podcasts: [Podcast]
 
+    let identifier: String = "top_five_podcast"
+
     let duration: TimeInterval = 5.seconds
 
     var body: some View {
@@ -79,11 +81,11 @@ struct TopFivePodcastsStory: StoryView {
     }
 
     func onAppear() {
-        Analytics.track(.endOfYearStoryShown, story: .topFivePodcasts)
+        Analytics.track(.endOfYearStoryShown, story: identifier)
     }
 
     func willShare() {
-        Analytics.track(.endOfYearStoryShare, story: .topFivePodcasts)
+        Analytics.track(.endOfYearStoryShare, story: identifier)
     }
 
     func sharingAssets() -> [Any] {

--- a/podcasts/End of Year/Stories/TopOnePodcastStory.swift
+++ b/podcasts/End of Year/Stories/TopOnePodcastStory.swift
@@ -87,10 +87,10 @@ struct TopOnePodcastStory: StoryView {
     }
 
     func sharingAssets() -> [Any] {
-            [
-                StoryShareableProvider.new(AnyView(self)),
-                StoryShareableText(L10n.eoyStoryTopPodcastShareText)
-            ]
+        [
+            StoryShareableProvider.new(AnyView(self)),
+            StoryShareableText(L10n.eoyStoryTopPodcastShareText)
+        ]
     }
 }
 

--- a/podcasts/End of Year/Stories/TopOnePodcastStory.swift
+++ b/podcasts/End of Year/Stories/TopOnePodcastStory.swift
@@ -91,7 +91,7 @@ struct TopOnePodcastStory: StoryView {
                 StoryShareableProvider.new(AnyView(self)),
                 StoryShareableText(L10n.eoyStoryTopPodcastShareText)
             ]
-        }
+    }
 }
 
 struct TopOnePodcastStory_Previews: PreviewProvider {

--- a/podcasts/End of Year/Stories/TopOnePodcastStory.swift
+++ b/podcasts/End of Year/Stories/TopOnePodcastStory.swift
@@ -89,7 +89,7 @@ struct TopOnePodcastStory: StoryView {
     func sharingAssets() -> [Any] {
         [
             StoryShareableProvider.new(AnyView(self)),
-            StoryShareableText(L10n.eoyStoryTopPodcastShareText)
+            StoryShareableText(L10n.eoyStoryTopPodcastShareText("%1$@"), podcast: topPodcast.podcast)
         ]
     }
 }

--- a/podcasts/End of Year/Stories/TopOnePodcastStory.swift
+++ b/podcasts/End of Year/Stories/TopOnePodcastStory.swift
@@ -85,6 +85,13 @@ struct TopOnePodcastStory: StoryView {
     func willShare() {
         Analytics.track(.endOfYearStoryShare, story: .topOnePodcast)
     }
+
+    func sharingAssets() -> [Any] {
+            [
+                StoryShareableProvider.new(AnyView(self)),
+                StoryShareableText(L10n.eoyStoryTopPodcastShareText)
+            ]
+        }
 }
 
 struct TopOnePodcastStory_Previews: PreviewProvider {

--- a/podcasts/End of Year/Stories/TopOnePodcastStory.swift
+++ b/podcasts/End of Year/Stories/TopOnePodcastStory.swift
@@ -5,6 +5,8 @@ import PocketCastsDataModel
 struct TopOnePodcastStory: StoryView {
     var duration: TimeInterval = 5.seconds
 
+    let identifier: String = "top_one_podcast"
+
     let topPodcast: TopPodcast
 
     var backgroundColor: Color {
@@ -79,11 +81,11 @@ struct TopOnePodcastStory: StoryView {
     }
 
     func onAppear() {
-        Analytics.track(.endOfYearStoryShown, story: .topOnePodcast)
+        Analytics.track(.endOfYearStoryShown, story: identifier)
     }
 
     func willShare() {
-        Analytics.track(.endOfYearStoryShare, story: .topOnePodcast)
+        Analytics.track(.endOfYearStoryShare, story: identifier)
     }
 
     func sharingAssets() -> [Any] {

--- a/podcasts/End of Year/StoriesDataSource.swift
+++ b/podcasts/End of Year/StoriesDataSource.swift
@@ -39,6 +39,9 @@ protocol Story {
     /// The amount of time this story should be show
     var duration: TimeInterval { get }
 
+    /// An optional string that identifies the story
+    var identifier: String? { get }
+
     /// Called when the story actually appears.
     ///
     /// If you use SwiftUI `onAppear` together with preload
@@ -58,6 +61,10 @@ protocol Story {
 }
 
 extension Story {
+    var identifier: String? {
+        nil
+    }
+
     func onAppear() {}
 
     func willShare() {}

--- a/podcasts/End of Year/StoriesDataSource.swift
+++ b/podcasts/End of Year/StoriesDataSource.swift
@@ -39,7 +39,7 @@ protocol Story {
     /// The amount of time this story should be show
     var duration: TimeInterval { get }
 
-    /// An optional string that identifies the story
+    /// A string that identifies the story
     var identifier: String { get }
 
     /// Called when the story actually appears.

--- a/podcasts/End of Year/StoriesDataSource.swift
+++ b/podcasts/End of Year/StoriesDataSource.swift
@@ -31,17 +31,6 @@ extension StoriesDataSource {
     func interactiveView(for: Int) -> AnyView {
         return AnyView(EmptyView())
     }
-
-    func shareableAsset(for storyNumber: Int) -> Any {
-        let story = story(for: storyNumber)
-        story.willShare()
-
-        return ZStack {
-            AnyView(story)
-        }
-        .frame(width: 370, height: 693)
-        .snapshot()
-    }
 }
 
 typealias StoryView = Story & View

--- a/podcasts/End of Year/StoriesDataSource.swift
+++ b/podcasts/End of Year/StoriesDataSource.swift
@@ -40,7 +40,7 @@ protocol Story {
     var duration: TimeInterval { get }
 
     /// An optional string that identifies the story
-    var identifier: String? { get }
+    var identifier: String { get }
 
     /// Called when the story actually appears.
     ///
@@ -61,8 +61,8 @@ protocol Story {
 }
 
 extension Story {
-    var identifier: String? {
-        nil
+    var identifier: String {
+        "unknown"
     }
 
     func onAppear() {}

--- a/podcasts/End of Year/StoriesDataSource.swift
+++ b/podcasts/End of Year/StoriesDataSource.swift
@@ -61,10 +61,19 @@ protocol Story {
 
     /// Called when the story will be shared
     func willShare()
+
+    /// Called to get the story shareable assets
+    ///
+    /// This will be given to `UIActivityViewController` as the `activityItems`
+    func sharingAssets() -> [Any]
 }
 
 extension Story {
     func onAppear() {}
 
     func willShare() {}
+
+    func sharingAssets() -> [Any] {
+        return []
+    }
 }

--- a/podcasts/End of Year/StoriesModel.swift
+++ b/podcasts/End of Year/StoriesModel.swift
@@ -77,6 +77,10 @@ class StoriesModel: ObservableObject {
         return AnyView(EmptyView())
     }
 
+    func sharingAssets() -> [Any] {
+        dataSource.story(for: currentStory).sharingAssets()
+    }
+
     func interactive(index: Int) -> AnyView {
         dataSource.interactiveView(for: index)
     }

--- a/podcasts/End of Year/StoriesModel.swift
+++ b/podcasts/End of Year/StoriesModel.swift
@@ -20,6 +20,8 @@ class StoriesModel: ObservableObject {
         dataSource.story(for: currentStory).duration
     }
 
+    var currentStoryIdentifier: String?
+
     var numberOfStories: Int {
         dataSource.numberOfStories
     }
@@ -66,7 +68,10 @@ class StoriesModel: ObservableObject {
     }
 
     func story(index: Int) -> AnyView {
-        dataSource.storyView(for: index)
+        let story = dataSource.story(for: index)
+        story.onAppear()
+        currentStoryIdentifier = story.identifier
+        return AnyView(story)
     }
 
     func preload(index: Int) -> AnyView {

--- a/podcasts/End of Year/StoriesModel.swift
+++ b/podcasts/End of Year/StoriesModel.swift
@@ -88,8 +88,8 @@ class StoriesModel: ObservableObject {
 
         // If any of the assets have additional handlers then make sure we add them to the array
         return story.sharingAssets().flatMap {
-            if let item = $0 as? TumblrDataSource {
-                return [$0, item.tumblrItemProvider]
+            if let item = $0 as? ShareableMetadataDataSource {
+                return [$0, item.shareableMetadataProvider]
             }
 
             return [$0]

--- a/podcasts/End of Year/StoriesModel.swift
+++ b/podcasts/End of Year/StoriesModel.swift
@@ -85,7 +85,15 @@ class StoriesModel: ObservableObject {
     func sharingAssets() -> [Any] {
         let story = dataSource.story(for: currentStory)
         story.willShare()
-        return story.sharingAssets()
+
+        // If any of the assets have additional handlers then make sure we add them to the array
+        return story.sharingAssets().flatMap {
+            if let item = $0 as? TumblrDataSource {
+                return [$0, item.tumblrItemProvider]
+            }
+
+            return [$0]
+        }
     }
 
     func interactive(index: Int) -> AnyView {

--- a/podcasts/End of Year/StoriesModel.swift
+++ b/podcasts/End of Year/StoriesModel.swift
@@ -20,7 +20,7 @@ class StoriesModel: ObservableObject {
         dataSource.story(for: currentStory).duration
     }
 
-    var currentStoryIdentifier: String?
+    private var currentStoryIdentifier: String = ""
 
     var numberOfStories: Int {
         dataSource.numberOfStories
@@ -109,6 +109,13 @@ class StoriesModel: ObservableObject {
         currentStory = 0
         pause()
         start()
+    }
+
+    func share() {
+        pause()
+        EndOfYear().share(assets: sharingAssets(), storyIdentifier: currentStoryIdentifier, onDismiss: { [weak self] in
+            self?.start()
+        })
     }
 }
 

--- a/podcasts/End of Year/StoriesModel.swift
+++ b/podcasts/End of Year/StoriesModel.swift
@@ -78,15 +78,13 @@ class StoriesModel: ObservableObject {
     }
 
     func sharingAssets() -> [Any] {
-        dataSource.story(for: currentStory).sharingAssets()
+        let story = dataSource.story(for: currentStory)
+        story.willShare()
+        return story.sharingAssets()
     }
 
     func interactive(index: Int) -> AnyView {
         dataSource.interactiveView(for: index)
-    }
-
-    func shareableAsset(index: Int) -> Any {
-        dataSource.shareableAsset(for: index)
     }
 
     func next() {

--- a/podcasts/End of Year/StoryShareableProvider.swift
+++ b/podcasts/End of Year/StoryShareableProvider.swift
@@ -1,4 +1,5 @@
 import UIKit
+import SwiftUI
 
 /// An Activity Provider used for the share sheet
 ///
@@ -7,7 +8,17 @@ import UIKit
 /// avoid blocking the main thread and the share sheet
 /// having a delay when appearing.
 class StoryShareableProvider: UIActivityItemProvider {
-    static var generatedItem: Any?
+    static var shared: StoryShareableProvider!
+
+    var generatedItem: Any?
+
+    var view: AnyView?
+
+    static func new(_ view: AnyView) -> StoryShareableProvider {
+        shared = StoryShareableProvider()
+        shared.view = view
+        return shared
+    }
 
     init() {
         super.init(placeholderItem: UIImage())
@@ -15,7 +26,24 @@ class StoryShareableProvider: UIActivityItemProvider {
 
     override var item: Any {
         get {
-            Self.generatedItem ?? UIImage()
+            generatedItem ?? UIImage()
         }
+    }
+
+    // This method is called when the share sheet appeared
+    // So we can go ahead and snapshot the view
+    func snapshot() {
+        guard let view else {
+            return
+        }
+
+        let snapshot = ZStack {
+            AnyView(view)
+        }
+        .frame(width: 370, height: 693)
+        .snapshot()
+
+        generatedItem = snapshot
+        self.view = nil
     }
 }

--- a/podcasts/End of Year/StoryShareableText.swift
+++ b/podcasts/End of Year/StoryShareableText.swift
@@ -5,8 +5,10 @@ class StoryShareableText: UIActivityItemProvider {
 
     private let hashtags = "#pocketcasts #endofyear2022"
 
+    private let pocketCastsUrl = "https://pca.st/"
+
     init(_ text: String) {
-        self.text = "\(text) \(hashtags)"
+        self.text = "\(text) \(hashtags) \(pocketCastsUrl)"
         super.init(placeholderItem: self.text)
     }
 

--- a/podcasts/End of Year/StoryShareableText.swift
+++ b/podcasts/End of Year/StoryShareableText.swift
@@ -5,11 +5,9 @@ class StoryShareableText: UIActivityItemProvider {
     private var text: String
 
     private let hashtags = "#pocketcasts #endofyear2022"
-
     private let pocketCastsUrl = "https://pca.st/"
 
     private var shortenedURL: String?
-
     private var longURL: String?
 
     init(_ text: String) {

--- a/podcasts/End of Year/StoryShareableText.swift
+++ b/podcasts/End of Year/StoryShareableText.swift
@@ -2,7 +2,7 @@ import UIKit
 import PocketCastsServer
 import PocketCastsDataModel
 
-class StoryShareableText: UIActivityItemProvider, TumblrDataSource {
+class StoryShareableText: UIActivityItemProvider, ShareableMetadataDataSource {
     private var text: String
 
     private let pocketCastsUrl = ServerConstants.Urls.share()
@@ -11,7 +11,7 @@ class StoryShareableText: UIActivityItemProvider, TumblrDataSource {
     private var longURL: String?
     private var podcastListURL: String?
 
-    var tumblrItemProvider = TumblrShareableMetadataProvider()
+    var shareableMetadataProvider = ShareableMetadataProvider()
 
     var hashtags: [String] {
         ["pocketcasts", "endofyear2022"]
@@ -48,7 +48,7 @@ class StoryShareableText: UIActivityItemProvider, TumblrDataSource {
     }
 
     override func activityViewController(_ activityViewController: UIActivityViewController, itemForActivityType activityType: UIActivity.ActivityType?) -> Any? {
-        tumblrItemProvider.dataSource = self
+        shareableMetadataProvider.dataSource = self
 
         // Facebook ignores text, so we only share the image
         // WhatsApp ignore the image if we share text, so we also share just the image
@@ -57,16 +57,16 @@ class StoryShareableText: UIActivityItemProvider, TumblrDataSource {
             return nil
         }
 
-        let isTumblr = activityType == .postToTumblr
-        let showHashTags = activityType != .message && !isTumblr
+        let supportsMetadata = activityType?.supportsShareableMetadata ?? false
+        let showHashTags = activityType != .message && !supportsMetadata
 
-        let text = shareableText(showLinks: !isTumblr, showHashTags: showHashTags).trim()
+        let text = shareableText(showLinks: !supportsMetadata, showHashTags: showHashTags).trim()
 
         // Remove any empty text to prevent gaps
         guard !text.isEmpty else { return nil }
-        guard isTumblr else { return text }
+        guard supportsMetadata else { return text }
 
-        // Show the text as a title when sharing to Tumblr
+        // Show the text as a title when sharing to a metadata network such as Tumblr
         let item = NSExtensionItem()
         item.attributedTitle = NSAttributedString(string: text)
         return item

--- a/podcasts/End of Year/StoryShareableText.swift
+++ b/podcasts/End of Year/StoryShareableText.swift
@@ -47,7 +47,7 @@ class StoryShareableText: UIActivityItemProvider {
             return String(format: text, podcastListURL)
         }
 
-        return text
+        return text.trim()
     }
 
     private func requestShortenedURL() {

--- a/podcasts/End of Year/StoryShareableText.swift
+++ b/podcasts/End of Year/StoryShareableText.swift
@@ -1,4 +1,5 @@
 import UIKit
+import PocketCastsDataModel
 
 class StoryShareableText: UIActivityItemProvider {
     private var text: String
@@ -7,12 +8,54 @@ class StoryShareableText: UIActivityItemProvider {
 
     private let pocketCastsUrl = "https://pca.st/"
 
+    private var shortenedURL: String?
+
+    private var longURL: String?
+
     init(_ text: String) {
         self.text = "\(text) \(hashtags) \(pocketCastsUrl)"
         super.init(placeholderItem: self.text)
     }
 
+    init(_ text: String, podcast: Podcast) {
+        self.text = "\(text) \(hashtags)"
+        super.init(placeholderItem: self.text)
+        self.longURL = podcast.shareURL
+        requestShortenedURL()
+    }
+
+    init(_ text: String, episode: Episode) {
+        self.text = "\(text) \(hashtags)"
+        super.init(placeholderItem: self.text)
+        self.longURL = episode.shareURL
+        requestShortenedURL()
+    }
+
     override var item: Any {
-        text
+        if let longURL {
+            return String(format: text, shortenedURL ?? longURL)
+        }
+
+        return text
+    }
+
+    private func requestShortenedURL() {
+        guard let longURL, let url = URL(string: longURL) else {
+            return
+        }
+
+        let task = URLSession(configuration: .default, delegate: self, delegateQueue: nil).dataTask(with: url) { _, _, _ in }
+
+        task.resume()
+    }
+}
+
+extension StoryShareableText: URLSessionDelegate, URLSessionTaskDelegate {
+    func urlSession(_ session: URLSession, task: URLSessionTask, willPerformHTTPRedirection response: HTTPURLResponse, newRequest request: URLRequest, completionHandler: @escaping (URLRequest?) -> Void) {
+        // Stops the redirection, and returns (internally) the response body.
+        completionHandler(nil)
+        if let url = request.url?.absoluteString {
+            shortenedURL = url
+        }
     }
 }

--- a/podcasts/End of Year/StoryShareableText.swift
+++ b/podcasts/End of Year/StoryShareableText.swift
@@ -6,8 +6,8 @@ class StoryShareableText: UIActivityItemProvider {
     private let hashtags = "#pocketcasts #endofyear2022"
 
     init(_ text: String) {
-        self.text = text
-        super.init(placeholderItem: "\(text) \(hashtags)")
+        self.text = "\(text) \(hashtags)"
+        super.init(placeholderItem: self.text)
     }
 
     override var item: Any {

--- a/podcasts/End of Year/StoryShareableText.swift
+++ b/podcasts/End of Year/StoryShareableText.swift
@@ -13,32 +13,46 @@ class StoryShareableText: UIActivityItemProvider {
     private var podcastListURL: String?
 
     init(_ text: String) {
-        self.text = "\(text) \(hashtags) \(pocketCastsUrl)"
+        self.text = text
         super.init(placeholderItem: self.text)
     }
 
     init(_ text: String, podcast: Podcast) {
-        self.text = "\(text) \(hashtags)"
+        self.text = text
         super.init(placeholderItem: self.text)
         self.longURL = podcast.shareURL
         requestShortenedURL()
     }
 
     init(_ text: String, episode: Episode) {
-        self.text = "\(text) \(hashtags)"
+        self.text = text
         super.init(placeholderItem: self.text)
         self.longURL = episode.shareURL
         requestShortenedURL()
     }
 
     init(_ text: String, podcasts: [Podcast]) {
-        self.text = "\(text) \(hashtags)"
+        self.text = text
         super.init(placeholderItem: self.text)
         podcastListURL = ""
         createList(from: podcasts)
     }
 
-    override var item: Any {
+    override func activityViewController(_ activityViewController: UIActivityViewController, itemForActivityType activityType: UIActivity.ActivityType?) -> Any? {
+        // Facebook ignores text, so we only share the image
+        // WhatsApp ignore the image if we share text, so we also share just the image
+        if activityType == .postToFacebook ||
+            activityType?.rawValue.contains("whatsapp") == true {
+            return nil
+        }
+
+        var text = self.text
+
+        // For Messages we don't want to add hashtags
+        if activityType != .message {
+            text = "\(text) \(hashtags)".trim()
+        }
+
         if let longURL {
             return String(format: text, shortenedURL ?? longURL)
         }
@@ -47,7 +61,7 @@ class StoryShareableText: UIActivityItemProvider {
             return String(format: text, podcastListURL)
         }
 
-        return text.trim()
+        return "\(text) \(pocketCastsUrl)"
     }
 
     private func requestShortenedURL() {

--- a/podcasts/End of Year/StoryShareableText.swift
+++ b/podcasts/End of Year/StoryShareableText.swift
@@ -1,0 +1,16 @@
+import UIKit
+
+class StoryShareableText: UIActivityItemProvider {
+    private var text: String
+
+    private let hashtags = "#pocketcasts #endofyear2022"
+
+    init(_ text: String) {
+        self.text = text
+        super.init(placeholderItem: "\(text) \(hashtags)")
+    }
+
+    override var item: Any {
+        text
+    }
+}

--- a/podcasts/End of Year/TumblrShareableMetadataProvider.swift
+++ b/podcasts/End of Year/TumblrShareableMetadataProvider.swift
@@ -1,0 +1,46 @@
+import Foundation
+import PocketCastsServer
+import PocketCastsDataModel
+
+protocol TumblrDataSource: AnyObject {
+    /// Create a provider to handle the additional meta data needed
+    var tumblrItemProvider: TumblrShareableMetadataProvider { get }
+
+    /// Returns the link that we should share in the metadata
+    var shareableLink: String { get }
+
+    /// Returns the array of hashtags to share
+    var hashtags: [String] { get }
+}
+
+class TumblrShareableMetadataProvider: UIActivityItemProvider {
+    weak var dataSource: TumblrDataSource?
+
+    init() {
+        super.init(placeholderItem: "")
+    }
+
+    override func activityViewController(_ activityViewController: UIActivityViewController, itemForActivityType activityType: UIActivity.ActivityType?) -> Any? {
+        guard let dataSource, activityType == .postToTumblr else { return nil }
+
+        let item = NSExtensionItem()
+
+        // Provide tags to Tumblr using the x-extension format
+        item.userInfo = [
+            "x-extension-item": [
+                "tags": dataSource.hashtags
+            ]
+        ]
+
+        // Send the links as attachments
+        item.attachments = [
+            NSItemProvider(item: NSURL(string: dataSource.shareableLink), typeIdentifier: UTType.url.identifier)
+        ]
+
+        return item
+    }
+}
+
+extension UIActivity.ActivityType {
+    public static let postToTumblr = UIActivity.ActivityType(rawValue: "com.tumblr.tumblr.share")
+}

--- a/podcasts/End of Year/Views/StoriesView.swift
+++ b/podcasts/End of Year/Views/StoriesView.swift
@@ -157,10 +157,7 @@ struct StoriesView: View {
 
     var shareButton: some View {
         Button(action: {
-            model.pause()
-            EndOfYear().share(assets: model.sharingAssets(), storyIdentifier: model.currentStoryIdentifier ?? "", onDismiss: {
-                model.start()
-            })
+            model.share()
         }) {
             HStack {
                 Spacer()

--- a/podcasts/End of Year/Views/StoriesView.swift
+++ b/podcasts/End of Year/Views/StoriesView.swift
@@ -158,7 +158,7 @@ struct StoriesView: View {
     var shareButton: some View {
         Button(action: {
             model.pause()
-            EndOfYear().share(assets: model.sharingAssets(), onDismiss: {
+            EndOfYear().share(assets: model.sharingAssets(), storyIdentifier: model.currentStoryIdentifier ?? "", onDismiss: {
                 model.start()
             })
         }) {

--- a/podcasts/End of Year/Views/StoriesView.swift
+++ b/podcasts/End of Year/Views/StoriesView.swift
@@ -158,7 +158,7 @@ struct StoriesView: View {
     var shareButton: some View {
         Button(action: {
             model.pause()
-            EndOfYear().share(asset: { model.shareableAsset(index: model.currentStory) }, onDismiss: {
+            EndOfYear().share(assets: model.sharingAssets(), onDismiss: {
                 model.start()
             })
         }) {

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -741,6 +741,16 @@ class Settings: NSObject {
         }
     }
 
+    class var top5PodcastsListLink: String? {
+        set {
+            UserDefaults.standard.set(newValue, forKey: Constants.UserDefaults.top5PodcastsListLink)
+        }
+
+        get {
+            UserDefaults.standard.string(forKey: Constants.UserDefaults.top5PodcastsListLink)
+        }
+    }
+
     // MARK: - Variables that are loaded/changed through Firebase
 
     #if !os(watchOS)

--- a/podcasts/SharingHelper.swift
+++ b/podcasts/SharingHelper.swift
@@ -8,7 +8,7 @@ class SharingHelper: NSObject {
     func shareLinkTo(podcast: Podcast, fromController: UIViewController, sourceRect: CGRect, sourceView: UIView) {
         AnalyticsHelper.sharedPodcast()
 
-        let sharingUrl = "\(ServerConstants.Urls.share())podcast/\(podcast.uuid)"
+        let sharingUrl = podcast.shareURL
         activityController = UIActivityViewController(activityItems: [URL(string: sharingUrl)!], applicationActivities: nil)
         activityController?.completionWithItemsHandler = { _, _, _, _ in
             NotificationCenter.postOnMainThread(notification: Constants.Notifications.closedNonOverlayableWindow)
@@ -46,7 +46,7 @@ class SharingHelper: NSObject {
     func shareLinkTo(podcast: Podcast, fromController: UIViewController, barButtonItem: UIBarButtonItem?) {
         AnalyticsHelper.sharedPodcast()
 
-        let sharingUrl = "\(ServerConstants.Urls.share())podcast/\(podcast.uuid)"
+        let sharingUrl = podcast.shareURL
         activityController = UIActivityViewController(activityItems: [URL(string: sharingUrl)!], applicationActivities: nil)
         activityController?.completionWithItemsHandler = { _, _, _, _ in
             NotificationCenter.postOnMainThread(notification: Constants.Notifications.closedNonOverlayableWindow)
@@ -108,7 +108,7 @@ class SharingHelper: NSObject {
     }
 
     func createActivityController(episode: Episode, shareTime: TimeInterval) -> UIActivityViewController {
-        var sharingUrl = "\(ServerConstants.Urls.share())episode/\(episode.uuid)"
+        var sharingUrl = episode.shareURL
         if shareTime > 0 {
             AnalyticsHelper.sharedEpisodeWithTimestamp()
             sharingUrl += "?t=\(round(episode.playedUpTo))"
@@ -121,5 +121,17 @@ class SharingHelper: NSObject {
             NotificationCenter.postOnMainThread(notification: Constants.Notifications.closedNonOverlayableWindow)
         }
         return activityController
+    }
+}
+
+extension Podcast {
+    var shareURL: String {
+        "\(ServerConstants.Urls.share())podcast/\(uuid)"
+    }
+}
+
+extension Episode {
+    var shareURL: String {
+        "\(ServerConstants.Urls.share())episode/\(uuid)"
     }
 }

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -628,6 +628,10 @@ internal enum L10n {
   }
   /// But there was one that you kept coming back to...
   internal static var eoyStoryListenedToNumbersSubtitle: String { return L10n.tr("Localizable", "eoy_story_listened_to_numbers_subtitle") }
+  /// I spent %1$@ listening to podcasts in 2022
+  internal static func eoyStoryListenedToShareText(_ p1: Any) -> String {
+    return L10n.tr("Localizable", "eoy_story_listened_to_share_text", String(describing: p1))
+  }
   /// The longest episode you listened to was %1$@ from the podcast %2$@
   internal static func eoyStoryLongestEpisode(_ p1: Any, _ p2: Any) -> String {
     return L10n.tr("Localizable", "eoy_story_longest_episode", String(describing: p1), String(describing: p2))

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -666,6 +666,8 @@ internal enum L10n {
   }
   /// Your Top Podcasts
   internal static var eoyStoryTopPodcasts: String { return L10n.tr("Localizable", "eoy_story_top_podcasts") }
+  /// My top podcasts of the year!
+  internal static var eoyStoryTopPodcastsShareText: String { return L10n.tr("Localizable", "eoy_story_top_podcasts_share_text") }
   /// Your Year in Podcasts
   internal static var eoyTitle: String { return L10n.tr("Localizable", "eoy_title") }
   /// View My 2022

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -620,6 +620,10 @@ internal enum L10n {
   internal static func eoyStoryListenedToCategories(_ p1: Any) -> String {
     return L10n.tr("Localizable", "eoy_story_listened_to_categories", String(describing: p1))
   }
+  /// I listened to %1$@ different categories in 2022
+  internal static func eoyStoryListenedToCategoriesShareText(_ p1: Any) -> String {
+    return L10n.tr("Localizable", "eoy_story_listened_to_categories_share_text", String(describing: p1))
+  }
   /// Let's take a look at some of your favorites...
   internal static var eoyStoryListenedToCategoriesSubtitle: String { return L10n.tr("Localizable", "eoy_story_listened_to_categories_subtitle") }
   /// You listened to %1$@ different podcasts and %2$@ episodes

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -648,6 +648,8 @@ internal enum L10n {
   internal static func eoyStoryLongestEpisodeDuration(_ p1: Any) -> String {
     return L10n.tr("Localizable", "eoy_story_longest_episode_duration", String(describing: p1))
   }
+  /// The longest episode I listened to in 2022
+  internal static var eoyStoryLongestEpisodeShareText: String { return L10n.tr("Localizable", "eoy_story_longest_episode_share_text") }
   /// Replay
   internal static var eoyStoryReplay: String { return L10n.tr("Localizable", "eoy_story_replay") }
   /// Your Top Categories

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -630,6 +630,10 @@ internal enum L10n {
   internal static func eoyStoryListenedToNumbers(_ p1: Any, _ p2: Any) -> String {
     return L10n.tr("Localizable", "eoy_story_listened_to_numbers", String(describing: p1), String(describing: p2))
   }
+  /// I listened to %1$@ different podcasts and %2$@ episodes in 2022
+  internal static func eoyStoryListenedToNumbersShareText(_ p1: Any, _ p2: Any) -> String {
+    return L10n.tr("Localizable", "eoy_story_listened_to_numbers_share_text", String(describing: p1), String(describing: p2))
+  }
   /// But there was one that you kept coming back to...
   internal static var eoyStoryListenedToNumbersSubtitle: String { return L10n.tr("Localizable", "eoy_story_listened_to_numbers_subtitle") }
   /// I spent %1$@ listening to podcasts in 2022

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -648,6 +648,8 @@ internal enum L10n {
   internal static var eoyStoryReplay: String { return L10n.tr("Localizable", "eoy_story_replay") }
   /// Your Top Categories
   internal static var eoyStoryTopCategories: String { return L10n.tr("Localizable", "eoy_story_top_categories") }
+  /// My most listened to podcast categories
+  internal static var eoyStoryTopCategoriesShareText: String { return L10n.tr("Localizable", "eoy_story_top_categories_share_text") }
   /// Your top podcast was %1$@ by %2$@
   internal static func eoyStoryTopPodcast(_ p1: Any, _ p2: Any) -> String {
     return L10n.tr("Localizable", "eoy_story_top_podcast", String(describing: p1), String(describing: p2))

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -658,6 +658,8 @@ internal enum L10n {
   internal static func eoyStoryTopPodcast(_ p1: Any, _ p2: Any) -> String {
     return L10n.tr("Localizable", "eoy_story_top_podcast", String(describing: p1), String(describing: p2))
   }
+  /// My favorite podcast of 2022!
+  internal static var eoyStoryTopPodcastShareText: String { return L10n.tr("Localizable", "eoy_story_top_podcast_share_text") }
   /// You listened to %1$@ episodes for a total of %2$@
   internal static func eoyStoryTopPodcastSubtitle(_ p1: Any, _ p2: Any) -> String {
     return L10n.tr("Localizable", "eoy_story_top_podcast_subtitle", String(describing: p1), String(describing: p2))

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -672,8 +672,12 @@ internal enum L10n {
   }
   /// Your Top Podcasts
   internal static var eoyStoryTopPodcasts: String { return L10n.tr("Localizable", "eoy_story_top_podcasts") }
-  /// My top podcasts of the year!
-  internal static var eoyStoryTopPodcastsShareText: String { return L10n.tr("Localizable", "eoy_story_top_podcasts_share_text") }
+  /// My top podcasts of 2022
+  internal static var eoyStoryTopPodcastsListTitle: String { return L10n.tr("Localizable", "eoy_story_top_podcasts_list_title") }
+  /// My top podcasts of the year! %1$@
+  internal static func eoyStoryTopPodcastsShareText(_ p1: Any) -> String {
+    return L10n.tr("Localizable", "eoy_story_top_podcasts_share_text", String(describing: p1))
+  }
   /// Your Year in Podcasts
   internal static var eoyTitle: String { return L10n.tr("Localizable", "eoy_title") }
   /// View My 2022

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -648,8 +648,10 @@ internal enum L10n {
   internal static func eoyStoryLongestEpisodeDuration(_ p1: Any) -> String {
     return L10n.tr("Localizable", "eoy_story_longest_episode_duration", String(describing: p1))
   }
-  /// The longest episode I listened to in 2022
-  internal static var eoyStoryLongestEpisodeShareText: String { return L10n.tr("Localizable", "eoy_story_longest_episode_share_text") }
+  /// The longest episode I listened to in 2022 %1$@
+  internal static func eoyStoryLongestEpisodeShareText(_ p1: Any) -> String {
+    return L10n.tr("Localizable", "eoy_story_longest_episode_share_text", String(describing: p1))
+  }
   /// Replay
   internal static var eoyStoryReplay: String { return L10n.tr("Localizable", "eoy_story_replay") }
   /// Your Top Categories
@@ -660,8 +662,10 @@ internal enum L10n {
   internal static func eoyStoryTopPodcast(_ p1: Any, _ p2: Any) -> String {
     return L10n.tr("Localizable", "eoy_story_top_podcast", String(describing: p1), String(describing: p2))
   }
-  /// My favorite podcast of 2022!
-  internal static var eoyStoryTopPodcastShareText: String { return L10n.tr("Localizable", "eoy_story_top_podcast_share_text") }
+  /// My favorite podcast of 2022! %1$@
+  internal static func eoyStoryTopPodcastShareText(_ p1: Any) -> String {
+    return L10n.tr("Localizable", "eoy_story_top_podcast_share_text", String(describing: p1))
+  }
   /// You listened to %1$@ episodes for a total of %2$@
   internal static func eoyStoryTopPodcastSubtitle(_ p1: Any, _ p2: Any) -> String {
     return L10n.tr("Localizable", "eoy_story_top_podcast_subtitle", String(describing: p1), String(describing: p2))

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -3315,6 +3315,9 @@
 /* Subtitle for the story containing number of podcasts and episodes played this year. Segway for the next story. */
 "eoy_story_listened_to_numbers_subtitle" = "But there was one that you kept coming back to...";
 
+/* Text that appear when someone share the listened numbers story to Twitter. %1$@ is a placeholder for the number of podcasts listened and %2$@ for the number of episodes. */
+"eoy_story_listened_to_numbers_share_text" = "I listened to %1$@ different podcasts and %2$@ episodes in 2022";
+
 /* Title for the story that display the most listened podcast by the user this year. %1$@ is a placeholder for the podcast title and %2$@ is a placeholder for the author. */
 "eoy_story_top_podcast" = "Your top podcast was %1$@ by %2$@";
 

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -3306,6 +3306,9 @@
 /* String prompting the user for the next story to check the most listened categories. */
 "eoy_story_listened_to_categories_subtitle" = "Let's take a look at some of your favorites...";
 
+/* Text that appear when someone share the listened categories to story to Twitter. %1$@ is a placeholder for the number of categories. */
+"eoy_story_listened_to_categories_share_text" = "I listened to %1$@ different categories in 2022";
+
 /* String telling the user how much podcasts and episodes they listened to this year, %1$@ is a placeholder for the number of podcasts and %2$@ is a placeholder fot eh number of episodes. */
 "eoy_story_listened_to_numbers" = "You listened to %1$@ different podcasts and %2$@ episodes";
 

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -3324,6 +3324,9 @@
 /* Subtitle for the story that display the most listened podcast by the user this year. %1$@ is a placeholder for the number of episodes and %2$@ is a placeholder for the listened time. */
 "eoy_story_top_podcast_subtitle" = "You listened to %1$@ episodes for a total of %2$@";
 
+/* Text that appear when someone share the top podcast of the year story to Twitter. */
+"eoy_story_top_podcast_share_text" = "My favorite podcast of 2022!";
+
 /* Title for the story showing the top podcasts for the user in the current year. */
 "eoy_story_top_podcasts" = "Your Top Podcasts";
 

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -3297,6 +3297,9 @@
 /* String telling the user how much time they listened to podcasts in 2022, %1$@ is a placeholder for the amount of time. */
 "eoy_story_listened_to" = "In 2022, you spent %1$@ listening to podcasts";
 
+/* Text that appear when someone share the listened to story to Twitter, for example. %1$@ is a placeholder for the amount of time. */
+"eoy_story_listened_to_share_text" = "I spent %1$@ listening to podcasts in 2022";
+
 /* String telling the user how much podcast categories they listened to podcasts in 2022, %1$@ is a placeholder for the number of categories. */
 "eoy_story_listened_to_categories" = "You listened to %1$@ different categories this year";
 

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -3306,7 +3306,7 @@
 /* String prompting the user for the next story to check the most listened categories. */
 "eoy_story_listened_to_categories_subtitle" = "Let's take a look at some of your favorites...";
 
-/* Text that appear when someone share the listened categories to story to Twitter. %1$@ is a placeholder for the number of categories. */
+/* Text that appears when someone shares the listened categories to story to Twitter, for example. %1$@ is a placeholder for the number of categories. */
 "eoy_story_listened_to_categories_share_text" = "I listened to %1$@ different categories in 2022";
 
 /* String telling the user how much podcasts and episodes they listened to this year, %1$@ is a placeholder for the number of podcasts and %2$@ is a placeholder fot eh number of episodes. */

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -3297,7 +3297,7 @@
 /* String telling the user how much time they listened to podcasts in 2022, %1$@ is a placeholder for the amount of time. */
 "eoy_story_listened_to" = "In 2022, you spent %1$@ listening to podcasts";
 
-/* Text that appear when someone share the listened to story to Twitter, for example. %1$@ is a placeholder for the amount of time. */
+/* Text that appears when someone shares the listened to story to Twitter, for example. %1$@ is a placeholder for the amount of time. */
 "eoy_story_listened_to_share_text" = "I spent %1$@ listening to podcasts in 2022";
 
 /* String telling the user how much podcast categories they listened to podcasts in 2022, %1$@ is a placeholder for the number of categories. */

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -3324,8 +3324,8 @@
 /* Subtitle for the story that display the most listened podcast by the user this year. %1$@ is a placeholder for the number of episodes and %2$@ is a placeholder for the listened time. */
 "eoy_story_top_podcast_subtitle" = "You listened to %1$@ episodes for a total of %2$@";
 
-/* Text that appear when someone share the top podcast of the year story to Twitter. */
-"eoy_story_top_podcast_share_text" = "My favorite podcast of 2022!";
+/* Text that appear when someone share the top podcast of the year story to Twitter. %1$@ is the URL to the podcast. */
+"eoy_story_top_podcast_share_text" = "My favorite podcast of 2022! %1$@";
 
 /* Title for the story showing the top podcasts for the user in the current year. */
 "eoy_story_top_podcasts" = "Your Top Podcasts";
@@ -3339,8 +3339,8 @@
 /* Subtitle for the story showing the longest episode listened for the user in the current year. %1$@ is a placeholder for the episode length. */
 "eoy_story_longest_episode_duration" = "This episode was %1$@ long";
 
-/* Text that appear when someone share the longest episode they listened to story to Twitter. */
-"eoy_story_longest_episode_share_text" = "The longest episode I listened to in 2022";
+/* Text that appear when someone share the longest episode they listened to story to Twitter. %1$@ is the URL to the episode. */
+"eoy_story_longest_episode_share_text" = "The longest episode I listened to in 2022 %1$@";
 
 /* Title for the epilogue story */
 "eoy_story_epilogue_title" = "Thank you for letting Pocket Casts be a part of your listening experience in 2022";

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -3330,8 +3330,11 @@
 /* Title for the story showing the top podcasts for the user in the current year. */
 "eoy_story_top_podcasts" = "Your Top Podcasts";
 
-/* Text that appear when someone share the top 5 podcasts of the year story to Twitter. */
-"eoy_story_top_podcasts_share_text" = "My top podcasts of the year!";
+/* Text that appear when someone share the top 5 podcasts of the year story to Twitter. %1$@ is a link to the list of the top podcasts. */
+"eoy_story_top_podcasts_share_text" = "My top podcasts of the year! %1$@";
+
+/* Title of a list of podcasts created containing the user's top 5 podcasts of 2022. */
+"eoy_story_top_podcasts_list_title" = "My top podcasts of 2022";
 
 /* Title for the story showing the longest episode listened for the user in the current year. %1$@ is a placeholder for the episode title and %2$@ is a placeholder for the podcast title. */
 "eoy_story_longest_episode" = "The longest episode you listened to was %1$@ from the podcast %2$@";

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -3339,6 +3339,9 @@
 /* Subtitle for the story showing the longest episode listened for the user in the current year. %1$@ is a placeholder for the episode length. */
 "eoy_story_longest_episode_duration" = "This episode was %1$@ long";
 
+/* Text that appear when someone share the longest episode they listened to story to Twitter. */
+"eoy_story_longest_episode_share_text" = "The longest episode I listened to in 2022";
+
 /* Title for the epilogue story */
 "eoy_story_epilogue_title" = "Thank you for letting Pocket Casts be a part of your listening experience in 2022";
 

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -3342,5 +3342,8 @@
 /* Title of the top categories story. */
 "eoy_story_top_categories" = "Your Top Categories";
 
+/* Text that appear when someone share the top categories story to Twitter. */
+"eoy_story_top_categories_share_text" = "My most listened to podcast categories";
+
 /* Description to why the user needs to create an account to see their end of year stats. */
 "eoy_create_account_to_see" = "Save your podcasts in the cloud, get your end of year review and sync your progress with other devices.";

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -3330,6 +3330,9 @@
 /* Title for the story showing the top podcasts for the user in the current year. */
 "eoy_story_top_podcasts" = "Your Top Podcasts";
 
+/* Text that appear when someone share the top 5 podcasts of the year story to Twitter. */
+"eoy_story_top_podcasts_share_text" = "My top podcasts of the year!";
+
 /* Title for the story showing the longest episode listened for the user in the current year. %1$@ is a placeholder for the episode title and %2$@ is a placeholder for the podcast title. */
 "eoy_story_longest_episode" = "The longest episode you listened to was %1$@ from the podcast %2$@";
 


### PR DESCRIPTION
| 📘 Project: #376 |
|:---:|

Adds text content for each story shared and for the top episode and longest episode add a link to them.

<img src="https://user-images.githubusercontent.com/7040243/199720704-b77606fe-6f08-4fb9-8300-cef66b18492b.png" width="300">

## Sharing content to other apps

How the shared content is handled is up to the app. Some apps work fine with images + text, and some do not. They all behave differently. Here's a list of apps I tested with and how they behave:

1. Tumblr: image + link. If the content doesn't have links, it shares the text.
2. WordPress: image + text
2. DayOne: image + text.
3. Facebook: only image. Facebook doesn't accept text and sharing just the image leaves the user to choose between sharing as a story or post.
4. Twitter: image + text.
5. WhatsApp: only image. If we share any text, the image will be ignored.
6. Telegram: image + text.
7. Messages: image + text without hashtags.

## To test

> **Note**
>
> 📱 For better testing, run this on your real device.

1. Enable `endOfYear` and `tracksLoggingEnabled` flags in `FeatureFlag.swift`
2. Run the app and make sure you're logged in to an account with a few items on Listening History
3. Check your 2022 EoY stats (either by tapping "View My 2022" on the modal or going to Profile and tapping the card there)
4. When the first story appears, tap "Share"
5. ✅ Ensure `end_of_year_story_share ["story": "intro"]` is tracked
6. Share to Notes or Twitter
7. ✅ Check the content and the image for the shared story
8. ✅ Ensure `end_of_year_story_shared ["activity": "com.apple.UIKit.activity.CopyToPasteboard", "story": "intro"]` is tracked, where activity depends on what action you've done
8. Repeat these steps for each story, always checking the events and the output (image + text)

### Additional checks

1. ✅ For the top 1 podcast, check that the URL contained in the text redirects to the podcast
2. ✅ For the longest episode, check that the URL contained in the text redirects to the episode
3. ✅ For the top 5 podcasts, check that the URL opens a list containing exactly the 5 top podcasts

Feel free to test sharing the content to other apps.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
