### PR TITLE
Add UIFont+FontStyle extension

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1369,6 +1369,7 @@
 		C7D6551528E5153200AD7174 /* Debounce.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D6551328E5153200AD7174 /* Debounce.swift */; };
 		C7D6551628E5450600AD7174 /* AnalyticsDescribable+Modules.swift in Sources */ = {isa = PBXBuildFile; fileRef = C750EF7E28E3475600E06BA9 /* AnalyticsDescribable+Modules.swift */; };
 		C7D854F328ADD98700877E87 /* AppLifecyleAnalyticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D854F228ADD98700877E87 /* AppLifecyleAnalyticsTests.swift */; };
+		C7F87F112913242C00C15980 /* UIFont+FontStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F87F0F2913242B00C15980 /* UIFont+FontStyle.swift */; };
 		C7F4BAB528DA6BBB001C9785 /* BackgroundSignOutListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F4BAB428DA6BBB001C9785 /* BackgroundSignOutListener.swift */; };
 		C7F4BAB728DA8666001C9785 /* BackgroundSignOutListenerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F4BAB628DA8666001C9785 /* BackgroundSignOutListenerTests.swift */; };
 		C7F4BABF28DB7F7C001C9785 /* DiscoverItem+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F4BABE28DB7F7C001C9785 /* DiscoverItem+Helper.swift */; };
@@ -2904,6 +2905,7 @@
 		C7C4CAF228ABFD0900CFC8CF /* Notifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Notifications.swift; sourceTree = "<group>"; };
 		C7D6551328E5153200AD7174 /* Debounce.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Debounce.swift; sourceTree = "<group>"; };
 		C7D854F228ADD98700877E87 /* AppLifecyleAnalyticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLifecyleAnalyticsTests.swift; sourceTree = "<group>"; };
+		C7F87F0F2913242B00C15980 /* UIFont+FontStyle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIFont+FontStyle.swift"; sourceTree = "<group>"; };
 		C7F4BAB428DA6BBB001C9785 /* BackgroundSignOutListener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundSignOutListener.swift; sourceTree = "<group>"; };
 		C7F4BAB628DA8666001C9785 /* BackgroundSignOutListenerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundSignOutListenerTests.swift; sourceTree = "<group>"; };
 		C7F4BABE28DB7F7C001C9785 /* DiscoverItem+Helper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DiscoverItem+Helper.swift"; sourceTree = "<group>"; };
@@ -5903,6 +5905,7 @@
 				46851BB62790D5E00065C8B2 /* PodcastCollectionColors+Helpers.swift */,
 				8B484F0028D25D1E001AFA97 /* UIViewController+requestReview.swift */,
 				C7F4BABE28DB7F7C001C9785 /* DiscoverItem+Helper.swift */,
+				C7F87F0F2913242B00C15980 /* UIFont+FontStyle.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -7808,6 +7811,7 @@
 				BDD3579327BCD50D0000D155 /* FolderViewController+CollectionView.swift in Sources */,
 				BDE5B8D81E6401F80039B409 /* EpisodeFileSizeUpdater.swift in Sources */,
 				408971AF2512F57100783253 /* BundleImageView.swift in Sources */,
+				C7F87F112913242C00C15980 /* UIFont+FontStyle.swift in Sources */,
 				BD65E51C1CD9BDE000B90A67 /* OnlineSupportController.swift in Sources */,
 				BDCF60EA22EFECA60051EDB3 /* ThemeableCell.swift in Sources */,
 				408C088E23155B34008C9667 /* WhatsNewHelper.swift in Sources */,

--- a/podcasts/UIFont+FontStyle.swift
+++ b/podcasts/UIFont+FontStyle.swift
@@ -1,0 +1,46 @@
+import UIKit
+
+extension UIFont {
+    /// Returns a dynamically sizing font with a custom TextStyle and Weight, and is scaled based off the default size category (large)
+    static func font(with style: UIFont.TextStyle,
+                     weight: UIFont.Weight = .regular,
+                     maxSizeCategory: UIContentSizeCategory = .accessibilityExtraExtraExtraLarge) -> UIFont {
+        let defaultPointSize = pointSize(for: style, sizeCategory: .large)
+        return font(ofSize: defaultPointSize, weight: weight, scalingWith: style, maxSizeCategory: maxSizeCategory)
+    }
+
+    /// Returns a dynamically sizing font based of the given defaultSize for the specified `UIFont.TextStyle` and `UIFont.Weight`
+    ///
+    /// When the current size category is set to the default (.large) the font will be set to `size` and as the size category changes it will be scaled your custom size and the `scalingStyle`.
+    ///
+    /// Example: Starting at the .large size category, a .body `TextStyle`, will have a pointSize of 17, and will scale to 19, 21, and 23 as the size category increases.
+    ///
+    /// However if you specified 18 as the default size, then its scale, from .large, would be: 18, 20, 22, and 23 at the largest size category `.accessibilityExtraExtraExtraLarge`
+    ///
+    /// - Parameters:
+    ///   - size: The base font size to use for the font
+    ///   - scalingStyle: The `UIFont.TextStyle` to scale the font with
+    ///   - weight: The `UIFont.Weight` to use
+    ///   - maxSize: When the `maxSize` category is set, the max font size will be limited to this category.
+    static func font(ofSize size: CGFloat,
+                     weight: UIFont.Weight = .regular,
+                     scalingWith style: UIFont.TextStyle,
+                     maxSizeCategory: UIContentSizeCategory = .accessibilityExtraExtraExtraLarge) -> UIFont {
+        // Get the basic system font for the given size and weight that we can scale from
+        let font = systemFont(ofSize: size, weight: weight)
+
+        // Setup the metrics for the font style we'll scale with
+        let metrics = UIFontMetrics(forTextStyle: style)
+
+        // Scale the given point size up to the largest size category that we'll allow
+        let maxPointSize = metrics.scaledValue(for: size, compatibleWith: UITraitCollection(preferredContentSizeCategory: maxSizeCategory))
+
+        return metrics.scaledFont(for: font, maximumPointSize: maxPointSize)
+    }
+
+    /// Calculates the point size for a font style with the specified size category
+    private static func pointSize(for style: UIFont.TextStyle, sizeCategory: UIContentSizeCategory) -> CGFloat {
+        let traits = UITraitCollection(preferredContentSizeCategory: sizeCategory)
+        return UIFontDescriptor.preferredFontDescriptor(withTextStyle: style, compatibleWith: traits).pointSize
+    }
+}


### PR DESCRIPTION
This adds the UIFont+FontStyle extension from the feature/single-sign-on branch into Trunk

## To test
This is just code changes, nothing to test so just a 🟢 Green CI

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
