### PR TITLE
End of Year: sync Listening History

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
@@ -74,6 +74,31 @@ class EndOfYearDataManager {
         return isFullListeningHistory
     }
 
+    /// Returns the number of episodes we have for this year
+    func numberOfEpisodes(dbQueue: FMDatabaseQueue) -> Int {
+        var numberOfEpisodes: Int = 0
+
+        dbQueue.inDatabase { db in
+            do {
+                let query = """
+                            SELECT COUNT(*) as numberOfEpisodes from \(DataManager.episodeTableName)
+                            WHERE
+                            \(listenedEpisodesThisYear)
+                            """
+                let resultSet = try db.executeQuery(query, values: nil)
+                defer { resultSet.close() }
+
+                if resultSet.next() {
+                    numberOfEpisodes = Int(resultSet.int(forColumn: "numberOfEpisodes"))
+                }
+            } catch {
+                FileLog.shared.addMessage("EndOfYearDataManager.numberOfEpisodes error: \(error)")
+            }
+        }
+
+        return numberOfEpisodes
+    }
+
     /// Returns the approximate listening time for the current year
     func listeningTime(dbQueue: FMDatabaseQueue) -> Double? {
         var listeningTime: Double?

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
@@ -63,8 +63,6 @@ class EndOfYearDataManager {
 
                 if resultSet.next() {
                     isFullListeningHistory = true
-                } else {
-                    isFullListeningHistory = numberOfItemsInListeningHistory(db: db) <= 100
                 }
             } catch {
                 FileLog.shared.addMessage("EndOfYearDataManager.isFullListeningHistory error: \(error)")

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
@@ -11,7 +11,7 @@ class EndOfYearDataManager {
 
     /// If the user is eligible to see End of Year stats
     ///
-    /// All it's needed is a single episode listened for more than 30 minutes.
+    /// All it's needed is a single episode listened for more than 5 minutes.
     func isEligible(dbQueue: FMDatabaseQueue) -> Bool {
         var isEligible = false
 
@@ -20,7 +20,7 @@ class EndOfYearDataManager {
                 let query = """
                             SELECT playedUpTo from \(DataManager.episodeTableName)
                             WHERE
-                            playedUpTo > 1800 AND
+                            playedUpTo > 300 AND
                             \(listenedEpisodesThisYear)
                             LIMIT 1
                             """

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -910,6 +910,10 @@ public extension DataManager {
         endOfYearManager.isFullListeningHistory(dbQueue: dbQueue)
     }
 
+    func numberOfEpisodesThisYear() -> Int {
+        endOfYearManager.numberOfEpisodes(dbQueue: dbQueue)
+    }
+
     func listeningTime() -> Double? {
         endOfYearManager.listeningTime(dbQueue: dbQueue)
     }

--- a/Modules/Server/Sources/PocketCastsServer/Private/Protobuffer/api.pb.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Private/Protobuffer/api.pb.swift
@@ -1655,6 +1655,78 @@ struct Api_HistoryResponse {
   init() {}
 }
 
+struct Api_YearHistoryRequest {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  var deviceTime: Int64 = 0
+
+  var version: String = String()
+
+  var count: Bool = false
+
+  var year: Int32 = 0
+
+  var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  init() {}
+}
+
+struct Api_YearHistoryResponse {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  var isModified: Bool = false
+
+  var record: Api_YearHistoryResponse.OneOf_Record? = nil
+
+  var count: Int32 {
+    get {
+      if case .count(let v)? = record {return v}
+      return 0
+    }
+    set {record = .count(newValue)}
+  }
+
+  var history: Api_HistoryResponse {
+    get {
+      if case .history(let v)? = record {return v}
+      return Api_HistoryResponse()
+    }
+    set {record = .history(newValue)}
+  }
+
+  var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  enum OneOf_Record: Equatable {
+    case count(Int32)
+    case history(Api_HistoryResponse)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: Api_YearHistoryResponse.OneOf_Record, rhs: Api_YearHistoryResponse.OneOf_Record) -> Bool {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch (lhs, rhs) {
+      case (.count, .count): return {
+        guard case .count(let l) = lhs, case .count(let r) = rhs else { preconditionFailure() }
+        return l == r
+      }()
+      case (.history, .history): return {
+        guard case .history(let l) = lhs, case .history(let r) = rhs else { preconditionFailure() }
+        return l == r
+      }()
+      default: return false
+      }
+    }
+  #endif
+  }
+
+  init() {}
+}
+
 struct Api_UpNextRemoveRequest {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
@@ -4475,6 +4547,9 @@ extension Api_UpNextResponse.EpisodeSyncResponse: @unchecked Sendable {}
 extension Api_HistoryChange: @unchecked Sendable {}
 extension Api_HistorySyncRequest: @unchecked Sendable {}
 extension Api_HistoryResponse: @unchecked Sendable {}
+extension Api_YearHistoryRequest: @unchecked Sendable {}
+extension Api_YearHistoryResponse: @unchecked Sendable {}
+extension Api_YearHistoryResponse.OneOf_Record: @unchecked Sendable {}
 extension Api_UpNextRemoveRequest: @unchecked Sendable {}
 extension Api_EpisodeSyncResponse: @unchecked Sendable {}
 extension Api_SearchPodcastsRequest: @unchecked Sendable {}
@@ -7679,6 +7754,127 @@ extension Api_HistoryResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImpl
     if lhs.serverModified != rhs.serverModified {return false}
     if lhs.lastCleared != rhs.lastCleared {return false}
     if lhs.changes != rhs.changes {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Api_YearHistoryRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  static let protoMessageName: String = _protobuf_package + ".YearHistoryRequest"
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .standard(proto: "device_time"),
+    2: .same(proto: "version"),
+    3: .same(proto: "count"),
+    4: .same(proto: "year"),
+  ]
+
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularInt64Field(value: &self.deviceTime) }()
+      case 2: try { try decoder.decodeSingularStringField(value: &self.version) }()
+      case 3: try { try decoder.decodeSingularBoolField(value: &self.count) }()
+      case 4: try { try decoder.decodeSingularInt32Field(value: &self.year) }()
+      default: break
+      }
+    }
+  }
+
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if self.deviceTime != 0 {
+      try visitor.visitSingularInt64Field(value: self.deviceTime, fieldNumber: 1)
+    }
+    if !self.version.isEmpty {
+      try visitor.visitSingularStringField(value: self.version, fieldNumber: 2)
+    }
+    if self.count != false {
+      try visitor.visitSingularBoolField(value: self.count, fieldNumber: 3)
+    }
+    if self.year != 0 {
+      try visitor.visitSingularInt32Field(value: self.year, fieldNumber: 4)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  static func ==(lhs: Api_YearHistoryRequest, rhs: Api_YearHistoryRequest) -> Bool {
+    if lhs.deviceTime != rhs.deviceTime {return false}
+    if lhs.version != rhs.version {return false}
+    if lhs.count != rhs.count {return false}
+    if lhs.year != rhs.year {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Api_YearHistoryResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  static let protoMessageName: String = _protobuf_package + ".YearHistoryResponse"
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .standard(proto: "is_modified"),
+    2: .same(proto: "count"),
+    3: .same(proto: "history"),
+  ]
+
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularBoolField(value: &self.isModified) }()
+      case 2: try {
+        var v: Int32?
+        try decoder.decodeSingularInt32Field(value: &v)
+        if let v = v {
+          if self.record != nil {try decoder.handleConflictingOneOf()}
+          self.record = .count(v)
+        }
+      }()
+      case 3: try {
+        var v: Api_HistoryResponse?
+        var hadOneofValue = false
+        if let current = self.record {
+          hadOneofValue = true
+          if case .history(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.record = .history(v)
+        }
+      }()
+      default: break
+      }
+    }
+  }
+
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    if self.isModified != false {
+      try visitor.visitSingularBoolField(value: self.isModified, fieldNumber: 1)
+    }
+    switch self.record {
+    case .count?: try {
+      guard case .count(let v)? = self.record else { preconditionFailure() }
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 2)
+    }()
+    case .history?: try {
+      guard case .history(let v)? = self.record else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+    }()
+    case nil: break
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  static func ==(lhs: Api_YearHistoryResponse, rhs: Api_YearHistoryResponse) -> Bool {
+    if lhs.isModified != rhs.isModified {return false}
+    if lhs.record != rhs.record {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Modules/Server/Sources/PocketCastsServer/Public/ServerPodcastManager.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/ServerPodcastManager.swift
@@ -111,6 +111,19 @@ public class ServerPodcastManager: NSObject {
         return nil
     }
 
+    public func addMissingPodcastAndEpisode(episodeUuid: String, podcastUuid: String) {
+        let url = ServerConstants.Urls.cache() + "mobile/podcast/findbyepisode/\(podcastUuid)/\(episodeUuid)"
+
+        if let info = loadFrom(url: url) {
+            // Ensure podcast is added, otherwise episode won't be
+            if !PodcastExistHelper.shared.exists(uuid: podcastUuid) {
+                _ = addPodcast(podcastInfo: info, subscribe: false, lastModified: nil)
+            }
+
+            _ = addEpisode(podcastInfo: info)
+        }
+    }
+
     private func addToDatabase(upNextItem: UpNextItem, to podcast: Podcast) {
         // if we have this episode already, then we don't need to do anything here
         guard DataManager.sharedManager.findEpisode(uuid: upNextItem.episodeUuid) == nil else { return }

--- a/Modules/Server/Sources/PocketCastsServer/Public/ServerPodcastManager.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/ServerPodcastManager.swift
@@ -116,7 +116,7 @@ public class ServerPodcastManager: NSObject {
 
         if let info = loadFrom(url: url) {
             // Ensure podcast is added, otherwise episode won't be
-            if !PodcastExistHelper.shared.exists(uuid: podcastUuid) {
+            if !PodcastExistsHelper.shared.exists(uuid: podcastUuid) {
                 _ = addPodcast(podcastInfo: info, subscribe: false, lastModified: nil)
             }
 

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncYearListeningHistory.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncYearListeningHistory.swift
@@ -1,0 +1,87 @@
+import Foundation
+import PocketCastsDataModel
+import PocketCastsUtils
+import SwiftProtobuf
+
+class SyncYearListeningHistory: ApiBaseTask {
+    private var token: String?
+
+    override func apiTokenAcquired(token: String) {
+        self.token = token
+
+        performRequest(token: token, shouldSync: false)
+    }
+
+    private func performRequest(token: String, shouldSync: Bool) {
+        var dataToSync = Api_YearHistoryRequest()
+        dataToSync.deviceTime = TimeFormatter.currentUTCTimeInMillis()
+        dataToSync.version = apiVersion
+        dataToSync.year = 2022
+        dataToSync.count = !shouldSync
+
+        let url = ServerConstants.Urls.api() + "history/year"
+        do {
+            let data = try dataToSync.serializedData()
+            let (response, httpStatus) = postToServer(url: url, token: token, data: data)
+            if let response = response, httpStatus == ServerConstants.HttpConstants.ok {
+                if !shouldSync {
+                    compareNumberOfEpisodes(serverData: response)
+                } else {
+                    syncMissingEpisodes(serverData: response)
+                }
+            } else {
+                print("SyncYearListeningHistory Unable to sync with server got status \(httpStatus)")
+            }
+        } catch {
+            print("SyncYearListeningHistory had issues encoding protobuf \(error.localizedDescription)")
+        }
+    }
+
+    private func compareNumberOfEpisodes(serverData: Data) {
+        do {
+            let response = try Api_YearHistoryResponse(serializedData: serverData)
+
+            let localNumberOfEpisodes = DataManager.sharedManager.numberOfEpisodesThisYear()
+
+            if response.count > localNumberOfEpisodes, let token {
+                performRequest(token: token, shouldSync: true)
+            }
+        } catch {
+            print("SyncYearListeningHistory had issues decoding protobuf \(error.localizedDescription)")
+        }
+    }
+
+    private func syncMissingEpisodes(serverData: Data) {
+        do {
+            let response = try Api_YearHistoryResponse(serializedData: serverData)
+
+            // on watchOS, we don't show history, so we also don't process server changes we only want to push changes up, not down
+            #if !os(watchOS)
+            updateEpisodes(updates: response.history.changes)
+            #endif
+        } catch {
+            print("SyncYearListeningHistory had issues decoding protobuf \(error.localizedDescription)")
+        }
+    }
+
+    private func updateEpisodes(updates: [Api_HistoryChange]) {
+        for change in updates {
+            let interactionDate = Date(timeIntervalSince1970: TimeInterval(change.modifiedAt / 1000))
+            if DataManager.sharedManager.findEpisode(uuid: change.episode) == nil {
+                // The episode is missing, add it
+
+                // TODO: the server response is missing `playedUpTo`, we need that
+
+                ServerPodcastManager.shared.addMissingPodcast(episodeUuid: change.episode, podcastUuid: change.podcast)
+                _ = ServerPodcastManager.shared.addMissingEpisode(episodeUuid: change.episode, podcastUuid: change.podcast)
+                DataManager.sharedManager.setEpisodePlaybackInteractionDate(interactionDate: interactionDate, episodeUuid: change.episode)
+            }
+        }
+    }
+}
+
+public class SyncYearListeningHistoryWrapper {
+    public static func start() {
+        SyncYearListeningHistory().start()
+    }
+}

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncYearListeningHistory.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncYearListeningHistory.swift
@@ -80,8 +80,8 @@ class SyncYearListeningHistory: ApiBaseTask {
     }
 }
 
-public class SyncYearListeningHistoryWrapper {
-    public static func start() {
+public class YearListeningHistory {
+    public static func sync() {
         SyncYearListeningHistory().start()
     }
 }

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncYearListeningHistory.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncYearListeningHistory.swift
@@ -97,7 +97,6 @@ class SyncYearListeningHistory: ApiBaseTask {
 
         // Sync episode status for the retrieved podcasts' episodes
         let uniqueUuidsToUpdate = Array(Set(podcastsToUpdate))
-        print("$$ \(uniqueUuidsToUpdate)")
         updateEpisodes(for: uniqueUuidsToUpdate)
     }
 

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncYearListeningHistoryTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncYearListeningHistoryTask.swift
@@ -6,7 +6,6 @@ import SwiftProtobuf
 class SyncYearListeningHistoryTask: ApiBaseTask {
     private var token: String?
 
-    private let podcastHelper = PodcastExistHelper()
     private let yearToSync: Int32
 
     var success: Bool = false
@@ -125,8 +124,8 @@ class SyncYearListeningHistoryTask: ApiBaseTask {
 
 /// Helper that checks for podcast existence
 /// It caches database requests
-class PodcastExistHelper {
-    static let shared = PodcastExistHelper()
+class PodcastExistsHelper {
+    static let shared = PodcastExistsHelper()
 
     var checkedUuidsThatExist: [String] = []
 

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncYearListeningHistoryTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncYearListeningHistoryTask.swift
@@ -31,7 +31,7 @@ class SyncYearListeningHistoryTask: ApiBaseTask {
         do {
             let data = try dataToSync.serializedData()
             let (response, httpStatus) = postToServer(url: url, token: token, data: data)
-            if let response = response, httpStatus == ServerConstants.HttpConstants.ok {
+            if let response, httpStatus == ServerConstants.HttpConstants.ok {
                 if !shouldSync {
                     compareNumberOfEpisodes(serverData: response)
                 } else {

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncYearListeningHistoryTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncYearListeningHistoryTask.swift
@@ -7,8 +7,13 @@ class SyncYearListeningHistoryTask: ApiBaseTask {
     private var token: String?
 
     private let podcastHelper = PodcastExistHelper()
+    private let yearToSync: Int32
 
     var success: Bool = false
+
+    init(year: Int32) {
+        self.yearToSync = year
+    }
 
     override func apiTokenAcquired(token: String) {
         self.token = token
@@ -20,7 +25,7 @@ class SyncYearListeningHistoryTask: ApiBaseTask {
         var dataToSync = Api_YearHistoryRequest()
         dataToSync.deviceTime = TimeFormatter.currentUTCTimeInMillis()
         dataToSync.version = apiVersion
-        dataToSync.year = 2022
+        dataToSync.year = yearToSync
         dataToSync.count = !shouldSync
 
         let url = ServerConstants.Urls.api() + "history/year"
@@ -147,7 +152,7 @@ class PodcastExistHelper {
 
 public class YearListeningHistory {
     public static func sync() -> Bool {
-        let syncYearListeningHistory = SyncYearListeningHistoryTask()
+        let syncYearListeningHistory = SyncYearListeningHistoryTask(year: 2022)
 
         syncYearListeningHistory.start()
 

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncYearListeningHistoryTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncYearListeningHistoryTask.swift
@@ -3,7 +3,7 @@ import PocketCastsDataModel
 import PocketCastsUtils
 import SwiftProtobuf
 
-class SyncYearListeningHistory: ApiBaseTask {
+class SyncYearListeningHistoryTask: ApiBaseTask {
     private var token: String?
 
     private let podcastHelper = PodcastExistHelper()
@@ -137,7 +137,7 @@ class PodcastExistHelper {
 
 public class YearListeningHistory {
     public static func sync(completionBlock: ((Bool) -> Void)? = nil) {
-        let syncYearListeningHistory = SyncYearListeningHistory()
+        let syncYearListeningHistory = SyncYearListeningHistoryTask()
 
         syncYearListeningHistory.completionBlock = {
             completionBlock?(syncYearListeningHistory.success)

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncYearListeningHistoryTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncYearListeningHistoryTask.swift
@@ -143,10 +143,6 @@ class PodcastExistHelper {
 
         return exists
     }
-
-    func markAsExistent(uuid: String) {
-        checkedUuidsThatExist.append(uuid)
-    }
 }
 
 public class YearListeningHistory {

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncYearListeningHistoryTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncYearListeningHistoryTask.swift
@@ -146,13 +146,11 @@ class PodcastExistHelper {
 }
 
 public class YearListeningHistory {
-    public static func sync(completionBlock: ((Bool) -> Void)? = nil) {
+    public static func sync() -> Bool {
         let syncYearListeningHistory = SyncYearListeningHistoryTask()
 
-        syncYearListeningHistory.completionBlock = {
-            completionBlock?(syncYearListeningHistory.success)
-        }
-
         syncYearListeningHistory.start()
+
+        return syncYearListeningHistory.success
     }
 }

--- a/PocketCastsTests/Tests/End of Year/EndOfYearStoriesBuilderTests.swift
+++ b/PocketCastsTests/Tests/End of Year/EndOfYearStoriesBuilderTests.swift
@@ -163,7 +163,7 @@ class EndOfYearStoriesBuilderTests: XCTestCase {
         var syncCalled = false
         let endOfYearManager = EndOfYearManagerMock()
         let dataManager = DataManagerMock(endOfYearManager: endOfYearManager)
-        let builder = EndOfYearStoriesBuilder(dataManager: dataManager, sync: { syncCalled = true })
+        let builder = EndOfYearStoriesBuilder(dataManager: dataManager, sync: { _ in syncCalled = true })
 
         endOfYearManager.isFullListeningHistoryToReturn = false
         let stories = await builder.build()
@@ -175,7 +175,7 @@ class EndOfYearStoriesBuilderTests: XCTestCase {
         var syncCalled = false
         let endOfYearManager = EndOfYearManagerMock()
         let dataManager = DataManagerMock(endOfYearManager: endOfYearManager)
-        let builder = EndOfYearStoriesBuilder(dataManager: dataManager, sync: { syncCalled = true })
+        let builder = EndOfYearStoriesBuilder(dataManager: dataManager, sync: { _ in syncCalled = true })
 
         endOfYearManager.isFullListeningHistoryToReturn = true
         let stories = await builder.build()

--- a/PocketCastsTests/Tests/End of Year/EndOfYearStoriesBuilderTests.swift
+++ b/PocketCastsTests/Tests/End of Year/EndOfYearStoriesBuilderTests.swift
@@ -168,7 +168,7 @@ class EndOfYearStoriesBuilderTests: XCTestCase {
         var syncCalled = false
         let endOfYearManager = EndOfYearManagerMock()
         let dataManager = DataManagerMock(endOfYearManager: endOfYearManager)
-        let builder = EndOfYearStoriesBuilder(dataManager: dataManager, sync: { _ in syncCalled = true })
+        let builder = EndOfYearStoriesBuilder(dataManager: dataManager, sync: { syncCalled = true; return true })
         Settings.hasSyncedAll2022Episodes = false
 
         endOfYearManager.isFullListeningHistoryToReturn = false
@@ -177,24 +177,11 @@ class EndOfYearStoriesBuilderTests: XCTestCase {
         XCTAssertTrue(syncCalled)
     }
 
-    func testDontSyncWhenNotNeeded() async {
-        var syncCalled = false
-        let endOfYearManager = EndOfYearManagerMock()
-        let dataManager = DataManagerMock(endOfYearManager: endOfYearManager)
-        let builder = EndOfYearStoriesBuilder(dataManager: dataManager, sync: { _ in syncCalled = true })
-        Settings.hasSyncedAll2022Episodes = false
-
-        endOfYearManager.isFullListeningHistoryToReturn = true
-        let stories = await builder.build()
-
-        XCTAssertFalse(syncCalled)
-    }
-
     func testDontSyncWhenAlreadySynced() async {
         var syncCalled = false
         let endOfYearManager = EndOfYearManagerMock()
         let dataManager = DataManagerMock(endOfYearManager: endOfYearManager)
-        let builder = EndOfYearStoriesBuilder(dataManager: dataManager, sync: { _ in syncCalled = true })
+        let builder = EndOfYearStoriesBuilder(dataManager: dataManager, sync: { syncCalled = true; return true })
         Settings.hasSyncedAll2022Episodes = true
 
         endOfYearManager.isFullListeningHistoryToReturn = false

--- a/PocketCastsTests/Tests/End of Year/EndOfYearStoriesBuilderTests.swift
+++ b/PocketCastsTests/Tests/End of Year/EndOfYearStoriesBuilderTests.swift
@@ -4,6 +4,11 @@ import XCTest
 @testable import PocketCastsDataModel
 
 class EndOfYearStoriesBuilderTests: XCTestCase {
+    override func setUp() {
+        // Do not sync for episodes
+        Settings.hasSyncedAll2022Episodes = true
+    }
+
     func testReturnListeningTimeStoryIfBiggerThanZero() async {
         let endOfYearManager = EndOfYearManagerMock()
         let dataManager = DataManagerMock(endOfYearManager: endOfYearManager)
@@ -164,6 +169,7 @@ class EndOfYearStoriesBuilderTests: XCTestCase {
         let endOfYearManager = EndOfYearManagerMock()
         let dataManager = DataManagerMock(endOfYearManager: endOfYearManager)
         let builder = EndOfYearStoriesBuilder(dataManager: dataManager, sync: { _ in syncCalled = true })
+        Settings.hasSyncedAll2022Episodes = false
 
         endOfYearManager.isFullListeningHistoryToReturn = false
         let stories = await builder.build()
@@ -176,8 +182,22 @@ class EndOfYearStoriesBuilderTests: XCTestCase {
         let endOfYearManager = EndOfYearManagerMock()
         let dataManager = DataManagerMock(endOfYearManager: endOfYearManager)
         let builder = EndOfYearStoriesBuilder(dataManager: dataManager, sync: { _ in syncCalled = true })
+        Settings.hasSyncedAll2022Episodes = false
 
         endOfYearManager.isFullListeningHistoryToReturn = true
+        let stories = await builder.build()
+
+        XCTAssertFalse(syncCalled)
+    }
+
+    func testDontSyncWhenAlreadySynced() async {
+        var syncCalled = false
+        let endOfYearManager = EndOfYearManagerMock()
+        let dataManager = DataManagerMock(endOfYearManager: endOfYearManager)
+        let builder = EndOfYearStoriesBuilder(dataManager: dataManager, sync: { _ in syncCalled = true })
+        Settings.hasSyncedAll2022Episodes = true
+
+        endOfYearManager.isFullListeningHistoryToReturn = false
         let stories = await builder.build()
 
         XCTAssertFalse(syncCalled)

--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -146,6 +146,7 @@ struct Constants {
 
         static let showBadgeFor2022EndOfYear = "showBadgeFor2022EndOfYear"
         static let modal2022HasBeenShown = "modal2022HasBeenShown"
+        static let hasSyncedAll2022Episodes = "hasSyncedAll2022Episodes"
     }
 
     enum Values {

--- a/podcasts/End of Year/EndOfYearStoriesBuilder.swift
+++ b/podcasts/End of Year/EndOfYearStoriesBuilder.swift
@@ -23,9 +23,9 @@ class EndOfYearStoriesBuilder {
 
     private let data = EndOfYearStoriesData()
 
-    private let sync: ((((Bool) -> Void)?) -> Void)?
+    private let sync: (() -> Bool)?
 
-    init(dataManager: DataManager = DataManager.sharedManager, sync: ((((Bool) -> Void)?) -> Void)? = YearListeningHistory.sync) {
+    init(dataManager: DataManager = DataManager.sharedManager, sync: (() -> Bool)? = YearListeningHistory.sync) {
         self.dataManager = dataManager
         self.sync = sync
     }
@@ -36,10 +36,13 @@ class EndOfYearStoriesBuilder {
 
             // Check if the user has the full listening history for this year
             if !Settings.hasSyncedAll2022Episodes {
-                sync? { success in
-                    if success {
-                        Settings.hasSyncedAll2022Episodes = true
-                    }
+                let syncedWithSuccess = sync?()
+
+                if syncedWithSuccess == true {
+                    Settings.hasSyncedAll2022Episodes = true
+                } else {
+                    continuation.resume(returning: ([], data))
+                    return
                 }
             }
 

--- a/podcasts/End of Year/EndOfYearStoriesBuilder.swift
+++ b/podcasts/End of Year/EndOfYearStoriesBuilder.swift
@@ -23,9 +23,9 @@ class EndOfYearStoriesBuilder {
 
     private let data = EndOfYearStoriesData()
 
-    private let sync: (() -> Void)?
+    private let sync: ((((Bool) -> Void)?) -> Void)?
 
-    init(dataManager: DataManager = DataManager.sharedManager, sync: (() -> Void)? = YearListeningHistory.sync) {
+    init(dataManager: DataManager = DataManager.sharedManager, sync: ((((Bool) -> Void)?) -> Void)? = YearListeningHistory.sync) {
         self.dataManager = dataManager
         self.sync = sync
     }
@@ -33,9 +33,14 @@ class EndOfYearStoriesBuilder {
     /// Call this method to build the list of stories and the data provider
     func build() async -> ([EndOfYearStory], EndOfYearStoriesData) {
         await withCheckedContinuation { continuation in
+
             // Check if the user has the full listening history for this year
-            if !dataManager.isFullListeningHistory() {
-                sync?()
+            if !dataManager.isFullListeningHistory(), !Settings.hasSyncedAll2022Episodes {
+                sync? { success in
+                    if success {
+                        Settings.hasSyncedAll2022Episodes = true
+                    }
+                }
             }
 
             // Listening time

--- a/podcasts/End of Year/EndOfYearStoriesBuilder.swift
+++ b/podcasts/End of Year/EndOfYearStoriesBuilder.swift
@@ -35,7 +35,7 @@ class EndOfYearStoriesBuilder {
         await withCheckedContinuation { continuation in
 
             // Check if the user has the full listening history for this year
-            if !dataManager.isFullListeningHistory(), !Settings.hasSyncedAll2022Episodes {
+            if !Settings.hasSyncedAll2022Episodes {
                 sync? { success in
                     if success {
                         Settings.hasSyncedAll2022Episodes = true

--- a/podcasts/End of Year/EndOfYearStoriesBuilder.swift
+++ b/podcasts/End of Year/EndOfYearStoriesBuilder.swift
@@ -1,5 +1,6 @@
 import Foundation
 import PocketCastsDataModel
+import PocketCastsServer
 
 /// The available stories for EoY
 enum EndOfYearStory: String {
@@ -24,7 +25,7 @@ class EndOfYearStoriesBuilder {
 
     private let sync: (() -> Void)?
 
-    init(dataManager: DataManager = DataManager.sharedManager, sync: (() -> Void)? = nil) {
+    init(dataManager: DataManager = DataManager.sharedManager, sync: (() -> Void)? = YearListeningHistory.sync) {
         self.dataManager = dataManager
         self.sync = sync
     }
@@ -34,7 +35,6 @@ class EndOfYearStoriesBuilder {
         await withCheckedContinuation { continuation in
             // Check if the user has the full listening history for this year
             if !dataManager.isFullListeningHistory() {
-                // TODO: update with the correct endpoint to sync history (eoy-todo)
                 sync?()
             }
 

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -741,6 +741,16 @@ class Settings: NSObject {
         }
     }
 
+    class var hasSyncedAll2022Episodes: Bool {
+        set {
+            UserDefaults.standard.set(newValue, forKey: Constants.UserDefaults.hasSyncedAll2022Episodes)
+        }
+
+        get {
+            UserDefaults.standard.bool(forKey: Constants.UserDefaults.hasSyncedAll2022Episodes)
+        }
+    }
+
     // MARK: - Variables that are loaded/changed through Firebase
 
     #if !os(watchOS)


### PR DESCRIPTION
| 📘 Project: #376 |
|:---:|

If we identify the user doesn't have the entire 2022 listening history, we sync this with the server adding the missing episodes.

This is a case that might happen for a very active user that switched devices during this year — given we only sync the latest 100 items.

**How do we identify if a user needs a sync?**

~We look at their listening history. If they have an episode from last year, we assume that their 2022 listening history is complete.~

~A much more bulletproof strategy would be to call the endpoint to check the number of items for the user, and sync if needed, **just once**. But I'm not sure what would be the impact of such a call on the backend (@Ferdev curious to hear your thoughts about it).~

We request the number of items the server has. If the returned number is smaller than what we have locally, we sync the necessary items.

## To test

You'll need an account with more than 100 items. Please ping me and I can provide one.

1. Enable the `endOfYear` flag in `FeatureFlag.swift`
2. Do a clean run of the app in Staging mode (Schemes > pocketcasts > change "Build Configuration" to Staging)
3. Login with an account with more than 100 items
4. Check your listening history, you should see just ~40 items
5. Put a breakpoint on `EndOfYearStoriesBuilder.swift` line `39`
6. Check your EoY stories
7. ✅ The hitpoint should be hit, proceed with execution
8. ✅ You should see the spinner for a few seconds
9. ✅ The stories should appear
10. Dismiss the stories
11. Check your Listening History
12. ✅ You should have more than 100 items there now (the oldest episode is an archived episode called "39. Mother"
13. Check your stories again
14. ✅ The breakpoint should not be hit (2022 sync happens just once)

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
