### PR TITLE
Fixed the width and height of the download indicator in Episode cells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 7.27
 -----
-
+- Fixed the download indicator width in iOS 14 in Episode list cells.
 
 7.26
 -----

--- a/podcasts/EpisodeCell.xib
+++ b/podcasts/EpisodeCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -18,7 +18,7 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <stackView opaque="NO" contentMode="scaleToFill" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="tHF-7Q-e0O" userLabel="Main Stack View">
-                        <rect key="frame" x="8" y="8" width="149.5" height="64"/>
+                        <rect key="frame" x="8" y="8" width="145.5" height="64"/>
                         <subviews>
                             <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="FSw-Tp-zBU">
                                 <rect key="frame" x="-44" y="10" width="44" height="44"/>
@@ -64,10 +64,10 @@
                                 </constraints>
                             </view>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="top" spacing="3" translatesAutoresizingMaskIntoConstraints="NO" id="FG0-AH-uw2" userLabel="Day Title Info Stack View">
-                                <rect key="frame" x="68" y="1.5" width="37.5" height="61"/>
+                                <rect key="frame" x="68" y="3.5" width="33.5" height="57"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="AM4-hC-bId">
-                                        <rect key="frame" x="0.0" y="0.0" width="37.5" height="17"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="33.5" height="17"/>
                                         <subviews>
                                             <imageView hidden="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="252" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" image="list_video" translatesAutoresizingMaskIntoConstraints="NO" id="coq-Rq-4hS" userLabel="Video Indicator">
                                                 <rect key="frame" x="0.0" y="0.5" width="16" height="16"/>
@@ -77,7 +77,7 @@
                                                 </constraints>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" text="DAY NAME" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="r76-GH-6nD" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="2" width="37.5" height="13.5"/>
+                                                <rect key="frame" x="0.0" y="2" width="33.5" height="13.5"/>
                                                 <accessibility key="accessibilityConfiguration">
                                                     <bool key="isElement" value="NO"/>
                                                 </accessibility>
@@ -90,10 +90,10 @@
                                         </constraints>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="IDe-pC-iLG" userLabel="Title Stack View">
-                                        <rect key="frame" x="0.0" y="20" width="37.5" height="18"/>
+                                        <rect key="frame" x="0.0" y="20" width="33.5" height="18"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eos-tq-mJC" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="0.0" width="37.5" height="18"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="33.5" height="18"/>
                                                 <accessibility key="accessibilityConfiguration">
                                                     <bool key="isElement" value="NO"/>
                                                 </accessibility>
@@ -115,20 +115,24 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="neM-x9-7TY" userLabel="Info Stack View">
-                                        <rect key="frame" x="0.0" y="41" width="37.5" height="20"/>
+                                        <rect key="frame" x="0.0" y="41" width="33.5" height="16"/>
                                         <subviews>
                                             <imageView hidden="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" image="list_upnext" translatesAutoresizingMaskIntoConstraints="NO" id="bvr-nR-R0Y">
-                                                <rect key="frame" x="-16" y="2" width="16" height="16"/>
+                                                <rect key="frame" x="-16" y="0.0" width="16" height="16"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="16" id="LoV-4U-0eL"/>
                                                     <constraint firstAttribute="width" constant="16" id="zWf-cZ-EYM"/>
                                                 </constraints>
                                             </imageView>
                                             <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="gray" translatesAutoresizingMaskIntoConstraints="NO" id="aTS-6i-zGz" customClass="ThemeLoadingIndicator" customModule="podcasts" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="0.0" width="20" height="20"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="16" height="16"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" constant="16" id="ko3-4h-f8E"/>
+                                                    <constraint firstAttribute="height" constant="16" id="xpe-9j-Lji"/>
+                                                </constraints>
                                             </activityIndicatorView>
                                             <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lhc-D5-z2c" customClass="ProgressPieView" customModule="podcasts" customModuleProvider="target">
-                                                <rect key="frame" x="22.5" y="2" width="16" height="16"/>
+                                                <rect key="frame" x="18.5" y="0.0" width="16" height="16"/>
                                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="16" id="V2u-HA-9cO"/>
@@ -136,21 +140,21 @@
                                                 </constraints>
                                             </view>
                                             <imageView hidden="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="list_downloaded" translatesAutoresizingMaskIntoConstraints="NO" id="G7K-3G-zGx" userLabel="Status Indicator">
-                                                <rect key="frame" x="22.5" y="2" width="16" height="16"/>
+                                                <rect key="frame" x="18.5" y="0.0" width="16" height="16"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="16" id="O1v-9M-01B"/>
                                                     <constraint firstAttribute="width" constant="16" id="cXQ-gy-xBS"/>
                                                 </constraints>
                                             </imageView>
                                             <imageView hidden="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="cloud-gold" translatesAutoresizingMaskIntoConstraints="NO" id="AFe-mm-Nlh" userLabel="Status Indicator">
-                                                <rect key="frame" x="22.5" y="2" width="16" height="16"/>
+                                                <rect key="frame" x="18.5" y="0.0" width="16" height="16"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="16" id="aEA-vy-1ZF"/>
                                                     <constraint firstAttribute="width" constant="16" id="aao-5L-9wZ"/>
                                                 </constraints>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="..." textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CYh-rx-5sN" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                                                <rect key="frame" x="25" y="2" width="12.5" height="16"/>
+                                                <rect key="frame" x="21" y="0.0" width="12.5" height="16"/>
                                                 <fontDescription key="fontDescription" type="system" weight="medium" pointSize="13"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
@@ -163,7 +167,7 @@
                                 </constraints>
                             </stackView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cxw-Qx-pW3" userLabel="One Butten" customClass="MainEpisodeActionView" customModule="podcasts" customModuleProvider="target">
-                                <rect key="frame" x="105.5" y="10" width="44" height="44"/>
+                                <rect key="frame" x="101.5" y="10" width="44" height="44"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="44" id="VHU-JA-EPG"/>
                                     <constraint firstAttribute="height" constant="44" id="oDl-RQ-A3W"/>
@@ -172,7 +176,7 @@
                         </subviews>
                     </stackView>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hSw-lh-n5l" customClass="ThemeDividerView" customModule="podcasts" customModuleProvider="target">
-                        <rect key="frame" x="0.0" y="79" width="165.5" height="1"/>
+                        <rect key="frame" x="0.0" y="79" width="161.5" height="1"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="1" id="Z0u-K8-l7r"/>


### PR DESCRIPTION
This PR fixes an iOS 14 layout issue with the width of the download indicator in Episode cells. 16px width and height constraints have been added to match other indicator icon constraints.

I spotted this issue while testing https://github.com/Automattic/pocket-casts-ios/pull/484 in iOS 14

| Before  | After |
| ------------- | ------------- |
| <img width="350" alt="Screenshot 2022-11-04 at 4 31 16 PM" src="https://user-images.githubusercontent.com/4081020/200072819-fea14bd0-5f2d-4587-a62e-286e053d5e06.png"> | <img width="359" alt="Screenshot 2022-11-04 at 4 54 27 PM" src="https://user-images.githubusercontent.com/4081020/200072946-6db2872a-b204-40b6-8b2c-aae8651b3141.png">  |

## To test

1. pull branch, build and launch in an iOS 14 simulator
2. Start downloading an episode
3. Return to the episodes list (Dismiss the episode view or visit Profile -> Downloads) for the podcast you downloaded an episode for
4. The download spinner should be a square shape (not surrounded by whitespace as wide as the `downloading...` text)
5. Test in an iOS 16 simulator as well to ensure no new layout issues appear


## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
