### PR TITLE
Sentry: connect crash with user account

### DIFF
--- a/podcasts/Analytics/Adapters/Crash Logging/CrashLoggingDataProvider.swift
+++ b/podcasts/Analytics/Adapters/Crash Logging/CrashLoggingDataProvider.swift
@@ -1,11 +1,18 @@
 import Foundation
+import PocketCastsServer
 import AutomatticRemoteLogging
 
 class CrashLoggingDataProvider: AutomatticRemoteLogging.CrashLoggingDataProvider {
     let sentryDSN = ApiCredentials.sentryDSN
     let userHasOptedOut = false
     let shouldEnableAutomaticSessionTracking = true
-    var currentUser: AutomatticTracksModel.TracksUser? = nil
+    var currentUser: AutomatticTracksModel.TracksUser? {
+        guard SyncManager.isUserLoggedIn() else {
+            return nil
+        }
+
+        return TracksUser(userID: ServerSettings.userId, email: ServerSettings.syncingEmail(), username: nil)
+    }
 
     var buildType: String {
     #if STAGING


### PR DESCRIPTION
In order to provide better support we'll connect crashes with the user account.

## To test

1. Change Build Configuration to "Release" (Manage Schemes > pocketcasts > Edit)
2. On `SettingsViewController.viewWillAppear` add a `fatalError("Testing")`
3. Stop running the app through Xcode
4. Open it and navigate to Settings
5. The app will crash
6. Open it again so the crash is sent to Sentry
7. ✅ Search in Sentry for your crash, and check user information. If you're logged it, it should contain your email/id, if not, it won't contain anything

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
