### PR TITLE
Onboarding: Adds some initial SwiftUI extensions and views

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Extensions/UI/Color+Hex.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Extensions/UI/Color+Hex.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+extension Color {
+    public init(hex: String) {
+        let hex = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
+        var int: UInt64 = 0
+        Scanner(string: hex).scanHexInt64(&int)
+        let a, r, g, b: UInt64
+        switch hex.count {
+        case 3: // RGB (12-bit)
+            (a, r, g, b) = (255, (int >> 8) * 17, (int >> 4 & 0xF) * 17, (int & 0xF) * 17)
+        case 6: // RGB (24-bit)
+            (a, r, g, b) = (255, int >> 16, int >> 8 & 0xFF, int & 0xFF)
+        case 8: // ARGB (32-bit)
+            (a, r, g, b) = (int >> 24, int >> 16 & 0xFF, int >> 8 & 0xFF, int & 0xFF)
+        default:
+            (a, r, g, b) = (1, 1, 1, 0)
+        }
+
+        self.init(
+            .sRGB,
+            red: Double(r) / 255,
+            green: Double(g) / 255,
+            blue: Double(b) / 255,
+            opacity: Double(a) / 255
+        )
+    }
+}

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1358,6 +1358,10 @@
 		C7AF578D289C60CA0089E435 /* FeatureFlag.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7AF5788289C60B70089E435 /* FeatureFlag.swift */; };
 		C7AF578E289C60CD0089E435 /* FeatureFlag.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7AF5788289C60B70089E435 /* FeatureFlag.swift */; };
 		C7AF5791289D87CF0089E435 /* Analytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7AF5790289D87CF0089E435 /* Analytics.swift */; };
+		C7B3C60A2919DCB700054145 /* ScrollViewIfNeeded.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7B3C6092919DCB700054145 /* ScrollViewIfNeeded.swift */; };
+		C7B3C60C2919DCC800054145 /* ActionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7B3C60B2919DCC800054145 /* ActionView.swift */; };
+		C7B3C60E2919DD1700054145 /* ContentSizeReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7B3C60D2919DD1700054145 /* ContentSizeReader.swift */; };
+		C7B3C6142919F47A00054145 /* HorizontalScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7B3C6132919F47A00054145 /* HorizontalScrollView.swift */; };
 		C7BF5E47290832FD00733C1E /* DiscoverCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7BF5E46290832FD00733C1E /* DiscoverCoordinator.swift */; };
 		C7BF5E4A29083B5300733C1E /* DiscoverCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7BF5E4929083B5300733C1E /* DiscoverCoordinatorTests.swift */; };
 		C7BF5E4D29083E2100733C1E /* PocketCastsServer in Frameworks */ = {isa = PBXBuildFile; productRef = C7BF5E4C29083E2100733C1E /* PocketCastsServer */; };
@@ -1372,11 +1376,11 @@
 		C7D6551528E5153200AD7174 /* Debounce.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D6551328E5153200AD7174 /* Debounce.swift */; };
 		C7D6551628E5450600AD7174 /* AnalyticsDescribable+Modules.swift in Sources */ = {isa = PBXBuildFile; fileRef = C750EF7E28E3475600E06BA9 /* AnalyticsDescribable+Modules.swift */; };
 		C7D854F328ADD98700877E87 /* AppLifecyleAnalyticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D854F228ADD98700877E87 /* AppLifecyleAnalyticsTests.swift */; };
-		C7F87F112913242C00C15980 /* UIFont+FontStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F87F0F2913242B00C15980 /* UIFont+FontStyle.swift */; };
 		C7F2257F29145988001E4547 /* ShareableMetadataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F2257E29145988001E4547 /* ShareableMetadataProvider.swift */; };
 		C7F4BAB528DA6BBB001C9785 /* BackgroundSignOutListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F4BAB428DA6BBB001C9785 /* BackgroundSignOutListener.swift */; };
 		C7F4BAB728DA8666001C9785 /* BackgroundSignOutListenerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F4BAB628DA8666001C9785 /* BackgroundSignOutListenerTests.swift */; };
 		C7F4BABF28DB7F7C001C9785 /* DiscoverItem+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F4BABE28DB7F7C001C9785 /* DiscoverItem+Helper.swift */; };
+		C7F87F112913242C00C15980 /* UIFont+FontStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F87F0F2913242B00C15980 /* UIFont+FontStyle.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -2904,6 +2908,10 @@
 		C79E1E3F28887549008524CB /* PlusUpgradeViewSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlusUpgradeViewSourceTests.swift; sourceTree = "<group>"; };
 		C7AF5788289C60B70089E435 /* FeatureFlag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlag.swift; sourceTree = "<group>"; };
 		C7AF5790289D87CF0089E435 /* Analytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Analytics.swift; sourceTree = "<group>"; };
+		C7B3C6092919DCB700054145 /* ScrollViewIfNeeded.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollViewIfNeeded.swift; sourceTree = "<group>"; };
+		C7B3C60B2919DCC800054145 /* ActionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionView.swift; sourceTree = "<group>"; };
+		C7B3C60D2919DD1700054145 /* ContentSizeReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentSizeReader.swift; sourceTree = "<group>"; };
+		C7B3C6132919F47A00054145 /* HorizontalScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HorizontalScrollView.swift; sourceTree = "<group>"; };
 		C7BF5E46290832FD00733C1E /* DiscoverCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverCoordinator.swift; sourceTree = "<group>"; };
 		C7BF5E4929083B5300733C1E /* DiscoverCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverCoordinatorTests.swift; sourceTree = "<group>"; };
 		C7C2391BA608F0CAB6E1D038 /* libPods-Pocket Casts Watch App Extension.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Pocket Casts Watch App Extension.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -4041,6 +4049,7 @@
 		BD2A49E31701A66E00C2F192 /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				C74887782919DC7B00EBC926 /* SwiftUI */,
 				C7AF578F289D7F1E0089E435 /* Analytics */,
 				BD2A49E41701A6AE00C2F192 /* SJCommonUtils.h */,
 				BD2A49E51701A6AE00C2F192 /* SJCommonUtils.m */,
@@ -5975,6 +5984,17 @@
 			path = Adapters;
 			sourceTree = "<group>";
 		};
+		C74887782919DC7B00EBC926 /* SwiftUI */ = {
+			isa = PBXGroup;
+			children = (
+				C7B3C6092919DCB700054145 /* ScrollViewIfNeeded.swift */,
+				C7B3C60D2919DD1700054145 /* ContentSizeReader.swift */,
+				C7B3C60B2919DCC800054145 /* ActionView.swift */,
+				C7B3C6132919F47A00054145 /* HorizontalScrollView.swift */,
+			);
+			path = SwiftUI;
+			sourceTree = "<group>";
+		};
 		C761300628E4CA060044C6C2 /* Helpers */ = {
 			isa = PBXGroup;
 			children = (
@@ -7720,6 +7740,7 @@
 				BD92323823629FAA00C1E118 /* ShowNotesPlayerItemViewController.swift in Sources */,
 				40A0A90B24B3FD7800C29362 /* DownloadsViewController+MultiSelect.swift in Sources */,
 				BD35BB6C1CF697650018D63E /* AudioUtils.swift in Sources */,
+				C7B3C60A2919DCB700054145 /* ScrollViewIfNeeded.swift in Sources */,
 				BDA9668F2189805F00DF9370 /* UITableView+MiniPlayer.swift in Sources */,
 				BD48D5A6216DB26A00391F9E /* HapticsHelper.swift in Sources */,
 				BD9313531D7970F1007A70FC /* SelectPodcastCell.swift in Sources */,
@@ -7746,6 +7767,7 @@
 				BDF15A401B54E064000EC323 /* PlaybackQueue.swift in Sources */,
 				46AA2E032767EF92001D647A /* PlayPauseLabeledButton.swift in Sources */,
 				BD6B1F011CE05159003CE958 /* AnalyticsHelper.swift in Sources */,
+				C7B3C60E2919DD1700054145 /* ContentSizeReader.swift in Sources */,
 				BD583AF421AE5F9E0048D78D /* EpisodeDateHelper.swift in Sources */,
 				BDC940B61BA7F5FB008CC635 /* BouncyButton.swift in Sources */,
 				409C792F222397BA00386495 /* UserEpisodeActionCell.swift in Sources */,
@@ -7796,6 +7818,7 @@
 				BD9F2FD627549BA300070958 /* AboutView.swift in Sources */,
 				BDCCBC8824BC444F009B4D1D /* CustomTimeStepper.swift in Sources */,
 				BDFB53CB2362B9080001806E /* UpNextViewController.swift in Sources */,
+				C7B3C60C2919DCC800054145 /* ActionView.swift in Sources */,
 				BD240C3F231E8BE000FB2CDD /* PCSearchBarController.swift in Sources */,
 				8B0EEDE2290065C100075772 /* ListenedCategoriesStory.swift in Sources */,
 				BD9FF61C1B8EDDBB009F075E /* NetworkCell.swift in Sources */,
@@ -7808,6 +7831,7 @@
 				BDCF3C8224283C78005B6933 /* UploadedViewController+Swipe.swift in Sources */,
 				BD3334501FC65A510017C3A8 /* EpisodeTableHelper.swift in Sources */,
 				BD2DE2321E65224900BE21A4 /* ShowNotesUpdater.swift in Sources */,
+				C7B3C6142919F47A00054145 /* HorizontalScrollView.swift in Sources */,
 				BDA0E2A322DDB5550029EBEB /* ThemeColor.swift in Sources */,
 				8BCB22B428F48282001A0315 /* EndOfYear.swift in Sources */,
 				BDCC55141CD0A448006BE239 /* AEXML.swift in Sources */,

--- a/podcasts/FeatureFlag.swift
+++ b/podcasts/FeatureFlag.swift
@@ -18,4 +18,7 @@ enum FeatureFlag {
 
     /// Adds the Sign In With Apple options to the login flow
     static let signInWithApple = false
+
+    /// Displays the new onboarding view updates
+    static let onboardingUpdates = true
 }

--- a/podcasts/Styles.swift
+++ b/podcasts/Styles.swift
@@ -228,3 +228,20 @@ struct NavButtonStyle: ButtonStyle {
             .opacity(isEnabled ? 1 : 0.4)
     }
 }
+
+// MARK: - Button Modifiers
+extension View {
+    /// Adds a subtle spring effect when the `isPressed` value is changed
+    /// This should be used from a `ButtonStyle` and passing in `configuration.isPressed`
+    ///
+    func makeSpringy(isPressed: Bool, enableHaptic: Bool = true) -> some View {
+        self
+            .scaleEffect(isPressed ? 0.98 : 1.0)
+            .animation(.interpolatingSpring(stiffness: 350, damping: 10, initialVelocity: 10), value: isPressed)
+            .onChange(of: isPressed) { pressed in
+                guard enableHaptic, pressed else { return }
+
+                UIImpactFeedbackGenerator(style: .rigid).impactOccurred()
+            }
+    }
+}

--- a/podcasts/SwiftUI/ActionView.swift
+++ b/podcasts/SwiftUI/ActionView.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+
+
+/// This is a helper view that allows you to run code inline of SwiftUI without needing to move logic into .onAppear
+/// It works by creating a completely empty view, waiting for .onAppear, and then trigering the action. Once the action
+/// has been triggered, the emptyview is replaced with a Group to prevent any possible layout issues
+/// Example Usage:
+///
+/// ```
+///  ZStack{
+///     Action { print("debugging is cool 😎") }
+///     VStack {
+///         ... some views ...
+///     }
+///
+///     ... some views ...
+///
+///     Action {
+///         viewModel.loadContent()
+///     }
+/// }
+/// ```
+struct Action: View {
+    init(_ action: @escaping () -> Void) {
+        self.action = action
+    }
+
+    private let action: () -> Void
+    @State private var didPerform: Bool? = nil
+
+    var body: some View {
+        // If we performed the action already, remove the "caller" view from the stack
+        // and just return a group
+        if didPerform != nil {
+            Group { }
+        } else {
+            // If the action hasn't been performed yet, we'll create an empty view and listen for the onAppear
+            NoView().onAppear() {
+                action()
+                didPerform = true
+            }
+        }
+    }
+
+    /// This clears a "view" that has no frame, and appears very far off screen.
+    /// This allows the onAppear to still be called, but doesn't allow it appear in view at all
+    private struct NoView: View {
+        var body: some View {
+            Color.clear
+                .frame(width: 0, height: 0)
+                .accessibility(hidden: true)
+                .allowsHitTesting(false)
+                .position(CGPoint(x: .max, y: .max))
+        }
+    }
+}

--- a/podcasts/SwiftUI/ActionView.swift
+++ b/podcasts/SwiftUI/ActionView.swift
@@ -54,3 +54,25 @@ struct Action: View {
         }
     }
 }
+
+struct ActionView_Example_Preview: PreviewProvider {
+    static var previews: some View {
+        ExampleView()
+    }
+
+    struct ExampleView: View {
+        @State private var text: String = "Waiting..."
+
+        var body: some View {
+            VStack {
+                Text(text)
+
+                Action {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(1)) {
+                        text = "🎉🎉 The Action has Ran 🎉🎉"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/podcasts/SwiftUI/ActionView.swift
+++ b/podcasts/SwiftUI/ActionView.swift
@@ -42,7 +42,7 @@ struct Action: View {
         }
     }
 
-    /// This clears a "view" that has no frame, and appears very far off screen.
+    /// This is a "view" that has no frame, and appears very far off screen.
     /// This allows the onAppear to still be called, but doesn't allow it appear in view at all
     private struct NoView: View {
         var body: some View {

--- a/podcasts/SwiftUI/ContentSizeReader.swift
+++ b/podcasts/SwiftUI/ContentSizeReader.swift
@@ -27,3 +27,29 @@ struct ContentSizeReader<Content: View>: View {
         }
     }
 }
+
+struct ContentSizeReader_Example_Preview: PreviewProvider {
+    static var previews: some View {
+        ExampleView()
+    }
+
+    struct ExampleView: View {
+        @State private var size: String = "Waiting.."
+
+        var body: some View {
+            VStack {
+                ContentSizeReader { contentSize in
+                    VStack {
+                        Text(size)
+                    }.frame(maxWidth: 200, maxHeight: 200)
+
+                    Action {
+                        if let contentSize {
+                            size = "Height: \(contentSize.height), Width: \(contentSize.width)"
+                        }
+                    }
+                }
+            }.background(Color.gray)
+        }
+    }
+}

--- a/podcasts/SwiftUI/ContentSizeReader.swift
+++ b/podcasts/SwiftUI/ContentSizeReader.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+/// Calculates the size of the containing view and returns it
+/// This allows you to get easily get the size of the view without needing all the boilerplate for `GeometryReader`
+struct ContentSizeReader<Content: View>: View {
+    private var content: (CGSize?) -> Content
+
+    init(@ViewBuilder _ content: @escaping (CGSize?) -> Content) {
+        self.content = content
+    }
+
+    @State private var size: CGSize?
+
+    var body: some View {
+        // If we've calculated the size, then just return it and the view
+        if let size {
+            content(size)
+        } else {
+            content(nil).background(
+                // Grab the size of just the content
+                GeometryReader { contentGeometry in
+                    Action {
+                        size = contentGeometry.size
+                    }
+                }
+            )
+        }
+    }
+}

--- a/podcasts/SwiftUI/ContentSizeReader.swift
+++ b/podcasts/SwiftUI/ContentSizeReader.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 /// Calculates the size of the containing view and returns it
-/// This allows you to get easily get the size of the view without needing all the boilerplate for `GeometryReader`
+/// This allows you to easily get the size of the view without needing all the boilerplate for `GeometryReader`
 struct ContentSizeReader<Content: View>: View {
     private let content: () -> Content
 

--- a/podcasts/SwiftUI/HorizontalScrollView.swift
+++ b/podcasts/SwiftUI/HorizontalScrollView.swift
@@ -32,3 +32,24 @@ struct HorizontalScrollView<Content: View>: View {
         }
     }
 }
+
+struct HorizontalScrollView_Example_Preview: PreviewProvider {
+    static var previews: some View {
+        ExampleView()
+    }
+
+    struct ExampleView: View {
+        var body: some View {
+            HorizontalScrollView {
+                ForEach(0..<100) { index in
+                    VStack {
+                        Text("Hello \(index)")
+                        Text("World")
+                    }.frame(width: 150, height: 150)
+                        .background(Color.blue)
+                        .padding([.leading, .trailing], 15)
+                }
+            }.background(Color.red)
+        }
+    }
+}

--- a/podcasts/SwiftUI/HorizontalScrollView.swift
+++ b/podcasts/SwiftUI/HorizontalScrollView.swift
@@ -21,11 +21,11 @@ struct HorizontalScrollView<Content: View>: View {
         HStack {
             ScrollView(.horizontal, showsIndicators: false) {
                 ContentSizeReader { contentSize in
-                    Action { self.contentSize = contentSize }
-
                     HStack(alignment: .top, spacing: 0) {
                         content()
                     }
+
+                    Action { self.contentSize = contentSize }
                 }
             }
             .frame(maxWidth: contentSize?.width ?? .zero)

--- a/podcasts/SwiftUI/HorizontalScrollView.swift
+++ b/podcasts/SwiftUI/HorizontalScrollView.swift
@@ -15,20 +15,18 @@ struct HorizontalScrollView<Content: View>: View {
         self.content = content
     }
 
-    @State private var contentSize: CGSize?
+    @State private var contentSize: CGSize = .zero
 
     var body: some View {
         HStack {
             ScrollView(.horizontal, showsIndicators: false) {
-                ContentSizeReader { contentSize in
+                ContentSizeReader(contentSize: $contentSize) {
                     HStack(alignment: .top, spacing: 0) {
                         content()
                     }
-
-                    Action { self.contentSize = contentSize }
                 }
             }
-            .frame(maxWidth: contentSize?.width ?? .zero)
+            .frame(maxWidth: contentSize.width)
         }
     }
 }

--- a/podcasts/SwiftUI/HorizontalScrollView.swift
+++ b/podcasts/SwiftUI/HorizontalScrollView.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+
+/// A simple Horizontally scrolling view that restricts its height to its content size
+/// Example:
+/// HorizontalScrollView {
+///     ForEach(models) {
+///         ... Setup View ...
+///     }
+/// }
+struct HorizontalScrollView<Content: View>: View {
+    private var content: () -> Content
+
+    public init(@ViewBuilder _ content: @escaping () -> Content) {
+        self.content = content
+    }
+
+    @State private var contentSize: CGSize?
+
+    var body: some View {
+        HStack {
+            ScrollView(.horizontal, showsIndicators: false) {
+                ContentSizeReader { contentSize in
+                    Action { self.contentSize = contentSize }
+
+                    HStack(alignment: .top, spacing: 0) {
+                        content()
+                    }
+                }
+            }
+            .frame(maxWidth: contentSize?.width ?? .zero)
+        }
+    }
+}

--- a/podcasts/SwiftUI/ScrollViewIfNeeded.swift
+++ b/podcasts/SwiftUI/ScrollViewIfNeeded.swift
@@ -38,3 +38,46 @@ public struct ScrollViewIfNeeded<Content: View>: View {
         }
     }
 }
+
+struct ScrollViewIfNeeded_Example_Preview: PreviewProvider {
+    static var previews: some View {
+        ExampleView()
+    }
+
+    struct ExampleView: View {
+        @State private var forceScroll: Bool = false
+
+        var body: some View {
+            VStack {
+                ScrollViewIfNeeded {
+                    VStack(alignment: .center) {
+                        Text("Top Text")
+                        Spacer()
+                        Button(forceScroll ? "⬇️ Scroll Down ⬇️" : "Click to make the view scrollable") {
+                            forceScroll.toggle()
+                        }.buttonStyle(ScrollButtonStyle())
+                        Spacer()
+                        Text(forceScroll ? "👋 Hi." : "Bottom Text")
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(Color.blue)
+                    .frame(height: forceScroll ? 1000 : nil)
+                }.id(forceScroll)
+            }
+        }
+    }
+
+    private struct ScrollButtonStyle: ButtonStyle {
+        func makeBody(configuration: Configuration) -> some View {
+            configuration.label
+                .font(.system(size: 18, weight: .semibold))
+                .frame(maxWidth: .infinity)
+                .padding()
+                .background(Color.white)
+                .cornerRadius(12)
+                .foregroundColor(.black)
+                .contentShape(Rectangle())
+        }
+    }
+}

--- a/podcasts/SwiftUI/ScrollViewIfNeeded.swift
+++ b/podcasts/SwiftUI/ScrollViewIfNeeded.swift
@@ -26,11 +26,9 @@ public struct ScrollViewIfNeeded<Content: View>: View {
             GeometryReader { geometry in
                 content().background(
                     // Calculate the content size again, but this time of the "true" size
-                    ContentSizeReader { contentSize in
+                    GeometryReader { contentSize in
                         Action {
-                            guard let contentSize else { return }
-
-                            willOverflow = contentSize.height > geometry.size.height
+                            willOverflow = contentSize.size.height > geometry.size.height
                         }
                     }
                 )

--- a/podcasts/SwiftUI/ScrollViewIfNeeded.swift
+++ b/podcasts/SwiftUI/ScrollViewIfNeeded.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+
+/// This will dynamically replace itself with a ScrollView if it detects that the containing content will overflow
+/// outside of its original bounds
+public struct ScrollViewIfNeeded<Content: View>: View {
+    private var content: () -> Content
+
+    public init(@ViewBuilder _ content: @escaping () -> Content) {
+        self.content = content
+    }
+
+    @State private var willOverflow: Bool? = nil
+
+    public var body: some View {
+        // If the content size if going to overflow outside of the view bounds, then wrap the content in a scrollview
+        if willOverflow == true {
+            ScrollView { content() }
+        }
+        // If we don't need to wrap in a scroll view, then just return the original content
+        else if willOverflow == false {
+            content()
+        }
+        // If the content size hasn't been calculated yet, then do that..
+        else {
+            // Create an initial geometry reader to compare against
+            GeometryReader { geometry in
+                content().background(
+                    // Calculate the content size again, but this time of the "true" size
+                    ContentSizeReader { contentSize in
+                        Action {
+                            guard let contentSize else { return }
+
+                            willOverflow = contentSize.height > geometry.size.height
+                        }
+                    }
+                )
+            }
+        }
+    }
+}

--- a/podcasts/UIFont+FontStyle.swift
+++ b/podcasts/UIFont+FontStyle.swift
@@ -1,4 +1,5 @@
 import UIKit
+import SwiftUI
 
 extension UIFont {
     /// Returns a dynamically sizing font with a custom TextStyle and Weight, and is scaled based off the default size category (large)
@@ -39,8 +40,114 @@ extension UIFont {
     }
 
     /// Calculates the point size for a font style with the specified size category
-    private static func pointSize(for style: UIFont.TextStyle, sizeCategory: UIContentSizeCategory) -> CGFloat {
+    static func pointSize(for style: UIFont.TextStyle, sizeCategory: UIContentSizeCategory) -> CGFloat {
         let traits = UITraitCollection(preferredContentSizeCategory: sizeCategory)
         return UIFontDescriptor.preferredFontDescriptor(withTextStyle: style, compatibleWith: traits).pointSize
+    }
+}
+
+// MARK: - SwiftUI Support
+
+public extension View {
+    func font(size: Double? = nil,
+              style: Font.TextStyle,
+              weight: Font.Weight = .regular,
+              maxSizeCategory: UIContentSizeCategory = .accessibilityExtraExtraExtraLarge) -> some View {
+        return modifier(DynamicallyScalableFont(size: size, style: style, weight: weight, maxSizeCategory: maxSizeCategory))
+    }
+}
+
+private struct DynamicallyScalableFont: ViewModifier {
+    @Environment(\.sizeCategory) var sizeCategory
+
+    var size: Double?
+    var style: Font.TextStyle
+    var weight: Font.Weight = .regular
+    var maxSizeCategory: UIContentSizeCategory = .accessibilityExtraExtraExtraLarge
+
+    func body(content: Content) -> some View {
+        // Setup the metrics for the font style we'll scale with
+        let metrics = UIFontMetrics(forTextStyle: style.UIFontTextStyle)
+        let traits = sizeCategory.traitCollection
+        let size = self.size ?? UIFont.pointSize(for: style.UIFontTextStyle, sizeCategory: UIContentSizeCategory.large)
+
+        // Scale the given point size up to the largest size that we'll allow
+        let maxPointSize = metrics.scaledValue(for: size, compatibleWith: UITraitCollection(preferredContentSizeCategory: maxSizeCategory))
+
+        // Scale the point size to the current size category, then limit it to the maximum point size
+        let scaledSize = min(maxPointSize, metrics.scaledValue(for: size, compatibleWith: sizeCategory.traitCollection))
+
+        // Return the new calculated font
+        return content.font(.system(size: scaledSize, weight: weight))
+    }
+}
+
+// MARK: - Enums to map SwiftUI -> UIKit font types
+
+private extension ContentSizeCategory {
+    var traitCollection: UITraitCollection {
+        UITraitCollection(preferredContentSizeCategory: UIContentSizeCategory)
+    }
+
+    var UIContentSizeCategory: UIContentSizeCategory {
+        switch self {
+        case .extraSmall:
+            return .extraSmall
+        case .small:
+            return .small
+        case .medium:
+            return .medium
+        case .large:
+            return .large
+        case .extraLarge:
+            return .extraLarge
+        case .extraExtraLarge:
+            return .extraExtraLarge
+        case .extraExtraExtraLarge:
+            return .extraExtraExtraLarge
+        case .accessibilityMedium:
+            return .accessibilityMedium
+        case .accessibilityLarge:
+            return .accessibilityLarge
+        case .accessibilityExtraLarge:
+            return .accessibilityExtraLarge
+        case .accessibilityExtraExtraLarge:
+            return .accessibilityExtraExtraLarge
+        case .accessibilityExtraExtraExtraLarge:
+            return .accessibilityExtraExtraLarge
+        @unknown default:
+            return .large
+        }
+    }
+}
+
+private extension Font.TextStyle {
+    var UIFontTextStyle: UIFont.TextStyle {
+        switch self {
+        case .largeTitle:
+            return .largeTitle
+        case .title:
+            return .title1
+        case .title2:
+            return .title2
+        case .title3:
+            return .title3
+        case .headline:
+            return .headline
+        case .subheadline:
+            return .subheadline
+        case .body:
+            return .body
+        case .callout:
+            return .callout
+        case .footnote:
+            return .footnote
+        case .caption:
+            return .caption1
+        case .caption2:
+            return .caption2
+        @unknown default:
+            return .body
+        }
     }
 }


### PR DESCRIPTION
| 📘 Project: #500 |
|:---:|

This adds some base views that I made while implementing the updated onboarding views:

- `ScrollViewIfNeeded`: Checks the size of its content and will dynamically wrap itself in a scrollview if the content will overflow outside the original bounds
- `ContentSizeReader`: Reads the size of the wrapped content and returns the contentSize
- `HorizontalScrollView`: A horizontally scrolling view that adjusts its height to the its content size
- `Action`:  A helper view that allows you to easily run code without needing to bind to .onAppear

This also adds a FeatureFlag, the ability to make a Color from Hex, dynamic font scaling for SwiftUI, and a Button modifier.

These will be used in the upcoming view updates and changes. 

## To test

Each of the classes has a demo preview in their respective files:

1. In Xcode go to Pocket Casts/Utilities/SwiftUI
2. Click on each of the items
3. Show the Canvas if needed
4. Verify each of them work as intended

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
