### PR TITLE
End of Year: small fixes

### DIFF
--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -588,6 +588,7 @@ enum AnalyticsEvent: String {
     case endOfYearModalShown
     case endOfYearStoriesShown
     case endOfYearStoriesDismissed
+    case endOfYearStoriesFailedToLoad
     case endOfYearStoryReplayButtonTapped
     case endOfYearStoryShown
     case endOfYearStoryShare

--- a/podcasts/End of Year/EndOfYear.swift
+++ b/podcasts/End of Year/EndOfYear.swift
@@ -102,25 +102,33 @@ struct EndOfYear {
     func share(assets: [Any], storyIdentifier: String = "unknown", onDismiss: (() -> Void)? = nil) {
         let presenter = SceneHelper.rootViewController()?.presentedViewController
 
+        let fakeViewController = FakeViewController()
+        fakeViewController.onDismiss = onDismiss
+        fakeViewController.modalPresentationStyle = .overFullScreen
+
         let activityViewController = UIActivityViewController(activityItems: assets, applicationActivities: nil)
         activityViewController.popoverPresentationController?.sourceView = presenter?.view
 
         activityViewController.completionWithItemsHandler = { activity, success, _, _ in
             if !success && activity == nil {
-                onDismiss?()
+                fakeViewController.dismiss(animated: false)
             }
 
             if let activity, success {
                 Analytics.track(.endOfYearStoryShared, properties: ["activity": activity.rawValue, "story": storyIdentifier])
-                onDismiss?()
+                fakeViewController.dismiss(animated: false)
             }
         }
 
-        presenter?.present(activityViewController, animated: true) {
-            // After the share sheet is presented we take the snapshot
-            // This action needs to happen on the main thread because
-            // the view needs to be rendered.
-            StoryShareableProvider.shared.snapshot()
+        // Present the fake view controller first to avoid issues with stories being dismissed
+        presenter?.present(fakeViewController, animated: false) { [weak fakeViewController] in
+            // Present the share sheet
+            fakeViewController?.present(activityViewController, animated: true) {
+                // After the share sheet is presented we take the snapshot
+                // This action needs to happen on the main thread because
+                // the view needs to be rendered.
+                StoryShareableProvider.shared.snapshot()
+            }
         }
     }
 
@@ -159,4 +167,20 @@ class StoriesHostingController<ContentView: View>: UIHostingController<ContentVi
 
 private enum EndOfYearState {
     case showModalIfNeeded, waitingForLogin, loggedIn
+}
+
+/// When selecting "Save Image" on the share sheet on iOS 15
+/// the sheets dismisses itself AND the stories.
+/// We don't want that, so we have this fake view controller to
+/// be dismissed instead.
+///
+/// The issue doesn't affect iOS 14 and 16, but given this fix
+/// don't interfere with them, we also use it for 14/16.
+private class FakeViewController: UIViewController {
+    var onDismiss: (() -> Void)?
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        onDismiss?()
+    }
 }

--- a/podcasts/End of Year/Stories/MDCSwiftUIWrapper.swift
+++ b/podcasts/End of Year/Stories/MDCSwiftUIWrapper.swift
@@ -13,6 +13,8 @@ class MDCSwiftUIWrapper<ContentView: View>: UIViewController {
     init(rootView content: ContentView) {
         super.init(nibName: nil, bundle: nil)
 
+        view = ThemeableView()
+
         view.addSubview(stackView)
         stackView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([

--- a/podcasts/End of Year/Stories/MDCSwiftUIWrapper.swift
+++ b/podcasts/End of Year/Stories/MDCSwiftUIWrapper.swift
@@ -13,8 +13,6 @@ class MDCSwiftUIWrapper<ContentView: View>: UIViewController {
     init(rootView content: ContentView) {
         super.init(nibName: nil, bundle: nil)
 
-        view = ThemeableView()
-
         view.addSubview(stackView)
         stackView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
@@ -31,6 +29,10 @@ class MDCSwiftUIWrapper<ContentView: View>: UIViewController {
         stackView.addArrangedSubview(hostingController.view)
         hostingController.didMove(toParent: self)
         hostingController.view.backgroundColor = AppTheme.colorForStyle(.primaryUi01)
+    }
+
+    override func loadView() {
+        view = ThemeableView()
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/podcasts/End of Year/StoriesModel.swift
+++ b/podcasts/End of Year/StoriesModel.swift
@@ -46,6 +46,10 @@ class StoriesModel: ObservableObject {
 
     func start() {
         cancellable = publisher.autoconnect().sink(receiveValue: { _ in
+            guard self.numberOfStories > 0 else {
+                return
+            }
+
             var newProgress = self.progress + (0.01 / self.interval)
 
             let currentStory = Int(newProgress)
@@ -101,10 +105,18 @@ class StoriesModel: ObservableObject {
     }
 
     func next() {
+        guard numberOfStories > 0 else {
+            return
+        }
+
         progress = min(Double(numberOfStories), Double(Int(progress) + 1))
     }
 
     func previous() {
+        guard numberOfStories > 0 else {
+            return
+        }
+
         progress = max(0, Double(Int(progress) - 1))
     }
 

--- a/podcasts/End of Year/StoryShareableProvider.swift
+++ b/podcasts/End of Year/StoryShareableProvider.swift
@@ -40,7 +40,7 @@ class StoryShareableProvider: UIActivityItemProvider {
         let snapshot = ZStack {
             AnyView(view)
         }
-        .frame(width: 370, height: 693)
+        .frame(width: 370, height: 658)
         .snapshot()
 
         generatedItem = snapshot

--- a/podcasts/End of Year/Views/StoriesView.swift
+++ b/podcasts/End of Year/Views/StoriesView.swift
@@ -70,10 +70,9 @@ struct StoriesView: View {
         ZStack {
             Spacer()
 
-            Text("Failed to load stories.")
+            Text(L10n.eoyStoriesFailed)
                 .foregroundColor(.white)
 
-            storySwitcher
             header
         }
     }

--- a/podcasts/End of Year/Views/StoriesView.swift
+++ b/podcasts/End of Year/Views/StoriesView.swift
@@ -62,6 +62,7 @@ struct StoriesView: View {
                 .padding()
                 .background(Color.black)
 
+            storySwitcher
             header
         }
     }
@@ -73,6 +74,7 @@ struct StoriesView: View {
             Text(L10n.eoyStoriesFailed)
                 .foregroundColor(.white)
 
+            storySwitcher
             header
         }
     }

--- a/podcasts/End of Year/Views/StoriesView.swift
+++ b/podcasts/End of Year/Views/StoriesView.swift
@@ -77,6 +77,9 @@ struct StoriesView: View {
             storySwitcher
             header
         }
+        .onAppear {
+            Analytics.track(.endOfYearStoriesFailedToLoad)
+        }
     }
 
     // Header containing the close button and the rectangles

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -606,6 +606,8 @@ internal enum L10n {
   internal static var eoyNotNow: String { return L10n.tr("Localizable", "eoy_not_now") }
   /// Year in Podcasts
   internal static var eoySmallTitle: String { return L10n.tr("Localizable", "eoy_small_title") }
+  /// Failed to load stories.
+  internal static var eoyStoriesFailed: String { return L10n.tr("Localizable", "eoy_stories_failed") }
   /// Don't forget to share with your friends and give a shout out to your favorite podcast creators
   internal static var eoyStoryEpilogueSubtitle: String { return L10n.tr("Localizable", "eoy_story_epilogue_subtitle") }
   /// Thank you for letting Pocket Casts be a part of your listening experience in 2022

--- a/podcasts/ThemeableCell.swift
+++ b/podcasts/ThemeableCell.swift
@@ -22,6 +22,17 @@ class ThemeableCell: UITableViewCell {
         updateColor()
     }
 
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+
+        NotificationCenter.default.addObserver(self, selector: #selector(themeDidChange), name: Constants.Notifications.themeChanged, object: nil)
+        updateColor()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+
     deinit {
         NotificationCenter.default.removeObserver(self)
     }

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -3362,3 +3362,6 @@
 
 /* Description to why the user needs to create an account to see their end of year stats. */
 "eoy_create_account_to_see" = "Save your podcasts in the cloud, get your end of year review and sync your progress with other devices.";
+
+/* When loading the End of Year stats stories fails. */
+"eoy_stories_failed" = "Failed to load stories.";


### PR DESCRIPTION
| 📘 Project: #376 |
|:---:|

While testing the feature on iOS 14/15/16 and different scenarios I found some small issues and they're all fixed in this PR.

I explain every issue in the "To test" section.

## To test

Make sure you have `tracksLoggingEnabled` and `endOfYear` enabled in `FeatureFlag.swift`.

### Modal being cut at the bottom on iOS 15

On iOS 15 in a device without the Home button, the modal was transparent in the bottom part. This was fixed by using a `ThemeableView` in `MDCSwiftUIWrapper`.

1. Run the app on iOS 15
2. Login so the bottom sheet appears
3. ✅ Check that the bottom part is not transparent

### Profile card

1. Run the app
2. Go to profile
3. Toggle light/dark mode
4. ✅ Check that the background of the cell that the card is embedded changes accordingly

### Stories failed and gestures

Go to `EndOfYearStoriesBuilder` and add this to line `36`:

```swift
continuation.resume(returning: ([], data))
return
```

1. Run the app
2. Check your stories
3. ✅ `end_of_year_stories_failed_to_load` should be tracked
4. Tap the left and right portions of the screen
5. ✅ Nothing should happen
6. Swipe to dismiss
7. ✅ Stories should dismiss

### 16:9 proportion and sharing to Facebook

The image height was slightly changed to be in the 16:9 proportion.

1. Run the app
2. Check your stories
3. Share any story as a Facebook story
4. ✅ Check that there aren't any left or right space left when sharing on FB

### Share Sheet on iOS 15

Specifically, on iOS 15, we have an issue where the sheet is dismissed when the "Saving Image" option is used. The problem is that this also dismisses the stories, and we don't want that. A fix was applied for iOS 15 but is also used for iOS 14 and 16 given that the result there is the same.

1. Run the app on iOS 15 (device or simulator)
2. Tap Share
3. Tap "Save Image"
4. ✅ The sheet should dismiss but the stories should still display
5. Tap Share again and dismiss
6. ✅ Stories should play again
7. You can also try sharing to other places, the behavior should be the same as before

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
