### PR TITLE
Add the s to the "in filters" plural format

### DIFF
--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -2072,7 +2072,7 @@ internal enum L10n {
   internal static var settingsHelp: String { return L10n.tr("Localizable", "settings_help") }
   /// Import / Export
   internal static var settingsImportExport: String { return L10n.tr("Localizable", "settings_import_export") }
-  /// Included In %1$@ Filter
+  /// Included In %1$@ Filters
   internal static func settingsInFiltersPluralFormat(_ p1: Any) -> String {
     return L10n.tr("Localizable", "settings_in_filters_plural_format", String(describing: p1))
   }

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -2388,7 +2388,7 @@
 "settings_import_export" = "Import / Export";
 
 /* Informs the user that the current podcast is included in one filter. '%1$@' is a placeholder for the number of filters this podcast is included in. */
-"settings_in_filters_plural_format" = "Included In %1$@ Filter";
+"settings_in_filters_plural_format" = "Included In %1$@ Filters";
 
 /* Informs the user that the current podcast is included in one filter. This is the singular form of an accompanying plural string. */
 "settings_in_filters_singular" = "Included In 1 Filter";


### PR DESCRIPTION
Fixes a missing s from the plural format on the Podcast settings screen

## To test

1. Launch the app
2. Add a podcast to more than 1 filter
3. Go to the Podcast settings
4. ✅ Scroll down to see the `Included in X Filters` where X is the number of filters its added to

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
