### PR TITLE
Make custom time stepper more accessible

### DIFF
--- a/podcasts/CustomTimeStepper.swift
+++ b/podcasts/CustomTimeStepper.swift
@@ -36,7 +36,11 @@ class CustomTimeStepper: UIControl {
     var bigIncrements: TimeInterval = 5.minutes
     var smallIncrements: TimeInterval = 1.minute
     var smallIncrementThreshold: TimeInterval = 5.minutes
-    var currentValue: TimeInterval = 1.hour
+    var currentValue: TimeInterval = 1.hour {
+        didSet {
+            accessibilityValue = L10n.timeShorthand(Int(currentValue))
+        }
+    }
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -176,15 +180,9 @@ class CustomTimeStepper: UIControl {
 
     override func accessibilityIncrement() {
         performIncrementAction()
-        setAccessibilityValue()
     }
 
     override func accessibilityDecrement() {
         performDecrementAction()
-        setAccessibilityValue()
-    }
-
-    private func setAccessibilityValue() {
-        accessibilityValue = L10n.timeShorthand(Int(currentValue))
     }
 }

--- a/podcasts/CustomTimeStepper.swift
+++ b/podcasts/CustomTimeStepper.swift
@@ -38,7 +38,7 @@ class CustomTimeStepper: UIControl {
     var smallIncrementThreshold: TimeInterval = 5.minutes
     var currentValue: TimeInterval = 1.hour {
         didSet {
-            accessibilityValue = L10n.time(Int(currentValue))
+            accessibilityValue = currentValue.localizedTimeDescription ?? ""
         }
     }
 

--- a/podcasts/CustomTimeStepper.swift
+++ b/podcasts/CustomTimeStepper.swift
@@ -51,12 +51,14 @@ class CustomTimeStepper: UIControl {
     }
 
     private func setup() {
+        isAccessibilityElement = true
+        accessibilityTraits = [.adjustable]
+
         minusButton.setImage(UIImage(named: "player_effects_less"), for: .normal)
         minusButton.addTarget(self, action: #selector(lessTouchUp), for: .touchUpInside)
         minusButton.addTarget(self, action: #selector(touchCancelled), for: .touchCancel)
         minusButton.addTarget(self, action: #selector(touchCancelled), for: .touchUpOutside)
         minusButton.addTarget(self, action: #selector(lessTouchDown), for: .touchDown)
-        minusButton.accessibilityLabel = L10n.playerDecrementTime
         addSubview(minusButton)
 
         minusButton.translatesAutoresizingMaskIntoConstraints = false
@@ -72,7 +74,6 @@ class CustomTimeStepper: UIControl {
         plusButton.addTarget(self, action: #selector(touchCancelled), for: .touchCancel)
         plusButton.addTarget(self, action: #selector(touchCancelled), for: .touchUpOutside)
         plusButton.addTarget(self, action: #selector(moreTouchDown), for: .touchDown)
-        plusButton.accessibilityLabel = L10n.playerIncrementTime
         addSubview(plusButton)
 
         plusButton.translatesAutoresizingMaskIntoConstraints = false
@@ -140,6 +141,10 @@ class CustomTimeStepper: UIControl {
     // MARK: - Button Taps
 
     @objc private func lessTouchUp() {
+        performDecrementAction()
+    }
+
+    private func performDecrementAction() {
         holdTimer?.invalidate()
         if currentValue == minimumValue { return }
 
@@ -148,6 +153,10 @@ class CustomTimeStepper: UIControl {
     }
 
     @objc private func moreTouchUp() {
+        performIncrementAction()
+    }
+
+    private func performIncrementAction() {
         holdTimer?.invalidate()
         if currentValue == maximumValue { return }
 
@@ -161,5 +170,21 @@ class CustomTimeStepper: UIControl {
 
     private func negativeIncrement() -> TimeInterval {
         currentValue <= smallIncrementThreshold ? smallIncrements : bigIncrements
+    }
+
+    // MARK: - Accessibility actions
+
+    override func accessibilityIncrement() {
+        performIncrementAction()
+        setAccessibilityValue()
+    }
+
+    override func accessibilityDecrement() {
+        performDecrementAction()
+        setAccessibilityValue()
+    }
+
+    private func setAccessibilityValue() {
+        accessibilityValue = L10n.timeShorthand(Int(currentValue))
     }
 }

--- a/podcasts/CustomTimeStepper.swift
+++ b/podcasts/CustomTimeStepper.swift
@@ -38,7 +38,7 @@ class CustomTimeStepper: UIControl {
     var smallIncrementThreshold: TimeInterval = 5.minutes
     var currentValue: TimeInterval = 1.hour {
         didSet {
-            accessibilityValue = L10n.timeShorthand(Int(currentValue))
+            accessibilityValue = L10n.time(Int(currentValue))
         }
     }
 

--- a/podcasts/GeneralSettingsViewController.swift
+++ b/podcasts/GeneralSettingsViewController.swift
@@ -54,13 +54,13 @@ class GeneralSettingsViewController: UIViewController, UITableViewDelegate, UITa
             cell.timeStepper.smallIncrements = 5.seconds
             cell.timeStepper.minimumValue = 0
             cell.timeStepper.maximumValue = 40.minutes
-            cell.configureAccessibilityLabel(text: cellLabelText, time: L10n.time(jumpFwdAmount))
+            cell.configureAccessibilityLabel(text: cellLabelText, time: jumpFwdAmount)
 
             cell.onValueChanged = { [weak self] value in
                 let newValue = Int(value)
                 ServerSettings.setSkipForwardTime(newValue)
                 cell.cellSecondaryLabel.text = L10n.timeShorthand(newValue)
-                cell.configureAccessibilityLabel(text: cellLabelText, time: L10n.time(newValue))
+                cell.configureAccessibilityLabel(text: cellLabelText, time: newValue)
 
                 NotificationCenter.postOnMainThread(notification: Constants.Notifications.skipTimesChanged)
 
@@ -82,13 +82,13 @@ class GeneralSettingsViewController: UIViewController, UITableViewDelegate, UITa
             cell.timeStepper.smallIncrements = 5.seconds
             cell.timeStepper.minimumValue = 0
             cell.timeStepper.maximumValue = 40.minutes
-            cell.configureAccessibilityLabel(text: cellLabelText, time: L10n.time(skipBackAmount))
+            cell.configureAccessibilityLabel(text: cellLabelText, time: skipBackAmount)
 
             cell.onValueChanged = { [weak self] value in
                 let newValue = Int(value)
                 ServerSettings.setSkipBackTime(newValue)
                 cell.cellSecondaryLabel.text = L10n.timeShorthand(newValue)
-                cell.configureAccessibilityLabel(text: cellLabelText, time: L10n.time(newValue))
+                cell.configureAccessibilityLabel(text: cellLabelText, time: newValue)
 
                 NotificationCenter.postOnMainThread(notification: Constants.Notifications.skipTimesChanged)
 

--- a/podcasts/GeneralSettingsViewController.swift
+++ b/podcasts/GeneralSettingsViewController.swift
@@ -44,7 +44,8 @@ class GeneralSettingsViewController: UIViewController, UITableViewDelegate, UITa
         switch row {
         case .skipForward:
             let cell = tableView.dequeueReusableCell(withIdentifier: timeStepperCellId, for: indexPath) as! TimeStepperCell
-            cell.cellLabel.text = L10n.skipForward
+            let cellLabelText = L10n.skipForward
+            cell.cellLabel.text = cellLabelText
             let jumpFwdAmount = ServerSettings.skipForwardTime()
             cell.cellSecondaryLabel.text = L10n.timeShorthand(jumpFwdAmount)
             cell.timeStepper.currentValue = TimeInterval(jumpFwdAmount)
@@ -53,11 +54,13 @@ class GeneralSettingsViewController: UIViewController, UITableViewDelegate, UITa
             cell.timeStepper.smallIncrements = 5.seconds
             cell.timeStepper.minimumValue = 0
             cell.timeStepper.maximumValue = 40.minutes
+            cell.configureAccessibilityLabel(text: cellLabelText, time: L10n.time(jumpFwdAmount))
 
             cell.onValueChanged = { [weak self] value in
                 let newValue = Int(value)
                 ServerSettings.setSkipForwardTime(newValue)
                 cell.cellSecondaryLabel.text = L10n.timeShorthand(newValue)
+                cell.configureAccessibilityLabel(text: cellLabelText, time: L10n.time(newValue))
 
                 NotificationCenter.postOnMainThread(notification: Constants.Notifications.skipTimesChanged)
 
@@ -69,6 +72,7 @@ class GeneralSettingsViewController: UIViewController, UITableViewDelegate, UITa
             return cell
         case .skipBack:
             let cell = tableView.dequeueReusableCell(withIdentifier: timeStepperCellId, for: indexPath) as! TimeStepperCell
+            let cellLabelText = L10n.skipBack
             cell.cellLabel.text = L10n.skipBack
             let skipBackAmount = ServerSettings.skipBackTime()
             cell.cellSecondaryLabel.text = L10n.timeShorthand(skipBackAmount)
@@ -78,11 +82,13 @@ class GeneralSettingsViewController: UIViewController, UITableViewDelegate, UITa
             cell.timeStepper.smallIncrements = 5.seconds
             cell.timeStepper.minimumValue = 0
             cell.timeStepper.maximumValue = 40.minutes
+            cell.configureAccessibilityLabel(text: cellLabelText, time: L10n.time(skipBackAmount))
 
             cell.onValueChanged = { [weak self] value in
                 let newValue = Int(value)
                 ServerSettings.setSkipBackTime(newValue)
                 cell.cellSecondaryLabel.text = L10n.timeShorthand(newValue)
+                cell.configureAccessibilityLabel(text: cellLabelText, time: L10n.time(newValue))
 
                 NotificationCenter.postOnMainThread(notification: Constants.Notifications.skipTimesChanged)
 

--- a/podcasts/Strings+L10n.swift
+++ b/podcasts/Strings+L10n.swift
@@ -108,13 +108,21 @@ extension L10n {
     }
 
     static func timeShorthand(_ time: Int) -> String {
+        localizedTime(time, secondsUnitStyle: .short, otherUnitsStyle: .abbreviated)
+    }
+
+    static func time(_ time: Int) -> String {
+        localizedTime(time, secondsUnitStyle: .full, otherUnitsStyle: .full)
+    }
+
+    private static func localizedTime(_ time: Int, secondsUnitStyle: DateComponentsFormatter.UnitsStyle, otherUnitsStyle: DateComponentsFormatter.UnitsStyle) -> String {
         let value = Double(time)
         if value < 60 {
             let components = DateComponents(calendar: .current, second: Int(value))
-            return DateComponentsFormatter.localizedString(from: components, unitsStyle: .short) ?? L10n.timePlaceholder
+            return DateComponentsFormatter.localizedString(from: components, unitsStyle: secondsUnitStyle) ?? L10n.timePlaceholder
         } else {
             let components = DateComponents(calendar: .current, minute: Int(floor(value / 60.0)), second: Int(value) % 60)
-            return DateComponentsFormatter.localizedString(from: components, unitsStyle: .abbreviated) ?? L10n.timePlaceholder
+            return DateComponentsFormatter.localizedString(from: components, unitsStyle: otherUnitsStyle) ?? L10n.timePlaceholder
         }
     }
 

--- a/podcasts/Strings+L10n.swift
+++ b/podcasts/Strings+L10n.swift
@@ -108,21 +108,13 @@ extension L10n {
     }
 
     static func timeShorthand(_ time: Int) -> String {
-        localizedTime(time, secondsUnitStyle: .short, otherUnitsStyle: .abbreviated)
-    }
-
-    static func time(_ time: Int) -> String {
-        localizedTime(time, secondsUnitStyle: .full, otherUnitsStyle: .full)
-    }
-
-    private static func localizedTime(_ time: Int, secondsUnitStyle: DateComponentsFormatter.UnitsStyle, otherUnitsStyle: DateComponentsFormatter.UnitsStyle) -> String {
         let value = Double(time)
         if value < 60 {
             let components = DateComponents(calendar: .current, second: Int(value))
-            return DateComponentsFormatter.localizedString(from: components, unitsStyle: secondsUnitStyle) ?? L10n.timePlaceholder
+            return DateComponentsFormatter.localizedString(from: components, unitsStyle: .short) ?? L10n.timePlaceholder
         } else {
             let components = DateComponents(calendar: .current, minute: Int(floor(value / 60.0)), second: Int(value) % 60)
-            return DateComponentsFormatter.localizedString(from: components, unitsStyle: otherUnitsStyle) ?? L10n.timePlaceholder
+            return DateComponentsFormatter.localizedString(from: components, unitsStyle: .abbreviated) ?? L10n.timePlaceholder
         }
     }
 

--- a/podcasts/TimeStepperCell.swift
+++ b/podcasts/TimeStepperCell.swift
@@ -39,8 +39,9 @@ class TimeStepperCell: ThemeableCell {
         cellImage.image = UIImage(named: imageName)
     }
 
-    func configureAccessibilityLabel(text: String, time: String) {
-        let accessibilityLabel = "\(text), \(time)"
+    func configureAccessibilityLabel(text: String, time: Int) {
+        let localizedTimeInterval = TimeInterval(time).localizedTimeDescription ?? ""
+        let accessibilityLabel = "\(text), \(localizedTimeInterval)"
         self.accessibilityLabel = accessibilityLabel
     }
 

--- a/podcasts/TimeStepperCell.swift
+++ b/podcasts/TimeStepperCell.swift
@@ -39,6 +39,11 @@ class TimeStepperCell: ThemeableCell {
         cellImage.image = UIImage(named: imageName)
     }
 
+    func configureAccessibilityLabel(text: String, time: String) {
+        let accessibilityLabel = "\(text), \(time)"
+        self.accessibilityLabel = accessibilityLabel
+    }
+
     @objc private func stepperChanged(_ sender: CustomTimeStepper) {
         onValueChanged?(sender.currentValue)
     }


### PR DESCRIPTION
Improves the usability of time stepper through out the app and makes it way easier to navigate through screens like settings.

## To test

1. Launch the app
2. Go to profile tab
3. Tap on settings
4. Tap on general
5. Turn voiceover on if you didn't turn it on already
6. Use swipe right gesture to get to the cell with time stepper (i.e. skip forward cell in player section)
7. When you hear current skip forward value (i.e. 45 seconds) swipe right once more and you should hear voiceover pronounce "adjustable" or "slider"
8. Use swipe up or down voiceover gestures to adjust the value

This significantly improves the experience for voiceover users and makes it much easier to navigate through settings screen.