### PR TITLE
End of Year: fix a glitch in the stories indicator when tap the "X"

### DIFF
--- a/podcasts/End of Year/StoriesModel.swift
+++ b/podcasts/End of Year/StoriesModel.swift
@@ -137,6 +137,11 @@ class StoriesModel: ObservableObject {
             self?.start()
         })
     }
+
+    func stopAndDismiss() {
+        pause()
+        NavigationManager.sharedManager.dismissPresentedViewController()
+    }
 }
 
 private extension StoriesModel {

--- a/podcasts/End of Year/Views/StoriesView.swift
+++ b/podcasts/End of Year/Views/StoriesView.swift
@@ -108,7 +108,7 @@ struct StoriesView: View {
                     Spacer()
                     Button(action: {
                         Analytics.track(.endOfYearStoriesDismissed, properties: ["source": "close_button"])
-                        NavigationManager.sharedManager.dismissPresentedViewController()
+                        model.stopAndDismiss()
                     }) {
                         Image(systemName: "xmark")
                             .foregroundColor(.white)
@@ -150,7 +150,7 @@ struct StoriesView: View {
                     // If a quick swipe down is performed, dismiss the view
                     if velocity.height > 200 {
                         Analytics.track(.endOfYearStoriesDismissed, properties: ["source": "swipe_down"])
-                        NavigationManager.sharedManager.dismissPresentedViewController()
+                        model.stopAndDismiss()
                     } else {
                         model.start()
                     }


### PR DESCRIPTION
Fixes #512

Fixes a glitch in the stories when dismissing stories by tapping the "X" button.

## To test

1. Run the app
2. Login with an account with a listening history
3. Check your stories
4. Tap the top-right "X" button
5. Open it again
6. ✅ Check that the stories indicator at the top is not blinking
7. Repeat this a few times and make sure there's no glitch

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
