### PR TITLE
End of Year: exclude empty categories from the top categories

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
@@ -130,7 +130,7 @@ class EndOfYearDataManager {
                             SELECT COUNT(DISTINCT podcastUuid) as numberOfPodcasts,
                                 SUM(playedUpTo) as totalPlayedTime,
                                 \(DataManager.podcastTableName).*,
-                                replace(IFNULL( nullif(substr(\(DataManager.podcastTableName).podcastCategory, 0, INSTR(\(DataManager.podcastTableName).podcastCategory, char(10))), '') , \(DataManager.podcastTableName).podcastCategory), CHAR(10), '') as category
+                                substr(trim(SJPodcast.podcastCategory),1,instr(trim(\(DataManager.podcastTableName).podcastCategory)||char(10),char(10))-1) as category
                             FROM \(DataManager.episodeTableName), \(DataManager.podcastTableName)
                             WHERE \(DataManager.podcastTableName).uuid = \(DataManager.episodeTableName).podcastUuid and
                                 \(listenedEpisodesThisYear)

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
@@ -130,10 +130,11 @@ class EndOfYearDataManager {
                             SELECT COUNT(DISTINCT podcastUuid) as numberOfPodcasts,
                                 SUM(playedUpTo) as totalPlayedTime,
                                 \(DataManager.podcastTableName).*,
-                                substr(trim(SJPodcast.podcastCategory),1,instr(trim(\(DataManager.podcastTableName).podcastCategory)||char(10),char(10))-1) as category
+                                substr(trim(\(DataManager.podcastTableName).podcastCategory),1,instr(trim(\(DataManager.podcastTableName).podcastCategory)||char(10),char(10))-1) as category
                             FROM \(DataManager.episodeTableName), \(DataManager.podcastTableName)
                             WHERE \(DataManager.podcastTableName).uuid = \(DataManager.episodeTableName).podcastUuid and
-                                \(listenedEpisodesThisYear)
+                                \(listenedEpisodesThisYear) and
+                            category IS NOT NULL and category != ''
                             GROUP BY category
                             ORDER BY totalPlayedTime DESC
 """
@@ -290,14 +291,9 @@ public struct ListenedCategory {
 
     public init(numberOfPodcasts: Int, categoryTitle: String, mostListenedPodcast: Podcast, totalPlayedTime: Double) {
         self.numberOfPodcasts = numberOfPodcasts
+        self.categoryTitle = categoryTitle
         self.mostListenedPodcast = mostListenedPodcast
         self.totalPlayedTime = totalPlayedTime
-
-        if categoryTitle == "" || categoryTitle.isEmpty {
-            self.categoryTitle = mostListenedPodcast.podcastCategory ?? ""
-        } else {
-            self.categoryTitle = categoryTitle
-        }
     }
 }
 

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
@@ -290,9 +290,14 @@ public struct ListenedCategory {
 
     public init(numberOfPodcasts: Int, categoryTitle: String, mostListenedPodcast: Podcast, totalPlayedTime: Double) {
         self.numberOfPodcasts = numberOfPodcasts
-        self.categoryTitle = categoryTitle
         self.mostListenedPodcast = mostListenedPodcast
         self.totalPlayedTime = totalPlayedTime
+
+        if categoryTitle == "" || categoryTitle.isEmpty {
+            self.categoryTitle = mostListenedPodcast.podcastCategory ?? ""
+        } else {
+            self.categoryTitle = categoryTitle
+        }
     }
 }
 

--- a/podcasts/End of Year/Stories/TopCategoriesStory/TopListenedCategoriesStory.swift
+++ b/podcasts/End of Year/Stories/TopCategoriesStory/TopListenedCategoriesStory.swift
@@ -55,7 +55,7 @@ struct TopListenedCategoriesStory: StoryView {
     @ViewBuilder
     func pillar(_ index: Int) -> some View {
         if let listenedCategory = listenedCategories[safe: index] {
-            CategoryPillar(color: contrastColor.tintColor, text: "\(index + 1)", title: listenedCategory.categoryTitle.localized(seperatingWith: \.isNewline) ?? "", subtitle: listenedCategory.totalPlayedTime.localizedTimeDescription ?? "", height: CGFloat(200 - (index * 55)))
+            CategoryPillar(color: contrastColor.tintColor, text: "\(index + 1)", title: listenedCategory.categoryTitle.localized, subtitle: listenedCategory.totalPlayedTime.localizedTimeDescription ?? "", height: CGFloat(200 - (index * 55)))
                 .padding(.bottom, index == 0 ? 70 : 0)
         } else {
             CategoryPillar(color: contrastColor.tintColor, text: "", title: "", subtitle: "", height: 200)

--- a/podcasts/End of Year/Stories/TopCategoriesStory/TopListenedCategoriesStory.swift
+++ b/podcasts/End of Year/Stories/TopCategoriesStory/TopListenedCategoriesStory.swift
@@ -55,7 +55,7 @@ struct TopListenedCategoriesStory: StoryView {
     @ViewBuilder
     func pillar(_ index: Int) -> some View {
         if let listenedCategory = listenedCategories[safe: index] {
-            CategoryPillar(color: contrastColor.tintColor, text: "\(index + 1)", title: listenedCategory.categoryTitle.localized, subtitle: listenedCategory.totalPlayedTime.localizedTimeDescription ?? "", height: CGFloat(200 - (index * 55)))
+            CategoryPillar(color: contrastColor.tintColor, text: "\(index + 1)", title: listenedCategory.categoryTitle.localized(seperatingWith: \.isNewline) ?? "", subtitle: listenedCategory.totalPlayedTime.localizedTimeDescription ?? "", height: CGFloat(200 - (index * 55)))
                 .padding(.bottom, index == 0 ? 70 : 0)
         } else {
             CategoryPillar(color: contrastColor.tintColor, text: "", title: "", subtitle: "", height: 200)


### PR DESCRIPTION
We had multiple reports of the title of the category not appearing on the top category's story. Eg.:

<img src="https://user-images.githubusercontent.com/7040243/201893162-5210fc72-f9da-42f3-a002-a946e1762d2a.png" width="300">

With the help of @emilylaguna, we discovered that some podcasts have their category set to empty or null. A lot of private feeds have this issue, but we cannot assume that all of them are private feeds.

Due to the lack of time, we'll ignore those podcasts from the calculation for now and just display data about the categories we have set.

cc @ashiagr  

## To test

1. Run `release/7.27` (or TestFlight version) and save your top categories story
2. Run this branch
3. Check your stories
4. Make sure it's the same as the one you saved

If you had any "empty" category before, it should not be shown anymore.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
