### PR TITLE
End of Year: consistent funny message

### DIFF
--- a/podcasts/End of Year/Stories/ListeningTimeStory.swift
+++ b/podcasts/End of Year/Stories/ListeningTimeStory.swift
@@ -25,7 +25,7 @@ struct ListeningTimeStory: StoryView {
                         .frame(maxHeight: geometry.size.height * 0.12)
                         .minimumScaleFactor(0.01)
 
-                    Text(FunnyTimeConverter.timeSecsToFunnyText(listeningTime))
+                    Text(FunMessage.timeSecsToFunnyText(listeningTime))
                         .font(.system(size: 15, weight: .bold))
                         .foregroundColor(.white)
                         .multilineTextAlignment(.center)
@@ -83,6 +83,20 @@ struct ListeningTimeStory: StoryView {
             StoryShareableProvider.new(AnyView(self)),
             StoryShareableText(L10n.eoyStoryListenedToShareText(listeningTime.localizedTimeDescription ?? ""))
         ]
+    }
+}
+
+/// Always return the same funny message
+struct FunMessage {
+    static var message: String?
+
+    static func timeSecsToFunnyText(_ timeInSeconds: Double) -> String {
+        guard let message = Self.message else {
+            Self.message = FunnyTimeConverter.timeSecsToFunnyText(timeInSeconds)
+            return Self.message ?? ""
+        }
+
+        return message
     }
 }
 


### PR DESCRIPTION
The funny message on the listening time story changes every time the story is viewed or shared. This changes it so the same message is displayed.

## To test

1. Run the app
2. Check your stories
3. Go to the seconds story
4. Check the subtitle (the funny message)
5. Go to the next or previous story and return
6. ✅ The message should be the same
7. Tap Share and "Save as Photo"
8. ✅ The saved image should have the same message

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
