### PR TITLE
End of Year: Updates the max font size and button styles for accessibility

### DIFF
--- a/podcasts/End of Year/Views/EndOfYearCard.swift
+++ b/podcasts/End of Year/Views/EndOfYearCard.swift
@@ -8,12 +8,11 @@ struct EndOfYearCard: View {
             HStack {
                 VStack(alignment: .leading, spacing: Constants.textSpace) {
                     Text(L10n.eoyTitle)
-                        .font(.title2)
-                        .fontWeight(.semibold)
+                        .font(style: .title2, weight: .semibold, maxSizeCategory: .extraExtraLarge)
                         .foregroundColor(.white)
+
                     Text(L10n.eoyCardDescription)
-                        .font(.footnote)
-                        .fontWeight(.semibold)
+                        .font(style: .footnote, weight: .semibold, maxSizeCategory: .accessibilityMedium)
                         .foregroundColor(.gray)
                 }
                 .padding()

--- a/podcasts/End of Year/Views/EndOfYearModal.swift
+++ b/podcasts/End of Year/Views/EndOfYearModal.swift
@@ -74,31 +74,17 @@ struct EndOfYearModal: View {
     }
 
     var showStoriesButton: some View {
-        Button(action: {
+        Button(L10n.eoyViewYear) {
             NavigationManager.sharedManager.navigateTo(NavigationManager.endOfYearStories, data: nil)
-        }) {
-            HStack {
-                Spacer()
-                Text(L10n.eoyViewYear)
-                Spacer()
-            }
         }
-        .textStyle(RoundedDarkButton())
-        .contentShape(Rectangle())
+        .buttonStyle(RoundedDarkButton(theme: theme))
     }
 
     var dismissButton: some View {
-        Button(action: {
+        Button(L10n.eoyNotNow) {
             NavigationManager.sharedManager.dismissPresentedViewController()
-        }) {
-            HStack {
-                Spacer()
-                Text(L10n.eoyNotNow)
-                Spacer()
-            }
         }
-        .textStyle(StrokeButton())
-        .contentShape(Rectangle())
+        .buttonStyle(StrokeButton(theme: theme))
     }
 
     private enum Constants {

--- a/podcasts/End of Year/Views/EndOfYearModal.swift
+++ b/podcasts/End of Year/Views/EndOfYearModal.swift
@@ -10,14 +10,15 @@ struct EndOfYearModal: View {
             VStack(alignment: .center, spacing: Constants.verticalSpacing) {
 
                 Text(L10n.eoyTitle)
-                    .font(.title2)
-                    .fontWeight(.semibold)
+                    .font(style: .title2, weight: .semibold, maxSizeCategory: .extraExtraExtraLarge)
+                    .fixedSize(horizontal: false, vertical: true)
 
                 cover
 
                 Text(L10n.eoyDescription)
-                    .font(.body)
+                    .font(style: .body, maxSizeCategory: .accessibilityMedium)
                     .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
                     .allowsTightening(false)
 
                 showStoriesButton

--- a/podcasts/End of Year/Views/StoriesView.swift
+++ b/podcasts/End of Year/Views/StoriesView.swift
@@ -207,15 +207,54 @@ private extension StoriesView {
         static let closeButtonTopPadding: CGFloat = 5
 
         static let storySwitcherSpacing: CGFloat = 0
+// MARK: - Custom Buttons
 
+private struct ShareButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        HStack {
+            Spacer()
+            Image(systemName: "square.and.arrow.up")
+            configuration.label
+            Spacer()
+        }
+        .font(style: .body, maxSizeCategory: .extraExtraExtraLarge)
+        .foregroundColor(Constants.shareButtonColor)
+
+        .padding([.top, .bottom], Constants.shareButtonVerticalPadding)
+
+        .overlay(
+            RoundedRectangle(cornerRadius: Constants.shareButtonCornerRadius)
+                .stroke(.white, style: StrokeStyle(lineWidth: Constants.shareButtonBorderSize))
+        )
+        .makeSpringy(isPressed: configuration.isPressed)
+        .contentShape(Rectangle())
+    }
+
+    private struct Constants {
+        static let shareButtonColor = Color.white
         static let shareButtonVerticalPadding: CGFloat = 10
-        static let shareButtonHorizontalPadding: CGFloat = 5
         static let shareButtonCornerRadius: CGFloat = 10
         static let shareButtonBorderSize: CGFloat = 1
+    }
+}
 
-        static let spaceBetweenShareAndStory: CGFloat = 15
+private struct CloseButtonStyle: ButtonStyle {
+    let showButtonShapes: Bool
 
-        static let storyCornerRadius: CGFloat = 15
+    func makeBody(configuration: Configuration) -> some View {
+        Image(systemName: "xmark")
+            .font(style: .body, maxSizeCategory: .extraExtraExtraLarge)
+            .foregroundColor(.white)
+            .padding(Constants.closeButtonPadding)
+            .background(showButtonShapes ? Color.white.opacity(0.2) : nil)
+            .cornerRadius(Constants.closeButtonRadius)
+            .contentShape(Rectangle())
+            .makeSpringy(isPressed: configuration.isPressed)
+    }
+
+    private enum Constants {
+        static let closeButtonPadding: CGFloat = 13
+        static let closeButtonRadius: CGFloat = 5
     }
 }
 

--- a/podcasts/End of Year/Views/StoriesView.swift
+++ b/podcasts/End of Year/Views/StoriesView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct StoriesView: View {
     @ObservedObject private var model: StoriesModel
+    @Environment(\.accessibilityShowButtonShapes) var showButtonShapes: Bool
 
     init(dataSource: StoriesDataSource, configuration: StoriesConfiguration = StoriesConfiguration()) {
         model = StoriesModel(dataSource: dataSource, configuration: configuration)
@@ -106,14 +107,14 @@ struct StoriesView: View {
             VStack {
                 HStack {
                     Spacer()
-                    Button(action: {
+                    Button("") {
                         Analytics.track(.endOfYearStoriesDismissed, properties: ["source": "close_button"])
                         model.stopAndDismiss()
-                    }) {
-                        Image(systemName: "xmark")
-                            .foregroundColor(.white)
-                            .padding(Constants.closeButtonPadding)
-                    }
+                    }.buttonStyle(CloseButtonStyle(showButtonShapes: showButtonShapes))
+                    // Inset the button a bit if we're showing the button shapes
+                    .padding(.trailing, showButtonShapes ? Constants.storyIndicatorVerticalPadding : 0)
+                    .padding(.top, showButtonShapes ? 5 : 0)
+                    .accessibilityLabel(L10n.accessibilityDismiss)
                 }
                 .padding(.top, Constants.closeButtonTopPadding)
                 Spacer()
@@ -159,27 +160,11 @@ struct StoriesView: View {
     }
 
     var shareButton: some View {
-        Button(action: {
+        Button(L10n.share) {
             model.share()
-        }) {
-            HStack {
-                Spacer()
-                Image(systemName: "square.and.arrow.up")
-                    .foregroundColor(.white)
-                Text("Share")
-                    .foregroundColor(.white)
-                Spacer()
-            }
         }
-        .contentShape(Rectangle())
-        .padding(.top, Constants.shareButtonVerticalPadding)
-        .padding(.bottom, Constants.shareButtonVerticalPadding)
-        .overlay(
-            RoundedRectangle(cornerRadius: Constants.shareButtonCornerRadius)
-                .stroke(.white, style: StrokeStyle(lineWidth: Constants.shareButtonBorderSize))
-        )
-        .padding(.leading, Constants.shareButtonHorizontalPadding)
-        .padding(.trailing, Constants.shareButtonHorizontalPadding)
+        .buttonStyle(ShareButtonStyle())
+        .padding([.leading, .trailing], Constants.shareButtonHorizontalPadding)
     }
 
     var storiesToPreload: some View {
@@ -207,6 +192,14 @@ private extension StoriesView {
         static let closeButtonTopPadding: CGFloat = 5
 
         static let storySwitcherSpacing: CGFloat = 0
+        static let shareButtonHorizontalPadding: CGFloat = 5
+
+        static let spaceBetweenShareAndStory: CGFloat = 15
+
+        static let storyCornerRadius: CGFloat = 15
+    }
+}
+
 // MARK: - Custom Buttons
 
 private struct ShareButtonStyle: ButtonStyle {

--- a/podcasts/Styles.swift
+++ b/podcasts/Styles.swift
@@ -178,42 +178,42 @@ struct RoundedButton: ViewModifier {
 }
 
 /// A dark button filled with a light color
-struct RoundedDarkButton: ViewModifier {
-    @EnvironmentObject var theme: Theme
+struct RoundedDarkButton: ButtonStyle {
+    @ObservedObject var theme: Theme
 
-    func body(content: Content) -> some View {
-        HStack {
-            Spacer()
-            content
-                .font(.system(size: 18, weight: .semibold))
-                .foregroundColor(ThemeColor.primaryUi01(for: theme.activeTheme).color)
-            Spacer()
-        }
-        .padding()
-        .background(ThemeColor.primaryText01(for: theme.activeTheme).color)
-        .cornerRadius(10)
-        .frame(height: 44)
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.system(size: 18, weight: .semibold))
+            .frame(maxWidth: .infinity)
+            .padding()
+
+            .foregroundColor(ThemeColor.primaryUi01(for: theme.activeTheme).color)
+            .background(ThemeColor.primaryText01(for: theme.activeTheme).color)
+
+            .cornerRadius(10)
+            .makeSpringy(isPressed: configuration.isPressed)
+            .contentShape(Rectangle())
+
     }
 }
 
 /// A button that contains a stroke
-struct StrokeButton: ViewModifier {
-    @EnvironmentObject var theme: Theme
+struct StrokeButton: ButtonStyle {
+    @ObservedObject var theme: Theme
 
-    func body(content: Content) -> some View {
-        HStack {
-            Spacer()
-            content
-                .font(.system(size: 18, weight: .semibold))
-                .foregroundColor(ThemeColor.primaryText01(for: theme.activeTheme).color)
-            Spacer()
-        }
-        .padding()
-        .overlay(
-            RoundedRectangle(cornerRadius: 10)
-                .stroke(ThemeColor.primaryText01(for: theme.activeTheme).color, lineWidth: 2)
-        )
-        .frame(height: 44)
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.system(size: 18, weight: .semibold))
+            .foregroundColor(ThemeColor.primaryText01(for: theme.activeTheme).color)
+            .frame(maxWidth: .infinity)
+            .padding()
+            .cornerRadius(10)
+            .overlay(
+                RoundedRectangle(cornerRadius: 10)
+                    .stroke(ThemeColor.primaryText01(for: theme.activeTheme).color, lineWidth: 2)
+            )
+            .makeSpringy(isPressed: configuration.isPressed)
+            .contentShape(Rectangle())
     }
 }
 


### PR DESCRIPTION
| 📘 Project: #376 | 🛫 Depends on: #517 |
|:---:|:---:|

## Screenshots
| Modal Prompt | Stories View | Card |
|:---:|:---:|:---:|
|<img width="200" src="https://user-images.githubusercontent.com/793774/201994683-c6c5c462-fee5-4015-80cb-88e0e29cc752.png">|<img width="200" src="https://user-images.githubusercontent.com/793774/201994671-b1be0ebc-e1a9-4ae2-b49a-f817329e31e9.png">|<img width="200" src="https://user-images.githubusercontent.com/793774/201994604-3e5f2f99-7585-4c3b-ac30-624c1da2dbf9.png">|

## To test

1. In Settings.app, enabled Button Shapes and change your text to the Largest accessibility size
2. In AppDelegate add: `Settings.endOfYearModalHasBeenShown = false` to force the modal to be shown
3. Launch the app
4. ✅ Verify the modal prompt appears, the font is scaled, and is readable (no cropping)
5. Dismiss the modal
6. Go to the Profile tab
7. ✅ Verify the end of year card appears with scaled font, and is readable (not super huge)
8. Tap the card
9. ✅ Verify the share button is scaled, but limited
10. ✅ Verify the X button has a border around it

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
