### PR TITLE
Onboarding: Adds the newsletter to the welcome view

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1335,7 +1335,7 @@
 		BDFF77301C9929660086282A /* NavigationProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDFF772F1C9929660086282A /* NavigationProtocol.swift */; };
 		BDFFC9AF2148A1460026D875 /* PCRoutePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDFFC9AE2148A1460026D875 /* PCRoutePickerView.swift */; };
 		BDFFC9B12148E87E0026D875 /* VideoViewController+Seek.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDFFC9B02148E87E0026D875 /* VideoViewController+Seek.swift */; };
-		C7080C082922DB5F00D7A432 /* WelcomeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7080C072922DB5F00D7A432 /* WelcomeCoordinator.swift */; };
+		C7080C082922DB5F00D7A432 /* WelcomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7080C072922DB5F00D7A432 /* WelcomeViewModel.swift */; };
 		C7080C0A2922F26500D7A432 /* WelcomeHostingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7080C092922F26500D7A432 /* WelcomeHostingViewController.swift */; };
 		C7080C5D2923070200D7A432 /* PlusAccountUpgradePrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7080C5C2923070200D7A432 /* PlusAccountUpgradePrompt.swift */; };
 		C7080C5F29233BA000D7A432 /* PlusAccountPromptViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7080C5E29233BA000D7A432 /* PlusAccountPromptViewModel.swift */; };
@@ -2915,7 +2915,7 @@
 		BDFF772F1C9929660086282A /* NavigationProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NavigationProtocol.swift; sourceTree = "<group>"; };
 		BDFFC9AE2148A1460026D875 /* PCRoutePickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PCRoutePickerView.swift; sourceTree = "<group>"; };
 		BDFFC9B02148E87E0026D875 /* VideoViewController+Seek.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VideoViewController+Seek.swift"; sourceTree = "<group>"; };
-		C7080C072922DB5F00D7A432 /* WelcomeCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeCoordinator.swift; sourceTree = "<group>"; };
+		C7080C072922DB5F00D7A432 /* WelcomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeViewModel.swift; sourceTree = "<group>"; };
 		C7080C092922F26500D7A432 /* WelcomeHostingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeHostingViewController.swift; sourceTree = "<group>"; };
 		C7080C5C2923070200D7A432 /* PlusAccountUpgradePrompt.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlusAccountUpgradePrompt.swift; sourceTree = "<group>"; };
 		C7080C5E29233BA000D7A432 /* PlusAccountPromptViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlusAccountPromptViewModel.swift; sourceTree = "<group>"; };
@@ -6058,7 +6058,7 @@
 			isa = PBXGroup;
 			children = (
 				C7A110F6291F65FB00887A90 /* WelcomeView.swift */,
-				C7080C072922DB5F00D7A432 /* WelcomeCoordinator.swift */,
+				C7080C072922DB5F00D7A432 /* WelcomeViewModel.swift */,
 				C7080C092922F26500D7A432 /* WelcomeHostingViewController.swift */,
 			);
 			path = Welcome;
@@ -7618,7 +7618,7 @@
 				40256C32223486A20091EFC6 /* UploadedStorageHeaderView.swift in Sources */,
 				C7B3C61B291AD05600054145 /* PlusLandingView.swift in Sources */,
 				BD70AFD5206B50BF00431F7F /* ListPodcast.swift in Sources */,
-				C7080C082922DB5F00D7A432 /* WelcomeCoordinator.swift in Sources */,
+				C7080C082922DB5F00D7A432 /* WelcomeViewModel.swift in Sources */,
 				46851BB72790D5E00065C8B2 /* PodcastCollectionColors+Helpers.swift in Sources */,
 				C72CED2F289DA1650017883A /* String+Analytics.swift in Sources */,
 				BD0B68742203EFCC002CCE3F /* EpisodeLimitCell.swift in Sources */,

--- a/podcasts/Onboarding/Models/PlusPurchaseModel.swift
+++ b/podcasts/Onboarding/Models/PlusPurchaseModel.swift
@@ -93,8 +93,8 @@ private extension PlusPurchaseModel {
     private func handleNext() {
         guard let parentController else { return }
 
-        let coordinator = WelcomeCoordinator(displayType: .plus)
-        let controller = WelcomeHostingViewController(rootView: WelcomeView(coordinator: coordinator).setupDefaultEnvironment())
+        let coordinator = WelcomeViewModel(displayType: .plus)
+        let controller = WelcomeHostingViewController(rootView: WelcomeView(viewModel: coordinator).setupDefaultEnvironment())
 
         guard let navigationController = parentController as? UINavigationController else {
             // Create a view controller to present the view in

--- a/podcasts/Onboarding/Welcome/WelcomeCoordinator.swift
+++ b/podcasts/Onboarding/Welcome/WelcomeCoordinator.swift
@@ -1,9 +1,12 @@
 import Foundation
+import PocketCastsServer
 
-class WelcomeCoordinator {
+class WelcomeCoordinator: ObservableObject {
     var navigationController: UINavigationController?
     let displayType: DisplayType
     let sections: [WelcomeSection] = [.importPodcasts, .discover]
+
+    var newsletterOptIn: Bool = true
 
     init(navigationController: UINavigationController? = nil, displayType: DisplayType) {
         self.navigationController = navigationController
@@ -11,6 +14,8 @@ class WelcomeCoordinator {
     }
 
     func sectionTapped(_ section: WelcomeSection) {
+        saveNewsletterOptIn()
+
         switch section {
         case .importPodcasts:
             print("TODO: Future Task")
@@ -22,7 +27,13 @@ class WelcomeCoordinator {
     }
 
     func doneTapped() {
+        saveNewsletterOptIn()
         navigationController?.dismiss(animated: true)
+    }
+
+    private func saveNewsletterOptIn() {
+        Analytics.track(.newsletterOptInChanged, properties: ["enabled": newsletterOptIn, "source": "account_updated"])
+        ServerSettings.setMarketingOptIn(newsletterOptIn)
     }
 
     // MARK: - Configuration

--- a/podcasts/Onboarding/Welcome/WelcomeView.swift
+++ b/podcasts/Onboarding/Welcome/WelcomeView.swift
@@ -2,10 +2,10 @@ import SwiftUI
 
 struct WelcomeView: View {
     @EnvironmentObject var theme: Theme
-    @ObservedObject var coordinator: WelcomeCoordinator
+    @ObservedObject var viewModel: WelcomeViewModel
 
     private var titleText: String {
-        switch coordinator.displayType {
+        switch viewModel.displayType {
         case .plus:
             return L10n.welcomePlusTitle
         case .newAccount:
@@ -14,7 +14,7 @@ struct WelcomeView: View {
     }
 
     private var isPlus: Bool {
-        coordinator.displayType == .plus
+        viewModel.displayType == .plus
     }
 
     var body: some View {
@@ -29,19 +29,21 @@ struct WelcomeView: View {
                         .padding(.bottom, 24)
 
                     VStack(spacing: 16) {
-                        ForEach(coordinator.sections) { section in
+                        ForEach(viewModel.sections) { section in
                             WelcomeSectionView(model: model(for: section)) {
-                                coordinator.sectionTapped(section)
+                                viewModel.sectionTapped(section)
                             }
                         }
                     }
 
                     newsletter
+                        .padding(.top, 30)
+                        .padding(.bottom, 16)
 
                     Spacer()
 
                     Button(L10n.done) {
-                        coordinator.doneTapped()
+                        viewModel.doneTapped()
                     }.buttonStyle(RoundedButtonStyle(theme: theme))
                 }
                 .padding([.leading, .trailing], Config.padding.horizontal)
@@ -61,15 +63,14 @@ struct WelcomeView: View {
 
             Spacer()
 
-            Toggle(isOn: $coordinator.newsletterOptIn) {
+            Toggle(isOn: $viewModel.newsletterOptIn) {
                 EmptyView()
             }.toggleStyle(SwitchToggleStyle(tint: AppTheme.color(for: .primaryInteractive01, theme: theme)))
                 .frame(maxWidth: 60)
         }
-        .padding(.bottom, 16)
     }
 
-    private func model(for section: WelcomeCoordinator.WelcomeSection) -> WelcomeSectionModel {
+    private func model(for section: WelcomeViewModel.WelcomeSection) -> WelcomeSectionModel {
         switch section {
 
         case .importPodcasts:
@@ -102,7 +103,7 @@ private enum Config {
 // MARK: - Preview
 struct WelcomeView_Previews: PreviewProvider {
     static var previews: some View {
-        WelcomeView(coordinator: WelcomeCoordinator(navigationController: UINavigationController(), displayType: .plus))
+        WelcomeView(viewModel: WelcomeViewModel(navigationController: UINavigationController(), displayType: .plus))
             .previewWithAllThemes()
     }
 }

--- a/podcasts/Onboarding/Welcome/WelcomeView.swift
+++ b/podcasts/Onboarding/Welcome/WelcomeView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct WelcomeView: View {
     @EnvironmentObject var theme: Theme
-    let coordinator: WelcomeCoordinator
+    @ObservedObject var coordinator: WelcomeCoordinator
 
     private var titleText: String {
         switch coordinator.displayType {
@@ -34,7 +34,9 @@ struct WelcomeView: View {
                                 coordinator.sectionTapped(section)
                             }
                         }
-                    }.padding(.bottom, 16)
+                    }
+
+                    newsletter
 
                     Spacer()
 
@@ -48,6 +50,23 @@ struct WelcomeView: View {
             }
             .background(AppTheme.color(for: .background, theme: theme).ignoresSafeArea())
         }
+    }
+
+    private var newsletter: some View {
+        HStack(spacing: 0) {
+            VStack(alignment: .leading, spacing: 4) {
+                Label(L10n.pocketCastsWelcomeNewsletterTitle, for: .newsletterTitle)
+                Label(L10n.pocketCastsNewsletterDescription, for: .newsletterDescription)
+            }
+
+            Spacer()
+
+            Toggle(isOn: $coordinator.newsletterOptIn) {
+                EmptyView()
+            }.toggleStyle(SwitchToggleStyle(tint: AppTheme.color(for: .primaryInteractive01, theme: theme)))
+                .frame(maxWidth: 60)
+        }
+        .padding(.bottom, 16)
     }
 
     private func model(for section: WelcomeCoordinator.WelcomeSection) -> WelcomeSectionModel {
@@ -129,6 +148,8 @@ private struct Label: View {
         case title
         case sectionTitle
         case sectionDescription
+        case newsletterTitle
+        case newsletterDescription
     }
 
     let text: String
@@ -151,9 +172,9 @@ private struct Label: View {
 
         case .title:
             return AppTheme.color(for: .text, theme: theme)
-        case .sectionTitle:
+        case .sectionTitle, .newsletterTitle:
             return AppTheme.color(for: .text, theme: theme)
-        case .sectionDescription:
+        case .sectionDescription, .newsletterDescription:
             return AppTheme.color(for: .sectionDescription, theme: theme)
         }
     }
@@ -169,6 +190,11 @@ private struct Label: View {
                 return content.font(size: 18, style: .body, weight: .semibold, maxSizeCategory: .extraExtraExtraLarge)
             case .sectionDescription:
                 return content.font(size: 13, style: .caption, maxSizeCategory: .extraExtraExtraLarge)
+            case .newsletterTitle:
+                return content.font(size: 15, style: .subheadline, weight: .medium, maxSizeCategory: .extraExtraExtraLarge)
+            case .newsletterDescription:
+                return content.font(size: 13, style: .footnote, maxSizeCategory: .extraExtraExtraLarge)
+
             }
         }
     }

--- a/podcasts/Onboarding/Welcome/WelcomeViewModel.swift
+++ b/podcasts/Onboarding/Welcome/WelcomeViewModel.swift
@@ -1,7 +1,7 @@
 import Foundation
 import PocketCastsServer
 
-class WelcomeCoordinator: ObservableObject {
+class WelcomeViewModel: ObservableObject {
     var navigationController: UINavigationController?
     let displayType: DisplayType
     let sections: [WelcomeSection] = [.importPodcasts, .discover]

--- a/podcasts/PodcastListViewController.swift
+++ b/podcasts/PodcastListViewController.swift
@@ -220,8 +220,8 @@ class PodcastListViewController: PCViewController, UIGestureRecognizerDelegate, 
 
     @objc private func createFolderTapped(_ sender: UIBarButtonItem) {
         if FeatureFlag.onboardingUpdates {
-            let coordinator = WelcomeCoordinator(displayType: .plus)
-            let controller = WelcomeHostingViewController(rootView: WelcomeView(coordinator: coordinator).setupDefaultEnvironment())
+            let coordinator = WelcomeViewModel(displayType: .plus)
+            let controller = WelcomeHostingViewController(rootView: WelcomeView(viewModel: coordinator).setupDefaultEnvironment())
             let navigationController = OnboardingNavigationViewController(rootViewController: controller)
             coordinator.navigationController = navigationController
 

--- a/podcasts/PodcastListViewController.swift
+++ b/podcasts/PodcastListViewController.swift
@@ -220,7 +220,12 @@ class PodcastListViewController: PCViewController, UIGestureRecognizerDelegate, 
 
     @objc private func createFolderTapped(_ sender: UIBarButtonItem) {
         if FeatureFlag.onboardingUpdates {
-            self.present(LoginCoordinator.make(), animated: true)
+            let coordinator = WelcomeCoordinator(displayType: .plus)
+            let controller = WelcomeHostingViewController(rootView: WelcomeView(coordinator: coordinator).setupDefaultEnvironment())
+            let navigationController = OnboardingNavigationViewController(rootViewController: controller)
+            coordinator.navigationController = navigationController
+
+            self.present(navigationController, animated: true)
             return
         }
 

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -1489,6 +1489,8 @@ internal enum L10n {
   internal static var pocketCastsPlus: String { return L10n.tr("Localizable", "pocket_casts_plus") }
   /// Plus
   internal static var pocketCastsPlusShort: String { return L10n.tr("Localizable", "pocket_casts_plus_short") }
+  /// Get the Newsletter
+  internal static var pocketCastsWelcomeNewsletterTitle: String { return L10n.tr("Localizable", "pocket_casts_welcome_newsletter_title") }
   /// Access ended: %1$@
   internal static func podcastAccessEnded(_ p1: Any) -> String {
     return L10n.tr("Localizable", "podcast_access_ended", String(describing: p1))

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -3089,6 +3089,9 @@
 /* The description for the Pocket Casts Newsletter */
 "pocket_casts_newsletter_description" = "Receive news, app updates, themed playlists, interviews, and more.";
 
+/* The heading shown for the Pocket Casts Newsletter */
+"pocket_casts_welcome_newsletter_title" = "Get the Newsletter";
+
 /* Title for page one of the 7.20 what's new dialog. */
 "whats_new_page_one_title_7_20" = "Folders";
 


### PR DESCRIPTION
| 📘 Project: #500 |
|:---:|

## Screenshots
| iPhone SE 14.1 | iPhone 8  - 15.5 | iPhone 14 Pro Max - 16.1 |
|:---:|:---:|:---:|
|<img width="200" src="https://user-images.githubusercontent.com/793774/202029574-19beba17-8758-492a-b975-47b44f86a4e0.png">|<img width="200" src="https://user-images.githubusercontent.com/793774/202030225-e5a07e2a-b0ed-4c39-a286-4394579fbbf6.png">|<img width="200" src="https://user-images.githubusercontent.com/793774/202030120-1a45ffb9-2052-4a50-8e08-8496edbdbde7.png">|

## To test

1. Launch the app with the onboardingUpdates feature flag enabled
2. Go to the Podcasts tab
3. Tap the Create folder button
4. ✅ Verify the newsletter view is shown and is enabled
5. in Xcode, open the WelcomeCoordinator, put a breakpoint on line 35
6. Tap the Done button
7. ✅ Verify the breakpoint is hit, and the value of `newsletterOptIn` is the value you chose
8. Present the view again, and tap the Find my Next Podcast button
9. ✅ Verify the breakpoint is hit, and the value of `newsletterOptIn` is the value you chose 

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
