### PR TITLE
End of Year: improve listening history sync

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
@@ -205,7 +205,7 @@ class EndOfYearDataManager {
                             WHERE `\(DataManager.podcastTableName)`.uuid = `\(DataManager.episodeTableName)`.podcastUuid and
                                 \(listenedEpisodesThisYear)
                             GROUP BY podcastUuid
-                            ORDER BY played_episodes DESC
+                            ORDER BY totalPlayedTime DESC
                             LIMIT \(limit)
                             """
                 let resultSet = try db.executeQuery(query, values: nil)

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
@@ -263,7 +263,7 @@ class EndOfYearDataManager {
         dbQueue.inDatabase { db in
             do {
                 let query = """
-                            SELECT uuid FROM \(DataManager.episodeTableName) WHERE \(DataManager.episodeTableName).uuid IN \(DBUtils.valuesQuestionMarks(amount: uuids.count)) and
+                            SELECT DISTINCT uuid FROM \(DataManager.episodeTableName) WHERE \(DataManager.episodeTableName).uuid IN \(DBUtils.valuesQuestionMarks(amount: uuids.count)) and
                                 \(listenedEpisodesThisYear)
                             """
                 let resultSet = try db.executeQuery(query, values: uuids)

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
@@ -256,6 +256,31 @@ class EndOfYearDataManager {
         return episode
     }
 
+    /// Given a list of UUIDs, return which UUIDs are present on the database
+    func episodesThatExists(dbQueue: FMDatabaseQueue, uuids: [String]) -> [String] {
+        var episodes: [String] = []
+
+        dbQueue.inDatabase { db in
+            do {
+                let query = """
+                            SELECT uuid FROM \(DataManager.episodeTableName) WHERE \(DataManager.episodeTableName).uuid IN \(DBUtils.valuesQuestionMarks(amount: uuids.count))
+                            """
+                let resultSet = try db.executeQuery(query, values: uuids)
+                defer { resultSet.close() }
+
+                while resultSet.next() {
+                    if let uuid = resultSet.string(forColumn: "uuid") {
+                        episodes.append(uuid)
+                    }
+                }
+            } catch {
+                FileLog.shared.addMessage("EndOfYearDataManager.episodesThatExists error: \(error)")
+            }
+        }
+
+        return episodes
+    }
+
     private func numberOfItemsInListeningHistory(db: FMDatabase) -> Int {
         var numberOfItemsInListeningHistory = 0
 

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
@@ -257,7 +257,7 @@ class EndOfYearDataManager {
     }
 
     /// Given a list of UUIDs, return which UUIDs are present on the database
-    func episodesThatExists(dbQueue: FMDatabaseQueue, uuids: [String]) -> [String] {
+    func episodesThatExist(dbQueue: FMDatabaseQueue, uuids: [String]) -> [String] {
         var episodes: [String] = []
 
         dbQueue.inDatabase { db in
@@ -275,7 +275,7 @@ class EndOfYearDataManager {
                     }
                 }
             } catch {
-                FileLog.shared.addMessage("EndOfYearDataManager.episodesThatExists error: \(error)")
+                FileLog.shared.addMessage("EndOfYearDataManager.episodesThatExist error: \(error)")
             }
         }
 

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
@@ -263,7 +263,8 @@ class EndOfYearDataManager {
         dbQueue.inDatabase { db in
             do {
                 let query = """
-                            SELECT uuid FROM \(DataManager.episodeTableName) WHERE \(DataManager.episodeTableName).uuid IN \(DBUtils.valuesQuestionMarks(amount: uuids.count))
+                            SELECT uuid FROM \(DataManager.episodeTableName) WHERE \(DataManager.episodeTableName).uuid IN \(DBUtils.valuesQuestionMarks(amount: uuids.count)) and
+                                \(listenedEpisodesThisYear)
                             """
                 let resultSet = try db.executeQuery(query, values: uuids)
                 defer { resultSet.close() }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -933,4 +933,8 @@ public extension DataManager {
     func longestEpisode() -> Episode? {
         endOfYearManager.longestEpisode(dbQueue: dbQueue)
     }
+
+    func episodesThatExists(uuids: [String]) -> [String] {
+        endOfYearManager.episodesThatExists(dbQueue: dbQueue, uuids: uuids)
+    }
 }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -934,7 +934,7 @@ public extension DataManager {
         endOfYearManager.longestEpisode(dbQueue: dbQueue)
     }
 
-    func episodesThatExists(uuids: [String]) -> [String] {
-        endOfYearManager.episodesThatExists(dbQueue: dbQueue, uuids: uuids)
+    func episodesThatExist(uuids: [String]) -> [String] {
+        endOfYearManager.episodesThatExist(dbQueue: dbQueue, uuids: uuids)
     }
 }

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncYearListeningHistoryTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncYearListeningHistoryTask.swift
@@ -82,8 +82,8 @@ class SyncYearListeningHistoryTask: ApiBaseTask {
 
         // Get the list of missing episodes in the database
         let uuids = updates.map { $0.episode }
-        let episodesThatExists = DataManager.sharedManager.episodesThatExists(uuids: uuids)
-        let missingEpisodes = updates.filter { !episodesThatExists.contains($0.episode) }
+        let episodesThatExist = DataManager.sharedManager.episodesThatExist(uuids: uuids)
+        let missingEpisodes = updates.filter { !episodesThatExist.contains($0.episode) }
 
         let dispatchGroup = DispatchGroup()
 


### PR DESCRIPTION
| 📘 Project: #376 |
|:---:|

This PR improves and speeds up the process of syncing the 2022 listening history. I tested with an account that was taking ~6 minutes to sync. This has been reduced to ~34s. There's still room for improvement but I'll leave that for another PR.

Before the change: sync took 296.6710090637207
After the change: sync took 34.58926796913147

 ## Improvements

The way we were doing before, we would check the database once per episode, it doesn't matter if the user had them or not. For users with a big list of episodes, the performance was very poor.

Instead, what we do now is to check the episodes that are missing and request and add only them.

## To test

1. Run the TestFlight version
2. Check your stories
3. Run this branch
4. ✅  Check your stories and make sure both versions match

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
