### PR TITLE
End of Year: Fix the modal being cropped sometimes

### DIFF
--- a/podcasts/End of Year/Views/EndOfYearModal.swift
+++ b/podcasts/End of Year/Views/EndOfYearModal.swift
@@ -78,6 +78,7 @@ struct EndOfYearModal: View {
             NavigationManager.sharedManager.navigateTo(NavigationManager.endOfYearStories, data: nil)
         }
         .buttonStyle(RoundedDarkButton(theme: theme))
+        .frame(height: 44)
     }
 
     var dismissButton: some View {
@@ -85,6 +86,7 @@ struct EndOfYearModal: View {
             NavigationManager.sharedManager.dismissPresentedViewController()
         }
         .buttonStyle(StrokeButton(theme: theme))
+        .frame(height: 44)
     }
 
     private enum Constants {


### PR DESCRIPTION

| Before | After |
|:---:|:---:|
|<img width="505" alt="Screen Shot 2022-11-16 at 4 43 02 PM" src="https://user-images.githubusercontent.com/793774/202306998-fab6220f-4f50-42da-851b-6a87b01e1088.png">|<img width="505" alt="Screen Shot 2022-11-16 at 5 21 07 PM" src="https://user-images.githubusercontent.com/793774/202307023-375629d4-8d4b-4047-9e44-10a3501312bd.png">|

## To test

1. Add `Settings.endOfYearModalHasBeenShown = false` to the App Delegate
2. Launch the app
3. ✅ Verify the modal is not cut off

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
