### PR TITLE
End of Year: small fixes

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
@@ -223,12 +223,12 @@ class EndOfYearDataManager {
             }
         }
 
-        // If there's a tie on number of played episodes, check played time
+        // If there's a tie on total played time, check number of played episodes
         return allPodcasts.sorted(by: {
-            if $0.numberOfPlayedEpisodes == $1.numberOfPlayedEpisodes {
-                return $0.totalPlayedTime > $1.totalPlayedTime
+            if $0.totalPlayedTime == $1.totalPlayedTime {
+                return $0.numberOfPlayedEpisodes > $1.numberOfPlayedEpisodes
             }
-            return $0.numberOfPlayedEpisodes > $1.numberOfPlayedEpisodes
+            return $0.totalPlayedTime > $1.totalPlayedTime
         })
     }
 

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -593,4 +593,5 @@ enum AnalyticsEvent: String {
     case endOfYearStoryShown
     case endOfYearStoryShare
     case endOfYearStoryShared
+    case endOfYearProfileCardTapped
 }

--- a/podcasts/End of Year/Stories/EpilogueStory.swift
+++ b/podcasts/End of Year/Stories/EpilogueStory.swift
@@ -16,7 +16,7 @@ struct EpilogueStory: StoryView {
                         Image("heart")
                             .padding(.bottom, 20)
 
-                        Text(L10n.eoyStoryEpilogueTitle)
+                        Text(L10n.eoyStoryEpilogueTitle.replacingOccurrences(of: "Pocket Casts", with: "Pocket\u{00a0}Casts"))
                             .foregroundColor(.white)
                             .font(.system(size: 25, weight: .heavy))
                             .foregroundColor(.white)

--- a/podcasts/ProfileViewController.swift
+++ b/podcasts/ProfileViewController.swift
@@ -448,6 +448,7 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
             let historyController = ListeningHistoryViewController()
             navigationController?.pushViewController(historyController, animated: true)
         case .endOfYearPrompt:
+            Analytics.track(.endOfYearProfileCardTapped)
             EndOfYear().showStories(in: self, from: .profile)
         }
     }


### PR DESCRIPTION
| 📘 Project: #376 |
|:---:|

This PR fixes 3 issues:

* The queries were changed in a previous PR but a Swift logic to order podcasts by the number of episodes remained. This PR fixes this.
* We do not breakline on "Pocket Casts"
* Track when the user tap the Profile's EOY card

## To test

1. Run the app
2. Check your stories
3. ✅ Check your top podcasts
4. Move to the last story
5. ✅ "Pocket Casts" should be in the same line
6. Dismiss stories
7. Go to profile
8. Tap the card
9. ✅ `end_of_year_profile_card_tapped` should be tracked

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
