### PR TITLE
Fix translation of "end of episode" inside the timer

### DIFF
--- a/podcasts/SleepTimerViewController.swift
+++ b/podcasts/SleepTimerViewController.swift
@@ -108,6 +108,7 @@ class SleepTimerViewController: SimpleNotificationsViewController {
 
     @IBOutlet var endOfEpisodeInactiveBtn: ThemeableUIButton! {
         didSet {
+            endOfEpisodeInactiveBtn.setTitle(L10n.sleepTimerEndOfEpisode, for: .normal)
             endOfEpisodeInactiveBtn.style = .playerContrast01
         }
     }


### PR DESCRIPTION
The "End of Episode" string was not being translated on the Podcast timer.

## To test

First, change your simulator language to spanish.

1. Run the app
2. Play a podcast if none is playing
3. Tap the miniplayer
4. Tap the timer icon
5. Check that the "End of Episode" is translated to "Final del episodio"

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
