### PR TITLE
End of Year: Hide "next story" text when being shared

### DIFF
--- a/podcasts/End of Year/Stories/EpilogueStory.swift
+++ b/podcasts/End of Year/Stories/EpilogueStory.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct EpilogueStory: StoryView {
+    @Environment(\.renderForSharing) var renderForSharing: Bool
     var duration: TimeInterval = 5.seconds
 
     var identifier: String = "epilogue"
@@ -53,6 +54,7 @@ struct EpilogueStory: StoryView {
                     }
                     .buttonStyle(ReplayButtonStyle())
                     .padding(.top, 20)
+                    .opacity(renderForSharing ? 0 : 1)
                 }
                 .padding()
             }

--- a/podcasts/End of Year/Stories/ListenedCategoriesStory.swift
+++ b/podcasts/End of Year/Stories/ListenedCategoriesStory.swift
@@ -3,6 +3,7 @@ import PocketCastsServer
 import PocketCastsDataModel
 
 struct ListenedCategoriesStory: StoryView {
+    @Environment(\.renderForSharing) var renderForSharing: Bool
     var duration: TimeInterval = 5.seconds
 
     let listenedCategories: [ListenedCategory]
@@ -40,7 +41,7 @@ struct ListenedCategoriesStory: StoryView {
                             .multilineTextAlignment(.center)
                             .frame(maxHeight: geometry.size.height * 0.07)
                             .minimumScaleFactor(0.01)
-                            .opacity(0.8)
+                            .opacity(renderForSharing ? 0.0 : 0.8)
                     }
                     .padding(.trailing, 40)
                     .padding(.leading, 40)

--- a/podcasts/End of Year/Stories/ListenedNumbersStory.swift
+++ b/podcasts/End of Year/Stories/ListenedNumbersStory.swift
@@ -3,6 +3,8 @@ import PocketCastsServer
 import PocketCastsDataModel
 
 struct ListenedNumbersStory: StoryView {
+    @Environment(\.renderForSharing) var renderForSharing: Bool
+
     var duration: TimeInterval = 5.seconds
 
     let identifier: String = "number_of_podcasts_and_episodes_listened"
@@ -70,7 +72,7 @@ struct ListenedNumbersStory: StoryView {
                         .multilineTextAlignment(.center)
                         .frame(maxHeight: geometry.size.height * 0.07)
                         .minimumScaleFactor(0.01)
-                        .opacity(0.8)
+                        .opacity(renderForSharing ? 0.0 : 0.8)
                         .padding(.bottom, geometry.size.height * 0.18)
                 }
                 .padding(.trailing, 40)

--- a/podcasts/End of Year/StoryShareableProvider.swift
+++ b/podcasts/End of Year/StoryShareableProvider.swift
@@ -40,10 +40,22 @@ class StoryShareableProvider: UIActivityItemProvider {
         let snapshot = ZStack {
             AnyView(view)
         }
+        .environment(\.renderForSharing, true)
         .frame(width: 370, height: 658)
         .snapshot()
 
         generatedItem = snapshot
         self.view = nil
+    }
+}
+
+extension EnvironmentValues {
+    var renderForSharing: Bool {
+        get { self[RenderSharingKey.self] }
+        set { self[RenderSharingKey.self] = newValue }
+    }
+
+    private struct RenderSharingKey: EnvironmentKey {
+        static let defaultValue: Bool = false
     }
 }


### PR DESCRIPTION
| 📘 Project: #376 |
|:---:|

Hides the "next text" for some images when being shared. This text doesn't make much sense in the context of a static image on social media, so this hides it. 

## To test

1. Launch app
2. Go to stories
3. Share the 3rd story to camera roll
4. ✅ Verify the subtitle is hidden
5. Share the 5th story to camera roll and verify the subtitle is hidden
6. Share the last view to camera roll, verify the replay button is hidden

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
