### PR TITLE
Onboarding: Adds support for single trials

### DIFF
--- a/podcasts/Onboarding/Models/PlusPricingInfoModel.swift
+++ b/podcasts/Onboarding/Models/PlusPricingInfoModel.swift
@@ -32,6 +32,9 @@ class PlusPricingInfoModel: ObservableObject {
             pricing.append(info)
         }
 
+        // Sort any products with free trials to the top of the list
+        pricing.sort { $0.freeTrialDuration != nil && $1.freeTrialDuration == nil }
+
         let hasFreeTrial = purchaseHandler.getFirstFreeTrialDetails() != nil
         return PlusPricingInfo(products: pricing, hasFreeTrial: hasFreeTrial)
     }

--- a/podcasts/Onboarding/Plus/PlusButtonStyles.swift
+++ b/podcasts/Onboarding/Plus/PlusButtonStyles.swift
@@ -84,8 +84,10 @@ struct PlusGradientStrokeButton: ButtonStyle {
 
 struct PlusFreeTrialLabel: View {
     let text: String
-    init(_ text: String) {
+    let isSelected: Bool
+    init(_ text: String, isSelected: Bool = true) {
         self.text = text
+        self.isSelected = isSelected
     }
 
     var body: some View {
@@ -98,6 +100,8 @@ struct PlusFreeTrialLabel: View {
                 Color.plusGradient.cornerRadius(4)
             )
             .foregroundColor(Color.plusButtonFilledTextColor)
+            .grayscale(isSelected ? 0 : 1)
+            .animation(.easeInOut, value: isSelected)
     }
 }
 

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -1422,6 +1422,8 @@ internal enum L10n {
   internal static var plusAccountTrialDetails: String { return L10n.tr("Localizable", "plus_account_trial_details") }
   /// Unlock All Features
   internal static var plusButtonTitleUnlockAll: String { return L10n.tr("Localizable", "plus_button_title_unlock_all") }
+  /// Can be canceled at anytime
+  internal static var plusCancelTerms: String { return L10n.tr("Localizable", "plus_cancel_terms") }
   /// %1$@ GB Cloud Storage
   internal static func plusCloudStorageLimitFormat(_ p1: Any) -> String {
     return L10n.tr("Localizable", "plus_cloud_storage_limit_format", String(describing: p1))

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -3494,3 +3494,6 @@
 
 /* Title of the button that informs the user they can unlock all the features in plus */
 "plus_button_title_unlock_all" = "Unlock All Features";
+
+/* Title of a label informing the user they can cancel their subscription at anytime */
+"plus_cancel_terms" = "Can be canceled at anytime";


### PR DESCRIPTION
| 📘 Project: #500 | 🛫 Depends on: #540 |
|:---:|:---:|

---
> **Note** At the time of writing CI is broken, so the below tests are expected to be ❌
---

This adds better support for displaying trial information when only 1 product has a trial enabled. 
- If there is only 1 product with a trial then we show the trial information in a floating label above the button
    - If only 1 product has a trial, then we sort that product to the top of the list so it's selected by default
- If all products have a trial then we show the trial information as a static label above the buttons


## Screenshots

| No trials | 1 product has a trial | All Products Have Trials |
|:---:|:---:|:---:|
|<img src="https://user-images.githubusercontent.com/793774/203223531-3b216387-97a3-4c52-aea9-ed1971572558.png" width="320" />|<img src="https://user-images.githubusercontent.com/793774/203223533-fde3c68c-d3bb-42b9-8a1d-f01fd88be111.png" width="320" />|<img src="https://user-images.githubusercontent.com/793774/203223537-ae2a9913-5024-4314-a63c-40d323245a88.png" width="320" />|

## To test

### Pre-testing setup:
1. Open the Xcode Project
3. Hit <kbd>Command</kbd>+<kbd>Shift</kbd>+<kbd>,</kbd> to open the Scheme editor
4. Click the options tab
5. Select the `Pocket Casts Configuration.storekit` file in the StoreKit configuration dropdown

### No Trials
1. Launch the app
2. Sign into an account without plus
3. Go to the Podcasts tab
4. Tap the Create Folder button
5. Tap the Unlock All button
6. ✅ Verify the view does not display any trial information

### Single Trial
1. In Xcode, open the `Pocket Casts Configuration.storekit` file
2. Tap on the Plus Yearly product in the sidebar
3. Tap on the Offer Type dropdown, and select 'Free'
4. Select 1 Month
5. Launch the app
3. Go to the Podcasts tab
4. Tap the Create Folder button
5. Tap the Unlock All button
6. ✅ Verify the view displays the trial information about the yearly button
7. Tap on the monthly button
8. ✅ Verify the trial grays out, and the bottom text no longer mentions the trial
9. ✅ Verify the subscribe button no longer mentions the trial

### All Products have Trials
1. In Xcode, open the `Pocket Casts Configuration.storekit` file
2. Tap on the Plus Yearly product in the sidebar
3. Tap on the Offer Type dropdown, and select 'Free'
4. Select 1 Month
5. Tap on the Plus Monthly item
6. Enable the 1 week trial for it using the same steps from above
7. Launch the app
3. Go to the Podcasts tab
4. Tap the Create Folder button
5. Tap the Unlock All button
8. ✅ Verify the view displays the trial information above both buttons
10. Tap on the monthly button
11. ✅ Verify the trial grays out trial label updates with the monthly trial duration
12. ✅ Verify the subscribe button still says trial
13. ✅ Verify the terms below the buttons updates to the correct trial duration

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
