### PR TITLE
Onboarding: Adds analytics

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1342,6 +1342,7 @@
 		C71C04C929243F7D00F2858A /* ImportViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71C04C829243F7D00F2858A /* ImportViewModel.swift */; };
 		C71C04CB2924403000F2858A /* ImportLandingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71C04CA2924403000F2858A /* ImportLandingView.swift */; };
 		C71C04CD2924403800F2858A /* ImportDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71C04CC2924403800F2858A /* ImportDetailsView.swift */; };
+		C72223D4292C918F006B3B55 /* OnboardingModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C72223D3292C918F006B3B55 /* OnboardingModel.swift */; };
 		C72CED2D289DA14F0017883A /* AnalyticsEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = C72CED2C289DA14F0017883A /* AnalyticsEvent.swift */; };
 		C72CED2F289DA1650017883A /* String+Analytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = C72CED2E289DA1650017883A /* String+Analytics.swift */; };
 		C72CED32289DA1900017883A /* TracksAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C72CED31289DA1900017883A /* TracksAdapter.swift */; };
@@ -2927,6 +2928,7 @@
 		C71C04C829243F7D00F2858A /* ImportViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportViewModel.swift; sourceTree = "<group>"; };
 		C71C04CA2924403000F2858A /* ImportLandingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportLandingView.swift; sourceTree = "<group>"; };
 		C71C04CC2924403800F2858A /* ImportDetailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportDetailsView.swift; sourceTree = "<group>"; };
+		C72223D3292C918F006B3B55 /* OnboardingModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingModel.swift; sourceTree = "<group>"; };
 		C72CED2C289DA14F0017883A /* AnalyticsEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsEvent.swift; sourceTree = "<group>"; };
 		C72CED2E289DA1650017883A /* String+Analytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Analytics.swift"; sourceTree = "<group>"; };
 		C72CED31289DA1900017883A /* TracksAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracksAdapter.swift; sourceTree = "<group>"; };
@@ -6108,6 +6110,7 @@
 				C7FF770D291C2CA80082A464 /* Login */,
 				C7B3C619291AD03A00054145 /* Plus */,
 				C7AF7B982926B307002F0025 /* OnboardingHostingViewController.swift */,
+				C72223D3292C918F006B3B55 /* OnboardingModel.swift */,
 			);
 			path = Onboarding;
 			sourceTree = "<group>";
@@ -7825,6 +7828,7 @@
 				40D9A4B1240746C30019E469 /* SignOutHelper.swift in Sources */,
 				BD43D9C01D52D423004077FA /* GoogleCastManager.swift in Sources */,
 				BDC3775C1C44CFFB001FD219 /* ListHeaderDelegate.swift in Sources */,
+				C72223D4292C918F006B3B55 /* OnboardingModel.swift in Sources */,
 				4029E3E02292686C0003BEEB /* ChangeEmailViewController.swift in Sources */,
 				4011B9432164641800661A7D /* EditFilterNameCell.swift in Sources */,
 				C7F4BAB528DA6BBB001C9785 /* BackgroundSignOutListener.swift in Sources */,

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1343,6 +1343,7 @@
 		C71C04CB2924403000F2858A /* ImportLandingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71C04CA2924403000F2858A /* ImportLandingView.swift */; };
 		C71C04CD2924403800F2858A /* ImportDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71C04CC2924403800F2858A /* ImportDetailsView.swift */; };
 		C72223D4292C918F006B3B55 /* OnboardingModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C72223D3292C918F006B3B55 /* OnboardingModel.swift */; };
+		C72223D6292CAE92006B3B55 /* OnboardingFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = C72223D5292CAE92006B3B55 /* OnboardingFlow.swift */; };
 		C72CED2D289DA14F0017883A /* AnalyticsEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = C72CED2C289DA14F0017883A /* AnalyticsEvent.swift */; };
 		C72CED2F289DA1650017883A /* String+Analytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = C72CED2E289DA1650017883A /* String+Analytics.swift */; };
 		C72CED32289DA1900017883A /* TracksAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C72CED31289DA1900017883A /* TracksAdapter.swift */; };
@@ -2929,6 +2930,7 @@
 		C71C04CA2924403000F2858A /* ImportLandingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportLandingView.swift; sourceTree = "<group>"; };
 		C71C04CC2924403800F2858A /* ImportDetailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportDetailsView.swift; sourceTree = "<group>"; };
 		C72223D3292C918F006B3B55 /* OnboardingModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingModel.swift; sourceTree = "<group>"; };
+		C72223D5292CAE92006B3B55 /* OnboardingFlow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingFlow.swift; sourceTree = "<group>"; };
 		C72CED2C289DA14F0017883A /* AnalyticsEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsEvent.swift; sourceTree = "<group>"; };
 		C72CED2E289DA1650017883A /* String+Analytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Analytics.swift"; sourceTree = "<group>"; };
 		C72CED31289DA1900017883A /* TracksAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracksAdapter.swift; sourceTree = "<group>"; };
@@ -6111,6 +6113,7 @@
 				C7B3C619291AD03A00054145 /* Plus */,
 				C7AF7B982926B307002F0025 /* OnboardingHostingViewController.swift */,
 				C72223D3292C918F006B3B55 /* OnboardingModel.swift */,
+				C72223D5292CAE92006B3B55 /* OnboardingFlow.swift */,
 			);
 			path = Onboarding;
 			sourceTree = "<group>";
@@ -7945,6 +7948,7 @@
 				8B0EEDEA2900990D00075772 /* LongestEpisodeStory.swift in Sources */,
 				BD42E31A1B940AFF000EA14F /* DiscoverPodcastTableCell.swift in Sources */,
 				4006E31123A88AE600174DEB /* ExpandedCollectionViewController.swift in Sources */,
+				C72223D6292CAE92006B3B55 /* OnboardingFlow.swift in Sources */,
 				BD240C45231F471B00FB2CDD /* PCSearchBarController+Animation.swift in Sources */,
 				4029E3ED229CD67B0003BEEB /* ProgressPieView.swift in Sources */,
 				BDF050801FBA677900194D68 /* EpisodeCell.swift in Sources */,

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -596,8 +596,16 @@ enum AnalyticsEvent: String {
     case endOfYearProfileCardTapped
 
     // MARK: - Onboarding Updates
+
     case onboardingUpgradeShown
     case onboardingUpgradeDismissed
     case onboardingUpgradeUnlockAllFeaturesTapped
     case onboardingUpgradeNotNowTapped
+
+    // MARK: - Welcome View
+
+    case welcomeShown
+    case welcomeImportTapped
+    case welcomeDiscoverTapped
+    case welcomeDismissed
 }

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -608,4 +608,11 @@ enum AnalyticsEvent: String {
     case welcomeImportTapped
     case welcomeDiscoverTapped
     case welcomeDismissed
+
+    // MARK: - Import
+
+    case onboardingImportShown
+    case onboardingImportAppSelected
+    case onboardingImportOpenAppTapped
+    case onboardingImportDismissed
 }

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -594,4 +594,10 @@ enum AnalyticsEvent: String {
     case endOfYearStoryShare
     case endOfYearStoryShared
     case endOfYearProfileCardTapped
+
+    // MARK: - Onboarding Updates
+    case onboardingUpgradeShown
+    case onboardingUpgradeDismissed
+    case onboardingUpgradeUnlockAllFeaturesTapped
+    case onboardingUpgradeNotNowTapped
 }

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -595,13 +595,6 @@ enum AnalyticsEvent: String {
     case endOfYearStoryShared
     case endOfYearProfileCardTapped
 
-    // MARK: - Onboarding Updates
-
-    case onboardingUpgradeShown
-    case onboardingUpgradeDismissed
-    case onboardingUpgradeUnlockAllFeaturesTapped
-    case onboardingUpgradeNotNowTapped
-
     // MARK: - Welcome View
 
     case welcomeShown

--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -70,7 +70,7 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
     private func showInitialOnboardingIfNeeded() {
         guard FeatureFlag.onboardingUpdates, Settings.shouldShowInitialOnboardingFlow else { return }
 
-        NavigationManager.sharedManager.navigateTo(NavigationManager.onboardingFlow, data: nil)
+        NavigationManager.sharedManager.navigateTo(NavigationManager.onboardingFlow, data: ["flow": OnboardingFlow.Flow.initialOnboarding])
 
         // Set the flag so the user won't see the on launch flow again
         Settings.shouldShowInitialOnboardingFlow = false
@@ -261,7 +261,7 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
             return
         }
 
-        let controller = PlusLandingViewModel.make(from: .upsell)
+        let controller = OnboardingFlow.shared.begin(flow: .plusUpsell, source: source.rawValue)
         presentingController?.present(controller, animated: true, completion: nil)
     }
 
@@ -387,14 +387,16 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
         presentedViewController?.dismiss(animated: true)
     }
 
-    func showOnboardingFlow() {
+    func showOnboardingFlow(flow: OnboardingFlow.Flow?) {
+        let controller = OnboardingFlow.shared.begin(flow: flow ?? .initialOnboarding)
+
         guard let presentedViewController else {
-            present(LoginCoordinator.make(), animated: true)
+            present(controller, animated: true)
             return
         }
 
         presentedViewController.dismiss(animated: true) {
-            self.present(LoginCoordinator.make(), animated: true)
+            self.present(controller, animated: true)
         }
     }
 

--- a/podcasts/NavigationManager.swift
+++ b/podcasts/NavigationManager.swift
@@ -192,7 +192,8 @@ class NavigationManager {
         } else if place == NavigationManager.endOfYearStories {
             mainController?.showEndOfYearStories()
         } else if place == NavigationManager.onboardingFlow {
-            mainController?.showOnboardingFlow()
+            let flow: OnboardingFlow.Flow? = data?["flow"] as? OnboardingFlow.Flow
+            mainController?.showOnboardingFlow(flow: flow)
         }
     }
 }

--- a/podcasts/NavigationProtocol.swift
+++ b/podcasts/NavigationProtocol.swift
@@ -44,5 +44,5 @@ protocol NavigationProtocol: AnyObject {
 
     func showEndOfYearStories()
     func dismissPresentedViewController()
-    func showOnboardingFlow()
+    func showOnboardingFlow(flow: OnboardingFlow.Flow?)
 }

--- a/podcasts/Onboarding/Import/ImportViewModel.swift
+++ b/podcasts/Onboarding/Import/ImportViewModel.swift
@@ -10,13 +10,13 @@ class ImportViewModel: OnboardingModel {
     }
 
     func didAppear() {
-        Analytics.track(.onboardingImportShown)
+        OnboardingFlow.shared.track(.onboardingImportShown)
     }
 
     func didDismiss(type: OnboardingDismissType) {
         guard type == .swipe else { return }
 
-        Analytics.track(.onboardingImportDismissed)
+        OnboardingFlow.shared.track(.onboardingImportDismissed)
     }
 
     // MARK: - Import apps
@@ -116,7 +116,7 @@ extension ImportViewModel {
 extension ImportViewModel {
     func didSelect(_ app: ImportApp) {
         guard let navigationController else { return }
-        Analytics.track(.onboardingImportAppSelected, properties: ["app": app.id])
+        OnboardingFlow.shared.track(.onboardingImportAppSelected, properties: ["app": app.id])
 
         let controller = UIHostingController(rootView: ImportDetailsView(app: app, viewModel: self).setupDefaultEnvironment())
 
@@ -128,7 +128,7 @@ extension ImportViewModel {
 // MARK: - Details
 extension ImportViewModel {
     func openApp(_ app: ImportApp) {
-        Analytics.track(.onboardingImportOpenAppTapped, properties: ["app": app.id])
+        OnboardingFlow.shared.track(.onboardingImportOpenAppTapped, properties: ["app": app.id])
 
         app.openApp()
     }

--- a/podcasts/Onboarding/Login/LoginLandingHostingController.swift
+++ b/podcasts/Onboarding/Login/LoginLandingHostingController.swift
@@ -2,19 +2,9 @@ import Foundation
 import SwiftUI
 
 class LoginLandingHostingController<Content>: OnboardingHostingViewController<Content> where Content: View {
-    let coordinator: LoginCoordinator
-
-    init(rootView: Content, coordinator: LoginCoordinator) {
-        self.coordinator = coordinator
-        super.init(rootView: rootView)
-    }
-
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        guard let viewModel = viewModel as? LoginCoordinator else { return }
 
         let imageView = ThemeableImageView(frame: .zero)
         imageView.imageNameFunc = AppTheme.pcLogoSmallHorizontalForBackgroundImageName
@@ -22,7 +12,7 @@ class LoginLandingHostingController<Content>: OnboardingHostingViewController<Co
         navigationItem.titleView = imageView
 
         if navigationController?.viewControllers.first == self {
-            let dismissItem = UIBarButtonItem(title: L10n.eoyNotNow, style: .plain, target: coordinator, action: #selector(LoginCoordinator.dismissTapped))
+            let dismissItem = UIBarButtonItem(title: L10n.eoyNotNow, style: .plain, target: viewModel, action: #selector(viewModel.dismissTapped))
             dismissItem.setTitleTextAttributes([NSAttributedString.Key.font: UIFont.font(with: .body, weight: .medium),
                                                 NSAttributedString.Key.foregroundColor: iconTintColor], for: .normal)
             navigationItem.rightBarButtonItem = dismissItem

--- a/podcasts/Onboarding/LoginCoordinator.swift
+++ b/podcasts/Onboarding/LoginCoordinator.swift
@@ -3,7 +3,7 @@ import PocketCastsServer
 import SwiftUI
 import PocketCastsDataModel
 
-class LoginCoordinator {
+class LoginCoordinator: OnboardingModel {
     var navigationController: UINavigationController? = nil
     let headerImages: [LoginHeaderImage]
     var presentedFromUpgrade: Bool = false
@@ -34,19 +34,31 @@ class LoginCoordinator {
         self.headerImages = randomPodcasts
     }
 
+    func didAppear() {
+        OnboardingFlow.shared.track(.setupAccountShown)
+    }
+
+    func didDismiss(type: OnboardingDismissType) {
+        guard type == .swipe else { return }
+        OnboardingFlow.shared.track(.setupAccountDismissed)
+    }
+
     func loginTapped() {
+        OnboardingFlow.shared.track(.setupAccountButtonTapped, properties: ["button": "sign_in"])
         let controller = SyncSigninViewController()
         controller.delegate = self
         navigationController?.pushViewController(controller, animated: true)
     }
 
     func signUpTapped() {
+        OnboardingFlow.shared.track(.setupAccountButtonTapped, properties: ["button": "create_account"])
         let controller = NewEmailViewController(newSubscription: NewSubscription(isNewAccount: true, iap_identifier: ""))
         controller.delegate = self
         navigationController?.pushViewController(controller, animated: true)
     }
 
     @objc func dismissTapped() {
+        OnboardingFlow.shared.track(.setupAccountDismissed)
         navigationController?.dismiss(animated: true)
     }
 
@@ -90,7 +102,7 @@ extension LoginCoordinator: SyncSigninDelegate, CreateAccountDelegate {
     }
 
     private func goToPlus(from source: PlusLandingViewModel.Source) {
-        let controller = PlusLandingViewModel.make(in: navigationController, from: source, continueUpgrade: presentedFromUpgrade)
+        let controller = PlusLandingViewModel.make(in: navigationController, from: source, continueUpgrade: presentedFromUpgrade, upgradeSource: "login")
         navigationController?.setViewControllers([controller], animated: true)
     }
 }
@@ -103,8 +115,8 @@ extension LoginCoordinator {
         coordinator.presentedFromUpgrade = fromUpgrade
 
         let view = LoginLandingView(coordinator: coordinator)
-        let controller = LoginLandingHostingController(rootView: view.setupDefaultEnvironment(),
-                                                       coordinator: coordinator)
+        let controller = LoginLandingHostingController(rootView: view.setupDefaultEnvironment())
+        controller.viewModel = coordinator
 
         let navController = navigationController ?? UINavigationController(rootViewController: controller)
         coordinator.navigationController = navController

--- a/podcasts/Onboarding/LoginCoordinator.swift
+++ b/podcasts/Onboarding/LoginCoordinator.swift
@@ -102,7 +102,10 @@ extension LoginCoordinator: SyncSigninDelegate, CreateAccountDelegate {
     }
 
     private func goToPlus(from source: PlusLandingViewModel.Source) {
-        let controller = PlusLandingViewModel.make(in: navigationController, from: source, continueUpgrade: presentedFromUpgrade, upgradeSource: "login")
+        // Update the flow to make sure the correct analytics source is passed on
+        OnboardingFlow.shared.updateAnalyticsSource(source == .login ? "login" : "account_created")
+
+        let controller = PlusLandingViewModel.make(in: navigationController, from: source, continueUpgrade: presentedFromUpgrade)
         navigationController?.setViewControllers([controller], animated: true)
     }
 }

--- a/podcasts/Onboarding/Models/PlusAccountPromptViewModel.swift
+++ b/podcasts/Onboarding/Models/PlusAccountPromptViewModel.swift
@@ -2,6 +2,7 @@ import UIKit
 
 class PlusAccountPromptViewModel: PlusPricingInfoModel {
     weak var parentController: UIViewController? = nil
+    var source: Source = .unknown
 
     func upgradeTapped() {
         loadPrices {
@@ -15,12 +16,19 @@ class PlusAccountPromptViewModel: PlusPricingInfoModel {
             }
         }
     }
+
+    enum Source: String {
+        case unknown
+        case accountDetails = "account_details"
+        case plusDetails = "plus_details"
+    }
 }
 
 private extension PlusAccountPromptViewModel {
     func showModal() {
         guard let parentController else { return }
-        let controller = OnboardingFlow.shared.begin(flow: .plusAccountUpgrade, in: parentController, source: "account_details")
+        let controller = OnboardingFlow.shared.begin(flow: .plusAccountUpgrade, in: parentController, source: source.rawValue)
+
         controller.presentModally(in: parentController)
     }
 

--- a/podcasts/Onboarding/Models/PlusAccountPromptViewModel.swift
+++ b/podcasts/Onboarding/Models/PlusAccountPromptViewModel.swift
@@ -20,7 +20,7 @@ class PlusAccountPromptViewModel: PlusPricingInfoModel {
 private extension PlusAccountPromptViewModel {
     func showModal() {
         guard let parentController else { return }
-        let controller = OnboardingFlow.shared.begin(flow: .plusAccountUpgrade, in: parentController)
+        let controller = OnboardingFlow.shared.begin(flow: .plusAccountUpgrade, in: parentController, source: "account_details")
         controller.presentModally(in: parentController)
     }
 

--- a/podcasts/Onboarding/Models/PlusAccountPromptViewModel.swift
+++ b/podcasts/Onboarding/Models/PlusAccountPromptViewModel.swift
@@ -20,7 +20,7 @@ class PlusAccountPromptViewModel: PlusPricingInfoModel {
 private extension PlusAccountPromptViewModel {
     func showModal() {
         guard let parentController else { return }
-        let controller = PlusPurchaseModel.make(in: parentController)
+        let controller = OnboardingFlow.shared.begin(flow: .plusAccountUpgrade, in: parentController)
         controller.presentModally(in: parentController)
     }
 

--- a/podcasts/Onboarding/Models/PlusPurchaseModel.swift
+++ b/podcasts/Onboarding/Models/PlusPurchaseModel.swift
@@ -21,6 +21,8 @@ class PlusPurchaseModel: PlusPricingInfoModel, OnboardingModel {
     }
 
     func didDismiss(type: OnboardingDismissType) {
+        guard state != .purchasing else { return }
+
         Analytics.track(.selectPaymentFrequencyDismissed)
     }
 

--- a/podcasts/Onboarding/Models/PlusPurchaseModel.swift
+++ b/podcasts/Onboarding/Models/PlusPurchaseModel.swift
@@ -17,13 +17,13 @@ class PlusPurchaseModel: PlusPricingInfoModel, OnboardingModel {
     }
 
     func didAppear() {
-        Analytics.track(.selectPaymentFrequencyShown)
+        OnboardingFlow.shared.track(.selectPaymentFrequencyShown)
     }
 
     func didDismiss(type: OnboardingDismissType) {
         guard state != .purchasing else { return }
 
-        Analytics.track(.selectPaymentFrequencyDismissed)
+        OnboardingFlow.shared.track(.selectPaymentFrequencyDismissed)
     }
 
     // MARK: - Triggers the purchase process
@@ -33,7 +33,7 @@ class PlusPurchaseModel: PlusPricingInfoModel, OnboardingModel {
             return
         }
 
-        Analytics.track(.selectPaymentFrequencyNextButtonTapped, properties: ["product": product.rawValue])
+        OnboardingFlow.shared.track(.selectPaymentFrequencyNextButtonTapped, properties: ["product": product.rawValue])
 
         purchasedProduct = product
         state = .purchasing
@@ -51,7 +51,7 @@ class PlusPurchaseModel: PlusPricingInfoModel, OnboardingModel {
 }
 
 extension PlusPurchaseModel {
-    static func make(in parentController: UIViewController) -> UIViewController {
+    static func make(in parentController: UIViewController?) -> UIViewController {
         let viewModel = PlusPurchaseModel()
         viewModel.parentController = parentController
 

--- a/podcasts/Onboarding/Models/PlusPurchaseModel.swift
+++ b/podcasts/Onboarding/Models/PlusPurchaseModel.swift
@@ -63,7 +63,6 @@ extension PlusPurchaseModel {
         let backgroundColor = UIColor(hex: PlusPurchaseModal.Config.backgroundColorHex)
         let modal = PlusPurchaseModal(coordinator: viewModel).setupDefaultEnvironment()
         let controller = OnboardingModalHostingViewController(rootView: modal, backgroundColor: backgroundColor)
-        controller.parentController = parentController
         controller.viewModel = viewModel
 
         return controller

--- a/podcasts/Onboarding/Models/PlusPurchaseModel.swift
+++ b/podcasts/Onboarding/Models/PlusPurchaseModel.swift
@@ -106,23 +106,16 @@ private extension PlusPurchaseModel {
     private func handleNext() {
         guard let parentController else { return }
 
-        let viewModel = WelcomeViewModel(displayType: .plus)
-        let controller = OnboardingHostingViewController(rootView: WelcomeView(viewModel: viewModel).setupDefaultEnvironment())
-        controller.navBarIsHidden = true
+        let controller = WelcomeViewModel.make(in: parentController as? UINavigationController, displayType: .plus)
 
         // Create a view controller to present the view in
         guard let navigationController = parentController as? UINavigationController else {
-            let navigationController = UINavigationController(rootViewController: controller)
-            viewModel.navigationController = navigationController
-
             parentController.dismiss(animated: true, completion: {
-                parentController.present(navigationController, animated: true)
+                parentController.present(controller, animated: true)
             })
             return
         }
 
-        // Show the welcome view inside the existing nav controller
-        viewModel.navigationController = navigationController
         navigationController.dismiss(animated: true, completion: {
             navigationController.setViewControllers([controller], animated: true)
         })

--- a/podcasts/Onboarding/OnboardingFlow.swift
+++ b/podcasts/Onboarding/OnboardingFlow.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+struct OnboardingFlow {
+    static var shared = OnboardingFlow()
+
+    var currentFlow: Flow = .none
+
+    mutating func begin(flow: Flow, in controller: UIViewController? = nil, source: String? = nil) -> UIViewController {
+        let navigationController = controller as? UINavigationController
+
+        let flowController: UIViewController
+        switch flow {
+        case .plusUpsell:
+            flowController = PlusLandingViewModel.make(in: navigationController, from: .upsell, upgradeSource: source)
+
+        case .plusAccountUpgrade:
+            flowController = PlusPurchaseModel.make(in: controller)
+
+        case .plusAccountUpgradeNeedsLogin:
+            flowController = LoginCoordinator.make(in: navigationController, fromUpgrade: true)
+
+        case .initialOnboarding, .loggedOut: fallthrough
+        default:
+            flowController = LoginCoordinator.make(in: navigationController)
+        }
+
+        currentFlow = flow
+
+        return flowController
+    }
+
+    func track(_ event: AnalyticsEvent, properties: [String: Any]? = nil) {
+        let defaultProperties: [String: Any] = ["flow": currentFlow]
+        let mergedProperties = defaultProperties.merging(properties ?? [:]) { current, _ in current }
+        Analytics.track(event, properties: mergedProperties)
+    }
+
+    // MARK: - Flow
+    enum Flow: String, AnalyticsDescribable {
+        /// Default state / not currently in a flow.. not tracked
+        case none
+
+        /// When the app first launches, and the user is asked to login/create account
+        case initialOnboarding = "initial_onboarding"
+
+        /// When the user taps on a locked feature or upsell dialog and is brought to the plus landing view
+        case plusUpsell = "plus_upsell"
+
+        /// When the user taps on an upgrade button and is brought directly to the purchase modal
+        /// From account details and plus details
+        case plusAccountUpgrade = "plus_account_upgrade"
+
+        /// When the user taps on an upgrade button but is logged out and needs to login
+        /// They are presented with the login first, then the modal
+        case plusAccountUpgradeNeedsLogin = "plus_account_upgrade_needs_login"
+
+        /// When the user is logged out and enters the login flow
+        /// This is the same as the onboarding flow
+        case loggedOut = "logged_out"
+
+        var analyticsDescription: String { rawValue }
+    }
+}

--- a/podcasts/Onboarding/OnboardingFlow.swift
+++ b/podcasts/Onboarding/OnboardingFlow.swift
@@ -3,7 +3,8 @@ import Foundation
 struct OnboardingFlow {
     static var shared = OnboardingFlow()
 
-    var currentFlow: Flow = .none
+    private var currentFlow: Flow = .none
+    private var source: String? = nil
 
     mutating func begin(flow: Flow, in controller: UIViewController? = nil, source: String? = nil) -> UIViewController {
         let navigationController = controller as? UINavigationController
@@ -27,6 +28,10 @@ struct OnboardingFlow {
         currentFlow = flow
 
         return flowController
+    }
+
+    mutating func reset() {
+        currentFlow = .none
     }
 
     func track(_ event: AnalyticsEvent, properties: [String: Any]? = nil) {

--- a/podcasts/Onboarding/OnboardingFlow.swift
+++ b/podcasts/Onboarding/OnboardingFlow.swift
@@ -17,7 +17,7 @@ struct OnboardingFlow {
         case .plusUpsell:
             // Only the upsell flow needs an unknown source
             self.source = source ?? "unknown"
-            flowController = PlusLandingViewModel.make(in: navigationController, from: .upsell, upgradeSource: source)
+            flowController = PlusLandingViewModel.make(in: navigationController, from: .upsell)
 
         case .plusAccountUpgrade:
             flowController = PlusPurchaseModel.make(in: controller)
@@ -33,15 +33,22 @@ struct OnboardingFlow {
         return flowController
     }
 
+    /// Resets the internal flow state to none and clears any analytics sources
     mutating func reset() {
         source = nil
         currentFlow = .none
     }
 
+    /// Updates the source passed for analytics
+    /// Any `track` events will use this new source
+    mutating func updateAnalyticsSource(_ source: String) {
+        self.source = source
+    }
+
     func track(_ event: AnalyticsEvent, properties: [String: Any]? = nil) {
         var defaultProperties: [String: Any] = ["flow": currentFlow]
 
-        // Append the source, only if it's set
+        // Append the source, only if it's set because not every event needs a source
         if let source {
             defaultProperties["source"] = source
         }

--- a/podcasts/Onboarding/OnboardingHostingViewController.swift
+++ b/podcasts/Onboarding/OnboardingHostingViewController.swift
@@ -1,9 +1,11 @@
 import Foundation
 import SwiftUI
 
-class OnboardingHostingViewController<Content>: UIHostingController<Content> where Content: View {
+class OnboardingHostingViewController<Content>: UIHostingController<Content>, UIAdaptivePresentationControllerDelegate where Content: View {
     var navBarIsHidden: Bool = false
     var iconTintColor: UIColor = AppTheme.colorForStyle(.primaryIcon01)
+
+    var viewModel: OnboardingModel?
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
@@ -12,6 +14,11 @@ class OnboardingHostingViewController<Content>: UIHostingController<Content> whe
         navigationController?.navigationBar.isHidden = navBarIsHidden
         navigationController?.navigationBar.tintColor = iconTintColor
         navigationItem.backButtonDisplayMode = .minimal
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        viewModel?.didAppear()
     }
 
     override func viewDidLoad() {

--- a/podcasts/Onboarding/OnboardingHostingViewController.swift
+++ b/podcasts/Onboarding/OnboardingHostingViewController.swift
@@ -27,7 +27,7 @@ class OnboardingHostingViewController<Content>: UIHostingController<Content>, UI
         guard controller.isBeingDismissed else { return }
 
         DispatchQueue.main.async {
-            OnboardingFlow.shared.currentFlow = .none
+            OnboardingFlow.shared.reset()
         }
     }
 

--- a/podcasts/Onboarding/OnboardingHostingViewController.swift
+++ b/podcasts/Onboarding/OnboardingHostingViewController.swift
@@ -23,6 +23,8 @@ class OnboardingHostingViewController<Content>: UIHostingController<Content>, UI
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        presentationController?.delegate = self
+        navigationController?.presentationController?.delegate = self
         updateNavigationBarStyle(animated: false)
 
         navigationItem.backButtonDisplayMode = .minimal
@@ -61,5 +63,9 @@ class OnboardingHostingViewController<Content>: UIHostingController<Content>, UI
 
         barAppearance.backIndicatorImage = image
         barAppearance.backIndicatorTransitionMaskImage = image
+    }
+
+    func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+        viewModel?.didDismiss()
     }
 }

--- a/podcasts/Onboarding/OnboardingHostingViewController.swift
+++ b/podcasts/Onboarding/OnboardingHostingViewController.swift
@@ -33,6 +33,12 @@ class OnboardingHostingViewController<Content>: UIHostingController<Content>, UI
         NotificationCenter.default.addObserver(self, selector: #selector(themeDidChange), name: Constants.Notifications.themeChanged, object: nil)
     }
 
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+
+        viewModel?.didDismiss(type: .viewDisappearing)
+    }
+
     @objc func themeDidChange() {
         updateNavigationBarStyle(animated: false)
     }
@@ -66,6 +72,21 @@ class OnboardingHostingViewController<Content>: UIHostingController<Content>, UI
     }
 
     func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
-        viewModel?.didDismiss()
+        viewModel?.didDismiss(type: .swipe)
+    }
+}
+
+class OnboardingModalHostingViewController<Content>: MDCSwiftUIWrapper<Content> where Content: View {
+    var viewModel: OnboardingModel?
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        viewModel?.didAppear()
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+
+        viewModel?.didDismiss(type: .viewDisappearing)
     }
 }

--- a/podcasts/Onboarding/OnboardingHostingViewController.swift
+++ b/podcasts/Onboarding/OnboardingHostingViewController.swift
@@ -21,6 +21,16 @@ class OnboardingHostingViewController<Content>: UIHostingController<Content>, UI
         viewModel?.didAppear()
     }
 
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        let controller = navigationController ?? self
+        guard controller.isBeingDismissed else { return }
+
+        DispatchQueue.main.async {
+            OnboardingFlow.shared.currentFlow = .none
+        }
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
         presentationController?.delegate = self

--- a/podcasts/Onboarding/OnboardingModel.swift
+++ b/podcasts/Onboarding/OnboardingModel.swift
@@ -2,5 +2,10 @@ import Foundation
 
 protocol OnboardingModel {
     func didAppear()
-    func didDismiss()
+    func didDismiss(type: OnboardingDismissType)
+}
+
+enum OnboardingDismissType {
+    case viewDisappearing
+    case swipe
 }

--- a/podcasts/Onboarding/OnboardingModel.swift
+++ b/podcasts/Onboarding/OnboardingModel.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+protocol OnboardingModel {
+    func didAppear()
+    func didDismiss()
+}

--- a/podcasts/Onboarding/Plus/Account Prompt/PlusAccountPromptTableCell.swift
+++ b/podcasts/Onboarding/Plus/Account Prompt/PlusAccountPromptTableCell.swift
@@ -29,6 +29,7 @@ class PlusAccountPromptTableCell: ThemeableCell {
     // Update the model's parent so we can present the modal
     func updateParent(_ controller: UIViewController) {
         model.parentController = controller
+        model.source = .accountDetails
     }
 
     required init?(coder: NSCoder) {

--- a/podcasts/Onboarding/Plus/PlusHostingViewController.swift
+++ b/podcasts/Onboarding/Plus/PlusHostingViewController.swift
@@ -2,8 +2,6 @@ import Foundation
 import SwiftUI
 
 class PlusHostingViewController<Content>: OnboardingHostingViewController<Content> where Content: View {
-    var viewModel: PlusLandingViewModel?
-
     override func viewDidLoad() {
         super.viewDidLoad()
         navigationController?.navigationBar.tintColor = .white
@@ -19,8 +17,4 @@ class PlusHostingViewController<Content>: OnboardingHostingViewController<Conten
         navigationController?.navigationBar.tintColor = iconTintColor
     }
 
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        viewModel?.didAppear()
-    }
 }

--- a/podcasts/Onboarding/Plus/PlusLandingViewModel.swift
+++ b/podcasts/Onboarding/Plus/PlusLandingViewModel.swift
@@ -7,6 +7,7 @@ class PlusLandingViewModel: PlusPricingInfoModel, OnboardingModel {
 
     var continueUpgrade: Bool
     let source: Source
+    var upgradeSource: String? = nil
 
     init(source: Source, continueUpgrade: Bool = false, purchaseHandler: IapHelper = .shared) {
         self.continueUpgrade = continueUpgrade
@@ -16,7 +17,7 @@ class PlusLandingViewModel: PlusPricingInfoModel, OnboardingModel {
     }
 
     func unlockTapped() {
-        Analytics.shared.track(.onboardingUpgradeUnlockAllFeaturesTapped)
+        OnboardingFlow.shared.track(.plusPromotionUpgradeButtonTapped, properties: ["source": upgradeSource ?? "unknown"])
 
         guard SyncManager.isUserLoggedIn() else {
             let controller = LoginCoordinator.make(in: navigationController, fromUpgrade: true)
@@ -28,7 +29,7 @@ class PlusLandingViewModel: PlusPricingInfoModel, OnboardingModel {
     }
 
     func didAppear() {
-        Analytics.shared.track(.onboardingUpgradeShown)
+        OnboardingFlow.shared.track(.plusPromotionShown, properties: ["source": upgradeSource ?? "unknown"])
 
         guard continueUpgrade else { return }
 
@@ -41,11 +42,11 @@ class PlusLandingViewModel: PlusPricingInfoModel, OnboardingModel {
     func didDismiss(type: OnboardingDismissType) {
         guard type == .swipe else { return }
 
-        Analytics.shared.track(.onboardingUpgradeDismissed)
+        OnboardingFlow.shared.track(.plusPromotionDismissed, properties: ["source": upgradeSource ?? "unknown"])
     }
 
     func dismissTapped() {
-        Analytics.shared.track(.onboardingUpgradeNotNowTapped)
+        OnboardingFlow.shared.track(.plusPromotionDismissed, properties: ["source": upgradeSource ?? "unknown"])
 
         guard source == .accountCreated else {
             navigationController?.dismiss(animated: true)
@@ -90,8 +91,10 @@ private extension PlusLandingViewModel {
 }
 
 extension PlusLandingViewModel {
-    static func make(in navigationController: UINavigationController? = nil, from source: Source, continueUpgrade: Bool = false) -> UIViewController {
+    static func make(in navigationController: UINavigationController? = nil, from source: Source, continueUpgrade: Bool = false, upgradeSource: String?) -> UIViewController {
         let viewModel = PlusLandingViewModel(source: source, continueUpgrade: continueUpgrade)
+        viewModel.upgradeSource = upgradeSource
+
         let view = PlusLandingView(viewModel: viewModel)
         let controller = PlusHostingViewController(rootView: view.setupDefaultEnvironment())
         controller.viewModel = viewModel

--- a/podcasts/Onboarding/Plus/PlusLandingViewModel.swift
+++ b/podcasts/Onboarding/Plus/PlusLandingViewModel.swift
@@ -7,7 +7,6 @@ class PlusLandingViewModel: PlusPricingInfoModel, OnboardingModel {
 
     var continueUpgrade: Bool
     let source: Source
-    var upgradeSource: String? = nil
 
     init(source: Source, continueUpgrade: Bool = false, purchaseHandler: IapHelper = .shared) {
         self.continueUpgrade = continueUpgrade
@@ -17,7 +16,7 @@ class PlusLandingViewModel: PlusPricingInfoModel, OnboardingModel {
     }
 
     func unlockTapped() {
-        OnboardingFlow.shared.track(.plusPromotionUpgradeButtonTapped, properties: ["source": upgradeSource ?? "unknown"])
+        OnboardingFlow.shared.track(.plusPromotionUpgradeButtonTapped)
 
         guard SyncManager.isUserLoggedIn() else {
             let controller = LoginCoordinator.make(in: navigationController, fromUpgrade: true)
@@ -29,7 +28,7 @@ class PlusLandingViewModel: PlusPricingInfoModel, OnboardingModel {
     }
 
     func didAppear() {
-        OnboardingFlow.shared.track(.plusPromotionShown, properties: ["source": upgradeSource ?? "unknown"])
+        OnboardingFlow.shared.track(.plusPromotionShown)
 
         guard continueUpgrade else { return }
 
@@ -42,11 +41,11 @@ class PlusLandingViewModel: PlusPricingInfoModel, OnboardingModel {
     func didDismiss(type: OnboardingDismissType) {
         guard type == .swipe else { return }
 
-        OnboardingFlow.shared.track(.plusPromotionDismissed, properties: ["source": upgradeSource ?? "unknown"])
+        OnboardingFlow.shared.track(.plusPromotionDismissed)
     }
 
     func dismissTapped() {
-        OnboardingFlow.shared.track(.plusPromotionDismissed, properties: ["source": upgradeSource ?? "unknown"])
+        OnboardingFlow.shared.track(.plusPromotionDismissed)
 
         guard source == .accountCreated else {
             navigationController?.dismiss(animated: true)
@@ -91,9 +90,8 @@ private extension PlusLandingViewModel {
 }
 
 extension PlusLandingViewModel {
-    static func make(in navigationController: UINavigationController? = nil, from source: Source, continueUpgrade: Bool = false, upgradeSource: String?) -> UIViewController {
+    static func make(in navigationController: UINavigationController? = nil, from source: Source, continueUpgrade: Bool = false) -> UIViewController {
         let viewModel = PlusLandingViewModel(source: source, continueUpgrade: continueUpgrade)
-        viewModel.upgradeSource = upgradeSource
 
         let view = PlusLandingView(viewModel: viewModel)
         let controller = PlusHostingViewController(rootView: view.setupDefaultEnvironment())

--- a/podcasts/Onboarding/Plus/PlusLandingViewModel.swift
+++ b/podcasts/Onboarding/Plus/PlusLandingViewModel.swift
@@ -2,7 +2,7 @@ import Foundation
 import PocketCastsServer
 import SwiftUI
 
-class PlusLandingViewModel: PlusPricingInfoModel {
+class PlusLandingViewModel: PlusPricingInfoModel, OnboardingModel {
     var navigationController: UINavigationController? = nil
 
     var continueUpgrade: Bool
@@ -13,9 +13,13 @@ class PlusLandingViewModel: PlusPricingInfoModel {
         self.source = source
 
         super.init(purchaseHandler: purchaseHandler)
+
+        Analytics.shared.track(.onboardingUpgradeShown)
     }
 
     func unlockTapped() {
+        Analytics.shared.track(.onboardingUpgradeUnlockAllFeaturesTapped)
+
         guard SyncManager.isUserLoggedIn() else {
             let controller = LoginCoordinator.make(in: navigationController, fromUpgrade: true)
             navigationController?.pushViewController(controller, animated: true)
@@ -34,7 +38,13 @@ class PlusLandingViewModel: PlusPricingInfoModel {
         self.loadPricesAndContinue()
     }
 
+    func didDismiss() {
+        Analytics.shared.track(.onboardingUpgradeDismissed)
+    }
+
     func dismissTapped() {
+        Analytics.shared.track(.onboardingUpgradeNotNowTapped)
+
         guard source == .accountCreated else {
             navigationController?.dismiss(animated: true)
             return

--- a/podcasts/Onboarding/Plus/PlusLandingViewModel.swift
+++ b/podcasts/Onboarding/Plus/PlusLandingViewModel.swift
@@ -13,8 +13,6 @@ class PlusLandingViewModel: PlusPricingInfoModel, OnboardingModel {
         self.source = source
 
         super.init(purchaseHandler: purchaseHandler)
-
-        Analytics.shared.track(.onboardingUpgradeShown)
     }
 
     func unlockTapped() {
@@ -30,6 +28,8 @@ class PlusLandingViewModel: PlusPricingInfoModel, OnboardingModel {
     }
 
     func didAppear() {
+        Analytics.shared.track(.onboardingUpgradeShown)
+
         guard continueUpgrade else { return }
 
         // Don't continually show when the user dismisses
@@ -38,7 +38,9 @@ class PlusLandingViewModel: PlusPricingInfoModel, OnboardingModel {
         self.loadPricesAndContinue()
     }
 
-    func didDismiss() {
+    func didDismiss(type: OnboardingDismissType) {
+        guard type == .swipe else { return }
+
         Analytics.shared.track(.onboardingUpgradeDismissed)
     }
 

--- a/podcasts/Onboarding/Welcome/WelcomeViewModel.swift
+++ b/podcasts/Onboarding/Welcome/WelcomeViewModel.swift
@@ -30,9 +30,7 @@ class WelcomeViewModel: ObservableObject, OnboardingModel {
         switch section {
         case .importPodcasts:
             track(.welcomeImportTapped)
-            let viewModel = ImportViewModel()
-            let controller = OnboardingHostingViewController(rootView: ImportLandingView(viewModel: viewModel).setupDefaultEnvironment())
-            viewModel.navigationController = navigationController
+            let controller = ImportViewModel.make(in: navigationController)
             navigationController?.pushViewController(controller, animated: true)
 
         case .discover:
@@ -54,6 +52,7 @@ class WelcomeViewModel: ObservableObject, OnboardingModel {
         case .newAccount: source = "welcome_new_account"
         case .plus: source = "welcome_plus"
         }
+
         Analytics.track(.newsletterOptInChanged, properties: ["enabled": newsletterOptIn, "source": source])
         ServerSettings.setMarketingOptIn(newsletterOptIn)
     }

--- a/podcasts/Onboarding/Welcome/WelcomeViewModel.swift
+++ b/podcasts/Onboarding/Welcome/WelcomeViewModel.swift
@@ -91,6 +91,6 @@ extension WelcomeViewModel {
 
 private extension WelcomeViewModel {
     func track(_ event: AnalyticsEvent) {
-        Analytics.track(event, properties: ["display_type": displayType])
+        OnboardingFlow.shared.track(event, properties: ["display_type": displayType])
     }
 }

--- a/podcasts/Onboarding/Welcome/WelcomeViewModel.swift
+++ b/podcasts/Onboarding/Welcome/WelcomeViewModel.swift
@@ -2,7 +2,7 @@ import Foundation
 import SwiftUI
 import PocketCastsServer
 
-class WelcomeViewModel: ObservableObject {
+class WelcomeViewModel: ObservableObject, OnboardingModel {
     var navigationController: UINavigationController?
     let displayType: DisplayType
     let sections: [WelcomeSection] = [.importPodcasts, .discover]
@@ -14,17 +14,29 @@ class WelcomeViewModel: ObservableObject {
         self.displayType = displayType
     }
 
+    func didAppear() {
+        track(.welcomeShown)
+    }
+
+    func didDismiss(type: OnboardingDismissType) {
+        guard type == .swipe else { return }
+
+        track(.welcomeDismissed)
+    }
+
     func sectionTapped(_ section: WelcomeSection) {
         saveNewsletterOptIn()
 
         switch section {
         case .importPodcasts:
+            track(.welcomeImportTapped)
             let viewModel = ImportViewModel()
             let controller = OnboardingHostingViewController(rootView: ImportLandingView(viewModel: viewModel).setupDefaultEnvironment())
             viewModel.navigationController = navigationController
             navigationController?.pushViewController(controller, animated: true)
 
         case .discover:
+            track(.welcomeDiscoverTapped)
             navigationController?.dismiss(animated: true)
             NavigationManager.sharedManager.navigateTo(NavigationManager.discoverPageKey, data: nil)
         }
@@ -32,18 +44,26 @@ class WelcomeViewModel: ObservableObject {
 
     func doneTapped() {
         saveNewsletterOptIn()
+        track(.welcomeDismissed)
         navigationController?.dismiss(animated: true)
     }
 
     private func saveNewsletterOptIn() {
-        Analytics.track(.newsletterOptInChanged, properties: ["enabled": newsletterOptIn, "source": "account_updated"])
+        let source: String
+        switch displayType {
+        case .newAccount: source = "welcome_new_account"
+        case .plus: source = "welcome_plus"
+        }
+        Analytics.track(.newsletterOptInChanged, properties: ["enabled": newsletterOptIn, "source": source])
         ServerSettings.setMarketingOptIn(newsletterOptIn)
     }
 
     // MARK: - Configuration
-    enum DisplayType {
+    enum DisplayType: String, AnalyticsDescribable {
         case plus
-        case newAccount
+        case newAccount = "created_account"
+
+        var analyticsDescription: String { rawValue }
     }
 
     enum WelcomeSection: Int, Identifiable {
@@ -57,14 +77,21 @@ class WelcomeViewModel: ObservableObject {
 extension WelcomeViewModel {
     static func make(in navigationController: UINavigationController? = nil, displayType: DisplayType) -> UIViewController {
         let viewModel = WelcomeViewModel(displayType: displayType)
-        viewModel.navigationController = navigationController
+
         let controller = OnboardingHostingViewController(rootView: WelcomeView(viewModel: viewModel).setupDefaultEnvironment())
         controller.navBarIsHidden = true
 
         // Create our own nav controller if we're not already going in one
         let navController = navigationController ?? UINavigationController(rootViewController: controller)
         viewModel.navigationController = navController
+        controller.viewModel = viewModel
 
         return (navigationController == nil) ? navController : controller
+    }
+}
+
+private extension WelcomeViewModel {
+    func track(_ event: AnalyticsEvent) {
+        Analytics.track(event, properties: ["display_type": displayType])
     }
 }

--- a/podcasts/PlusDetailsViewController.swift
+++ b/podcasts/PlusDetailsViewController.swift
@@ -145,9 +145,10 @@ class PlusDetailsViewController: PCViewController {
     private func handleUpgrade() {
         if SyncManager.isUserLoggedIn() {
             let model = PlusAccountPromptViewModel()
+            model.parentController = self
             model.upgradeTapped()
         } else {
-            present(LoginCoordinator.make(fromUpgrade: true), animated: true)
+            present(OnboardingFlow.shared.begin(flow: .plusAccountUpgradeNeedsLogin), animated: true)
         }
 
         Analytics.track(.settingsPlusUpgradeButtonTapped)

--- a/podcasts/PlusDetailsViewController.swift
+++ b/podcasts/PlusDetailsViewController.swift
@@ -148,7 +148,7 @@ class PlusDetailsViewController: PCViewController {
             model.parentController = self
             model.upgradeTapped()
         } else {
-            present(OnboardingFlow.shared.begin(flow: .plusAccountUpgradeNeedsLogin), animated: true)
+            present(OnboardingFlow.shared.begin(flow: .plusAccountUpgradeNeedsLogin, source: "plus_details"), animated: true)
         }
 
         Analytics.track(.settingsPlusUpgradeButtonTapped)

--- a/podcasts/PlusDetailsViewController.swift
+++ b/podcasts/PlusDetailsViewController.swift
@@ -143,12 +143,14 @@ class PlusDetailsViewController: PCViewController {
     }
 
     private func handleUpgrade() {
+        let source = PlusAccountPromptViewModel.Source.plusDetails
         if SyncManager.isUserLoggedIn() {
             let model = PlusAccountPromptViewModel()
             model.parentController = self
+            model.source = source
             model.upgradeTapped()
         } else {
-            present(OnboardingFlow.shared.begin(flow: .plusAccountUpgradeNeedsLogin, source: "plus_details"), animated: true)
+            present(OnboardingFlow.shared.begin(flow: .plusAccountUpgradeNeedsLogin, source: source.rawValue), animated: true)
         }
 
         Analytics.track(.settingsPlusUpgradeButtonTapped)

--- a/podcasts/ProfileViewController.swift
+++ b/podcasts/ProfileViewController.swift
@@ -223,8 +223,7 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
 
     func showProfileSetupController() {
         if FeatureFlag.onboardingUpdates {
-            NavigationManager.sharedManager.navigateTo(NavigationManager.onboardingFlow, data: nil)
-
+            NavigationManager.sharedManager.navigateTo(NavigationManager.onboardingFlow, data: ["flow": OnboardingFlow.Flow.loggedOut])
             return
         }
 


### PR DESCRIPTION
| 📘 Project: #500 | 🛫 Depends on: #541 |
|:---:|:---:|


This adds the analytics for the onboarding flow. This reuses whichever existing events we have for the similar views. 

Since the "onboarding" flow isn't just 1 singular thing, and can be entered from a variety of different places, I have added an OnboardingFlow struct that helps keep track of which flow we're in and appends that to the events. 

The flows that I have defined so far are:
- `initial_onboarding`: When the app first launches, and the user is asked to login/create account
- `plus_upsell`: When the user taps on a locked feature or upsell dialog and is brought to the plus landing view
- `plus_account_upgrade`: When the user taps on an upgrade button and is brought directly to the purchase modal
- `plus_account_upgrade_needs_login`: When the user taps on an upgrade button but is logged out and needs to login, They are presented with the login first, then the modal
- `logged_out`: When the user is logged out and enters the login flow, this flow is the same as the onboarding flow

Each of these flows have their own potential sub-flows such as pushing to the login from the landing or skipping steps. 

## To test
1. Enable the onboardingUpdates and tracksLogging FeatureFlags
2. Add `Settings.shouldShowInitialOnboardingFlow = true` to the AppDelegate `didFinishLaunchingWithOptions`

**Enable local IAP purchasing using StoreKit**
1. Open the Xcode Project
3. Hit <kbd>Command</kbd>+<kbd>Shift</kbd>+<kbd>,</kbd> to open the Scheme editor
4. Click the options tab
5. Select the `Pocket Casts Configuration.storekit` file in the StoreKit configuration dropdown


### Initial Onboarding
1. Launch the app
2. ✅ Verify you see the login view
4. ✅ Verify you see: `🔵 Tracked: setup_account_shown ["flow": "initial_onboarding"]`
5. Tap the Not Now button
6. ✅ `🔵 Tracked: setup_account_dismissed ["flow": "initial_onboarding"]`
7. Relaunch the app
8. Swipe down to dismiss the view
9. ✅ `🔵 Tracked: setup_account_dismissed ["flow": "initial_onboarding"]`
10. Relaunch the app
11. Tap on the Sign Up button
12. ✅ `🔵 Tracked: setup_account_button_tapped ["flow": "initial_onboarding", "button": "create_account"]`
13. Tap back
14. Tap on the Login Button
15. ✅ `🔵 Tracked: setup_account_button_tapped ["flow": "initial_onboarding", "button": "sign_in"]`
16. Login to an account without plus
17. After signing in a syncing
18. ✅ `🔵 Tracked: plus_promotion_shown ["flow": "initial_onboarding", "source": "login"]`
19. Tap the Unlock button
20. ✅ `🔵 Tracked: plus_promotion_upgrade_button_tapped ["flow": "initial_onboarding", "source": "login"]`
21. ✅ `🔵 Tracked: select_payment_frequency_shown ["flow": "initial_onboarding"]`
22. Dismiss the modal
23. ✅ `🔵 Tracked: select_payment_frequency_dismissed ["flow": "initial_onboarding"]`
24. Open it again
25. Tap on the subscribe button
26. ✅ `🔵 Tracked: select_payment_frequency_next_button_tapped ["product": "com.pocketcasts.plus.yearly", "flow": "initial_onboarding"]`
27. Subscribe
28. ✅ `🔵 Tracked: purchase_successful ["is_free_trial_available": false, "product": "com.pocketcasts.plus.yearly", "is_free_trial_eligible": BOOL]`
29. ✅ `🔵 Tracked: welcome_shown ["flow": "initial_onboarding", "display_type": "plus"]`
30. Tap the Import Podcasts option
31. ✅ `🔵 Tracked: welcome_import_tapped ["display_type": "plus", "flow": "initial_onboarding"]`
32. ✅ `🔵 Tracked: onboarding_import_shown ["flow": "initial_onboarding"]`
33. Tap on any app
34. ✅ `🔵 Tracked: onboarding_import_app_selected ["flow": "initial_onboarding", "app": "NAME OF APP YOU TAPPED"]`
35. Tap on the Open button
36. ✅ `🔵 Tracked: onboarding_import_open_app_tapped ["app": "NAME OF APP", "flow": "initial_onboarding"]`
37. Go back to the app
38. Go back to the welcome view
39. Tap the Discover button (find my next...)
40. ✅ `🔵 Tracked: welcome_discover_tapped ["flow": "initial_onboarding", "display_type": "plus"]`

### Plus Upsell
1. Sign into an account without plus
    - Or go to Profile > Cog > Developer > Set to No Plus
2. Go to the Podcasts tab
3. Tap on the Create Folder button
4. ✅ `🔵 Tracked: plus_promotion_shown ["flow": "plus_upsell", "source": "folders"]`
5. Proceed through the various parts of the flow as outlined above and ✅ verify the flow property is `plus_upsell`
6. Tap the various upsell buttons: Profile tab, Locked settings, etc
7. ✅ Verify the "source" appears correctly


### Plus Account Upgrade
1. Sign into an account without plus
2. Go to the Profile Tab
3. Tap on the Account Bubble
4. Tap Upgrade to Plus
5. ✅ `🔵 Tracked: select_payment_frequency_shown ["flow": "plus_account_upgrade", "source": "account_details"]`
6. Complete the purchase and verify flow is set to `plus_account_upgrade` and the `source` is `account_details`
7. Go to Profile Tab > Settings Cog > Plus item
8. Tap the Upgrade button
9. ✅ `🔵 Tracked: select_payment_frequency_shown ["flow": "plus_account_upgrade", "source": "plus_details"]`
10. Complete the purchase and verify flow is set to `plus_account_upgrade` and the `source` is `account_details`

### Plus Account Upgrade Needs Login
1. Sign out
2. Go to Profile Tab > Settings Cog > Plus item
3. Tap the Upgrade Button
4. ✅ Verify you see the login view
5. ✅ `🔵 Tracked: setup_account_shown ["flow": "plus_account_upgrade_needs_login"]`
6. Login to your account without plus
7. ✅ `🔵 Tracked: plus_promotion_shown ["flow": "plus_account_upgrade_needs_login", "source": "login"]`
8. ✅ Verify the purchase modal opens automatically
9. ✅ `🔵 Tracked: select_payment_frequency_shown ["flow": "plus_account_upgrade_needs_login"]`
11. Complete the rest of the steps and ✅ verify the flow is `plus_account_upgrade_needs_login`

### Logged Out
1. Launch the app
2. Dismiss the onboarding prompt
3. Go to the Profile tab
4. Tap the Set up account bubble
5. ✅ `🔵 Tracked: setup_account_shown ["flow": "logged_out"]`
6. Complete the rest of the steps and ✅ verify the flow is `logged_out`

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
