### PR TITLE
Lint `.strings` generation in CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,7 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/bash-cache#2.8.0
+    - automattic/bash-cache#2.12.0
     - automattic/git-s3-cache#v1.1.3:
         bucket: a8c-repo-mirrors
         repo: automattic/pocket-casts-ios/

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -21,8 +21,10 @@ steps:
     env: *common_env
     plugins: *common_plugins
 
-  - label: Lints via Danger
-    command: .buildkite/commands/danger.sh
-    agents: *common_agents
-    env: *common_env
-    plugins: *common_plugins
+  - group: Linters
+    steps:
+      - label: Lints via Danger
+        command: .buildkite/commands/danger.sh
+        agents: *common_agents
+        env: *common_env
+        plugins: *common_plugins

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -28,3 +28,8 @@ steps:
         agents: *common_agents
         env: *common_env
         plugins: *common_plugins
+
+      - label: ":sleuth_or_spy: Lint Localized Strings Format"
+        command: lint_localized_strings_format
+        plugins: *common_plugins
+        env: *common_env

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -496,10 +496,12 @@ platform :ios do
   # Generates the `.strings` file to be imported by GlotPress, by parsing source
   # code.
   #
+  # @option [Boolean] skip_commit (default: false) If true, does not commit the changes made to the `.strings` file.
+  #
   # @note Uses `genstrings` under the hood.
   # @called_by `complete_code_freeze`.
   #
-  lane :generate_strings_file_for_glotpress do
+  lane :generate_strings_file_for_glotpress do |options|
     # For reference: Other apps run `cocoapods` here (equivalent to `bundle
     # exec pod install`) because they have internal libraries that bring in
     # their own strings. Pocket Casts does not have dependencies with strings
@@ -526,6 +528,8 @@ platform :ios do
       paths_to_merge: MANUALLY_MAINTAINED_STRINGS_FILES,
       destination: FROZEN_STRINGS_PATH
     )
+
+    next if options.fetch(:skip_commit, false)
 
     git_commit(
       path: FROZEN_STRINGS_PATH,


### PR DESCRIPTION
Adds a CI steps that ensures the frozen `.strings` can be generated correctly. The idea is to get feedback on `.strings` issues as soon as possible, to avoid learning about them at code freeze time.

See also https://github.com/woocommerce/woocommerce-ios/pull/8214
## To test

See it in action in the happy path [here](https://buildkite.com/automattic/pocket-casts-ios/builds/2246#0184ad28-778e-483e-84ea-4c729cb8ab4e)

![image](https://user-images.githubusercontent.com/1218433/203909469-7f8500d7-33ee-4004-89d3-d457d0b5069c.png)

I don't know how to force a failure via this projects SwiftGen's setup, but you can see how the check catches an issue in this [Jetpack/WordPress iOS demo build](https://buildkite.com/automattic/wordpress-ios/builds/10908#01848e60-7644-4858-8b11-a2a72b2f84be):

![image](https://user-images.githubusercontent.com/1218433/203909571-76a8ab4f-ea69-40f0-8ad6-72dfbad2236d.png)

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary. – N.A.
- [x] I have considered adding unit tests for my changes. – N.A.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics. – N.A.