### PR TITLE
End of Year: Changs the end date to the end of December instead of the end of November

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 7.28
 -----
 - Updates the onboarding and login process: (#548)
+- Updates the end of year calculation to include the month of December (#554)
 
 7.27
 -----

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
@@ -13,7 +13,7 @@ class EndOfYearDataManager {
     private let endDate = "2023-01-01"
 
     private lazy var listenedEpisodesThisYear = """
-                                            lastPlaybackInteractionDate IS NOT NULL AND lastPlaybackInteractionDate BETWEEN strftime('%s', '2022-01-01') and strftime('%s', '\(endPeriod)')
+                                            lastPlaybackInteractionDate IS NOT NULL AND lastPlaybackInteractionDate BETWEEN strftime('%s', '\(startDate)') and strftime('%s', '\(endDate)')
                                            """
 
     /// If the user is eligible to see End of Year stats
@@ -62,7 +62,7 @@ class EndOfYearDataManager {
                 let query = """
                             SELECT * from \(DataManager.episodeTableName)
                             WHERE
-                            lastPlaybackInteractionDate IS NOT NULL AND lastPlaybackInteractionDate < strftime('%s', '2022-01-01')
+                            lastPlaybackInteractionDate IS NOT NULL AND lastPlaybackInteractionDate < strftime('%s', '\(startDate)')
                             LIMIT 1
                             """
                 let resultSet = try db.executeQuery(query, values: nil)

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
@@ -172,7 +172,7 @@ class EndOfYearDataManager {
     /// Return the number of podcasts and episodes listened
     ///
     func listenedNumbers(dbQueue: FMDatabaseQueue) -> ListenedNumbers {
-        var listenedNumbers: ListenedNumbers = ListenedNumbers(numberOfPodcasts: 0, numberOfEpisodes: 0)
+        var listenedNumbers = ListenedNumbers(numberOfPodcasts: 0, numberOfEpisodes: 0)
 
         dbQueue.inDatabase { db in
             do {
@@ -307,7 +307,6 @@ class EndOfYearDataManager {
             if resultSet.next() {
                 numberOfItemsInListeningHistory = Int(resultSet.int(forColumn: "total"))
             } else {
-
             }
         } catch {
             FileLog.shared.addMessage("EndOfYearDataManager.numberOfItemsInListeningHistory error: \(error)")
@@ -315,7 +314,6 @@ class EndOfYearDataManager {
 
         return numberOfItemsInListeningHistory
     }
-
 }
 
 public struct ListenedCategory {

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
@@ -3,10 +3,14 @@ import PocketCastsUtils
 
 /// Calculates user End of Year stats
 class EndOfYearDataManager {
-    private let endPeriod = "2022-12-01"
     /// The date to start calculating results from
     /// The data will start from 00:00:00 (midnight) the users device time
     private let startDate = "2022-01-01"
+
+    /// The date to stop including results from
+    /// This is set to the day after the final day we want to include in the results to make sure we include the full
+    /// day up to midnight
+    private let endDate = "2023-01-01"
 
     private lazy var listenedEpisodesThisYear = """
                                             lastPlaybackInteractionDate IS NOT NULL AND lastPlaybackInteractionDate BETWEEN strftime('%s', '2022-01-01') and strftime('%s', '\(endPeriod)')

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
@@ -4,6 +4,9 @@ import PocketCastsUtils
 /// Calculates user End of Year stats
 class EndOfYearDataManager {
     private let endPeriod = "2022-12-01"
+    /// The date to start calculating results from
+    /// The data will start from 00:00:00 (midnight) the users device time
+    private let startDate = "2022-01-01"
 
     private lazy var listenedEpisodesThisYear = """
                                             lastPlaybackInteractionDate IS NOT NULL AND lastPlaybackInteractionDate BETWEEN strftime('%s', '2022-01-01') and strftime('%s', '\(endPeriod)')


### PR DESCRIPTION
| 📘 Project: #376 |
|:---:|

This changes the End of year calculations so it will include the entire year of data instead of only calculating until the end of November.

## To test

1. Launch the release version of the app
2. Tap Profile > End Of Year card
3. Make note of your results (screenshots will probably help with this)
4. Build and run this PR
5. Tap Profile > End Of Year card
6. ✅ Verify the results returned are exactly the same

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
