### PR TITLE
End of Year: Hide the share button for the intro/epilogue views

### DIFF
--- a/PocketCastsTests/Tests/End of Year/StoriesModelTests.swift
+++ b/PocketCastsTests/Tests/End of Year/StoriesModelTests.swift
@@ -83,6 +83,10 @@ class MockStoriesDataSource: StoriesDataSource {
         }
     }
 
+    func shareableStory(for storyNumber: Int) -> (any ShareableStory)? {
+        nil
+    }
+
     func isReady() async -> Bool {
         true
     }

--- a/podcasts/End of Year/Stories/EndOfYearStoriesDataSource.swift
+++ b/podcasts/End of Year/Stories/EndOfYearStoriesDataSource.swift
@@ -33,6 +33,10 @@ class EndOfYearStoriesDataSource: StoriesDataSource {
         }
     }
 
+    func shareableStory(for storyNumber: Int) -> (any ShareableStory)? {
+        story(for: storyNumber) as? (any ShareableStory)
+    }
+
     /// The only interactive view we have is the last one, with the replay button
     func interactiveView(for storyNumber: Int) -> AnyView {
         switch stories[storyNumber] {

--- a/podcasts/End of Year/Stories/EpilogueStory.swift
+++ b/podcasts/End of Year/Stories/EpilogueStory.swift
@@ -74,17 +74,6 @@ struct EpilogueStory: StoryView {
     func onAppear() {
         Analytics.track(.endOfYearStoryShown, story: identifier)
     }
-
-    func willShare() {
-        Analytics.track(.endOfYearStoryShare, story: identifier)
-    }
-
-    func sharingAssets() -> [Any] {
-        [
-            StoryShareableProvider.new(AnyView(self)),
-            StoryShareableText("")
-        ]
-    }
 }
 
 struct ReplayButtonStyle: ButtonStyle {

--- a/podcasts/End of Year/Stories/IntroStory.swift
+++ b/podcasts/End of Year/Stories/IntroStory.swift
@@ -36,17 +36,6 @@ struct IntroStory: StoryView {
         Analytics.track(.endOfYearStoryShown, story: identifier)
     }
 
-    func willShare() {
-        Analytics.track(.endOfYearStoryShare, story: identifier)
-    }
-
-    func sharingAssets() -> [Any] {
-        [
-            StoryShareableProvider.new(AnyView(self)),
-            StoryShareableText("")
-        ]
-    }
-
     private struct Constants {
         static let imageVerticalPadding: CGFloat = 60
         static let imageHeightInPercentage: CGFloat = 0.54

--- a/podcasts/End of Year/Stories/ListenedCategoriesStory.swift
+++ b/podcasts/End of Year/Stories/ListenedCategoriesStory.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import PocketCastsServer
 import PocketCastsDataModel
 
-struct ListenedCategoriesStory: StoryView {
+struct ListenedCategoriesStory: ShareableStory {
     @Environment(\.renderForSharing) var renderForSharing: Bool
     var duration: TimeInterval = 5.seconds
 

--- a/podcasts/End of Year/Stories/ListenedNumbersStory.swift
+++ b/podcasts/End of Year/Stories/ListenedNumbersStory.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import PocketCastsServer
 import PocketCastsDataModel
 
-struct ListenedNumbersStory: StoryView {
+struct ListenedNumbersStory: ShareableStory {
     @Environment(\.renderForSharing) var renderForSharing: Bool
 
     var duration: TimeInterval = 5.seconds

--- a/podcasts/End of Year/Stories/ListeningTimeStory.swift
+++ b/podcasts/End of Year/Stories/ListeningTimeStory.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import PocketCastsServer
 import PocketCastsDataModel
 
-struct ListeningTimeStory: StoryView {
+struct ListeningTimeStory: ShareableStory {
     var duration: TimeInterval = 5.seconds
 
     let identifier: String = "listening_time"

--- a/podcasts/End of Year/Stories/LongestEpisodeStory.swift
+++ b/podcasts/End of Year/Stories/LongestEpisodeStory.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import PocketCastsServer
 import PocketCastsDataModel
 
-struct LongestEpisodeStory: StoryView {
+struct LongestEpisodeStory: ShareableStory {
     let duration: TimeInterval = 5.seconds
 
     var identifier: String = "longest_episode"

--- a/podcasts/End of Year/Stories/TopCategoriesStory/TopListenedCategoriesStory.swift
+++ b/podcasts/End of Year/Stories/TopCategoriesStory/TopListenedCategoriesStory.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 import PocketCastsDataModel
 
-struct TopListenedCategoriesStory: StoryView {
+struct TopListenedCategoriesStory: ShareableStory {
     var duration: TimeInterval = 5.seconds
 
     let identifier: String = "top_categories"

--- a/podcasts/End of Year/Stories/TopFivePodcastsStory.swift
+++ b/podcasts/End of Year/Stories/TopFivePodcastsStory.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import PocketCastsServer
 import PocketCastsDataModel
 
-struct TopFivePodcastsStory: StoryView {
+struct TopFivePodcastsStory: ShareableStory {
     let podcasts: [Podcast]
 
     let identifier: String = "top_five_podcast"

--- a/podcasts/End of Year/Stories/TopOnePodcastStory.swift
+++ b/podcasts/End of Year/Stories/TopOnePodcastStory.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import PocketCastsServer
 import PocketCastsDataModel
 
-struct TopOnePodcastStory: StoryView {
+struct TopOnePodcastStory: ShareableStory {
     var duration: TimeInterval = 5.seconds
 
     let identifier: String = "top_one_podcast"

--- a/podcasts/End of Year/StoriesDataSource.swift
+++ b/podcasts/End of Year/StoriesDataSource.swift
@@ -6,6 +6,9 @@ protocol StoriesDataSource {
     func story(for: Int) -> any StoryView
     func storyView(for: Int) -> AnyView
 
+    /// Returns a story that supports being shared, or nil if it doesn't
+    func shareableStory(for: Int) -> (any ShareableStory)?
+
     /// An interactive view that is put on top of the Stories control
     ///
     /// This allows having interactive elements, such as buttons.

--- a/podcasts/End of Year/StoriesDataSource.swift
+++ b/podcasts/End of Year/StoriesDataSource.swift
@@ -33,6 +33,7 @@ extension StoriesDataSource {
     }
 }
 
+// MARK: - Story Views
 typealias StoryView = Story & View
 
 protocol Story {
@@ -50,7 +51,20 @@ protocol Story {
     /// This method instead will only be called when the story
     /// is being presented.
     func onAppear()
+}
 
+extension Story {
+    var identifier: String {
+        "unknown"
+    }
+
+    func onAppear() {}
+}
+
+// MARK: - Shareable Stories
+typealias ShareableStory = StoryView & StorySharing
+
+protocol StorySharing {
     /// Called when the story will be shared
     func willShare()
 
@@ -60,13 +74,7 @@ protocol Story {
     func sharingAssets() -> [Any]
 }
 
-extension Story {
-    var identifier: String {
-        "unknown"
-    }
-
-    func onAppear() {}
-
+extension StorySharing {
     func willShare() {}
 
     func sharingAssets() -> [Any] {

--- a/podcasts/End of Year/StoriesModel.swift
+++ b/podcasts/End of Year/StoriesModel.swift
@@ -78,6 +78,10 @@ class StoriesModel: ObservableObject {
         return AnyView(story)
     }
 
+    func storyIsShareable(index: Int) -> Bool {
+        dataSource.shareableStory(for: index) != nil ? true : false
+    }
+
     func preload(index: Int) -> AnyView {
         if index < numberOfStories {
             return AnyView(dataSource.story(for: index))
@@ -86,8 +90,11 @@ class StoriesModel: ObservableObject {
         return AnyView(EmptyView())
     }
 
-    func sharingAssets() -> [Any] {
-        let story = dataSource.story(for: currentStory)
+    func sharingAssets() -> [Any]? {
+        guard let story = dataSource.shareableStory(for: currentStory) else {
+            return nil
+        }
+
         story.willShare()
 
         // If any of the assets have additional handlers then make sure we add them to the array
@@ -132,8 +139,10 @@ class StoriesModel: ObservableObject {
     }
 
     func share() {
+        guard let assets = sharingAssets() else { return }
+
         pause()
-        EndOfYear().share(assets: sharingAssets(), storyIdentifier: currentStoryIdentifier, onDismiss: { [weak self] in
+        EndOfYear().share(assets: assets, storyIdentifier: currentStoryIdentifier, onDismiss: { [weak self] in
             self?.start()
         })
     }

--- a/podcasts/End of Year/Views/StoriesView.swift
+++ b/podcasts/End of Year/Views/StoriesView.swift
@@ -44,10 +44,13 @@ struct StoriesView: View {
                 header
             }
 
-            ZStack {}
-                .frame(height: Constants.spaceBetweenShareAndStory)
+            // Hide the share button if needed
+            if model.storyIsShareable(index: model.currentStory) {
+                ZStack {}
+                    .frame(height: Constants.spaceBetweenShareAndStory)
 
-            shareButton
+                shareButton
+            }
         }
         .background(Color.black)
     }
@@ -132,13 +135,13 @@ struct StoriesView: View {
                 .contentShape(Rectangle())
                 .onTapGesture {
                     model.previous()
-            }
+                }
             Rectangle()
                 .foregroundColor(.clear)
                 .contentShape(Rectangle())
                 .onTapGesture {
                     model.next()
-            }
+                }
         }
         .simultaneousGesture(
             DragGesture(minimumDistance: 0, coordinateSpace: .local)


### PR DESCRIPTION
| 📘 Project: #376 |
|:---:|

This hides the share button on the first and last story views.

## To test

1. Launch the app
2. Go to Profile > Tap End of Year card
3. ✅ Verify the Share button is hidden on the first view
4. Tap through the next stories, and ✅ verify they all show the share button
5. ✅ Verify the Share button works and you're able to share the assets
6. ✅ Verify the shared assets are correct for each story
7. Go to the last view
8. ✅ Verify the Share button is hidden

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
