### PR TITLE
End of Year: Add highlighting of key values

### DIFF
--- a/podcasts/End of Year/Stories/ListenedCategoriesStory.swift
+++ b/podcasts/End of Year/Stories/ListenedCategoriesStory.swift
@@ -27,14 +27,12 @@ struct ListenedCategoriesStory: ShareableStory {
                         }
                     }
 
-                    VStack {
-                        StoryLabel(L10n.eoyStoryListenedToCategories("\n\(listenedCategories.count)"), for: .title)
-                            .frame(maxHeight: geometry.size.height * 0.12)
-                            .minimumScaleFactor(0.01)
-
+                    VStack(spacing: 20) {
+                        let categories = L10n.eoyStoryListenedToCategoriesText(listenedCategories.count)
+                        StoryLabel(L10n.eoyStoryListenedToCategories("\n\(categories)\n"),
+                                   highlighting: [categories],
+                                   for: .title)
                         StoryLabel(L10n.eoyStoryListenedToCategoriesSubtitle, for: .subtitle)
-                            .frame(maxHeight: geometry.size.height * 0.07)
-                            .minimumScaleFactor(0.01)
                             .opacity(renderForSharing ? 0.0 : 0.8)
                     }
                 }

--- a/podcasts/End of Year/Stories/ListenedNumbersStory.swift
+++ b/podcasts/End of Year/Stories/ListenedNumbersStory.swift
@@ -58,7 +58,9 @@ struct ListenedNumbersStory: ShareableStory {
                 VStack {
                     Spacer()
 
-                    StoryLabel(L10n.eoyStoryListenedToNumbers("\n\(listenedNumbers.numberOfPodcasts)", "\(listenedNumbers.numberOfEpisodes)"), for: .title)
+                    let podcasts = L10n.eoyStoryListenedToPodcastText(listenedNumbers.numberOfPodcasts)
+                    let episodes = L10n.eoyStoryListenedToPodcastText(listenedNumbers.numberOfEpisodes)
+                    StoryLabel(L10n.eoyStoryListenedToNumbers("\n\(podcasts)", "\(episodes)"), highlighting: [podcasts, episodes], for: .title)
                         .frame(maxHeight: geometry.size.height * 0.12)
                         .minimumScaleFactor(0.01)
 

--- a/podcasts/End of Year/Stories/ListenedNumbersStory.swift
+++ b/podcasts/End of Year/Stories/ListenedNumbersStory.swift
@@ -59,14 +59,10 @@ struct ListenedNumbersStory: ShareableStory {
                     Spacer()
 
                     let podcasts = L10n.eoyStoryListenedToPodcastText(listenedNumbers.numberOfPodcasts)
-                    let episodes = L10n.eoyStoryListenedToPodcastText(listenedNumbers.numberOfEpisodes)
+                    let episodes = L10n.eoyStoryListenedToEpisodesText(listenedNumbers.numberOfEpisodes)
                     StoryLabel(L10n.eoyStoryListenedToNumbers("\n\(podcasts)", "\(episodes)"), highlighting: [podcasts, episodes], for: .title)
-                        .frame(maxHeight: geometry.size.height * 0.12)
-                        .minimumScaleFactor(0.01)
 
                     StoryLabel(L10n.eoyStoryListenedToNumbersSubtitle, for: .subtitle)
-                        .frame(maxHeight: geometry.size.height * 0.07)
-                        .minimumScaleFactor(0.01)
                         .opacity(renderForSharing ? 0.0 : 0.8)
                         .padding(.bottom, geometry.size.height * 0.18)
                 }

--- a/podcasts/End of Year/Stories/ListenedNumbersStory.swift
+++ b/podcasts/End of Year/Stories/ListenedNumbersStory.swift
@@ -61,8 +61,12 @@ struct ListenedNumbersStory: ShareableStory {
                     let podcasts = L10n.eoyStoryListenedToPodcastText(listenedNumbers.numberOfPodcasts)
                     let episodes = L10n.eoyStoryListenedToEpisodesText(listenedNumbers.numberOfEpisodes)
                     StoryLabel(L10n.eoyStoryListenedToNumbers("\n\(podcasts)", "\(episodes)"), highlighting: [podcasts, episodes], for: .title)
+                        .frame(maxHeight: geometry.size.height * 0.12)
+                        .minimumScaleFactor(0.01)
 
                     StoryLabel(L10n.eoyStoryListenedToNumbersSubtitle, for: .subtitle)
+                        .frame(maxHeight: geometry.size.height * 0.07)
+                        .minimumScaleFactor(0.01)
                         .opacity(renderForSharing ? 0.0 : 0.8)
                         .padding(.bottom, geometry.size.height * 0.18)
                 }

--- a/podcasts/End of Year/Stories/ListeningTimeStory.swift
+++ b/podcasts/End of Year/Stories/ListeningTimeStory.swift
@@ -15,7 +15,8 @@ struct ListeningTimeStory: ShareableStory {
         GeometryReader { geometry in
             VStack(spacing: 0) {
                 VStack(spacing: Constants.spaceBetweenLabels) {
-                    StoryLabel(L10n.eoyStoryListenedTo("\n\(listeningTime.storyTimeDescription)"), for: .title)
+                    let time = listeningTime.storyTimeDescription
+                    StoryLabel(L10n.eoyStoryListenedTo("\n\(time)"), highlighting: [time], for: .title)
 
                     StoryLabel(FunMessage.timeSecsToFunnyText(listeningTime), for: .subtitle)
                         .opacity(0.8)

--- a/podcasts/End of Year/Stories/ListeningTimeStory.swift
+++ b/podcasts/End of Year/Stories/ListeningTimeStory.swift
@@ -16,7 +16,7 @@ struct ListeningTimeStory: ShareableStory {
             VStack(spacing: 0) {
                 VStack(spacing: Constants.spaceBetweenLabels) {
                     let time = listeningTime.storyTimeDescription
-                    StoryLabel(L10n.eoyStoryListenedTo("\n\(time)"), highlighting: [time], for: .title)
+                    StoryLabel(L10n.eoyStoryListenedTo("\n\(time)\n"), highlighting: [time], for: .title)
 
                     StoryLabel(FunMessage.timeSecsToFunnyText(listeningTime), for: .subtitle)
                         .opacity(0.8)

--- a/podcasts/End of Year/Stories/LongestEpisodeStory.swift
+++ b/podcasts/End of Year/Stories/LongestEpisodeStory.swift
@@ -45,11 +45,14 @@ struct LongestEpisodeStory: ShareableStory {
                                 .modifier(PodcastCoverPerspective())
                         }
 
-                        StoryLabel(L10n.eoyStoryLongestEpisode(episode.title ?? "", podcast.title ?? ""), for: .title)
+                        let time = episode.duration.storyTimeDescription
+                        let title = podcast.title?.replacingOccurrences(of: " ", with: "\u{00a0}") ?? ""
+
+                        StoryLabel(L10n.eoyStoryLongestEpisodeTime(time), highlighting: [time], for: .title)
                             .frame(maxHeight: geometry.size.height * 0.12)
                             .minimumScaleFactor(0.01)
                             .padding(.top)
-                        StoryLabel(L10n.eoyStoryLongestEpisodeDuration(episode.duration.storyTimeDescription), for: .subtitle)
+                        StoryLabel(L10n.eoyStoryLongestEpisodeFromPodcast(title), highlighting: [title], for: .subtitle)
                             .frame(maxHeight: geometry.size.height * 0.07)
                             .minimumScaleFactor(0.01)
                             .opacity(0.8)

--- a/podcasts/End of Year/Stories/TopOnePodcastStory.swift
+++ b/podcasts/End of Year/Stories/TopOnePodcastStory.swift
@@ -43,7 +43,9 @@ struct TopOnePodcastStory: ShareableStory {
                                 .modifier(PodcastCoverPerspective())
                         }
 
-                        StoryLabel(L10n.eoyStoryTopPodcast(topPodcast.podcast.title ?? "", topPodcast.podcast.author ?? ""), for: .title)
+                        let title = topPodcast.podcast.title ?? ""
+                        let author = topPodcast.podcast.author ?? ""
+                        StoryLabel(L10n.eoyStoryTopPodcast("\n" + title, author), highlighting: [title, author], for: .title)
                             .frame(maxHeight: geometry.size.height * 0.12)
                             .minimumScaleFactor(0.01)
                         StoryLabel(L10n.eoyStoryTopPodcastSubtitle(topPodcast.numberOfPlayedEpisodes, topPodcast.totalPlayedTime.storyTimeDescription), for: .subtitle)

--- a/podcasts/End of Year/Stories/Views/CommonStoryViews.swift
+++ b/podcasts/End of Year/Stories/Views/CommonStoryViews.swift
@@ -14,12 +14,8 @@ struct StoryLabel: View {
     }
 
     var body: some View {
-        if #available(iOS 15, *) {
-            if let attributedString {
-                applyDefaults(Text(attributedString), forHighlights: true)
-            } else {
-                applyDefaults(Text(text))
-            }
+        if #available(iOS 15, *), let attributedString {
+            applyDefaults(Text(attributedString), forHighlights: true)
         } else {
             applyDefaults(Text(text))
         }

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -626,7 +626,7 @@ internal enum L10n {
   internal static func eoyStoryListenedTo(_ p1: Any) -> String {
     return L10n.tr("Localizable", "eoy_story_listened_to", String(describing: p1))
   }
-  /// You listened to %1$@ different categories this year
+  /// You listened to %1$@ this year
   internal static func eoyStoryListenedToCategories(_ p1: Any) -> String {
     return L10n.tr("Localizable", "eoy_story_listened_to_categories", String(describing: p1))
   }
@@ -636,7 +636,15 @@ internal enum L10n {
   }
   /// Let's take a look at some of your favorites...
   internal static var eoyStoryListenedToCategoriesSubtitle: String { return L10n.tr("Localizable", "eoy_story_listened_to_categories_subtitle") }
-  /// You listened to %1$@ different podcasts and %2$@ episodes
+  /// %1$@ different categories
+  internal static func eoyStoryListenedToCategoriesText(_ p1: Any) -> String {
+    return L10n.tr("Localizable", "eoy_story_listened_to_categories_text", String(describing: p1))
+  }
+  /// %1$@ episodes
+  internal static func eoyStoryListenedToEpisodeText(_ p1: Any) -> String {
+    return L10n.tr("Localizable", "eoy_story_listened_to_episode_text", String(describing: p1))
+  }
+  /// You listened to %1$@ and %2$@
   internal static func eoyStoryListenedToNumbers(_ p1: Any, _ p2: Any) -> String {
     return L10n.tr("Localizable", "eoy_story_listened_to_numbers", String(describing: p1), String(describing: p2))
   }
@@ -646,6 +654,10 @@ internal enum L10n {
   }
   /// But there was one that you kept coming back to...
   internal static var eoyStoryListenedToNumbersSubtitle: String { return L10n.tr("Localizable", "eoy_story_listened_to_numbers_subtitle") }
+  /// %1$@ different podcasts
+  internal static func eoyStoryListenedToPodcastText(_ p1: Any) -> String {
+    return L10n.tr("Localizable", "eoy_story_listened_to_podcast_text", String(describing: p1))
+  }
   /// I spent %1$@ listening to podcasts in 2022
   internal static func eoyStoryListenedToShareText(_ p1: Any) -> String {
     return L10n.tr("Localizable", "eoy_story_listened_to_share_text", String(describing: p1))
@@ -658,9 +670,19 @@ internal enum L10n {
   internal static func eoyStoryLongestEpisodeDuration(_ p1: Any) -> String {
     return L10n.tr("Localizable", "eoy_story_longest_episode_duration", String(describing: p1))
   }
+  /// from the podcast
+  /// %1$@
+  internal static func eoyStoryLongestEpisodeFromPodcast(_ p1: Any) -> String {
+    return L10n.tr("Localizable", "eoy_story_longest_episode_from_podcast", String(describing: p1))
+  }
   /// The longest episode I listened to in 2022 %1$@
   internal static func eoyStoryLongestEpisodeShareText(_ p1: Any) -> String {
     return L10n.tr("Localizable", "eoy_story_longest_episode_share_text", String(describing: p1))
+  }
+  /// The longest episode you listened to was
+  /// %1$@
+  internal static func eoyStoryLongestEpisodeTime(_ p1: Any) -> String {
+    return L10n.tr("Localizable", "eoy_story_longest_episode_time", String(describing: p1))
   }
   /// Replay
   internal static var eoyStoryReplay: String { return L10n.tr("Localizable", "eoy_story_replay") }

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -641,8 +641,8 @@ internal enum L10n {
     return L10n.tr("Localizable", "eoy_story_listened_to_categories_text", String(describing: p1))
   }
   /// %1$@ episodes
-  internal static func eoyStoryListenedToEpisodeText(_ p1: Any) -> String {
-    return L10n.tr("Localizable", "eoy_story_listened_to_episode_text", String(describing: p1))
+  internal static func eoyStoryListenedToEpisodesText(_ p1: Any) -> String {
+    return L10n.tr("Localizable", "eoy_story_listened_to_episodes_text", String(describing: p1))
   }
   /// You listened to %1$@ and %2$@
   internal static func eoyStoryListenedToNumbers(_ p1: Any, _ p2: Any) -> String {

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -3361,7 +3361,7 @@
 "eoy_story_listened_to_podcast_text" = "%1$@ different podcasts";
 
 /* String telling the user how many episodes they listened to this year, %1$@ is a placeholder for the number number of episodes. */
-"eoy_story_listened_to_episode_text" = "%1$@ episodes";
+"eoy_story_listened_to_episodes_text" = "%1$@ episodes";
 
 /* Subtitle for the story containing number of podcasts and episodes played this year. Segway for the next story. */
 "eoy_story_listened_to_numbers_subtitle" = "But there was one that you kept coming back to...";

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -3342,8 +3342,11 @@
 /* Text that appears when someone shares the listened to story to Twitter, for example. %1$@ is a placeholder for the amount of time. */
 "eoy_story_listened_to_share_text" = "I spent %1$@ listening to podcasts in 2022";
 
-/* String telling the user how much podcast categories they listened to podcasts in 2022, %1$@ is a placeholder for the number of categories. */
-"eoy_story_listened_to_categories" = "You listened to %1$@ different categories this year";
+/* String telling the user how much podcast categories they listened to podcasts in 2022, %1$@ is a placeholder a segment of text that contains the number of categories . */
+"eoy_story_listened_to_categories" = "You listened to %1$@ this year";
+
+/* String telling the user how much podcast categories they listened to podcasts in 2022, %1$@ is a placeholder for the number of different categories. */
+"eoy_story_listened_to_categories_text" = "%1$@ different categories";
 
 /* String prompting the user for the next story to check the most listened categories. */
 "eoy_story_listened_to_categories_subtitle" = "Let's take a look at some of your favorites...";
@@ -3351,8 +3354,14 @@
 /* Text that appears when someone shares the listened categories to story to Twitter, for example. %1$@ is a placeholder for the number of categories. */
 "eoy_story_listened_to_categories_share_text" = "I listened to %1$@ different categories in 2022";
 
-/* String telling the user how much podcasts and episodes they listened to this year, %1$@ is a placeholder for the number of podcasts and %2$@ is a placeholder fot eh number of episodes. */
-"eoy_story_listened_to_numbers" = "You listened to %1$@ different podcasts and %2$@ episodes";
+/* String telling the user how many podcasts and episodes they listened to this year, %1$@ is a placeholder for the number of podcasts and %2$@ is a placeholder for the number of episodes. */
+"eoy_story_listened_to_numbers" = "You listened to %1$@ and %2$@";
+
+/* String telling the user how many podcasts they listened to this year, %1$@ is a placeholder for the number of podcasts*/
+"eoy_story_listened_to_podcast_text" = "%1$@ different podcasts";
+
+/* String telling the user how many episodes they listened to this year, %1$@ is a placeholder for the number number of episodes. */
+"eoy_story_listened_to_episode_text" = "%1$@ episodes";
 
 /* Subtitle for the story containing number of podcasts and episodes played this year. Segway for the next story. */
 "eoy_story_listened_to_numbers_subtitle" = "But there was one that you kept coming back to...";
@@ -3380,6 +3389,12 @@
 
 /* Title for the story showing the longest episode listened for the user in the current year. %1$@ is a placeholder for the episode title and %2$@ is a placeholder for the podcast title. */
 "eoy_story_longest_episode" = "The longest episode you listened to was %1$@ from the podcast %2$@";
+
+/* Title for the story showing the longest episode listened for the user in the current year. %1$@ is a placeholder for the duration of the episode. */
+"eoy_story_longest_episode_time" = "The longest episode you listened to was\n%1$@";
+
+/* Title for the story showing the longest episode listened for the user in the current year. %1$@ is a placeholder for the title of the podcast for the longest episode. */
+"eoy_story_longest_episode_from_podcast" = "from the podcast\n%1$@";
 
 /* Subtitle for the story showing the longest episode listened for the user in the current year. %1$@ is a placeholder for the episode length. */
 "eoy_story_longest_episode_duration" = "This episode was %1$@ long";


### PR DESCRIPTION
| 📘 Project: #376 | 🛫 Depends on: #559 |
|:---:|:---:|

This addresses the feedback of making the numbers and other key values appear more prominently within the story. This adds a way to highlight those values within the text. 

The implementation uses AttributedString which is only available on iOS 15+ so I included a fallback for iOS 14 devices to just display as it did before. 


## Screenshots

### Design vs Implementation Comparison
<p align="center"><img src="https://user-images.githubusercontent.com/793774/205213448-5830ae00-98e0-4f52-aead-881e41ba8c93.png" width="100%" /></p>

### Devices
| iPhone SE - 14.1 | iPhone 13 | iPhone 14 Pro Max |
|:---:|:---:|:---:|
|<img src="https://user-images.githubusercontent.com/793774/205213633-042fbe4a-f89d-49cc-816a-5f439ccf5980.png" width="320" />|<img src="https://user-images.githubusercontent.com/793774/205216124-38ba5308-4f77-4cfe-8b09-6a887031d71a.png" width="320" />|<img src="https://user-images.githubusercontent.com/793774/205213685-6038447e-cfd4-429f-96eb-aa6dadc13c22.png" width="320" />|


## To test

1. Run the app before applying this PR, and take screenshots of each story to compare against
2. Launch the app after applying this PR
3. Tap on the Profile > End of Year Card
4. Tap through the stories and ✅ verify the key values appear bold and the rest of the text appears at a regular weight
5. ✅ Verify the wording appears the same for most stories (there are a couple that have updated wording from [the designs](https://www.figma.com/file/lH66LwxxgG8btQ8NrM0ldx/End-of-Year-2022?node-id=958%3A23682&t=JZB2eKQAaJfdoIvP-4))
6. ✅ Verify the highlighted values appear according to [the designs](https://www.figma.com/file/lH66LwxxgG8btQ8NrM0ldx/End-of-Year-2022?node-id=958%3A23682&t=JZB2eKQAaJfdoIvP-4)]
7. Repeat the steps on various device sizes
8. Test on iOS 14 and ✅ Verify the labels all appear correctly and have a bold weight

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
