### PR TITLE
End of Year: Implements design feedback for the Top Categories story

### DIFF
--- a/podcasts/End of Year/Stories/TopCategoriesStory/CategoryPillar.swift
+++ b/podcasts/End of Year/Stories/TopCategoriesStory/CategoryPillar.swift
@@ -11,17 +11,18 @@ struct CategoryPillar: View {
         ZStack {
             VStack(spacing: 0) {
                 StoryLabel(title, for: .pillarTitle)
-                    .frame(width: 90)
+                    .frame(width: Constants.width)
                     .fixedSize()
                     .padding(.bottom, 2)
                 StoryLabel(subtitle, for: .pillarSubtitle)
-                    .frame(width: 90)
+                    .frame(width: Constants.width)
                     .fixedSize()
                     .opacity(0.8)
                     .padding(.bottom, 20)
 
                 ZStack(alignment: .top) {
                     Group {
+                        // Main pillar
                         Rectangle()
                             .fill(LinearGradient(gradient: Gradient(colors: [color, color.opacity(0)]), startPoint: .top, endPoint: .bottom))
                             .frame(width: 103, height: height)
@@ -30,9 +31,8 @@ struct CategoryPillar: View {
                         // Left Shadow
                         Rectangle()
                             .fill(LinearGradient(gradient: Gradient(colors: [.black, .black.opacity(0)]), startPoint: .top, endPoint: .bottom))
-                            .frame(width: 103 - 29.5, height: height)
+                            .frame(width: 73.5, height: height)
                             .padding(.top, 40)
-
                             .rotation3DEffect(
                                 Angle(degrees: 45),
                                 axis: (x: 0, y: -1, z: 0),
@@ -64,12 +64,16 @@ struct CategoryPillar: View {
                                 .foregroundColor(textColor)
                         }.modifier(PodcastCoverPerspective(scaleAnchor: .center))
                     }
-                    .frame(width: 90)
+                    .frame(width: Constants.width)
                 }
             }
 
             Spacer()
         }
         .fixedSize(horizontal: true, vertical: false)
+    }
+
+    private enum Constants {
+        static let width = 90.0
     }
 }

--- a/podcasts/End of Year/Stories/TopCategoriesStory/CategoryPillar.swift
+++ b/podcasts/End of Year/Stories/TopCategoriesStory/CategoryPillar.swift
@@ -26,28 +26,19 @@ struct CategoryPillar: View {
                         .frame(width: 90, height: height)
                         .padding(.top, 26)
 
-                    ZStack {
-                        Image("square_perspective")
-                            .resizable()
-                            .renderingMode(.template)
-                            .frame(width: 90, height: 52)
-                            .foregroundColor(color)
+                        ZStack {
+                            RoundedRectangle(cornerRadius: 4)
+                                .fill(color)
+                                .frame(width: 75.0, height: 75.0)
 
-                        let whiteContrast = color.contrast(with: .white)
-                        let textColor = whiteContrast < 2 ? UIColor.black.color : UIColor.white.color
+                            let whiteContrast = color.contrast(with: .white)
+                            let textColor = whiteContrast < 2 ? Color.black : Color.white
 
-                        let values: [CGFloat] = [1, 0, 0.50, 1, 0, 0]
-                        Text(text)
-                            .font(.system(size: 18, weight: .heavy))
-                            .multilineTextAlignment(.center)
-                            .foregroundColor(textColor)
-                            .padding(.leading, -8)
-                        .transformEffect(CGAffineTransform(
-                            a: values[0], b: values[1],
-                            c: values[2], d: values[3],
-                            tx: 0, ty: 0
-                        ))
-                        .rotationEffect(.init(degrees: -30))
+                            Text(text)
+                                .font(.system(size: 24, weight: .heavy))
+                                .multilineTextAlignment(.center)
+                                .foregroundColor(textColor)
+                        }.modifier(PodcastCoverPerspective(scaleAnchor: .center))
                     }
                 }
             }

--- a/podcasts/End of Year/Stories/TopCategoriesStory/CategoryPillar.swift
+++ b/podcasts/End of Year/Stories/TopCategoriesStory/CategoryPillar.swift
@@ -26,6 +26,29 @@ struct CategoryPillar: View {
                             .frame(width: 103, height: height)
                             .padding(.top, 37)
 
+                        // Left Shadow
+                        Rectangle()
+                            .fill(LinearGradient(gradient: Gradient(colors: [.black, .black.opacity(0)]), startPoint: .top, endPoint: .bottom))
+                            .frame(width: 103 - 29.5, height: height)
+                            .padding(.top, 40)
+
+                            .rotation3DEffect(
+                                Angle(degrees: 45),
+                                axis: (x: 0, y: -1, z: 0),
+                                anchor: .center,
+                                anchorZ: 0,
+                                perspective: 0
+                            )
+                            .rotation3DEffect(
+                                Angle(degrees: 10),
+                                axis: (x: 0, y: 1, z: 0),
+                                anchor: .center,
+                                anchorZ: 0,
+                                perspective: 1
+                            )
+                            .opacity(0.3)
+                            .offset(x: -25.5)
+
                         ZStack {
                             RoundedRectangle(cornerRadius: 4)
                                 .fill(color)

--- a/podcasts/End of Year/Stories/TopCategoriesStory/CategoryPillar.swift
+++ b/podcasts/End of Year/Stories/TopCategoriesStory/CategoryPillar.swift
@@ -9,10 +9,11 @@ struct CategoryPillar: View {
 
     var body: some View {
         ZStack {
-            VStack {
+            VStack(spacing: 0) {
                 StoryLabel(title, for: .pillarTitle)
                     .frame(width: 90)
                     .fixedSize()
+                    .padding(.bottom, 2)
                 StoryLabel(subtitle, for: .pillarSubtitle)
                     .frame(width: 90)
                     .fixedSize()

--- a/podcasts/End of Year/Stories/TopCategoriesStory/CategoryPillar.swift
+++ b/podcasts/End of Year/Stories/TopCategoriesStory/CategoryPillar.swift
@@ -21,6 +21,7 @@ struct CategoryPillar: View {
                     .padding(.bottom, 20)
 
                 ZStack(alignment: .top) {
+                    Group {
                         Rectangle()
                             .fill(LinearGradient(gradient: Gradient(colors: [color, color.opacity(0)]), startPoint: .top, endPoint: .bottom))
                             .frame(width: 103, height: height)
@@ -63,6 +64,7 @@ struct CategoryPillar: View {
                                 .foregroundColor(textColor)
                         }.modifier(PodcastCoverPerspective(scaleAnchor: .center))
                     }
+                    .frame(width: 90)
                 }
             }
 

--- a/podcasts/End of Year/Stories/TopCategoriesStory/CategoryPillar.swift
+++ b/podcasts/End of Year/Stories/TopCategoriesStory/CategoryPillar.swift
@@ -21,10 +21,10 @@ struct CategoryPillar: View {
                     .padding(.bottom, 20)
 
                 ZStack(alignment: .top) {
-                    Rectangle()
-                        .fill(LinearGradient(gradient: Gradient(colors: [color, .black.opacity(0)]), startPoint: .top, endPoint: .bottom))
-                        .frame(width: 90, height: height)
-                        .padding(.top, 26)
+                        Rectangle()
+                            .fill(LinearGradient(gradient: Gradient(colors: [color, color.opacity(0)]), startPoint: .top, endPoint: .bottom))
+                            .frame(width: 103, height: height)
+                            .padding(.top, 37)
 
                         ZStack {
                             RoundedRectangle(cornerRadius: 4)

--- a/podcasts/End of Year/Stories/TopCategoriesStory/TopListenedCategoriesStory.swift
+++ b/podcasts/End of Year/Stories/TopCategoriesStory/TopListenedCategoriesStory.swift
@@ -20,21 +20,18 @@ struct TopListenedCategoriesStory: ShareableStory {
             ZStack {
                 DynamicBackgroundView(backgroundColor: contrastColor.backgroundColor, foregroundColor: contrastColor.foregroundColor)
 
-                VStack {
+                VStack(spacing: 0) {
                     StoryLabel(L10n.eoyStoryTopCategories, for: .title2)
-                        .frame(maxHeight: geometry.size.height * 0.07)
-                        .minimumScaleFactor(0.01)
                         .opacity(0.8)
-                        .padding(.bottom, geometry.size.height * 0.1)
-                        .padding(.top, geometry.size.height * 0.05)
+                        .padding(.top, geometry.size.height * 0.09)
 
                     HStack(alignment: .bottom, spacing: 25) {
                         ForEach([1, 0, 2], id: \.self) {
-                            pillar($0)
+                            pillar($0, size: geometry.size)
                         }
-                    }
+                    }.padding(.top, geometry.size.height * 0.091)
+                    Spacer()
                 }
-                .padding(.bottom, 100)
             }
         }
     }

--- a/podcasts/End of Year/Stories/TopCategoriesStory/TopListenedCategoriesStory.swift
+++ b/podcasts/End of Year/Stories/TopCategoriesStory/TopListenedCategoriesStory.swift
@@ -40,13 +40,22 @@ struct TopListenedCategoriesStory: ShareableStory {
     }
 
     @ViewBuilder
-    func pillar(_ index: Int) -> some View {
+    func pillar(_ index: Int, size: CGSize) -> some View {
+        let heights = [0.32882883, 0.29279279, 0.22222222]
+
         if let listenedCategory = listenedCategories[safe: index] {
-            CategoryPillar(color: contrastColor.tintColor, text: "\(index + 1)", title: listenedCategory.categoryTitle.localized, subtitle: listenedCategory.totalPlayedTime.storyTimeDescriptionForPillars, height: CGFloat(200 - (index * 55)))
+            CategoryPillar(color: contrastColor.tintColor,
+                           text: "\(index + 1)",
+                           title: listenedCategory.categoryTitle.localized,
+                           subtitle: listenedCategory.totalPlayedTime.storyTimeDescriptionForPillars,
+                           height: size.height * heights[index])
                 .padding(.bottom, index == 0 ? 70 : 0)
         } else {
-            CategoryPillar(color: contrastColor.tintColor, text: "", title: "", subtitle: "", height: 200)
-                .opacity(0)
+            CategoryPillar(color: contrastColor.tintColor,
+                           text: "",
+                           title: "",
+                           subtitle: "",
+                           height: (size.height * heights[0])).opacity(0)
         }
     }
 

--- a/podcasts/End of Year/Stories/Views/CommonStoryViews.swift
+++ b/podcasts/End of Year/Stories/Views/CommonStoryViews.swift
@@ -95,13 +95,13 @@ struct StoryLabel: View {
         case .title:
             return .system(size: 22, weight: .bold)
         case .title2:
-            return .system(size: 18, weight: .bold)
+            return .system(size: 18, weight: .semibold)
         case .subtitle:
             return .system(size: 15, weight: .regular)
         case .pillarTitle:
-            return .system(size: 14, weight: .heavy)
+            return .system(size: 14, weight: .bold)
         case .pillarSubtitle:
-            return .system(size: 12, weight: .bold)
+            return .system(size: 13, weight: .regular)
         }
     }
 


### PR DESCRIPTION
| 📘 Project: #376 | 🛫 Depends on: #559 |
|:---:|:---:|

This addresses the following items:
- Columns are missing the dark shadow on the left
- Columns appear too low on the view
- Perspective of the column header is a bit off compared to the other perspectives used in the stories
- The column header's corners aren't rounded
- This also adjusts some fonts and weights to match the designs

## Screenshots

### Design vs Implementation Comparison
Note: the designs don't reflect all of the feedback notes. 

<p align="center"><img src="https://user-images.githubusercontent.com/793774/205213135-2cb99235-192a-43b9-a9c6-a090595534b7.png" width="100%" /></p>


### Devices
| iPhone SE - 14.1 | iPhone 13 | iPhone 14 Pro Max |
|:---:|:---:|:---:|
|<img src="https://user-images.githubusercontent.com/793774/205212975-738beba9-56fb-46c9-9ba1-ed61e37ebc35.png" width="320" />|<img src="https://user-images.githubusercontent.com/793774/205212987-4ee65849-35b4-4c28-bc2e-de6a1cc4ad9b.png" width="320" />|<img src="https://user-images.githubusercontent.com/793774/205212968-90d80357-18bd-4ec5-9891-e15e860aafec.png" width="320" />|

## To test

1. Launch the app
2. Go to Profile Tab > End of Year Card
3. Tap through to the 4th story - Top Categories
4. ✅ Verify the view appears correctly
5. Repeat the steps on multiple device sizes
6. Also please test only showing a couple of the pillars (ie: you only have 1 or 2 top categories)
   - You can test this by making a new account then listening to a couple episodes from 1 or 2 categories (scrub ahead to the end and you'll get credit for listening to the entire episode)

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
