### PR TITLE
End of Year: Fix sharing logo not appearing

### DIFF
--- a/podcasts/End of Year/StoryShareableProvider.swift
+++ b/podcasts/End of Year/StoryShareableProvider.swift
@@ -37,7 +37,7 @@ class StoryShareableProvider: UIActivityItemProvider {
             return
         }
 
-        let snapshot = ZStack {
+        let snapshot = StoryViewContainer {
             AnyView(view)
         }
         .environment(\.renderForSharing, true)

--- a/podcasts/End of Year/Views/StoriesView.swift
+++ b/podcasts/End of Year/Views/StoriesView.swift
@@ -29,19 +29,16 @@ struct StoriesView: View {
 
                 storiesToPreload
 
-                ZStack {
+                StoryViewContainer {
                     // Manually set the zIndex order to ensure we can change the order when needed
                     model.story(index: model.currentStory).zIndex(3)
-
-                    StoryLogoView().zIndex(4)
 
                     // By default the story switcher will appear above the story and override all
                     // interaction, but if the story contains interactive elements then move the
                     // switcher to appear behind the view to allow the story override the switcher, or
                     // allow the story to pass switcher events thru by controlling the allowsHitTesting
                     storySwitcher.zIndex(model.isInteractiveView(index: model.currentStory) ? 2 : 5)
-                }
-                .cornerRadius(Constants.storyCornerRadius)
+                }.cornerRadius(Constants.storyCornerRadius)
 
                 header
             }
@@ -256,6 +253,20 @@ private struct CloseButtonStyle: ButtonStyle {
     private enum Constants {
         static let closeButtonPadding: CGFloat = 13
         static let closeButtonRadius: CGFloat = 5
+    }
+}
+
+struct StoryViewContainer<Content: View>: View {
+    private var content: () -> Content
+
+    init(@ViewBuilder _ content: @escaping () -> Content) {
+        self.content = content
+    }
+    var body: some View {
+        ZStack {
+            content()
+            StoryLogoView().zIndex(4)
+        }
     }
 }
 


### PR DESCRIPTION
| 📘 Project: #376 | 🛫 Depends on: #566 |
|:---:|:---:|

This fixes an issue where the PC logo would not appear when being shared. It fixes this by creating a shared container view that the story and logo are rendered in.

## Screenshots

| Before | After |
|:---:|:---:|
|<img src="https://user-images.githubusercontent.com/793774/205430409-a088e12a-efc8-4a4e-9fb0-c4c45782ebac.jpeg" width="320" />|<img src="https://user-images.githubusercontent.com/793774/205430406-5bb9cb53-a819-455f-8f6c-7c0d3e6f2a20.jpeg" width="320" />|

## To test

1. Launch the app
2. Tap the Profile Tab > End of Year Card
3. Tap through each story and share the image
4. ✅ Verify the PC logo appears
5. ✅ Verify the view renders, and looks good
6. Repeat the steps for various screen sizes

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
