### PR TITLE
End of Year: Prevent issues with unlocalized text

### DIFF
--- a/podcasts/End of Year/Stories/IntroStory.swift
+++ b/podcasts/End of Year/Stories/IntroStory.swift
@@ -13,7 +13,8 @@ struct IntroStory: StoryView {
                         .aspectRatio(contentMode: .fit)
                         .padding(.top, geometry.size.height * Constants.imageVerticalPadding)
 
-                    StoryLabel(L10n.eoyStoryIntroTitle, for: .title)
+                    let title = L10n.eoyStoryIntroTitle.replacingOccurrences(of: "...", with: "!")
+                    StoryLabel(title, for: .title)
                         .padding(.top, Constants.spaceBetweenImageAndText)
 
                     Spacer()

--- a/podcasts/End of Year/Stories/ListenedCategoriesStory.swift
+++ b/podcasts/End of Year/Stories/ListenedCategoriesStory.swift
@@ -17,9 +17,14 @@ struct ListenedCategoriesStory: ShareableStory {
 
                 StoryLabelContainer(geometry: geometry) {
                     let categories = L10n.eoyStoryListenedToCategoriesText(listenedCategories.count)
-                    StoryLabel(L10n.eoyStoryListenedToCategories("\n\(categories)\n"),
-                               highlighting: [categories],
-                               for: .title)
+                    if NSLocale.isCurrentLanguageEnglish {
+                        StoryLabel(L10n.eoyStoryListenedToCategoriesHighlighted("\n\(categories)\n"),
+                                   highlighting: [categories],
+                                   for: .title)
+                    } else {
+                        StoryLabel(L10n.eoyStoryListenedToCategories("\n\(listenedCategories.count)"),
+                                   for: .title)
+                    }
                     StoryLabel(L10n.eoyStoryListenedToCategoriesSubtitle, for: .subtitle)
                         .opacity(renderForSharing ? 0.0 : 0.8)
                 }

--- a/podcasts/End of Year/Stories/ListenedNumbersStory.swift
+++ b/podcasts/End of Year/Stories/ListenedNumbersStory.swift
@@ -49,12 +49,18 @@ struct ListenedNumbersStory: ShareableStory {
                 .applyPodcastCoverPerspective()
 
                 StoryLabelContainer(geometry: geometry) {
-                    let podcasts = L10n.eoyStoryListenedToPodcastText(listenedNumbers.numberOfPodcasts)
-                    let episodes = L10n.eoyStoryListenedToEpisodesText(listenedNumbers.numberOfEpisodes)
+                    if NSLocale.isCurrentLanguageEnglish {
+                        let podcasts = L10n.eoyStoryListenedToPodcastText(listenedNumbers.numberOfPodcasts)
+                        let episodes = L10n.eoyStoryListenedToEpisodesText(listenedNumbers.numberOfEpisodes)
 
-                    StoryLabel(L10n.eoyStoryListenedToNumbers(podcasts, episodes), highlighting: [podcasts, episodes], for: .title)
-                    StoryLabel(L10n.eoyStoryListenedToNumbersSubtitle, for: .subtitle)
-                        .opacity(renderForSharing ? 0.0 : 0.8)
+                        StoryLabel(L10n.eoyStoryListenedToNumbersUpdated("\n" + podcasts + "\n", episodes), highlighting: [podcasts, episodes], for: .title)
+                        StoryLabel(L10n.eoyStoryListenedToNumbersSubtitleUpdated, for: .subtitle)
+                            .opacity(renderForSharing ? 0.0 : 0.8)
+                    } else {
+                        StoryLabel(L10n.eoyStoryListenedToNumbers("\n\(listenedNumbers.numberOfPodcasts)", "\(listenedNumbers.numberOfEpisodes)"), for: .title)
+                        StoryLabel(L10n.eoyStoryListenedToNumbersSubtitle, for: .subtitle)
+                            .opacity(renderForSharing ? 0.0 : 0.8)
+                    }
                 }
                 Spacer()
             }

--- a/podcasts/End of Year/Stories/ListeningTimeStory.swift
+++ b/podcasts/End of Year/Stories/ListeningTimeStory.swift
@@ -15,11 +15,16 @@ struct ListeningTimeStory: ShareableStory {
         GeometryReader { geometry in
             VStack(spacing: 0) {
                     StoryLabelContainer(topPadding: geometry.size.height * Constants.topPadding, geometry: geometry) {
-                    let time = listeningTime.storyTimeDescription
-                    StoryLabel(L10n.eoyStoryListenedTo("\n\(time)\n"), highlighting: [time], for: .title)
 
+                        let time = listeningTime.storyTimeDescription
+                        if NSLocale.isCurrentLanguageEnglish {
+                            StoryLabel(L10n.eoyStoryListenedToUpdated("\n\(time)\n"), highlighting: [time], for: .title)
+                        } else {
+                            StoryLabel(L10n.eoyStoryListenedTo("\n\(time)\n"), highlighting: [time], for: .title)
+                        }
                     StoryLabel(FunMessage.timeSecsToFunnyText(listeningTime), for: .subtitle)
                         .opacity(0.8)
+                            
                 }
 
                 // Podcast images angled to fill the width of the view

--- a/podcasts/End of Year/Stories/ListeningTimeStory.swift
+++ b/podcasts/End of Year/Stories/ListeningTimeStory.swift
@@ -24,7 +24,7 @@ struct ListeningTimeStory: ShareableStory {
                         }
                     StoryLabel(FunMessage.timeSecsToFunnyText(listeningTime), for: .subtitle)
                         .opacity(0.8)
-                            
+
                 }
 
                 // Podcast images angled to fill the width of the view

--- a/podcasts/End of Year/Stories/LongestEpisodeStory.swift
+++ b/podcasts/End of Year/Stories/LongestEpisodeStory.swift
@@ -25,11 +25,17 @@ struct LongestEpisodeStory: ShareableStory {
                 PodcastStackView(podcasts: [podcast], geometry: geometry)
 
                 StoryLabelContainer(geometry: geometry) {
-                    let time = episode.duration.storyTimeDescription
-                    let title = podcast.title?.nonBreakingSpaces() ?? ""
-                    StoryLabel(L10n.eoyStoryLongestEpisodeTime(time), highlighting: [time], for: .title)
-                    StoryLabel(L10n.eoyStoryLongestEpisodeFromPodcast(title), highlighting: [title], for: .subtitle)
-                        .opacity(0.8)
+                    if NSLocale.isCurrentLanguageEnglish {
+                        let time = episode.duration.storyTimeDescription
+                        let title = podcast.title?.nonBreakingSpaces() ?? ""
+                        StoryLabel(L10n.eoyStoryLongestEpisodeTime(time), highlighting: [time], for: .title)
+                        StoryLabel(L10n.eoyStoryLongestEpisodeFromPodcast(title), highlighting: [title], for: .subtitle)
+                            .opacity(0.8)
+                    } else {
+                        StoryLabel(L10n.eoyStoryLongestEpisode(episode.title ?? "", podcast.title ?? ""), for: .title)
+                        StoryLabel(L10n.eoyStoryLongestEpisodeDuration(episode.duration.localizedTimeDescription ?? ""), for: .subtitle)
+                            .opacity(0.8)
+                    }
                 }
             }
         }.background(DynamicBackgroundView(podcast: podcast))

--- a/podcasts/End of Year/Stories/Views/CommonStoryViews.swift
+++ b/podcasts/End of Year/Stories/Views/CommonStoryViews.swift
@@ -405,3 +405,14 @@ extension String {
         self.replacingOccurrences(of: " ", with: Self.nbsp)
     }
 }
+
+extension NSLocale {
+    static var isCurrentLanguageEnglish: Bool {
+        // Get the current language from the user defaults, or default to checking the locale if that fails
+        let currentLanguageCode = UserDefaults.standard.stringArray(forKey: "AppleLanguages")?.first ?? NSLocale.autoupdatingCurrent.languageCode
+        guard let currentLanguageCode else { return false }
+
+        // Support multiple english languag checks en-US, en-GB
+        return currentLanguageCode.hasPrefix("en")
+    }
+}

--- a/podcasts/End of Year/Stories/Views/CommonStoryViews.swift
+++ b/podcasts/End of Year/Stories/Views/CommonStoryViews.swift
@@ -412,7 +412,7 @@ extension NSLocale {
         let currentLanguageCode = UserDefaults.standard.stringArray(forKey: "AppleLanguages")?.first ?? NSLocale.autoupdatingCurrent.languageCode
         guard let currentLanguageCode else { return false }
 
-        // Support multiple english languag checks en-US, en-GB
+        // Support multiple english language checks en-US, en-GB
         return currentLanguageCode.hasPrefix("en")
     }
 }

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -620,15 +620,19 @@ internal enum L10n {
   internal static var eoyStoryEpilogueSubtitle: String { return L10n.tr("Localizable", "eoy_story_epilogue_subtitle") }
   /// Thank you for letting Pocket Casts be a part of your listening experience in 2022
   internal static var eoyStoryEpilogueTitle: String { return L10n.tr("Localizable", "eoy_story_epilogue_title") }
-  /// Let's celebrate your year of listening!
+  /// Let's celebrate your year of listening...
   internal static var eoyStoryIntroTitle: String { return L10n.tr("Localizable", "eoy_story_intro_title") }
-  /// This year, you spent %1$@ listening to podcasts
+  /// In 2022, you spent %1$@ listening to podcasts
   internal static func eoyStoryListenedTo(_ p1: Any) -> String {
     return L10n.tr("Localizable", "eoy_story_listened_to", String(describing: p1))
   }
-  /// You listened to %1$@ this year
+  /// You listened to %1$@ different categories this year
   internal static func eoyStoryListenedToCategories(_ p1: Any) -> String {
     return L10n.tr("Localizable", "eoy_story_listened_to_categories", String(describing: p1))
+  }
+  /// You listened to %1$@ this year
+  internal static func eoyStoryListenedToCategoriesHighlighted(_ p1: Any) -> String {
+    return L10n.tr("Localizable", "eoy_story_listened_to_categories_highlighted", String(describing: p1))
   }
   /// I listened to %1$@ different categories in 2022
   internal static func eoyStoryListenedToCategoriesShareText(_ p1: Any) -> String {
@@ -644,9 +648,7 @@ internal enum L10n {
   internal static func eoyStoryListenedToEpisodesText(_ p1: Any) -> String {
     return L10n.tr("Localizable", "eoy_story_listened_to_episodes_text", String(describing: p1))
   }
-  /// You listened to
-  /// %1$@
-  /// and %2$@
+  /// You listened to %1$@ different podcasts and %2$@ episodes
   internal static func eoyStoryListenedToNumbers(_ p1: Any, _ p2: Any) -> String {
     return L10n.tr("Localizable", "eoy_story_listened_to_numbers", String(describing: p1), String(describing: p2))
   }
@@ -654,9 +656,15 @@ internal enum L10n {
   internal static func eoyStoryListenedToNumbersShareText(_ p1: Any, _ p2: Any) -> String {
     return L10n.tr("Localizable", "eoy_story_listened_to_numbers_share_text", String(describing: p1), String(describing: p2))
   }
+  /// But there was one that you kept coming back to...
+  internal static var eoyStoryListenedToNumbersSubtitle: String { return L10n.tr("Localizable", "eoy_story_listened_to_numbers_subtitle") }
   /// But there was one that you
   /// kept coming back to...
-  internal static var eoyStoryListenedToNumbersSubtitle: String { return L10n.tr("Localizable", "eoy_story_listened_to_numbers_subtitle") }
+  internal static var eoyStoryListenedToNumbersSubtitleUpdated: String { return L10n.tr("Localizable", "eoy_story_listened_to_numbers_subtitle_updated") }
+  /// You listened to %1$@ and %2$@
+  internal static func eoyStoryListenedToNumbersUpdated(_ p1: Any, _ p2: Any) -> String {
+    return L10n.tr("Localizable", "eoy_story_listened_to_numbers_updated", String(describing: p1), String(describing: p2))
+  }
   /// %1$@ different podcasts
   internal static func eoyStoryListenedToPodcastText(_ p1: Any) -> String {
     return L10n.tr("Localizable", "eoy_story_listened_to_podcast_text", String(describing: p1))
@@ -664,6 +672,10 @@ internal enum L10n {
   /// I spent %1$@ listening to podcasts in 2022
   internal static func eoyStoryListenedToShareText(_ p1: Any) -> String {
     return L10n.tr("Localizable", "eoy_story_listened_to_share_text", String(describing: p1))
+  }
+  /// This year, you spent %1$@ listening to podcasts
+  internal static func eoyStoryListenedToUpdated(_ p1: Any) -> String {
+    return L10n.tr("Localizable", "eoy_story_listened_to_updated", String(describing: p1))
   }
   /// The longest episode you listened to was %1$@ from the podcast %2$@
   internal static func eoyStoryLongestEpisode(_ p1: Any, _ p2: Any) -> String {

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -3334,16 +3334,22 @@
 "eoy_card_description" = "See your top podcasts, categories, listening stats and more.";
 
 /* Description that appears on the first story of the 2022 Pocket Casts wrap up (End of Year) */
-"eoy_story_intro_title" = "Let's celebrate your year of listening!";
+"eoy_story_intro_title" = "Let's celebrate your year of listening...";
 
 /* String telling the user how much time they listened to podcasts in 2022, %1$@ is a placeholder for the amount of time. */
-"eoy_story_listened_to" = "This year, you spent %1$@ listening to podcasts";
+"eoy_story_listened_to" = "In 2022, you spent %1$@ listening to podcasts";
+
+/* String telling the user how much time they listened to podcasts in 2022, %1$@ is a placeholder for the amount of time. */
+"eoy_story_listened_to_updated" = "This year, you spent %1$@ listening to podcasts";
 
 /* Text that appears when someone shares the listened to story to Twitter, for example. %1$@ is a placeholder for the amount of time. */
 "eoy_story_listened_to_share_text" = "I spent %1$@ listening to podcasts in 2022";
 
 /* String telling the user how much podcast categories they listened to podcasts in 2022, %1$@ is a placeholder a segment of text that contains the number of categories . */
-"eoy_story_listened_to_categories" = "You listened to %1$@ this year";
+"eoy_story_listened_to_categories" = "You listened to %1$@ different categories this year";
+
+/* String telling the user how much podcast categories they listened to podcasts in 2022, %1$@ is a placeholder a segment of text that contains the number of categories . */
+"eoy_story_listened_to_categories_highlighted" = "You listened to %1$@ this year";
 
 /* String telling the user how much podcast categories they listened to podcasts in 2022, %1$@ is a placeholder for the number of different categories. */
 "eoy_story_listened_to_categories_text" = "%1$@ different categories";
@@ -3355,7 +3361,10 @@
 "eoy_story_listened_to_categories_share_text" = "I listened to %1$@ different categories in 2022";
 
 /* String telling the user how many podcasts and episodes they listened to this year, %1$@ is a placeholder for the number of podcasts and %2$@ is a placeholder for the number of episodes. */
-"eoy_story_listened_to_numbers" = "You listened to\n%1$@\nand %2$@";
+"eoy_story_listened_to_numbers" = "You listened to %1$@ different podcasts and %2$@ episodes";
+
+/* String telling the user how many podcasts and episodes they listened to this year, %1$@ is a placeholder for the number of podcasts and %2$@ is a placeholder for the number of episodes. */
+"eoy_story_listened_to_numbers_updated" = "You listened to %1$@ and %2$@";
 
 /* String telling the user how many podcasts they listened to this year, %1$@ is a placeholder for the number of podcasts*/
 "eoy_story_listened_to_podcast_text" = "%1$@ different podcasts";
@@ -3364,7 +3373,10 @@
 "eoy_story_listened_to_episodes_text" = "%1$@ episodes";
 
 /* Subtitle for the story containing number of podcasts and episodes played this year. Segway for the next story. */
-"eoy_story_listened_to_numbers_subtitle" = "But there was one that you\nkept coming back to...";
+"eoy_story_listened_to_numbers_subtitle" = "But there was one that you kept coming back to...";
+
+/* Subtitle for the story containing number of podcasts and episodes played this year. Segway for the next story. */
+"eoy_story_listened_to_numbers_subtitle_updated" = "But there was one that you\nkept coming back to...";
 
 /* Text that appear when someone share the listened numbers story to Twitter. %1$@ is a placeholder for the number of podcasts listened and %2$@ for the number of episodes. */
 "eoy_story_listened_to_numbers_share_text" = "I listened to %1$@ different podcasts and %2$@ episodes in 2022";


### PR DESCRIPTION
| 📘 Project: #376 |
|:---:|

Restricts the new strings to english only to prevent issues with untranslated languages

## To test

1. Launch the app in a language other than English
2. Go to Profile Tab > End of Year Card
3. Tap through the stories and ✅ make sure all the titles and subtitles (besides podcast titles and authors) are localized in the chosen language

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
