### PR TITLE
End of Year: Allow passthrough when the user taps the background on the epilogue story

### DIFF
--- a/podcasts/End of Year/Stories/EpilogueStory.swift
+++ b/podcasts/End of Year/Stories/EpilogueStory.swift
@@ -31,7 +31,7 @@ struct EpilogueStory: StoryView {
 
                 Spacer()
             }
-        }.background(Constants.backgroundColor)
+        }.background(Constants.backgroundColor.allowsHitTesting(false))
     }
 
     func onAppear() {


### PR DESCRIPTION
| 📘 Project: #376 |
|:---:|

Disables hit testing on the background so the events still work as intended on the epilogue

## To test

1. Launch the app
2. Tap Profile Tab > End of year card
3. Tap to the end story
4. ✅ Verify tapping the left side lets you go back a story
5. ✅ Verify swiping dismisses the view
6. ✅ Verify tapping the replay button replays the story

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
