### PR TITLE
End of Year: Add the episode title to the longest episode story

### DIFF
--- a/podcasts/End of Year/Stories/LongestEpisodeStory.swift
+++ b/podcasts/End of Year/Stories/LongestEpisodeStory.swift
@@ -26,9 +26,10 @@ struct LongestEpisodeStory: ShareableStory {
 
                 StoryLabelContainer(geometry: geometry) {
                     let time = episode.duration.storyTimeDescription
-                    let title = podcast.title?.nonBreakingSpaces() ?? ""
+                    let podcastTitle = podcast.title?.limited(to: 30).nonBreakingSpaces() ?? ""
+                    let episodeTitle = episode.title?.limited(to: 30).nonBreakingSpaces().nonBreakingSpaces() ?? ""
                     StoryLabel(L10n.eoyStoryLongestEpisodeTime(time), highlighting: [time], for: .title)
-                    StoryLabel(L10n.eoyStoryLongestEpisodeFromPodcast(title), highlighting: [title], for: .subtitle)
+                    StoryLabel(L10n.eoyStoryLongestEpisodeSubtitle(episodeTitle, podcastTitle), highlighting: [episodeTitle, podcastTitle], for: .subtitle)
                         .opacity(0.8)
                 }
             }

--- a/podcasts/End of Year/Stories/LongestEpisodeStory.swift
+++ b/podcasts/End of Year/Stories/LongestEpisodeStory.swift
@@ -26,6 +26,7 @@ struct LongestEpisodeStory: ShareableStory {
 
                 StoryLabelContainer(geometry: geometry) {
                     if NSLocale.isCurrentLanguageEnglish {
+                        let time = episode.duration.storyTimeDescription
                         let podcastTitle = podcast.title?.limited(to: 30).nonBreakingSpaces() ?? ""
                         let episodeTitle = episode.title?.limited(to: 30).nonBreakingSpaces().nonBreakingSpaces() ?? ""
                         StoryLabel(L10n.eoyStoryLongestEpisodeTime(time), highlighting: [time], for: .title)

--- a/podcasts/End of Year/Stories/Views/CommonStoryViews.swift
+++ b/podcasts/End of Year/Stories/Views/CommonStoryViews.swift
@@ -404,4 +404,16 @@ extension String {
     func nonBreakingSpaces() -> String {
         self.replacingOccurrences(of: " ", with: Self.nbsp)
     }
+
+
+    /// Limit the string to given length or truncate it with ...
+    func limited(to len: Int) -> String {
+        // If the length is less than the max, then allow it
+        // or if the string isn't going to go too much over the limit allow it
+        if count < len || count - len < 5 {
+            return self
+        }
+
+        return self.prefix(len).trimmingCharacters(in: .whitespacesAndNewlines) + "..."
+    }
 }

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -673,14 +673,13 @@ internal enum L10n {
   internal static func eoyStoryLongestEpisodeDuration(_ p1: Any) -> String {
     return L10n.tr("Localizable", "eoy_story_longest_episode_duration", String(describing: p1))
   }
-  /// from the podcast
-  /// %1$@
-  internal static func eoyStoryLongestEpisodeFromPodcast(_ p1: Any) -> String {
-    return L10n.tr("Localizable", "eoy_story_longest_episode_from_podcast", String(describing: p1))
-  }
   /// The longest episode I listened to in 2022 %1$@
   internal static func eoyStoryLongestEpisodeShareText(_ p1: Any) -> String {
     return L10n.tr("Localizable", "eoy_story_longest_episode_share_text", String(describing: p1))
+  }
+  /// The episode was %1$@ from %2$@
+  internal static func eoyStoryLongestEpisodeSubtitle(_ p1: Any, _ p2: Any) -> String {
+    return L10n.tr("Localizable", "eoy_story_longest_episode_subtitle", String(describing: p1), String(describing: p2))
   }
   /// The longest episode
   /// you listened to was

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -3394,7 +3394,7 @@
 "eoy_story_longest_episode_time" = "The longest episode\nyou listened to was\n%1$@";
 
 /* Title for the story showing the longest episode listened for the user in the current year. %1$@ is a placeholder for the title of the podcast for the longest episode. */
-"eoy_story_longest_episode_from_podcast" = "from the podcast\n%1$@";
+"eoy_story_longest_episode_subtitle" = "The episode was %1$@ from %2$@";
 
 /* Subtitle for the story showing the longest episode listened for the user in the current year. %1$@ is a placeholder for the episode length. */
 "eoy_story_longest_episode_duration" = "This episode was %1$@ long";


### PR DESCRIPTION
| 📘 Project: #376 |
|:---:|

<img src="https://user-images.githubusercontent.com/793774/205715406-f7ca8892-b591-4181-910c-1676230bc829.png" width="300" />

## To test

1. Launch the app
2. Tap on the Profile Tab > End of Year card
3. Tap to the longest episode story
4. ✅ Verify it includes the episode name and podcast name

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
