### PR TITLE
Onboarding: Make sure the end of year modal is triggered after a user logs in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 -----
 - Updates the onboarding and login process: (#548)
 - Updates the end of year calculation to include the month of December (#554)
+- Updates the End of Year stats designs
 
 7.27
 -----

--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -389,7 +389,6 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
 
     func showOnboardingFlow(flow: OnboardingFlow.Flow?) {
         let controller = OnboardingFlow.shared.begin(flow: flow ?? .initialOnboarding)
-
         guard let presentedViewController else {
             present(controller, animated: true)
             return
@@ -440,6 +439,10 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
 
         NotificationCenter.default.addObserver(forName: .userSignedIn, object: nil, queue: .main) { notification in
             self.endOfYear.resetStateIfNeeded()
+        }
+
+        NotificationCenter.default.addObserver(forName: .onboardingFlowDidDismiss, object: nil, queue: .main) { notification in
+            self.endOfYear.showPromptBasedOnState(in: self)
         }
 
         // If the requirement for EOY changes and registration is not required anymore

--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -29,9 +29,7 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
         let profileViewController = ProfileViewController()
         profileViewController.tabBarItem = profileTabBarItem
 
-        if EndOfYear.isEligible && Settings.showBadgeFor2022EndOfYear {
-            profileTabBarItem.badgeValue = "●"
-        }
+        displayEndOfYearBadgeIfNeeded()
 
         viewControllers = [podcastsController, filtersViewController, discoverViewController, profileViewController].map { SJUIUtils.navController(for: $0) }
         selectedIndex = UserDefaults.standard.integer(forKey: Constants.UserDefaults.lastTabOpened)
@@ -443,6 +441,8 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
 
         NotificationCenter.default.addObserver(forName: .onboardingFlowDidDismiss, object: nil, queue: .main) { notification in
             self.endOfYear.showPromptBasedOnState(in: self)
+
+            self.displayEndOfYearBadgeIfNeeded()
         }
 
         // If the requirement for EOY changes and registration is not required anymore
@@ -465,21 +465,21 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
         .portrait
     }
 
+    // MARK: - End of Year
+
     private func updateTabBarColor() {
         let appearance = UITabBarAppearance()
         appearance.configureWithOpaqueBackground()
         appearance.backgroundColor = AppTheme.tabBarBackgroundColor()
 
-        if EndOfYear.isEligible {
-            // Change badge colors
-            [appearance.stackedLayoutAppearance,
-             appearance.inlineLayoutAppearance,
-             appearance.compactInlineLayoutAppearance]
-                .forEach {
-                    $0.normal.badgeBackgroundColor = .clear
-                    $0.normal.badgeTextAttributes = [NSAttributedString.Key.foregroundColor: UIColor.systemRed]
-                }
-        }
+        // Change badge colors
+        [appearance.stackedLayoutAppearance,
+         appearance.inlineLayoutAppearance,
+         appearance.compactInlineLayoutAppearance]
+            .forEach {
+                $0.normal.badgeBackgroundColor = .clear
+                $0.normal.badgeTextAttributes = [NSAttributedString.Key.foregroundColor: UIColor.systemRed]
+            }
 
         tabBar.standardAppearance = appearance
         if #available(iOS 15.0, *) {
@@ -489,6 +489,12 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
         }
         tabBar.unselectedItemTintColor = AppTheme.unselectedTabBarItemColor()
         tabBar.tintColor = AppTheme.tabBarItemTintColor()
+    }
+
+    private func displayEndOfYearBadgeIfNeeded() {
+        if EndOfYear.isEligible && Settings.showBadgeFor2022EndOfYear {
+            profileTabBarItem.badgeValue = "●"
+        }
     }
 
     @objc private func willEnterForeground() {

--- a/podcasts/Notifications.swift
+++ b/podcasts/Notifications.swift
@@ -9,4 +9,7 @@ extension NSNotification.Name {
 
     /// When the requirement for having an account or not to see End Of Year Stats changes
     static let eoyRegistrationNotRequired = NSNotification.Name("EOY.RegistrationNotRequired")
+
+    /// When the updated onboarding flow dismisses
+    static let onboardingFlowDidDismiss = NSNotification.Name("Onboarding.didDismiss")
 }

--- a/podcasts/Onboarding/LoginCoordinator.swift
+++ b/podcasts/Onboarding/LoginCoordinator.swift
@@ -90,7 +90,11 @@ extension LoginCoordinator: SyncSigninDelegate, CreateAccountDelegate {
         let shouldDismiss = SubscriptionHelper.hasActiveSubscription() && !presentedFromUpgrade
 
         if shouldDismiss {
-            navigationController?.dismiss(animated: true)
+            navigationController?.dismiss(animated: true) {
+                DispatchQueue.main.async {
+                    OnboardingFlow.shared.reset()
+                }
+            }
             return
         }
 

--- a/podcasts/Onboarding/OnboardingFlow.swift
+++ b/podcasts/Onboarding/OnboardingFlow.swift
@@ -37,6 +37,8 @@ struct OnboardingFlow {
     mutating func reset() {
         source = nil
         currentFlow = .none
+
+        NotificationCenter.default.post(name: .onboardingFlowDidDismiss, object: nil)
     }
 
     /// Updates the source passed for analytics


### PR DESCRIPTION
| 📘 Project: #500 |
|:---:|

This fixes an issue where the onboarding flow doesn't trigger the viewDidAppear on the MainTabBarController which means a user who is logging in may not see the modal when the should.

## To test

1. Launch the app
2. Logout if you're logged in
3. Go to Profile > Tap the login button
4. Login to account that has listening history in 2022
5. ✅ Verify you see the end of year modal after logging in
6. ✅ Verify you see the badge under Profile
7. Tap on Profile
7. ✅ Verify the badge is gone
8. Re-run the app
9. ✅ The badge is not shown

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
