### PR TITLE
Switch to using the cached podcast image instead of the url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 7.29
 -----
 - Fixed an issue where episodes wouldn't resume downloading on next launch if the app was force quit (#472)
+- Fixed an issue where the podcast artwork wasn't appearin in the Now Playing Siri suggestions (#579)
 
 7.28
 -----

--- a/podcasts/SiriShortcutsManager.swift
+++ b/podcasts/SiriShortcutsManager.swift
@@ -172,7 +172,7 @@ class SiriShortcutsManager: CustomObserver {
     }
 
     func playPodcastIntent(podcastTitle: String, podcastUuid: String) -> INIntent {
-        var podcastArtwork: INImage? = INImage(named: "noartwork-page")
+        var podcastArtwork: INImage? = INImage(named: "noartwork-page-dark")
 
         // Load the artwork from cache, or default to the no artwork image
         if let image = ImageManager.sharedManager.cachedImageFor(podcastUuid: podcastUuid, size: .grid) {

--- a/podcasts/SiriShortcutsManager.swift
+++ b/podcasts/SiriShortcutsManager.swift
@@ -172,8 +172,12 @@ class SiriShortcutsManager: CustomObserver {
     }
 
     func playPodcastIntent(podcastTitle: String, podcastUuid: String) -> INIntent {
-        let podcastUrl = ServerHelper.imageUrl(podcastUuid: podcastUuid, size: 400)
-        let podcastArtwork = INImage(url: podcastUrl)
+        var podcastArtwork: INImage? = INImage(named: "noartwork-page")
+
+        // Load the artwork from cache, or default to the no artwork image
+        if let image = ImageManager.sharedManager.cachedImageFor(podcastUuid: podcastUuid, size: .grid) {
+            podcastArtwork = INImage(uiImage: image)
+        }
 
         let episode = INMediaItem(identifier: Constants.SiriActions.playPodcastId,
                                   title: L10n.siriShortcutPlayEpisodeTitle,


### PR DESCRIPTION
Fixes #43

Thanks to [@rviljoen's insight](https://github.com/Automattic/pocket-casts-ios/issues/43#issuecomment-1325672014) I switched the Siri intents to use the cached artwork for a podcast instead of the URL or default to showing the noartwork image if it's not available.

## Screenshot
<img src="https://user-images.githubusercontent.com/793774/205990293-e5d0f6ed-9113-44ee-a44c-941aa3a479ab.jpeg" width="320" />


## To test

1. Launch the app on a real device
2. Make sure there are no other apps playing anything
3. Play a subscribed podcast
4. Wait for it to buffer and play, then press and hold the player bar
5. Tap Mark as Played
6. Open the Control Center on your phone
7. Press and hold the Now Playing widget
8. ✅ Verify you see the podcast with the correct artwork


## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
