### PR TITLE
End of Year: fixes Index out of range

### DIFF
--- a/PocketCastsTests/Tests/End of Year/EndOfYearStoriesBuilderTests.swift
+++ b/PocketCastsTests/Tests/End of Year/EndOfYearStoriesBuilderTests.swift
@@ -18,6 +18,11 @@ class EndOfYearStoriesBuilderTests: XCTestCase {
         let dataManager = DataManagerMock(endOfYearManager: endOfYearManager)
         let builder = EndOfYearStoriesBuilder(dataManager: dataManager)
 
+        endOfYearManager.topPodcastsToReturn = [
+            TopPodcast(podcast: Podcast.previewPodcast(),
+                       numberOfPlayedEpisodes: 3,
+                       totalPlayedTime: 3000)
+        ]
         endOfYearManager.listeningTimeToReturn = 3000
         let stories = await builder.build()
 
@@ -71,6 +76,11 @@ class EndOfYearStoriesBuilderTests: XCTestCase {
         let dataManager = DataManagerMock(endOfYearManager: endOfYearManager)
         let builder = EndOfYearStoriesBuilder(dataManager: dataManager)
 
+        endOfYearManager.topPodcastsToReturn = [
+            TopPodcast(podcast: Podcast.previewPodcast(),
+                       numberOfPlayedEpisodes: 3,
+                       totalPlayedTime: 3000)
+        ]
         endOfYearManager.listenedNumbersToReturn = ListenedNumbers(numberOfPodcasts: 3, numberOfEpisodes: 10)
         let stories = await builder.build()
 

--- a/podcasts/End of Year/EndOfYearStoriesBuilder.swift
+++ b/podcasts/End of Year/EndOfYearStoriesBuilder.swift
@@ -46,9 +46,16 @@ class EndOfYearStoriesBuilder {
                 }
             }
 
+            // First, search for top 10 podcasts to use throughout different stories
+            let topPodcasts = dataManager.topPodcasts(limit: 10)
+            if !topPodcasts.isEmpty {
+                data.topPodcasts = Array(topPodcasts.prefix(5))
+                data.top10Podcasts = Array(topPodcasts.suffix(8)).map { $0.podcast }.reversed()
+            }
+
             // Listening time
             if let listeningTime = dataManager.listeningTime(),
-                listeningTime > 0 {
+               listeningTime > 0, !data.top10Podcasts.isEmpty {
                 stories.append(.listeningTime)
                 data.listeningTime = listeningTime
             }
@@ -64,16 +71,14 @@ class EndOfYearStoriesBuilder {
             // Listened podcasts and episodes
             let listenedNumbers = dataManager.listenedNumbers()
             if listenedNumbers.numberOfEpisodes > 0
-                && listenedNumbers.numberOfPodcasts > 0 {
+                && listenedNumbers.numberOfPodcasts > 0
+                && !data.top10Podcasts.isEmpty {
                 data.listenedNumbers = listenedNumbers
                 stories.append(.numberOfPodcastsAndEpisodesListened)
             }
 
             // Top podcasts
-            let topPodcasts = dataManager.topPodcasts(limit: 10)
-            if !topPodcasts.isEmpty {
-                data.topPodcasts = Array(topPodcasts.prefix(5))
-                data.top10Podcasts = Array(topPodcasts.suffix(8)).map { $0.podcast }.reversed()
+            if !data.topPodcasts.isEmpty {
                 stories.append(.topOnePodcast)
             }
 
@@ -89,10 +94,6 @@ class EndOfYearStoriesBuilder {
                 data.longestEpisodePodcast = podcast
                 stories.append(.longestEpisode)
             }
-
-            // TODO: the color of podcasts is downloaded when needed
-            // We need to check here for the ones missing the color
-            // and download it.
 
             continuation.resume(returning: (stories, data))
         }


### PR DESCRIPTION
[There is a crash affecting 11 users](https://sentry.io/share/issue/08935f64c9e341ad805ce7faa48accfc/) when showing `ListeningTimeStory`. (You can easily reproduce that by changing `EndOfYearStoriesDataSource` to instantiate the `ListeningTimeStory` with an empty array: `return ListeningTimeStory(listeningTime: data.listeningTime, podcasts: [])`).

It's not clear to me how a user might have listening time but not any podcasts to display. Anyway, it's happening and this PR prevents that.

## To test

1. Run the app on the simulator and on your device (TestFlight or App Store version and this branch)
2. ✅ Compare the stories, they should be the same on both device and simulator

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
