### PR TITLE
End of Year: scale down the image in case of display zoomed

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/General/A11y.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/General/A11y.swift
@@ -1,0 +1,9 @@
+import UIKit
+
+public struct A11y {
+    #if os(iOS)
+    public static var isDisplayZoomed: Bool {
+        UIScreen.main.nativeScale > UIScreen.main.scale
+    }
+    #endif
+}

--- a/podcasts/End of Year/Views/EndOfYearCard.swift
+++ b/podcasts/End of Year/Views/EndOfYearCard.swift
@@ -1,7 +1,12 @@
 import SwiftUI
+import PocketCastsUtils
 
 struct EndOfYearCard: View {
     @EnvironmentObject var theme: Theme
+
+    private var imageScale: Double {
+        A11y.isDisplayZoomed ? 0.75 : 1.0
+    }
 
     var body: some View {
         ZStack {
@@ -20,8 +25,8 @@ struct EndOfYearCard: View {
                 Image("2022_small")
                     .resizable()
                     .scaledToFit()
-                    .frame(width: Constants.eoyImageSize.width,
-                           height: Constants.eoyImageSize.height)
+                    .frame(width: Constants.eoyImageSize.width * imageScale,
+                           height: Constants.eoyImageSize.height * imageScale)
                     .padding(.trailing, Constants.eoyImageTrailingPadding)
             }
             .background(theme.activeTheme.isDark ? Constants.darkThemeBackgroundColor : Constants.lightThemeBackgroundColor)
@@ -46,5 +51,6 @@ struct EndOfYearCard: View {
 struct EndOfYearCard_Previews: PreviewProvider {
     static var previews: some View {
         EndOfYearCard()
+            .environmentObject(Theme(previewTheme: .light))
     }
 }


### PR DESCRIPTION
Fixes #

| Without Display Zoom | With Display Zoom |
| ---------------------- | ------------------- |
| ![Simulator Screen Shot - iPhone 8 - 2022-12-06 at 18 00 17](https://user-images.githubusercontent.com/7040243/206021954-95253de9-dfe2-4ac7-aae1-42525c206c4c.png) | ![Simulator Screen Shot - iPhone 8 - 2022-12-06 at 17 59 45](https://user-images.githubusercontent.com/7040243/206021988-99186f32-5579-4fe1-b7a5-af6af123bcc7.png) |

This PR fixes an issue with the card squeezing the text in case display zoom is enabled.

## To test

1. Go to Settings > Developer > Display Zoom (View) > Zoomed > Set
2. Run the app
3. ✅ Check the card, the image should be sized down to avoid shrinking the text

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
