### PR TITLE
End of Year: Fix the heart disappear if you tilted the device too much

### DIFF
--- a/podcasts/SwiftUI/HolographicEffect.swift
+++ b/podcasts/SwiftUI/HolographicEffect.swift
@@ -29,9 +29,9 @@ struct HolographicEffect<Content>: View where Content: View {
             // make tighter rings
             let colors = rainbowColors + rainbowColors + rainbowColors
             RadialGradient(colors: colors, center: .center, startRadius: 0, endRadius: radius(proxy.size))
-            .scaleEffect(scale(proxy.size))
-            .offset(position)
-            .mask(content())
+                .scaleEffect(scale(proxy.size))
+                .offset(position)
+                .mask(content())
         }
     }
 
@@ -41,7 +41,7 @@ struct HolographicEffect<Content>: View where Content: View {
     }
 
     private func scale(_ size: CGSize) -> Double {
-        min(geometry.size.width, geometry.size.height) / radius(size) * multiplier
+        max(geometry.size.width, geometry.size.height) / radius(size) * multiplier
     }
 
     private func radius(_ size: CGSize) -> Double {

--- a/podcasts/SwiftUI/Motion.swift
+++ b/podcasts/SwiftUI/Motion.swift
@@ -44,11 +44,12 @@ class MotionManager: ObservableObject {
             let attitude = data.attitude
 
             if !attitude.pitch.isNaN && !attitude.roll.isNaN {
-                if attitude.pitch <= 1.3 {
-                    roll = attitude.roll
-                }
+                let gz = data.gravity.z
+                let pitch = adjustValueForUpsideDown(attitude.pitch, gravityZ: gz)
+                let roll = adjustValueForUpsideDown(attitude.roll, gravityZ: gz)
 
-                pitch = attitude.pitch
+                self.pitch = pitch
+                self.roll = roll
             }
         }
 
@@ -58,6 +59,15 @@ class MotionManager: ObservableObject {
         }
 
         self.objectWillChange.send()
+    }
+
+    private func adjustValueForUpsideDown(_ value: Double, gravityZ: Double) -> Double {
+        // Gravity Z will be less than 0 when the device is near upside down
+        guard gravityZ > 0 else {
+            return value
+        }
+
+        return value > 0 ? .pi - value : -(.pi + value)
     }
 
     struct MotionOptions: OptionSet {


### PR DESCRIPTION
Fixes an issue where the epilogue heart could disappear if you tilted your device too much

## To test

1. Test on a real device
2. Launch the app
3. Tap on Profile > End of Year Card
4. Go to the last story
5. Tilt your device upside down
6. ✅ Make sure the heart is visible 

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
