### PR TITLE
Feature Flag: add toggle screen

### DIFF
--- a/PocketCastsTests/Tests/FeatureFlagTests.swift
+++ b/PocketCastsTests/Tests/FeatureFlagTests.swift
@@ -1,0 +1,96 @@
+import XCTest
+
+@testable import podcasts
+
+class FeatureFlagTests: XCTestCase {
+    var store: FeatureFlagOverrideStore!
+
+    override func setUp() {
+        store = FeatureFlagOverrideStore(store: UserDefaults(suiteName: "\(Int.random(in: 0..<1000))")!)
+    }
+
+    func testEnabledFeatureFlagValueIsOverridden() {
+        let flag = MockFeatureFlag.enabledFeature
+
+        XCTAssertNil(store.overriddenValue(for: flag))
+        try? store.override(flag, withValue: false)
+
+        let value = store.overriddenValue(for: flag)
+        XCTAssertNotNil(value)
+        XCTAssert(value == false)
+    }
+
+    func testDisabledFeatureFlagValueIsOverridden() {
+        let flag = MockFeatureFlag.disabledFeature
+
+        XCTAssertNil(store.overriddenValue(for: flag))
+        try? store.override(flag, withValue: true)
+
+        let value = store.overriddenValue(for: flag)
+        XCTAssertNotNil(value)
+        XCTAssert(value == true)
+    }
+
+    func testNonOverrideableFeatureFlagCannotBeOverridden() {
+        let flag = MockFeatureFlag.nonOverrideableFeature
+
+        try? store.override(flag, withValue: false)
+        XCTAssertFalse(store.isOverridden(flag))
+    }
+
+    func testEnabledFeatureFlagValueIsNotOverriddenWhenResetToNormalState() {
+        let flag = MockFeatureFlag.enabledFeature
+
+        XCTAssertFalse(store.isOverridden(flag))
+
+        try? store.override(flag, withValue: false)
+        XCTAssertTrue(store.isOverridden(flag))
+
+        try? store.override(flag, withValue: true)
+        XCTAssertFalse(store.isOverridden(flag))
+    }
+
+    func testDisabledFeatureFlagValueIsNotOverriddenWhenResetToNormalState() {
+        let flag = MockFeatureFlag.disabledFeature
+
+        XCTAssertFalse(store.isOverridden(flag))
+
+        try? store.override(flag, withValue: true)
+        XCTAssertTrue(store.isOverridden(flag))
+
+        try? store.override(flag, withValue: false)
+        XCTAssertFalse(store.isOverridden(flag))
+    }
+}
+
+enum MockFeatureFlag: OverrideableFlag {
+    case enabledFeature
+    case disabledFeature
+    case nonOverrideableFeature
+
+    var enabled: Bool {
+        switch self {
+        case .enabledFeature:
+            return true
+        case .disabledFeature:
+            return false
+        case .nonOverrideableFeature:
+            return true
+        }
+    }
+
+    var canOverride: Bool {
+        return self != .nonOverrideableFeature
+    }
+
+    var description: String {
+        switch self {
+        case .enabledFeature:
+            return "Enabled feature"
+        case .disabledFeature:
+            return "Disabled feature"
+        case .nonOverrideableFeature:
+            return "Non overrideable feature"
+        }
+    }
+}

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -482,6 +482,7 @@
 		8B5AB48E2901A8BD0018C637 /* StoriesController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B5AB48D2901A8BD0018C637 /* StoriesController.swift */; };
 		8B5F9A6728EFBB9800DE1C12 /* AppIcon-Halloween@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 8B5F9A6528EFBB9700DE1C12 /* AppIcon-Halloween@2x.png */; };
 		8B5F9A6828EFBB9800DE1C12 /* AppIcon-Halloween@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = 8B5F9A6628EFBB9800DE1C12 /* AppIcon-Halloween@3x.png */; };
+		8B68C1CF2942134300CF25C5 /* BetaMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B68C1CE2942134300CF25C5 /* BetaMenu.swift */; };
 		8B6B68E528F744520032BFFF /* StoriesDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6B68E428F744520032BFFF /* StoriesDataSource.swift */; };
 		8B6B68E728F74A010032BFFF /* StoriesModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6B68E628F74A010032BFFF /* StoriesModel.swift */; };
 		8B6B68E928F7527C0032BFFF /* StoryIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6B68E828F7527C0032BFFF /* StoryIndicator.swift */; };
@@ -2080,6 +2081,7 @@
 		8B5AB48D2901A8BD0018C637 /* StoriesController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoriesController.swift; sourceTree = "<group>"; };
 		8B5F9A6528EFBB9700DE1C12 /* AppIcon-Halloween@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "AppIcon-Halloween@2x.png"; sourceTree = "<group>"; };
 		8B5F9A6628EFBB9800DE1C12 /* AppIcon-Halloween@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "AppIcon-Halloween@3x.png"; sourceTree = "<group>"; };
+		8B68C1CE2942134300CF25C5 /* BetaMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BetaMenu.swift; sourceTree = "<group>"; };
 		8B6B68E428F744520032BFFF /* StoriesDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoriesDataSource.swift; sourceTree = "<group>"; };
 		8B6B68E628F74A010032BFFF /* StoriesModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoriesModel.swift; sourceTree = "<group>"; };
 		8B6B68E828F7527C0032BFFF /* StoryIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoryIndicator.swift; sourceTree = "<group>"; };
@@ -3797,6 +3799,14 @@
 			path = Tests;
 			sourceTree = "<group>";
 		};
+		8B68C1CD2942132C00CF25C5 /* Beta */ = {
+			isa = PBXGroup;
+			children = (
+				8B68C1CE2942134300CF25C5 /* BetaMenu.swift */,
+			);
+			path = Beta;
+			sourceTree = "<group>";
+		};
 		8B71828B28CF68D300B98F04 /* App Icon */ = {
 			isa = PBXGroup;
 			children = (
@@ -4597,6 +4607,7 @@
 		BD5B79191783F9CF00A0F407 /* Settings */ = {
 			isa = PBXGroup;
 			children = (
+				8B68C1CD2942132C00CF25C5 /* Beta */,
 				46C22EE128F7496000F4173B /* Developer Menu */,
 				BD69EBBD1CD1D39F007F273B /* Helpers */,
 				BD69EBB61CD1C7EE007F273B /* Support */,
@@ -7621,6 +7632,7 @@
 				4022A4C0236BA15800900734 /* SleepTimerViewController.swift in Sources */,
 				40F0DE8D22E45236001DAA52 /* PlusLockedInfoCell.swift in Sources */,
 				4086511B23B1CE8400D7585A /* CreateSiriShortcutCell.swift in Sources */,
+				8B68C1CF2942134300CF25C5 /* BetaMenu.swift in Sources */,
 				4053CE092159E477001C92B1 /* CreateFilterViewController.swift in Sources */,
 				BD86D94B217EB5060010FA1B /* FilterSelectionViewController.swift in Sources */,
 				40B26ABE213BB29200386173 /* FeaturedTableViewCell.swift in Sources */,

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -483,6 +483,12 @@
 		8B5F9A6728EFBB9800DE1C12 /* AppIcon-Halloween@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 8B5F9A6528EFBB9700DE1C12 /* AppIcon-Halloween@2x.png */; };
 		8B5F9A6828EFBB9800DE1C12 /* AppIcon-Halloween@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = 8B5F9A6628EFBB9800DE1C12 /* AppIcon-Halloween@3x.png */; };
 		8B68C1CF2942134300CF25C5 /* BetaMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B68C1CE2942134300CF25C5 /* BetaMenu.swift */; };
+		8B68C1D1294219EB00CF25C5 /* FeatureFlagOverrideStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B68C1D0294219EB00CF25C5 /* FeatureFlagOverrideStore.swift */; };
+		8B68C1D229421B4200CF25C5 /* FeatureFlagOverrideStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B68C1D0294219EB00CF25C5 /* FeatureFlagOverrideStore.swift */; };
+		8B68C1D329421B4300CF25C5 /* FeatureFlagOverrideStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B68C1D0294219EB00CF25C5 /* FeatureFlagOverrideStore.swift */; };
+		8B68C1D429421B4700CF25C5 /* FeatureFlagOverrideStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B68C1D0294219EB00CF25C5 /* FeatureFlagOverrideStore.swift */; };
+		8B68C1D529421B4800CF25C5 /* FeatureFlagOverrideStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B68C1D0294219EB00CF25C5 /* FeatureFlagOverrideStore.swift */; };
+		8B68C1D629421B4800CF25C5 /* FeatureFlagOverrideStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B68C1D0294219EB00CF25C5 /* FeatureFlagOverrideStore.swift */; };
 		8B6B68E528F744520032BFFF /* StoriesDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6B68E428F744520032BFFF /* StoriesDataSource.swift */; };
 		8B6B68E728F74A010032BFFF /* StoriesModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6B68E628F74A010032BFFF /* StoriesModel.swift */; };
 		8B6B68E928F7527C0032BFFF /* StoryIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6B68E828F7527C0032BFFF /* StoryIndicator.swift */; };
@@ -2082,6 +2088,7 @@
 		8B5F9A6528EFBB9700DE1C12 /* AppIcon-Halloween@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "AppIcon-Halloween@2x.png"; sourceTree = "<group>"; };
 		8B5F9A6628EFBB9800DE1C12 /* AppIcon-Halloween@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "AppIcon-Halloween@3x.png"; sourceTree = "<group>"; };
 		8B68C1CE2942134300CF25C5 /* BetaMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BetaMenu.swift; sourceTree = "<group>"; };
+		8B68C1D0294219EB00CF25C5 /* FeatureFlagOverrideStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagOverrideStore.swift; sourceTree = "<group>"; };
 		8B6B68E428F744520032BFFF /* StoriesDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoriesDataSource.swift; sourceTree = "<group>"; };
 		8B6B68E628F74A010032BFFF /* StoriesModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoriesModel.swift; sourceTree = "<group>"; };
 		8B6B68E828F7527C0032BFFF /* StoryIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoryIndicator.swift; sourceTree = "<group>"; };
@@ -4143,6 +4150,7 @@
 				46305CEC272AFA5F003AC87B /* UserDefaults+Helpers.swift */,
 				BD6275BE27D1C5370020A28C /* TraceHelper.swift */,
 				C7AF5788289C60B70089E435 /* FeatureFlag.swift */,
+				8B68C1D0294219EB00CF25C5 /* FeatureFlagOverrideStore.swift */,
 				C7C4CAF228ABFD0900CFC8CF /* Notifications.swift */,
 				C7D6551328E5153200AD7174 /* Debounce.swift */,
 			);
@@ -7338,6 +7346,7 @@
 				40E8037423FE9E9200B4E1F8 /* IntentHandler.swift in Sources */,
 				40043F0D23FDFD91004A9B57 /* SiriPodcastItem.swift in Sources */,
 				40E8037323FE9E9200B4E1F8 /* SleepTimerIntentHandler.swift in Sources */,
+				8B68C1D529421B4800CF25C5 /* FeatureFlagOverrideStore.swift in Sources */,
 				40E8037123FE9E9200B4E1F8 /* ChapterIntentHandler.swift in Sources */,
 				40E8037623FE9EDB00B4E1F8 /* SiriPodcastSearchManager.swift in Sources */,
 				40E8037223FE9E9200B4E1F8 /* PlayMediaIntentHandler.swift in Sources */,
@@ -7353,6 +7362,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8B68C1D629421B4800CF25C5 /* FeatureFlagOverrideStore.swift in Sources */,
 				40043F1123FE0A05004A9B57 /* SiriPodcastItem.swift in Sources */,
 				40043F1323FE0D9E004A9B57 /* SharedConstants.swift in Sources */,
 				46FBD8B7276A874F00867746 /* Intents.intentdefinition in Sources */,
@@ -7453,6 +7463,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8B68C1D229421B4200CF25C5 /* FeatureFlagOverrideStore.swift in Sources */,
 				C7AF578A289C60C50089E435 /* FeatureFlag.swift in Sources */,
 				BD3A21101E6CFC2400F42241 /* NotificationService.swift in Sources */,
 			);
@@ -7714,6 +7725,7 @@
 				BD674B0B1F68F2BD00AC1B2B /* PlaylistManager.swift in Sources */,
 				BD955FC2219513240094DF1C /* NothingUpNextCell.swift in Sources */,
 				BD6C3F062379236A00C01403 /* ShelfCell.swift in Sources */,
+				8B68C1D1294219EB00CF25C5 /* FeatureFlagOverrideStore.swift in Sources */,
 				BDFFC9B12148E87E0026D875 /* VideoViewController+Seek.swift in Sources */,
 				BD8032D52123F0AF00BFBB03 /* SleepTimerButton.swift in Sources */,
 				BD1F97821FD7C64600F89CCD /* PlaylistViewController+TableData.swift in Sources */,
@@ -8180,6 +8192,7 @@
 				BDE48A292410D27300ECA6CA /* BaseEpisode+Formatting.swift in Sources */,
 				4633FEC127D7E6B700996077 /* EpisodeRow.swift in Sources */,
 				468A0FBE27D68B1A00F800C8 /* EpisodeActionView.swift in Sources */,
+				8B68C1D429421B4700CF25C5 /* FeatureFlagOverrideStore.swift in Sources */,
 				46C843B927E373B100D1DBF3 /* NowPlayingImage.swift in Sources */,
 				BD74F15827F2955D00222785 /* FolderView.swift in Sources */,
 				BD4910CD2457DC86005202CF /* SessionManager+Send.swift in Sources */,
@@ -8264,6 +8277,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8B68C1D329421B4300CF25C5 /* FeatureFlagOverrideStore.swift in Sources */,
 				C7AF578B289C60C60089E435 /* FeatureFlag.swift in Sources */,
 				BDEFBA1A1E6D3C2300B9024B /* NotificationViewController.swift in Sources */,
 			);

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -489,6 +489,7 @@
 		8B68C1D429421B4700CF25C5 /* FeatureFlagOverrideStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B68C1D0294219EB00CF25C5 /* FeatureFlagOverrideStore.swift */; };
 		8B68C1D529421B4800CF25C5 /* FeatureFlagOverrideStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B68C1D0294219EB00CF25C5 /* FeatureFlagOverrideStore.swift */; };
 		8B68C1D629421B4800CF25C5 /* FeatureFlagOverrideStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B68C1D0294219EB00CF25C5 /* FeatureFlagOverrideStore.swift */; };
+		8B68C1D829421E3400CF25C5 /* FeatureFlagTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B68C1D729421E3400CF25C5 /* FeatureFlagTests.swift */; };
 		8B6B68E528F744520032BFFF /* StoriesDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6B68E428F744520032BFFF /* StoriesDataSource.swift */; };
 		8B6B68E728F74A010032BFFF /* StoriesModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6B68E628F74A010032BFFF /* StoriesModel.swift */; };
 		8B6B68E928F7527C0032BFFF /* StoryIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6B68E828F7527C0032BFFF /* StoryIndicator.swift */; };
@@ -2089,6 +2090,7 @@
 		8B5F9A6628EFBB9800DE1C12 /* AppIcon-Halloween@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "AppIcon-Halloween@3x.png"; sourceTree = "<group>"; };
 		8B68C1CE2942134300CF25C5 /* BetaMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BetaMenu.swift; sourceTree = "<group>"; };
 		8B68C1D0294219EB00CF25C5 /* FeatureFlagOverrideStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagOverrideStore.swift; sourceTree = "<group>"; };
+		8B68C1D729421E3400CF25C5 /* FeatureFlagTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagTests.swift; sourceTree = "<group>"; };
 		8B6B68E428F744520032BFFF /* StoriesDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoriesDataSource.swift; sourceTree = "<group>"; };
 		8B6B68E628F74A010032BFFF /* StoriesModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoriesModel.swift; sourceTree = "<group>"; };
 		8B6B68E828F7527C0032BFFF /* StoryIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoryIndicator.swift; sourceTree = "<group>"; };
@@ -3802,6 +3804,7 @@
 				45ECEF8527E910FB00C65030 /* ShowNotesFormatterUtilsTests.swift */,
 				C79E1E3F28887549008524CB /* PlusUpgradeViewSourceTests.swift */,
 				C7F4BAB628DA8666001C9785 /* BackgroundSignOutListenerTests.swift */,
+				8B68C1D729421E3400CF25C5 /* FeatureFlagTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -7413,6 +7416,7 @@
 			files = (
 				8B317BA528906CAB00A26A13 /* TestingSceneDelegate.swift in Sources */,
 				8B2319432902CF170001C3DE /* EndOfYearManagerMock.swift in Sources */,
+				8B68C1D829421E3400CF25C5 /* FeatureFlagTests.swift in Sources */,
 				8B317BA328906C8100A26A13 /* TestingAppDelegate.swift in Sources */,
 				8B484EFD28D2574D001AFA97 /* EpisodeBuilder.swift in Sources */,
 				8B484EFB28D25719001AFA97 /* Double+Ext.swift in Sources */,

--- a/podcasts/AccountViewController.swift
+++ b/podcasts/AccountViewController.swift
@@ -124,7 +124,7 @@ class AccountViewController: UIViewController, ChangeEmailDelegate {
     }
 
     private func hideOldUpgradeViewIfNeeded() {
-        guard FeatureFlag.onboardingUpdates.isEnabled else { return }
+        guard FeatureFlag.onboardingUpdates.enabled else { return }
         oldUpgradeView.removeFromSuperview()
     }
 
@@ -270,7 +270,7 @@ class AccountViewController: UIViewController, ChangeEmailDelegate {
                 newTableRows[0].append(.cancelSubscription)
             }
 
-            if FeatureFlag.onboardingUpdates.isEnabled, !upgradeHidden {
+            if FeatureFlag.onboardingUpdates.enabled, !upgradeHidden {
                 newTableRows[0].insert(.upgradeView, at: 0)
             }
 
@@ -298,7 +298,7 @@ class AccountViewController: UIViewController, ChangeEmailDelegate {
                 newTableRows[0].insert(.supporterContributions, at: 0)
             }
 
-            if FeatureFlag.onboardingUpdates.isEnabled {
+            if FeatureFlag.onboardingUpdates.enabled {
                 newTableRows[0].insert(.upgradeView, at: 0)
             }
 
@@ -311,7 +311,7 @@ class AccountViewController: UIViewController, ChangeEmailDelegate {
         // If we're not hiding the upgrade view, then refresh the pricing info
         // If the IAP information hasn't been pulled in yet, this method will trigger a refresh and the view will
         // be updated via `iapProductsUpdated`
-        if !FeatureFlag.onboardingUpdates.isEnabled, upgradeHidden == false {
+        if !FeatureFlag.onboardingUpdates.enabled, upgradeHidden == false {
             updatePricingLabels()
         }
 

--- a/podcasts/AccountViewController.swift
+++ b/podcasts/AccountViewController.swift
@@ -124,7 +124,7 @@ class AccountViewController: UIViewController, ChangeEmailDelegate {
     }
 
     private func hideOldUpgradeViewIfNeeded() {
-        guard FeatureFlag.onboardingUpdates else { return }
+        guard FeatureFlag.onboardingUpdates.isEnabled else { return }
         oldUpgradeView.removeFromSuperview()
     }
 
@@ -270,7 +270,7 @@ class AccountViewController: UIViewController, ChangeEmailDelegate {
                 newTableRows[0].append(.cancelSubscription)
             }
 
-            if FeatureFlag.onboardingUpdates, !upgradeHidden {
+            if FeatureFlag.onboardingUpdates.isEnabled, !upgradeHidden {
                 newTableRows[0].insert(.upgradeView, at: 0)
             }
 
@@ -298,7 +298,7 @@ class AccountViewController: UIViewController, ChangeEmailDelegate {
                 newTableRows[0].insert(.supporterContributions, at: 0)
             }
 
-            if FeatureFlag.onboardingUpdates {
+            if FeatureFlag.onboardingUpdates.isEnabled {
                 newTableRows[0].insert(.upgradeView, at: 0)
             }
 
@@ -311,7 +311,7 @@ class AccountViewController: UIViewController, ChangeEmailDelegate {
         // If we're not hiding the upgrade view, then refresh the pricing info
         // If the IAP information hasn't been pulled in yet, this method will trigger a refresh and the view will
         // be updated via `iapProductsUpdated`
-        if !FeatureFlag.onboardingUpdates, upgradeHidden == false {
+        if !FeatureFlag.onboardingUpdates.isEnabled, upgradeHidden == false {
             updatePricingLabels()
         }
 

--- a/podcasts/Analytics/Adapters/AnalyticsLoggingAdapter.swift
+++ b/podcasts/Analytics/Adapters/AnalyticsLoggingAdapter.swift
@@ -4,7 +4,7 @@ import PocketCastsUtils
 /// Simple tracking adapter that just logs the event
 struct AnalyticsLoggingAdapter: AnalyticsAdapter {
     func track(name: String, properties: [AnyHashable: Any]?) {
-        guard FeatureFlag.tracksLoggingEnabled.isEnabled else { return }
+        guard FeatureFlag.tracksLogging.isEnabled else { return }
 
         guard let properties = properties as? [String: Any] else {
             log("🔵 Tracked: \(name)")

--- a/podcasts/Analytics/Adapters/AnalyticsLoggingAdapter.swift
+++ b/podcasts/Analytics/Adapters/AnalyticsLoggingAdapter.swift
@@ -4,7 +4,7 @@ import PocketCastsUtils
 /// Simple tracking adapter that just logs the event
 struct AnalyticsLoggingAdapter: AnalyticsAdapter {
     func track(name: String, properties: [AnyHashable: Any]?) {
-        guard FeatureFlag.tracksLogging.isEnabled else { return }
+        guard FeatureFlag.tracksLogging.enabled else { return }
 
         guard let properties = properties as? [String: Any] else {
             log("🔵 Tracked: \(name)")

--- a/podcasts/Analytics/Adapters/AnalyticsLoggingAdapter.swift
+++ b/podcasts/Analytics/Adapters/AnalyticsLoggingAdapter.swift
@@ -4,7 +4,7 @@ import PocketCastsUtils
 /// Simple tracking adapter that just logs the event
 struct AnalyticsLoggingAdapter: AnalyticsAdapter {
     func track(name: String, properties: [AnyHashable: Any]?) {
-        guard FeatureFlag.tracksLoggingEnabled else { return }
+        guard FeatureFlag.tracksLoggingEnabled.isEnabled else { return }
 
         guard let properties = properties as? [String: Any] else {
             log("🔵 Tracked: \(name)")

--- a/podcasts/AnalyticsHelper.swift
+++ b/podcasts/AnalyticsHelper.swift
@@ -389,7 +389,7 @@ private extension AnalyticsHelper {
         #if !os(watchOS)
             Firebase.Analytics.logEvent(name, parameters: parameters)
 
-        if FeatureFlag.firebaseLogging.isEnabled {
+        if FeatureFlag.firebaseLogging.enabled {
                 if let parameters = parameters {
                     logger.debug("🟢 Tracked: \(name) \(parameters)")
                 } else {

--- a/podcasts/AnalyticsHelper.swift
+++ b/podcasts/AnalyticsHelper.swift
@@ -389,7 +389,7 @@ private extension AnalyticsHelper {
         #if !os(watchOS)
             Firebase.Analytics.logEvent(name, parameters: parameters)
 
-            if FeatureFlag.firebaseLoggingEnabled {
+        if FeatureFlag.firebaseLoggingEnabled.isEnabled {
                 if let parameters = parameters {
                     logger.debug("🟢 Tracked: \(name) \(parameters)")
                 } else {

--- a/podcasts/AnalyticsHelper.swift
+++ b/podcasts/AnalyticsHelper.swift
@@ -389,7 +389,7 @@ private extension AnalyticsHelper {
         #if !os(watchOS)
             Firebase.Analytics.logEvent(name, parameters: parameters)
 
-        if FeatureFlag.firebaseLoggingEnabled.isEnabled {
+        if FeatureFlag.firebaseLogging.isEnabled {
                 if let parameters = parameters {
                     logger.debug("🟢 Tracked: \(name) \(parameters)")
                 } else {

--- a/podcasts/AppDelegate+Analytics.swift
+++ b/podcasts/AppDelegate+Analytics.swift
@@ -3,7 +3,7 @@ import PocketCastsUtils
 
 extension AppDelegate {
     func setupAnalytics() {
-        guard FeatureFlag.tracks.isEnabled, !Settings.analyticsOptOut() else {
+        guard FeatureFlag.tracks.enabled, !Settings.analyticsOptOut() else {
             return
         }
 

--- a/podcasts/AppDelegate+Analytics.swift
+++ b/podcasts/AppDelegate+Analytics.swift
@@ -3,7 +3,7 @@ import PocketCastsUtils
 
 extension AppDelegate {
     func setupAnalytics() {
-        guard FeatureFlag.tracksEnabled.isEnabled, !Settings.analyticsOptOut() else {
+        guard FeatureFlag.tracks.isEnabled, !Settings.analyticsOptOut() else {
             return
         }
 

--- a/podcasts/AppDelegate+Analytics.swift
+++ b/podcasts/AppDelegate+Analytics.swift
@@ -3,7 +3,7 @@ import PocketCastsUtils
 
 extension AppDelegate {
     func setupAnalytics() {
-        guard FeatureFlag.tracksEnabled, !Settings.analyticsOptOut() else {
+        guard FeatureFlag.tracksEnabled.isEnabled, !Settings.analyticsOptOut() else {
             return
         }
 

--- a/podcasts/Beta/BetaMenu.swift
+++ b/podcasts/Beta/BetaMenu.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+struct BetaMenu: View {
+    var body: some View {
+        Text("Hello, World!")
+    }
+}
+
+struct BetaMenu_Previews: PreviewProvider {
+    static var previews: some View {
+        BetaMenu()
+    }
+}

--- a/podcasts/Beta/BetaMenu.swift
+++ b/podcasts/Beta/BetaMenu.swift
@@ -5,19 +5,22 @@ struct BetaMenu: View {
     var body: some View {
         List {
             ForEach(FeatureFlag.allCases, id: \.self) { feature in
-                Toggle(feature.rawValue, isOn: isEnabled(feature))
+                Toggle(feature.rawValue, isOn: feature.isOn)
             }
         }
     }
+}
 
-    func isEnabled(_ featureFlag: FeatureFlag) -> Binding<Bool> {
+private extension FeatureFlag {
+    var isOn: Binding<Bool> {
         return Binding<Bool>(
             get: {
-                return featureFlag.isEnabled
+                return isEnabled
             },
             set: { enabled in
-                try? FeatureFlagOverrideStore().override(featureFlag, withValue: enabled)
-            })
+                try? FeatureFlagOverrideStore().override(self, withValue: enabled)
+            }
+        )
     }
 }
 

--- a/podcasts/Beta/BetaMenu.swift
+++ b/podcasts/Beta/BetaMenu.swift
@@ -14,7 +14,7 @@ private extension FeatureFlag {
     var isOn: Binding<Bool> {
         return Binding<Bool>(
             get: {
-                return isEnabled
+                return enabled
             },
             set: { enabled in
                 try? FeatureFlagOverrideStore().override(self, withValue: enabled)

--- a/podcasts/Beta/BetaMenu.swift
+++ b/podcasts/Beta/BetaMenu.swift
@@ -4,7 +4,7 @@ struct BetaMenu: View {
     var body: some View {
         List {
             ForEach(FeatureFlag.allCases, id: \.self) { feature in
-                Toggle(feature.rawValue, isOn: feature.isOn)
+                Toggle(String(describing: feature), isOn: feature.isOn)
             }
         }
     }

--- a/podcasts/Beta/BetaMenu.swift
+++ b/podcasts/Beta/BetaMenu.swift
@@ -1,8 +1,18 @@
 import SwiftUI
 
 struct BetaMenu: View {
+    @State var enabled = true
     var body: some View {
-        Text("Hello, World!")
+        List {
+            ForEach(FeatureFlag.allCases, id: \.self) { feature in
+                Toggle(feature.rawValue, isOn: isEnabled(feature))
+            }
+        }
+    }
+
+    func isEnabled(_ featureFlag: FeatureFlag) -> Binding<Bool> {
+        return Binding<Bool>(get: {return featureFlag.isEnabled},
+                                                     set: {_ in })
     }
 }
 

--- a/podcasts/Beta/BetaMenu.swift
+++ b/podcasts/Beta/BetaMenu.swift
@@ -1,7 +1,6 @@
 import SwiftUI
 
 struct BetaMenu: View {
-    @State var enabled = true
     var body: some View {
         List {
             ForEach(FeatureFlag.allCases, id: \.self) { feature in

--- a/podcasts/Beta/BetaMenu.swift
+++ b/podcasts/Beta/BetaMenu.swift
@@ -11,8 +11,13 @@ struct BetaMenu: View {
     }
 
     func isEnabled(_ featureFlag: FeatureFlag) -> Binding<Bool> {
-        return Binding<Bool>(get: {return featureFlag.isEnabled},
-                                                     set: {_ in })
+        return Binding<Bool>(
+            get: {
+                return featureFlag.isEnabled
+            },
+            set: { enabled in
+                try? FeatureFlagOverrideStore().override(featureFlag, withValue: enabled)
+            })
     }
 }
 

--- a/podcasts/End of Year/EndOfYear.swift
+++ b/podcasts/End of Year/EndOfYear.swift
@@ -12,7 +12,7 @@ enum EndOfYearPresentationSource: String {
 struct EndOfYear {
     // We'll calculate this just once
     static var isEligible: Bool {
-        FeatureFlag.endOfYear.isEnabled && DataManager.sharedManager.isEligibleForEndOfYearStories()
+        FeatureFlag.endOfYear.enabled && DataManager.sharedManager.isEligibleForEndOfYearStories()
     }
 
     /// Internal state machine to determine how we should react to login changes
@@ -71,7 +71,7 @@ struct EndOfYear {
     }
 
     func showStories(in viewController: UIViewController, from source: EndOfYearPresentationSource) {
-        guard FeatureFlag.endOfYear.isEnabled else {
+        guard FeatureFlag.endOfYear.enabled else {
             return
         }
 

--- a/podcasts/End of Year/EndOfYear.swift
+++ b/podcasts/End of Year/EndOfYear.swift
@@ -12,7 +12,7 @@ enum EndOfYearPresentationSource: String {
 struct EndOfYear {
     // We'll calculate this just once
     static var isEligible: Bool {
-        FeatureFlag.endOfYear && DataManager.sharedManager.isEligibleForEndOfYearStories()
+        FeatureFlag.endOfYear.isEnabled && DataManager.sharedManager.isEligibleForEndOfYearStories()
     }
 
     /// Internal state machine to determine how we should react to login changes
@@ -71,7 +71,7 @@ struct EndOfYear {
     }
 
     func showStories(in viewController: UIViewController, from source: EndOfYearPresentationSource) {
-        guard FeatureFlag.endOfYear else {
+        guard FeatureFlag.endOfYear.isEnabled else {
             return
         }
 

--- a/podcasts/FeatureFlag.swift
+++ b/podcasts/FeatureFlag.swift
@@ -23,6 +23,10 @@ enum FeatureFlag: String, CaseIterable {
     case onboardingUpdates
 
     var isEnabled: Bool {
+        if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
+            return overriddenValue
+        }
+
         switch self {
         case .freeTrialsEnabled:
             return true
@@ -39,5 +43,15 @@ enum FeatureFlag: String, CaseIterable {
         case .onboardingUpdates:
             return true
         }
+    }
+}
+
+extension FeatureFlag: OverrideableFlag {
+    var description: String {
+        self.rawValue
+    }
+
+    var canOverride: Bool {
+        true
     }
 }

--- a/podcasts/FeatureFlag.swift
+++ b/podcasts/FeatureFlag.swift
@@ -22,7 +22,7 @@ enum FeatureFlag: String, CaseIterable {
     /// Displays the new onboarding view updates
     case onboardingUpdates
 
-    var isEnabled: Bool {
+    var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
         }

--- a/podcasts/FeatureFlag.swift
+++ b/podcasts/FeatureFlag.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum FeatureFlag {
+enum FeatureFlag: String, CaseIterable {
     /// Whether we should detect and show the free trial UI
     case freeTrialsEnabled
 

--- a/podcasts/FeatureFlag.swift
+++ b/podcasts/FeatureFlag.swift
@@ -2,23 +2,42 @@ import Foundation
 
 enum FeatureFlag {
     /// Whether we should detect and show the free trial UI
-    static let freeTrialsEnabled = true
+    case freeTrialsEnabled
 
     /// Whether the Tracks analytics are enabled
-    static let tracksEnabled = true
+    case tracksEnabled
 
     /// Whether logging of Tracks events in console are enabled
-    static let tracksLoggingEnabled = false
+    case tracksLoggingEnabled
 
     /// Whether logging of Firebase events in console are enabled
-    static let firebaseLoggingEnabled = false
+    case firebaseLoggingEnabled
 
     /// Whether End Of Year feature is enabled
-    static let endOfYear = true
+    case endOfYear
 
     /// Adds the Sign In With Apple options to the login flow
-    static let signInWithApple = false
+    case signInWithApple
 
     /// Displays the new onboarding view updates
-    static let onboardingUpdates = true
+    case onboardingUpdates
+
+    var isEnabled: Bool {
+        switch self {
+        case .freeTrialsEnabled:
+            return true
+        case .tracksEnabled:
+            return true
+        case .tracksLoggingEnabled:
+            return false
+        case .firebaseLoggingEnabled:
+            return false
+        case .endOfYear:
+            return true
+        case .signInWithApple:
+            return false
+        case .onboardingUpdates:
+            return true
+        }
+    }
 }

--- a/podcasts/FeatureFlag.swift
+++ b/podcasts/FeatureFlag.swift
@@ -48,7 +48,7 @@ enum FeatureFlag: String, CaseIterable {
 
 extension FeatureFlag: OverrideableFlag {
     var description: String {
-        self.rawValue
+        rawValue
     }
 
     var canOverride: Bool {

--- a/podcasts/FeatureFlag.swift
+++ b/podcasts/FeatureFlag.swift
@@ -5,13 +5,13 @@ enum FeatureFlag: String, CaseIterable {
     case freeTrialsEnabled
 
     /// Whether the Tracks analytics are enabled
-    case tracksEnabled
+    case tracks
 
     /// Whether logging of Tracks events in console are enabled
-    case tracksLoggingEnabled
+    case tracksLogging
 
     /// Whether logging of Firebase events in console are enabled
-    case firebaseLoggingEnabled
+    case firebaseLogging
 
     /// Whether End Of Year feature is enabled
     case endOfYear
@@ -30,11 +30,11 @@ enum FeatureFlag: String, CaseIterable {
         switch self {
         case .freeTrialsEnabled:
             return true
-        case .tracksEnabled:
+        case .tracks:
             return true
-        case .tracksLoggingEnabled:
+        case .tracksLogging:
             return false
-        case .firebaseLoggingEnabled:
+        case .firebaseLogging:
             return false
         case .endOfYear:
             return true

--- a/podcasts/FeatureFlagOverrideStore.swift
+++ b/podcasts/FeatureFlagOverrideStore.swift
@@ -4,7 +4,7 @@ import Foundation
 // feature flags to use in test cases.
 //
 protocol OverrideableFlag: CustomStringConvertible {
-    var isEnabled: Bool { get }
+    var enabled: Bool { get }
     var canOverride: Bool { get }
 }
 
@@ -40,7 +40,7 @@ struct FeatureFlagOverrideStore {
             store.removeObject(forKey: key)
         }
 
-        if value != featureFlag.isEnabled {
+        if value != featureFlag.enabled {
             store.set(value, forKey: key)
         }
     }

--- a/podcasts/FeatureFlagOverrideStore.swift
+++ b/podcasts/FeatureFlagOverrideStore.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+// Protocol allows easier unit testing, so we can implement mock
+// feature flags to use in test cases.
+//
+protocol OverrideableFlag: CustomStringConvertible {
+    var isEnabled: Bool { get }
+    var canOverride: Bool { get }
+}
+
+/// Used to override values for feature flags at runtime in debug builds
+///
+struct FeatureFlagOverrideStore {
+    private let store: UserDefaults
+
+    init(store: UserDefaults = UserDefaults.standard) {
+        self.store = store
+    }
+
+    private func key(for flag: OverrideableFlag) -> String {
+        return "ff-override-\(String(describing: flag))"
+    }
+
+    /// - returns: True if the specified feature flag is overridden
+    ///
+    func isOverridden(_ featureFlag: OverrideableFlag) -> Bool {
+        return overriddenValue(for: featureFlag) != nil
+    }
+
+    /// Removes any existing overridden value and stores the new value
+    ///
+    func override(_ featureFlag: OverrideableFlag, withValue value: Bool) throws {
+        guard featureFlag.canOverride == true else {
+            throw FeatureFlagError.cannotBeOverridden
+        }
+
+        let key = self.key(for: featureFlag)
+
+        if isOverridden(featureFlag) {
+            store.removeObject(forKey: key)
+        }
+
+        if value != featureFlag.isEnabled {
+            store.set(value, forKey: key)
+        }
+    }
+
+    /// - returns: The overridden value for the specified feature flag, if one exists.
+    /// If no override exists, returns `nil`.
+    ///
+    func overriddenValue(for featureFlag: OverrideableFlag) -> Bool? {
+        guard let value = store.object(forKey: key(for: featureFlag)) as? Bool else {
+            return nil
+        }
+
+        return value
+    }
+}
+
+enum FeatureFlagError: Error {
+    case cannotBeOverridden
+}

--- a/podcasts/IapHelper.swift
+++ b/podcasts/IapHelper.swift
@@ -174,7 +174,7 @@ extension IapHelper {
     }
 
     func isEligibleForFreeTrial() -> Bool {
-        return FeatureFlag.freeTrialsEnabled && isEligibleForTrial
+        return FeatureFlag.freeTrialsEnabled.isEnabled && isEligibleForTrial
     }
 
     /// Checks if there is a free trial introductory offer for the given product
@@ -218,7 +218,7 @@ private extension IapHelper {
     private func updateTrialEligibility() {
         guard
             isCheckingEligibility == false,
-            FeatureFlag.freeTrialsEnabled,
+            FeatureFlag.freeTrialsEnabled.isEnabled,
             getFirstFreeTrialProductId() != nil,
             SubscriptionHelper.hasActiveSubscription() == false,
             let receiptUrl = Bundle.main.appStoreReceiptURL,

--- a/podcasts/IapHelper.swift
+++ b/podcasts/IapHelper.swift
@@ -174,7 +174,7 @@ extension IapHelper {
     }
 
     func isEligibleForFreeTrial() -> Bool {
-        return FeatureFlag.freeTrialsEnabled.isEnabled && isEligibleForTrial
+        return FeatureFlag.freeTrialsEnabled.enabled && isEligibleForTrial
     }
 
     /// Checks if there is a free trial introductory offer for the given product
@@ -218,7 +218,7 @@ private extension IapHelper {
     private func updateTrialEligibility() {
         guard
             isCheckingEligibility == false,
-            FeatureFlag.freeTrialsEnabled.isEnabled,
+            FeatureFlag.freeTrialsEnabled.enabled,
             getFirstFreeTrialProductId() != nil,
             SubscriptionHelper.hasActiveSubscription() == false,
             let receiptUrl = Bundle.main.appStoreReceiptURL,

--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -66,7 +66,7 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
     }
 
     private func showInitialOnboardingIfNeeded() {
-        guard FeatureFlag.onboardingUpdates, Settings.shouldShowInitialOnboardingFlow else { return }
+        guard FeatureFlag.onboardingUpdates.isEnabled, Settings.shouldShowInitialOnboardingFlow else { return }
 
         NavigationManager.sharedManager.navigateTo(NavigationManager.onboardingFlow, data: ["flow": OnboardingFlow.Flow.initialOnboarding])
 
@@ -253,7 +253,7 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
         // If we're already presenting a view, then present from that view if possible
         let presentingController = presentedViewController ?? view.window?.rootViewController
 
-        guard FeatureFlag.onboardingUpdates else {
+        guard FeatureFlag.onboardingUpdates.isEnabled else {
             let upgradeVC = UpgradeRequiredViewController(upgradeRootViewController: upgradeRootViewController, source: source)
             presentingController?.present(SJUIUtils.popupNavController(for: upgradeVC), animated: true, completion: nil)
             return
@@ -335,7 +335,7 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
         guard !SyncManager.isUserLoggedIn() else { return }
 
         let signInController: UIViewController
-        if FeatureFlag.signInWithApple {
+        if FeatureFlag.signInWithApple.isEnabled {
             signInController = ProfileIntroViewController()
         }
         else {
@@ -431,7 +431,7 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
     }
 
     func observersForEndOfYearStats() {
-        guard FeatureFlag.endOfYear else {
+        guard FeatureFlag.endOfYear.isEnabled else {
             return
         }
 

--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -66,7 +66,7 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
     }
 
     private func showInitialOnboardingIfNeeded() {
-        guard FeatureFlag.onboardingUpdates.isEnabled, Settings.shouldShowInitialOnboardingFlow else { return }
+        guard FeatureFlag.onboardingUpdates.enabled, Settings.shouldShowInitialOnboardingFlow else { return }
 
         NavigationManager.sharedManager.navigateTo(NavigationManager.onboardingFlow, data: ["flow": OnboardingFlow.Flow.initialOnboarding])
 
@@ -253,7 +253,7 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
         // If we're already presenting a view, then present from that view if possible
         let presentingController = presentedViewController ?? view.window?.rootViewController
 
-        guard FeatureFlag.onboardingUpdates.isEnabled else {
+        guard FeatureFlag.onboardingUpdates.enabled else {
             let upgradeVC = UpgradeRequiredViewController(upgradeRootViewController: upgradeRootViewController, source: source)
             presentingController?.present(SJUIUtils.popupNavController(for: upgradeVC), animated: true, completion: nil)
             return
@@ -335,7 +335,7 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
         guard !SyncManager.isUserLoggedIn() else { return }
 
         let signInController: UIViewController
-        if FeatureFlag.signInWithApple.isEnabled {
+        if FeatureFlag.signInWithApple.enabled {
             signInController = ProfileIntroViewController()
         }
         else {
@@ -431,7 +431,7 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
     }
 
     func observersForEndOfYearStats() {
-        guard FeatureFlag.endOfYear.isEnabled else {
+        guard FeatureFlag.endOfYear.enabled else {
             return
         }
 

--- a/podcasts/Onboarding/Login/LoginLandingView.swift
+++ b/podcasts/Onboarding/Login/LoginLandingView.swift
@@ -24,7 +24,7 @@ private struct LoginLandingContent: View {
 
     /// Reduce the header height to allow the buttons to fit for larger size categories
     private var useSmallHeader: Bool {
-        (smallHeight && sizeCategory > .extraLarge) || FeatureFlag.signInWithApple
+        (smallHeight && sizeCategory > .extraLarge) || FeatureFlag.signInWithApple.isEnabled
     }
 
     let coordinator: LoginCoordinator
@@ -306,7 +306,7 @@ private struct SocialLoginButtons: View {
     let coordinator: LoginCoordinator
 
     var body: some View {
-        if !FeatureFlag.signInWithApple {
+        if !FeatureFlag.signInWithApple.isEnabled {
             EmptyView()
         } else {
             Button("Continue with Apple") {

--- a/podcasts/Onboarding/Login/LoginLandingView.swift
+++ b/podcasts/Onboarding/Login/LoginLandingView.swift
@@ -24,7 +24,7 @@ private struct LoginLandingContent: View {
 
     /// Reduce the header height to allow the buttons to fit for larger size categories
     private var useSmallHeader: Bool {
-        (smallHeight && sizeCategory > .extraLarge) || FeatureFlag.signInWithApple.isEnabled
+        (smallHeight && sizeCategory > .extraLarge) || FeatureFlag.signInWithApple.enabled
     }
 
     let coordinator: LoginCoordinator
@@ -306,7 +306,7 @@ private struct SocialLoginButtons: View {
     let coordinator: LoginCoordinator
 
     var body: some View {
-        if !FeatureFlag.signInWithApple.isEnabled {
+        if !FeatureFlag.signInWithApple.enabled {
             EmptyView()
         } else {
             Button("Continue with Apple") {

--- a/podcasts/PlusDetailsViewController.swift
+++ b/podcasts/PlusDetailsViewController.swift
@@ -157,7 +157,7 @@ class PlusDetailsViewController: PCViewController {
     }
 
     @IBAction func upgradeTapped(_ sender: Any) {
-        guard !FeatureFlag.onboardingUpdates else {
+        guard !FeatureFlag.onboardingUpdates.isEnabled else {
             handleUpgrade()
             return
         }

--- a/podcasts/PlusDetailsViewController.swift
+++ b/podcasts/PlusDetailsViewController.swift
@@ -157,7 +157,7 @@ class PlusDetailsViewController: PCViewController {
     }
 
     @IBAction func upgradeTapped(_ sender: Any) {
-        guard !FeatureFlag.onboardingUpdates.isEnabled else {
+        guard !FeatureFlag.onboardingUpdates.enabled else {
             handleUpgrade()
             return
         }

--- a/podcasts/ProfileIntroViewController.swift
+++ b/podcasts/ProfileIntroViewController.swift
@@ -27,7 +27,7 @@ class ProfileIntroViewController: PCViewController, SyncSigninDelegate {
     @IBOutlet var authenticationProviders: UIStackView!
     @IBOutlet var signInBtn: ThemeableRoundedButton! {
         didSet {
-            signInBtn.isHidden = FeatureFlag.signInWithApple.isEnabled
+            signInBtn.isHidden = FeatureFlag.signInWithApple.enabled
             signInBtn.setTitle(L10n.signIn, for: .normal)
             signInBtn.shouldFill = false
             signInBtn.titleLabel?.font = buttonFont
@@ -36,7 +36,7 @@ class ProfileIntroViewController: PCViewController, SyncSigninDelegate {
 
     @IBOutlet var passwordAuthOption: ThemeableUIButton! {
         didSet {
-            passwordAuthOption.isHidden = !FeatureFlag.signInWithApple.isEnabled
+            passwordAuthOption.isHidden = !FeatureFlag.signInWithApple.enabled
             passwordAuthOption.setTitle(L10n.accountLogin, for: .normal)
             passwordAuthOption.titleLabel?.font = buttonFont
         }
@@ -142,7 +142,7 @@ class ProfileIntroViewController: PCViewController, SyncSigninDelegate {
 // MARK: - Apple Auth
 extension ProfileIntroViewController {
     func setupProviderLoginView() {
-        guard FeatureFlag.signInWithApple.isEnabled else { return }
+        guard FeatureFlag.signInWithApple.enabled else { return }
 
         let authorizationButton = ASAuthorizationAppleIDButton(type: .continue, style: .whiteOutline)
         authorizationButton.cornerRadius = createAccountBtn.cornerRadius

--- a/podcasts/ProfileIntroViewController.swift
+++ b/podcasts/ProfileIntroViewController.swift
@@ -27,7 +27,7 @@ class ProfileIntroViewController: PCViewController, SyncSigninDelegate {
     @IBOutlet var authenticationProviders: UIStackView!
     @IBOutlet var signInBtn: ThemeableRoundedButton! {
         didSet {
-            signInBtn.isHidden = FeatureFlag.signInWithApple
+            signInBtn.isHidden = FeatureFlag.signInWithApple.isEnabled
             signInBtn.setTitle(L10n.signIn, for: .normal)
             signInBtn.shouldFill = false
             signInBtn.titleLabel?.font = buttonFont
@@ -36,7 +36,7 @@ class ProfileIntroViewController: PCViewController, SyncSigninDelegate {
 
     @IBOutlet var passwordAuthOption: ThemeableUIButton! {
         didSet {
-            passwordAuthOption.isHidden = !FeatureFlag.signInWithApple
+            passwordAuthOption.isHidden = !FeatureFlag.signInWithApple.isEnabled
             passwordAuthOption.setTitle(L10n.accountLogin, for: .normal)
             passwordAuthOption.titleLabel?.font = buttonFont
         }
@@ -142,7 +142,7 @@ class ProfileIntroViewController: PCViewController, SyncSigninDelegate {
 // MARK: - Apple Auth
 extension ProfileIntroViewController {
     func setupProviderLoginView() {
-        guard FeatureFlag.signInWithApple else { return }
+        guard FeatureFlag.signInWithApple.isEnabled else { return }
 
         let authorizationButton = ASAuthorizationAppleIDButton(type: .continue, style: .whiteOutline)
         authorizationButton.cornerRadius = createAccountBtn.cornerRadius

--- a/podcasts/ProfileViewController.swift
+++ b/podcasts/ProfileViewController.swift
@@ -222,7 +222,7 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
     }
 
     func showProfileSetupController() {
-        if FeatureFlag.onboardingUpdates {
+        if FeatureFlag.onboardingUpdates.isEnabled {
             NavigationManager.sharedManager.navigateTo(NavigationManager.onboardingFlow, data: ["flow": OnboardingFlow.Flow.loggedOut])
             return
         }

--- a/podcasts/ProfileViewController.swift
+++ b/podcasts/ProfileViewController.swift
@@ -222,7 +222,7 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
     }
 
     func showProfileSetupController() {
-        if FeatureFlag.onboardingUpdates.isEnabled {
+        if FeatureFlag.onboardingUpdates.enabled {
             NavigationManager.sharedManager.navigateTo(NavigationManager.onboardingFlow, data: ["flow": OnboardingFlow.Flow.loggedOut])
             return
         }

--- a/podcasts/SelectPaymentFreqViewController.swift
+++ b/podcasts/SelectPaymentFreqViewController.swift
@@ -189,7 +189,7 @@ class SelectPaymentFreqViewController: UIViewController {
     @objc func iapProductsFailed() {
         #if !targetEnvironment(simulator)
             errorView.isHidden = false
-            tryAgainButton.enabled = true
+            tryAgainButton.isEnabled = true
             tryAgainActivityIndicator.stopAnimating()
         #endif
     }

--- a/podcasts/SelectPaymentFreqViewController.swift
+++ b/podcasts/SelectPaymentFreqViewController.swift
@@ -189,7 +189,7 @@ class SelectPaymentFreqViewController: UIViewController {
     @objc func iapProductsFailed() {
         #if !targetEnvironment(simulator)
             errorView.isHidden = false
-            tryAgainButton.isEnabled = true
+            tryAgainButton.enabled = true
             tryAgainActivityIndicator.stopAnimating()
         #endif
     }

--- a/podcasts/SettingsViewController.swift
+++ b/podcasts/SettingsViewController.swift
@@ -5,7 +5,7 @@ import WatchConnectivity
 
 class SettingsViewController: PCViewController, UITableViewDataSource, UITableViewDelegate {
     private enum TableRow: String {
-        case general, notifications, appearance, storageAndDataUse, autoArchive, autoDownload, autoAddToUpNext, siriShortcuts, watch, customFiles, help, opml, about, pocketCastsPlus, privacy, developer
+        case general, notifications, appearance, storageAndDataUse, autoArchive, autoDownload, autoAddToUpNext, siriShortcuts, watch, customFiles, help, opml, about, pocketCastsPlus, privacy, developer, beta
 
         var display: (text: String, image: UIImage?) {
             switch self {
@@ -41,6 +41,8 @@ class SettingsViewController: PCViewController, UITableViewDataSource, UITableVi
                 return (L10n.settingsPrivacy, UIImage(systemName: "lock.fill"))
             case .developer:
                 return ("Developer", UIImage(systemName: "ladybug.fill"))
+            case .beta:
+                return ("Beta Features", UIImage(systemName: "testtube.2"))
             }
         }
     }
@@ -142,6 +144,10 @@ class SettingsViewController: PCViewController, UITableViewDataSource, UITableVi
         case .developer:
             let hostingController = UIHostingController(rootView: DeveloperMenu().setupDefaultEnvironment())
             navigationController?.pushViewController(hostingController, animated: true)
+        case .beta:
+            let hostingController = UIHostingController(rootView: BetaMenu().setupDefaultEnvironment())
+            hostingController.title = "Beta Features"
+            navigationController?.pushViewController(hostingController, animated: true)
         }
     }
 
@@ -161,7 +167,7 @@ class SettingsViewController: PCViewController, UITableViewDataSource, UITableVi
         }
 
         #if DEBUG
-        tableData.insert([.developer], at: 0)
+        tableData.insert([.developer, .beta], at: 0)
         #endif
 
         settingsTable.reloadData()


### PR DESCRIPTION
When developing, we often toggle Feature Flags on/off. So far, this has been done manually editing `FeatureFlag.swift`.

This PR adds a screen to toggle FeatureFlag values and persist them among builds/branches — the same way (and same code!) WPiOS do it.

We can also improve this screen with a better description of the Features but I wanted to keep this PR as simple as possible.

**This is only available for DEBUG builds.**

| New option under Settings | Beta Features screen |
| -------------------------- | --------------------- |
| ![Simulator Screen Shot - iPhone 14 - 2022-12-08 at 13 32 13](https://user-images.githubusercontent.com/7040243/206509033-98131069-a6c7-4c4e-a945-1cb3646b7eb9.png) | ![Simulator Screen Shot - iPhone 14 - 2022-12-08 at 10 53 16](https://user-images.githubusercontent.com/7040243/206509116-1a1b0b97-53e2-41f7-b812-b31a19823e70.png) |

## To test

1. Run the app
2. Go to Settings
3. Tap "Beta Features"
4. Toggle "End of Year" (off)
5. ✅ Go to Profile and check that the card disappeared
6. Go back to Settings > Beta Features > toggle End of Year on
7. ✅ Go back to Profile and check that the card is back
8. You can also check the other flags

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
