### PR TITLE
Adds a SwiftUI view to allow for highlighting of text 

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Extensions/String+PreventWidows.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Extensions/String+PreventWidows.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+public extension String {
+    /// A non-breaking space
+    static let nbsp = "\u{00a0}"
+
+    /// Replaces all spaces with non-breaking spaces
+    func nonBreakingSpaces() -> String {
+        self.replacingOccurrences(of: Constants.space, with: Self.nbsp)
+    }
+
+    /// This attempts to prevent widows/orphaned text by applying a non-breaking space between the last words
+    /// This also prevents the Pocket Casts from being split up
+    func preventWidows() -> String {
+        // Prevent Pocket Casts from being separated
+        let returnText = self.replacingOccurrences(of: Constants.pocketCasts, with: Constants.pocketCastsNBSP)
+
+        let components = returnText.components(separatedBy: Constants.space)
+
+        guard components.count > 1 else {
+            return returnText
+        }
+
+        let count = components.count - 1
+        var builder: [String] = []
+
+        for (index, word) in components.enumerated() {
+            if index > 0 {
+                let isLast = index == count
+                builder.append(isLast ? .nbsp : Constants.space)
+            }
+            builder.append(word)
+        }
+
+        return builder.joined()
+    }
+
+    private enum Constants {
+        static let space = " "
+        static let pocketCasts = "Pocket Casts"
+        static let pocketCastsNBSP = "Pocket" + .nbsp + "Casts"
+    }
+}

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1407,7 +1407,7 @@
 		C7F4BAB728DA8666001C9785 /* BackgroundSignOutListenerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F4BAB628DA8666001C9785 /* BackgroundSignOutListenerTests.swift */; };
 		C7F4BABF28DB7F7C001C9785 /* DiscoverItem+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F4BABE28DB7F7C001C9785 /* DiscoverItem+Helper.swift */; };
 		C7F87F112913242C00C15980 /* UIFont+FontStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F87F0F2913242B00C15980 /* UIFont+FontStyle.swift */; };
-		C7FAFF5829417F5E00329B40 /* HighlightedText.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7FAFF5729417F5E00329B40 /* HighlightedText.swift */; };
+		C7FAFF692942E6A500329B40 /* HighlightedText.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7FAFF682942E6A400329B40 /* HighlightedText.swift */; };
 		C7FF76C0291B4F430082A464 /* ProportionalValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7FF76BF291B4F430082A464 /* ProportionalValue.swift */; };
 		C7FF76C2291B5F100082A464 /* PlusButtonStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7FF76C1291B5F100082A464 /* PlusButtonStyles.swift */; };
 		C7FF770C291C2C4D0082A464 /* LoginLandingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7FF770B291C2C4D0082A464 /* LoginLandingView.swift */; };
@@ -2984,7 +2984,7 @@
 		C7F4BAB628DA8666001C9785 /* BackgroundSignOutListenerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundSignOutListenerTests.swift; sourceTree = "<group>"; };
 		C7F4BABE28DB7F7C001C9785 /* DiscoverItem+Helper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DiscoverItem+Helper.swift"; sourceTree = "<group>"; };
 		C7F87F0F2913242B00C15980 /* UIFont+FontStyle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIFont+FontStyle.swift"; sourceTree = "<group>"; };
-		C7FAFF5729417F5E00329B40 /* HighlightedText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightedText.swift; sourceTree = "<group>"; };
+		C7FAFF682942E6A400329B40 /* HighlightedText.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HighlightedText.swift; sourceTree = "<group>"; };
 		C7FF76BF291B4F430082A464 /* ProportionalValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProportionalValue.swift; sourceTree = "<group>"; };
 		C7FF76C1291B5F100082A464 /* PlusButtonStyles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlusButtonStyles.swift; sourceTree = "<group>"; };
 		C7FF770B291C2C4D0082A464 /* LoginLandingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginLandingView.swift; sourceTree = "<group>"; };
@@ -6071,6 +6071,7 @@
 				C7B3C60D2919DD1700054145 /* ContentSizeReader.swift */,
 				C7B3C60B2919DCC800054145 /* ActionView.swift */,
 				C7B3C6132919F47A00054145 /* HorizontalScrollView.swift */,
+				C7FAFF682942E6A400329B40 /* HighlightedText.swift */,
 				C7FF76BF291B4F430082A464 /* ProportionalValue.swift */,
 				C7FF7716291D50880082A464 /* Motion.swift */,
 				C7A110F1291F1EC300887A90 /* HTMLTextView.swift */,
@@ -8019,7 +8020,7 @@
 				BDCC55141CD0A448006BE239 /* AEXML.swift in Sources */,
 				8B1C974628FE1C7E00BD5EB9 /* ImageView.swift in Sources */,
 				40484F0122F1507F007DBD55 /* ThemeableRoundedButton.swift in Sources */,
-				C7FAFF5829417F5E00329B40 /* HighlightedText.swift in Sources */,
+				C7FAFF692942E6A500329B40 /* HighlightedText.swift in Sources */,
 				BDEBD3A91BA0108800AD038F /* BufferedAudio.swift in Sources */,
 				402772D721B6105D00769811 /* PodcastManager+Delete.swift in Sources */,
 				403B5B02217D5F1500821A54 /* TitleViewWithCollapseButton.swift in Sources */,

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1407,6 +1407,7 @@
 		C7F4BAB728DA8666001C9785 /* BackgroundSignOutListenerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F4BAB628DA8666001C9785 /* BackgroundSignOutListenerTests.swift */; };
 		C7F4BABF28DB7F7C001C9785 /* DiscoverItem+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F4BABE28DB7F7C001C9785 /* DiscoverItem+Helper.swift */; };
 		C7F87F112913242C00C15980 /* UIFont+FontStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F87F0F2913242B00C15980 /* UIFont+FontStyle.swift */; };
+		C7FAFF5829417F5E00329B40 /* HighlightedText.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7FAFF5729417F5E00329B40 /* HighlightedText.swift */; };
 		C7FF76C0291B4F430082A464 /* ProportionalValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7FF76BF291B4F430082A464 /* ProportionalValue.swift */; };
 		C7FF76C2291B5F100082A464 /* PlusButtonStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7FF76C1291B5F100082A464 /* PlusButtonStyles.swift */; };
 		C7FF770C291C2C4D0082A464 /* LoginLandingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7FF770B291C2C4D0082A464 /* LoginLandingView.swift */; };
@@ -2983,6 +2984,7 @@
 		C7F4BAB628DA8666001C9785 /* BackgroundSignOutListenerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundSignOutListenerTests.swift; sourceTree = "<group>"; };
 		C7F4BABE28DB7F7C001C9785 /* DiscoverItem+Helper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DiscoverItem+Helper.swift"; sourceTree = "<group>"; };
 		C7F87F0F2913242B00C15980 /* UIFont+FontStyle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIFont+FontStyle.swift"; sourceTree = "<group>"; };
+		C7FAFF5729417F5E00329B40 /* HighlightedText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightedText.swift; sourceTree = "<group>"; };
 		C7FF76BF291B4F430082A464 /* ProportionalValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProportionalValue.swift; sourceTree = "<group>"; };
 		C7FF76C1291B5F100082A464 /* PlusButtonStyles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlusButtonStyles.swift; sourceTree = "<group>"; };
 		C7FF770B291C2C4D0082A464 /* LoginLandingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginLandingView.swift; sourceTree = "<group>"; };
@@ -8017,6 +8019,7 @@
 				BDCC55141CD0A448006BE239 /* AEXML.swift in Sources */,
 				8B1C974628FE1C7E00BD5EB9 /* ImageView.swift in Sources */,
 				40484F0122F1507F007DBD55 /* ThemeableRoundedButton.swift in Sources */,
+				C7FAFF5829417F5E00329B40 /* HighlightedText.swift in Sources */,
 				BDEBD3A91BA0108800AD038F /* BufferedAudio.swift in Sources */,
 				402772D721B6105D00769811 /* PodcastManager+Delete.swift in Sources */,
 				403B5B02217D5F1500821A54 /* TitleViewWithCollapseButton.swift in Sources */,

--- a/podcasts/End of Year/Stories/Views/CommonStoryViews.swift
+++ b/podcasts/End of Year/Stories/Views/CommonStoryViews.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import PocketCastsDataModel
+import PocketCastsUtils
 
 /// A label used in the end of year stories that provides consistent styling
 /// This preprocesses the text to improve the typography
@@ -54,29 +55,8 @@ struct StoryLabel: View {
     }
 
     private static func processText(_ text: String) -> String {
-        let returnText = text
         // Typographic apostrophes
-            .replacingOccurrences(of: "'", with: "ʼ")
-        // Prevent Pocket Casts from being separated
-            .replacingOccurrences(of: "Pocket Casts", with: "Pocket Casts".nonBreakingSpaces())
-
-        let components = returnText.components(separatedBy: " ")
-
-        guard components.count > 1 else {
-            return returnText
-        }
-
-        let count = components.count - 1
-        var builder: [String] = []
-
-        for (index, word) in components.enumerated() {
-            let isLast = index == count
-
-            builder.append(isLast ? .nbsp : " ")
-            builder.append(word)
-        }
-
-        return builder.joined()
+        text.preventWidows().replacingOccurrences(of: "'", with: "ʼ")
     }
 
     enum StoryLabelType {
@@ -399,13 +379,6 @@ struct PodcastStackView: View {
 }
 
 extension String {
-    static let nbsp = "\u{00a0}"
-
-    func nonBreakingSpaces() -> String {
-        self.replacingOccurrences(of: " ", with: Self.nbsp)
-    }
-
-
     /// Limit the string to given length or truncate it with ...
     func limited(to len: Int) -> String {
         // If the length is less than the max, then allow it

--- a/podcasts/SwiftUI/HighlightedText.swift
+++ b/podcasts/SwiftUI/HighlightedText.swift
@@ -6,7 +6,7 @@ struct HighlightedText: View {
     typealias HighlightStyleBlock = (Highlight) -> HighlightStyle?
 
     // Internal config
-    private var highlights: Set<String> = []
+    private var highlights: [String] = []
     private var font: Font = .body
     private var highlightBlocks: [String: HighlightStyleBlock] = [:]
     private let text: String
@@ -37,7 +37,7 @@ struct HighlightedText: View {
     func highlight(_ string: String?, _ highlightBlock: HighlightStyleBlock? = nil) -> Self {
         var mutableSelf = self
         if let string, !string.isEmpty {
-            mutableSelf.highlights.insert(string)
+            mutableSelf.highlights.append(string)
             mutableSelf.highlightBlocks[Self.key(string)] = highlightBlock
         }
         return mutableSelf
@@ -48,7 +48,7 @@ struct HighlightedText: View {
         var mutableSelf = self
 
         if let strings, !strings.isEmpty {
-            mutableSelf.highlights.formUnion(strings)
+            mutableSelf.highlights.append(contentsOf: strings)
 
             for string in strings {
                 mutableSelf.highlightBlocks[Self.key(string)] = highlightBlock

--- a/podcasts/SwiftUI/HighlightedText.swift
+++ b/podcasts/SwiftUI/HighlightedText.swift
@@ -1,0 +1,295 @@
+import SwiftUI
+import PocketCastsUtils
+
+/// Allows applying to styles to subtext located within a string
+struct HighlightedText: View {
+    typealias HighlightStyleBlock = (HighlightTokenizer.Token) -> HighlightStyle?
+
+    /// Internal configuration to allow the view to "configure itself" without
+    /// needing to pass everything through the init
+    @ObservedObject private var config = Configuration()
+
+    private let text: String
+
+    init(_ text: String) {
+        self.text = text.preventWidows()
+    }
+
+    var body: some View {
+        if #available(iOS 15, *), let attributedString {
+            Text(attributedString)
+                .dynamicTypeSize(...DynamicTypeSize.xxxLarge)
+        } else {
+            Text(text)
+        }
+    }
+
+    // MARK: - View Configuration
+
+    /// Sets the font for the entire text
+    func font(_ font: Font) -> Self {
+        config.font = font
+        return self
+    }
+
+    /// Adds a new highlight string
+    func highlight(_ string: String?) -> Self {
+        if let string, !string.isEmpty {
+            config.highlights.append(string)
+        }
+        return self
+    }
+
+    /// Adds new highlight strings
+    func highlight(_ strings: [String]?) -> Self {
+        if let strings, !strings.isEmpty {
+            config.highlights.append(contentsOf: strings)
+        }
+        return self
+    }
+
+
+    /// This is called when a highlight match is ready for styling
+    /// By default this will return `HighlightStyleBlock.defaultStyle`
+    func onHighlight(_ block: @escaping HighlightStyleBlock) -> Self {
+        config.highlightBlock = block
+        return self
+    }
+
+    // MARK: - Private
+
+    @available(iOS 15, *)
+    private var attributedString: AttributedString? {
+        let highlights = config.highlights
+        guard !highlights.isEmpty else { return nil }
+
+        // Get all the highlight matches in the form of tokens
+        let tokenizer = HighlightTokenizer(text: text, highlights: highlights)
+        let tokens = tokenizer.tokenize()
+
+        // Create the base attributed string to return
+        var string = AttributedString()
+
+        for token in tokens {
+            // Configure the base text
+            var substring = AttributedString(token.string)
+            substring.font = config.font
+
+            defer { string += substring }
+
+            // Apply highlight style below...
+            guard token.type == .highlight else { continue }
+
+            // If there isn't a style block defined, then use the default style
+            let styleBlock = config.highlightBlock ?? { token in
+                .defaultStyle
+            }
+
+            // If the style block returns nil, then don't apply a style
+            guard let style = styleBlock(token) else { continue }
+
+            // Use the base font if only the weight is specified
+            if style.font == nil, let weight = style.weight {
+                substring.font = config.font.weight(weight)
+            } else {
+                substring.font = style.font
+            }
+
+            // Set the foreground and background
+            substring.foregroundColor = style.color
+            substring.backgroundColor = style.backgroundColor
+        }
+
+        return string
+    }
+
+    // MARK: - Internal configuration state
+    private class Configuration: ObservableObject {
+        @Published var highlights: [String] = []
+        @Published var font: Font = .body
+        @Published var highlightBlock: HighlightStyleBlock? = nil
+    }
+
+    /// Defines a style for a highlight
+    struct HighlightStyle {
+        let font: Font?
+        let weight: Font.Weight?
+        let color: Color?
+        let backgroundColor: Color?
+
+        init(font: Font? = nil, weight: Font.Weight? = nil, color: Color? = nil, backgroundColor: Color? = nil) {
+            self.font = font
+            self.weight = weight
+            self.color = color
+            self.backgroundColor = backgroundColor
+        }
+
+        static let defaultStyle: HighlightStyle = .init(weight: .bold)
+    }
+}
+
+// MARK: - Tokenizer
+
+/// Converts the given text and highlights into a tokenized array
+struct HighlightTokenizer {
+    let text: String
+    let highlights: [String]
+
+    func tokenize() -> [Token] {
+        var result = text
+
+        for highlight in highlights {
+            // If there's at least 1 match of the highlight, then replace all instances with a token
+            if result.range(of: highlight) != nil {
+                result = result.replacingOccurrences(of: highlight, with: token(string: highlight))
+            }
+
+            // If highlight string is multiple words, then also replace the nbsp version of the string
+            // this will make sure we highlight the last few words of a string
+            let nbspHighlight = highlight.nonBreakingSpaces()
+
+            if highlight.contains(" "), result.range(of: nbspHighlight) != nil {
+                result = result.replacingOccurrences(of: nbspHighlight, with: token(string: nbspHighlight))
+            }
+        }
+
+        // Split on the delimiter to get a list of the token'd strings
+        let components = result.components(separatedBy: Constants.delimeter)
+
+        var tokens: [Token] = []
+        var counter: [String: Int] = [:]
+
+        for component in components {
+            if component.isEmpty { continue }
+
+            var string = component
+            var type = Token.TokenType.string
+            let key = string.nonBreakingSpaces()
+
+            // If the first character is our highlight indicator
+            // then remove the indicator, mark it as a highlight, and keep a running tally
+            if string.first == Constants.highlight {
+                string = String(component.dropFirst())
+                type = .highlight
+
+                counter[key] = (counter[key] ?? -1) + 1
+            }
+
+            tokens.append(Token(string: string, type: type, matchNumber: counter[key] ?? 0))
+        }
+
+        // Update all the total match counts for the highlights
+        for var token in tokens {
+            let key = token.string.nonBreakingSpaces()
+            token.matchCount = counter[key] ?? 0
+        }
+
+        return tokens
+    }
+
+    // Wrap the highlight with the delimeter to split the text
+    // Append the highlight token character so we can easily process it below
+    private func token(string: String) -> String {
+        Constants.delimeter + (String(Constants.highlight) + string) + Constants.delimeter
+    }
+
+    struct Token {
+        let string: String
+        let type: TokenType
+
+        /// If there are multiple matches, this indicate which order it appeared in the text
+        let matchNumber: Int
+
+        /// The total number of matches for this highlight
+        var matchCount: Int = 0
+
+        enum TokenType {
+            case string, highlight
+        }
+    }
+
+    private enum Constants {
+        /// The token wrapping delimeter
+        /// This is a group separator character to prevent clashing with the actual text
+        static let delimeter = "\u{001D}"
+
+        /// The highlight indicator
+        /// This is a a substitute character to prevent clashing with the actual text
+        static let highlight = Character("\u{001A}")
+    }
+}
+
+// MARK: - Demo
+
+struct HighlightedText_Previews: PreviewProvider {
+    struct DemoView: View {
+        @State var toggle = true
+
+        var body: some View {
+            List {
+                HighlightedText("Hello this has no highlighting applied to it")
+                    .font(.body)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                HighlightedText("The word world will be bolded")
+                    .highlight("world")
+                    .font(.body)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                HighlightedText("The highlighted words will now be in a different font and background color 😱!")
+                    .highlight(["highlighted", "now", "font"])
+                    .font(.body)
+                    .onHighlight { token in
+                            .init(font: .title3.italic().weight(.heavy),
+                                  color: .purple,
+                                  backgroundColor: .yellow.opacity(0.3))
+                    }.fixedSize(horizontal: false, vertical: true)
+
+                HighlightedText("Match all words! One! Two! One! Two!")
+                    .highlight("One")
+                    .font(.body)
+                    .onHighlight { token in
+                            .init(font: .title3.italic().weight(.heavy),
+                                  color: .purple,
+                                  backgroundColor: .yellow.opacity(0.3))
+                    }.fixedSize(horizontal: false, vertical: true)
+
+                let diffString = "Have different styles for each match WOW!"
+                let highlights = diffString.components(separatedBy: .whitespaces)
+                let rainbow: [Color] = [.red, .orange, .yellow, .green, .blue, .purple, .pink]
+
+                HighlightedText(diffString)
+                    .highlight(highlights)
+                    .font(.body)
+                    .onHighlight { token in
+                        guard let index = highlights.firstIndex(of: token.string) else {
+                            return nil
+                        }
+
+                        return .init(font: .body.bold(), color: rainbow[index])
+                    }.fixedSize(horizontal: false, vertical: true)
+
+                HighlightedText("Tap to toggle: Match \(toggle ? "first" : "last") occurence!\nWord Word Word Word")
+                    .highlight("Word")
+                    .font(.body)
+                    .onHighlight { token in
+                        if (toggle && token.matchNumber != 0) || (!toggle && token.matchNumber < token.matchCount) {
+                            return nil
+                        }
+
+                        return .defaultStyle
+                    }
+                    .fixedSize(horizontal: false, vertical: true)
+                    .onTapGesture {
+                        toggle.toggle()
+                    }
+
+            }.listStyle(.plain)
+
+        }
+    }
+
+    static var previews: some View {
+        DemoView()
+    }
+}


### PR DESCRIPTION
This extracts the highlighting from the `StoryLabel` and adds some new features such as:
- Matching all occurrences, not just the first
- Applying custom styles to the highlight
- Supporting font, color, weight, and background color styles

## Screenshot
<img width="320" src="https://user-images.githubusercontent.com/793774/206621578-90ff1264-345e-4bcc-a4ea-364113bbd6a7.png">

## To test

1. Open HighlightedText
2. Run the SwiftUI Preview
3. Verify it works
4. Review the code

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
