### PR TITLE
Adds a cancel confirmation view

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1408,6 +1408,7 @@
 		C7F4BABF28DB7F7C001C9785 /* DiscoverItem+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F4BABE28DB7F7C001C9785 /* DiscoverItem+Helper.swift */; };
 		C7F87F112913242C00C15980 /* UIFont+FontStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F87F0F2913242B00C15980 /* UIFont+FontStyle.swift */; };
 		C7FAFF5829417F5E00329B40 /* HighlightedText.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7FAFF5729417F5E00329B40 /* HighlightedText.swift */; };
+		C7FAFF5D2941844C00329B40 /* CancelConfirmationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7FAFF5C2941844C00329B40 /* CancelConfirmationViewModel.swift */; };
 		C7FF76C0291B4F430082A464 /* ProportionalValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7FF76BF291B4F430082A464 /* ProportionalValue.swift */; };
 		C7FF76C2291B5F100082A464 /* PlusButtonStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7FF76C1291B5F100082A464 /* PlusButtonStyles.swift */; };
 		C7FF770C291C2C4D0082A464 /* LoginLandingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7FF770B291C2C4D0082A464 /* LoginLandingView.swift */; };
@@ -2985,6 +2986,7 @@
 		C7F4BABE28DB7F7C001C9785 /* DiscoverItem+Helper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DiscoverItem+Helper.swift"; sourceTree = "<group>"; };
 		C7F87F0F2913242B00C15980 /* UIFont+FontStyle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIFont+FontStyle.swift"; sourceTree = "<group>"; };
 		C7FAFF5729417F5E00329B40 /* HighlightedText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightedText.swift; sourceTree = "<group>"; };
+		C7FAFF5C2941844C00329B40 /* CancelConfirmationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancelConfirmationViewModel.swift; sourceTree = "<group>"; };
 		C7FF76BF291B4F430082A464 /* ProportionalValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProportionalValue.swift; sourceTree = "<group>"; };
 		C7FF76C1291B5F100082A464 /* PlusButtonStyles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlusButtonStyles.swift; sourceTree = "<group>"; };
 		C7FF770B291C2C4D0082A464 /* LoginLandingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginLandingView.swift; sourceTree = "<group>"; };
@@ -6187,6 +6189,14 @@
 			path = "Account Prompt";
 			sourceTree = "<group>";
 		};
+		C7FAFF592941839A00329B40 /* Cancel */ = {
+			isa = PBXGroup;
+			children = (
+				C7FAFF5C2941844C00329B40 /* CancelConfirmationViewModel.swift */,
+			);
+			name = Cancel;
+			sourceTree = "<group>";
+		};
 		C7FF770D291C2CA80082A464 /* Login */ = {
 			isa = PBXGroup;
 			children = (
@@ -7552,6 +7562,7 @@
 				BDB5F0C52045036200437669 /* OptionAction.swift in Sources */,
 				40FFAD93214A170200024FCF /* FilterSettingsOverlayController.swift in Sources */,
 				BD998ACC27B2436000B38857 /* NameFolderView.swift in Sources */,
+				C7FAFF5D2941844C00329B40 /* CancelConfirmationViewModel.swift in Sources */,
 				BD14CCDF1D7D3CB800DB4547 /* SelectedPodcastCell.swift in Sources */,
 				BD93FDA120157B2000F6EF55 /* PodcastImageView.swift in Sources */,
 				BDD5253A20477E4400AAD211 /* NSObject+AppDelegate.swift in Sources */,

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1408,6 +1408,7 @@
 		C7F4BABF28DB7F7C001C9785 /* DiscoverItem+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F4BABE28DB7F7C001C9785 /* DiscoverItem+Helper.swift */; };
 		C7F87F112913242C00C15980 /* UIFont+FontStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F87F0F2913242B00C15980 /* UIFont+FontStyle.swift */; };
 		C7FAFF5829417F5E00329B40 /* HighlightedText.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7FAFF5729417F5E00329B40 /* HighlightedText.swift */; };
+		C7FAFF5B294183AA00329B40 /* CancelConfirmationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7FAFF5A294183AA00329B40 /* CancelConfirmationView.swift */; };
 		C7FAFF5D2941844C00329B40 /* CancelConfirmationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7FAFF5C2941844C00329B40 /* CancelConfirmationViewModel.swift */; };
 		C7FF76C0291B4F430082A464 /* ProportionalValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7FF76BF291B4F430082A464 /* ProportionalValue.swift */; };
 		C7FF76C2291B5F100082A464 /* PlusButtonStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7FF76C1291B5F100082A464 /* PlusButtonStyles.swift */; };
@@ -2986,6 +2987,7 @@
 		C7F4BABE28DB7F7C001C9785 /* DiscoverItem+Helper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DiscoverItem+Helper.swift"; sourceTree = "<group>"; };
 		C7F87F0F2913242B00C15980 /* UIFont+FontStyle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIFont+FontStyle.swift"; sourceTree = "<group>"; };
 		C7FAFF5729417F5E00329B40 /* HighlightedText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightedText.swift; sourceTree = "<group>"; };
+		C7FAFF5A294183AA00329B40 /* CancelConfirmationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancelConfirmationView.swift; sourceTree = "<group>"; };
 		C7FAFF5C2941844C00329B40 /* CancelConfirmationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancelConfirmationViewModel.swift; sourceTree = "<group>"; };
 		C7FF76BF291B4F430082A464 /* ProportionalValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProportionalValue.swift; sourceTree = "<group>"; };
 		C7FF76C1291B5F100082A464 /* PlusButtonStyles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlusButtonStyles.swift; sourceTree = "<group>"; };
@@ -3328,6 +3330,7 @@
 		40542E292265600200046330 /* Account Management */ = {
 			isa = PBXGroup;
 			children = (
+				C7FAFF592941839A00329B40 /* Cancel */,
 				4051A57322819FB200C13C12 /* Cells */,
 				40542E2B2265604700046330 /* AccountViewController.swift */,
 				403D1AB32281C36100CE7C9B /* AccountViewController+TableView.swift */,
@@ -6078,6 +6081,7 @@
 				C7A110F1291F1EC300887A90 /* HTMLTextView.swift */,
 				C7A110F8291F66C700887A90 /* Confetti.swift */,
 				C7CA0558293E8918000E41BD /* HolographicEffect.swift */,
+				C7FAFF5729417F5E00329B40 /* HighlightedText.swift */,
 			);
 			path = SwiftUI;
 			sourceTree = "<group>";
@@ -6192,6 +6196,7 @@
 		C7FAFF592941839A00329B40 /* Cancel */ = {
 			isa = PBXGroup;
 			children = (
+				C7FAFF5A294183AA00329B40 /* CancelConfirmationView.swift */,
 				C7FAFF5C2941844C00329B40 /* CancelConfirmationViewModel.swift */,
 			);
 			name = Cancel;
@@ -7810,6 +7815,7 @@
 				C73CD7A82916E8A900EAE879 /* SwiftUI+Previews.swift in Sources */,
 				BDB002BF211A9E1B00224A55 /* ProgressLine.swift in Sources */,
 				C7A110FF2922971100887A90 /* LoginLandingHostingController.swift in Sources */,
+				C7FAFF5B294183AA00329B40 /* CancelConfirmationView.swift in Sources */,
 				BD51481F1B9FE81F0029C6D9 /* StatsViewController.swift in Sources */,
 				BDA7A0A824C6C5B100ADA8AA /* GradientButton.swift in Sources */,
 				BDE6AB6F1CC49B010087D195 /* SyncSigninViewController.swift in Sources */,

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1409,7 +1409,6 @@
 		C7F87F112913242C00C15980 /* UIFont+FontStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F87F0F2913242B00C15980 /* UIFont+FontStyle.swift */; };
 		C7FAFF5B294183AA00329B40 /* CancelConfirmationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7FAFF5A294183AA00329B40 /* CancelConfirmationView.swift */; };
 		C7FAFF5D2941844C00329B40 /* CancelConfirmationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7FAFF5C2941844C00329B40 /* CancelConfirmationViewModel.swift */; };
-		C7FAFF692942E6A500329B40 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		C7FAFF6A2942E78A00329B40 /* HighlightedText.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7FAFF682942E6A400329B40 /* HighlightedText.swift */; };
 		C7FF76C0291B4F430082A464 /* ProportionalValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7FF76BF291B4F430082A464 /* ProportionalValue.swift */; };
 		C7FF76C2291B5F100082A464 /* PlusButtonStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7FF76C1291B5F100082A464 /* PlusButtonStyles.swift */; };
@@ -8038,7 +8037,6 @@
 				BDCC55141CD0A448006BE239 /* AEXML.swift in Sources */,
 				8B1C974628FE1C7E00BD5EB9 /* ImageView.swift in Sources */,
 				40484F0122F1507F007DBD55 /* ThemeableRoundedButton.swift in Sources */,
-				C7FAFF692942E6A500329B40 /* (null) in Sources */,
 				BDEBD3A91BA0108800AD038F /* BufferedAudio.swift in Sources */,
 				402772D721B6105D00769811 /* PodcastManager+Delete.swift in Sources */,
 				403B5B02217D5F1500821A54 /* TitleViewWithCollapseButton.swift in Sources */,

--- a/podcasts/AccountViewController+TableView.swift
+++ b/podcasts/AccountViewController+TableView.swift
@@ -155,9 +155,10 @@ extension AccountViewController: UITableViewDataSource, UITableViewDelegate {
         case .deleteAccount:
             deleteAccountTapped()
         case .cancelSubscription:
-            let cancelVC = CancelInfoViewController()
-            cancelVC.modalPresentationStyle = .fullScreen
-            present(SJUIUtils.navController(for: cancelVC), animated: true, completion: nil)
+            let controller = CancelConfirmationViewModel.make()
+            
+            present(controller, animated: true, completion: nil)
+            Analytics.track(.accountDetailsCancelTapped)
         case .privacyPolicy:
             NavigationManager.sharedManager.navigateTo(NavigationManager.showPrivacyPolicyPageKey, data: nil)
             Analytics.track(.accountDetailsShowPrivacyPolicy)

--- a/podcasts/AccountViewController+TableView.swift
+++ b/podcasts/AccountViewController+TableView.swift
@@ -156,7 +156,7 @@ extension AccountViewController: UITableViewDataSource, UITableViewDelegate {
             deleteAccountTapped()
         case .cancelSubscription:
             let controller = CancelConfirmationViewModel.make()
-            
+
             present(controller, animated: true, completion: nil)
             Analytics.track(.accountDetailsCancelTapped)
         case .privacyPolicy:

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -112,6 +112,7 @@ enum AnalyticsEvent: String {
     case profileAccountButtonTapped
     case profileRefreshButtonTapped
 
+    case accountDetailsCancelTapped
     case accountDetailsShowTOS
     case accountDetailsShowPrivacyPolicy
 
@@ -608,4 +609,10 @@ enum AnalyticsEvent: String {
     case onboardingImportAppSelected
     case onboardingImportOpenAppTapped
     case onboardingImportDismissed
+
+    // MARK: - Cancel
+    case cancelConfirmationViewShown
+    case cancelConfirmationViewDismissed
+    case cancelConfirmationStayButtonTapped
+    case cancelConfirmationCancelButtonTapped
 }

--- a/podcasts/CancelConfirmationView.swift
+++ b/podcasts/CancelConfirmationView.swift
@@ -172,8 +172,7 @@ private struct ListRow: View {
 
             HighlightedText(title)
                 .font(.body.leading(.loose))
-                .highlight(highlightedText)
-                .onHighlight { _ in
+                .highlight(highlightedText) { _ in
                     .init(weight: .medium, color: AppTheme.color(for: .highlightColor, theme: theme))
                 }
                 .fixedSize(horizontal: false, vertical: true)

--- a/podcasts/CancelConfirmationView.swift
+++ b/podcasts/CancelConfirmationView.swift
@@ -1,0 +1,183 @@
+import SwiftUI
+
+struct CancelConfirmationView: View {
+    @EnvironmentObject var theme: Theme
+    private let rows: [Row]
+
+    let viewModel: CancelConfirmationViewModel
+
+    init(viewModel: CancelConfirmationViewModel) {
+        self.viewModel = viewModel
+
+        // Make sure the expiration date doesn't wrap
+        let expiration = viewModel.expirationDate?.nonBreakingSpaces()
+
+        self.rows = [
+            .init(imageName: "dollar-recycle-gold", text: L10n.cancelConfirmSubExpiry(expiration ?? L10n.cancelConfirmSubExpiryDateFallback), highlight: expiration),
+            .init(imageName: "locked-large", text: L10n.cancelConfirmItemPlus),
+            .init(imageName: "folder-locked", text: L10n.cancelConfirmItemFolders),
+            .init(imageName: "remove_from_cloud", text: L10n.cancelConfirmItemUploads),
+            .init(imageName: "about_website", text: L10n.cancelConfirmItemWebPlayer),
+        ]
+    }
+
+    var body: some View {
+        ScrollViewIfNeeded {
+            VStack(spacing: Constants.padding.vertical) {
+                header
+
+                // List view
+                VStack(alignment: .leading, spacing: Constants.padding.vertical) {
+                    ForEach(rows) { row in
+                        ListRow(row.text, image: row.imageName, highlightedText: row.highlight)
+                    }
+                }
+
+                Spacer()
+
+                // Bottom buttons
+                VStack {
+                    shadowDivider
+                    buttons
+                }
+
+            }.padding([.leading, .trailing], Constants.padding.horizontal)
+        }.background(color(for: .background).ignoresSafeArea())
+    }
+
+    private var header: some View {
+        VStack(spacing: 0) {
+            Image(AppTheme.paymentFailedImageName())
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(height: 100)
+
+            Text(L10n.cancelSubscription)
+                .font(style: .title, weight: .bold, maxSizeCategory: .extraExtraExtraLarge)
+                .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
+                .foregroundColor(color(for: .text))
+                .padding(.bottom, 5)
+
+            Text(L10n.cancelConfirmSubtitle)
+                .font(style: .headline, weight: .medium, maxSizeCategory: .extraExtraExtraLarge)
+                .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
+                .foregroundColor(color(for: .subtitle))
+        }
+    }
+
+    @ViewBuilder
+    private var buttons: some View {
+        Button(L10n.cancelConfirmStayButtonTitle) {
+            viewModel.goBackTapped()
+        }.buttonStyle(RoundedButtonStyle(theme: theme))
+
+        Button(L10n.cancelConfirmCancelButtonTitle) {
+            viewModel.cancelTapped()
+        }
+        .buttonStyle(SimpleTextButtonStyle(theme: theme, textColor: .cancelButton))
+        // Reduce the padding a bit to make it look more visually centered
+        .padding([.top, .bottom], -5)
+    }
+
+    private var shadowDivider: some View {
+        ZStack(alignment: .top) {
+            Rectangle()
+                .foregroundColor(color(for: .background))
+                .frame(height: Constants.shadowRadius * 2)
+                .shadow(color: color(for: .divider).opacity(0.15), radius: Constants.shadowRadius, x: 0, y: -Constants.shadowRadius)
+                // Clip the bottom part of the shadow off
+                .mask(Rectangle().padding(.top, -Constants.shadowRadius * 4))
+
+            divider.opacity(0.5)
+        }
+        // Apply a negative padding to make the view stretch to the full width of the view ignoring the parents padding
+        .padding([.leading, .trailing], -Constants.padding.horizontal)
+        .padding(.bottom, 10)
+    }
+
+    private var divider: some View {
+        Divider().overlay(color(for: .divider))
+    }
+
+    private func color(for style: ThemeStyle) -> Color {
+        AppTheme.color(for: style, theme: theme)
+    }
+
+    private enum Constants {
+        enum padding {
+            static let horizontal = 24.0
+            static let vertical = 20.0
+        }
+        static let shadowRadius = 2.0
+    }
+
+    /// Internal model for the rows
+    private struct Row: Identifiable {
+        let imageName: String
+        let text: String
+        let highlight: String?
+
+        init(imageName: String, text: String, highlight: String? = nil) {
+            self.imageName = imageName
+            self.text = text
+            self.highlight = highlight
+        }
+
+        // Identifiable makes using ForEach cleaner
+        var id: String { imageName }
+    }
+}
+
+// MARK: - Style configuration
+private extension ThemeStyle {
+    static let background = Self.primaryUi01
+    static let text = Self.primaryText01
+
+    static let subtitle = Self.primaryText02
+    static let list = Self.primaryText01
+    static let divider = Self.primaryUi05Selected
+
+    static let cancelButton = Self.support05
+
+    static let iconColor = Self.primaryIcon01
+    static let highlightColor = Self.primaryIcon01
+}
+
+// MARK: - Private: Views
+
+private struct ListRow: View {
+    @EnvironmentObject var theme: Theme
+
+    let title: String
+    let image: String
+    let highlightedText: String?
+
+    init(_ title: String, image: String, highlightedText: String? = nil) {
+        self.title = title
+        self.image = image
+        self.highlightedText = highlightedText
+    }
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 20) {
+            Image(image)
+                .resizable()
+                .renderingMode(.template)
+                .aspectRatio(contentMode: .fill)
+                .frame(width: 24, height: 24)
+                .foregroundColor(AppTheme.color(for: .iconColor, theme: theme))
+                .padding(.top, 3)
+
+            HighlightedText(title)
+                .font(.body.leading(.loose))
+                .highlight(highlightedText)
+                .onHighlight { _ in
+                    .init(weight: .medium, color: AppTheme.color(for: .highlightColor, theme: theme))
+                }
+                .fixedSize(horizontal: false, vertical: true)
+                .foregroundColor(AppTheme.color(for: .text, theme: theme))
+        }
+    }
+}

--- a/podcasts/CancelConfirmationViewModel.swift
+++ b/podcasts/CancelConfirmationViewModel.swift
@@ -35,6 +35,9 @@ class CancelConfirmationViewModel: OnboardingModel {
     }
 
     func didDismiss(type: OnboardingDismissType) {
+        // Since the view can only be dismissed via swipe, only check for that
+        guard type == .swipe else { return }
+
         Analytics.track(.cancelConfirmationViewDismissed)
     }
 }

--- a/podcasts/CancelConfirmationViewModel.swift
+++ b/podcasts/CancelConfirmationViewModel.swift
@@ -1,0 +1,67 @@
+import SwiftUI
+import PocketCastsServer
+import PocketCastsUtils
+
+class CancelConfirmationViewModel: OnboardingModel {
+    let navigationController: UINavigationController
+    let expirationDate: String?
+
+    init(navigationController: UINavigationController) {
+        self.navigationController = navigationController
+
+        // Update the expiration date for the view
+        let expiriation = SubscriptionHelper.subscriptionRenewalDate()
+        self.expirationDate = DateFormatHelper.sharedHelper.longLocalizedFormat(expiriation)
+    }
+
+    // MARK: - View actions
+
+    func goBackTapped() {
+        Analytics.track(.cancelConfirmationStayButtonTapped)
+        navigationController.dismiss(animated: true)
+    }
+
+    func cancelTapped() {
+        Analytics.track(.cancelConfirmationCancelButtonTapped)
+
+        let controller = CancelInfoViewController()
+        navigationController.pushViewController(controller, animated: true)
+    }
+
+    // MARK: - Show / Hide
+
+    func didAppear() {
+        Analytics.track(.cancelConfirmationViewShown)
+    }
+
+    func didDismiss(type: OnboardingDismissType) {
+        Analytics.track(.cancelConfirmationViewDismissed)
+    }
+}
+
+extension CancelConfirmationViewModel {
+    /// Make the view, and allow it to be shown by itself or within another navigation flow
+    static func make(in navigationController: UINavigationController? = nil) -> UIViewController {
+        // If we're not being presented within another nav controller then wrap ourselves in one
+        let navController = navigationController ?? UINavigationController()
+        let viewModel = CancelConfirmationViewModel(navigationController: navController)
+
+        // Wrap the SwiftUI view in the hosting view controller
+        let swiftUIView = CancelConfirmationView(viewModel: viewModel).setupDefaultEnvironment()
+
+        // Configure the controller
+        let controller = OnboardingHostingViewController(rootView: swiftUIView)
+        controller.navBarIsHidden = true
+        controller.viewModel = viewModel
+
+        // Just return the controller if we're not presenting ourselves
+        if navigationController != nil {
+            return controller
+        }
+
+        // Set the root view of the new nav controller
+        navController.setViewControllers([controller], animated: false)
+
+        return navController
+    }
+}

--- a/podcasts/Onboarding/OnboardingHostingViewController.swift
+++ b/podcasts/Onboarding/OnboardingHostingViewController.swift
@@ -31,10 +31,15 @@ class OnboardingHostingViewController<Content>: UIHostingController<Content>, UI
         }
     }
 
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        .portrait
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
         presentationController?.delegate = self
         navigationController?.presentationController?.delegate = self
+
         updateNavigationBarStyle(animated: false)
 
         navigationItem.backButtonDisplayMode = .minimal

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -242,6 +242,26 @@ internal enum L10n {
   }
   /// Cancel
   internal static var cancel: String { return L10n.tr("Localizable", "cancel") }
+  /// Yes, Cancel my Subscription
+  internal static var cancelConfirmCancelButtonTitle: String { return L10n.tr("Localizable", "cancel_confirm_cancel_button_title") }
+  /// Your folders will be removed and their contents will move back to the Podcasts screen.
+  internal static var cancelConfirmItemFolders: String { return L10n.tr("Localizable", "cancel_confirm_item_folders") }
+  /// Access to Pocket Casts Plus features will be locked after this date.
+  internal static var cancelConfirmItemPlus: String { return L10n.tr("Localizable", "cancel_confirm_item_plus") }
+  /// All files uploaded to your Pocket Casts account will be deleted (but downloaded files on your mobile devices will remain)
+  internal static var cancelConfirmItemUploads: String { return L10n.tr("Localizable", "cancel_confirm_item_uploads") }
+  /// You will no longer be able to access Pocket Casts using your web browser, or desktop computer.
+  internal static var cancelConfirmItemWebPlayer: String { return L10n.tr("Localizable", "cancel_confirm_item_web_player") }
+  /// Actually, I want to stay
+  internal static var cancelConfirmStayButtonTitle: String { return L10n.tr("Localizable", "cancel_confirm_stay_button_title") }
+  /// Your current subscription will remain active until %1$@.
+  internal static func cancelConfirmSubExpiry(_ p1: Any) -> String {
+    return L10n.tr("Localizable", "cancel_confirm_sub_expiry", String(describing: p1))
+  }
+  /// your expiration date
+  internal static var cancelConfirmSubExpiryDateFallback: String { return L10n.tr("Localizable", "cancel_confirm_sub_expiry_date_fallback") }
+  /// This will change your plan to a free account.
+  internal static var cancelConfirmSubtitle: String { return L10n.tr("Localizable", "cancel_confirm_subtitle") }
   /// Cancel Download
   internal static var cancelDownload: String { return L10n.tr("Localizable", "cancel_download") }
   /// Unable To Cancel

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -3524,3 +3524,30 @@
 
 /* Title of a label informing the user they can cancel their subscription at anytime */
 "plus_cancel_terms" = "Can be canceled at anytime";
+
+/* Sub title of a view that informs the user what will happen if they cancel their subscription */
+"cancel_confirm_subtitle" = "This will change your plan to a free account.";
+
+/* Title of a list item that informs the user the date their subscription will expire. %1$@ is the date of expiriation */
+"cancel_confirm_sub_expiry" = "Your current subscription will remain active until %1$@.";
+
+/* Item that appears in place of the user's missing expiration date if it's not available. */
+"cancel_confirm_sub_expiry_date_fallback" = "your expiration date";
+
+/* Title of a list item that informs the user their plus features will be locked if they cancel */
+"cancel_confirm_item_plus" = "Access to Pocket Casts Plus features will be locked after this date.";
+
+/* Title of a list item that informs the user their folders will be removed if they cancel */
+"cancel_confirm_item_folders" = "Your folders will be removed and their contents will move back to the Podcasts screen.";
+
+/* Title of a list item that informs the user uploaded files will be removed if they cancel */
+"cancel_confirm_item_uploads" = "All files uploaded to your Pocket Casts account will be deleted (but downloaded files on your mobile devices will remain)";
+
+/* Title of a list item that informs the user they will no longer be able to access plus on the web if they cancel */
+"cancel_confirm_item_web_player" =  "You will no longer be able to access Pocket Casts using your web browser, or desktop computer.";
+
+/* Button title that lets the user stop the cancellation process */
+"cancel_confirm_stay_button_title" =  "Actually, I want to stay";
+
+/* Button title that lets the user contine the cancellation process */
+"cancel_confirm_cancel_button_title" =  "Yes, Cancel my Subscription";


### PR DESCRIPTION
| 🛫 Depends on: #590 |
|:---:|

## Screenshots
<img width="320" src="https://user-images.githubusercontent.com/793774/206620431-ff27e049-da42-4a09-b05a-bc9713592e25.png">

## To test
1. Enable the tracksLogging Feature Flag
2. Launch the app
3. Sign into an account with non-gifted plus
   - You can also tap Profile -> Cog -> Developer -> Set to Paid to temporarily change your plus status
4. Tap Profile tab
5. Tap your account
6. Tap Cancel Subscription
7. ✅ Verify you see the following in console: `🔵 Tracked: account_details_cancel_tapped`
8. ✅ Verify you see the following in console: `🔵 Tracked: cancel_confirmation_view_shown`
9. ✅ Verify the view looks good
10. Swipe down to dismiss
11. ✅ Verify you see the following in console: `🔵 Tracked: cancel_confirmation_view_dismissed`
12. Reopen the view
13. Tap the stay button
14. ✅ Verify you see the following in console: `🔵 Tracked: cancel_confirmation_stay_button_tapped`
15. Reopen the view, and tap cancel 
16. ✅ Verify you see the following in console: `🔵 Tracked: cancel_confirmation_cancel_button_tapped`

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
