### PR TITLE
End of Year: disable it

### DIFF
--- a/podcasts/FeatureFlag.swift
+++ b/podcasts/FeatureFlag.swift
@@ -37,7 +37,7 @@ enum FeatureFlag: String, CaseIterable {
         case .firebaseLogging:
             return false
         case .endOfYear:
-            return true
+            return false
         case .signInWithApple:
             return false
         case .onboardingUpdates:


### PR DESCRIPTION
The beginning of the year is not the end of the year, so we're disabling End of Year stats.

See you in Dec 2023! ;) 

## To test

1. Run the app
2. ✅ You should not see any popup or card prompting to check your stats

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
