### PR TITLE
Tracks: Fix a nan crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fixed Edit Folder screen layout (#53)
 - Fixed an issue where episodes wouldn't resume downloading on next launch if the app was force quit (#472)
 - Fixed an issue where the podcast artwork wasn't appearin in the Now Playing Siri suggestions (#579)
+- Fixed a crash that could happen when scrubbing the player (#605)
 
 7.28
 -----

--- a/podcasts/Analytics/Helpers/AnalyticsPlaybackHelper.swift
+++ b/podcasts/Analytics/Helpers/AnalyticsPlaybackHelper.swift
@@ -33,9 +33,14 @@ class AnalyticsPlaybackHelper: AnalyticsCoordinator {
             return
         }
 
+        let from = (from / duration)
+        let to = (to / duration)
+
+        guard !from.isNaN, !to.isNaN else { return }
+
         // Use percents to relativize the seeking across any duration episode
-        let seekFrom = Int((from / duration) * 100)
-        let seekPercent = Int((to / duration) * 100)
+        let seekFrom = Int(from * 100)
+        let seekPercent = Int(to * 100)
 
         track(.playbackSeek, properties: ["seek_to_percent": seekPercent, "seek_from_percent": seekFrom])
     }


### PR DESCRIPTION
This adds an isNan check to prevent a crash. 

## To test

1. Launch the app
2. Enable Tracks Loggin
3. Play any episode
4. Change the player position
5. ✅ Verify you see `🔵 Tracked: playback_seek ["seek_from_percent": PERCENT, "seek_to_percent": PERCENT, "source": "player"]`
6. In Xcode, open `PlaybackManager` and change line 391 to:
7. `analyticsPlaybackHelper.seek(from: 0, to: 0, duration: 0)`
8. Relaunch the app and change the player position
9. ✅ Verify the app doesn't crash and you don't see the log

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
