### PR TITLE
Process the gravatars as png's to prevent white corners

### DIFF
--- a/podcasts/ProfileProgressCircleView.swift
+++ b/podcasts/ProfileProgressCircleView.swift
@@ -127,9 +127,14 @@ class ProfileProgressCircleView: ThemeableView {
     @objc private func updateAvatar() {
         if let email = ServerSettings.syncingEmail() {
             let imageSize = frame.size.width - (4 * lineWidth)
-            let gravatar = "https://www.gravatar.com/avatar/\(email.md5))?d=404"
+            let gravatar = "https://www.gravatar.com/avatar/\(email.md5)?d=404"
             let processor = RoundCornerImageProcessor(cornerRadius: imageSize)
-            gravatarImageView.kf.setImage(with: URL(string: gravatar), placeholder: nil, options: [.processor(processor)])
+            let options: KingfisherOptionsInfo = [
+                .processor(processor), // rounder corners
+                .cacheSerializer(FormatIndicatedCacheSerializer.png) // convert to a png
+            ]
+
+            gravatarImageView.kf.setImage(with: URL(string: gravatar), placeholder: nil, options: options)
         } else {
             gravatarImageView.image = nil
         }


### PR DESCRIPTION
Fixes an issue where if a user has a jpeg returned via gravatar the image may have white corners. 

| Before | After |
|:---:|:---:|
|<img width="156" src="https://user-images.githubusercontent.com/793774/207700808-8928fe4c-722f-4b55-89dd-c5639e6bf14a.png">|<img width="164" src="https://user-images.githubusercontent.com/793774/207700970-abdf84fc-61c4-48f2-a99c-4d9db5c07779.png">|


## To test

1. Upload a .jpeg image to gravatar
2. Launch the app
3. Sign in with the email with the jpeg
4. Go to the Profile tab
5. ✅ The image is rounded
6. Tap on the account bubble
7. ✅ Verify the image is rounded

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
