### PR TITLE
Fix encoding issue

### DIFF
--- a/podcasts/SwiftUI/HTMLTextView.swift
+++ b/podcasts/SwiftUI/HTMLTextView.swift
@@ -43,10 +43,10 @@ struct HTMLTextView: UIViewRepresentable {
     }
 
     private var attributedString: NSAttributedString {
-        let data = Data(text.utf8)
         let options = [NSAttributedString.DocumentReadingOptionKey.documentType: NSAttributedString.DocumentType.html]
 
-        guard let attributedString = try? NSMutableAttributedString(data: data, options: options, documentAttributes: nil) else {
+        guard let data = text.data(using: .unicode),
+            let attributedString = try? NSMutableAttributedString(data: data, options: options, documentAttributes: nil) else {
             return NSAttributedString(string: text)
         }
 


### PR DESCRIPTION
Fixes #626

Fixes the footer encoding of the sell modal.

| Before | After |
| ------ | ----- |
| ![Simulator Screen Shot - iPhone 14 - 2023-01-09 at 15 44 57](https://user-images.githubusercontent.com/7040243/211384183-65590c53-2dad-459b-9ce2-d52b4d3199bb.png) | ![Simulator Screen Shot - iPhone 14 - 2023-01-09 at 15 43 07](https://user-images.githubusercontent.com/7040243/211384218-9b927f9d-d305-49a8-9e53-021466a575f4.png) |

## To test

1. Change the language to German or Portuguese
2. Run the app
3. Login to an account without Plus
4. Tap the Folder icon under "Podcasts"
5. Tap the first button (the yellow one)
6. ✅  Check that the footer displays the content correctly, without encoding issues (you can compare to the original string)

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
