### PR TITLE
Fix distorted playback when playback speed is bigger than 1.0

### DIFF
--- a/podcasts/DefaultPlayer.swift
+++ b/podcasts/DefaultPlayer.swift
@@ -439,11 +439,8 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
         }
 
         player?.rate = Float(requiredPlaybackRate)
-        if requiredPlaybackRate < 1.0 || requiredPlaybackRate > 1.0 {
-            player?.currentItem?.audioTimePitchAlgorithm = .timeDomain
-        } else {
-            player?.currentItem?.audioTimePitchAlgorithm = .lowQualityZeroLatency
-        }
+
+        player?.currentItem?.audioTimePitchAlgorithm = .lowQualityZeroLatency
     }
 
     private func jumpToStartingPosition() {

--- a/podcasts/EffectsPlayer.swift
+++ b/podcasts/EffectsPlayer.swift
@@ -376,7 +376,7 @@ class EffectsPlayer: PlaybackProtocol, Hashable {
     private func createTimePitchUnit() -> AVAudioUnitTimePitch {
         var componentDescription = AudioComponentDescription()
         componentDescription.componentType = kAudioUnitType_FormatConverter
-        componentDescription.componentSubType = kAudioUnitSubType_AUiPodTimeOther
+        componentDescription.componentSubType = kAudioUnitSubType_TimePitch
         componentDescription.componentManufacturer = kAudioUnitManufacturer_Apple
 
         return AVAudioUnitTimePitch(audioComponentDescription: componentDescription)


### PR DESCRIPTION
Fixes #54 

We've been having issues with distorted sounds when the playback speed is more than 1.0. This is not due to Bluetooth, but because of the pitch algorithm, we've been using on the default and effects player.

This PR changes the used algorithm thus solving the problem. Although it seems we don't have too many complaints about this issue, when compared to other apps this is very noticeable.

## To test

This needs to be tested on a real device. I couldn't reproduce the issue on simulator.

### Reproducing the problem

Before testing the solution, I'd recommend seeing the problem in place.

1. Run the app on your phone
2. Play a podcast and change the speed to 1,1 or bigger ([you can use this one](https://pca.st/episode/c9a7667e-c22b-4271-9397-f48f01c046a1))
3. ✅ Notice that after a few seconds the sound is a little bit distorted
4. Download the episode and test again (this will ensure effects player is used)

### Testing the fix

1. Run the app on your phone
2. Play a podcast without downloading it (so the default player is used)
3. Increase the speed to 1,1 or bigger if it's not already
4. ✅ Make sure the sound is ok and there isn't any distortion
5. Download the episode (so effects player is used)
6. Play the episode
7. ✅ Make sure the sound is ok and there isn't any distortion

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
