### PR TITLE
Revert change of algorithms for playback speed

### DIFF
--- a/podcasts/DefaultPlayer.swift
+++ b/podcasts/DefaultPlayer.swift
@@ -440,7 +440,11 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
 
         player?.rate = Float(requiredPlaybackRate)
 
-        player?.currentItem?.audioTimePitchAlgorithm = .lowQualityZeroLatency
+        if requiredPlaybackRate < 1.0 || requiredPlaybackRate > 1.0 {
+             player?.currentItem?.audioTimePitchAlgorithm = .timeDomain
+         } else {
+             player?.currentItem?.audioTimePitchAlgorithm = .lowQualityZeroLatency
+         }
     }
 
     private func jumpToStartingPosition() {

--- a/podcasts/EffectsPlayer.swift
+++ b/podcasts/EffectsPlayer.swift
@@ -376,7 +376,7 @@ class EffectsPlayer: PlaybackProtocol, Hashable {
     private func createTimePitchUnit() -> AVAudioUnitTimePitch {
         var componentDescription = AudioComponentDescription()
         componentDescription.componentType = kAudioUnitType_FormatConverter
-        componentDescription.componentSubType = kAudioUnitSubType_TimePitch
+        componentDescription.componentSubType = kAudioUnitSubType_AUiPodTimeOther
         componentDescription.componentManufacturer = kAudioUnitManufacturer_Apple
 
         return AVAudioUnitTimePitch(audioComponentDescription: componentDescription)


### PR DESCRIPTION
#633 caused an issue with the sound of podcasts sounding metallic. This reverts it so the playback is back to normal but the distortion will also happen again.

My plan is to look deep into that in a follow-up PR.

## To test

Just make sure code is back to what it was before #633.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
