### PR TITLE
Fix distorted playback when playback speed is bigger than 1.0

### DIFF
--- a/podcasts/DefaultPlayer.swift
+++ b/podcasts/DefaultPlayer.swift
@@ -441,7 +441,7 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
         player?.rate = Float(requiredPlaybackRate)
 
         if requiredPlaybackRate < 1.0 || requiredPlaybackRate > 1.0 {
-             player?.currentItem?.audioTimePitchAlgorithm = .timeDomain
+             player?.currentItem?.audioTimePitchAlgorithm = .spectral
          } else {
              player?.currentItem?.audioTimePitchAlgorithm = .lowQualityZeroLatency
          }

--- a/podcasts/EffectsPlayer.swift
+++ b/podcasts/EffectsPlayer.swift
@@ -376,10 +376,10 @@ class EffectsPlayer: PlaybackProtocol, Hashable {
     private func createTimePitchUnit() -> AVAudioUnitTimePitch {
         var componentDescription = AudioComponentDescription()
         componentDescription.componentType = kAudioUnitType_FormatConverter
-        componentDescription.componentSubType = kAudioUnitSubType_AUiPodTimeOther
+        componentDescription.componentSubType = kAudioQueueTimePitchAlgorithm_Spectral
         componentDescription.componentManufacturer = kAudioUnitManufacturer_Apple
 
-        return AVAudioUnitTimePitch(audioComponentDescription: componentDescription)
+        return AVAudioUnitTimePitch()
     }
 
     private func createHighPassUnit() -> AVAudioUnitEffect {


### PR DESCRIPTION
Fixes #54

We've been having issues with distorted sounds when the playback speed is more than 1.0. This is not due to Bluetooth, but because of the pitch algorithm, we've been using on the default and effects player.

This is another take on fixing the issue, the previous solution caused differences in the sound quality. My plan is to release this as a beta and gather feedback.

## Discussion

In order to solve this problem, I changed the pitch algorithm from `timeDomain` to `spectral` in `DefaultPlayer` and from `AUiPodTimeOther` to `Spectral` on `EffectsPlayer`.

However, this comes with a caveat: spectral is definitely the highest-quality time pitch algorithm but it's also the most computationally intensive.

My plan, for now, is to keep things simple, release this as a beta and gather feedback.

However, we should also keep an eye on battery consumption. If it turns out this is leading to more battery consumption we can add this as an option in Settings for people to turn on/off. But, as mentioned before, let's try to keep things simple for now.

## To test

1. Run the app on your phone
2. Play a podcast and change the speed to 1,1 or bigger ([you can use this one](https://pca.st/episode/c9a7667e-c22b-4271-9397-f48f01c046a1))
3. ✅ Notice that after a few seconds the sound is a little bit distorted
4. Download the episode and test again (this will ensure effects player is used)

### Testing the fix

1. Run the app on your phone
2. Play a podcast without downloading it (so the default player is used)
3. Increase the speed to 1,1 or bigger if it's not already
4. ✅ Make sure the sound is ok and there isn't any distortion
5. Download the episode (so effects player is used)
6. Play the episode
7. ✅ Make sure the sound is ok and there isn't any distortion

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
