### PR TITLE
SSO: Add Apple Sign-in to the new login flow

### DIFF
--- a/podcasts/Onboarding/Login/LoginLandingView.swift
+++ b/podcasts/Onboarding/Login/LoginLandingView.swift
@@ -351,11 +351,11 @@ private struct SocialLoginButtons: View {
         if !FeatureFlag.signInWithApple.enabled {
             EmptyView()
         } else {
-            Button("Continue with Apple") {
+            Button(L10n.socialSignInContinueWithApple) {
                 coordinator.signInWithAppleTapped()
             }.buttonStyle(SocialButtonStyle(imageName: AppTheme.socialIconAppleImageName()))
 
-            Button("Continue with Google") {
+            Button(L10n.socialSignInContinueWithGoogle) {
                 coordinator.signInWithGoogleTapped()
             }.buttonStyle(SocialButtonStyle(imageName: AppTheme.socialIconGoogleImageName()))
         }

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -2476,6 +2476,10 @@ internal enum L10n {
   internal static func sleepTimerTimeRemaining(_ p1: Any) -> String {
     return L10n.tr("Localizable", "sleep_timer_time_remaining", String(describing: p1))
   }
+  /// Continue with Apple
+  internal static var socialSignInContinueWithApple: String { return L10n.tr("Localizable", "social_sign_in_continue_with_apple") }
+  /// Continue with Google
+  internal static var socialSignInContinueWithGoogle: String { return L10n.tr("Localizable", "social_sign_in_continue_with_google") }
   /// CONNECT
   internal static var sonosConnectAction: String { return L10n.tr("Localizable", "sonos_connect_action") }
   /// Connect To Sonos

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -3551,3 +3551,9 @@
 
 /* Button title that lets the user contine the cancellation process */
 "cancel_confirm_cancel_button_title" =  "Yes, Cancel my Subscription";
+
+/* Label of a button that lets the user login/signup with Apple */
+"social_sign_in_continue_with_apple" = "Continue with Apple";
+
+/* Label of a button that lets the user login/signup with Google */
+"social_sign_in_continue_with_google" = "Continue with Google";


### PR DESCRIPTION
| 📘 Project: #381 |
|:---:|

Given the onboarding project, our login flow has changed. This PR adds the Sign-In with Apple flow to the new screen. No changes were made in terms of functionality and the login won't work.

I also changed how the error is presented to keep the code simple, at least for now. Before the [error was displayed on the screen](https://github.com/Automattic/pocket-casts-ios/pull/394), now it is presented using a modal.

## To test

You can test this on the simulator.

1. Go to Settings > Beta Features > enable `signInWithApple`
2. Go to Profile
3. Tap the bubble account at the top
4. Tap Continue with Apple
5. When asked to login with your Apple Account, tap close
6. ✅ Make sure a modal is displayed saying the login failed

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
