### PR TITLE
SSO: use refresh token for token update

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Private/TokenHelper.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Private/TokenHelper.swift
@@ -163,7 +163,7 @@ class TokenHelper {
             logMessages.append("no password")
         }
 
-        if ServerSettings.appleAuthIdentityToken == nil {
+        if ServerSettings.refreshToken == nil {
             logMessages.append("no SSO token")
         }
 

--- a/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+SocialAuth.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+SocialAuth.swift
@@ -77,7 +77,6 @@ public extension ApiServerHandler {
         data.grantType = "refresh_token"
 
         var request = ServerHelper.createProtoRequest(url: url, data: try! data.serializedData())
-        request?.setValue("Bearer \(ServerSettings.syncingV2Token!)", forHTTPHeaderField: ServerConstants.HttpHeaders.authorization)
         return request
 
     }

--- a/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+SocialAuth.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+SocialAuth.swift
@@ -53,7 +53,7 @@ public extension ApiServerHandler {
         return try await obtainToken(request: request, provider: provider)
     }
 
-    func refreshIdentityToken() async throws -> (String?, String?) {
+    func refreshIdentityToken() async throws -> AuthenticationResponse {
         guard
             let identityToken = ServerSettings.refreshToken,
             let request = tokenRequest(identityToken: identityToken, cachePolicy: .reloadIgnoringLocalCacheData, timeoutInterval: 30.seconds)
@@ -62,8 +62,7 @@ public extension ApiServerHandler {
             throw APIError.UNKNOWN
         }
 
-        let response = try await obtainToken(request: request, provider: .google)
-        return (response.token, response.refreshToken)
+        return try await obtainToken(request: request, provider: .google)
     }
 
     private func tokenRequest(identityToken: String?, cachePolicy: URLRequest.CachePolicy = .useProtocolCachePolicy, timeoutInterval: TimeInterval = 15.seconds) -> URLRequest? {

--- a/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+SocialAuth.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+SocialAuth.swift
@@ -55,7 +55,7 @@ public extension ApiServerHandler {
 
     func refreshIdentityToken() async throws -> String? {
         guard
-            let identityToken = ServerSettings.appleAuthIdentityToken,
+            let identityToken = ServerSettings.refreshToken,
             let request = tokenRequest(identityToken: identityToken, cachePolicy: .reloadIgnoringLocalCacheData, timeoutInterval: 30.seconds)
         else {
             FileLog.shared.addMessage("Unable to locate Apple SSO token in Keychain")

--- a/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+SocialAuth.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+SocialAuth.swift
@@ -50,7 +50,7 @@ public extension ApiServerHandler {
             throw APIError.UNKNOWN
         }
 
-        return try await obtainToken(request: request, provider: provider)
+        return try await obtainToken(request: request)
     }
 
     func refreshIdentityToken() async throws -> AuthenticationResponse {
@@ -62,7 +62,7 @@ public extension ApiServerHandler {
             throw APIError.UNKNOWN
         }
 
-        return try await obtainToken(request: request, provider: .google)
+        return try await obtainToken(request: request)
     }
 
     private func tokenRequest(identityToken: String?, cachePolicy: URLRequest.CachePolicy = .useProtocolCachePolicy, timeoutInterval: TimeInterval = 15.seconds) -> URLRequest? {

--- a/Modules/Server/Sources/PocketCastsServer/Public/Models/AuthenticationResponse.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Models/AuthenticationResponse.swift
@@ -4,12 +4,14 @@ public struct AuthenticationResponse: Codable {
     public let token: String?
     public let uuid: String?
     public let email: String?
+    public let refreshToken: String?
     public let isNewAccount: Bool?
 
     internal init(from apiResponse: Api_UserLoginResponse) {
         token = apiResponse.token.isEmpty ? nil : apiResponse.token
         uuid = apiResponse.uuid.isEmpty ? nil : apiResponse.uuid
         email = apiResponse.email.isEmpty ? nil : apiResponse.email
+        refreshToken = nil
         isNewAccount = false
     }
 
@@ -17,6 +19,7 @@ public struct AuthenticationResponse: Codable {
         token = apiResponse.accessToken.isEmpty ? nil : apiResponse.accessToken
         uuid = apiResponse.uuid.isEmpty ? nil : apiResponse.uuid
         email = apiResponse.email.isEmpty ? nil : apiResponse.email
+        refreshToken = apiResponse.refreshToken
         isNewAccount = apiResponse.isNew
     }
 }

--- a/Modules/Server/Sources/PocketCastsServer/Public/ServerSettings.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/ServerSettings.swift
@@ -336,13 +336,13 @@ public extension ServerSettings {
         }
     }
 
-    class var appleAuthIdentityToken: String? {
+    class var refreshToken: String? {
         get {
-            KeychainHelper.string(for: ServerConstants.Values.appleAuthIdentityTokenKey)
+            KeychainHelper.string(for: ServerConstants.Values.refreshTokenKey)
         }
 
         set {
-            KeychainHelper.save(string: newValue, key: ServerConstants.Values.appleAuthIdentityTokenKey, accessibility: kSecAttrAccessibleAfterFirstUnlock)
+            KeychainHelper.save(string: newValue, key: ServerConstants.Values.refreshTokenKey, accessibility: kSecAttrAccessibleAfterFirstUnlock)
         }
     }
 

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerConstants.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerConstants.swift
@@ -89,7 +89,7 @@ public enum ServerConstants {
         static let syncingEmailKey = "SJSyncingEmail"
         static let syncingPasswordKey = "SJSyncingPwd"
         static let syncingV2TokenKey = "SJSyncV2Token"
-        static let appleAuthIdentityTokenKey = "SJAppleAuthIdentityToken"
+        static let refreshTokenKey = "SJRefreshToken"
         static let appleAuthUserIDKey = "SJAppleAuthUserID"
         public static let appUserAgent = "Pocket Casts"
         static let customStorageUsed = "SJCustomStorageUsed"

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncManager.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncManager.swift
@@ -61,7 +61,7 @@ public class SyncManager {
         KeychainHelper.removeKey(ServerConstants.Values.syncingEmailKey)
         KeychainHelper.removeKey(ServerConstants.Values.syncingPasswordKey)
         KeychainHelper.removeKey(ServerConstants.Values.syncingV2TokenKey)
-        KeychainHelper.removeKey(ServerConstants.Values.appleAuthIdentityTokenKey)
+        KeychainHelper.removeKey(ServerConstants.Values.refreshTokenKey)
         KeychainHelper.removeKey(ServerConstants.Values.appleAuthUserIDKey)
     }
 }

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncManager.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncManager.swift
@@ -38,6 +38,7 @@ public class SyncManager {
 
         ServerSettings.setSyncingEmail(email: nil)
         ServerSettings.userId = nil
+        ServerSettings.refreshToken = nil
 
         UserDefaults.standard.removeObject(forKey: ServerConstants.UserDefaults.lastModifiedServerDate)
         UserDefaults.standard.removeObject(forKey: ServerConstants.UserDefaults.upNextServerLastModified)

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncManager.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncManager.swift
@@ -38,7 +38,6 @@ public class SyncManager {
 
         ServerSettings.setSyncingEmail(email: nil)
         ServerSettings.userId = nil
-        ServerSettings.refreshToken = nil
 
         UserDefaults.standard.removeObject(forKey: ServerConstants.UserDefaults.lastModifiedServerDate)
         UserDefaults.standard.removeObject(forKey: ServerConstants.UserDefaults.upNextServerLastModified)

--- a/Pocket Casts Watch App Extension/WatchSyncManager.swift
+++ b/Pocket Casts Watch App Extension/WatchSyncManager.swift
@@ -110,7 +110,7 @@ class WatchSyncManager {
 
                 ServerSettings.setSyncingEmail(email: username)
                 ServerSettings.saveSyncingPassword(password)
-                ServerSettings.appleAuthIdentityToken = appleAuthToken
+                ServerSettings.refreshToken = appleAuthToken
                 ServerSettings.appleAuthUserID = appleUserId
 
                 if !username.isEmpty {
@@ -178,7 +178,7 @@ class WatchSyncManager {
 
             ServerSettings.setSyncingEmail(email: username)
             ServerSettings.saveSyncingPassword(password)
-            ServerSettings.appleAuthIdentityToken = appleAuthToken
+            ServerSettings.refreshToken = appleAuthToken
             ServerSettings.appleAuthUserID = appleUserId
 
             if SyncManager.isUserLoggedIn(), username.isEmpty {

--- a/podcasts/AuthenticationHelper.swift
+++ b/podcasts/AuthenticationHelper.swift
@@ -63,6 +63,7 @@ class AuthenticationHelper {
 
         ServerSettings.userId = response.uuid
         ServerSettings.syncingV2Token = response.token
+        ServerSettings.refreshToken = response.refreshToken
 
         // we've signed in, set all our existing podcasts to be non synced
         DataManager.sharedManager.markAllPodcastsUnsynced()

--- a/podcasts/AuthenticationHelper.swift
+++ b/podcasts/AuthenticationHelper.swift
@@ -13,7 +13,7 @@ class AuthenticationHelper {
         if let username = ServerSettings.syncingEmail(), let password = ServerSettings.syncingPassword(), !password.isEmpty {
             return try await validateLogin(username: username, password: password, scope: scope).token
         }
-        else if FeatureFlag.signInWithApple.enabled, let token = ServerSettings.appleAuthIdentityToken, let userID = ServerSettings.appleAuthUserID {
+        else if FeatureFlag.signInWithApple.enabled, let token = ServerSettings.refreshToken, let userID = ServerSettings.appleAuthUserID {
             return try await validateLogin(identityToken: token, userID: userID).token
         }
 
@@ -43,7 +43,7 @@ class AuthenticationHelper {
         let response = try await ApiServerHandler.shared.validateLogin(identityToken: identityToken)
         handleSuccessfulSignIn(response, .ssoApple)
 
-        ServerSettings.appleAuthIdentityToken = identityToken
+        ServerSettings.refreshToken = identityToken
         ServerSettings.appleAuthUserID = userID
 
         return response

--- a/podcasts/Onboarding/LoginCoordinator.swift
+++ b/podcasts/Onboarding/LoginCoordinator.swift
@@ -13,6 +13,8 @@ class LoginCoordinator: NSObject, OnboardingModel {
 
     private var progressAlert: ShiftyLoadingAlert?
 
+    private var loginFinished = false
+
     /// Used to determine which screen after login to show to the user
     private var newAccountCreated = false
 
@@ -148,6 +150,13 @@ extension LoginCoordinator: SyncSigninDelegate, CreateAccountDelegate {
      }
 
     func signingProcessCompleted() {
+        // This can be called multiple times depending on the flow
+        // With this check we ensure this will be executed only once
+        guard !loginFinished else {
+            return
+        }
+
+        loginFinished = true
         let shouldDismiss = SubscriptionHelper.hasActiveSubscription() && !presentedFromUpgrade
 
         if shouldDismiss {

--- a/podcasts/Onboarding/LoginCoordinator.swift
+++ b/podcasts/Onboarding/LoginCoordinator.swift
@@ -5,7 +5,7 @@ import SwiftUI
 import PocketCastsDataModel
 
 class LoginCoordinator: NSObject, OnboardingModel {
-    var navigationController: UINavigationController? = nil
+    weak var navigationController: UINavigationController? = nil
     let headerImages: [LoginHeaderImage]
     var presentedFromUpgrade: Bool = false
 

--- a/podcasts/WatchManager.swift
+++ b/podcasts/WatchManager.swift
@@ -334,7 +334,7 @@ class WatchManager: NSObject, WCSessionDelegate {
         if let password = ServerSettings.syncingPassword() {
             response[WatchConstants.Messages.LoginDetailsResponse.password] = password
         }
-        else if let authToken = ServerSettings.appleAuthIdentityToken, let appleUserId = ServerSettings.appleAuthUserID {
+        else if let authToken = ServerSettings.refreshToken, let appleUserId = ServerSettings.appleAuthUserID {
             response[WatchConstants.Messages.LoginDetailsResponse.appleAuthToken] = authToken
             response[WatchConstants.Messages.LoginDetailsResponse.appleAuthUserID] = appleUserId
         }


### PR DESCRIPTION
| 📘 Project: #381 |
|:---:|

Add the token refresh logic for SSO logins.

Keep in mind that the username/password flow hasn't changed and it works as it was before.

## To test

1. Make sure `signInWithApple` is enabled in Profile -> Settings -> Beta Features
2. Go to `podcasts` scheme and change Build Configuration to `Staging`

### Username/password

1. Run the app
2. Create an account using an email/password
3. ✅ Your account should be created, you should see the Plus screen and the confetti screen
4. Go to Settings -> Developer -> Corrupt Sync Login Token
5. Go back to Profile and tap "Refresh Now"
6. ✅ The app should refresh (you can check the console for a "Sync succeeded")
7. Log out
8. Login with the created account and repeat the steps

### Google Sign In

1. Go to Staging console and remove the account with your Google Sign In (if there's any)
1. Run the app
2. Create an account using Google Sign In
3. ✅ Your account should be created, you should see the Plus screen and the confetti screen
4. Go to Settings -> Developer -> Corrupt Sync Login Token
5. Go back to Profile and tap "Refresh Now"
6. ✅ The app should refresh (you can check the console for a "Sync succeeded")
7. Log out
8. Login with the created account and repeat the steps

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
