### PR TITLE
SSO: Add Apple Login

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+SocialAuth.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+SocialAuth.swift
@@ -96,7 +96,7 @@ public extension ApiServerHandler {
     }
 }
 
-public enum SocialAuthProvider {
+public enum SocialAuthProvider: CaseIterable {
     case apple
     case google
 

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -469,6 +469,7 @@
 		8B317BA728906CC200A26A13 /* TestingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B317BA628906CC200A26A13 /* TestingViewController.swift */; };
 		8B317BA92890704400A26A13 /* TestingScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8B317BA82890704400A26A13 /* TestingScreen.storyboard */; };
 		8B3654172926C13000FD7216 /* CircularProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B3654162926C13000FD7216 /* CircularProgressView.swift */; };
+		8B44446229785287007E0AA8 /* AppleSocialLogin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B44446129785287007E0AA8 /* AppleSocialLogin.swift */; };
 		8B484EF528D23BEF001AFA97 /* PlaybackTimeHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B484EF428D23BEF001AFA97 /* PlaybackTimeHelper.swift */; };
 		8B484EF728D23F06001AFA97 /* PlaybackTimeHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B484EF628D23F06001AFA97 /* PlaybackTimeHelperTests.swift */; };
 		8B484EF928D256F5001AFA97 /* Date+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B484EF828D256F5001AFA97 /* Date+Ext.swift */; };
@@ -2081,6 +2082,7 @@
 		8B317BA628906CC200A26A13 /* TestingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestingViewController.swift; sourceTree = "<group>"; };
 		8B317BA82890704400A26A13 /* TestingScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = TestingScreen.storyboard; sourceTree = "<group>"; };
 		8B3654162926C13000FD7216 /* CircularProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircularProgressView.swift; sourceTree = "<group>"; };
+		8B44446129785287007E0AA8 /* AppleSocialLogin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleSocialLogin.swift; sourceTree = "<group>"; };
 		8B484EF428D23BEF001AFA97 /* PlaybackTimeHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaybackTimeHelper.swift; sourceTree = "<group>"; };
 		8B484EF628D23F06001AFA97 /* PlaybackTimeHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaybackTimeHelperTests.swift; sourceTree = "<group>"; };
 		8B484EF828D256F5001AFA97 /* Date+Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Ext.swift"; sourceTree = "<group>"; };
@@ -3883,6 +3885,7 @@
 		8BAD6E5F2975AF9900DB7259 /* Login */ = {
 			isa = PBXGroup;
 			children = (
+				8B44446129785287007E0AA8 /* AppleSocialLogin.swift */,
 				8BAD6E602975AFAA00DB7259 /* GoogleSocialLogin.swift */,
 			);
 			path = Login;
@@ -7940,6 +7943,7 @@
 				BD77E9031B9D2CF600DC4ADF /* AngularProgressIndicator.swift in Sources */,
 				BD8032D32123EAD600BFBB03 /* EffectsButton.swift in Sources */,
 				4030D4682498579D00BEC7D9 /* MultiSelectActionProtocol.swift in Sources */,
+				8B44446229785287007E0AA8 /* AppleSocialLogin.swift in Sources */,
 				BD86D94F217EB81C0010FA1B /* FilterDownloadCell.swift in Sources */,
 				BD6B432A2755F516005E4017 /* AboutViewLogos.swift in Sources */,
 				C7AF7B992926B307002F0025 /* OnboardingHostingViewController.swift in Sources */,

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -470,6 +470,7 @@
 		8B317BA92890704400A26A13 /* TestingScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8B317BA82890704400A26A13 /* TestingScreen.storyboard */; };
 		8B3654172926C13000FD7216 /* CircularProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B3654162926C13000FD7216 /* CircularProgressView.swift */; };
 		8B44446229785287007E0AA8 /* AppleSocialLogin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B44446129785287007E0AA8 /* AppleSocialLogin.swift */; };
+		8B44446429785947007E0AA8 /* SocialLogin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B44446329785947007E0AA8 /* SocialLogin.swift */; };
 		8B484EF528D23BEF001AFA97 /* PlaybackTimeHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B484EF428D23BEF001AFA97 /* PlaybackTimeHelper.swift */; };
 		8B484EF728D23F06001AFA97 /* PlaybackTimeHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B484EF628D23F06001AFA97 /* PlaybackTimeHelperTests.swift */; };
 		8B484EF928D256F5001AFA97 /* Date+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B484EF828D256F5001AFA97 /* Date+Ext.swift */; };
@@ -2083,6 +2084,7 @@
 		8B317BA82890704400A26A13 /* TestingScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = TestingScreen.storyboard; sourceTree = "<group>"; };
 		8B3654162926C13000FD7216 /* CircularProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircularProgressView.swift; sourceTree = "<group>"; };
 		8B44446129785287007E0AA8 /* AppleSocialLogin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleSocialLogin.swift; sourceTree = "<group>"; };
+		8B44446329785947007E0AA8 /* SocialLogin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialLogin.swift; sourceTree = "<group>"; };
 		8B484EF428D23BEF001AFA97 /* PlaybackTimeHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaybackTimeHelper.swift; sourceTree = "<group>"; };
 		8B484EF628D23F06001AFA97 /* PlaybackTimeHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaybackTimeHelperTests.swift; sourceTree = "<group>"; };
 		8B484EF828D256F5001AFA97 /* Date+Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Ext.swift"; sourceTree = "<group>"; };
@@ -3887,6 +3889,7 @@
 			children = (
 				8B44446129785287007E0AA8 /* AppleSocialLogin.swift */,
 				8BAD6E602975AFAA00DB7259 /* GoogleSocialLogin.swift */,
+				8B44446329785947007E0AA8 /* SocialLogin.swift */,
 			);
 			path = Login;
 			sourceTree = "<group>";
@@ -8178,6 +8181,7 @@
 				BDD3579027BCD33D0000D155 /* FolderViewController.swift in Sources */,
 				BDD71CF41BA935E8006D2CE3 /* NetworkViewController.swift in Sources */,
 				8B723755291185B300FA8219 /* Analytics+story.swift in Sources */,
+				8B44446429785947007E0AA8 /* SocialLogin.swift in Sources */,
 				BD44A4452302DAC6004F55B2 /* CommonUpNextItem.swift in Sources */,
 				BDA2065D1BB3AF5D00D38389 /* DownloadProgress.swift in Sources */,
 				407083C625423F0A002FC9F8 /* EpisodePreviewCell.swift in Sources */,

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -471,6 +471,7 @@
 		8B3654172926C13000FD7216 /* CircularProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B3654162926C13000FD7216 /* CircularProgressView.swift */; };
 		8B44446229785287007E0AA8 /* AppleSocialLogin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B44446129785287007E0AA8 /* AppleSocialLogin.swift */; };
 		8B44446429785947007E0AA8 /* SocialLogin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B44446329785947007E0AA8 /* SocialLogin.swift */; };
+		8B44446729785BD0007E0AA8 /* SocialLoginFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B44446629785BD0007E0AA8 /* SocialLoginFactory.swift */; };
 		8B484EF528D23BEF001AFA97 /* PlaybackTimeHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B484EF428D23BEF001AFA97 /* PlaybackTimeHelper.swift */; };
 		8B484EF728D23F06001AFA97 /* PlaybackTimeHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B484EF628D23F06001AFA97 /* PlaybackTimeHelperTests.swift */; };
 		8B484EF928D256F5001AFA97 /* Date+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B484EF828D256F5001AFA97 /* Date+Ext.swift */; };
@@ -2085,6 +2086,7 @@
 		8B3654162926C13000FD7216 /* CircularProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircularProgressView.swift; sourceTree = "<group>"; };
 		8B44446129785287007E0AA8 /* AppleSocialLogin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleSocialLogin.swift; sourceTree = "<group>"; };
 		8B44446329785947007E0AA8 /* SocialLogin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialLogin.swift; sourceTree = "<group>"; };
+		8B44446629785BD0007E0AA8 /* SocialLoginFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialLoginFactory.swift; sourceTree = "<group>"; };
 		8B484EF428D23BEF001AFA97 /* PlaybackTimeHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaybackTimeHelper.swift; sourceTree = "<group>"; };
 		8B484EF628D23F06001AFA97 /* PlaybackTimeHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaybackTimeHelperTests.swift; sourceTree = "<group>"; };
 		8B484EF828D256F5001AFA97 /* Date+Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Ext.swift"; sourceTree = "<group>"; };
@@ -3890,6 +3892,7 @@
 				8B44446129785287007E0AA8 /* AppleSocialLogin.swift */,
 				8BAD6E602975AFAA00DB7259 /* GoogleSocialLogin.swift */,
 				8B44446329785947007E0AA8 /* SocialLogin.swift */,
+				8B44446629785BD0007E0AA8 /* SocialLoginFactory.swift */,
 			);
 			path = Login;
 			sourceTree = "<group>";
@@ -7644,6 +7647,7 @@
 				BD93FDA120157B2000F6EF55 /* PodcastImageView.swift in Sources */,
 				BDD5253A20477E4400AAD211 /* NSObject+AppDelegate.swift in Sources */,
 				C7080C5D2923070200D7A432 /* PlusAccountUpgradePrompt.swift in Sources */,
+				8B44446729785BD0007E0AA8 /* SocialLoginFactory.swift in Sources */,
 				46305CED272AFA5F003AC87B /* UserDefaults+Helpers.swift in Sources */,
 				BD2F3BA22366C0DA00416633 /* PlayerContainerViewController+Update.swift in Sources */,
 				8B2E055228F88D7300C2DBDE /* EndOfYearPromptCell.swift in Sources */,

--- a/podcasts/Login/AppleSocialLogin.swift
+++ b/podcasts/Login/AppleSocialLogin.swift
@@ -1,0 +1,65 @@
+import Foundation
+import AuthenticationServices
+import PocketCastsServer
+
+class AppleSocialLogin: NSObject {
+    private weak var viewController: UIViewController?
+
+    private var idToken = ""
+
+    private var continuation: UnsafeContinuation<String, Error>?
+
+    func getToken(from viewController: UIViewController) async throws {
+        self.viewController = viewController
+        idToken = try await idToken(from: viewController)
+    }
+
+    func login() async throws -> AuthenticationResponse {
+        try await AuthenticationHelper.validateLogin(identityToken: idToken, provider: .apple)
+    }
+
+    @MainActor
+    private func idToken(from viewController: UIViewController) async throws -> String {
+        try await withUnsafeThrowingContinuation { continuation in
+            self.continuation = continuation
+
+            let appleIDProvider = ASAuthorizationAppleIDProvider()
+            let request = appleIDProvider.createRequest()
+            request.requestedScopes = [.email]
+
+            let authorizationController = ASAuthorizationController(authorizationRequests: [request])
+            authorizationController.delegate = self
+            authorizationController.presentationContextProvider = self
+            authorizationController.performRequests()
+        }
+    }
+}
+
+// MARK: - Sign In With Apple
+
+extension AppleSocialLogin: ASAuthorizationControllerPresentationContextProviding {
+    func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+        guard let window = viewController?.view.window else { return UIApplication.shared.windows.first! }
+        return window
+    }
+}
+
+extension AppleSocialLogin: ASAuthorizationControllerDelegate {
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
+        switch authorization.credential {
+        case let appleIDCredential as ASAuthorizationAppleIDCredential:
+            if let identityTokenData = appleIDCredential.identityToken,
+               let identityToken = String(data: identityTokenData, encoding: .utf8) {
+                continuation?.resume(returning: identityToken)
+            } else {
+                // throw error
+            }
+        default:
+            break
+        }
+    }
+
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
+        continuation?.resume(throwing: error)
+    }
+}

--- a/podcasts/Login/AppleSocialLogin.swift
+++ b/podcasts/Login/AppleSocialLogin.swift
@@ -2,6 +2,10 @@ import Foundation
 import AuthenticationServices
 import PocketCastsServer
 
+enum AppleSocialLoginError: Error {
+    case emptyIdToken
+}
+
 class AppleSocialLogin: NSObject {
     private weak var viewController: UIViewController?
 
@@ -52,7 +56,7 @@ extension AppleSocialLogin: ASAuthorizationControllerDelegate {
                let identityToken = String(data: identityTokenData, encoding: .utf8) {
                 continuation?.resume(returning: identityToken)
             } else {
-                // throw error
+                continuation?.resume(throwing: AppleSocialLoginError.emptyIdToken)
             }
         default:
             break

--- a/podcasts/Login/AppleSocialLogin.swift
+++ b/podcasts/Login/AppleSocialLogin.swift
@@ -6,16 +6,19 @@ enum AppleSocialLoginError: Error {
     case emptyIdToken
 }
 
-class AppleSocialLogin: NSObject {
+class AppleSocialLogin: NSObject, SocialLogin {
     private weak var viewController: UIViewController?
 
     private var idToken = ""
 
     private var continuation: UnsafeContinuation<String, Error>?
 
-    func getToken(from viewController: UIViewController) async throws {
+    required init(viewController: UIViewController) {
         self.viewController = viewController
-        idToken = try await idToken(from: viewController)
+    }
+
+    func getToken() async throws {
+        idToken = try await idToken(from: viewController!)
     }
 
     func login() async throws -> AuthenticationResponse {

--- a/podcasts/Login/AppleSocialLogin.swift
+++ b/podcasts/Login/AppleSocialLogin.swift
@@ -67,6 +67,11 @@ extension AppleSocialLogin: ASAuthorizationControllerDelegate {
     }
 
     func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
+        if let err = error as? ASAuthorizationError, err.code == .canceled {
+            continuation?.resume(throwing: SocialLoginError.canceled)
+            return
+        }
+
         continuation?.resume(throwing: error)
     }
 }

--- a/podcasts/Login/GoogleSocialLogin.swift
+++ b/podcasts/Login/GoogleSocialLogin.swift
@@ -33,6 +33,12 @@ class GoogleSocialLogin: SocialLogin {
 
             GIDSignIn.sharedInstance.signIn(with: config, presenting: viewController) { signInResult, error in
                 if let error {
+
+                    if let err = error as? GIDSignInError, err.code == .canceled {
+                        continuation.resume(throwing: SocialLoginError.canceled)
+                        return
+                    }
+
                     continuation.resume(throwing: error)
                     return
                 }

--- a/podcasts/Login/GoogleSocialLogin.swift
+++ b/podcasts/Login/GoogleSocialLogin.swift
@@ -6,11 +6,17 @@ enum GoogleSocialLoginError: Error {
     case emptyIdToken
 }
 
-class GoogleSocialLogin {
+class GoogleSocialLogin: SocialLogin {
+    private weak var viewController: UIViewController?
+
     private var idToken = ""
 
-    func getToken(from viewController: UIViewController) async throws {
-        idToken = try await idToken(from: viewController)
+    required init(viewController: UIViewController) {
+        self.viewController = viewController
+    }
+
+    func getToken() async throws {
+        idToken = try await idToken(from: viewController!)
     }
 
     func login() async throws -> AuthenticationResponse {

--- a/podcasts/Login/SocialLogin.swift
+++ b/podcasts/Login/SocialLogin.swift
@@ -1,0 +1,13 @@
+import Foundation
+import PocketCastsServer
+
+protocol SocialLogin {
+    init(viewController: UIViewController)
+
+    /// This is the step in which an identification token is retrieved from the provider
+    func getToken()
+
+    /// Once the identification token is retrieved, this step is responsible to sending this to
+    /// the server so the user identity may be verified
+    func login() async throws -> AuthenticationResponse
+}

--- a/podcasts/Login/SocialLogin.swift
+++ b/podcasts/Login/SocialLogin.swift
@@ -1,6 +1,10 @@
 import Foundation
 import PocketCastsServer
 
+enum SocialLoginError: Error {
+    case canceled
+}
+
 protocol SocialLogin {
     init(viewController: UIViewController)
 

--- a/podcasts/Login/SocialLogin.swift
+++ b/podcasts/Login/SocialLogin.swift
@@ -5,7 +5,7 @@ protocol SocialLogin {
     init(viewController: UIViewController)
 
     /// This is the step in which an identification token is retrieved from the provider
-    func getToken()
+    func getToken() async throws
 
     /// Once the identification token is retrieved, this step is responsible to sending this to
     /// the server so the user identity may be verified

--- a/podcasts/Login/SocialLoginFactory.swift
+++ b/podcasts/Login/SocialLoginFactory.swift
@@ -1,0 +1,13 @@
+import Foundation
+import PocketCastsServer
+
+class SocialLoginFactory {
+    static func provider(for provider: SocialAuthProvider, from viewController: UIViewController) -> SocialLogin {
+        switch provider {
+        case .apple:
+            return AppleSocialLogin(viewController: viewController)
+        case .google:
+            return GoogleSocialLogin(viewController: viewController)
+        }
+    }
+}

--- a/podcasts/Onboarding/Login/LoginLandingView.swift
+++ b/podcasts/Onboarding/Login/LoginLandingView.swift
@@ -352,15 +352,15 @@ private struct SocialLoginButtons: View {
         if !FeatureFlag.signInWithApple.enabled {
             EmptyView()
         } else {
-            ForEach(SocialAuthProvider.allCases, id: \.self) {
-                switch $0 {
+            ForEach(SocialAuthProvider.allCases, id: \.self) { provider in
+                switch provider {
                 case .apple:
                     Button(L10n.socialSignInContinueWithApple) {
-                        coordinator.signInWithAppleTapped()
+                        coordinator.signIn(with: provider)
                     }.buttonStyle(SocialButtonStyle(imageName: AppTheme.socialIconAppleImageName()))
                 case .google:
                     Button(L10n.socialSignInContinueWithGoogle) {
-                        coordinator.signInWithGoogleTapped()
+                        coordinator.signIn(with: provider)
                     }.buttonStyle(SocialButtonStyle(imageName: AppTheme.socialIconGoogleImageName()))
                 }
             }

--- a/podcasts/Onboarding/Login/LoginLandingView.swift
+++ b/podcasts/Onboarding/Login/LoginLandingView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import PocketCastsServer
 
 struct LoginLandingView: View {
     @EnvironmentObject var theme: Theme
@@ -351,13 +352,18 @@ private struct SocialLoginButtons: View {
         if !FeatureFlag.signInWithApple.enabled {
             EmptyView()
         } else {
-            Button(L10n.socialSignInContinueWithApple) {
-                coordinator.signInWithAppleTapped()
-            }.buttonStyle(SocialButtonStyle(imageName: AppTheme.socialIconAppleImageName()))
-
-            Button(L10n.socialSignInContinueWithGoogle) {
-                coordinator.signInWithGoogleTapped()
-            }.buttonStyle(SocialButtonStyle(imageName: AppTheme.socialIconGoogleImageName()))
+            ForEach(SocialAuthProvider.allCases, id: \.self) {
+                switch $0 {
+                case .apple:
+                    Button(L10n.socialSignInContinueWithApple) {
+                        coordinator.signInWithAppleTapped()
+                    }.buttonStyle(SocialButtonStyle(imageName: AppTheme.socialIconAppleImageName()))
+                case .google:
+                    Button(L10n.socialSignInContinueWithGoogle) {
+                        coordinator.signInWithGoogleTapped()
+                    }.buttonStyle(SocialButtonStyle(imageName: AppTheme.socialIconGoogleImageName()))
+                }
+            }
         }
     }
 }

--- a/podcasts/Onboarding/LoginCoordinator.swift
+++ b/podcasts/Onboarding/LoginCoordinator.swift
@@ -171,7 +171,10 @@ extension LoginCoordinator: SyncSigninDelegate, CreateAccountDelegate {
     }
 
     func showError(_ error: Error) {
-        navigationController?.presentedViewController?.dismiss(animated: true)
+        guard (error as? SocialLoginError) != .canceled else {
+            return
+        }
+
         SJUIUtils.showAlert(title: L10n.accountSsoFailed, message: nil, from: navigationController)
     }
 

--- a/podcasts/Onboarding/LoginCoordinator.swift
+++ b/podcasts/Onboarding/LoginCoordinator.swift
@@ -111,10 +111,10 @@ extension LoginCoordinator {
                     }
                 }
 
-                listenToSync()
-
                 let response = try await self.socialLogin?.login()
                 newAccountCreated = response?.isNewAccount ?? false
+
+                listenToSync()
             } catch {
                 progressAlert?.hideAlert(false) {
                     self.showError(error)

--- a/podcasts/Onboarding/LoginCoordinator.swift
+++ b/podcasts/Onboarding/LoginCoordinator.swift
@@ -45,10 +45,6 @@ class LoginCoordinator: NSObject, OnboardingModel {
 
     func didAppear() {
         OnboardingFlow.shared.track(.setupAccountShown)
-
-        NotificationCenter.default.addObserver(self, selector: #selector(syncCompleted), name: ServerNotifications.syncCompleted, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(syncCompleted), name: ServerNotifications.syncFailed, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(syncCompleted), name: ServerNotifications.podcastRefreshFailed, object: nil)
     }
 
     func didDismiss(type: OnboardingDismissType) {
@@ -114,6 +110,9 @@ extension LoginCoordinator {
                         continuation.resume()
                     }
                 }
+
+                listenToSync()
+
                 let response = try await self.socialLogin?.login()
                 newAccountCreated = response?.isNewAccount ?? false
             } catch {
@@ -126,6 +125,12 @@ extension LoginCoordinator {
 }
 
 extension LoginCoordinator: SyncSigninDelegate, CreateAccountDelegate {
+    private func listenToSync() {
+        NotificationCenter.default.addObserver(self, selector: #selector(syncCompleted), name: ServerNotifications.syncCompleted, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(syncCompleted), name: ServerNotifications.syncFailed, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(syncCompleted), name: ServerNotifications.podcastRefreshFailed, object: nil)
+    }
+
     @objc private func syncCompleted() {
          DispatchQueue.main.async {
              self.progressAlert?.hideAlert(false)

--- a/podcasts/Onboarding/LoginCoordinator.swift
+++ b/podcasts/Onboarding/LoginCoordinator.swift
@@ -95,7 +95,17 @@ class LoginCoordinator: NSObject, OnboardingModel {
 
 // MARK: - Social Buttons
 extension LoginCoordinator {
-    func signInWithAppleTapped() {
+    @MainActor
+    func signIn(with provider: SocialAuthProvider) {
+        switch provider {
+        case .google:
+            signInWithGoogleTapped()
+        case .apple:
+            signInWithAppleTapped()
+        }
+    }
+
+    private func signInWithAppleTapped() {
         let appleIDProvider = ASAuthorizationAppleIDProvider()
         let request = appleIDProvider.createRequest()
         request.requestedScopes = [.email]
@@ -107,7 +117,7 @@ extension LoginCoordinator {
     }
 
     @MainActor
-    func signInWithGoogleTapped() {
+    private func signInWithGoogleTapped() {
         guard let navigationController else {
             return
         }


### PR DESCRIPTION
| 📘 Project: #381 |
|:---:|

* Adds Apple login
* Refactor the code so adding other providers in the future is easier

## To test

Before everything:

2. Go to `podcasts` scheme and change Build Configuration to `Staging`
3. Go to Settings > Beta Features > enable `signInWithApple`

### Account creation

1. Go to Staging console and remove the account with your Apple email (if there's any)
2. Run the app
3. Profile > tap the login bubble
4. Select "Continue with Apple"
5. Select an account
6. ✅ You should see the Plus screen and the confetti screen
7. Log out

### Login

1. Run the app
2. Go to Profile and tap the login bubble
4. Select "Continue with Apple"
5. Finish the flow
5. ✅ You should see the plus screen
6. Dismiss it
7. Go to Staging and gift yourself plus
8. Sign out
9. Sign In again using an Apple account
10. ✅ The login flow should just be dismissed without presenting the Plus screen

### Token refresh

1. While logged in with an account initiated through Apple Sign In go to Settings -> Developer -> Corrupt Sync Login Token
5. Go back to Profile and tap "Refresh Now"
6. ✅ The app should refresh (you can check the console for a "Sync succeeded")

### Cancel flow

1. Run the app
2. Go to Profile and tap the login bubble
4. Select "Continue with Apple"
4. Dismiss the bottom sheet
4. ✅ Nothing should be shown
4. Repeat the same with Googlem when the webview appears, dismiss it
4. ✅ Nothing should be shown

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
