### PR TITLE
SSO: add support for logins made through Apple/Google on Apple Watch

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+Account.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+Account.swift
@@ -20,7 +20,7 @@ public extension ApiServerHandler {
             throw APIError.UNKNOWN
         }
 
-        return try await obtainToken(request: request)
+        return try await obtainToken(request: request, usingRefreshToken: false)
     }
 
     func validateLogin(username: String, password: String, completion: @escaping (_ success: Bool, _ userId: String?, _ error: APIError?) -> Void) {
@@ -143,7 +143,7 @@ public extension ApiServerHandler {
     func obtainToken(request: URLRequest, completion: @escaping (Result<AuthenticationResponse, APIError>) -> Void) {
         Task {
             do {
-                let response = try await obtainToken(request: request)
+                let response = try await obtainToken(request: request, usingRefreshToken: false)
                 completion(.success(response))
             } catch {
                 completion(.failure((error as? APIError) ?? .UNKNOWN))
@@ -151,7 +151,7 @@ public extension ApiServerHandler {
         }
     }
 
-    func obtainToken(request: URLRequest) async throws -> AuthenticationResponse {
+    func obtainToken(request: URLRequest, usingRefreshToken: Bool) async throws -> AuthenticationResponse {
         try await withUnsafeThrowingContinuation { continuation in
             URLSession.shared.dataTask(with: request) { data, response, error in
                 guard let responseData = data, error == nil, response?.extractStatusCode() == ServerConstants.HttpConstants.ok else {
@@ -162,7 +162,8 @@ public extension ApiServerHandler {
                 }
 
                 do {
-                    if let response = try? Api_TokenLoginResponse(serializedData: responseData) {
+                    if usingRefreshToken {
+                        let response = try Api_TokenLoginResponse(serializedData: responseData)
                         continuation.resume(returning: AuthenticationResponse(from: response))
                     } else {
                         let userLoginResponse = try Api_UserLoginResponse(serializedData: responseData)

--- a/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+Account.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+Account.swift
@@ -20,7 +20,7 @@ public extension ApiServerHandler {
             throw APIError.UNKNOWN
         }
 
-        return try await obtainToken(request: request)
+        return try await obtainToken(request: request, usingRefreshToken: false)
     }
 
     func validateLogin(username: String, password: String, completion: @escaping (_ success: Bool, _ userId: String?, _ error: APIError?) -> Void) {
@@ -143,7 +143,7 @@ public extension ApiServerHandler {
     func obtainToken(request: URLRequest, completion: @escaping (Result<AuthenticationResponse, APIError>) -> Void) {
         Task {
             do {
-                let response = try await obtainToken(request: request)
+                let response = try await obtainToken(request: request, usingRefreshToken: false)
                 completion(.success(response))
             } catch {
                 completion(.failure((error as? APIError) ?? .UNKNOWN))
@@ -151,7 +151,7 @@ public extension ApiServerHandler {
         }
     }
 
-    func obtainToken(request: URLRequest) async throws -> AuthenticationResponse {
+    func obtainToken(request: URLRequest, usingRefreshToken: Bool) async throws -> AuthenticationResponse {
         try await withUnsafeThrowingContinuation { continuation in
             URLSession.shared.dataTask(with: request) { data, response, error in
                 guard let responseData = data, error == nil, response?.extractStatusCode() == ServerConstants.HttpConstants.ok else {
@@ -162,11 +162,10 @@ public extension ApiServerHandler {
                 }
 
                 do {
-                    // Response that contains the refresh token
-                    if let response = try? Api_TokenLoginResponse(serializedData: responseData) {
+                    if usingRefreshToken {
+                        let response = try Api_TokenLoginResponse(serializedData: responseData)
                         continuation.resume(returning: AuthenticationResponse(from: response))
                     } else {
-                        // Old response for username/password without refresh token
                         let userLoginResponse = try Api_UserLoginResponse(serializedData: responseData)
                         continuation.resume(returning: AuthenticationResponse(from: userLoginResponse))
                     }

--- a/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+Account.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+Account.swift
@@ -162,8 +162,7 @@ public extension ApiServerHandler {
                 }
 
                 do {
-                    if request.url?.absoluteString == ServerConstants.Urls.refreshToken() {
-                        let response = try Api_TokenLoginResponse(serializedData: responseData)
+                    if let response = try? Api_TokenLoginResponse(serializedData: responseData) {
                         continuation.resume(returning: AuthenticationResponse(from: response))
                     } else {
                         let userLoginResponse = try Api_UserLoginResponse(serializedData: responseData)

--- a/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+SocialAuth.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+SocialAuth.swift
@@ -40,7 +40,7 @@ public extension ApiServerHandler {
             throw APIError.UNKNOWN
         }
 
-        return try await obtainToken(request: request, usingRefreshToken: true)
+        return try await obtainToken(request: request)
     }
 
     func validateLogin(identityToken: String, provider: SocialAuthProvider) async throws -> AuthenticationResponse {
@@ -50,7 +50,7 @@ public extension ApiServerHandler {
             throw APIError.UNKNOWN
         }
 
-        return try await obtainToken(request: request, usingRefreshToken: true)
+        return try await obtainToken(request: request)
     }
 
     func refreshIdentityToken() async throws -> AuthenticationResponse {
@@ -62,7 +62,7 @@ public extension ApiServerHandler {
             throw APIError.UNKNOWN
         }
 
-        return try await obtainToken(request: request, usingRefreshToken: true)
+        return try await obtainToken(request: request)
     }
 
     private func tokenRequest(identityToken: String?, cachePolicy: URLRequest.CachePolicy = .useProtocolCachePolicy, timeoutInterval: TimeInterval = 15.seconds) -> URLRequest? {
@@ -70,7 +70,7 @@ public extension ApiServerHandler {
             return nil
         }
 
-        let url = ServerHelper.asUrl(ServerConstants.Urls.api() + "user/token")
+        let url = ServerHelper.asUrl(ServerConstants.Urls.refreshToken())
 
         var data = Api_UserTokenRequest()
         data.refreshToken = identityToken

--- a/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+SocialAuth.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+SocialAuth.swift
@@ -70,7 +70,7 @@ public extension ApiServerHandler {
             return nil
         }
 
-        let url = ServerHelper.asUrl(ServerConstants.Urls.refreshToken())
+        let url = ServerHelper.asUrl(ServerConstants.Urls.api() + "user/token")
 
         var data = Api_UserTokenRequest()
         data.refreshToken = identityToken

--- a/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+SocialAuth.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+SocialAuth.swift
@@ -40,7 +40,7 @@ public extension ApiServerHandler {
             throw APIError.UNKNOWN
         }
 
-        return try await obtainToken(request: request)
+        return try await obtainToken(request: request, usingRefreshToken: true)
     }
 
     func validateLogin(identityToken: String, provider: SocialAuthProvider) async throws -> AuthenticationResponse {
@@ -50,7 +50,7 @@ public extension ApiServerHandler {
             throw APIError.UNKNOWN
         }
 
-        return try await obtainToken(request: request)
+        return try await obtainToken(request: request, usingRefreshToken: true)
     }
 
     func refreshIdentityToken() async throws -> AuthenticationResponse {
@@ -62,7 +62,7 @@ public extension ApiServerHandler {
             throw APIError.UNKNOWN
         }
 
-        return try await obtainToken(request: request)
+        return try await obtainToken(request: request, usingRefreshToken: true)
     }
 
     private func tokenRequest(identityToken: String?, cachePolicy: URLRequest.CachePolicy = .useProtocolCachePolicy, timeoutInterval: TimeInterval = 15.seconds) -> URLRequest? {

--- a/Modules/Server/Sources/PocketCastsServer/Public/ServerSettings.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/ServerSettings.swift
@@ -345,14 +345,4 @@ public extension ServerSettings {
             KeychainHelper.save(string: newValue, key: ServerConstants.Values.refreshTokenKey, accessibility: kSecAttrAccessibleAfterFirstUnlock)
         }
     }
-
-    class var appleAuthUserID: String? {
-        get {
-            KeychainHelper.string(for: ServerConstants.Values.appleAuthUserIDKey)
-        }
-
-        set {
-            KeychainHelper.save(string: newValue, key: ServerConstants.Values.appleAuthUserIDKey, accessibility: kSecAttrAccessibleAfterFirstUnlock)
-        }
-    }
 }

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerConstants.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerConstants.swift
@@ -38,10 +38,6 @@ public enum ServerConstants {
             production() ? "https://lists.pocketcasts.com/" : "https://lists.pocketcasts.net/"
         }
 
-        public static func refreshToken() -> String {
-            Self.api() + "user/token"
-        }
-
         public static let support = "https://support.pocketcasts.com/ios/"
         public static let cancelSubscription = "https://support.pocketcasts.com/article/subscription-info/"
         public static let termsOfUse = "https://support.pocketcasts.com/article/terms-of-use/"

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerConstants.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerConstants.swift
@@ -38,6 +38,10 @@ public enum ServerConstants {
             production() ? "https://lists.pocketcasts.com/" : "https://lists.pocketcasts.net/"
         }
 
+        public static func refreshToken() -> String {
+            Self.api() + "user/token"
+        }
+
         public static let support = "https://support.pocketcasts.com/ios/"
         public static let cancelSubscription = "https://support.pocketcasts.com/article/subscription-info/"
         public static let termsOfUse = "https://support.pocketcasts.com/article/terms-of-use/"

--- a/Pocket Casts Watch App Extension/WatchSyncManager.swift
+++ b/Pocket Casts Watch App Extension/WatchSyncManager.swift
@@ -105,13 +105,11 @@ class WatchSyncManager {
             SessionManager.shared.requestLoginDetails(replyHandler: { response in
                 let username = response[WatchConstants.Messages.LoginDetailsResponse.username] as? String ?? ""
                 let password = response[WatchConstants.Messages.LoginDetailsResponse.password] as? String ?? ""
-                let appleAuthToken = response[WatchConstants.Messages.LoginDetailsResponse.appleAuthToken] as? String
-                let appleUserId = response[WatchConstants.Messages.LoginDetailsResponse.appleAuthUserID] as? String
+                let refreshToken = response[WatchConstants.Messages.LoginDetailsResponse.refreshToken] as? String
 
                 ServerSettings.setSyncingEmail(email: username)
                 ServerSettings.saveSyncingPassword(password)
-                ServerSettings.refreshToken = appleAuthToken
-                ServerSettings.appleAuthUserID = appleUserId
+                ServerSettings.refreshToken = refreshToken
 
                 if !username.isEmpty {
                     self.login()
@@ -173,13 +171,11 @@ class WatchSyncManager {
         SessionManager.shared.requestLoginDetails(replyHandler: { response in
             let username = response[WatchConstants.Messages.LoginDetailsResponse.username] as? String ?? ""
             let password = response[WatchConstants.Messages.LoginDetailsResponse.password] as? String ?? ""
-            let appleAuthToken = response[WatchConstants.Messages.LoginDetailsResponse.appleAuthToken] as? String
-            let appleUserId = response[WatchConstants.Messages.LoginDetailsResponse.appleAuthUserID] as? String
+            let refreshToken = response[WatchConstants.Messages.LoginDetailsResponse.refreshToken] as? String
 
             ServerSettings.setSyncingEmail(email: username)
             ServerSettings.saveSyncingPassword(password)
-            ServerSettings.refreshToken = appleAuthToken
-            ServerSettings.appleAuthUserID = appleUserId
+            ServerSettings.refreshToken = refreshToken
 
             if SyncManager.isUserLoggedIn(), username.isEmpty {
                 FileLog.shared.addMessage("Logging out as phone has logged out ")

--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -83,8 +83,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         NotificationCenter.default.addObserver(self, selector: #selector(showOverlays), name: Constants.Notifications.closedNonOverlayableWindow, object: nil)
 
         setupSignOutListener()
-        AuthenticationHelper.validateAppleSSOCredentials()
-        AuthenticationHelper.observeAppleSSOEvents()
 
         return true
     }

--- a/podcasts/AuthenticationHelper.swift
+++ b/podcasts/AuthenticationHelper.swift
@@ -13,8 +13,8 @@ class AuthenticationHelper {
         if let username = ServerSettings.syncingEmail(), let password = ServerSettings.syncingPassword(), !password.isEmpty {
             return try await validateLogin(username: username, password: password, scope: scope).token
         }
-        else if FeatureFlag.signInWithApple.enabled, let token = ServerSettings.refreshToken, let userID = ServerSettings.appleAuthUserID {
-            return try await validateLogin(identityToken: token, userID: userID).token
+        else if let token = ServerSettings.refreshToken {
+            return try await validateLogin(identityToken: token).token
         }
 
         return nil
@@ -39,12 +39,11 @@ class AuthenticationHelper {
 
     // MARK: Apple SSO
 
-    static func validateLogin(identityToken: String, userID: String)  async throws -> AuthenticationResponse {
+    static func validateLogin(identityToken: String)  async throws -> AuthenticationResponse {
         let response = try await ApiServerHandler.shared.validateLogin(identityToken: identityToken)
         handleSuccessfulSignIn(response, .ssoApple)
 
-        ServerSettings.refreshToken = identityToken
-        ServerSettings.appleAuthUserID = userID
+        ServerSettings.refreshToken = response.refreshToken
 
         return response
     }
@@ -83,51 +82,6 @@ class AuthenticationHelper {
         Settings.setLoginDetailsUpdated()
     }
 }
-
-// MARK: - Only available to the main app, not the watch app
-#if !os(watchOS)
-extension AuthenticationHelper {
-    static func validateLogin(appleIDCredential: ASAuthorizationAppleIDCredential) async throws {
-        guard let identityToken = appleIDCredential.identityToken,
-              let token = String(data: identityToken, encoding: .utf8)
-        else {
-            FileLog.shared.addMessage("Unable to parse Apple SSO token")
-            throw APIError.UNKNOWN
-        }
-
-        try await validateLogin(identityToken: token, userID: appleIDCredential.user)
-    }
-
-    static func validateAppleSSOCredentials() {
-        guard ServerSettings.appleAuthUserID != nil else {
-            // No need to Check if we don't have a user ID
-            return
-        }
-        Task {
-            let state = try await ApiServerHandler.shared.ssoCredentialState()
-            FileLog.shared.addMessage("Validated Apple SSO token state: \(state.loggingValue)")
-            switch state {
-            case .revoked, .transferred:
-                handleSSOTokenRevoked()
-            default:
-                break
-            }
-        }
-    }
-
-    static func observeAppleSSOEvents() {
-        NotificationCenter.default.addObserver(forName: ASAuthorizationAppleIDProvider.credentialRevokedNotification, object: nil, queue: .main) { _ in
-            handleSSOTokenRevoked()
-        }
-    }
-
-    private static func handleSSOTokenRevoked() {
-        FileLog.shared.addMessage("Apple SSO token has been revoked. Signing user out.")
-        SyncManager.signout()
-        Settings.setLoginDetailsUpdated()
-    }
-}
-#endif
 
 // MARK: - Enums
 enum AuthenticationSource: String, AnalyticsDescribable {

--- a/podcasts/AuthenticationHelper.swift
+++ b/podcasts/AuthenticationHelper.swift
@@ -41,7 +41,7 @@ class AuthenticationHelper {
 
     static func validateLogin(identityToken: String)  async throws -> AuthenticationResponse {
         let response = try await ApiServerHandler.shared.validateLogin(identityToken: identityToken)
-        handleSuccessfulSignIn(response, .ssoApple)
+        handleSuccessfulSignIn(response, .sso)
 
         ServerSettings.refreshToken = response.refreshToken
 
@@ -50,7 +50,7 @@ class AuthenticationHelper {
 
     static func validateLogin(identityToken: String, provider: SocialAuthProvider)  async throws -> AuthenticationResponse {
         let response = try await ApiServerHandler.shared.validateLogin(identityToken: identityToken, provider: provider)
-        handleSuccessfulSignIn(response, .ssoApple)
+        handleSuccessfulSignIn(response, .sso)
 
         return response
     }
@@ -86,7 +86,7 @@ class AuthenticationHelper {
 // MARK: - Enums
 enum AuthenticationSource: String, AnalyticsDescribable {
     case password = "password"
-    case ssoApple = "sso_apple"
+    case sso = "sso"
 
     var analyticsDescription: String { rawValue }
 }

--- a/podcasts/ProfileIntroViewController.swift
+++ b/podcasts/ProfileIntroViewController.swift
@@ -1,7 +1,6 @@
 import UIKit
 import PocketCastsUtils
 import PocketCastsServer
-import AuthenticationServices
 
 class ProfileIntroViewController: PCViewController, SyncSigninDelegate {
     weak var upgradeRootViewController: UIViewController?
@@ -159,49 +158,5 @@ private extension ProfileIntroViewController {
 
         errorLabel.text = L10n.accountSsoFailed
         errorLabel.alpha = 1
-    }
-}
-
-extension ProfileIntroViewController: ASAuthorizationControllerPresentationContextProviding {
-    func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
-        guard let window = view.window else { return UIApplication.shared.windows.first! }
-        return window
-    }
-}
-
-extension ProfileIntroViewController: ASAuthorizationControllerDelegate {
-    func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
-        switch authorization.credential {
-        case let appleIDCredential as ASAuthorizationAppleIDCredential:
-            DispatchQueue.main.async {
-                self.handleAppleIDCredential(appleIDCredential)
-            }
-        default:
-            break
-        }
-    }
-
-    func handleAppleIDCredential(_ appleIDCredential: ASAuthorizationAppleIDCredential) {
-        let progressAlert = ShiftyLoadingAlert(title: L10n.syncAccountLogin)
-        progressAlert.showAlert(self, hasProgress: false, completion: {
-            Task {
-                var success = false
-                do {
-                    try await AuthenticationHelper.validateLogin(appleIDCredential: appleIDCredential)
-                    success = true
-                } catch {
-                    DispatchQueue.main.async {
-                        self.showError(error)
-                    }
-                }
-
-                DispatchQueue.main.async {
-                    progressAlert.hideAlert(false)
-                    if success {
-                        self.signingProcessCompleted()
-                    }
-                }
-            }
-        })
     }
 }

--- a/podcasts/WatchConstants.swift
+++ b/podcasts/WatchConstants.swift
@@ -229,8 +229,7 @@ public enum WatchConstants {
         enum LoginDetailsResponse {
             public static let username = "username"
             public static let password = "password"
-            public static let appleAuthToken = "appleAuthToken"
-            public static let appleAuthUserID = "appleAuthUserID"
+            public static let refreshToken = "refreshToken"
         }
     }
 }

--- a/podcasts/WatchManager.swift
+++ b/podcasts/WatchManager.swift
@@ -334,9 +334,8 @@ class WatchManager: NSObject, WCSessionDelegate {
         if let password = ServerSettings.syncingPassword() {
             response[WatchConstants.Messages.LoginDetailsResponse.password] = password
         }
-        else if let authToken = ServerSettings.refreshToken, let appleUserId = ServerSettings.appleAuthUserID {
-            response[WatchConstants.Messages.LoginDetailsResponse.appleAuthToken] = authToken
-            response[WatchConstants.Messages.LoginDetailsResponse.appleAuthUserID] = appleUserId
+        else if let refreshToken = ServerSettings.refreshToken {
+            response[WatchConstants.Messages.LoginDetailsResponse.refreshToken] = refreshToken
         }
 
         Settings.clearLoginDetailsUpdated()


### PR DESCRIPTION
| 📘 Project: #381 |
|:---:|

* Adds support for logins made with Apple/Google on Apple Watch
* Remove a lot of code related to the previous Apple SSO implementation

## To test

1. You can test this on Simulator.
2. Go to `podcasts` scheme and change Build Configuration to `Staging`
3. Do the same for Pocket Casts Watch App (if you don't see them, tap "Autocreate Schemes Now" in the Schemes screen)
3. On the app, go to Settings > Beta Features > enable `signInWithApple`
3. When running, select the `Pocket Casts Watch App` scheme, not the `pocketcasts`

### Regular username/password login

1. On the iOS app, login using a username/password
2. Go to the watch app and tap "Refresh Data"
3. ✅ You should see your email on the Apple Watch app and a `Sync succeeded` on the console
4. For the Watch simulator, go to Device > Erase All Content And Settings... and erase it ¶
5. Remove the app from the iPhone simulator and close all the simulators (the Watch loses the connection with the device)

¶ This is needed because some Keychain keys are kept on the Watch app when you change your login. Fixing that is out of the scope of this PR.

### Apple login

1. On the iOS app, go to Settings > Beta Features > enable `signInWithApple`
1. Login with an Apple account on the main app
1. 2. Go to the watch app and tap "Refresh Data"
3. ✅ You should see your email on the Apple Watch app and a `Sync succeeded` on the console

### Apple login token refresh

3. Go to `SourceInterfaceController.swift` and add this as the first line of `refreshAccountTapped()`: `ServerSettings.syncingV2Token = "corrupt"`
3. Re-run the app
3. Tap "Refresh Data"
3. ✅ You should see your email on the Apple Watch app and a `Sync succeeded` on the console
4. For the Watch simulator, go to Device > Erase All Content And Settings... and erase it ¶
5. Remove the app from the iPhone simulator and close all the simulators (the Watch loses the connection with the device)

### Google login

1. On the iOS app, go to Settings > Beta Features > enable `signInWithApple`
1. Login with a Google account on the main app
1. 2. Go to the watch app and tap "Refresh Data"
3. ✅ You should see your email on the Apple Watch app and a `Sync succeeded` on the console

### Google login token refresh

3. Go to `SourceInterfaceController.swift` and add this as the first line of `refreshAccountTapped()`: `ServerSettings.syncingV2Token = "corrupt"`
3. Re-run the app
3. Tap "Refresh Data"
3. ✅ You should see your email on the Apple Watch app and a `Sync succeeded` on the console

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
