### PR TITLE
Show notes scroll fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 -----
 - Fixed an issue where the close button was rendered as a solid white circle when the Dark Contrast theme was active (#552)
 - Updated the import process in Settings (#641)
+- Fixed shownotes not always scrolling back to the beginning when new episode is loaded (#651)
 
 7.30
 -----

--- a/podcasts/ShowNotesPlayerItemViewController.swift
+++ b/podcasts/ShowNotesPlayerItemViewController.swift
@@ -161,6 +161,10 @@ class ShowNotesPlayerItemViewController: PlayerItemViewController, SFSafariViewC
                 let isCurrentEpisode = PlaybackManager.shared.isNowPlayingEpisode(episodeUuid: episode.uuid)
                 let formattedNotes = ShowNotesFormatter.format(showNotes: showNotes, tintColor: tintColor, convertTimesToLinks: isCurrentEpisode, bgColor: nil, textColor: ThemeColor.playerContrast01())
                 strongSelf.showNotesWebView.loadHTMLString(formattedNotes, baseURL: URL(fileURLWithPath: Bundle.main.bundlePath))
+                // We need to ensure that the scroll view offset is back at 0,0 to cater for instances
+                // where the user scrolled the previous show notes
+                // See https://github.com/Automattic/pocket-casts-ios/issues/651
+                strongSelf.showNotesScrollView.setContentOffset(CGPointZero, animated: false)
             }
         }
     }


### PR DESCRIPTION
Fixes #651

Fixed show notes not scrolling back to the beginning when a new episode is loaded. This can result in a blank screen if the previous show notes were longer than the new episode's notes. The original issue has a video showing the bug.

## To test

1. Add a podcast with long show notes to the top of the queue (i.e. show notes must scroll beyond bottom of screen)
2. Add a second podcast with short notes (i.e. not going beyond bottom of sceen)
3. Play first podcast, forward towards the end (20s or so remaining)
4. Go to show notes tab and scroll to the bottom
5. Wait for next episode to play. The show notes should display without the user having to scroll up to the start.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
