### PR TITLE
Logged out users can now star episodes from Now Playing screen without being prompted to log in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Fixed an issue where the close button was rendered as a solid white circle when the Dark Contrast theme was active (#552)
 - Updated the import process in Settings (#641)
 - Fixed shownotes not always scrolling back to the beginning when new episode is loaded (#651)
+- Fixed an issue where logged out users were incorrectly prompted to sign in when starring episodes on the Now Playing screen (#653)
 
 7.30
 -----

--- a/podcasts/NowPlayingPlayerItemViewController+Shelf.swift
+++ b/podcasts/NowPlayingPlayerItemViewController+Shelf.swift
@@ -1,4 +1,5 @@
 import AVKit
+import PocketCastsServer
 import Foundation
 import MaterialComponents.MaterialBottomSheet
 import PocketCastsDataModel
@@ -322,7 +323,7 @@ extension NowPlayingPlayerItemViewController: NowPlayingActionsDelegate {
 
         AnalyticsEpisodeHelper.shared.currentSource = analyticsSource
 
-        EpisodeManager.setStarred(!episode.keepEpisode, episode: episode, updateSyncStatus: true)
+        EpisodeManager.setStarred(!episode.keepEpisode, episode: episode, updateSyncStatus: SyncManager.isUserLoggedIn())
 
         if let starBtn = starBtn {
             let starImage = episode.keepEpisode ? UIImage(named: "player_star_filled") : UIImage(named: "player_star_empty")


### PR DESCRIPTION
Fixes #653 

`performStarAction` updated the episode and always requested a server sync, regardless of the user login status. This incorrectly triggered the login flow. We now first check the user login status and pass that to the update method, similar to other parts of the code (e.g. `EpisodeDetailViewController`)

## To test

1. Log out
2. Go to fullscreen player and star en episode
3. While the star (or un-star) is performed correctly, the user is also asked to log in, which should not be the case
4. Install the update and repeat steps above. Logged out user should no longer be prompted to sign in when starring an episode on the player screen

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
