### PR TITLE
Onboarding: Display initial onboarding to any logged out users who haven't seen it before

### DIFF
--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -66,7 +66,10 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
     }
 
     private func showInitialOnboardingIfNeeded() {
-        guard FeatureFlag.onboardingUpdates.enabled, Settings.shouldShowInitialOnboardingFlow else { return }
+        // Show if the user is not logged in and has never seen the prompt before
+        if SyncManager.isUserLoggedIn() || (Settings.shouldShowInitialOnboardingFlow == false && Settings.hasSeenInitialOnboardingBefore == true) {
+            return
+        }
 
         NavigationManager.sharedManager.navigateTo(NavigationManager.onboardingFlow, data: ["flow": OnboardingFlow.Flow.initialOnboarding])
 

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -770,6 +770,12 @@ class Settings: NSObject {
         }
     }
 
+    static var hasSeenInitialOnboardingBefore: Bool {
+        get {
+            UserDefaults.standard.object(forKey: Constants.UserDefaults.shouldShowInitialOnboardingFlow) != nil
+        }
+    }
+
     // MARK: - Variables that are loaded/changed through Firebase
 
     #if !os(watchOS)


### PR DESCRIPTION
| 📘 Project: #500  | 
|:---:|

This updates the logic to display the initial onboarding to any logged out user who hasn't seen it before. 

This does a check to see if the `shouldShowInitialOnboardingFlow` key is nil which means the user did not install at least version 7.28 which sets the initial value to true, and will show the prompt. 

This means that if it's nil then the user never saw the initial prompt. 

## To test

### Already saw the prompt
1. Launch the app on an account that already saw the onboarding prompt
2. ✅ Verify you do not see the prompt again

### App upgrade logged out
1. Uninstall the app and reinstall version 7.27 (before onboarding was released)
2. Stay logged out
3. Install the PR version of the app
4. ✅ Verify you see the prompt

### Logged out
1. Uninstall the app and reinstall version 7.27 (before onboarding was released)
   - alternatively you can run: `UserDefaults.standard.set(nil, forKey: Constants.UserDefaults.shouldShowInitialOnboardingFlow)`
3. Stay logged out
4. Install the PR version of the app
5. ✅ Verify you see the prompt
6. Dismiss the prompt
7. Relaunch the app
8. ✅ Verify you do not see the prompt again

### App upgrade logged in
1. Uninstall the app and reinstall version 7.27 (before onboarding was released)
2. Sign into an account
4. Install the PR version of the app
9. ✅ Verify you do not see the prompt

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
