### PR TITLE
Fix Siri playback speed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Updated the Now Playing metadata to put podcast author in the Artist fields to fix Siri responses and Siri Suggestions (#48)
 - Fixed shownotes not always scrolling back to the beginning when new episode is loaded (#651)
 - Fixed an issue where logged out users were incorrectly prompted to sign in when starring episodes on the Now Playing screen (#653)
+- Fixed an issue where playback speed was incorrectly set to 1x when using the "Play my podcasts" Siri intent (#41)
 
 7.30
 -----

--- a/podcasts/AppDelelgate+SiriShortcuts.swift
+++ b/podcasts/AppDelelgate+SiriShortcuts.swift
@@ -151,7 +151,11 @@ extension AppDelegate {
             }
         }
 
-        if let spokenSpeed = thisIntent.playbackSpeed, responseCode == .success {
+        // We need to set the playback speed from the intent, but only if the value
+        // is not 1. Siri always passes along 1, even if the user did not specify a speed.
+        // This may result in incorrectly overriding the existing speed set in the player
+        // See https://github.com/Automattic/pocket-casts-ios/issues/41
+        if let spokenSpeed = thisIntent.playbackSpeed, spokenSpeed != 1.0, responseCode == .success {
             let effects = PlaybackManager.shared.effects()
             effects.playbackSpeed = spokenSpeed
 


### PR DESCRIPTION
Fixes #41

When using the Siri _"Play my podcast"_ phrase, Siri would pass along 1 as the playback speed in cases where the user did not specify a speed. This resulted in overriding the player speed previously set by the user. We no longer update the speed if the Siri intent requests a playback speed of 1.

## To test

1. Play podcast on 1.2x
2. Pause
3. Exit app
4. Ask Siri to "Play my podcast in Pocket Casts"
5. Playback will resume, but at 1x
6. Install the update and repeat steps above. Playback will now resume at the previous speed set.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
