### PR TITLE
Show episode date on album property so it's displayed on Carplay

### DIFF
--- a/podcasts/NowPlayingHelper.swift
+++ b/podcasts/NowPlayingHelper.swift
@@ -87,7 +87,11 @@ class NowPlayingHelper {
             nowPlayingInfo[MPMediaItemPropertyArtist] = safeCharacterPodcastAuthor as NSString
             nowPlayingInfo[MPMediaItemPropertyComposer] = safeCharacterPodcastAuthor as NSString
 
-            nowPlayingInfo[MPMediaItemPropertyAlbumTitle] = safeCharacterPodcastTitle as NSString
+            // we purposely show the date here instead, but as with the above there's a car stereo bug we need to work around as well where we don't show the word "Wednesday" in the artist field
+            // because on some car stereos that have embedded image databases, this comes up with a really grotesque image (more info: https://github.com/shiftyjelly/pocketcasts-ios/issues/3874)
+            let publishedDate = DateFormatHelper.sharedHelper.tinyLocalizedFormat(episode.publishedDate).replacingOccurrences(of: "Wednesday", with: "Wed", options: .caseInsensitive)
+            nowPlayingInfo[MPMediaItemPropertyAlbumTitle] = publishedDate as NSString
+
             nowPlayingInfo[MPMediaItemPropertyPodcastTitle] = safeCharacterPodcastTitle as NSString
 
             // genre


### PR DESCRIPTION
Fixes #48

This is a follow-up from #655.

In this PR I added back the episode date but as a `MPMediaItemPropertyAlbumTitle`. This guarantees that:

* The Now Playing on iOS 16 shows the correct information
* Siri responds correctly to "what's playing"
* We show episode date on Carplay

## To test

Test on a device.

2. Start playing a podcast
3. Ask siri "what is playing", it should say something like "[podcast title] by [podcast author]"
4. If you have a car with bluetooth, pair your phone with the car and check that your car's "now playing" display info shows the podcast author and on Carplay it displays the date too (you can use Simulator to test that)

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
