### PR TITLE
SSO: when logged out show the onboarding flow

### DIFF
--- a/PocketCastsTests/Tests/BackgroundSignOutListenerTests.swift
+++ b/PocketCastsTests/Tests/BackgroundSignOutListenerTests.swift
@@ -38,7 +38,7 @@ final class BackgroundSignOutListenerTests: XCTestCase {
     func testSignOutAlertActionWillOpenSignIn() {
         signOutListener.showSignIn()
 
-        XCTAssertEqual(NavigationManager.signInPage, navigationManager.navigatedPlace)
+        XCTAssertEqual(NavigationManager.onboardingFlow, navigationManager.navigatedPlace)
     }
 
     func testSignOutAlertCanShowAgain() {

--- a/podcasts/BackgroundSignOutListener.swift
+++ b/podcasts/BackgroundSignOutListener.swift
@@ -25,7 +25,7 @@ class BackgroundSignOutListener {
 
     func showSignIn() {
         canShowSignOut = true
-        NavigationManager.sharedManager.navigateTo(NavigationManager.onboardingFlow, data: ["flow": OnboardingFlow.Flow.forcedLoggedOut])
+        navigationManager.navigateTo(NavigationManager.onboardingFlow, data: ["flow": OnboardingFlow.Flow.forcedLoggedOut])
     }
 }
 

--- a/podcasts/BackgroundSignOutListener.swift
+++ b/podcasts/BackgroundSignOutListener.swift
@@ -25,7 +25,7 @@ class BackgroundSignOutListener {
 
     func showSignIn() {
         canShowSignOut = true
-        NavigationManager.sharedManager.navigateTo(NavigationManager.onboardingFlow, data: ["flow": OnboardingFlow.Flow.loggedOut])
+        NavigationManager.sharedManager.navigateTo(NavigationManager.onboardingFlow, data: ["flow": OnboardingFlow.Flow.forcedLoggedOut])
     }
 }
 

--- a/podcasts/BackgroundSignOutListener.swift
+++ b/podcasts/BackgroundSignOutListener.swift
@@ -25,7 +25,7 @@ class BackgroundSignOutListener {
 
     func showSignIn() {
         canShowSignOut = true
-        navigationManager.navigateTo(NavigationManager.signInPage, data: nil)
+        navigationManager.navigateTo(NavigationManager.signInPage, data: ["flow": OnboardingFlow.Flow.sonosLink])
     }
 }
 

--- a/podcasts/BackgroundSignOutListener.swift
+++ b/podcasts/BackgroundSignOutListener.swift
@@ -25,7 +25,7 @@ class BackgroundSignOutListener {
 
     func showSignIn() {
         canShowSignOut = true
-        navigationManager.navigateTo(NavigationManager.signInPage, data: ["flow": OnboardingFlow.Flow.sonosLink])
+        NavigationManager.sharedManager.navigateTo(NavigationManager.onboardingFlow, data: ["flow": OnboardingFlow.Flow.loggedOut])
     }
 }
 

--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -333,21 +333,13 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
         }
     }
 
-    func showSignInPage() {
+    func showSignIn(flow: OnboardingFlow.Flow) {
         switchToTab(.profile)
         guard !SyncManager.isUserLoggedIn() else { return }
 
-        let signInController: UIViewController
-        if FeatureFlag.signInWithApple.enabled {
-            signInController = ProfileIntroViewController()
-        }
-        else {
-            signInController = SyncSigninViewController()
-            (signInController as! SyncSigninViewController).dismissOnCancel = true
-        }
+        let signInController = OnboardingFlow.shared.begin(flow: flow)
 
-        let navController = SJUIUtils.popupNavController(for: signInController)
-        present(navController, animated: true, completion: nil)
+        present(signInController, animated: true, completion: nil)
     }
 
     func showSupporterSignIn(podcastInfo: PodcastInfo) {

--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -333,15 +333,6 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
         }
     }
 
-    func showSignIn(flow: OnboardingFlow.Flow) {
-        switchToTab(.profile)
-        guard !SyncManager.isUserLoggedIn() else { return }
-
-        let signInController = OnboardingFlow.shared.begin(flow: flow)
-
-        present(signInController, animated: true, completion: nil)
-    }
-
     func showSupporterSignIn(podcastInfo: PodcastInfo) {
         let supporterVC = SupporterGratitudeViewController(podcastInfo: podcastInfo)
         let controller = view.window?.rootViewController

--- a/podcasts/NavigationManager.swift
+++ b/podcasts/NavigationManager.swift
@@ -52,7 +52,6 @@ class NavigationManager {
 
     static let settingsAppearanceKey = "appearancePage"
     static let settingsProfileKey = "profilePage"
-    static let signInPage = "signInPage"
 
     static let endOfYearStories = "endOfYearStories"
     static let onboardingFlow = "onboardingFlow"
@@ -161,9 +160,6 @@ class NavigationManager {
             mainController?.showSettingsAppearance()
         } else if place == NavigationManager.settingsProfileKey {
             mainController?.showProfilePage()
-        } else if place == NavigationManager.signInPage {
-            let flow: OnboardingFlow.Flow = data?["flow"] as? OnboardingFlow.Flow ?? .initialOnboarding
-            mainController?.showSignIn(flow: flow)
         } else if place == NavigationManager.showPromotionPageKey {
             var promoCode: String?
             if let data = data, let promoString = data[NavigationManager.promotionInfoKey] as? String {

--- a/podcasts/NavigationManager.swift
+++ b/podcasts/NavigationManager.swift
@@ -162,7 +162,8 @@ class NavigationManager {
         } else if place == NavigationManager.settingsProfileKey {
             mainController?.showProfilePage()
         } else if place == NavigationManager.signInPage {
-            mainController?.showSignInPage()
+            let flow: OnboardingFlow.Flow = data?["flow"] as? OnboardingFlow.Flow ?? .initialOnboarding
+            mainController?.showSignIn(flow: flow)
         } else if place == NavigationManager.showPromotionPageKey {
             var promoCode: String?
             if let data = data, let promoString = data[NavigationManager.promotionInfoKey] as? String {

--- a/podcasts/NavigationProtocol.swift
+++ b/podcasts/NavigationProtocol.swift
@@ -31,7 +31,6 @@ protocol NavigationProtocol: AnyObject {
     func showPromotionFinishedAcknowledge()
     func showProfilePage()
 
-    func showSignIn(flow: OnboardingFlow.Flow)
     func showSupporterSignIn(podcastInfo: PodcastInfo)
     func showSupporterSignIn(bundleUuid: String)
     func showSupporterBundleDetails(bundleUuid: String?)

--- a/podcasts/NavigationProtocol.swift
+++ b/podcasts/NavigationProtocol.swift
@@ -31,7 +31,7 @@ protocol NavigationProtocol: AnyObject {
     func showPromotionFinishedAcknowledge()
     func showProfilePage()
 
-    func showSignInPage()
+    func showSignIn(flow: OnboardingFlow.Flow)
     func showSupporterSignIn(podcastInfo: PodcastInfo)
     func showSupporterSignIn(bundleUuid: String)
     func showSupporterBundleDetails(bundleUuid: String?)

--- a/podcasts/Onboarding/LoginCoordinator.swift
+++ b/podcasts/Onboarding/LoginCoordinator.swift
@@ -143,7 +143,7 @@ extension LoginCoordinator: SyncSigninDelegate, CreateAccountDelegate {
      }
 
     func signingProcessCompleted() {
-        let shouldDismiss = OnboardingFlow.shared.currentFlow == .sonosLink || (SubscriptionHelper.hasActiveSubscription() && !presentedFromUpgrade)
+        let shouldDismiss = OnboardingFlow.shared.currentFlow.shouldDismiss || (SubscriptionHelper.hasActiveSubscription() && !presentedFromUpgrade)
 
         if shouldDismiss {
             handleDismiss()

--- a/podcasts/Onboarding/LoginCoordinator.swift
+++ b/podcasts/Onboarding/LoginCoordinator.swift
@@ -154,7 +154,7 @@ extension LoginCoordinator: SyncSigninDelegate, CreateAccountDelegate {
     }
 
     func handleAccountCreated() {
-        let shouldDismiss = OnboardingFlow.shared.currentFlow == .sonosLink
+        let shouldDismiss = OnboardingFlow.shared.currentFlow.shouldDismiss
 
         if shouldDismiss {
             handleDismiss()

--- a/podcasts/Onboarding/OnboardingFlow.swift
+++ b/podcasts/Onboarding/OnboardingFlow.swift
@@ -87,13 +87,16 @@ struct OnboardingFlow {
         /// continue with the Sonos connection process
         case sonosLink = "sonos_link"
 
+        /// When the user was logged in but was forced logged out
+        case forcedLoggedOut = "forced_logged_out"
+
         var analyticsDescription: String { rawValue }
 
         /// If after a successful sign in or sign up the onboarding flow
         /// should be dismissed right away
         var shouldDismiss: Bool {
             switch self {
-            case .sonosLink, .loggedOut:
+            case .sonosLink, .forcedLoggedOut:
                 return true
             default:
                 return false

--- a/podcasts/Onboarding/OnboardingFlow.swift
+++ b/podcasts/Onboarding/OnboardingFlow.swift
@@ -87,7 +87,8 @@ struct OnboardingFlow {
         /// continue with the Sonos connection process
         case sonosLink = "sonos_link"
 
-        /// When the user was logged in but was forced logged out
+        /// When the user was logged out due to a server or token issue, not as a result of user interaction and is
+        /// asked to sign in again. See the `BackgroundSignOutListener`
         case forcedLoggedOut = "forced_logged_out"
 
         var analyticsDescription: String { rawValue }

--- a/podcasts/Onboarding/OnboardingFlow.swift
+++ b/podcasts/Onboarding/OnboardingFlow.swift
@@ -88,5 +88,16 @@ struct OnboardingFlow {
         case sonosLink = "sonos_link"
 
         var analyticsDescription: String { rawValue }
+
+        /// If after a successful sign in or sign up the onboarding flow
+        /// should be dismissed right away
+        var shouldDismiss: Bool {
+            switch self {
+            case .sonosLink, .loggedOut:
+                return true
+            default:
+                return false
+            }
+        }
     }
 }


### PR DESCRIPTION
| 📘 Project: #381 |
|:---:|

Changes the logged-out flow to show the new onboarding screen with Apple and Google buttons.

## To test

2. Go to `podcasts` scheme and change Build Configuration to `Debug`
3. On the app, go to Settings > Beta Features > enable `signInWithApple`
3. Login (using username/password)
4. Go to `podcasts` scheme and change Build Configuration to `Staging`
4. Re-run the app
4. Go to Profile > tap "Refresh Now"
4. You should see the logged-out modal, tap "Log in"
4. Login with username/password, Google or Apple
4. ✅ The login should work successfully and the onboarding flow should dismiss

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
