### PR TITLE
Idea: Set the FileProtection.None for all files and folders Pocket Casts creates

### DIFF
--- a/StorageManager.swift
+++ b/StorageManager.swift
@@ -1,0 +1,78 @@
+import Foundation
+import PocketCastsUtils
+
+struct StorageManager {
+    typealias Attributes = [FileAttributeKey: Any]
+
+    private static var fileManager: FileManager = .default
+
+    @discardableResult
+    static func moveItem(at fromURL: URL, to toURL: URL, attributes: Attributes? = nil, options: Options? = nil) throws -> Bool {
+        if let options, options.contains(.overwriteExisting) {
+            removeItem(at: toURL)
+        }
+
+        try moveItem(at: fromURL, to: toURL)
+
+        let attrs = (attributes ?? [:]).merging(Constants.defaultAttributes) { current, _ in current }
+        setAttributes(attrs, of: toURL)
+
+        #if DEBUG
+        FileLog.shared.addMessage("🟢 [StorageManager] moveItem: fromURL: \(fromURL.path) to: \(toURL.path)")
+        #endif
+        return true
+    }
+
+    @discardableResult
+    static func createDirectory(atPath path: String, withIntermediateDirectories createIntermediates: Bool, attributes: Attributes? = nil) -> Bool {
+        let attrs = (attributes ?? [:]).merging(Constants.defaultAttributes) { current, _ in current }
+
+        return tryLog(try fileManager.createDirectory(atPath: path, withIntermediateDirectories: createIntermediates, attributes: attrs), operation: "createDirectory")
+    }
+
+    @discardableResult
+    static func removeItem(at url: URL) -> Bool {
+        guard fileManager.fileExists(atPath: url.path) else {
+            return true
+        }
+
+        return tryLog(try fileManager.removeItem(at: url), operation: "removeItem")
+    }
+
+    @discardableResult
+    static func setAttributes(_ attributes: Attributes, of url: URL) -> Bool {
+        tryLog(try fileManager.setAttributes(attributes, ofItemAtPath: url.path), operation: "setAttributes")
+    }
+
+    private static func moveItem(at fromURL: URL, to toURL: URL) throws {
+        try fileManager.moveItem(at: fromURL, to: toURL)
+    }
+
+    // MARK: - Config
+
+    struct Options: OptionSet {
+        static let overwriteExisting = Options(rawValue: 1 << 0)
+
+        let rawValue: Int
+    }
+
+    private enum Constants {
+        static let defaultAttributes: Attributes = [
+            .protectionKey: FileProtectionType.none
+        ]
+    }
+}
+
+private extension StorageManager {
+    @discardableResult
+    static func tryLog(_ block: @autoclosure () throws -> Void, operation: String, error handler: @autoclosure () -> ((Error) -> Void)? = nil) -> Bool {
+        do {
+            try block()
+            return true
+        } catch {
+            FileLog.shared.addMessage("StorageManager[\(operation)] failed with error \(error)")
+            handler()?(error)
+            return false
+        }
+    }
+}

--- a/StorageManager.swift
+++ b/StorageManager.swift
@@ -17,9 +17,6 @@ struct StorageManager {
         let attrs = (attributes ?? [:]).merging(Constants.defaultAttributes) { current, _ in current }
         setAttributes(attrs, of: toURL)
 
-        #if DEBUG
-        FileLog.shared.addMessage("🟢 [StorageManager] moveItem: fromURL: \(fromURL.path) to: \(toURL.path)")
-        #endif
         return true
     }
 

--- a/StorageManager.swift
+++ b/StorageManager.swift
@@ -44,6 +44,11 @@ struct StorageManager {
         tryLog(try fileManager.setAttributes(attributes, ofItemAtPath: url.path), operation: "setAttributes")
     }
 
+    @discardableResult
+    static func updateFileProtectionToDefault(for url: URL) -> Bool {
+        return setAttributes(Constants.defaultAttributes, of: url)
+    }
+
     private static func moveItem(at fromURL: URL, to toURL: URL) throws {
         try fileManager.moveItem(at: fromURL, to: toURL)
     }

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1369,6 +1369,8 @@
 		C761300028E3BC090044C6C2 /* AnalyticsEpisodeHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7612FFE28E397A00044C6C2 /* AnalyticsEpisodeHelper.swift */; };
 		C761300B28E4CA4F0044C6C2 /* AnalyticsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C761300A28E4CA4E0044C6C2 /* AnalyticsCoordinator.swift */; };
 		C761300C28E4CAE90044C6C2 /* AnalyticsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C761300A28E4CA4E0044C6C2 /* AnalyticsCoordinator.swift */; };
+		C791418D294CE32D00F1852B /* StorageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C791418C294CE32D00F1852B /* StorageManager.swift */; };
+		C791418E294CE33700F1852B /* StorageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C791418C294CE32D00F1852B /* StorageManager.swift */; };
 		C79E1E4028887549008524CB /* PlusUpgradeViewSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79E1E3F28887549008524CB /* PlusUpgradeViewSourceTests.swift */; };
 		C7A110E6291EF2DF00887A90 /* PlusLandingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A110E5291EF2DF00887A90 /* PlusLandingViewModel.swift */; };
 		C7A110F0291EFF7A00887A90 /* PlusPurchaseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A110EF291EFF7A00887A90 /* PlusPurchaseModel.swift */; };
@@ -2964,6 +2966,7 @@
 		C7547F77286F571900DC1C9E /* Pocket Casts Configuration.storekit */ = {isa = PBXFileReference; lastKnownFileType = text; path = "Pocket Casts Configuration.storekit"; sourceTree = "<group>"; };
 		C7612FFE28E397A00044C6C2 /* AnalyticsEpisodeHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsEpisodeHelper.swift; sourceTree = "<group>"; };
 		C761300A28E4CA4E0044C6C2 /* AnalyticsCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnalyticsCoordinator.swift; sourceTree = "<group>"; };
+		C791418C294CE32D00F1852B /* StorageManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageManager.swift; sourceTree = "<group>"; };
 		C79E1E3F28887549008524CB /* PlusUpgradeViewSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlusUpgradeViewSourceTests.swift; sourceTree = "<group>"; };
 		C7A110E5291EF2DF00887A90 /* PlusLandingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlusLandingViewModel.swift; sourceTree = "<group>"; };
 		C7A110EF291EFF7A00887A90 /* PlusPurchaseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlusPurchaseModel.swift; sourceTree = "<group>"; };
@@ -5450,6 +5453,7 @@
 		BDBD53E317019B290048C8C5 = {
 			isa = PBXGroup;
 			children = (
+				C791418C294CE32D00F1852B /* StorageManager.swift */,
 				3F299D882872BF3600F2ED7F /* config */,
 				BDBD53F717019B2A0048C8C5 /* Pocket Casts */,
 				BD3A210E1E6CFC2400F42241 /* NotificationExtension */,
@@ -7990,6 +7994,7 @@
 				BD27B8C52756F486007A0EA7 /* UIColor+SwiftUI.swift in Sources */,
 				40A0A90D24B57B1C00C29362 /* MultiSelectHelper.swift in Sources */,
 				BDAE54CC230C055600330680 /* NoSearchResultsPlaceholder.swift in Sources */,
+				C791418D294CE32D00F1852B /* StorageManager.swift in Sources */,
 				40251CEC22BB0F6E00551C51 /* CancelledAcknowledgeViewController.swift in Sources */,
 				BDD3579527BCD6DF0000D155 /* GridHelper.swift in Sources */,
 				BD023C672251C192008A9C6F /* HeadingCell.swift in Sources */,
@@ -8262,6 +8267,7 @@
 				BDDAE72D27F2E76B003741A1 /* FileTypeUtil.swift in Sources */,
 				464B481F27E8FC7E00107CBF /* NowPlayingViewModel.swift in Sources */,
 				BDD301971EFB9A95004A9972 /* WatchFilter.swift in Sources */,
+				C791418E294CE33700F1852B /* StorageManager.swift in Sources */,
 				46E905A727E285F20039558C /* UpNextViewModel.swift in Sources */,
 				46D88ABE27DFDB6E00F3BC43 /* FilesListViewModel.swift in Sources */,
 				BD0EE37F1EFCF15400F2A6DC /* WatchImageHelper.swift in Sources */,

--- a/podcasts/AddCustomViewController.swift
+++ b/podcasts/AddCustomViewController.swift
@@ -320,7 +320,7 @@ class AddCustomViewController: PCViewController, UITextFieldDelegate {
         navigationController?.navigationBar.isHidden = false
         if episodeToEdit == nil {
             if let destinationUrl = destinationUrl {
-                do { try FileManager.default.removeItem(at: destinationUrl) } catch {}
+                StorageManager.removeItem(at: destinationUrl)
             }
             dismiss(animated: true, completion: nil)
         } else {

--- a/podcasts/AppDelegate+Defaults.swift
+++ b/podcasts/AppDelegate+Defaults.swift
@@ -100,6 +100,12 @@ extension AppDelegate {
             retrieveUserIdIfNeeded()
         }
 
+        performUpdateIfRequired(updateKey: "UpdateFileProtection1") {
+            Task {
+                await DownloadManager.shared.updateProtectionPermissionsForAllExistingFiles()
+            }
+        }
+
         defaults.synchronize()
     }
 

--- a/podcasts/AppDelegate+Defaults.swift
+++ b/podcasts/AppDelegate+Defaults.swift
@@ -100,7 +100,7 @@ extension AppDelegate {
             retrieveUserIdIfNeeded()
         }
 
-        performUpdateIfRequired(updateKey: "UpdateFileProtection1") {
+        performUpdateIfRequired(updateKey: "UpdateFileProtection") {
             Task {
                 await DownloadManager.shared.updateProtectionPermissionsForAllExistingFiles()
             }

--- a/podcasts/DownloadManager+URLSessionDelegate.swift
+++ b/podcasts/DownloadManager+URLSessionDelegate.swift
@@ -118,9 +118,7 @@ extension DownloadManager: URLSessionDelegate, URLSessionDownloadDelegate {
         let destinationPath = autoDownloadStatus == .playerDownloadedForStreaming ? streamingBufferPathForEpisode(episode) : pathForEpisode(episode)
         let destinationUrl = URL(fileURLWithPath: destinationPath)
         do {
-            do { try fileManager.removeItem(at: destinationUrl) } catch {} // this one will throw if the file doesn't exist, which is perfectly fine
-
-            try fileManager.moveItem(at: location, to: destinationUrl)
+            try StorageManager.moveItem(at: location, to: destinationUrl, options: .overwriteExisting)
 
             let newDownloadStatus: DownloadStatus = autoDownloadStatus == .playerDownloadedForStreaming ? .downloadedForStreaming : .downloaded
             DataManager.sharedManager.saveEpisode(downloadStatus: newDownloadStatus, sizeInBytes: fileSize, downloadTaskId: nil, episode: episode)

--- a/podcasts/DownloadManager.swift
+++ b/podcasts/DownloadManager.swift
@@ -79,19 +79,20 @@ class DownloadManager: NSObject, FilePathProtocol {
         if let cachePath = paths.first as NSString? {
             tempDownloadFolder = cachePath.appendingPathComponent("temp_download")
 
-            let fileManager = FileManager.default
+            let fileManager = StorageManager.self
 
-            do {
-                try fileManager.createDirectory(atPath: tempDownloadFolder, withIntermediateDirectories: true, attributes: nil)
-                try fileManager.createDirectory(atPath: podcastsDirectory, withIntermediateDirectories: true, attributes: nil)
-                #if !os(watchOS)
-                    SJCommonUtils.setDontBackupFlag(URL(fileURLWithPath: podcastsDirectory))
-                #endif
-                try fileManager.createDirectory(atPath: streamingBufferDirectory, withIntermediateDirectories: true, attributes: nil)
-                #if !os(watchOS)
-                    SJCommonUtils.setDontBackupFlag(URL(fileURLWithPath: streamingBufferDirectory))
-                #endif
-            } catch {}
+            fileManager.createDirectory(atPath: tempDownloadFolder, withIntermediateDirectories: true)
+            fileManager.createDirectory(atPath: podcastsDirectory, withIntermediateDirectories: true)
+            #if !os(watchOS)
+                SJCommonUtils.setDontBackupFlag(URL(fileURLWithPath: podcastsDirectory))
+            #endif
+            fileManager.createDirectory(atPath: streamingBufferDirectory, withIntermediateDirectories: true)
+            #if !os(watchOS)
+                SJCommonUtils.setDontBackupFlag(URL(fileURLWithPath: streamingBufferDirectory))
+            #endif
+        }
+    }
+
     func updateProtectionPermissionsForAllExistingFiles() async {
         // Update the root permissions for the directory
         let folders = [

--- a/podcasts/DownloadManager.swift
+++ b/podcasts/DownloadManager.swift
@@ -92,6 +92,27 @@ class DownloadManager: NSObject, FilePathProtocol {
                     SJCommonUtils.setDontBackupFlag(URL(fileURLWithPath: streamingBufferDirectory))
                 #endif
             } catch {}
+    func updateProtectionPermissionsForAllExistingFiles() async {
+        // Update the root permissions for the directory
+        let folders = [
+            tempDownloadFolder,
+            podcastsDirectory,
+            streamingBufferDirectory
+        ]
+
+        for folder in folders {
+            let url = URL(fileURLWithPath: folder)
+            StorageManager.setAttributes([.protectionKey: FileProtectionType.none], of: url)
+        }
+
+        // Update all the downloaded files existing protections
+        guard let paths = FileManager.default.subpaths(atPath: podcastsDirectory), paths.count > 0 else {
+            return
+        }
+
+        for path in paths {
+            let url = URL(fileURLWithPath: podcastsDirectory + "/" + path)
+            StorageManager.setAttributes([.protectionKey: FileProtectionType.none], of: url)
         }
     }
 

--- a/podcasts/DownloadManager.swift
+++ b/podcasts/DownloadManager.swift
@@ -170,9 +170,7 @@ class DownloadManager: NSObject, FilePathProtocol {
             let destinationUrl = URL(fileURLWithPath: pathForEpisode(episode))
             let fileManager = FileManager.default
             do {
-                do { try fileManager.removeItem(at: destinationUrl) } catch {} // this one will throw if the file doesn't exist, which is perfectly fine
-
-                try fileManager.moveItem(at: sourceUrl, to: destinationUrl)
+                try StorageManager.moveItem(at: sourceUrl, to: destinationUrl, options: .overwriteExisting)
 
                 DataManager.sharedManager.saveEpisode(downloadStatus: .downloaded, sizeInBytes: episode.sizeInBytes, downloadTaskId: nil, episode: episode)
                 NotificationCenter.postOnMainThread(notification: Constants.Notifications.episodeDownloaded, object: episode.uuid)

--- a/podcasts/DownloadManager.swift
+++ b/podcasts/DownloadManager.swift
@@ -103,7 +103,7 @@ class DownloadManager: NSObject, FilePathProtocol {
 
         for folder in folders {
             let url = URL(fileURLWithPath: folder)
-            StorageManager.setAttributes([.protectionKey: FileProtectionType.none], of: url)
+            StorageManager.updateFileProtectionToDefault(for: url)
         }
 
         // Update all the downloaded files existing protections
@@ -113,7 +113,7 @@ class DownloadManager: NSObject, FilePathProtocol {
 
         for path in paths {
             let url = URL(fileURLWithPath: podcastsDirectory + "/" + path)
-            StorageManager.setAttributes([.protectionKey: FileProtectionType.none], of: url)
+            StorageManager.updateFileProtectionToDefault(for: url)
         }
     }
 

--- a/podcasts/DownloadManager.swift
+++ b/podcasts/DownloadManager.swift
@@ -119,14 +119,11 @@ class DownloadManager: NSObject, FilePathProtocol {
 
     func addLocalFile(url: URL, uuid: String) -> URL? {
         let destinationUrl = URL(fileURLWithPath: pathForUrl(fileUrl: url, uuid: uuid))
-        let fileManager = FileManager.default
         do {
-            do { try fileManager.removeItem(at: destinationUrl) } catch {} // this one will throw if the file doesn't exist, which is perfectly fine
-            try fileManager.moveItem(at: url, to: destinationUrl)
-            return destinationUrl
-        } catch {
-            return nil
-        }
+            try StorageManager.moveItem(at: url, to: destinationUrl, options: .overwriteExisting)
+        } catch { return nil }
+
+        return destinationUrl
     }
 
     func queueForLaterDownload(episodeUuid: String, fireNotification: Bool, autoDownloadStatus: AutoDownloadStatus) {


### PR DESCRIPTION
### Description
This is a continuation of the following PRs:
- https://github.com/Automattic/pocket-casts-ios/pull/344
- https://github.com/Automattic/pocket-casts-ios/pull/345

This is an attempt to mitigate some potential audio playback issues by setting the default file protection to None instead of using the default which is `CompleteUntilFirstUserAuthentication` for any files and folders that are created by the app.

### What issues could this fix?
While this doesn't target one specific issue I hope that by changing the file protection we can reduce some of the random playback failures for downloaded or custom files that do not trigger crashes such as:
- User Report: After locking my device and pausing using my Airpods the playback will not resume and I have to unlock my phone then it will work. 
- [CarPlay: Playback Pauses on the First Attempt](https://github.com/Automattic/pocket-casts-ios/issues/498)

Streaming audio files are managed by the AVPlayer cache and I don't see a way to change the protections for them. 

### Why would this fix things?

I suspect there is a bug with the default file protection that for some reason causes the system to reject us permission to access files while the app is in the background. Despite the documentation saying that we'll have access after the user unlocks their phone for the first time. 

Because of this while the app is running in the background, the app may no longer have permissions to a file and when someone attempts to play it via Siri, Now Playing, or CarPlay the playback will fail with an error such as:

```
activating audio session succeeded
[default]          ExtAudioFile.cpp:210   about to throw -54: open audio file
[avae]            AVAEInternal.h:109   [AVAudioFile.mm:135:AVAudioFileImpl: (ExtAudioFileOpenURL((CFURLRef)fileURL, &_extAudioFile)): error -54
playbackDidFail: The operation couldn’t be completed. (com.apple.coreaudio.avfaudio error -54.)
```

We have also seen success with making this change in the above PRs and have completely removed some of our top crashes for DataManager and Tracks DB creation. 

## To test

### Reproducing the issue and applying the fix
> **Warning**
> This is a bit difficult to reproduce, and requires running on a real device, and using AirPods

1. In Xcode, Go to StorageManager.swift line 66
2. Change `FileProtectionType.none` to `FileProtectionType.complete`
   - This is the only way I know how to simulate this issue
6. In Xcode, go to: Window > Devices and Simulators > Open Console
7. Click the Start Streaming action
8. In the search field in the top right corner search for `process:podcasts`
10. Run the app on your phone. 
3. Run the App
4. Download any episode of a podcast
5. Start playing it
6. Pause it
7. Then quit the app
8. In the Console.app: Click the Clear button
9. Wait about 10 seconds, this step is required because the data protection expires after about 7 - 10 seconds
10. Cover your FaceID if you have it, to prevent unlocking the device
16. Use the play action on your AirPods
    - This forces the app to open in the background while the device is locked
17. In Console.app on your Mac
18. ✅ Verify you see the following error: `ExtAudioFile.cpp:210   about to throw -54: open audio file`

<img width="350" alt="Screen Shot 2023-01-26 at 1 40 09 PM" src="https://user-images.githubusercontent.com/793774/214921785-0cdca54b-50bc-475a-9a9f-a4764b770f9b.png">

18. You may need to scroll a bit to find it
20. Revert the change to StorageManager.swift, and open AppDelegate+Defaults
21. Go to line 103, and change `UpdateFileProtection` to `UpdateFileProtection1`
    - This forces the "update all" action to be fired again which will reset the protection for the downloaded files
23. Rerun the app
24. Play the same downloaded episode again
25. Pause it and quit the app
26. Wait about 10 seconds, cover your FaceID and then use the play action 
27. ✅ Verify the audio plays, and you do not see any errors in console
28. Download a new episode and repeat the steps and verify they play in the background
29. Add a new local file and repeat the steps and verify they play in the background

### Testing the existing app functions
1. Launch the app
2. Play an episode via streaming and verify it plays correctly in the foreground and background
3. Download an episode and verify it plays correctly in the foreground and the background
4. Add a local file and verify it plays correctly in the foreground and the background
5. Reinstall the app and repeat the steps to make sure it all works correctly

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
