### PR TITLE
Fix the next episode in the up next queue not playing when streaming on AirPlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 7.32
 -----
-
+- Fixed an issue where the Up Next queue doesn't continue playing the next episode when connected to AirPlay (#676)
 
 7.31
 -----

--- a/Modules/Utils/Sources/PocketCastsUtils/Logging/FileLog.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Logging/FileLog.swift
@@ -45,7 +45,7 @@ public class FileLog {
         guard let message = message, message.count > 0 else { return }
 
         // if it's important enough to log to file, write it to the debug console as well
-        Self.logger.log("\(message)")
+        Self.logger.log("🦄 \(message)")
         let dateFormatter = DateFormatHelper.sharedHelper.localTimeJsonDateFormatter
         appendStringToLog("\(dateFormatter.string(from: Date())) \(message)\n")
     }

--- a/Modules/Utils/Sources/PocketCastsUtils/Logging/FileLog.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Logging/FileLog.swift
@@ -45,7 +45,7 @@ public class FileLog {
         guard let message = message, message.count > 0 else { return }
 
         // if it's important enough to log to file, write it to the debug console as well
-        Self.logger.log("🦄 \(message)")
+        Self.logger.log("\(message)")
         let dateFormatter = DateFormatHelper.sharedHelper.localTimeJsonDateFormatter
         appendStringToLog("\(dateFormatter.string(from: Date())) \(message)\n")
     }

--- a/podcasts/DefaultPlayer.swift
+++ b/podcasts/DefaultPlayer.swift
@@ -83,7 +83,7 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
         return 0
     }
 
-    func play(completion: (() -> Void)?) {
+    func play(completion: (() -> Void)? = nil) {
         startBackgroundTask()
 
         shouldKeepPlaying = true

--- a/podcasts/DefaultPlayer.swift
+++ b/podcasts/DefaultPlayer.swift
@@ -516,9 +516,10 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
         }
 
         rateObserver = player?.observe(\.rate) { [weak self] _, _ in
+        rateObserver = player?.observe(\.rate) { [weak self] player, _ in
             guard let self = self else { return }
 
-            if let rate = self.player?.rate, rate == 1 {
+            if player.rate == 1 {
                 // there's a bug where playback can be resumed from outside our app, and Apple sets the wrong playback rate, fix that here
                 // the easiest way to repeat this is to play a video at 2x, and press pause once it's in picture in picture mode
                 let requiredSpeed = PlaybackManager.shared.effects().playbackSpeed
@@ -527,7 +528,7 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
                 }
             }
 
-            if let lastBackgroundedDate = self.lastBackgroundedDate, let player = self.player {
+            if let lastBackgroundedDate = self.lastBackgroundedDate {
                 let timeintervalSinceBackground = fabs(lastBackgroundedDate.timeIntervalSinceNow)
                 // we were backgrounded in the last 2 seconds, then the rate has changed, sounds like iOS is pausing video
                 if player.rate <= 0, self.shouldKeepPlaying, timeintervalSinceBackground > 0, timeintervalSinceBackground < 2 {


### PR DESCRIPTION
Fixes #47 

## Description

This took a long time to figure out and I'm not 100% sure the fix I applied the correct one. 

So for some reason, when you're connected to AirPlay the AVPlayer will pause itself once the episode resumes. If you monitor its various statuses:
- rate (0 means it's paused)
- timeControlStatus
- reasonForWaitingToPlay

You'll see that the app sets the rate as it does normally, and the rate is confirmed by the AVPlayer, but after a second or 2 the rate gets set to `0.0` and then `timeControlStatus` gets set to `paused` and the `reasonForWaitingToPlay` is nil. Which is a bit odd. 

I tried a lot of things to fix this:
- Tried using the iOS 16 `defaultRate` value, didn't work. 
- Tried changing `actionAtItemEnd` to `none`, didn't work
- Tried changing the rate, didn't work
- and about 200 other things, heh. 

So instead I opted to try and monitor the paused state and resume if needed. I'm using the existing `shouldKeepPlaying` flag that is used elsewhere in the player to auto resume. 

In my testing this works really well. 

## To test

1. On your Mac, go to System Preferences > Sharing > Enable Airplay Receiver
   - This will allow your Mac to act as an Airplay speaker
2. On your device add many items to your up next
3. Tap the Airplay icon and select your Mac as the receiver
4. Play an episode
   - To speed things up you can skip to the last 20 seconds or so
6. Put the app in the background
13. Let the episode play out
14. ✅ Verify the playback continues as planned
15. ✅ Verify you see: `[DefaultPlayer] Detected that playback was paused while trying to play the next item. Attempting to resume playback...` in the logs to indicate that the fix was applied

Please also make sure to test:
- Normal playback
- Playback Effects
- Local Files
- Streaming to AirPods
- etc

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
