### PR TITLE
SSO: add Tracks

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+SocialAuth.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+SocialAuth.swift
@@ -94,7 +94,7 @@ public extension ApiServerHandler {
     }
 }
 
-public enum SocialAuthProvider: String, CaseIterable {
+public enum SocialAuthProvider: CaseIterable {
     case apple
     case google
 

--- a/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+SocialAuth.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+SocialAuth.swift
@@ -94,7 +94,7 @@ public extension ApiServerHandler {
     }
 }
 
-public enum SocialAuthProvider: CaseIterable {
+public enum SocialAuthProvider: String, CaseIterable {
     case apple
     case google
 

--- a/podcasts/Analytics/AnalyticsDescribable+Modules.swift
+++ b/podcasts/Analytics/AnalyticsDescribable+Modules.swift
@@ -159,3 +159,14 @@ extension PodcastInfo: AnalyticsDescribable {
         return "unknown"
     }
 }
+
+extension SocialAuthProvider: AnalyticsDescribable {
+    var analyticsDescription: String {
+        switch self {
+        case .apple:
+            return "apple"
+        case .google:
+            return "google"
+        }
+    }
+}

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -42,7 +42,7 @@ enum AnalyticsEvent: String {
 
     case signInShown
     case signInDismissed
-    case signInStarted
+    case ssoStarted
 
     // MARK: - Select Account Type
 

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -42,6 +42,7 @@ enum AnalyticsEvent: String {
 
     case signInShown
     case signInDismissed
+    case signInStarted
 
     // MARK: - Select Account Type
 

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -19,6 +19,7 @@ enum AnalyticsEvent: String {
     case userEmailUpdated
     case userPasswordUpdated
     case userPasswordReset
+    case ssoStarted
 
     // MARK: - Payment Events
 
@@ -42,7 +43,6 @@ enum AnalyticsEvent: String {
 
     case signInShown
     case signInDismissed
-    case ssoStarted
 
     // MARK: - Select Account Type
 

--- a/podcasts/AuthenticationHelper.swift
+++ b/podcasts/AuthenticationHelper.swift
@@ -24,7 +24,7 @@ class AuthenticationHelper {
 
     static func validateLogin(username: String, password: String, scope: AuthenticationScope) async throws -> AuthenticationResponse {
         let response = try await ApiServerHandler.shared.validateLogin(username: username, password: password, scope: scope.rawValue)
-        handleSuccessfulSignIn(response, .password)
+        handleSuccessfulSignIn(response)
 
         // If the server didn't return a new email, and the call was successful, then reset the email to the one used to
         // validate the login
@@ -41,7 +41,7 @@ class AuthenticationHelper {
 
     static func validateLogin(identityToken: String)  async throws -> AuthenticationResponse {
         let response = try await ApiServerHandler.shared.validateLogin(identityToken: identityToken)
-        handleSuccessfulSignIn(response, .sso)
+        handleSuccessfulSignIn(response)
 
         ServerSettings.refreshToken = response.refreshToken
 
@@ -50,14 +50,14 @@ class AuthenticationHelper {
 
     static func validateLogin(identityToken: String, provider: SocialAuthProvider)  async throws -> AuthenticationResponse {
         let response = try await ApiServerHandler.shared.validateLogin(identityToken: identityToken, provider: provider)
-        handleSuccessfulSignIn(response, .sso)
+        handleSuccessfulSignIn(response)
 
         return response
     }
 
     // MARK: Common
 
-    private static func handleSuccessfulSignIn(_ response: AuthenticationResponse, _ source: AuthenticationSource) {
+    private static func handleSuccessfulSignIn(_ response: AuthenticationResponse) {
         SyncManager.clearTokensFromKeyChain()
 
         ServerSettings.userId = response.uuid
@@ -75,8 +75,7 @@ class AuthenticationHelper {
             ServerSettings.setSyncingEmail(email: response.email)
         }
 
-        NotificationCenter.postOnMainThread(notification: .userLoginDidChange)
-        Analytics.track(.userSignedIn, properties: ["source": source])
+        NotificationCenter.postOnMainThread(notification: .userLoginDidChange, userInfo: ["status": "signIn"])
 
         RefreshManager.shared.refreshPodcasts(forceEvenIfRefreshedRecently: true)
         Settings.setPromotionFinishedAcknowledged(true)
@@ -85,12 +84,6 @@ class AuthenticationHelper {
 }
 
 // MARK: - Enums
-enum AuthenticationSource: String, AnalyticsDescribable {
-    case password = "password"
-    case sso = "sso"
-
-    var analyticsDescription: String { rawValue }
-}
 
 enum AuthenticationScope: String {
     case mobile

--- a/podcasts/AuthenticationHelper.swift
+++ b/podcasts/AuthenticationHelper.swift
@@ -24,7 +24,7 @@ class AuthenticationHelper {
 
     static func validateLogin(username: String, password: String, scope: AuthenticationScope) async throws -> AuthenticationResponse {
         let response = try await ApiServerHandler.shared.validateLogin(username: username, password: password, scope: scope.rawValue)
-        handleSuccessfulSignIn(response, .password)
+        handleSuccessfulSignIn(response)
 
         // If the server didn't return a new email, and the call was successful, then reset the email to the one used to
         // validate the login
@@ -41,7 +41,7 @@ class AuthenticationHelper {
 
     static func validateLogin(identityToken: String)  async throws -> AuthenticationResponse {
         let response = try await ApiServerHandler.shared.validateLogin(identityToken: identityToken)
-        handleSuccessfulSignIn(response, .sso)
+        handleSuccessfulSignIn(response)
 
         ServerSettings.refreshToken = response.refreshToken
 
@@ -50,14 +50,14 @@ class AuthenticationHelper {
 
     static func validateLogin(identityToken: String, provider: SocialAuthProvider)  async throws -> AuthenticationResponse {
         let response = try await ApiServerHandler.shared.validateLogin(identityToken: identityToken, provider: provider)
-        handleSuccessfulSignIn(response, .sso)
+        handleSuccessfulSignIn(response)
 
         return response
     }
 
     // MARK: Common
 
-    private static func handleSuccessfulSignIn(_ response: AuthenticationResponse, _ source: AuthenticationSource) {
+    private static func handleSuccessfulSignIn(_ response: AuthenticationResponse) {
         SyncManager.clearTokensFromKeyChain()
 
         ServerSettings.userId = response.uuid
@@ -76,7 +76,6 @@ class AuthenticationHelper {
         }
 
         NotificationCenter.postOnMainThread(notification: .userLoginDidChange)
-        Analytics.track(.userSignedIn, properties: ["source": source])
 
         RefreshManager.shared.refreshPodcasts(forceEvenIfRefreshedRecently: true)
         Settings.setPromotionFinishedAcknowledged(true)
@@ -85,12 +84,6 @@ class AuthenticationHelper {
 }
 
 // MARK: - Enums
-enum AuthenticationSource: String, AnalyticsDescribable {
-    case password = "password"
-    case sso = "sso"
-
-    var analyticsDescription: String { rawValue }
-}
 
 enum AuthenticationScope: String {
     case mobile

--- a/podcasts/NewEmailViewController.swift
+++ b/podcasts/NewEmailViewController.swift
@@ -262,8 +262,6 @@ class NewEmailViewController: PCViewController, UITextFieldDelegate {
 
         NotificationCenter.default.post(name: .userLoginDidChange, object: nil)
         NotificationCenter.postOnMainThread(notification: .userSignedIn)
-
-        Analytics.track(.userAccountCreated)
     }
 
     // MARK: - UITextField Methods

--- a/podcasts/NewEmailViewController.swift
+++ b/podcasts/NewEmailViewController.swift
@@ -192,8 +192,6 @@ class NewEmailViewController: PCViewController, UITextFieldDelegate {
                     }
                     self.nextButton.setTitle(L10n.next, for: .normal)
                     return
-                } else {
-                    Analytics.track(.userSignedIn, properties: ["source": "password"])
                 }
 
                 FileLog.shared.addMessage("Registered new account for \(username)")

--- a/podcasts/NewEmailViewController.swift
+++ b/podcasts/NewEmailViewController.swift
@@ -192,6 +192,8 @@ class NewEmailViewController: PCViewController, UITextFieldDelegate {
                     }
                     self.nextButton.setTitle(L10n.next, for: .normal)
                     return
+                } else {
+                    Analytics.track(.userSignedIn, properties: ["source": "password"])
                 }
 
                 FileLog.shared.addMessage("Registered new account for \(username)")

--- a/podcasts/Onboarding/LoginCoordinator.swift
+++ b/podcasts/Onboarding/LoginCoordinator.swift
@@ -120,7 +120,7 @@ extension LoginCoordinator {
                 newAccountCreated = response?.isNewAccount ?? false
 
                 if !newAccountCreated {
-                    Analytics.track(.userSignedIn, properties: ["source": provider.analyticsDescription])
+                    Analytics.track(.userSignedIn, properties: ["source": provider])
                 }
 
                 listenToSync()

--- a/podcasts/Onboarding/LoginCoordinator.swift
+++ b/podcasts/Onboarding/LoginCoordinator.swift
@@ -99,7 +99,7 @@ extension LoginCoordinator {
 
         socialAuthProvider = provider
 
-        Analytics.track(.signInStarted, properties: ["source": provider.rawValue])
+        Analytics.track(.ssoStarted, properties: ["source": provider.rawValue])
 
         socialLogin = SocialLoginFactory.provider(for: provider, from: navigationController)
 

--- a/podcasts/Onboarding/LoginCoordinator.swift
+++ b/podcasts/Onboarding/LoginCoordinator.swift
@@ -9,6 +9,7 @@ class LoginCoordinator: NSObject, OnboardingModel {
     var presentedFromUpgrade: Bool = false
 
     private var socialLogin: SocialLogin?
+    private var socialAuthProvider: SocialAuthProvider?
 
     private var progressAlert: ShiftyLoadingAlert?
 
@@ -51,6 +52,7 @@ class LoginCoordinator: NSObject, OnboardingModel {
     }
 
     func loginTapped() {
+        socialAuthProvider = nil
         OnboardingFlow.shared.track(.setupAccountButtonTapped, properties: ["button": "sign_in"])
         let controller = SyncSigninViewController()
         controller.delegate = self
@@ -58,6 +60,7 @@ class LoginCoordinator: NSObject, OnboardingModel {
     }
 
     func signUpTapped() {
+        socialAuthProvider = nil
         OnboardingFlow.shared.track(.setupAccountButtonTapped, properties: ["button": "create_account"])
         let controller = NewEmailViewController(newSubscription: NewSubscription(isNewAccount: true, iap_identifier: ""))
         controller.delegate = self
@@ -93,6 +96,8 @@ extension LoginCoordinator {
         guard let navigationController else {
             return
         }
+
+        socialAuthProvider = provider
 
         Analytics.track(.signInStarted, properties: ["source": provider.rawValue])
 
@@ -156,9 +161,9 @@ extension LoginCoordinator: SyncSigninDelegate, CreateAccountDelegate {
     }
 
     func handleAccountCreated() {
-        let shouldDismiss = OnboardingFlow.shared.currentFlow.shouldDismiss
+        Analytics.track(.userAccountCreated, properties: ["source": socialAuthProvider?.rawValue ?? "password"])
 
-        if shouldDismiss {
+        if OnboardingFlow.shared.currentFlow.shouldDismiss {
             handleDismiss()
             return
         }

--- a/podcasts/Onboarding/LoginCoordinator.swift
+++ b/podcasts/Onboarding/LoginCoordinator.swift
@@ -44,8 +44,6 @@ class LoginCoordinator: NSObject, OnboardingModel {
 
     func didAppear() {
         OnboardingFlow.shared.track(.setupAccountShown)
-
-        NotificationCenter.default.addObserver(self, selector: #selector(userLoginDidChange(_:)), name: .userLoginDidChange, object: nil)
     }
 
     func didDismiss(type: OnboardingDismissType) {
@@ -136,12 +134,6 @@ extension LoginCoordinator: SyncSigninDelegate, CreateAccountDelegate {
         NotificationCenter.default.addObserver(self, selector: #selector(syncCompleted), name: ServerNotifications.syncCompleted, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(syncCompleted), name: ServerNotifications.syncFailed, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(syncCompleted), name: ServerNotifications.podcastRefreshFailed, object: nil)
-    }
-
-    @objc private func userLoginDidChange(_ notification: Notification) {
-        if notification.userInfo?["status"] as? String == "signedIn" {
-            Analytics.track(.userSignedIn, properties: ["source": socialAuthProvider?.rawValue ?? "password"])
-        }
     }
 
     @objc private func syncCompleted() {

--- a/podcasts/Onboarding/LoginCoordinator.swift
+++ b/podcasts/Onboarding/LoginCoordinator.swift
@@ -188,7 +188,7 @@ extension LoginCoordinator: SyncSigninDelegate, CreateAccountDelegate {
             return
         }
 
-        Analytics.track(.userSignInFailed, properties: ["source": socialAuthProvider?.analyticsDescription ?? "password", "error_code": (error as NSError).code])
+        Analytics.track(.userSignInFailed, properties: ["source": socialAuthProvider ?? "password", "error_code": (error as NSError).code])
         SJUIUtils.showAlert(title: L10n.accountSsoFailed, message: nil, from: navigationController)
     }
 

--- a/podcasts/Onboarding/LoginCoordinator.swift
+++ b/podcasts/Onboarding/LoginCoordinator.swift
@@ -44,6 +44,8 @@ class LoginCoordinator: NSObject, OnboardingModel {
 
     func didAppear() {
         OnboardingFlow.shared.track(.setupAccountShown)
+
+        NotificationCenter.default.addObserver(self, selector: #selector(userLoginDidChange(_:)), name: .userLoginDidChange, object: nil)
     }
 
     func didDismiss(type: OnboardingDismissType) {
@@ -134,6 +136,12 @@ extension LoginCoordinator: SyncSigninDelegate, CreateAccountDelegate {
         NotificationCenter.default.addObserver(self, selector: #selector(syncCompleted), name: ServerNotifications.syncCompleted, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(syncCompleted), name: ServerNotifications.syncFailed, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(syncCompleted), name: ServerNotifications.podcastRefreshFailed, object: nil)
+    }
+
+    @objc private func userLoginDidChange(_ notification: Notification) {
+        if notification.userInfo?["status"] as? String == "signedIn" {
+            Analytics.track(.userSignedIn, properties: ["source": socialAuthProvider?.rawValue ?? "password"])
+        }
     }
 
     @objc private func syncCompleted() {

--- a/podcasts/Onboarding/LoginCoordinator.swift
+++ b/podcasts/Onboarding/LoginCoordinator.swift
@@ -119,6 +119,8 @@ extension LoginCoordinator {
                 let response = try await self.socialLogin?.login()
                 newAccountCreated = response?.isNewAccount ?? false
 
+                Analytics.track(.userSignedIn, properties: ["source": provider.rawValue])
+
                 listenToSync()
             } catch {
                 progressAlert?.hideAlert(false) {

--- a/podcasts/Onboarding/LoginCoordinator.swift
+++ b/podcasts/Onboarding/LoginCoordinator.swift
@@ -165,7 +165,7 @@ extension LoginCoordinator: SyncSigninDelegate, CreateAccountDelegate {
     }
 
     func handleAccountCreated() {
-        Analytics.track(.userAccountCreated, properties: ["source": socialAuthProvider?.analyticsDescription ?? "password"])
+        Analytics.track(.userAccountCreated, properties: ["source": socialAuthProvider ?? "password"])
 
         if OnboardingFlow.shared.currentFlow.shouldDismiss {
             handleDismiss()

--- a/podcasts/Onboarding/LoginCoordinator.swift
+++ b/podcasts/Onboarding/LoginCoordinator.swift
@@ -186,6 +186,7 @@ extension LoginCoordinator: SyncSigninDelegate, CreateAccountDelegate {
             return
         }
 
+        Analytics.track(.userSignInFailed, properties: ["source": socialAuthProvider?.rawValue ?? "password", "error_code": (error as NSError).code])
         SJUIUtils.showAlert(title: L10n.accountSsoFailed, message: nil, from: navigationController)
     }
 

--- a/podcasts/Onboarding/LoginCoordinator.swift
+++ b/podcasts/Onboarding/LoginCoordinator.swift
@@ -99,7 +99,7 @@ extension LoginCoordinator {
 
         socialAuthProvider = provider
 
-        Analytics.track(.ssoStarted, properties: ["source": provider.rawValue])
+        Analytics.track(.ssoStarted, properties: ["source": provider.analyticsDescription])
 
         socialLogin = SocialLoginFactory.provider(for: provider, from: navigationController)
 
@@ -120,7 +120,7 @@ extension LoginCoordinator {
                 newAccountCreated = response?.isNewAccount ?? false
 
                 if !newAccountCreated {
-                    Analytics.track(.userSignedIn, properties: ["source": provider.rawValue])
+                    Analytics.track(.userSignedIn, properties: ["source": provider.analyticsDescription])
                 }
 
                 listenToSync()
@@ -165,7 +165,7 @@ extension LoginCoordinator: SyncSigninDelegate, CreateAccountDelegate {
     }
 
     func handleAccountCreated() {
-        Analytics.track(.userAccountCreated, properties: ["source": socialAuthProvider?.rawValue ?? "password"])
+        Analytics.track(.userAccountCreated, properties: ["source": socialAuthProvider?.analyticsDescription ?? "password"])
 
         if OnboardingFlow.shared.currentFlow.shouldDismiss {
             handleDismiss()
@@ -188,7 +188,7 @@ extension LoginCoordinator: SyncSigninDelegate, CreateAccountDelegate {
             return
         }
 
-        Analytics.track(.userSignInFailed, properties: ["source": socialAuthProvider?.rawValue ?? "password", "error_code": (error as NSError).code])
+        Analytics.track(.userSignInFailed, properties: ["source": socialAuthProvider?.analyticsDescription ?? "password", "error_code": (error as NSError).code])
         SJUIUtils.showAlert(title: L10n.accountSsoFailed, message: nil, from: navigationController)
     }
 

--- a/podcasts/Onboarding/LoginCoordinator.swift
+++ b/podcasts/Onboarding/LoginCoordinator.swift
@@ -99,7 +99,7 @@ extension LoginCoordinator {
 
         socialAuthProvider = provider
 
-        Analytics.track(.ssoStarted, properties: ["source": provider.analyticsDescription])
+        Analytics.track(.ssoStarted, properties: ["source": provider])
 
         socialLogin = SocialLoginFactory.provider(for: provider, from: navigationController)
 

--- a/podcasts/Onboarding/LoginCoordinator.swift
+++ b/podcasts/Onboarding/LoginCoordinator.swift
@@ -119,7 +119,9 @@ extension LoginCoordinator {
                 let response = try await self.socialLogin?.login()
                 newAccountCreated = response?.isNewAccount ?? false
 
-                Analytics.track(.userSignedIn, properties: ["source": provider.rawValue])
+                if !newAccountCreated {
+                    Analytics.track(.userSignedIn, properties: ["source": provider.rawValue])
+                }
 
                 listenToSync()
             } catch {

--- a/podcasts/Onboarding/LoginCoordinator.swift
+++ b/podcasts/Onboarding/LoginCoordinator.swift
@@ -94,6 +94,8 @@ extension LoginCoordinator {
             return
         }
 
+        Analytics.track(.signInStarted, properties: ["source": provider.rawValue])
+
         socialLogin = SocialLoginFactory.provider(for: provider, from: navigationController)
 
         Task {

--- a/podcasts/SyncSigninViewController.swift
+++ b/podcasts/SyncSigninViewController.swift
@@ -8,7 +8,6 @@ protocol SyncSigninDelegate: AnyObject {
 }
 
 class SyncSigninViewController: PCViewController, UITextFieldDelegate {
-    private let authSource = AuthenticationSource.password.rawValue
     @IBOutlet var emailField: ThemeableTextField! {
         didSet {
             emailField.placeholder = L10n.signInEmailAddressPrompt
@@ -275,7 +274,7 @@ class SyncSigninViewController: PCViewController, UITextFieldDelegate {
         ApiServerHandler.shared.validateLogin(username: username, password: password) { success, userId, error in
             DispatchQueue.main.async {
                 if !success {
-                    Analytics.track(.userSignInFailed, properties: ["source": self.authSource, "error_code": (error ?? .UNKNOWN).rawValue])
+                    Analytics.track(.userSignInFailed, properties: ["source": "password", "error_code": (error ?? .UNKNOWN).rawValue])
 
                     if error != .UNKNOWN, let message = error?.localizedDescription, !message.isEmpty {
                         self.showErrorMessage(message)
@@ -340,7 +339,7 @@ class SyncSigninViewController: PCViewController, UITextFieldDelegate {
 
         NotificationCenter.default.post(name: .userLoginDidChange, object: nil)
 
-        Analytics.track(.userSignedIn, properties: ["source": authSource])
+        Analytics.track(.userSignedIn, properties: ["source": "password"])
     }
 
     private func showErrorMessage(_ message: String) {

--- a/podcasts/SyncSigninViewController.swift
+++ b/podcasts/SyncSigninViewController.swift
@@ -8,7 +8,6 @@ protocol SyncSigninDelegate: AnyObject {
 }
 
 class SyncSigninViewController: PCViewController, UITextFieldDelegate {
-    private let authSource = AuthenticationSource.password.rawValue
     @IBOutlet var emailField: ThemeableTextField! {
         didSet {
             emailField.placeholder = L10n.signInEmailAddressPrompt
@@ -275,7 +274,7 @@ class SyncSigninViewController: PCViewController, UITextFieldDelegate {
         ApiServerHandler.shared.validateLogin(username: username, password: password) { success, userId, error in
             DispatchQueue.main.async {
                 if !success {
-                    Analytics.track(.userSignInFailed, properties: ["source": self.authSource, "error_code": (error ?? .UNKNOWN).rawValue])
+                    Analytics.track(.userSignInFailed, properties: ["source": "password", "error_code": (error ?? .UNKNOWN).rawValue])
 
                     if error != .UNKNOWN, let message = error?.localizedDescription, !message.isEmpty {
                         self.showErrorMessage(message)
@@ -339,8 +338,6 @@ class SyncSigninViewController: PCViewController, UITextFieldDelegate {
         ServerSettings.setSyncingEmail(email: username)
 
         NotificationCenter.default.post(name: .userLoginDidChange, object: nil)
-
-        Analytics.track(.userSignedIn, properties: ["source": authSource])
     }
 
     private func showErrorMessage(_ message: String) {

--- a/podcasts/SyncSigninViewController.swift
+++ b/podcasts/SyncSigninViewController.swift
@@ -8,6 +8,7 @@ protocol SyncSigninDelegate: AnyObject {
 }
 
 class SyncSigninViewController: PCViewController, UITextFieldDelegate {
+    private let authSource = AuthenticationSource.password.rawValue
     @IBOutlet var emailField: ThemeableTextField! {
         didSet {
             emailField.placeholder = L10n.signInEmailAddressPrompt
@@ -274,7 +275,7 @@ class SyncSigninViewController: PCViewController, UITextFieldDelegate {
         ApiServerHandler.shared.validateLogin(username: username, password: password) { success, userId, error in
             DispatchQueue.main.async {
                 if !success {
-                    Analytics.track(.userSignInFailed, properties: ["source": "password", "error_code": (error ?? .UNKNOWN).rawValue])
+                    Analytics.track(.userSignInFailed, properties: ["source": self.authSource, "error_code": (error ?? .UNKNOWN).rawValue])
 
                     if error != .UNKNOWN, let message = error?.localizedDescription, !message.isEmpty {
                         self.showErrorMessage(message)
@@ -338,6 +339,8 @@ class SyncSigninViewController: PCViewController, UITextFieldDelegate {
         ServerSettings.setSyncingEmail(email: username)
 
         NotificationCenter.default.post(name: .userLoginDidChange, object: nil)
+
+        Analytics.track(.userSignedIn, properties: ["source": authSource])
     }
 
     private func showErrorMessage(_ message: String) {


### PR DESCRIPTION
| 📘 Project: #381 |
|:---:|

Track logins/account creation made with Apple/Google.

I decided to refactor the code a little bit and move events to be close to the view. Before it was closer to the backend calls, and that might end up creating issues such as triggering the event when we didn't want to or making it hard to change that in the future.

While this approach duplicates some events being triggered, I think it's better than having a flag that go through multiple methods.

## To test

1. Delete any previous account you might have on Staging for your Google/Apple credentials
1. Do a clean run on the app
1. Go to Profile > Settings > Beta Features > Enable `tracksLogging` and `signInWithApple`
1. Go to Profile > tap bubble account at the top then tap "Sign Up"
1. Create a new account
1. ✅ `user_signed_in` and `user_account_created` should be tracked with `["source": "password"]`
1. Log out
1. Login with the account you just created
1. ✅ Ensure `Tracked: user_signed_in ["source": "password"]` is tracked but `user_account_created` is not
1. Log out
1. Tap the Google button
1. ✅ Ensure `Tracked: sso_started ["source": "google"]` is tracked
1. Create an account
1. ✅ `user_signed_in` and `user_account_created` should be tracked with `["source": "google"]`
1. Log out
1. Login with your Google account
1. ✅ Ensure `Tracked: user_signed_in ["source": "google"]` is tracked but `user_account_created` is not
1. Log out
1. Tap the Apple button
1. ✅ Ensure `Tracked: sso_started ["source": "apple"]` is tracked
1. Create an account
1. ✅ `user_signed_in` and `user_account_created` should be tracked with `["source": "apple"]`
1. Log out
1. Login with your Apple account
1. ✅ Ensure `Tracked: user_signed_in ["source": "apple"]` is tracked but `user_account_created` is not

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
