### PR TITLE
CarPlay: Show the up next queue whether you're playing something or not

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 7.32
 -----
-
+- When connected to CarPlay the Up Next Queue will more consistently display at the top of the podcasts list (#680)
 
 7.31
 -----

--- a/podcasts/CarPlaySceneDelegate+Tabs.swift
+++ b/podcasts/CarPlaySceneDelegate+Tabs.swift
@@ -28,7 +28,7 @@ extension CarPlaySceneDelegate {
         // the podcast tab is always what CarPlay opens first, however it doesn't show the Now Playing tab unless something is actively playing
         // so with that in mind if the user has something in Up Next and Pocket Casts is paused, help them find their now playing stuff by adding that as a section here
         let upNextEpisodes = PlaybackManager.shared.allEpisodesInQueue(includeNowPlaying: true)
-        if upNextEpisodes.count > 0, !PlaybackManager.shared.playing() {
+        if upNextEpisodes.count > 0 {
             let truncatedList = Array(upNextEpisodes.prefix(8))
             let imageRowItem = createUpNextImageItem(episodes: truncatedList)
 


### PR DESCRIPTION
Fixes #427

This removes the restriction that only shows the CarPlay Up Next queue only when you're not playing something.

## Screenshots

| Before | After |
|:---:|:---:|
|<img src="https://user-images.githubusercontent.com/793774/215614346-cb6f4cca-466f-42cc-8936-6a1b52607c34.png" width="320"/>|<img src="https://user-images.githubusercontent.com/793774/215614048-cebee35b-8cf7-446c-be5c-cbc8d7187a24.png" width="320" />|

## To test
> **Note**
> You'll want to test on a real device

1. Download the CarPlay Simulator from the [Additional Tools for Xcode](https://developer.apple.com/download/all/?q=Additional%20Tools%20for%20Xcode) package
2. Launch the Simulator
3. Connect your phone
4. Launch the app
5. Play an episode from your up next queue
6. Launch the Pocket Casts CarPlay app in the simulator
7. ✅ Verify you see the up next queue at the top
8. Pause the playing episode
9. In the CarPlay Simulator hit `Command-D` twice (this disconnects and reconnects)
10. ✅ Verify you see the up next queue at the top

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
