### PR TITLE
Switch to EffectsPlayer if required when disconnecting Airplay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 7.32
 -----
-
+- Fixed an issue where effects were not re-enabled when switching from an Airplay device back to phone output (#678)
 
 7.31
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 7.32
 -----
 - Fixed an issue where effects were not re-enabled when switching from an Airplay device back to phone output (#678)
+- Fixed an issue where the Up Next queue doesn't continue playing the next episode when connected to AirPlay (#676)
 
 7.31
 -----

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -1670,7 +1670,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         guard let userInfo = notification.userInfo, let changeReason = userInfo[AVAudioSessionRouteChangeReasonKey] as? NSNumber else { return }
 
         let reason = changeReason.uintValue
-        if let currEpisode = currentEpisode(), playingOverAirplay() && playerSwitchRequired() {
+        if let currEpisode = currentEpisode(), playerSwitchRequired() {
             load(episode: currEpisode, autoPlay: true, overrideUpNext: false)
         } else if reason == AVAudioSession.RouteChangeReason.oldDeviceUnavailable.rawValue {
             player?.routeDidChange(shouldPause: true)


### PR DESCRIPTION
Fixes #678 

When the audio route changes to an Airplay device, we switch to `DefaultPlayer`. When the route changes back, the same check is not performed and we keep using `DefaultPlayer`, even when the user has effects enabled.

We now always check if a player switch is required when the audio route changes.

## To test

- Use Airplay to play audio from a podcast with Mad Max Trim Silence or Volume Boost enabled (you can use your Mac as Airplay receiver)
- You should hear that the effects does not work (which is expected for Airplay, which uses `DefaultPlayer`)
- Disconnect from Airplay and start playing the audio on your phone speakers
- You should notice that the effects are enabled in the app UI, but still not active in the audio
- Apply the fix and repeat steps above. Effects will now be audible after switching back from Airplay.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
