### PR TITLE
Disable the up next swipe actions when a reorder is taking place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 -----
 - When connected to CarPlay the Up Next Queue will more consistently display at the top of the podcasts list (#680)
 - Fixed an issue where the Up Next queue doesn't continue playing the next episode when connected to AirPlay (#676)
+- Fixed an issue where the swipe actions in Up Next could be triggered when trying to reorder a row (#684)
 
 7.31
 -----

--- a/podcasts/Notifications.swift
+++ b/podcasts/Notifications.swift
@@ -12,4 +12,7 @@ extension NSNotification.Name {
 
     /// When the updated onboarding flow dismisses
     static let onboardingFlowDidDismiss = NSNotification.Name("Onboarding.didDismiss")
+
+    static let tableViewReorderWillBegin = NSNotification.Name("TableView.ReorderWillBegin")
+    static let tableViewReorderDidEnd = NSNotification.Name("TableView.ReorderDidEnd")
 }

--- a/podcasts/PlayerCell.swift
+++ b/podcasts/PlayerCell.swift
@@ -88,6 +88,22 @@ class PlayerCell: SwipeTableViewCell {
         overrideUserInterfaceStyle = .dark
     }
 
+    override func addSubview(_ view: UIView) {
+        super.addSubview(view)
+
+        // The handle view (`UITableViewCellReorderControl`) is a subclass of UIControl
+        // Add a gesture on it to detect when we're about to reorder
+        guard (view as? UIControl) != nil, view.gestureRecognizers == nil else {
+            return
+        }
+
+        let gesture = UILongPressGestureRecognizer(target: self, action: #selector(didTouchHandle))
+        gesture.minimumPressDuration = 0.1
+        gesture.cancelsTouchesInView = false
+
+        view.addGestureRecognizer(gesture)
+    }
+
     deinit {
         NotificationCenter.default.removeObserver(self)
     }
@@ -104,7 +120,6 @@ class PlayerCell: SwipeTableViewCell {
         updateDownloadStatus()
 
         EpisodeDateHelper.setDate(episode: episode, on: dayName, tintColor: ThemeColor.primaryText01(for: themeOverride))
-
         accessibilityLabel = labelForAccessibility(episode: episode)
     }
 
@@ -243,6 +258,19 @@ class PlayerCell: SwipeTableViewCell {
             if !show {
                 setHighlightedState(false)
             }
+        }
+    }
+}
+
+// MARK: - Handle Tap Detection
+private extension PlayerCell {
+    @objc func didTouchHandle(gesture: UILongPressGestureRecognizer) {
+        switch gesture.state {
+        case .began:
+            NotificationCenter.default.post(name: .tableViewReorderWillBegin, object: nil)
+        case .ended, .cancelled:
+            NotificationCenter.default.post(name: .tableViewReorderDidEnd, object: nil)
+        default: break
         }
     }
 }

--- a/podcasts/UpNextViewController+Swipe.swift
+++ b/podcasts/UpNextViewController+Swipe.swift
@@ -4,6 +4,10 @@ import PocketCastsUtils
 import SwipeCellKit
 
 extension UpNextViewController: SwipeTableViewCellDelegate {
+    func swipeCurrentlyAllowed() -> Bool {
+        return isReorderInProgress == false
+    }
+
     func tableView(_ tableView: UITableView, editActionsForRowAt indexPath: IndexPath, for orientation: SwipeActionsOrientation) -> [SwipeAction]? {
         switch orientation {
         case .left:

--- a/podcasts/UpNextViewController.swift
+++ b/podcasts/UpNextViewController.swift
@@ -60,6 +60,7 @@ class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
     }
 
     var multiSelectGestureInProgress = false
+    var isReorderInProgress = false
 
     @IBOutlet var upNextTable: ThemeableTable! {
         didSet {
@@ -124,6 +125,8 @@ class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
         NotificationCenter.default.addObserver(self, selector: #selector(upNextChanged), name: Constants.Notifications.upNextEpisodeRemoved, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(updateTimeRemainingLabel), name: Constants.Notifications.playbackProgress, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(appDidBecomeActive), name: UIApplication.didBecomeActiveNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(reorderingDidBegin), name: .tableViewReorderWillBegin, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(reorderingDidEnd), name: .tableViewReorderDidEnd, object: nil)
 
         remainingLabel.font = UIFont.systemFont(ofSize: 14, weight: .medium)
         remainingLabel.adjustsFontSizeToFitWidth = true
@@ -269,6 +272,18 @@ class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
 
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         .portrait
+    }
+}
+
+// MARK: - Reordering Notifications
+
+extension UpNextViewController {
+    @objc func reorderingDidBegin() {
+        isReorderInProgress = true
+    }
+
+    @objc func reorderingDidEnd() {
+        isReorderInProgress = false
     }
 }
 


### PR DESCRIPTION
Fixes #15 

## Videos

<details>
  <summary>Before - Swipe actions can be triggered if you do not swipe directly up or down</summary>

https://user-images.githubusercontent.com/793774/215897766-c17cf04a-2aff-4411-b127-5bc7efb56d7d.mp4

</details>

<details>
  <summary>After - The move gesture disables the swipe actions until release</summary>


https://user-images.githubusercontent.com/793774/215898236-4e21d354-0400-4ab8-acd1-9afbae7f570a.mp4



</details>

## Description

This adds detection when the user taps and holds onto the handle to trigger a reorder and disables the swipe actions while it's taking place. 

Apple doesn't provide an easy way to determine when a reorder will start or end, so I did this using a "hack" by adding a gesture onto the handle control that's added to the table cell. 

I did this in addSubview to make sure the gesture is only added once, and the reorder view isn't present on awakeFromNib. 

The current delay to trigger the gesture is 0.1 seconds, in my testing this works well. We can adjust if needed though.

## To test

1. Launch the app
2. Add items to your Up Next Queue
3. Open the Up Next Queue
4. Tap on the handle to begin a reorder
5. Drag to the left or right
6. ✅ Verify the swipe actions do not trigger
7. Release the cell
8. Swipe to the left/right
9. ✅ Verify the swipe actions trigger

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
