### PR TITLE
Revert #683

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - When connected to CarPlay the Up Next Queue will more consistently display at the top of the podcasts list (#680)
 - Fixed an issue where the Up Next queue doesn't continue playing the next episode when connected to AirPlay (#676)
 
+
 7.31
 -----
 - Fixed an issue where the close button was rendered as a solid white circle when the Dark Contrast theme was active (#552)

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -1670,7 +1670,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         guard let userInfo = notification.userInfo, let changeReason = userInfo[AVAudioSessionRouteChangeReasonKey] as? NSNumber else { return }
 
         let reason = changeReason.uintValue
-        if let currEpisode = currentEpisode(), playerSwitchRequired() {
+        if let currEpisode = currentEpisode(), playingOverAirplay() && playerSwitchRequired() {
             load(episode: currEpisode, autoPlay: true, overrideUpNext: false)
         } else if reason == AVAudioSession.RouteChangeReason.oldDeviceUnavailable.rawValue {
             player?.routeDidChange(shouldPause: true)


### PR DESCRIPTION
The fix done in #683 had a side effect on CarPlay: if the episode is downloaded, pause doesn't work, the episode keeps resuming.

https://user-images.githubusercontent.com/7040243/216113096-7b91bc2e-8108-43dd-9d87-cf6dd1cac96f.mov

This PR reverts to the previous behavior.

## To test

1. Run the app
2. Run the CarPlay simulator (Download the CarPlay Simulator from the [Additional Tools for Xcode](https://developer.apple.com/download/all/?q=Additional%20Tools%20for%20Xcode) package)
3. Connect your phone
4. Download any episode and play it
4. Lock the phone
4. Pause it
4. ✅ The pause should work and the episode should not play again

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
