### PR TITLE
i18n: Add Catalan

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -77,7 +77,8 @@ GLOTPRESS_TO_LPROJ_APP_LOCALE_CODES = {
   'ru' => 'ru',         # Russian
   'es' => 'es',         # Spanish
   'es-mx' => 'es-MX',   # Spanish (Mexico)
-  'sv' => 'sv'          # Swedish
+  'sv' => 'sv',         # Swedish
+  'ca' => 'ca'          # Catalan
 }.freeze
 
 # Mapping of all locales which can be used for AppStore metadata

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -2072,6 +2072,9 @@
 		8B0EEDE729008B6300075772 /* TopOnePodcastStory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopOnePodcastStory.swift; sourceTree = "<group>"; };
 		8B0EEDE92900990D00075772 /* LongestEpisodeStory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LongestEpisodeStory.swift; sourceTree = "<group>"; };
 		8B10E78528D908A900702C54 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
+		8B17365B298D47B10057E893 /* ca */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ca; path = ca.lproj/Intents.strings; sourceTree = "<group>"; };
+		8B17365C298D47B10057E893 /* ca */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ca; path = ca.lproj/Localizable.strings; sourceTree = "<group>"; };
+		8B17365D298D47B20057E893 /* ca */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ca; path = ca.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		8B1C974528FE1C7E00BD5EB9 /* ImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageView.swift; sourceTree = "<group>"; };
 		8B1C974728FE234B00BD5EB9 /* View+Snapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Snapshot.swift"; sourceTree = "<group>"; };
 		8B23193E2902C84A0001C3DE /* EndOfYearStoriesBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndOfYearStoriesBuilder.swift; sourceTree = "<group>"; };
@@ -6646,6 +6649,7 @@
 				"zh-Hant",
 				"fr-CA",
 				"es-MX",
+				ca,
 			);
 			mainGroup = BDBD53E317019B290048C8C5;
 			packageReferences = (
@@ -8468,6 +8472,7 @@
 				BD6E223F27338A3600474349 /* zh-Hant */,
 				BDCE59A827D9A394009642C1 /* fr-CA */,
 				BDCE59AB27D9A3B6009642C1 /* es-MX */,
+				8B17365C298D47B10057E893 /* ca */,
 			);
 			name = Localizable.strings;
 			sourceTree = "<group>";
@@ -8490,6 +8495,7 @@
 				46FBD8D1276A876D00867746 /* sv */,
 				BDCE59A727D9A394009642C1 /* fr-CA */,
 				BDCE59AA27D9A3B6009642C1 /* es-MX */,
+				8B17365B298D47B10057E893 /* ca */,
 			);
 			name = Intents.intentdefinition;
 			sourceTree = "<group>";
@@ -8511,6 +8517,7 @@
 				BD6E224027338A3600474349 /* zh-Hant */,
 				BDCE59A927D9A394009642C1 /* fr-CA */,
 				BDCE59AC27D9A3B6009642C1 /* es-MX */,
+				8B17365D298D47B20057E893 /* ca */,
 			);
 			name = InfoPlist.strings;
 			sourceTree = "<group>";

--- a/podcasts/ca.lproj/InfoPlist.strings
+++ b/podcasts/ca.lproj/InfoPlist.strings
@@ -1,17 +1,19 @@
-/* A message that tells the user why the app is requesting access to the device’s camera. */
-NSCameraUsageDescription = "This allows you to add custom images to your files";
-
-/* A message that tells the user why the app needs access to Bluetooth. */
-NSBluetoothAlwaysUsageDescription = "Pocket Casts needs to access your bluetooth in order to detect nearby Google Cast devices.";
-
-/* A message that tells the user why the app is requesting access to the local network. */
-NSLocalNetworkUsageDescription = "Pocket Casts uses this to find Google Cast devices on your network. If you don't use this feature feel free to say no.";
-
-/* A message that tells the user why the app is requesting access to the device’s microphone. */
-NSMicrophoneUsageDescription = "Pocket Casts needs to access your microphone in order to detect nearby Google Cast devices.";
-
-/* A message that tells the user why the app is requesting access to the user’s photo library. */
-NSPhotoLibraryUsageDescription = "Pocket Casts needs permission to save this image to your photo library.";
-
-/* A message that tells the user why the app is requesting add-only access to the user’s photo library. */
-NSPhotoLibraryAddUsageDescription = "Pocket Casts needs permission to save this image to your photo library.";
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--Warning: Auto-generated file, do not edit.-->
+<plist version="1.0">
+  <dict>
+    <key>NSBluetoothAlwaysUsageDescription</key>
+    <string>Pocket Casts necessita accedir al teu Bluetooth per detectar dispositius Google Cast que es trobin a prop.</string>
+    <key>NSCameraUsageDescription</key>
+    <string>Això et permet afegir imatges personalitzades als teus fitxers.</string>
+    <key>NSLocalNetworkUsageDescription</key>
+    <string>Pocket Casts l'utilitza per trobar dispositius Google Cast a la teva xarxa. Si no utilitzes aquesta funció, no dubtis a denegar el permís.</string>
+    <key>NSMicrophoneUsageDescription</key>
+    <string>Pocket Casts necessita accedir al teu micròfon per detectar dispositius Google Cast que es trobin a prop.</string>
+    <key>NSPhotoLibraryAddUsageDescription</key>
+    <string>Pocket Casts necessita permís per desar aquesta imatge a la teva biblioteca de fotos.</string>
+    <key>NSPhotoLibraryUsageDescription</key>
+    <string>Pocket Casts necessita permís per desar aquesta imatge a la teva biblioteca de fotos.</string>
+  </dict>
+</plist>

--- a/podcasts/ca.lproj/InfoPlist.strings
+++ b/podcasts/ca.lproj/InfoPlist.strings
@@ -1,0 +1,17 @@
+/* A message that tells the user why the app is requesting access to the device’s camera. */
+NSCameraUsageDescription = "This allows you to add custom images to your files";
+
+/* A message that tells the user why the app needs access to Bluetooth. */
+NSBluetoothAlwaysUsageDescription = "Pocket Casts needs to access your bluetooth in order to detect nearby Google Cast devices.";
+
+/* A message that tells the user why the app is requesting access to the local network. */
+NSLocalNetworkUsageDescription = "Pocket Casts uses this to find Google Cast devices on your network. If you don't use this feature feel free to say no.";
+
+/* A message that tells the user why the app is requesting access to the device’s microphone. */
+NSMicrophoneUsageDescription = "Pocket Casts needs to access your microphone in order to detect nearby Google Cast devices.";
+
+/* A message that tells the user why the app is requesting access to the user’s photo library. */
+NSPhotoLibraryUsageDescription = "Pocket Casts needs permission to save this image to your photo library.";
+
+/* A message that tells the user why the app is requesting add-only access to the user’s photo library. */
+NSPhotoLibraryAddUsageDescription = "Pocket Casts needs permission to save this image to your photo library.";

--- a/podcasts/ca.lproj/Intents.strings
+++ b/podcasts/ca.lproj/Intents.strings
@@ -1,104 +1,101 @@
-"0EmR82" = "Open ${filterName} Filter";
-
-"0YXvyS" = "Previous";
-
-"1uT6VF" = "Media Search";
-
-"3aWmex" = "Chapter";
-
-"5oBQUn" = "${mediaItems}";
-
-"5yWeuV" = "Play at ${playbackSpeed}";
-
-"ApUiZd" = "${mediaItems}";
-
-"CXbd65" = "Set Sleep Timer";
-
-"E6Nzn4-No0K9w" = "resume Pocket Casts";
-
-"E6Nzn4-Pk1Fkx" = "don't resume Pocket Casts";
-
-"ErAaNp" = "Repeat Mode";
-
-"EwNFJ5" = "Extend Sleep Timer";
-
-"G0iCil" = "Unable to skip chapter";
-
-"G3J6fP" = "Play podcast";
-
-"IyhbAH" = "Open Filter";
-
-"KcCcQu" = "${mediaItems}";
-
-"LdrEPN" = "A request to play media";
-
-"MbU5ep" = "Shuffle ${mediaItems}";
-
-"No0K9w" = "resume";
-
-"Ntulol" = "Skip Chapter";
-
-"OJvsVr" = "Extend Sleep Timer by 5 mins";
-
-"Pk1Fkx" = "don't resume";
-
-"QektJm" = "Open Filter";
-
-"QqdHiR" = "shuffled";
-
-"RvX3Zd" = "Playback Speed";
-
-"WEjMGd" = "Play ${mediaContainer}";
-
-"Wj0EAI" = "Skip";
-
-"WktFNa" = "Shuffled";
-
-"YYfsKp" = "Play ${mediaContainer}";
-
-"bVm1vW" = "Set sleep timer";
-
-"cV2HLF" = "Queue Location";
-
-"cfJexL" = "Items";
-
-"dBTobY" = "Skip chapter";
-
-"emhqzv" = "Podcast doesn't support chapters";
-
-"gD0dlx" = "Next";
-
-"iQo0yQ-0YXvyS" = "Previous Chapter";
-
-"iQo0yQ-Wj0EAI" = "Skip Chapter";
-
-"iQo0yQ-gD0dlx" = "Next Chapter";
-
-"mCAocc" = "not shuffled";
-
-"mIvv3D" = " ${mediaItems}";
-
-"nAv25k" = "Shuffle ${mediaContainer}";
-
-"nNozW1" = "Shuffle ${mediaContainer}";
-
-"nR0neu" = "Sleep Timer";
-
-"ny98Lo" = "Extend Sleep Timer";
-
-"o6CuZu" = "Resume ${mediaContainer}";
-
-"q8QY8B" = "Play ${mediaItems} at ${playbackSpeed}";
-
-"rnkZnd" = "Skip chapter";
-
-"rvNMpm" = "Resume";
-
-"sLPQxZ" = "Play ${mediaContainer}";
-
-"vUAqfM" = "${mediaItems}";
-
-"xdnqvn" = "Container";
-
-"zvlpk3" = "Skipped chapter";
-
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--Warning: Auto-generated file, do not edit.-->
+<plist version="1.0">
+  <dict>
+    <key>0EmR82</key>
+    <string>Obrir el filtre ${filterName}</string>
+    <key>0YXvyS</key>
+    <string>Anterior</string>
+    <key>1uT6VF</key>
+    <string>Cerca de contingut multimèdia</string>
+    <key>3aWmex</key>
+    <string>Capítol</string>
+    <key>5yWeuV</key>
+    <string>Reprodueix a ${playbackSpeed}</string>
+    <key>CXbd65</key>
+    <string>Configurar temporitzador</string>
+    <key>E6Nzn4-No0K9w</key>
+    <string>reprendre Pocket Casts</string>
+    <key>E6Nzn4-Pk1Fkx</key>
+    <string>no reprendre Pocket Casts</string>
+    <key>ErAaNp</key>
+    <string>Mode de repetició</string>
+    <key>EwNFJ5</key>
+    <string>Ampliar temporitzador</string>
+    <key>G0iCil</key>
+    <string>No es pot saltar el capítol</string>
+    <key>G3J6fP</key>
+    <string>Reproduir podcast</string>
+    <key>IyhbAH</key>
+    <string>Obrir filtre</string>
+    <key>LdrEPN</key>
+    <string>Una petició per reproduir contingut multimèdia</string>
+    <key>MbU5ep</key>
+    <string>Reproduir aleatòriament ${mediaItems}</string>
+    <key>No0K9w</key>
+    <string>reprendre</string>
+    <key>Ntulol</key>
+    <string>Saltar capítol</string>
+    <key>OJvsVr</key>
+    <string>Ampliar el temporitzador 5 minuts</string>
+    <key>Pk1Fkx</key>
+    <string>no reprendre</string>
+    <key>QektJm</key>
+    <string>Obrir el filtre</string>
+    <key>QqdHiR</key>
+    <string>aleatori</string>
+    <key>RvX3Zd</key>
+    <string>Velocitat de reproducció</string>
+    <key>WEjMGd</key>
+    <string>Reproduir ${mediaContainer}</string>
+    <key>Wj0EAI</key>
+    <string>Saltar</string>
+    <key>WktFNa</key>
+    <string>Aleatori</string>
+    <key>YYfsKp</key>
+    <string>Reproduir ${mediaContainer}</string>
+    <key>bVm1vW</key>
+    <string>Configurar temporitzador</string>
+    <key>cV2HLF</key>
+    <string>Ubicació a la cua</string>
+    <key>cfJexL</key>
+    <string>Elements</string>
+    <key>dBTobY</key>
+    <string>Saltar capítol</string>
+    <key>emhqzv</key>
+    <string>El podcast no admet capítols</string>
+    <key>gD0dlx</key>
+    <string>Següent</string>
+    <key>iQo0yQ-0YXvyS</key>
+    <string>Capitol anterior</string>
+    <key>iQo0yQ-Wj0EAI</key>
+    <string>Saltar capítol</string>
+    <key>iQo0yQ-gD0dlx</key>
+    <string>Capítol següent</string>
+    <key>mCAocc</key>
+    <string>no aleatori</string>
+    <key>nAv25k</key>
+    <string> Reproduir aleatòriament ${mediaContainer} </string>
+    <key>nNozW1</key>
+    <string>Reproduir aleatòriament ${mediaContainer}</string>
+    <key>nR0neu</key>
+    <string>Temporitzador</string>
+    <key>ny98Lo</key>
+    <string>Ampliar temporitzador</string>
+    <key>o6CuZu</key>
+    <string>Reprendre ${mediaContainer}</string>
+    <key>q8QY8B</key>
+    <string>Reproduir ${mediaItems} a ${playbackSpeed}</string>
+    <key>rnkZnd</key>
+    <string>Saltar capítol</string>
+    <key>rvNMpm</key>
+    <string>Reanudar</string>
+    <key>sLPQxZ</key>
+    <string>Reproduir ${mediaContainer}</string>
+    <key>xdnqvn</key>
+    <string>Contenidor</string>
+    <key>zvlpk3</key>
+    <string>Capítol saltat</string>
+  </dict>
+</plist>

--- a/podcasts/ca.lproj/Intents.strings
+++ b/podcasts/ca.lproj/Intents.strings
@@ -1,0 +1,104 @@
+"0EmR82" = "Open ${filterName} Filter";
+
+"0YXvyS" = "Previous";
+
+"1uT6VF" = "Media Search";
+
+"3aWmex" = "Chapter";
+
+"5oBQUn" = "${mediaItems}";
+
+"5yWeuV" = "Play at ${playbackSpeed}";
+
+"ApUiZd" = "${mediaItems}";
+
+"CXbd65" = "Set Sleep Timer";
+
+"E6Nzn4-No0K9w" = "resume Pocket Casts";
+
+"E6Nzn4-Pk1Fkx" = "don't resume Pocket Casts";
+
+"ErAaNp" = "Repeat Mode";
+
+"EwNFJ5" = "Extend Sleep Timer";
+
+"G0iCil" = "Unable to skip chapter";
+
+"G3J6fP" = "Play podcast";
+
+"IyhbAH" = "Open Filter";
+
+"KcCcQu" = "${mediaItems}";
+
+"LdrEPN" = "A request to play media";
+
+"MbU5ep" = "Shuffle ${mediaItems}";
+
+"No0K9w" = "resume";
+
+"Ntulol" = "Skip Chapter";
+
+"OJvsVr" = "Extend Sleep Timer by 5 mins";
+
+"Pk1Fkx" = "don't resume";
+
+"QektJm" = "Open Filter";
+
+"QqdHiR" = "shuffled";
+
+"RvX3Zd" = "Playback Speed";
+
+"WEjMGd" = "Play ${mediaContainer}";
+
+"Wj0EAI" = "Skip";
+
+"WktFNa" = "Shuffled";
+
+"YYfsKp" = "Play ${mediaContainer}";
+
+"bVm1vW" = "Set sleep timer";
+
+"cV2HLF" = "Queue Location";
+
+"cfJexL" = "Items";
+
+"dBTobY" = "Skip chapter";
+
+"emhqzv" = "Podcast doesn't support chapters";
+
+"gD0dlx" = "Next";
+
+"iQo0yQ-0YXvyS" = "Previous Chapter";
+
+"iQo0yQ-Wj0EAI" = "Skip Chapter";
+
+"iQo0yQ-gD0dlx" = "Next Chapter";
+
+"mCAocc" = "not shuffled";
+
+"mIvv3D" = " ${mediaItems}";
+
+"nAv25k" = "Shuffle ${mediaContainer}";
+
+"nNozW1" = "Shuffle ${mediaContainer}";
+
+"nR0neu" = "Sleep Timer";
+
+"ny98Lo" = "Extend Sleep Timer";
+
+"o6CuZu" = "Resume ${mediaContainer}";
+
+"q8QY8B" = "Play ${mediaItems} at ${playbackSpeed}";
+
+"rnkZnd" = "Skip chapter";
+
+"rvNMpm" = "Resume";
+
+"sLPQxZ" = "Play ${mediaContainer}";
+
+"vUAqfM" = "${mediaItems}";
+
+"xdnqvn" = "Container";
+
+"zvlpk3" = "Skipped chapter";
+

--- a/podcasts/ca.lproj/Localizable.strings
+++ b/podcasts/ca.lproj/Localizable.strings
@@ -1,3559 +1,2411 @@
-/* A common string used throughout the app. An accessibility label to direct the user to turn off the multi-select mode. */
-"accessibility_cancel_multiselect" = "Cancel multiselect";
-
-/* A common string used throughout the app. Accessibility hint to inform that the control closes the current dialog window. */
-"accessibility_close_dialog" = "Close dialog";
-
-/* A common string used throughout the app. Accessibility hint to inform the user that this control will deselect the episode. */
-"accessibility_deselect_episode" = "Deselect Episode";
-
-/* A common string used throughout the app. Accessibility hint to inform that the control is disabled. */
-"accessibility_disabled" = "Disabled";
-
-/* A common string used throughout the app. Accessibility hint to inform that the control dismisses the current window. */
-"accessibility_dismiss" = "Dismiss";
-
-/* An accessibility label to direct the user tap to get access to filter details. */
-"accessibility_hide_filter_details" = "Tap to hide filter details";
-
-/* Accessibility hint to inform the user how to star (favorite) for an episode. */
-"accessibility_hint_star" = "Double tap to star episode";
-
-/* Accessibility hint to inform the user how to un-star (remove favorite) for an episode. */
-"accessibility_hint_unstar" = "Double tap to remove star from episode";
-
-/* A common string used throughout the app. Accessibility hint to inform that the control opens a menu for more options. */
-"accessibility_more_actions" = "More actions";
-
-/* A common string used throughout the app. An accessibility label to inform the user the completed percentage of a given task. '%1$@' is a placeholder for the localized spelled out number for Voice Over */
-"accessibility_percent_complete_format" = "%1$@ percent completed";
-
-/* Accessibility text listing the current value for the playback speed. '%1$@' is a placeholder for the playback speed. */
-"accessibility_player_effects_playback_speed" = "Playback speed %1$@ times";
-
-/* Accessibility hint to inform the user which filter color flag is being used. '%1$@' is a placeholder for the filter color number. */
-"accessibility_playlist_color" = "Playlist color %1$@";
-
-/* A common string used throughout the app. An accessibility label to inform the user that the selected item is locked behind Pocket Casts Plus subscription. */
-"accessibility_plus_only" = "Locked, Plus Feature";
-
-/* Accessibility label fir the profile settings icon in the app. 'Pocket Casts' is treated as a proper noun and hasn't been localized in other places of the app. */
-"accessibility_profile_settings" = "Pocket Casts Settings";
-
-/* A common string used throughout the app. Accessibility hint to inform the user that this control will select the episode. */
-"accessibility_select_episode" = "Select Episode";
-
-/* An accessibility label to direct the user tap to get access to filter details. */
-"accessibility_show_filter_details" = "Tap to show filter details";
-
-/* An accessibility hint to prompt the user to tap to open their account details or sign in. */
-"accessibility_sign_in" = "Tap to view or setup account";
-
-/* A common string used throughout the app. An accessibility label to direct the user to sort and option menus. */
-"accessibility_sort_and_options" = "Sort and Options";
-
-/* Prompt to allow the user to update the email associated to their account. */
-"account_change_email" = "Change Email";
-
-/* Nudge to inform the user that they are nearly done with the account set up steps. */
-"account_completion_nudge" = "Almost There!";
-
-/* Message portion of the nudge to inform the user that they are nearly done with the account set up steps. */
-"account_completion_nudge_msg" = "Finalize your payment to finish upgrading your account.";
-
-/* Title informing the user that their account has been successfully created */
-"account_created" = "Account Created";
-
-/* Title for the final screen in the account creation flow. */
-"account_creation_complete" = "Complete Account";
-
-/* Prompt to allow the user to delete their account. */
-"account_delete_account" = "Delete Account";
-
-/* Confirmation option for deleting the user account. */
-"account_delete_account_conf" = "Yes, Delete It";
-
-/* Error title for when the delete account process has failed. */
-"account_delete_account_error" = "Delete Account Failed";
-
-/* Error message for when the delete account process has failed. */
-"account_delete_account_error_msg" = "Unable to delete account.";
-
-/* The final alert message for the confirmation dialog asking the user to confirm they want to delete their account. */
-"account_delete_account_final_alert_msg" = "Last chance, you definitely want to delete your account? You will lose all your subscriptions and play history permanently!";
-
-/* The first message for the confirmation dialog asking the user to confirm they want to delete their account. */
-"account_delete_account_first_alert_msg" = "Are you sure you want to delete your account, there's no way to undo this!";
-
-/* Title for the confirmation dialog asking the user to confirm they want to delete their account. */
-"account_delete_account_title" = "Delete Account?";
-
-/* Button title to prompt a user to login. */
-"account_login" = "Log in";
-
-/* Informs the user that their purchase will be automatically renewed monthly */
-"account_payment_renews_monthly" = "Renews automatically monthly";
-
-/* Informs the user that their purchase will be automatically renewed yearly */
-"account_payment_renews_yearly" = "Renews automatically yearly";
-
-/* Allows the user to ope a screen to review the Privacy Policy */
-"account_privacy_policy" = "Privacy Policy";
-
-/* Error message for when the account registration request has failed. */
-"account_registration_failed" = "Registration failed, please try again later";
-
-/* Prompt to allow the user to choose their account time when setting up their account. */
-"account_select_type" = "Select Account Type";
-
-/* Prompt to allow the user to sign out of their account. */
-"account_sign_out" = "Sign Out";
-
-/* Confirmation dialog informing the user that signing out will remove the given number of supported podcasts. '%1$@' is a placeholder for the number of supported podcasts. */
-"account_sign_out_supporter_prompt" = "Signing out will remove %1$@ supported podcasts from this device. Are you sure?";
-
-/* Subtitle to the Confirmation dialog informing the user that signing out will remove the given number of supported podcasts. */
-"account_sign_out_supporter_subtitle" = "You can sign in again to regain access.";
-
-/* Error message for when the account registration request has failed. */
-"account_sso_failed" = "Sign in failed. Please try again.";
-
-/* Title for the account screen for the user's Pocket Casts Account. 'Pocket Casts' refers to the app name and is treated as a proper noun so it shouldn't be localized. */
-"account_title" = "Pocket Casts Account";
-
-/* Title informing the user that their account has been successfully upgraded to Pocket Casts Plus */
-"account_upgraded" = "Account Upgraded";
-
-/* Welcome message presented after a user has signed up for Pocket Casts */
-"account_welcome" = "Welcome to Pocket Casts!";
-
-/* Welcome message presented after a user has signed up for Pocket Casts Plus */
-"account_welcome_plus" = "Welcome to Pocket Casts Plus!";
-
-/* Title of an alert that informs the user that they have been signed out of their account */
-"account_signed_out_alert_title" = "You've been signed out.";
-
-/* Message/Body of an alert that explains that the user should tap a button and sign in again */
-"account_signed_out_alert_message" = "Turns out, if you type Google into Google, you can break the internet. 🫢 \n\nTap the button below to sign into your Pocket Casts account again.";
-
-/* A common string used throughout the app. Title for the prompt to add an episode to the up next queue. */
-"add_to_up_next" = "Add to Up Next";
-
-/* A common string used throughout the app. Option that determines the behavior of the app after playing an item. */
-"after_playing" = "After Playing";
-
-/* A common string used throughout the app. References to Badge settings for the app. */
-"app_badge" = "App Badge";
-
-/* The name for the Classic App Icon */
-"app_icon_classic" = "Classic";
-
-/* The name for the Dark App Icon */
-"app_icon_dark" = "Dark";
-
-/* The name for the Default App Icon */
-"app_icon_default" = "Default";
-
-/* The name for the Electric Blue App Icon */
-"app_icon_electric_blue" = "Electric Blue";
-
-/* The name for the Electric Pink App Icon */
-"app_icon_electric_pink" = "Electric Pink";
-
-/* The name for the Indigo App Icon */
-"app_icon_indigo" = "Indigo";
-
-/* The name for the Pocket Casts Plus App Icon */
-"app_icon_plus" = "Plus";
-
-/* The name for the Pocket Cats App Icon. The name for this one is meant to be a play on the App name Pocket Casts and the icon includes a cat image. */
-"app_icon_pocket_cats" = "Pocket Cats";
-
-/* The name for the Radioactivity App Icon */
-"app_icon_radioactivity" = "Radioactivity";
-
-/* The name for the Red Velvet App Icon */
-"app_icon_red_velvet" = "Red Velvet";
-
-/* The name for the Rosé App Icon */
-"app_icon_rose" = "Rosé";
-
-/* The name for the Round Dark App Icon */
-"app_icon_round_dark" = "Round Dark";
-
-/* The name for the Round Light App Icon */
-"app_icon_round_light" = "Round Light";
-
-/* Halloween app icon name */
-"app_icon_halloween" = "Halloween";
-
-/* App version label in the about controller. `%1$@` is a placeholder for the version number and %2$@ is a placeholder for the build number */
-"app_version" = "Version %1$@ (%2$@)";
-
-/* Section header for the appearance settings related to app icons. */
-"appearance_app_icon_header" = "App Icon";
-
-/* Section header for the appearance settings related to artwork. */
-"appearance_artwork_header" = "Podcast Artwork";
-
-/* Prompt to toggle on the use of artwork that's embedded in the episode download files. */
-"appearance_embedded_artwork" = "Use Embedded Artwork";
-
-/* Subtitle explaining embedded artwork in the episode download files. */
-"appearance_embedded_artwork_subtitle" = "Shows artwork from the downloaded file (if it exists) in the player instead of using the show's artwork.";
-
-/* Prompt to toggle whether the theme will match the device theme or not. */
-"appearance_match_device_theme" = "Use iOS Light/Dark Mode";
-
-/* Prompt to refresh the artwork for all podcasts. */
-"appearance_refresh_all_artwork" = "Refresh All Podcast Artwork";
-
-/* Confirmation message used to inform the user that the refresh has been successfully triggered. */
-"appearance_refresh_all_artwork_conf_msg" = "Refreshing your artwork now";
-
-/* Confirmation title used to inform the user that the refresh has been successfully triggered. */
-"appearance_refresh_all_artwork_conf_title" = "Aye Aye Captain";
-
-/* Section header for the appearance settings related to themes. */
-"appearance_theme_header" = "Theme";
-
-/* Header for asking the user to select a theme. */
-"appearance_theme_select" = "Select Theme";
-
-/* Label for letting the user choose a theme for iOS light mode. */
-"appearance_light_theme" = "Light Theme";
-
-/* Label for letting the user choose a theme for iOS dark mode. */
-"appearance_dark_theme" = "Dark Theme";
-
-/* A common string used throughout the app. Prompt to archive the selected item(s). */
-"archive" = "Archive";
-
-/* A common string used throughout the app. Confirmation prompt before moving forward. */
-"are_you_sure" = "Are You Sure?";
-
-/* A common string used throughout the app. Prompt to configure the auto add options for a podcast. */
-"auto_add" = "Auto Add To";
-
-/* Option in the auto add dialog to add the items to the bottom of the queue. */
-"auto_add_to_bottom" = "To Bottom";
-
-/* Option in the auto add dialog to add the items to the top of the queue. */
-"auto_add_to_top" = "To Top";
-
-/* Option in the auto add settings to stop adding options once the limit is reached. This option will add the podcast to the top top the queue and drop the bottom. */
-"auto_add_to_up_next_top_only" = "Only Add To Top";
-
-/* Option in the auto add settings to stop adding options once the limit is reached. This option will add the podcast to the top top the queue and drop the bottom. To conserve space this shouldn't be longer than the English string. If needed "Add To Top" or "To Top" can be translated instead */
-"auto_add_to_up_next_top_only_short" = "Only Add To Top";
-
-/* Option in the auto add settings to stop adding options once the limit is reached. This option won't add new episodes. */
-"auto_add_to_up_next_stop" = "Stop Adding New Episodes";
-
-/* Option in the auto add settings to stop adding options once the limit is reached. This option won't add new episodes. To conserve space this should be a more concise version of 'Stop Adding New Episodes' */
-"auto_add_to_up_next_stop_short" = "Stop Adding";
-
-/* Title for the dialog box that presents the available options for how many episodes for auto download from a filter. */
-"auto_download_first" = "Auto Download First";
-
-/* Subtitle for the auto download setting. This is displayed when the option is turned off. */
-"auto_download_off_subtitle" = "Enable to auto download episodes in this filter";
-
-/* Subtitle for the auto download setting. This is displayed when the option is turned on. '%1$@' is a placeholder for the number of episodes, this will be more than one. */
-"auto_download_on_plural_format" = "The first %1$@ episodes in this filter will be automatically downloaded";
-
-/* Provides hint text to auto download the a the first of a configurable amount of episodes. Accompanied by a label indicating how many episodes will be auto downloaded. */
-"auto_download_prompt_first" = "First";
-
-/* A common string used throughout the app. Title for the back button. Used with the accessibility settings. */
-"back" = "Back";
-
-/* A common string used throughout the app. Title option to place the item at the bottom of the queue. */
-"bottom" = "Bottom";
-
-/* A common string used throughout the app. Informs the user of the maximum amount of bulk downloads. '%1$@' is a placeholder for maximum amount of bulk downloads. */
-"bulk_download_max_format" = "Bulk downloads are limited to %1$@.";
-
-/* A common string used throughout the app. Prompt to cancel the current flow. */
-"cancel" = "Cancel";
-
-/* An activity message indicating that the process to cancel is running. */
-"canceling" = "Canceling...";
-
-/* A common string used throughout the app. Prompt to cancel the download for the selected item(s). */
-"cancel_download" = "Cancel Download";
-
-/* Message title indicating that the cancel process has failed. */
-"cancel_failed" = "Unable To Cancel";
-
-/* Prompt to allow the user to cancel their Pocket Casts Plus subscription. */
-"cancel_subscription" = "Cancel Subscription";
-
-/* CarPlay subtitle information label that includes the current chapter and total chapter count and the current chapter length. '%1$@' is a placeholder for the current chapter. '%2$@' is a placeholder for the total chapters. '%3$@' is a placeholder for the length of the current chapter. */
-"carplay_chapter_count" = "%1$@ of %2$@. %3$@";
-
-/* Provides a link to the menu to present more options. */
-"carplay_more" = "More";
-
-/* CarPlay option to modify the playback speed. */
-"carplay_playback_speed" = "Playback Speed";
-
-/* CarPlay prompt to navigate to the up next Queue. */
-"carplay_up_next_queue" = "Up Next Queue";
-
-/* Prompt to allow the user to update their email address. */
-"change_email" = "Change Email Address";
-
-/* Confirmation message title informing the user that their email has been successfully updated. */
-"change_email_conf" = "Email Address Changed";
-
-/* Prompt to allow the user to Update their password. */
-"change_password" = "Change Password";
-
-/* Confirmation message title informing the user that their password has been successfully updated. */
-"change_password_conf" = "Password Changed";
-
-/* Error message informing the user that the change password process failed. */
-"change_password_error" = "Unable to change password. Invalid password.";
-
-/* Error message informing the user that the change password process failed because they failed to enter matching passwords. */
-"change_password_error_mismatch" = "Passwords do not match";
-
-/* Error message informing the user that they need to choose a longer password. */
-"change_password_length_error" = "Must be at least 6 characters";
-
-/* A common string used throughout the app. Often refers to the Chapters list or Chapters tab in the player. */
-"chapters" = "Chapters";
-
-/* A common string used throughout the app. Informs the user how many podcasts have been chosen. '%1$@' is a placeholder for the number of podcasts, this will be more than one. */
-"chosen_podcasts_plural_format" = "%1$@ Podcasts Chosen";
-
-/* A common string used throughout the app. Informs the user how many podcasts have been chosen. This is the singular format for an accompanying plural option. */
-"chosen_podcasts_singular" = "1 Podcast Chosen";
-
-/* Title for the screen that provides the list of available ChromeCast devices. */
-"chromecast_cast_to" = "Cast to";
-
-/* Informs the user that ChromeCast has connected. */
-"chromecast_connected" = "Connected";
-
-/* Informs the user that ChromeCast has connected to the device. Used as a title when no episode is playing. */
-"chromecast_connected_to_device" = "Connected to device";
-
-/* Error message informing the user that the app is unable to Cast local files in ChromeCast. */
-"chromecast_error" = "Unable to cast local file";
-
-/* Informs the user that ChromeCast has connected to the device but no episode is playing. */
-"chromecast_nothing_playing" = "Nothing is playing";
-
-/* Placeholder name for when ChromeCast doesn't have a device name. */
-"chromecast_unnamed_device" = "Un-named device";
-
-/* A common string used throughout the app. Prompt to perform a clean up operation on the selected items. */
-"clean_up" = "Clean Up";
-
-/* A common string used throughout the app. Prompt to clear the up next queue. */
-"clear" = "Clear";
-
-/* A common string used throughout the app. Prompt to clear the up next queue. */
-"clear_up_next" = "Clear Up Next";
-
-/* A common string used throughout the app. Message to clear the up next queue. */
-"clear_up_next_message" = "Are you sure you want to clear your Up Next queue?";
-
-/* A common string used throughout the app. Prompt to close the current screen. */
-"close" = "Close";
-
-/* A common string used throughout the app. Generic confirmation */
-"confirm" = "Confirm";
-
-/* A common string used throughout the app. A prompt to move to the next step of a flow. */
-"continue" = "Continue";
-
-/* Prompt to open the create account options. */
-"create_account" = "Create Account";
-
-/* Error title shown when Pocket Casts can't connect to the App Store to retrieve in app purchase details */
-"create_account_app_store_error_title" = "Unable to contact App Store";
-
-/* Error message shown when Pocket Casts can't connect to the App Store to retrieve in app purchase details */
-"create_account_app_store_error_message" = "Pocket Casts is having trouble connecting to the App Store. Please check your connection and try again.";
-
-/* Price shown for the free tier. "Free" in this case meaning the cost is free */
-"create_account_free_price" = "Free";
-
-/* Account type shown on the select account page. Regular as in the normal or default option */
-"create_account_free_account_type" = "Regular";
-
-/* Shown under the create account type to indicate what you get with a free Pocket Casts account */
-"create_account_free_details" = "Almost everything";
-
-/* Shown under the create account type to indicate what you get in Pocket Casts Plus */
-"create_account_plus_details" = "Everything unlocked";
-
-/* Button title to find out more about Pocket Casts Plus. Note that "Pocket Casts Plus" shouldn't be translated as it's a product name */
-"create_account_find_out_more_plus" = "Find out more about Pocket Casts Plus";
-
-/* Title for the screen where a user starts creating a filter */
-"create_filter" = "Create Filter";
-
-/* An indicator that the current episode is a user generated episode */
-"custom_episode" = "Custom Episode";
-
-/* Prompt to cancel an active upload of a file. */
-"custom_episode_cancel_upload" = "Cancel Upload";
-
-/* Prompt to delete an uploaded file from the cloud. */
-"custom_episode_remove_upload" = "Remove from Cloud";
-
-/* Prompt to upload a file to the cloud. */
-"custom_episode_upload" = "Upload to Cloud";
-
-/* A common string used throughout the app. Prompt to delete the selected item(s). */
-"delete" = "Delete";
-
-/* A prompt to delete the downloaded file */
-"delete_download" = "Delete Download";
-
-/* Prompt to delete the selected item(s) from the device storage and the cloud. */
-"delete_everywhere" = "Delete From Everywhere";
-
-/* Prompt to delete the selected item(s) from the device storage and the cloud. */
-"delete_everywhere_short" = "Delete Everywhere";
-
-/* A common string used throughout the app. Title portion of the prompt to delete the selected file. */
-"delete_file" = "Delete File";
-
-/* A common string used throughout the app. Message portion of the prompt to delete the selected file. */
-"delete_file_message" = "Are you sure you want to delete this file?";
-
-/* A common string used throughout the app. Prompt to delete the selected item(s) from the cloud storage. */
-"delete_from_cloud" = "Delete From Cloud";
-
-/* A common string used throughout the app. Prompt to delete the selected item(s) from the device storage. */
-"delete_from_device" = "Delete From Device";
-
-/* A common string used throughout the app. Prompt to delete the selected item(s) from the device storage. 'Only' is used to emphasize that the item is also stored in the cloud and that file won't be deleted. */
-"delete_from_device_only" = "Delete From Device Only";
-
-/* A common string used throughout the app. Prompt to deselect all items in the presented list. */
-"deselect_all" = "Deselect All";
-
-/* A common string used throughout the app. Refers to the Discover tab. */
-"discover" = "Discover";
-
-/* Title for the section that allows the user to explore different podcast categories. */
-"discover_browse_by_category" = "Browse By Category";
-
-/* Title for the podcast category Arts */
-"discover_browse_by_category_art" = "Arts";
-
-/* Title for the podcast category Business */
-"discover_browse_by_category_business" = "Business";
-
-/* Title for the podcast category Comedy */
-"discover_browse_by_category_comedy" = "Comedy";
-
-/* Title for the podcast category Education */
-"discover_browse_by_category_education" = "Education";
-
-/* Title for the podcast category Fiction */
-"discover_browse_by_category_fiction" = "Fiction";
-
-/* Title for the podcast category Games & Hobbies */
-"discover_browse_by_category_games_and_hobbies" = "Games & Hobbies";
-
-/* Title for the podcast category Government */
-"discover_browse_by_category_government" = "Government";
-
-/* Title for the podcast category Government & Organizations */
-"discover_browse_by_category_government_and_organizations" = "Government & Organizations";
-
-/* Title for the podcast category History */
-"discover_browse_by_category_history" = "History";
-
-/* Title for the podcast category Health */
-"discover_browse_by_category_health" = "Health";
-
-/* Title for the podcast category Health & Fitness */
-"discover_browse_by_category_health_and_fitness" = "Health & Fitness";
-
-/* Title for the podcast category Kids & Family */
-"discover_browse_by_category_kids_and_family" = "Kids & Family";
-
-/* Title for the podcast category Leisure */
-"discover_browse_by_category_leisure" = "Leisure";
-
-/* Title for the podcast category Music */
-"discover_browse_by_category_music" = "Music";
-
-/* Title for the podcast category News */
-"discover_browse_by_category_news" = "News";
-
-/* Title for the podcast category News & Politics */
-"discover_browse_by_category_news_and_politics" = "News & Politics";
-
-/* Title for the podcast category Religion & Spirituality */
-"discover_browse_by_category_religion_and_spirituality" = "Religion & Spirituality";
-
-/* Title for the podcast category Science */
-"discover_browse_by_category_science" = "Science";
-
-/* Title for the podcast category Science & Medicine */
-"discover_browse_by_category_science_and_medicine" = "Science & Medicine";
-
-/* Title for the podcast category Society */
-"discover_browse_by_category_society" = "Society";
-
-/* Title for the podcast category Society & Culture */
-"discover_browse_by_category_society_and_culture" = "Society & Culture";
-
-/* Title for the podcast category Sports */
-"discover_browse_by_category_sports" = "Sports";
-
-/* Title for the podcast category Sports & Recreation */
-"discover_browse_by_category_sports_and_recreation" = "Sports & Recreation";
-
-/* Title for the podcast category Technology */
-"discover_browse_by_category_technology" = "Technology";
-
-/* Title for the podcast category True Crime */
-"discover_browse_by_category_true_crime" = "True Crime";
-
-/* Title for the podcast category TV & Film */
-"discover_browse_by_category_tv_and_film" = "TV & Film";
-
-/* Prompt to allow the user to manually change the regional information for the Discover tab. '%1$@' is a placeholder for the current region. */
-"discover_change_region" = "Change Region, currently %1$@";
-
-/* Badge used to mark featured podcasts. */
-"discover_featured" = "Featured";
-
-/* Informative label letting the users know that the displayed episode is a featured episode. */
-"discover_featured_episode" = "FEATURED EPISODE";
-
-/* Error message informing the user that the episode they tapped could not be found, with instructions on how to fix the issue. */
-"discover_featured_episode_error_not_found" = "Featured podcast or episode not found. Make sure you are connected to the internet and try again.";
-
-/* Informative label letting the users know that the displayed podcast is a featured new podcast. */
-"discover_fresh_pick" = "FRESH PICK";
-
-/* Informational title when the search succeeds but returns no results. */
-"discover_no_podcasts_found" = "No podcasts found";
-
-/* Informational title when the search succeeds but returns no results. */
-"discover_no_podcasts_found_msg" = "Try more general or different keywords.";
-
-/* Display title for calling out a podcast network on the discover tab. '%1$@' is a placeholder for the podcast's network title. */
-"discover_podcast_network" = "%1$@ Network";
-
-/* Title used for promotional purposes to highlight podcasts that are popular worldwide. */
-"discover_popular" = "Popular";
-
-/* Title used for promotional purposes to highlight podcasts that are popular in a specific region. '%1$@' is a placeholder for the region's name. */
-"discover_popular_in" = "Popular in %1$@";
-
-/* Button prompt on the discover page to play the featured episode. */
-"discover_play_episode" = "Play Episode";
-
-/* Button prompt on the discover page to play the trailer of a featured episode. */
-"discover_play_trailer" = "Play Trailer";
-
-/* Region name for Australia used in the Discover Section */
-"discover_region_australia" = "Australia";
-
-/* Region name for Austria used in the Discover Section */
-"discover_region_austria" = "Austria";
-
-/* Region name for Belgium used in the Discover Section */
-"discover_region_belgium" = "Belgium";
-
-/* Region name for Brazil used in the Discover Section */
-"discover_region_brazil" = "Brazil";
-
-/* Region name for Canada used in the Discover Section */
-"discover_region_canada" = "Canada";
-
-/* Region name for China used in the Discover Section */
-"discover_region_china" = "China";
-
-/* Region name for Czechia used in the Discover Section */
-"discover_region_czechia" = "Czechia";
-
-/* Region name for Denmark used in the Discover Section */
-"discover_region_denmark" = "Denmark";
-
-/* Region name for Finland used in the Discover Section */
-"discover_region_finland" = "Finland";
-
-/* Region name for France used in the Discover Section */
-"discover_region_france" = "France";
-
-/* Region name for Germany used in the Discover Section */
-"discover_region_germany" = "Germany";
-
-/* Region name for Hong Kong used in the Discover Section */
-"discover_region_hong_kong" = "Hong Kong";
-
-/* Region name for India used in the Discover Section */
-"discover_region_india" = "India";
-
-/* Region name for Ireland used in the Discover Section */
-"discover_region_ireland" = "Ireland";
-
-/* Region name for Israel used in the Discover Section */
-"discover_region_israel" = "Israel";
-
-/* Region name for Italy used in the Discover Section */
-"discover_region_italy" = "Italy";
-
-/* Region name for Japan used in the Discover Section */
-"discover_region_japan" = "Japan";
-
-/* Region name for Mexico used in the Discover Section */
-"discover_region_mexico" = "Mexico";
-
-/* Region name for Netherlands used in the Discover Section */
-"discover_region_netherlands" = "Netherlands";
-
-/* Region name for New Zealand used in the Discover Section */
-"discover_region_new_zealand" = "New Zealand";
-
-/* Region name for Norway used in the Discover Section */
-"discover_region_norway" = "Norway";
-
-/* Region name for Philippines used in the Discover Section */
-"discover_region_philippines" = "Philippines";
-
-/* Region name for Poland used in the Discover Section */
-"discover_region_poland" = "Poland";
-
-/* Region name for Portugal used in the Discover Section */
-"discover_region_portugal" = "Portugal";
-
-/* Region name for Russia used in the Discover Section */
-"discover_region_russia" = "Russia";
-
-/* Region name for Saudi Arabia used in the Discover Section */
-"discover_region_saudi_arabia" = "Saudi Arabia";
-
-/* Region name for Singapore used in the Discover Section */
-"discover_region_singapore" = "Singapore";
-
-/* Region name for South Africa used in the Discover Section */
-"discover_region_south_africa" = "South Africa";
-
-/* Region name for South Korea used in the Discover Section */
-"discover_region_south_korea" = "South Korea";
-
-/* Region name for Spain used in the Discover Section */
-"discover_region_spain" = "Spain";
-
-/* Region name for Sweden used in the Discover Section */
-"discover_region_sweden" = "Sweden";
-
-/* Region name for Switzerland used in the Discover Section */
-"discover_region_switzerland" = "Switzerland";
-
-/* Region name for Taiwan used in the Discover Section */
-"discover_region_taiwan" = "Taiwan";
-
-/* Region name for Turkey used in the Discover Section */
-"discover_region_turkey" = "Turkey";
-
-/* Region name for Ukraine used in the Discover Section */
-"discover_region_ukraine" = "Ukraine";
-
-/* Region name for United Kingdom used in the Discover Section */
-"discover_region_united_kingdom" = "United Kingdom";
-
-/* Region name for United States used in the Discover Section */
-"discover_region_united_states" = "United States";
-
-/* Region name used in the Discover Section for a genreic global setting instead of a specific region. */
-"discover_region_worldwide" = "Worldwide";
-
-/* Error message when a user performs a search using a search term that's too short. */
-"discover_search_error_msg" = "Please enter at least 2 characters.";
-
-/* Error title when a user performs a search using a search term that's too short. */
-"discover_search_error_title" = "Length Challenged";
-
-/* Informational title informing the users that the search has failed. */
-"discover_search_failed" = "Search Failed";
-
-/* Informational message suggesting that the user checks their internet connection when an error occurs. */
-"discover_search_failed_msg" = "Check your Internet connection.";
-
-/* Screen title to allow the user to manually change the regional information for the Discover tab. This screen shows the available options. */
-"discover_select_region" = "Select Content Region";
-
-/* Button prompt used on the Discover Tab. Opens the linked list to show all podcasts in the section. */
-"discover_show_all" = "SHOW ALL";
-
-/* Informative label letting the users know that the displayed podcast is a paid placement ad. */
-"discover_sponsored" = "SPONSORED";
-
-/* Title used for promotional purposes to highlight trending podcasts. */
-"discover_trending" = "Trending";
-
-/* A common string used throughout the app. Confirmation text. */
-"done" = "Done";
-
-/* A common string used throughout the app. Prompt to download the selected item(s). */
-"download" = "Download";
-
-/* A common string used throughout the app. Prompt to download all of the selected item(s). */
-"download_all" = "Download All";
-
-/* A common string used throughout the app. Prompt to warn the user that continuing with the download will consume data. Used in tandem with a notice that the user is not on WiFi. */
-"download_data_warning" = "Downloading will use data.";
-
-/* A common string used throughout the app. Prompts the user that they have selected multiple episodes to download. '%1$@' is a placeholder for the count of the selected items, will be more than one. */
-"download_episode_plural_format" = "Download %1$@ Episodes";
-
-/* A common string used throughout the app. Prompts the user that they have selected one episode to download. */
-"download_episode_singular" = "Download 1 Episode";
-
-/* The episode failed to download due to an issue with the feed. Suggesting the user reaches out to the Podcast Author. */
-"download_error_contact_author" = "Episode not available due to an error in the podcast feed. Contact the podcast author.";
-
-/* The episode failed to download due to an issue with the feed. Suggesting the user reaches out to the Podcast Author. */
-"download_error_contact_author_version_2" = "This episode may have been moved or deleted. Contact the podcast author.";
-
-/* The episode failed to download due to the user running out of storage space. */
-"download_error_not_enough_space" = "Unable to save episode, have you run out of space?";
-
-/* The episode failed to download because the file wasn't available on the server */
-"download_error_not_uploaded" = "File not uploaded, unable to play";
-
-/* The episode failed to download due to an issue with the feed. Suggesting the user reaches out to the Podcast Author. '%1$@' is a placeholder for the status code that the app received. */
-"download_error_status_code" = "Download failed, error code %1$@. Contact the podcast author.";
-
-/* The episode failed to download but the app wasn't able to determine why. Suggesting to try again after waiting for a bit. */
-"download_error_try_again" = "Unable to download episode. Please try again later.";
-
-/* A common string used throughout the app. Informs the user the download has failed. */
-"download_failed" = "Download Failed";
-
-/* A common string used throughout the app. Title for screens and prompts related to storage and downloaded files. */
-"downloaded_files" = "Downloaded Files";
-
-/* Message for an unsubscribe message box that informs the user that unsubscribing will remove downloaded files. */
-"downloaded_files_conf_message" = "Unsubscribing will delete all downloaded files in this Podcast, are you sure?";
-
-/* Title for an unsubscribe message box that informs the user that unsubscribing will remove downloaded files. Informs the user how many files have been downloaded. '%1$@' is a placeholder for the number of downloaded files, will be more than one. */
-"downloaded_files_conf_plural_format" = "%1$@ Downloaded Files";
-
-/* Title for an unsubscribe message box that informs the user that unsubscribing will remove downloaded files. Informs the user one file has been downloaded. Singular version of an accompanying plural message. */
-"downloaded_files_conf_singular" = "1 Downloaded File";
-
-/* Confirmation message when you choose to delete a set of downloaded files */
-"downloaded_files_cleanup_confirmation" = "Are you sure you want to delete these downloaded files?";
-
-/* A common string used throughout the app. Often refers to the Downloads screen. */
-"downloads" = "Downloads";
-
-/* Prompt to navigate the user to the Auto Downloads settings menu. */
-"downloads_auto_download" = "Auto Download Settings";
-
-/* Title for the empty state when there are no downloads available */
-"downloads_no_downloads_title" = "No Downloaded Episodes";
-
-/* The description for the empty state when there are no downloads available */
-"downloads_no_downloads_desc" = "Oh no! You’re fresh out of downloads. Download some more and they’ll show up here.";
-
-/* Prompt to allow the user to retry failed downloads. */
-"downloads_retry_failed_downloads" = "Retry Failed Downloads";
-
-/* Prompt to allow the user to stop active downloads. */
-"downloads_stop_all_downloads" = "Stop All Downloads";
-
-/* Refers to an Episode in the singular form. */
-"episode" = "Episode";
-
-/* A common string used throughout the app. Display configurable options related to a number of episodes. '%1$@' is a placeholder for the number of episodes, the value will be more than one. */
-"episode_count_plural_format" = "%1$@ episodes";
-
-/* Message shown when you have no episodes in an episode filter */
-"episode_filter_no_episodes_msg" = "Either it's time to celebrate completing this list, or edit your filter settings to get some more.";
-
-/* Title shown when you have no episodes in an episode filter */
-"episode_filter_no_episodes_title" = "No Episodes";
-
-/* Label for adding duration filtering to an episode filter, eg: filter by the duration of an episode */
-"episode_filter_by_duration_label" = "Filter by duration";
-
-/* Episode indicator that the current episode is a bonus episode. */
-"episode_indicator_bonus" = "Bonus";
-
-/* Episode indicator that the current episode is a trailer for an upcoming season of the podcast. '%1$@' is a placeholder for the season number. */
-"episode_indicator_season_trailer" = "Season %1$@ Trailer";
-
-/* Episode indicator that the current episode is a trailer. */
-"episode_indicator_trailer" = "Trailer";
-
-/* Shorthand format used to show the Episode number of a podcast. '%1$@' is a placeholder for the episode number. */
-"episode_shorthand_format" = "EPISODE %1$@";
-
-/* Shorthand format used to show the Episode number of a podcast. 'EP' is short for Episode. '%1$@' is a placeholder for the episode number. */
-"episode_shorthand_format_short" = "EP %1$@";
-
-/* A common string used throughout the app. Generic title informing the user of an Error. Accompanied with an error message. */
-"error" = "Error";
-
-/* A common string used throughout the app. Generic title informing the user of an Error. General error message used when the app is unable to locate the podcast that was selected. This usually comes from a sharing or import feature. */
-"error_general_podcast_not_found" = "Unable to find podcast. Please contact the podcast author.";
-
-/* Describes how the process to export podcasts from Pocket Casts works. */
-"export_podcasts_description" = "Exports all your podcasts as an OPML file, which you can import into other podcast apps.";
-
-/* Title for the button that allows the user to export podcasts from Pocket Casts */
-"export_podcasts_option" = "Export Podcasts";
-
-/* Title for the section that provides information on how to export podcasts from Pocket Casts */
-"export_podcasts_title" = "EXPORT";
-
-/* Indicator during the new feature tour serves as a prompt to end the tour. */
-"feature_tour_end_tour" = "End Tour";
-
-/* Indicator during the new feature tour. Used as a navigation indicator when the tour is on the first step. This is replaced with 'position of total' as the user progresses. */
-"feature_tour_new" = "NEW";
-
-/* Indicator during the new feature tour. Used as a navigation indicator as the user progresses through the tour. '%1$@' is a placeholder for the current position. '%2$@' is a placeholder for the total number of steps. */
-"feature_tour_step_format" = "%1$@ of %2$@";
-
-/* Option to continue with a Third-Party Mail app when the default Apple mail app isn't available. */
-"feedback_continue_with_mail" = "Open Default Mail App";
-
-/* Error message for when the user has a mail app configured that's not the default mail app. */
-"feedback_mail_not_configured_msg" = "To send a debug attachment, the Apple Mail app has to be configured on your phone. What would you like to do?";
-
-/* Error title for when the user has a mail app configured that's not the default mail app. */
-"feedback_mail_not_configured_title" = "Mail Not Configured";
-
-/* Title for the file upload settings screen. This is used when a user is uploading a new file. */
-"file_upload_add_file" = "Add File";
-
-/* Prompt to add a custom image to the uploaded file. */
-"file_upload_add_image" = "Add Custom Image";
-
-/* Title for the dialog that allows the user to pick the image source for selecting a custom image. either Camera or Photo Library. */
-"file_upload_choose_image" = "Choose Image";
-
-/* Option for selecting the image source for an uploaded image. */
-"file_upload_choose_image_camera" = "Camera";
-
-/* Option for selecting the image source for an uploaded image. */
-"file_upload_choose_image_photo_Library" = "Photo Library";
-
-/* Title for the file upload settings screen. This is used when a user is editing an uploaded file. */
-"file_upload_edit_file" = "Edit File";
-
-/* Error message displayed when the user has used all of their storage space. */
-"file_upload_error" = "Not enough space to upload this file.";
-
-/* Subtitle for the error message displayed when the user has used all of their storage space. Instructs the user to try freeing up space. */
-"file_upload_error_subtitle" = "Remove some files and try again.";
-
-/* Prompt indicating that the user needs to name the file in order to upload it. */
-"file_upload_name_required" = "Name required";
-
-/* The description for the screen when there are no files currently uploaded. '\n' is a line break format to allow a clean wrapping of text */
-"file_upload_no_files_description" = "Want to listen to your own files?\nShare them with Pocket Casts, and they’ll appear here";
-
-/* The helper link describing how to add files to Pocket Casts. */
-"file_upload_no_files_helper" = "How do I do that?";
-
-/* Title for the screen when there are no files currently uploaded */
-"file_upload_no_files_title" = "No Files";
-
-/* Prompt to remove the image from the uploaded file. */
-"file_upload_remove_image" = "Remove Image";
-
-/* Prompt to save the changes to an edited file. */
-"file_upload_save" = "Save";
-
-/* Error message displayed when the user has attempted to upload an unsupported file type. */
-"file_upload_support_error" = "This file type is not supported";
-
-/* A common string used throughout the app. Refers to the Files settings menu */
-"files" = "Files";
-
-/* Prompt to open a menu to allow sorting of manually added files. */
-"files_sort" = "Sort Files";
-
-/* Title for the screen that details how to add a file to Pocket Casts. */
-"files_how_to_title" = "How to save a file";
-
-/* Subtitle informing the user that new podcasts will be automatically added to this filter. */
-"filter_auto_add_subtitle" = "New podcasts you subscribe to will be automatically added";
-
-/* Title for the filter option that indicates all podcasts will be included. */
-"filter_chips_all_podcasts" = "All Your Podcasts";
-
-/* Title for the filter option that that opens the episode duration options. */
-"filter_chips_duration" = "Duration";
-
-/* Filter option to select podcasts that will be included in the filter. */
-"filter_choose_podcasts" = "Choose Podcasts";
-
-/* Used on the screen to create a new filter. Provides a prompt to continue refining the filter selections. */
-"filter_create_add_more" = "Add more criteria to finish refining your filter.";
-
-/* Used on the screen to create a new filter. The section header for the list of options to use with the filter. */
-"filter_create_filter_by" = "FILTER BY";
-
-/* Used on the screen to create a new filter. Provides instructions on how to set up a new filter. */
-"filter_create_instructions" = "Select your filter criteria using these buttons to create an up to date smart playlist of episodes.";
-
-/* Used on the screen to create a new filter. Title for the state where their selection doesn't include any content. */
-"filter_create_no_episodes" = "No Matching Episodes";
-
-/* Used on the screen to create a new filter. The description about why the list of filtered episodes is empty. */
-"filter_create_no_episodes_description_explanation" = "The criteria you selected doesn’t match any current episodes in your subscriptions";
-
-/* Used on the screen to create a new filter. The prompt about what they can do in order to make sure their filter returns results. */
-"filter_create_no_episodes_description_prompt" = "Choose different criteria, or save this filter if you think it will match episodes in the future.";
-
-/* Used on the screen to create a new filter. The section that shows a preview of waht podcast episodes will be included in the filter. */
-"filter_create_preview" = "PREVIEW";
-
-/* Used on the screen to create a new filter. Title for the toggle to include all podcasts in the filter. */
-"filter_create_podcasts_all_podcasts" = "All Podcasts";
-
-/* Used on the screen to create a new filter. Title for the button to save the filter. */
-"filter_create_save" = "Save Filter";
-
-/* Title for the screen where a user can set the initial details for a new filter. */
-"filter_details" = "Filter Details";
-
-/* Hint text above the sections for the user to select the filter color and icon. */
-"filter_details_color_icon" = "COLOUR & ICON";
-
-/* Accessibility hint text for color selection on filters. */
-"filter_details_color_selection" = "Colour Selector";
-
-/* Accessibility hint text for icon selection on filters. */
-"filter_details_icon_selection" = "Icon Selector";
-
-/* Hint text above the dialog box to enter the filter's name. */
-"filter_details_name" = "NAME";
-
-/* Title for filter options related to Download Status. */
-"filter_download_status" = "Download Status";
-
-/* Title for filter sections that relate to episode status. */
-"filter_episode_status" = "Episode Status";
-
-/* Subtitle informing the user that new podcasts will not be automatically added to this filter. */
-"filter_manual_add_subtitle" = "New podcasts you subscribe to will not be automatically added";
-
-/* Title for filter options related to media type settings. */
-"filter_media_type" = "Media Type";
-
-/* Media Type filter option for audio media types. */
-"filter_media_type_audio" = "Audio";
-
-/* Media Type filter option for video media types. */
-"filter_media_type_video" = "Video";
-
-/* Screen title for the filter options for configuring filter settings related to episode duration. */
-"filter_option_episode_duration" = "Episode Duration";
-
-/* Label for the longer than duration filter time */
-"filter_longer_than_label" = "Longer than";
-
-/* Label for the shorter than duration filter time */
-"filter_shorter_than_label" = "Shorter than";
-
-/* Error message for when the user attempts to set a filter where the minimal duration is higher than the max duration. Meant to be a fun/funny message. '%1$@' and '%2$@' are placeholders for the configured minimum and maximum times, respectively. */
-"filter_option_episode_duration_error_msg_format" = "Filtering for episodes longer than %1$@ but shorter than %2$@ would cause a rift in our space time continuum. Sorry.";
-
-/* Error title for when the user attempts to set a filter where the minimal duration is higher than the max duration. Meant to be a fun/funny message. */
-"filter_option_episode_duration_error_title" = "Yes, But No";
-
-/* Menu prompt to open the Filter options. Also used for the title of the filter options screen. */
-"filter_options" = "Filter Options";
-
-/* Title for filter options related to release date settings. */
-"filter_release_date" = "Release Date";
-
-/* Release Date filter option for any release date. */
-"filter_release_date_anytime" = "Any time";
-
-/* Release Date filter option for episodes with a release date with in the last day. */
-"filter_release_date_last_24_hours" = "Last 24 hours";
-
-/* Release Date filter option for episodes with a release date with in the last 2 weeks. */
-"filter_release_date_last_2_weeks" = "Last 2 weeks";
-
-/* Release Date filter option for episodes with a release date with in the last three day. */
-"filter_release_date_last_3_days" = "Last 3 days";
-
-/* Release Date filter option for episodes with a release date with in the last month. */
-"filter_release_date_last_month" = "Last month";
-
-/* Release Date filter option for episodes with a release date with in the last week. */
-"filter_release_date_last_week" = "Last week";
-
-/* Prompt to save the changes to an existing filter. */
-"filter_update" = "Update Filter";
-
-/* A common string used throughout the app. Filter option for the default setting on multiple filters. */
-"filter_value_all" = "All";
-
-/* A common string used throughout the app. Often refers to the Filters screen. */
-"filters" = "Filters";
-
-/* Button title for adding a new filter. */
-"filters_new_filter_button" = "+ New Filter";
-
-/* A placeholder title for a newly created filter. */
-"filters_default_new_filter" = "New Filter";
-
-/* The title for the auto generated 'New Release' filter. */
-"filters_default_new_releases" = "New Releases";
-
-/* Funny confirmation message accompanying several descriptive dialogs */
-"funny_conf_msg" = "It really matches your eyes ✨";
-
-/* The default value when the user has listened for under one minute. */
-"funny_time_not_enough" = "You really don't listen much, do you?";
-
-/* A funny time unit used in stats comparing the listening time to the number of times an airplane has taken off. '%1$@' is a placeholder for the amount of time listened compared to the stat. */
-"funny_time_unit_airplane_takeoffs" = "During which time %1$@ planes took off. Please fasten your seatbelt. 🛫";
-
-/* A funny time unit used in stats comparing the listening time to the number of times an astronaut has sneezed. '%1$@' is a placeholder for the amount of time listened compared to the stat. */
-"funny_time_unit_astronaut_sneezes" = "During which time an astronaut sneezed %1$@ times. Achoo! 😤";
-
-/* A funny time unit used in stats comparing the listening time to the number of times you could have traveled around the world. '%1$@' is a placeholder for the amount of time listened compared to the stat. */
-"funny_time_unit_balloon_travel" = "During which time you could have gone around the world %1$@ times in an air balloon. 🌏";
-
-/* A funny time unit used in stats comparing the listening time to the number of births that have happened. '%1$@' is a placeholder for the amount of time listened compared to the stat. */
-"funny_time_unit_births" = "During which time %1$@ babies were born. Wahhh! 🍼";
-
-/* A funny time unit used in stats comparing the listening time to the number of times you've blinked. '%1$@' is a placeholder for the amount of time listened compared to the stat. */
-"funny_time_unit_blinks" = "During which time you blinked %1$@ times. Heyooo! 👀";
-
-/* A funny time unit used in stats comparing the listening time to the number of emails that have been sent. '%1$@' is a placeholder for the amount of time listened compared to the stat. */
-"funny_time_unit_emails" = "During which time %1$@ emails were sent. 💌";
-
-/* A funny time unit used in stats comparing the listening time to the number of times you farted. '%1$@' is a placeholder for the amount of time listened compared to the stat. */
-"funny_time_unit_farts" = "During which time you released %1$@ oz of air biscuits. Gross! 💨";
-
-/* A funny time unit used in stats comparing the listening time to the number of times a Google search was performed. '%1$@' is a placeholder for the amount of time listened compared to the stat. */
-"funny_time_unit_google" = "During which time %1$@ Google searches were performed. Bazinga. 🔎";
-
-/* A funny time unit used in stats comparing the listening time to the number of times lightning has struck. '%1$@' is a placeholder for the amount of time listened compared to the stat. */
-"funny_time_unit_lightning" = "During which time lightning struck %1$@ times. Boom. ⚡️";
-
-/* A funny time unit used in stats comparing the listening time to the number of phones that have been produced. '%1$@' is a placeholder for the amount of time listened compared to the stat. */
-"funny_time_unit_phone_production" = "During which time a certain fruit vendor made $%1$@ 🍏";
-
-/* A funny time unit used in stats comparing the listening time to the amount of skin cells you've shed. '%1$@' is a placeholder for the amount of time listened compared to the stat. */
-"funny_time_unit_shed_skin" = "During which time you shed %1$@ skin cells. Ew? 😅";
-
-/* A funny time unit used in stats comparing the listening time to the number of times you tied your shoes. '%1$@' is a placeholder for the amount of time listened compared to the stat. */
-"funny_time_unit_tied_shoes" = "During which time you could have tied %1$@ shoe laces. Maybe. 👟";
-
-/* A funny time unit used in stats comparing the listening time to the number of tweets that have been sent. '%1$@' is a placeholder for the amount of time listened compared to the stat. */
-"funny_time_unit_tweets" = "During which time %1$@ tweets were tooted. Toot! Toot! 🐣";
-
-/* A common string used throughout the app. Title for the prompt to navigate the user to the podcast associated to the selected item. */
-"go_to_podcast" = "Go to Podcast";
-
-/* A common string used throughout the app. Title accompanying the group option setting. */
-"group_episodes" = "Group Episodes";
-
-/* Prompt to clear the full listening history for the user. */
-"history_clear_all" = "Clear All";
-
-/* Title for the details prompt to confirm the user wants to clear their listening history. */
-"history_clear_all_details" = "Clear Listening History";
-
-/* Message for the details prompt to confirm the user wants to clear their listening history. */
-"history_clear_all_details_msg" = "This action cannot be undone.";
-
-/* Time format to display a set number of hours. '%1$@' is a placeholder for a number of hours, this value will be more than one. */
-"hours_plural_format" = "%1$@ hours";
-
-/* The initial informational text explaining how to upload a file */
-"how_to_upload_explanation" = "First, open an app that has the audio files you'd like to save";
-
-/* The title for the first instructional image that explains how to upload a file */
-"how_to_upload_first_instruction" = "Choose to share that file";
-
-/* The title for the second instructional image that explains how to upload a file */
-"how_to_upload_second_instruction" = "In the menu tap \"Copy to Pocket Casts\"";
-
-/* The summary text at the end of the screen explaining how to upload a file */
-"how_to_upload_summary" = "That's it, you're done. Change any details you want, hit save and play!";
-
-/* Describes the process about how to import podcasts to Pocket Casts. '\\n\\n' Is a line break format to separate the description from the following note. */
-"import_podcasts_description" = "You can import your podcasts subscriptions to Pocket Casts using the widely supported OPML format. Export the file from another app and choose open in Pocket Casts.\n\nNote: You may need to email the OPML file to yourself, long press on the attachment and select Pocket Casts.";
-
-/* Title for the section that provides information on how to import podcasts to Pocket Casts */
-"import_podcasts_title" = "IMPORT TO POCKET CASTS";
-
-/* A common string used throughout the app. Status message informing the user that the episode has been started but not finished. */
-"in_progress" = "In Progress";
-
-/* Title for the hardware keyboard command that closes the player. */
-"keycommand_close_player" = "Close Player";
-
-/* Title for the hardware keyboard command that decreases the playback speed. */
-"keycommand_decrease_speed" = "Decrease Speed";
-
-/* Title for the hardware keyboard command that increases the playback speed. */
-"keycommand_increase_speed" = "Increase Speed";
-
-/* Title for the hardware keyboard command that opens the player. */
-"keycommand_open_player" = "Open Player";
-
-/* Title for the hardware keyboard command that toggles play and pause of playback. */
-"keycommand_play_pause" = "Play/Pause";
-
-/* A common string used throughout the app. Often refers to the Listening History screen. */
-"listening_history" = "Listening History";
-
-/* Progress indicator informing the user that the selected item is still loading. */
-"loading" = "Loading...";
-
-/* A common string used throughout the app. Prompt to mark the selected item(s) as played. */
-"mark_played" = "Mark as Played";
-
-/* A common string used throughout the app. Prompt to mark the selected item(s) as played. Similar to 'Mark as Played' but more concise. */
-"mark_played_short" = "Mark Played";
-
-/* A common string used throughout the app. Prompt to mark the selected item(s) as not played. */
-"mark_unplayed_short" = "Mark Unplayed";
-
-/* Prompt to close the mini player and clear the queue. */
-"mini_player_close" = "Close And Clear Up Next";
-
-/* Basic string used in formats like 'price / month' */
-"month" = "month";
-
-/* Basic string used to callout payment intervals like yearly vs monthly */
-"monthly" = "Monthly";
-
-/* A common string used throughout the app. Prompt to move the selected item(s) to the end of the up next queue. */
-"move_to_bottom" = "Move to Bottom";
-
-/* A common string used throughout the app. Prompt to move the selected item(s) to the top of the up next queue. */
-"move_to_top" = "Move to Top";
-
-/* Multi-select status message for adding multiple episodes. Notifies that the selected list exceeds the bulk limit so only the first set up to the limit will be added. '%1$@' is a placeholder for the max amount of episodes to add. */
-"multi_select_add_episodes_max_format" = "Adding max %1$@ episodes.";
-
-/* Multi-select status message for adding multiple episodes. '%1$@' is a placeholder for the amount of episodes to add. */
-"multi_select_adding_episodes_plural_format" = "Adding %1$@ episodes.";
-
-/* Multi-select status message for adding an episode. '%1$@' is a placeholder for the amount of episodes to add. */
-"multi_select_adding_episodes_singular" = "Adding 1 episode.";
-
-/* Multi-select status message for archiving multiple episodes. '%1$@' is a placeholder for the count of files to be archived (the number will be more than one). */
-"multi_select_archiving_episodes_plural_format" = "Archiving %1$@ episodes";
-
-/* Multi-select status message for archiving one episode. */
-"multi_select_archiving_episodes_singular" = "Archiving 1 episode";
-
-/* Message portion of the prompt to delete the selected files on the multi select UI. '%1$@' is a placeholder for the count of files to be deleted (the number will be more than one). */
-"multi_select_delete_file_message_plural" = "Are you sure you want to delete %1$@ files?";
-
-/* Message portion of the prompt to delete a selected file on the multi select UI. */
-"multi_select_delete_file_message_singular" = "Are you sure you want to delete 1 file?";
-
-/* Multi-select status message informing the user that downloads have begun. '%1$@' is a placeholder for the count of the selected items being downloaded. */
-"multi_select_downloading_episodes_format" = "Downloading %1$@";
-
-/* Multi-select status message for marking multiple episodes as played. '%1$@' is a placeholder for the count of episodes to be marked played (the number will be more than one). */
-"multi_select_mark_episodes_played_plural_format" = "Marking %1$@ episodes as played.";
-
-/* Multi-select status message for marking one episode as played. */
-"multi_select_mark_episodes_played_singular" = "Marking 1 episode as played.";
-
-/* Multi-select status message for marking multiple episodes as not played. '%1$@' is a placeholder for the count of episodes to be marked not played (the number will be more than one). */
-"multi_select_mark_episodes_unplayed_plural_format" = "Marking %1$@ episodes as unplayed.";
-
-/* Multi-select status message for marking one episode as not played. */
-"multi_select_mark_episodes_unplayed_singular" = "Marking 1 episode as unplayed.";
-
-/* Multi-select status message informing the user how many episodes have been queued for download. '%1$@' is a placeholder for the count of the selected items be queued for download. */
-"multi_select_queuing_episodes_format" = "Queuing %1$@";
-
-/* Multi-select status message informing the user one episode download is being removed. */
-"multi_select_remove_download_singular" = "Removing 1 download.";
-
-/* Multi-select status message informing the user how many episodes downloads are being removed. '%1$@' is a placeholder for the count of the selected items be removed for download. */
-"multi_select_remove_downloads_plural_format" = "Removing %1$@ downloads.";
-
-/* Title for the prompt to mark the selected items as not having been played. */
-"multi_select_remove_mark_unplayed" = "Mark as Unplayed";
-
-/* Multi-select label indicating the number of selected items. '%1$@' is a placeholder for the number of selected items, this will be more than one. */
-"multi_select_selected_count_plural" = "%1$@ SELECTED EPISODES";
-
-/* Multi-select label indicating that there is one item selected. */
-"multi_select_selected_count_singular" = "1 SELECTED EPISODE";
-
-/* Multi-select menu section header. Indicates that the options in this section will appear in the action bar. */
-"multi_select_shortcut_in_action_bar" = "SHORTCUT IN ACTION BAR";
-
-/* Title for the prompt to mark the selected items as stared (favorited). */
-"multi_select_star" = "Star Episodes";
-
-/* Multi-select status message for marking multiple episodes as favorited (starred). '%1$@' is a placeholder for the count of episodes to be starred (the number will be more than one). */
-"multi_select_starring_episodes_plural_format" = "Starring %1$@ episodes.";
-
-/* Multi-select status message for marking one episode as favorited (starred). */
-"multi_select_starring_episodes_singular" = "Starring 1 episode.";
-
-/* Multi-select status message for unarchiving multiple episodes. '%1$@' is a placeholder for the count of files to be unarchived (the number will be more than one). */
-"multi_select_unarchiving_episodes_plural_format" = "Unarchiving %1$@ episodes.";
-
-/* Multi-select status message for unarchiving one episode. */
-"multi_select_unarchiving_episodes_singular" = "Unarchiving 1 episode";
-
-/* Title for the prompt to remove the selected items from being stared (favorited). */
-"multi_select_unstar" = "Unstar Episodes";
-
-/* Multi-select status message for marking multiple episodes as not favorited (un-starred). '%1$@' is a placeholder for the count of episodes to be un-starred (the number will be more than one). */
-"multi_select_unstarring_episodes_plural_format" = "Unstarring %1$@ episodes.";
-
-/* Multi-select status message for marking one episode as not favorited (un-starred). */
-"multi_select_unstarring_episodes_singular" = "Unstarring 1 episode";
-
-/* A common string used throughout the app. References to new episodes. */
-"new_episodes" = "New episodes";
-
-/* A common string used throughout the app. Prompt to move forward in the flow. */
-"next" = "Next";
-
-/* A common string used throughout the app. Prompt to move to the next episode. */
-"next_episode" = "Next Episode";
-
-/* A common string used throughout the app. Format used to call out when the associated subscription will be renewed. '%1$@' is a placeholder for a localized date indicating when the renewal will process. */
-"next_payment_format" = "Next payment: %1$@";
-
-/* A common string used throughout the app. Default 'not set' option mostly used with group settings. */
-"none" = "None";
-
-/* A common string used throughout the app. Informs the user that they are not on WiFi and the action they're about to take will use data. Used for downloads and uploads. */
-"not_on_wifi" = "You're not on WiFi";
-
-/* Prompt to play the selected item now. */
-"notifications_play_now" = "Play Now";
-
-/* A common string used throughout the app. Refers to the Now Playing tab in the player. */
-"now_playing" = "Now Playing";
-
-/* A common string used throughout the app. Specifically calls out the item that is currently being played. '%1$@' is a placeholder for the item'r name that is being played. */
-"now_playing_item" = "Now Playing %1$@";
-
-/* A common string used throughout the app. Refers to the Now Playing tab in the player. Removes 'Now' to conserve space. */
-"now_playing_short_title" = "Playing";
-
-/* A common string used throughout the app. Indicates that the feature is not enabled. */
-"off" = "Off";
-
-/* A common string used throughout the app. Used as a confirmation or acceptance. */
-"ok" = "OK";
-
-/* A common string used throughout the app. Often used as a toggle to enable a feature only when the user is on Wifi. */
-"only_on_wifi" = "Only On WiFi";
-
-/* Message for the dialog box informing the user that the podcast import from the provided OPML file has failed. */
-"opml_import_failed_message" = "Unable to import podcasts from the OPML file you specified. Please check that it's valid";
-
-/* Title for the dialog box informing the user that the podcast import from the provided OPML file has failed. */
-"opml_import_failed_title" = "OPML Import Failed";
-
-/* Progress message indicating the total number of podcasts imported from an OPML file. '%1$@' serves as a placeholder for the current number of imported podcasts. '%2$@' serves as a placeholder for the total number of podcasts to import. */
-"opml_import_progress_format" = "Importing %1$@ of %2$@";
-
-/* Progress message indicating that the import process of an OPML file is running. */
-"opml_importing" = "Importing Podcasts...";
-
-/* Format used to indicate the current page and total in a custom page control. '%1$@' is a placeholder for the current page. '%2$@' is a placeholder for the total pages. */
-"page_control_page_progress_format" = "Page %1$@ of %2$@";
-
-/* A label indicating the number of podcasts the user has subscribed to compared to the total number of podcasts in the bundle. '%1$@' is a placeholder for the number of subscribed podcasts. '%2$@' is a placeholder for the number of podcasts in the bundle. */
-"paid_podcast_bundled_subscriptions" = "%1$@ / %2$@ SUBSCRIBED";
-
-/* Option to allow the user to cancel their subscription to a paid podcast feed. */
-"paid_podcast_cancel" = "Cancel Contribution";
-
-/* Message displayed when the user selects to cancel their paid podcast subscription. This message is used when the user is canceling multiple subscriptions. '%1$@' is a placeholder for the last date that the current subscriptions will remain active. */
-"paid_podcast_cancel_msg_plural" = "Supporter status will remain active until %1$@. After that you won't be able to play these podcast anymore.";
-
-/* Message displayed when the user selects to cancel their paid podcast subscription. This message is used when the podcast allows the user to access episodes that were available to them during their subscription window. '%1$@' is a placeholder for the last date that the current subscription will remain active. */
-"paid_podcast_cancel_msg_retain_access" = "Supporter status will remain active until %1$@. You will only be able to listen to episodes released before this date.";
-
-/* Message displayed when the user selects to cancel their paid podcast subscription. This message is used when the user is only canceling a singular subscription. '%1$@' is a placeholder for the last date that the current subscription will remain active. */
-"paid_podcast_cancel_msg_singular" = "Supporter status will remain active until %1$@. After that you won't be able to play this podcast anymore.";
-
-/* A generic error indicating that the app failed to load information about the paid feed. */
-"paid_podcast_generic_error" = "Unable to load info";
-
-/* Prompt to open settings to adjust settings for a paid feed. */
-"paid_podcast_manage" = "Manage";
-
-/* Informational label informing the user when to expect the next episode. '%1$@' is a placeholder for the next upcoming release date. */
-"paid_podcast_next_episode_format" = "Next episode %1$@";
-
-/* Informational label informing the user when the latest episode was released. '%1$@' is a placeholder for the latest release date. */
-"paid_podcast_release_frequency_format" = "Released %1$@";
-
-/* Prompt to get the user to sign in to see updates. This acts as the details message for a section. '\n' is the new line character to cause a line wrap. */
-"paid_podcast_signin_prompt_msg" = "SIGN IN FOR\nUPDATES";
-
-/* Prompt to get the user to sign in to see updates. This acts as the title for a section. */
-"paid_podcast_signin_prompt_title" = "Sign in for new episodes";
-
-/* Format used to indicate the subscription for the paid podcast has ended. '%1$@' is a placeholder for the date that the subscription ended on. */
-"paid_podcast_subscription_ended" = "ENDED: %1$@";
-
-/* Format used to indicate the subscription for the paid podcast will end on the specified date. '%1$@' is a placeholder for the date that the subscription will end. */
-"paid_podcast_subscription_ends" = "ENDS: %1$@";
-
-/* A label used to inform the user that the selected podcast feed is for paid supporters only. */
-"paid_podcast_supporter_only_msg" = "Supporter-only feed";
-
-/* Prompt to get the user to sign in after selecting to support a podcast while signed out. '%1$@' is a placeholder for the name of the podcast the user has subscribed to. */
-"paid_podcast_supporter_signin_prompt" =  "Thanks for signing up as a %1$@ supporter. To access your special content, you’ll need to sign in.";
-
-/* A confirmation message for when a user has selected too unsubscribe and has downloaded files. */
-"paid_podcast_unsubscribe_msg" = "Unsubscribing from all these podcasts will delete any downloaded files they have, are you sure?";
-
-/* A common string used throughout the app. Prompt to pause the playback. */
-"pause" = "Pause";
-
-/* A common string used throughout the app. Used to reference the Phone as the playing source with in the Apple Watch App (Watch is the other option for this use case) */
-"phone" = "Phone";
-
-/* A common string used throughout the app. Prompt to start playback. */
-"play" = "Play";
-
-/* A common string used throughout the app. Prompt to start playback and add the remaining selected items to the queue. */
-"play_all" = "Play All";
-
-/* A common string used throughout the app. Prompt to add the selected item(s) to the end of the queue. */
-"play_last" = "Play Last";
-
-/* A common string used throughout the app. Prompt to add the selected item(s) to the top of the queue. */
-"play_next" = "Play Next";
-
-/* One of the options for how aggressive to be in trimming silence. Sets it to max the highest setting. */
-"playback_effect_trim_silence_max" = "Mad Max";
-
-/* One of the options for how aggressive to be in trimming silence. Sets it to medium the middle setting. */
-"playback_effect_trim_silence_medium" = "Medium";
-
-/* One of the options for how aggressive to be in trimming silence. Sets it to mild the lowest setting. */
-"playback_effect_trim_silence_mild" = "Mild";
-
-/* A common string used throughout the app. Generic message informing the user that playback failed. */
-"playback_failed" = "Playback Failed";
-
-/* Label indicating the current value for the playback speed. '%1$@' is a placeholder for the playback speed and 'x' is meant to read as 'times' as in '1.1 times' for '1.1x' */
-"playback_speed" = "%1$@x";
-
-/* Accessibility hint text informing the user that the Sleep timer is enabled. */
-"player_accessibility_sleep_timer_on" = "Sleep timer on";
-
-/* Subtitle for settings indicating this item operates as delete for files. */
-"player_action_subtitle_delete" = "Shown as Delete for custom episodes";
-
-/* Subtitle for settings indicating this item is hidden for files. */
-"player_action_subtitle_hidden" = "Hidden for custom episodes";
-
-/* Header for the available playback effect options. */
-"player_action_title_effects" = "Playback Effects";
-
-/* Title for the prompt to navigate the user to the files section of the app. */
-"player_action_title_go_to_file" = "Go to Files";
-
-/* Title for the available output device options. */
-"player_action_title_output_options" = "Output Device";
-
-/* Header for the available timer options for auto-pausing playback. */
-"player_action_title_sleep_timer" = "Sleep Timer";
-
-/* Title for the prompt to remove an episode from the favorites. */
-"player_action_title_unstar_episode" = "Unstar Episode";
-
-/* Title for a page where you can rearrange common actions (eg sort/reorder and move the ones you like more to the top) */
-"player_actions_rearrange_title" = "Rearrange Actions";
-
-/* Confirmation prompt for archiving an episode. */
-"player_archived_confirmation" = "Archive this episode?";
-
-/* Accessibility label calling out the current artwork that's being displayed. '%1$@' is a placeholder for either the episode name or the chapter title. */
-"player_artwork" = "%1$@ Artwork";
-
-/* Information label that includes the current chapter and total chapter count example '1 of 3'. '%1$@' is a placeholder for the current chapter. '%2$@' is a placeholder for the total chapters. */
-"player_chapter_count" = "%1$@ of %2$@";
-
-/* Accessibility label for the player control that rewinds the current playback position by a customizable time. */
-"player_decrement_time" = "Decrement time";
-
-/* Detail text explaining that trim silence feature. */
-"player_effects_trim_silence_details" = "Reduces the length of an episode by trimming silence in conversations.";
-
-/* Detail text celebrating how much time has been saved using the trim silence feature. '%1$@' is a placeholder for the amount of time saved using the feature. */
-"player_effects_trim_silence_progress" = "In total you've saved %1$@ using this feature.";
-
-/* Generic error used when playback fails but the episode has a downloaded file. Warns the user that playback is failing because the associated file likely has been corrupted. */
-"player_error_corrupted_file" = "The episode might be corrupted, but you can try to play it again.";
-
-/* Generic error used when playback fails while streaming. Asks the user to verify their internet connection. */
-"player_error_internet_connection" = "Check your Internet connection and try again.";
-
-/* Accessibility label for the player control that fast-forwards the current playback position by a customizable time. */
-"player_increment_time" = "Increment time";
-
-/* Confirmation prompt for marking an episode as played. */
-"player_mark_as_played_confirmation" = "Mark this episode as played?";
-
-/* Warning that comes along with selecting to play all. Informs the user that their queue will be cleared. */
-"player_options_play_all_message" = "This will clear your current Up Next queue.";
-
-/* Prompt to play a single episode from a multi-select screen. */
-"player_options_play_episode_singular" = "Play 1 Episode";
-
-/* Prompt to play a multiple episodes from a multi-select screen. '%1$@' is a placeholder for the number of episodes; the value will be more than one. */
-"player_options_play_episodes_plural" = "Play %1$@ Episodes";
-
-/* Section header for organizing which options will show in the player vs in the menu. */
-"player_options_shortcut_on_player" = "SHORTCUT ON PLAYER";
-
-/* Accessibility label for the Route selector control. Opens the Apple menu for selecting the playback device such as headphones or a Bluetooth speaker. */
-"player_route_selection" = "Route Selector";
-
-/* Header for the share menu where the user selects to share the podcast, episode, or episode at the current position */
-"player_share_header" = "SHARE LINK TO";
-
-/* Error title when there is a download error. */
-"player_user_episode_download_error" = "Download Error";
-
-/* Error title when there is a playback error. */
-"player_user_episode_playback_error" = "Playback Error";
-
-/* Error title when there is an upload error. */
-"player_user_episode_upload_error" = "Upload Error";
-
-/* Used in the player to describe effects you can use to change audio playback. Things like speed, volume, etc. */
-"playback_effects" = "Playback effects";
-
-/* Description for the empty state on screen where the user can review their starred (favorited) podcast epsiodes */
-"profile_starred_no_episodes_desc" = "You haven't starred any episodes yet.";
-
-/* Title for the empty state on screen where the user can review their starred (favorited) podcast epsiodes */
-"profile_starred_no_episodes_title" = "Nothing Starred";
-
-/* Used next to a setting for how fast audio will play */
-"speed" = "Speed";
-
-/* The Trim Silence feature, removes silence from podcasts to make them shorter. */
-"trim_silence" = "Trim Silence";
-
-/* The Volume Boost feature. Makes voices louder. */
-"volume_boost" = "Volume Boost";
-
-/* A short description of what the Volume Boost feature does */
-"volume_boost_description" = "Voices sound louder";
-
-/* A common string used throughout the app. Catch all prompt to suggest to the user to try the task again. */
-"please_try_again" = "Please try again";
-
-/* A common string used throughout the app. Catch all prompt to suggest to the user to try the task again later. */
-"please_try_again_later" = "Please try again later.";
-
-/* Prompt informing the user that an account is required in order to sign up for Pocket Casts Plus */
-"plus_account_required_prompt" = "A Pocket Casts account is required for Pocket Casts Plus. This ensures seamless listening across all your devices.";
-
-/* Details prompt informing the user that an account is required in order to sign up for Pocket Casts Plus */
-"plus_account_required_prompt_details" = "Create an account or sign in to redeem your access to Pocket Casts Plus.";
-
-/* Details message informing the user that they'll return to a free account at the end of their trial */
-"plus_account_trial_details" = "When your trial is over you’ll still have all the great benefits of your regular account. Happy podcasting!";
-
-/* The available cloud storage limit available to Pocket Casts Plus Subscribers. '%1$@' is a placeholder for the available storage. */
-"plus_cloud_storage_limit_format" = "%1$@ GB Cloud Storage";
-
-/* Error message informing the user that they have already signed up for plus with this account. */
-"plus_error_already_registered" = "You already have a Pocket Casts Plus account";
-
-/* Error message details informing the user that they have already signed up for plus with this account so they can't take advantage of the entered promotion. */
-"plus_error_already_registered_details" = "Thanks for your support, but unfortunately this means you can’t take part in this promotion.";
-
-/* Account detail message informing the user when their Plus account will expire. '%1$@' is a placeholder for when the account will expire. */
-"plus_expiration_format" = "Expires %1$@";
-
-/* A common string used throughout the app. often used as a section header to divide settings related to Pocket Casts Plus vs free features. 'PLUS' refers to Pocket Casts Plus. */
-"plus_features" = "PLUS FEATURES";
-
-/* Account detail message informing the user that they have been granted a limited free membership. '%1$@' is a placeholder for a localized string for the free time period. */
-"plus_free_membership_format" = "%1$@ Free";
-
-/* Account detail message informing the user that they have been granted a lifetime membership. */
-"plus_lifetime_membership" = "Lifetime Member";
-
-/* Pocket Casts Plus marketing page, description of the Cloud Storage feature */
-"plus_marketing_cloud_storage_description" = "Speed up your lectures. Burn through other content. Be your own Podcast DJ.";
-
-/* Pocket Casts Plus marketing page, description of the Cloud Storage feature */
-"plus_marketing_updated_cloud_storage_description" = "Upload your files to cloud storage and have it available everywhere";
-
-/* Pocket Casts Plus marketing page, title of the Cloud Storage feature */
-"plus_marketing_cloud_storage_title" = "Cloud Storage";
-
-/* Pocket Casts Plus marketing page, description of the Desktop Apps feature */
-"plus_marketing_desktop_apps_description" = "Take your podcasts to more places with our Windows, macOS and Web apps.";
-
-/* Pocket Casts Plus marketing page, description of the Desktop Apps feature */
-"plus_marketing_updated_desktop_apps_description" = "Listen in more places with our Windows, macOS and Web apps";
-
-/* Pocket Casts Plus marketing page, title of the Desktop Apps feature */
-"plus_marketing_desktop_apps_title" = "Desktop Apps";
-
-/* Pocket Casts Plus marketing page, the final call to action to get people to upgrade */
-"plus_marketing_final_call_to_action" = "Time to up your podcasting game?\nGet desktop apps, bring your own files and spruce things up with fresh new themes, exclusive to plus members.";
-
-/* Pocket Casts Plus marketing page, learn more button. Note that Pocket Casts is a proper noun and shouldn't be translated */
-"plus_marketing_learn_more_button" = "Learn more about Pocket Casts Plus";
-
-/* Pocket Casts Plus marketing page, the main description of Pocket Casts Plus */
-"plus_marketing_main_description" = "Get personal, and get distributed, all at once. Upload your personal audio files to our cloud servers, access your account via our web player, and make the app yours.";
-
-/* Pocket Casts Plus marketing page, the main title */
-"plus_marketing_main_title" = "Enhanced Features For Advanced Listeners";
-
-/* Pocket Casts Plus marketing page, description of the Themes & Icons feature */
-"plus_marketing_themes_icons_description" = "Fly your true colors. Exclusive icons and themes for the plus club only.";
-
-/* Pocket Casts Plus marketing page, title of the Themes & Icons feature */
-"plus_marketing_themes_icons_title" = "Themes & Icons";
-
-/* Pocket Casts Plus marketing page, description of the Watch Playback feature */
-"plus_marketing_watch_playback_description" = "Ditch the phone and go for a run – without missing a beat. Apple Watch stands alone.";
-
-/* Pocket Casts Plus marketing page, title of the Watch Playback feature */
-"plus_marketing_watch_playback_title" = "Watch Playback";
-
-/* Pocket Casts Plus marketing page, the text on the upgrade button */
-"plus_marketing_upgrade_button" = "Upgrade To Plus";
-
-/* Pocket Casts Plus marketing page, description of the Folders feature */
-"plus_marketing_folders_description" = "Create folders to organise your podcast collection.";
-
-/* Pocket Casts Plus marketing page, description of the Folders feature */
-"plus_marketing_updated_folders_description" = "Organise your podcasts in folders, and keep them in sync across all your devices.";
-
-/* Pocket Casts Plus marketing page, title of the hide ads feature */
-"plus_marketing_hide_ads_title" = "Hide Ads";
-
-/* Pocket Casts Plus marketing page, description of the hide ads feature */
-"plus_marketing_hide_ads_description" = "Ad-free experience which gives you more of what you love and less of what you don't";
-
-/* Informational message informing the user that their recurring payments for Plus have been canceled. */
-"plus_payment_canceled" = "Payment Cancelled";
-
-/* Label that goes along with the yearly subscription used to indicate that the yearly plan is the best overall value. */
-"plus_payment_frequency_best_value" = "Best Value";
-
-/* Informational label that's below the monthly price of Pocket Casts Plus. This label sits below a localized price. */
-"plus_per_month" = "per month";
-
-/* The price of Pocket Casts Plus per month. '%1$@' is a localized monthly price. */
-"plus_price_per_month" = "%1$@ / monthly";
-
-/* Error message informing the user the promotion code has expired */
-"plus_promotion_expired" = "Promotion Expired or Invalid";
-
-/* A nudge to ask the user to continue the sign up process even though they encountered an error. */
-"plus_promotion_expired_nudge" = "You’re welcome to sign up for Pocket Casts Plus anyway, create a regular account, or just dive right in.";
-
-/* Error message informing the user the promotion code has already been used */
-"plus_promotion_used" = "Code already used";
-
-/* Title for the screen to allow the user to choose between a monthly or yearly subscription. */
-"plus_select_payment_frequency" = "Select Payment Frequency";
-
-/* Message informing the user that their Pocket Casts Plus subscription is managed by Apple's system and needs to be managed there. */
-"plus_subscription_apple" = "Your subscription is managed by the Apple App Store";
-
-/* Message informing the user where to manage their Pocket Casts Plus subscription managed by Apple. */
-"plus_subscription_apple_details" = "To cancel your subscription, you’ll need to cancel via Settings.";
-
-/* Message informing the user when their Pocket Casts Plus subscription will expire. %1$@ is a placeholder for the expiration date. */
-"plus_subscription_expiration" = "PLUS EXPIRES IN %1$@";
-
-/* Message informing the user that their Pocket Casts Plus subscription is managed by Google's system and needs to be managed there. */
-"plus_subscription_google" = "It looks like you subscribed to Pocket Casts Plus from an Android device";
-
-/* Message informing the user where to manage their Pocket Casts Plus subscription managed by Google. */
-"plus_subscription_google_details" = "To cancel your subscription, you’ll need to cancel via Settings.";
-
-/* Message informing the user that their Pocket Casts Plus subscription is managed by Web's system and needs to be managed there. */
-"plus_subscription_web" = "It looks like you subscribed to Pocket Casts Plus from the web";
-
-/* Message informing the user where to manage their Pocket Casts Plus subscription managed by Web. */
-"plus_subscription_web_details" = "To cancel your subscription, you’ll need to cancel via Pocketcasts.com.";
-
-/* Feature of Pocket Casts plus, Web Player. As in our web based version capable of playing podcasts */
-"plus_feature_web_player" = "Web Player";
-
-/* Feature of Pocket Casts plus, Apple Watch app. Standalone meaning it can run with your iPhone */
-"plus_feature_watch_app" = "Standalone Watch Playback";
-
-/* Feature of Pocket Casts plus, Themes and icons. Themes for changing the way the app looks, icons to change the icon shown on your home screen */
-"plus_feature_themes_icons" = "Extra Themes & App Icons";
-
-/* Feature of Pocket Casts plus, Cloud Storage. Being able to upload your files to the Pocket Casts servers */
-"plus_feature_cloud_storage" = "Cloud Storage";
-
-/* A common string used throughout the app. Refers to the subscription program Pocket Casts Plus subscription. 'Pocket Casts' as a proper noun should not be localized. */
-"pocket_casts_plus" = "Pocket Casts Plus";
-
-/* A shortened version of the common string used throughout the app. Refers to the subscription program Pocket Casts Plus subscription. */
-"pocket_casts_plus_short" = "Plus";
-
-/* Indicates that the access to the podcast has ended on the specified date. '%1$@' is a placeholder for date that the access expired. */
-"podcast_access_ended" = "Access ended: %1$@";
-
-/* Indicates that the access to the podcast will end on the specified date. '%1$@' is a placeholder for date that the access will end. */
-"podcast_access_ends" = "Access ends: %1$@";
-
-/* Prompt to archive all of the selected items. */
-"podcast_archive_all" = "Archive All";
-
-/* Prompt to archive all played episodes of the current podcast. */
-"podcast_archive_all_played" = "Archive All Played";
-
-/* Confirmation to archive a certain number of podcast episodes. This is the singular form of an accompanying plural form. */
-"podcast_archive_episode_count_singular" = "Archive 1 Episode";
-
-/* Confirmation to archive a certain number of podcast episodes. '%1$@' is a placeholder for the number of episodes. */
-"podcast_archive_episodes_count_plural_format" = "Archive %1$@ Episodes";
-
-/* Confirmation message that appears alongside the various bulk archive prompts. */
-"podcast_archive_prompt_msg" = "You should only do this if you don't want to see them anymore.";
-
-/* Indicates that the episode has been archived. */
-"podcast_archived" = "Archived";
-
-/* Label used to display the number or archived episodes in a podcast. '%1$@' is a placeholder for the archived episode number. */
-"podcast_archived_count_format" = "%1$@ archived";
-
-/* Informational message informing the user that no episodes are being displayed because they're all archived. '%1$@' is a placeholder for the number of episodes. */
-"podcast_archived_msg" = "All %1$@ episodes of this podcast have been archived";
-
-/* A common string used throughout the app. Displays the count of selected podcasts. '%1$@' is a placeholder for the number of podcasts, the value will be more than one. */
-"podcast_count_plural_format" = "%1$@ podcasts";
-
-/* A common string used throughout the app. Displays the count of selected podcasts. This is the singular version of an accompanying plural format. */
-"podcast_count_singular" = "1 podcast";
-
-/* Error message informing the user that the episode encountered a download error. */
-"podcast_details_download_error" = "Episode download failed";
-
-/* Message informing the user that the episode will download once the device restores a WiFi connection. */
-"podcast_details_download_wifi_queue" = "This episode will automatically download when you're next on WiFi";
-
-/* Message details informing the user that the episode has been unarchived manually and won't be archived when the episode limit is reached. '%1$@' is a placeholder for the episode limit. */
-"podcast_details_manual_unarchive_msg" = "It won't be auto archived by your new episode limit of %1$@";
-
-/* Message informing the user that the episode has been unarchived manually. Used with episode limits. */
-"podcast_details_manual_unarchive_title" = "Episode Manually Unarchived";
-
-/* Error message informing the user that the episode encountered a playback error. */
-"podcast_details_playback_error" = "Unable to play episode";
-
-/* Indicates that the episode is queued for download. */
-"podcast_details_queued" = "Queued";
-
-/* Confirmation prompt to remove the episode file for the selected podcast episode. */
-"podcast_details_remove_download" = "REMOVE DOWNLOADED FILE?";
-
-/* Prompt to download the selected podcast now. */
-"podcast_download_now" = "Download Now";
-
-/* Indicates that a file is being downloaded and includes the completed percentage. '%1$@' is a placeholder for percentage that has been downloaded so far. */
-"podcast_downloading" = "Downloading... %1$@";
-
-/* Label used to display the number of episodes in a podcast. '%1$@' is a placeholder for the number of episodes. */
-"podcast_episode_count_plural_format" = "%1$@ episodes";
-
-/* Label used to display the number of episodes in a podcast. This is the singular form of an accompanying plural form. */
-"podcast_episode_count_singular" = "1 episode";
-
-/* Label used to display the episode limit for a podcast. '%1$@' is a placeholder for the episode limit. */
-"podcast_episode_limit_count_format" = "Limited to %1$@";
-
-/* Message for a generic error used when a podcast fails to load without a more detailed reason why. ':(' is meant to be ASCII art for a sad face. */
-"podcast_error_message" = "Unable to load podcast details :(";
-
-/* Title for a generic error used when a podcast fails to load without a more detailed reason why. Meant to be a fun cultural reference. */
-"podcast_error_title" = "Literally Can't Even";
-
-/* Indicates that a file has failed to download. */
-"podcast_failed_download" = "Episode download failed.";
-
-/* Indicates that a file has failed to upload. */
-"podcast_failed_upload" = "Failed to upload";
-
-/* Button text shown on the podcast grid when you have no podcasts, takes you to the Discover section of the app */
-"podcast_grid_discover_podcasts" = "Discover Podcasts";
-
-/* Description shown when you have no podcasts on the podcast grid */
-"podcast_grid_no_podcasts_msg" = "Coming from another app? Import your podcasts via Profile > Settings > Import & Export.\n\n\nIf you're looking for inspiration try the Discover tab.";
-
-/* Title of the message on the podcast grid when you have no podcasts */
-"podcast_grid_no_podcasts_title" = "Time to add some Podcasts!";
-
-/* Title for the options box that allows the user to pick from the various grouping options. */
-"podcast_group_options_title" = "GROUP BY";
-
-/* Prompt to hide archived episodes from the episode list. */
-"podcast_hide_archived" = "Hide Archived";
-
-/* Longer form informational label informing users that this podcast is limited to a configured set of episodes. '%1$@' is a placeholder for the number of episodes. */
-"podcast_limit_plural_format" = "Limited to %1$@ most recent episodes";
-
-/* Longer form informational label informing users that this podcast is limited to one episode. Singular version of an accompanying plural format. */
-"podcast_limit_singular" = "Limited to 1 most recent episode";
-
-/* Progress indicator informing the user that the podcasts that have been shared or imported are currently loading. */
-"podcast_loading" = "Loading Podcast...";
-
-/* Used to indicate no date was provided. */
-"podcast_no_date" = "Date Not Set";
-
-/* Label used to indicate that the podcast episode isn't grouped into a season. */
-"podcast_no_season" = "No Season";
-
-/* Accessibility label to prompt to pause an active download. */
-"podcast_pause_download" = "Pause download";
-
-/* Accessibility label to prompt to pause a playback. */
-"podcast_pause_playback" = "Pause playback";
-
-/* Indicates that a file is queued for download and includes the estimated size.*/
-"podcast_queued" = "Queued";
-
-/* Indicates that the episode is queued for download. */
-"podcast_queuing" = "Queued...";
-
-/* Prompt to trigger an artwork refresh on the podcast. */
-"podcast_refresh_artwork" = "Refresh Artwork";
-
-/* Format used to show the Season number of a podcast. '%1$@' is a placeholder for the Season number. */
-"podcast_season_format" = "Season %1$@";
-
-/* Prompt to allow the user to share the currently selected episode. */
-"podcast_share_episode" = "Share Link to Episode";
-
-/* Error message used when there are no available apps that can accept the podcast file. */
-"podcast_share_episode_error_msg" = "You don't have any apps installed that will accept this file";
-
-/* Error message for when a podcast can't be found after it has been shared. */
-"podcast_share_error_msg" = "The podcast author may have removed it since this link was shared.";
-
-/* Error title for when a podcast can't be found after it has been shared. */
-"podcast_share_error_title" = "Unable To Find Episode";
-
-/* Progress message shown while the users curated list is being synced to the server. */
-"podcast_share_list_creating" = "Creating list...";
-
-/* Placeholder for the description of the podcast list. Used when users create a curated list of podcasts. This item is optional. */
-"podcast_share_list_description" = "Description (optional)";
-
-/* Placeholder for the name of the podcast list. Used when users create a curated list of podcasts. */
-"podcast_share_list_name" = "List Name";
-
-/* Option to share the episode file to other apps. */
-"podcast_share_open_file" = "Open File in...";
-
-/* Prompt to Show archived episodes in the episode list. */
-"podcast_show_archived" = "Show Archived";
-
-/* A common string used throughout the app. Refers to Podcasts in the singular form. */
-"podcast_singular" = "Podcast";
-
-/* Used to reference that a new podcast episode will be available in the near future. */
-"podcast_soon" = "Any day now";
-
-/* Title for the options box that allows the user to pick from the various sort options. */
-"podcast_sort_order_title" = "SORT ORDER";
-
-/* Confirmation option to stream the selected episode. Used in tandem with a notice that the user is not on WiFi. */
-"podcast_stream_confirmation" = "Stream Anyway";
-
-/* Prompt to warn the user that continuing with the option to stream will consume data. Used in tandem with a notice that the user is not on WiFi. */
-"podcast_stream_data_warning" = "Streaming this episode will use data";
-
-/* Used to reference the episode was published this month. */
-"podcast_this_month" = "This Month";
-
-/* Indicates the remaining amount of time left in the episode. '%1$@' is a placeholder for the remaining time. */
-"podcast_time_left" = "%1$@ left";
-
-/* Used to reference tomorrow in terms of when the next episode will be available. */
-"podcast_tomorrow" = "Tomorrow";
-
-/* Prompt to unarchive all of the selected items. */
-"podcast_unarchive_all" = "Unarchive All";
-
-/* Indicates that the updates to the podcast has ended on the specified date. '%1$@' is a placeholder for date that the updates ended. */
-"podcast_updates_ended" = "Updates ended: %1$@";
-
-/* Indicates that the updates to the podcast will end on the specified date. '%1$@' is a placeholder for date that the updates will end. */
-"podcast_updates_ends" = "Updates ends: %1$@";
-
-/* Confirmation option to upload the selected file. Used in tandem with a notice that the user is not on WiFi. */
-"podcast_upload_confirmation" = "Upload Now";
-
-/* Indicates that a file is being uploaded and includes the completed percentage. '%1$@' is a placeholder for a localized percentage that has been uploaded so far. */
-"podcast_uploading" = "Uploading... %1$@";
-
-/* Indicates that a file is queued to be uploaded but hasn't started yet. */
-"podcast_waiting_upload" = "Waiting to upload";
-
-/* Used to reference yesterday. */
-"podcast_yesterday" = "Yesterday";
-
-/* The badge feature is set to show the number of unplayed episodes. */
-"podcasts_badge_all_unplayed" = "Unfinished Episodes";
-
-/* The badge feature is set to show an indicator if an unplayed episode exists. */
-"podcasts_badge_latest_episode" = "Only Latest Episode";
-
-/* Title for the options to configure badge display options. */
-"podcasts_badges" = "Badges";
-
-/* Episodes will be displayed in order from the longest to the shortest. */
-"podcasts_episode_sort_longest_to_shortest" = "Longest to Shortest";
-
-/* Episodes will be displayed in order from the most resent to the oldest. */
-"podcasts_episode_sort_newest_to_oldest" = "Newest to oldest";
-
-/* Episodes will be displayed in order from the oldest to the most resent. */
-"podcasts_episode_sort_oldest_to_newest" = "Oldest to newest";
-
-/* Episodes will be displayed in order from the shortest to the longest. */
-"podcasts_episode_sort_shortest_to_longest" = "Shortest to Longest";
-
-/* Presents the podcasts with large podcast artwork tiles. */
-"podcasts_large_grid" = "Large Grid";
-
-/* Title for the set of options for the presentation styles like grid sizes vs list view. */
-"podcasts_layout" = "Layout";
-
-/* Grid Items will be sorted sorted based on the users custom ordering. This is performed by dragging and dropping a podcast to the desired order. */
-"podcasts_library_sort_custom" = "Drag and Drop";
-
-/* Grid Items will be sorted based on the date the user subscribed to them. Newest to oldest. */
-"podcasts_library_sort_date_added" = "Date Added";
-
-/* Grid Items will be sorted based on the date of their newest episode. Newest to oldest. */
-"podcasts_library_sort_episode_release_date" = "Episode Release Date";
-
-/* Grid Items will be sorted alphabetically based on name. */
-"podcasts_library_sort_title" = "Name";
-
-/* Presents the podcasts in a list view. */
-"podcasts_list" = "List";
-
-/* A common string used throughout the app. Refers to Podcasts in the plural form as well as the Podcasts screen. */
-"podcasts_plural" = "Podcasts";
-
-/* Prompt to open the menu to share your podcasts list. */
-"podcasts_share" = "Share Podcasts";
-
-/* Presents the podcasts with small podcast artwork tiles. */
-"podcasts_small_grid" = "Small Grid";
-
-/* Prompt to open the menu to allow the user to sort their podcasts. */
-"podcasts_sort" = "Sort Podcasts";
-
-/* A common string used throughout the app. Refers to the Profile tab. */
-"profile" = "Profile";
-
-/* Informational label indicating the last time the app was refreshed. '%1$@' is a placeholder for a date string indicating when the last refresh occurred. */
-"profile_last_app_refresh" = "App last refreshed %1$@";
-
-/* Displays the number of files for when there are multiple files. '%1$@' is a placeholder for the number of files. */
-"profile_number_of_files" = "%1$@ Files";
-
-/* The percentage of file storage space that is currently being used. '%1$@' is a placeholder for a localized percentage. */
-"profile_percent_full" = "%1$@ Full";
-
-/* Prompt to allow the user to reset their account password. */
-"profile_reset_password" = "Reset Password";
-
-/* Notice informing the user that the email to reset their password is being prepared to be sent. */
-"profile_sending_reset_email" = "Sending Reset Email";
-
-/* Notice informing the user that the email to reset their password has been successfully sent. This serves as the message body for an alert accompanied with a title. ':)' is meant to be ASCII art for a happy face. */
-"profile_sending_reset_email_conf_msg" = "Check your email :)";
-
-/* */
-/* Notice informing the user that the email to reset their password has been successfully sent. This serves as the title for an alert. */
-"profile_sending_reset_email_conf_title" = "Password Reset Link Sent";
-
-/* Notice informing the user that the attempt to send the password reset email has failed. */
-"profile_sending_reset_email_failed" = "Failed to send reset email, please try again later.";
-
-/* Displays the number of files for when there is a single file. */
-"profile_single_file" = "1 File";
-
-/* Confirmation message to clear the give number of episodes from the queue. '%1$@' is a placeholder for the number of episodes, this will be more than one. */
-"queue_clear_episode_queue_plural" = "Clear %1$@ Episodes";
-
-/* Prompt to allow the user to clear their queue. */
-"queue_clear_queue" = "CLEAR QUEUE";
-
-/* A common string used throughout the app. Provides an option to add the selected item(s) to a queue instead of performing the action now. Used for downloads and uploads. */
-"queue_for_later" = "Queue For Later";
-
-/* Accessibility label indicating the current podcast is playing and it's episode date. '%1$@' is a placeholder for the episode date. */
-"queue_now_playing_accessibility" = "Now Playing. %1$@";
-
-/* Label indicating the amount of time remains on an episode. '%1$@' is a placeholder for a localized time format for the remaining time. */
-"queue_time_remaining" = "%1$@ remaining";
-
-/* Information label indication the total time remaining in the queue. This is a total across all episodes in the up next queue. '%1$@' is a placeholder for the total time remaining in the queue. */
-"queue_total_time_remaining" = "%1$@ total time remaining";
-
-/* A common string used throughout the app. Error title indicating that the refresh process has failed. */
-"refresh_failed" = "Refresh failed";
-
-/* A common string used throughout the app. Prompt to perform a manual refresh of the displayed data. */
-"refresh_now" = "Refresh Now";
-
-/* A common string used throughout the app. Informational label indicating the last time the refresh occurred. '%1$@' is a placeholder for a localized string indicating when the refresh happened. */
-"refresh_previous_run" = "Last refresh: %1$@";
-
-/* Activity indicator letting the user know that the process to refresh the current content is running. */
-"refreshing" = "Refreshing...";
-
-/* Hint text in the pull to refresh custom control. Provides a notice that new Podcast episodes are being fetched. */
-"refresh_control_fetching_episodes" = "FINDING NEW PODCAST EPISODES";
-
-/* Hint text in the pull to refresh custom control. */
-"refresh_control_pull_to_refresh" = "PULL TO REFRESH";
-
-/* Hint text in the pull to refresh custom control. Informs the user that the refresh has finished successfully. */
-"refresh_control_refresh_complete" = "REFRESH COMPLETE";
-
-/* Hint text in the pull to refresh custom control. Informs the user that the refresh has failed. ':(' is meant as sad face ASCII art. */
-"refresh_control_refresh_failed" = "REFRESH FAILED :(";
-
-/* Hint text in the pull to refresh custom control. Provides a notice that files are being synced with the server. */
-"refresh_control_refreshing_files" = "REFRESHING FILES";
-
-/* Hint text in the pull to refresh custom control. Provides a prompt to release the control to trigger the refresh. */
-"refresh_control_release_to_refresh" = "RELEASE TO REFRESH";
-
-/* Hint text in the pull to refresh custom control. Informs the user that the sync has failed. ':(' is meant as sad face ASCII art. */
-"refresh_control_sync_failed" = "SYNC FAILED :(";
-
-/* Hint text in the pull to refresh custom control. Provides a notice that Podcasts are being synced with the server. */
-"refresh_control_syncing_podcasts" = "SYNCING PODCASTS AND PROGRESS";
-
-/* A common string used throughout the app. Prompt to remove the selected item(s). */
-"remove" = "Remove";
-
-/* A common string used throughout the app. Prompt to remove all of the selected item(s). */
-"remove_all" = "Remove All";
-
-/* A common string used throughout the app. Prompt to delete the selected item(s) local file download. */
-"remove_download" = "Remove Download";
-
-/* A common string used throughout the app. Prompt to remove the selected item(s) from the up next queue. */
-"remove_from_up_next" = "Remove From Up Next";
-
-/* A common string used throughout the app. Prompt to remove the selected item(s) from the up next queue. Shorter form of 'Remove From Up Next' to conserve space on the Apple Watch. */
-"remove_up_next" = "Remove Up Next";
-
-/* A common string used throughout the app. Prompt to retry the recent request. */
-"retry" = "Retry";
-
-/* A common string used throughout the app. Placeholder text used in search boxes. */
-"search" = "Search";
-
-/* A common string used throughout the app when searching podcasts. Placeholder text used in search boxes. */
-"search_podcasts" = "Search Podcasts";
-
-/* A common string used throughout the app. Refers to the season a podcast episode is in. */
-"season" = "Season";
-
-/* Shorthand format used to show the Season number of a podcast. 'S' is short for Season. '%1$@' is a placeholder for the season number. */
-"season_only_shorthand_format" = "S%1$@";
-
-/* Shorthand format used to show the Season and the Episode number of a podcast. 'S' is short for Season. '%1$@' is a placeholder for the season number. 'E' is short for Episode. '%2$@' is a placeholder for the episode number. */
-"season_episode_shorthand_format" = "S%1$@ E%2$@";
-
-/* A common string used throughout the app. Prompt to select items. */
-"select" = "Select";
-
-/* A common string used throughout the app. Prompt to select all items in the presented list. */
-"select_all" = "Select All";
-
-/* A common string used throughout the app. Prompt to select all items above the currently selected item. */
-"select_all_above" = "Select all above";
-
-/* A common string used throughout the app. Prompt to select all items below the currently selected item. */
-"select_all_below" = "Select all below";
-
-/* A common string used throughout the app. Prompt to select episodes in the presented list. */
-"select_episodes" = "Select Episodes";
-
-/* A common string used throughout the app. Indicates the number of selected items. '%1$@' is a placeholder for the selected items. */
-"selected_count_format" = "%1$@ selected";
-
-/* Server error message for when the user tries to upload a file that is too large. */
-"server_error_files_file_too_large" = "This file is too big too upload.";
-
-/* Server error message for when the user tries to upload a file with an invalid file type. */
-"server_error_files_invalid_content_type" = "Unable to upload, as we're unable to determine the content type of this file.";
-
-/* Server error message for when the user tries to upload a file while not logged in. */
-"server_error_files_invalid_user" = "User is not logged in.";
-
-/* Server error message for when the user tries to upload a file but doesn't have sufficient space remaining. */
-"server_error_files_storage_limit_exceeded" = "You have exceeded the storage limit for your account.";
-
-/* Server error message for when the user tries to upload a file without a title. */
-"server_error_files_title_required" = "Title is required.";
-
-/* Server error message indicating a generic error for when the file uploads fail. */
-"server_error_files_upload_failed_generic" = "Unable to upload file, please try again later.";
-
-/* Server error message for when a file upload files because a unique identifier failed wasn't created. */
-"server_error_files_uuid_required" = "File uuid is required.";
-
-/* Server error message for when the user account has been locked. */
-"server_error_login_account_locked" = "Your account has been locked due too many login attempts, please try again later.";
-
-/* Server error message for when the user attempted to login without their email. */
-"server_error_login_email_blank" = "Enter an email address.";
-
-/* Server error message for when the user enters an invalid email. */
-"server_error_login_email_invalid" = "Invalid email";
-
-/* Server error message for when the user's email couldn't be identified on the server . */
-"server_error_login_email_not_found" = "Email not found";
-
-/* Server error message for when the user tries to create an account for an email tied to an existing account. */
-"server_error_login_email_taken" = "Email taken";
-
-/* Server error message for when the user attempted to login without their password. */
-"server_error_login_password_blank" = "Enter a password.";
-
-/* Server error message for when the user enters an invalid password. */
-"server_error_login_password_invalid" = "Invalid password";
-
-/* Server error message for when the user enters an invalid password. */
-"server_error_login_password_incorrect" = "Incorrect password";
-
-/* Server error message for when the user tries to access a feature they don't have access to. */
-"server_error_login_permission_denied_not_admin" = "Permission denied";
-
-/* Server error message for when the server failed to create the account fro the user. */
-"server_error_login_user_register_failed" = "Unable to create account, please try again later";
-
-/* Server error message for when the server failed to create the account fro the user. */
-"server_error_login_unable_to_create_account" = "We couldn't set up that account, sorry.";
-
-/* Server error message for when the user tries to redeem a promo when they are already a plus subscriber. */
-"server_error_promo_already_plus" = "You are already a Pocket Casts Plus subscriber, there's no need to redeem any codes.";
-
-/* Server error message for when the user tries to redeem a promo code that has already been used. */
-"server_error_promo_already_redeemed" = "You have already claimed this promo code. It was worth a shot though!";
-
-/* Server error message for when the user attempts to redeem a promo code that is no longer active. */
-"server_error_promo_code_expired_or_invalid" = "This promo code has expired or is invalid.";
-
-/* Generic server error message for when an unexpected or unhandled issue occurred. */
-"server_error_unknown" = "Something went wrong";
-
-/* Server message thanking the user for signing up to the service. */
-"server_message_login_thanks_signing_up" = "Thanks for signing up!";
-
-/* A common string used throughout the app. Reference to the settings menus. */
-"settings" = "Settings";
-
-/* A common string used throughout the app. Refers to the About settings menu */
-"settings_about" = "About";
-
-/* A common string used throughout the app. Refers to the Privacy settings menu */
-"settings_privacy" = "Privacy";
-
-/* A common string used throughout the app. Refers to the Appearance settings menu. */
-"settings_appearance" = "Appearance";
-
-/* Provides a prompt for the user to configure the settings related to Inactive Episodes. Used in places like configuring Auto Archive settings. */
-"settings_archive_inactive_episodes" = "Inactive Episodes";
-
-/* Title for the options menu to configure the settings related to archiving Inactive Episodes. */
-"settings_archive_inactive_title" = "Archive Inactive";
-
-/* Provides a prompt for the user to configure the settings related to Played Episodes. Used in places like configuring Auto Archive settings. */
-"settings_archive_played_episodes" = "Played Episodes";
-
-/* Title for the options menu to configure the settings related to archiving Played Episodes. */
-"settings_archive_played_title" = "Archive Played";
-
-/* A common string used throughout the app. Refers to the Auto Add to Up Next settings menu */
-"settings_auto_add" = "Auto Add to Up Next";
-
-/* Prompt to select the episode limit for auto adding podcasts to the Up Next Queue. */
-"settings_auto_add_limit" = "Auto Add Limit";
-
-/* Prompt to select the behavior of the app if the auto add limit has been reached. */
-"settings_auto_add_limit_reached" = "If Limit Reached";
-
-/* Subtitle explaining the app's behavior when the episode limit is reached and new episodes are not add to the Up Next Queue. '%1$@' is a placeholder for the auto add limit. */
-"settings_auto_add_limit_subtitle_stop" = "New episodes will stop being added when Up Next reaches %1$@ episodes.";
-
-/* Subtitle explaining the app's behavior when the episode limit is reached and new episodes are added to the top of the Up Next Queue. '%1$@' is a placeholder for the auto add limit. */
-"settings_auto_add_limit_subtitle_top" = "When Up Next reaches %1$@, new episodes auto-added to the top will remove the last episode in the queue. No new episodes will be added to the bottom.";
-
-/* Section header that displays all of the Podcasts that will automatically add new episodes to the Up Next Queue. */
-"settings_auto_add_podcasts" = "Auto-Add Podcasts";
-
-/* A common string used throughout the app. Refers to the Auto Archive settings menu */
-"settings_auto_archive" = "Auto Archive";
-
-/* Setting to auto archive a podcast episode. This value will auto archive the episode after 1 Week has passed. */
-"settings_auto_archive_1_week" = "After 1 Week";
-
-/* Setting to auto archive a podcast episode. This value will auto archive the episode after 24 Hours has passed. */
-"settings_auto_archive_24_hours" = "After 24 Hours";
-
-/* Setting to auto archive a podcast episode. This value will auto archive the episode after 2 Days has passed. */
-"settings_auto_archive_2_days" = "After 2 Days";
-
-/* Setting to auto archive a podcast episode. This value will auto archive the episode after 2 Weeks has passed. */
-"settings_auto_archive_2_weeks" = "After 2 Weeks";
-
-/* Setting to auto archive a podcast episode. This value will auto archive the episode after 30 Days has passed. */
-"settings_auto_archive_30_days" = "After 30 Days";
-
-/* Setting to auto archive a podcast episode. This value will auto archive the episode after 3 Months has passed. */
-"settings_auto_archive_3_months" = "After 3 Months";
-
-/* Prompt for the toggle to include starred episodes when auto archiving. */
-"settings_auto_archive_include_starred" = "Include Starred Episodes";
-
-/* Subtitle for the toggle to include starred episodes when auto archiving. This is the text that will be shown when the toggle is on. */
-"settings_auto_archive_include_starred_off_subtitle" = "Starred episodes won't be auto archived";
-
-/* Subtitle for the toggle to include starred episodes when auto archiving. This is the text that will be shown when the toggle is on. */
-"settings_auto_archive_include_starred_on_subtitle" = "Starred episodes will be auto archived";
-
-/* Subtitle for the main section of auto archive settings. This section sets the time limits or event triggers for when episodes are auto archived. */
-"settings_auto_archive_subtitle" = "Archive episodes after set time limits. Downloads are removed when the episode is archived.";
-
-/* A common string used throughout the app. Refers to the Auto Download settings menu */
-"settings_auto_download" = "Auto Download";
-
-/* Label indicating the number of selected filters. '%1$@' is a placeholder for the number of filters selected. */
-"settings_auto_downloads_filters_selected_format" = "%1$@ filters selected";
-
-/* Label indicating the number of selected filters. This is the singular form for an accompanying plural option. */
-"settings_auto_downloads_filters_selected_singular" = "1 filter selected";
-
-/* Label indicating no filters have been selected. */
-"settings_auto_downloads_no_filters_selected" = "No Filters Selected";
-
-/* Label indicating no podcasts have been selected. */
-"settings_auto_downloads_no_podcasts_selected" = "No Podcasts Selected";
-
-/* Label indicating the number of selected podcasts. '%1$@' is a placeholder for the number of podcasts selected. */
-"settings_auto_downloads_podcasts_selected_format" = "%1$@ podcasts selected";
-
-/* Label indicating the number of selected podcasts. This is the singular form for an accompanying plural option. */
-"settings_auto_downloads_podcasts_selected_singular" = "1 podcast selected";
-
-/* Subtitle explaining the toggle to auto download the top episodes of a filter. */
-"settings_auto_downloads_subtitle_filters" = "Download the top episodes in a filter.";
-
-/* Subtitle explaining the toggle to auto download New Episodes. */
-"settings_auto_downloads_subtitle_new_episodes" = "Download new episodes when they are released.";
-
-/* Subtitle explaining the toggle to auto download items in the Up Next Queue. */
-"settings_auto_downloads_subtitle_up_next" = "Download episodes added to Up Next.";
-
-/* Section Header for selecting the options for setting the app badge based on the user's filters. */
-"settings_badge_filter_header" = "EPISODE FILTER COUNT";
-
-/* Option for setting the app badge based on the new episodes since the app opened. */
-"settings_badge_new_since_opened" = "New Since App Opened";
-
-/* Option for setting the app badge based on the total unplayed episodes. */
-"settings_badge_total_unplayed" = "Total Unplayed";
-
-/* Prompt to open the menu to create a new Siri shortcut. 'Siri' refers to Apple's voice assistant. */
-"settings_create_siri_shortcut" = "Create Siri Shortcut";
-
-/* Informational message to accompany a prompt to create a Siri Shortcut. 'Siri' refers to Apple's voice assistant. '%1$@' is a placeholder for the podcasts name. */
-"settings_create_siri_shortcut_msg" = "Create a Siri Shortcut to play the newest episode of %1$@";
-
-/* A common string used throughout the app. Indicates an option(s) to customize the settings for this podcast. */
-"settings_custom" = "Custom For This Podcast";
-
-/* A message accompanying the toggle to enable auto archive settings that are specific to the selected podcast. */
-"settings_custom_auto_archive_msg" = "Need more fine grained control? Enable auto-archive settings for this podcast";
-
-/* A message accompanying the toggle to set custom settings for a particular podcast. */
-"settings_custom_msg" = "Pocket Casts will remember your last playback effects and use them on all podcasts. You can enable this if you want to create custom ones for just this podcast.";
-
-/* Provides a prompt for the user to configure the settings related to episode limits. This controls how many episodes will be preserved before auto archiving them. */
-"settings_episode_limit" = "Episode Limit";
-
-/* Informs the user of max episode count for the up next queue. This value is configurable. '%1$@' is a placeholder for the current value as set by the user. */
-"settings_episode_limit_format" = "%1$@ Episode Limit";
-
-/* A format for values accompanying the setting to auto archive based on a set limit. '%1$@' is a placeholder for the number of episodes that will be saved before auto archiving the oldest ones. */
-"settings_episode_limit_limit_format" = "%1$@ most recent";
-
-/* A message accompanying the episode limit settings providing a hint towards one use case for this feature. */
-"settings_episode_limit_msg" = "For shows that release hourly or daily episodes, setting an episode limit can help keep only the most recent ones, while archiving any that are older.";
-
-/* A value accompanying the setting to auto archive based on a set limit. This value disables the feature. */
-"settings_episode_limit_no_limit" = "No Limit";
-
-/* Alert title informing the user that the OPML export has encountered an error. 'OPML' refers to the file type that will be exported. */
-"settings_export_error" = "Export Error";
-
-/* Alert message informing the user that the OPML export has encountered an error. 'OPML' refers to the file type that will be exported. */
-"settings_export_error_msg" = "Unable to export OPML, please try again later.";
-
-/* Alert title informing the user that the OPML export is processing. 'OPML' refers to the file type that will be exported. */
-"settings_export_opml" = "Exporting OPML";
-
-/* Informs the user that Pocket Casts has dedicated an issue with this podcasts feed. */
-"settings_feed_error" = "Feed Error";
-
-/* Informs the user that Pocket Casts has stopped updating this feed due to too many errors. Provides a prompt to tap the refresh button that is presented above this message box. */
-"settings_feed_error_msg" = "The feed for this podcast stopped updating because it had too many errors. Tap above to fix this.";
-
-/* Title used in a dialog box. Prompt user to try refreshing the feed after encountering an error. */
-"settings_feed_fix_refresh" = "Try To Update It";
-
-/* The message body for a dialog box used to inform the user the request to update the feed has failed. */
-"settings_feed_fix_refresh_failed_msg" = "Unable to update this feed, please try again later.";
-
-/* The title for a dialog box used to inform the user that the request to update the feed has failed. */
-"settings_feed_fix_refresh_failed_title" = "Update Failed";
-
-/* The message body for a dialog box used to inform the user that the an update to the feed has been queued. */
-"settings_feed_fix_refresh_success_msg" = "We've queued an update for this podcast. Our server will re-check it and if it works you should have new episodes soon. Please check back in about an hour.";
-
-/* The title for a dialog box used to inform the user that the an update to the feed has been queued. */
-"settings_feed_fix_refresh_success_title" = "Update Queued";
-
-/* Informs the user that Pocket Casts has dedicated an issue with this podcasts feed. */
-"settings_feed_issue" = "Feed Issue";
-
-/* Informs the user that Pocket Casts has stopped updating this feed due to too many errors. */
-"settings_feed_issue_msg" = "The feed for this podcast stopped updating because it had too many errors.";
-
-/* Prompt to navigate the user to the files setting screen. */
-"settings_files" = "Files Settings";
-
-/* Subtitle for the toggle to auto add new files to the Up Next Queue. */
-"Settings_files_add_up_next_subtitle" = "Add new files to Up Next automatically";
-
-/* Prompt for the toggle to enable auto downloads for uploaded files. */
-"settings_files_auto_download" = "Auto Download from Cloud";
-
-/* Subtitle explaining the app behavior when the toggle to for auto downloads for uploaded files is off. */
-"settings_files_auto_download_subtitle_off" = "Files added to the cloud from other devices will not be automatically downloaded.";
-
-/* Subtitle explaining the app behavior when the toggle to for auto downloads for uploaded files is on. */
-"settings_files_auto_download_subtitle_on" = "Files added to the cloud from other devices will be automatically downloaded.";
-
-/* Prompt for the toggle to enable auto uploads for uploaded files. */
-"settings_files_auto_upload" = "Auto Upload to Cloud";
-
-/* Subtitle explaining the app behavior when the toggle to for auto uploads is off. */
-"settings_files_auto_upload_subtitle_off" = "Files added to this device will not be automatically uploaded to the Cloud.";
-
-/* Subtitle explaining the app behavior when the toggle to for auto uploads is on. */
-"settings_files_auto_upload_subtitle_on" = "Files added to this device will be automatically uploaded to the Cloud.";
-
-/* Prompt for the toggle to enable the option to delete the cloud file after playing. */
-"settings_files_delete_cloud_file" = "Delete Cloud File";
-
-/* Prompt for the toggle to enable the option to delete the local file after playing. */
-"settings_files_delete_local_file" = "Delete Local File";
-
-/* A common string used throughout the app. Reference to the General settings menu. */
-"settings_general" = "General";
-
-/* Confirmation to apply a setting change to all podcasts. */
-"settings_general_apply_all_conf" = "Apply to existing";
-
-/* Prompt to apply a setting change to all podcasts. */
-"settings_general_apply_all_title" = "Apply to existing podcasts?";
-
-/* Setting option to choose the default display archived episodes. */
-"settings_general_archived_episodes" = "Archived Episodes";
-
-/* Prompt to ask the user if they'd like to show/hide archived episodes for all podcasts. '%1$@' is a placeholder for a localized string 'show' or 'hide' based on the current setting. */
-"settings_general_archived_episodes_prompt_format" = "Would you like to change all your existing podcasts to %1$@ archived episodes?";
-
-/* Setting toggle to enable the feature to automatically open the player when playback starts. */
-"settings_general_auto_open_player" = "Open Player Automatically";
-
-/* Section header for the general settings that are more general app related. */
-"settings_general_defaults_header" = "DEFAULTS";
-
-/* Setting option to choose the primary way in which episodes are grouped. */
-"settings_general_episode_groups" = "Podcast Episode Grouping";
-
-/* Setting option to choose to hide archived episodes. */
-"settings_general_hide" = "Hide";
-
-/* Setting toggle to enable the app to keep your screen awake. */
-"settings_general_keep_screen_awake" = "Keep Screen Awake";
-
-/* Setting toggle to modify which bluetooth protocol to use. */
-"settings_general_legacy_bluetooth" = "Legacy Bluetooth Support";
-
-/* Subtitle explaining the toggle to modify which bluetooth protocol to use. */
-"settings_general_legacy_bluetooth_subtitle" = "If you have a Bluetooth Device or Car Stereo that seems to be pausing Pocket Casts while it's playing, or resetting the playback position to 0, try turning this setting on to fix it.";
-
-/* Setting toggle to enable the gesture for multi-select. */
-"settings_general_multi_select_gesture" = "Multi-select Gesture";
-
-/* Subtitle explaining the toggle to enable the gesture for multi-select. */
-"settings_general_multi_select_gesture_subtitle" = "Multi-select by dragging 2 fingers down on any episode list. Turn this off if you find yourself triggering this accidentally or it interferes with the accessibility features you use.";
-
-/* Option to not move forward with a prompt to apply to all podcasts. */
-"settings_general_no_thanks" = "No thanks";
-
-/* Setting toggle to enable the app to open the links in an external browser. */
-"settings_general_open_in_browser" = "Open Links In Browser";
-
-/* Setting toggle to modify what controls are available on the lock screen. */
-"settings_general_play_back_actions" = "Extra Playback Actions";
-
-/* Subtitle explaining the toggle to modify what controls are available on the lock screen. */
-"settings_general_play_back_actions_subtitle" = "Adds a mark played and star option to your phone lock screen and CarPlay. Note: on the lock screen this will replace the skip back button.";
-
-/* Section header for the general settings that are more player related. */
-"settings_general_player_header" = "PLAYER";
-
-/* Setting toggle to enable publishing chapter titles to the device's "Now Playing Info Center" data used by bluetooth and other connected devices. */
-"settings_general_publish_chapter_titles" = "Publish Chapter Titles";
-
-/* Subtitle explaining the toggle to publish chapter titles. */
-"settings_general_publish_chapter_titles_subtitle" = "If on, this will send chapter titles over Bluetooth and other connected devices instead of the episode title.";
-
-/* Setting toggle to change the behavior of the skip button on external devices. */
-"settings_general_remote_skips_chapters" = "Remote Skips Chapters";
-
-/* Subtitle explaining the toggle to change the behavior of the skip button on external devices. */
-"settings_general_remote_skips_chapters_subtitle" = "When enabled and an episode has chapters, pressing the skip button in your car or headphones will skip to the next chapter.";
-
-/* Prompt to ask the user if they'd like to remove the grouping from all podcasts. */
-"settings_general_remove_groups_apply_all" = "Would you like to change all your existing podcasts to be not be grouped as well?";
-
-/* Setting option to choose the default action when selecting an episode row. */
-"settings_general_row_action" = "Row Action";
-
-/* Prompt to ask the user if they'd like to apply the grouping to all podcasts. '%1$@' is a placeholder for a localized name for the grouping type. */
-"settings_general_selected_group_apply_all" = "Would you like to change all your existing podcasts to be grouped by %1$@?";
-
-/* Setting option to choose to show archived episodes. */
-"settings_general_show" = "Show";
-
-/* Setting toggle to enable the feature that adjusts the playback position when resuming. */
-"settings_general_smart_playback" = "Intelligent Playback Resumption";
-
-/* Subtitle explaining the feature that adjusts the playback position when resuming. */
-"settings_general_smart_playback_subtitle" = "If on, Pocket Casts will go back a little in episodes you resume so you can catch up more comfortably.";
-
-/* Setting option to choose how to handle swiping to add something to the queue. */
-"settings_general_up_next_swipe" = "Up Next Swipe";
-
-/* Setting toggle to modify how a tap is handled in the up next queue. */
-"settings_general_up_next_tap" = "Play Up Next On Tap";
-
-/* Subtitle explaining the toggle to modify how a tap is handled in the up next queue. This is used when the toggle is off. */
-"settings_general_up_next_tap_off_subtitle" = "Tapping an episode in Up Next shows the actions page. Long press plays the episode. Turn on to switch these around.";
-
-/* Subtitle explaining the toggle to modify how a tap is handled in the up next queue. This is used when the toggle is on. */
-"settings_general_up_next_tap_on_subtitle" = "Tapping an episode in Up Next will play it. Long press shows episode options. Turn off to switch these around.";
-
-/* Title for the menu that takes you to the global up next queue settings */
-"settings_global_settings" = "Global Settings";
-
-/* A common string used throughout the app. Refers to the Help & Feedback settings menu */
-"settings_help" = "Help & Feedback";
-
-/* Title for the screen that manages the importing and exporting of podcasts. */
-"settings_import_export" = "Import / Export";
-
-/* Informs the user that the current podcast is included in one filter. '%1$@' is a placeholder for the number of filters this podcast is included in. */
-"settings_in_filters_plural_format" = "Included In %1$@ Filters";
-
-/* Informs the user that the current podcast is included in one filter. This is the singular form of an accompanying plural string. */
-"settings_in_filters_singular" = "Included In 1 Filter";
-
-/* Setting section header. Indicates that the options in this section will appear in the menu vs an action bar. */
-"settings_in_menu" = "IN MENU";
-
-/* A message accompanying the settings for inactive episodes explaining what is considered an inactive episode. */
-"settings_inactive_episodes_msg" = "Inactive episodes are episodes you haven't played or downloaded in the time you specify above. Downloads are removed when the episode is archived.";
-
-/* Informs the user that the current podcast isn't included in any filters. */
-"settings_not_in_filters" = "Not Included In Any Filters";
-
-/* A common string used throughout the app. Refers to the Notifications settings menu. */
-"settings_notifications" = "Notifications";
-
-/* App badge choice to have the badge reflect the filter count */
-"settings_notifications_filter_count" = "Filter count";
-
-/* Subtitle explaining what notifications to expect when you enable notifications. */
-"settings_notifications_subtitle" = "Notifies you when a new episode is available. Also useful for improving the reliability of auto downloads.";
-
-/* A common string used throughout the app. Refers to the Import/Export OPML settings menu */
-"settings_opml" = "Import/Export OPML";
-
-/* Provides a prompt for the user to configure the playback speed options. */
-"settings_play_speed" = "Play Speed";
-
-/* Informational label breaking down the pricing structure for Pocket Casts Plus. '%1$@' is a placeholder for the localized price if paid per month, '%2$@' is a placeholder for the localized price if paid per year */
-"settings_plus_pricing_format" = "%1$@ per month / %2$@ per year";
-
-/* Title for the options to configure the queue position when a podcast is set to be auto added to the up next queue. */
-"settings_queue_position" = "Position in Queue";
-
-/* Prompt to select a filter */
-"settings_select_filter_singular" = "Select Filter";
-
-/* Prompt to select filters */
-"settings_select_filters_plural" = "Select Filters";
-
-/* Option for the filter Siri Shortcut. This sets the app to open the filter when the shortcut is triggered. */
-"settings_shortcuts_filter_open_filter" = "Open Filter";
-
-/* Option for the filter Siri Shortcut. This sets the filter to play all episodes in the filter when the shortcut is triggered. */
-"settings_shortcuts_filter_play_all_episodes" = "Play all episodes";
-
-/* Option for the filter Siri Shortcut. This sets the filter to play the top episode in the filter when the shortcut is triggered. */
-"settings_shortcuts_filter_play_top_episode" = "Play the top episode";
-
-/* Prompt to open the menu to interact with a pre-configured Siri shortcut. 'Siri' refers to Apple's voice assistant. */
-"settings_siri_shortcut" = "Siri Shortcut";
-
-/* Informational message that accompanies an existing Siri shortcut for a particular podcast. 'Siri' refers to Apple's voice assistant. '%1$@' is a placeholder for the podcasts name. */
-"settings_siri_shortcut_msg" = "A Siri Shortcut to play the top episode in %1$@";
-
-/* A common string used throughout the app. Refers to the Siri Shortcuts settings menu. 'Siri' refers to Apple's voice assistant. */
-"settings_siri_shortcuts" = "Siri Shortcuts";
-
-/* Section header for the available Siri shortcuts (not yet enabled). */
-"settings_siri_shortcuts_available" = "Available shortcuts";
-
-/* Section header for the enabled Siri shortcuts. */
-"settings_siri_shortcuts_enabled" = "Enabled shortcuts";
-
-/* Option to create a Siri Shortcut to a specific filter. */
-"settings_siri_shortcuts_specific_filter" = "Shortcut to a specific filter";
-
-/* Option to create a Siri Shortcut to a specific podcast. */
-"settings_siri_shortcuts_specific_podcast" = "Shortcut to a specific podcast";
-
-/* Prompt to open the configurable options to have the podcast skip an initial portion of the selected podcast. */
-"settings_skip_first" = "Skip First";
-
-/* Prompt to open the configurable options to have the podcast skip the final portion of the selected podcast. */
-"settings_skip_last" = "Skip Last";
-
-/* Fun informational message about the skip options available in the settings. */
-"settings_skip_msg" = "Skip intro and outro music like the power user you were born to be.";
-
-/* A common string used throughout the app. Refers to the Stats settings menu */
-"settings_stats" = "Stats";
-
-/* A common string used throughout the app. Refers to the Storage & Data Use settings menu. */
-"settings_storage" = "Storage & Data Use";
-
-/* Prompt for the toggle that turns on the dialog that warns the user before using data. */
-"settings_storage_data_warning" = "Warn Before Using Data";
-
-/* Prompt for the toggle that will include starred files in the clean up operation. */
-"settings_storage_downloads_starred" = "Include Starred";
-
-/* Section header for settings related to data usage. */
-"settings_storage_mobile_data" = "MOBILE DATA";
-
-/* Section header for information about storage space used. */
-"settings_storage_usage" = "USAGE";
-
-/* Title for the settings screen */
-"settings_title" = "Podcast Settings";
-
-/* Provides a prompt for the user to configure the sensitivity associated to the auto trimming silence setting. */
-"settings_trim_level" = "Trim Level";
-
-/* Provides a prompt for the user to configure the trim silence options. */
-"settings_trim_silence" = "Trim Silence";
-
-/* Informs the user about how the Queue will be adjusted when the episode limit is reached. '%1$@' is a placeholder for the current queue limit. */
-"settings_up_next_limit" = "Automatically add new episodes to Up Next. New episodes will stop being added when Up Next reaches %1$@.";
-
-/* Informs the user about how the Queue will be adjusted when the episode limit is reached. '%1$@' is a placeholder for the current queue limit. */
-"settings_up_next_limit_add_to_top" = "Automatically add new episodes to Up Next. When Up Next reaches %1$@, new episodes auto-added to the top will remove the last episode in the queue.";
-
-/* Provides a prompt for the user to toggle on the volume boosting setting. */
-"settings_volume_boost" = "Volume Boost";
-
-/* Prompt for the toggle that enables auto downloads for the Apple Watch app. */
-"settings_watch_auto_download" = "Auto Download Up Next";
-
-/* Subtitle for the toggle that explains the behavior for the auto download feature for the Apple Watch app. */
-"settings_watch_auto_download_off_subtitle" = "Set the number of episodes from your Up Next queue Pocket Casts will download to your watch for offline playback.";
-
-/* Prompt for the toggle that enables the feature to delete auto downloads that fall outside episode limit for the Apple Watch app. */
-"settings_watch_delete_downloads" = "Delete Downloads Outside Limit";
-
-/* Subtitle explaining the behavior of the app for when the toggle to delete auto downloads is turned off. */
-"settings_watch_delete_downloads_off_subtitle" = "To conserve watch storage, a maximum of 25 episodes in your Up Next queue will be auto-downloaded. Older download files outside this limit will be automatically deleted.";
-
-/* Subtitle explaining the behavior of the app for when the toggle to delete auto downloads is turned on. */
-"settings_watch_delete_downloads_on_subtitle" = "All download files in your Up Next queue that are outside this limit will be automatically deleted. Manual downloads aren't managed by these settings.";
-
-/* Prompt for the option to select the number of episodes to auto downloads for the Apple Watch app. */
-"settings_watch_episode_limit" = "Number of Episodes";
-
-/* Subtitle explaining for the option to select the number of episodes to auto downloads for the Apple Watch app. '%1$@' is a placeholder for the number of items to download. */
-"settings_watch_episode_limit_subtitle" = "Pocket Casts will download the top %1$@ episodes of your Up Next queue to your watch for offline playback.";
-
-/* Prompt for the option format to select the number of episodes to auto downloads for the Apple Watch app. '%1$@' is a placeholder for the number of items to download */
-"settings_watch_episode_number_option_format" = "Top %1$@";
-
-/* Label displayed right next the button to opt-in/out for Analytics tracking */
-"settings_collect_information" = "Collect information";
-
-/* Additional information about how the information collected is and how it's used */
-"settings_collect_information_additional_information" = "Allowing us to collect analytics helps us build a better app. We understand if you would prefer not to share this information.";
-
-/* Label for an input that takes the user to the privacy policy */
-"settings_read_privacy_policy" = "Read privacy policy";
-
-/* Title for the options for the user to configure their account. */
-"setup_account" = "Set Up Account";
-
-/* A common string used throughout the app. Prompt to open the share settings for the selected item(s). */
-"share" = "Share";
-
-/* A common string used throughout the app. Option to share the episode at the current playback position. */
-"share_current_position" = "Current Position";
-
-/* Message indicating that the process to subscribe to a podcast list is in progress. */
-"share_list_subscribing" = "Subscribing...";
-
-/* Message indicating that all of the podcasts have been selected. */
-"share_podcasts_all_selected" = "ALL SELECTED";
-
-/* Title for the screen to finalize options to create a list of podcasts to share. */
-"share_podcasts_create_list" = "Create List";
-
-/* Message indicating that the process to share a podcast list is in progress. */
-"share_podcasts_sharing" = "Sharing...";
-
-/* Error message for when sharing fails. */
-"share_podcasts_sharing_failed_msg" = "Something went wrong creating your share page";
-
-/* Title indicating that sharing has failed. */
-"share_podcasts_sharing_failed_title" = "Sharing Failed";
-
-/* A common string used throughout the app. Title for the screen to select multiple podcasts to share. */
-"share_select_podcasts" = "Select Podcasts";
-
-/* Progress indicator informing the user that the item that has been sent to them via share is loading. */
-"shared_item_loading" = "Loading Shared Item...";
-
-/* Title for the screen that shows the podcasts from a shared list of podcasts. */
-"shared_list" = "Shared List";
-
-/* Confirmation option presented when a user selects to subscribe to all podcasts in a list. */
-"shared_list_subscribe_conf_action" = "Heck Yes!";
-
-/* Message for a dialog presented when a user selects to subscribe to all podcasts in a list. '%1$@' is a placeholder for the number of podcasts that will be subscribed to. */
-"shared_list_subscribe_conf_msg" = "Are you sure you want to subscribe to %1$@ podcasts?";
-
-/* Title for a dialog presented when a user selects to subscribe to all podcasts in a list. */
-"shared_list_subscribe_conf_title" = "That's a lot of podcasts!";
-
-/* A common string used throughout the app. Refers to the Notes (show notes) tab in the player. */
-"show_notes" = "Notes";
-
-/* A common string used throughout the app. Prompt for the user to sign into their account. */
-"sign_in" = "Sign In";
-
-/* Prompt for the user to sign into their account or create an account */
-"sign_in_prompt" = "Sign in or create account";
-
-/* Message shown below the sign in prompt to give users more details about what it does */
-"sign_in_message" = "Save your podcast subscriptions in the cloud and sync your progress with other devices.";
-
-/* Button text to go to the forgot password page */
-"sign_in_forgot_password" = "I forgot my password";
-
-/* Email address field prompt */
-"sign_in_email_address_prompt" = "Email Address";
-
-/* Password field prompt */
-"sign_in_password_prompt" = "Password";
-
-/* Label indicating which account the user is signed into. The accounts email address is displayed in close proximity to this label. */
-"signed_in_as" = "SIGNED IN AS";
-
-/* Label indicating which account is not signed in. */
-"signed_out" = "Not Signed In";
-
-/* Siri shortcut phrase for increasing the sleep timer by a specified amount.*/
-"siri_shortcut_extend_sleep_timer_five_min" = "Extend sleep timer by 5 minutes";
-
-/* Siri shortcut title for increasing the sleep timer by a specified amount. '%1$@' is the placeholder for the time specified amount or time. */
-"siri_shortcut_extend_sleep_timer" = "Set sleep timer to %1$@";
-
-/* Siri shortcut title and phrase for having siri skip to the next chapter of a podcast */
-"siri_shortcut_next_chapter" = "Next chapter";
-
-/* Siri shortcut invocation phrase for opening a specified filter. '%1$@' is the placeholder for the specified filter. */
-"siri_shortcut_open_filter_phrase" = "Open %1$@";
-
-/* Siri shortcut title for pausing the current episode */
-"siri_shortcut_pause_title" = "Pause Current Episode";
-
-/* Siri shortcut invocation phrase for pausing the current episode */
-"siri_shortcut_pause_phrase" = "Pause";
-
-/* Siri shortcut title for playing all episodes of a particular filter */
-"siri_shortcut_play_all_title" = "Playing all episodes";
-
-/* Siri shortcut invocation phrase for playing all episodes of a particular filter. '%1$@' is a placeholder for the name of the filter to play from */
-"siri_shortcut_play_all_phrase" = "Play all %1$@";
-
-/* Siri shortcut title for playing the top episode of a particular podcast or filter */
-"siri_shortcut_play_episode_title" = "Playing the top episode";
-
-/* Siri shortcut invocation phrase for playing the specified filter. '%1$@' is a placeholder for the name of the filter to play from */
-"siri_shortcut_play_filter_phrase" = "Play top %1$@";
-
-/* Siri shortcut invocation phrase for playing the specified podcast. '%1$@' is a placeholder for the name of the podcast */
-"siri_shortcut_play_podcast_phrase" = "Play %1$@";
-
-/* Siri shortcut suggested title for playing a suggested podcast */
-"siri_shortcut_play_suggested_podcast_suggested_title" = "Surprise Me!";
-
-/* Siri shortcut title for playing a suggested podcast */
-"siri_shortcut_play_suggested_podcast_title" = "Playing a suggested episode";
-
-/* Siri shortcut phrase title for playing a suggested podcast */
-"siri_shortcut_play_suggested_podcast_phrase" = "Play a suggested episode";
-
-/* Siri shortcut title for playing the next episode in the queue */
-"siri_shortcut_play_up_next_title" = "Playing next episode";
-
-/* Siri shortcut invocation phrase for playing the next episode in the queue. */
-"siri_shortcut_play_up_next_phrase" = "Up Next";
-
-/* Siri shortcut title and phrase for having siri skip to the previous chapter of a podcast */
-"siri_shortcut_previous_chapter" = "Previous chapter";
-
-/* Siri shortcut title for resuming the current episode */
-"siri_shortcut_resume_title" = "Resuming Current Episode";
-
-/* Siri shortcut invocation phrase for resuming the current episode */
-"siri_shortcut_resume_phrase" = "Resume";
-
-/* Title for the siri shortcuts page to create a shortcut to a podcast */
-"siri_shortcut_to_podcast" = "Create Shortcut to Podcast";
-
-/* A common string used throughout the app. Prompt to rewind the playback by a configurable amount. */
-"skip_back" = "Skip Back";
-
-/* A common string used throughout the app. Prompt to fast-forward the playback by a configurable amount. */
-"skip_forward" = "Skip Forward";
-
-/* The Sleep Timer feature. */
-"sleep_timer" = "Sleep Timer";
-
-/* Prompt to add five minutes to an active timer. */
-"sleep_timer_add_5_mins" = "+ 5 Minutes";
-
-/* Prompt to cancel the active sleep timer. */
-"sleep_timer_cancel" = "Cancel Timer";
-
-/* Prompt to change the active sleep timer to be end of episode. */
-"sleep_timer_end_of_episode" = "End Of Episode";
-
-/* Accessibility hint that displays the remaining amount of time for the sleep timer. '%1$@' is a placeholder for the remaining time. */
-"sleep_timer_time_remaining" = "Sleep Timer on, %1$@ remaining";
-
-/* Prompt to confirm when presented with a connection prompt. Used when connecting to a Sonos speaker. */
-"sonos_connect_action" = "CONNECT";
-
-/* Prompt to connect to a Sonos speaker. 'Sonos' refers the the speaker manufacturer. */
-"sonos_connect_prompt" = "Connect To Sonos";
-
-/* Notice indicating that the app is attempting to make a connection to a Sonos device. 'Sonos' refers the the speaker manufacturer. */
-"sonos_connecting" = "CONNECTING...";
-
-/* Notice indicating that the app failed to make a connection to a Sonos device because the accounts weren't successfully linked. 'Sonos' refers the the speaker manufacturer. */
-"sonos_connection_failed_account_link" = "Unable to link Pocket Casts account at this time. Please try again later.";
-
-/* Notice indicating that the app failed to make a connection to a Sonos device because because it couldn't detect the Sonos App. 'Sonos' refers the the speaker manufacturer. */
-"sonos_connection_failed_app_missing" = "Unable to open Sonos app to complete linking process.";
-
-/* Notice indicating that the app failed to make a connection to a Sonos device. 'Sonos' refers the the speaker manufacturer. */
-"sonos_connection_failed_title" = "Linking Failed";
-
-/* Notice informing the users about what data will be provided to the Sonos speaker upon connection. 'Sonos' refers the the speaker manufacturer. */
-"sonos_connection_privacy_notice" = "Connecting to Sonos will allow the Sonos app to access your episode information.\n\nYour email address, password and other sensitive items are never shared.";
-
-/* Notice informing the users they need Pocket Casts account and need to sign in before connecting to the Sonos speaker. 'Sonos' refers the the speaker manufacturer. */
-"sonos_connection_sign_in_prompt" = "You need to have a Pocket Casts account before you can connect with Sonos.";
-
-/* A common string used throughout the app. Prompt for the sort option menus. */
-"sort_by" = "Sort By";
-
-/* A common string used throughout the app. Title accompanying the sort option setting. */
-"sort_episodes" = "Sort Episodes";
-
-/* A common string used throughout the app. Prompt to mark an episode(s) as favorited. */
-"star_episode" = "Star Episode";
-
-/* A common string used throughout the app. Prompt to mark an episode(s) as favorited. Similar to 'Star Episode' but more concise. */
-"star_episode_short" = "Star";
-
-/* Accessibility message for the cell displaying the time for how long they've listened to Pocket Casts. '%1$@' is a placeholder for how long they've listened and '%2$@' is a placeholder for a localized funny stat related to their listening history. */
-"stats_accessibility_listen_history_format" = "You've listened for %1$@. %2$@";
-
-/* Row header that displays the amount of time saved from Auto skipping episode parts. */
-"stats_auto_skip" = "Auto Skipping";
-
-/* Error message for when stats fail to load due to internet connection error. */
-"stats_error" = "Unable to load stats, check your Internet connection";
-
-/* Message informing the user how long they've been a user. '%1$@' is a placeholder for the date for when they created their account. */
-"stats_listen_history_format" = "Since %1$@ you’ve listened for";
-
-/* Loading message displayed while stats are being pulled. */
-"stats_listen_history_loading" = "You’ve listened for";
-
-/* Header for the cell displaying the time for how long they've listened to Pocket Casts. */
-"stats_listen_history_no_date" = "You’ve listened for";
-
-/* Row header that displays the amount of time saved from the Skip forward feature. */
-"stats_skipping" = "Skipping";
-
-/* Section header that breaks down how much listening time has been saved across a variety of features. */
-"stats_time_saved" = "TIME SAVED BY";
-
-/* A placeholder string for when the app fails to generate a time from the given inputs. */
-"stats_time_zero_seconds" = "0 seconds";
-
-/* A common string used throughout the app. Status header showing the totals for accumulated stat numbers. */
-"stats_total" = "Total";
-
-/* Row header that displays the amount of time saved from adjusting the Playback speed feature. */
-"stats_variable_speed" = "Variable Speed";
-
-/* A common string used throughout the app. Status message informing the user that the episode has been downloaded. */
-"status_downloaded" = "Downloaded";
-
-/* A common string used throughout the app. Status message informing the user that the episode is downloading. */
-"status_downloading" = "Downloading";
-
-/* A common string used throughout the app. Status message informing the user that the episode has not been downloaded. */
-"status_not_downloaded" = "Not Downloaded";
-
-/* A common string used throughout the app. Status message informing the user that the episode is currently not selected. Used with accessibility. */
-"status_not_selected" = "Not Selected";
-
-/* A common string used throughout the app. Status message informing the user that the episode has not been starred (favorited). */
-"status_not_starred" = "Not Starred";
-
-/* A common string used throughout the app. Status message informing the user that the episode has been played. */
-"status_played" = "Played";
-
-/* A common string used throughout the app. Status message informing the user that the episode is currently selected. Used with accessibility. */
-"status_selected" = "Selected";
-
-/* A common string used throughout the app. Status message informing the user that the episode has been starred (favorited). */
-"status_starred" = "Starred";
-
-/* A common string used throughout the app. Status message informing the user that the episode has not been played. */
-"status_unplayed" = "Unplayed";
-
-/* A common string used throughout the app. Status message informing the user that the episode has been uploaded. */
-"status_uploaded" = "Uploaded";
-
-/* A common string used throughout the app. Prompt to cancel the download for the selected item(s). */
-"stop_download" = "Stop Download";
-
-/* Prompt to subscribe to the selected podcast. */
-"subscribe" = "Subscribe";
-
-/* Label indicating that the user is currently subscribed to the selected podcast. */
-"subscribed" = "Subscribed";
-
-/* Prompt to subscribe to all of the selected podcast. */
-"subscribe_all" = "Subscribe All";
-
-/* Title for the subscription details page informing the users that the selected subscription has been canceled. */
-"subscription_cancelled" = "Subscription Cancelled";
-
-/* Message on the subscription details page informing the users when the canceled subscription will officially end. '%1$@' is a placeholder for the date in which the subscription expires. */
-"subscription_cancelled_msg" = "Subscription Cancelled %1$@ ";
-
-/* A common string used throughout the app. Thanks the user for their support. Used for paid feeds and Pocket Casts Plus. */
-"subscriptions_thank_you" = "Thanks for your support!";
-
-/* A label used to identify that a user is a supporter of the selected podcast. */
-"supporter" = "Supporter";
-
-/* Menu option to open details on available podcast supporter contribution options. */
-"supporter_contributions" = "Supporter Contributions";
-
-/* Subtitle to prompt the user to review their supports contribution details for more information. */
-"supporter_contributions_subtitle" = "Check contributions for details";
-
-/* Informational message informing the user that their recurring payments for supporter contributions have been canceled. */
-"supporter_payment_canceled" = "Supporter: Cancelled";
-
-/* Notice the sync failed due to an account error. */
-"sync_account_error" = "Check your username and password.";
-
-/* Sync status update notifying the user that the app is logged in. */
-"sync_account_login" = "Logged in...";
-
-/* A common string used throughout the app. Used to indicate that the sync process has failed. */
-"sync_failed" = "Sync failed";
-
-/* Notice that the app is syncing the up next and history for the account. */
-"sync_in_progress" = "Syncing Up Next and History";
-
-/* Progress message indicating the total number of podcasts being synced. '%1$@' serves as a placeholder for the current number of synced podcasts. '%2$@' serves as a placeholder for the total number of podcasts to sync. */
-"sync_progress" = "Podcast %1$@ of %2$@";
-
-/* Progress message indicating the total number of podcasts that have been synced. '%1$@' serves as a placeholder for the current number of synced podcasts, will be more than one. */
-"sync_progress_unknown_count_plural_format" = "Synced %1$@ podcasts";
-
-/* Progress message indicating the total number of podcasts that have been synced. Used in the singular case. */
-"sync_progress_unknown_count_singular" = "Synced 1 podcast";
-
-/* A common string used throughout the app. Used to indicate that the sync process in running. */
-"syncing" = "Syncing...";
-
-/* Prompt to allow the user to review the Terms of Use. */
-"terms_of_use" = "Terms of Use";
-
-/* Theme name for the Classic theme. */
-"theme_classic" = "Classic";
-
-/* Theme name for the Dark theme. */
-"theme_dark" = "Default Dark";
-
-/* Theme name for the Dark Contrast theme. */
-"theme_dark_contrast" = "Dark Contrast";
-
-/* Theme name for the Electricity theme. */
-"theme_electricity" = "Electricity";
-
-/* Theme name for the Extra Dark theme. */
-"theme_extra_dark" = "Extra Dark";
-
-/* Theme name for the Indigo theme. */
-"theme_indigo" = "Indigo";
-
-/* Theme name for the Light theme. */
-"theme_light" = "Default Light";
-
-/* Theme name for the Light Contrast theme. */
-"theme_light_contrast" = "Light Contrast";
-
-/* Theme name for the Radioactivity theme. */
-"theme_radioactivity" = "Radioactivity";
-
-/* Theme name for the Rosé theme. */
-"theme_rose" = "Rosé";
-
-/* Open ended time format describing either unknown or truly never */
-"time_format_never" = "never";
-
-/* A placeholder when time conversions fail. Sets the value to zero seconds */
-"time_placeholder" = "0 sec";
-
-/* A common string used throughout the app. Used to reference today. */
-"today" = "Today";
-
-/* A common string used throughout the app. Title option to place the item at the top of the queue. */
-"top" = "Top";
-
-/* Label indicating that the trial period for the subscription or promotion has ended. */
-"trial_finished" = "Trial Finished";
-
-/* A common string used throughout the app. Catch all prompt to suggest to the user to try the the task again. */
-"try_again" = "Try Again";
-
-/* A common string used throughout the app. Prompt to restore the selected item(s) from an archived state. */
-"unarchive" = "Unarchive";
-
-/* A common string used throughout the app. Used to reference an unknown duration '?' is an indicator that the amount of time isn't known and 'm' is a reference for minutes. */
-"unknown_duration" = "? m";
-
-/* A common string used throughout the app. Prompt to un-star the selected item (remove from favorited). */
-"unstar" = "Unstar";
-
-/* A common string used throughout the app. Prompt to unsubscribe from the selected podcast(s). */
-"unsubscribe" = "Unsubscribe";
-
-/* A common string used throughout the app. Prompt to unsubscribe from all of the selected podcast. */
-"unsubscribe_all" = "Unsubscribe All";
-
-/* A common string used throughout the app. Title for the prompt to display the queue of episodes to play next. */
-"up_next" = "Up Next";
-
-/* Heading shown when your Up Next list is empty */
-"up_next_empty_title" = "Nothing in Up Next";
-
-/* Description shown when your Up Next list is empty. Note that for non right to left languages "right" should be change to "left" (and translated) */
-"up_next_empty_description" = "You can queue episodes to play next by swiping right on episode rows, or tapping the icon on an episode card.";
-
-/* An alphabetical sort option for uploaded files. */
-"upload_sort_alpha" = "Title (A-Z)";
-
-/* A common string used throughout the app. Informs the user that the app is waiting for wifi to reconnect. */
-"wait_for_wifi" = "Waiting for WiFi";
-
-/* A common string used throughout the app. Used to reference the Watch as the playing source with in the Apple Watch App (Phone is the other option for this use case) */
-"watch" = "Watch";
-
-/* Indicates that the episode is being played is currently buffering to download more content for playback. */
-"watch_buffering" = "Buffering ...";
-
-/* Prompt in the Apple Watch App for the controls to move to the next chapter of the podcast. */
-"watch_chapter_next" = "Next Chapter";
-
-/* Prompt in the Apple Watch App for the controls to move to the previous chapter of the podcast. */
-"watch_chapter_prev" = "Prev Chapter";
-
-/* Title for the playback effects screen on the Apple Watch */
-"watch_effects" = "Effects";
-
-/* Prompt in the Apple Watch App to open episode details. */
-"watch_episode_details" = "Episode Details";
-
-/* Prompt in the Apple Watch app to return to the Main Menu */
-"watch_main_menu" = "Main Menu";
-
-/* Label in the Apple Watch app informing the user that they don't have any episodes in their selected list. */
-"watch_no_episodes" = "No Episodes";
-
-/* Label in the Apple Watch app informing the user that they haven't configured any of their filters. */
-"watch_no_filters" = "No Filters";
-
-/* Label in the Apple Watch app informing the user that they haven't subscribed to podcasts. */
-"watch_no_podcasts" = "No Podcasts";
-
-/* Title text used on the now playing screen in the Watch App. Indicates there is nothing palying or paused in the app. */
-"watch_nothing_playing_title" = "Nothing Playing";
-
-/* Subtitle text used on the now playing screen in the Watch App. Indicates there is nothing palying or paused in the app. Please leave the "\\n\\n" part in there, that's a new line indicator. */
-"watch_nothing_playing_subtitle" = "Enjoy the silence, or find something new to play.\n\nHonestly both are solid choices. 🙂";
-
-/* Information label providing a brief explanation of Pocket Casts Plus. */
-"watch_source_plus_info" = "Download direct to your watch and listen without your phone. Check out Pocket Casts Plus on your phone app, or on the web.";
-
-/* Message detailing where the audio will play from when selecting the source on the Apple Watch */
-"watch_source_msg" = "Podcasts will play from the speaker that the chosen device is connected to";
-
-/* Button that allows the user to manually trigger a refresh of their profile from the watch app. */
-"watch_source_refresh_account" = "Refresh Account";
-
-/* Information label accompanying the Refresh Account button. */
-"watch_source_refresh_account_info" = "If you have a Pocket Casts Plus account, refresh account to attempt to enable it";
-
-/* Button that allows the user to manually trigger a refresh of their data from the watch app. */
-"watch_source_refresh_data" = "Refresh Data";
-
-/* Information label informing users if they want to sign in to the Watch app they need to do that from the phone app. */
-"watch_source_sign_in_info" = "Sign in or create an account on your phone";
-
-/* Apple Watch complication prompt to tap the control to open the watch app. */
-"watch_tap_to_open" = "Tap to open";
-
-/* Title for the up next screen when a user has no episode queued up to play. */
-"watch_up_next_no_items_title" = "Nothing in Up Next";
-
-/* Subtitle for the up next screen when a user has no episode queued up to play. */
-"watch_up_next_no_items_subtitle" = "You can queue episodes to play next from the episode details screen, or adding them on your phone.";
-
-/* Text on the about page button to tell people's what's new in this version. %1$@ is placeholder for the version number, for example 7.1. */
-"whats_new_in_version" = "What's New In %1$@";
-
-/* Title for the announcement screen that calls out new features. */
-"whats_new" = "What's New";
-
-/* Widget prompt title to direct the user to the discover tab to add new podcasts to their queue */
-"widgets_discover_prompt_title" = "Ears hungry for more?";
-
-/* Widget prompt message to direct the user to the discover tab to add new podcasts to their queue */
-"widgets_discover_prompt_msg" = "Check out the Discover Tab";
-
-/* Widget label informing the user that nothing is currently being played. */
-"widgets_nothing_playing" = "Nothing Playing";
-
-/* Description for the now playing widget. */
-"widgets_now_playing_desc" = "Quickly access the currently playing episode.";
-
-/* Call to action for a tap on a widget to open the Discover tab. */
-"widgets_now_playing_tap_discover" = "Tap to Discover";
-
-/* Title of a widget that displays the app icon */
-"widgets_app_icon_name" = "Icon";
-
-/* Description of a widget to launch the app */
-"widgets_app_icon_description" = "Quickly Launch Pocket Casts";
-
-/* Up Next Lock Screen Widget description */
-"widgets_up_next_description" = "See the number of items in your Up Next queue or details about the next episode.";
-
-/* Basic string used in formats like 'price / year' */
-"year" = "year";
-
-/* Basic string used to callout payment intervals like yearly vs monthly */
-"yearly" = "Yearly";
-
-/* Label shown for minutes listened when it's singular, eg: 1 minute listened. */
-"minute_listened" = "Minute listened";
-
-/* Label shown for minutes saved when it's singular, eg: 1 minute saved. */
-"minute_saved" = "Minute saved";
-
-/* Label shown for hours listened when it's singular, eg: 1 hour listened. */
-"hour_listened" = "Hour listened";
-
-/* Label shown for hours saved when it's singular, eg: 1 hour saved. */
-"hour_saved" = "Hour saved";
-
-/* Label shown for days listened when it's singular, eg: 1 day listened. */
-"day_listened" = "Day listened";
-
-/* Label shown for days saved when it's singular, eg: 1 day saved. */
-"day_saved" = "Day saved";
-
-/* Label shown for seconds listened when it's plural, eg: 15 seconds listened. */
-"seconds_listened" = "Seconds listened";
-
-/* Label shown for seconds saved when it's plural, eg: 15 seconds saved. */
-"seconds_saved" = "Seconds saved";
-
-/* Label shown for minutes listened when it's plural, eg: 2 minutes listened. */
-"minutes_listened" = "Minutes listened";
-
-/* Label shown for minutes saved when it's plural, eg: 2 minutes saved. */
-"minutes_saved" = "Minutes saved";
-
-/* Label shown for hours listened when it's plural, eg: 1 hours listened. */
-"hours_listened" = "Hours listened";
-
-/* Label shown for hours saved when it's plural, eg: 1 hours saved. */
-"hours_saved" = "Hours saved";
-
-/* Label shown for days listened when it's singular, eg: 2 days listened. */
-"days_listened" = "Days listened";
-
-/* Label shown for days saved when it's singular, eg: 2 days saved. */
-"days_saved" = "Days saved";
-
-/* The heading shown for the Pocket Casts Newsletter */
-"pocket_casts_newsletter" = "Pocket Casts Newsletter";
-
-/* The description for the Pocket Casts Newsletter */
-"pocket_casts_newsletter_description" = "Receive news, app updates, themed playlists, interviews, and more.";
-
-/* The heading shown for the Pocket Casts Newsletter */
-"pocket_casts_welcome_newsletter_title" = "Get the Newsletter";
-
-/* Title for page one of the 7.20 what's new dialog. */
-"whats_new_page_one_title_7_20" = "Folders";
-
-/* What's new for 7.20 description for page one. Please leave the "\\n\\n" part in there, these are new line indicator. */
-"whats_new_page_one_7_20" = "If you love podcasts half as much as we do, you probably have a lot of them. If you're a Pocket Casts Plus subscriber, you can now sort these into folders and file them into neat groups.\n\nThanks to your support, your Home Screen has never looked better!";
-
-/* Title for page two of the 7.20 what's new dialog. */
-"whats_new_page_two_title_7_20" = "Home Grid Syncing";
-
-/* What's new for 7.20 description for page two. Please leave the "\\n\\n" part in there, these are new line indicator.*/
-"whats_new_page_two_7_20" = "We now sync your Home Screen (including your sort options) across devices! And you can drag and drop in the Web Player now as well.\n\nThis means you can rest easier, knowing the hard work you put in to arranging your podcasts page is being synced to your account.";
-
-/* Text for a link that goes to our blog where people can read more about the current update */
-"whats_new_blog_more_link_text" = "Read more about this update on our blog";
-
-/* Promotional information for Pocket Casts Plus. Please note that "Pocket Casts Plus" should not be translated because it's a product name */
-"plus_promo_paragraph" = "Get Pocket Casts Plus to unlock this feature, plus lots more!";
-
-/* Body of Plus promotional section
- */
-"profile_help_support" = "Help support Pocket Casts by upgrading your account";
-
-/* Text for a button where you learn more about a feature */
-"learn_more" = "Learn More";
-
-/* Heading for things that require Pocket Casts Plus to work. Please note that "Pocket Casts Plus" should not be translated because it's a product name */
-"plus_required_feature" = "This feature requires Pocket Casts Plus";
-
-/* About page text to ask the user to rate our app in the App Store */
-"about_rate_us" = "Rate Us";
-
-/* About page text to ask the user to share a link to our app with friends */
-"about_share_friends" = "Share With Friends";
-
-/* Button that takes people to our website */
-"about_website" = "Website";
-
-/* Button that takes you to other Automattic apps, eg: our Automattic family of apps */
-"about_a8c_family" = "Automattic Family";
-
-/* Main callout to come get a job with Automattic */
-"about_work_with_us" = "Work With Us";
-
-/* Secondary text on our come with with us call out */
-"about_join_from_anywhere" = "Join From Anywhere";
-
-/* Button that takes the user to legal and more screen */
-"about_legal_and_more" = "Legal and More";
-
-/* Button that takes the user to terms of service screen */
-"about_terms_of_service" = "Terms of service";
-
-/* Button that takes the user to privacy policy screen */
-"about_privacy_policy" = "Privacy Policy";
-
-/* Button that takes the user to the Acknowledgements screen */
-"about_acknowledgements" = "Acknowledgements";
-
-/* Text sent when sharing a link to our app with other people */
-"app_share_text" = "Hey! Here is a link to download the Pocket Casts app. I'm really enjoying it and thought you might too.";
-
-/* Email change form current email label */
-"current_email_prompt" = "Current Email";
-
-/* Email change form new email address field prompt */
-"new_email_address_prompt" = "New Email Address";
-
-/* Password change form new password field prompt */
-"new_password_prompt" = "New Password";
-
-/* Password change form confirm new password field prompt */
-"confirm_new_password_prompt" = "Confirm New Password";
-
-/* Password change form current password field prompt */
-"current_password_prompt" = "Current Password";
-
-/* Voiceover label for creating a new folder */
-"folder_create_new" = "Create New Folder";
-
-/* Title for the create folder page */
-"folder_create" = "Create Folder";
-
-/* Label for the button to create a new folder */
-"folder_new" = "New Folder";
-
-/* A common string used throughout the app. Informs the user how many podcasts have been chosen. This is the singular format for an accompanying plural option. */
-"folder_add_podcasts_singular" = "Add 1 Podcast";
-
-/* A common string used throughout the app. Informs the user how many podcasts are being added. '%1$@' is a placeholder for the number of podcasts, this will be more than one. */
-"folder_add_podcasts_plural_format" = "Add %1$@ Podcasts";
-
-/* Title for the folder name page*/
-"folder_name_title" = "Name your folder";
-
-/* Placeholder text in the field asking you to name a folder */
-"folder_name" = "Folder name";
-
-/* Text shown on button to remove a podcast from a folder */
-"folder_remove_from" = "Remove from folder";
-
-/* Text shown on button to change the folder a podcast is in */
-"folder_change" = "Change folder";
-
-/* Text shown on button to go to the folder a podcast is in */
-"folder_go_to" = "Go to folder";
-
-/* Common word used as a title when asking the user to name something */
-"name" = "Name";
-
-/* Common word used as in the app to denote a folder of items */
-"folder" = "Folder";
-
-/* Common word used as in the app to denote the folders feature */
-"folders" = "Folders";
-
-/* Common word, the color of something */
-"color" = "Color";
-
-/* Reason shown below a color picker for folders */
-"folder_color_detail" = "Makes it easier to find folders";
-
-/* Common word to denote a preview of something is being shown */
-"preview" = "Preview";
-
-/* Common word used to denote editting something */
-"edit" = "Edit";
-
-/* Shown on a button to save the folder */
-"folder_save_folder" = "Save Folder";
-
-/* Prompt to choose a folder color */
-"folder_choose_color" = "Choose a color";
-
-/* Label for the option that lets you edit a folder */
-"folder_edit" = "Edit Folder";
-
-/* Label for the option to add and remove podcasts from a folder */
-"folder_add_remove_podcasts" = "Add or Remove Podcasts";
-
-/* Label for the delete folder button */
-"folder_delete" = "Delete Folder";
-
-/* Confirmation prompt title after you try to delete a folder */
-"folder_delete_prompt_title" = "Are You Sure?";
-
-/* Confirmation prompt message after you try to delete a folder */
-"folder_delete_prompt_msg" = "This folder will be deleted, and its contents will be moved back to the Podcasts screen.";
-
-/* Title for the page where you select which podcasts are in a folder */
-"folder_choose_podcasts" = "Choose Podcasts";
-
-/* Title for the page where you select which folder a podcast is in */
-"folder_podcast_choose_folder" = "Choose Folder";
-
-/* Title shown for podcasts that aren't in a folder */
-"folder_no_folder" = "No Folder";
-
-/* Name shown for folders that don't have names */
-"folder_unnamed" = "Unnamed Folder";
-
-/* Label used when a podcast releases hourly episodes */
-"release_frequency_hourly" = "Hourly";
-
-/* Label used when a podcast releases daily episodes */
-"release_frequency_daily" = "Daily";
-
-/* Label used when a podcast releases episodes every week */
-"release_frequency_weekly" = "Weekly";
-
-/* Label used when a podcast releases episodes every two weeks */
-"release_frequency_fortnightly" = "Fortnightly";
-
-/* Label used when a podcast releases episodes every month */
-"release_frequency_monthly" = "Monthly";
-
-/* Title shown in an empty folder */
-"folder_empty_title" = "Your folder is empty";
-
-/* Description shown under the title of an empty folder */
-"folder_empty_description" = "Add podcasts to your folder and they’ll appear here.";
-
-/* Upsell dialog title label when a free trial is active, %1$@ refers to the duration of the trial (1 month) */
-"free_trial_title_label" = "Try Plus with %1$@ free";
-
-/* Upsell dialog free trial detail label that informs the user that they no payment is needed, and can cancel at anytime */
-"free_trial_detail_label" = "No Payment Now – Cancel Anytime";
-
-/* Upsell dialog confirmation button title when a free trial is active */
-"free_trial_start_button" = "Start Free Trial";
-
-/* Free trial terms where %1$@ refers to the trial duration (30 days) and %2$@ is the price after the trial ($0.99 / month) */
-"free_trial_pricing_terms" = "%1$@ free then %2$@";
-
-/* Free trial duration with the word free emphasized, %1$@ is the localize trial duration (1 month) */
-"free_trial_duration_free" = "%1$@ FREE";
-
-/* Pricing terms explaining how much will be charged after a free trial ends, %1$@ is the price ($0.99 / month) */
-"pricing_terms_after_trial" = "then %1$@";
-
-/* Free trial duration with the word free trial emphasized, %1$@ is the localized trial duration (1 month) */
-"free_trial_duration_free_trial" = "%1$@ FREE TRIAL";
-
-/* Title for a button that allows the user to subscrbe with a free trial */
-"free_trial_start_and_subscribe_button" = "Start Free Trial & Subscribe";
-
-/* Pricing terms explaining that the user will be charged after their free trial ends, %1$@ is the free trial duration (1 month), \n is a new line */
-"pricing_terms_after_trial_long" = "Recurring payments will begin after your\n%1$@ free trial";
-
-/* Monthly pricing format, %1$@ is the price */
-"plus_monthly_frequency_pricing_format" = "%1$@ per month";
-
-/* Yearly pricing format, %1$@ is the price */
-"plus_yearly_frequency_pricing_format" = "%1$@ per year";
-
-/* Payment failed error message */
-"plus_purchase_failed" = "It looks like there was a problem processing your payment. Please try again.";
-
-/* The title of the purchase promo */
-"plus_purchase_promo_title" = "Become a Plus member and unlock all Pocket Casts features";
-
-/* The purchase agreement terms, the %1$@, %3$@ are the opening of a HTML link tag (<a href="">), %2$@ and %4$@ are closing tags (</a>) */
-"purchase_terms" = "By continuing, you agree to %1$@Privacy Policy%2$@ and %3$@Terms and Conditions%4$@";
-
-/* Title for the End of Year feature */
-"eoy_title" = "Your Year in Podcasts";
-
-/* A smaller title for the End of Year feature */
-"eoy_small_title" = "Year in Podcasts";
-
-/* A description of the End of Year feature */
-"eoy_description" = "See your top podcasts, categories, listening stats, and more. Share with friends and shout out your favorite creators!";
-
-/* Label of the End of Year call to action button */
-"eoy_view_year" = "View My 2022";
-
-/* Label of the End of Year dismiss button */
-"eoy_not_now" = "Not Now";
-
-/* End of Year card description that appears under Profile */
-"eoy_card_description" = "See your top podcasts, categories, listening stats and more.";
-
-/* Description that appears on the first story of the 2022 Pocket Casts wrap up (End of Year) */
-"eoy_story_intro_title" = "Let's celebrate your year of listening...";
-
-/* String telling the user how much time they listened to podcasts in 2022, %1$@ is a placeholder for the amount of time. */
-"eoy_story_listened_to" = "In 2022, you spent %1$@ listening to podcasts";
-
-/* String telling the user how much time they listened to podcasts in 2022, %1$@ is a placeholder for the amount of time. */
-"eoy_story_listened_to_updated" = "This year, you spent %1$@ listening to podcasts";
-
-/* Text that appears when someone shares the listened to story to Twitter, for example. %1$@ is a placeholder for the amount of time. */
-"eoy_story_listened_to_share_text" = "I spent %1$@ listening to podcasts in 2022";
-
-/* String telling the user how much podcast categories they listened to podcasts in 2022, %1$@ is a placeholder a segment of text that contains the number of categories . */
-"eoy_story_listened_to_categories" = "You listened to %1$@ different categories this year";
-
-/* String telling the user how much podcast categories they listened to podcasts in 2022, %1$@ is a placeholder a segment of text that contains the number of categories . */
-"eoy_story_listened_to_categories_highlighted" = "You listened to %1$@ this year";
-
-/* String telling the user how much podcast categories they listened to podcasts in 2022, %1$@ is a placeholder for the number of different categories. */
-"eoy_story_listened_to_categories_text" = "%1$@ different categories";
-
-/* String prompting the user for the next story to check the most listened categories. */
-"eoy_story_listened_to_categories_subtitle" = "Let's take a look at some of your favorites...";
-
-/* Text that appears when someone shares the listened categories to story to Twitter, for example. %1$@ is a placeholder for the number of categories. */
-"eoy_story_listened_to_categories_share_text" = "I listened to %1$@ different categories in 2022";
-
-/* String telling the user how many podcasts and episodes they listened to this year, %1$@ is a placeholder for the number of podcasts and %2$@ is a placeholder for the number of episodes. */
-"eoy_story_listened_to_numbers" = "You listened to %1$@ different podcasts and %2$@ episodes";
-
-/* String telling the user how many podcasts and episodes they listened to this year, %1$@ is a placeholder for the number of podcasts and %2$@ is a placeholder for the number of episodes. */
-"eoy_story_listened_to_numbers_updated" = "You listened to %1$@ and %2$@";
-
-/* String telling the user how many podcasts they listened to this year, %1$@ is a placeholder for the number of podcasts*/
-"eoy_story_listened_to_podcast_text" = "%1$@ different podcasts";
-
-/* String telling the user how many episodes they listened to this year, %1$@ is a placeholder for the number number of episodes. */
-"eoy_story_listened_to_episodes_text" = "%1$@ episodes";
-
-/* Subtitle for the story containing number of podcasts and episodes played this year. Segway for the next story. */
-"eoy_story_listened_to_numbers_subtitle" = "But there was one that you kept coming back to...";
-
-/* Subtitle for the story containing number of podcasts and episodes played this year. Segway for the next story. */
-"eoy_story_listened_to_numbers_subtitle_updated" = "But there was one that you\nkept coming back to...";
-
-/* Text that appear when someone share the listened numbers story to Twitter. %1$@ is a placeholder for the number of podcasts listened and %2$@ for the number of episodes. */
-"eoy_story_listened_to_numbers_share_text" = "I listened to %1$@ different podcasts and %2$@ episodes in 2022";
-
-/* Title for the story that display the most listened podcast by the user this year. %1$@ is a placeholder for the podcast title and %2$@ is a placeholder for the author. */
-"eoy_story_top_podcast" = "Your top podcast was %1$@ by %2$@";
-
-/* Subtitle for the story that display the most listened podcast by the user this year. %1$@ is a placeholder for the number of episodes and %2$@ is a placeholder for the listened time. */
-"eoy_story_top_podcast_subtitle" = "You listened to %1$@ episodes for a total of %2$@";
-
-/* Text that appear when someone share the top podcast of the year story to Twitter. %1$@ is the URL to the podcast. */
-"eoy_story_top_podcast_share_text" = "My favorite podcast of 2022! %1$@";
-
-/* Title for the story showing the top podcasts for the user in the current year. */
-"eoy_story_top_podcasts" = "Your Top Podcasts";
-
-/* Text that appear when someone share the top 5 podcasts of the year story to Twitter. %1$@ is a link to the list of the top podcasts. */
-"eoy_story_top_podcasts_share_text" = "My top podcasts of the year! %1$@";
-
-/* Title of a list of podcasts created containing the user's top 5 podcasts of 2022. */
-"eoy_story_top_podcasts_list_title" = "My top podcasts of 2022";
-
-/* Title for the story showing the longest episode listened for the user in the current year. %1$@ is a placeholder for the episode title and %2$@ is a placeholder for the podcast title. */
-"eoy_story_longest_episode" = "The longest episode you listened to was %1$@ from the podcast %2$@";
-
-/* Title for the story showing the longest episode listened for the user in the current year. %1$@ is a placeholder for the duration of the episode. */
-"eoy_story_longest_episode_time" = "The longest episode\nyou listened to was\n%1$@";
-
-/* Title for the story showing the longest episode listened for the user in the current year. %1$@ is a placeholder for the title of the podcast for the longest episode. */
-"eoy_story_longest_episode_subtitle" = "The episode was %1$@ from %2$@";
-
-/* Subtitle for the story showing the longest episode listened for the user in the current year. %1$@ is a placeholder for the episode length. */
-"eoy_story_longest_episode_duration" = "This episode was %1$@ long";
-
-/* Text that appear when someone share the longest episode they listened to story to Twitter. %1$@ is the URL to the episode. */
-"eoy_story_longest_episode_share_text" = "The longest episode I listened to in 2022 %1$@";
-
-/* Title for the epilogue story */
-"eoy_story_epilogue_title" = "Thank you for letting Pocket Casts be a part of your listening experience in 2022";
-
-/* Subtitle for the epilogue story */
-"eoy_story_epilogue_subtitle" = "Don't forget to share with your friends and give a shout out to your favorite podcast creators";
-
-/* Label for the replay button, which when tapped started the end of year stories from the first one. */
-"eoy_story_replay" = "Replay";
-
-/* Title of the top categories story. */
-"eoy_story_top_categories" = "Your Top Categories";
-
-/* Text that appear when someone share the top categories story to Twitter. */
-"eoy_story_top_categories_share_text" = "My most listened to podcast categories";
-
-/* Description to why the user needs to create an account to see their end of year stats. */
-"eoy_create_account_to_see" = "Save your podcasts in the cloud, get your end of year review and sync your progress with other devices.";
-
-/* When loading the End of Year stats stories fails. */
-"eoy_stories_failed" = "Failed to load stories.";
-
-/* Title of the view displayed after a user successfully upgrades to plus */
-"welcome_plus_title" = "Thank you, now let's get you listening!";
-
-/* Title of the view displayed after a user successfully creates an account */
-"welcome_new_account_title" = "Welcome, now let's get you listening!";
-
-/* Title of a section informing the user they can import their podcasts from another app */
-"welcome_import_title" = "Import your podcasts";
-
-/* Description of a section informing the user they can import their podcasts from another app */
-"welcome_import_description" = "Coming from another app? Bring your podcasts with you.";
-
-/* Title of a button prompting the user to import their podcasts */
-"welcome_import_button" = "Import Podcasts";
-
-/* Title of a section informing the user they can find new podcasts in the discover section */
-"welcome_discover_title" = "Discover something new";
-
-/* Description of a section informing the user they can find new podcasts in the discover section */
-"welcome_discover_description" = "Find under-the-radar and trending podcasts in our hand-curated Discover page.";
-
-/* Title of a button prompting the user find new podcasts in discover */
-"welcome_discover_button" = "Find My Next Podcast";
-
-/* Label that informs the user they have a free account */
-"account_details_free_account" = "Free Account";
-
-/* Label that shows the user how much time they have listened to podcasts for, %1$@ is the localized formatted time, ie: 2 hours */
-"account_details_listened_for" = "Listened for %1$@";
-
-/* Marketing text that promotes the plus feature to the user */
-"account_details_plus_title" = "Take your podcasting experience to the next level with exclusive access to features and customisation options.";
-
-/* Body of a message informing the user the request failed */
-"plus_upgrade_no_internet_title" = "Unable to Load";
-
-/* Body of a message informing the user they need an internet connect to upgrade to plus */
-"plus_upgrade_no_internet_message" = "Please check your internet connection and try again.";
-
-/* Step by Step instructions on how to import from the app Overcast. \n are new lines and Overcast is a proper noun and should not be translated. */
-"import_instructions_overcast" = "1. Tap the button below to open Overcast\n2. Tap the Cog icon in the top corner of the app\n3. Swipe down until you see Export OPML, then tap on it\n4. When the dialog opens locate the Pocket Casts icon, and tap on it";
-
-/* Step by Step instructions on how to import from the app Breaker. \n are new lines and Breaker is a proper noun and should not be translated. */
-"import_instructions_breaker" = "1. Tap the Open Breaker button below\n2. Tap on Settings in the bottom tab bar\n3. Tap on Connection\n4. Tap on Export subscriptions\n5. When the dialog opens locate the Pocket Casts icon, and tap on it";
-
-/* Step by Step instructions on how to import from the app Castro. \n are new lines and Castro is a proper noun and should not be translated. */
-"import_instructions_castro" = "1. Tap the Open Castro button below\n2. Tap the Cog icon in the top corner of the app\n3. Swipe down until you see the User Data option, then tap on it\n4. Tap the Export Subscriptions item\n5. When the share dialog opens, locate the Pocket Casts icon, then tap on it";
-
-/* Step by Step instructions on how to import from the app Castbox. \n are new lines and Castbox is a proper noun and should not be translated. */
-"import_instructions_castbox" = "1. Tap the Open Castbox button below\n2. Tap the Personal tab\n3. Swipe down until you see the Settings option, then tap on it\n4. Swipe down until you see the OPML Export option, then tap on it\n5. If prompted, tap \"Open in Pocket Casts\"\n6. If the file opens in Safari, tap the Download button\n7. Once the download is complete, tap the download icon in the URL bar\n8. Tap the Downloads item\n9. Tap the castbox_opml file \n10. If needed, tap the Share icon, then open the file using Pocket Casts\n11. When the share dialog opens, locate the Pocket Casts icon, then tap on it";
-
-/* Step by Step instructions on how to import from the app Apple Podcasts. \n are new lines and Apple Podcasts is a proper noun and should not be translated. */
-"import_instructions_apple_podcasts_steps" = "We can import your podcasts from Apple Podcasts by using the built-in Shortcuts app.\nNote: If you previously deleted the shortcuts app you will be prompted to reinstall it.\n\n1. Tap the Install Shortcut button below.\n2. When prompted tap the Add Shortcut button.\n3. Tap on the Shortcuts tab.\n4. Locate the \"Apple Podcasts to Pocket Casts\" shortcut in the list.\n5. Tap it to start the import process.\n6. Once the shortcut is done running Pocket Casts will reopen and finish the import process.";
-
-/* Title of an option to import from other apps */
-"import_instructions_other_apps_title" = "other apps";
-
-/* Button title to install a shortcut */
-"import_instructions_install_shortcut" = "Install Shortcut";
-
-/* Button title to open the given app name,  %1$@ is the name of the app */
-"import_instructions_open_in" = "Open %1$@";
-
-/* Button title to import from the given app name,  %1$@ is the name of the app */
-"import_instructions_import_from" = "Import from %1$@";
-
-/* Title of a view promoting the import feature */
-"import_title" = "Bring your\npodcasts with you";
-
-/* Title of a view explaining the import feature */
-"import_subtitle" = "Coming from another app? Import your podcasts and get listening. You can always do this later in settings.";
-
-/* Title of the login marketing view */
-"login_title" = "Discover your next favorite podcast";
-
-/* Subtitle of the login marketing view */
-"login_subtitle" = "Create an account to sync your listening experience across all your devices.";
-
-/* Title of the plus marketing view */
-"plus_marketing_title" = "Everything you love about Pocket Casts, plus more";
-
-/* Subtitle of the plus marketing view */
-"plus_marketing_subtitle" = "Get access to exclusive features and customisation options";
-
-/* Title of the button that informs the user they can unlock all the features in plus */
-"plus_button_title_unlock_all" = "Unlock All Features";
-
-/* Title of a label informing the user they can cancel their subscription at any time */
-"plus_cancel_terms" = "Can be canceled at any time";
-
-/* Sub title of a view that informs the user what will happen if they cancel their subscription */
-"cancel_confirm_subtitle" = "This will change your plan to a free account.";
-
-/* Title of a list item that informs the user the date their subscription will expire. %1$@ is the date of expiriation */
-"cancel_confirm_sub_expiry" = "Your current subscription will remain active until %1$@.";
-
-/* Item that appears in place of the user's missing expiration date if it's not available. */
-"cancel_confirm_sub_expiry_date_fallback" = "your expiration date";
-
-/* Title of a list item that informs the user their plus features will be locked if they cancel */
-"cancel_confirm_item_plus" = "Access to Pocket Casts Plus features will be locked after this date.";
-
-/* Title of a list item that informs the user their folders will be removed if they cancel */
-"cancel_confirm_item_folders" = "Your folders will be removed and their contents will move back to the Podcasts screen.";
-
-/* Title of a list item that informs the user uploaded files will be removed if they cancel */
-"cancel_confirm_item_uploads" = "All files uploaded to your Pocket Casts account will be deleted (but downloaded files on your mobile devices will remain)";
-
-/* Title of a list item that informs the user they will no longer be able to access plus on the web if they cancel */
-"cancel_confirm_item_web_player" =  "You will no longer be able to access Pocket Casts using your web browser, or desktop computer.";
-
-/* Button title that lets the user stop the cancellation process */
-"cancel_confirm_stay_button_title" =  "Actually, I want to stay";
-
-/* Button title that lets the user contine the cancellation process */
-"cancel_confirm_cancel_button_title" =  "Yes, Cancel my Subscription";
-
-/* Label of a button that lets the user login/signup with Apple */
-"social_sign_in_continue_with_apple" = "Continue with Apple";
-
-/* Label of a button that lets the user login/signup with Google */
-"social_sign_in_continue_with_google" = "Continue with Google";
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--Warning: Auto-generated file, do not edit.-->
+<plist version="1.0">
+  <dict>
+    <key>Settings_files_add_up_next_subtitle</key>
+    <string>Afegir automàticament els nous arxius a la llista 'Tot seguit'</string>
+    <key>about_a8c_family</key>
+    <string>Família d'Automattic</string>
+    <key>about_acknowledgements</key>
+    <string>Agraïments</string>
+    <key>about_join_from_anywhere</key>
+    <string>Uneix-te des de qualsevol lloc</string>
+    <key>about_legal_and_more</key>
+    <string>Legal i altres</string>
+    <key>about_privacy_policy</key>
+    <string>Política de privadesa</string>
+    <key>about_rate_us</key>
+    <string>Puntua'ns</string>
+    <key>about_share_friends</key>
+    <string>Compartir amb amics</string>
+    <key>about_terms_of_service</key>
+    <string>Condicions del servei</string>
+    <key>about_website</key>
+    <string>Pàgina web</string>
+    <key>about_work_with_us</key>
+    <string>Treballa amb nosaltres</string>
+    <key>accessibility_cancel_multiselect</key>
+    <string>Cancel·la la selecció múltiple</string>
+    <key>accessibility_close_dialog</key>
+    <string>Tancar la finestra</string>
+    <key>accessibility_deselect_episode</key>
+    <string>Anul·lar selecció de l'episodi</string>
+    <key>accessibility_disabled</key>
+    <string>Desactivat</string>
+    <key>accessibility_dismiss</key>
+    <string>Descartar</string>
+    <key>accessibility_hide_filter_details</key>
+    <string>Toca per amagar la informació del filtre</string>
+    <key>accessibility_hint_star</key>
+    <string>Fés doble clic per destacar l'episodi</string>
+    <key>accessibility_hint_unstar</key>
+    <string>Fés doble clic per eliminar l'episodi de destacats</string>
+    <key>accessibility_more_actions</key>
+    <string>Més accions</string>
+    <key>accessibility_percent_complete_format</key>
+    <string>%1$@ per cent completat</string>
+    <key>accessibility_player_effects_playback_speed</key>
+    <string>Velocitat de reproducció  de %1$@ vegades</string>
+    <key>accessibility_playlist_color</key>
+    <string>Color de la llista de reproducció %1$@</string>
+    <key>accessibility_plus_only</key>
+    <string>Bloquejat, és una funció Plus</string>
+    <key>accessibility_profile_settings</key>
+    <string>Configuració de Pocket Casts</string>
+    <key>accessibility_select_episode</key>
+    <string>Triar l'episodi</string>
+    <key>accessibility_show_filter_details</key>
+    <string>Fes click per mostrar la informació del filtre</string>
+    <key>accessibility_sign_in</key>
+    <string>Prem per veure o configurar el compte</string>
+    <key>accessibility_sort_and_options</key>
+    <string>Ordre i opcions</string>
+    <key>account_change_email</key>
+    <string>Canviar l'adreça de correu electrònic</string>
+    <key>account_completion_nudge</key>
+    <string>Ja gairebé has acabat!</string>
+    <key>account_completion_nudge_msg</key>
+    <string>Acaba el pagament perquè el teu compte es pugui actualitzar.</string>
+    <key>account_created</key>
+    <string>Compte creat</string>
+    <key>account_creation_complete</key>
+    <string>Completar el compte</string>
+    <key>account_delete_account</key>
+    <string>Esborrar compte</string>
+    <key>account_delete_account_conf</key>
+    <string>Sí, esborra-ho</string>
+    <key>account_delete_account_error</key>
+    <string>Ha fallat quan s'ha volgut esborrar el compte.</string>
+    <key>account_delete_account_error_msg</key>
+    <string>No es pot esborrar el compte.</string>
+    <key>account_delete_account_final_alert_msg</key>
+    <string>Darrera oportunitat: vols esborrar definitivament el compte? Perdràs totes les subscripcions i l'historial de reproduccions de manera permanent.</string>
+    <key>account_delete_account_first_alert_msg</key>
+    <string>Estàs segur que vols esborrar el compte? Si ho fas, no podràs tornar enrere!</string>
+    <key>account_delete_account_title</key>
+    <string>Esborrar el compte?</string>
+    <key>account_details_free_account</key>
+    <string>Compte gratuït</string>
+    <key>account_details_listened_for</key>
+    <string>Escoltat durant %1$@</string>
+    <key>account_details_plus_title</key>
+    <string>Porta la teva experiència amb els podcasts a un altre nivell amb accés exclusiu a funcions i opcions de personalització.</string>
+    <key>account_login</key>
+    <string>Entrar</string>
+    <key>account_payment_renews_monthly</key>
+    <string>Es renova automàticament cada mes</string>
+    <key>account_payment_renews_yearly</key>
+    <string>Es renova automàticament cada any</string>
+    <key>account_privacy_policy</key>
+    <string>Política de privacitat</string>
+    <key>account_registration_failed</key>
+    <string>Hi ha hagut un error en el regisrtre. Torna-ho a provar més tard</string>
+    <key>account_select_type</key>
+    <string>Triar el tipus de compte</string>
+    <key>account_sign_out</key>
+    <string>Surt</string>
+    <key>account_sign_out_supporter_prompt</key>
+    <string>Quan es tanqui la sessió, s'eliminaran %1$@ podcasts compatibles amb aquest dispositiu. Segur que vols continuar?</string>
+    <key>account_sign_out_supporter_subtitle</key>
+    <string>Per a recuperar l'accés, pots tornar a iniciar la sessió.</string>
+    <key>account_signed_out_alert_message</key>
+    <string>Si escrius Google a Google, pots trencar Internet.
+
+ Prem el botó d'abaix per tornar a accedir al teu compte de Pocket Casts. </string>
+    <key>account_signed_out_alert_title</key>
+    <string>La teva sessió s'ha tancat.</string>
+    <key>account_sso_failed</key>
+    <string>Ha fallat l'acés amb Apple. Prova-ho de nou.</string>
+    <key>account_title</key>
+    <string>Compte del Pocket Casts</string>
+    <key>account_upgraded</key>
+    <string>Compte actualitzat</string>
+    <key>account_welcome</key>
+    <string>Benvigut a Pocket Casts!</string>
+    <key>account_welcome_plus</key>
+    <string>Benvingut a Pocket Casts Plus!</string>
+    <key>add_to_up_next</key>
+    <string>Afegir a la llista 'Tot seguit'</string>
+    <key>after_playing</key>
+    <string>Després de reproduir-lo</string>
+    <key>app_badge</key>
+    <string>Insígnia de l'aplicació</string>
+    <key>app_icon_classic</key>
+    <string>Clàssic</string>
+    <key>app_icon_dark</key>
+    <string>Fosc</string>
+    <key>app_icon_default</key>
+    <string>Predeterminat</string>
+    <key>app_icon_electric_blue</key>
+    <string>Blau elèctric</string>
+    <key>app_icon_electric_pink</key>
+    <string>Rosat elèctric</string>
+    <key>app_icon_halloween</key>
+    <string>Halloween</string>
+    <key>app_icon_indigo</key>
+    <string>Índigo</string>
+    <key>app_icon_plus</key>
+    <string>Plus</string>
+    <key>app_icon_pocket_cats</key>
+    <string>Pocket Cats</string>
+    <key>app_icon_radioactivity</key>
+    <string>Radioactivitat</string>
+    <key>app_icon_red_velvet</key>
+    <string>Vellut vermell</string>
+    <key>app_icon_rose</key>
+    <string>Rosat</string>
+    <key>app_icon_round_dark</key>
+    <string>Arrodonit fosc</string>
+    <key>app_icon_round_light</key>
+    <string>Arrodonit clar</string>
+    <key>app_share_text</key>
+    <string>Hola! A continuació trobaràs un enllaç per descarregar Pocket Casts. Aquesta aplicació m'està agradant molt i crec que a tu també et pot interessar.</string>
+    <key>app_version</key>
+    <string>Versió %1$@ (%2$@)</string>
+    <key>appearance_app_icon_header</key>
+    <string>Icona de l'aplicació</string>
+    <key>appearance_artwork_header</key>
+    <string>Caràtules del podcast</string>
+    <key>appearance_dark_theme</key>
+    <string>Tema fosc</string>
+    <key>appearance_embedded_artwork</key>
+    <string>Empra les caràtules integrades</string>
+    <key>appearance_embedded_artwork_subtitle</key>
+    <string>Al reproductor, mostra les caràtules des de l'arxiu integrat (si existeix), enlloc d'emprar les del programa.</string>
+    <key>appearance_light_theme</key>
+    <string>Tema clar</string>
+    <key>appearance_match_device_theme</key>
+    <string>Empra el mode clar/fosc de l'iOS</string>
+    <key>appearance_refresh_all_artwork</key>
+    <string>Refresca totes les il·lustracions dels podcasts</string>
+    <key>appearance_refresh_all_artwork_conf_msg</key>
+    <string>Actualizant les caràtules ara</string>
+    <key>appearance_refresh_all_artwork_conf_title</key>
+    <string>Entesos, capità!</string>
+    <key>appearance_theme_header</key>
+    <string>Tema</string>
+    <key>appearance_theme_select</key>
+    <string>Triar tema</string>
+    <key>archive</key>
+    <string>Arxiva-ho</string>
+    <key>are_you_sure</key>
+    <string>Estàs segur?</string>
+    <key>auto_add</key>
+    <string>Afegir automàticament a</string>
+    <key>auto_add_to_bottom</key>
+    <string>Cap al final</string>
+    <key>auto_add_to_top</key>
+    <string>Al principi</string>
+    <key>auto_add_to_up_next_stop</key>
+    <string>Deixar d'afegir episodis nous</string>
+    <key>auto_add_to_up_next_stop_short</key>
+    <string>Deixar d'afegir</string>
+    <key>auto_add_to_up_next_top_only</key>
+    <string>Afegir al principi de la llista</string>
+    <key>auto_add_to_up_next_top_only_short</key>
+    <string>Només afegeix al principi</string>
+    <key>auto_download_first</key>
+    <string>Descarregar primer automàticament</string>
+    <key>auto_download_off_subtitle</key>
+    <string>Activa la descàrrega automàtica d'episodis per a aquest filtre</string>
+    <key>auto_download_on_plural_format</key>
+    <string>Es descarregaran automàticament els %1$@ primers episodis d'aquest filtre</string>
+    <key>auto_download_prompt_first</key>
+    <string>Primer</string>
+    <key>back</key>
+    <string>Enrere</string>
+    <key>bottom</key>
+    <string>Darrer de la cua</string>
+    <key>bulk_download_max_format</key>
+    <string>Les descàrregues massives tenen un límit de %1$@.</string>
+    <key>cancel</key>
+    <string>Cancel·lar</string>
+    <key>cancel_confirm_item_folders</key>
+    <string>Les carpetes s'eliminaran i els seus continguts es traslladaran a la pantalla Podcast</string>
+    <key>cancel_confirm_item_plus</key>
+    <string>L'accés a les funcions de Pocket Casts Plus estarà bloquejat després d'aquesta data.</string>
+    <key>cancel_confirm_item_uploads</key>
+    <string>Tots els fitxers pujats al vostre compte de Pocket Casts s'eliminaran (però els fitxers que heu baixat al dispositiu mòbil es mantindran)</string>
+    <key>cancel_confirm_sub_expiry</key>
+    <string>La teva subscripció actual estarà activa fins el %1$@.</string>
+    <key>cancel_confirm_sub_expiry_date_fallback</key>
+    <string>la data de caducitat</string>
+    <key>cancel_confirm_subtitle</key>
+    <string>Això canviarà el teu pla a un compte de franc.</string>
+    <key>cancel_download</key>
+    <string>Cancel·la la descàrrega</string>
+    <key>cancel_failed</key>
+    <string>No es pot cancel·lar</string>
+    <key>cancel_subscription</key>
+    <string>Cancel·lar subscripció</string>
+    <key>canceling</key>
+    <string>Cancel·lant...</string>
+    <key>carplay_chapter_count</key>
+    <string>%1$@ de %2$@. %3$@</string>
+    <key>carplay_more</key>
+    <string>Més</string>
+    <key>carplay_playback_speed</key>
+    <string>Velocitat de reproducció</string>
+    <key>carplay_up_next_queue</key>
+    <string>Llista 'Tot seguit'</string>
+    <key>change_email</key>
+    <string>Canviar l'adreça de correu electrònic</string>
+    <key>change_email_conf</key>
+    <string>Adreça de correu electrònic canviada</string>
+    <key>change_password</key>
+    <string>Canviar la contrasenya</string>
+    <key>change_password_conf</key>
+    <string>Contrasenya canviada</string>
+    <key>change_password_error</key>
+    <string>No es pot canviar la contrasenya. No és vàlida.</string>
+    <key>change_password_error_mismatch</key>
+    <string>Les contrasenyes no coincideixen</string>
+    <key>change_password_length_error</key>
+    <string>Ha de tenir 6 caràcters com a mínim</string>
+    <key>chapters</key>
+    <string>Capítols</string>
+    <key>chosen_podcasts_plural_format</key>
+    <string>%1$@ podcasts triats</string>
+    <key>chosen_podcasts_singular</key>
+    <string>1 podcast triat</string>
+    <key>chromecast_cast_to</key>
+    <string>Emetre a</string>
+    <key>chromecast_connected</key>
+    <string>Connectat</string>
+    <key>chromecast_connected_to_device</key>
+    <string>Connectat al dispositiu</string>
+    <key>chromecast_error</key>
+    <string>No es pot emetre l'arxiu local</string>
+    <key>chromecast_nothing_playing</key>
+    <string>No hi ha res sonant ara</string>
+    <key>chromecast_unnamed_device</key>
+    <string>Dispositiu sense nom</string>
+    <key>clean_up</key>
+    <string>Buidar</string>
+    <key>clear</key>
+    <string>Esborrar</string>
+    <key>clear_up_next</key>
+    <string>Esborrar la llista 'Tot seguit'</string>
+    <key>clear_up_next_message</key>
+    <string>Estàs segur que vols esborrar la teva llista de 'Tot seguit'?</string>
+    <key>close</key>
+    <string>Tancar</string>
+    <key>color</key>
+    <string>Color</string>
+    <key>confirm</key>
+    <string>Confirmar</string>
+    <key>confirm_new_password_prompt</key>
+    <string>Confirmar la novca contrasenya</string>
+    <key>continue</key>
+    <string>Segueix</string>
+    <key>create_account</key>
+    <string>Crear un compte</string>
+    <key>create_account_app_store_error_message</key>
+    <string>Pocket Casts té problemes per connectar-se a l'App Store. Comprova la connexió i torna-ho a provar.</string>
+    <key>create_account_app_store_error_title</key>
+    <string>No es pot contactar amb l'App Store</string>
+    <key>create_account_find_out_more_plus</key>
+    <string>Més informació sobre Pocket Casts Plus</string>
+    <key>create_account_free_account_type</key>
+    <string>Normal</string>
+    <key>create_account_free_details</key>
+    <string>Gairebé tot</string>
+    <key>create_account_free_price</key>
+    <string>De franc</string>
+    <key>create_account_plus_details</key>
+    <string>Tot desbloquejat</string>
+    <key>create_filter</key>
+    <string>Crear filtre</string>
+    <key>current_email_prompt</key>
+    <string>Adreça de correu electrònc acrual</string>
+    <key>current_password_prompt</key>
+    <string>Contrasenya actual</string>
+    <key>custom_episode</key>
+    <string>Episodi personalitzat</string>
+    <key>custom_episode_cancel_upload</key>
+    <string>Cancel·lar la pujada</string>
+    <key>custom_episode_remove_upload</key>
+    <string>Esborrar del núvol</string>
+    <key>custom_episode_upload</key>
+    <string>Pujar al núvol</string>
+    <key>day_listened</key>
+    <string>Dies escoltats</string>
+    <key>day_saved</key>
+    <string>Dies estalviats</string>
+    <key>days_listened</key>
+    <string>Dies escoltats</string>
+    <key>days_saved</key>
+    <string>Dies estalviats</string>
+    <key>delete</key>
+    <string>Esborrar</string>
+    <key>delete_download</key>
+    <string>Esborrar la descàrrega</string>
+    <key>delete_everywhere</key>
+    <string>Esborrar de tots els llocs</string>
+    <key>delete_everywhere_short</key>
+    <string>Esborra-ho de tots els llocs</string>
+    <key>delete_file</key>
+    <string>Esborrar fitxer</string>
+    <key>delete_file_message</key>
+    <string>Estàs segur que vols esborrar aquest fitxer?</string>
+    <key>delete_from_cloud</key>
+    <string>Esborrar del núvol</string>
+    <key>delete_from_device</key>
+    <string>Esborrar del dispositiu</string>
+    <key>delete_from_device_only</key>
+    <string>Esborrar només del dispositiu</string>
+    <key>deselect_all</key>
+    <string>Anul·lar totes les seleccions</string>
+    <key>discover</key>
+    <string>Descobrir</string>
+    <key>discover_browse_by_category</key>
+    <string>Cercar per categoria</string>
+    <key>discover_browse_by_category_art</key>
+    <string>Arts</string>
+    <key>discover_browse_by_category_business</key>
+    <string>Empresa</string>
+    <key>discover_browse_by_category_comedy</key>
+    <string>Comèdia</string>
+    <key>discover_browse_by_category_education</key>
+    <string>Educació</string>
+    <key>discover_browse_by_category_fiction</key>
+    <string>Ficció</string>
+    <key>discover_browse_by_category_games_and_hobbies</key>
+    <string>Jocs i aficions</string>
+    <key>discover_browse_by_category_government</key>
+    <string>Política</string>
+    <key>discover_browse_by_category_government_and_organizations</key>
+    <string>Govern i organitzacions</string>
+    <key>discover_browse_by_category_health</key>
+    <string>Salut</string>
+    <key>discover_browse_by_category_health_and_fitness</key>
+    <string>Salut</string>
+    <key>discover_browse_by_category_history</key>
+    <string>Història</string>
+    <key>discover_browse_by_category_kids_and_family</key>
+    <string>Fillets i família</string>
+    <key>discover_browse_by_category_leisure</key>
+    <string>Entreteniment</string>
+    <key>discover_browse_by_category_music</key>
+    <string>Música</string>
+    <key>discover_browse_by_category_news</key>
+    <string>Notícies</string>
+    <key>discover_browse_by_category_news_and_politics</key>
+    <string>Notícies i política</string>
+    <key>discover_browse_by_category_religion_and_spirituality</key>
+    <string>Religió i espiritualitat</string>
+    <key>discover_browse_by_category_science</key>
+    <string>Ciència</string>
+    <key>discover_browse_by_category_science_and_medicine</key>
+    <string>Ciència i medicina</string>
+    <key>discover_browse_by_category_society</key>
+    <string>Societat</string>
+    <key>discover_browse_by_category_society_and_culture</key>
+    <string>Societat i cultura</string>
+    <key>discover_browse_by_category_sports</key>
+    <string>Esports</string>
+    <key>discover_browse_by_category_sports_and_recreation</key>
+    <string>Esports i jocs</string>
+    <key>discover_browse_by_category_technology</key>
+    <string>Tecnologia</string>
+    <key>discover_browse_by_category_true_crime</key>
+    <string>Crims</string>
+    <key>discover_browse_by_category_tv_and_film</key>
+    <string>Cine i televisió</string>
+    <key>discover_change_region</key>
+    <string>Canviar la regió. Actualment %1$@</string>
+    <key>discover_featured</key>
+    <string>Destacat</string>
+    <key>discover_featured_episode</key>
+    <string>EPISODI DESTACAT</string>
+    <key>discover_featured_episode_error_not_found</key>
+    <string>No s'ha trobat el podcast o episodi destacat. Comprova que estigues connectat a Internet i torneu-ho a provar.</string>
+    <key>discover_fresh_pick</key>
+    <string>PODCAST NOU</string>
+    <key>discover_no_podcasts_found</key>
+    <string>No s'han trobat podcasts</string>
+    <key>discover_no_podcasts_found_msg</key>
+    <string>Prova paraules clau més generals o diferents.</string>
+    <key>discover_play_episode</key>
+    <string>Reproduir episodi</string>
+    <key>discover_play_trailer</key>
+    <string>Reproduir tràiler</string>
+    <key>discover_podcast_network</key>
+    <string>Xarxa %1$@</string>
+    <key>discover_popular</key>
+    <string>Popular</string>
+    <key>discover_popular_in</key>
+    <string>Popular a %1$@</string>
+    <key>discover_region_australia</key>
+    <string>Austràlia</string>
+    <key>discover_region_austria</key>
+    <string>Àustria</string>
+    <key>discover_region_belgium</key>
+    <string>Bèlgica</string>
+    <key>discover_region_brazil</key>
+    <string>Brasil</string>
+    <key>discover_region_canada</key>
+    <string>Canadà</string>
+    <key>discover_region_china</key>
+    <string>Xina</string>
+    <key>discover_region_czechia</key>
+    <string>Txèquia</string>
+    <key>discover_region_denmark</key>
+    <string>Dinamarca</string>
+    <key>discover_region_finland</key>
+    <string>Finlàndia</string>
+    <key>discover_region_france</key>
+    <string>França</string>
+    <key>discover_region_germany</key>
+    <string>Alemanya</string>
+    <key>discover_region_hong_kong</key>
+    <string>Hong Kong</string>
+    <key>discover_region_india</key>
+    <string>Índia</string>
+    <key>discover_region_ireland</key>
+    <string>Irlanda</string>
+    <key>discover_region_israel</key>
+    <string>Israel</string>
+    <key>discover_region_italy</key>
+    <string>Itàlia</string>
+    <key>discover_region_japan</key>
+    <string>Japó</string>
+    <key>discover_region_mexico</key>
+    <string>Mèxic</string>
+    <key>discover_region_netherlands</key>
+    <string>Països Baixos</string>
+    <key>discover_region_new_zealand</key>
+    <string>Nova Zelanda</string>
+    <key>discover_region_norway</key>
+    <string>Noruega</string>
+    <key>discover_region_philippines</key>
+    <string>Filipines</string>
+    <key>discover_region_poland</key>
+    <string>Polònia</string>
+    <key>discover_region_portugal</key>
+    <string>Portugal</string>
+    <key>discover_region_russia</key>
+    <string>Rússia</string>
+    <key>discover_region_saudi_arabia</key>
+    <string>Aràbia Saudita</string>
+    <key>discover_region_singapore</key>
+    <string>Singapur</string>
+    <key>discover_region_south_africa</key>
+    <string>Àfrica del Sud</string>
+    <key>discover_region_south_korea</key>
+    <string>Corea del Sud</string>
+    <key>discover_region_spain</key>
+    <string>Espanya</string>
+    <key>discover_region_sweden</key>
+    <string>Suècia</string>
+    <key>discover_region_switzerland</key>
+    <string>Suïssa</string>
+    <key>discover_region_taiwan</key>
+    <string>Taiwan</string>
+    <key>discover_region_turkey</key>
+    <string>Turquia</string>
+    <key>discover_region_ukraine</key>
+    <string>Ucraïna</string>
+    <key>discover_region_united_kingdom</key>
+    <string>Regne Unit</string>
+    <key>discover_region_united_states</key>
+    <string>Estats Units</string>
+    <key>discover_region_worldwide</key>
+    <string>De tot el món</string>
+    <key>discover_search_error_msg</key>
+    <string>Introdueix 2 caràcters com a mínim.</string>
+    <key>discover_search_error_title</key>
+    <string>Longitud insuficient</string>
+    <key>discover_search_failed</key>
+    <string>Ha fallat la cerca</string>
+    <key>discover_search_failed_msg</key>
+    <string>Comprova la teva connexió a Internet.</string>
+    <key>discover_select_region</key>
+    <string>Seleccionar la regió del contingut</string>
+    <key>discover_show_all</key>
+    <string>MOSTRAR TOT</string>
+    <key>discover_sponsored</key>
+    <string>PATROCINAT</string>
+    <key>discover_trending</key>
+    <string>Tendències</string>
+    <key>done</key>
+    <string>Fet</string>
+    <key>download</key>
+    <string>Descarregar</string>
+    <key>download_all</key>
+    <string>Descarrega-ho tot</string>
+    <key>download_data_warning</key>
+    <string>La descàrrega emprarà dades mòbils.</string>
+    <key>download_episode_plural_format</key>
+    <string>Descarregar %1$@ episodis</string>
+    <key>download_episode_singular</key>
+    <string>Descarregar 1 episodi</string>
+    <key>download_error_contact_author</key>
+    <string>L'episodi no està disponible a causa d'un error al feed del podcast. Posa't en contacte amb el seu autor.</string>
+    <key>download_error_contact_author_version_2</key>
+    <string>És possible que aquest episodi s'hagi mogut o esborrat. Posa't en contacte amb l'autor del podcast.</string>
+    <key>download_error_not_enough_space</key>
+    <string>No s'ha pogut desar el fitxer. T'has quedat sense espai?</string>
+    <key>download_error_not_uploaded</key>
+    <string>El fitxer no s'ha pujat i no es pot reproduir</string>
+    <key>download_error_status_code</key>
+    <string>S'ha produït un error a la descàrrega. El codi d'error és %1$@. Posa't en contacte amb l'autor del podcast.</string>
+    <key>download_error_try_again</key>
+    <string>No s'ha pogut descarregar l'episodi. Torna-ho a provar més tard.</string>
+    <key>download_failed</key>
+    <string>Error a la descàrrega</string>
+    <key>downloaded_files</key>
+    <string>Fitxers descarregats</string>
+    <key>downloaded_files_cleanup_confirmation</key>
+    <string>Estàs seguir que vols eliminar aquests arxius descarregats?</string>
+    <key>downloaded_files_conf_message</key>
+    <string>Si et dones de baixa, s'esborraran tots els fitxers descarregats d'aquest podcast. N'estàs segur?</string>
+    <key>downloaded_files_conf_plural_format</key>
+    <string>%1$@ arxius descarregats</string>
+    <key>downloaded_files_conf_singular</key>
+    <string>1 arxiu descarregat</string>
+    <key>downloads</key>
+    <string>Descàrregues</string>
+    <key>downloads_auto_download</key>
+    <string>Configuració de la descàrrega automàtica</string>
+    <key>downloads_no_downloads_desc</key>
+    <string>Vaja! No tens més descàrregues. Descàrrega'ns algunes més i apareixeran aquí.</string>
+    <key>downloads_no_downloads_title</key>
+    <string>No hi ha episodis descarregats</string>
+    <key>downloads_retry_failed_downloads</key>
+    <string>Reintentar les descàrregues fallides</string>
+    <key>downloads_stop_all_downloads</key>
+    <string>Aturar totes les descàrregues</string>
+    <key>edit</key>
+    <string>Editar</string>
+    <key>eoy_card_description</key>
+    <string>Consulta quins han estat els podcasts i les categories que més has escoltat, les estadístiques d'escolta i molt més.</string>
+    <key>eoy_create_account_to_see</key>
+    <string>Guarda els teus podcasts al núvol, aconsegueix un resum al final de l'any i sincronitza el teu progrés amb altres dispositius.</string>
+    <key>eoy_description</key>
+    <string>Consulta quins han estat els podcasts i les categories que més has escoltat, les estadístiques d'escolta i molt més. Comparteix-ho amb els teus amics i fes que tothom sapiga quins són els teus creadors favorits.</string>
+    <key>eoy_not_now</key>
+    <string>Ara no</string>
+    <key>eoy_small_title</key>
+    <string>L'any en podcasts</string>
+    <key>eoy_stories_failed</key>
+    <string>No s'han pogut carregar les històries.</string>
+    <key>eoy_story_epilogue_subtitle</key>
+    <string>No oblidis de compartir-los amb els teus amics i enviar una salutació als teus creadors de podcast preferits.</string>
+    <key>eoy_story_epilogue_title</key>
+    <string>Gràcies per permetre que Pocket Casts sigui part de la teva experiència auditiva al 2022.</string>
+    <key>eoy_story_intro_title</key>
+    <string>Celebra l'any que portes escoltant podcast...</string>
+    <key>eoy_story_listened_to</key>
+    <string>Al 2022, has estat %1$@ escoltant podcast.</string>
+    <key>eoy_story_listened_to_categories</key>
+    <string>Has escoltat %1$@ categories diferents enguany.</string>
+    <key>eoy_story_listened_to_categories_highlighted</key>
+    <string>Has escoltat %1$@ enguany</string>
+    <key>eoy_story_listened_to_categories_share_text</key>
+    <string>He escoltat %1$@ categories diferents al 2022</string>
+    <key>eoy_story_listened_to_categories_subtitle</key>
+    <string>Anem a fer un cop d'ull a alguns dels teus favorits...</string>
+    <key>eoy_story_listened_to_categories_text</key>
+    <string>%1$@ categories diferents</string>
+    <key>eoy_story_listened_to_episodes_text</key>
+    <string>%1$@ episodis</string>
+    <key>eoy_story_listened_to_numbers</key>
+    <string>Has escoltat %1$@ podcast diferents i %2$@ episodis.</string>
+    <key>eoy_story_listened_to_numbers_share_text</key>
+    <string>Al 2022 vaig escoltar %1$@ podcast diferents i %2$@ episodis</string>
+    <key>eoy_story_listened_to_numbers_subtitle</key>
+    <string>Però n'hi havia un al que tornaves...</string>
+    <key>eoy_story_listened_to_numbers_subtitle_updated</key>
+    <string>Així i tot, n'hi ha un que has escoltat una vegada i una altra...</string>
+    <key>eoy_story_listened_to_numbers_updated</key>
+    <string>Has escoltat %1$@ i %2$@</string>
+    <key>eoy_story_listened_to_podcast_text</key>
+    <string>%1$@ podcasts diferents</string>
+    <key>eoy_story_listened_to_share_text</key>
+    <string>Al 2022 he estat %1$@ escoltant podcasts</string>
+    <key>eoy_story_listened_to_updated</key>
+    <string>Enguany, has passat %1$@ escoltant podcasts</string>
+    <key>eoy_story_longest_episode</key>
+    <string>L'episodi més llarg que has sentit ha estat %1$@ del podcast %2$@.</string>
+    <key>eoy_story_longest_episode_duration</key>
+    <string>Aquest episodi va durar %1$@</string>
+    <key>eoy_story_longest_episode_share_text</key>
+    <string>L'episodi més llarg que vaig sentir el 2022 %1$@</string>
+    <key>eoy_story_longest_episode_subtitle</key>
+    <string>L'episodi es titula %1$@ de %2$@</string>
+    <key>eoy_story_longest_episode_time</key>
+    <string>L'episodi més llarg que has sentit dura %1$@</string>
+    <key>eoy_story_replay</key>
+    <string>Torna a reproduir</string>
+    <key>eoy_story_top_categories</key>
+    <string>Les teves principals categories</string>
+    <key>eoy_story_top_categories_share_text</key>
+    <string>Les meves categories de podcasts més escoltats</string>
+    <key>eoy_story_top_podcast</key>
+    <string>El vostre podcast preferit va ser %1$@ de %2$@.</string>
+    <key>eoy_story_top_podcast_share_text</key>
+    <string>El meu podcast favorit de 2022! %1$@</string>
+    <key>eoy_story_top_podcast_subtitle</key>
+    <string>Has escoltat %1$@ episodis d'un total de %2$@.</string>
+    <key>eoy_story_top_podcasts</key>
+    <string>Els teus podcasts favorits</string>
+    <key>eoy_story_top_podcasts_list_title</key>
+    <string>Els meus podcasts principals de 2022</string>
+    <key>eoy_story_top_podcasts_share_text</key>
+    <string>Els meus podcasts principals de l'any! %1$@</string>
+    <key>eoy_title</key>
+    <string>El teu any en podcasts</string>
+    <key>eoy_view_year</key>
+    <string>Veure el meu 2022</string>
+    <key>episode</key>
+    <string>Episodi</string>
+    <key>episode_count_plural_format</key>
+    <string>%1$@ episodis</string>
+    <key>episode_filter_by_duration_label</key>
+    <string>Filtrar per durada</string>
+    <key>episode_filter_no_episodes_msg</key>
+    <string>Arribats aquí, pots celebrar que la llista està acabada o modificar la configuració dels filtres per trobar més episodis.</string>
+    <key>episode_filter_no_episodes_title</key>
+    <string>No hi ha episodis</string>
+    <key>episode_indicator_bonus</key>
+    <string>Bonus</string>
+    <key>episode_indicator_season_trailer</key>
+    <string>Tràiler de la temporada %1$@</string>
+    <key>episode_indicator_trailer</key>
+    <string>Tràiler</string>
+    <key>episode_shorthand_format</key>
+    <string>EPISODI %1$@</string>
+    <key>episode_shorthand_format_short</key>
+    <string>EP %1$@</string>
+    <key>error</key>
+    <string>Error</string>
+    <key>error_general_podcast_not_found</key>
+    <string>No s'ha pogut trobar el podcast. Posa't en contacte amb el seu autor.</string>
+    <key>export_podcasts_description</key>
+    <string>Exporta tots els teus podcasts a un fitxer OPML, que pots importar a altres aplicacions de podcasts.</string>
+    <key>export_podcasts_option</key>
+    <string>Exportar podcasts</string>
+    <key>export_podcasts_title</key>
+    <string>EXPORTAR</string>
+    <key>feature_tour_end_tour</key>
+    <string>Acabar la guia</string>
+    <key>feature_tour_new</key>
+    <string>NOU</string>
+    <key>feature_tour_step_format</key>
+    <string>%1$@ de %2$@</string>
+    <key>feedback_continue_with_mail</key>
+    <string>Obrir l'aplicacio de correu predeterminada</string>
+    <key>feedback_mail_not_configured_msg</key>
+    <string>Per enviar un fitxer adjunt i corregir errors de programació, has de configurar l'aplicació Mail d'Apple al vostre mòbil. Què vols fer?</string>
+    <key>feedback_mail_not_configured_title</key>
+    <string>No s'ha configurat un correu electrònic</string>
+    <key>file_upload_add_file</key>
+    <string>Afegir fitxer</string>
+    <key>file_upload_add_image</key>
+    <string>Afegir una imatge personalitzada</string>
+    <key>file_upload_choose_image</key>
+    <string>Triar la imatge</string>
+    <key>file_upload_choose_image_camera</key>
+    <string>Càmera</string>
+    <key>file_upload_choose_image_photo_Library</key>
+    <string>Biblioteca de fotos</string>
+    <key>file_upload_edit_file</key>
+    <string>Editar el fitxer</string>
+    <key>file_upload_error</key>
+    <string>No hi ha prou espai per pujar aquest arxiu.</string>
+    <key>file_upload_error_subtitle</key>
+    <string>Esborra alguns arxius i prova-ho de nou.</string>
+    <key>file_upload_name_required</key>
+    <string>El nom és necessari</string>
+    <key>file_upload_no_files_description</key>
+    <string>Vols escoltar els teus propis fitxers?
+Comparteix-los amb Pocket Casts i apareixeran aquí.</string>
+    <key>file_upload_no_files_helper</key>
+    <string>Com ho faig?</string>
+    <key>file_upload_no_files_title</key>
+    <string>No hi ha arxius</string>
+    <key>file_upload_remove_image</key>
+    <string>Esborrar la imatge</string>
+    <key>file_upload_save</key>
+    <string>Desar</string>
+    <key>file_upload_support_error</key>
+    <string>Aquest tipus d'arxiu  no és compatible</string>
+    <key>files</key>
+    <string>Arxius</string>
+    <key>files_how_to_title</key>
+    <string>Com desar un arxiu</string>
+    <key>files_sort</key>
+    <string>Ordenar els arxius</string>
+    <key>filter_auto_add_subtitle</key>
+    <string>Els nous podcasts als que et subscriguis s'afegiran automàticament</string>
+    <key>filter_chips_all_podcasts</key>
+    <string>Tots els teus podcasts</string>
+    <key>filter_chips_duration</key>
+    <string>Durada</string>
+    <key>filter_choose_podcasts</key>
+    <string>Triar podcasts</string>
+    <key>filter_create_add_more</key>
+    <string>Afegeix més paràmetres per acabar de millor el teu filtre.</string>
+    <key>filter_create_filter_by</key>
+    <string>FILTRAR PER</string>
+    <key>filter_create_instructions</key>
+    <string>Seleccioneu els vostres criteris de filtre amb aquests botons per crear una llista de reproducció intel·ligent d'episodis actualitzada.</string>
+    <key>filter_create_no_episodes</key>
+    <string>No hi ha episodis que coincideixin</string>
+    <key>filter_create_no_episodes_description_explanation</key>
+    <string>Els paràmetres que heu triat no coincideixen amb cap episodi en les vostres subscripcions</string>
+    <key>filter_create_no_episodes_description_prompt</key>
+    <string>Selecciona altres paràmetres o desa aquest filtre si creus que coincidirà amb algun episodi més endavant.</string>
+    <key>filter_create_podcasts_all_podcasts</key>
+    <string>Tots els podcasts</string>
+    <key>filter_create_preview</key>
+    <string>VISTA PRÈVIA</string>
+    <key>filter_create_save</key>
+    <string>Guardar filtre</string>
+    <key>filter_details</key>
+    <string>Detalls del filtre</string>
+    <key>filter_details_color_icon</key>
+    <string>COLOR I ICONA</string>
+    <key>filter_details_color_selection</key>
+    <string>Selector de color</string>
+    <key>filter_details_icon_selection</key>
+    <string>Selector d'icones</string>
+    <key>filter_details_name</key>
+    <string>NOM</string>
+    <key>filter_download_status</key>
+    <string>Estat de la descàrrega</string>
+    <key>filter_episode_status</key>
+    <string>Estast de l'episodi</string>
+    <key>filter_longer_than_label</key>
+    <string>Més de</string>
+    <key>filter_manual_add_subtitle</key>
+    <string>Els nous podcasts als que et subscriguis no s'afegiran automàticament</string>
+    <key>filter_media_type</key>
+    <string>Tipus d'arxiu multimèdia</string>
+    <key>filter_media_type_audio</key>
+    <string>Àudio</string>
+    <key>filter_media_type_video</key>
+    <string>Vídeo</string>
+    <key>filter_option_episode_duration</key>
+    <string>Durada de l'episodi</string>
+    <key>filter_option_episode_duration_error_msg_format</key>
+    <string>Filtrar els episodis més llargs de %1$@ però més curts de %2$@ provocaria una fissura en el nostre continu espai-temps. Ho sentim.</string>
+    <key>filter_option_episode_duration_error_title</key>
+    <string>Sí, però no</string>
+    <key>filter_options</key>
+    <string>Opcions del filtre</string>
+    <key>filter_release_date</key>
+    <string>Data de publicació</string>
+    <key>filter_release_date_anytime</key>
+    <string>Qualsevol moment</string>
+    <key>filter_release_date_last_24_hours</key>
+    <string>Les darreres 24 hores</string>
+    <key>filter_release_date_last_2_weeks</key>
+    <string>Les 2 darreres setmanes</string>
+    <key>filter_release_date_last_3_days</key>
+    <string>Els darrers 3 dies</string>
+    <key>filter_release_date_last_month</key>
+    <string>El darrer mes</string>
+    <key>filter_release_date_last_week</key>
+    <string>La setmana passada</string>
+    <key>filter_shorter_than_label</key>
+    <string>Menys de</string>
+    <key>filter_update</key>
+    <string>Actualitzar el filtre</string>
+    <key>filter_value_all</key>
+    <string>Tot</string>
+    <key>filters</key>
+    <string>Filtres</string>
+    <key>filters_default_new_filter</key>
+    <string>Filtre nou</string>
+    <key>filters_default_new_releases</key>
+    <string>Novetats</string>
+    <key>filters_new_filter_button</key>
+    <string>Afegir filtre nou</string>
+    <key>folder</key>
+    <string>Carpeta</string>
+    <key>folder_add_podcasts_plural_format</key>
+    <string>Afegir %1$@ podcasts</string>
+    <key>folder_add_podcasts_singular</key>
+    <string>Afegir 1 podcast</string>
+    <key>folder_add_remove_podcasts</key>
+    <string>Afegir o eliminar podcasts</string>
+    <key>folder_change</key>
+    <string>Canviar de carpeta</string>
+    <key>folder_choose_color</key>
+    <string>Tria un color</string>
+    <key>folder_choose_podcasts</key>
+    <string>Triar podcasts</string>
+    <key>folder_color_detail</key>
+    <string>Simplifica la identificació de les carpetes</string>
+    <key>folder_create</key>
+    <string>Crear carpeta</string>
+    <key>folder_create_new</key>
+    <string>Crear una carpeta nova</string>
+    <key>folder_delete</key>
+    <string>Esborrar carpeta</string>
+    <key>folder_delete_prompt_msg</key>
+    <string>Aquesta carpeta s'eliminarà i tot el seu contingut es traslladarà a la pantalla de podcasts.</string>
+    <key>folder_delete_prompt_title</key>
+    <string>Estàs segur?</string>
+    <key>folder_edit</key>
+    <string>Editar carpeta</string>
+    <key>folder_empty_description</key>
+    <string>Afegeix podcasts a la teva carpeta i apareixeran aquí.</string>
+    <key>folder_empty_title</key>
+    <string>La teva carpeta és buida</string>
+    <key>folder_go_to</key>
+    <string>Anar a la carpeta</string>
+    <key>folder_name</key>
+    <string>Nom de la carpeta</string>
+    <key>folder_name_title</key>
+    <string>Nom de la carpeta</string>
+    <key>folder_new</key>
+    <string>Carpeta nova</string>
+    <key>folder_no_folder</key>
+    <string>Sense carpetes</string>
+    <key>folder_podcast_choose_folder</key>
+    <string>Triar la carpeta</string>
+    <key>folder_remove_from</key>
+    <string>Esborrar de la carpeta</string>
+    <key>folder_save_folder</key>
+    <string>Guardar carpeta</string>
+    <key>folder_unnamed</key>
+    <string>Carpeta sense nom</string>
+    <key>folders</key>
+    <string>Carpetes</string>
+    <key>free_trial_detail_label</key>
+    <string>Sense pagament per avançat. Cancel·la en qualsevol moment</string>
+    <key>free_trial_duration_free</key>
+    <string>%1$@ GRATUÏT</string>
+    <key>free_trial_duration_free_trial</key>
+    <string>PROVA GRATUÏTA DE %1$@</string>
+    <key>free_trial_pricing_terms</key>
+    <string>%1$@ gratuït, i després %2$@</string>
+    <key>free_trial_start_and_subscribe_button</key>
+    <string>Començar una prova gratuïta i subscriure's</string>
+    <key>free_trial_start_button</key>
+    <string>Començar la prova gratuïta</string>
+    <key>free_trial_title_label</key>
+    <string>Prova Plus durant %1$@ de franc</string>
+    <key>funny_conf_msg</key>
+    <string>Combina amb els teus ulls ✨</string>
+    <key>funny_time_not_enough</key>
+    <string>No has escoltat durant molt temps, no?</string>
+    <key>funny_time_unit_airplane_takeoffs</key>
+    <string>Durant aquest temps s'han enlairat %1$@ avions. Cordeu-vos els cinturons. 🛫</string>
+    <key>funny_time_unit_astronaut_sneezes</key>
+    <string>Durant aquest temps, un astronauta va esternudar %1$@ vegades. Atxim! 😤</string>
+    <key>funny_time_unit_balloon_travel</key>
+    <string>Durant aquest temps, podries haver fet la volta al món en globus aerostàtic %1$@ vegades. 🌏</string>
+    <key>funny_time_unit_births</key>
+    <string>Durant aquest temps, han nascut %1$@ nadons. Bua, bua! 🍼</string>
+    <key>funny_time_unit_blinks</key>
+    <string>Durant aquest temps, has parpellejat %1$@ vegades. Ostres! 👀</string>
+    <key>funny_time_unit_emails</key>
+    <string>Durant aquest temps, s'han enviat %1$@ correus electrònics. 💌</string>
+    <key>funny_time_unit_farts</key>
+    <string>Durant aquest temps, el teu cos ha alliberat %1$@ g d'aire. Quin fastic! 💨</string>
+    <key>funny_time_unit_google</key>
+    <string>Durant aquest temps, s'han fet %1$@ cerques a Google. Zas! 🔎</string>
+    <key>funny_time_unit_lightning</key>
+    <string>Durant aquest temps, han caigut %1$@ llamps. Bum! ⚡️</string>
+    <key>funny_time_unit_phone_production</key>
+    <string>Durant aquest temps, un determinat venedor de fruites va guanyar $%1$@ 🍏</string>
+    <key>funny_time_unit_shed_skin</key>
+    <string>Durant aquest temps, s'han desprès %1$@ cèl·lules de la pell. De debò? 😅</string>
+    <key>funny_time_unit_tied_shoes</key>
+    <string>Durant aquest temps, podries haver-te lligat els cordons de les sabates %1$@ vegades. Pot ser. 👟</string>
+    <key>funny_time_unit_tweets</key>
+    <string>Durant aquest temps s'han enviat %1$@ tiuts. Piu! Piu! 🐣</string>
+    <key>go_to_podcast</key>
+    <string>Anar al podcast</string>
+    <key>group_episodes</key>
+    <string>Agrupar episodis</string>
+    <key>history_clear_all</key>
+    <string>Esborra-ho tot</string>
+    <key>history_clear_all_details</key>
+    <string>Esborrar l'historial d'elements escoltats</string>
+    <key>history_clear_all_details_msg</key>
+    <string>Aquesta acció no es pot desfer.</string>
+    <key>hour_listened</key>
+    <string>Hores escoltades</string>
+    <key>hour_saved</key>
+    <string>Hores estalviades</string>
+    <key>hours_listened</key>
+    <string>Hores escoltades</string>
+    <key>hours_plural_format</key>
+    <string>%1$@ hores</string>
+    <key>hours_saved</key>
+    <string>Hores estalviades</string>
+    <key>how_to_upload_explanation</key>
+    <string>Primer, obre una aplicacio que tingui els arxius d'àudio que vols desar.</string>
+    <key>how_to_upload_first_instruction</key>
+    <string>Tria compartir aquest arxiu</string>
+    <key>how_to_upload_second_instruction</key>
+    <string>Al menú, toca 'Copiar a Pocket Casts'</string>
+    <key>how_to_upload_summary</key>
+    <string>Ja està. Canvia les dades que vulguis, prem desar i ja pots reproduir-los. </string>
+    <key>import_instructions_apple_podcasts_steps</key>
+    <string>Podem importar els teus podcasts des d'Apple Podcasts mitjançant l'aplicació Dreceres incorporada.
+Nota: En cas que hagis eliminat l'aplicació Dreceres, se't demanarà que la torneu a instal·lar.
+1. Toca el botó Instal·lar drecera que apareix a continuació.
+2. Quan se't demani, toca el botó Afegeix drecera.
+3. Vés a la pestanya Dreceres. 
+4. A la llista, localitza la drecera "Apple Podcasts a Pocket Casts". 
+5. Toca aquesta opció per iniciar el procés d'importació. 
+6. Quan la drecera estigui feta, en executar Pocket Casts es tornarà a obrir i es finalitzarà el procés d'importació.</string>
+    <key>import_instructions_breaker</key>
+    <string>1. Toca el botó Obrir a Breaker que apareix a sota. 
+2. Vés a Paràmetres a la barra de pestanyes inferior. 
+3. Vés a Connexió 
+4. Vés a Exportar subscripcions. 
+5. Quan obris el diàleg, cerca la icona de Pocket Casts i vés-hi.</string>
+    <key>import_instructions_castbox</key>
+    <string>1. Toca el botó Obrir a Castbox que apareix a sota. 
+2. Vés a la pestanya Personal. 
+3. Feu lliscar cap avall fins que veieu l'opció Configuració i tocala. 
+4. Fes lliscar cap avall fins que vegis l'opció Exportació d'OPML i pitja-hi
+ 5. Si apareix, toca "Obrir a Pocket Casts". 
+6. Si el fitxer s'obre a Safari, toca el botó Descarregar. 
+7. Quan la baixada hagi acabat, toca la icona de baixada que apareix a la barra d'URL. 
+8. Vés a l'element Descàrregues.
+9. Toca el fitxer castbox_opml. 
+10. Si cal, toca la icona Compartir i, a continuació, obre el fitxer amb Pocket Casts. 
+11. Quan obris el diàleg de compartir, cerca la icona de Pocket Casts i tocala.</string>
+    <key>import_instructions_castro</key>
+    <string>1. Toca el botó Obrir a Castro que surt a sota.
+2. Toca la icona d'engranatge que apareix a la part superior de l'aplicació. 
+3. Fes lliscar cap avall fins que vegis l'opció Dades d'usuari i llavors pica-hi.
+4. Toca l'element Exportar subscripcions. 
+5. Quan obriu el diàleg de compartir, cerqueu la icona de Pocket Casts i toqueu-la.</string>
+    <key>import_instructions_import_from</key>
+    <string>Importar des de %1$@</string>
+    <key>import_instructions_install_shortcut</key>
+    <string>Instal·lar l'accés directe</string>
+    <key>import_instructions_open_in</key>
+    <string>Obrir %1$@</string>
+    <key>import_instructions_other_apps_title</key>
+    <string>altres aplicacions</string>
+    <key>import_instructions_overcast</key>
+    <string>1. Toca el botó de sota per obrir a Overcast. 
+2. Toca la icona d'engranatge que apareix a la part superior de l'aplicació. 
+3. Fes lliscar cap avall fins que vegis l'opció Exportar OPML i vés-hi. 
+4. Quan obriu el diàleg, cerca la icona de Pocket Casts i vés-hi.</string>
+    <key>import_podcasts_description</key>
+    <string>Pots importar les subscripcions de podcasts a Pocket Casts amb el format OPML, que s'admet en moltes aplicacions. Exporta el fitxer a l'altra aplicació i tria obrir-lo a Pocket Casts.
+
+Nota: És possible que t'hagis d'enviar el fitxer OPML a tu mateix per correu electrònic, mantingues premut el fitxer adjunt i seleccioneu Pocket Casts.</string>
+    <key>import_podcasts_title</key>
+    <string>IMPORTAR A POCKET CASTS</string>
+    <key>import_subtitle</key>
+    <string>Vens des d'una altra aplicació? Importa els teus podcasts i escolta'ls. Sempre pots fer això més endavant des de la configuració.</string>
+    <key>import_title</key>
+    <string>Emporta't els teus podcasts amb tu</string>
+    <key>in_progress</key>
+    <string>En progrés</string>
+    <key>keycommand_close_player</key>
+    <string>Tancar el reproductor</string>
+    <key>keycommand_decrease_speed</key>
+    <string>Disminueix la velocitat</string>
+    <key>keycommand_increase_speed</key>
+    <string>Augmentar la velocitat</string>
+    <key>keycommand_open_player</key>
+    <string>Obrir el reproductor</string>
+    <key>keycommand_play_pause</key>
+    <string>Reproduir / Pausar</string>
+    <key>learn_more</key>
+    <string>Més informació</string>
+    <key>listening_history</key>
+    <string>Historial d'episodis escoltats</string>
+    <key>loading</key>
+    <string>Carregant...</string>
+    <key>login_subtitle</key>
+    <string>Crea un compte per a sincronitzar la vostra experiència auditiva en tots els teus dispositius.</string>
+    <key>login_title</key>
+    <string>Descobreix el teu proper podcast favorit</string>
+    <key>mark_played</key>
+    <string>Marca-ho com a reproduït</string>
+    <key>mark_played_short</key>
+    <string>Marca-ho a com a reproduït</string>
+    <key>mark_unplayed_short</key>
+    <string>Marca-ho com a no reproduït</string>
+    <key>mini_player_close</key>
+    <string>Tancar i esborrar 'Tot seguit'</string>
+    <key>minute_listened</key>
+    <string>Minuts escoltats</string>
+    <key>minute_saved</key>
+    <string>Minuts estalviats</string>
+    <key>minutes_listened</key>
+    <string>Minuts escoltats</string>
+    <key>minutes_saved</key>
+    <string>Minuts escoltats</string>
+    <key>month</key>
+    <string>mes</string>
+    <key>monthly</key>
+    <string>Mensualment</string>
+    <key>move_to_bottom</key>
+    <string>Moure al final</string>
+    <key>move_to_top</key>
+    <string>Moure al principi</string>
+    <key>multi_select_add_episodes_max_format</key>
+    <string>Afegint %1$@ episodis com a màxim.</string>
+    <key>multi_select_adding_episodes_plural_format</key>
+    <string>Afegint %1$@ episodis.</string>
+    <key>multi_select_adding_episodes_singular</key>
+    <string>Afegint 1 episodi.</string>
+    <key>multi_select_archiving_episodes_plural_format</key>
+    <string>Arxivant %1$@ episodis</string>
+    <key>multi_select_archiving_episodes_singular</key>
+    <string>Arxivant 1 episodi</string>
+    <key>multi_select_delete_file_message_plural</key>
+    <string>Estàs segur que vols esborrar %1$@ arxius? </string>
+    <key>multi_select_delete_file_message_singular</key>
+    <string>Estàs segur que vols esborrar 1 arxiu?</string>
+    <key>multi_select_downloading_episodes_format</key>
+    <string>Descarregant %1$@</string>
+    <key>multi_select_mark_episodes_played_plural_format</key>
+    <string>Marcant %1$@ episodis com a reproduïts.</string>
+    <key>multi_select_mark_episodes_played_singular</key>
+    <string>Marcant 1 episodi com a reproduït.</string>
+    <key>multi_select_mark_episodes_unplayed_plural_format</key>
+    <string>Marcant %1$@ episodis com no reproduïts.</string>
+    <key>multi_select_mark_episodes_unplayed_singular</key>
+    <string>Marcant 1 episodi com a  no reproduït.</string>
+    <key>multi_select_queuing_episodes_format</key>
+    <string>%1$@ episodis a la cua</string>
+    <key>multi_select_remove_download_singular</key>
+    <string>Esborrant 1 descàrrega.</string>
+    <key>multi_select_remove_downloads_plural_format</key>
+    <string>Esborrant %1$@ descàrregues.</string>
+    <key>multi_select_remove_mark_unplayed</key>
+    <string>Marca-ho com a no reproduït</string>
+    <key>multi_select_selected_count_plural</key>
+    <string>%1$@ EPISODIS SELECCIONATS</string>
+    <key>multi_select_selected_count_singular</key>
+    <string>1 EPISODI SELECCIONAT</string>
+    <key>multi_select_shortcut_in_action_bar</key>
+    <string>ACCESSOS DIRECTES A LA BARRA D'ACCIONS</string>
+    <key>multi_select_star</key>
+    <string>Destacar episodis</string>
+    <key>multi_select_starring_episodes_plural_format</key>
+    <string>Destacant  %1$@ episodis.</string>
+    <key>multi_select_starring_episodes_singular</key>
+    <string>Destacant 1 episodi.</string>
+    <key>multi_select_unarchiving_episodes_plural_format</key>
+    <string>Eliminant 1 episodis dels arxivats</string>
+    <key>multi_select_unarchiving_episodes_singular</key>
+    <string>Eliminant 1 episodi dels arxivats</string>
+    <key>multi_select_unstar</key>
+    <string>Eliminar episodis dels destacats</string>
+    <key>multi_select_unstarring_episodes_plural_format</key>
+    <string>Eliminant %1$@ episodis dels destacats.</string>
+    <key>multi_select_unstarring_episodes_singular</key>
+    <string>Eliminant 1 episodi dels destacats</string>
+    <key>name</key>
+    <string>Nom</string>
+    <key>new_email_address_prompt</key>
+    <string>Nova adreça de correu electrònic</string>
+    <key>new_episodes</key>
+    <string>Episodis nous</string>
+    <key>new_password_prompt</key>
+    <string>Contrasenya nova</string>
+    <key>next</key>
+    <string>Següent</string>
+    <key>next_episode</key>
+    <string>Episodi següent</string>
+    <key>next_payment_format</key>
+    <string>Pròxim pagament: %1$@</string>
+    <key>none</key>
+    <string>Cap</string>
+    <key>not_on_wifi</key>
+    <string>No estàs connectat a una Wi-Fi</string>
+    <key>notifications_play_now</key>
+    <string>Reproduir ara</string>
+    <key>now_playing</key>
+    <string>Ara sona</string>
+    <key>now_playing_item</key>
+    <string>%1$@ ara sonant</string>
+    <key>now_playing_short_title</key>
+    <string>Reproduint</string>
+    <key>off</key>
+    <string>Desactivat</string>
+    <key>ok</key>
+    <string>OK</string>
+    <key>only_on_wifi</key>
+    <string>Només amb Wi-Fi</string>
+    <key>opml_import_failed_message</key>
+    <string>No s'han pogut carregar els podcasts des de l'OPML que heu especificat. Comproveu que sigui vàlid</string>
+    <key>opml_import_failed_title</key>
+    <string>Ha fallat la importació des de l'OPML</string>
+    <key>opml_import_progress_format</key>
+    <string>Important %1$@ de %2$@</string>
+    <key>opml_importing</key>
+    <string>Important els podcasts...</string>
+    <key>page_control_page_progress_format</key>
+    <string>Pàgina %1$@ de %2$@</string>
+    <key>paid_podcast_bundled_subscriptions</key>
+    <string>%1$@ / %2$@ SUBSCRITS</string>
+    <key>paid_podcast_cancel</key>
+    <string>Cancel·lar la contribució</string>
+    <key>paid_podcast_cancel_msg_plural</key>
+    <string>L'estat del seguidor seguirà actiu fins al %1$@. Després d'aquesta data, no podrás reproduir aquests podcasts.</string>
+    <key>paid_podcast_cancel_msg_retain_access</key>
+    <string>L'estat de col·laborador seguirà actiu fins al %1$@. Només podrás escoltar els episodis publicats abans d'aquesta data.</string>
+    <key>paid_podcast_cancel_msg_singular</key>
+    <string>L'estatus de col·laborador estarà actiu fins al %1$@. Després ja no podrás reproduir aquest podcast.</string>
+    <key>paid_podcast_generic_error</key>
+    <string>No s'ha pogut carregar la informació</string>
+    <key>paid_podcast_manage</key>
+    <string>Administrar</string>
+    <key>paid_podcast_next_episode_format</key>
+    <string>Episodi següent: %1$@</string>
+    <key>paid_podcast_release_frequency_format</key>
+    <string>Publicat:%1$@</string>
+    <key>paid_podcast_signin_prompt_msg</key>
+    <string>INICIA LA SESSIÓ PER A
+ACTUALITZACIONS</string>
+    <key>paid_podcast_signin_prompt_title</key>
+    <string>Inicia la sessió per a nous episodis</string>
+    <key>paid_podcast_subscription_ended</key>
+    <string>ACABAT: %1$@</string>
+    <key>paid_podcast_subscription_ends</key>
+    <string>ACABA: %1$@</string>
+    <key>paid_podcast_supporter_only_msg</key>
+    <string>Feed exclusiu per a subscriptors</string>
+    <key>paid_podcast_unsubscribe_msg</key>
+    <string>Estàs segur que vols cancel·lar la subscripció a tots aquests podcasts? Això eliminarà tots els seus arxius descarregats.</string>
+    <key>pause</key>
+    <string>Pausa</string>
+    <key>phone</key>
+    <string>Telèfon</string>
+    <key>play</key>
+    <string>Reproduir</string>
+    <key>play_all</key>
+    <string>Reprodueix-ho tot</string>
+    <key>play_last</key>
+    <string>Reprodueix el darrer</string>
+    <key>play_next</key>
+    <string>Reprodueix següent</string>
+    <key>playback_effect_trim_silence_max</key>
+    <string>Màxim</string>
+    <key>playback_effect_trim_silence_medium</key>
+    <string>Mitjà</string>
+    <key>playback_effect_trim_silence_mild</key>
+    <string>Mínim</string>
+    <key>playback_effects</key>
+    <string>Efectes de reproducció</string>
+    <key>playback_failed</key>
+    <string>Error en reproduir</string>
+    <key>playback_speed</key>
+    <string>%1$@x</string>
+    <key>player_accessibility_sleep_timer_on</key>
+    <string>Temporitzador activat</string>
+    <key>player_action_subtitle_delete</key>
+    <string>Mostra com Esborrar per episodis personalitzats</string>
+    <key>player_action_subtitle_hidden</key>
+    <string>Amagat per episodis personalitzats</string>
+    <key>player_action_title_effects</key>
+    <string>Efectes de reproducció</string>
+    <key>player_action_title_go_to_file</key>
+    <string>Vés a Arxius</string>
+    <key>player_action_title_output_options</key>
+    <string>Dispositiu de sortida</string>
+    <key>player_action_title_sleep_timer</key>
+    <string>Temporitzador</string>
+    <key>player_action_title_unstar_episode</key>
+    <string>Treure aquest episodi de destacats</string>
+    <key>player_actions_rearrange_title</key>
+    <string>Reorganitzar les accions</string>
+    <key>player_archived_confirmation</key>
+    <string>Arxivar aquest episodi?</string>
+    <key>player_artwork</key>
+    <string>Caràtula de %1$@</string>
+    <key>player_chapter_count</key>
+    <string>%1$@ de %2$@</string>
+    <key>player_decrement_time</key>
+    <string>Temps de disminució</string>
+    <key>player_effects_trim_silence_details</key>
+    <string>Redueix la durada de l'episodi retallant els silencis a les converses.</string>
+    <key>player_effects_trim_silence_progress</key>
+    <string>En total has estalviat %1$@ emprant aquesta funció.</string>
+    <key>player_error_corrupted_file</key>
+    <string>És possible que aquest episodi estigui danyat, però pots intentar reproduir-lo una altra vegada.</string>
+    <key>player_error_internet_connection</key>
+    <string>Comprova la teva connexió a Internet i torna-ho a intentar.</string>
+    <key>player_increment_time</key>
+    <string>Temps addicional</string>
+    <key>player_mark_as_played_confirmation</key>
+    <string>Marcar aquest episodi com a reproduït?</string>
+    <key>player_options_play_all_message</key>
+    <string>Això esborrarà la teva cua actual de la llista 'Tot seguit'.</string>
+    <key>player_options_play_episode_singular</key>
+    <string>Reprodueix 1 episodi</string>
+    <key>player_options_play_episodes_plural</key>
+    <string>Reproduir %1$@ episodis</string>
+    <key>player_options_shortcut_on_player</key>
+    <string>ACCÉS DIRECTE AL REPRODUCTOR</string>
+    <key>player_route_selection</key>
+    <string>Selector de la ruta</string>
+    <key>player_share_header</key>
+    <string>COMPARTEIX L'ENLLAÇ A</string>
+    <key>player_user_episode_download_error</key>
+    <string>Error de la descàrrega</string>
+    <key>player_user_episode_playback_error</key>
+    <string>Error de reproducció</string>
+    <key>player_user_episode_upload_error</key>
+    <string>Error a la càrrega</string>
+    <key>please_try_again</key>
+    <string>Per favor, torna-ho a intentar</string>
+    <key>please_try_again_later</key>
+    <string>Per favor, intenta-ho més tard.</string>
+    <key>plus_account_required_prompt</key>
+    <string>Es necessite un compte de Pocket Casts per entrar a Pocket Casts Plus. Això garanteix una escolta perfecta a tots els dispositius.</string>
+    <key>plus_account_required_prompt_details</key>
+    <string>Crea un compte o inicia sessió per canviar el teu accés a Pocket Casts Plus.</string>
+    <key>plus_account_trial_details</key>
+    <string>Quan acabi la prova, podràs continuar gaudint de tots els avantatges del teu compte de sempre. Gaudeix dels podcasts!</string>
+    <key>plus_button_title_unlock_all</key>
+    <string>Desbloqueja totes les funcions</string>
+    <key>plus_cancel_terms</key>
+    <string>Es pot cancel·lar en qualsevol moment</string>
+    <key>plus_cloud_storage_limit_format</key>
+    <string>%1$@ GB d'emmagatzematge al núvol</string>
+    <key>plus_error_already_registered</key>
+    <string>Ja tens un compte de Pocket Casts Plus</string>
+    <key>plus_error_already_registered_details</key>
+    <string>Gràcies pel teu suport, però lamentablement això significa que no pots participar en aquesta promoció.</string>
+    <key>plus_expiration_format</key>
+    <string>Caduca %1$@</string>
+    <key>plus_feature_cloud_storage</key>
+    <string>Emmagatzematge al núvol</string>
+    <key>plus_feature_themes_icons</key>
+    <string>Més temes i icones de l'aplicació</string>
+    <key>plus_feature_watch_app</key>
+    <string>Reproducció independent a l'Apple Watch</string>
+    <key>plus_feature_web_player</key>
+    <string>Reproductor web</string>
+    <key>plus_features</key>
+    <string>FUNCIONS PLUS</string>
+    <key>plus_free_membership_format</key>
+    <string>%1$@ grauït</string>
+    <key>plus_lifetime_membership</key>
+    <string>Membre vitalici</string>
+    <key>plus_marketing_cloud_storage_description</key>
+    <string>Accelera les teves conferències. Gaudeix d'altres continguts. Sigues el teu propi DJ de podcast.</string>
+    <key>plus_marketing_cloud_storage_title</key>
+    <string>Emmagatzematge al núvol</string>
+    <key>plus_marketing_desktop_apps_description</key>
+    <string>Amb les nostres aplicaciones per a Windows, mac OS i web, podràs escoltar els teus podcasts a més llocs.</string>
+    <key>plus_marketing_desktop_apps_title</key>
+    <string>Aplicacions per a ordinador</string>
+    <key>plus_marketing_final_call_to_action</key>
+    <string>Vols millorar la teva manera descoltar podcasts?
+Aconsegueix aplicacions per a ordinador, porta els teus propis fitxers i adorna-ho tot amb nous temes, exclusius per als membres Plus.</string>
+    <key>plus_marketing_folders_description</key>
+    <string>Crea carpetes per organitzar la teva col·lecció de podcats.</string>
+    <key>plus_marketing_hide_ads_description</key>
+    <string>L'experiència sense anuncis que et dóna més del que t'encanta i menys del que et desagrada</string>
+    <key>plus_marketing_hide_ads_title</key>
+    <string>Amagar els anuncis</string>
+    <key>plus_marketing_learn_more_button</key>
+    <string>Més informació sobre Pocket Casts Plus</string>
+    <key>plus_marketing_main_description</key>
+    <string>Personal i organitzat, tot a la vegada. Puja els teus arxius d'àudio personals als nostres servidors al núvol, accedeix al teu compte a través del nostre reproductor web i personalitza l'aplicació.</string>
+    <key>plus_marketing_main_title</key>
+    <string>Funcions millorades per a oients avançats</string>
+    <key>plus_marketing_subtitle</key>
+    <string>Accedeix a funcions i opcions de personalització exclusives</string>
+    <key>plus_marketing_themes_icons_description</key>
+    <string>Mostra't tal i com ets. Icones i temes exlusius només per a membres Plus.</string>
+    <key>plus_marketing_themes_icons_title</key>
+    <string>Temes i icones</string>
+    <key>plus_marketing_title</key>
+    <string>Tot el que t'agrada de Pocket Casts, i molt més</string>
+    <key>plus_marketing_updated_cloud_storage_description</key>
+    <string>Carrega els teus arxius a l'emmagatzematge al núvol per poder accedir-hi des de qualsevol lloc</string>
+    <key>plus_marketing_updated_desktop_apps_description</key>
+    <string>Escolta els teus podcast a més llocs amb les nostres aplicacions per a Windows, macOS i web</string>
+    <key>plus_marketing_updated_folders_description</key>
+    <string>Organitza els teus podcasts en carpetes i així els podràs tenir sincronitzats en tots els teus dispositius.</string>
+    <key>plus_marketing_upgrade_button</key>
+    <string>Actualitzar a Plus</string>
+    <key>plus_marketing_watch_playback_description</key>
+    <string>Deixa el telèfon i surt a córrer, sense perdre el ritme. Apple Watch té autonomia tot sol.</string>
+    <key>plus_marketing_watch_playback_title</key>
+    <string>Reproducció a l'Apple Watch</string>
+    <key>plus_monthly_frequency_pricing_format</key>
+    <string>%1$@ al mes</string>
+    <key>plus_payment_canceled</key>
+    <string>Pagament cancel·lat</string>
+    <key>plus_payment_frequency_best_value</key>
+    <string>Millor oferta</string>
+    <key>plus_per_month</key>
+    <string>al mes</string>
+    <key>plus_price_per_month</key>
+    <string>%1$@ / al mes</string>
+    <key>plus_promo_paragraph</key>
+    <string>Aconsegueix Pocket Casts Plus per desbloquejar aquesta funció i moltes més!</string>
+    <key>plus_promotion_expired</key>
+    <string>Promoció caducada o no vàlida</string>
+    <key>plus_promotion_expired_nudge</key>
+    <string>De tota manera, pots registrar-te a Pocket Casts Plus, crear un compte normal o simpelment començar a emprar-ho ara mateix.</string>
+    <key>plus_promotion_used</key>
+    <string>Aquest codi ja s'ha emprat</string>
+    <key>plus_purchase_failed</key>
+    <string>Sembla que s'ha produït un error en processar el pagament. Torneu-ho a provar.</string>
+    <key>plus_purchase_promo_title</key>
+    <string>Passa't a membre Plus i gaudeix de totes les funcions de Pocket Casts</string>
+    <key>plus_required_feature</key>
+    <string>Aquesta funció necessita Pocket Casts Plus</string>
+    <key>plus_select_payment_frequency</key>
+    <string>Seleccionar la freqüència de pagament</string>
+    <key>plus_subscription_apple</key>
+    <string>La teva subscripció s'administra a través de l'App Store d'Apple</string>
+    <key>plus_subscription_apple_details</key>
+    <string>Per cancel·lar la subscripció, ho hauràs de fer anant a Configuració.</string>
+    <key>plus_subscription_expiration</key>
+    <string>PLUS CADUCA EL %1$@</string>
+    <key>plus_subscription_google</key>
+    <string>Sembla que t'has subscrit a Pocket Casts Plus des d'un dispositiu Android</string>
+    <key>plus_subscription_google_details</key>
+    <string>Per cancel·lar la subscripció, ho hauràs de fer anant a Configuració.</string>
+    <key>plus_subscription_web</key>
+    <string>Sembla que t'has subscrit a Pocket Casts Plus des de la web</string>
+    <key>plus_subscription_web_details</key>
+    <string>Per cancel·lar la subscripció, ho hauràs de fer anant a  Pocketcasts.com.</string>
+    <key>plus_upgrade_no_internet_message</key>
+    <string>Per favor, revisa la teva connexió a la xarxa i prova-ho de nou.</string>
+    <key>plus_upgrade_no_internet_title</key>
+    <string>No es pot carregar</string>
+    <key>plus_yearly_frequency_pricing_format</key>
+    <string>%1$@ a l'any</string>
+    <key>pocket_casts_newsletter</key>
+    <string>Butlletí de Pocket Casts</string>
+    <key>pocket_casts_newsletter_description</key>
+    <string>Rep notícies, actualitzacions de l'aplicació, llistes de reproducció per tema, entrevistes i més.</string>
+    <key>pocket_casts_plus</key>
+    <string>Pocket Casts Plus</string>
+    <key>pocket_casts_plus_short</key>
+    <string>Plus</string>
+    <key>pocket_casts_welcome_newsletter_title</key>
+    <string>Rep la newsletter</string>
+    <key>podcast_access_ended</key>
+    <string>Accés acabat: %1$@</string>
+    <key>podcast_access_ends</key>
+    <string>L'accés s'acaba: %1$@</string>
+    <key>podcast_archive_all</key>
+    <string>Arxiva-ho tot</string>
+    <key>podcast_archive_all_played</key>
+    <string>Arxivar tots els reproduïts</string>
+    <key>podcast_archive_episode_count_singular</key>
+    <string>Arxivar 1 episodi</string>
+    <key>podcast_archive_episodes_count_plural_format</key>
+    <string>Arxivar %1$@ episodis</string>
+    <key>podcast_archive_prompt_msg</key>
+    <string>Fes-ho només si no vols veure més aquests episodis.</string>
+    <key>podcast_archived</key>
+    <string>Arxivat</string>
+    <key>podcast_archived_count_format</key>
+    <string>%1$@ arxivats</string>
+    <key>podcast_archived_msg</key>
+    <string>S'han arxivat tots els %1$@ episodis d'aquest podcast</string>
+    <key>podcast_count_plural_format</key>
+    <string>%1$@ podcasts</string>
+    <key>podcast_count_singular</key>
+    <string>1 podcast</string>
+    <key>podcast_details_download_error</key>
+    <string>S'ha produït un error quan es descarregava l'episodi</string>
+    <key>podcast_details_download_wifi_queue</key>
+    <string>Aquest episodi es descarregarà automàticament quan tornis a estar connectar a una Wi-Fi</string>
+    <key>podcast_details_manual_unarchive_msg</key>
+    <string>No s'arxivarà automàticament a causa del nou límit d'episodis de %1$@</string>
+    <key>podcast_details_manual_unarchive_title</key>
+    <string>Episodi eliminat manualment dels arxius</string>
+    <key>podcast_details_playback_error</key>
+    <string>No es pot reproduir l'episodi</string>
+    <key>podcast_details_queued</key>
+    <string>A la cua</string>
+    <key>podcast_details_remove_download</key>
+    <string>ESBORRAR L'ARXIU DESCARREGAT?</string>
+    <key>podcast_download_now</key>
+    <string>Descarregar ara</string>
+    <key>podcast_downloading</key>
+    <string>Descarregant... %1$@</string>
+    <key>podcast_episode_count_plural_format</key>
+    <string>%1$@ episodis</string>
+    <key>podcast_episode_count_singular</key>
+    <string>1 episodi</string>
+    <key>podcast_episode_limit_count_format</key>
+    <string>Limitat a %1$@</string>
+    <key>podcast_error_message</key>
+    <string>No s'ha pogut carregar la informació del podcast :(</string>
+    <key>podcast_error_title</key>
+    <string>Literalment, ni tan sols</string>
+    <key>podcast_failed_download</key>
+    <string>Error en descarregar l'episodi</string>
+    <key>podcast_failed_upload</key>
+    <string>S'ha produït un error a la pujada</string>
+    <key>podcast_grid_discover_podcasts</key>
+    <string>Descobrir podcasts</string>
+    <key>podcast_grid_no_podcasts_msg</key>
+    <string>Vens des d'una altra aplicació? Importa els teus podcasts anant a Perfil &gt; Configuració &gt; Importar i exportar. 
+
+Si vols noves idees, vés a la pestanya Descobrir.</string>
+    <key>podcast_grid_no_podcasts_title</key>
+    <string>És hora d'afegir alguns podcasts!</string>
+    <key>podcast_group_options_title</key>
+    <string>AGRUPAR PER</string>
+    <key>podcast_hide_archived</key>
+    <string>Amagar els arxivats</string>
+    <key>podcast_limit_plural_format</key>
+    <string>Limitat a %1$@ episodis més recents</string>
+    <key>podcast_limit_singular</key>
+    <string>Limitat a 1 episodi més recent</string>
+    <key>podcast_loading</key>
+    <string>Carregant el podcast...</string>
+    <key>podcast_no_date</key>
+    <string>Data sense determinar</string>
+    <key>podcast_no_season</key>
+    <string>No hi ha temporades</string>
+    <key>podcast_pause_download</key>
+    <string>Pausar la descàrrega</string>
+    <key>podcast_pause_playback</key>
+    <string>Pausar la reproducció</string>
+    <key>podcast_queued</key>
+    <string>A la cua</string>
+    <key>podcast_queuing</key>
+    <string>A la cua...</string>
+    <key>podcast_refresh_artwork</key>
+    <string>Actualitzar les caràtules</string>
+    <key>podcast_season_format</key>
+    <string>Temporada %1$@</string>
+    <key>podcast_share_episode</key>
+    <string>Compartir un enllaç de l'episodi</string>
+    <key>podcast_share_episode_error_msg</key>
+    <string>No tens cap aplicació instal·lada que accepti aquest tipus d'arxiu</string>
+    <key>podcast_share_error_msg</key>
+    <string>És possible que l'autor del podcast l'hagi eliminat des que es va compartir l'enllaç.</string>
+    <key>podcast_share_error_title</key>
+    <string>No s'ha pogut trobar l'episodi</string>
+    <key>podcast_share_list_creating</key>
+    <string>Creant llista...</string>
+    <key>podcast_share_list_description</key>
+    <string>Descripció (opcional)</string>
+    <key>podcast_share_list_name</key>
+    <string>Nom de la llista</string>
+    <key>podcast_share_open_file</key>
+    <string>Obrir l'arxiu a...</string>
+    <key>podcast_show_archived</key>
+    <string>Mostrar els arxivats</string>
+    <key>podcast_singular</key>
+    <string>Podcast</string>
+    <key>podcast_soon</key>
+    <string>en qualsevol moment</string>
+    <key>podcast_sort_order_title</key>
+    <string>ORDENAR PER</string>
+    <key>podcast_stream_confirmation</key>
+    <string>Reprodueix-ho de totes maneres</string>
+    <key>podcast_stream_data_warning</key>
+    <string>La reproducció d'aquest episodi emprarà dades</string>
+    <key>podcast_this_month</key>
+    <string>Aquest mes</string>
+    <key>podcast_time_left</key>
+    <string>Queden %1$@</string>
+    <key>podcast_tomorrow</key>
+    <string>Demà</string>
+    <key>podcast_unarchive_all</key>
+    <string>Desarxiva-ho tot</string>
+    <key>podcast_updates_ended</key>
+    <string>Actualitzacions finalitzades: %1$@</string>
+    <key>podcast_updates_ends</key>
+    <string>Les actualitzacions acaben: %1$@</string>
+    <key>podcast_upload_confirmation</key>
+    <string>Pujar ara</string>
+    <key>podcast_uploading</key>
+    <string>Pujant... %1$@</string>
+    <key>podcast_waiting_upload</key>
+    <string>Esperant per pujar</string>
+    <key>podcast_yesterday</key>
+    <string>Ahir</string>
+    <key>podcasts_badge_all_unplayed</key>
+    <string>Episodis que no has acabat</string>
+    <key>podcasts_badge_latest_episode</key>
+    <string>Només el darrer episodi</string>
+    <key>podcasts_badges</key>
+    <string>Insígnia</string>
+    <key>podcasts_episode_sort_longest_to_shortest</key>
+    <string>Del més llarg al més curt</string>
+    <key>podcasts_episode_sort_newest_to_oldest</key>
+    <string>Del més nou al més antic</string>
+    <key>podcasts_episode_sort_oldest_to_newest</key>
+    <string>Del més antic al més nou</string>
+    <key>podcasts_episode_sort_shortest_to_longest</key>
+    <string>Del més curt al més llarg</string>
+    <key>podcasts_large_grid</key>
+    <string>Graella gran</string>
+    <key>podcasts_layout</key>
+    <string>Disseny</string>
+    <key>podcasts_library_sort_custom</key>
+    <string>Arrossegar i deixar anar</string>
+    <key>podcasts_library_sort_date_added</key>
+    <string>Data de publicació</string>
+    <key>podcasts_library_sort_episode_release_date</key>
+    <string>Data de publicació de l'episodi</string>
+    <key>podcasts_library_sort_title</key>
+    <string>Nom</string>
+    <key>podcasts_list</key>
+    <string>Llista</string>
+    <key>podcasts_plural</key>
+    <string>Podcasts</string>
+    <key>podcasts_share</key>
+    <string>Compartir els podcasts</string>
+    <key>podcasts_small_grid</key>
+    <string>Graella petita</string>
+    <key>podcasts_sort</key>
+    <string>Ordenar els podcasts</string>
+    <key>preview</key>
+    <string>Vista prèvia</string>
+    <key>pricing_terms_after_trial</key>
+    <string>i després %1$@</string>
+    <key>pricing_terms_after_trial_long</key>
+    <string>Els pagaments recurrents començaran després de la teva prova gratuïta de %1$@</string>
+    <key>profile</key>
+    <string>Perfil</string>
+    <key>profile_help_support</key>
+    <string>Millora el teu compte i ajuda a la compatibilitat de Pocket Casts</string>
+    <key>profile_last_app_refresh</key>
+    <string>Darrera actualizació de l'aplicació: %1$@</string>
+    <key>profile_number_of_files</key>
+    <string>%1$@ arxius</string>
+    <key>profile_percent_full</key>
+    <string>%1$@ completat</string>
+    <key>profile_reset_password</key>
+    <string>Reestablir la contrasenya</string>
+    <key>profile_sending_reset_email</key>
+    <string>Enviant el correu electrònic de recuperació</string>
+    <key>profile_sending_reset_email_conf_msg</key>
+    <string>Comprova el teu correu electrònic :)</string>
+    <key>profile_sending_reset_email_conf_title</key>
+    <string>S'ha enviat l'enllaç per recuperar la contrasenya</string>
+    <key>profile_sending_reset_email_failed</key>
+    <string>No s'ha pogut enviar el correu electrònic de recuperació. Intenta-ho més tard.</string>
+    <key>profile_single_file</key>
+    <string>1 arxiu</string>
+    <key>profile_starred_no_episodes_desc</key>
+    <string>Encara no has destacat encara cap capítol.</string>
+    <key>profile_starred_no_episodes_title</key>
+    <string>No hi ha res destacat</string>
+    <key>purchase_terms</key>
+    <string>Si segueixes, acceptes la %1$@política de privacitat%2$@ i els %3$@termes i condicions%4$@</string>
+    <key>queue_clear_episode_queue_plural</key>
+    <string>Esborrar %1$@ episodis</string>
+    <key>queue_clear_queue</key>
+    <string>ESBORRAR LA CUA</string>
+    <key>queue_for_later</key>
+    <string>Posar a la cua per més tard</string>
+    <key>queue_now_playing_accessibility</key>
+    <string>Ara sona. %1$@</string>
+    <key>queue_time_remaining</key>
+    <string>%1$@ queden</string>
+    <key>queue_total_time_remaining</key>
+    <string>%1$@ queda del temps total</string>
+    <key>refresh_control_fetching_episodes</key>
+    <string>CERCANT NOUS EPISODIS DELS PODCASTS</string>
+    <key>refresh_control_pull_to_refresh</key>
+    <string>ESTIRA PER ACTUALITZAR</string>
+    <key>refresh_control_refresh_complete</key>
+    <string>ACTUALITZACIÓ COMPLETADA</string>
+    <key>refresh_control_refresh_failed</key>
+    <string>ERROR EN ACTUALITZAR :(</string>
+    <key>refresh_control_refreshing_files</key>
+    <string>ACTUALITZANT ELS ARXIUS</string>
+    <key>refresh_control_release_to_refresh</key>
+    <string>ESPERA MENTRE S'ACTUALITZA</string>
+    <key>refresh_control_sync_failed</key>
+    <string>HA FALLAT LA SINCRONITZACIÓ :(</string>
+    <key>refresh_control_syncing_podcasts</key>
+    <string>SINCRONITZANT ELS PODCASTS I EL PROGRÉS</string>
+    <key>refresh_failed</key>
+    <string>S'ha produït un error en actualitzar</string>
+    <key>refresh_now</key>
+    <string>Actualitzar ara</string>
+    <key>refresh_previous_run</key>
+    <string>Darrera actualizació: %1$@</string>
+    <key>refreshing</key>
+    <string>Actualitzant...</string>
+    <key>release_frequency_daily</key>
+    <string>Diari</string>
+    <key>release_frequency_fortnightly</key>
+    <string>Quinzenal</string>
+    <key>release_frequency_hourly</key>
+    <string>Cada hora</string>
+    <key>release_frequency_monthly</key>
+    <string>Mensual</string>
+    <key>release_frequency_weekly</key>
+    <string>Setmanal</string>
+    <key>remove</key>
+    <string>Esborrar</string>
+    <key>remove_all</key>
+    <string>Esborra-ho tot</string>
+    <key>remove_download</key>
+    <string>Esborrar la descàrrega</string>
+    <key>remove_from_up_next</key>
+    <string>Eliminar de la llista 'Tot seguit'</string>
+    <key>remove_up_next</key>
+    <string>Eliminar de 'Tot seguit'</string>
+    <key>retry</key>
+    <string>Reintentar</string>
+    <key>search</key>
+    <string>Cercar</string>
+    <key>search_podcasts</key>
+    <string>Cerca podcasts</string>
+    <key>season</key>
+    <string>Temporada</string>
+    <key>season_episode_shorthand_format</key>
+    <string>T%1$@ E%2$@</string>
+    <key>season_only_shorthand_format</key>
+    <string>S%1$@</string>
+    <key>seconds_listened</key>
+    <string>Segons escoltats</string>
+    <key>seconds_saved</key>
+    <string>Segons estalviats</string>
+    <key>select</key>
+    <string>Seleccionar</string>
+    <key>select_all</key>
+    <string>Selecciona-ho tot</string>
+    <key>select_all_above</key>
+    <string>Seleccinar tots els anteriors</string>
+    <key>select_all_below</key>
+    <string>Seleccionar tots els següents</string>
+    <key>select_episodes</key>
+    <string>Seleccionar episodis</string>
+    <key>selected_count_format</key>
+    <string>%1$@ seleccionats</string>
+    <key>server_error_files_file_too_large</key>
+    <string>Aquest arxiu és massa gran i no es pot pujar.</string>
+    <key>server_error_files_invalid_content_type</key>
+    <string>No s'ha pogut pujar aquest arxiu perquè  no podem determinar quin contingut té.</string>
+    <key>server_error_files_invalid_user</key>
+    <string>L'usuari no està connectat.</string>
+    <key>server_error_files_storage_limit_exceeded</key>
+    <string>Has superat el límit d'emmagatzematge del compte.</string>
+    <key>server_error_files_title_required</key>
+    <string>Es necessita un títol.</string>
+    <key>server_error_files_upload_failed_generic</key>
+    <string>No s'ha pogut pujar el fitxer, intenta-ho més tard.</string>
+    <key>server_error_files_uuid_required</key>
+    <string>Es necessita l'identificador únic universilal (UUID)  de l'arxiu.</string>
+    <key>server_error_login_account_locked</key>
+    <string>El teu compte s'ha bloquejat perquè hi ha hagut massa intents d'inici de sessió. Tornau-ho a provar més tard.</string>
+    <key>server_error_login_email_blank</key>
+    <string>Introdueix una adreça de correu electrònic.</string>
+    <key>server_error_login_email_invalid</key>
+    <string>Correu electrònic no vàlid</string>
+    <key>server_error_login_email_not_found</key>
+    <string>No s'ha trobat el correu electrònic</string>
+    <key>server_error_login_email_taken</key>
+    <string>El correu electrònic ja està en ús</string>
+    <key>server_error_login_password_blank</key>
+    <string>Introdueix una contrasenya.</string>
+    <key>server_error_login_password_incorrect</key>
+    <string>Contrasenya incorrecta</string>
+    <key>server_error_login_password_invalid</key>
+    <string>Contrasenya incorrecta</string>
+    <key>server_error_login_permission_denied_not_admin</key>
+    <string>Permís denegat</string>
+    <key>server_error_login_unable_to_create_account</key>
+    <string>Ens sap greu, no s'ha pogut configurar el compte.</string>
+    <key>server_error_login_user_register_failed</key>
+    <string>No s'ha pogut crear el compte. Prova-ho més tard</string>
+    <key>server_error_promo_already_plus</key>
+    <string>Ja estàs subscrit a Pocket Casts Plus. No és necessari  bescanviar cap codi més.</string>
+    <key>server_error_promo_already_redeemed</key>
+    <string>Ja has emprat aquest codi promocional. Però ha valgut la pena intentar-ho.</string>
+    <key>server_error_promo_code_expired_or_invalid</key>
+    <string>Aquest codi promocional ha caducat o no és vàlid.</string>
+    <key>server_error_unknown</key>
+    <string>Alguna cosa no ha anat bé</string>
+    <key>server_message_login_thanks_signing_up</key>
+    <string>Gràcies per registrar-te!</string>
+    <key>settings</key>
+    <string>Configuració</string>
+    <key>settings_about</key>
+    <string>Quant a</string>
+    <key>settings_appearance</key>
+    <string>Aspecte</string>
+    <key>settings_archive_inactive_episodes</key>
+    <string>Episodis inactius</string>
+    <key>settings_archive_inactive_title</key>
+    <string>Arxivar episodis inactius</string>
+    <key>settings_archive_played_episodes</key>
+    <string>Episodis reproduïts</string>
+    <key>settings_archive_played_title</key>
+    <string>Arxivar els episodis reproduïts</string>
+    <key>settings_auto_add</key>
+    <string>Afegir automàticament a la llista 'Tot seguit'</string>
+    <key>settings_auto_add_limit</key>
+    <string>Límit d'episodis afegits automàticament</string>
+    <key>settings_auto_add_limit_reached</key>
+    <string>Si s'arriba al límit</string>
+    <key>settings_auto_add_limit_subtitle_stop</key>
+    <string>Els episodis nous deixaran d'afegir-se quan 'Tot seguit' arribi a %1$@ episodis.</string>
+    <key>settings_auto_add_limit_subtitle_top</key>
+    <string>Quan la llista 'Tot seguit' arribeu a %1$@, els nous episodis que s'afegeixin automàticament es col·locaran al principi i eliminaran l'últim episodi de la cua. No s'afegiran nous episodis al final.</string>
+    <key>settings_auto_add_podcasts</key>
+    <string>Afegir podcasts automàticament</string>
+    <key>settings_auto_archive</key>
+    <string>Arxivar automàticament</string>
+    <key>settings_auto_archive_1_week</key>
+    <string>Després d'1 setmana</string>
+    <key>settings_auto_archive_24_hours</key>
+    <string>Després de 24 hores</string>
+    <key>settings_auto_archive_2_days</key>
+    <string>Després de 2 dies</string>
+    <key>settings_auto_archive_2_weeks</key>
+    <string>Després de 2 setmanes</string>
+    <key>settings_auto_archive_30_days</key>
+    <string>Després de 30 dies</string>
+    <key>settings_auto_archive_3_months</key>
+    <string>Després de 3 mesos</string>
+    <key>settings_auto_archive_include_starred</key>
+    <string>Incloure els episodis destacats</string>
+    <key>settings_auto_archive_include_starred_off_subtitle</key>
+    <string>Els episodis destacats no s'arxivaran</string>
+    <key>settings_auto_archive_include_starred_on_subtitle</key>
+    <string>Els episodis destacats s'arxivaran automàticament</string>
+    <key>settings_auto_archive_subtitle</key>
+    <string>Arxiva els episodis després dels límits de temps establerts. Les descàrregues s'eliminaran quan s'arxiva l'episodi.</string>
+    <key>settings_auto_download</key>
+    <string>Descarregar automàticament</string>
+    <key>settings_auto_downloads_filters_selected_format</key>
+    <string>%1$@ filtres seleccionats</string>
+    <key>settings_auto_downloads_filters_selected_singular</key>
+    <string>1 filtre seleccionat</string>
+    <key>settings_auto_downloads_no_filters_selected</key>
+    <string>Cap filtre seleccionat</string>
+    <key>settings_auto_downloads_no_podcasts_selected</key>
+    <string>Cap podcast seleccionat</string>
+    <key>settings_auto_downloads_podcasts_selected_format</key>
+    <string>%1$@ podcasts seleccionats</string>
+    <key>settings_auto_downloads_podcasts_selected_singular</key>
+    <string>1 podcast seleccionat</string>
+    <key>settings_auto_downloads_subtitle_filters</key>
+    <string>Descarregar els primers episodis d'un filtre.</string>
+    <key>settings_auto_downloads_subtitle_new_episodes</key>
+    <string>Descarrega els nous episodis quan es publiquin.</string>
+    <key>settings_auto_downloads_subtitle_up_next</key>
+    <string>Descarregar els episodis afegit a la llista 'Tot seguit'.</string>
+    <key>settings_badge_filter_header</key>
+    <string>NÚMERO DE FILTRES D'EPISODIS</string>
+    <key>settings_badge_new_since_opened</key>
+    <string>Nous episodis des que s'ha obert l'aplicació</string>
+    <key>settings_badge_total_unplayed</key>
+    <string>Total d'episodis sense reproduir</string>
+    <key>settings_collect_information</key>
+    <string>Recopilar la informació</string>
+    <key>settings_collect_information_additional_information</key>
+    <string>Si ens permets recopilar anàlitiques podrem millorar l'aplicació. Tanmateix, entenem que prefereixis no compartir aquesta informació</string>
+    <key>settings_create_siri_shortcut</key>
+    <string>Crear una drecera de Siri</string>
+    <key>settings_create_siri_shortcut_msg</key>
+    <string>Per a reproduir el darrer episodi de %1$@, crea una drecera de Siri</string>
+    <key>settings_custom</key>
+    <string>Personalitzat per a aquest podcast</string>
+    <key>settings_custom_auto_archive_msg</key>
+    <string>Necessites un control més precís? Activa els paràmetres d'arxiu automàtic per a aquest podcast</string>
+    <key>settings_custom_msg</key>
+    <string>Pocket Casts recordarà els últims efectes de reproducció i els utilitzarà a tots els podcasts. Per crear efectes personalitzats exclusius per a aquest podcast, podeu activar aquesta opció.</string>
+    <key>settings_episode_limit</key>
+    <string>Límit d'episodis</string>
+    <key>settings_episode_limit_format</key>
+    <string>Límit de %1$@ episodis</string>
+    <key>settings_episode_limit_limit_format</key>
+    <string>%1$@ més recents</string>
+    <key>settings_episode_limit_msg</key>
+    <string>En el cas dels programes que publiquen episodis cada hora o cada dia, podeu establir un límit d'episodis per conservar només els més recents i arxivar els més antics.</string>
+    <key>settings_episode_limit_no_limit</key>
+    <string>Sense límit</string>
+    <key>settings_export_error</key>
+    <string>Error en exportar</string>
+    <key>settings_export_error_msg</key>
+    <string>No s'ha pogut exportar l'OPML. Torna-ho a provar més tard.</string>
+    <key>settings_export_opml</key>
+    <string>Exportant l'OPML</string>
+    <key>settings_feed_error</key>
+    <string>Error al feed</string>
+    <key>settings_feed_error_msg</key>
+    <string>El feed d'aquest podcast s'ha deixat d'actualitzar perquè hi havia massa errors. Clica amunt per arreglar-ho.</string>
+    <key>settings_feed_fix_refresh</key>
+    <string>Intenta actualitzar-lo</string>
+    <key>settings_feed_fix_refresh_failed_msg</key>
+    <string>No s'ha pogut actualitzar aquest feed. Torna-ho a provar més tard.</string>
+    <key>settings_feed_fix_refresh_failed_title</key>
+    <string>S'ha produït un error en actualitzar</string>
+    <key>settings_feed_fix_refresh_success_msg</key>
+    <string>Hem posat a la cua una actualització per a aquest podcast. El nostre servidor tornarà a comprovar-ho i, si funciona, aviat hi haurà nous episodis. Torna-ho a revisar en una hora.</string>
+    <key>settings_feed_fix_refresh_success_title</key>
+    <string>Actualització a la cua</string>
+    <key>settings_feed_issue</key>
+    <string>Problema amb el feed</string>
+    <key>settings_feed_issue_msg</key>
+    <string>El feed d'aquest podcast s'ha deixat d'actualitzar perquè tenia massa errors.</string>
+    <key>settings_files</key>
+    <string>Configuració dels arxius</string>
+    <key>settings_files_auto_download</key>
+    <string>Descarregar automàticament des del núvol</string>
+    <key>settings_files_auto_download_subtitle_off</key>
+    <string>Els arxius pujats al núvol des d'altres dispositius no es descarregaran automàticament.</string>
+    <key>settings_files_auto_download_subtitle_on</key>
+    <string>Els arxius pujats al núvol des d'altres dispositius es descarregaran automàticament.</string>
+    <key>settings_files_auto_upload</key>
+    <string>Pujar automàticament al núvol</string>
+    <key>settings_files_auto_upload_subtitle_off</key>
+    <string>Els arxius afegits a aquest dispositiu no es pujaran automàticament al núvol.</string>
+    <key>settings_files_auto_upload_subtitle_on</key>
+    <string>Els arxius afegits a aquests dispositiu es pujaran automàticament al núvol.</string>
+    <key>settings_files_delete_cloud_file</key>
+    <string>Esborrar l'arxiu del núvol</string>
+    <key>settings_files_delete_local_file</key>
+    <string>Esborrar l'arxiu local</string>
+    <key>settings_general</key>
+    <string>General</string>
+    <key>settings_general_apply_all_conf</key>
+    <string>Aplicar als existents</string>
+    <key>settings_general_apply_all_title</key>
+    <string>Ho aplico a tots els podcasts actuals?</string>
+    <key>settings_general_archived_episodes</key>
+    <string>Episodis arxivats</string>
+    <key>settings_general_archived_episodes_prompt_format</key>
+    <string>Vols canviar tots els teus podcasts actuals per %1$@ episodis arxivats?</string>
+    <key>settings_general_auto_open_player</key>
+    <string>Obrir el reproductor automàticament</string>
+    <key>settings_general_defaults_header</key>
+    <string>PREDETERMINATS</string>
+    <key>settings_general_episode_groups</key>
+    <string>Agrupació d'episodis de podcast</string>
+    <key>settings_general_hide</key>
+    <string>Amagar</string>
+    <key>settings_general_keep_screen_awake</key>
+    <string>Mantenir la pantalla activa</string>
+    <key>settings_general_legacy_bluetooth</key>
+    <string>Compatibilitat amb la tecnologia Bluetooth heretada</string>
+    <key>settings_general_legacy_bluetooth_subtitle</key>
+    <string>Si teniu un dispositiu amb Bluetooth o un estèreo d'automòbil que pausa Pocket Casts mentre es reprodueix o restableix la posició de reproducció a 0, intenteu activar aquesta configuració per solucionar-ho.</string>
+    <key>settings_general_multi_select_gesture</key>
+    <string>Gestos per a selecció múltiple d'elements</string>
+    <key>settings_general_multi_select_gesture_subtitle</key>
+    <string>Seleccioneu diversos elements en lliscar 2 dits cap avall en qualsevol llista d'episodis. Desactiva aquesta opció si ho fas sense voler o interfereix amb les funcions d'accessibilitat que utilitzes.</string>
+    <key>settings_general_no_thanks</key>
+    <string>No, gràcies</string>
+    <key>settings_general_open_in_browser</key>
+    <string>Obrir els enllaços al navegador</string>
+    <key>settings_general_play_back_actions</key>
+    <string>Altres accions de reproducció</string>
+    <key>settings_general_play_back_actions_subtitle</key>
+    <string>Afegeix una opció per marcar els reproduïts i destacats a la pantalla de bloqueig del mòbil i a CarPlay. Nota: a la pantalla de bloqueig, aquesta opció substitueix el botó de saltar enrere.</string>
+    <key>settings_general_player_header</key>
+    <string>REPRODUCTOR</string>
+    <key>settings_general_publish_chapter_titles</key>
+    <string>Publica títol de capítols</string>
+    <key>settings_general_publish_chapter_titles_subtitle</key>
+    <string>Si aquesta opció està activada, s'enviarà el títol dels capítols (en lloc del títol d'episodi) mitjançant Bluetooth i altres dispositius connectats.</string>
+    <key>settings_general_remote_skips_chapters</key>
+    <string>El control remot permet saltar els capítols</string>
+    <key>settings_general_remote_skips_chapters_subtitle</key>
+    <string>Quan el botó del salt està activat i un episodi té capítols, en prémer-lo al cotxe o els auriculars permet saltar al següent capítol.</string>
+    <key>settings_general_remove_groups_apply_all</key>
+    <string>Vols canviar tots els teus podcasts actuals perquè no s'agrupin?</string>
+    <key>settings_general_row_action</key>
+    <string>Acció per files</string>
+    <key>settings_general_selected_group_apply_all</key>
+    <string>Vols canviar tots els teus podcasts actuals i que s'agrupin per %1$@?</string>
+    <key>settings_general_show</key>
+    <string>Mostrar</string>
+    <key>settings_general_smart_playback</key>
+    <string>Represa intel·ligent de la reproducció</string>
+    <key>settings_general_smart_playback_subtitle</key>
+    <string>Si està activat, Pocket Casts retrocedirà una mica els episodis que reprenguis perquè puguis posar-te al dia fàcilment.</string>
+    <key>settings_general_up_next_swipe</key>
+    <string>Desplaçar per incloure a la llista 'Tot seguit'</string>
+    <key>settings_general_up_next_tap</key>
+    <string>Reproduir la llista 'Tot seguit' en prémer</string>
+    <key>settings_general_up_next_tap_off_subtitle</key>
+    <string>Quan toquis un episodi de la llista 'Tot seguit' es mostra la pàgina d'accions. Quan premis de forma perllongada es reproduirà l'episodi. Per canviar una per l'altra, activa aquesta opció</string>
+    <key>settings_general_up_next_tap_on_subtitle</key>
+    <string>Quan toquis un episodi de la llista 'Tot seguit' aquest es reproduirà. Quan premis de forma perllongada s'ensenyaran les opcions dels episodis. Per canviar una per l'altra, desactiva aquesta opció</string>
+    <key>settings_global_settings</key>
+    <string>Configuració general</string>
+    <key>settings_help</key>
+    <string>Ajuda i comentaris</string>
+    <key>settings_import_export</key>
+    <string>Importar / exportar</string>
+    <key>settings_in_filters_plural_format</key>
+    <string>Inclòs a %1$@ filtres</string>
+    <key>settings_in_filters_singular</key>
+    <string>Inclòs en 1 filtre</string>
+    <key>settings_in_menu</key>
+    <string>AL MENÚ</string>
+    <key>settings_inactive_episodes_msg</key>
+    <string>Els episodis inactius són aquells que no has reproduit o descarregat en el temps que vas especificar anteriorment. Les descàrregues s'eliminen quan l'episodi s'arxiva</string>
+    <key>settings_not_in_filters</key>
+    <string>No està inclòs a cap filtre</string>
+    <key>settings_notifications</key>
+    <string>Notificacions</string>
+    <key>settings_notifications_filter_count</key>
+    <string>Número de filtres</string>
+    <key>settings_notifications_subtitle</key>
+    <string>Notifica quan hi ha un nou episodi disponible. També és útil per millorar la fiabilitat de les descàrregues automàtiques</string>
+    <key>settings_opml</key>
+    <string>Importar/exportar OPML</string>
+    <key>settings_play_speed</key>
+    <string>Velocitat de reproducció</string>
+    <key>settings_plus_pricing_format</key>
+    <string>%1$@ al mes / %2$@ a l'any</string>
+    <key>settings_privacy</key>
+    <string>Privacitat</string>
+    <key>settings_queue_position</key>
+    <string>Posició a la cua</string>
+    <key>settings_read_privacy_policy</key>
+    <string>Llegeix la política de privacitat</string>
+    <key>settings_select_filter_singular</key>
+    <string>Seleccionar filtre</string>
+    <key>settings_select_filters_plural</key>
+    <string>Seleccionar filtres</string>
+    <key>settings_shortcuts_filter_open_filter</key>
+    <string>Obrir el filtre</string>
+    <key>settings_shortcuts_filter_play_all_episodes</key>
+    <string>Reproduir tots els episodis</string>
+    <key>settings_shortcuts_filter_play_top_episode</key>
+    <string>Reproduir el primer episodi</string>
+    <key>settings_siri_shortcut</key>
+    <string>Drecera de Siri</string>
+    <key>settings_siri_shortcut_msg</key>
+    <string>Una drecera de Siri per a reproduir el primer episodi de %1$@</string>
+    <key>settings_siri_shortcuts</key>
+    <string>Dreceres de Siri</string>
+    <key>settings_siri_shortcuts_available</key>
+    <string>Accessos directes disponibles</string>
+    <key>settings_siri_shortcuts_enabled</key>
+    <string>Accessos directes activats</string>
+    <key>settings_siri_shortcuts_specific_filter</key>
+    <string>Accés directe a un filtre concret</string>
+    <key>settings_siri_shortcuts_specific_podcast</key>
+    <string>Accés directe a un podcast concret</string>
+    <key>settings_skip_first</key>
+    <string>Saltar al començament</string>
+    <key>settings_skip_last</key>
+    <string>Saltar final</string>
+    <key>settings_skip_msg</key>
+    <string>Salta't la música de la introducció i del final com a bon usuari experimentat que ets.</string>
+    <key>settings_stats</key>
+    <string>Estadístiques</string>
+    <key>settings_storage</key>
+    <string>Emmagatzematge i ús de dades</string>
+    <key>settings_storage_data_warning</key>
+    <string>Avisar abans d'emprar les dades</string>
+    <key>settings_storage_downloads_starred</key>
+    <string>Incloure destacats</string>
+    <key>settings_storage_mobile_data</key>
+    <string>DADES MÒBILS</string>
+    <key>settings_storage_usage</key>
+    <string>ÚS</string>
+    <key>settings_title</key>
+    <string>Configuració del podcast</string>
+    <key>settings_trim_level</key>
+    <string>Ajustar nivell</string>
+    <key>settings_trim_silence</key>
+    <string>Retallar silencis</string>
+    <key>settings_up_next_limit</key>
+    <string>Afegeix automàticament nous episodis a la llista 'Tot seguit'. Quan arribeu a %1$@, es deixaran d'afegir nous episodis.</string>
+    <key>settings_up_next_limit_add_to_top</key>
+    <string>Afegeix automàticament nous episodis a la llista 'Tot seguit'. Quan arribeu a %1$@, els nous episodis que s'afegeixin automàticament es col·locaran al principi i eliminaran el darrer episodi de la llista.</string>
+    <key>settings_volume_boost</key>
+    <string>Pujar volum</string>
+    <key>settings_watch_auto_download</key>
+    <string>Descàrrega automàtica de la llista 'Tot seguit'</string>
+    <key>settings_watch_auto_download_off_subtitle</key>
+    <string>Estableix el número d'episodis de la llista 'Tot seguit' que Pocket Casts descarregarà al teu rellotge perquè els puguis reproduir sense connexió.</string>
+    <key>settings_watch_delete_downloads</key>
+    <string>Esborrar les descàrregues que superin el límit</string>
+    <key>settings_watch_delete_downloads_off_subtitle</key>
+    <string>Per estalviar emmagatzematge al rellotge, es descarregarà automàticament un màxim de 25 episodis de la llista 'Tot seguit'. S'esborraran automàticament els fitxers de descàrrega més antics que superin aquest límit.</string>
+    <key>settings_watch_delete_downloads_on_subtitle</key>
+    <string>S'esborraran automàticament tots els fitxers descarregats a la llista 'Tot seguit' que superin aquest límit. Aquests paràmetres no afecten les descàrregues manuals.</string>
+    <key>settings_watch_episode_limit</key>
+    <string>Número d'episodis</string>
+    <key>settings_watch_episode_limit_subtitle</key>
+    <string>Pocket Casts descarregarà al teu rellotge els %1$@ millors episodis de la llista 'Tot seguit' perquè puguis reproduir-los sense connexió.</string>
+    <key>settings_watch_episode_number_option_format</key>
+    <string>Els  %1$@ millors</string>
+    <key>setup_account</key>
+    <string>Configurar el compte</string>
+    <key>share</key>
+    <string>Compartir</string>
+    <key>share_current_position</key>
+    <string>Posició actual</string>
+    <key>share_list_subscribing</key>
+    <string>Subscrivint-te…</string>
+    <key>share_podcasts_all_selected</key>
+    <string>TOT SELECCIONAT</string>
+    <key>share_podcasts_create_list</key>
+    <string>Crear llista</string>
+    <key>share_podcasts_sharing</key>
+    <string>Compartint...</string>
+    <key>share_podcasts_sharing_failed_msg</key>
+    <string>S'ha produït un error en crear la teva pàgina compartida</string>
+    <key>share_podcasts_sharing_failed_title</key>
+    <string>S'ha produït un error en compartir</string>
+    <key>share_select_podcasts</key>
+    <string>Seleccionar podcasts</string>
+    <key>shared_item_loading</key>
+    <string>Carregant un element compartit...</string>
+    <key>shared_list</key>
+    <string>Llista compartida</string>
+    <key>shared_list_subscribe_conf_action</key>
+    <string>És clar que sí!</string>
+    <key>shared_list_subscribe_conf_msg</key>
+    <string>Estàs segur que et vols subscriure a %1$@ podcasts?</string>
+    <key>shared_list_subscribe_conf_title</key>
+    <string>Són molts podcasts!</string>
+    <key>show_notes</key>
+    <string>Notes</string>
+    <key>sign_in</key>
+    <string>Iniciar sessió</string>
+    <key>sign_in_email_address_prompt</key>
+    <string>Adreça de correu electrònic</string>
+    <key>sign_in_forgot_password</key>
+    <string>He oblidat la contrasenya</string>
+    <key>sign_in_message</key>
+    <string>Desa les teves subscripcions a podcasts al núvol i sincronitza el progrés amb altres dispositius.</string>
+    <key>sign_in_password_prompt</key>
+    <string>Contrasenya</string>
+    <key>sign_in_prompt</key>
+    <string>Iniciar sessió o crear un compte</string>
+    <key>signed_in_as</key>
+    <string>HAS INICIAT LA SESSIÓ COM</string>
+    <key>signed_out</key>
+    <string>No s'ha iniciat la sessió</string>
+    <key>siri_shortcut_extend_sleep_timer</key>
+    <string>Configurar el temporitzador en %1$@</string>
+    <key>siri_shortcut_extend_sleep_timer_five_min</key>
+    <string>Ampliar el temporitzador en 5 minuts</string>
+    <key>siri_shortcut_next_chapter</key>
+    <string>Capítol següent</string>
+    <key>siri_shortcut_open_filter_phrase</key>
+    <string>Obrir %1$@</string>
+    <key>siri_shortcut_pause_phrase</key>
+    <string>Pausar</string>
+    <key>siri_shortcut_pause_title</key>
+    <string>Pausar l'actual capítol</string>
+    <key>siri_shortcut_play_all_phrase</key>
+    <string>Reproduir tot %1$@</string>
+    <key>siri_shortcut_play_all_title</key>
+    <string>Reproduint tots els capítols</string>
+    <key>siri_shortcut_play_episode_title</key>
+    <string>Reproduint el capítol primer</string>
+    <key>siri_shortcut_play_filter_phrase</key>
+    <string>Reproduir el primer %1$@</string>
+    <key>siri_shortcut_play_podcast_phrase</key>
+    <string>Reproduir %1$@</string>
+    <key>siri_shortcut_play_suggested_podcast_phrase</key>
+    <string>Reproduir un capítol recomanat</string>
+    <key>siri_shortcut_play_suggested_podcast_suggested_title</key>
+    <string>Sorprèn-me!</string>
+    <key>siri_shortcut_play_suggested_podcast_title</key>
+    <string>Reproduint un capítol recomanat</string>
+    <key>siri_shortcut_play_up_next_phrase</key>
+    <string>Tot seguit</string>
+    <key>siri_shortcut_play_up_next_title</key>
+    <string>Reproduint el capítol següent</string>
+    <key>siri_shortcut_previous_chapter</key>
+    <string>Capítol anterior</string>
+    <key>siri_shortcut_resume_phrase</key>
+    <string>Reprendre</string>
+    <key>siri_shortcut_resume_title</key>
+    <string>Reprenent el capítol actual</string>
+    <key>siri_shortcut_to_podcast</key>
+    <string>Crear accés directe al podcast</string>
+    <key>skip_back</key>
+    <string>Endarrerir</string>
+    <key>skip_forward</key>
+    <string>Avançar</string>
+    <key>sleep_timer</key>
+    <string>Temporitzador</string>
+    <key>sleep_timer_add_5_mins</key>
+    <string>+ 5 minuts</string>
+    <key>sleep_timer_cancel</key>
+    <string>Cancel·lar el temporitzador</string>
+    <key>sleep_timer_end_of_episode</key>
+    <string>Final de l'episodi</string>
+    <key>sleep_timer_time_remaining</key>
+    <string>Temporitzador activat, queden %1$@</string>
+    <key>sonos_connect_action</key>
+    <string>CONNECTAR</string>
+    <key>sonos_connect_prompt</key>
+    <string>Connectar amb Sonos</string>
+    <key>sonos_connecting</key>
+    <string>CONNECTANT...</string>
+    <key>sonos_connection_failed_account_link</key>
+    <string>Ara mateix no es pot vincular el compte de Pocket Casts. Torna-ho a provar més tard.</string>
+    <key>sonos_connection_failed_app_missing</key>
+    <string>No s'ha pogut obrir l'aplicació Sonos per completar el procés de vinculació.</string>
+    <key>sonos_connection_failed_title</key>
+    <string>S'ha produit un error a la vinculació</string>
+    <key>sonos_connection_privacy_notice</key>
+    <string>En connectar-te a Sonos, permetràs que l'aplicació accedeixi a la informació de l'episodi. 
+Mai es compartirà la teva adreça de correu electrònic, ni la contrasenya ni cap altra informació confidencial.</string>
+    <key>sonos_connection_sign_in_prompt</key>
+    <string>Per poder connectar-ne amb Sonos, necessites un compte de Pocket Casts.</string>
+    <key>sort_by</key>
+    <string>Ordenar per</string>
+    <key>sort_episodes</key>
+    <string>Ordenar episodis</string>
+    <key>speed</key>
+    <string>Velocitat</string>
+    <key>star_episode</key>
+    <string>Destacar episodi</string>
+    <key>star_episode_short</key>
+    <string>Destacar</string>
+    <key>stats_accessibility_listen_history_format</key>
+    <string>Has escoltat durant %1$@. %2$@</string>
+    <key>stats_auto_skip</key>
+    <string>Salt automàtic</string>
+    <key>stats_error</key>
+    <string>No s'han pogut carregar les estadístiques. Comprova la connexió a la xarxa</string>
+    <key>stats_listen_history_format</key>
+    <string>Des de %1$@ has escoltat durant</string>
+    <key>stats_listen_history_loading</key>
+    <string>Has escoltat durant</string>
+    <key>stats_listen_history_no_date</key>
+    <string>Has escoltat durant</string>
+    <key>stats_skipping</key>
+    <string>Saltant</string>
+    <key>stats_time_saved</key>
+    <string>TEMPS ESTALVIAT PER</string>
+    <key>stats_time_zero_seconds</key>
+    <string>0 segons</string>
+    <key>stats_total</key>
+    <string>Total</string>
+    <key>stats_variable_speed</key>
+    <string>Velocitat variable</string>
+    <key>status_downloaded</key>
+    <string>Descarregat</string>
+    <key>status_downloading</key>
+    <string>Descarregant</string>
+    <key>status_not_downloaded</key>
+    <string>No descarregat</string>
+    <key>status_not_selected</key>
+    <string>No s'ha seleccionat</string>
+    <key>status_not_starred</key>
+    <string>No s'ha destacat</string>
+    <key>status_played</key>
+    <string>Reproduït</string>
+    <key>status_selected</key>
+    <string>Seleccionat</string>
+    <key>status_starred</key>
+    <string>Destacat</string>
+    <key>status_unplayed</key>
+    <string>No reproduït</string>
+    <key>status_uploaded</key>
+    <string>Pujat</string>
+    <key>stop_download</key>
+    <string>Atura la descàrrega</string>
+    <key>subscribe</key>
+    <string>Subscriure'm</string>
+    <key>subscribe_all</key>
+    <string>Subscriure's a tot</string>
+    <key>subscribed</key>
+    <string>Subscrit</string>
+    <key>subscription_cancelled</key>
+    <string>Has cancel·lat la teva subscripció</string>
+    <key>subscription_cancelled_msg</key>
+    <string>La teva subscripció es cancel·larà el %1$@ </string>
+    <key>subscriptions_thank_you</key>
+    <string>Gràcies pel teu suport!</string>
+    <key>supporter</key>
+    <string>Col·laborador</string>
+    <key>supporter_contributions</key>
+    <string>Contribucions dels col·laboradors</string>
+    <key>supporter_contributions_subtitle</key>
+    <string>Per a més informació, consulta les contribucions</string>
+    <key>supporter_payment_canceled</key>
+    <string>Seguidor: cancel·lat</string>
+    <key>sync_account_error</key>
+    <string>Comprova el teu nom d'usuari i contrasenya.</string>
+    <key>sync_account_login</key>
+    <string>Connectat...</string>
+    <key>sync_failed</key>
+    <string>Ha fallat la sincronització</string>
+    <key>sync_in_progress</key>
+    <string>Sincronitzant la llista 'Tot seguit' i l'historial</string>
+    <key>sync_progress</key>
+    <string>Podcast %1$@ de %2$@</string>
+    <key>sync_progress_unknown_count_plural_format</key>
+    <string>S'han sincronitzat %1$@ podcasts</string>
+    <key>sync_progress_unknown_count_singular</key>
+    <string>S'ha sincronitzat 1 podcast</string>
+    <key>syncing</key>
+    <string>Sincronitzant...</string>
+    <key>terms_of_use</key>
+    <string>Condicions d'ús</string>
+    <key>theme_classic</key>
+    <string>Clàssic</string>
+    <key>theme_dark</key>
+    <string>Predeterminat fosc</string>
+    <key>theme_dark_contrast</key>
+    <string>Contrast fosc</string>
+    <key>theme_electricity</key>
+    <string>Electricitat</string>
+    <key>theme_extra_dark</key>
+    <string>Extra fosc</string>
+    <key>theme_indigo</key>
+    <string>Indigo</string>
+    <key>theme_light</key>
+    <string>Predeterminat clar</string>
+    <key>theme_light_contrast</key>
+    <string>Contrast clar</string>
+    <key>theme_radioactivity</key>
+    <string>Radioactivitat</string>
+    <key>theme_rose</key>
+    <string>Rosa</string>
+    <key>time_format_never</key>
+    <string>mai</string>
+    <key>time_placeholder</key>
+    <string>0 seg</string>
+    <key>today</key>
+    <string>avui</string>
+    <key>top</key>
+    <string>Top</string>
+    <key>trial_finished</key>
+    <string>Prova acabada</string>
+    <key>trim_silence</key>
+    <string>Retallar silencis</string>
+    <key>try_again</key>
+    <string>Tornar-ho a provar</string>
+    <key>unarchive</key>
+    <string>Desarxivar</string>
+    <key>unknown_duration</key>
+    <string>? min</string>
+    <key>unstar</key>
+    <string>Treure de destacats</string>
+    <key>unsubscribe</key>
+    <string>Cancel·lar la subscripció</string>
+    <key>unsubscribe_all</key>
+    <string>Cancel·lar totes les subscripcions</string>
+    <key>up_next</key>
+    <string>Tot seguit</string>
+    <key>up_next_empty_description</key>
+    <string>Pots posar episodis a la llista perquè es reprodueixin a tot seguit si llisques cap a la dreta a les files dels episodis o si toques la icona a la targeta de l'episodi.</string>
+    <key>up_next_empty_title</key>
+    <string>No hi ha res a la llista de 'Tot seguit'</string>
+    <key>upload_sort_alpha</key>
+    <string>Títol (A-Z)</string>
+    <key>volume_boost</key>
+    <string>Pujar el volum</string>
+    <key>volume_boost_description</key>
+    <string>Augmenta el volum de les veus</string>
+    <key>wait_for_wifi</key>
+    <string>Esperant a la xarxa Wi-Fi</string>
+    <key>watch</key>
+    <string>Rellotge</string>
+    <key>watch_buffering</key>
+    <string>Emmagatzemant a la memòria...</string>
+    <key>watch_chapter_next</key>
+    <string>Següent capítol</string>
+    <key>watch_chapter_prev</key>
+    <string>Capítol anterior</string>
+    <key>watch_effects</key>
+    <string>Efectes</string>
+    <key>watch_episode_details</key>
+    <string>Informació de l'episodi</string>
+    <key>watch_main_menu</key>
+    <string>Menú principal</string>
+    <key>watch_no_episodes</key>
+    <string>No hi ha episodis</string>
+    <key>watch_no_filters</key>
+    <string>Sense filtres</string>
+    <key>watch_no_podcasts</key>
+    <string>No hi ha podcasts</string>
+    <key>watch_nothing_playing_subtitle</key>
+    <string>Gaudeix del silenci o troba alguna cosa nova per reproduir.
+
+Sincerament, ambdues són bones decisions.</string>
+    <key>watch_nothing_playing_title</key>
+    <string>No sona res</string>
+    <key>watch_source_msg</key>
+    <string>Els podcasts es reproduiran a través de l'altaveu al que estigui connectat el dispositiu triat</string>
+    <key>watch_source_plus_info</key>
+    <string>Descarrega el contingut directament al rellotge i escolta'l sense el mòbil. Fes una ullada a Pocket Casts Plus a l'aplicació mòbil o a la web.</string>
+    <key>watch_source_refresh_account</key>
+    <string>Actualitzar el compte</string>
+    <key>watch_source_refresh_account_info</key>
+    <string>Si tens un compte de Pocket Casts Plus, actualitza per intentar activar-la</string>
+    <key>watch_source_refresh_data</key>
+    <string>Actualitza les dades</string>
+    <key>watch_source_sign_in_info</key>
+    <string>Inicia sessió o crea un compte des del teu telèfon</string>
+    <key>watch_tap_to_open</key>
+    <string>Toca per obrir</string>
+    <key>watch_up_next_no_items_subtitle</key>
+    <string>Per tal que els episodis es reprodueixin a continuació, pots posar-los a la cua des de la pantalla de detalls de l'episodi o afegir-los amb el telèfon.</string>
+    <key>watch_up_next_no_items_title</key>
+    <string>No hi ha res a Tot seguit</string>
+    <key>welcome_discover_button</key>
+    <string>Cercar el meu podcast següent</string>
+    <key>welcome_discover_description</key>
+    <string>Troba podcasts poc coneguts i podcasts populars a la nostra pàgina Descobrir, amb seleccions triades a ma.</string>
+    <key>welcome_discover_title</key>
+    <string>Descobreix alguna cosa nova</string>
+    <key>welcome_import_button</key>
+    <string>Importar podcasts</string>
+    <key>welcome_import_description</key>
+    <string>Véns des d'una altra app? Emporta't els teus podcasts amb tu</string>
+    <key>welcome_import_title</key>
+    <string>Importa els teus podcasts</string>
+    <key>welcome_new_account_title</key>
+    <string>Benvingut. I ara, a escoltar!</string>
+    <key>welcome_plus_title</key>
+    <string>Gràcies. I ara, comença a escoltar contingut!</string>
+    <key>whats_new</key>
+    <string>Novetats</string>
+    <key>whats_new_blog_more_link_text</key>
+    <string>Per tenir més informació sobre aquesta actuaiització, consulta el nostre blog.</string>
+    <key>whats_new_in_version</key>
+    <string>Què hi ha de nou a %1$@</string>
+    <key>whats_new_page_one_7_20</key>
+    <string>Si t'agraden els podcasts la meitat del que ens agraden a nosaltres, probablement en segueixis molts. Ara, amb la subscripció a Pocket Casts Plus, pots classificar-los en carpetes i arxivar-los en grups ordenats. 
+
+Gràcies al teu suport, la vostra pantalla d'inici  té un aspecte fantàstic!</string>
+    <key>whats_new_page_one_title_7_20</key>
+    <string>Carpetes</string>
+    <key>whats_new_page_two_7_20</key>
+    <string>Ara, sincronitzem la teva pantalla inicial (i les opcions d'ordenació) a tots els dispositius. A més, també pots arrossegar i deixar anar al reproductor web. 
+
+Amb aquesta funció, la feina que has fet per organitzar la teva pàgina de podcasts se sincronitza amb el teu compte, així que et pots relaxar.</string>
+    <key>whats_new_page_two_title_7_20</key>
+    <string>Sincronització de la pantalla d'inici</string>
+    <key>widgets_app_icon_description</key>
+    <string>Iniciar ràpidament Pocket Casts</string>
+    <key>widgets_app_icon_name</key>
+    <string>Icona</string>
+    <key>widgets_discover_prompt_msg</key>
+    <string>Consulta la pestanya 'Descobrir'</string>
+    <key>widgets_discover_prompt_title</key>
+    <string>Tens ganes d'escoltar més?</string>
+    <key>widgets_nothing_playing</key>
+    <string>No sona res</string>
+    <key>widgets_now_playing_desc</key>
+    <string>Accedeix ràpidament a l'episodi que està sonant en aquest moment.</string>
+    <key>widgets_now_playing_tap_discover</key>
+    <string>Toca per a descobrir</string>
+    <key>widgets_up_next_description</key>
+    <string>Consulta el nombre d'episodis a la cua a la secció Tot seguit o obté informació sobre l'episodi següent</string>
+    <key>year</key>
+    <string>any</string>
+    <key>yearly</key>
+    <string>Per any</string>
+  </dict>
+</plist>

--- a/podcasts/ca.lproj/Localizable.strings
+++ b/podcasts/ca.lproj/Localizable.strings
@@ -1,0 +1,3559 @@
+/* A common string used throughout the app. An accessibility label to direct the user to turn off the multi-select mode. */
+"accessibility_cancel_multiselect" = "Cancel multiselect";
+
+/* A common string used throughout the app. Accessibility hint to inform that the control closes the current dialog window. */
+"accessibility_close_dialog" = "Close dialog";
+
+/* A common string used throughout the app. Accessibility hint to inform the user that this control will deselect the episode. */
+"accessibility_deselect_episode" = "Deselect Episode";
+
+/* A common string used throughout the app. Accessibility hint to inform that the control is disabled. */
+"accessibility_disabled" = "Disabled";
+
+/* A common string used throughout the app. Accessibility hint to inform that the control dismisses the current window. */
+"accessibility_dismiss" = "Dismiss";
+
+/* An accessibility label to direct the user tap to get access to filter details. */
+"accessibility_hide_filter_details" = "Tap to hide filter details";
+
+/* Accessibility hint to inform the user how to star (favorite) for an episode. */
+"accessibility_hint_star" = "Double tap to star episode";
+
+/* Accessibility hint to inform the user how to un-star (remove favorite) for an episode. */
+"accessibility_hint_unstar" = "Double tap to remove star from episode";
+
+/* A common string used throughout the app. Accessibility hint to inform that the control opens a menu for more options. */
+"accessibility_more_actions" = "More actions";
+
+/* A common string used throughout the app. An accessibility label to inform the user the completed percentage of a given task. '%1$@' is a placeholder for the localized spelled out number for Voice Over */
+"accessibility_percent_complete_format" = "%1$@ percent completed";
+
+/* Accessibility text listing the current value for the playback speed. '%1$@' is a placeholder for the playback speed. */
+"accessibility_player_effects_playback_speed" = "Playback speed %1$@ times";
+
+/* Accessibility hint to inform the user which filter color flag is being used. '%1$@' is a placeholder for the filter color number. */
+"accessibility_playlist_color" = "Playlist color %1$@";
+
+/* A common string used throughout the app. An accessibility label to inform the user that the selected item is locked behind Pocket Casts Plus subscription. */
+"accessibility_plus_only" = "Locked, Plus Feature";
+
+/* Accessibility label fir the profile settings icon in the app. 'Pocket Casts' is treated as a proper noun and hasn't been localized in other places of the app. */
+"accessibility_profile_settings" = "Pocket Casts Settings";
+
+/* A common string used throughout the app. Accessibility hint to inform the user that this control will select the episode. */
+"accessibility_select_episode" = "Select Episode";
+
+/* An accessibility label to direct the user tap to get access to filter details. */
+"accessibility_show_filter_details" = "Tap to show filter details";
+
+/* An accessibility hint to prompt the user to tap to open their account details or sign in. */
+"accessibility_sign_in" = "Tap to view or setup account";
+
+/* A common string used throughout the app. An accessibility label to direct the user to sort and option menus. */
+"accessibility_sort_and_options" = "Sort and Options";
+
+/* Prompt to allow the user to update the email associated to their account. */
+"account_change_email" = "Change Email";
+
+/* Nudge to inform the user that they are nearly done with the account set up steps. */
+"account_completion_nudge" = "Almost There!";
+
+/* Message portion of the nudge to inform the user that they are nearly done with the account set up steps. */
+"account_completion_nudge_msg" = "Finalize your payment to finish upgrading your account.";
+
+/* Title informing the user that their account has been successfully created */
+"account_created" = "Account Created";
+
+/* Title for the final screen in the account creation flow. */
+"account_creation_complete" = "Complete Account";
+
+/* Prompt to allow the user to delete their account. */
+"account_delete_account" = "Delete Account";
+
+/* Confirmation option for deleting the user account. */
+"account_delete_account_conf" = "Yes, Delete It";
+
+/* Error title for when the delete account process has failed. */
+"account_delete_account_error" = "Delete Account Failed";
+
+/* Error message for when the delete account process has failed. */
+"account_delete_account_error_msg" = "Unable to delete account.";
+
+/* The final alert message for the confirmation dialog asking the user to confirm they want to delete their account. */
+"account_delete_account_final_alert_msg" = "Last chance, you definitely want to delete your account? You will lose all your subscriptions and play history permanently!";
+
+/* The first message for the confirmation dialog asking the user to confirm they want to delete their account. */
+"account_delete_account_first_alert_msg" = "Are you sure you want to delete your account, there's no way to undo this!";
+
+/* Title for the confirmation dialog asking the user to confirm they want to delete their account. */
+"account_delete_account_title" = "Delete Account?";
+
+/* Button title to prompt a user to login. */
+"account_login" = "Log in";
+
+/* Informs the user that their purchase will be automatically renewed monthly */
+"account_payment_renews_monthly" = "Renews automatically monthly";
+
+/* Informs the user that their purchase will be automatically renewed yearly */
+"account_payment_renews_yearly" = "Renews automatically yearly";
+
+/* Allows the user to ope a screen to review the Privacy Policy */
+"account_privacy_policy" = "Privacy Policy";
+
+/* Error message for when the account registration request has failed. */
+"account_registration_failed" = "Registration failed, please try again later";
+
+/* Prompt to allow the user to choose their account time when setting up their account. */
+"account_select_type" = "Select Account Type";
+
+/* Prompt to allow the user to sign out of their account. */
+"account_sign_out" = "Sign Out";
+
+/* Confirmation dialog informing the user that signing out will remove the given number of supported podcasts. '%1$@' is a placeholder for the number of supported podcasts. */
+"account_sign_out_supporter_prompt" = "Signing out will remove %1$@ supported podcasts from this device. Are you sure?";
+
+/* Subtitle to the Confirmation dialog informing the user that signing out will remove the given number of supported podcasts. */
+"account_sign_out_supporter_subtitle" = "You can sign in again to regain access.";
+
+/* Error message for when the account registration request has failed. */
+"account_sso_failed" = "Sign in failed. Please try again.";
+
+/* Title for the account screen for the user's Pocket Casts Account. 'Pocket Casts' refers to the app name and is treated as a proper noun so it shouldn't be localized. */
+"account_title" = "Pocket Casts Account";
+
+/* Title informing the user that their account has been successfully upgraded to Pocket Casts Plus */
+"account_upgraded" = "Account Upgraded";
+
+/* Welcome message presented after a user has signed up for Pocket Casts */
+"account_welcome" = "Welcome to Pocket Casts!";
+
+/* Welcome message presented after a user has signed up for Pocket Casts Plus */
+"account_welcome_plus" = "Welcome to Pocket Casts Plus!";
+
+/* Title of an alert that informs the user that they have been signed out of their account */
+"account_signed_out_alert_title" = "You've been signed out.";
+
+/* Message/Body of an alert that explains that the user should tap a button and sign in again */
+"account_signed_out_alert_message" = "Turns out, if you type Google into Google, you can break the internet. 🫢 \n\nTap the button below to sign into your Pocket Casts account again.";
+
+/* A common string used throughout the app. Title for the prompt to add an episode to the up next queue. */
+"add_to_up_next" = "Add to Up Next";
+
+/* A common string used throughout the app. Option that determines the behavior of the app after playing an item. */
+"after_playing" = "After Playing";
+
+/* A common string used throughout the app. References to Badge settings for the app. */
+"app_badge" = "App Badge";
+
+/* The name for the Classic App Icon */
+"app_icon_classic" = "Classic";
+
+/* The name for the Dark App Icon */
+"app_icon_dark" = "Dark";
+
+/* The name for the Default App Icon */
+"app_icon_default" = "Default";
+
+/* The name for the Electric Blue App Icon */
+"app_icon_electric_blue" = "Electric Blue";
+
+/* The name for the Electric Pink App Icon */
+"app_icon_electric_pink" = "Electric Pink";
+
+/* The name for the Indigo App Icon */
+"app_icon_indigo" = "Indigo";
+
+/* The name for the Pocket Casts Plus App Icon */
+"app_icon_plus" = "Plus";
+
+/* The name for the Pocket Cats App Icon. The name for this one is meant to be a play on the App name Pocket Casts and the icon includes a cat image. */
+"app_icon_pocket_cats" = "Pocket Cats";
+
+/* The name for the Radioactivity App Icon */
+"app_icon_radioactivity" = "Radioactivity";
+
+/* The name for the Red Velvet App Icon */
+"app_icon_red_velvet" = "Red Velvet";
+
+/* The name for the Rosé App Icon */
+"app_icon_rose" = "Rosé";
+
+/* The name for the Round Dark App Icon */
+"app_icon_round_dark" = "Round Dark";
+
+/* The name for the Round Light App Icon */
+"app_icon_round_light" = "Round Light";
+
+/* Halloween app icon name */
+"app_icon_halloween" = "Halloween";
+
+/* App version label in the about controller. `%1$@` is a placeholder for the version number and %2$@ is a placeholder for the build number */
+"app_version" = "Version %1$@ (%2$@)";
+
+/* Section header for the appearance settings related to app icons. */
+"appearance_app_icon_header" = "App Icon";
+
+/* Section header for the appearance settings related to artwork. */
+"appearance_artwork_header" = "Podcast Artwork";
+
+/* Prompt to toggle on the use of artwork that's embedded in the episode download files. */
+"appearance_embedded_artwork" = "Use Embedded Artwork";
+
+/* Subtitle explaining embedded artwork in the episode download files. */
+"appearance_embedded_artwork_subtitle" = "Shows artwork from the downloaded file (if it exists) in the player instead of using the show's artwork.";
+
+/* Prompt to toggle whether the theme will match the device theme or not. */
+"appearance_match_device_theme" = "Use iOS Light/Dark Mode";
+
+/* Prompt to refresh the artwork for all podcasts. */
+"appearance_refresh_all_artwork" = "Refresh All Podcast Artwork";
+
+/* Confirmation message used to inform the user that the refresh has been successfully triggered. */
+"appearance_refresh_all_artwork_conf_msg" = "Refreshing your artwork now";
+
+/* Confirmation title used to inform the user that the refresh has been successfully triggered. */
+"appearance_refresh_all_artwork_conf_title" = "Aye Aye Captain";
+
+/* Section header for the appearance settings related to themes. */
+"appearance_theme_header" = "Theme";
+
+/* Header for asking the user to select a theme. */
+"appearance_theme_select" = "Select Theme";
+
+/* Label for letting the user choose a theme for iOS light mode. */
+"appearance_light_theme" = "Light Theme";
+
+/* Label for letting the user choose a theme for iOS dark mode. */
+"appearance_dark_theme" = "Dark Theme";
+
+/* A common string used throughout the app. Prompt to archive the selected item(s). */
+"archive" = "Archive";
+
+/* A common string used throughout the app. Confirmation prompt before moving forward. */
+"are_you_sure" = "Are You Sure?";
+
+/* A common string used throughout the app. Prompt to configure the auto add options for a podcast. */
+"auto_add" = "Auto Add To";
+
+/* Option in the auto add dialog to add the items to the bottom of the queue. */
+"auto_add_to_bottom" = "To Bottom";
+
+/* Option in the auto add dialog to add the items to the top of the queue. */
+"auto_add_to_top" = "To Top";
+
+/* Option in the auto add settings to stop adding options once the limit is reached. This option will add the podcast to the top top the queue and drop the bottom. */
+"auto_add_to_up_next_top_only" = "Only Add To Top";
+
+/* Option in the auto add settings to stop adding options once the limit is reached. This option will add the podcast to the top top the queue and drop the bottom. To conserve space this shouldn't be longer than the English string. If needed "Add To Top" or "To Top" can be translated instead */
+"auto_add_to_up_next_top_only_short" = "Only Add To Top";
+
+/* Option in the auto add settings to stop adding options once the limit is reached. This option won't add new episodes. */
+"auto_add_to_up_next_stop" = "Stop Adding New Episodes";
+
+/* Option in the auto add settings to stop adding options once the limit is reached. This option won't add new episodes. To conserve space this should be a more concise version of 'Stop Adding New Episodes' */
+"auto_add_to_up_next_stop_short" = "Stop Adding";
+
+/* Title for the dialog box that presents the available options for how many episodes for auto download from a filter. */
+"auto_download_first" = "Auto Download First";
+
+/* Subtitle for the auto download setting. This is displayed when the option is turned off. */
+"auto_download_off_subtitle" = "Enable to auto download episodes in this filter";
+
+/* Subtitle for the auto download setting. This is displayed when the option is turned on. '%1$@' is a placeholder for the number of episodes, this will be more than one. */
+"auto_download_on_plural_format" = "The first %1$@ episodes in this filter will be automatically downloaded";
+
+/* Provides hint text to auto download the a the first of a configurable amount of episodes. Accompanied by a label indicating how many episodes will be auto downloaded. */
+"auto_download_prompt_first" = "First";
+
+/* A common string used throughout the app. Title for the back button. Used with the accessibility settings. */
+"back" = "Back";
+
+/* A common string used throughout the app. Title option to place the item at the bottom of the queue. */
+"bottom" = "Bottom";
+
+/* A common string used throughout the app. Informs the user of the maximum amount of bulk downloads. '%1$@' is a placeholder for maximum amount of bulk downloads. */
+"bulk_download_max_format" = "Bulk downloads are limited to %1$@.";
+
+/* A common string used throughout the app. Prompt to cancel the current flow. */
+"cancel" = "Cancel";
+
+/* An activity message indicating that the process to cancel is running. */
+"canceling" = "Canceling...";
+
+/* A common string used throughout the app. Prompt to cancel the download for the selected item(s). */
+"cancel_download" = "Cancel Download";
+
+/* Message title indicating that the cancel process has failed. */
+"cancel_failed" = "Unable To Cancel";
+
+/* Prompt to allow the user to cancel their Pocket Casts Plus subscription. */
+"cancel_subscription" = "Cancel Subscription";
+
+/* CarPlay subtitle information label that includes the current chapter and total chapter count and the current chapter length. '%1$@' is a placeholder for the current chapter. '%2$@' is a placeholder for the total chapters. '%3$@' is a placeholder for the length of the current chapter. */
+"carplay_chapter_count" = "%1$@ of %2$@. %3$@";
+
+/* Provides a link to the menu to present more options. */
+"carplay_more" = "More";
+
+/* CarPlay option to modify the playback speed. */
+"carplay_playback_speed" = "Playback Speed";
+
+/* CarPlay prompt to navigate to the up next Queue. */
+"carplay_up_next_queue" = "Up Next Queue";
+
+/* Prompt to allow the user to update their email address. */
+"change_email" = "Change Email Address";
+
+/* Confirmation message title informing the user that their email has been successfully updated. */
+"change_email_conf" = "Email Address Changed";
+
+/* Prompt to allow the user to Update their password. */
+"change_password" = "Change Password";
+
+/* Confirmation message title informing the user that their password has been successfully updated. */
+"change_password_conf" = "Password Changed";
+
+/* Error message informing the user that the change password process failed. */
+"change_password_error" = "Unable to change password. Invalid password.";
+
+/* Error message informing the user that the change password process failed because they failed to enter matching passwords. */
+"change_password_error_mismatch" = "Passwords do not match";
+
+/* Error message informing the user that they need to choose a longer password. */
+"change_password_length_error" = "Must be at least 6 characters";
+
+/* A common string used throughout the app. Often refers to the Chapters list or Chapters tab in the player. */
+"chapters" = "Chapters";
+
+/* A common string used throughout the app. Informs the user how many podcasts have been chosen. '%1$@' is a placeholder for the number of podcasts, this will be more than one. */
+"chosen_podcasts_plural_format" = "%1$@ Podcasts Chosen";
+
+/* A common string used throughout the app. Informs the user how many podcasts have been chosen. This is the singular format for an accompanying plural option. */
+"chosen_podcasts_singular" = "1 Podcast Chosen";
+
+/* Title for the screen that provides the list of available ChromeCast devices. */
+"chromecast_cast_to" = "Cast to";
+
+/* Informs the user that ChromeCast has connected. */
+"chromecast_connected" = "Connected";
+
+/* Informs the user that ChromeCast has connected to the device. Used as a title when no episode is playing. */
+"chromecast_connected_to_device" = "Connected to device";
+
+/* Error message informing the user that the app is unable to Cast local files in ChromeCast. */
+"chromecast_error" = "Unable to cast local file";
+
+/* Informs the user that ChromeCast has connected to the device but no episode is playing. */
+"chromecast_nothing_playing" = "Nothing is playing";
+
+/* Placeholder name for when ChromeCast doesn't have a device name. */
+"chromecast_unnamed_device" = "Un-named device";
+
+/* A common string used throughout the app. Prompt to perform a clean up operation on the selected items. */
+"clean_up" = "Clean Up";
+
+/* A common string used throughout the app. Prompt to clear the up next queue. */
+"clear" = "Clear";
+
+/* A common string used throughout the app. Prompt to clear the up next queue. */
+"clear_up_next" = "Clear Up Next";
+
+/* A common string used throughout the app. Message to clear the up next queue. */
+"clear_up_next_message" = "Are you sure you want to clear your Up Next queue?";
+
+/* A common string used throughout the app. Prompt to close the current screen. */
+"close" = "Close";
+
+/* A common string used throughout the app. Generic confirmation */
+"confirm" = "Confirm";
+
+/* A common string used throughout the app. A prompt to move to the next step of a flow. */
+"continue" = "Continue";
+
+/* Prompt to open the create account options. */
+"create_account" = "Create Account";
+
+/* Error title shown when Pocket Casts can't connect to the App Store to retrieve in app purchase details */
+"create_account_app_store_error_title" = "Unable to contact App Store";
+
+/* Error message shown when Pocket Casts can't connect to the App Store to retrieve in app purchase details */
+"create_account_app_store_error_message" = "Pocket Casts is having trouble connecting to the App Store. Please check your connection and try again.";
+
+/* Price shown for the free tier. "Free" in this case meaning the cost is free */
+"create_account_free_price" = "Free";
+
+/* Account type shown on the select account page. Regular as in the normal or default option */
+"create_account_free_account_type" = "Regular";
+
+/* Shown under the create account type to indicate what you get with a free Pocket Casts account */
+"create_account_free_details" = "Almost everything";
+
+/* Shown under the create account type to indicate what you get in Pocket Casts Plus */
+"create_account_plus_details" = "Everything unlocked";
+
+/* Button title to find out more about Pocket Casts Plus. Note that "Pocket Casts Plus" shouldn't be translated as it's a product name */
+"create_account_find_out_more_plus" = "Find out more about Pocket Casts Plus";
+
+/* Title for the screen where a user starts creating a filter */
+"create_filter" = "Create Filter";
+
+/* An indicator that the current episode is a user generated episode */
+"custom_episode" = "Custom Episode";
+
+/* Prompt to cancel an active upload of a file. */
+"custom_episode_cancel_upload" = "Cancel Upload";
+
+/* Prompt to delete an uploaded file from the cloud. */
+"custom_episode_remove_upload" = "Remove from Cloud";
+
+/* Prompt to upload a file to the cloud. */
+"custom_episode_upload" = "Upload to Cloud";
+
+/* A common string used throughout the app. Prompt to delete the selected item(s). */
+"delete" = "Delete";
+
+/* A prompt to delete the downloaded file */
+"delete_download" = "Delete Download";
+
+/* Prompt to delete the selected item(s) from the device storage and the cloud. */
+"delete_everywhere" = "Delete From Everywhere";
+
+/* Prompt to delete the selected item(s) from the device storage and the cloud. */
+"delete_everywhere_short" = "Delete Everywhere";
+
+/* A common string used throughout the app. Title portion of the prompt to delete the selected file. */
+"delete_file" = "Delete File";
+
+/* A common string used throughout the app. Message portion of the prompt to delete the selected file. */
+"delete_file_message" = "Are you sure you want to delete this file?";
+
+/* A common string used throughout the app. Prompt to delete the selected item(s) from the cloud storage. */
+"delete_from_cloud" = "Delete From Cloud";
+
+/* A common string used throughout the app. Prompt to delete the selected item(s) from the device storage. */
+"delete_from_device" = "Delete From Device";
+
+/* A common string used throughout the app. Prompt to delete the selected item(s) from the device storage. 'Only' is used to emphasize that the item is also stored in the cloud and that file won't be deleted. */
+"delete_from_device_only" = "Delete From Device Only";
+
+/* A common string used throughout the app. Prompt to deselect all items in the presented list. */
+"deselect_all" = "Deselect All";
+
+/* A common string used throughout the app. Refers to the Discover tab. */
+"discover" = "Discover";
+
+/* Title for the section that allows the user to explore different podcast categories. */
+"discover_browse_by_category" = "Browse By Category";
+
+/* Title for the podcast category Arts */
+"discover_browse_by_category_art" = "Arts";
+
+/* Title for the podcast category Business */
+"discover_browse_by_category_business" = "Business";
+
+/* Title for the podcast category Comedy */
+"discover_browse_by_category_comedy" = "Comedy";
+
+/* Title for the podcast category Education */
+"discover_browse_by_category_education" = "Education";
+
+/* Title for the podcast category Fiction */
+"discover_browse_by_category_fiction" = "Fiction";
+
+/* Title for the podcast category Games & Hobbies */
+"discover_browse_by_category_games_and_hobbies" = "Games & Hobbies";
+
+/* Title for the podcast category Government */
+"discover_browse_by_category_government" = "Government";
+
+/* Title for the podcast category Government & Organizations */
+"discover_browse_by_category_government_and_organizations" = "Government & Organizations";
+
+/* Title for the podcast category History */
+"discover_browse_by_category_history" = "History";
+
+/* Title for the podcast category Health */
+"discover_browse_by_category_health" = "Health";
+
+/* Title for the podcast category Health & Fitness */
+"discover_browse_by_category_health_and_fitness" = "Health & Fitness";
+
+/* Title for the podcast category Kids & Family */
+"discover_browse_by_category_kids_and_family" = "Kids & Family";
+
+/* Title for the podcast category Leisure */
+"discover_browse_by_category_leisure" = "Leisure";
+
+/* Title for the podcast category Music */
+"discover_browse_by_category_music" = "Music";
+
+/* Title for the podcast category News */
+"discover_browse_by_category_news" = "News";
+
+/* Title for the podcast category News & Politics */
+"discover_browse_by_category_news_and_politics" = "News & Politics";
+
+/* Title for the podcast category Religion & Spirituality */
+"discover_browse_by_category_religion_and_spirituality" = "Religion & Spirituality";
+
+/* Title for the podcast category Science */
+"discover_browse_by_category_science" = "Science";
+
+/* Title for the podcast category Science & Medicine */
+"discover_browse_by_category_science_and_medicine" = "Science & Medicine";
+
+/* Title for the podcast category Society */
+"discover_browse_by_category_society" = "Society";
+
+/* Title for the podcast category Society & Culture */
+"discover_browse_by_category_society_and_culture" = "Society & Culture";
+
+/* Title for the podcast category Sports */
+"discover_browse_by_category_sports" = "Sports";
+
+/* Title for the podcast category Sports & Recreation */
+"discover_browse_by_category_sports_and_recreation" = "Sports & Recreation";
+
+/* Title for the podcast category Technology */
+"discover_browse_by_category_technology" = "Technology";
+
+/* Title for the podcast category True Crime */
+"discover_browse_by_category_true_crime" = "True Crime";
+
+/* Title for the podcast category TV & Film */
+"discover_browse_by_category_tv_and_film" = "TV & Film";
+
+/* Prompt to allow the user to manually change the regional information for the Discover tab. '%1$@' is a placeholder for the current region. */
+"discover_change_region" = "Change Region, currently %1$@";
+
+/* Badge used to mark featured podcasts. */
+"discover_featured" = "Featured";
+
+/* Informative label letting the users know that the displayed episode is a featured episode. */
+"discover_featured_episode" = "FEATURED EPISODE";
+
+/* Error message informing the user that the episode they tapped could not be found, with instructions on how to fix the issue. */
+"discover_featured_episode_error_not_found" = "Featured podcast or episode not found. Make sure you are connected to the internet and try again.";
+
+/* Informative label letting the users know that the displayed podcast is a featured new podcast. */
+"discover_fresh_pick" = "FRESH PICK";
+
+/* Informational title when the search succeeds but returns no results. */
+"discover_no_podcasts_found" = "No podcasts found";
+
+/* Informational title when the search succeeds but returns no results. */
+"discover_no_podcasts_found_msg" = "Try more general or different keywords.";
+
+/* Display title for calling out a podcast network on the discover tab. '%1$@' is a placeholder for the podcast's network title. */
+"discover_podcast_network" = "%1$@ Network";
+
+/* Title used for promotional purposes to highlight podcasts that are popular worldwide. */
+"discover_popular" = "Popular";
+
+/* Title used for promotional purposes to highlight podcasts that are popular in a specific region. '%1$@' is a placeholder for the region's name. */
+"discover_popular_in" = "Popular in %1$@";
+
+/* Button prompt on the discover page to play the featured episode. */
+"discover_play_episode" = "Play Episode";
+
+/* Button prompt on the discover page to play the trailer of a featured episode. */
+"discover_play_trailer" = "Play Trailer";
+
+/* Region name for Australia used in the Discover Section */
+"discover_region_australia" = "Australia";
+
+/* Region name for Austria used in the Discover Section */
+"discover_region_austria" = "Austria";
+
+/* Region name for Belgium used in the Discover Section */
+"discover_region_belgium" = "Belgium";
+
+/* Region name for Brazil used in the Discover Section */
+"discover_region_brazil" = "Brazil";
+
+/* Region name for Canada used in the Discover Section */
+"discover_region_canada" = "Canada";
+
+/* Region name for China used in the Discover Section */
+"discover_region_china" = "China";
+
+/* Region name for Czechia used in the Discover Section */
+"discover_region_czechia" = "Czechia";
+
+/* Region name for Denmark used in the Discover Section */
+"discover_region_denmark" = "Denmark";
+
+/* Region name for Finland used in the Discover Section */
+"discover_region_finland" = "Finland";
+
+/* Region name for France used in the Discover Section */
+"discover_region_france" = "France";
+
+/* Region name for Germany used in the Discover Section */
+"discover_region_germany" = "Germany";
+
+/* Region name for Hong Kong used in the Discover Section */
+"discover_region_hong_kong" = "Hong Kong";
+
+/* Region name for India used in the Discover Section */
+"discover_region_india" = "India";
+
+/* Region name for Ireland used in the Discover Section */
+"discover_region_ireland" = "Ireland";
+
+/* Region name for Israel used in the Discover Section */
+"discover_region_israel" = "Israel";
+
+/* Region name for Italy used in the Discover Section */
+"discover_region_italy" = "Italy";
+
+/* Region name for Japan used in the Discover Section */
+"discover_region_japan" = "Japan";
+
+/* Region name for Mexico used in the Discover Section */
+"discover_region_mexico" = "Mexico";
+
+/* Region name for Netherlands used in the Discover Section */
+"discover_region_netherlands" = "Netherlands";
+
+/* Region name for New Zealand used in the Discover Section */
+"discover_region_new_zealand" = "New Zealand";
+
+/* Region name for Norway used in the Discover Section */
+"discover_region_norway" = "Norway";
+
+/* Region name for Philippines used in the Discover Section */
+"discover_region_philippines" = "Philippines";
+
+/* Region name for Poland used in the Discover Section */
+"discover_region_poland" = "Poland";
+
+/* Region name for Portugal used in the Discover Section */
+"discover_region_portugal" = "Portugal";
+
+/* Region name for Russia used in the Discover Section */
+"discover_region_russia" = "Russia";
+
+/* Region name for Saudi Arabia used in the Discover Section */
+"discover_region_saudi_arabia" = "Saudi Arabia";
+
+/* Region name for Singapore used in the Discover Section */
+"discover_region_singapore" = "Singapore";
+
+/* Region name for South Africa used in the Discover Section */
+"discover_region_south_africa" = "South Africa";
+
+/* Region name for South Korea used in the Discover Section */
+"discover_region_south_korea" = "South Korea";
+
+/* Region name for Spain used in the Discover Section */
+"discover_region_spain" = "Spain";
+
+/* Region name for Sweden used in the Discover Section */
+"discover_region_sweden" = "Sweden";
+
+/* Region name for Switzerland used in the Discover Section */
+"discover_region_switzerland" = "Switzerland";
+
+/* Region name for Taiwan used in the Discover Section */
+"discover_region_taiwan" = "Taiwan";
+
+/* Region name for Turkey used in the Discover Section */
+"discover_region_turkey" = "Turkey";
+
+/* Region name for Ukraine used in the Discover Section */
+"discover_region_ukraine" = "Ukraine";
+
+/* Region name for United Kingdom used in the Discover Section */
+"discover_region_united_kingdom" = "United Kingdom";
+
+/* Region name for United States used in the Discover Section */
+"discover_region_united_states" = "United States";
+
+/* Region name used in the Discover Section for a genreic global setting instead of a specific region. */
+"discover_region_worldwide" = "Worldwide";
+
+/* Error message when a user performs a search using a search term that's too short. */
+"discover_search_error_msg" = "Please enter at least 2 characters.";
+
+/* Error title when a user performs a search using a search term that's too short. */
+"discover_search_error_title" = "Length Challenged";
+
+/* Informational title informing the users that the search has failed. */
+"discover_search_failed" = "Search Failed";
+
+/* Informational message suggesting that the user checks their internet connection when an error occurs. */
+"discover_search_failed_msg" = "Check your Internet connection.";
+
+/* Screen title to allow the user to manually change the regional information for the Discover tab. This screen shows the available options. */
+"discover_select_region" = "Select Content Region";
+
+/* Button prompt used on the Discover Tab. Opens the linked list to show all podcasts in the section. */
+"discover_show_all" = "SHOW ALL";
+
+/* Informative label letting the users know that the displayed podcast is a paid placement ad. */
+"discover_sponsored" = "SPONSORED";
+
+/* Title used for promotional purposes to highlight trending podcasts. */
+"discover_trending" = "Trending";
+
+/* A common string used throughout the app. Confirmation text. */
+"done" = "Done";
+
+/* A common string used throughout the app. Prompt to download the selected item(s). */
+"download" = "Download";
+
+/* A common string used throughout the app. Prompt to download all of the selected item(s). */
+"download_all" = "Download All";
+
+/* A common string used throughout the app. Prompt to warn the user that continuing with the download will consume data. Used in tandem with a notice that the user is not on WiFi. */
+"download_data_warning" = "Downloading will use data.";
+
+/* A common string used throughout the app. Prompts the user that they have selected multiple episodes to download. '%1$@' is a placeholder for the count of the selected items, will be more than one. */
+"download_episode_plural_format" = "Download %1$@ Episodes";
+
+/* A common string used throughout the app. Prompts the user that they have selected one episode to download. */
+"download_episode_singular" = "Download 1 Episode";
+
+/* The episode failed to download due to an issue with the feed. Suggesting the user reaches out to the Podcast Author. */
+"download_error_contact_author" = "Episode not available due to an error in the podcast feed. Contact the podcast author.";
+
+/* The episode failed to download due to an issue with the feed. Suggesting the user reaches out to the Podcast Author. */
+"download_error_contact_author_version_2" = "This episode may have been moved or deleted. Contact the podcast author.";
+
+/* The episode failed to download due to the user running out of storage space. */
+"download_error_not_enough_space" = "Unable to save episode, have you run out of space?";
+
+/* The episode failed to download because the file wasn't available on the server */
+"download_error_not_uploaded" = "File not uploaded, unable to play";
+
+/* The episode failed to download due to an issue with the feed. Suggesting the user reaches out to the Podcast Author. '%1$@' is a placeholder for the status code that the app received. */
+"download_error_status_code" = "Download failed, error code %1$@. Contact the podcast author.";
+
+/* The episode failed to download but the app wasn't able to determine why. Suggesting to try again after waiting for a bit. */
+"download_error_try_again" = "Unable to download episode. Please try again later.";
+
+/* A common string used throughout the app. Informs the user the download has failed. */
+"download_failed" = "Download Failed";
+
+/* A common string used throughout the app. Title for screens and prompts related to storage and downloaded files. */
+"downloaded_files" = "Downloaded Files";
+
+/* Message for an unsubscribe message box that informs the user that unsubscribing will remove downloaded files. */
+"downloaded_files_conf_message" = "Unsubscribing will delete all downloaded files in this Podcast, are you sure?";
+
+/* Title for an unsubscribe message box that informs the user that unsubscribing will remove downloaded files. Informs the user how many files have been downloaded. '%1$@' is a placeholder for the number of downloaded files, will be more than one. */
+"downloaded_files_conf_plural_format" = "%1$@ Downloaded Files";
+
+/* Title for an unsubscribe message box that informs the user that unsubscribing will remove downloaded files. Informs the user one file has been downloaded. Singular version of an accompanying plural message. */
+"downloaded_files_conf_singular" = "1 Downloaded File";
+
+/* Confirmation message when you choose to delete a set of downloaded files */
+"downloaded_files_cleanup_confirmation" = "Are you sure you want to delete these downloaded files?";
+
+/* A common string used throughout the app. Often refers to the Downloads screen. */
+"downloads" = "Downloads";
+
+/* Prompt to navigate the user to the Auto Downloads settings menu. */
+"downloads_auto_download" = "Auto Download Settings";
+
+/* Title for the empty state when there are no downloads available */
+"downloads_no_downloads_title" = "No Downloaded Episodes";
+
+/* The description for the empty state when there are no downloads available */
+"downloads_no_downloads_desc" = "Oh no! You’re fresh out of downloads. Download some more and they’ll show up here.";
+
+/* Prompt to allow the user to retry failed downloads. */
+"downloads_retry_failed_downloads" = "Retry Failed Downloads";
+
+/* Prompt to allow the user to stop active downloads. */
+"downloads_stop_all_downloads" = "Stop All Downloads";
+
+/* Refers to an Episode in the singular form. */
+"episode" = "Episode";
+
+/* A common string used throughout the app. Display configurable options related to a number of episodes. '%1$@' is a placeholder for the number of episodes, the value will be more than one. */
+"episode_count_plural_format" = "%1$@ episodes";
+
+/* Message shown when you have no episodes in an episode filter */
+"episode_filter_no_episodes_msg" = "Either it's time to celebrate completing this list, or edit your filter settings to get some more.";
+
+/* Title shown when you have no episodes in an episode filter */
+"episode_filter_no_episodes_title" = "No Episodes";
+
+/* Label for adding duration filtering to an episode filter, eg: filter by the duration of an episode */
+"episode_filter_by_duration_label" = "Filter by duration";
+
+/* Episode indicator that the current episode is a bonus episode. */
+"episode_indicator_bonus" = "Bonus";
+
+/* Episode indicator that the current episode is a trailer for an upcoming season of the podcast. '%1$@' is a placeholder for the season number. */
+"episode_indicator_season_trailer" = "Season %1$@ Trailer";
+
+/* Episode indicator that the current episode is a trailer. */
+"episode_indicator_trailer" = "Trailer";
+
+/* Shorthand format used to show the Episode number of a podcast. '%1$@' is a placeholder for the episode number. */
+"episode_shorthand_format" = "EPISODE %1$@";
+
+/* Shorthand format used to show the Episode number of a podcast. 'EP' is short for Episode. '%1$@' is a placeholder for the episode number. */
+"episode_shorthand_format_short" = "EP %1$@";
+
+/* A common string used throughout the app. Generic title informing the user of an Error. Accompanied with an error message. */
+"error" = "Error";
+
+/* A common string used throughout the app. Generic title informing the user of an Error. General error message used when the app is unable to locate the podcast that was selected. This usually comes from a sharing or import feature. */
+"error_general_podcast_not_found" = "Unable to find podcast. Please contact the podcast author.";
+
+/* Describes how the process to export podcasts from Pocket Casts works. */
+"export_podcasts_description" = "Exports all your podcasts as an OPML file, which you can import into other podcast apps.";
+
+/* Title for the button that allows the user to export podcasts from Pocket Casts */
+"export_podcasts_option" = "Export Podcasts";
+
+/* Title for the section that provides information on how to export podcasts from Pocket Casts */
+"export_podcasts_title" = "EXPORT";
+
+/* Indicator during the new feature tour serves as a prompt to end the tour. */
+"feature_tour_end_tour" = "End Tour";
+
+/* Indicator during the new feature tour. Used as a navigation indicator when the tour is on the first step. This is replaced with 'position of total' as the user progresses. */
+"feature_tour_new" = "NEW";
+
+/* Indicator during the new feature tour. Used as a navigation indicator as the user progresses through the tour. '%1$@' is a placeholder for the current position. '%2$@' is a placeholder for the total number of steps. */
+"feature_tour_step_format" = "%1$@ of %2$@";
+
+/* Option to continue with a Third-Party Mail app when the default Apple mail app isn't available. */
+"feedback_continue_with_mail" = "Open Default Mail App";
+
+/* Error message for when the user has a mail app configured that's not the default mail app. */
+"feedback_mail_not_configured_msg" = "To send a debug attachment, the Apple Mail app has to be configured on your phone. What would you like to do?";
+
+/* Error title for when the user has a mail app configured that's not the default mail app. */
+"feedback_mail_not_configured_title" = "Mail Not Configured";
+
+/* Title for the file upload settings screen. This is used when a user is uploading a new file. */
+"file_upload_add_file" = "Add File";
+
+/* Prompt to add a custom image to the uploaded file. */
+"file_upload_add_image" = "Add Custom Image";
+
+/* Title for the dialog that allows the user to pick the image source for selecting a custom image. either Camera or Photo Library. */
+"file_upload_choose_image" = "Choose Image";
+
+/* Option for selecting the image source for an uploaded image. */
+"file_upload_choose_image_camera" = "Camera";
+
+/* Option for selecting the image source for an uploaded image. */
+"file_upload_choose_image_photo_Library" = "Photo Library";
+
+/* Title for the file upload settings screen. This is used when a user is editing an uploaded file. */
+"file_upload_edit_file" = "Edit File";
+
+/* Error message displayed when the user has used all of their storage space. */
+"file_upload_error" = "Not enough space to upload this file.";
+
+/* Subtitle for the error message displayed when the user has used all of their storage space. Instructs the user to try freeing up space. */
+"file_upload_error_subtitle" = "Remove some files and try again.";
+
+/* Prompt indicating that the user needs to name the file in order to upload it. */
+"file_upload_name_required" = "Name required";
+
+/* The description for the screen when there are no files currently uploaded. '\n' is a line break format to allow a clean wrapping of text */
+"file_upload_no_files_description" = "Want to listen to your own files?\nShare them with Pocket Casts, and they’ll appear here";
+
+/* The helper link describing how to add files to Pocket Casts. */
+"file_upload_no_files_helper" = "How do I do that?";
+
+/* Title for the screen when there are no files currently uploaded */
+"file_upload_no_files_title" = "No Files";
+
+/* Prompt to remove the image from the uploaded file. */
+"file_upload_remove_image" = "Remove Image";
+
+/* Prompt to save the changes to an edited file. */
+"file_upload_save" = "Save";
+
+/* Error message displayed when the user has attempted to upload an unsupported file type. */
+"file_upload_support_error" = "This file type is not supported";
+
+/* A common string used throughout the app. Refers to the Files settings menu */
+"files" = "Files";
+
+/* Prompt to open a menu to allow sorting of manually added files. */
+"files_sort" = "Sort Files";
+
+/* Title for the screen that details how to add a file to Pocket Casts. */
+"files_how_to_title" = "How to save a file";
+
+/* Subtitle informing the user that new podcasts will be automatically added to this filter. */
+"filter_auto_add_subtitle" = "New podcasts you subscribe to will be automatically added";
+
+/* Title for the filter option that indicates all podcasts will be included. */
+"filter_chips_all_podcasts" = "All Your Podcasts";
+
+/* Title for the filter option that that opens the episode duration options. */
+"filter_chips_duration" = "Duration";
+
+/* Filter option to select podcasts that will be included in the filter. */
+"filter_choose_podcasts" = "Choose Podcasts";
+
+/* Used on the screen to create a new filter. Provides a prompt to continue refining the filter selections. */
+"filter_create_add_more" = "Add more criteria to finish refining your filter.";
+
+/* Used on the screen to create a new filter. The section header for the list of options to use with the filter. */
+"filter_create_filter_by" = "FILTER BY";
+
+/* Used on the screen to create a new filter. Provides instructions on how to set up a new filter. */
+"filter_create_instructions" = "Select your filter criteria using these buttons to create an up to date smart playlist of episodes.";
+
+/* Used on the screen to create a new filter. Title for the state where their selection doesn't include any content. */
+"filter_create_no_episodes" = "No Matching Episodes";
+
+/* Used on the screen to create a new filter. The description about why the list of filtered episodes is empty. */
+"filter_create_no_episodes_description_explanation" = "The criteria you selected doesn’t match any current episodes in your subscriptions";
+
+/* Used on the screen to create a new filter. The prompt about what they can do in order to make sure their filter returns results. */
+"filter_create_no_episodes_description_prompt" = "Choose different criteria, or save this filter if you think it will match episodes in the future.";
+
+/* Used on the screen to create a new filter. The section that shows a preview of waht podcast episodes will be included in the filter. */
+"filter_create_preview" = "PREVIEW";
+
+/* Used on the screen to create a new filter. Title for the toggle to include all podcasts in the filter. */
+"filter_create_podcasts_all_podcasts" = "All Podcasts";
+
+/* Used on the screen to create a new filter. Title for the button to save the filter. */
+"filter_create_save" = "Save Filter";
+
+/* Title for the screen where a user can set the initial details for a new filter. */
+"filter_details" = "Filter Details";
+
+/* Hint text above the sections for the user to select the filter color and icon. */
+"filter_details_color_icon" = "COLOUR & ICON";
+
+/* Accessibility hint text for color selection on filters. */
+"filter_details_color_selection" = "Colour Selector";
+
+/* Accessibility hint text for icon selection on filters. */
+"filter_details_icon_selection" = "Icon Selector";
+
+/* Hint text above the dialog box to enter the filter's name. */
+"filter_details_name" = "NAME";
+
+/* Title for filter options related to Download Status. */
+"filter_download_status" = "Download Status";
+
+/* Title for filter sections that relate to episode status. */
+"filter_episode_status" = "Episode Status";
+
+/* Subtitle informing the user that new podcasts will not be automatically added to this filter. */
+"filter_manual_add_subtitle" = "New podcasts you subscribe to will not be automatically added";
+
+/* Title for filter options related to media type settings. */
+"filter_media_type" = "Media Type";
+
+/* Media Type filter option for audio media types. */
+"filter_media_type_audio" = "Audio";
+
+/* Media Type filter option for video media types. */
+"filter_media_type_video" = "Video";
+
+/* Screen title for the filter options for configuring filter settings related to episode duration. */
+"filter_option_episode_duration" = "Episode Duration";
+
+/* Label for the longer than duration filter time */
+"filter_longer_than_label" = "Longer than";
+
+/* Label for the shorter than duration filter time */
+"filter_shorter_than_label" = "Shorter than";
+
+/* Error message for when the user attempts to set a filter where the minimal duration is higher than the max duration. Meant to be a fun/funny message. '%1$@' and '%2$@' are placeholders for the configured minimum and maximum times, respectively. */
+"filter_option_episode_duration_error_msg_format" = "Filtering for episodes longer than %1$@ but shorter than %2$@ would cause a rift in our space time continuum. Sorry.";
+
+/* Error title for when the user attempts to set a filter where the minimal duration is higher than the max duration. Meant to be a fun/funny message. */
+"filter_option_episode_duration_error_title" = "Yes, But No";
+
+/* Menu prompt to open the Filter options. Also used for the title of the filter options screen. */
+"filter_options" = "Filter Options";
+
+/* Title for filter options related to release date settings. */
+"filter_release_date" = "Release Date";
+
+/* Release Date filter option for any release date. */
+"filter_release_date_anytime" = "Any time";
+
+/* Release Date filter option for episodes with a release date with in the last day. */
+"filter_release_date_last_24_hours" = "Last 24 hours";
+
+/* Release Date filter option for episodes with a release date with in the last 2 weeks. */
+"filter_release_date_last_2_weeks" = "Last 2 weeks";
+
+/* Release Date filter option for episodes with a release date with in the last three day. */
+"filter_release_date_last_3_days" = "Last 3 days";
+
+/* Release Date filter option for episodes with a release date with in the last month. */
+"filter_release_date_last_month" = "Last month";
+
+/* Release Date filter option for episodes with a release date with in the last week. */
+"filter_release_date_last_week" = "Last week";
+
+/* Prompt to save the changes to an existing filter. */
+"filter_update" = "Update Filter";
+
+/* A common string used throughout the app. Filter option for the default setting on multiple filters. */
+"filter_value_all" = "All";
+
+/* A common string used throughout the app. Often refers to the Filters screen. */
+"filters" = "Filters";
+
+/* Button title for adding a new filter. */
+"filters_new_filter_button" = "+ New Filter";
+
+/* A placeholder title for a newly created filter. */
+"filters_default_new_filter" = "New Filter";
+
+/* The title for the auto generated 'New Release' filter. */
+"filters_default_new_releases" = "New Releases";
+
+/* Funny confirmation message accompanying several descriptive dialogs */
+"funny_conf_msg" = "It really matches your eyes ✨";
+
+/* The default value when the user has listened for under one minute. */
+"funny_time_not_enough" = "You really don't listen much, do you?";
+
+/* A funny time unit used in stats comparing the listening time to the number of times an airplane has taken off. '%1$@' is a placeholder for the amount of time listened compared to the stat. */
+"funny_time_unit_airplane_takeoffs" = "During which time %1$@ planes took off. Please fasten your seatbelt. 🛫";
+
+/* A funny time unit used in stats comparing the listening time to the number of times an astronaut has sneezed. '%1$@' is a placeholder for the amount of time listened compared to the stat. */
+"funny_time_unit_astronaut_sneezes" = "During which time an astronaut sneezed %1$@ times. Achoo! 😤";
+
+/* A funny time unit used in stats comparing the listening time to the number of times you could have traveled around the world. '%1$@' is a placeholder for the amount of time listened compared to the stat. */
+"funny_time_unit_balloon_travel" = "During which time you could have gone around the world %1$@ times in an air balloon. 🌏";
+
+/* A funny time unit used in stats comparing the listening time to the number of births that have happened. '%1$@' is a placeholder for the amount of time listened compared to the stat. */
+"funny_time_unit_births" = "During which time %1$@ babies were born. Wahhh! 🍼";
+
+/* A funny time unit used in stats comparing the listening time to the number of times you've blinked. '%1$@' is a placeholder for the amount of time listened compared to the stat. */
+"funny_time_unit_blinks" = "During which time you blinked %1$@ times. Heyooo! 👀";
+
+/* A funny time unit used in stats comparing the listening time to the number of emails that have been sent. '%1$@' is a placeholder for the amount of time listened compared to the stat. */
+"funny_time_unit_emails" = "During which time %1$@ emails were sent. 💌";
+
+/* A funny time unit used in stats comparing the listening time to the number of times you farted. '%1$@' is a placeholder for the amount of time listened compared to the stat. */
+"funny_time_unit_farts" = "During which time you released %1$@ oz of air biscuits. Gross! 💨";
+
+/* A funny time unit used in stats comparing the listening time to the number of times a Google search was performed. '%1$@' is a placeholder for the amount of time listened compared to the stat. */
+"funny_time_unit_google" = "During which time %1$@ Google searches were performed. Bazinga. 🔎";
+
+/* A funny time unit used in stats comparing the listening time to the number of times lightning has struck. '%1$@' is a placeholder for the amount of time listened compared to the stat. */
+"funny_time_unit_lightning" = "During which time lightning struck %1$@ times. Boom. ⚡️";
+
+/* A funny time unit used in stats comparing the listening time to the number of phones that have been produced. '%1$@' is a placeholder for the amount of time listened compared to the stat. */
+"funny_time_unit_phone_production" = "During which time a certain fruit vendor made $%1$@ 🍏";
+
+/* A funny time unit used in stats comparing the listening time to the amount of skin cells you've shed. '%1$@' is a placeholder for the amount of time listened compared to the stat. */
+"funny_time_unit_shed_skin" = "During which time you shed %1$@ skin cells. Ew? 😅";
+
+/* A funny time unit used in stats comparing the listening time to the number of times you tied your shoes. '%1$@' is a placeholder for the amount of time listened compared to the stat. */
+"funny_time_unit_tied_shoes" = "During which time you could have tied %1$@ shoe laces. Maybe. 👟";
+
+/* A funny time unit used in stats comparing the listening time to the number of tweets that have been sent. '%1$@' is a placeholder for the amount of time listened compared to the stat. */
+"funny_time_unit_tweets" = "During which time %1$@ tweets were tooted. Toot! Toot! 🐣";
+
+/* A common string used throughout the app. Title for the prompt to navigate the user to the podcast associated to the selected item. */
+"go_to_podcast" = "Go to Podcast";
+
+/* A common string used throughout the app. Title accompanying the group option setting. */
+"group_episodes" = "Group Episodes";
+
+/* Prompt to clear the full listening history for the user. */
+"history_clear_all" = "Clear All";
+
+/* Title for the details prompt to confirm the user wants to clear their listening history. */
+"history_clear_all_details" = "Clear Listening History";
+
+/* Message for the details prompt to confirm the user wants to clear their listening history. */
+"history_clear_all_details_msg" = "This action cannot be undone.";
+
+/* Time format to display a set number of hours. '%1$@' is a placeholder for a number of hours, this value will be more than one. */
+"hours_plural_format" = "%1$@ hours";
+
+/* The initial informational text explaining how to upload a file */
+"how_to_upload_explanation" = "First, open an app that has the audio files you'd like to save";
+
+/* The title for the first instructional image that explains how to upload a file */
+"how_to_upload_first_instruction" = "Choose to share that file";
+
+/* The title for the second instructional image that explains how to upload a file */
+"how_to_upload_second_instruction" = "In the menu tap \"Copy to Pocket Casts\"";
+
+/* The summary text at the end of the screen explaining how to upload a file */
+"how_to_upload_summary" = "That's it, you're done. Change any details you want, hit save and play!";
+
+/* Describes the process about how to import podcasts to Pocket Casts. '\\n\\n' Is a line break format to separate the description from the following note. */
+"import_podcasts_description" = "You can import your podcasts subscriptions to Pocket Casts using the widely supported OPML format. Export the file from another app and choose open in Pocket Casts.\n\nNote: You may need to email the OPML file to yourself, long press on the attachment and select Pocket Casts.";
+
+/* Title for the section that provides information on how to import podcasts to Pocket Casts */
+"import_podcasts_title" = "IMPORT TO POCKET CASTS";
+
+/* A common string used throughout the app. Status message informing the user that the episode has been started but not finished. */
+"in_progress" = "In Progress";
+
+/* Title for the hardware keyboard command that closes the player. */
+"keycommand_close_player" = "Close Player";
+
+/* Title for the hardware keyboard command that decreases the playback speed. */
+"keycommand_decrease_speed" = "Decrease Speed";
+
+/* Title for the hardware keyboard command that increases the playback speed. */
+"keycommand_increase_speed" = "Increase Speed";
+
+/* Title for the hardware keyboard command that opens the player. */
+"keycommand_open_player" = "Open Player";
+
+/* Title for the hardware keyboard command that toggles play and pause of playback. */
+"keycommand_play_pause" = "Play/Pause";
+
+/* A common string used throughout the app. Often refers to the Listening History screen. */
+"listening_history" = "Listening History";
+
+/* Progress indicator informing the user that the selected item is still loading. */
+"loading" = "Loading...";
+
+/* A common string used throughout the app. Prompt to mark the selected item(s) as played. */
+"mark_played" = "Mark as Played";
+
+/* A common string used throughout the app. Prompt to mark the selected item(s) as played. Similar to 'Mark as Played' but more concise. */
+"mark_played_short" = "Mark Played";
+
+/* A common string used throughout the app. Prompt to mark the selected item(s) as not played. */
+"mark_unplayed_short" = "Mark Unplayed";
+
+/* Prompt to close the mini player and clear the queue. */
+"mini_player_close" = "Close And Clear Up Next";
+
+/* Basic string used in formats like 'price / month' */
+"month" = "month";
+
+/* Basic string used to callout payment intervals like yearly vs monthly */
+"monthly" = "Monthly";
+
+/* A common string used throughout the app. Prompt to move the selected item(s) to the end of the up next queue. */
+"move_to_bottom" = "Move to Bottom";
+
+/* A common string used throughout the app. Prompt to move the selected item(s) to the top of the up next queue. */
+"move_to_top" = "Move to Top";
+
+/* Multi-select status message for adding multiple episodes. Notifies that the selected list exceeds the bulk limit so only the first set up to the limit will be added. '%1$@' is a placeholder for the max amount of episodes to add. */
+"multi_select_add_episodes_max_format" = "Adding max %1$@ episodes.";
+
+/* Multi-select status message for adding multiple episodes. '%1$@' is a placeholder for the amount of episodes to add. */
+"multi_select_adding_episodes_plural_format" = "Adding %1$@ episodes.";
+
+/* Multi-select status message for adding an episode. '%1$@' is a placeholder for the amount of episodes to add. */
+"multi_select_adding_episodes_singular" = "Adding 1 episode.";
+
+/* Multi-select status message for archiving multiple episodes. '%1$@' is a placeholder for the count of files to be archived (the number will be more than one). */
+"multi_select_archiving_episodes_plural_format" = "Archiving %1$@ episodes";
+
+/* Multi-select status message for archiving one episode. */
+"multi_select_archiving_episodes_singular" = "Archiving 1 episode";
+
+/* Message portion of the prompt to delete the selected files on the multi select UI. '%1$@' is a placeholder for the count of files to be deleted (the number will be more than one). */
+"multi_select_delete_file_message_plural" = "Are you sure you want to delete %1$@ files?";
+
+/* Message portion of the prompt to delete a selected file on the multi select UI. */
+"multi_select_delete_file_message_singular" = "Are you sure you want to delete 1 file?";
+
+/* Multi-select status message informing the user that downloads have begun. '%1$@' is a placeholder for the count of the selected items being downloaded. */
+"multi_select_downloading_episodes_format" = "Downloading %1$@";
+
+/* Multi-select status message for marking multiple episodes as played. '%1$@' is a placeholder for the count of episodes to be marked played (the number will be more than one). */
+"multi_select_mark_episodes_played_plural_format" = "Marking %1$@ episodes as played.";
+
+/* Multi-select status message for marking one episode as played. */
+"multi_select_mark_episodes_played_singular" = "Marking 1 episode as played.";
+
+/* Multi-select status message for marking multiple episodes as not played. '%1$@' is a placeholder for the count of episodes to be marked not played (the number will be more than one). */
+"multi_select_mark_episodes_unplayed_plural_format" = "Marking %1$@ episodes as unplayed.";
+
+/* Multi-select status message for marking one episode as not played. */
+"multi_select_mark_episodes_unplayed_singular" = "Marking 1 episode as unplayed.";
+
+/* Multi-select status message informing the user how many episodes have been queued for download. '%1$@' is a placeholder for the count of the selected items be queued for download. */
+"multi_select_queuing_episodes_format" = "Queuing %1$@";
+
+/* Multi-select status message informing the user one episode download is being removed. */
+"multi_select_remove_download_singular" = "Removing 1 download.";
+
+/* Multi-select status message informing the user how many episodes downloads are being removed. '%1$@' is a placeholder for the count of the selected items be removed for download. */
+"multi_select_remove_downloads_plural_format" = "Removing %1$@ downloads.";
+
+/* Title for the prompt to mark the selected items as not having been played. */
+"multi_select_remove_mark_unplayed" = "Mark as Unplayed";
+
+/* Multi-select label indicating the number of selected items. '%1$@' is a placeholder for the number of selected items, this will be more than one. */
+"multi_select_selected_count_plural" = "%1$@ SELECTED EPISODES";
+
+/* Multi-select label indicating that there is one item selected. */
+"multi_select_selected_count_singular" = "1 SELECTED EPISODE";
+
+/* Multi-select menu section header. Indicates that the options in this section will appear in the action bar. */
+"multi_select_shortcut_in_action_bar" = "SHORTCUT IN ACTION BAR";
+
+/* Title for the prompt to mark the selected items as stared (favorited). */
+"multi_select_star" = "Star Episodes";
+
+/* Multi-select status message for marking multiple episodes as favorited (starred). '%1$@' is a placeholder for the count of episodes to be starred (the number will be more than one). */
+"multi_select_starring_episodes_plural_format" = "Starring %1$@ episodes.";
+
+/* Multi-select status message for marking one episode as favorited (starred). */
+"multi_select_starring_episodes_singular" = "Starring 1 episode.";
+
+/* Multi-select status message for unarchiving multiple episodes. '%1$@' is a placeholder for the count of files to be unarchived (the number will be more than one). */
+"multi_select_unarchiving_episodes_plural_format" = "Unarchiving %1$@ episodes.";
+
+/* Multi-select status message for unarchiving one episode. */
+"multi_select_unarchiving_episodes_singular" = "Unarchiving 1 episode";
+
+/* Title for the prompt to remove the selected items from being stared (favorited). */
+"multi_select_unstar" = "Unstar Episodes";
+
+/* Multi-select status message for marking multiple episodes as not favorited (un-starred). '%1$@' is a placeholder for the count of episodes to be un-starred (the number will be more than one). */
+"multi_select_unstarring_episodes_plural_format" = "Unstarring %1$@ episodes.";
+
+/* Multi-select status message for marking one episode as not favorited (un-starred). */
+"multi_select_unstarring_episodes_singular" = "Unstarring 1 episode";
+
+/* A common string used throughout the app. References to new episodes. */
+"new_episodes" = "New episodes";
+
+/* A common string used throughout the app. Prompt to move forward in the flow. */
+"next" = "Next";
+
+/* A common string used throughout the app. Prompt to move to the next episode. */
+"next_episode" = "Next Episode";
+
+/* A common string used throughout the app. Format used to call out when the associated subscription will be renewed. '%1$@' is a placeholder for a localized date indicating when the renewal will process. */
+"next_payment_format" = "Next payment: %1$@";
+
+/* A common string used throughout the app. Default 'not set' option mostly used with group settings. */
+"none" = "None";
+
+/* A common string used throughout the app. Informs the user that they are not on WiFi and the action they're about to take will use data. Used for downloads and uploads. */
+"not_on_wifi" = "You're not on WiFi";
+
+/* Prompt to play the selected item now. */
+"notifications_play_now" = "Play Now";
+
+/* A common string used throughout the app. Refers to the Now Playing tab in the player. */
+"now_playing" = "Now Playing";
+
+/* A common string used throughout the app. Specifically calls out the item that is currently being played. '%1$@' is a placeholder for the item'r name that is being played. */
+"now_playing_item" = "Now Playing %1$@";
+
+/* A common string used throughout the app. Refers to the Now Playing tab in the player. Removes 'Now' to conserve space. */
+"now_playing_short_title" = "Playing";
+
+/* A common string used throughout the app. Indicates that the feature is not enabled. */
+"off" = "Off";
+
+/* A common string used throughout the app. Used as a confirmation or acceptance. */
+"ok" = "OK";
+
+/* A common string used throughout the app. Often used as a toggle to enable a feature only when the user is on Wifi. */
+"only_on_wifi" = "Only On WiFi";
+
+/* Message for the dialog box informing the user that the podcast import from the provided OPML file has failed. */
+"opml_import_failed_message" = "Unable to import podcasts from the OPML file you specified. Please check that it's valid";
+
+/* Title for the dialog box informing the user that the podcast import from the provided OPML file has failed. */
+"opml_import_failed_title" = "OPML Import Failed";
+
+/* Progress message indicating the total number of podcasts imported from an OPML file. '%1$@' serves as a placeholder for the current number of imported podcasts. '%2$@' serves as a placeholder for the total number of podcasts to import. */
+"opml_import_progress_format" = "Importing %1$@ of %2$@";
+
+/* Progress message indicating that the import process of an OPML file is running. */
+"opml_importing" = "Importing Podcasts...";
+
+/* Format used to indicate the current page and total in a custom page control. '%1$@' is a placeholder for the current page. '%2$@' is a placeholder for the total pages. */
+"page_control_page_progress_format" = "Page %1$@ of %2$@";
+
+/* A label indicating the number of podcasts the user has subscribed to compared to the total number of podcasts in the bundle. '%1$@' is a placeholder for the number of subscribed podcasts. '%2$@' is a placeholder for the number of podcasts in the bundle. */
+"paid_podcast_bundled_subscriptions" = "%1$@ / %2$@ SUBSCRIBED";
+
+/* Option to allow the user to cancel their subscription to a paid podcast feed. */
+"paid_podcast_cancel" = "Cancel Contribution";
+
+/* Message displayed when the user selects to cancel their paid podcast subscription. This message is used when the user is canceling multiple subscriptions. '%1$@' is a placeholder for the last date that the current subscriptions will remain active. */
+"paid_podcast_cancel_msg_plural" = "Supporter status will remain active until %1$@. After that you won't be able to play these podcast anymore.";
+
+/* Message displayed when the user selects to cancel their paid podcast subscription. This message is used when the podcast allows the user to access episodes that were available to them during their subscription window. '%1$@' is a placeholder for the last date that the current subscription will remain active. */
+"paid_podcast_cancel_msg_retain_access" = "Supporter status will remain active until %1$@. You will only be able to listen to episodes released before this date.";
+
+/* Message displayed when the user selects to cancel their paid podcast subscription. This message is used when the user is only canceling a singular subscription. '%1$@' is a placeholder for the last date that the current subscription will remain active. */
+"paid_podcast_cancel_msg_singular" = "Supporter status will remain active until %1$@. After that you won't be able to play this podcast anymore.";
+
+/* A generic error indicating that the app failed to load information about the paid feed. */
+"paid_podcast_generic_error" = "Unable to load info";
+
+/* Prompt to open settings to adjust settings for a paid feed. */
+"paid_podcast_manage" = "Manage";
+
+/* Informational label informing the user when to expect the next episode. '%1$@' is a placeholder for the next upcoming release date. */
+"paid_podcast_next_episode_format" = "Next episode %1$@";
+
+/* Informational label informing the user when the latest episode was released. '%1$@' is a placeholder for the latest release date. */
+"paid_podcast_release_frequency_format" = "Released %1$@";
+
+/* Prompt to get the user to sign in to see updates. This acts as the details message for a section. '\n' is the new line character to cause a line wrap. */
+"paid_podcast_signin_prompt_msg" = "SIGN IN FOR\nUPDATES";
+
+/* Prompt to get the user to sign in to see updates. This acts as the title for a section. */
+"paid_podcast_signin_prompt_title" = "Sign in for new episodes";
+
+/* Format used to indicate the subscription for the paid podcast has ended. '%1$@' is a placeholder for the date that the subscription ended on. */
+"paid_podcast_subscription_ended" = "ENDED: %1$@";
+
+/* Format used to indicate the subscription for the paid podcast will end on the specified date. '%1$@' is a placeholder for the date that the subscription will end. */
+"paid_podcast_subscription_ends" = "ENDS: %1$@";
+
+/* A label used to inform the user that the selected podcast feed is for paid supporters only. */
+"paid_podcast_supporter_only_msg" = "Supporter-only feed";
+
+/* Prompt to get the user to sign in after selecting to support a podcast while signed out. '%1$@' is a placeholder for the name of the podcast the user has subscribed to. */
+"paid_podcast_supporter_signin_prompt" =  "Thanks for signing up as a %1$@ supporter. To access your special content, you’ll need to sign in.";
+
+/* A confirmation message for when a user has selected too unsubscribe and has downloaded files. */
+"paid_podcast_unsubscribe_msg" = "Unsubscribing from all these podcasts will delete any downloaded files they have, are you sure?";
+
+/* A common string used throughout the app. Prompt to pause the playback. */
+"pause" = "Pause";
+
+/* A common string used throughout the app. Used to reference the Phone as the playing source with in the Apple Watch App (Watch is the other option for this use case) */
+"phone" = "Phone";
+
+/* A common string used throughout the app. Prompt to start playback. */
+"play" = "Play";
+
+/* A common string used throughout the app. Prompt to start playback and add the remaining selected items to the queue. */
+"play_all" = "Play All";
+
+/* A common string used throughout the app. Prompt to add the selected item(s) to the end of the queue. */
+"play_last" = "Play Last";
+
+/* A common string used throughout the app. Prompt to add the selected item(s) to the top of the queue. */
+"play_next" = "Play Next";
+
+/* One of the options for how aggressive to be in trimming silence. Sets it to max the highest setting. */
+"playback_effect_trim_silence_max" = "Mad Max";
+
+/* One of the options for how aggressive to be in trimming silence. Sets it to medium the middle setting. */
+"playback_effect_trim_silence_medium" = "Medium";
+
+/* One of the options for how aggressive to be in trimming silence. Sets it to mild the lowest setting. */
+"playback_effect_trim_silence_mild" = "Mild";
+
+/* A common string used throughout the app. Generic message informing the user that playback failed. */
+"playback_failed" = "Playback Failed";
+
+/* Label indicating the current value for the playback speed. '%1$@' is a placeholder for the playback speed and 'x' is meant to read as 'times' as in '1.1 times' for '1.1x' */
+"playback_speed" = "%1$@x";
+
+/* Accessibility hint text informing the user that the Sleep timer is enabled. */
+"player_accessibility_sleep_timer_on" = "Sleep timer on";
+
+/* Subtitle for settings indicating this item operates as delete for files. */
+"player_action_subtitle_delete" = "Shown as Delete for custom episodes";
+
+/* Subtitle for settings indicating this item is hidden for files. */
+"player_action_subtitle_hidden" = "Hidden for custom episodes";
+
+/* Header for the available playback effect options. */
+"player_action_title_effects" = "Playback Effects";
+
+/* Title for the prompt to navigate the user to the files section of the app. */
+"player_action_title_go_to_file" = "Go to Files";
+
+/* Title for the available output device options. */
+"player_action_title_output_options" = "Output Device";
+
+/* Header for the available timer options for auto-pausing playback. */
+"player_action_title_sleep_timer" = "Sleep Timer";
+
+/* Title for the prompt to remove an episode from the favorites. */
+"player_action_title_unstar_episode" = "Unstar Episode";
+
+/* Title for a page where you can rearrange common actions (eg sort/reorder and move the ones you like more to the top) */
+"player_actions_rearrange_title" = "Rearrange Actions";
+
+/* Confirmation prompt for archiving an episode. */
+"player_archived_confirmation" = "Archive this episode?";
+
+/* Accessibility label calling out the current artwork that's being displayed. '%1$@' is a placeholder for either the episode name or the chapter title. */
+"player_artwork" = "%1$@ Artwork";
+
+/* Information label that includes the current chapter and total chapter count example '1 of 3'. '%1$@' is a placeholder for the current chapter. '%2$@' is a placeholder for the total chapters. */
+"player_chapter_count" = "%1$@ of %2$@";
+
+/* Accessibility label for the player control that rewinds the current playback position by a customizable time. */
+"player_decrement_time" = "Decrement time";
+
+/* Detail text explaining that trim silence feature. */
+"player_effects_trim_silence_details" = "Reduces the length of an episode by trimming silence in conversations.";
+
+/* Detail text celebrating how much time has been saved using the trim silence feature. '%1$@' is a placeholder for the amount of time saved using the feature. */
+"player_effects_trim_silence_progress" = "In total you've saved %1$@ using this feature.";
+
+/* Generic error used when playback fails but the episode has a downloaded file. Warns the user that playback is failing because the associated file likely has been corrupted. */
+"player_error_corrupted_file" = "The episode might be corrupted, but you can try to play it again.";
+
+/* Generic error used when playback fails while streaming. Asks the user to verify their internet connection. */
+"player_error_internet_connection" = "Check your Internet connection and try again.";
+
+/* Accessibility label for the player control that fast-forwards the current playback position by a customizable time. */
+"player_increment_time" = "Increment time";
+
+/* Confirmation prompt for marking an episode as played. */
+"player_mark_as_played_confirmation" = "Mark this episode as played?";
+
+/* Warning that comes along with selecting to play all. Informs the user that their queue will be cleared. */
+"player_options_play_all_message" = "This will clear your current Up Next queue.";
+
+/* Prompt to play a single episode from a multi-select screen. */
+"player_options_play_episode_singular" = "Play 1 Episode";
+
+/* Prompt to play a multiple episodes from a multi-select screen. '%1$@' is a placeholder for the number of episodes; the value will be more than one. */
+"player_options_play_episodes_plural" = "Play %1$@ Episodes";
+
+/* Section header for organizing which options will show in the player vs in the menu. */
+"player_options_shortcut_on_player" = "SHORTCUT ON PLAYER";
+
+/* Accessibility label for the Route selector control. Opens the Apple menu for selecting the playback device such as headphones or a Bluetooth speaker. */
+"player_route_selection" = "Route Selector";
+
+/* Header for the share menu where the user selects to share the podcast, episode, or episode at the current position */
+"player_share_header" = "SHARE LINK TO";
+
+/* Error title when there is a download error. */
+"player_user_episode_download_error" = "Download Error";
+
+/* Error title when there is a playback error. */
+"player_user_episode_playback_error" = "Playback Error";
+
+/* Error title when there is an upload error. */
+"player_user_episode_upload_error" = "Upload Error";
+
+/* Used in the player to describe effects you can use to change audio playback. Things like speed, volume, etc. */
+"playback_effects" = "Playback effects";
+
+/* Description for the empty state on screen where the user can review their starred (favorited) podcast epsiodes */
+"profile_starred_no_episodes_desc" = "You haven't starred any episodes yet.";
+
+/* Title for the empty state on screen where the user can review their starred (favorited) podcast epsiodes */
+"profile_starred_no_episodes_title" = "Nothing Starred";
+
+/* Used next to a setting for how fast audio will play */
+"speed" = "Speed";
+
+/* The Trim Silence feature, removes silence from podcasts to make them shorter. */
+"trim_silence" = "Trim Silence";
+
+/* The Volume Boost feature. Makes voices louder. */
+"volume_boost" = "Volume Boost";
+
+/* A short description of what the Volume Boost feature does */
+"volume_boost_description" = "Voices sound louder";
+
+/* A common string used throughout the app. Catch all prompt to suggest to the user to try the task again. */
+"please_try_again" = "Please try again";
+
+/* A common string used throughout the app. Catch all prompt to suggest to the user to try the task again later. */
+"please_try_again_later" = "Please try again later.";
+
+/* Prompt informing the user that an account is required in order to sign up for Pocket Casts Plus */
+"plus_account_required_prompt" = "A Pocket Casts account is required for Pocket Casts Plus. This ensures seamless listening across all your devices.";
+
+/* Details prompt informing the user that an account is required in order to sign up for Pocket Casts Plus */
+"plus_account_required_prompt_details" = "Create an account or sign in to redeem your access to Pocket Casts Plus.";
+
+/* Details message informing the user that they'll return to a free account at the end of their trial */
+"plus_account_trial_details" = "When your trial is over you’ll still have all the great benefits of your regular account. Happy podcasting!";
+
+/* The available cloud storage limit available to Pocket Casts Plus Subscribers. '%1$@' is a placeholder for the available storage. */
+"plus_cloud_storage_limit_format" = "%1$@ GB Cloud Storage";
+
+/* Error message informing the user that they have already signed up for plus with this account. */
+"plus_error_already_registered" = "You already have a Pocket Casts Plus account";
+
+/* Error message details informing the user that they have already signed up for plus with this account so they can't take advantage of the entered promotion. */
+"plus_error_already_registered_details" = "Thanks for your support, but unfortunately this means you can’t take part in this promotion.";
+
+/* Account detail message informing the user when their Plus account will expire. '%1$@' is a placeholder for when the account will expire. */
+"plus_expiration_format" = "Expires %1$@";
+
+/* A common string used throughout the app. often used as a section header to divide settings related to Pocket Casts Plus vs free features. 'PLUS' refers to Pocket Casts Plus. */
+"plus_features" = "PLUS FEATURES";
+
+/* Account detail message informing the user that they have been granted a limited free membership. '%1$@' is a placeholder for a localized string for the free time period. */
+"plus_free_membership_format" = "%1$@ Free";
+
+/* Account detail message informing the user that they have been granted a lifetime membership. */
+"plus_lifetime_membership" = "Lifetime Member";
+
+/* Pocket Casts Plus marketing page, description of the Cloud Storage feature */
+"plus_marketing_cloud_storage_description" = "Speed up your lectures. Burn through other content. Be your own Podcast DJ.";
+
+/* Pocket Casts Plus marketing page, description of the Cloud Storage feature */
+"plus_marketing_updated_cloud_storage_description" = "Upload your files to cloud storage and have it available everywhere";
+
+/* Pocket Casts Plus marketing page, title of the Cloud Storage feature */
+"plus_marketing_cloud_storage_title" = "Cloud Storage";
+
+/* Pocket Casts Plus marketing page, description of the Desktop Apps feature */
+"plus_marketing_desktop_apps_description" = "Take your podcasts to more places with our Windows, macOS and Web apps.";
+
+/* Pocket Casts Plus marketing page, description of the Desktop Apps feature */
+"plus_marketing_updated_desktop_apps_description" = "Listen in more places with our Windows, macOS and Web apps";
+
+/* Pocket Casts Plus marketing page, title of the Desktop Apps feature */
+"plus_marketing_desktop_apps_title" = "Desktop Apps";
+
+/* Pocket Casts Plus marketing page, the final call to action to get people to upgrade */
+"plus_marketing_final_call_to_action" = "Time to up your podcasting game?\nGet desktop apps, bring your own files and spruce things up with fresh new themes, exclusive to plus members.";
+
+/* Pocket Casts Plus marketing page, learn more button. Note that Pocket Casts is a proper noun and shouldn't be translated */
+"plus_marketing_learn_more_button" = "Learn more about Pocket Casts Plus";
+
+/* Pocket Casts Plus marketing page, the main description of Pocket Casts Plus */
+"plus_marketing_main_description" = "Get personal, and get distributed, all at once. Upload your personal audio files to our cloud servers, access your account via our web player, and make the app yours.";
+
+/* Pocket Casts Plus marketing page, the main title */
+"plus_marketing_main_title" = "Enhanced Features For Advanced Listeners";
+
+/* Pocket Casts Plus marketing page, description of the Themes & Icons feature */
+"plus_marketing_themes_icons_description" = "Fly your true colors. Exclusive icons and themes for the plus club only.";
+
+/* Pocket Casts Plus marketing page, title of the Themes & Icons feature */
+"plus_marketing_themes_icons_title" = "Themes & Icons";
+
+/* Pocket Casts Plus marketing page, description of the Watch Playback feature */
+"plus_marketing_watch_playback_description" = "Ditch the phone and go for a run – without missing a beat. Apple Watch stands alone.";
+
+/* Pocket Casts Plus marketing page, title of the Watch Playback feature */
+"plus_marketing_watch_playback_title" = "Watch Playback";
+
+/* Pocket Casts Plus marketing page, the text on the upgrade button */
+"plus_marketing_upgrade_button" = "Upgrade To Plus";
+
+/* Pocket Casts Plus marketing page, description of the Folders feature */
+"plus_marketing_folders_description" = "Create folders to organise your podcast collection.";
+
+/* Pocket Casts Plus marketing page, description of the Folders feature */
+"plus_marketing_updated_folders_description" = "Organise your podcasts in folders, and keep them in sync across all your devices.";
+
+/* Pocket Casts Plus marketing page, title of the hide ads feature */
+"plus_marketing_hide_ads_title" = "Hide Ads";
+
+/* Pocket Casts Plus marketing page, description of the hide ads feature */
+"plus_marketing_hide_ads_description" = "Ad-free experience which gives you more of what you love and less of what you don't";
+
+/* Informational message informing the user that their recurring payments for Plus have been canceled. */
+"plus_payment_canceled" = "Payment Cancelled";
+
+/* Label that goes along with the yearly subscription used to indicate that the yearly plan is the best overall value. */
+"plus_payment_frequency_best_value" = "Best Value";
+
+/* Informational label that's below the monthly price of Pocket Casts Plus. This label sits below a localized price. */
+"plus_per_month" = "per month";
+
+/* The price of Pocket Casts Plus per month. '%1$@' is a localized monthly price. */
+"plus_price_per_month" = "%1$@ / monthly";
+
+/* Error message informing the user the promotion code has expired */
+"plus_promotion_expired" = "Promotion Expired or Invalid";
+
+/* A nudge to ask the user to continue the sign up process even though they encountered an error. */
+"plus_promotion_expired_nudge" = "You’re welcome to sign up for Pocket Casts Plus anyway, create a regular account, or just dive right in.";
+
+/* Error message informing the user the promotion code has already been used */
+"plus_promotion_used" = "Code already used";
+
+/* Title for the screen to allow the user to choose between a monthly or yearly subscription. */
+"plus_select_payment_frequency" = "Select Payment Frequency";
+
+/* Message informing the user that their Pocket Casts Plus subscription is managed by Apple's system and needs to be managed there. */
+"plus_subscription_apple" = "Your subscription is managed by the Apple App Store";
+
+/* Message informing the user where to manage their Pocket Casts Plus subscription managed by Apple. */
+"plus_subscription_apple_details" = "To cancel your subscription, you’ll need to cancel via Settings.";
+
+/* Message informing the user when their Pocket Casts Plus subscription will expire. %1$@ is a placeholder for the expiration date. */
+"plus_subscription_expiration" = "PLUS EXPIRES IN %1$@";
+
+/* Message informing the user that their Pocket Casts Plus subscription is managed by Google's system and needs to be managed there. */
+"plus_subscription_google" = "It looks like you subscribed to Pocket Casts Plus from an Android device";
+
+/* Message informing the user where to manage their Pocket Casts Plus subscription managed by Google. */
+"plus_subscription_google_details" = "To cancel your subscription, you’ll need to cancel via Settings.";
+
+/* Message informing the user that their Pocket Casts Plus subscription is managed by Web's system and needs to be managed there. */
+"plus_subscription_web" = "It looks like you subscribed to Pocket Casts Plus from the web";
+
+/* Message informing the user where to manage their Pocket Casts Plus subscription managed by Web. */
+"plus_subscription_web_details" = "To cancel your subscription, you’ll need to cancel via Pocketcasts.com.";
+
+/* Feature of Pocket Casts plus, Web Player. As in our web based version capable of playing podcasts */
+"plus_feature_web_player" = "Web Player";
+
+/* Feature of Pocket Casts plus, Apple Watch app. Standalone meaning it can run with your iPhone */
+"plus_feature_watch_app" = "Standalone Watch Playback";
+
+/* Feature of Pocket Casts plus, Themes and icons. Themes for changing the way the app looks, icons to change the icon shown on your home screen */
+"plus_feature_themes_icons" = "Extra Themes & App Icons";
+
+/* Feature of Pocket Casts plus, Cloud Storage. Being able to upload your files to the Pocket Casts servers */
+"plus_feature_cloud_storage" = "Cloud Storage";
+
+/* A common string used throughout the app. Refers to the subscription program Pocket Casts Plus subscription. 'Pocket Casts' as a proper noun should not be localized. */
+"pocket_casts_plus" = "Pocket Casts Plus";
+
+/* A shortened version of the common string used throughout the app. Refers to the subscription program Pocket Casts Plus subscription. */
+"pocket_casts_plus_short" = "Plus";
+
+/* Indicates that the access to the podcast has ended on the specified date. '%1$@' is a placeholder for date that the access expired. */
+"podcast_access_ended" = "Access ended: %1$@";
+
+/* Indicates that the access to the podcast will end on the specified date. '%1$@' is a placeholder for date that the access will end. */
+"podcast_access_ends" = "Access ends: %1$@";
+
+/* Prompt to archive all of the selected items. */
+"podcast_archive_all" = "Archive All";
+
+/* Prompt to archive all played episodes of the current podcast. */
+"podcast_archive_all_played" = "Archive All Played";
+
+/* Confirmation to archive a certain number of podcast episodes. This is the singular form of an accompanying plural form. */
+"podcast_archive_episode_count_singular" = "Archive 1 Episode";
+
+/* Confirmation to archive a certain number of podcast episodes. '%1$@' is a placeholder for the number of episodes. */
+"podcast_archive_episodes_count_plural_format" = "Archive %1$@ Episodes";
+
+/* Confirmation message that appears alongside the various bulk archive prompts. */
+"podcast_archive_prompt_msg" = "You should only do this if you don't want to see them anymore.";
+
+/* Indicates that the episode has been archived. */
+"podcast_archived" = "Archived";
+
+/* Label used to display the number or archived episodes in a podcast. '%1$@' is a placeholder for the archived episode number. */
+"podcast_archived_count_format" = "%1$@ archived";
+
+/* Informational message informing the user that no episodes are being displayed because they're all archived. '%1$@' is a placeholder for the number of episodes. */
+"podcast_archived_msg" = "All %1$@ episodes of this podcast have been archived";
+
+/* A common string used throughout the app. Displays the count of selected podcasts. '%1$@' is a placeholder for the number of podcasts, the value will be more than one. */
+"podcast_count_plural_format" = "%1$@ podcasts";
+
+/* A common string used throughout the app. Displays the count of selected podcasts. This is the singular version of an accompanying plural format. */
+"podcast_count_singular" = "1 podcast";
+
+/* Error message informing the user that the episode encountered a download error. */
+"podcast_details_download_error" = "Episode download failed";
+
+/* Message informing the user that the episode will download once the device restores a WiFi connection. */
+"podcast_details_download_wifi_queue" = "This episode will automatically download when you're next on WiFi";
+
+/* Message details informing the user that the episode has been unarchived manually and won't be archived when the episode limit is reached. '%1$@' is a placeholder for the episode limit. */
+"podcast_details_manual_unarchive_msg" = "It won't be auto archived by your new episode limit of %1$@";
+
+/* Message informing the user that the episode has been unarchived manually. Used with episode limits. */
+"podcast_details_manual_unarchive_title" = "Episode Manually Unarchived";
+
+/* Error message informing the user that the episode encountered a playback error. */
+"podcast_details_playback_error" = "Unable to play episode";
+
+/* Indicates that the episode is queued for download. */
+"podcast_details_queued" = "Queued";
+
+/* Confirmation prompt to remove the episode file for the selected podcast episode. */
+"podcast_details_remove_download" = "REMOVE DOWNLOADED FILE?";
+
+/* Prompt to download the selected podcast now. */
+"podcast_download_now" = "Download Now";
+
+/* Indicates that a file is being downloaded and includes the completed percentage. '%1$@' is a placeholder for percentage that has been downloaded so far. */
+"podcast_downloading" = "Downloading... %1$@";
+
+/* Label used to display the number of episodes in a podcast. '%1$@' is a placeholder for the number of episodes. */
+"podcast_episode_count_plural_format" = "%1$@ episodes";
+
+/* Label used to display the number of episodes in a podcast. This is the singular form of an accompanying plural form. */
+"podcast_episode_count_singular" = "1 episode";
+
+/* Label used to display the episode limit for a podcast. '%1$@' is a placeholder for the episode limit. */
+"podcast_episode_limit_count_format" = "Limited to %1$@";
+
+/* Message for a generic error used when a podcast fails to load without a more detailed reason why. ':(' is meant to be ASCII art for a sad face. */
+"podcast_error_message" = "Unable to load podcast details :(";
+
+/* Title for a generic error used when a podcast fails to load without a more detailed reason why. Meant to be a fun cultural reference. */
+"podcast_error_title" = "Literally Can't Even";
+
+/* Indicates that a file has failed to download. */
+"podcast_failed_download" = "Episode download failed.";
+
+/* Indicates that a file has failed to upload. */
+"podcast_failed_upload" = "Failed to upload";
+
+/* Button text shown on the podcast grid when you have no podcasts, takes you to the Discover section of the app */
+"podcast_grid_discover_podcasts" = "Discover Podcasts";
+
+/* Description shown when you have no podcasts on the podcast grid */
+"podcast_grid_no_podcasts_msg" = "Coming from another app? Import your podcasts via Profile > Settings > Import & Export.\n\n\nIf you're looking for inspiration try the Discover tab.";
+
+/* Title of the message on the podcast grid when you have no podcasts */
+"podcast_grid_no_podcasts_title" = "Time to add some Podcasts!";
+
+/* Title for the options box that allows the user to pick from the various grouping options. */
+"podcast_group_options_title" = "GROUP BY";
+
+/* Prompt to hide archived episodes from the episode list. */
+"podcast_hide_archived" = "Hide Archived";
+
+/* Longer form informational label informing users that this podcast is limited to a configured set of episodes. '%1$@' is a placeholder for the number of episodes. */
+"podcast_limit_plural_format" = "Limited to %1$@ most recent episodes";
+
+/* Longer form informational label informing users that this podcast is limited to one episode. Singular version of an accompanying plural format. */
+"podcast_limit_singular" = "Limited to 1 most recent episode";
+
+/* Progress indicator informing the user that the podcasts that have been shared or imported are currently loading. */
+"podcast_loading" = "Loading Podcast...";
+
+/* Used to indicate no date was provided. */
+"podcast_no_date" = "Date Not Set";
+
+/* Label used to indicate that the podcast episode isn't grouped into a season. */
+"podcast_no_season" = "No Season";
+
+/* Accessibility label to prompt to pause an active download. */
+"podcast_pause_download" = "Pause download";
+
+/* Accessibility label to prompt to pause a playback. */
+"podcast_pause_playback" = "Pause playback";
+
+/* Indicates that a file is queued for download and includes the estimated size.*/
+"podcast_queued" = "Queued";
+
+/* Indicates that the episode is queued for download. */
+"podcast_queuing" = "Queued...";
+
+/* Prompt to trigger an artwork refresh on the podcast. */
+"podcast_refresh_artwork" = "Refresh Artwork";
+
+/* Format used to show the Season number of a podcast. '%1$@' is a placeholder for the Season number. */
+"podcast_season_format" = "Season %1$@";
+
+/* Prompt to allow the user to share the currently selected episode. */
+"podcast_share_episode" = "Share Link to Episode";
+
+/* Error message used when there are no available apps that can accept the podcast file. */
+"podcast_share_episode_error_msg" = "You don't have any apps installed that will accept this file";
+
+/* Error message for when a podcast can't be found after it has been shared. */
+"podcast_share_error_msg" = "The podcast author may have removed it since this link was shared.";
+
+/* Error title for when a podcast can't be found after it has been shared. */
+"podcast_share_error_title" = "Unable To Find Episode";
+
+/* Progress message shown while the users curated list is being synced to the server. */
+"podcast_share_list_creating" = "Creating list...";
+
+/* Placeholder for the description of the podcast list. Used when users create a curated list of podcasts. This item is optional. */
+"podcast_share_list_description" = "Description (optional)";
+
+/* Placeholder for the name of the podcast list. Used when users create a curated list of podcasts. */
+"podcast_share_list_name" = "List Name";
+
+/* Option to share the episode file to other apps. */
+"podcast_share_open_file" = "Open File in...";
+
+/* Prompt to Show archived episodes in the episode list. */
+"podcast_show_archived" = "Show Archived";
+
+/* A common string used throughout the app. Refers to Podcasts in the singular form. */
+"podcast_singular" = "Podcast";
+
+/* Used to reference that a new podcast episode will be available in the near future. */
+"podcast_soon" = "Any day now";
+
+/* Title for the options box that allows the user to pick from the various sort options. */
+"podcast_sort_order_title" = "SORT ORDER";
+
+/* Confirmation option to stream the selected episode. Used in tandem with a notice that the user is not on WiFi. */
+"podcast_stream_confirmation" = "Stream Anyway";
+
+/* Prompt to warn the user that continuing with the option to stream will consume data. Used in tandem with a notice that the user is not on WiFi. */
+"podcast_stream_data_warning" = "Streaming this episode will use data";
+
+/* Used to reference the episode was published this month. */
+"podcast_this_month" = "This Month";
+
+/* Indicates the remaining amount of time left in the episode. '%1$@' is a placeholder for the remaining time. */
+"podcast_time_left" = "%1$@ left";
+
+/* Used to reference tomorrow in terms of when the next episode will be available. */
+"podcast_tomorrow" = "Tomorrow";
+
+/* Prompt to unarchive all of the selected items. */
+"podcast_unarchive_all" = "Unarchive All";
+
+/* Indicates that the updates to the podcast has ended on the specified date. '%1$@' is a placeholder for date that the updates ended. */
+"podcast_updates_ended" = "Updates ended: %1$@";
+
+/* Indicates that the updates to the podcast will end on the specified date. '%1$@' is a placeholder for date that the updates will end. */
+"podcast_updates_ends" = "Updates ends: %1$@";
+
+/* Confirmation option to upload the selected file. Used in tandem with a notice that the user is not on WiFi. */
+"podcast_upload_confirmation" = "Upload Now";
+
+/* Indicates that a file is being uploaded and includes the completed percentage. '%1$@' is a placeholder for a localized percentage that has been uploaded so far. */
+"podcast_uploading" = "Uploading... %1$@";
+
+/* Indicates that a file is queued to be uploaded but hasn't started yet. */
+"podcast_waiting_upload" = "Waiting to upload";
+
+/* Used to reference yesterday. */
+"podcast_yesterday" = "Yesterday";
+
+/* The badge feature is set to show the number of unplayed episodes. */
+"podcasts_badge_all_unplayed" = "Unfinished Episodes";
+
+/* The badge feature is set to show an indicator if an unplayed episode exists. */
+"podcasts_badge_latest_episode" = "Only Latest Episode";
+
+/* Title for the options to configure badge display options. */
+"podcasts_badges" = "Badges";
+
+/* Episodes will be displayed in order from the longest to the shortest. */
+"podcasts_episode_sort_longest_to_shortest" = "Longest to Shortest";
+
+/* Episodes will be displayed in order from the most resent to the oldest. */
+"podcasts_episode_sort_newest_to_oldest" = "Newest to oldest";
+
+/* Episodes will be displayed in order from the oldest to the most resent. */
+"podcasts_episode_sort_oldest_to_newest" = "Oldest to newest";
+
+/* Episodes will be displayed in order from the shortest to the longest. */
+"podcasts_episode_sort_shortest_to_longest" = "Shortest to Longest";
+
+/* Presents the podcasts with large podcast artwork tiles. */
+"podcasts_large_grid" = "Large Grid";
+
+/* Title for the set of options for the presentation styles like grid sizes vs list view. */
+"podcasts_layout" = "Layout";
+
+/* Grid Items will be sorted sorted based on the users custom ordering. This is performed by dragging and dropping a podcast to the desired order. */
+"podcasts_library_sort_custom" = "Drag and Drop";
+
+/* Grid Items will be sorted based on the date the user subscribed to them. Newest to oldest. */
+"podcasts_library_sort_date_added" = "Date Added";
+
+/* Grid Items will be sorted based on the date of their newest episode. Newest to oldest. */
+"podcasts_library_sort_episode_release_date" = "Episode Release Date";
+
+/* Grid Items will be sorted alphabetically based on name. */
+"podcasts_library_sort_title" = "Name";
+
+/* Presents the podcasts in a list view. */
+"podcasts_list" = "List";
+
+/* A common string used throughout the app. Refers to Podcasts in the plural form as well as the Podcasts screen. */
+"podcasts_plural" = "Podcasts";
+
+/* Prompt to open the menu to share your podcasts list. */
+"podcasts_share" = "Share Podcasts";
+
+/* Presents the podcasts with small podcast artwork tiles. */
+"podcasts_small_grid" = "Small Grid";
+
+/* Prompt to open the menu to allow the user to sort their podcasts. */
+"podcasts_sort" = "Sort Podcasts";
+
+/* A common string used throughout the app. Refers to the Profile tab. */
+"profile" = "Profile";
+
+/* Informational label indicating the last time the app was refreshed. '%1$@' is a placeholder for a date string indicating when the last refresh occurred. */
+"profile_last_app_refresh" = "App last refreshed %1$@";
+
+/* Displays the number of files for when there are multiple files. '%1$@' is a placeholder for the number of files. */
+"profile_number_of_files" = "%1$@ Files";
+
+/* The percentage of file storage space that is currently being used. '%1$@' is a placeholder for a localized percentage. */
+"profile_percent_full" = "%1$@ Full";
+
+/* Prompt to allow the user to reset their account password. */
+"profile_reset_password" = "Reset Password";
+
+/* Notice informing the user that the email to reset their password is being prepared to be sent. */
+"profile_sending_reset_email" = "Sending Reset Email";
+
+/* Notice informing the user that the email to reset their password has been successfully sent. This serves as the message body for an alert accompanied with a title. ':)' is meant to be ASCII art for a happy face. */
+"profile_sending_reset_email_conf_msg" = "Check your email :)";
+
+/* */
+/* Notice informing the user that the email to reset their password has been successfully sent. This serves as the title for an alert. */
+"profile_sending_reset_email_conf_title" = "Password Reset Link Sent";
+
+/* Notice informing the user that the attempt to send the password reset email has failed. */
+"profile_sending_reset_email_failed" = "Failed to send reset email, please try again later.";
+
+/* Displays the number of files for when there is a single file. */
+"profile_single_file" = "1 File";
+
+/* Confirmation message to clear the give number of episodes from the queue. '%1$@' is a placeholder for the number of episodes, this will be more than one. */
+"queue_clear_episode_queue_plural" = "Clear %1$@ Episodes";
+
+/* Prompt to allow the user to clear their queue. */
+"queue_clear_queue" = "CLEAR QUEUE";
+
+/* A common string used throughout the app. Provides an option to add the selected item(s) to a queue instead of performing the action now. Used for downloads and uploads. */
+"queue_for_later" = "Queue For Later";
+
+/* Accessibility label indicating the current podcast is playing and it's episode date. '%1$@' is a placeholder for the episode date. */
+"queue_now_playing_accessibility" = "Now Playing. %1$@";
+
+/* Label indicating the amount of time remains on an episode. '%1$@' is a placeholder for a localized time format for the remaining time. */
+"queue_time_remaining" = "%1$@ remaining";
+
+/* Information label indication the total time remaining in the queue. This is a total across all episodes in the up next queue. '%1$@' is a placeholder for the total time remaining in the queue. */
+"queue_total_time_remaining" = "%1$@ total time remaining";
+
+/* A common string used throughout the app. Error title indicating that the refresh process has failed. */
+"refresh_failed" = "Refresh failed";
+
+/* A common string used throughout the app. Prompt to perform a manual refresh of the displayed data. */
+"refresh_now" = "Refresh Now";
+
+/* A common string used throughout the app. Informational label indicating the last time the refresh occurred. '%1$@' is a placeholder for a localized string indicating when the refresh happened. */
+"refresh_previous_run" = "Last refresh: %1$@";
+
+/* Activity indicator letting the user know that the process to refresh the current content is running. */
+"refreshing" = "Refreshing...";
+
+/* Hint text in the pull to refresh custom control. Provides a notice that new Podcast episodes are being fetched. */
+"refresh_control_fetching_episodes" = "FINDING NEW PODCAST EPISODES";
+
+/* Hint text in the pull to refresh custom control. */
+"refresh_control_pull_to_refresh" = "PULL TO REFRESH";
+
+/* Hint text in the pull to refresh custom control. Informs the user that the refresh has finished successfully. */
+"refresh_control_refresh_complete" = "REFRESH COMPLETE";
+
+/* Hint text in the pull to refresh custom control. Informs the user that the refresh has failed. ':(' is meant as sad face ASCII art. */
+"refresh_control_refresh_failed" = "REFRESH FAILED :(";
+
+/* Hint text in the pull to refresh custom control. Provides a notice that files are being synced with the server. */
+"refresh_control_refreshing_files" = "REFRESHING FILES";
+
+/* Hint text in the pull to refresh custom control. Provides a prompt to release the control to trigger the refresh. */
+"refresh_control_release_to_refresh" = "RELEASE TO REFRESH";
+
+/* Hint text in the pull to refresh custom control. Informs the user that the sync has failed. ':(' is meant as sad face ASCII art. */
+"refresh_control_sync_failed" = "SYNC FAILED :(";
+
+/* Hint text in the pull to refresh custom control. Provides a notice that Podcasts are being synced with the server. */
+"refresh_control_syncing_podcasts" = "SYNCING PODCASTS AND PROGRESS";
+
+/* A common string used throughout the app. Prompt to remove the selected item(s). */
+"remove" = "Remove";
+
+/* A common string used throughout the app. Prompt to remove all of the selected item(s). */
+"remove_all" = "Remove All";
+
+/* A common string used throughout the app. Prompt to delete the selected item(s) local file download. */
+"remove_download" = "Remove Download";
+
+/* A common string used throughout the app. Prompt to remove the selected item(s) from the up next queue. */
+"remove_from_up_next" = "Remove From Up Next";
+
+/* A common string used throughout the app. Prompt to remove the selected item(s) from the up next queue. Shorter form of 'Remove From Up Next' to conserve space on the Apple Watch. */
+"remove_up_next" = "Remove Up Next";
+
+/* A common string used throughout the app. Prompt to retry the recent request. */
+"retry" = "Retry";
+
+/* A common string used throughout the app. Placeholder text used in search boxes. */
+"search" = "Search";
+
+/* A common string used throughout the app when searching podcasts. Placeholder text used in search boxes. */
+"search_podcasts" = "Search Podcasts";
+
+/* A common string used throughout the app. Refers to the season a podcast episode is in. */
+"season" = "Season";
+
+/* Shorthand format used to show the Season number of a podcast. 'S' is short for Season. '%1$@' is a placeholder for the season number. */
+"season_only_shorthand_format" = "S%1$@";
+
+/* Shorthand format used to show the Season and the Episode number of a podcast. 'S' is short for Season. '%1$@' is a placeholder for the season number. 'E' is short for Episode. '%2$@' is a placeholder for the episode number. */
+"season_episode_shorthand_format" = "S%1$@ E%2$@";
+
+/* A common string used throughout the app. Prompt to select items. */
+"select" = "Select";
+
+/* A common string used throughout the app. Prompt to select all items in the presented list. */
+"select_all" = "Select All";
+
+/* A common string used throughout the app. Prompt to select all items above the currently selected item. */
+"select_all_above" = "Select all above";
+
+/* A common string used throughout the app. Prompt to select all items below the currently selected item. */
+"select_all_below" = "Select all below";
+
+/* A common string used throughout the app. Prompt to select episodes in the presented list. */
+"select_episodes" = "Select Episodes";
+
+/* A common string used throughout the app. Indicates the number of selected items. '%1$@' is a placeholder for the selected items. */
+"selected_count_format" = "%1$@ selected";
+
+/* Server error message for when the user tries to upload a file that is too large. */
+"server_error_files_file_too_large" = "This file is too big too upload.";
+
+/* Server error message for when the user tries to upload a file with an invalid file type. */
+"server_error_files_invalid_content_type" = "Unable to upload, as we're unable to determine the content type of this file.";
+
+/* Server error message for when the user tries to upload a file while not logged in. */
+"server_error_files_invalid_user" = "User is not logged in.";
+
+/* Server error message for when the user tries to upload a file but doesn't have sufficient space remaining. */
+"server_error_files_storage_limit_exceeded" = "You have exceeded the storage limit for your account.";
+
+/* Server error message for when the user tries to upload a file without a title. */
+"server_error_files_title_required" = "Title is required.";
+
+/* Server error message indicating a generic error for when the file uploads fail. */
+"server_error_files_upload_failed_generic" = "Unable to upload file, please try again later.";
+
+/* Server error message for when a file upload files because a unique identifier failed wasn't created. */
+"server_error_files_uuid_required" = "File uuid is required.";
+
+/* Server error message for when the user account has been locked. */
+"server_error_login_account_locked" = "Your account has been locked due too many login attempts, please try again later.";
+
+/* Server error message for when the user attempted to login without their email. */
+"server_error_login_email_blank" = "Enter an email address.";
+
+/* Server error message for when the user enters an invalid email. */
+"server_error_login_email_invalid" = "Invalid email";
+
+/* Server error message for when the user's email couldn't be identified on the server . */
+"server_error_login_email_not_found" = "Email not found";
+
+/* Server error message for when the user tries to create an account for an email tied to an existing account. */
+"server_error_login_email_taken" = "Email taken";
+
+/* Server error message for when the user attempted to login without their password. */
+"server_error_login_password_blank" = "Enter a password.";
+
+/* Server error message for when the user enters an invalid password. */
+"server_error_login_password_invalid" = "Invalid password";
+
+/* Server error message for when the user enters an invalid password. */
+"server_error_login_password_incorrect" = "Incorrect password";
+
+/* Server error message for when the user tries to access a feature they don't have access to. */
+"server_error_login_permission_denied_not_admin" = "Permission denied";
+
+/* Server error message for when the server failed to create the account fro the user. */
+"server_error_login_user_register_failed" = "Unable to create account, please try again later";
+
+/* Server error message for when the server failed to create the account fro the user. */
+"server_error_login_unable_to_create_account" = "We couldn't set up that account, sorry.";
+
+/* Server error message for when the user tries to redeem a promo when they are already a plus subscriber. */
+"server_error_promo_already_plus" = "You are already a Pocket Casts Plus subscriber, there's no need to redeem any codes.";
+
+/* Server error message for when the user tries to redeem a promo code that has already been used. */
+"server_error_promo_already_redeemed" = "You have already claimed this promo code. It was worth a shot though!";
+
+/* Server error message for when the user attempts to redeem a promo code that is no longer active. */
+"server_error_promo_code_expired_or_invalid" = "This promo code has expired or is invalid.";
+
+/* Generic server error message for when an unexpected or unhandled issue occurred. */
+"server_error_unknown" = "Something went wrong";
+
+/* Server message thanking the user for signing up to the service. */
+"server_message_login_thanks_signing_up" = "Thanks for signing up!";
+
+/* A common string used throughout the app. Reference to the settings menus. */
+"settings" = "Settings";
+
+/* A common string used throughout the app. Refers to the About settings menu */
+"settings_about" = "About";
+
+/* A common string used throughout the app. Refers to the Privacy settings menu */
+"settings_privacy" = "Privacy";
+
+/* A common string used throughout the app. Refers to the Appearance settings menu. */
+"settings_appearance" = "Appearance";
+
+/* Provides a prompt for the user to configure the settings related to Inactive Episodes. Used in places like configuring Auto Archive settings. */
+"settings_archive_inactive_episodes" = "Inactive Episodes";
+
+/* Title for the options menu to configure the settings related to archiving Inactive Episodes. */
+"settings_archive_inactive_title" = "Archive Inactive";
+
+/* Provides a prompt for the user to configure the settings related to Played Episodes. Used in places like configuring Auto Archive settings. */
+"settings_archive_played_episodes" = "Played Episodes";
+
+/* Title for the options menu to configure the settings related to archiving Played Episodes. */
+"settings_archive_played_title" = "Archive Played";
+
+/* A common string used throughout the app. Refers to the Auto Add to Up Next settings menu */
+"settings_auto_add" = "Auto Add to Up Next";
+
+/* Prompt to select the episode limit for auto adding podcasts to the Up Next Queue. */
+"settings_auto_add_limit" = "Auto Add Limit";
+
+/* Prompt to select the behavior of the app if the auto add limit has been reached. */
+"settings_auto_add_limit_reached" = "If Limit Reached";
+
+/* Subtitle explaining the app's behavior when the episode limit is reached and new episodes are not add to the Up Next Queue. '%1$@' is a placeholder for the auto add limit. */
+"settings_auto_add_limit_subtitle_stop" = "New episodes will stop being added when Up Next reaches %1$@ episodes.";
+
+/* Subtitle explaining the app's behavior when the episode limit is reached and new episodes are added to the top of the Up Next Queue. '%1$@' is a placeholder for the auto add limit. */
+"settings_auto_add_limit_subtitle_top" = "When Up Next reaches %1$@, new episodes auto-added to the top will remove the last episode in the queue. No new episodes will be added to the bottom.";
+
+/* Section header that displays all of the Podcasts that will automatically add new episodes to the Up Next Queue. */
+"settings_auto_add_podcasts" = "Auto-Add Podcasts";
+
+/* A common string used throughout the app. Refers to the Auto Archive settings menu */
+"settings_auto_archive" = "Auto Archive";
+
+/* Setting to auto archive a podcast episode. This value will auto archive the episode after 1 Week has passed. */
+"settings_auto_archive_1_week" = "After 1 Week";
+
+/* Setting to auto archive a podcast episode. This value will auto archive the episode after 24 Hours has passed. */
+"settings_auto_archive_24_hours" = "After 24 Hours";
+
+/* Setting to auto archive a podcast episode. This value will auto archive the episode after 2 Days has passed. */
+"settings_auto_archive_2_days" = "After 2 Days";
+
+/* Setting to auto archive a podcast episode. This value will auto archive the episode after 2 Weeks has passed. */
+"settings_auto_archive_2_weeks" = "After 2 Weeks";
+
+/* Setting to auto archive a podcast episode. This value will auto archive the episode after 30 Days has passed. */
+"settings_auto_archive_30_days" = "After 30 Days";
+
+/* Setting to auto archive a podcast episode. This value will auto archive the episode after 3 Months has passed. */
+"settings_auto_archive_3_months" = "After 3 Months";
+
+/* Prompt for the toggle to include starred episodes when auto archiving. */
+"settings_auto_archive_include_starred" = "Include Starred Episodes";
+
+/* Subtitle for the toggle to include starred episodes when auto archiving. This is the text that will be shown when the toggle is on. */
+"settings_auto_archive_include_starred_off_subtitle" = "Starred episodes won't be auto archived";
+
+/* Subtitle for the toggle to include starred episodes when auto archiving. This is the text that will be shown when the toggle is on. */
+"settings_auto_archive_include_starred_on_subtitle" = "Starred episodes will be auto archived";
+
+/* Subtitle for the main section of auto archive settings. This section sets the time limits or event triggers for when episodes are auto archived. */
+"settings_auto_archive_subtitle" = "Archive episodes after set time limits. Downloads are removed when the episode is archived.";
+
+/* A common string used throughout the app. Refers to the Auto Download settings menu */
+"settings_auto_download" = "Auto Download";
+
+/* Label indicating the number of selected filters. '%1$@' is a placeholder for the number of filters selected. */
+"settings_auto_downloads_filters_selected_format" = "%1$@ filters selected";
+
+/* Label indicating the number of selected filters. This is the singular form for an accompanying plural option. */
+"settings_auto_downloads_filters_selected_singular" = "1 filter selected";
+
+/* Label indicating no filters have been selected. */
+"settings_auto_downloads_no_filters_selected" = "No Filters Selected";
+
+/* Label indicating no podcasts have been selected. */
+"settings_auto_downloads_no_podcasts_selected" = "No Podcasts Selected";
+
+/* Label indicating the number of selected podcasts. '%1$@' is a placeholder for the number of podcasts selected. */
+"settings_auto_downloads_podcasts_selected_format" = "%1$@ podcasts selected";
+
+/* Label indicating the number of selected podcasts. This is the singular form for an accompanying plural option. */
+"settings_auto_downloads_podcasts_selected_singular" = "1 podcast selected";
+
+/* Subtitle explaining the toggle to auto download the top episodes of a filter. */
+"settings_auto_downloads_subtitle_filters" = "Download the top episodes in a filter.";
+
+/* Subtitle explaining the toggle to auto download New Episodes. */
+"settings_auto_downloads_subtitle_new_episodes" = "Download new episodes when they are released.";
+
+/* Subtitle explaining the toggle to auto download items in the Up Next Queue. */
+"settings_auto_downloads_subtitle_up_next" = "Download episodes added to Up Next.";
+
+/* Section Header for selecting the options for setting the app badge based on the user's filters. */
+"settings_badge_filter_header" = "EPISODE FILTER COUNT";
+
+/* Option for setting the app badge based on the new episodes since the app opened. */
+"settings_badge_new_since_opened" = "New Since App Opened";
+
+/* Option for setting the app badge based on the total unplayed episodes. */
+"settings_badge_total_unplayed" = "Total Unplayed";
+
+/* Prompt to open the menu to create a new Siri shortcut. 'Siri' refers to Apple's voice assistant. */
+"settings_create_siri_shortcut" = "Create Siri Shortcut";
+
+/* Informational message to accompany a prompt to create a Siri Shortcut. 'Siri' refers to Apple's voice assistant. '%1$@' is a placeholder for the podcasts name. */
+"settings_create_siri_shortcut_msg" = "Create a Siri Shortcut to play the newest episode of %1$@";
+
+/* A common string used throughout the app. Indicates an option(s) to customize the settings for this podcast. */
+"settings_custom" = "Custom For This Podcast";
+
+/* A message accompanying the toggle to enable auto archive settings that are specific to the selected podcast. */
+"settings_custom_auto_archive_msg" = "Need more fine grained control? Enable auto-archive settings for this podcast";
+
+/* A message accompanying the toggle to set custom settings for a particular podcast. */
+"settings_custom_msg" = "Pocket Casts will remember your last playback effects and use them on all podcasts. You can enable this if you want to create custom ones for just this podcast.";
+
+/* Provides a prompt for the user to configure the settings related to episode limits. This controls how many episodes will be preserved before auto archiving them. */
+"settings_episode_limit" = "Episode Limit";
+
+/* Informs the user of max episode count for the up next queue. This value is configurable. '%1$@' is a placeholder for the current value as set by the user. */
+"settings_episode_limit_format" = "%1$@ Episode Limit";
+
+/* A format for values accompanying the setting to auto archive based on a set limit. '%1$@' is a placeholder for the number of episodes that will be saved before auto archiving the oldest ones. */
+"settings_episode_limit_limit_format" = "%1$@ most recent";
+
+/* A message accompanying the episode limit settings providing a hint towards one use case for this feature. */
+"settings_episode_limit_msg" = "For shows that release hourly or daily episodes, setting an episode limit can help keep only the most recent ones, while archiving any that are older.";
+
+/* A value accompanying the setting to auto archive based on a set limit. This value disables the feature. */
+"settings_episode_limit_no_limit" = "No Limit";
+
+/* Alert title informing the user that the OPML export has encountered an error. 'OPML' refers to the file type that will be exported. */
+"settings_export_error" = "Export Error";
+
+/* Alert message informing the user that the OPML export has encountered an error. 'OPML' refers to the file type that will be exported. */
+"settings_export_error_msg" = "Unable to export OPML, please try again later.";
+
+/* Alert title informing the user that the OPML export is processing. 'OPML' refers to the file type that will be exported. */
+"settings_export_opml" = "Exporting OPML";
+
+/* Informs the user that Pocket Casts has dedicated an issue with this podcasts feed. */
+"settings_feed_error" = "Feed Error";
+
+/* Informs the user that Pocket Casts has stopped updating this feed due to too many errors. Provides a prompt to tap the refresh button that is presented above this message box. */
+"settings_feed_error_msg" = "The feed for this podcast stopped updating because it had too many errors. Tap above to fix this.";
+
+/* Title used in a dialog box. Prompt user to try refreshing the feed after encountering an error. */
+"settings_feed_fix_refresh" = "Try To Update It";
+
+/* The message body for a dialog box used to inform the user the request to update the feed has failed. */
+"settings_feed_fix_refresh_failed_msg" = "Unable to update this feed, please try again later.";
+
+/* The title for a dialog box used to inform the user that the request to update the feed has failed. */
+"settings_feed_fix_refresh_failed_title" = "Update Failed";
+
+/* The message body for a dialog box used to inform the user that the an update to the feed has been queued. */
+"settings_feed_fix_refresh_success_msg" = "We've queued an update for this podcast. Our server will re-check it and if it works you should have new episodes soon. Please check back in about an hour.";
+
+/* The title for a dialog box used to inform the user that the an update to the feed has been queued. */
+"settings_feed_fix_refresh_success_title" = "Update Queued";
+
+/* Informs the user that Pocket Casts has dedicated an issue with this podcasts feed. */
+"settings_feed_issue" = "Feed Issue";
+
+/* Informs the user that Pocket Casts has stopped updating this feed due to too many errors. */
+"settings_feed_issue_msg" = "The feed for this podcast stopped updating because it had too many errors.";
+
+/* Prompt to navigate the user to the files setting screen. */
+"settings_files" = "Files Settings";
+
+/* Subtitle for the toggle to auto add new files to the Up Next Queue. */
+"Settings_files_add_up_next_subtitle" = "Add new files to Up Next automatically";
+
+/* Prompt for the toggle to enable auto downloads for uploaded files. */
+"settings_files_auto_download" = "Auto Download from Cloud";
+
+/* Subtitle explaining the app behavior when the toggle to for auto downloads for uploaded files is off. */
+"settings_files_auto_download_subtitle_off" = "Files added to the cloud from other devices will not be automatically downloaded.";
+
+/* Subtitle explaining the app behavior when the toggle to for auto downloads for uploaded files is on. */
+"settings_files_auto_download_subtitle_on" = "Files added to the cloud from other devices will be automatically downloaded.";
+
+/* Prompt for the toggle to enable auto uploads for uploaded files. */
+"settings_files_auto_upload" = "Auto Upload to Cloud";
+
+/* Subtitle explaining the app behavior when the toggle to for auto uploads is off. */
+"settings_files_auto_upload_subtitle_off" = "Files added to this device will not be automatically uploaded to the Cloud.";
+
+/* Subtitle explaining the app behavior when the toggle to for auto uploads is on. */
+"settings_files_auto_upload_subtitle_on" = "Files added to this device will be automatically uploaded to the Cloud.";
+
+/* Prompt for the toggle to enable the option to delete the cloud file after playing. */
+"settings_files_delete_cloud_file" = "Delete Cloud File";
+
+/* Prompt for the toggle to enable the option to delete the local file after playing. */
+"settings_files_delete_local_file" = "Delete Local File";
+
+/* A common string used throughout the app. Reference to the General settings menu. */
+"settings_general" = "General";
+
+/* Confirmation to apply a setting change to all podcasts. */
+"settings_general_apply_all_conf" = "Apply to existing";
+
+/* Prompt to apply a setting change to all podcasts. */
+"settings_general_apply_all_title" = "Apply to existing podcasts?";
+
+/* Setting option to choose the default display archived episodes. */
+"settings_general_archived_episodes" = "Archived Episodes";
+
+/* Prompt to ask the user if they'd like to show/hide archived episodes for all podcasts. '%1$@' is a placeholder for a localized string 'show' or 'hide' based on the current setting. */
+"settings_general_archived_episodes_prompt_format" = "Would you like to change all your existing podcasts to %1$@ archived episodes?";
+
+/* Setting toggle to enable the feature to automatically open the player when playback starts. */
+"settings_general_auto_open_player" = "Open Player Automatically";
+
+/* Section header for the general settings that are more general app related. */
+"settings_general_defaults_header" = "DEFAULTS";
+
+/* Setting option to choose the primary way in which episodes are grouped. */
+"settings_general_episode_groups" = "Podcast Episode Grouping";
+
+/* Setting option to choose to hide archived episodes. */
+"settings_general_hide" = "Hide";
+
+/* Setting toggle to enable the app to keep your screen awake. */
+"settings_general_keep_screen_awake" = "Keep Screen Awake";
+
+/* Setting toggle to modify which bluetooth protocol to use. */
+"settings_general_legacy_bluetooth" = "Legacy Bluetooth Support";
+
+/* Subtitle explaining the toggle to modify which bluetooth protocol to use. */
+"settings_general_legacy_bluetooth_subtitle" = "If you have a Bluetooth Device or Car Stereo that seems to be pausing Pocket Casts while it's playing, or resetting the playback position to 0, try turning this setting on to fix it.";
+
+/* Setting toggle to enable the gesture for multi-select. */
+"settings_general_multi_select_gesture" = "Multi-select Gesture";
+
+/* Subtitle explaining the toggle to enable the gesture for multi-select. */
+"settings_general_multi_select_gesture_subtitle" = "Multi-select by dragging 2 fingers down on any episode list. Turn this off if you find yourself triggering this accidentally or it interferes with the accessibility features you use.";
+
+/* Option to not move forward with a prompt to apply to all podcasts. */
+"settings_general_no_thanks" = "No thanks";
+
+/* Setting toggle to enable the app to open the links in an external browser. */
+"settings_general_open_in_browser" = "Open Links In Browser";
+
+/* Setting toggle to modify what controls are available on the lock screen. */
+"settings_general_play_back_actions" = "Extra Playback Actions";
+
+/* Subtitle explaining the toggle to modify what controls are available on the lock screen. */
+"settings_general_play_back_actions_subtitle" = "Adds a mark played and star option to your phone lock screen and CarPlay. Note: on the lock screen this will replace the skip back button.";
+
+/* Section header for the general settings that are more player related. */
+"settings_general_player_header" = "PLAYER";
+
+/* Setting toggle to enable publishing chapter titles to the device's "Now Playing Info Center" data used by bluetooth and other connected devices. */
+"settings_general_publish_chapter_titles" = "Publish Chapter Titles";
+
+/* Subtitle explaining the toggle to publish chapter titles. */
+"settings_general_publish_chapter_titles_subtitle" = "If on, this will send chapter titles over Bluetooth and other connected devices instead of the episode title.";
+
+/* Setting toggle to change the behavior of the skip button on external devices. */
+"settings_general_remote_skips_chapters" = "Remote Skips Chapters";
+
+/* Subtitle explaining the toggle to change the behavior of the skip button on external devices. */
+"settings_general_remote_skips_chapters_subtitle" = "When enabled and an episode has chapters, pressing the skip button in your car or headphones will skip to the next chapter.";
+
+/* Prompt to ask the user if they'd like to remove the grouping from all podcasts. */
+"settings_general_remove_groups_apply_all" = "Would you like to change all your existing podcasts to be not be grouped as well?";
+
+/* Setting option to choose the default action when selecting an episode row. */
+"settings_general_row_action" = "Row Action";
+
+/* Prompt to ask the user if they'd like to apply the grouping to all podcasts. '%1$@' is a placeholder for a localized name for the grouping type. */
+"settings_general_selected_group_apply_all" = "Would you like to change all your existing podcasts to be grouped by %1$@?";
+
+/* Setting option to choose to show archived episodes. */
+"settings_general_show" = "Show";
+
+/* Setting toggle to enable the feature that adjusts the playback position when resuming. */
+"settings_general_smart_playback" = "Intelligent Playback Resumption";
+
+/* Subtitle explaining the feature that adjusts the playback position when resuming. */
+"settings_general_smart_playback_subtitle" = "If on, Pocket Casts will go back a little in episodes you resume so you can catch up more comfortably.";
+
+/* Setting option to choose how to handle swiping to add something to the queue. */
+"settings_general_up_next_swipe" = "Up Next Swipe";
+
+/* Setting toggle to modify how a tap is handled in the up next queue. */
+"settings_general_up_next_tap" = "Play Up Next On Tap";
+
+/* Subtitle explaining the toggle to modify how a tap is handled in the up next queue. This is used when the toggle is off. */
+"settings_general_up_next_tap_off_subtitle" = "Tapping an episode in Up Next shows the actions page. Long press plays the episode. Turn on to switch these around.";
+
+/* Subtitle explaining the toggle to modify how a tap is handled in the up next queue. This is used when the toggle is on. */
+"settings_general_up_next_tap_on_subtitle" = "Tapping an episode in Up Next will play it. Long press shows episode options. Turn off to switch these around.";
+
+/* Title for the menu that takes you to the global up next queue settings */
+"settings_global_settings" = "Global Settings";
+
+/* A common string used throughout the app. Refers to the Help & Feedback settings menu */
+"settings_help" = "Help & Feedback";
+
+/* Title for the screen that manages the importing and exporting of podcasts. */
+"settings_import_export" = "Import / Export";
+
+/* Informs the user that the current podcast is included in one filter. '%1$@' is a placeholder for the number of filters this podcast is included in. */
+"settings_in_filters_plural_format" = "Included In %1$@ Filters";
+
+/* Informs the user that the current podcast is included in one filter. This is the singular form of an accompanying plural string. */
+"settings_in_filters_singular" = "Included In 1 Filter";
+
+/* Setting section header. Indicates that the options in this section will appear in the menu vs an action bar. */
+"settings_in_menu" = "IN MENU";
+
+/* A message accompanying the settings for inactive episodes explaining what is considered an inactive episode. */
+"settings_inactive_episodes_msg" = "Inactive episodes are episodes you haven't played or downloaded in the time you specify above. Downloads are removed when the episode is archived.";
+
+/* Informs the user that the current podcast isn't included in any filters. */
+"settings_not_in_filters" = "Not Included In Any Filters";
+
+/* A common string used throughout the app. Refers to the Notifications settings menu. */
+"settings_notifications" = "Notifications";
+
+/* App badge choice to have the badge reflect the filter count */
+"settings_notifications_filter_count" = "Filter count";
+
+/* Subtitle explaining what notifications to expect when you enable notifications. */
+"settings_notifications_subtitle" = "Notifies you when a new episode is available. Also useful for improving the reliability of auto downloads.";
+
+/* A common string used throughout the app. Refers to the Import/Export OPML settings menu */
+"settings_opml" = "Import/Export OPML";
+
+/* Provides a prompt for the user to configure the playback speed options. */
+"settings_play_speed" = "Play Speed";
+
+/* Informational label breaking down the pricing structure for Pocket Casts Plus. '%1$@' is a placeholder for the localized price if paid per month, '%2$@' is a placeholder for the localized price if paid per year */
+"settings_plus_pricing_format" = "%1$@ per month / %2$@ per year";
+
+/* Title for the options to configure the queue position when a podcast is set to be auto added to the up next queue. */
+"settings_queue_position" = "Position in Queue";
+
+/* Prompt to select a filter */
+"settings_select_filter_singular" = "Select Filter";
+
+/* Prompt to select filters */
+"settings_select_filters_plural" = "Select Filters";
+
+/* Option for the filter Siri Shortcut. This sets the app to open the filter when the shortcut is triggered. */
+"settings_shortcuts_filter_open_filter" = "Open Filter";
+
+/* Option for the filter Siri Shortcut. This sets the filter to play all episodes in the filter when the shortcut is triggered. */
+"settings_shortcuts_filter_play_all_episodes" = "Play all episodes";
+
+/* Option for the filter Siri Shortcut. This sets the filter to play the top episode in the filter when the shortcut is triggered. */
+"settings_shortcuts_filter_play_top_episode" = "Play the top episode";
+
+/* Prompt to open the menu to interact with a pre-configured Siri shortcut. 'Siri' refers to Apple's voice assistant. */
+"settings_siri_shortcut" = "Siri Shortcut";
+
+/* Informational message that accompanies an existing Siri shortcut for a particular podcast. 'Siri' refers to Apple's voice assistant. '%1$@' is a placeholder for the podcasts name. */
+"settings_siri_shortcut_msg" = "A Siri Shortcut to play the top episode in %1$@";
+
+/* A common string used throughout the app. Refers to the Siri Shortcuts settings menu. 'Siri' refers to Apple's voice assistant. */
+"settings_siri_shortcuts" = "Siri Shortcuts";
+
+/* Section header for the available Siri shortcuts (not yet enabled). */
+"settings_siri_shortcuts_available" = "Available shortcuts";
+
+/* Section header for the enabled Siri shortcuts. */
+"settings_siri_shortcuts_enabled" = "Enabled shortcuts";
+
+/* Option to create a Siri Shortcut to a specific filter. */
+"settings_siri_shortcuts_specific_filter" = "Shortcut to a specific filter";
+
+/* Option to create a Siri Shortcut to a specific podcast. */
+"settings_siri_shortcuts_specific_podcast" = "Shortcut to a specific podcast";
+
+/* Prompt to open the configurable options to have the podcast skip an initial portion of the selected podcast. */
+"settings_skip_first" = "Skip First";
+
+/* Prompt to open the configurable options to have the podcast skip the final portion of the selected podcast. */
+"settings_skip_last" = "Skip Last";
+
+/* Fun informational message about the skip options available in the settings. */
+"settings_skip_msg" = "Skip intro and outro music like the power user you were born to be.";
+
+/* A common string used throughout the app. Refers to the Stats settings menu */
+"settings_stats" = "Stats";
+
+/* A common string used throughout the app. Refers to the Storage & Data Use settings menu. */
+"settings_storage" = "Storage & Data Use";
+
+/* Prompt for the toggle that turns on the dialog that warns the user before using data. */
+"settings_storage_data_warning" = "Warn Before Using Data";
+
+/* Prompt for the toggle that will include starred files in the clean up operation. */
+"settings_storage_downloads_starred" = "Include Starred";
+
+/* Section header for settings related to data usage. */
+"settings_storage_mobile_data" = "MOBILE DATA";
+
+/* Section header for information about storage space used. */
+"settings_storage_usage" = "USAGE";
+
+/* Title for the settings screen */
+"settings_title" = "Podcast Settings";
+
+/* Provides a prompt for the user to configure the sensitivity associated to the auto trimming silence setting. */
+"settings_trim_level" = "Trim Level";
+
+/* Provides a prompt for the user to configure the trim silence options. */
+"settings_trim_silence" = "Trim Silence";
+
+/* Informs the user about how the Queue will be adjusted when the episode limit is reached. '%1$@' is a placeholder for the current queue limit. */
+"settings_up_next_limit" = "Automatically add new episodes to Up Next. New episodes will stop being added when Up Next reaches %1$@.";
+
+/* Informs the user about how the Queue will be adjusted when the episode limit is reached. '%1$@' is a placeholder for the current queue limit. */
+"settings_up_next_limit_add_to_top" = "Automatically add new episodes to Up Next. When Up Next reaches %1$@, new episodes auto-added to the top will remove the last episode in the queue.";
+
+/* Provides a prompt for the user to toggle on the volume boosting setting. */
+"settings_volume_boost" = "Volume Boost";
+
+/* Prompt for the toggle that enables auto downloads for the Apple Watch app. */
+"settings_watch_auto_download" = "Auto Download Up Next";
+
+/* Subtitle for the toggle that explains the behavior for the auto download feature for the Apple Watch app. */
+"settings_watch_auto_download_off_subtitle" = "Set the number of episodes from your Up Next queue Pocket Casts will download to your watch for offline playback.";
+
+/* Prompt for the toggle that enables the feature to delete auto downloads that fall outside episode limit for the Apple Watch app. */
+"settings_watch_delete_downloads" = "Delete Downloads Outside Limit";
+
+/* Subtitle explaining the behavior of the app for when the toggle to delete auto downloads is turned off. */
+"settings_watch_delete_downloads_off_subtitle" = "To conserve watch storage, a maximum of 25 episodes in your Up Next queue will be auto-downloaded. Older download files outside this limit will be automatically deleted.";
+
+/* Subtitle explaining the behavior of the app for when the toggle to delete auto downloads is turned on. */
+"settings_watch_delete_downloads_on_subtitle" = "All download files in your Up Next queue that are outside this limit will be automatically deleted. Manual downloads aren't managed by these settings.";
+
+/* Prompt for the option to select the number of episodes to auto downloads for the Apple Watch app. */
+"settings_watch_episode_limit" = "Number of Episodes";
+
+/* Subtitle explaining for the option to select the number of episodes to auto downloads for the Apple Watch app. '%1$@' is a placeholder for the number of items to download. */
+"settings_watch_episode_limit_subtitle" = "Pocket Casts will download the top %1$@ episodes of your Up Next queue to your watch for offline playback.";
+
+/* Prompt for the option format to select the number of episodes to auto downloads for the Apple Watch app. '%1$@' is a placeholder for the number of items to download */
+"settings_watch_episode_number_option_format" = "Top %1$@";
+
+/* Label displayed right next the button to opt-in/out for Analytics tracking */
+"settings_collect_information" = "Collect information";
+
+/* Additional information about how the information collected is and how it's used */
+"settings_collect_information_additional_information" = "Allowing us to collect analytics helps us build a better app. We understand if you would prefer not to share this information.";
+
+/* Label for an input that takes the user to the privacy policy */
+"settings_read_privacy_policy" = "Read privacy policy";
+
+/* Title for the options for the user to configure their account. */
+"setup_account" = "Set Up Account";
+
+/* A common string used throughout the app. Prompt to open the share settings for the selected item(s). */
+"share" = "Share";
+
+/* A common string used throughout the app. Option to share the episode at the current playback position. */
+"share_current_position" = "Current Position";
+
+/* Message indicating that the process to subscribe to a podcast list is in progress. */
+"share_list_subscribing" = "Subscribing...";
+
+/* Message indicating that all of the podcasts have been selected. */
+"share_podcasts_all_selected" = "ALL SELECTED";
+
+/* Title for the screen to finalize options to create a list of podcasts to share. */
+"share_podcasts_create_list" = "Create List";
+
+/* Message indicating that the process to share a podcast list is in progress. */
+"share_podcasts_sharing" = "Sharing...";
+
+/* Error message for when sharing fails. */
+"share_podcasts_sharing_failed_msg" = "Something went wrong creating your share page";
+
+/* Title indicating that sharing has failed. */
+"share_podcasts_sharing_failed_title" = "Sharing Failed";
+
+/* A common string used throughout the app. Title for the screen to select multiple podcasts to share. */
+"share_select_podcasts" = "Select Podcasts";
+
+/* Progress indicator informing the user that the item that has been sent to them via share is loading. */
+"shared_item_loading" = "Loading Shared Item...";
+
+/* Title for the screen that shows the podcasts from a shared list of podcasts. */
+"shared_list" = "Shared List";
+
+/* Confirmation option presented when a user selects to subscribe to all podcasts in a list. */
+"shared_list_subscribe_conf_action" = "Heck Yes!";
+
+/* Message for a dialog presented when a user selects to subscribe to all podcasts in a list. '%1$@' is a placeholder for the number of podcasts that will be subscribed to. */
+"shared_list_subscribe_conf_msg" = "Are you sure you want to subscribe to %1$@ podcasts?";
+
+/* Title for a dialog presented when a user selects to subscribe to all podcasts in a list. */
+"shared_list_subscribe_conf_title" = "That's a lot of podcasts!";
+
+/* A common string used throughout the app. Refers to the Notes (show notes) tab in the player. */
+"show_notes" = "Notes";
+
+/* A common string used throughout the app. Prompt for the user to sign into their account. */
+"sign_in" = "Sign In";
+
+/* Prompt for the user to sign into their account or create an account */
+"sign_in_prompt" = "Sign in or create account";
+
+/* Message shown below the sign in prompt to give users more details about what it does */
+"sign_in_message" = "Save your podcast subscriptions in the cloud and sync your progress with other devices.";
+
+/* Button text to go to the forgot password page */
+"sign_in_forgot_password" = "I forgot my password";
+
+/* Email address field prompt */
+"sign_in_email_address_prompt" = "Email Address";
+
+/* Password field prompt */
+"sign_in_password_prompt" = "Password";
+
+/* Label indicating which account the user is signed into. The accounts email address is displayed in close proximity to this label. */
+"signed_in_as" = "SIGNED IN AS";
+
+/* Label indicating which account is not signed in. */
+"signed_out" = "Not Signed In";
+
+/* Siri shortcut phrase for increasing the sleep timer by a specified amount.*/
+"siri_shortcut_extend_sleep_timer_five_min" = "Extend sleep timer by 5 minutes";
+
+/* Siri shortcut title for increasing the sleep timer by a specified amount. '%1$@' is the placeholder for the time specified amount or time. */
+"siri_shortcut_extend_sleep_timer" = "Set sleep timer to %1$@";
+
+/* Siri shortcut title and phrase for having siri skip to the next chapter of a podcast */
+"siri_shortcut_next_chapter" = "Next chapter";
+
+/* Siri shortcut invocation phrase for opening a specified filter. '%1$@' is the placeholder for the specified filter. */
+"siri_shortcut_open_filter_phrase" = "Open %1$@";
+
+/* Siri shortcut title for pausing the current episode */
+"siri_shortcut_pause_title" = "Pause Current Episode";
+
+/* Siri shortcut invocation phrase for pausing the current episode */
+"siri_shortcut_pause_phrase" = "Pause";
+
+/* Siri shortcut title for playing all episodes of a particular filter */
+"siri_shortcut_play_all_title" = "Playing all episodes";
+
+/* Siri shortcut invocation phrase for playing all episodes of a particular filter. '%1$@' is a placeholder for the name of the filter to play from */
+"siri_shortcut_play_all_phrase" = "Play all %1$@";
+
+/* Siri shortcut title for playing the top episode of a particular podcast or filter */
+"siri_shortcut_play_episode_title" = "Playing the top episode";
+
+/* Siri shortcut invocation phrase for playing the specified filter. '%1$@' is a placeholder for the name of the filter to play from */
+"siri_shortcut_play_filter_phrase" = "Play top %1$@";
+
+/* Siri shortcut invocation phrase for playing the specified podcast. '%1$@' is a placeholder for the name of the podcast */
+"siri_shortcut_play_podcast_phrase" = "Play %1$@";
+
+/* Siri shortcut suggested title for playing a suggested podcast */
+"siri_shortcut_play_suggested_podcast_suggested_title" = "Surprise Me!";
+
+/* Siri shortcut title for playing a suggested podcast */
+"siri_shortcut_play_suggested_podcast_title" = "Playing a suggested episode";
+
+/* Siri shortcut phrase title for playing a suggested podcast */
+"siri_shortcut_play_suggested_podcast_phrase" = "Play a suggested episode";
+
+/* Siri shortcut title for playing the next episode in the queue */
+"siri_shortcut_play_up_next_title" = "Playing next episode";
+
+/* Siri shortcut invocation phrase for playing the next episode in the queue. */
+"siri_shortcut_play_up_next_phrase" = "Up Next";
+
+/* Siri shortcut title and phrase for having siri skip to the previous chapter of a podcast */
+"siri_shortcut_previous_chapter" = "Previous chapter";
+
+/* Siri shortcut title for resuming the current episode */
+"siri_shortcut_resume_title" = "Resuming Current Episode";
+
+/* Siri shortcut invocation phrase for resuming the current episode */
+"siri_shortcut_resume_phrase" = "Resume";
+
+/* Title for the siri shortcuts page to create a shortcut to a podcast */
+"siri_shortcut_to_podcast" = "Create Shortcut to Podcast";
+
+/* A common string used throughout the app. Prompt to rewind the playback by a configurable amount. */
+"skip_back" = "Skip Back";
+
+/* A common string used throughout the app. Prompt to fast-forward the playback by a configurable amount. */
+"skip_forward" = "Skip Forward";
+
+/* The Sleep Timer feature. */
+"sleep_timer" = "Sleep Timer";
+
+/* Prompt to add five minutes to an active timer. */
+"sleep_timer_add_5_mins" = "+ 5 Minutes";
+
+/* Prompt to cancel the active sleep timer. */
+"sleep_timer_cancel" = "Cancel Timer";
+
+/* Prompt to change the active sleep timer to be end of episode. */
+"sleep_timer_end_of_episode" = "End Of Episode";
+
+/* Accessibility hint that displays the remaining amount of time for the sleep timer. '%1$@' is a placeholder for the remaining time. */
+"sleep_timer_time_remaining" = "Sleep Timer on, %1$@ remaining";
+
+/* Prompt to confirm when presented with a connection prompt. Used when connecting to a Sonos speaker. */
+"sonos_connect_action" = "CONNECT";
+
+/* Prompt to connect to a Sonos speaker. 'Sonos' refers the the speaker manufacturer. */
+"sonos_connect_prompt" = "Connect To Sonos";
+
+/* Notice indicating that the app is attempting to make a connection to a Sonos device. 'Sonos' refers the the speaker manufacturer. */
+"sonos_connecting" = "CONNECTING...";
+
+/* Notice indicating that the app failed to make a connection to a Sonos device because the accounts weren't successfully linked. 'Sonos' refers the the speaker manufacturer. */
+"sonos_connection_failed_account_link" = "Unable to link Pocket Casts account at this time. Please try again later.";
+
+/* Notice indicating that the app failed to make a connection to a Sonos device because because it couldn't detect the Sonos App. 'Sonos' refers the the speaker manufacturer. */
+"sonos_connection_failed_app_missing" = "Unable to open Sonos app to complete linking process.";
+
+/* Notice indicating that the app failed to make a connection to a Sonos device. 'Sonos' refers the the speaker manufacturer. */
+"sonos_connection_failed_title" = "Linking Failed";
+
+/* Notice informing the users about what data will be provided to the Sonos speaker upon connection. 'Sonos' refers the the speaker manufacturer. */
+"sonos_connection_privacy_notice" = "Connecting to Sonos will allow the Sonos app to access your episode information.\n\nYour email address, password and other sensitive items are never shared.";
+
+/* Notice informing the users they need Pocket Casts account and need to sign in before connecting to the Sonos speaker. 'Sonos' refers the the speaker manufacturer. */
+"sonos_connection_sign_in_prompt" = "You need to have a Pocket Casts account before you can connect with Sonos.";
+
+/* A common string used throughout the app. Prompt for the sort option menus. */
+"sort_by" = "Sort By";
+
+/* A common string used throughout the app. Title accompanying the sort option setting. */
+"sort_episodes" = "Sort Episodes";
+
+/* A common string used throughout the app. Prompt to mark an episode(s) as favorited. */
+"star_episode" = "Star Episode";
+
+/* A common string used throughout the app. Prompt to mark an episode(s) as favorited. Similar to 'Star Episode' but more concise. */
+"star_episode_short" = "Star";
+
+/* Accessibility message for the cell displaying the time for how long they've listened to Pocket Casts. '%1$@' is a placeholder for how long they've listened and '%2$@' is a placeholder for a localized funny stat related to their listening history. */
+"stats_accessibility_listen_history_format" = "You've listened for %1$@. %2$@";
+
+/* Row header that displays the amount of time saved from Auto skipping episode parts. */
+"stats_auto_skip" = "Auto Skipping";
+
+/* Error message for when stats fail to load due to internet connection error. */
+"stats_error" = "Unable to load stats, check your Internet connection";
+
+/* Message informing the user how long they've been a user. '%1$@' is a placeholder for the date for when they created their account. */
+"stats_listen_history_format" = "Since %1$@ you’ve listened for";
+
+/* Loading message displayed while stats are being pulled. */
+"stats_listen_history_loading" = "You’ve listened for";
+
+/* Header for the cell displaying the time for how long they've listened to Pocket Casts. */
+"stats_listen_history_no_date" = "You’ve listened for";
+
+/* Row header that displays the amount of time saved from the Skip forward feature. */
+"stats_skipping" = "Skipping";
+
+/* Section header that breaks down how much listening time has been saved across a variety of features. */
+"stats_time_saved" = "TIME SAVED BY";
+
+/* A placeholder string for when the app fails to generate a time from the given inputs. */
+"stats_time_zero_seconds" = "0 seconds";
+
+/* A common string used throughout the app. Status header showing the totals for accumulated stat numbers. */
+"stats_total" = "Total";
+
+/* Row header that displays the amount of time saved from adjusting the Playback speed feature. */
+"stats_variable_speed" = "Variable Speed";
+
+/* A common string used throughout the app. Status message informing the user that the episode has been downloaded. */
+"status_downloaded" = "Downloaded";
+
+/* A common string used throughout the app. Status message informing the user that the episode is downloading. */
+"status_downloading" = "Downloading";
+
+/* A common string used throughout the app. Status message informing the user that the episode has not been downloaded. */
+"status_not_downloaded" = "Not Downloaded";
+
+/* A common string used throughout the app. Status message informing the user that the episode is currently not selected. Used with accessibility. */
+"status_not_selected" = "Not Selected";
+
+/* A common string used throughout the app. Status message informing the user that the episode has not been starred (favorited). */
+"status_not_starred" = "Not Starred";
+
+/* A common string used throughout the app. Status message informing the user that the episode has been played. */
+"status_played" = "Played";
+
+/* A common string used throughout the app. Status message informing the user that the episode is currently selected. Used with accessibility. */
+"status_selected" = "Selected";
+
+/* A common string used throughout the app. Status message informing the user that the episode has been starred (favorited). */
+"status_starred" = "Starred";
+
+/* A common string used throughout the app. Status message informing the user that the episode has not been played. */
+"status_unplayed" = "Unplayed";
+
+/* A common string used throughout the app. Status message informing the user that the episode has been uploaded. */
+"status_uploaded" = "Uploaded";
+
+/* A common string used throughout the app. Prompt to cancel the download for the selected item(s). */
+"stop_download" = "Stop Download";
+
+/* Prompt to subscribe to the selected podcast. */
+"subscribe" = "Subscribe";
+
+/* Label indicating that the user is currently subscribed to the selected podcast. */
+"subscribed" = "Subscribed";
+
+/* Prompt to subscribe to all of the selected podcast. */
+"subscribe_all" = "Subscribe All";
+
+/* Title for the subscription details page informing the users that the selected subscription has been canceled. */
+"subscription_cancelled" = "Subscription Cancelled";
+
+/* Message on the subscription details page informing the users when the canceled subscription will officially end. '%1$@' is a placeholder for the date in which the subscription expires. */
+"subscription_cancelled_msg" = "Subscription Cancelled %1$@ ";
+
+/* A common string used throughout the app. Thanks the user for their support. Used for paid feeds and Pocket Casts Plus. */
+"subscriptions_thank_you" = "Thanks for your support!";
+
+/* A label used to identify that a user is a supporter of the selected podcast. */
+"supporter" = "Supporter";
+
+/* Menu option to open details on available podcast supporter contribution options. */
+"supporter_contributions" = "Supporter Contributions";
+
+/* Subtitle to prompt the user to review their supports contribution details for more information. */
+"supporter_contributions_subtitle" = "Check contributions for details";
+
+/* Informational message informing the user that their recurring payments for supporter contributions have been canceled. */
+"supporter_payment_canceled" = "Supporter: Cancelled";
+
+/* Notice the sync failed due to an account error. */
+"sync_account_error" = "Check your username and password.";
+
+/* Sync status update notifying the user that the app is logged in. */
+"sync_account_login" = "Logged in...";
+
+/* A common string used throughout the app. Used to indicate that the sync process has failed. */
+"sync_failed" = "Sync failed";
+
+/* Notice that the app is syncing the up next and history for the account. */
+"sync_in_progress" = "Syncing Up Next and History";
+
+/* Progress message indicating the total number of podcasts being synced. '%1$@' serves as a placeholder for the current number of synced podcasts. '%2$@' serves as a placeholder for the total number of podcasts to sync. */
+"sync_progress" = "Podcast %1$@ of %2$@";
+
+/* Progress message indicating the total number of podcasts that have been synced. '%1$@' serves as a placeholder for the current number of synced podcasts, will be more than one. */
+"sync_progress_unknown_count_plural_format" = "Synced %1$@ podcasts";
+
+/* Progress message indicating the total number of podcasts that have been synced. Used in the singular case. */
+"sync_progress_unknown_count_singular" = "Synced 1 podcast";
+
+/* A common string used throughout the app. Used to indicate that the sync process in running. */
+"syncing" = "Syncing...";
+
+/* Prompt to allow the user to review the Terms of Use. */
+"terms_of_use" = "Terms of Use";
+
+/* Theme name for the Classic theme. */
+"theme_classic" = "Classic";
+
+/* Theme name for the Dark theme. */
+"theme_dark" = "Default Dark";
+
+/* Theme name for the Dark Contrast theme. */
+"theme_dark_contrast" = "Dark Contrast";
+
+/* Theme name for the Electricity theme. */
+"theme_electricity" = "Electricity";
+
+/* Theme name for the Extra Dark theme. */
+"theme_extra_dark" = "Extra Dark";
+
+/* Theme name for the Indigo theme. */
+"theme_indigo" = "Indigo";
+
+/* Theme name for the Light theme. */
+"theme_light" = "Default Light";
+
+/* Theme name for the Light Contrast theme. */
+"theme_light_contrast" = "Light Contrast";
+
+/* Theme name for the Radioactivity theme. */
+"theme_radioactivity" = "Radioactivity";
+
+/* Theme name for the Rosé theme. */
+"theme_rose" = "Rosé";
+
+/* Open ended time format describing either unknown or truly never */
+"time_format_never" = "never";
+
+/* A placeholder when time conversions fail. Sets the value to zero seconds */
+"time_placeholder" = "0 sec";
+
+/* A common string used throughout the app. Used to reference today. */
+"today" = "Today";
+
+/* A common string used throughout the app. Title option to place the item at the top of the queue. */
+"top" = "Top";
+
+/* Label indicating that the trial period for the subscription or promotion has ended. */
+"trial_finished" = "Trial Finished";
+
+/* A common string used throughout the app. Catch all prompt to suggest to the user to try the the task again. */
+"try_again" = "Try Again";
+
+/* A common string used throughout the app. Prompt to restore the selected item(s) from an archived state. */
+"unarchive" = "Unarchive";
+
+/* A common string used throughout the app. Used to reference an unknown duration '?' is an indicator that the amount of time isn't known and 'm' is a reference for minutes. */
+"unknown_duration" = "? m";
+
+/* A common string used throughout the app. Prompt to un-star the selected item (remove from favorited). */
+"unstar" = "Unstar";
+
+/* A common string used throughout the app. Prompt to unsubscribe from the selected podcast(s). */
+"unsubscribe" = "Unsubscribe";
+
+/* A common string used throughout the app. Prompt to unsubscribe from all of the selected podcast. */
+"unsubscribe_all" = "Unsubscribe All";
+
+/* A common string used throughout the app. Title for the prompt to display the queue of episodes to play next. */
+"up_next" = "Up Next";
+
+/* Heading shown when your Up Next list is empty */
+"up_next_empty_title" = "Nothing in Up Next";
+
+/* Description shown when your Up Next list is empty. Note that for non right to left languages "right" should be change to "left" (and translated) */
+"up_next_empty_description" = "You can queue episodes to play next by swiping right on episode rows, or tapping the icon on an episode card.";
+
+/* An alphabetical sort option for uploaded files. */
+"upload_sort_alpha" = "Title (A-Z)";
+
+/* A common string used throughout the app. Informs the user that the app is waiting for wifi to reconnect. */
+"wait_for_wifi" = "Waiting for WiFi";
+
+/* A common string used throughout the app. Used to reference the Watch as the playing source with in the Apple Watch App (Phone is the other option for this use case) */
+"watch" = "Watch";
+
+/* Indicates that the episode is being played is currently buffering to download more content for playback. */
+"watch_buffering" = "Buffering ...";
+
+/* Prompt in the Apple Watch App for the controls to move to the next chapter of the podcast. */
+"watch_chapter_next" = "Next Chapter";
+
+/* Prompt in the Apple Watch App for the controls to move to the previous chapter of the podcast. */
+"watch_chapter_prev" = "Prev Chapter";
+
+/* Title for the playback effects screen on the Apple Watch */
+"watch_effects" = "Effects";
+
+/* Prompt in the Apple Watch App to open episode details. */
+"watch_episode_details" = "Episode Details";
+
+/* Prompt in the Apple Watch app to return to the Main Menu */
+"watch_main_menu" = "Main Menu";
+
+/* Label in the Apple Watch app informing the user that they don't have any episodes in their selected list. */
+"watch_no_episodes" = "No Episodes";
+
+/* Label in the Apple Watch app informing the user that they haven't configured any of their filters. */
+"watch_no_filters" = "No Filters";
+
+/* Label in the Apple Watch app informing the user that they haven't subscribed to podcasts. */
+"watch_no_podcasts" = "No Podcasts";
+
+/* Title text used on the now playing screen in the Watch App. Indicates there is nothing palying or paused in the app. */
+"watch_nothing_playing_title" = "Nothing Playing";
+
+/* Subtitle text used on the now playing screen in the Watch App. Indicates there is nothing palying or paused in the app. Please leave the "\\n\\n" part in there, that's a new line indicator. */
+"watch_nothing_playing_subtitle" = "Enjoy the silence, or find something new to play.\n\nHonestly both are solid choices. 🙂";
+
+/* Information label providing a brief explanation of Pocket Casts Plus. */
+"watch_source_plus_info" = "Download direct to your watch and listen without your phone. Check out Pocket Casts Plus on your phone app, or on the web.";
+
+/* Message detailing where the audio will play from when selecting the source on the Apple Watch */
+"watch_source_msg" = "Podcasts will play from the speaker that the chosen device is connected to";
+
+/* Button that allows the user to manually trigger a refresh of their profile from the watch app. */
+"watch_source_refresh_account" = "Refresh Account";
+
+/* Information label accompanying the Refresh Account button. */
+"watch_source_refresh_account_info" = "If you have a Pocket Casts Plus account, refresh account to attempt to enable it";
+
+/* Button that allows the user to manually trigger a refresh of their data from the watch app. */
+"watch_source_refresh_data" = "Refresh Data";
+
+/* Information label informing users if they want to sign in to the Watch app they need to do that from the phone app. */
+"watch_source_sign_in_info" = "Sign in or create an account on your phone";
+
+/* Apple Watch complication prompt to tap the control to open the watch app. */
+"watch_tap_to_open" = "Tap to open";
+
+/* Title for the up next screen when a user has no episode queued up to play. */
+"watch_up_next_no_items_title" = "Nothing in Up Next";
+
+/* Subtitle for the up next screen when a user has no episode queued up to play. */
+"watch_up_next_no_items_subtitle" = "You can queue episodes to play next from the episode details screen, or adding them on your phone.";
+
+/* Text on the about page button to tell people's what's new in this version. %1$@ is placeholder for the version number, for example 7.1. */
+"whats_new_in_version" = "What's New In %1$@";
+
+/* Title for the announcement screen that calls out new features. */
+"whats_new" = "What's New";
+
+/* Widget prompt title to direct the user to the discover tab to add new podcasts to their queue */
+"widgets_discover_prompt_title" = "Ears hungry for more?";
+
+/* Widget prompt message to direct the user to the discover tab to add new podcasts to their queue */
+"widgets_discover_prompt_msg" = "Check out the Discover Tab";
+
+/* Widget label informing the user that nothing is currently being played. */
+"widgets_nothing_playing" = "Nothing Playing";
+
+/* Description for the now playing widget. */
+"widgets_now_playing_desc" = "Quickly access the currently playing episode.";
+
+/* Call to action for a tap on a widget to open the Discover tab. */
+"widgets_now_playing_tap_discover" = "Tap to Discover";
+
+/* Title of a widget that displays the app icon */
+"widgets_app_icon_name" = "Icon";
+
+/* Description of a widget to launch the app */
+"widgets_app_icon_description" = "Quickly Launch Pocket Casts";
+
+/* Up Next Lock Screen Widget description */
+"widgets_up_next_description" = "See the number of items in your Up Next queue or details about the next episode.";
+
+/* Basic string used in formats like 'price / year' */
+"year" = "year";
+
+/* Basic string used to callout payment intervals like yearly vs monthly */
+"yearly" = "Yearly";
+
+/* Label shown for minutes listened when it's singular, eg: 1 minute listened. */
+"minute_listened" = "Minute listened";
+
+/* Label shown for minutes saved when it's singular, eg: 1 minute saved. */
+"minute_saved" = "Minute saved";
+
+/* Label shown for hours listened when it's singular, eg: 1 hour listened. */
+"hour_listened" = "Hour listened";
+
+/* Label shown for hours saved when it's singular, eg: 1 hour saved. */
+"hour_saved" = "Hour saved";
+
+/* Label shown for days listened when it's singular, eg: 1 day listened. */
+"day_listened" = "Day listened";
+
+/* Label shown for days saved when it's singular, eg: 1 day saved. */
+"day_saved" = "Day saved";
+
+/* Label shown for seconds listened when it's plural, eg: 15 seconds listened. */
+"seconds_listened" = "Seconds listened";
+
+/* Label shown for seconds saved when it's plural, eg: 15 seconds saved. */
+"seconds_saved" = "Seconds saved";
+
+/* Label shown for minutes listened when it's plural, eg: 2 minutes listened. */
+"minutes_listened" = "Minutes listened";
+
+/* Label shown for minutes saved when it's plural, eg: 2 minutes saved. */
+"minutes_saved" = "Minutes saved";
+
+/* Label shown for hours listened when it's plural, eg: 1 hours listened. */
+"hours_listened" = "Hours listened";
+
+/* Label shown for hours saved when it's plural, eg: 1 hours saved. */
+"hours_saved" = "Hours saved";
+
+/* Label shown for days listened when it's singular, eg: 2 days listened. */
+"days_listened" = "Days listened";
+
+/* Label shown for days saved when it's singular, eg: 2 days saved. */
+"days_saved" = "Days saved";
+
+/* The heading shown for the Pocket Casts Newsletter */
+"pocket_casts_newsletter" = "Pocket Casts Newsletter";
+
+/* The description for the Pocket Casts Newsletter */
+"pocket_casts_newsletter_description" = "Receive news, app updates, themed playlists, interviews, and more.";
+
+/* The heading shown for the Pocket Casts Newsletter */
+"pocket_casts_welcome_newsletter_title" = "Get the Newsletter";
+
+/* Title for page one of the 7.20 what's new dialog. */
+"whats_new_page_one_title_7_20" = "Folders";
+
+/* What's new for 7.20 description for page one. Please leave the "\\n\\n" part in there, these are new line indicator. */
+"whats_new_page_one_7_20" = "If you love podcasts half as much as we do, you probably have a lot of them. If you're a Pocket Casts Plus subscriber, you can now sort these into folders and file them into neat groups.\n\nThanks to your support, your Home Screen has never looked better!";
+
+/* Title for page two of the 7.20 what's new dialog. */
+"whats_new_page_two_title_7_20" = "Home Grid Syncing";
+
+/* What's new for 7.20 description for page two. Please leave the "\\n\\n" part in there, these are new line indicator.*/
+"whats_new_page_two_7_20" = "We now sync your Home Screen (including your sort options) across devices! And you can drag and drop in the Web Player now as well.\n\nThis means you can rest easier, knowing the hard work you put in to arranging your podcasts page is being synced to your account.";
+
+/* Text for a link that goes to our blog where people can read more about the current update */
+"whats_new_blog_more_link_text" = "Read more about this update on our blog";
+
+/* Promotional information for Pocket Casts Plus. Please note that "Pocket Casts Plus" should not be translated because it's a product name */
+"plus_promo_paragraph" = "Get Pocket Casts Plus to unlock this feature, plus lots more!";
+
+/* Body of Plus promotional section
+ */
+"profile_help_support" = "Help support Pocket Casts by upgrading your account";
+
+/* Text for a button where you learn more about a feature */
+"learn_more" = "Learn More";
+
+/* Heading for things that require Pocket Casts Plus to work. Please note that "Pocket Casts Plus" should not be translated because it's a product name */
+"plus_required_feature" = "This feature requires Pocket Casts Plus";
+
+/* About page text to ask the user to rate our app in the App Store */
+"about_rate_us" = "Rate Us";
+
+/* About page text to ask the user to share a link to our app with friends */
+"about_share_friends" = "Share With Friends";
+
+/* Button that takes people to our website */
+"about_website" = "Website";
+
+/* Button that takes you to other Automattic apps, eg: our Automattic family of apps */
+"about_a8c_family" = "Automattic Family";
+
+/* Main callout to come get a job with Automattic */
+"about_work_with_us" = "Work With Us";
+
+/* Secondary text on our come with with us call out */
+"about_join_from_anywhere" = "Join From Anywhere";
+
+/* Button that takes the user to legal and more screen */
+"about_legal_and_more" = "Legal and More";
+
+/* Button that takes the user to terms of service screen */
+"about_terms_of_service" = "Terms of service";
+
+/* Button that takes the user to privacy policy screen */
+"about_privacy_policy" = "Privacy Policy";
+
+/* Button that takes the user to the Acknowledgements screen */
+"about_acknowledgements" = "Acknowledgements";
+
+/* Text sent when sharing a link to our app with other people */
+"app_share_text" = "Hey! Here is a link to download the Pocket Casts app. I'm really enjoying it and thought you might too.";
+
+/* Email change form current email label */
+"current_email_prompt" = "Current Email";
+
+/* Email change form new email address field prompt */
+"new_email_address_prompt" = "New Email Address";
+
+/* Password change form new password field prompt */
+"new_password_prompt" = "New Password";
+
+/* Password change form confirm new password field prompt */
+"confirm_new_password_prompt" = "Confirm New Password";
+
+/* Password change form current password field prompt */
+"current_password_prompt" = "Current Password";
+
+/* Voiceover label for creating a new folder */
+"folder_create_new" = "Create New Folder";
+
+/* Title for the create folder page */
+"folder_create" = "Create Folder";
+
+/* Label for the button to create a new folder */
+"folder_new" = "New Folder";
+
+/* A common string used throughout the app. Informs the user how many podcasts have been chosen. This is the singular format for an accompanying plural option. */
+"folder_add_podcasts_singular" = "Add 1 Podcast";
+
+/* A common string used throughout the app. Informs the user how many podcasts are being added. '%1$@' is a placeholder for the number of podcasts, this will be more than one. */
+"folder_add_podcasts_plural_format" = "Add %1$@ Podcasts";
+
+/* Title for the folder name page*/
+"folder_name_title" = "Name your folder";
+
+/* Placeholder text in the field asking you to name a folder */
+"folder_name" = "Folder name";
+
+/* Text shown on button to remove a podcast from a folder */
+"folder_remove_from" = "Remove from folder";
+
+/* Text shown on button to change the folder a podcast is in */
+"folder_change" = "Change folder";
+
+/* Text shown on button to go to the folder a podcast is in */
+"folder_go_to" = "Go to folder";
+
+/* Common word used as a title when asking the user to name something */
+"name" = "Name";
+
+/* Common word used as in the app to denote a folder of items */
+"folder" = "Folder";
+
+/* Common word used as in the app to denote the folders feature */
+"folders" = "Folders";
+
+/* Common word, the color of something */
+"color" = "Color";
+
+/* Reason shown below a color picker for folders */
+"folder_color_detail" = "Makes it easier to find folders";
+
+/* Common word to denote a preview of something is being shown */
+"preview" = "Preview";
+
+/* Common word used to denote editting something */
+"edit" = "Edit";
+
+/* Shown on a button to save the folder */
+"folder_save_folder" = "Save Folder";
+
+/* Prompt to choose a folder color */
+"folder_choose_color" = "Choose a color";
+
+/* Label for the option that lets you edit a folder */
+"folder_edit" = "Edit Folder";
+
+/* Label for the option to add and remove podcasts from a folder */
+"folder_add_remove_podcasts" = "Add or Remove Podcasts";
+
+/* Label for the delete folder button */
+"folder_delete" = "Delete Folder";
+
+/* Confirmation prompt title after you try to delete a folder */
+"folder_delete_prompt_title" = "Are You Sure?";
+
+/* Confirmation prompt message after you try to delete a folder */
+"folder_delete_prompt_msg" = "This folder will be deleted, and its contents will be moved back to the Podcasts screen.";
+
+/* Title for the page where you select which podcasts are in a folder */
+"folder_choose_podcasts" = "Choose Podcasts";
+
+/* Title for the page where you select which folder a podcast is in */
+"folder_podcast_choose_folder" = "Choose Folder";
+
+/* Title shown for podcasts that aren't in a folder */
+"folder_no_folder" = "No Folder";
+
+/* Name shown for folders that don't have names */
+"folder_unnamed" = "Unnamed Folder";
+
+/* Label used when a podcast releases hourly episodes */
+"release_frequency_hourly" = "Hourly";
+
+/* Label used when a podcast releases daily episodes */
+"release_frequency_daily" = "Daily";
+
+/* Label used when a podcast releases episodes every week */
+"release_frequency_weekly" = "Weekly";
+
+/* Label used when a podcast releases episodes every two weeks */
+"release_frequency_fortnightly" = "Fortnightly";
+
+/* Label used when a podcast releases episodes every month */
+"release_frequency_monthly" = "Monthly";
+
+/* Title shown in an empty folder */
+"folder_empty_title" = "Your folder is empty";
+
+/* Description shown under the title of an empty folder */
+"folder_empty_description" = "Add podcasts to your folder and they’ll appear here.";
+
+/* Upsell dialog title label when a free trial is active, %1$@ refers to the duration of the trial (1 month) */
+"free_trial_title_label" = "Try Plus with %1$@ free";
+
+/* Upsell dialog free trial detail label that informs the user that they no payment is needed, and can cancel at anytime */
+"free_trial_detail_label" = "No Payment Now – Cancel Anytime";
+
+/* Upsell dialog confirmation button title when a free trial is active */
+"free_trial_start_button" = "Start Free Trial";
+
+/* Free trial terms where %1$@ refers to the trial duration (30 days) and %2$@ is the price after the trial ($0.99 / month) */
+"free_trial_pricing_terms" = "%1$@ free then %2$@";
+
+/* Free trial duration with the word free emphasized, %1$@ is the localize trial duration (1 month) */
+"free_trial_duration_free" = "%1$@ FREE";
+
+/* Pricing terms explaining how much will be charged after a free trial ends, %1$@ is the price ($0.99 / month) */
+"pricing_terms_after_trial" = "then %1$@";
+
+/* Free trial duration with the word free trial emphasized, %1$@ is the localized trial duration (1 month) */
+"free_trial_duration_free_trial" = "%1$@ FREE TRIAL";
+
+/* Title for a button that allows the user to subscrbe with a free trial */
+"free_trial_start_and_subscribe_button" = "Start Free Trial & Subscribe";
+
+/* Pricing terms explaining that the user will be charged after their free trial ends, %1$@ is the free trial duration (1 month), \n is a new line */
+"pricing_terms_after_trial_long" = "Recurring payments will begin after your\n%1$@ free trial";
+
+/* Monthly pricing format, %1$@ is the price */
+"plus_monthly_frequency_pricing_format" = "%1$@ per month";
+
+/* Yearly pricing format, %1$@ is the price */
+"plus_yearly_frequency_pricing_format" = "%1$@ per year";
+
+/* Payment failed error message */
+"plus_purchase_failed" = "It looks like there was a problem processing your payment. Please try again.";
+
+/* The title of the purchase promo */
+"plus_purchase_promo_title" = "Become a Plus member and unlock all Pocket Casts features";
+
+/* The purchase agreement terms, the %1$@, %3$@ are the opening of a HTML link tag (<a href="">), %2$@ and %4$@ are closing tags (</a>) */
+"purchase_terms" = "By continuing, you agree to %1$@Privacy Policy%2$@ and %3$@Terms and Conditions%4$@";
+
+/* Title for the End of Year feature */
+"eoy_title" = "Your Year in Podcasts";
+
+/* A smaller title for the End of Year feature */
+"eoy_small_title" = "Year in Podcasts";
+
+/* A description of the End of Year feature */
+"eoy_description" = "See your top podcasts, categories, listening stats, and more. Share with friends and shout out your favorite creators!";
+
+/* Label of the End of Year call to action button */
+"eoy_view_year" = "View My 2022";
+
+/* Label of the End of Year dismiss button */
+"eoy_not_now" = "Not Now";
+
+/* End of Year card description that appears under Profile */
+"eoy_card_description" = "See your top podcasts, categories, listening stats and more.";
+
+/* Description that appears on the first story of the 2022 Pocket Casts wrap up (End of Year) */
+"eoy_story_intro_title" = "Let's celebrate your year of listening...";
+
+/* String telling the user how much time they listened to podcasts in 2022, %1$@ is a placeholder for the amount of time. */
+"eoy_story_listened_to" = "In 2022, you spent %1$@ listening to podcasts";
+
+/* String telling the user how much time they listened to podcasts in 2022, %1$@ is a placeholder for the amount of time. */
+"eoy_story_listened_to_updated" = "This year, you spent %1$@ listening to podcasts";
+
+/* Text that appears when someone shares the listened to story to Twitter, for example. %1$@ is a placeholder for the amount of time. */
+"eoy_story_listened_to_share_text" = "I spent %1$@ listening to podcasts in 2022";
+
+/* String telling the user how much podcast categories they listened to podcasts in 2022, %1$@ is a placeholder a segment of text that contains the number of categories . */
+"eoy_story_listened_to_categories" = "You listened to %1$@ different categories this year";
+
+/* String telling the user how much podcast categories they listened to podcasts in 2022, %1$@ is a placeholder a segment of text that contains the number of categories . */
+"eoy_story_listened_to_categories_highlighted" = "You listened to %1$@ this year";
+
+/* String telling the user how much podcast categories they listened to podcasts in 2022, %1$@ is a placeholder for the number of different categories. */
+"eoy_story_listened_to_categories_text" = "%1$@ different categories";
+
+/* String prompting the user for the next story to check the most listened categories. */
+"eoy_story_listened_to_categories_subtitle" = "Let's take a look at some of your favorites...";
+
+/* Text that appears when someone shares the listened categories to story to Twitter, for example. %1$@ is a placeholder for the number of categories. */
+"eoy_story_listened_to_categories_share_text" = "I listened to %1$@ different categories in 2022";
+
+/* String telling the user how many podcasts and episodes they listened to this year, %1$@ is a placeholder for the number of podcasts and %2$@ is a placeholder for the number of episodes. */
+"eoy_story_listened_to_numbers" = "You listened to %1$@ different podcasts and %2$@ episodes";
+
+/* String telling the user how many podcasts and episodes they listened to this year, %1$@ is a placeholder for the number of podcasts and %2$@ is a placeholder for the number of episodes. */
+"eoy_story_listened_to_numbers_updated" = "You listened to %1$@ and %2$@";
+
+/* String telling the user how many podcasts they listened to this year, %1$@ is a placeholder for the number of podcasts*/
+"eoy_story_listened_to_podcast_text" = "%1$@ different podcasts";
+
+/* String telling the user how many episodes they listened to this year, %1$@ is a placeholder for the number number of episodes. */
+"eoy_story_listened_to_episodes_text" = "%1$@ episodes";
+
+/* Subtitle for the story containing number of podcasts and episodes played this year. Segway for the next story. */
+"eoy_story_listened_to_numbers_subtitle" = "But there was one that you kept coming back to...";
+
+/* Subtitle for the story containing number of podcasts and episodes played this year. Segway for the next story. */
+"eoy_story_listened_to_numbers_subtitle_updated" = "But there was one that you\nkept coming back to...";
+
+/* Text that appear when someone share the listened numbers story to Twitter. %1$@ is a placeholder for the number of podcasts listened and %2$@ for the number of episodes. */
+"eoy_story_listened_to_numbers_share_text" = "I listened to %1$@ different podcasts and %2$@ episodes in 2022";
+
+/* Title for the story that display the most listened podcast by the user this year. %1$@ is a placeholder for the podcast title and %2$@ is a placeholder for the author. */
+"eoy_story_top_podcast" = "Your top podcast was %1$@ by %2$@";
+
+/* Subtitle for the story that display the most listened podcast by the user this year. %1$@ is a placeholder for the number of episodes and %2$@ is a placeholder for the listened time. */
+"eoy_story_top_podcast_subtitle" = "You listened to %1$@ episodes for a total of %2$@";
+
+/* Text that appear when someone share the top podcast of the year story to Twitter. %1$@ is the URL to the podcast. */
+"eoy_story_top_podcast_share_text" = "My favorite podcast of 2022! %1$@";
+
+/* Title for the story showing the top podcasts for the user in the current year. */
+"eoy_story_top_podcasts" = "Your Top Podcasts";
+
+/* Text that appear when someone share the top 5 podcasts of the year story to Twitter. %1$@ is a link to the list of the top podcasts. */
+"eoy_story_top_podcasts_share_text" = "My top podcasts of the year! %1$@";
+
+/* Title of a list of podcasts created containing the user's top 5 podcasts of 2022. */
+"eoy_story_top_podcasts_list_title" = "My top podcasts of 2022";
+
+/* Title for the story showing the longest episode listened for the user in the current year. %1$@ is a placeholder for the episode title and %2$@ is a placeholder for the podcast title. */
+"eoy_story_longest_episode" = "The longest episode you listened to was %1$@ from the podcast %2$@";
+
+/* Title for the story showing the longest episode listened for the user in the current year. %1$@ is a placeholder for the duration of the episode. */
+"eoy_story_longest_episode_time" = "The longest episode\nyou listened to was\n%1$@";
+
+/* Title for the story showing the longest episode listened for the user in the current year. %1$@ is a placeholder for the title of the podcast for the longest episode. */
+"eoy_story_longest_episode_subtitle" = "The episode was %1$@ from %2$@";
+
+/* Subtitle for the story showing the longest episode listened for the user in the current year. %1$@ is a placeholder for the episode length. */
+"eoy_story_longest_episode_duration" = "This episode was %1$@ long";
+
+/* Text that appear when someone share the longest episode they listened to story to Twitter. %1$@ is the URL to the episode. */
+"eoy_story_longest_episode_share_text" = "The longest episode I listened to in 2022 %1$@";
+
+/* Title for the epilogue story */
+"eoy_story_epilogue_title" = "Thank you for letting Pocket Casts be a part of your listening experience in 2022";
+
+/* Subtitle for the epilogue story */
+"eoy_story_epilogue_subtitle" = "Don't forget to share with your friends and give a shout out to your favorite podcast creators";
+
+/* Label for the replay button, which when tapped started the end of year stories from the first one. */
+"eoy_story_replay" = "Replay";
+
+/* Title of the top categories story. */
+"eoy_story_top_categories" = "Your Top Categories";
+
+/* Text that appear when someone share the top categories story to Twitter. */
+"eoy_story_top_categories_share_text" = "My most listened to podcast categories";
+
+/* Description to why the user needs to create an account to see their end of year stats. */
+"eoy_create_account_to_see" = "Save your podcasts in the cloud, get your end of year review and sync your progress with other devices.";
+
+/* When loading the End of Year stats stories fails. */
+"eoy_stories_failed" = "Failed to load stories.";
+
+/* Title of the view displayed after a user successfully upgrades to plus */
+"welcome_plus_title" = "Thank you, now let's get you listening!";
+
+/* Title of the view displayed after a user successfully creates an account */
+"welcome_new_account_title" = "Welcome, now let's get you listening!";
+
+/* Title of a section informing the user they can import their podcasts from another app */
+"welcome_import_title" = "Import your podcasts";
+
+/* Description of a section informing the user they can import their podcasts from another app */
+"welcome_import_description" = "Coming from another app? Bring your podcasts with you.";
+
+/* Title of a button prompting the user to import their podcasts */
+"welcome_import_button" = "Import Podcasts";
+
+/* Title of a section informing the user they can find new podcasts in the discover section */
+"welcome_discover_title" = "Discover something new";
+
+/* Description of a section informing the user they can find new podcasts in the discover section */
+"welcome_discover_description" = "Find under-the-radar and trending podcasts in our hand-curated Discover page.";
+
+/* Title of a button prompting the user find new podcasts in discover */
+"welcome_discover_button" = "Find My Next Podcast";
+
+/* Label that informs the user they have a free account */
+"account_details_free_account" = "Free Account";
+
+/* Label that shows the user how much time they have listened to podcasts for, %1$@ is the localized formatted time, ie: 2 hours */
+"account_details_listened_for" = "Listened for %1$@";
+
+/* Marketing text that promotes the plus feature to the user */
+"account_details_plus_title" = "Take your podcasting experience to the next level with exclusive access to features and customisation options.";
+
+/* Body of a message informing the user the request failed */
+"plus_upgrade_no_internet_title" = "Unable to Load";
+
+/* Body of a message informing the user they need an internet connect to upgrade to plus */
+"plus_upgrade_no_internet_message" = "Please check your internet connection and try again.";
+
+/* Step by Step instructions on how to import from the app Overcast. \n are new lines and Overcast is a proper noun and should not be translated. */
+"import_instructions_overcast" = "1. Tap the button below to open Overcast\n2. Tap the Cog icon in the top corner of the app\n3. Swipe down until you see Export OPML, then tap on it\n4. When the dialog opens locate the Pocket Casts icon, and tap on it";
+
+/* Step by Step instructions on how to import from the app Breaker. \n are new lines and Breaker is a proper noun and should not be translated. */
+"import_instructions_breaker" = "1. Tap the Open Breaker button below\n2. Tap on Settings in the bottom tab bar\n3. Tap on Connection\n4. Tap on Export subscriptions\n5. When the dialog opens locate the Pocket Casts icon, and tap on it";
+
+/* Step by Step instructions on how to import from the app Castro. \n are new lines and Castro is a proper noun and should not be translated. */
+"import_instructions_castro" = "1. Tap the Open Castro button below\n2. Tap the Cog icon in the top corner of the app\n3. Swipe down until you see the User Data option, then tap on it\n4. Tap the Export Subscriptions item\n5. When the share dialog opens, locate the Pocket Casts icon, then tap on it";
+
+/* Step by Step instructions on how to import from the app Castbox. \n are new lines and Castbox is a proper noun and should not be translated. */
+"import_instructions_castbox" = "1. Tap the Open Castbox button below\n2. Tap the Personal tab\n3. Swipe down until you see the Settings option, then tap on it\n4. Swipe down until you see the OPML Export option, then tap on it\n5. If prompted, tap \"Open in Pocket Casts\"\n6. If the file opens in Safari, tap the Download button\n7. Once the download is complete, tap the download icon in the URL bar\n8. Tap the Downloads item\n9. Tap the castbox_opml file \n10. If needed, tap the Share icon, then open the file using Pocket Casts\n11. When the share dialog opens, locate the Pocket Casts icon, then tap on it";
+
+/* Step by Step instructions on how to import from the app Apple Podcasts. \n are new lines and Apple Podcasts is a proper noun and should not be translated. */
+"import_instructions_apple_podcasts_steps" = "We can import your podcasts from Apple Podcasts by using the built-in Shortcuts app.\nNote: If you previously deleted the shortcuts app you will be prompted to reinstall it.\n\n1. Tap the Install Shortcut button below.\n2. When prompted tap the Add Shortcut button.\n3. Tap on the Shortcuts tab.\n4. Locate the \"Apple Podcasts to Pocket Casts\" shortcut in the list.\n5. Tap it to start the import process.\n6. Once the shortcut is done running Pocket Casts will reopen and finish the import process.";
+
+/* Title of an option to import from other apps */
+"import_instructions_other_apps_title" = "other apps";
+
+/* Button title to install a shortcut */
+"import_instructions_install_shortcut" = "Install Shortcut";
+
+/* Button title to open the given app name,  %1$@ is the name of the app */
+"import_instructions_open_in" = "Open %1$@";
+
+/* Button title to import from the given app name,  %1$@ is the name of the app */
+"import_instructions_import_from" = "Import from %1$@";
+
+/* Title of a view promoting the import feature */
+"import_title" = "Bring your\npodcasts with you";
+
+/* Title of a view explaining the import feature */
+"import_subtitle" = "Coming from another app? Import your podcasts and get listening. You can always do this later in settings.";
+
+/* Title of the login marketing view */
+"login_title" = "Discover your next favorite podcast";
+
+/* Subtitle of the login marketing view */
+"login_subtitle" = "Create an account to sync your listening experience across all your devices.";
+
+/* Title of the plus marketing view */
+"plus_marketing_title" = "Everything you love about Pocket Casts, plus more";
+
+/* Subtitle of the plus marketing view */
+"plus_marketing_subtitle" = "Get access to exclusive features and customisation options";
+
+/* Title of the button that informs the user they can unlock all the features in plus */
+"plus_button_title_unlock_all" = "Unlock All Features";
+
+/* Title of a label informing the user they can cancel their subscription at any time */
+"plus_cancel_terms" = "Can be canceled at any time";
+
+/* Sub title of a view that informs the user what will happen if they cancel their subscription */
+"cancel_confirm_subtitle" = "This will change your plan to a free account.";
+
+/* Title of a list item that informs the user the date their subscription will expire. %1$@ is the date of expiriation */
+"cancel_confirm_sub_expiry" = "Your current subscription will remain active until %1$@.";
+
+/* Item that appears in place of the user's missing expiration date if it's not available. */
+"cancel_confirm_sub_expiry_date_fallback" = "your expiration date";
+
+/* Title of a list item that informs the user their plus features will be locked if they cancel */
+"cancel_confirm_item_plus" = "Access to Pocket Casts Plus features will be locked after this date.";
+
+/* Title of a list item that informs the user their folders will be removed if they cancel */
+"cancel_confirm_item_folders" = "Your folders will be removed and their contents will move back to the Podcasts screen.";
+
+/* Title of a list item that informs the user uploaded files will be removed if they cancel */
+"cancel_confirm_item_uploads" = "All files uploaded to your Pocket Casts account will be deleted (but downloaded files on your mobile devices will remain)";
+
+/* Title of a list item that informs the user they will no longer be able to access plus on the web if they cancel */
+"cancel_confirm_item_web_player" =  "You will no longer be able to access Pocket Casts using your web browser, or desktop computer.";
+
+/* Button title that lets the user stop the cancellation process */
+"cancel_confirm_stay_button_title" =  "Actually, I want to stay";
+
+/* Button title that lets the user contine the cancellation process */
+"cancel_confirm_cancel_button_title" =  "Yes, Cancel my Subscription";
+
+/* Label of a button that lets the user login/signup with Apple */
+"social_sign_in_continue_with_apple" = "Continue with Apple";
+
+/* Label of a button that lets the user login/signup with Google */
+"social_sign_in_continue_with_google" = "Continue with Google";


### PR DESCRIPTION
Add Catalan:

* To the app
* To the release tooling

## To test

1. Go Schemes > pocketcasts > Options > change "App Language" to "Catalan"
2. Run the app
3. ✅ Check that strings are in Catalan

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
