### PR TITLE
Onboarding: fix retain cycle

### DIFF
--- a/podcasts/Onboarding/Plus/PlusLandingViewModel.swift
+++ b/podcasts/Onboarding/Plus/PlusLandingViewModel.swift
@@ -3,7 +3,7 @@ import PocketCastsServer
 import SwiftUI
 
 class PlusLandingViewModel: PlusPricingInfoModel, OnboardingModel {
-    var navigationController: UINavigationController? = nil
+    weak var navigationController: UINavigationController? = nil
 
     var continueUpgrade: Bool
     let source: Source

--- a/podcasts/Onboarding/Welcome/WelcomeViewModel.swift
+++ b/podcasts/Onboarding/Welcome/WelcomeViewModel.swift
@@ -3,7 +3,7 @@ import SwiftUI
 import PocketCastsServer
 
 class WelcomeViewModel: ObservableObject, OnboardingModel {
-    var navigationController: UINavigationController?
+    weak var navigationController: UINavigationController?
     let displayType: DisplayType
     let sections: [WelcomeSection] = [.importPodcasts, .discover]
 


### PR DESCRIPTION
| 📘 Project: #381 |
|:---:|

Fixes a retain cycle that was making `PlusLandingViewModel`, `PlusHostingViewController`, and `WelcomeViewModel` not deallocated.

## To test

1. Run a clean install of the app
2. Open Instruments > Allocations
3. Select the running instance of Pocket Casts
4. At the bottom, on the filter, add: `SyncSignInViewController` `PlusLandingViewModel` `NewEmailViewController` `PlusHostingViewController` `WelcomeViewModel` (they need to be added one by one, unfortunately)
5. Go through the whole Sign Up flow
6. After finishing it, check that no one of the filtered entities was left allocated ¶

¶ There's a SwiftUI observable that doesn't seem to go away. However, it's just a Bool so it's not a big issue and I think it's ok to leave it as it is for now.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
