### PR TITLE
Adds exception handling to the replace_secrets.rb and provides a helpful resolution message

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -7279,6 +7279,7 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\n$SRCROOT/scripts/build-phases/generate-credentials.sh\n";
+			showEnvVarsInLog = 0;
 		};
 		462F3AA2274EB4C3005FEB1F /* L10n */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/podcasts/Credentials/replace_secrets.rb
+++ b/podcasts/Credentials/replace_secrets.rb
@@ -62,7 +62,7 @@ def process(template_path, secrets_path)
     end
     template.close
   rescue => exception
-    STDERR.puts("\n🚨🚨 Failed to generate the ApiCredentials file. 🚨🚨")
+    STDERR.puts("\n🚨🚨 Failed to generate credentials file from template: " + File.basename(template_path) +  " 🚨🚨")
     STDERR.puts("\n-> Exception: " + exception.message)
     STDERR.puts("-> Reason: Secrets are most likely out of date.")
     STDERR.puts("-> Solution: Run: bundle exec fastlane run configure_apply\n\n")

--- a/podcasts/Credentials/replace_secrets.rb
+++ b/podcasts/Credentials/replace_secrets.rb
@@ -56,9 +56,7 @@ def process(template_path, secrets_path)
   secrets = load(secrets_path)
   template = File.open(template_path, 'r')
 
-  template.each_line do |line|
-    puts line % secrets
-  end
+  template.each_line { |line| puts line % secrets }
   template.close
 rescue StandardError => e
   warn("\n🚨🚨 Failed to generate credentials file from template: #{File.basename(template_path)} 🚨🚨")

--- a/podcasts/Credentials/replace_secrets.rb
+++ b/podcasts/Credentials/replace_secrets.rb
@@ -53,14 +53,21 @@ end
 ## located at a given path.
 ##
 def process(template_path, secrets_path)
-  secrets = load(secrets_path)
-  template = File.open(template_path, 'r')
+  begin
+    secrets = load(secrets_path)
+    template = File.open(template_path, 'r')
 
-  template.each_line do |line|
-    puts line % secrets
+    template.each_line do |line|
+      puts line % secrets
+    end
+    template.close
+  rescue => exception
+    STDERR.puts("\n🚨🚨 Failed to generate the ApiCredentials file. 🚨🚨")
+    STDERR.puts("\n-> Exception: " + exception.message)
+    STDERR.puts("-> Reason: Secrets are most likely out of date.")
+    STDERR.puts("-> Solution: Run: bundle exec fastlane run configure_apply\n\n")
+    exit(false)
   end
-
-  template.close
 end
 
 ## Main!

--- a/podcasts/Credentials/replace_secrets.rb
+++ b/podcasts/Credentials/replace_secrets.rb
@@ -53,21 +53,19 @@ end
 ## located at a given path.
 ##
 def process(template_path, secrets_path)
-  begin
-    secrets = load(secrets_path)
-    template = File.open(template_path, 'r')
+  secrets = load(secrets_path)
+  template = File.open(template_path, 'r')
 
-    template.each_line do |line|
-      puts line % secrets
-    end
-    template.close
-  rescue => exception
-    STDERR.puts("\n🚨🚨 Failed to generate credentials file from template: " + File.basename(template_path) +  " 🚨🚨")
-    STDERR.puts("\n-> Exception: " + exception.message)
-    STDERR.puts("-> Reason: Secrets are most likely out of date.")
-    STDERR.puts("-> Solution: Run: bundle exec fastlane run configure_apply\n\n")
-    exit(false)
+  template.each_line do |line|
+    puts line % secrets
   end
+  template.close
+rescue StandardError => e
+  warn("\n🚨🚨 Failed to generate credentials file from template: #{File.basename(template_path)} 🚨🚨")
+  warn("\n-> Exception: #{e.message}")
+  warn('-> Reason: Secrets are most likely out of date.')
+  warn("-> Solution: Run: bundle exec fastlane run configure_apply\n\n")
+  exit(false)
 end
 
 ## Main!


### PR DESCRIPTION
This adds some additional messaging when `replace_secrets.rb` fails to generate, and provides a resolution message.

This also disables showing all the environment variables when the script is ran.

## Screenshots

### Before
<img width="1322" alt="Screen Shot 2023-02-06 at 10 51 29 AM" src="https://user-images.githubusercontent.com/793774/217018911-9dfc963f-767a-47fa-8cbb-9ad9512fe676.png">

### After
<img width="1253" alt="Screen Shot 2023-02-06 at 10 50 40 AM" src="https://user-images.githubusercontent.com/793774/217018726-8fa4681b-3910-4bce-b8cf-effb3d8b8e87.png">


## To test

1. In Xcode open `ApiCredentials.tpl`
2. Add a line like: `static let test = "%{test_key}"` to the bottom
3. Open ApiCredentials.swift
4. Right Click it and Show it in Finder
5. Delete it
6. Run the build again, it should fail
7. View the build details and locate the PreBuildActions step
8. Click the ☰ icon to show the error details
9. ✅ Verify you see the more detailed failure message

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
