### PR TITLE
Onboarding: do not push user to Plus view if they didn't signed in

### DIFF
--- a/podcasts/Onboarding/LoginCoordinator.swift
+++ b/podcasts/Onboarding/LoginCoordinator.swift
@@ -154,6 +154,12 @@ extension LoginCoordinator: SyncSigninDelegate, CreateAccountDelegate {
      }
 
     func signingProcessCompleted() {
+        // Due to connection issues this might be called even if the user didn't actually
+        // signed in. So we make sure the user is actually logged in.
+        guard SyncManager.isUserLoggedIn() else {
+            return
+        }
+
         let shouldDismiss = OnboardingFlow.shared.currentFlow.shouldDismiss || (SubscriptionHelper.hasActiveSubscription() && !presentedFromUpgrade)
 
         if shouldDismiss {


### PR DESCRIPTION
We have a specific case in which the Plus view was being pushed even if the user didn't log in, this PR fixes it.

## To test

1. Before testing, go to `RefreshManager` and change `forceEvenIfRefreshedRecently` to `true` and set `minTimeBetweenRefreshes` to `1.second`
2. Disable your Wi-Fi
3. Run the app
4. Open the onboarding flow, tap Login
5. Put the app on background (swipe up)
6. Open the app again
7. ✅ Nothing should happen
8. Turn Wi-Fi on
9. Either login or create a new account
10. Plus view should be shown


## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
