### PR TITLE
Update the Buildkite CI image to Xcode 14.2

### DIFF
--- a/.buildkite/cache_builder.yml
+++ b/.buildkite/cache_builder.yml
@@ -26,7 +26,7 @@ steps:
     agents:
       queue: mac
     env:
-      IMAGE_ID: xcode-14
+      IMAGE_ID: xcode-14.2
 
   # Because this repo is large (~2m 20s to checkout), we periodically create a
   # Git Mirror and copy it to S3, from where it can be fetched by agents more

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,7 +9,7 @@ common_params:
   # Common environment values to use with the `env` key.
   - &common_env
     # If you update the image to a newer Xcode version, don't forget to also update the badge in the README.md file accordingly for consistency
-    IMAGE_ID: xcode-14
+    IMAGE_ID: xcode-14.2
   # Common agents values to use with the `agents` key.
   - &common_agents
     queue: mac

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -10,7 +10,7 @@ common_params:
         repo: "automattic/pocket-casts-ios/"
   # Common environment values to use with the `env` key.
   - &common_env
-    IMAGE_ID: xcode-14
+    IMAGE_ID: xcode-14.2
 
 steps:
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
     <a href="https://buildkite.com/automattic/pocket-casts-ios"><img src="https://badge.buildkite.com/6c995de3d1584006341cc4dfda1312619f375385f5c0319dfe.svg?branch=trunk" /></a>
     <a href="https://github.com/Automattic/pocket-casts-ios/blob/trunk/LICENSE.md"><img src="https://img.shields.io/badge/license-MPL-black" /></a>
     <img src="https://img.shields.io/badge/platform-ios%20%7C%20watchos-lightgrey" />
-    <img src="https://img.shields.io/badge/Xcode-v14.0%2B-informational" />
+    <img src="https://img.shields.io/badge/Xcode-v14.2%2B-informational" />
 </p>
 
 <p align="center">


### PR DESCRIPTION
This PR updates the Buildkite image from `xcode-14` to `xcode-14.2`. 

### Testing
If CI passes, these changes are good to go. 👍

## Checklist

- [X] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [X] I have considered adding unit tests for my changes.
- [X] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
