### PR TITLE
Run RuboCop with autocorrect on top of #693

### DIFF
--- a/podcasts/Credentials/replace_secrets.rb
+++ b/podcasts/Credentials/replace_secrets.rb
@@ -56,9 +56,7 @@ def process(template_path, secrets_path)
   secrets = load(secrets_path)
   template = File.open(template_path, 'r')
 
-  template.each_line do |line|
-    puts line % secrets
-  end
+  template.each_line { |line| puts line % secrets }
   template.close
 rescue StandardError => e
   warn("\n🚨🚨 Failed to generate credentials file from template: #{File.basename(template_path)} 🚨🚨")

--- a/podcasts/Credentials/replace_secrets.rb
+++ b/podcasts/Credentials/replace_secrets.rb
@@ -53,21 +53,19 @@ end
 ## located at a given path.
 ##
 def process(template_path, secrets_path)
-  begin
-    secrets = load(secrets_path)
-    template = File.open(template_path, 'r')
+  secrets = load(secrets_path)
+  template = File.open(template_path, 'r')
 
-    template.each_line do |line|
-      puts line % secrets
-    end
-    template.close
-  rescue => exception
-    STDERR.puts("\n🚨🚨 Failed to generate credentials file from template: " + File.basename(template_path) +  " 🚨🚨")
-    STDERR.puts("\n-> Exception: " + exception.message)
-    STDERR.puts("-> Reason: Secrets are most likely out of date.")
-    STDERR.puts("-> Solution: Run: bundle exec fastlane run configure_apply\n\n")
-    exit(false)
+  template.each_line do |line|
+    puts line % secrets
   end
+  template.close
+rescue StandardError => e
+  warn("\n🚨🚨 Failed to generate credentials file from template: #{File.basename(template_path)} 🚨🚨")
+  warn("\n-> Exception: #{e.message}")
+  warn('-> Reason: Secrets are most likely out of date.')
+  warn("-> Solution: Run: bundle exec fastlane run configure_apply\n\n")
+  exit(false)
 end
 
 ## Main!


### PR DESCRIPTION
What it says in the title.

Once merge, this should make #693 build and unblock it.

I wanted to suggest a way to update the "Command PhaseScriptExecution failed with a nonzero exit code" to a custom text suggesting to check the build log, but it's not a one liner operation as I initially thought, because the Ruby script edited here is itself called by another script. Might get to that at some point later...

## To test

I repeated the steps from #693 and verified the error is appropriate and it disappears once the missing key is removed from the `tpl` file

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
