### PR TITLE
CarPlay: Fixes Up Next and the other main tabs not updating

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1385,6 +1385,7 @@
 		C7A110F7291F65FB00887A90 /* WelcomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A110F6291F65FB00887A90 /* WelcomeView.swift */; };
 		C7A110F9291F66C700887A90 /* Confetti.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A110F8291F66C700887A90 /* Confetti.swift */; };
 		C7A110FF2922971100887A90 /* LoginLandingHostingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A110FE2922971100887A90 /* LoginLandingHostingController.swift */; };
+		C7A654032991A7C900BB84C1 /* CarPlayListData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A654022991A7C900BB84C1 /* CarPlayListData.swift */; };
 		C7ACD7F62878B07300AF3AB8 /* AnalyticsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD6B1F001CE05159003CE958 /* AnalyticsHelper.swift */; };
 		C7AF5789289C60B70089E435 /* FeatureFlag.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7AF5788289C60B70089E435 /* FeatureFlag.swift */; };
 		C7AF578A289C60C50089E435 /* FeatureFlag.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7AF5788289C60B70089E435 /* FeatureFlag.swift */; };
@@ -2989,6 +2990,7 @@
 		C7A110F6291F65FB00887A90 /* WelcomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeView.swift; sourceTree = "<group>"; };
 		C7A110F8291F66C700887A90 /* Confetti.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Confetti.swift; sourceTree = "<group>"; };
 		C7A110FE2922971100887A90 /* LoginLandingHostingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginLandingHostingController.swift; sourceTree = "<group>"; };
+		C7A654022991A7C900BB84C1 /* CarPlayListData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlayListData.swift; sourceTree = "<group>"; };
 		C7AF5788289C60B70089E435 /* FeatureFlag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlag.swift; sourceTree = "<group>"; };
 		C7AF5790289D87CF0089E435 /* Analytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Analytics.swift; sourceTree = "<group>"; };
 		C7AF7B902925E5CD002F0025 /* PlusHostingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlusHostingViewController.swift; sourceTree = "<group>"; };
@@ -5953,6 +5955,7 @@
 				BDED930A251DC515000BF622 /* CarPlaySceneDelegate+Interaction.swift */,
 				BDED9311251DD5EB000BF622 /* CarPlayImageHelper.swift */,
 				BD43BEF725246CFF00ACBE11 /* CarPlayListHelper.swift */,
+				C7A654022991A7C900BB84C1 /* CarPlayListData.swift */,
 			);
 			name = CarPlay;
 			sourceTree = "<group>";
@@ -7603,6 +7606,7 @@
 				BD1F07F91BAAA6F0007A768D /* CategoryPodcastsViewController.swift in Sources */,
 				BD998ACA27B2408500B38857 /* CreateFolderView.swift in Sources */,
 				4067563124D7B163003684FC /* CategorySponsoredCell.swift in Sources */,
+				C7A654032991A7C900BB84C1 /* CarPlayListData.swift in Sources */,
 				BD9FF6121B8EC90C009F075E /* ImageManager.swift in Sources */,
 				BD6B432C27561EA8005E4017 /* PCHostingController.swift in Sources */,
 				BDCA84F21C1FB7260022ED4D /* DownloadSettingsViewController.swift in Sources */,

--- a/podcasts/CarPlayListData.swift
+++ b/podcasts/CarPlayListData.swift
@@ -1,0 +1,47 @@
+import CarPlay
+import Foundation
+
+final class CarPlayListData {
+    typealias SectionDataSource = () -> [CPListSection]?
+
+    private var dataSource: SectionDataSource
+
+    /// Track whether we need to refresh the data source
+    /// fileprivate on purpose to allow it to only be used by the template extension below
+    fileprivate var needsUpdate = false
+
+    init(_ dataSource: @escaping SectionDataSource) {
+        self.dataSource = dataSource
+    }
+
+    /// Refresh the given template data from the dataSource
+    func reloadData(_ template: CPListTemplate) {
+        // If the data returned is missing, don't update
+        guard let data = dataSource() else { return }
+
+        template.updateSections(data)
+    }
+
+    /// Creates a new `CPListTemplate` with a data source attached to it
+    static func template(title: String, emptyTitle: String, image: UIImage? = nil, _ dataSource: @escaping SectionDataSource) -> CPListTemplate {
+        let template = CPListTemplate(title: title, sections: dataSource() ?? [])
+        template.tabTitle = title
+        template.tabImage = image
+        template.emptyViewSubtitleVariants = [emptyTitle]
+        template.userInfo = CarPlayListData(dataSource)
+        return template
+    }
+}
+
+// MARK: - Template Reloading
+
+extension CPTemplate {
+    /// Refresh the data for the template if possible
+    func reloadData() {
+        guard let list = self as? CPListTemplate, let dataSource = userInfo as? CarPlayListData else {
+            return
+        }
+
+        dataSource.reloadData(list)
+    }
+}

--- a/podcasts/CarPlayListData.swift
+++ b/podcasts/CarPlayListData.swift
@@ -36,6 +36,23 @@ final class CarPlayListData {
 // MARK: - Template Reloading
 
 extension CPTemplate {
+    /// Will reloadData if needed
+    func didAppear() {
+        guard let dataSource = userInfo as? CarPlayListData else { return }
+
+        if dataSource.needsUpdate {
+            reloadData()
+        }
+
+        dataSource.needsUpdate = false
+    }
+
+    /// Tracks whether the data needs to be updated on appear
+    func didDisappear() {
+        guard let dataSource = userInfo as? CarPlayListData else { return }
+        dataSource.needsUpdate = true
+    }
+
     /// Refresh the data for the template if possible
     func reloadData() {
         guard let list = self as? CPListTemplate, let dataSource = userInfo as? CarPlayListData else {

--- a/podcasts/CarPlaySceneDelegate+Convert.swift
+++ b/podcasts/CarPlaySceneDelegate+Convert.swift
@@ -67,8 +67,7 @@ extension CarPlaySceneDelegate {
         item.handler = { [weak self] _, completion in
             guard let self = self else { return }
 
-            let upNext = self.createUpNextList(includeNowPlaying: true)
-            self.interfaceController?.pushTemplate(upNext, animated: true, completion: nil)
+            self.upNextTapped(showNowPlaying: true)
             completion()
         }
 

--- a/podcasts/CarPlaySceneDelegate+Interaction.swift
+++ b/podcasts/CarPlaySceneDelegate+Interaction.swift
@@ -4,6 +4,12 @@ import PocketCastsDataModel
 import PocketCastsUtils
 
 extension CarPlaySceneDelegate {
+    func upNextTapped(showNowPlaying: Bool) {
+        pushEpisodeList(title: L10n.upNext, showArtwork: true, closeListOnTap: false) { () -> [BaseEpisode] in
+            PlaybackManager.shared.queue.allEpisodes(includeNowPlaying: showNowPlaying)
+        }
+    }
+
     func filterTapped(_ filter: EpisodeFilter) {
         pushEpisodeList(title: filter.playlistName, showArtwork: true, closeListOnTap: false) { () -> [BaseEpisode] in
             let query = PlaylistHelper.queryFor(filter: filter, episodeUuidToAdd: filter.episodeUuidToAddToQueries(), limit: Constants.Limits.maxCarplayItems)

--- a/podcasts/CarPlaySceneDelegate+Tabs.swift
+++ b/podcasts/CarPlaySceneDelegate+Tabs.swift
@@ -2,8 +2,9 @@ import CarPlay
 import Foundation
 import PocketCastsDataModel
 
+// MARK: - Podcasts
 extension CarPlaySceneDelegate {
-    func createPodcastsTab() -> CPTemplate {
+    var podcastTabSections: [CPListSection] {
         var podcastItems = [CPListTemplateItem]()
 
         let gridItems = HomeGridDataHelper.gridItems(orderedBy: Settings.homeFolderSortOrder())
@@ -18,7 +19,7 @@ extension CarPlaySceneDelegate {
 
                 item.accessoryType = .disclosureIndicator
                 item.handler = { [weak self] _, completion in
-                    self?.folderTapped(folder, closeListOnTap: false)
+                    self?.folderTapped(folder)
                     completion()
                 }
                 podcastItems.append(item)
@@ -35,15 +36,22 @@ extension CarPlaySceneDelegate {
             podcastItems.insert(imageRowItem, at: 0)
         }
 
-        let podcastsSection = CPListSection(items: podcastItems)
-        let template = CPListTemplate(title: L10n.podcastsPlural, sections: [podcastsSection])
-        template.tabTitle = L10n.podcastsPlural
-        template.tabImage = UIImage(named: "car_tab_podcasts")
-
-        return template
+        return [CPListSection(items: podcastItems)]
     }
 
-    func createFiltersTab() -> CPTemplate {
+    func createPodcastsTab() -> CPListTemplate {
+        return CarPlayListData.template(title: L10n.podcastsPlural, emptyTitle: L10n.watchNoPodcasts, image: UIImage(named: "car_tab_podcasts")) { [weak self] in
+            guard let self else { return nil }
+
+            return self.podcastTabSections
+        }
+    }
+}
+
+// MARK: - Filters
+
+extension CarPlaySceneDelegate {
+    private var filterTabSections: [CPListSection] {
         var filterItems = [CPListItem]()
         for filter in DataManager.sharedManager.allFilters(includeDeleted: false) {
             let item = CPListItem(text: filter.playlistName, detailText: nil, image: UIImage(named: filter.iconImageNameCarPlay()))
@@ -56,46 +64,56 @@ extension CarPlaySceneDelegate {
             filterItems.append(item)
         }
 
-        let filtersSection = CPListSection(items: filterItems)
-        let template = CPListTemplate(title: L10n.filters, sections: [filtersSection])
-        template.tabTitle = L10n.filters
-        template.tabImage = UIImage(named: "car_tab_filters")
-
-        return template
+        return [CPListSection(items: filterItems)]
     }
 
-    func createDownloadsTab() -> CPTemplate {
+    func createFiltersTab() -> CPListTemplate {
+        return CarPlayListData.template(title: L10n.filters, emptyTitle: L10n.watchNoFilters, image: UIImage(named: "car_tab_filters")) { [weak self] in
+            guard let self else { return nil }
+            return self.filterTabSections
+        }
+    }
+}
+
+// MARK: - Downloads
+
+extension CarPlaySceneDelegate {
+    private var downloadTabSections: [CPListSection] {
         let downloadedEpisodes = DataManager.sharedManager.findEpisodesWhere(customWhere: "episodeStatus == \(DownloadStatus.downloaded.rawValue) ORDER BY lastDownloadAttemptDate DESC LIMIT \(Constants.Limits.maxCarplayItems)", arguments: nil)
-        let items = convertToListItems(episodes: downloadedEpisodes, showArtwork: true, closeListOnTap: false)
+        let items = convertToListItems(episodes: downloadedEpisodes, showArtwork: true)
 
-        let episodeSection = CPListSection(items: items)
-        let template = CPListTemplate(title: L10n.downloads, sections: [episodeSection])
-        template.tabTitle = L10n.downloads
-        template.tabImage = UIImage(named: "car_tab_downloads")
-
-        return template
+        return [CPListSection(items: items)]
     }
 
-    func createMoreTab() -> CPTemplate {
-        let listeningHistoryItem = CPListItem(text: L10n.listeningHistory, detailText: nil, image: UIImage(named: "car_more_listening_history"))
-        listeningHistoryItem.accessoryType = .disclosureIndicator
-        listeningHistoryItem.handler = { [weak self] _, completion in
-            self?.listeningHistoryTapped()
-            completion()
+    func createDownloadsTab() -> CPListTemplate {
+        return CarPlayListData.template(title: L10n.downloads, emptyTitle: L10n.downloadsNoDownloadsTitle, image: UIImage(named: "car_tab_downloads")) { [weak self] in
+            guard let self else { return nil }
+
+            return self.downloadTabSections
         }
+    }
+}
 
-        let filesItem = CPListItem(text: L10n.files, detailText: nil, image: UIImage(named: "car_more_files"))
-        filesItem.accessoryType = .disclosureIndicator
-        filesItem.handler = { [weak self] _, completion in
-            self?.filesTapped(closeListOnTap: false)
-            completion()
+// MARK: - More
+
+extension CarPlaySceneDelegate {
+    func createMoreTab() -> CPListTemplate {
+        return CarPlayListData.template(title: L10n.carplayMore, emptyTitle: L10n.watchNoPodcasts, image: UIImage(named: "car_tab_more")) {
+            let listeningHistoryItem = CPListItem(text: L10n.listeningHistory, detailText: nil, image: UIImage(named: "car_more_listening_history"))
+            listeningHistoryItem.accessoryType = .disclosureIndicator
+            listeningHistoryItem.handler = { [weak self] _, completion in
+                self?.listeningHistoryTapped()
+                completion()
+            }
+
+            let filesItem = CPListItem(text: L10n.files, detailText: nil, image: UIImage(named: "car_more_files"))
+            filesItem.accessoryType = .disclosureIndicator
+            filesItem.handler = { [weak self] _, completion in
+                self?.filesTapped()
+                completion()
+            }
+
+            return [CPListSection(items: [listeningHistoryItem, filesItem])]
         }
-
-        let mainSection = CPListSection(items: [listeningHistoryItem, filesItem])
-        let template = CPListTemplate(title: L10n.carplayMore, sections: [mainSection])
-        template.tabTitle = L10n.carplayMore
-        template.tabImage = UIImage(named: "car_tab_more")
-
-        return template
     }
 }

--- a/podcasts/CarPlaySceneDelegate+Tabs.swift
+++ b/podcasts/CarPlaySceneDelegate+Tabs.swift
@@ -19,7 +19,7 @@ extension CarPlaySceneDelegate {
 
                 item.accessoryType = .disclosureIndicator
                 item.handler = { [weak self] _, completion in
-                    self?.folderTapped(folder)
+                    self?.folderTapped(folder, closeListOnTap: false)
                     completion()
                 }
                 podcastItems.append(item)
@@ -80,7 +80,7 @@ extension CarPlaySceneDelegate {
 extension CarPlaySceneDelegate {
     private var downloadTabSections: [CPListSection] {
         let downloadedEpisodes = DataManager.sharedManager.findEpisodesWhere(customWhere: "episodeStatus == \(DownloadStatus.downloaded.rawValue) ORDER BY lastDownloadAttemptDate DESC LIMIT \(Constants.Limits.maxCarplayItems)", arguments: nil)
-        let items = convertToListItems(episodes: downloadedEpisodes, showArtwork: true)
+        let items = convertToListItems(episodes: downloadedEpisodes, showArtwork: true, closeListOnTap: false)
 
         return [CPListSection(items: items)]
     }
@@ -109,7 +109,7 @@ extension CarPlaySceneDelegate {
             let filesItem = CPListItem(text: L10n.files, detailText: nil, image: UIImage(named: "car_more_files"))
             filesItem.accessoryType = .disclosureIndicator
             filesItem.handler = { [weak self] _, completion in
-                self?.filesTapped()
+                self?.filesTapped(closeListOnTap: false)
                 completion()
             }
 

--- a/podcasts/CarPlaySceneDelegate.swift
+++ b/podcasts/CarPlaySceneDelegate.swift
@@ -131,8 +131,7 @@ class CarPlaySceneDelegate: CustomObserver, CPTemplateApplicationSceneDelegate, 
     // MARK: - CPNowPlayingTemplateObserver
 
     func nowPlayingTemplateUpNextButtonTapped(_ nowPlayingTemplate: CPNowPlayingTemplate) {
-        let upNextList = createUpNextList(includeNowPlaying: false)
-        interfaceController?.pushTemplate(upNextList, animated: true, completion: nil)
+        upNextTapped(showNowPlaying: false)
     }
 
     func nowPlayingTemplateAlbumArtistButtonTapped(_ nowPlayingTemplate: CPNowPlayingTemplate) {

--- a/podcasts/CarPlaySceneDelegate.swift
+++ b/podcasts/CarPlaySceneDelegate.swift
@@ -156,6 +156,10 @@ class CarPlaySceneDelegate: CustomObserver, CPTemplateApplicationSceneDelegate, 
     private func themeTintedImage(named imageName: String) -> UIImage? {
         // default to dark if no theme information is available since that's a more commone setup
         let isDarkTheme = interfaceController?.carTraitCollection.userInterfaceStyle != .light
+        return UIImage(named: imageName)?.tintedImage(isDarkTheme ? UIColor.white : UIColor.black)
+    }
+}
+
 // MARK: - CPInterfaceControllerDelegate
 extension CarPlaySceneDelegate: CPInterfaceControllerDelegate {
     func templateDidAppear(_ template: CPTemplate, animated: Bool) {
@@ -169,7 +173,7 @@ extension CarPlaySceneDelegate: CPInterfaceControllerDelegate {
         template.didAppear()
     }
 
-        return UIImage(named: imageName)?.tintedImage(isDarkTheme ? UIColor.white : UIColor.black)
+
     func templateDidDisappear(_ template: CPTemplate, animated: Bool) {
         template.didDisappear()
     }

--- a/podcasts/CarPlaySceneDelegate.swift
+++ b/podcasts/CarPlaySceneDelegate.swift
@@ -118,16 +118,6 @@ class CarPlaySceneDelegate: CustomObserver, CPTemplateApplicationSceneDelegate, 
         template.updateNowPlayingButtons(buttons)
     }
 
-    func createUpNextList(includeNowPlaying: Bool) -> CPListTemplate {
-        let episodes = PlaybackManager.shared.queue.allEpisodes(includeNowPlaying: includeNowPlaying)
-        let upNextEpisodes = convertToListItems(episodes: episodes, showArtwork: true, closeListOnTap: true)
-
-        let upNextSection = CPListSection(items: upNextEpisodes)
-        let template = CPListTemplate(title: L10n.upNext, sections: [upNextSection])
-
-        return template
-    }
-
     // MARK: - CPNowPlayingTemplateObserver
 
     func nowPlayingTemplateUpNextButtonTapped(_ nowPlayingTemplate: CPNowPlayingTemplate) {

--- a/podcasts/CarPlaySceneDelegate.swift
+++ b/podcasts/CarPlaySceneDelegate.swift
@@ -8,6 +8,8 @@ class CarPlaySceneDelegate: CustomObserver, CPTemplateApplicationSceneDelegate, 
     var interfaceController: CPInterfaceController?
 
     var currentList: CarPlayListHelper?
+    // Reloading
+    var debouncer: Debounce = .init(delay: 0.2)
     weak var visibleTemplate: CPTemplate?
 
     func templateApplicationScene(_ templateApplicationScene: CPTemplateApplicationScene, didConnect interfaceController: CPInterfaceController) {

--- a/podcasts/CarPlaySceneDelegate.swift
+++ b/podcasts/CarPlaySceneDelegate.swift
@@ -8,12 +8,15 @@ class CarPlaySceneDelegate: CustomObserver, CPTemplateApplicationSceneDelegate, 
     var interfaceController: CPInterfaceController?
 
     var currentList: CarPlayListHelper?
+    weak var visibleTemplate: CPTemplate?
 
     func templateApplicationScene(_ templateApplicationScene: CPTemplateApplicationScene, didConnect interfaceController: CPInterfaceController) {
         self.interfaceController = interfaceController
 
         let tabTemplate = CPTabBarTemplate(templates: [createPodcastsTab(), createFiltersTab(), createDownloadsTab(), createMoreTab()])
         interfaceController.setRootTemplate(tabTemplate, animated: true, completion: nil)
+
+        self.visibleTemplate = tabTemplate.selectedTemplate
 
         setupNowPlaying()
         addChangeListeners()

--- a/podcasts/CarPlaySceneDelegate.swift
+++ b/podcasts/CarPlaySceneDelegate.swift
@@ -12,6 +12,7 @@ class CarPlaySceneDelegate: CustomObserver, CPTemplateApplicationSceneDelegate, 
 
     func templateApplicationScene(_ templateApplicationScene: CPTemplateApplicationScene, didConnect interfaceController: CPInterfaceController) {
         self.interfaceController = interfaceController
+        interfaceController.delegate = self
 
         let tabTemplate = CPTabBarTemplate(templates: [createPodcastsTab(), createFiltersTab(), createDownloadsTab(), createMoreTab()])
         interfaceController.setRootTemplate(tabTemplate, animated: true, completion: nil)
@@ -24,7 +25,7 @@ class CarPlaySceneDelegate: CustomObserver, CPTemplateApplicationSceneDelegate, 
 
     func templateApplicationScene(_ templateApplicationScene: CPTemplateApplicationScene, didDisconnectInterfaceController interfaceController: CPInterfaceController) {
         removeAllCustomObservers()
-
+        self.interfaceController?.delegate = nil
         self.interfaceController = nil
         currentList = nil
     }
@@ -141,6 +142,17 @@ class CarPlaySceneDelegate: CustomObserver, CPTemplateApplicationSceneDelegate, 
     private func themeTintedImage(named imageName: String) -> UIImage? {
         // default to dark if no theme information is available since that's a more commone setup
         let isDarkTheme = interfaceController?.carTraitCollection.userInterfaceStyle != .light
+// MARK: - CPInterfaceControllerDelegate
+extension CarPlaySceneDelegate: CPInterfaceControllerDelegate {
+    func templateDidAppear(_ template: CPTemplate, animated: Bool) {
+        // We ignore the tab template because we only want to get the selected tab template
+        // This will be called for both the tab template, and the selected tab
+        guard (template as? CPTabBarTemplate) == nil, visibleTemplate != template else {
+            return
+        }
+
+        visibleTemplate = template
+    }
 
         return UIImage(named: imageName)?.tintedImage(isDarkTheme ? UIColor.white : UIColor.black)
     }

--- a/podcasts/CarPlaySceneDelegate.swift
+++ b/podcasts/CarPlaySceneDelegate.swift
@@ -67,10 +67,18 @@ class CarPlaySceneDelegate: CustomObserver, CPTemplateApplicationSceneDelegate, 
 
             let nowPlayingTemplate = CPNowPlayingTemplate.shared
             self.updateNowPlayingButtons(template: nowPlayingTemplate)
+
+            // Also update the episode list if needed, this makes sure its updated when the episode ends
+            self.reloadVisibleTemplate()
         }
     }
 
     @objc private func handleDataUpdated() {
+        // Prevent updating too often when multiple notifications fire at once
+        debouncer.call {
+            self.reloadVisibleTemplate()
+        }
+
         guard let currentList = currentList else { return }
         DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }
@@ -81,6 +89,10 @@ class CarPlaySceneDelegate: CustomObserver, CPTemplateApplicationSceneDelegate, 
 
             currentList.list.updateSections([mainSection])
         }
+    }
+
+    func reloadVisibleTemplate() {
+        visibleTemplate?.reloadData()
     }
 
     private func setupNowPlaying() {

--- a/podcasts/CarPlaySceneDelegate.swift
+++ b/podcasts/CarPlaySceneDelegate.swift
@@ -152,8 +152,11 @@ extension CarPlaySceneDelegate: CPInterfaceControllerDelegate {
         }
 
         visibleTemplate = template
+        template.didAppear()
     }
 
         return UIImage(named: imageName)?.tintedImage(isDarkTheme ? UIColor.white : UIColor.black)
+    func templateDidDisappear(_ template: CPTemplate, animated: Bool) {
+        template.didDisappear()
     }
 }


### PR DESCRIPTION
Fixes #338

## Description
This introduces some core changes to the CarPlay code to allow templates to reload the data easily:

- Adding a new `CarPlayListData` class that:
   - keeps track of the closure needed to reload the data
   - Creates new list templates and adds itself to the userInfo property for tracking
- Adding a `CPTemplate` extension to make reloading any template easy `template.reloadData()`
- Keeping track of the visible template and reloading it when a notification fires, or if it comes back into view
   - The code prior only reloaded templates if they were the current visible so if you have a template stack and you tap back that template will show outdated content

The new logic is applied to each of the main tabs (Podcasts, Filters, Downloads, More). This makes sure the up next on the podcasts tab is up to date. 

This also updates the up next tap handler to use `pushEpisodeList` which allows it to auto update based on changes if it's the currently visible template. 

## To test
> **Note**
> You'll want to test on a real device 📱

### Up Next Updating
1. Download the CarPlay Simulator from the [Additional Tools for Xcode](https://developer.apple.com/download/all/?q=Additional%20Tools%20for%20Xcode) package
2. Launch the CarPlay Simulator
3. Connect your phone via USB
4. Launch the app on your phone and CarPlay Simulator
5. ✅ Verify each of the tabs load correctly and show the correct data
6. Tap the Podcasts tab in CarPlay
7. Modify your Up Next from your phone
8. ✅ Verify the Up Next bubble updates correctly
9. Tap the Up next bubble to view the list
10. Modify your Up Next from your phone
11. ✅ Verify the Up Next list updates correctly
12. Tap back
13. ✅ Verify the Up Next bubble is updated automatically when it appears
14. Play an episode
15. Tap the Now Playing icon in the top right corner
16. Tap the Playing Next item
17. Modify your Up Next from your phone
18. ✅ Verify the list updates correctly

### Filters / Downloads
1. Tap the Filters tab
2. On your phone Add a new filter
3. ✅ Verify the filter appears
4. ⚠️ Deleting a filter doesn't auto update because the notification isn't posted.
6. Tap on the Downloads tab
7. On your Phone download a new episode
8. ✅ Verify it appears here
9. ✅ If you have no downloaded episodes a new empty state will be shown

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
