### PR TITLE
CarPlay: Push to now playing when tapping an episode

### DIFF
--- a/podcasts/CPInterfaceController+Helpers.swift
+++ b/podcasts/CPInterfaceController+Helpers.swift
@@ -3,6 +3,15 @@ import PocketCastsUtils
 
 extension CPInterfaceController {
 
+    /// Shows the Now Playing template regardless of whether it's in the stack already or not.
+    /// This will push to it if it's not already in the stack, or pop back to it if it is.
+    func showNowPlaying() {
+        let template = CPNowPlayingTemplate.shared
+
+        // We can't push to it if it exists in the stack, so pop to it instead
+        // TODO: Try not to use templates
+        templates.contains(template) ? pop(to: template) : push(template)
+    }
 
     /// Sets the root template of the controller, and will log any errors on failure
     func setRootTemplate(_ template: CPTemplate) {

--- a/podcasts/CPInterfaceController+Helpers.swift
+++ b/podcasts/CPInterfaceController+Helpers.swift
@@ -9,7 +9,6 @@ extension CPInterfaceController {
         let template = CPNowPlayingTemplate.shared
 
         // We can't push to it if it exists in the stack, so pop to it instead
-        // TODO: Try not to use templates
         templates.contains(template) ? pop(to: template) : push(template)
     }
 

--- a/podcasts/CarPlaySceneDelegate+Convert.swift
+++ b/podcasts/CarPlaySceneDelegate+Convert.swift
@@ -3,7 +3,7 @@ import Foundation
 import PocketCastsDataModel
 
 extension CarPlaySceneDelegate {
-    func convertToListItems(episodes: [BaseEpisode], showArtwork: Bool, closeListOnTap: Bool) -> [CPListItem] {
+    func convertToListItems(episodes: [BaseEpisode], showArtwork: Bool) -> [CPListItem] {
         var items = [CPListItem]()
         for episode in episodes {
             let artwork = showArtwork ? CarPlayImageHelper.imageForEpisode(episode) : nil
@@ -28,7 +28,7 @@ extension CarPlaySceneDelegate {
             item.isPlaying = PlaybackManager.shared.isNowPlayingEpisode(episodeUuid: episode.uuid)
 
             item.handler = { [weak self] _, completion in
-                self?.episodeTapped(episode, closeListOnTap: closeListOnTap)
+                self?.episodeTapped(episode)
                 completion()
             }
 
@@ -43,7 +43,7 @@ extension CarPlaySceneDelegate {
 
         item.accessoryType = .disclosureIndicator
         item.handler = { [weak self] _, completion in
-            self?.podcastTapped(podcast, closeListOnTap: false)
+            self?.podcastTapped(podcast)
             completion()
         }
 
@@ -60,7 +60,7 @@ extension CarPlaySceneDelegate {
         item.listImageRowHandler = { [weak self] _, index, completion in
             guard let episode = episodes[safe: index] else { return }
 
-            self?.episodeTapped(episode, closeListOnTap: false)
+            self?.episodeTapped(episode)
             completion()
         }
 

--- a/podcasts/CarPlaySceneDelegate+Interaction.swift
+++ b/podcasts/CarPlaySceneDelegate+Interaction.swift
@@ -35,13 +35,22 @@ extension CarPlaySceneDelegate {
     func episodeTapped(_ episode: BaseEpisode) {
         AnalyticsPlaybackHelper.shared.currentSource = .carPlay
 
-        if PlaybackManager.shared.isNowPlayingEpisode(episodeUuid: episode.uuid) {
-            PlaybackManager.shared.playPause()
-        } else {
-            PlaybackManager.shared.load(episode: episode, autoPlay: true, overrideUpNext: false)
+        defer {
+            interfaceController?.showNowPlaying()
         }
 
-        interfaceController?.showNowPlaying()
+        // Don't change the playing state if the user taps the actively playing episode
+        // Just push to the now playing view and allow further action from there.
+        guard !PlaybackManager.shared.isActivelyPlaying(episodeUuid: episode.uuid) else { return }
+
+        // If the episode is the currently playing one but isn't actively being played, then start playing it
+        if PlaybackManager.shared.isNowPlayingEpisode(episodeUuid: episode.uuid) {
+            PlaybackManager.shared.play()
+            return
+        }
+
+        // Anything else, load the episode and start playing it
+        PlaybackManager.shared.load(episode: episode, autoPlay: true, overrideUpNext: false)
     }
 
     func listeningHistoryTapped() {

--- a/podcasts/CarPlaySceneDelegate+Interaction.swift
+++ b/podcasts/CarPlaySceneDelegate+Interaction.swift
@@ -133,19 +133,15 @@ extension CarPlaySceneDelegate {
         itemList.append(item)
     }
 
-    private func pushEpisodeList(title: String, showArtwork: Bool, closeListOnTap: Bool, episodeLoader: @escaping (() -> [BaseEpisode])) {
-        let listTemplate = CarPlayListData.template(title: title, emptyTitle: L10n.watchNoEpisodes) { [weak self] in
             guard let self else { return nil }
 
             let episodes = episodeLoader()
-            let episodeItems = self.convertToListItems(episodes: episodes, showArtwork: showArtwork, closeListOnTap: closeListOnTap)
             return [CPListSection(items: episodeItems)]
         }
 
         interfaceController?.push(listTemplate)
     }
 
-    private func pushPodcastList(title: String, closeListOnTap: Bool, podcastLoader: @escaping (() -> [Podcast])) {
         let listTemplate = CarPlayListData.template(title: title, emptyTitle: L10n.watchNoEpisodes) { [weak self] in
             guard let self else { return nil }
 

--- a/podcasts/CarPlaySceneDelegate+Interaction.swift
+++ b/podcasts/CarPlaySceneDelegate+Interaction.swift
@@ -41,6 +41,7 @@ extension CarPlaySceneDelegate {
             PlaybackManager.shared.load(episode: episode, autoPlay: true, overrideUpNext: false)
         }
 
+        interfaceController?.showNowPlaying()
     }
 
     func listeningHistoryTapped() {

--- a/podcasts/CarPlaySceneDelegate+Tabs.swift
+++ b/podcasts/CarPlaySceneDelegate+Tabs.swift
@@ -19,7 +19,7 @@ extension CarPlaySceneDelegate {
 
                 item.accessoryType = .disclosureIndicator
                 item.handler = { [weak self] _, completion in
-                    self?.folderTapped(folder, closeListOnTap: false)
+                    self?.folderTapped(folder)
                     completion()
                 }
                 podcastItems.append(item)
@@ -80,7 +80,7 @@ extension CarPlaySceneDelegate {
 extension CarPlaySceneDelegate {
     private var downloadTabSections: [CPListSection] {
         let downloadedEpisodes = DataManager.sharedManager.findEpisodesWhere(customWhere: "episodeStatus == \(DownloadStatus.downloaded.rawValue) ORDER BY lastDownloadAttemptDate DESC LIMIT \(Constants.Limits.maxCarplayItems)", arguments: nil)
-        let items = convertToListItems(episodes: downloadedEpisodes, showArtwork: true, closeListOnTap: false)
+        let items = convertToListItems(episodes: downloadedEpisodes, showArtwork: true)
 
         return [CPListSection(items: items)]
     }
@@ -109,7 +109,7 @@ extension CarPlaySceneDelegate {
             let filesItem = CPListItem(text: L10n.files, detailText: nil, image: UIImage(named: "car_more_files"))
             filesItem.accessoryType = .disclosureIndicator
             filesItem.handler = { [weak self] _, completion in
-                self?.filesTapped(closeListOnTap: false)
+                self?.filesTapped()
                 completion()
             }
 

--- a/podcasts/CarPlaySceneDelegate.swift
+++ b/podcasts/CarPlaySceneDelegate.swift
@@ -134,9 +134,9 @@ class CarPlaySceneDelegate: CustomObserver, CPTemplateApplicationSceneDelegate, 
         guard let playingEpisode = PlaybackManager.shared.currentEpisode() else { return }
 
         if let episode = playingEpisode as? Episode, let podcast = episode.parentPodcast() {
-            podcastTapped(podcast, closeListOnTap: true)
+            podcastTapped(podcast)
         } else if playingEpisode is UserEpisode {
-            filesTapped(closeListOnTap: true)
+            filesTapped()
         }
     }
 }

--- a/podcasts/CarPlaySceneDelegate.swift
+++ b/podcasts/CarPlaySceneDelegate.swift
@@ -69,7 +69,7 @@ class CarPlaySceneDelegate: CustomObserver, CPTemplateApplicationSceneDelegate, 
             self.updateNowPlayingButtons(template: nowPlayingTemplate)
 
             // Also update the episode list if needed, this makes sure its updated when the episode ends
-            self.reloadVisibleTemplate()
+            self.handleDataUpdated()
         }
     }
 


### PR DESCRIPTION
| 🚧 Fixes #592  | 🛫 Depends on: #701 |
|:---:|:---:|

## Description
This removes the existing "closeOnTap" logic which attempts to pop back to the now playing screen when tapping on an episode in a list that originated from the now playing view. 

Instead this adds logic to automagically pop or push to the now playing template when tapping on an episode. 

This also updates how the episode tap interaction works to mirror other CarPlay audio apps:
- If tapping on the episode in a list that is actively playing, we just push to the now playing screen
   - Before the episode would toggle between play and pause which could cause confusion
- If tapping on the now playing episode that is currently paused, we play it, and show the now playing screen
- Everything else, play and push to now playing

## To test

> **Note**
> You'll want to test on a real device 📱

1. Download the CarPlay Simulator from the [Additional Tools for Xcode](https://developer.apple.com/download/all/?q=Additional%20Tools%20for%20Xcode) package
2. Launch the CarPlay Simulator
3. Connect your phone via USB
4. Launch the app in the CarPlay Simulator
5. From the Podcasts tab tap on a podcast, and tap on an episode
6. ✅ Verify you are **pushed** to the now playing screen and the episode starts playing
7. Tap the Playing Next item
8. Tap on any episode there
9. ✅ Verify you are **popped** to the now playing screen and the episode starts playing
10. Tap back to the podcasts screen
11. Tap the Up Next queue bubble
12. Tap the currently playing episode
13. ✅ Verify you are brought to the now playing screen and the episode continues to play
14. Pause the playback
15. Tap back
16. Tap the episode again
17. ✅ Verify playback starts and you are pushed to the now playing screen

### 

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
