### PR TITLE
Add higher CI priority to release builds

### DIFF
--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -16,6 +16,7 @@ steps:
 
   - label: "🛠 Release Build (App Store Connect)"
     command: ".buildkite/commands/release-build.sh $BETA_RELEASE"
+    priority: 1
     env: *common_env
     plugins: *common_plugins
     notify:


### PR DESCRIPTION
### Summary of changes:

This PR increases the priority of release builds on Buildkite. This will be useful so that release builds won't get delayed if the CI queue gets backed up. The default priority of a build is 0, so increasing the release builds to 1 will put them before other builds: https://buildkite.com/docs/pipelines/managing-priorities