### PR TITLE
CarPlay: Improve the speed and reduce overall memory usage of CarPlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 7.33
 -----
+- CarPlay: Improved speed and reduced crashing (#705)
+- CarPlay: Tapping an episode now goes to the now playing screen (#702)
+- CarPlay: The mark as played and chapter icons now update with the dark/light mode (#700)
+- CarPlay: Fixed many issues where the UI would not refresh correctly (#699)
 
 
 7.32

--- a/Modules/Utils/Sources/PocketCastsUtils/Extensions/UI/UIImage+Tint.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Extensions/UI/UIImage+Tint.swift
@@ -26,8 +26,8 @@ public extension UIImage {
         return coloredImage
     }
 
-    func resized(to newSize: CGSize) -> UIImage? {
-        UIGraphicsBeginImageContextWithOptions(newSize, false, 0)
+    func resized(to newSize: CGSize, scale: CGFloat = 0) -> UIImage? {
+        UIGraphicsBeginImageContextWithOptions(newSize, false, scale)
         defer { UIGraphicsEndImageContext() }
 
         draw(in: CGRect(origin: .zero, size: newSize))

--- a/Modules/Utils/Sources/PocketCastsUtils/Extensions/UI/UIImage+Tint.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Extensions/UI/UIImage+Tint.swift
@@ -26,7 +26,28 @@ public extension UIImage {
         return coloredImage
     }
 
-    func resized(to newSize: CGSize, scale: CGFloat = 0) -> UIImage? {
+
+    /// Resize the image using the aspect ration to the given size
+    /// Specify the displayScale to set the UIImage.scale factor of the image
+    func resizeProportionally(to newSize: CGSize, displayScale: CGFloat = 0) -> UIImage {
+        let widthRatio = newSize.width / size.width
+        let heightRatio = newSize.height / size.height
+
+        let scaleFactor = min(widthRatio, heightRatio)
+        let scaledImageSize = CGSize(
+            width: size.width * scaleFactor,
+            height: size.height * scaleFactor
+        )
+
+        // If it fails, just return the same image
+        guard let resized = resized(to: scaledImageSize, displayScale: displayScale) else {
+            return self
+        }
+
+        return resized
+    }
+
+    func resized(to newSize: CGSize, displayScale: CGFloat = 0) -> UIImage? {
         UIGraphicsBeginImageContextWithOptions(newSize, false, scale)
         defer { UIGraphicsEndImageContext() }
 

--- a/podcasts/CarPlayImageHelper.swift
+++ b/podcasts/CarPlayImageHelper.swift
@@ -51,3 +51,56 @@ class CarPlayImageHelper {
         static let folderPreviewSize: CGRect = .init(x: 0, y: 0, width: 240, height: 240)
     }
 }
+
+// MARK: - CarPlay Resizing
+
+private extension UIImage {
+    /// This will process the image for us and return an image that CarPlay expects for its current traits (ie: scaling)
+    func carPlayImage(with traits: UITraitCollection, maxSize: CGSize) -> UIImage {
+        let imageAsset = UIImageAsset()
+        imageAsset.register(self, with: traits)
+        let processedImage = imageAsset.image(with: traits)
+
+        // Don't resize if we don't need to
+        if processedImage.size == maxSize {
+            return processedImage
+        }
+
+        // Scale the image to the max size CarPlay expects
+        return processedImage.scaleTo(maxSize: maxSize, traits: traits)
+    }
+
+    /// Resize the image to the CPListItem.maximumImageSize
+    func scaleTo(maxSize: CGSize, traits: UITraitCollection) -> UIImage {
+        let displayScale = traits.displayScale
+
+        let widthRatio = maxSize.width / size.width
+        let heightRatio = maxSize.height / size.height
+
+        let scaleFactor = min(widthRatio, heightRatio)
+        let scaledImageSize = CGSize(
+            width: size.width * scaleFactor,
+            height: size.height * scaleFactor
+        )
+
+        guard let resized = resized(to: scaledImageSize, scale: displayScale) else {
+            return self
+        }
+
+        return resized
+    }
+}
+
+private extension BaseEpisode {
+    var cacheKey: String {
+        if let episode = self as? Episode {
+            return episode.podcastUuid
+        }
+
+        if let userEpisode = self as? UserEpisode {
+            return userEpisode.urlForImage().absoluteString
+        }
+
+        return uuid
+    }
+}

--- a/podcasts/CarPlayImageHelper.swift
+++ b/podcasts/CarPlayImageHelper.swift
@@ -119,27 +119,7 @@ private extension UIImage {
         }
 
         // Scale the image to the max size CarPlay expects
-        return processedImage.scaleTo(maxSize: maxSize, traits: traits)
-    }
-
-    /// Resize the image to the CPListItem.maximumImageSize
-    func scaleTo(maxSize: CGSize, traits: UITraitCollection) -> UIImage {
-        let displayScale = traits.displayScale
-
-        let widthRatio = maxSize.width / size.width
-        let heightRatio = maxSize.height / size.height
-
-        let scaleFactor = min(widthRatio, heightRatio)
-        let scaledImageSize = CGSize(
-            width: size.width * scaleFactor,
-            height: size.height * scaleFactor
-        )
-
-        guard let resized = resized(to: scaledImageSize, scale: displayScale) else {
-            return self
-        }
-
-        return resized
+        return processedImage.resizeProportionally(to: maxSize, displayScale: traits.displayScale)
     }
 }
 

--- a/podcasts/CarPlayImageHelper.swift
+++ b/podcasts/CarPlayImageHelper.swift
@@ -1,8 +1,9 @@
 import Foundation
+import Kingfisher
 import PocketCastsDataModel
 
 class CarPlayImageHelper {
-    class func imageForPodcast(_ podcast: Podcast) -> UIImage {
+    static var imageCache = ImageCache(name: "carplay_cache")
     static var carTraitCollection: UITraitCollection?
         let image = ImageManager.sharedManager.cachedImageFor(podcastUuid: podcast.uuid, size: .list) ?? UIImage(named: "noartwork-grid-dark")!
 

--- a/podcasts/CarPlayImageHelper.swift
+++ b/podcasts/CarPlayImageHelper.swift
@@ -3,6 +3,7 @@ import PocketCastsDataModel
 
 class CarPlayImageHelper {
     class func imageForPodcast(_ podcast: Podcast) -> UIImage {
+    static var carTraitCollection: UITraitCollection?
         let image = ImageManager.sharedManager.cachedImageFor(podcastUuid: podcast.uuid, size: .list) ?? UIImage(named: "noartwork-grid-dark")!
 
         return adjustImageIfRequired(image: image)

--- a/podcasts/CarPlayImageHelper.swift
+++ b/podcasts/CarPlayImageHelper.swift
@@ -74,7 +74,7 @@ class CarPlayImageHelper {
         }
 
         var cachedImage: UIImage? = nil
-        
+
         imageCache.retrieveImageInDiskCache(forKey: cacheKey, options: [.loadDiskFileSynchronously]) { result in
             switch result {
             case let .success(image):

--- a/podcasts/CarPlayListData.swift
+++ b/podcasts/CarPlayListData.swift
@@ -5,25 +5,35 @@ final class CarPlayListData {
     typealias SectionDataSource = () -> [CPListSection]?
 
     private var dataSource: SectionDataSource
+    private let emptyTitle: String
 
     /// Track whether we need to refresh the data source
     /// fileprivate on purpose to allow it to only be used by the template extension below
-    fileprivate var needsUpdate = false
+    fileprivate var needsUpdate = true
 
-    init(_ dataSource: @escaping SectionDataSource) {
+    init(emptyTitle: String, _ dataSource: @escaping SectionDataSource) {
+        self.emptyTitle = emptyTitle
         self.dataSource = dataSource
     }
 
     /// Refresh the given template data from the dataSource
     func reloadData(_ template: CPListTemplate) {
+        template.emptyViewSubtitleVariants = [emptyTitle]
+
         // If the data returned is missing, don't update
         guard let data = dataSource() else { return }
-
         template.updateSections(data)
     }
 
     /// Creates a new `CPListTemplate` with a data source attached to it
     static func template(title: String, emptyTitle: String, image: UIImage? = nil, _ dataSource: @escaping SectionDataSource) -> CPListTemplate {
+        let template = CPListTemplate(title: title, sections: [])
+        template.tabTitle = title
+        template.tabImage = image
+        template.emptyViewSubtitleVariants = [L10n.loading]
+        template.userInfo = CarPlayListData(emptyTitle: emptyTitle, dataSource)
+        return template
+    }
         let template = CPListTemplate(title: title, sections: dataSource() ?? [])
         template.tabTitle = title
         template.tabImage = image

--- a/podcasts/CarPlayListData.swift
+++ b/podcasts/CarPlayListData.swift
@@ -34,11 +34,12 @@ final class CarPlayListData {
         template.userInfo = CarPlayListData(emptyTitle: emptyTitle, dataSource)
         return template
     }
+
+    /// Creates a new `CPListTemplate` that doesn't update
+    static func staticTemplate(title: String, image: UIImage? = nil, _ dataSource: @escaping SectionDataSource) -> CPListTemplate {
         let template = CPListTemplate(title: title, sections: dataSource() ?? [])
         template.tabTitle = title
         template.tabImage = image
-        template.emptyViewSubtitleVariants = [emptyTitle]
-        template.userInfo = CarPlayListData(dataSource)
         return template
     }
 }

--- a/podcasts/CarPlaySceneDelegate+Convert.swift
+++ b/podcasts/CarPlaySceneDelegate+Convert.swift
@@ -53,7 +53,7 @@ extension CarPlaySceneDelegate {
     func createUpNextImageItem(episodes: [BaseEpisode]) -> CPListImageRowItem {
         var images = [UIImage]()
         for episode in episodes {
-            images.append(CarPlayImageHelper.imageForEpisode(episode))
+            images.append(CarPlayImageHelper.imageForEpisode(episode, maxSize: CPListImageRowItem.maximumImageSize))
         }
 
         let item = CPListImageRowItem(text: L10n.carplayUpNextQueue, images: images)

--- a/podcasts/CarPlaySceneDelegate+Tabs.swift
+++ b/podcasts/CarPlaySceneDelegate+Tabs.swift
@@ -98,7 +98,7 @@ extension CarPlaySceneDelegate {
 
 extension CarPlaySceneDelegate {
     func createMoreTab() -> CPListTemplate {
-        return CarPlayListData.template(title: L10n.carplayMore, emptyTitle: L10n.watchNoPodcasts, image: UIImage(named: "car_tab_more")) {
+        return CarPlayListData.staticTemplate(title: L10n.carplayMore, image: UIImage(named: "car_tab_more")) {
             let listeningHistoryItem = CPListItem(text: L10n.listeningHistory, detailText: nil, image: UIImage(named: "car_more_listening_history"))
             listeningHistoryItem.accessoryType = .disclosureIndicator
             listeningHistoryItem.handler = { [weak self] _, completion in

--- a/podcasts/CarPlaySceneDelegate.swift
+++ b/podcasts/CarPlaySceneDelegate.swift
@@ -29,6 +29,8 @@ class CarPlaySceneDelegate: CustomObserver, CPTemplateApplicationSceneDelegate, 
     }
 
     func sceneDidBecomeActive(_ scene: UIScene) {
+        // The traits are only set after the scene is active, and needed to size the images properly
+        CarPlayImageHelper.carTraitCollection = interfaceController?.carTraitCollection
         self.visibleTemplate?.reloadData()
 
         appDelegate()?.handleBecomeActive()

--- a/podcasts/CarPlaySceneDelegate.swift
+++ b/podcasts/CarPlaySceneDelegate.swift
@@ -32,6 +32,7 @@ class CarPlaySceneDelegate: CustomObserver, CPTemplateApplicationSceneDelegate, 
 
     func sceneDidBecomeActive(_ scene: UIScene) {
         appDelegate()?.handleBecomeActive()
+        addChangeListeners()
     }
 
     private func addChangeListeners() {

--- a/podcasts/CarPlaySceneDelegate.swift
+++ b/podcasts/CarPlaySceneDelegate.swift
@@ -93,9 +93,11 @@ class CarPlaySceneDelegate: CustomObserver, CPTemplateApplicationSceneDelegate, 
     }
 
     @objc private func handleDataUpdated() {
-        // Prevent updating too often when multiple notifications fire at once
-        debouncer.call {
-            self.reloadVisibleTemplate()
+        DispatchQueue.main.async {
+            // Prevent updating too often when multiple notifications fire at once
+            self.debouncer.call {
+                self.reloadVisibleTemplate()
+            }
         }
     }
 

--- a/podcasts/CarPlaySceneDelegate.swift
+++ b/podcasts/CarPlaySceneDelegate.swift
@@ -26,6 +26,8 @@ class CarPlaySceneDelegate: CustomObserver, CPTemplateApplicationSceneDelegate, 
         removeAllCustomObservers()
         self.interfaceController?.delegate = nil
         self.interfaceController = nil
+
+        CPNowPlayingTemplate.shared.remove(self)
     }
 
     func sceneDidBecomeActive(_ scene: UIScene) {

--- a/podcasts/CarPlaySceneDelegate.swift
+++ b/podcasts/CarPlaySceneDelegate.swift
@@ -19,9 +19,7 @@ class CarPlaySceneDelegate: CustomObserver, CPTemplateApplicationSceneDelegate, 
         interfaceController.setRootTemplate(tabTemplate)
 
         self.visibleTemplate = tabTemplate.selectedTemplate
-
         setupNowPlaying()
-        addChangeListeners()
     }
 
     func templateApplicationScene(_ templateApplicationScene: CPTemplateApplicationScene, didDisconnectInterfaceController interfaceController: CPInterfaceController) {
@@ -31,6 +29,8 @@ class CarPlaySceneDelegate: CustomObserver, CPTemplateApplicationSceneDelegate, 
     }
 
     func sceneDidBecomeActive(_ scene: UIScene) {
+        self.visibleTemplate?.reloadData()
+
         appDelegate()?.handleBecomeActive()
         addChangeListeners()
     }

--- a/podcasts/CarPlaySceneDelegate.swift
+++ b/podcasts/CarPlaySceneDelegate.swift
@@ -35,30 +35,48 @@ class CarPlaySceneDelegate: CustomObserver, CPTemplateApplicationSceneDelegate, 
     }
 
     private func addChangeListeners() {
-        addCustomObserver(ServerNotifications.podcastsRefreshed, selector: #selector(handleDataUpdated))
-        addCustomObserver(Constants.Notifications.opmlImportCompleted, selector: #selector(handleDataUpdated))
-        addCustomObserver(Constants.Notifications.filterChanged, selector: #selector(handleDataUpdated))
-        addCustomObserver(Constants.Notifications.episodeDownloaded, selector: #selector(handleDataUpdated))
-        addCustomObserver(Constants.Notifications.episodePlayStatusChanged, selector: #selector(handleDataUpdated))
-        addCustomObserver(Constants.Notifications.episodeArchiveStatusChanged, selector: #selector(handleDataUpdated))
-        addCustomObserver(Constants.Notifications.episodeDurationChanged, selector: #selector(handleDataUpdated))
-        addCustomObserver(Constants.Notifications.episodeDownloadStatusChanged, selector: #selector(handleDataUpdated))
-        addCustomObserver(ServerNotifications.episodeTypeOrLengthChanged, selector: #selector(handleDataUpdated))
-        addCustomObserver(Constants.Notifications.manyEpisodesChanged, selector: #selector(handleDataUpdated))
-        addCustomObserver(Constants.Notifications.upNextQueueChanged, selector: #selector(handleDataUpdated))
-        addCustomObserver(Constants.Notifications.upNextEpisodeAdded, selector: #selector(handleDataUpdated))
-        addCustomObserver(Constants.Notifications.upNextEpisodeRemoved, selector: #selector(handleDataUpdated))
+        let notifications = [
+            // Podcast Changes
+            ServerNotifications.podcastsRefreshed,
+            Constants.Notifications.opmlImportCompleted,
 
-        // playback related
-        addCustomObserver(Constants.Notifications.playbackTrackChanged, selector: #selector(handlePlaybackStateChanged))
-        addCustomObserver(Constants.Notifications.playbackEnded, selector: #selector(handlePlaybackStateChanged))
-        addCustomObserver(Constants.Notifications.podcastChaptersDidUpdate, selector: #selector(handlePlaybackStateChanged))
-        addCustomObserver(Constants.Notifications.playbackStarted, selector: #selector(handlePlaybackStateChanged))
+            // Filters
+            Constants.Notifications.filterChanged,
 
-        // user episode notifications
-        addCustomObserver(Constants.Notifications.userEpisodeUpdated, selector: #selector(handleDataUpdated))
-        addCustomObserver(Constants.Notifications.userEpisodeDeleted, selector: #selector(handleDataUpdated))
-        addCustomObserver(ServerNotifications.userEpisodesRefreshed, selector: #selector(handleDataUpdated))
+            // Episode changes
+            Constants.Notifications.episodeDownloaded,
+            Constants.Notifications.episodePlayStatusChanged,
+            Constants.Notifications.episodeArchiveStatusChanged,
+            Constants.Notifications.episodeDurationChanged,
+            Constants.Notifications.episodeDownloadStatusChanged,
+            ServerNotifications.episodeTypeOrLengthChanged,
+            Constants.Notifications.manyEpisodesChanged,
+
+            // Up Next Changes
+            Constants.Notifications.upNextQueueChanged,
+            Constants.Notifications.upNextEpisodeAdded,
+            Constants.Notifications.upNextEpisodeRemoved,
+
+            // User Episodes
+            Constants.Notifications.userEpisodeUpdated,
+            Constants.Notifications.userEpisodeDeleted,
+            ServerNotifications.userEpisodesRefreshed,
+        ]
+
+        for notification in notifications {
+            addCustomObserver(notification, selector: #selector(handleDataUpdated))
+        }
+
+        let playbackNotifications = [
+            Constants.Notifications.playbackTrackChanged,
+            Constants.Notifications.playbackEnded,
+            Constants.Notifications.podcastChaptersDidUpdate,
+            Constants.Notifications.playbackStarted
+        ]
+
+        for notification in playbackNotifications {
+            addCustomObserver(notification, selector: #selector(handlePlaybackStateChanged))
+        }
     }
 
     @objc private func handlePlaybackStateChanged() {


### PR DESCRIPTION
| 🚧 Fixes #64 | 
|:---:|

I am having this mark #64 as complete because I think that based on the changes in this pr and the other improvements we should see a dramatic reduction of CarPlay related crashes. 

## Description

When reviewing crash logs for CarPlay the top crash is `Unable to allocate enough memory to encode data` which means the users device is running out of memory and the CarPlay app doesn't have enough free memory to encode the lists/images/etc. 

When reviewing the memory usage of the app:
1. On first load, we load the content of every initial tab
2. The images are loaded from Cache, but then processed in `adjustImageIfRequired` which creates a new image instance for each image for every reload.
3. The images that are passed to CarPlay are too big, CarPlay has 2 properties for: `CPListImageRowItem.maximumImageSize` and `CPListItem.maximumImageSize` which are set to 40x40 and 60x60, however we are passing 210x210 images.

Each refresh increases the memory footprint of the CarPlay app which can cause out of memory issues.

This introduces the following:

1. Only the podcasts tab data is loaded when the CarPlay app first launches
2. The data loading is deferred until the app becomes fully active
3. The data is only loaded once when the app first launches (before it would load at minimum twice)
4. Each tab now shows a loading message before loading the data to prevent hanging
5. The images:
   - Are now properly resized to the max size CarPlay expects
   - The image scale is set using the traits that CarPlay provides
   - The images are cached on disk and in memory
       - If a memory warning happens the memory cache is cleared defaulting to loading from the disk again

In my testing on my very old iPhone 8 Plus this has:
- Reduced the memory footprint **27.4%** (62 MB from 85.4 MB)
- Reduced the time to first launch by **61.83%** (645ms from 1.69s)

## Demo Videos

<details>
  <summary>Before 2</summary>

https://user-images.githubusercontent.com/793774/217630192-b35b9948-e4e6-49da-bda7-d8399d6b62c4.mov

</details>

<details>
  <summary>After</summary>

https://user-images.githubusercontent.com/793774/217630276-eaedf30d-ee36-4977-bfcc-5d1f005befb1.mov

</details>

## To test

> **Note**
> You'll want to test on a real device 📱

### Setup
1. Download the CarPlay Simulator from the [Additional Tools for Xcode](https://developer.apple.com/download/all/?q=Additional%20Tools%20for%20Xcode) package
2. Launch the CarPlay Simulator
3. Connect your phone via USB
4. Launch the app in the CarPlay Simulator
6. ✅ Verify you see a loading message and then the list loads
7. ✅ Verify the images appear correctly (not weird cropping or pixelations)
8. Tap on the Up Next bubble
9. ✅ Verify you see a loading indicator and the images load correctly
10. Tap back
11. ✅ Verify you don't see a loading indicator
12. Tap on the filters tab
13. Select a filter
14. ✅ Verify you see a loading indicator and the images load correctly
15. Tap on an Episode to play it
16. Tap on the Playing Next item
17. ✅ Verify you see a loading indicator and the images load correctly

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
