### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 7.32
 -----
-- Fixed an issue where effects were not re-enabled when switching from an Airplay device back to phone output (#678)
 - When connected to CarPlay the Up Next Queue will more consistently display at the top of the podcasts list (#680)
 - Fixed an issue where the Up Next queue doesn't continue playing the next episode when connected to AirPlay (#676)
 - Show Starred for logged out users (#685)


### PR DESCRIPTION
Update CHANGELOG.md to remove reference to fix for #678 which was backed out in https://github.com/Automattic/pocket-casts-ios/commit/c790a47fadc9b6e18db9b6d296aaff8a47fcfa4d