### PR TITLE
Enable sponsored for everyone

### DIFF
--- a/PocketCastsTests/Tests/Discover/DiscoverCoordinatorTests.swift
+++ b/PocketCastsTests/Tests/Discover/DiscoverCoordinatorTests.swift
@@ -12,18 +12,18 @@ final class DiscoverCoordinatorTests: XCTestCase {
         coordinator = DiscoverCoordinator(subscriptionData: subscriptionData)
     }
 
-    func testDoesNotDisplayWithPaidPlatforms() {
+    func testDoesDisplayWithPaidPlatforms() {
         let item = DiscoverItem.make(isSponsored: true)
         subscriptionData.mockHasActiveSubscription = true
 
         subscriptionData.mocksubscriptionPlatform = .iOS
-        XCTAssertFalse(coordinator.shouldDisplay(item))
+        XCTAssertTrue(coordinator.shouldDisplay(item))
 
         subscriptionData.mocksubscriptionPlatform = .web
-        XCTAssertFalse(coordinator.shouldDisplay(item))
+        XCTAssertTrue(coordinator.shouldDisplay(item))
 
         subscriptionData.mocksubscriptionPlatform = .android
-        XCTAssertFalse(coordinator.shouldDisplay(item))
+        XCTAssertTrue(coordinator.shouldDisplay(item))
     }
 
     func testDisplaysWithoutActiveSubscription() {

--- a/podcasts/DiscoverCoordinator.swift
+++ b/podcasts/DiscoverCoordinator.swift
@@ -9,14 +9,6 @@ class DiscoverCoordinator {
     }
 
     func shouldDisplay(_ item: DiscoverItem) -> Bool {
-        let platform = subscriptionData.subscriptionPlatform()
-        let isSponsored = item.isSponsored ?? false
-
-        // don't show sponsored items to active plus subscribers. Those who don't have a subscription, or have a gift (lifetime or otherwise) will still get them
-        if isSponsored, subscriptionData.hasActiveSubscription(), platform.isPaidSubscriptionPlatform {
-            return false
-        }
-
-        return true
+        true
     }
 }

--- a/podcasts/Onboarding/Plus/Account Prompt/PlusAccountUpgradePrompt.swift
+++ b/podcasts/Onboarding/Plus/Account Prompt/PlusAccountUpgradePrompt.swift
@@ -59,7 +59,6 @@ struct PlusAccountUpgradePrompt: View {
         PlusMiniFeature(iconName: "plus-feature-watch", title: L10n.plusMarketingWatchPlaybackTitle),
         PlusMiniFeature(iconName: "plus-feature-cloud", title: L10n.plusCloudStorageLimitFormat(Constants.RemoteParams.customStorageLimitGBDefault.localized())),
         PlusMiniFeature(iconName: "plus-feature-folders", title: L10n.folders),
-        PlusMiniFeature(iconName: "plus-feature-hide-ads", title: L10n.plusMarketingHideAdsTitle),
         PlusMiniFeature(iconName: "plus-feature-themes", title: L10n.plusMarketingThemesIconsTitle)
     ]
 }

--- a/podcasts/Onboarding/Plus/PlusLandingView.swift
+++ b/podcasts/Onboarding/Plus/PlusLandingView.swift
@@ -85,9 +85,6 @@ struct PlusLandingView: View {
         PlusFeature(iconName: "plus-feature-watch",
                     title: L10n.plusMarketingWatchPlaybackTitle,
                     description: L10n.plusMarketingWatchPlaybackDescription),
-        PlusFeature(iconName: "plus-feature-hide-ads",
-                    title: L10n.plusMarketingHideAdsTitle,
-                    description: L10n.plusMarketingHideAdsDescription),
         PlusFeature(iconName: "plus-feature-themes",
                     title: L10n.plusMarketingThemesIconsTitle,
                     description: L10n.plusMarketingThemesIconsDescription)


### PR DESCRIPTION
Enable sponsored to everyone.

## To test

1. Run the app in Staging mode
2. Buy Plus
3. Go to Discover
4. ✅ Make sure Sponsored appears

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
