### PR TITLE
Add initial Search Improvements structure

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -514,6 +514,7 @@
 		8BA55A1328CA7425002BECC5 /* XCTestCase+eventually.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA55A1228CA7425002BECC5 /* XCTestCase+eventually.swift */; };
 		8BA55A1528CA8FEB002BECC5 /* PrivacySettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA55A1428CA8FEB002BECC5 /* PrivacySettingsViewController.swift */; };
 		8BA55A1728CA92A7002BECC5 /* PrivacySettingsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8BA55A1628CA92A7002BECC5 /* PrivacySettingsViewController.xib */; };
+		8BAB8B2F299ABC8200B8404C /* SearchResultsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BAB8B2E299ABC8200B8404C /* SearchResultsViewController.swift */; };
 		8BAD6E5E2975ADB800DB7259 /* GoogleSignIn in Frameworks */ = {isa = PBXBuildFile; productRef = 8BAD6E5D2975ADB800DB7259 /* GoogleSignIn */; };
 		8BAD6E612975AFAA00DB7259 /* GoogleSocialLogin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BAD6E602975AFAA00DB7259 /* GoogleSocialLogin.swift */; };
 		8BB1187F290C56F7009E3A39 /* CategoryPillar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB1187E290C56F7009E3A39 /* CategoryPillar.swift */; };
@@ -2130,6 +2131,7 @@
 		8BA55A1228CA7425002BECC5 /* XCTestCase+eventually.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+eventually.swift"; sourceTree = "<group>"; };
 		8BA55A1428CA8FEB002BECC5 /* PrivacySettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacySettingsViewController.swift; sourceTree = "<group>"; };
 		8BA55A1628CA92A7002BECC5 /* PrivacySettingsViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = PrivacySettingsViewController.xib; sourceTree = "<group>"; };
+		8BAB8B2E299ABC8200B8404C /* SearchResultsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultsViewController.swift; sourceTree = "<group>"; };
 		8BAD6E602975AFAA00DB7259 /* GoogleSocialLogin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleSocialLogin.swift; sourceTree = "<group>"; };
 		8BB1187E290C56F7009E3A39 /* CategoryPillar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryPillar.swift; sourceTree = "<group>"; };
 		8BB11880290C5720009E3A39 /* CategoriesContrastingColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoriesContrastingColor.swift; sourceTree = "<group>"; };
@@ -3894,6 +3896,14 @@
 				8BA55A1228CA7425002BECC5 /* XCTestCase+eventually.swift */,
 			);
 			path = Extensions;
+			sourceTree = "<group>";
+		};
+		8BAB8B2D299ABC5E00B8404C /* New Search */ = {
+			isa = PBXGroup;
+			children = (
+				8BAB8B2E299ABC8200B8404C /* SearchResultsViewController.swift */,
+			);
+			path = "New Search";
 			sourceTree = "<group>";
 		};
 		8BAD6E5F2975AF9900DB7259 /* Login */ = {
@@ -6282,6 +6292,7 @@
 				BD98C5511BA808CF00E85D3B /* Cells */,
 				BD95ED631BAFA1FB004335B0 /* Country */,
 				BD18FB1C219ACC770012C41D /* Search */,
+				8BAB8B2D299ABC5E00B8404C /* New Search */,
 				BDB1E4DB1B8C5998009AD30F /* DiscoverViewController.swift */,
 				BDE60ACD2108597D00A7281B /* DiscoverViewController+DiscoverDelegate.swift */,
 				BDDA14D4219AF8D50066441E /* DiscoverViewController+Search.swift */,
@@ -7996,6 +8007,7 @@
 				BD90134F275F3346004AC104 /* ThemeSelectorView.swift in Sources */,
 				8BAD6E612975AFAA00DB7259 /* GoogleSocialLogin.swift in Sources */,
 				46C22EE328F7497300F4173B /* DeveloperMenu.swift in Sources */,
+				8BAB8B2F299ABC8200B8404C /* SearchResultsViewController.swift in Sources */,
 				BD2219F1253EAEAF000025BE /* PlaybackCatchUpHelper.swift in Sources */,
 				BD1BA4191D07EED9001383F0 /* ActionSheetRootViewController.swift in Sources */,
 				BD2D0AD7243C506C000B313A /* AnimatedImageButton+Pointer.swift in Sources */,

--- a/podcasts/DiscoverViewController+Search.swift
+++ b/podcasts/DiscoverViewController+Search.swift
@@ -37,7 +37,7 @@ extension DiscoverViewController: PCSearchBarDelegate, UIScrollViewDelegate {
     }
 
     func searchDidBegin() {
-        guard let searchView = searchResultsController.view else { return }
+        guard let searchView = FeatureFlag.newSearch.enabled ? newSearchResultsController.view : searchResultsController.view else { return }
 
         searchView.alpha = 0
         view.addSubview(searchView)
@@ -51,15 +51,17 @@ extension DiscoverViewController: PCSearchBarDelegate, UIScrollViewDelegate {
         ])
 
         UIView.animate(withDuration: Constants.Animation.defaultAnimationTime) {
-            self.searchResultsController.view.alpha = 1
+            searchView.alpha = 1
         }
     }
 
     func searchDidEnd() {
+        guard let searchView = FeatureFlag.newSearch.enabled ? newSearchResultsController.view : searchResultsController.view else { return }
+
         UIView.animate(withDuration: Constants.Animation.defaultAnimationTime, animations: {
-            self.searchResultsController.view.alpha = 0
+            searchView.alpha = 0
         }) { _ in
-            self.searchResultsController.view.removeFromSuperview()
+            searchView.removeFromSuperview()
             self.searchResultsController.clearSearchResults()
         }
     }

--- a/podcasts/DiscoverViewController.swift
+++ b/podcasts/DiscoverViewController.swift
@@ -20,7 +20,7 @@ class DiscoverViewController: PCViewController {
     var searchController: PCSearchBarController!
     var searchResultsController: DiscoverPodcastSearchResultsController!
 
-    var newSearchResultsController: SearchResultsViewController!
+    lazy var newSearchResultsController = SearchResultsViewController()
 
     private var loadingContent = false
 

--- a/podcasts/DiscoverViewController.swift
+++ b/podcasts/DiscoverViewController.swift
@@ -20,6 +20,8 @@ class DiscoverViewController: PCViewController {
     var searchController: PCSearchBarController!
     var searchResultsController: DiscoverPodcastSearchResultsController!
 
+    var newSearchResultsController: SearchResultsViewController!
+
     private var loadingContent = false
 
     var discoverLayout: DiscoverLayout?

--- a/podcasts/FeatureFlag.swift
+++ b/podcasts/FeatureFlag.swift
@@ -22,6 +22,9 @@ enum FeatureFlag: String, CaseIterable {
     /// Displays the new onboarding view updates
     case onboardingUpdates
 
+    /// New search
+    case newSearch
+
     var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -42,6 +45,8 @@ enum FeatureFlag: String, CaseIterable {
             return false
         case .onboardingUpdates:
             return true
+        case .newSearch:
+            return false
         }
     }
 }

--- a/podcasts/New Search/SearchResultsViewController.swift
+++ b/podcasts/New Search/SearchResultsViewController.swift
@@ -2,5 +2,7 @@ import Foundation
 
 /// The new search, including episodes
 class SearchResultsViewController: UIViewController {
-
+    override func viewDidLoad() {
+        view.backgroundColor = .black
+    }
 }

--- a/podcasts/New Search/SearchResultsViewController.swift
+++ b/podcasts/New Search/SearchResultsViewController.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+/// The new search, including episodes
+class SearchResultsViewController: UIViewController {
+
+}

--- a/podcasts/PodcastListSearchResultsController.swift
+++ b/podcasts/PodcastListSearchResultsController.swift
@@ -99,7 +99,7 @@ class PodcastListSearchResultsController: UIViewController, UITableViewDelegate,
 
         remoteResults.removeAll()
         localResults = filteredItems
-        searchResultsTable.reloadData()
+        searchResultsTable?.reloadData()
     }
 
     func performRemoteSearch(searchTerm: String, completion: @escaping (() -> Void)) {

--- a/podcasts/PodcastListSearchResultsController.swift
+++ b/podcasts/PodcastListSearchResultsController.swift
@@ -91,7 +91,7 @@ class PodcastListSearchResultsController: UIViewController, UITableViewDelegate,
     func clearSearch() {
         localResults.removeAll()
         remoteResults.removeAll()
-        searchResultsTable.reloadData()
+        searchResultsTable?.reloadData()
     }
 
     func performLocalSearch(searchTerm: String) {

--- a/podcasts/PodcastListViewController+Search.swift
+++ b/podcasts/PodcastListViewController+Search.swift
@@ -1,15 +1,19 @@
 import UIKit
 
 extension PodcastListViewController: UIScrollViewDelegate, PCSearchBarDelegate {
+    var searchControllerView: UIView {
+        FeatureFlag.newSearch.enabled ? newSearchResultsController.view : searchResultsControler.view
+    }
+
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        guard searchResultsControler?.view?.superview == nil else { return } // don't send scroll events while the search results are up
+        guard searchControllerView.superview == nil else { return } // don't send scroll events while the search results are up
 
         searchController.parentScrollViewDidScroll(scrollView)
         refreshControl?.scrollViewDidScroll(scrollView)
     }
 
     func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
-        guard searchResultsControler?.view?.superview == nil else { return } // don't send scroll events while the search results are up
+        guard searchControllerView.superview == nil else { return } // don't send scroll events while the search results are up
 
         searchController.parentScrollViewDidEndDragging(scrollView, willDecelerate: decelerate)
         refreshControl?.scrollViewDidEndDragging(scrollView)
@@ -84,7 +88,7 @@ extension PodcastListViewController: UIScrollViewDelegate, PCSearchBarDelegate {
     // MARK: - PCSearchBarDelegate
 
     func searchDidBegin() {
-        guard let searchView = searchResultsControler.view else { return }
+        let searchView = searchControllerView
 
         searchView.alpha = 0
         view.addSubview(searchView)
@@ -98,15 +102,15 @@ extension PodcastListViewController: UIScrollViewDelegate, PCSearchBarDelegate {
         ])
 
         UIView.animate(withDuration: Constants.Animation.defaultAnimationTime) {
-            self.searchResultsControler.view.alpha = 1
+            searchView.alpha = 1
         }
     }
 
     func searchDidEnd() {
         UIView.animate(withDuration: Constants.Animation.defaultAnimationTime, animations: {
-            self.searchResultsControler.view.alpha = 0
+            self.searchControllerView.alpha = 0
         }) { _ in
-            self.searchResultsControler.view.removeFromSuperview()
+            self.searchControllerView.removeFromSuperview()
             self.searchResultsControler.clearSearch()
         }
     }

--- a/podcasts/PodcastListViewController.swift
+++ b/podcasts/PodcastListViewController.swift
@@ -65,6 +65,8 @@ class PodcastListViewController: PCViewController, UIGestureRecognizerDelegate, 
     var searchController: PCSearchBarController!
     var searchResultsControler: PodcastListSearchResultsController!
 
+    lazy var newSearchResultsController = SearchResultsViewController()
+
     override func viewDidLoad() {
         customRightBtn = UIBarButtonItem(image: UIImage(named: "more"), style: .plain, target: self, action: #selector(podcastOptionsTapped(_:)))
         customRightBtn?.accessibilityLabel = L10n.accessibilityMoreActions


### PR DESCRIPTION
* Adds a Feature Flag to enable/disable the new search
* Shows the old search VC or the new search View Controller based on the FF value

## To test

1. Run the app
2. Go to Discover
3. Search for something
4. ✅ Search should behave as always
5. Go to Podcasts
6. Search for something
7. ✅ Search should behave as always
8. Go to Profile > Settings > Beta Features > enable `newSearch`
9. Go to Discover
10. Tap the search
11. ✅ A black view should appear
12. Cancel the search
13. ✅ The black view should dismiss
14. Go to Podcasts and perform the same
15. ✅ Black view should appear and when the search is canceled it is dismissed

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
