### PR TITLE
Up Next: Save the auto add candidates to the DB to make sure they are processed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - CarPlay: Tapping an episode now goes to the now playing screen (#702)
 - CarPlay: The mark as played and chapter icons now update with the dark/light mode (#700)
 - CarPlay: Fixed many issues where the UI would not refresh correctly (#699)
+- Auto Add Up Next: Fixed an issue that could cause items in Auto Add Up Next to not be added (#711)
 
 
 7.32

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/AutoAddQueueDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/AutoAddQueueDataManager.swift
@@ -1,0 +1,122 @@
+import FMDB
+import PocketCastsUtils
+
+public struct AutoAddCandidatesDataManager {
+    private let dbQueue: FMDatabaseQueue
+
+    init(dbQueue: FMDatabaseQueue) {
+        self.dbQueue = dbQueue
+    }
+
+    /// Adds a new auto add candidate to the database
+    public func add(podcastUUID: String, episodeUUID: String) {
+        dbQueue.inDatabase { db in
+            do {
+                try db.executeUpdate("INSERT INTO \(Constants.tableName) (episode_uuid, podcast_uuid) VALUES (?, ?)", values: [episodeUUID, podcastUUID])
+            } catch {
+                FileLog.shared.addMessage("AutoAddCandidatesDataManager.add error: \(error)")
+            }
+        }
+    }
+
+    /// Removes a single candidate from the DB
+    public func remove(_ candidate: AutoAddCandidate) {
+        dbQueue.inDatabase { db in
+            do {
+                try db.executeUpdate("""
+                DELETE FROM \(Constants.tableName) WHERE id = ? LIMIT 1
+                """, values: [candidate.id])
+            } catch {
+                FileLog.shared.addMessage("AutoAddCandidatesDataManager.remove error: \(error)")
+            }
+        }
+    }
+
+    /// Reset the the entire candidates table
+    public func clearAll() {
+        dbQueue.inDatabase { db in
+            do {
+                try db.executeUpdate("DELETE FROM \(Constants.tableName)", values: nil)
+            } catch {
+                FileLog.shared.addMessage("AutoAddCandidatesDataManager.clearAll error: \(error)")
+            }
+        }
+    }
+
+    /// Returns the auto add up next candidates
+    /// Each candidate contains the
+    public func candidates() -> [AutoAddCandidate] {
+        var results: [AutoAddCandidate] = []
+
+        dbQueue.inDatabase { db in
+            do {
+                let query = """
+                SELECT
+                    -- Get the Podcast Auto Add Setting
+                    podcast.autoAddToUpNext AS \(Constants.autoAddSettingColumnName),
+
+                    -- Get the episode UUID
+                    queue.id AS \(Constants.idColumnName),
+                    queue.episode_uuid AS \(Constants.episodeColumnName)
+                FROM
+                    \(Constants.tableName) AS queue
+                    JOIN \(DataManager.podcastTableName) AS podcast ON podcast.uuid = queue.podcast_uuid
+                -- Process the oldest items first
+                ORDER BY queue.id ASC
+                """
+
+                let resultSet = try db.executeQuery(query, values: nil)
+
+                defer { resultSet.close() }
+                while resultSet.next() {
+                    if let result = AutoAddCandidate(from: resultSet) {
+                        results.append(result)
+                    }
+                }
+            } catch {
+                FileLog.shared.addMessage("candidates error: \(error)")
+            }
+        }
+
+        return results
+    }
+
+    // MARK: - Model
+
+    /// The `AutoAddCandidate` represents an episode that could be auto added to the up next queue.
+    /// To reduce the number of queries needed this also includes the related Podcast's auto add up next setting
+    public struct AutoAddCandidate {
+        let id: Int
+
+        /// The Podcast.autoAddToUpNext setting value
+        public let autoAddToUpNextSetting: AutoAddToUpNextSetting
+
+        /// The UUID of the candidate episode to add
+        public let episodeUuid: String
+
+        init?(from resultSet: FMResultSet) {
+            let setting = resultSet.int(forColumn: Constants.autoAddSettingColumnName)
+
+            guard
+                let idObj = resultSet.object(forColumn: Constants.idColumnName) as? NSNumber,
+                let episodeUuid = resultSet.string(forColumn: Constants.episodeColumnName),
+                let autoAddSetting = AutoAddToUpNextSetting(rawValue: setting)
+            else {
+                return nil
+            }
+
+            self.id = idObj.intValue
+            self.autoAddToUpNextSetting = autoAddSetting
+            self.episodeUuid = episodeUuid
+        }
+    }
+
+    // MARK: - Config
+
+    private enum Constants {
+        static let tableName = "AutoAddCandidates"
+        static let autoAddSettingColumnName = "auto_add_setting"
+        static let episodeColumnName = "episode_uuid"
+        static let idColumnName = "id"
+    }
+}

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseHelper.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseHelper.swift
@@ -641,6 +641,26 @@ class DatabaseHelper {
             }
         }
 
+        if schemaVersion < 41 {
+            do {
+                try db.executeUpdate("""
+                CREATE TABLE IF NOT EXISTS AutoAddCandidates (
+                    id INTEGER PRIMARY KEY,
+                    episode_uuid varchar(40) NOT NULL,
+                    podcast_uuid varchar(40) NOT NULL
+                );
+                """, values: nil)
+
+                try db.executeUpdate("CREATE INDEX IF NOT EXISTS episode ON AutoAddCandidates (episode_uuid)", values: nil)
+                try db.executeUpdate("CREATE INDEX IF NOT EXISTS podcast ON AutoAddCandidates (podcast_uuid)", values: nil)
+
+                schemaVersion = 41
+            } catch {
+                failedAt(41)
+                return
+            }
+        }
+
         db.commit()
     }
 }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -22,6 +22,8 @@ public class DataManager {
     private let folderManager = FolderDataManager()
     private lazy var endOfYearManager = EndOfYearDataManager()
 
+    public let autoAddCandidates: AutoAddCandidatesDataManager
+
     private let dbQueue: FMDatabaseQueue
 
     public static let sharedManager = DataManager()
@@ -41,6 +43,8 @@ public class DataManager {
         podcastManager.setup(dbQueue: dbQueue)
         folderManager.setup(dbQueue: dbQueue)
         upNextManager.setup(dbQueue: dbQueue)
+
+        autoAddCandidates = AutoAddCandidatesDataManager(dbQueue: dbQueue)
     }
 
     convenience init(endOfYearManager: EndOfYearDataManager) {

--- a/Modules/Server/Sources/PocketCastsServer/Public/Refresh/RefreshOperation.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Refresh/RefreshOperation.swift
@@ -181,6 +181,11 @@ class RefreshOperation: Operation {
         }
 
         for candidate in autoAddCandidates {
+            // Ignore any podcasts that no longer have the setting on
+            guard candidate.autoAddToUpNextSetting != .off else {
+                continue
+            }
+
             let episodeUuid = candidate.episodeUuid
             let toTop = candidate.autoAddToUpNextSetting == .addFirst
 

--- a/Modules/Server/Sources/PocketCastsServer/Public/Refresh/RefreshOperation.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Refresh/RefreshOperation.swift
@@ -168,6 +168,8 @@ class RefreshOperation: Operation {
                     var newEpisodes = addToUpNextCandidateEpisodes[podcast.uuid] ?? [String]()
                     newEpisodes.append(newEpisode.uuid)
                     addToUpNextCandidateEpisodes[podcast.uuid] = newEpisodes
+
+                    DataManager.sharedManager.autoAddCandidates.add(podcastUUID: podcast.uuid, episodeUUID: newEpisode.uuid)
                 }
 
                 #if !os(watchOS)

--- a/Modules/Server/Sources/PocketCastsServer/Public/Refresh/RefreshOperation.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Refresh/RefreshOperation.swift
@@ -181,7 +181,7 @@ class RefreshOperation: Operation {
         }
 
         for candidate in autoAddCandidates {
-            // Ignore any podcasts that no longer have the setting on
+            // Ignore any podcasts that no longer have the setting enabled
             guard candidate.autoAddToUpNextSetting != .off else {
                 continue
             }
@@ -207,10 +207,10 @@ class RefreshOperation: Operation {
             DataManager.sharedManager.autoAddCandidates.remove(candidate)
         }
 
-        // We have finished processing all of the up next candiates.
+        // We have finished processing all of the up next candidates.
         //
-        // There is a chance that some candidates are invalid and were not processed. We'll solve this clearing all
-        // of the candidates from the DB to ensure there are no orphaned or ghost episodes.
+        // There is a chance that some candidates are invalid and were not processed. We'll solve this by deleting all
+        // of the candidates from the DB to ensure there are no ghost episodes left over.
         DataManager.sharedManager.autoAddCandidates.clearAll()
     }
 }

--- a/Modules/Server/Sources/PocketCastsServer/Public/Refresh/RefreshOperation.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Refresh/RefreshOperation.swift
@@ -206,5 +206,11 @@ class RefreshOperation: Operation {
             // The candidate has been processed, remove it from the database
             DataManager.sharedManager.autoAddCandidates.remove(candidate)
         }
+
+        // We have finished processing all of the up next candiates.
+        //
+        // There is a chance that some candidates are invalid and were not processed. We'll solve this clearing all
+        // of the candidates from the DB to ensure there are no orphaned or ghost episodes.
+        DataManager.sharedManager.autoAddCandidates.clearAll()
     }
 }


### PR DESCRIPTION
Fixes #40
Fixes: #189

## Description
During a sync any episodes that are candidates to be added to the auto add up next were stored in a single property `RefreshOperation.addToUpNextCandidateEpisodes` when the `performRefresh` method was called, and then processed later in the `RefreshOperation.main` call. 

The problem with this is that if the refresh operation fails for any reason (cancelation, crashing, etc) all of the candidates could be lost and upon refreshing or restarting the app, the server may not return the old candidates again. 

This aims to solve that by saving the candidates to the local database and then later retrieving them from there. This means that the candidates are persisted until they have been processed.

### Candidates table
When we add a candidate row we store the `episode_uuid` and `podcast_uuid`. When we retrieve the candidates we also perform a join to retrieve the related podcasts `AutoAddToUpNextSetting` which helps speed up the processing later by not needing to first find the podcast, and then the episode for the podcast. 

I originally wrote a query that avoided the need for performing any additional processing (checking archived, up next queue existences, etc). But, I found for larger databases this query was too slow (500ms+) and reduced it to the single join. 

In my testing the final query takes less than 3ms to complete on a DB that has over 200k episodes, and 900 podcasts.

### Future Improvements

During my exploration I found there are a few things we could do to improve the performance of the auto add up next for people with a lot of podcasts, but I didn't want to include them all in this PR to keep it simple. 

1. Make sure the `RefreshOperation.completionHandler` isn't called before we're fully done processing the refresh
   - The completionHandler can be called before the auto archive/up next items are processed and for a background refresh this means we tell the system the task is done and it will cancel it. 
2. Reduce the number of notifications fired during the auto add process
   - Currently the `Constants.Notifications.upNextQueueChanged` is called for each item that is auto added, and for users with watch's this could slow down the performance because it's also added each of those items
3. For background refreshing we should limit what the refresh does as it can be killed before it has a chance to fully process everything. (We have about 26 seconds before the system expires the task).


## To test

### Setup
Testing this is requires some setup. 

1. In Xcode, open `MainServerHandler`, go to line 240 and replace it with:

```
jsonRequest["last_episodes"].string = podcasts.map { $0.latestEpisodeUuid; return "" }.joined(separator: ",")
```

4. This makes it so we no longer send the latest episode UUIDs to the server and force it to return the latest 10 for each of the podcasts 
5. In `RefreshOperation`, go to line 126 and replace it with:

```
if let _ = DataManager.sharedManager.findEpisode(uuid: episodeUuid) {
    DataManager.sharedManager.delete(episodeUuid: episodeUuid)
}
```

6. This removes the existence check, and just deleted the existing episode instead

### Testing: Order
#### Getting the old episode order from the release app
1. Load the current release code in Xocde
2. Apply the changes from the Setup section above
3. Run the app
5. Clear your up next and now playing
6. Enable auto add up next on 1 podcast that has more than 10 episodes
7. Perform a refresh
8. Save a screenshot / make note of the episode order

#### Verifying the old episode order against the new order
1. Load this PR
2. Apply the changes from the Setup section above
3. Run the app
4. Clear your up next and now playing
5. Enable auto add up next on the same podcast from above
6. Perform a refresh
13. ✅ Verify you now have 1 item playing and 9 items in your up next
14. ✅ Verify the order of episodes is the same as the production app

**Note:** This only verifies the episode order and not the old podcast order because before the podcasts/episodes were stored in a Dictionary and when processed the Dictionary keys were used to determine the order. Because [The order of the elements in the array is not defined](https://developer.apple.com/documentation/foundation/nsdictionary/1409150-allkeys) this resulted in there being no specific order that the podcasts were processed in.  

### Testing: Restoration
This will attempt to simulate the server sending new auto add up next items and the app crashing/cancelling/etc before they have a chance to be added.

1. In RefreshOperation.swift
2. Put a breakpoint on line 96
3. Launch the app, clear your up next and playing
4. Perform a refresh
5. When the breakpoint is hit, kill the app
6. In RefreshOperation.swift, comment out line 143 (`DataManager.sharedManager.autoAddCandidates.add...`)
   - This simulates the server returning no new auto add items
7. Restart the app and perform a refresh
8. ✅ Verify the "old" auto add items are processed and added
9. Clear your up next queue and now playing, and perform a refresh
10. ✅ Verify the "old" items are not added again.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
