### PR TITLE
Up Next: Add prefix to the auto add candidate index name

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseHelper.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseHelper.swift
@@ -651,8 +651,8 @@ class DatabaseHelper {
                 );
                 """, values: nil)
 
-                try db.executeUpdate("CREATE INDEX IF NOT EXISTS episode ON AutoAddCandidates (episode_uuid)", values: nil)
-                try db.executeUpdate("CREATE INDEX IF NOT EXISTS podcast ON AutoAddCandidates (podcast_uuid)", values: nil)
+                try db.executeUpdate("CREATE INDEX IF NOT EXISTS candidate_episode ON AutoAddCandidates (episode_uuid)", values: nil)
+                try db.executeUpdate("CREATE INDEX IF NOT EXISTS candidate_podcast ON AutoAddCandidates (podcast_uuid)", values: nil)
 
                 schemaVersion = 41
             } catch {


### PR DESCRIPTION
I forgot to add a prefix to the auto add candidate index names in https://github.com/Automattic/pocket-casts-ios/pull/711. 

This is needed because the index names are unique and should be a bit more specific to prevent conflicts. 

## To test
1. Reinstall the app (needed to reset the schema version)
2. ✅ Verify there are no DB errors on start up

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
