### PR TITLE
Bookmarks: Add bookmarking when the previous track command is fired

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1360,6 +1360,8 @@
 		C72223D4292C918F006B3B55 /* OnboardingModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C72223D3292C918F006B3B55 /* OnboardingModel.swift */; };
 		C72223D6292CAE92006B3B55 /* OnboardingFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = C72223D5292CAE92006B3B55 /* OnboardingFlow.swift */; };
 		C722245C2936CA15006B3B55 /* StoryLogoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C722245A2936C8FA006B3B55 /* StoryLogoView.swift */; };
+		C725285F299B315000A582C3 /* BookmarkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C725285E299B315000A582C3 /* BookmarkManager.swift */; };
+		C7252863299B353A00A582C3 /* BookmarkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C725285E299B315000A582C3 /* BookmarkManager.swift */; };
 		C72CED2D289DA14F0017883A /* AnalyticsEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = C72CED2C289DA14F0017883A /* AnalyticsEvent.swift */; };
 		C72CED2F289DA1650017883A /* String+Analytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = C72CED2E289DA1650017883A /* String+Analytics.swift */; };
 		C72CED32289DA1900017883A /* TracksAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C72CED31289DA1900017883A /* TracksAdapter.swift */; };
@@ -2969,6 +2971,7 @@
 		C72223D3292C918F006B3B55 /* OnboardingModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingModel.swift; sourceTree = "<group>"; };
 		C72223D5292CAE92006B3B55 /* OnboardingFlow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingFlow.swift; sourceTree = "<group>"; };
 		C722245A2936C8FA006B3B55 /* StoryLogoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoryLogoView.swift; sourceTree = "<group>"; };
+		C725285E299B315000A582C3 /* BookmarkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkManager.swift; sourceTree = "<group>"; };
 		C72CED2C289DA14F0017883A /* AnalyticsEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsEvent.swift; sourceTree = "<group>"; };
 		C72CED2E289DA1650017883A /* String+Analytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Analytics.swift"; sourceTree = "<group>"; };
 		C72CED31289DA1900017883A /* TracksAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracksAdapter.swift; sourceTree = "<group>"; };
@@ -4429,6 +4432,7 @@
 				BDF15A451B54E21B000EC323 /* PlaybackEffects.swift */,
 				BD44A4442302DAC6004F55B2 /* CommonUpNextItem.swift */,
 				BD2219F0253EAEAF000025BE /* PlaybackCatchUpHelper.swift */,
+				C725285E299B315000A582C3 /* BookmarkManager.swift */,
 			);
 			name = Playback;
 			sourceTree = "<group>";
@@ -7795,6 +7799,7 @@
 				BD2E8ED31FB18A7C005E4B7C /* PodcastManager.swift in Sources */,
 				C7FF7717291D50880082A464 /* Motion.swift in Sources */,
 				BD83DE0C2068B8E000012C06 /* MiniPlayerViewController+Gestures.swift in Sources */,
+				C725285F299B315000A582C3 /* BookmarkManager.swift in Sources */,
 				BDC8CDDE203C02F600D88313 /* PodcastListViewController+Search.swift in Sources */,
 				BD27B8C72756F4C9007A0EA7 /* Styles.swift in Sources */,
 				8B484F0228D25DB5001AFA97 /* UIViewController+requestReview.swift in Sources */,
@@ -8286,6 +8291,7 @@
 				BDADFF9B2431AA48006497B9 /* EpisodeDateHelper.swift in Sources */,
 				BDE48A242410D0D400ECA6CA /* UserEpisodeManager.swift in Sources */,
 				461C46CE274D9E400003D3A9 /* LocalizationHelpers.swift in Sources */,
+				C7252863299B353A00A582C3 /* BookmarkManager.swift in Sources */,
 				46D88AB727DF97CA00F3BC43 /* PodcastsListView.swift in Sources */,
 				BDD3019A1EFB9EE8004A9972 /* TopLevelItemRowController.swift in Sources */,
 				463FCE7D27BEA90B00E5AF89 /* WatchInterfaceType.swift in Sources */,

--- a/podcasts/BookmarkManager.swift
+++ b/podcasts/BookmarkManager.swift
@@ -7,4 +7,19 @@ struct BookmarkManager {
     /// How long a bookmark clip is
     /// TODO: Make configurable
     private let clipLength = 1.minute
+
+    /// Adds a new bookmark for an episode at the given time
+    func add(to episode: BaseEpisode, at time: TimeInterval) {
+        // If the episode has a podcast attached, also save that
+        let podcastUuid: String? = (episode as? Episode)?.podcastUuid
+
+        // If someone is bookmarking a point in time, they probably want to remember the info leading up to the bookmark
+        // time, so calculate the start of the clip as X seconds before the bookmark time
+        let startTime = max(0, time - clipLength)
+
+        dataManager.add(episodeUuid: episode.uuid, podcastUuid: podcastUuid, start: startTime, end: time)
+
+
+        FileLog.shared.addMessage("[Bookmarks] Added bookmark for \(episode.displayableTitle()) from \(startTime) to \(time)")
+    }
     func bookmarks(for podcast: Podcast) -> [Bookmark] {

--- a/podcasts/BookmarkManager.swift
+++ b/podcasts/BookmarkManager.swift
@@ -4,4 +4,7 @@ import PocketCastsUtils
 
 struct BookmarkManager {
     private let dataManager = DataManager.sharedManager.bookmarks
+    /// How long a bookmark clip is
+    /// TODO: Make configurable
+    private let clipLength = 1.minute
     func bookmarks(for podcast: Podcast) -> [Bookmark] {

--- a/podcasts/BookmarkManager.swift
+++ b/podcasts/BookmarkManager.swift
@@ -69,7 +69,7 @@ private extension BookmarkManager {
             #if !os(watchOS)
             // This just plays a system sound instead.
             if let url = FileManager.default.urls(for: .libraryDirectory, in: .systemDomainMask).first {
-                let audioFile = url.appendingPathComponent("Audio/UISounds/PINSubmit_AX.caf")
+                let audioFile = url.appendingPathComponent("Audio/UISounds/jbl_confirm.caf")
                 var soundID: SystemSoundID = .zero
                 AudioServicesCreateSystemSoundID(audioFile as CFURL, &soundID)
                 AudioServicesPlaySystemSoundWithCompletion(soundID) {

--- a/podcasts/BookmarkManager.swift
+++ b/podcasts/BookmarkManager.swift
@@ -11,7 +11,11 @@ import PocketCastsUtils
 struct BookmarkManager {
     typealias Bookmark = BookmarkDataManager.Bookmark
 
-    private let dataManager = DataManager.sharedManager.bookmarks
+    private let dataManager: BookmarkDataManager
+
+    init(dataManager: BookmarkDataManager = DataManager.sharedManager.bookmarks) {
+        self.dataManager = dataManager
+    }
 
     /// Plays the "bookmark created" tone
     private lazy var tonePlayer: AVAudioPlayer? = {

--- a/podcasts/BookmarkManager.swift
+++ b/podcasts/BookmarkManager.swift
@@ -22,4 +22,15 @@ struct BookmarkManager {
 
         FileLog.shared.addMessage("[Bookmarks] Added bookmark for \(episode.displayableTitle()) from \(startTime) to \(time)")
     }
+
+    /// Retrieves all the bookmarks for a episode
+    func bookmarks(for episode: BaseEpisode) -> [Bookmark] {
+        dataManager.bookmarks(forEpisode: episode.uuid)
+    }
+
+    /// Retrieves all the bookmarks for a podcast
     func bookmarks(for podcast: Podcast) -> [Bookmark] {
+        dataManager.bookmarks(forEpisode: podcast.uuid)
+    }
+}
+

--- a/podcasts/BookmarkManager.swift
+++ b/podcasts/BookmarkManager.swift
@@ -1,0 +1,7 @@
+import Foundation
+import PocketCastsDataModel
+import PocketCastsUtils
+
+struct BookmarkManager {
+    private let dataManager = DataManager.sharedManager.bookmarks
+    func bookmarks(for podcast: Podcast) -> [Bookmark] {

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -1466,11 +1466,13 @@ class PlaybackManager: ServerPlaybackDelegate {
                     strongSelf.seekTo(time: ceil(previousChapter.startTime.seconds))
                 } else {
                     if fabs(strongSelf.lastSeekTime.timeIntervalSinceNow) > Constants.Limits.minTimeBetweenRemoteSkips {
-//                        strongSelf.lastSeekTime = Date()
-//                        strongSelf.skipBack()
-
-                        // TODO: Add detecting of a setting let the user choose to not override this
-                        strongSelf.bookmark()
+                        if FeatureFlag.bookmarks.enabled {
+                            // TODO: Add detecting of a setting let the user choose to not override this
+                            strongSelf.bookmark()
+                        } else {
+                            strongSelf.lastSeekTime = Date()
+                            strongSelf.skipBack()
+                        }
                     } else {
                         FileLog.shared.addMessage("Remote control: previousTrackCommand ignored, too soon since previous command")
                     }
@@ -1874,6 +1876,7 @@ class PlaybackManager: ServerPlaybackDelegate {
 
 extension PlaybackManager {
     func bookmark() {
+        guard FeatureFlag.bookmarks.enabled else { return }
         guard let episode = currentEpisode() else { return }
         let currentTime = currentTime()
 

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -1876,8 +1876,13 @@ class PlaybackManager: ServerPlaybackDelegate {
 
 extension PlaybackManager {
     func bookmark() {
-        guard FeatureFlag.bookmarks.enabled else { return }
-        guard let episode = currentEpisode() else { return }
+        guard
+            FeatureFlag.bookmarks.enabled,
+            let episode = currentEpisode()
+        else {
+            return
+        }
+        
         let currentTime = currentTime()
 
         bookmarkManager.add(to: episode, at: currentTime)

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -1882,7 +1882,7 @@ extension PlaybackManager {
         else {
             return
         }
-        
+
         let currentTime = currentTime()
 
         bookmarkManager.add(to: episode, at: currentTime)

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -58,6 +58,8 @@ class PlaybackManager: ServerPlaybackDelegate {
 
     private let analyticsPlaybackHelper = AnalyticsPlaybackHelper.shared
 
+    private let bookmarkManager = BookmarkManager()
+
     init() {
         queue = PlaybackQueue()
         queue.loadPersistedQueue()
@@ -1464,8 +1466,11 @@ class PlaybackManager: ServerPlaybackDelegate {
                     strongSelf.seekTo(time: ceil(previousChapter.startTime.seconds))
                 } else {
                     if fabs(strongSelf.lastSeekTime.timeIntervalSinceNow) > Constants.Limits.minTimeBetweenRemoteSkips {
-                        strongSelf.lastSeekTime = Date()
-                        strongSelf.skipBack()
+//                        strongSelf.lastSeekTime = Date()
+//                        strongSelf.skipBack()
+
+                        // TODO: Add detecting of a setting let the user choose to not override this
+                        strongSelf.bookmark()
                     } else {
                         FileLog.shared.addMessage("Remote control: previousTrackCommand ignored, too soon since previous command")
                     }
@@ -1865,4 +1870,13 @@ class PlaybackManager: ServerPlaybackDelegate {
     // MARK: - Analytics
 
     private let commandCenterSource: AnalyticsSource = .nowPlayingWidget
+}
+
+extension PlaybackManager {
+    func bookmark() {
+        guard let episode = currentEpisode() else { return }
+        let currentTime = currentTime()
+
+        bookmarkManager.add(to: episode, at: currentTime)
+    }
 }


### PR DESCRIPTION
| 📘 Project: #717 | 🛫 Depends on: #719  |
|:---:|:---:|

This adds the BookmarkManager which acts as the app interface to the BookmarkDataManager. It currently can:

1. Add a new bookmark for any episode
2. Play a test confirmation tone
3. Retrieve bookmarks

This also adds the basic action to create a bookmark using the previous track command via headphones or an external remote. 

### TODO Messages
We don't currently have a tone to play when the bookmark is created so I added TODO's to remind me to replace the temporary tone that I am using (which is just a system sound).

## To test
> **Note** You'll want to test on a real device using headphones that have a previous track action (triple click on AirPods)

1. Connect your headphones to your device
2. Launch the app
3. Play any episode
5. Perform a previous track action (triple click on AirPods)
6. ✅ Verify the episode goes back to the beginning
7. Enable the Bookmarks FeatureFlag in Profile > Cog > Beta Features
8. Perform a previous track action again
9. ✅ Verify you hear a pleasant tone,
   - If you don't, you will need to bring your phone off silent because it won't play
10. ✅ Verify you see a log message for `[Bookmarks] Added bookmark for Episode_Title from Start_Time to End_Time`
11. ✅ Verify the End_Time is the point in time the episode was playing at
12. ✅ Verify the Start_Time is 60 seconds before that

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
