### PR TITLE
Auto scroll Discover Featured collection view by adhering to new AutoScroll protocol

### DIFF
--- a/podcasts/FeatureFlag.swift
+++ b/podcasts/FeatureFlag.swift
@@ -28,6 +28,9 @@ enum FeatureFlag: String, CaseIterable {
     /// Bookmarks / Highlights
     case bookmarks
 
+    /// Auto scrolls Discover Featured carousel
+    case discoverFeaturedAutoScroll
+
     var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -51,6 +54,8 @@ enum FeatureFlag: String, CaseIterable {
         case .newSearch:
             return false
         case .bookmarks:
+            return false
+        case .discoverFeaturedAutoScroll:
             return false
         }
     }

--- a/podcasts/FeaturedSummaryViewController.swift
+++ b/podcasts/FeaturedSummaryViewController.swift
@@ -64,7 +64,7 @@ class FeaturedSummaryViewController: SimpleNotificationsViewController, GridLayo
     override func viewWillAppear(_ animated: Bool) {
         featuredCollectionView.reloadData()
         if FeatureFlag.discoverFeaturedAutoScroll.enabled {
-            featuredCollectionView.intializeAutoScrollTimer()
+            featuredCollectionView.initializeAutoScrollTimer()
         }
     }
 

--- a/podcasts/FeaturedSummaryViewController.swift
+++ b/podcasts/FeaturedSummaryViewController.swift
@@ -2,7 +2,7 @@ import PocketCastsServer
 import UIKit
 
 class FeaturedSummaryViewController: SimpleNotificationsViewController, GridLayoutDelegate, UICollectionViewDataSource, UICollectionViewDelegate, DiscoverSummaryProtocol, TinyPageControlDelegate {
-    @IBOutlet var featuredCollectionView: UICollectionView!
+    @IBOutlet var featuredCollectionView: ThemeableCollectionView!
     @IBOutlet var pageControl: TinyPageControl! {
         didSet {
             pageControl.delegate = self
@@ -63,6 +63,11 @@ class FeaturedSummaryViewController: SimpleNotificationsViewController, GridLayo
 
     override func viewWillAppear(_ animated: Bool) {
         featuredCollectionView.reloadData()
+        featuredCollectionView.intializeAutoScrollTimer()
+    }
+
+    override func viewDidDisappear(_ animated: Bool) {
+        featuredCollectionView.stopAutoScrollTimer()
     }
 
     @objc private func podcastStatusChanged(notificiation: Notification) {

--- a/podcasts/FeaturedSummaryViewController.swift
+++ b/podcasts/FeaturedSummaryViewController.swift
@@ -128,6 +128,14 @@ class FeaturedSummaryViewController: SimpleNotificationsViewController, GridLayo
         updateCurrentPage()
     }
 
+    func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
+        featuredCollectionView.initializeAutoScrollTimer()
+    }
+
+    func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
+        featuredCollectionView.stopAutoScrollTimer()
+    }
+
     override var preferredStatusBarStyle: UIStatusBarStyle {
         AppTheme.defaultStatusBarStyle()
     }

--- a/podcasts/FeaturedSummaryViewController.swift
+++ b/podcasts/FeaturedSummaryViewController.swift
@@ -63,11 +63,15 @@ class FeaturedSummaryViewController: SimpleNotificationsViewController, GridLayo
 
     override func viewWillAppear(_ animated: Bool) {
         featuredCollectionView.reloadData()
-        featuredCollectionView.intializeAutoScrollTimer()
+        if FeatureFlag.discoverFeaturedAutoScroll.enabled {
+            featuredCollectionView.intializeAutoScrollTimer()
+        }
     }
 
     override func viewDidDisappear(_ animated: Bool) {
-        featuredCollectionView.stopAutoScrollTimer()
+        if FeatureFlag.discoverFeaturedAutoScroll.enabled {
+            featuredCollectionView.stopAutoScrollTimer()
+        }
     }
 
     @objc private func podcastStatusChanged(notificiation: Notification) {

--- a/podcasts/ThemeableCollectionView.swift
+++ b/podcasts/ThemeableCollectionView.swift
@@ -8,7 +8,7 @@ protocol AutoScrollCollectionViewDelegate: UICollectionView {
     func stopAutoScrollTimer()
 }
 
-class ThemeableCollectionView: UICollectionView {
+class ThemeableCollectionView: UICollectionView, AutoScrollCollectionViewDelegate {
     var style: ThemeStyle = .primaryUi04 {
         didSet {
             updateColor()
@@ -32,17 +32,9 @@ class ThemeableCollectionView: UICollectionView {
         backgroundColor = AppTheme.colorForStyle(style)
         indicatorStyle = AppTheme.indicatorStyle()
     }
-}
 
-extension ThemeableCollectionView: AutoScrollCollectionViewDelegate {
-    var timer: Timer? {
-        get {
-            return nil
-        }
-        set {
-        }
-    }
-
+   // MARK: - Auto scroll handling
+    var timer: Timer?
     func intializeAutoScrollTimer() {
         timer = Timer.scheduledTimer(timeInterval: 3.0, target: self, selector: #selector(scrolltoNextItem), userInfo: nil, repeats: true)
        }

--- a/podcasts/ThemeableCollectionView.swift
+++ b/podcasts/ThemeableCollectionView.swift
@@ -35,6 +35,7 @@ class ThemeableCollectionView: UICollectionView, AutoScrollCollectionViewDelegat
 
    // MARK: - Auto scroll handling
     var timer: Timer?
+
     func intializeAutoScrollTimer() {
         timer = Timer.scheduledTimer(timeInterval: 3.0, target: self, selector: #selector(scrolltoNextItem), userInfo: nil, repeats: true)
        }

--- a/podcasts/ThemeableCollectionView.swift
+++ b/podcasts/ThemeableCollectionView.swift
@@ -1,6 +1,13 @@
 
 import UIKit
 
+protocol AutoScrollCollectionViewDelegate: UICollectionView {
+    var timer: Timer? { get set }
+    func intializeAutoScrollTimer()
+    func scrolltoNextItem()
+    func stopAutoScrollTimer()
+}
+
 class ThemeableCollectionView: UICollectionView {
     var style: ThemeStyle = .primaryUi04 {
         didSet {
@@ -24,5 +31,34 @@ class ThemeableCollectionView: UICollectionView {
     private func updateColor() {
         backgroundColor = AppTheme.colorForStyle(style)
         indicatorStyle = AppTheme.indicatorStyle()
+    }
+}
+
+extension ThemeableCollectionView: AutoScrollCollectionViewDelegate {
+    var timer: Timer? {
+        get {
+            return nil
+        }
+        set {
+        }
+    }
+
+    func intializeAutoScrollTimer() {
+        timer = Timer.scheduledTimer(timeInterval: 3.0, target: self, selector: #selector(scrolltoNextItem), userInfo: nil, repeats: true)
+       }
+
+    @objc func scrolltoNextItem() {
+        let nextIndex = (indexPathsForVisibleItems.last?.item ?? 0) + 1
+        let indexPath = IndexPath(item: nextIndex, section: 0)
+        if nextIndex < numberOfItems(inSection: 0) {
+            scrollToItem(at: indexPath, at: .left, animated: true)
+        } else if numberOfItems(inSection: 0) > 0 {
+            scrollToItem(at: IndexPath(item: 0, section: 0), at: .left, animated: false)
+        }
+    }
+
+    func stopAutoScrollTimer() {
+        timer?.invalidate()
+        timer = nil
     }
 }

--- a/podcasts/ThemeableCollectionView.swift
+++ b/podcasts/ThemeableCollectionView.swift
@@ -3,7 +3,7 @@ import UIKit
 
 protocol AutoScrollCollectionViewDelegate: UICollectionView {
     var timer: Timer? { get set }
-    func intializeAutoScrollTimer()
+    func initializeAutoScrollTimer()
     func scrolltoNextItem()
     func stopAutoScrollTimer()
 }

--- a/podcasts/ThemeableCollectionView.swift
+++ b/podcasts/ThemeableCollectionView.swift
@@ -36,7 +36,7 @@ class ThemeableCollectionView: UICollectionView, AutoScrollCollectionViewDelegat
    // MARK: - Auto scroll handling
     var timer: Timer?
 
-    func intializeAutoScrollTimer() {
+    func initializeAutoScrollTimer() {
         timer = Timer.scheduledTimer(timeInterval: 3.0, target: self, selector: #selector(scrolltoNextItem), userInfo: nil, repeats: true)
        }
 


### PR DESCRIPTION
As part of upcoming Discover updates, we want to allow the Featured collection view to auto scroll.

This PR:
1. Adds a new protocol `AutoScrollCollectionViewDelegate` and adheres ThemeableCollectionView to it. 
2. Defines featuredCollectionView as ThemeableCollectionView (which it already was in Xib) and initializes its timer to auto scroll in `FeaturedSummaryViewController`   
3. Adds a feature flag disabled by default to control activation of auto scroll

## To test
**No auto scroll on default**
1. Launch the app
2. Open Discover 
3. Notice the Featured Carousel doesn't auto scroll 

**Auto Scroll**
1. Go to profile -> Settings -> Beta Features 
2. Enable discoverFeaturedAutoScroll
3. Open Discover 
4. Watch the Featured  carousel auto scroll 
5. Watch that on the last item the carousel returns to the first item 

**Auto scroll and manual scroll**
1. Swipe to scroll the carousel forward or backwards
3. See the autoscroll continues to the next item as expected


https://user-images.githubusercontent.com/1335657/219984569-2b7799f1-73aa-4aef-9f72-5c133465e7d1.mov



Steps to test your PR.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
