### PR TITLE
Updates the AirPlay auto play logic to be more explicit about when it can be triggered

### DIFF
--- a/podcasts.xcodeproj/xcshareddata/xcschemes/pocketcasts.xcscheme
+++ b/podcasts.xcodeproj/xcshareddata/xcschemes/pocketcasts.xcscheme
@@ -82,6 +82,13 @@
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "CG_NUMERICS_SHOW_BACKTRACE"
+            value = "YES"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Debug"

--- a/podcasts.xcodeproj/xcshareddata/xcschemes/pocketcasts.xcscheme
+++ b/podcasts.xcodeproj/xcshareddata/xcschemes/pocketcasts.xcscheme
@@ -82,13 +82,6 @@
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>
-      <EnvironmentVariables>
-         <EnvironmentVariable
-            key = "CG_NUMERICS_SHOW_BACKTRACE"
-            value = "YES"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-      </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Debug"

--- a/podcasts/DefaultPlayer.swift
+++ b/podcasts/DefaultPlayer.swift
@@ -533,11 +533,13 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
         // This should fix: https://github.com/Automattic/pocket-casts-ios/issues/47
         timeControlStatusObserver = player?.observe(\.timeControlStatus) { [weak self] player, _ in
             guard player.timeControlStatus == .paused, self?.shouldKeepPlaying == true else {
+            #if !os(watchOS)
                 return
             }
 
             FileLog.shared.addMessage("[DefaultPlayer] Detected that playback was paused while trying to play the next item. Attempting to resume playback...")
             self?.play()
+            #endif
         }
 
         rateObserver = player?.observe(\.rate) { [weak self] player, _ in

--- a/podcasts/DefaultPlayer.swift
+++ b/podcasts/DefaultPlayer.swift
@@ -16,6 +16,8 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
 
     private var lastBackgroundedDate: Date?
 
+    /// Internal flag that keeps track of whether we're waiting for the initial playback to begin
+    private var isWaitingForInitialPlayback = false
     private var durationObserver: NSKeyValueObservation?
     private var rateObserver: NSKeyValueObservation?
     private var playerStatusObserver: NSKeyValueObservation?
@@ -50,6 +52,8 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
             handlePlaybackError("Unable to create playback item")
             return
         }
+
+        isWaitingForInitialPlayback = true
 
         player = AVPlayer(playerItem: playerItem)
 
@@ -228,6 +232,8 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
                 createAudioMix()
                 player?.currentItem?.audioMix = audioMix
             #endif
+
+            isWaitingForInitialPlayback = false
         }
 
         PlaybackManager.shared.playerDidChangeNowPlayingInfo()

--- a/podcasts/DefaultPlayer.swift
+++ b/podcasts/DefaultPlayer.swift
@@ -18,6 +18,11 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
 
     /// Internal flag that keeps track of whether we're waiting for the initial playback to begin
     private var isWaitingForInitialPlayback = false
+
+    // Keep track of the previous playback and waiting state
+    private var previousReasonForWaiting: AVPlayer.WaitingReason?
+    private var previousTimeControlStatus: AVPlayer.TimeControlStatus?
+
     private var durationObserver: NSKeyValueObservation?
     private var rateObserver: NSKeyValueObservation?
     private var playerStatusObserver: NSKeyValueObservation?


### PR DESCRIPTION
Fixes #735

This updates the AirPlay play next episode logic that was added in (https://github.com/Automattic/pocket-casts-ios/pull/676) with more checks to ensure its only triggered when:
- We are waiting for the initial load of an episode
- We want to keep playing
- The previous playback status is "Waiting to play"
- The previous reason we are waiting is "no item" and there is no current reason.
- Only apply when we detect we're on AirPlay

## To test

**Note:** You'll need to test on a real device. 

### Verify the original issue is still fixed

1. On your Mac, go to System Preferences > Sharing > Enable Airplay Receiver
   - This will allow your Mac to act as an Airplay speaker
2. On your device add many items to your up next
3. Tap the Airplay icon and select your Mac as the receiver
4. Play an episode
   - To speed things up you can skip to the last 20 seconds or so
6. Put the app in the background
13. Let the episode play out
14. ✅ Verify the playback continues as planned
15. ✅ Verify you see: `[DefaultPlayer] Detected that playback was paused while trying to play the next item. Attempting to resume playback...` in the logs to indicate that the fix was applied

### Verify the new issue is fixed
1. Launch the app
2. Stream an episode with no effects so that the DefaultPlayer is used
3. Call any number on your phone
6. ✅ Verify the podcast stops playing
7. Hang up
8. ✅ Verify the podcast starts playing again
9. You can also test this by opening another app that plays such as a video on Reddit and playing an item

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
