### PR TITLE
Fix no downloads description label

### DIFF
--- a/podcasts/DownloadsViewController.xib
+++ b/podcasts/DownloadsViewController.xib
@@ -43,7 +43,7 @@
                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <nil key="highlightedColor"/>
                         </label>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" usesAttributedText="YES" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="U9d-CR-ZP6" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" usesAttributedText="YES" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="U9d-CR-ZP6" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
                             <rect key="frame" x="30" y="408.5" width="315" height="40.5"/>
                             <attributedString key="attributedText">
                                 <fragment content="Oh no! You’re fresh out of downloads. Download some more and they’ll show up here.">


### PR DESCRIPTION
I found that the description label on the DownloadsViewController can be omitted depending on the language setting (German, French, etc. ) for small screen like iPhone SE.

Befor | After
--- | ---
<img src="https://user-images.githubusercontent.com/7476703/222901431-b2d54b5e-3370-4b56-99e6-3724adacef67.png" width="300" /> |<img src="https://user-images.githubusercontent.com/7476703/222901429-6fa21d35-63c1-4d86-a14c-f8d52644f117.png" width="300" /> 

## To test

Steps to test your PR.

- Make sure you do not have episodes downloaded
- Change language settings to German
- Launch the app
- Go to Profile > Downloads
- Check the description label

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
