### PR TITLE
Discover Carousel: prepare it to receive Sponsored podcasts

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
@@ -239,7 +239,6 @@ public struct DiscoverItem: Decodable {
     public var summaryStyle: String?
     public var expandedStyle: String?
     public var source: String?
-    public var sponsored: [CarouselSponsoredPodcast]
     public var expandedTopItemLabel: String?
     public var curated: Bool?
     public var regions: [String]
@@ -252,39 +251,6 @@ public struct DiscoverItem: Decodable {
         case expandedTopItemLabel = "expanded_top_item_label"
         case type, title, source, regions, curated, uuid
     }
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        do {
-            sponsored = []
-            isSponsored = try container.decode(Bool.self, forKey: .isSponsored)
-        } catch DecodingError.typeMismatch {
-            // There was something for the "manage_stock" key, but it wasn't a boolean value. Try a string.
-            if let array = try container.decodeIfPresent([CarouselSponsoredPodcast].self, forKey: .isSponsored) {
-                // Can check for "parent" specifically if you want.
-                sponsored = array
-                isSponsored = true
-            }
-        } catch {
-            sponsored = []
-            isSponsored = false
-        }
-
-        uuid = try? container.decode(String.self, forKey: .uuid)
-        title = try? container.decode(String.self, forKey: .title)
-        type = try? container.decode(String.self, forKey: .type)
-        summaryStyle = try? container.decode(String.self, forKey: .summaryStyle)
-        expandedStyle = try? container.decode(String.self, forKey: .expandedStyle)
-        source = try? container.decode(String.self, forKey: .source)
-        expandedTopItemLabel = try? container.decode(String.self, forKey: .expandedTopItemLabel)
-        curated = try? container.decode(Bool.self, forKey: .curated)
-        regions = try container.decode([String].self, forKey: .regions)
-    }
-}
-
-public struct CarouselSponsoredPodcast: Decodable {
-    public var position: Int?
-    public var source: String?
 }
 
 public struct PodcastNetwork: Decodable {

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
@@ -239,6 +239,7 @@ public struct DiscoverItem: Decodable {
     public var summaryStyle: String?
     public var expandedStyle: String?
     public var source: String?
+    public var sponsoredPodcasts: [CarouselSponsoredPodcast]?
     public var expandedTopItemLabel: String?
     public var curated: Bool?
     public var regions: [String]
@@ -248,9 +249,15 @@ public struct DiscoverItem: Decodable {
         case summaryStyle = "summary_style"
         case expandedStyle = "expanded_style"
         case isSponsored = "sponsored"
+        case sponsoredPodcasts = "sponsored_podcasts"
         case expandedTopItemLabel = "expanded_top_item_label"
         case type, title, source, regions, curated, uuid
     }
+}
+
+public struct CarouselSponsoredPodcast: Decodable {
+    public var position: Int?
+    public var source: String?
 }
 
 public struct PodcastNetwork: Decodable {

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
@@ -239,6 +239,7 @@ public struct DiscoverItem: Decodable {
     public var summaryStyle: String?
     public var expandedStyle: String?
     public var source: String?
+    public var sponsored: [CarouselSponsoredPodcast]
     public var expandedTopItemLabel: String?
     public var curated: Bool?
     public var regions: [String]
@@ -251,6 +252,39 @@ public struct DiscoverItem: Decodable {
         case expandedTopItemLabel = "expanded_top_item_label"
         case type, title, source, regions, curated, uuid
     }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        do {
+            sponsored = []
+            isSponsored = try container.decode(Bool.self, forKey: .isSponsored)
+        } catch DecodingError.typeMismatch {
+            // There was something for the "manage_stock" key, but it wasn't a boolean value. Try a string.
+            if let array = try container.decodeIfPresent([CarouselSponsoredPodcast].self, forKey: .isSponsored) {
+                // Can check for "parent" specifically if you want.
+                sponsored = array
+                isSponsored = true
+            }
+        } catch {
+            sponsored = []
+            isSponsored = false
+        }
+
+        uuid = try? container.decode(String.self, forKey: .uuid)
+        title = try? container.decode(String.self, forKey: .title)
+        type = try? container.decode(String.self, forKey: .type)
+        summaryStyle = try? container.decode(String.self, forKey: .summaryStyle)
+        expandedStyle = try? container.decode(String.self, forKey: .expandedStyle)
+        source = try? container.decode(String.self, forKey: .source)
+        expandedTopItemLabel = try? container.decode(String.self, forKey: .expandedTopItemLabel)
+        curated = try? container.decode(Bool.self, forKey: .curated)
+        regions = try container.decode([String].self, forKey: .regions)
+    }
+}
+
+public struct CarouselSponsoredPodcast: Decodable {
+    public var position: Int?
+    public var source: String?
 }
 
 public struct PodcastNetwork: Decodable {

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
@@ -305,7 +305,7 @@ public struct PodcastCollection: Decodable {
     }
 }
 
-public struct DiscoverPodcast: Codable {
+public struct DiscoverPodcast: Codable, Equatable {
     public var title: String?
     public var author: String?
     public var shortDescription: String?

--- a/podcasts/ArrayExtension.swift
+++ b/podcasts/ArrayExtension.swift
@@ -4,4 +4,11 @@ extension Array {
             Array(self[$0 ..< Swift.min($0 + size, count)])
         }
     }
+
+    @discardableResult
+    mutating func insert(_ element: Element, safelyAt at: Int) -> Int {
+        let indexToInsert = at <= count ? at : count
+        insert(element, at: indexToInsert)
+        return indexToInsert
+    }
 }

--- a/podcasts/ArrayExtension.swift
+++ b/podcasts/ArrayExtension.swift
@@ -7,7 +7,7 @@ extension Array {
 
     @discardableResult
     mutating func insert(_ element: Element, safelyAt at: Int) -> Int {
-        let indexToInsert = at <= count ? at : count
+        let indexToInsert = Swift.min(at, count)
         insert(element, at: indexToInsert)
         return indexToInsert
     }

--- a/podcasts/DiscoverFeaturedView.swift
+++ b/podcasts/DiscoverFeaturedView.swift
@@ -65,9 +65,9 @@ class DiscoverFeaturedView: ThemeableView {
         podcastImage.alpha = selected ? 0.6 : 1.0
     }
 
-    func populateFrom(_ discoverPodcast: DiscoverPodcast, isSubscribed: Bool, listName: String) {
+    func populateFrom(_ discoverPodcast: DiscoverPodcast, isSubscribed: Bool, listName: String, isSponsored: Bool) {
         self.discoverPodcast = discoverPodcast
-        listType.text = listName.uppercased()
+        listType.text = isSponsored ? L10n.discoverSponsored : listName.uppercased()
         listType.setLetterSpacing(1.57)
 
         if let title = discoverPodcast.title?.localized {

--- a/podcasts/FeaturedCollectionViewCell.swift
+++ b/podcasts/FeaturedCollectionViewCell.swift
@@ -4,8 +4,8 @@ import UIKit
 class FeaturedCollectionViewCell: UICollectionViewCell {
     @IBOutlet var featuredView: DiscoverFeaturedView!
 
-    func populateFrom(_ discoverPodcast: DiscoverPodcast, isSubscribed: Bool, listName: String) {
-        featuredView.populateFrom(discoverPodcast, isSubscribed: isSubscribed, listName: listName)
+    func populateFrom(_ discoverPodcast: DiscoverPodcast, isSubscribed: Bool, listName: String, isSponsored: Bool) {
+        featuredView.populateFrom(discoverPodcast, isSubscribed: isSubscribed, listName: listName, isSponsored: isSponsored)
     }
 
     func setPodcastColor(_ color: UIColor) {

--- a/podcasts/FeaturedSummaryViewController.swift
+++ b/podcasts/FeaturedSummaryViewController.swift
@@ -149,6 +149,9 @@ class FeaturedSummaryViewController: SimpleNotificationsViewController, GridLayo
             listType = delegate.replaceRegionName(string: title)
         }
 
+        let dispatchGroup = DispatchGroup()
+
+        dispatchGroup.enter()
         DiscoverServerHandler.shared.discoverPodcastList(source: source, completion: { [weak self] podcastList in
             guard let strongSelf = self, let discoverPodcast = podcastList?.podcasts else { return }
 
@@ -158,11 +161,13 @@ class FeaturedSummaryViewController: SimpleNotificationsViewController, GridLayo
                 if index == (strongSelf.maxFeaturedItems - 1) { break }
             }
 
-            DispatchQueue.main.async {
-                strongSelf.updatePageCount()
-                strongSelf.featuredCollectionView.reloadData()
-            }
+            dispatchGroup.leave()
         })
+
+        dispatchGroup.notify(queue: DispatchQueue.main) { [weak self] in
+            self?.updatePageCount()
+            self?.featuredCollectionView.reloadData()
+        }
     }
 
     func registerDiscoverDelegate(_ delegate: DiscoverDelegate) {

--- a/podcasts/FeaturedSummaryViewController.swift
+++ b/podcasts/FeaturedSummaryViewController.swift
@@ -10,6 +10,7 @@ class FeaturedSummaryViewController: SimpleNotificationsViewController, GridLayo
     }
 
     private var podcasts = [DiscoverPodcast]()
+    private var sponsoredPodcasts = [DiscoverPodcast]()
     private static let cellId = "FeaturedCollectionViewCell"
 
     private var maxCellWidth = 400 as CGFloat
@@ -183,8 +184,9 @@ class FeaturedSummaryViewController: SimpleNotificationsViewController, GridLayo
 
         dispatchGroup.notify(queue: DispatchQueue.main) { [weak self] in
             for sponsoredPodcastToAdd in sponsoredPodcastsToAdd {
-                self?.podcasts.insert(sponsoredPodcastToAdd.1, at: sponsoredPodcastToAdd.0)
+                self?.podcasts.insert(sponsoredPodcastToAdd.1, safelyAt: sponsoredPodcastToAdd.0)
             }
+            self?.sponsoredPodcasts = sponsoredPodcastsToAdd.map { $0.1 }
 
             self?.updatePageCount()
             self?.featuredCollectionView.reloadData()

--- a/podcasts/FeaturedSummaryViewController.swift
+++ b/podcasts/FeaturedSummaryViewController.swift
@@ -152,17 +152,15 @@ class FeaturedSummaryViewController: SimpleNotificationsViewController, GridLayo
 
         let dispatchGroup = DispatchGroup()
 
+        var podcastsToShow: [DiscoverPodcast] = []
+
         var sponsoredPodcastsToAdd: [Int: DiscoverPodcast] = [:]
 
         dispatchGroup.enter()
         DiscoverServerHandler.shared.discoverPodcastList(source: source, completion: { [weak self] podcastList in
             guard let strongSelf = self, let discoverPodcast = podcastList?.podcasts else { return }
 
-            for (index, discoverPodcast) in discoverPodcast.enumerated() {
-                strongSelf.podcasts.append(discoverPodcast)
-
-                if index == (strongSelf.maxFeaturedItems - 1) { break }
-            }
+            podcastsToShow = discoverPodcast
 
             dispatchGroup.leave()
         })
@@ -183,13 +181,26 @@ class FeaturedSummaryViewController: SimpleNotificationsViewController, GridLayo
         }
 
         dispatchGroup.notify(queue: DispatchQueue.main) { [weak self] in
-            for sponsoredPodcastToAdd in sponsoredPodcastsToAdd {
-                self?.podcasts.insert(sponsoredPodcastToAdd.value, safelyAt: sponsoredPodcastToAdd.key)
+            guard let self else {
+                return
             }
-            self?.sponsoredPodcasts = sponsoredPodcastsToAdd.map { $0.value }
 
-            self?.updatePageCount()
-            self?.featuredCollectionView.reloadData()
+            // Add featured podcasts
+            for (index, discoverPodcast) in podcastsToShow.enumerated() {
+                self.podcasts.append(discoverPodcast)
+
+                if index == (self.maxFeaturedItems - 1) { break }
+            }
+
+            // Add sponsored podcasts
+            for sponsoredPodcastToAdd in sponsoredPodcastsToAdd {
+                self.podcasts.insert(sponsoredPodcastToAdd.value, safelyAt: sponsoredPodcastToAdd.key)
+            }
+            self.sponsoredPodcasts = sponsoredPodcastsToAdd.map { $0.value }
+
+            // Update and reload
+            self.updatePageCount()
+            self.featuredCollectionView.reloadData()
         }
     }
 

--- a/podcasts/FeaturedSummaryViewController.swift
+++ b/podcasts/FeaturedSummaryViewController.swift
@@ -157,8 +157,8 @@ class FeaturedSummaryViewController: SimpleNotificationsViewController, GridLayo
         var sponsoredPodcastsToAdd: [Int: DiscoverPodcast] = [:]
 
         dispatchGroup.enter()
-        DiscoverServerHandler.shared.discoverPodcastList(source: source, completion: { [weak self] podcastList in
-            guard let strongSelf = self, let discoverPodcast = podcastList?.podcasts else { return }
+        DiscoverServerHandler.shared.discoverPodcastList(source: source, completion: { podcastList in
+            guard let discoverPodcast = podcastList?.podcasts else { return }
 
             podcastsToShow = discoverPodcast
 

--- a/podcasts/FeaturedSummaryViewController.swift
+++ b/podcasts/FeaturedSummaryViewController.swift
@@ -100,7 +100,7 @@ class FeaturedSummaryViewController: SimpleNotificationsViewController, GridLayo
 
         let podcast = podcasts[indexPath.row]
         if let delegate = delegate {
-            cell.populateFrom(podcast, isSubscribed: delegate.isSubscribed(podcast: podcast), listName: listType)
+            cell.populateFrom(podcast, isSubscribed: delegate.isSubscribed(podcast: podcast), listName: listType, isSponsored: sponsoredPodcasts.contains(podcast))
             cell.featuredView.onSubscribe = { delegate.subscribe(podcast: podcast) }
         }
 

--- a/podcasts/FeaturedSummaryViewController.swift
+++ b/podcasts/FeaturedSummaryViewController.swift
@@ -152,7 +152,7 @@ class FeaturedSummaryViewController: SimpleNotificationsViewController, GridLayo
 
         let dispatchGroup = DispatchGroup()
 
-        var sponsoredPodcastsToAdd: [(Int, DiscoverPodcast)] = []
+        var sponsoredPodcastsToAdd: [Int: DiscoverPodcast] = [:]
 
         dispatchGroup.enter()
         DiscoverServerHandler.shared.discoverPodcastList(source: source, completion: { [weak self] podcastList in
@@ -174,7 +174,7 @@ class FeaturedSummaryViewController: SimpleNotificationsViewController, GridLayo
                     DiscoverServerHandler.shared.discoverPodcastList(source: source, completion: { podcastList in
                         guard let discoverPodcast = podcastList?.podcasts?.first else { return }
 
-                        sponsoredPodcastsToAdd.append((position, discoverPodcast))
+                        sponsoredPodcastsToAdd[position] = discoverPodcast
 
                         dispatchGroup.leave()
                     })
@@ -184,9 +184,9 @@ class FeaturedSummaryViewController: SimpleNotificationsViewController, GridLayo
 
         dispatchGroup.notify(queue: DispatchQueue.main) { [weak self] in
             for sponsoredPodcastToAdd in sponsoredPodcastsToAdd {
-                self?.podcasts.insert(sponsoredPodcastToAdd.1, safelyAt: sponsoredPodcastToAdd.0)
+                self?.podcasts.insert(sponsoredPodcastToAdd.value, safelyAt: sponsoredPodcastToAdd.key)
             }
-            self?.sponsoredPodcasts = sponsoredPodcastsToAdd.map { $0.1 }
+            self?.sponsoredPodcasts = sponsoredPodcastsToAdd.map { $0.value }
 
             self?.updatePageCount()
             self?.featuredCollectionView.reloadData()

--- a/podcasts/FeaturedSummaryViewController.swift
+++ b/podcasts/FeaturedSummaryViewController.swift
@@ -186,11 +186,7 @@ class FeaturedSummaryViewController: SimpleNotificationsViewController, GridLayo
             }
 
             // Add featured podcasts
-            for (index, discoverPodcast) in podcastsToShow.enumerated() {
-                self.podcasts.append(discoverPodcast)
-
-                if index == (self.maxFeaturedItems - 1) { break }
-            }
+            self.podcasts = Array(podcastsToShow.prefix(self.maxFeaturedItems))
 
             // Add sponsored podcasts
             for sponsoredPodcastToAdd in sponsoredPodcastsToAdd {

--- a/podcasts/FeaturedTableViewCell.swift
+++ b/podcasts/FeaturedTableViewCell.swift
@@ -4,8 +4,8 @@ import UIKit
 class FeaturedTableViewCell: UITableViewCell {
     @IBOutlet var featuredView: DiscoverFeaturedView!
 
-    func populateFrom(_ discoverPodcast: DiscoverPodcast, isSubscribed: Bool, listName: String) {
-        featuredView.populateFrom(discoverPodcast, isSubscribed: isSubscribed, listName: listName)
+    func populateFrom(_ discoverPodcast: DiscoverPodcast, isSubscribed: Bool, listName: String, isSponsored: Bool) {
+        featuredView.populateFrom(discoverPodcast, isSubscribed: isSubscribed, listName: listName, isSponsored: isSponsored)
     }
 
     func populateFrom(_ discoverPodcast: DiscoverPodcast, listName: String) {


### PR DESCRIPTION
This PR prepares the Discover Carousel to be able to show sponsored podcasts.

**Tracks is gonna be tackled in a separated task.**

## To test

1. First, run this PR with `Debug` Build Configuration (Manage Schemes > pocketcasts > Run > Info > Build Configuration: Debug)
2. ✅ Make sure the carousel appears just fine
3. Change the `Debug` Build Configuration to `Staging`
4. Go to `DiscoverServerHandler.swift` and change line 31 to `discoverRequest(path: ServerConstants.Urls.discover() + "ios/content-carousel.json", type: DiscoverLayout.self) { discoverItems, cachedResponse in` (so it will use the mock)
5. Run the app
6. ✅ The carousel should appear. All the items should display the "Featured" label except the first and the fourth, which displays "Sponsored"

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
