### PR TITLE
Discover Carousel: fix autoscroll running while the feature flag is false

### DIFF
--- a/podcasts/FeaturedSummaryViewController.swift
+++ b/podcasts/FeaturedSummaryViewController.swift
@@ -63,15 +63,11 @@ class FeaturedSummaryViewController: SimpleNotificationsViewController, GridLayo
 
     override func viewWillAppear(_ animated: Bool) {
         featuredCollectionView.reloadData()
-        if FeatureFlag.discoverFeaturedAutoScroll.enabled {
-            featuredCollectionView.initializeAutoScrollTimer()
-        }
+        featuredCollectionView.initializeAutoScrollTimer()
     }
 
     override func viewDidDisappear(_ animated: Bool) {
-        if FeatureFlag.discoverFeaturedAutoScroll.enabled {
-            featuredCollectionView.stopAutoScrollTimer()
-        }
+        featuredCollectionView.stopAutoScrollTimer()
     }
 
     @objc private func podcastStatusChanged(notificiation: Notification) {

--- a/podcasts/ThemeableCollectionView.swift
+++ b/podcasts/ThemeableCollectionView.swift
@@ -37,8 +37,12 @@ class ThemeableCollectionView: UICollectionView, AutoScrollCollectionViewDelegat
     var timer: Timer?
 
     func initializeAutoScrollTimer() {
+        guard FeatureFlag.discoverFeaturedAutoScroll.enabled else {
+            return
+        }
+
         timer = Timer.scheduledTimer(timeInterval: 3.0, target: self, selector: #selector(scrolltoNextItem), userInfo: nil, repeats: true)
-       }
+    }
 
     @objc func scrolltoNextItem() {
         let nextIndex = (indexPathsForVisibleItems.last?.item ?? 0) + 1


### PR DESCRIPTION
The auto-scroll feature was enabled when the user scrolled, even if the Feature Flag is set to false.

## To test

1. Run the app
2. Go to Discover
3. ✅ Make sure the autoscroll doesn't happen on the carousel
4. Swipe to the next item
4. ✅ Make sure the autoscroll doesn't happen on the carousel
4. Go to Profile > Settings > Beta Features > enable `discoverFeaturedAutoScroll`
4. GO back to Discover
4. ✅ Make sure the autoscroll happens

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
