### PR TITLE
Discover Carousel: add tracks for sponsored podcasts

### DIFF
--- a/podcasts/AnalyticsHelper.swift
+++ b/podcasts/AnalyticsHelper.swift
@@ -375,11 +375,7 @@ private extension AnalyticsHelper {
     static let logger = Logger()
 
     class func bumpStat(_ name: String, parameters: [String: Any]? = nil) {
-        guard optedOut == false else { return }
-
-        #if !os(watchOS)
-            Self.logEvent(name, parameters: parameters)
-        #endif
+        Self.logEvent(name, parameters: parameters)
     }
 
     class func logEvent(_ name: String, parameters: [String: Any]? = nil) {

--- a/podcasts/AnalyticsHelper.swift
+++ b/podcasts/AnalyticsHelper.swift
@@ -378,7 +378,7 @@ private extension AnalyticsHelper {
         guard optedOut == false else { return }
 
         #if !os(watchOS)
-            Firebase.Analytics.logEvent(name, parameters: parameters)
+            Self.logEvent(name, parameters: parameters)
         #endif
     }
 

--- a/podcasts/FeaturedSummaryViewController.swift
+++ b/podcasts/FeaturedSummaryViewController.swift
@@ -125,7 +125,7 @@ class FeaturedSummaryViewController: SimpleNotificationsViewController, GridLayo
         guard let delegate = delegate else { return }
 
         let podcast = podcasts[indexPath.row]
-        delegate.show(discoverPodcast: podcast, placeholderImage: nil, isFeatured: true, listUuid: nil)
+        delegate.show(discoverPodcast: podcast, placeholderImage: nil, isFeatured: true, listUuid: lists.first(where: { $0.podcasts?.contains(podcast) ?? false })?.listId)
     }
 
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {

--- a/podcasts/FeaturedSummaryViewController.swift
+++ b/podcasts/FeaturedSummaryViewController.swift
@@ -104,7 +104,7 @@ class FeaturedSummaryViewController: SimpleNotificationsViewController, GridLayo
         if let delegate = delegate {
             cell.populateFrom(podcast, isSubscribed: delegate.isSubscribed(podcast: podcast), listName: listType, isSponsored: sponsoredPodcasts.contains(podcast))
             cell.featuredView.onSubscribe = { [weak self] in
-                if let listId = self?.lists.first(where: { $0.podcasts?.contains(podcast) ?? false })?.listId, let podcastUuid = podcast.uuid {
+                if let listId = self?.listId(for: podcast), let podcastUuid = podcast.uuid {
                     AnalyticsHelper.podcastSubscribedFromList(listId: listId, podcastUuid: podcastUuid)
                 }
                 delegate.subscribe(podcast: podcast)
@@ -125,7 +125,7 @@ class FeaturedSummaryViewController: SimpleNotificationsViewController, GridLayo
         guard let delegate = delegate else { return }
 
         let podcast = podcasts[indexPath.row]
-        let listId = lists.first(where: { $0.podcasts?.contains(podcast) ?? false })?.listId
+        let listId = listId(for: podcast)
         delegate.show(discoverPodcast: podcast, placeholderImage: nil, isFeatured: true, listUuid: listId)
 
         if let listId = listId, let podcastUuid = podcast.uuid {
@@ -239,5 +239,11 @@ class FeaturedSummaryViewController: SimpleNotificationsViewController, GridLayo
         pageControl.currentPage = currentPage
 
         Analytics.track(.discoverFeaturedPageChanged, properties: ["current_page": currentPage + 1, "total_pages": pageControl.numberOfPages])
+    }
+
+    // MARK: - Sponsored Podcast methods
+
+    func listId(for podcast: DiscoverPodcast) -> String? {
+        lists.first(where: { $0.podcasts?.contains(podcast) ?? false })?.listId
     }
 }

--- a/podcasts/FeaturedSummaryViewController.swift
+++ b/podcasts/FeaturedSummaryViewController.swift
@@ -202,8 +202,8 @@ class FeaturedSummaryViewController: SimpleNotificationsViewController, GridLayo
             }
             self?.sponsoredPodcasts = sponsoredPodcastsToAdd.map { $0.value }
 
-            for list in self?.lists ?? [] {
-                if let listId = list.listId {
+            self?.lists.forEach {
+                if let listId = $0.listId {
                     AnalyticsHelper.listImpression(listId: listId)
                 }
             }

--- a/podcasts/FeaturedSummaryViewController.swift
+++ b/podcasts/FeaturedSummaryViewController.swift
@@ -103,7 +103,12 @@ class FeaturedSummaryViewController: SimpleNotificationsViewController, GridLayo
         let podcast = podcasts[indexPath.row]
         if let delegate = delegate {
             cell.populateFrom(podcast, isSubscribed: delegate.isSubscribed(podcast: podcast), listName: listType, isSponsored: sponsoredPodcasts.contains(podcast))
-            cell.featuredView.onSubscribe = { delegate.subscribe(podcast: podcast) }
+            cell.featuredView.onSubscribe = { [weak self] in
+                if let listId = self?.lists.first(where: { $0.podcasts?.contains(podcast) ?? false })?.listId, let podcastUuid = podcast.uuid {
+                    AnalyticsHelper.podcastSubscribedFromList(listId: listId, podcastUuid: podcastUuid)
+                }
+                delegate.subscribe(podcast: podcast)
+            }
         }
 
         if let uuid = podcast.uuid {

--- a/podcasts/FeaturedSummaryViewController.swift
+++ b/podcasts/FeaturedSummaryViewController.swift
@@ -125,7 +125,12 @@ class FeaturedSummaryViewController: SimpleNotificationsViewController, GridLayo
         guard let delegate = delegate else { return }
 
         let podcast = podcasts[indexPath.row]
-        delegate.show(discoverPodcast: podcast, placeholderImage: nil, isFeatured: true, listUuid: lists.first(where: { $0.podcasts?.contains(podcast) ?? false })?.listId)
+        let listId = lists.first(where: { $0.podcasts?.contains(podcast) ?? false })?.listId
+        delegate.show(discoverPodcast: podcast, placeholderImage: nil, isFeatured: true, listUuid: listId)
+
+        if let listId = listId, let podcastUuid = podcast.uuid {
+            AnalyticsHelper.podcastTappedFromList(listId: listId, podcastUuid: podcastUuid)
+        }
     }
 
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {


### PR DESCRIPTION
Add Firebase and Tracks events for the sponsored podcasts on the Discover Carousel.

## To test

3. Change the app `Debug` Build Configuration to `Staging`
4. Go to `DiscoverServerHandler.swift` and change line 31 to `discoverRequest(path: ServerConstants.Urls.discover() + "ios/content-carousel.json", type: DiscoverLayout.self) { discoverItems, cachedResponse in` (so it will use the mock file)
5. Run the app
6. Open Discover
6. ✅ `discover_list_impression ["list_id": "59b88279-f856-4448-9422-8680d4181704"]` should be tracked for Tracks and Firebase
6. ✅ Swipe the carousel, once the next Sponsored podcast is shown `discover_list_impression ["list_id": "e46179c2-4ef7-4ac4-9138-700fe80e2ef2"]` should be tracked for Tracks and Firebase
6. Subscribe to the first sponsored podcast
6. ✅ `discover_list_podcast_subscribe ["podcast_uuid": "f27fe110-584a-0137-f266-1d245fc5f9cf", "list_id": "59b88279-f856-4448-9422-8680d4181704"]` should be tracked for Tracks and Firebase
6. Tap the first sponsored podcast
6. ✅ `discover_list_podcast_tap ["list_id": "59b88279-f856-4448-9422-8680d4181704", "podcast_uuid": "f27fe110-584a-0137-f266-1d245fc5f9cf"]` should be tracked for Tracks and Firebase
6. Play an episode for the podcast you just tapped
6. ✅ `Tracked: discover_list_episode_play ["list_id": "59b88279-f856-4448-9422-8680d4181704", "podcast_uuid": "f27fe110-584a-0137-f266-1d245fc5f9cf"]` should be tracked for Tracks and Firebase


## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.