### PR TITLE
Search: fix search crash

### DIFF
--- a/podcasts/PodcastListViewController+Search.swift
+++ b/podcasts/PodcastListViewController+Search.swift
@@ -21,6 +21,8 @@ extension PodcastListViewController: UIScrollViewDelegate, PCSearchBarDelegate {
 
     func setupSearchBar() {
         searchController = PCSearchBarController()
+        searchResultsControler = PodcastListSearchResultsController()
+
         searchController.view.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(searchController.view)
 
@@ -37,7 +39,6 @@ extension PodcastListViewController: UIScrollViewDelegate, PCSearchBarDelegate {
         searchController.searchDebounce = Settings.podcastSearchDebounceTime()
         searchController.searchDelegate = self
 
-        searchResultsControler = PodcastListSearchResultsController()
         searchResultsControler.searchTextField = searchController.searchTextField
     }
 

--- a/podcasts/PodcastListViewController+Search.swift
+++ b/podcasts/PodcastListViewController+Search.swift
@@ -2,7 +2,7 @@ import UIKit
 
 extension PodcastListViewController: UIScrollViewDelegate, PCSearchBarDelegate {
     var searchControllerView: UIView? {
-        FeatureFlag.newSearch.enabled ? newSearchResultsController.view : searchResultsControler.view
+        FeatureFlag.newSearch.enabled ? newSearchResultsController.view : searchResultsControler?.view
     }
 
     func scrollViewDidScroll(_ scrollView: UIScrollView) {

--- a/podcasts/PodcastListViewController+Search.swift
+++ b/podcasts/PodcastListViewController+Search.swift
@@ -1,19 +1,19 @@
 import UIKit
 
 extension PodcastListViewController: UIScrollViewDelegate, PCSearchBarDelegate {
-    var searchControllerView: UIView {
+    var searchControllerView: UIView? {
         FeatureFlag.newSearch.enabled ? newSearchResultsController.view : searchResultsControler.view
     }
 
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        guard searchControllerView.superview == nil else { return } // don't send scroll events while the search results are up
+        guard searchControllerView?.superview == nil else { return } // don't send scroll events while the search results are up
 
         searchController.parentScrollViewDidScroll(scrollView)
         refreshControl?.scrollViewDidScroll(scrollView)
     }
 
     func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
-        guard searchControllerView.superview == nil else { return } // don't send scroll events while the search results are up
+        guard searchControllerView?.superview == nil else { return } // don't send scroll events while the search results are up
 
         searchController.parentScrollViewDidEndDragging(scrollView, willDecelerate: decelerate)
         refreshControl?.scrollViewDidEndDragging(scrollView)
@@ -88,7 +88,9 @@ extension PodcastListViewController: UIScrollViewDelegate, PCSearchBarDelegate {
     // MARK: - PCSearchBarDelegate
 
     func searchDidBegin() {
-        let searchView = searchControllerView
+        guard let searchView = searchControllerView else {
+            return
+        }
 
         searchView.alpha = 0
         view.addSubview(searchView)
@@ -107,10 +109,14 @@ extension PodcastListViewController: UIScrollViewDelegate, PCSearchBarDelegate {
     }
 
     func searchDidEnd() {
+        guard let searchView = searchControllerView else {
+            return
+        }
+
         UIView.animate(withDuration: Constants.Animation.defaultAnimationTime, animations: {
-            self.searchControllerView.alpha = 0
+            searchView.alpha = 0
         }) { _ in
-            self.searchControllerView.removeFromSuperview()
+            searchView.removeFromSuperview()
             self.searchResultsControler.clearSearch()
         }
     }


### PR DESCRIPTION
Fixes #763

This PR fixes a new crash introduced in 7.33: https://a8c.sentry.io/share/issue/74e8d33bea4b4f09b8c29e78c4c5e804/

While I haven't been able to reproduce it, making the `var` optional will fix it.

## To test

1. Do a clean install of the app
2. Go to Discover
3. Subscribe to any podcast
4. Go to Podcasts
5. ✅ Perform a search and make sure it works just fine

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
