### PR TITLE
Search Improvements: search history

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/Search/EpisodeSearchTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Search/EpisodeSearchTask.swift
@@ -4,7 +4,7 @@ public struct EpisodeSearchEnvelope: Decodable {
     public let episodes: [EpisodeSearchResult]
 }
 
-public struct EpisodeSearchResult: Decodable {
+public struct EpisodeSearchResult: Codable {
     public let uuid: String
     public let title: String
     public let publishedDate: Date

--- a/Modules/Server/Sources/PocketCastsServer/Public/Search/EpisodeSearchTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Search/EpisodeSearchTask.swift
@@ -4,7 +4,7 @@ public struct EpisodeSearchEnvelope: Decodable {
     public let episodes: [EpisodeSearchResult]
 }
 
-public struct EpisodeSearchResult: Codable {
+public struct EpisodeSearchResult: Codable, Hashable {
     public let uuid: String
     public let title: String
     public let publishedDate: Date

--- a/Modules/Server/Sources/PocketCastsServer/Public/Search/PodcastSearchTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Search/PodcastSearchTask.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct PodcastSearchResult: Decodable {
+public struct PodcastSearchResult: Codable {
     public let uuid: String
     public let title: String
     public let author: String

--- a/Modules/Server/Sources/PocketCastsServer/Public/Search/PodcastSearchTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Search/PodcastSearchTask.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct PodcastSearchResult: Codable {
+public struct PodcastSearchResult: Codable, Hashable {
     public let uuid: String
     public let title: String
     public let author: String

--- a/PocketCastsTests/Tests/New Search/SearchHistoryModelTests.swift
+++ b/PocketCastsTests/Tests/New Search/SearchHistoryModelTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+
+@testable import podcasts
+
+class SearchHistoryModelTests: XCTestCase {
+    private var userDefaults: UserDefaults!
+    private var model: SearchHistoryModel!
+
+    override func setUp() {
+        userDefaults = UserDefaults(suiteName: "SearchHistoryModelTests")
+        userDefaults.removePersistentDomain(forName: "SearchHistoryModelTests")
+
+        model = SearchHistoryModel(userDefaults: userDefaults)
+    }
+
+    // MARK: - Add entries
+
+    func testAddEntry() {
+        model.add(searchTerm: "foo")
+
+        XCTAssertEqual(model.entries.first, SearchHistoryEntry(searchTerm: "foo"))
+    }
+
+    func testEntryIsPersisted() {
+        model.add(searchTerm: "foo")
+
+        let newModelInstance = SearchHistoryModel(userDefaults: userDefaults)
+
+        XCTAssertEqual(newModelInstance.entries.first, SearchHistoryEntry(searchTerm: "foo"))
+    }
+}

--- a/PocketCastsTests/Tests/New Search/SearchHistoryModelTests.swift
+++ b/PocketCastsTests/Tests/New Search/SearchHistoryModelTests.swift
@@ -37,4 +37,12 @@ class SearchHistoryModelTests: XCTestCase {
 
         XCTAssertEqual(model.entries, [SearchHistoryEntry(searchTerm: "doe"), SearchHistoryEntry(searchTerm: "john"), SearchHistoryEntry(searchTerm: "bar"), SearchHistoryEntry(searchTerm: "foo")])
     }
+
+    func testSameEntryIsNotAddedTwice() {
+        model.add(searchTerm: "foo")
+        model.add(searchTerm: "bar")
+        model.add(searchTerm: "foo")
+
+        XCTAssertEqual(model.entries, [SearchHistoryEntry(searchTerm: "foo"), SearchHistoryEntry(searchTerm: "bar")])
+    }
 }

--- a/PocketCastsTests/Tests/New Search/SearchHistoryModelTests.swift
+++ b/PocketCastsTests/Tests/New Search/SearchHistoryModelTests.swift
@@ -28,4 +28,13 @@ class SearchHistoryModelTests: XCTestCase {
 
         XCTAssertEqual(newModelInstance.entries.first, SearchHistoryEntry(searchTerm: "foo"))
     }
+
+    func testAddMultipleEntries() {
+        model.add(searchTerm: "foo")
+        model.add(searchTerm: "bar")
+        model.add(searchTerm: "john")
+        model.add(searchTerm: "doe")
+
+        XCTAssertEqual(model.entries, [SearchHistoryEntry(searchTerm: "doe"), SearchHistoryEntry(searchTerm: "john"), SearchHistoryEntry(searchTerm: "bar"), SearchHistoryEntry(searchTerm: "foo")])
+    }
 }

--- a/PocketCastsTests/Tests/New Search/SearchHistoryModelTests.swift
+++ b/PocketCastsTests/Tests/New Search/SearchHistoryModelTests.swift
@@ -68,19 +68,9 @@ class SearchHistoryModelTests: XCTestCase {
 
     // MARK: Limit
 
-    func testAddAMaximumOf10Entries() {
-        model.add(searchTerm: "1")
-        model.add(searchTerm: "2")
-        model.add(searchTerm: "3")
-        model.add(searchTerm: "4")
-        model.add(searchTerm: "5")
-        model.add(searchTerm: "6")
-        model.add(searchTerm: "7")
-        model.add(searchTerm: "8")
-        model.add(searchTerm: "9")
-        model.add(searchTerm: "10")
-        model.add(searchTerm: "11")
+    func testAddAMaximumOf20Entries() {
+        Array(0...21).forEach { model.add(searchTerm: "\($0)") }
 
-        XCTAssertEqual(model.entries.count, 10)
+        XCTAssertEqual(model.entries.count, 20)
     }
 }

--- a/PocketCastsTests/Tests/New Search/SearchHistoryModelTests.swift
+++ b/PocketCastsTests/Tests/New Search/SearchHistoryModelTests.swift
@@ -65,4 +65,22 @@ class SearchHistoryModelTests: XCTestCase {
 
         XCTAssertTrue(model.entries.isEmpty)
     }
+
+    // MARK: Limit
+
+    func testAddAMaximumOf10Entries() {
+        model.add(searchTerm: "1")
+        model.add(searchTerm: "2")
+        model.add(searchTerm: "3")
+        model.add(searchTerm: "4")
+        model.add(searchTerm: "5")
+        model.add(searchTerm: "6")
+        model.add(searchTerm: "7")
+        model.add(searchTerm: "8")
+        model.add(searchTerm: "9")
+        model.add(searchTerm: "10")
+        model.add(searchTerm: "11")
+
+        XCTAssertEqual(model.entries.count, 10)
+    }
 }

--- a/PocketCastsTests/Tests/New Search/SearchHistoryModelTests.swift
+++ b/PocketCastsTests/Tests/New Search/SearchHistoryModelTests.swift
@@ -51,8 +51,18 @@ class SearchHistoryModelTests: XCTestCase {
     func testRemoveEntry() {
         model.add(searchTerm: "foo")
         model.add(searchTerm: "bar")
+
         model.remove(entry: SearchHistoryEntry(searchTerm: "foo"))
 
         XCTAssertEqual(model.entries, [SearchHistoryEntry(searchTerm: "bar")])
+    }
+
+    func testRemoveAllEntries() {
+        model.add(searchTerm: "foo")
+        model.add(searchTerm: "bar")
+
+        model.removeAll()
+
+        XCTAssertTrue(model.entries.isEmpty)
     }
 }

--- a/PocketCastsTests/Tests/New Search/SearchHistoryModelTests.swift
+++ b/PocketCastsTests/Tests/New Search/SearchHistoryModelTests.swift
@@ -45,4 +45,14 @@ class SearchHistoryModelTests: XCTestCase {
 
         XCTAssertEqual(model.entries, [SearchHistoryEntry(searchTerm: "foo"), SearchHistoryEntry(searchTerm: "bar")])
     }
+
+    // MARK: - Removal
+
+    func testRemoveEntry() {
+        model.add(searchTerm: "foo")
+        model.add(searchTerm: "bar")
+        model.remove(entry: SearchHistoryEntry(searchTerm: "foo"))
+
+        XCTAssertEqual(model.entries, [SearchHistoryEntry(searchTerm: "bar")])
+    }
 }

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -456,6 +456,7 @@
 		8B14E3AC29B773FA0069B6F2 /* SearchResultsModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B14E3AB29B773FA0069B6F2 /* SearchResultsModel.swift */; };
 		8B14E3AE29B8E71D0069B6F2 /* SubscribeButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B14E3AD29B8E71D0069B6F2 /* SubscribeButtonView.swift */; };
 		8B14E3B029B9159B0069B6F2 /* SearchHistoryModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B14E3AF29B9159B0069B6F2 /* SearchHistoryModel.swift */; };
+		8B14E3B329BA43A00069B6F2 /* SearchHistoryModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B14E3B229BA43A00069B6F2 /* SearchHistoryModelTests.swift */; };
 		8B1C974628FE1C7E00BD5EB9 /* ImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B1C974528FE1C7E00BD5EB9 /* ImageView.swift */; };
 		8B1C974828FE234B00BD5EB9 /* View+Snapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B1C974728FE234B00BD5EB9 /* View+Snapshot.swift */; };
 		8B23193F2902C84A0001C3DE /* EndOfYearStoriesBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B23193E2902C84A0001C3DE /* EndOfYearStoriesBuilder.swift */; };
@@ -2088,6 +2089,7 @@
 		8B14E3AB29B773FA0069B6F2 /* SearchResultsModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultsModel.swift; sourceTree = "<group>"; };
 		8B14E3AD29B8E71D0069B6F2 /* SubscribeButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscribeButtonView.swift; sourceTree = "<group>"; };
 		8B14E3AF29B9159B0069B6F2 /* SearchHistoryModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchHistoryModel.swift; sourceTree = "<group>"; };
+		8B14E3B229BA43A00069B6F2 /* SearchHistoryModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchHistoryModelTests.swift; sourceTree = "<group>"; };
 		8B17365B298D47B10057E893 /* ca */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ca; path = ca.lproj/Intents.strings; sourceTree = "<group>"; };
 		8B17365C298D47B10057E893 /* ca */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ca; path = ca.lproj/Localizable.strings; sourceTree = "<group>"; };
 		8B17365D298D47B20057E893 /* ca */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ca; path = ca.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -3836,6 +3838,14 @@
 			path = Model;
 			sourceTree = "<group>";
 		};
+		8B14E3B129BA43840069B6F2 /* New Search */ = {
+			isa = PBXGroup;
+			children = (
+				8B14E3B229BA43A00069B6F2 /* SearchHistoryModelTests.swift */,
+			);
+			path = "New Search";
+			sourceTree = "<group>";
+		};
 		8B2E054E28F8577200C2DBDE /* End of Year */ = {
 			isa = PBXGroup;
 			children = (
@@ -3862,6 +3872,7 @@
 				C7BF5E4829083B3F00733C1E /* Discover */,
 				8B2E054E28F8577200C2DBDE /* End of Year */,
 				C7D854F128ADD97700877E87 /* Analytics */,
+				8B14E3B129BA43840069B6F2 /* New Search */,
 				8BF0BBCF28918B36006BBECF /* Podcasts */,
 				8BF1C61B2881F049007E80BF /* Folders */,
 				2F63CE9428809E5A00A34B51 /* ThemeTests.swift */,
@@ -7584,6 +7595,7 @@
 				C7BF5E4A29083B5300733C1E /* DiscoverCoordinatorTests.swift in Sources */,
 				C79E1E4028887549008524CB /* PlusUpgradeViewSourceTests.swift in Sources */,
 				8B2319412902C8FE0001C3DE /* EndOfYearStoriesBuilderTests.swift in Sources */,
+				8B14E3B329BA43A00069B6F2 /* SearchHistoryModelTests.swift in Sources */,
 				8BF0BBD92891AFB5006BBECF /* PodcastBuilder.swift in Sources */,
 				8B2E055028F8579700C2DBDE /* StoriesModelTests.swift in Sources */,
 				C7F4BAB728DA8666001C9785 /* BackgroundSignOutListenerTests.swift in Sources */,

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -455,6 +455,7 @@
 		8B10E78A28D9094A00702C54 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 8B10E78528D908A900702C54 /* GoogleService-Info.plist */; };
 		8B14E3AC29B773FA0069B6F2 /* SearchResultsModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B14E3AB29B773FA0069B6F2 /* SearchResultsModel.swift */; };
 		8B14E3AE29B8E71D0069B6F2 /* SubscribeButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B14E3AD29B8E71D0069B6F2 /* SubscribeButtonView.swift */; };
+		8B14E3B029B9159B0069B6F2 /* SearchHistoryModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B14E3AF29B9159B0069B6F2 /* SearchHistoryModel.swift */; };
 		8B1C974628FE1C7E00BD5EB9 /* ImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B1C974528FE1C7E00BD5EB9 /* ImageView.swift */; };
 		8B1C974828FE234B00BD5EB9 /* View+Snapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B1C974728FE234B00BD5EB9 /* View+Snapshot.swift */; };
 		8B23193F2902C84A0001C3DE /* EndOfYearStoriesBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B23193E2902C84A0001C3DE /* EndOfYearStoriesBuilder.swift */; };
@@ -2086,6 +2087,7 @@
 		8B10E78528D908A900702C54 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		8B14E3AB29B773FA0069B6F2 /* SearchResultsModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultsModel.swift; sourceTree = "<group>"; };
 		8B14E3AD29B8E71D0069B6F2 /* SubscribeButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscribeButtonView.swift; sourceTree = "<group>"; };
+		8B14E3AF29B9159B0069B6F2 /* SearchHistoryModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchHistoryModel.swift; sourceTree = "<group>"; };
 		8B17365B298D47B10057E893 /* ca */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ca; path = ca.lproj/Intents.strings; sourceTree = "<group>"; };
 		8B17365C298D47B10057E893 /* ca */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ca; path = ca.lproj/Localizable.strings; sourceTree = "<group>"; };
 		8B17365D298D47B20057E893 /* ca */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ca; path = ca.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -3829,6 +3831,7 @@
 			isa = PBXGroup;
 			children = (
 				8B14E3AB29B773FA0069B6F2 /* SearchResultsModel.swift */,
+				8B14E3AF29B9159B0069B6F2 /* SearchHistoryModel.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -7738,6 +7741,7 @@
 				BD14CCDF1D7D3CB800DB4547 /* SelectedPodcastCell.swift in Sources */,
 				BD93FDA120157B2000F6EF55 /* PodcastImageView.swift in Sources */,
 				BDD5253A20477E4400AAD211 /* NSObject+AppDelegate.swift in Sources */,
+				8B14E3B029B9159B0069B6F2 /* SearchHistoryModel.swift in Sources */,
 				C7080C5D2923070200D7A432 /* PlusAccountUpgradePrompt.swift in Sources */,
 				8B44446729785BD0007E0AA8 /* SocialLoginFactory.swift in Sources */,
 				46305CED272AFA5F003AC87B /* UserDefaults+Helpers.swift in Sources */,

--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -150,6 +150,8 @@ struct Constants {
         static let hasSyncedAll2022Episodes = "hasSyncedAll2022Episodes"
         static let top5PodcastsListLink = "top5PodcastsListLink"
         static let shouldShowInitialOnboardingFlow = "shouldShowInitialOnboardingFlow"
+
+        static let searchHistoryEntried = "SearchHistoryEntries"
     }
 
     enum Values {

--- a/podcasts/New Search/Model/SearchHistoryModel.swift
+++ b/podcasts/New Search/Model/SearchHistoryModel.swift
@@ -10,7 +10,8 @@ struct SearchHistoryEntry: Codable, Hashable {
 class SearchHistoryModel: ObservableObject {
     @Published var entries: [SearchHistoryEntry] = []
 
-    let defaults: UserDefaults
+    private let defaults: UserDefaults
+    private let maxNumberOfEntries = 10
 
     init(userDefaults: UserDefaults = UserDefaults.standard) {
         self.defaults = userDefaults
@@ -55,6 +56,7 @@ class SearchHistoryModel: ObservableObject {
     }
 
     private func save() {
+        entries = Array(entries.prefix(maxNumberOfEntries))
         let encoder = JSONEncoder()
         if let encoded = try? encoder.encode(entries) {
             defaults.set(encoded, forKey: "SearchHistoryEntries")

--- a/podcasts/New Search/Model/SearchHistoryModel.swift
+++ b/podcasts/New Search/Model/SearchHistoryModel.swift
@@ -31,4 +31,14 @@ class SearchHistoryModel: ObservableObject {
             defaults.set(encoded, forKey: "SearchHistoryEntries")
         }
     }
+
+    func remove(entry: SearchHistoryEntry) {
+        entries.removeAll(where: { $0 == entry })
+
+        let encoder = JSONEncoder()
+        if let encoded = try? encoder.encode(entries) {
+            let defaults = UserDefaults.standard
+            defaults.set(encoded, forKey: "SearchHistoryEntries")
+        }
+    }
 }

--- a/podcasts/New Search/Model/SearchHistoryModel.swift
+++ b/podcasts/New Search/Model/SearchHistoryModel.swift
@@ -41,4 +41,10 @@ class SearchHistoryModel: ObservableObject {
             defaults.set(encoded, forKey: "SearchHistoryEntries")
         }
     }
+
+    func removeAll() {
+        entries = []
+
+        UserDefaults.standard.removeObject(forKey: "SearchHistoryEntries")
+    }
 }

--- a/podcasts/New Search/Model/SearchHistoryModel.swift
+++ b/podcasts/New Search/Model/SearchHistoryModel.swift
@@ -16,7 +16,7 @@ class SearchHistoryModel: ObservableObject {
     init(userDefaults: UserDefaults = UserDefaults.standard) {
         self.defaults = userDefaults
 
-        if let entriesData = defaults.object(forKey: "SearchHistoryEntries") as? Data {
+        if let entriesData = defaults.data(forKey: "SearchHistoryEntries") {
             let decoder = JSONDecoder()
             if let entries = try? decoder.decode([SearchHistoryEntry].self, from: entriesData) {
                 self.entries = entries

--- a/podcasts/New Search/Model/SearchHistoryModel.swift
+++ b/podcasts/New Search/Model/SearchHistoryModel.swift
@@ -27,11 +27,12 @@ class SearchHistoryModel: ObservableObject {
         add(entry: SearchHistoryEntry(searchTerm: searchTerm))
     }
 
-    func add(entry: SearchHistoryEntry) {
-        entries.removeAll(where: { $0 == entry })
-        entries.insert(entry, at: 0)
+    func add(episode: EpisodeSearchResult) {
+        add(entry: SearchHistoryEntry(episode: episode))
+    }
 
-        save()
+    func add(podcast: PodcastSearchResult) {
+        add(entry: SearchHistoryEntry(podcast: podcast))
     }
 
     func remove(entry: SearchHistoryEntry) {
@@ -42,6 +43,13 @@ class SearchHistoryModel: ObservableObject {
 
     func removeAll() {
         entries = []
+
+        save()
+    }
+
+    private func add(entry: SearchHistoryEntry) {
+        entries.removeAll(where: { $0 == entry })
+        entries.insert(entry, at: 0)
 
         save()
     }

--- a/podcasts/New Search/Model/SearchHistoryModel.swift
+++ b/podcasts/New Search/Model/SearchHistoryModel.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+import PocketCastsServer
+
+struct SearchHistoryEntry: Codable {
+    var searchTerm: String?
+    var episode: EpisodeSearchResult?
+    var podcast: PodcastSearchResult?
+}
+
+class SearchHistoryModel: ObservableObject {
+    @Published var entries: [SearchHistoryEntry] = []
+
+    let defaults = UserDefaults.standard
+
+    init() {
+        if let entriesData = defaults.object(forKey: "SearchHistoryEntries") as? Data {
+            let decoder = JSONDecoder()
+            if let entries = try? decoder.decode([SearchHistoryEntry].self, from: entriesData) {
+                self.entries = entries
+            }
+        }
+    }
+
+    func add(entry: SearchHistoryEntry) {
+        entries.insert(entry, at: 0)
+
+        let encoder = JSONEncoder()
+        if let encoded = try? encoder.encode(entries) {
+            let defaults = UserDefaults.standard
+            defaults.set(encoded, forKey: "SavedPerson")
+        }
+    }
+}

--- a/podcasts/New Search/Model/SearchHistoryModel.swift
+++ b/podcasts/New Search/Model/SearchHistoryModel.swift
@@ -27,7 +27,7 @@ class SearchHistoryModel: ObservableObject {
         let encoder = JSONEncoder()
         if let encoded = try? encoder.encode(entries) {
             let defaults = UserDefaults.standard
-            defaults.set(encoded, forKey: "SavedPerson")
+            defaults.set(encoded, forKey: "SearchHistoryEntries")
         }
     }
 }

--- a/podcasts/New Search/Model/SearchHistoryModel.swift
+++ b/podcasts/New Search/Model/SearchHistoryModel.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 import PocketCastsServer
 
-struct SearchHistoryEntry: Codable {
+struct SearchHistoryEntry: Codable, Hashable {
     var searchTerm: String?
     var episode: EpisodeSearchResult?
     var podcast: PodcastSearchResult?

--- a/podcasts/New Search/Model/SearchHistoryModel.swift
+++ b/podcasts/New Search/Model/SearchHistoryModel.swift
@@ -31,24 +31,25 @@ class SearchHistoryModel: ObservableObject {
         entries.removeAll(where: { $0 == entry })
         entries.insert(entry, at: 0)
 
-        let encoder = JSONEncoder()
-        if let encoded = try? encoder.encode(entries) {
-            defaults.set(encoded, forKey: "SearchHistoryEntries")
-        }
+        save()
     }
 
     func remove(entry: SearchHistoryEntry) {
         entries.removeAll(where: { $0 == entry })
 
-        let encoder = JSONEncoder()
-        if let encoded = try? encoder.encode(entries) {
-            defaults.set(encoded, forKey: "SearchHistoryEntries")
-        }
+        save()
     }
 
     func removeAll() {
         entries = []
 
-        UserDefaults.standard.removeObject(forKey: "SearchHistoryEntries")
+        save()
+    }
+
+    private func save() {
+        let encoder = JSONEncoder()
+        if let encoded = try? encoder.encode(entries) {
+            defaults.set(encoded, forKey: "SearchHistoryEntries")
+        }
     }
 }

--- a/podcasts/New Search/Model/SearchHistoryModel.swift
+++ b/podcasts/New Search/Model/SearchHistoryModel.swift
@@ -16,12 +16,9 @@ class SearchHistoryModel: ObservableObject {
     init(userDefaults: UserDefaults = UserDefaults.standard) {
         self.defaults = userDefaults
 
-        if let entriesData = defaults.data(forKey: Constants.UserDefaults.searchHistoryEntried) {
-            let decoder = JSONDecoder()
-            if let entries = try? decoder.decode([SearchHistoryEntry].self, from: entriesData) {
-                self.entries = entries
-            }
-        }
+        self.entries = userDefaults.data(forKey: "SearchHistoryEntries").flatMap {
+            try? JSONDecoder().decode([SearchHistoryEntry].self, from: $0)
+        } ?? []
     }
 
     func add(searchTerm: String) {

--- a/podcasts/New Search/Model/SearchHistoryModel.swift
+++ b/podcasts/New Search/Model/SearchHistoryModel.swift
@@ -10,9 +10,11 @@ struct SearchHistoryEntry: Codable, Hashable {
 class SearchHistoryModel: ObservableObject {
     @Published var entries: [SearchHistoryEntry] = []
 
-    let defaults = UserDefaults.standard
+    let defaults: UserDefaults
 
-    init() {
+    init(userDefaults: UserDefaults = UserDefaults.standard) {
+        self.defaults = userDefaults
+
         if let entriesData = defaults.object(forKey: "SearchHistoryEntries") as? Data {
             let decoder = JSONDecoder()
             if let entries = try? decoder.decode([SearchHistoryEntry].self, from: entriesData) {
@@ -21,13 +23,16 @@ class SearchHistoryModel: ObservableObject {
         }
     }
 
+    func add(searchTerm: String) {
+        add(entry: SearchHistoryEntry(searchTerm: searchTerm))
+    }
+
     func add(entry: SearchHistoryEntry) {
         entries.removeAll(where: { $0 == entry })
         entries.insert(entry, at: 0)
 
         let encoder = JSONEncoder()
         if let encoded = try? encoder.encode(entries) {
-            let defaults = UserDefaults.standard
             defaults.set(encoded, forKey: "SearchHistoryEntries")
         }
     }
@@ -37,7 +42,6 @@ class SearchHistoryModel: ObservableObject {
 
         let encoder = JSONEncoder()
         if let encoded = try? encoder.encode(entries) {
-            let defaults = UserDefaults.standard
             defaults.set(encoded, forKey: "SearchHistoryEntries")
         }
     }

--- a/podcasts/New Search/Model/SearchHistoryModel.swift
+++ b/podcasts/New Search/Model/SearchHistoryModel.swift
@@ -16,7 +16,7 @@ class SearchHistoryModel: ObservableObject {
     init(userDefaults: UserDefaults = UserDefaults.standard) {
         self.defaults = userDefaults
 
-        if let entriesData = defaults.data(forKey: "SearchHistoryEntries") {
+        if let entriesData = defaults.data(forKey: Constants.UserDefaults.searchHistoryEntried) {
             let decoder = JSONDecoder()
             if let entries = try? decoder.decode([SearchHistoryEntry].self, from: entriesData) {
                 self.entries = entries
@@ -59,7 +59,7 @@ class SearchHistoryModel: ObservableObject {
         entries = Array(entries.prefix(maxNumberOfEntries))
         let encoder = JSONEncoder()
         if let encoded = try? encoder.encode(entries) {
-            defaults.set(encoded, forKey: "SearchHistoryEntries")
+            defaults.set(encoded, forKey: Constants.UserDefaults.searchHistoryEntried)
         }
     }
 }

--- a/podcasts/New Search/Model/SearchHistoryModel.swift
+++ b/podcasts/New Search/Model/SearchHistoryModel.swift
@@ -11,7 +11,7 @@ class SearchHistoryModel: ObservableObject {
     @Published var entries: [SearchHistoryEntry] = []
 
     private let defaults: UserDefaults
-    private let maxNumberOfEntries = 10
+    private let maxNumberOfEntries = 20
 
     init(userDefaults: UserDefaults = UserDefaults.standard) {
         self.defaults = userDefaults

--- a/podcasts/New Search/Model/SearchHistoryModel.swift
+++ b/podcasts/New Search/Model/SearchHistoryModel.swift
@@ -22,6 +22,7 @@ class SearchHistoryModel: ObservableObject {
     }
 
     func add(entry: SearchHistoryEntry) {
+        entries.removeAll(where: { $0 == entry })
         entries.insert(entry, at: 0)
 
         let encoder = JSONEncoder()

--- a/podcasts/New Search/SearchResultsViewController.swift
+++ b/podcasts/New Search/SearchResultsViewController.swift
@@ -16,10 +16,11 @@ extension SearchResultsDelegate {
 
 class SearchResultsViewController: UIHostingController<AnyView> {
     private var displaySearch: SearchVisibilityModel = SearchVisibilityModel()
-    private var searchResults = SearchResultsModel()
+    private var searchHistoryModel: SearchHistoryModel = SearchHistoryModel()
+    private var searchResults: SearchResultsModel = SearchResultsModel()
 
     init() {
-        super.init(rootView: AnyView(SearchView(displaySearch: displaySearch, searchResults: searchResults).setupDefaultEnvironment()))
+        super.init(rootView: AnyView(SearchView(displaySearch: displaySearch, searchResults: searchResults, searchHistory: searchHistoryModel).setupDefaultEnvironment()))
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/podcasts/New Search/SearchResultsViewController.swift
+++ b/podcasts/New Search/SearchResultsViewController.swift
@@ -14,9 +14,9 @@ extension SearchResultsDelegate {
 }
 
 class SearchResultsViewController: UIHostingController<AnyView> {
-    private var displaySearch: SearchVisibilityModel = SearchVisibilityModel()
-    private var searchHistoryModel: SearchHistoryModel = SearchHistoryModel()
-    private var searchResults: SearchResultsModel = SearchResultsModel()
+    private let displaySearch: SearchVisibilityModel = SearchVisibilityModel()
+    private let searchHistoryModel: SearchHistoryModel = SearchHistoryModel()
+    private let searchResults: SearchResultsModel = SearchResultsModel()
 
     init() {
         super.init(rootView: AnyView(SearchView(displaySearch: displaySearch, searchResults: searchResults, searchHistory: searchHistoryModel).setupDefaultEnvironment()))

--- a/podcasts/New Search/SearchResultsViewController.swift
+++ b/podcasts/New Search/SearchResultsViewController.swift
@@ -47,7 +47,7 @@ extension SearchResultsViewController: SearchResultsDelegate {
     func performSearch(searchTerm: String, triggeredByTimer: Bool, completion: @escaping (() -> Void)) {
         displaySearch.isSearching = true
         searchResults.search(term: searchTerm)
-        searchHistoryModel.add(entry: SearchHistoryEntry(searchTerm: searchTerm))
+        searchHistoryModel.add(searchTerm: searchTerm)
         completion()
     }
 }

--- a/podcasts/New Search/SearchResultsViewController.swift
+++ b/podcasts/New Search/SearchResultsViewController.swift
@@ -47,6 +47,7 @@ extension SearchResultsViewController: SearchResultsDelegate {
     func performSearch(searchTerm: String, triggeredByTimer: Bool, completion: @escaping (() -> Void)) {
         displaySearch.isSearching = true
         searchResults.search(term: searchTerm)
+        searchHistoryModel.add(entry: SearchHistoryEntry(searchTerm: searchTerm))
         completion()
     }
 }

--- a/podcasts/New Search/Views/History/SearchHistoryCell.swift
+++ b/podcasts/New Search/Views/History/SearchHistoryCell.swift
@@ -9,6 +9,10 @@ struct SearchHistoryCell: View {
 
     var searchHistory: SearchHistoryModel
 
+    let searchResults: SearchResultsModel
+
+    let displaySearch: SearchVisibilityModel
+
     private var subtitle: String {
         if let episode = entry.episode {
             return "\(L10n.episode) • \(TimeFormatter.shared.multipleUnitFormattedShortTime(time: TimeInterval(episode.duration ?? 0))) • \(episode.podcastTitle)"
@@ -26,8 +30,9 @@ struct SearchHistoryCell: View {
                     NavigationManager.sharedManager.navigateTo(NavigationManager.episodePageKey, data: [NavigationManager.episodeUuidKey: episode.uuid, NavigationManager.podcastKey: episode.podcastUuid])
                 } else if let podcast = entry.podcast {
                     NavigationManager.sharedManager.navigateTo(NavigationManager.podcastPageKey, data: [NavigationManager.podcastKey: podcast])
-                } else {
-                    
+                } else if let searchTerm = entry.searchTerm {
+                    displaySearch.isSearching = true
+                    searchResults.search(term: searchTerm)
                 }
             }) {
                 Rectangle()

--- a/podcasts/New Search/Views/History/SearchHistoryCell.swift
+++ b/podcasts/New Search/Views/History/SearchHistoryCell.swift
@@ -33,6 +33,7 @@ struct SearchHistoryCell: View {
                 } else if let searchTerm = entry.searchTerm {
                     displaySearch.isSearching = true
                     searchResults.search(term: searchTerm)
+                    NotificationCenter.postOnMainThread(notification: Constants.Notifications.podcastSearchRequest, object: searchTerm)
                 }
             }) {
                 Rectangle()

--- a/podcasts/New Search/Views/History/SearchHistoryCell.swift
+++ b/podcasts/New Search/Views/History/SearchHistoryCell.swift
@@ -5,12 +5,9 @@ import PocketCastsUtils
 struct SearchHistoryCell: View {
     @EnvironmentObject var theme: Theme
 
-    var entry: SearchHistoryEntry
-
-    var searchHistory: SearchHistoryModel
-
+    let entry: SearchHistoryEntry
+    let searchHistory: SearchHistoryModel
     let searchResults: SearchResultsModel
-
     let displaySearch: SearchVisibilityModel
 
     private var subtitle: String {

--- a/podcasts/New Search/Views/History/SearchHistoryCell.swift
+++ b/podcasts/New Search/Views/History/SearchHistoryCell.swift
@@ -5,16 +5,12 @@ import PocketCastsUtils
 struct SearchHistoryCell: View {
     @EnvironmentObject var theme: Theme
 
-    var podcast: Podcast?
-
-    var episode: Episode?
-
-    var searchTerm: String?
+    var entry: SearchHistoryEntry
 
     private var subtitle: String {
-        if let episode, let podcast {
-            return "\(L10n.episode) • \(episode.displayableDuration) • \(podcast.title ?? "")"
-        } else if let podcast {
+        if let episode = entry.episode, let podcast = entry.podcast {
+            return "\(L10n.episode) • \(TimeFormatter.shared.multipleUnitFormattedShortTime(time: TimeInterval(episode.duration ?? 0))) • \(podcast.title)"
+        } else if let podcast = entry.podcast {
             return [L10n.podcastSingular, podcast.author].compactMap { $0 }.joined(separator: " • ")
         }
 
@@ -34,13 +30,13 @@ struct SearchHistoryCell: View {
 
             VStack(spacing: 12) {
                 HStack(spacing: 0) {
-                    if let podcast {
+                    if let podcast = entry.podcast {
                         PodcastCover(podcastUuid: podcast.uuid)
                             .frame(width: 48, height: 48)
                             .allowsHitTesting(false)
                             .padding(.trailing, 12)
                         VStack(alignment: .leading, spacing: 2) {
-                            Text(podcast.title ?? "")
+                            Text(podcast.title)
                                 .font(style: .subheadline, weight: .medium)
                                 .foregroundColor(AppTheme.color(for: .primaryText01, theme: theme))
                                 .lineLimit(2)
@@ -50,7 +46,7 @@ struct SearchHistoryCell: View {
                                 .lineLimit(1)
                         }
                         .allowsHitTesting(false)
-                    } else if let searchTerm {
+                    } else if let searchTerm = entry.searchTerm {
                         Image("custom_search")
                             .frame(width: 48, height: 48)
                             .foregroundColor(AppTheme.color(for: .primaryText02, theme: theme))

--- a/podcasts/New Search/Views/History/SearchHistoryCell.swift
+++ b/podcasts/New Search/Views/History/SearchHistoryCell.swift
@@ -22,7 +22,13 @@ struct SearchHistoryCell: View {
     var body: some View {
         ZStack {
             Button(action: {
-                print("row tapped")
+                if let episode = entry.episode {
+                    NavigationManager.sharedManager.navigateTo(NavigationManager.episodePageKey, data: [NavigationManager.episodeUuidKey: episode.uuid, NavigationManager.podcastKey: episode.podcastUuid])
+                } else if let podcast = entry.podcast {
+                    NavigationManager.sharedManager.navigateTo(NavigationManager.podcastPageKey, data: [NavigationManager.podcastKey: podcast])
+                } else {
+                    
+                }
             }) {
                 Rectangle()
                     .foregroundColor(.clear)

--- a/podcasts/New Search/Views/History/SearchHistoryCell.swift
+++ b/podcasts/New Search/Views/History/SearchHistoryCell.swift
@@ -8,8 +8,8 @@ struct SearchHistoryCell: View {
     var entry: SearchHistoryEntry
 
     private var subtitle: String {
-        if let episode = entry.episode, let podcast = entry.podcast {
-            return "\(L10n.episode) • \(TimeFormatter.shared.multipleUnitFormattedShortTime(time: TimeInterval(episode.duration ?? 0))) • \(podcast.title)"
+        if let episode = entry.episode {
+            return "\(L10n.episode) • \(TimeFormatter.shared.multipleUnitFormattedShortTime(time: TimeInterval(episode.duration ?? 0))) • \(episode.podcastTitle)"
         } else if let podcast = entry.podcast {
             return [L10n.podcastSingular, podcast.author].compactMap { $0 }.joined(separator: " • ")
         }
@@ -30,13 +30,14 @@ struct SearchHistoryCell: View {
 
             VStack(spacing: 12) {
                 HStack(spacing: 0) {
-                    if let podcast = entry.podcast {
-                        PodcastCover(podcastUuid: podcast.uuid)
+                    if let title = entry.podcast?.title ?? entry.episode?.title,
+                        let uuid = entry.podcast?.uuid ?? entry.episode?.podcastUuid {
+                        PodcastCover(podcastUuid: uuid)
                             .frame(width: 48, height: 48)
                             .allowsHitTesting(false)
                             .padding(.trailing, 12)
                         VStack(alignment: .leading, spacing: 2) {
-                            Text(podcast.title)
+                            Text(title)
                                 .font(style: .subheadline, weight: .medium)
                                 .foregroundColor(AppTheme.color(for: .primaryText01, theme: theme))
                                 .lineLimit(2)

--- a/podcasts/New Search/Views/History/SearchHistoryCell.swift
+++ b/podcasts/New Search/Views/History/SearchHistoryCell.swift
@@ -7,6 +7,8 @@ struct SearchHistoryCell: View {
 
     var entry: SearchHistoryEntry
 
+    var searchHistory: SearchHistoryModel
+
     private var subtitle: String {
         if let episode = entry.episode {
             return "\(L10n.episode) • \(TimeFormatter.shared.multipleUnitFormattedShortTime(time: TimeInterval(episode.duration ?? 0))) • \(episode.podcastTitle)"
@@ -58,7 +60,9 @@ struct SearchHistoryCell: View {
 
                     Spacer()
                     Button(action: {
-                        print("remove tapped")
+                        withAnimation {
+                            searchHistory.remove(entry: entry)
+                        }
                     }) {
                         Image("close")
                     }

--- a/podcasts/New Search/Views/History/SearchHistoryView.swift
+++ b/podcasts/New Search/Views/History/SearchHistoryView.swift
@@ -8,7 +8,6 @@ struct SearchHistoryView: View {
     @ObservedObject var searchHistory: SearchHistoryModel
 
     let searchResults: SearchResultsModel
-
     let displaySearch: SearchVisibilityModel
 
     private var episode: Episode {

--- a/podcasts/New Search/Views/History/SearchHistoryView.swift
+++ b/podcasts/New Search/Views/History/SearchHistoryView.swift
@@ -24,7 +24,7 @@ struct SearchHistoryView: View {
 
                     Section {
                         ForEach(searchHistory.entries, id: \.self) { entry in
-                            SearchHistoryCell(entry: entry)
+                            SearchHistoryCell(entry: entry, searchHistory: searchHistory)
                             .listRowInsets(EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0))
                             .listRowSeparator(.hidden)
                             .listSectionSeparator(.hidden)

--- a/podcasts/New Search/Views/History/SearchHistoryView.swift
+++ b/podcasts/New Search/Views/History/SearchHistoryView.swift
@@ -5,6 +5,8 @@ import PocketCastsUtils
 struct SearchHistoryView: View {
     @EnvironmentObject var theme: Theme
 
+    @ObservedObject var searchHistory: SearchHistoryModel
+
     private var episode: Episode {
         let episode = Episode()
         episode.title = "Episode title"
@@ -12,32 +14,30 @@ struct SearchHistoryView: View {
         return episode
     }
 
-    init() {
-        UITableViewHeaderFooterView.appearance().backgroundView = UIView()
-    }
-
     var body: some View {
         VStack(spacing: 0) {
             ThemedDivider()
 
             List {
-                ThemeableListHeader(title: L10n.searchRecent, actionTitle: L10n.historyClearAll)
+                if !searchHistory.entries.isEmpty {
+                    ThemeableListHeader(title: L10n.searchRecent, actionTitle: L10n.historyClearAll)
 
-                Section {
-                    SearchHistoryCell(podcast: Podcast.previewPodcast())
-                    .listRowInsets(EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0))
-                    .listRowSeparator(.hidden)
-                    .listSectionSeparator(.hidden)
+                    Section {
+                        SearchHistoryCell(podcast: Podcast.previewPodcast())
+                        .listRowInsets(EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0))
+                        .listRowSeparator(.hidden)
+                        .listSectionSeparator(.hidden)
 
-                    SearchHistoryCell(searchTerm: "Search term")
-                    .listRowInsets(EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0))
-                    .listRowSeparator(.hidden)
-                    .listSectionSeparator(.hidden)
+                        SearchHistoryCell(searchTerm: "Search term")
+                        .listRowInsets(EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0))
+                        .listRowSeparator(.hidden)
+                        .listSectionSeparator(.hidden)
 
-                    SearchHistoryCell(podcast: Podcast.previewPodcast(), episode: episode)
-                    .listRowInsets(EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0))
-                    .listRowSeparator(.hidden)
-                    .listSectionSeparator(.hidden)
+                        SearchHistoryCell(podcast: Podcast.previewPodcast(), episode: episode)
+                        .listRowInsets(EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0))
+                        .listRowSeparator(.hidden)
+                        .listSectionSeparator(.hidden)
+                    }
                 }
             }
         }
@@ -49,7 +49,7 @@ struct SearchHistoryView: View {
 
 struct SearchHistoryView_Previews: PreviewProvider {
     static var previews: some View {
-        SearchHistoryView()
+        SearchHistoryView(searchHistory: SearchHistoryModel())
             .previewWithAllThemes()
     }
 }

--- a/podcasts/New Search/Views/History/SearchHistoryView.swift
+++ b/podcasts/New Search/Views/History/SearchHistoryView.swift
@@ -20,7 +20,11 @@ struct SearchHistoryView: View {
 
             List {
                 if !searchHistory.entries.isEmpty {
-                    ThemeableListHeader(title: L10n.searchRecent, actionTitle: L10n.historyClearAll)
+                    ThemeableListHeader(title: L10n.searchRecent, actionTitle: L10n.historyClearAll) {
+                        withAnimation {
+                            searchHistory.removeAll()
+                        }
+                    }
 
                     Section {
                         ForEach(searchHistory.entries, id: \.self) { entry in

--- a/podcasts/New Search/Views/History/SearchHistoryView.swift
+++ b/podcasts/New Search/Views/History/SearchHistoryView.swift
@@ -23,20 +23,12 @@ struct SearchHistoryView: View {
                     ThemeableListHeader(title: L10n.searchRecent, actionTitle: L10n.historyClearAll)
 
                     Section {
-                        SearchHistoryCell(podcast: Podcast.previewPodcast())
-                        .listRowInsets(EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0))
-                        .listRowSeparator(.hidden)
-                        .listSectionSeparator(.hidden)
-
-                        SearchHistoryCell(searchTerm: "Search term")
-                        .listRowInsets(EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0))
-                        .listRowSeparator(.hidden)
-                        .listSectionSeparator(.hidden)
-
-                        SearchHistoryCell(podcast: Podcast.previewPodcast(), episode: episode)
-                        .listRowInsets(EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0))
-                        .listRowSeparator(.hidden)
-                        .listSectionSeparator(.hidden)
+                        ForEach(searchHistory.entries, id: \.self) { entry in
+                            SearchHistoryCell(entry: entry)
+                            .listRowInsets(EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0))
+                            .listRowSeparator(.hidden)
+                            .listSectionSeparator(.hidden)
+                        }
                     }
                 }
             }

--- a/podcasts/New Search/Views/History/SearchHistoryView.swift
+++ b/podcasts/New Search/Views/History/SearchHistoryView.swift
@@ -7,6 +7,10 @@ struct SearchHistoryView: View {
 
     @ObservedObject var searchHistory: SearchHistoryModel
 
+    let searchResults: SearchResultsModel
+
+    let displaySearch: SearchVisibilityModel
+
     private var episode: Episode {
         let episode = Episode()
         episode.title = "Episode title"
@@ -28,7 +32,7 @@ struct SearchHistoryView: View {
 
                     Section {
                         ForEach(searchHistory.entries, id: \.self) { entry in
-                            SearchHistoryCell(entry: entry, searchHistory: searchHistory)
+                            SearchHistoryCell(entry: entry, searchHistory: searchHistory, searchResults: searchResults, displaySearch: displaySearch)
                             .listRowInsets(EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0))
                             .listRowSeparator(.hidden)
                             .listSectionSeparator(.hidden)
@@ -45,7 +49,7 @@ struct SearchHistoryView: View {
 
 struct SearchHistoryView_Previews: PreviewProvider {
     static var previews: some View {
-        SearchHistoryView(searchHistory: SearchHistoryModel())
+        SearchHistoryView(searchHistory: SearchHistoryModel(), searchResults: SearchResultsModel(), displaySearch: SearchVisibilityModel())
             .previewWithAllThemes()
     }
 }

--- a/podcasts/New Search/Views/Results/PodcastCarouselView.swift
+++ b/podcasts/New Search/Views/Results/PodcastCarouselView.swift
@@ -69,8 +69,7 @@ struct PodcastResultCell: View {
     @EnvironmentObject var theme: Theme
 
     let podcast: PodcastSearchResult
-
-    var searchHistory: SearchHistoryModel?
+    let searchHistory: SearchHistoryModel?
 
     var body: some View {
         VStack(alignment: .leading) {

--- a/podcasts/New Search/Views/Results/PodcastCarouselView.swift
+++ b/podcasts/New Search/Views/Results/PodcastCarouselView.swift
@@ -7,6 +7,8 @@ struct PodcastsCarouselView: View {
 
     @ObservedObject var searchResults: SearchResultsModel
 
+    var searchHistory: SearchHistoryModel?
+
     @State private var tabSelection = 0
 
     var body: some View {
@@ -28,9 +30,9 @@ struct PodcastsCarouselView: View {
                                 ForEach(0..<(searchResults.podcasts.count/2), id: \.self) { i in
                                     GeometryReader { geometry in
                                         HStack(spacing: 10) {
-                                            PodcastResultCell(podcast: searchResults.podcasts[(i * 2)])
+                                            PodcastResultCell(podcast: searchResults.podcasts[(i * 2)], searchHistory: searchHistory)
 
-                                            PodcastResultCell(podcast: searchResults.podcasts[(i * 2) + 1])
+                                            PodcastResultCell(podcast: searchResults.podcasts[(i * 2) + 1], searchHistory: searchHistory)
                                         }
                                     }
                                 }
@@ -68,11 +70,14 @@ struct PodcastResultCell: View {
 
     let podcast: PodcastSearchResult
 
+    var searchHistory: SearchHistoryModel?
+
     var body: some View {
         VStack(alignment: .leading) {
             ZStack(alignment: .bottomTrailing) {
                 Button(action: {
                     NavigationManager.sharedManager.navigateTo(NavigationManager.podcastPageKey, data: [NavigationManager.podcastKey: podcast])
+                    searchHistory?.add(entry: SearchHistoryEntry(podcast: podcast))
                 }) {
                     PodcastCover(podcastUuid: podcast.uuid)
                 }
@@ -81,6 +86,7 @@ struct PodcastResultCell: View {
 
             Button(action: {
                 NavigationManager.sharedManager.navigateTo(NavigationManager.podcastPageKey, data: [NavigationManager.podcastKey: podcast])
+                searchHistory?.add(entry: SearchHistoryEntry(podcast: podcast))
             }) {
                 VStack(alignment: .leading, spacing: 2) {
                     Text(podcast.title)

--- a/podcasts/New Search/Views/Results/PodcastCarouselView.swift
+++ b/podcasts/New Search/Views/Results/PodcastCarouselView.swift
@@ -77,7 +77,7 @@ struct PodcastResultCell: View {
             ZStack(alignment: .bottomTrailing) {
                 Button(action: {
                     NavigationManager.sharedManager.navigateTo(NavigationManager.podcastPageKey, data: [NavigationManager.podcastKey: podcast])
-                    searchHistory?.add(entry: SearchHistoryEntry(podcast: podcast))
+                    searchHistory?.add(podcast: podcast)
                 }) {
                     PodcastCover(podcastUuid: podcast.uuid)
                 }
@@ -86,7 +86,7 @@ struct PodcastResultCell: View {
 
             Button(action: {
                 NavigationManager.sharedManager.navigateTo(NavigationManager.podcastPageKey, data: [NavigationManager.podcastKey: podcast])
-                searchHistory?.add(entry: SearchHistoryEntry(podcast: podcast))
+                searchHistory?.add(podcast: podcast)
             }) {
                 VStack(alignment: .leading, spacing: 2) {
                     Text(podcast.title)

--- a/podcasts/New Search/Views/Results/SearchEpisodeCell.swift
+++ b/podcasts/New Search/Views/Results/SearchEpisodeCell.swift
@@ -8,10 +8,13 @@ struct SearchEpisodeCell: View {
 
     var episode: EpisodeSearchResult
 
+    var searchHistory: SearchHistoryModel?
+
     var body: some View {
         ZStack {
             Button(action: {
                 NavigationManager.sharedManager.navigateTo(NavigationManager.episodePageKey, data: [NavigationManager.episodeUuidKey: episode.uuid, NavigationManager.podcastKey: episode.podcastUuid])
+                searchHistory?.add(entry: SearchHistoryEntry(episode: episode))
             }) {
                 Rectangle()
                     .foregroundColor(.clear)

--- a/podcasts/New Search/Views/Results/SearchEpisodeCell.swift
+++ b/podcasts/New Search/Views/Results/SearchEpisodeCell.swift
@@ -14,7 +14,7 @@ struct SearchEpisodeCell: View {
         ZStack {
             Button(action: {
                 NavigationManager.sharedManager.navigateTo(NavigationManager.episodePageKey, data: [NavigationManager.episodeUuidKey: episode.uuid, NavigationManager.podcastKey: episode.podcastUuid])
-                searchHistory?.add(entry: SearchHistoryEntry(episode: episode))
+                searchHistory?.add(episode: episode)
             }) {
                 Rectangle()
                     .foregroundColor(.clear)

--- a/podcasts/New Search/Views/Results/SearchEpisodeCell.swift
+++ b/podcasts/New Search/Views/Results/SearchEpisodeCell.swift
@@ -6,9 +6,8 @@ import PocketCastsUtils
 struct SearchEpisodeCell: View {
     @EnvironmentObject var theme: Theme
 
-    var episode: EpisodeSearchResult
-
-    var searchHistory: SearchHistoryModel?
+    let episode: EpisodeSearchResult
+    let searchHistory: SearchHistoryModel?
 
     var body: some View {
         ZStack {

--- a/podcasts/New Search/Views/Results/SearchResultsView.swift
+++ b/podcasts/New Search/Views/Results/SearchResultsView.swift
@@ -7,6 +7,8 @@ struct SearchResultsView: View {
 
     @ObservedObject var searchResults: SearchResultsModel
 
+    var searchHistory: SearchHistoryModel
+
     @State var identifier = 0
 
     var body: some View {
@@ -66,7 +68,7 @@ struct SearchResultsView: View {
 
 struct SearchResultsView_Previews: PreviewProvider {
     static var previews: some View {
-        SearchResultsView(searchResults: SearchResultsModel())
+        SearchResultsView(searchResults: SearchResultsModel(), searchHistory: SearchHistoryModel())
             .previewWithAllThemes()
     }
 }

--- a/podcasts/New Search/Views/Results/SearchResultsView.swift
+++ b/podcasts/New Search/Views/Results/SearchResultsView.swift
@@ -7,7 +7,7 @@ struct SearchResultsView: View {
 
     @ObservedObject var searchResults: SearchResultsModel
 
-    var searchHistory: SearchHistoryModel
+    let searchHistory: SearchHistoryModel
 
     @State var identifier = 0
 

--- a/podcasts/New Search/Views/Results/SearchResultsView.swift
+++ b/podcasts/New Search/Views/Results/SearchResultsView.swift
@@ -19,7 +19,7 @@ struct SearchResultsView: View {
                 ThemeableListHeader(title: L10n.podcastsPlural, actionTitle: L10n.discoverShowAll)
 
                 Section {
-                    PodcastsCarouselView(searchResults: searchResults)
+                    PodcastsCarouselView(searchResults: searchResults, searchHistory: searchHistory)
                 }
 
                 ThemeableListHeader(title: L10n.episodes, actionTitle: nil)

--- a/podcasts/New Search/Views/Results/SearchResultsView.swift
+++ b/podcasts/New Search/Views/Results/SearchResultsView.swift
@@ -36,9 +36,9 @@ struct SearchResultsView: View {
                     }
                 } else if searchResults.episodes.count > 0 {
                     Section {
-                        ForEach(0..<searchResults.episodes.count, id: \.self) { index in
+                        ForEach(searchResults.episodes, id: \.self) { episode in
 
-                            SearchEpisodeCell(episode: searchResults.episodes[index], searchHistory: searchHistory)
+                            SearchEpisodeCell(episode: episode, searchHistory: searchHistory)
                             .listRowInsets(EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0))
                             .listRowSeparator(.hidden)
                             .listSectionSeparator(.hidden)

--- a/podcasts/New Search/Views/Results/SearchResultsView.swift
+++ b/podcasts/New Search/Views/Results/SearchResultsView.swift
@@ -38,7 +38,7 @@ struct SearchResultsView: View {
                     Section {
                         ForEach(0..<searchResults.episodes.count, id: \.self) { index in
 
-                            SearchEpisodeCell(episode: searchResults.episodes[index])
+                            SearchEpisodeCell(episode: searchResults.episodes[index], searchHistory: searchHistory)
                             .listRowInsets(EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0))
                             .listRowSeparator(.hidden)
                             .listSectionSeparator(.hidden)

--- a/podcasts/New Search/Views/Results/ThemeableListHeader.swift
+++ b/podcasts/New Search/Views/Results/ThemeableListHeader.swift
@@ -7,15 +7,25 @@ struct ThemeableListHeader: View {
 
     let actionTitle: String?
 
+    let action: (() -> ())?
+
+    init(title: String, actionTitle: String?, action: (() -> Void)? = nil) {
+        self.title = title
+        self.actionTitle = actionTitle
+        self.action = action
+    }
+
     var body: some View {
         HStack {
             Text(title)
                 .font(style: .title2, weight: .bold)
             Spacer()
             if let actionTitle {
-                Button(actionTitle.uppercased()) {}
-                    .font(style: .footnote, weight: .bold)
-                    .buttonStyle(PrimaryButtonStyle())
+                Button(actionTitle.uppercased()) {
+                    action?()
+                }
+                .font(style: .footnote, weight: .bold)
+                .buttonStyle(PrimaryButtonStyle())
             }
         }
         .listRowInsets(EdgeInsets(top: 12, leading: 16, bottom: 0, trailing: 12))

--- a/podcasts/New Search/Views/SearchView.swift
+++ b/podcasts/New Search/Views/SearchView.swift
@@ -20,7 +20,7 @@ struct SearchView: View {
     @ViewBuilder
     private var searchView: some View {
         if displaySearch.isSearching {
-            SearchResultsView(searchResults: searchResults)
+            SearchResultsView(searchResults: searchResults, searchHistory: searchHistory)
         } else {
             SearchHistoryView(searchHistory: searchHistory)
         }

--- a/podcasts/New Search/Views/SearchView.swift
+++ b/podcasts/New Search/Views/SearchView.swift
@@ -22,7 +22,7 @@ struct SearchView: View {
         if displaySearch.isSearching {
             SearchResultsView(searchResults: searchResults, searchHistory: searchHistory)
         } else {
-            SearchHistoryView(searchHistory: searchHistory)
+            SearchHistoryView(searchHistory: searchHistory, searchResults: searchResults, displaySearch: displaySearch)
         }
     }
 }

--- a/podcasts/New Search/Views/SearchView.swift
+++ b/podcasts/New Search/Views/SearchView.swift
@@ -7,9 +7,8 @@ class SearchVisibilityModel: ObservableObject {
 struct SearchView: View {
     @ObservedObject var displaySearch: SearchVisibilityModel
 
-    var searchResults: SearchResultsModel
-
-    var searchHistory: SearchHistoryModel
+    let searchResults: SearchResultsModel
+    let searchHistory: SearchHistoryModel
 
     var body: some View {
         searchView

--- a/podcasts/New Search/Views/SearchView.swift
+++ b/podcasts/New Search/Views/SearchView.swift
@@ -9,6 +9,8 @@ struct SearchView: View {
 
     var searchResults: SearchResultsModel
 
+    var searchHistory: SearchHistoryModel
+
     var body: some View {
         searchView
         .padding(.bottom, (PlaybackManager.shared.currentEpisode() != nil) ? Constants.Values.miniPlayerOffset : 0)
@@ -20,13 +22,14 @@ struct SearchView: View {
         if displaySearch.isSearching {
             SearchResultsView(searchResults: searchResults)
         } else {
-            SearchHistoryView()
+            SearchHistoryView(searchHistory: searchHistory)
         }
     }
 }
 
 struct SearchView_Previews: PreviewProvider {
     static var previews: some View {
-        SearchView(displaySearch: SearchVisibilityModel(), searchResults: SearchResultsModel())
+        SearchView(displaySearch: SearchVisibilityModel(), searchResults: SearchResultsModel(),
+        searchHistory: SearchHistoryModel())
     }
 }

--- a/podcasts/PCSearchBarController.swift
+++ b/podcasts/PCSearchBarController.swift
@@ -66,6 +66,7 @@ class PCSearchBarController: UIViewController {
     @objc private func searchRequest(notification: Notification) {
         if let searchTerm = notification.object as? String {
             searchTextField.text = searchTerm
+            clearSearchBtn.isHidden = false
             view.endEditing(true)
         }
     }

--- a/podcasts/PCSearchBarController.swift
+++ b/podcasts/PCSearchBarController.swift
@@ -56,10 +56,18 @@ class PCSearchBarController: UIViewController {
 
         updateColors()
         NotificationCenter.default.addObserver(self, selector: #selector(themeDidChange), name: Constants.Notifications.themeChanged, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(searchRequest), name: Constants.Notifications.podcastSearchRequest, object: nil)
     }
 
     @objc private func themeDidChange() {
         updateColors()
+    }
+
+    @objc private func searchRequest(notification: Notification) {
+        if let searchTerm = notification.object as? String {
+            searchTextField.text = searchTerm
+            view.endEditing(true)
+        }
     }
 
     private func updateColors() {


### PR DESCRIPTION
| 📘 Project: #709 |
|:---:|

Adds the search history functionality.

<img src="https://user-images.githubusercontent.com/7040243/224128811-a855e9fc-d5ed-4c7f-9ba8-5e1fa942a18d.png" width="300">

## To test

### Before everything

1. Run the app
2. Go to Profile > Settings > Beta Features > enable `newSearch`
3. Change the app Build Configuration to `Staging`

### Keeping track of search history

1. Go to discover
2. Perform a search
3. Tap in a few results (podcasts and episodes)
4. Tap "X" at the search bar
5. ✅ Your search history should be shown, including the episodes and podcasts you interacted with

### Interacting with search history

1. Tap a podcast
1. ✅ The podcast should show
1. Tap an episode
1. ✅ The episode should show
1. Tap the search term
1. ✅ The search should be performed

### Removing items

1. Tap "X" so you're back at search history
1. On any of the search history items, tap the "X" button
1. ✅ The entry should be removed
1. Tap "Remove all"
1. ✅ Everything should be removed

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
