### PR TITLE
Search Improvements: search from Podcasts and Discover tab

### DIFF
--- a/podcasts/DiscoverViewController+Search.swift
+++ b/podcasts/DiscoverViewController+Search.swift
@@ -16,7 +16,9 @@ extension DiscoverViewController: PCSearchBarDelegate, UIScrollViewDelegate {
     func setupSearchBar() {
         searchController = PCSearchBarController()
         searchController.view.translatesAutoresizingMaskIntoConstraints = false
+        addChild(searchController)
         view.addSubview(searchController.view)
+        searchController.didMove(toParent: self)
 
         let topAnchor = searchController.view.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: -PCSearchBarController.defaultHeight)
         NSLayoutConstraint.activate([

--- a/podcasts/DiscoverViewController.swift
+++ b/podcasts/DiscoverViewController.swift
@@ -47,9 +47,9 @@ class DiscoverViewController: PCViewController {
 
         title = L10n.discover
 
-        setupSearchBar()
         handleThemeChanged()
         reloadData()
+        setupSearchBar()
 
         addCustomObserver(Constants.Notifications.chartRegionChanged, selector: #selector(chartRegionDidChange))
         addCustomObserver(Constants.Notifications.tappedOnSelectedTab, selector: #selector(checkForScrollTap(_:)))

--- a/podcasts/New Search/SearchResultsViewController.swift
+++ b/podcasts/New Search/SearchResultsViewController.swift
@@ -30,6 +30,7 @@ class SearchResultsViewController: UIHostingController<AnyView> {
 extension SearchResultsViewController: SearchResultsDelegate {
     func clearSearch() {
         displaySearch.isSearching = false
+        searchResults.clearSearch()
     }
 
     func performLocalSearch(searchTerm: String) {

--- a/podcasts/New Search/SearchResultsViewController.swift
+++ b/podcasts/New Search/SearchResultsViewController.swift
@@ -33,13 +33,13 @@ extension SearchResultsViewController: SearchResultsDelegate {
     }
 
     func performLocalSearch(searchTerm: String) {
-        displaySearch.isSearching = true
         print("local search: \(searchTerm)")
     }
 
     func performRemoteSearch(searchTerm: String, completion: @escaping (() -> Void)) {
         displaySearch.isSearching = true
-        print("remote search: \(searchTerm)")
+        searchResults.search(term: searchTerm)
+        searchHistoryModel.add(searchTerm: searchTerm)
         completion()
     }
 

--- a/podcasts/PCSearchBarController.swift
+++ b/podcasts/PCSearchBarController.swift
@@ -51,6 +51,8 @@ class PCSearchBarController: UIViewController {
 
     weak var searchDelegate: PCSearchBarDelegate?
 
+    private var isVisible = false
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -59,12 +61,22 @@ class PCSearchBarController: UIViewController {
         NotificationCenter.default.addObserver(self, selector: #selector(searchRequest), name: Constants.Notifications.podcastSearchRequest, object: nil)
     }
 
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        isVisible = true
+    }
+
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        isVisible = false
+    }
+
     @objc private func themeDidChange() {
         updateColors()
     }
 
     @objc private func searchRequest(notification: Notification) {
-        if let searchTerm = notification.object as? String {
+        if isVisible, let searchTerm = notification.object as? String {
             searchTextField.text = searchTerm
             clearSearchBtn.isHidden = false
             view.endEditing(true)

--- a/podcasts/PodcastListViewController+Search.swift
+++ b/podcasts/PodcastListViewController+Search.swift
@@ -127,7 +127,11 @@ extension PodcastListViewController: UIScrollViewDelegate, PCSearchBarDelegate {
             searchView.alpha = 0
         }) { _ in
             searchView.removeFromSuperview()
-            self.searchResultsControler.clearSearch()
+            if FeatureFlag.newSearch.enabled {
+                self.newSearchResultsController.clearSearch()
+            } else {
+                self.searchResultsControler.clearSearch()
+            }
         }
     }
 

--- a/podcasts/PodcastListViewController+Search.swift
+++ b/podcasts/PodcastListViewController+Search.swift
@@ -24,7 +24,9 @@ extension PodcastListViewController: UIScrollViewDelegate, PCSearchBarDelegate {
         searchResultsControler = PodcastListSearchResultsController()
 
         searchController.view.translatesAutoresizingMaskIntoConstraints = false
+        addChild(searchController)
         view.addSubview(searchController.view)
+        searchController.didMove(toParent: self)
 
         let topAnchor = searchController.view.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: -PCSearchBarController.defaultHeight)
         NSLayoutConstraint.activate([


### PR DESCRIPTION
| 📘 Project: #709 |
|:---:|

Search now works correctly from both "Podcasts" tab and "Discover" tab.

## To test

### Before everything

1. Run the app
2. Go to Profile > Settings > Beta Features > enable `newSearch`
3. Change the app Build Configuration to `Staging`

### Independently search

1. Go to Podcasts
1. Search for something
1. ✅ Make sure results are appearing
1. Without closing this search, go to Discover
1. Make another search
1. ✅ Check Podcasts and Discover, they should display independently results based on your search
1. Dismiss both searches

### Redoing a search from History

1. Make sure search is appearing under Podcasts
1. Tap the search field
1. In the history, select any search term
1. Go to Discover
1. ✅ The search input should be clear
1. Tap on it
1. Select any search term
1. Go back to Podcasts
1. Teh search term should display the search term you selected on step 3


## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
