### PR TITLE
Search Improvements: show local podcasts and folders

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/Search/PodcastSearchTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Search/PodcastSearchTask.swift
@@ -1,7 +1,7 @@
 import Foundation
 import PocketCastsDataModel
 
-public struct PodcastSearchResult: Codable, Hashable {
+public struct PodcastFolderSearchResult: Codable, Hashable {
     public let uuid: String
     public let title: String
     public let author: String
@@ -32,7 +32,7 @@ public class PodcastSearchTask {
     public init(session: URLSession = .shared) {
         self.session = session
     }
-    public func search(term: String) async throws -> [PodcastSearchResult] {
+    public func search(term: String) async throws -> [PodcastFolderSearchResult] {
         let searchURL = URL(string: "\(ServerConstants.Urls.cache())discover/search")!
         var request = URLRequest(url: searchURL)
         request.httpMethod = "POST"
@@ -45,6 +45,6 @@ public class PodcastSearchTask {
 
         let (data, _) = try await session.data(for: request)
         let decoder = JSONDecoder()
-        return try decoder.decode([PodcastSearchResult].self, from: data)
+        return try decoder.decode([PodcastFolderSearchResult].self, from: data)
     }
 }

--- a/Modules/Server/Sources/PocketCastsServer/Public/Search/PodcastSearchTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Search/PodcastSearchTask.swift
@@ -5,14 +5,22 @@ public struct PodcastFolderSearchResult: Codable, Hashable {
     public let uuid: String
     public let title: String
     public let author: String
-    public let isFolder: Bool?
+    public let kind: Kind
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.uuid = try container.decode(String.self, forKey: .uuid)
+        self.title = try container.decode(String.self, forKey: .title)
+        self.author = try container.decode(String.self, forKey: .author)
+        self.kind = .podcast
+    }
 
     public init?(from podcast: Podcast) {
         if let title = podcast.title, let author = podcast.author {
             self.uuid = podcast.uuid
             self.title = title
             self.author = author
-            self.isFolder = nil
+            self.kind = .podcast
         } else {
             return nil
         }
@@ -22,7 +30,11 @@ public struct PodcastFolderSearchResult: Codable, Hashable {
         self.uuid = folder.uuid
         self.title = folder.name
         self.author = ""
-        self.isFolder = true
+        self.kind = .folder
+    }
+
+    public enum Kind: Codable {
+        case podcast, folder
     }
 }
 

--- a/Modules/Server/Sources/PocketCastsServer/Public/Search/PodcastSearchTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Search/PodcastSearchTask.swift
@@ -12,7 +12,7 @@ public struct PodcastFolderSearchResult: Codable, Hashable {
         self.uuid = try container.decode(String.self, forKey: .uuid)
         self.title = try container.decode(String.self, forKey: .title)
         self.author = try container.decode(String.self, forKey: .author)
-        self.kind = .podcast
+        self.kind = (try? container.decodeIfPresent(Kind.self, forKey: .kind)) ?? .podcast
     }
 
     public init?(from podcast: Podcast) {

--- a/Modules/Server/Sources/PocketCastsServer/Public/Search/PodcastSearchTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Search/PodcastSearchTask.swift
@@ -1,9 +1,20 @@
 import Foundation
+import PocketCastsDataModel
 
 public struct PodcastSearchResult: Codable, Hashable {
     public let uuid: String
     public let title: String
     public let author: String
+
+    public init?(from podcast: Podcast) {
+        if let title = podcast.title, let author = podcast.author {
+            self.uuid = podcast.uuid
+            self.title = title
+            self.author = author
+        } else {
+            return nil
+        }
+    }
 }
 
 public class PodcastSearchTask {

--- a/Modules/Server/Sources/PocketCastsServer/Public/Search/PodcastSearchTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Search/PodcastSearchTask.swift
@@ -12,7 +12,7 @@ public struct PodcastFolderSearchResult: Codable, Hashable {
             self.uuid = podcast.uuid
             self.title = title
             self.author = author
-            self.isFolder = false
+            self.isFolder = nil
         } else {
             return nil
         }

--- a/Modules/Server/Sources/PocketCastsServer/Public/Search/PodcastSearchTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Search/PodcastSearchTask.swift
@@ -5,15 +5,24 @@ public struct PodcastSearchResult: Codable, Hashable {
     public let uuid: String
     public let title: String
     public let author: String
+    public let isFolder: Bool?
 
     public init?(from podcast: Podcast) {
         if let title = podcast.title, let author = podcast.author {
             self.uuid = podcast.uuid
             self.title = title
             self.author = author
+            self.isFolder = false
         } else {
             return nil
         }
+    }
+
+    public init?(from folder: Folder) {
+        self.uuid = folder.uuid
+        self.title = folder.name
+        self.author = ""
+        self.isFolder = true
     }
 }
 

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
@@ -161,7 +161,7 @@ public struct PodcastInfo: Codable {
 
     public init() {}
 
-    public init(from searchResult: PodcastSearchResult) {
+    public init(from searchResult: PodcastFolderSearchResult) {
         author = searchResult.author
         title = searchResult.title
         uuid = searchResult.uuid

--- a/podcasts/FolderPreviewWrapper.swift
+++ b/podcasts/FolderPreviewWrapper.swift
@@ -19,3 +19,19 @@ struct FolderPreviewWrapper: UIViewRepresentable {
         }
     }
 }
+
+struct SearchFolderPreviewWrapper: UIViewRepresentable {
+    @State var uuid: String
+
+    func makeUIView(context: Context) -> FolderPreviewView {
+        FolderPreviewView()
+    }
+
+    func updateUIView(_ folderView: FolderPreviewView, context: Context) {
+        folderView.showFolderName = false
+
+        if let folder = DataManager.sharedManager.findFolder(uuid: uuid) {
+            folderView.populateFrom(folder: folder)
+        }
+    }
+}

--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -177,7 +177,7 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
         }
     }
 
-    func navigateTo(podcast searchResult: PodcastSearchResult) {
+    func navigateTo(podcast searchResult: PodcastFolderSearchResult) {
         if let navController = selectedViewController as? UINavigationController {
             let podcastController = PodcastViewController(podcastInfo: PodcastInfo(from: searchResult), existingImage: nil)
             navController.pushViewController(podcastController, animated: true)

--- a/podcasts/NavigationManager.swift
+++ b/podcasts/NavigationManager.swift
@@ -112,7 +112,7 @@ class NavigationManager {
                 podcastInfo.iTunesId = podcastHeader.itunesId?.intValue
 
                 mainController?.navigateToPodcastInfo(podcastInfo)
-            } else if let searchResult = data[NavigationManager.podcastKey] as? PodcastSearchResult {
+            } else if let searchResult = data[NavigationManager.podcastKey] as? PodcastFolderSearchResult {
                 mainController?.navigateTo(podcast: searchResult)
             }
         } else if place == NavigationManager.folderPageKey {

--- a/podcasts/NavigationProtocol.swift
+++ b/podcasts/NavigationProtocol.swift
@@ -7,7 +7,7 @@ protocol NavigationProtocol: AnyObject {
     func navigateToPodcastList(_ animated: Bool)
     func navigateToPodcast(_ podcast: Podcast)
     func navigateToPodcastInfo(_ podcastInfo: PodcastInfo)
-    func navigateTo(podcast searchResult: PodcastSearchResult)
+    func navigateTo(podcast searchResult: PodcastFolderSearchResult)
 
     func navigateToFolder(_ folder: Folder)
 

--- a/podcasts/New Search/Model/SearchHistoryModel.swift
+++ b/podcasts/New Search/Model/SearchHistoryModel.swift
@@ -4,7 +4,7 @@ import PocketCastsServer
 struct SearchHistoryEntry: Codable, Hashable {
     var searchTerm: String?
     var episode: EpisodeSearchResult?
-    var podcast: PodcastSearchResult?
+    var podcast: PodcastFolderSearchResult?
 }
 
 class SearchHistoryModel: ObservableObject {
@@ -32,7 +32,7 @@ class SearchHistoryModel: ObservableObject {
         add(entry: SearchHistoryEntry(episode: episode))
     }
 
-    func add(podcast: PodcastSearchResult) {
+    func add(podcast: PodcastFolderSearchResult) {
         add(entry: SearchHistoryEntry(podcast: podcast))
     }
 

--- a/podcasts/New Search/Model/SearchResultsModel.swift
+++ b/podcasts/New Search/Model/SearchResultsModel.swift
@@ -9,7 +9,7 @@ class SearchResultsModel: ObservableObject {
     @Published var isSearchingForPodcasts = false
     @Published var isSearchingForEpisodes = false
 
-    @Published var podcasts: [PodcastSearchResult] = []
+    @Published var podcasts: [PodcastFolderSearchResult] = []
     @Published var episodes: [EpisodeSearchResult] = []
 
     @Published var isShowingLocalResultsOnly = false
@@ -44,14 +44,14 @@ class SearchResultsModel: ObservableObject {
     func searchLocally(term searchTerm: String) {
         let allPodcasts = DataManager.sharedManager.allPodcasts(includeUnsubscribed: false)
 
-        var results = [PodcastSearchResult?]()
+        var results = [PodcastFolderSearchResult?]()
         for podcast in allPodcasts {
             guard let title = podcast.title else { continue }
 
             if title.localizedCaseInsensitiveContains(searchTerm) {
-                results.append(PodcastSearchResult(from: podcast))
+                results.append(PodcastFolderSearchResult(from: podcast))
             } else if let author = podcast.author, author.localizedCaseInsensitiveContains(searchTerm) {
-                results.append(PodcastSearchResult(from: podcast))
+                results.append(PodcastFolderSearchResult(from: podcast))
             }
         }
 
@@ -59,7 +59,7 @@ class SearchResultsModel: ObservableObject {
             let allFolders = DataManager.sharedManager.allFolders()
             for folder in allFolders {
                 if folder.name.localizedCaseInsensitiveContains(searchTerm) {
-                    results.append(PodcastSearchResult(from: folder))
+                    results.append(PodcastFolderSearchResult(from: folder))
                 }
             }
         }
@@ -69,7 +69,7 @@ class SearchResultsModel: ObservableObject {
         isShowingLocalResultsOnly = true
     }
 
-    private func show(podcastResults: [PodcastSearchResult]) {
+    private func show(podcastResults: [PodcastFolderSearchResult]) {
         if isShowingLocalResultsOnly {
             podcasts.append(contentsOf: podcastResults.filter { !podcasts.contains($0) })
             isShowingLocalResultsOnly = false

--- a/podcasts/New Search/Model/SearchResultsModel.swift
+++ b/podcasts/New Search/Model/SearchResultsModel.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import PocketCastsServer
+import PocketCastsDataModel
 
 class SearchResultsModel: ObservableObject {
     private let podcastSearch = PodcastSearchTask()
@@ -33,5 +34,23 @@ class SearchResultsModel: ObservableObject {
             isSearchingForEpisodes = false
             episodes = results ?? []
         }
+    }
+
+    @MainActor
+    func searchLocally(term searchTerm: String) {
+        let allPodcasts = DataManager.sharedManager.allPodcasts(includeUnsubscribed: false)
+
+        var results = [PodcastSearchResult?]()
+        for podcast in allPodcasts {
+            guard let title = podcast.title else { continue }
+
+            if title.localizedCaseInsensitiveContains(searchTerm) {
+                results.append(PodcastSearchResult(from: podcast))
+            } else if let author = podcast.author, author.localizedCaseInsensitiveContains(searchTerm) {
+                results.append(PodcastSearchResult(from: podcast))
+            }
+        }
+
+        self.podcasts = results.compactMap { $0 }
     }
 }

--- a/podcasts/New Search/Model/SearchResultsModel.swift
+++ b/podcasts/New Search/Model/SearchResultsModel.swift
@@ -55,6 +55,15 @@ class SearchResultsModel: ObservableObject {
             }
         }
 
+        if SubscriptionHelper.hasActiveSubscription() {
+            let allFolders = DataManager.sharedManager.allFolders()
+            for folder in allFolders {
+                if folder.name.localizedCaseInsensitiveContains(searchTerm) {
+                    results.append(PodcastSearchResult(from: folder))
+                }
+            }
+        }
+
         self.podcasts = results.compactMap { $0 }
 
         isShowingLocalResultsOnly = true

--- a/podcasts/New Search/Model/SearchResultsModel.swift
+++ b/podcasts/New Search/Model/SearchResultsModel.swift
@@ -42,6 +42,8 @@ class SearchResultsModel: ObservableObject {
 
     @MainActor
     func searchLocally(term searchTerm: String) {
+        clearSearch()
+
         let allPodcasts = DataManager.sharedManager.allPodcasts(includeUnsubscribed: false)
 
         var results = [PodcastFolderSearchResult?]()

--- a/podcasts/New Search/Model/SearchResultsModel.swift
+++ b/podcasts/New Search/Model/SearchResultsModel.swift
@@ -12,7 +12,7 @@ class SearchResultsModel: ObservableObject {
     @Published var podcasts: [PodcastSearchResult] = []
     @Published var episodes: [EpisodeSearchResult] = []
 
-    var isShowingLocalResultsOnly = false
+    @Published var isShowingLocalResultsOnly = false
 
     func clearSearch() {
         podcasts = []

--- a/podcasts/New Search/SearchResultsViewController.swift
+++ b/podcasts/New Search/SearchResultsViewController.swift
@@ -30,6 +30,7 @@ class SearchResultsViewController: UIHostingController<AnyView> {
 extension SearchResultsViewController: SearchResultsDelegate {
     func clearSearch() {
         displaySearch.isSearching = false
+        searchResults.clearSearch()
     }
 
     func performLocalSearch(searchTerm: String) {

--- a/podcasts/New Search/SearchResultsViewController.swift
+++ b/podcasts/New Search/SearchResultsViewController.swift
@@ -33,7 +33,8 @@ extension SearchResultsViewController: SearchResultsDelegate {
     }
 
     func performLocalSearch(searchTerm: String) {
-        print("local search: \(searchTerm)")
+        displaySearch.isSearching = true
+        searchResults.searchLocally(term: searchTerm)
     }
 
     func performRemoteSearch(searchTerm: String, completion: @escaping (() -> Void)) {

--- a/podcasts/New Search/Views/History/SearchHistoryCell.swift
+++ b/podcasts/New Search/Views/History/SearchHistoryCell.swift
@@ -14,10 +14,10 @@ struct SearchHistoryCell: View {
         if let episode = entry.episode {
             return "\(L10n.episode) • \(TimeFormatter.shared.multipleUnitFormattedShortTime(time: TimeInterval(episode.duration ?? 0))) • \(episode.podcastTitle)"
         } else if let podcast = entry.podcast {
-            if podcast.kind == .folder {
+            switch podcast.kind {
+            case .folder:
                 return L10n.folder
-            }
-            else {
+            case .podcast:
                 return [L10n.podcastSingular, podcast.author].compactMap { $0 }.joined(separator: " • ")
             }
         }

--- a/podcasts/New Search/Views/History/SearchHistoryCell.swift
+++ b/podcasts/New Search/Views/History/SearchHistoryCell.swift
@@ -50,6 +50,7 @@ struct SearchHistoryCell: View {
                         let uuid = entry.podcast?.uuid ?? entry.episode?.podcastUuid {
                         if entry.podcast?.isFolder == true {
                             SearchFolderPreviewWrapper(uuid: uuid)
+                                .modifier(NormalCoverShadow())
                                 .frame(width: 48, height: 48)
                                 .allowsHitTesting(false)
                                 .padding(.trailing, 12)

--- a/podcasts/New Search/Views/History/SearchHistoryCell.swift
+++ b/podcasts/New Search/Views/History/SearchHistoryCell.swift
@@ -14,7 +14,12 @@ struct SearchHistoryCell: View {
         if let episode = entry.episode {
             return "\(L10n.episode) • \(TimeFormatter.shared.multipleUnitFormattedShortTime(time: TimeInterval(episode.duration ?? 0))) • \(episode.podcastTitle)"
         } else if let podcast = entry.podcast {
-            return [L10n.podcastSingular, podcast.author].compactMap { $0 }.joined(separator: " • ")
+            if podcast.isFolder == true {
+                return L10n.folder
+            }
+            else {
+                return [L10n.podcastSingular, podcast.author].compactMap { $0 }.joined(separator: " • ")
+            }
         }
 
         return ""
@@ -26,7 +31,7 @@ struct SearchHistoryCell: View {
                 if let episode = entry.episode {
                     NavigationManager.sharedManager.navigateTo(NavigationManager.episodePageKey, data: [NavigationManager.episodeUuidKey: episode.uuid, NavigationManager.podcastKey: episode.podcastUuid])
                 } else if let podcast = entry.podcast {
-                    NavigationManager.sharedManager.navigateTo(NavigationManager.podcastPageKey, data: [NavigationManager.podcastKey: podcast])
+                    podcast.navigateTo()
                 } else if let searchTerm = entry.searchTerm {
                     displaySearch.isSearching = true
                     searchResults.search(term: searchTerm)
@@ -43,10 +48,18 @@ struct SearchHistoryCell: View {
                 HStack(spacing: 0) {
                     if let title = entry.podcast?.title ?? entry.episode?.title,
                         let uuid = entry.podcast?.uuid ?? entry.episode?.podcastUuid {
-                        PodcastCover(podcastUuid: uuid)
-                            .frame(width: 48, height: 48)
-                            .allowsHitTesting(false)
-                            .padding(.trailing, 12)
+                        if entry.podcast?.isFolder == true {
+                            SearchFolderPreviewWrapper(uuid: uuid)
+                                .frame(width: 48, height: 48)
+                                .allowsHitTesting(false)
+                                .padding(.trailing, 12)
+                        } else {
+                            PodcastCover(podcastUuid: uuid)
+                                .frame(width: 48, height: 48)
+                                .allowsHitTesting(false)
+                                .padding(.trailing, 12)
+                        }
+
                         VStack(alignment: .leading, spacing: 2) {
                             Text(title)
                                 .font(style: .subheadline, weight: .medium)

--- a/podcasts/New Search/Views/History/SearchHistoryCell.swift
+++ b/podcasts/New Search/Views/History/SearchHistoryCell.swift
@@ -14,7 +14,7 @@ struct SearchHistoryCell: View {
         if let episode = entry.episode {
             return "\(L10n.episode) • \(TimeFormatter.shared.multipleUnitFormattedShortTime(time: TimeInterval(episode.duration ?? 0))) • \(episode.podcastTitle)"
         } else if let podcast = entry.podcast {
-            if podcast.isFolder == true {
+            if podcast.kind == .folder {
                 return L10n.folder
             }
             else {
@@ -48,7 +48,7 @@ struct SearchHistoryCell: View {
                 HStack(spacing: 0) {
                     if let title = entry.podcast?.title ?? entry.episode?.title,
                         let uuid = entry.podcast?.uuid ?? entry.episode?.podcastUuid {
-                        if entry.podcast?.isFolder == true {
+                        if entry.podcast?.kind == .folder {
                             SearchFolderPreviewWrapper(uuid: uuid)
                                 .modifier(NormalCoverShadow())
                                 .frame(width: 48, height: 48)

--- a/podcasts/New Search/Views/Results/PodcastCarouselView.swift
+++ b/podcasts/New Search/Views/Results/PodcastCarouselView.swift
@@ -82,6 +82,7 @@ struct PodcastResultCell: View {
                 }) {
                     if result.isFolder == true {
                         SearchFolderPreviewWrapper(uuid: result.uuid)
+                            .modifier(NormalCoverShadow())
                     } else {
                         PodcastCover(podcastUuid: result.uuid)
                     }

--- a/podcasts/New Search/Views/Results/PodcastCarouselView.swift
+++ b/podcasts/New Search/Views/Results/PodcastCarouselView.swift
@@ -80,14 +80,14 @@ struct PodcastResultCell: View {
                     result.navigateTo()
                     searchHistory?.add(podcast: result)
                 }) {
-                    if result.isFolder == true {
+                    if result.kind == .folder {
                         SearchFolderPreviewWrapper(uuid: result.uuid)
                             .modifier(NormalCoverShadow())
                     } else {
                         PodcastCover(podcastUuid: result.uuid)
                     }
                 }
-                if !(result.isFolder == true) {
+                if result.kind == .podcast {
                     RoundedSubscribeButtonView(podcastUuid: result.uuid)
                 }
             }
@@ -112,7 +112,7 @@ struct PodcastResultCell: View {
 
 extension PodcastFolderSearchResult {
     func navigateTo() {
-        if isFolder == true {
+        if kind == .folder {
             NavigationManager.sharedManager.navigateTo(NavigationManager.folderPageKey, data: [NavigationManager.folderKey: DataManager.sharedManager.findFolder(uuid: uuid) as Any])
         } else {
             NavigationManager.sharedManager.navigateTo(NavigationManager.podcastPageKey, data: [NavigationManager.podcastKey: self])

--- a/podcasts/New Search/Views/Results/PodcastCarouselView.swift
+++ b/podcasts/New Search/Views/Results/PodcastCarouselView.swift
@@ -27,12 +27,14 @@ struct PodcastsCarouselView: View {
                             }
 
                             TabView(selection: $tabSelection) {
-                                ForEach(0..<(searchResults.podcasts.count/2), id: \.self) { i in
+                                ForEach(0..<max(1, searchResults.podcasts.count/2), id: \.self) { i in
                                     GeometryReader { geometry in
                                         HStack(spacing: 10) {
                                             PodcastResultCell(podcast: searchResults.podcasts[(i * 2)], searchHistory: searchHistory)
 
-                                            PodcastResultCell(podcast: searchResults.podcasts[(i * 2) + 1], searchHistory: searchHistory)
+                                            if let podcast = searchResults.podcasts[safe: (i * 2) + 1] {
+                                                PodcastResultCell(podcast: podcast, searchHistory: searchHistory)
+                                            }
                                         }
                                     }
                                 }

--- a/podcasts/New Search/Views/Results/PodcastCarouselView.swift
+++ b/podcasts/New Search/Views/Results/PodcastCarouselView.swift
@@ -15,7 +15,7 @@ struct PodcastsCarouselView: View {
         ScrollView {
             LazyHStack {
                 Group {
-                    if searchResults.isSearchingForPodcasts {
+                    if searchResults.isSearchingForPodcasts && !searchResults.isShowingLocalResultsOnly {
                         ZStack(alignment: .center) {
                             ProgressView()
                         }

--- a/podcasts/New Search/Views/Results/PodcastCarouselView.swift
+++ b/podcasts/New Search/Views/Results/PodcastCarouselView.swift
@@ -70,7 +70,7 @@ struct PodcastsCarouselView: View {
 struct PodcastResultCell: View {
     @EnvironmentObject var theme: Theme
 
-    let result: PodcastSearchResult
+    let result: PodcastFolderSearchResult
     let searchHistory: SearchHistoryModel?
 
     var body: some View {
@@ -109,7 +109,7 @@ struct PodcastResultCell: View {
     }
 }
 
-extension PodcastSearchResult {
+extension PodcastFolderSearchResult {
     func navigateTo() {
         if isFolder == true {
             NavigationManager.sharedManager.navigateTo(NavigationManager.folderPageKey, data: [NavigationManager.folderKey: DataManager.sharedManager.findFolder(uuid: uuid) as Any])

--- a/podcasts/New Search/Views/Results/PodcastCarouselView.swift
+++ b/podcasts/New Search/Views/Results/PodcastCarouselView.swift
@@ -30,10 +30,10 @@ struct PodcastsCarouselView: View {
                                 ForEach(0..<max(1, searchResults.podcasts.count/2), id: \.self) { i in
                                     GeometryReader { geometry in
                                         HStack(spacing: 10) {
-                                            PodcastResultCell(podcast: searchResults.podcasts[(i * 2)], searchHistory: searchHistory)
+                                            PodcastResultCell(result: searchResults.podcasts[(i * 2)], searchHistory: searchHistory)
 
-                                            if let podcast = searchResults.podcasts[safe: (i * 2) + 1] {
-                                                PodcastResultCell(podcast: podcast, searchHistory: searchHistory)
+                                            if let result = searchResults.podcasts[safe: (i * 2) + 1] {
+                                                PodcastResultCell(result: result, searchHistory: searchHistory)
                                             }
                                         }
                                     }
@@ -70,35 +70,51 @@ struct PodcastsCarouselView: View {
 struct PodcastResultCell: View {
     @EnvironmentObject var theme: Theme
 
-    let podcast: PodcastSearchResult
+    let result: PodcastSearchResult
     let searchHistory: SearchHistoryModel?
 
     var body: some View {
         VStack(alignment: .leading) {
             ZStack(alignment: .bottomTrailing) {
                 Button(action: {
-                    NavigationManager.sharedManager.navigateTo(NavigationManager.podcastPageKey, data: [NavigationManager.podcastKey: podcast])
-                    searchHistory?.add(podcast: podcast)
+                    result.navigateTo()
+                    searchHistory?.add(podcast: result)
                 }) {
-                    PodcastCover(podcastUuid: podcast.uuid)
+                    if result.isFolder == true {
+                        SearchFolderPreviewWrapper(uuid: result.uuid)
+                    } else {
+                        PodcastCover(podcastUuid: result.uuid)
+                    }
                 }
-                RoundedSubscribeButtonView(podcastUuid: podcast.uuid)
+                if !(result.isFolder == true) {
+                    RoundedSubscribeButtonView(podcastUuid: result.uuid)
+                }
             }
 
             Button(action: {
-                NavigationManager.sharedManager.navigateTo(NavigationManager.podcastPageKey, data: [NavigationManager.podcastKey: podcast])
-                searchHistory?.add(podcast: podcast)
+                result.navigateTo()
+                searchHistory?.add(podcast: result)
             }) {
                 VStack(alignment: .leading, spacing: 2) {
-                    Text(podcast.title)
+                    Text(result.title)
                         .lineLimit(1)
                         .font(style: .subheadline, weight: .medium)
-                    Text(podcast.author)
+                    Text(result.author)
                         .lineLimit(1)
                         .font(size: 14, style: .subheadline, weight: .medium)
                         .foregroundColor(AppTheme.color(for: .primaryText02, theme: theme))
                 }
             }
+        }
+    }
+}
+
+extension PodcastSearchResult {
+    func navigateTo() {
+        if isFolder == true {
+            NavigationManager.sharedManager.navigateTo(NavigationManager.folderPageKey, data: [NavigationManager.folderKey: DataManager.sharedManager.findFolder(uuid: uuid) as Any])
+        } else {
+            NavigationManager.sharedManager.navigateTo(NavigationManager.podcastPageKey, data: [NavigationManager.podcastKey: self])
         }
     }
 }

--- a/podcasts/New Search/Views/Results/PodcastCarouselView.swift
+++ b/podcasts/New Search/Views/Results/PodcastCarouselView.swift
@@ -80,10 +80,11 @@ struct PodcastResultCell: View {
                     result.navigateTo()
                     searchHistory?.add(podcast: result)
                 }) {
-                    if result.kind == .folder {
+                    switch result.kind {
+                    case .folder:
                         SearchFolderPreviewWrapper(uuid: result.uuid)
                             .modifier(NormalCoverShadow())
-                    } else {
+                    case .podcast:
                         PodcastCover(podcastUuid: result.uuid)
                     }
                 }
@@ -112,9 +113,10 @@ struct PodcastResultCell: View {
 
 extension PodcastFolderSearchResult {
     func navigateTo() {
-        if kind == .folder {
+        switch kind {
+        case .folder:
             NavigationManager.sharedManager.navigateTo(NavigationManager.folderPageKey, data: [NavigationManager.folderKey: DataManager.sharedManager.findFolder(uuid: uuid) as Any])
-        } else {
+        case .podcast:
             NavigationManager.sharedManager.navigateTo(NavigationManager.podcastPageKey, data: [NavigationManager.podcastKey: self])
         }
     }

--- a/podcasts/New Search/Views/Results/SearchResultCell.swift
+++ b/podcasts/New Search/Views/Results/SearchResultCell.swift
@@ -7,7 +7,7 @@ struct SearchResultCell: View {
     @EnvironmentObject var theme: Theme
 
     let episode: EpisodeSearchResult?
-    let podcast: PodcastSearchResult?
+    let podcast: PodcastFolderSearchResult?
     let searchHistory: SearchHistoryModel?
 
     var body: some View {

--- a/podcasts/New Search/Views/Results/SearchResultsView.swift
+++ b/podcasts/New Search/Views/Results/SearchResultsView.swift
@@ -30,6 +30,7 @@ struct SearchResultsView: View {
                     PodcastsCarouselView(searchResults: searchResults, searchHistory: searchHistory)
                 }
 
+                // If local results are being shown, we hide the episodes header
                 if !(searchResults.isShowingLocalResultsOnly && searchResults.isSearchingForEpisodes) {
                     ThemeableListHeader(title: L10n.episodes, actionTitle: searchResults.episodes.count > 20 ? L10n.discoverShowAll : nil) {
                         showPodcasts = false

--- a/podcasts/New Search/Views/Results/SearchResultsView.swift
+++ b/podcasts/New Search/Views/Results/SearchResultsView.swift
@@ -30,9 +30,11 @@ struct SearchResultsView: View {
                     PodcastsCarouselView(searchResults: searchResults, searchHistory: searchHistory)
                 }
 
-                ThemeableListHeader(title: L10n.episodes, actionTitle: searchResults.episodes.count > 20 ? L10n.discoverShowAll : nil) {
-                    showPodcasts = false
-                    showInlineResults = true
+                if !(searchResults.isShowingLocalResultsOnly && searchResults.isSearchingForEpisodes) {
+                    ThemeableListHeader(title: L10n.episodes, actionTitle: searchResults.episodes.count > 20 ? L10n.discoverShowAll : nil) {
+                        showPodcasts = false
+                        showInlineResults = true
+                    }
                 }
 
                 if searchResults.isSearchingForEpisodes {

--- a/podcasts/New Search/Views/Results/SearchResultsView.swift
+++ b/podcasts/New Search/Views/Results/SearchResultsView.swift
@@ -31,7 +31,7 @@ struct SearchResultsView: View {
                 }
 
                 // If local results are being shown, we hide the episodes header
-                if !(searchResults.isShowingLocalResultsOnly && searchResults.isSearchingForEpisodes) {
+                if !searchResults.isShowingLocalResultsOnly {
                     ThemeableListHeader(title: L10n.episodes, actionTitle: searchResults.episodes.count > 20 ? L10n.discoverShowAll : nil) {
                         showPodcasts = false
                         showInlineResults = true
@@ -58,7 +58,7 @@ struct SearchResultsView: View {
                             .listSectionSeparator(.hidden)
                         }
                     }
-                } else {
+                } else if !searchResults.isShowingLocalResultsOnly {
                     VStack(spacing: 2) {
                         Text(L10n.discoverNoEpisodesFound)
                             .font(style: .subheadline, weight: .medium)

--- a/podcasts/PodcastListViewController+Search.swift
+++ b/podcasts/PodcastListViewController+Search.swift
@@ -127,7 +127,11 @@ extension PodcastListViewController: UIScrollViewDelegate, PCSearchBarDelegate {
             searchView.alpha = 0
         }) { _ in
             searchView.removeFromSuperview()
-            self.searchResultsControler.clearSearch()
+            if FeatureFlag.newSearch.enabled {
+                self.newSearchResultsController.clearSearch()
+            } else {
+                self.searchResultsControler.clearSearch()
+            }
         }
     }
 


### PR DESCRIPTION
| 📘 Project: #709 |
|:---:|

Show local podcasts and folders when searching from "Podcasts".

https://user-images.githubusercontent.com/7040243/224776262-de56c635-1704-43ce-889f-3dd595f42970.mp4

**UI is part of another task.**

## To test

### Before everything

1. Run the app
2. Go to Profile > Settings > Beta Features > enable `newSearch`
3. Change the app Build Configuration to `Staging`
4. Login into an account with Plus, folders and subscribed podcasts

### Local podcasts and folders

1. Go to "Podcasts"
2. Search for a term that matches the name of your folders and podcasts
3. ✅ Your local podcasts and folders should appear at the beginning of "Podcasts" section. Also, after a while, a remote search is performed, and remote podcasts/folders are shown
4. Tap a folder
4. ✅ The folder should open
4. Clear the search
4. ✅ The folder should appear on the search history and tapping it open the folder
4. Go to Discover
5. Search for the same
6. ✅ Only remote podcasts should be returned, no local results and/or folders

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
