### PR TITLE
Search Improvements: add tracks

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/Search/PodcastSearchTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Search/PodcastSearchTask.swift
@@ -6,12 +6,14 @@ public struct PodcastFolderSearchResult: Codable, Hashable {
     public let title: String
     public let author: String
     public let isFolder: Bool?
+    public var isLocal: Bool?
 
     public init?(from podcast: Podcast) {
         if let title = podcast.title, let author = podcast.author {
             self.uuid = podcast.uuid
             self.title = title
             self.author = author
+            self.isLocal = true
             self.isFolder = nil
         } else {
             return nil
@@ -23,6 +25,7 @@ public struct PodcastFolderSearchResult: Codable, Hashable {
         self.title = folder.name
         self.author = ""
         self.isFolder = true
+        self.isLocal = true
     }
 }
 

--- a/Modules/Server/Sources/PocketCastsServer/Public/Search/PodcastSearchTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Search/PodcastSearchTask.swift
@@ -14,7 +14,7 @@ public struct PodcastFolderSearchResult: Codable, Hashable {
         self.title = try container.decode(String.self, forKey: .title)
         self.author = try container.decode(String.self, forKey: .author)
         self.kind = (try? container.decodeIfPresent(Kind.self, forKey: .kind)) ?? .podcast
-        self.isLocal = try container.decode(Bool.self, forKey: .isLocal)
+        self.isLocal = (try? container.decode(Bool.self, forKey: .isLocal)) ?? false
     }
 
     public init?(from podcast: Podcast) {

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -513,6 +513,7 @@
 		8B723755291185B300FA8219 /* Analytics+story.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B723754291185B300FA8219 /* Analytics+story.swift */; };
 		8B7298F829144EEC0059C077 /* PodcastCover.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B7298F729144EEC0059C077 /* PodcastCover.swift */; };
 		8B738F3128F5CBE0004E7526 /* StoriesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B738F3028F5CBE0004E7526 /* StoriesView.swift */; };
+		8B938E2B29BFB4F2008997B9 /* SearchAnalyticsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B938E2A29BFB4F2008997B9 /* SearchAnalyticsHelper.swift */; };
 		8B99197429A67A7100A5C81C /* SearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B99197329A67A7100A5C81C /* SearchView.swift */; };
 		8B99197729A686BA00A5C81C /* SearchResultsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B99197629A686BA00A5C81C /* SearchResultsView.swift */; };
 		8B9D459C28F9A6260034219E /* TopFivePodcastsStory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B9D459B28F9A6260034219E /* TopFivePodcastsStory.swift */; };
@@ -2145,6 +2146,7 @@
 		8B723754291185B300FA8219 /* Analytics+story.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Analytics+story.swift"; sourceTree = "<group>"; };
 		8B7298F729144EEC0059C077 /* PodcastCover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PodcastCover.swift; sourceTree = "<group>"; };
 		8B738F3028F5CBE0004E7526 /* StoriesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoriesView.swift; sourceTree = "<group>"; };
+		8B938E2A29BFB4F2008997B9 /* SearchAnalyticsHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchAnalyticsHelper.swift; sourceTree = "<group>"; };
 		8B99197329A67A7100A5C81C /* SearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchView.swift; sourceTree = "<group>"; };
 		8B99197629A686BA00A5C81C /* SearchResultsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultsView.swift; sourceTree = "<group>"; };
 		8B9D459B28F9A6260034219E /* TopFivePodcastsStory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopFivePodcastsStory.swift; sourceTree = "<group>"; };
@@ -3945,6 +3947,14 @@
 			path = Views;
 			sourceTree = "<group>";
 		};
+		8B938E2929BFB4E3008997B9 /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				8B938E2A29BFB4F2008997B9 /* SearchAnalyticsHelper.swift */,
+			);
+			path = Helpers;
+			sourceTree = "<group>";
+		};
 		8B9D459D28F9ACFB0034219E /* Stories */ = {
 			isa = PBXGroup;
 			children = (
@@ -3978,6 +3988,7 @@
 		8BAB8B2D299ABC5E00B8404C /* New Search */ = {
 			isa = PBXGroup;
 			children = (
+				8B938E2929BFB4E3008997B9 /* Helpers */,
 				8B14E3AA29B773EB0069B6F2 /* Model */,
 				8B67A25F29A7D5780076886D /* Views */,
 				8BAB8B2E299ABC8200B8404C /* SearchResultsViewController.swift */,
@@ -8004,6 +8015,7 @@
 				4007B053230E3115008DDCF5 /* WhatsNewPageView.swift in Sources */,
 				BDCF3C8024283B0F005B6933 /* ListeningHistoryViewController+Swipe.swift in Sources */,
 				BD7641332588272B0070CBF3 /* ThemeableSwitch.swift in Sources */,
+				8B938E2B29BFB4F2008997B9 /* SearchAnalyticsHelper.swift in Sources */,
 				BD585C1F2047887700AC842C /* AppDelegate+UrlHandling.swift in Sources */,
 				C73CD7A82916E8A900EAE879 /* SwiftUI+Previews.swift in Sources */,
 				BDB002BF211A9E1B00224A55 /* ProgressLine.swift in Sources */,

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -561,6 +561,7 @@ enum AnalyticsEvent: String {
 
     // MARK: - Podcast Search
 
+    case searchShown
     case searchPerformed
     case searchFailed
     case searchResultTapped

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -616,4 +616,7 @@ enum AnalyticsEvent: String {
     case cancelConfirmationViewDismissed
     case cancelConfirmationStayButtonTapped
     case cancelConfirmationCancelButtonTapped
+
+    // MARK: - Search History
+    case searchHistoryCleared
 }

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -566,6 +566,7 @@ enum AnalyticsEvent: String {
     case searchPerformed
     case searchFailed
     case searchResultTapped
+    case searchListShown
 
     // MARK: - Chromecast
 

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -620,4 +620,5 @@ enum AnalyticsEvent: String {
     // MARK: - Search History
     case searchHistoryCleared
     case searchHistoryItemTapped
+    case searchHistoryItemDeleteButtonTapped
 }

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -619,4 +619,5 @@ enum AnalyticsEvent: String {
 
     // MARK: - Search History
     case searchHistoryCleared
+    case searchHistoryItemTapped
 }

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -562,6 +562,7 @@ enum AnalyticsEvent: String {
     // MARK: - Podcast Search
 
     case searchShown
+    case searchDismissed
     case searchPerformed
     case searchFailed
     case searchResultTapped

--- a/podcasts/DiscoverViewController+Search.swift
+++ b/podcasts/DiscoverViewController+Search.swift
@@ -75,6 +75,8 @@ extension DiscoverViewController: PCSearchBarDelegate, UIScrollViewDelegate {
             searchView.removeFromSuperview()
             self.resultsControllerDelegate.clearSearch()
         }
+
+        Analytics.track(.searchDismissed, properties: ["source": AnalyticsSource.discover])
     }
 
     func searchWasCleared() {

--- a/podcasts/DiscoverViewController.swift
+++ b/podcasts/DiscoverViewController.swift
@@ -20,7 +20,7 @@ class DiscoverViewController: PCViewController {
     var searchController: PCSearchBarController!
 
     var searchResultsController: DiscoverPodcastSearchResultsController!
-    lazy var newSearchResultsController = SearchResultsViewController()
+    lazy var newSearchResultsController = SearchResultsViewController(source: .discover)
 
     var resultsControllerDelegate: SearchResultsDelegate {
         FeatureFlag.newSearch.enabled ? newSearchResultsController : searchResultsController

--- a/podcasts/New Search/Helpers/SearchAnalyticsHelper.swift
+++ b/podcasts/New Search/Helpers/SearchAnalyticsHelper.swift
@@ -18,8 +18,8 @@ class SearchAnalyticsHelper: ObservableObject {
         Analytics.track(.searchPerformed, properties: ["source": source])
     }
 
-    func trackFailed() {
-        Analytics.track(.searchFailed, properties: ["source": source])
+    func trackFailed(_ error: Error) {
+        Analytics.track(.searchFailed, properties: ["source": source, "error_code": (error as NSError).code])
     }
 
     func trackResultTapped(_ searchResult: AnalyticsSearchResultItem) {

--- a/podcasts/New Search/Helpers/SearchAnalyticsHelper.swift
+++ b/podcasts/New Search/Helpers/SearchAnalyticsHelper.swift
@@ -17,6 +17,10 @@ class SearchAnalyticsHelper: ObservableObject {
         Analytics.track(.searchDismissed, properties: ["source": source])
     }
 
+    func trackSearchPerformed() {
+        Analytics.track(.searchPerformed, properties: ["source": source])
+    }
+
     // MARK: - Search History
 
     func trackHistoryCleared() {

--- a/podcasts/New Search/Helpers/SearchAnalyticsHelper.swift
+++ b/podcasts/New Search/Helpers/SearchAnalyticsHelper.swift
@@ -14,10 +14,6 @@ class SearchAnalyticsHelper: ObservableObject {
         Analytics.track(.searchShown, properties: ["source": source])
     }
 
-    func trackDismissed() {
-        Analytics.track(.searchDismissed, properties: ["source": source])
-    }
-
     func trackSearchPerformed() {
         Analytics.track(.searchPerformed, properties: ["source": source])
     }

--- a/podcasts/New Search/Helpers/SearchAnalyticsHelper.swift
+++ b/podcasts/New Search/Helpers/SearchAnalyticsHelper.swift
@@ -7,6 +7,12 @@ class SearchAnalyticsHelper: ObservableObject {
         self.source = source
     }
 
+    // MARK: - Search
+
+    func trackShown() {
+        Analytics.track(.searchShown, properties: ["source": source])
+    }
+
     // MARK: - Search History
 
     func trackHistoryCleared() {

--- a/podcasts/New Search/Helpers/SearchAnalyticsHelper.swift
+++ b/podcasts/New Search/Helpers/SearchAnalyticsHelper.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+class SearchAnalyticsHelper {
+    let source: AnalyticsSource
+
+    init(source: AnalyticsSource) {
+        self.source = source
+    }
+
+    // MARK: - Search History
+
+    func trackHistoryCleared() {
+        Analytics.track(.searchHistoryCleared, properties: ["source": source])
+    }
+}

--- a/podcasts/New Search/Helpers/SearchAnalyticsHelper.swift
+++ b/podcasts/New Search/Helpers/SearchAnalyticsHelper.swift
@@ -60,7 +60,7 @@ class SearchAnalyticsHelper: ObservableObject {
 
 private extension SearchHistoryEntry {
     var type: String {
-        if podcast?.isFolder == true {
+        if podcast?.kind == .folder {
             return "folder"
         } else if podcast != nil {
             return "podcast"
@@ -74,7 +74,7 @@ private extension SearchHistoryEntry {
 
 private extension PodcastFolderSearchResult {
     var type: String {
-        if isFolder == true {
+        if kind == .folder {
             return "folder"
         } else if isLocal == true {
             return "podcast_local_result"

--- a/podcasts/New Search/Helpers/SearchAnalyticsHelper.swift
+++ b/podcasts/New Search/Helpers/SearchAnalyticsHelper.swift
@@ -22,17 +22,8 @@ class SearchAnalyticsHelper: ObservableObject {
         Analytics.track(.searchFailed, properties: ["source": source])
     }
 
-    func trackResultTapped(_ searchResult: Any) {
-        var type = "unknown"
-        var uuid = ""
-        if let folderOrPodcast = searchResult as? PodcastFolderSearchResult {
-            type = folderOrPodcast.type
-            uuid = folderOrPodcast.uuid
-        } else if let episode = searchResult as? EpisodeSearchResult {
-            type = "episode"
-            uuid = episode.uuid
-        }
-        Analytics.track(.searchResultTapped, properties: ["source": source, "uuid": uuid, "result_type": type])
+    func trackResultTapped(_ searchResult: AnalyticsSearchResultItem) {
+        Analytics.track(.searchResultTapped, properties: ["source": source, "uuid": searchResult.uuid, "result_type": searchResult])
     }
 
     // MARK: - Search History
@@ -74,6 +65,28 @@ private extension SearchHistoryEntry {
 
 private extension PodcastFolderSearchResult {
     var type: String {
+        if kind == .folder {
+            return "folder"
+        } else if isLocal == true {
+            return "podcast_local_result"
+        } else {
+            return "podcast_remote_result"
+        }
+    }
+}
+
+protocol AnalyticsSearchResultItem: AnalyticsDescribable {
+    var uuid: String { get }
+}
+
+extension EpisodeSearchResult: AnalyticsSearchResultItem {
+    var analyticsDescription: String {
+        "episode"
+    }
+}
+
+extension PodcastFolderSearchResult: AnalyticsSearchResultItem {
+    var analyticsDescription: String {
         if kind == .folder {
             return "folder"
         } else if isLocal == true {

--- a/podcasts/New Search/Helpers/SearchAnalyticsHelper.swift
+++ b/podcasts/New Search/Helpers/SearchAnalyticsHelper.swift
@@ -17,6 +17,11 @@ class SearchAnalyticsHelper: ObservableObject {
         let uuid = entry.podcast?.uuid ?? entry.episode?.uuid ?? ""
         Analytics.track(.searchHistoryItemTapped, properties: ["source": source, "uuid": uuid, "type": entry.type])
     }
+
+    func historyItemDeleted(_ entry: SearchHistoryEntry) {
+        let uuid = entry.podcast?.uuid ?? entry.episode?.uuid ?? ""
+        Analytics.track(.searchHistoryItemDeleteButtonTapped, properties: ["source": source, "uuid": uuid, "type": entry.type])
+    }
 }
 
 private extension SearchHistoryEntry {

--- a/podcasts/New Search/Helpers/SearchAnalyticsHelper.swift
+++ b/podcasts/New Search/Helpers/SearchAnalyticsHelper.swift
@@ -12,4 +12,23 @@ class SearchAnalyticsHelper: ObservableObject {
     func trackHistoryCleared() {
         Analytics.track(.searchHistoryCleared, properties: ["source": source])
     }
+
+    func historyItemTapped(_ entry: SearchHistoryEntry) {
+        let uuid = entry.podcast?.uuid ?? entry.episode?.uuid ?? ""
+        Analytics.track(.searchHistoryItemTapped, properties: ["source": source, "uuid": uuid, "type": entry.type])
+    }
+}
+
+private extension SearchHistoryEntry {
+    var type: String {
+        if podcast?.isFolder == true {
+            return "folder"
+        } else if podcast != nil {
+            return "podcast"
+        } else if episode != nil {
+            return "episode"
+        } else {
+            return "search_term"
+        }
+    }
 }

--- a/podcasts/New Search/Helpers/SearchAnalyticsHelper.swift
+++ b/podcasts/New Search/Helpers/SearchAnalyticsHelper.swift
@@ -53,8 +53,8 @@ class SearchAnalyticsHelper: ObservableObject {
 
     // MARK: - Search list results
 
-    func trackListShown() {
-        Analytics.track(.searchListShown, properties: ["source": source])
+    func trackListShown(_ displaying: SearchResultsListView.DisplayMode) {
+        Analytics.track(.searchListShown, properties: ["source": source, "displaying": displaying])
     }
 }
 

--- a/podcasts/New Search/Helpers/SearchAnalyticsHelper.swift
+++ b/podcasts/New Search/Helpers/SearchAnalyticsHelper.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import PocketCastsServer
 
 class SearchAnalyticsHelper: ObservableObject {
     let source: AnalyticsSource
@@ -23,6 +24,19 @@ class SearchAnalyticsHelper: ObservableObject {
 
     func trackFailed() {
         Analytics.track(.searchFailed, properties: ["source": source])
+    }
+
+    func trackResultTapped(_ searchResult: Any) {
+        var type = "unknown"
+        var uuid = ""
+        if let folderOrPodcast = searchResult as? PodcastFolderSearchResult {
+            type = folderOrPodcast.type
+            uuid = folderOrPodcast.uuid
+        } else if let episode = searchResult as? EpisodeSearchResult {
+            type = "episode"
+            uuid = episode.uuid
+        }
+        Analytics.track(.searchResultTapped, properties: ["source": source, "uuid": uuid, "result_type": type])
     }
 
     // MARK: - Search History
@@ -52,6 +66,18 @@ private extension SearchHistoryEntry {
             return "episode"
         } else {
             return "search_term"
+        }
+    }
+}
+
+private extension PodcastFolderSearchResult {
+    var type: String {
+        if isFolder == true {
+            return "folder"
+        } else if isLocal == true {
+            return "podcast_local_result"
+        } else {
+            return "podcast"
         }
     }
 }

--- a/podcasts/New Search/Helpers/SearchAnalyticsHelper.swift
+++ b/podcasts/New Search/Helpers/SearchAnalyticsHelper.swift
@@ -50,6 +50,12 @@ class SearchAnalyticsHelper: ObservableObject {
         let uuid = entry.podcast?.uuid ?? entry.episode?.uuid ?? ""
         Analytics.track(.searchHistoryItemDeleteButtonTapped, properties: ["source": source, "uuid": uuid, "type": entry.type])
     }
+
+    // MARK: - Search list results
+
+    func trackListShown() {
+        Analytics.track(.searchListShown, properties: ["source": source])
+    }
 }
 
 private extension SearchHistoryEntry {

--- a/podcasts/New Search/Helpers/SearchAnalyticsHelper.swift
+++ b/podcasts/New Search/Helpers/SearchAnalyticsHelper.swift
@@ -32,46 +32,18 @@ class SearchAnalyticsHelper: ObservableObject {
         Analytics.track(.searchHistoryCleared, properties: ["source": source])
     }
 
-    func historyItemTapped(_ entry: SearchHistoryEntry) {
-        let uuid = entry.podcast?.uuid ?? entry.episode?.uuid ?? ""
-        Analytics.track(.searchHistoryItemTapped, properties: ["source": source, "uuid": uuid, "type": entry.type])
+    func historyItemTapped(_ entry: AnalyticsSearchResultItem) {
+        Analytics.track(.searchHistoryItemTapped, properties: ["source": source, "uuid": entry.uuid, "type": entry])
     }
 
-    func historyItemDeleted(_ entry: SearchHistoryEntry) {
-        let uuid = entry.podcast?.uuid ?? entry.episode?.uuid ?? ""
-        Analytics.track(.searchHistoryItemDeleteButtonTapped, properties: ["source": source, "uuid": uuid, "type": entry.type])
+    func historyItemDeleted(_ entry: AnalyticsSearchResultItem) {
+        Analytics.track(.searchHistoryItemDeleteButtonTapped, properties: ["source": source, "uuid": entry.uuid, "type": entry])
     }
 
     // MARK: - Search list results
 
     func trackListShown(_ displaying: SearchResultsListView.DisplayMode) {
         Analytics.track(.searchListShown, properties: ["source": source, "displaying": displaying])
-    }
-}
-
-private extension SearchHistoryEntry {
-    var type: String {
-        if podcast?.kind == .folder {
-            return "folder"
-        } else if podcast != nil {
-            return "podcast"
-        } else if episode != nil {
-            return "episode"
-        } else {
-            return "search_term"
-        }
-    }
-}
-
-private extension PodcastFolderSearchResult {
-    var type: String {
-        if kind == .folder {
-            return "folder"
-        } else if isLocal == true {
-            return "podcast_local_result"
-        } else {
-            return "podcast_remote_result"
-        }
     }
 }
 
@@ -94,5 +66,15 @@ extension PodcastFolderSearchResult: AnalyticsSearchResultItem {
         } else {
             return "podcast_remote_result"
         }
+    }
+}
+
+extension SearchHistoryEntry: AnalyticsSearchResultItem {
+    var uuid: String {
+        podcast?.uuid ?? episode?.uuid ?? ""
+    }
+
+    var analyticsDescription: String {
+        podcast?.analyticsDescription ?? episode?.analyticsDescription ?? "search_term"
     }
 }

--- a/podcasts/New Search/Helpers/SearchAnalyticsHelper.swift
+++ b/podcasts/New Search/Helpers/SearchAnalyticsHelper.swift
@@ -73,7 +73,7 @@ private extension PodcastFolderSearchResult {
         } else if isLocal == true {
             return "podcast_local_result"
         } else {
-            return "podcast"
+            return "podcast_remote_result"
         }
     }
 }

--- a/podcasts/New Search/Helpers/SearchAnalyticsHelper.swift
+++ b/podcasts/New Search/Helpers/SearchAnalyticsHelper.swift
@@ -1,6 +1,6 @@
-import Foundation
+import SwiftUI
 
-class SearchAnalyticsHelper {
+class SearchAnalyticsHelper: ObservableObject {
     let source: AnalyticsSource
 
     init(source: AnalyticsSource) {

--- a/podcasts/New Search/Helpers/SearchAnalyticsHelper.swift
+++ b/podcasts/New Search/Helpers/SearchAnalyticsHelper.swift
@@ -21,6 +21,10 @@ class SearchAnalyticsHelper: ObservableObject {
         Analytics.track(.searchPerformed, properties: ["source": source])
     }
 
+    func trackFailed() {
+        Analytics.track(.searchFailed, properties: ["source": source])
+    }
+
     // MARK: - Search History
 
     func trackHistoryCleared() {

--- a/podcasts/New Search/Helpers/SearchAnalyticsHelper.swift
+++ b/podcasts/New Search/Helpers/SearchAnalyticsHelper.swift
@@ -13,6 +13,10 @@ class SearchAnalyticsHelper: ObservableObject {
         Analytics.track(.searchShown, properties: ["source": source])
     }
 
+    func trackDismissed() {
+        Analytics.track(.searchDismissed, properties: ["source": source])
+    }
+
     // MARK: - Search History
 
     func trackHistoryCleared() {

--- a/podcasts/New Search/Model/SearchResultsModel.swift
+++ b/podcasts/New Search/Model/SearchResultsModel.swift
@@ -37,7 +37,7 @@ class SearchResultsModel: ObservableObject {
                 let results = try await podcastSearch.search(term: term)
                 show(podcastResults: results)
             } catch {
-                analyticsHelper.trackFailed()
+                analyticsHelper.trackFailed(error)
             }
 
             isSearchingForPodcasts = false
@@ -49,7 +49,7 @@ class SearchResultsModel: ObservableObject {
                 let results = try await episodeSearch.search(term: term)
                 episodes = results
             } catch {
-                analyticsHelper.trackFailed()
+                analyticsHelper.trackFailed(error)
             }
 
             isSearchingForEpisodes = false

--- a/podcasts/New Search/Model/SearchResultsModel.swift
+++ b/podcasts/New Search/Model/SearchResultsModel.swift
@@ -39,16 +39,26 @@ class SearchResultsModel: ObservableObject {
 
         Task {
             isSearchingForPodcasts = true
-            let results = try? await podcastSearch.search(term: term)
+            do {
+                let results = try await podcastSearch.search(term: term)
+                show(podcastResults: results)
+            } catch {
+                analyticsHelper.trackFailed()
+            }
+
             isSearchingForPodcasts = false
-            show(podcastResults: results ?? [])
         }
 
         Task {
             isSearchingForEpisodes = true
-            let results = try? await episodeSearch.search(term: term)
+            do {
+                let results = try await episodeSearch.search(term: term)
+                episodes = results
+            } catch {
+                analyticsHelper.trackFailed()
+            }
+
             isSearchingForEpisodes = false
-            episodes = results ?? []
         }
 
         analyticsHelper.trackSearchPerformed()

--- a/podcasts/New Search/Model/SearchResultsModel.swift
+++ b/podcasts/New Search/Model/SearchResultsModel.swift
@@ -16,15 +16,9 @@ class SearchResultsModel: ObservableObject {
 
     @Published var isShowingLocalResultsOnly = false
 
-    init(analyticsHelper: SearchAnalyticsHelper) {
+    init(analyticsHelper: SearchAnalyticsHelper = SearchAnalyticsHelper(source: .unknown)) {
         self.analyticsHelper = analyticsHelper
     }
-
-    #if DEBUG
-    init() {
-        self.analyticsHelper = SearchAnalyticsHelper(source: .discover)
-    }
-    #endif
 
     func clearSearch() {
         podcasts = []

--- a/podcasts/New Search/Model/SearchResultsModel.swift
+++ b/podcasts/New Search/Model/SearchResultsModel.swift
@@ -6,6 +6,8 @@ class SearchResultsModel: ObservableObject {
     private let podcastSearch = PodcastSearchTask()
     private let episodeSearch = EpisodeSearchTask()
 
+    private let analyticsHelper: SearchAnalyticsHelper
+
     @Published var isSearchingForPodcasts = false
     @Published var isSearchingForEpisodes = false
 
@@ -13,6 +15,16 @@ class SearchResultsModel: ObservableObject {
     @Published var episodes: [EpisodeSearchResult] = []
 
     @Published var isShowingLocalResultsOnly = false
+
+    init(analyticsHelper: SearchAnalyticsHelper) {
+        self.analyticsHelper = analyticsHelper
+    }
+
+    #if DEBUG
+    init() {
+        self.analyticsHelper = SearchAnalyticsHelper(source: .discover)
+    }
+    #endif
 
     func clearSearch() {
         podcasts = []
@@ -38,6 +50,8 @@ class SearchResultsModel: ObservableObject {
             isSearchingForEpisodes = false
             episodes = results ?? []
         }
+
+        analyticsHelper.trackSearchPerformed()
     }
 
     @MainActor

--- a/podcasts/New Search/SearchResultsViewController.swift
+++ b/podcasts/New Search/SearchResultsViewController.swift
@@ -17,8 +17,10 @@ class SearchResultsViewController: UIHostingController<AnyView> {
     private let displaySearch: SearchVisibilityModel = SearchVisibilityModel()
     private let searchHistoryModel: SearchHistoryModel = SearchHistoryModel()
     private let searchResults: SearchResultsModel = SearchResultsModel()
+    private let searchAnalyticsHelper: SearchAnalyticsHelper
 
-    init() {
+    init(source: AnalyticsSource) {
+        searchAnalyticsHelper = SearchAnalyticsHelper(source: source)
         super.init(rootView: AnyView(SearchView(displaySearch: displaySearch, searchResults: searchResults, searchHistory: searchHistoryModel).setupDefaultEnvironment()))
     }
 

--- a/podcasts/New Search/SearchResultsViewController.swift
+++ b/podcasts/New Search/SearchResultsViewController.swift
@@ -39,6 +39,11 @@ class SearchResultsViewController: UIHostingController<AnyView> {
         super.viewDidAppear(animated)
         searchAnalyticsHelper.trackShown()
     }
+
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        searchAnalyticsHelper.trackDismissed()
+    }
 }
 
 extension SearchResultsViewController: SearchResultsDelegate {

--- a/podcasts/New Search/SearchResultsViewController.swift
+++ b/podcasts/New Search/SearchResultsViewController.swift
@@ -16,11 +16,12 @@ extension SearchResultsDelegate {
 class SearchResultsViewController: UIHostingController<AnyView> {
     private let displaySearch: SearchVisibilityModel = SearchVisibilityModel()
     private let searchHistoryModel: SearchHistoryModel = SearchHistoryModel()
-    private let searchResults: SearchResultsModel = SearchResultsModel()
+    private let searchResults: SearchResultsModel
     private let searchAnalyticsHelper: SearchAnalyticsHelper
 
     init(source: AnalyticsSource) {
         searchAnalyticsHelper = SearchAnalyticsHelper(source: source)
+        self.searchResults = SearchResultsModel(analyticsHelper: searchAnalyticsHelper)
         super.init(rootView: AnyView(
             SearchView(
                 displaySearch: displaySearch,

--- a/podcasts/New Search/SearchResultsViewController.swift
+++ b/podcasts/New Search/SearchResultsViewController.swift
@@ -34,6 +34,11 @@ class SearchResultsViewController: UIHostingController<AnyView> {
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        searchAnalyticsHelper.trackShown()
+    }
 }
 
 extension SearchResultsViewController: SearchResultsDelegate {

--- a/podcasts/New Search/SearchResultsViewController.swift
+++ b/podcasts/New Search/SearchResultsViewController.swift
@@ -21,7 +21,14 @@ class SearchResultsViewController: UIHostingController<AnyView> {
 
     init(source: AnalyticsSource) {
         searchAnalyticsHelper = SearchAnalyticsHelper(source: source)
-        super.init(rootView: AnyView(SearchView(displaySearch: displaySearch, searchResults: searchResults, searchHistory: searchHistoryModel).setupDefaultEnvironment()))
+        super.init(rootView: AnyView(
+            SearchView(
+                displaySearch: displaySearch,
+                searchResults: searchResults,
+                searchHistory: searchHistoryModel)
+            .setupDefaultEnvironment()
+            .environmentObject(searchAnalyticsHelper))
+        )
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/podcasts/New Search/SearchResultsViewController.swift
+++ b/podcasts/New Search/SearchResultsViewController.swift
@@ -40,11 +40,6 @@ class SearchResultsViewController: UIHostingController<AnyView> {
         super.viewDidAppear(animated)
         searchAnalyticsHelper.trackShown()
     }
-
-    override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
-        searchAnalyticsHelper.trackDismissed()
-    }
 }
 
 extension SearchResultsViewController: SearchResultsDelegate {

--- a/podcasts/New Search/Views/History/SearchHistoryCell.swift
+++ b/podcasts/New Search/Views/History/SearchHistoryCell.swift
@@ -4,6 +4,7 @@ import PocketCastsUtils
 
 struct SearchHistoryCell: View {
     @EnvironmentObject var theme: Theme
+    @EnvironmentObject var searchAnalyticsHelper: SearchAnalyticsHelper
 
     let entry: SearchHistoryEntry
     let searchHistory: SearchHistoryModel
@@ -37,6 +38,7 @@ struct SearchHistoryCell: View {
                     searchResults.search(term: searchTerm)
                     NotificationCenter.postOnMainThread(notification: Constants.Notifications.podcastSearchRequest, object: searchTerm)
                 }
+                searchAnalyticsHelper.historyItemTapped(entry)
             }) {
                 Rectangle()
                     .foregroundColor(.clear)

--- a/podcasts/New Search/Views/History/SearchHistoryCell.swift
+++ b/podcasts/New Search/Views/History/SearchHistoryCell.swift
@@ -87,6 +87,7 @@ struct SearchHistoryCell: View {
                     Button(action: {
                         withAnimation {
                             searchHistory.remove(entry: entry)
+                            searchAnalyticsHelper.historyItemDeleted(entry)
                         }
                     }) {
                         Image("close")

--- a/podcasts/New Search/Views/History/SearchHistoryView.swift
+++ b/podcasts/New Search/Views/History/SearchHistoryView.swift
@@ -4,6 +4,7 @@ import PocketCastsUtils
 
 struct SearchHistoryView: View {
     @EnvironmentObject var theme: Theme
+    @EnvironmentObject var searchAnalyticsHelper: SearchAnalyticsHelper
 
     @ObservedObject var searchHistory: SearchHistoryModel
 
@@ -26,7 +27,7 @@ struct SearchHistoryView: View {
                     ThemeableListHeader(title: L10n.searchRecent, actionTitle: L10n.historyClearAll) {
                         withAnimation {
                             searchHistory.removeAll()
-                            Analytics.track(.searchHistoryCleared)
+                            searchAnalyticsHelper.trackHistoryCleared()
                         }
                     }
 

--- a/podcasts/New Search/Views/History/SearchHistoryView.swift
+++ b/podcasts/New Search/Views/History/SearchHistoryView.swift
@@ -26,6 +26,7 @@ struct SearchHistoryView: View {
                     ThemeableListHeader(title: L10n.searchRecent, actionTitle: L10n.historyClearAll) {
                         withAnimation {
                             searchHistory.removeAll()
+                            Analytics.track(.searchHistoryCleared)
                         }
                     }
 

--- a/podcasts/New Search/Views/Results/InlineResultsView.swift
+++ b/podcasts/New Search/Views/Results/InlineResultsView.swift
@@ -3,6 +3,7 @@ import PocketCastsServer
 
 struct InlineResultsView: View {
     @EnvironmentObject var theme: Theme
+    @EnvironmentObject var searchAnalyticsHelper: SearchAnalyticsHelper
 
     @ObservedObject var searchResults: SearchResultsModel
 
@@ -35,6 +36,9 @@ struct InlineResultsView: View {
         }
         .padding(.bottom, (PlaybackManager.shared.currentEpisode() != nil) ? Constants.Values.miniPlayerOffset : 0)
         .ignoresSafeArea(.keyboard)
+        .onAppear {
+            searchAnalyticsHelper.trackListShown()
+        }
     }
 }
 

--- a/podcasts/New Search/Views/Results/PodcastCarouselView.swift
+++ b/podcasts/New Search/Views/Results/PodcastCarouselView.swift
@@ -69,6 +69,7 @@ struct PodcastsCarouselView: View {
 
 struct PodcastResultCell: View {
     @EnvironmentObject var theme: Theme
+    @EnvironmentObject var searchAnalyticsHelper: SearchAnalyticsHelper
 
     let result: PodcastFolderSearchResult
     let searchHistory: SearchHistoryModel?
@@ -79,6 +80,7 @@ struct PodcastResultCell: View {
                 Button(action: {
                     result.navigateTo()
                     searchHistory?.add(podcast: result)
+                    searchAnalyticsHelper.trackResultTapped(result)
                 }) {
                     if result.isFolder == true {
                         SearchFolderPreviewWrapper(uuid: result.uuid)
@@ -95,6 +97,7 @@ struct PodcastResultCell: View {
             Button(action: {
                 result.navigateTo()
                 searchHistory?.add(podcast: result)
+                searchAnalyticsHelper.trackResultTapped(result)
             }) {
                 VStack(alignment: .leading, spacing: 2) {
                     Text(result.title)

--- a/podcasts/New Search/Views/Results/SearchResultCell.swift
+++ b/podcasts/New Search/Views/Results/SearchResultCell.swift
@@ -5,6 +5,7 @@ import PocketCastsUtils
 
 struct SearchResultCell: View {
     @EnvironmentObject var theme: Theme
+    @EnvironmentObject var searchAnalyticsHelper: SearchAnalyticsHelper
 
     let episode: EpisodeSearchResult?
     let podcast: PodcastFolderSearchResult?
@@ -16,9 +17,11 @@ struct SearchResultCell: View {
                 if let episode {
                     NavigationManager.sharedManager.navigateTo(NavigationManager.episodePageKey, data: [NavigationManager.episodeUuidKey: episode.uuid, NavigationManager.podcastKey: episode.podcastUuid])
                     searchHistory?.add(episode: episode)
+                    searchAnalyticsHelper.trackResultTapped(episode)
                 } else if let podcast {
                     NavigationManager.sharedManager.navigateTo(NavigationManager.podcastPageKey, data: [NavigationManager.podcastKey: podcast])
                     searchHistory?.add(podcast: podcast)
+                    searchAnalyticsHelper.trackResultTapped(podcast)
                 }
             }) {
                 Rectangle()

--- a/podcasts/New Search/Views/Results/SearchResultsListView.swift
+++ b/podcasts/New Search/Views/Results/SearchResultsListView.swift
@@ -2,9 +2,13 @@ import SwiftUI
 import PocketCastsServer
 
 struct SearchResultsListView: View {
-    enum DisplayMode {
+    enum DisplayMode: String, AnalyticsDescribable {
         case podcasts
         case episodes
+
+        var analyticsDescription: String {
+            rawValue
+        }
     }
 
     @EnvironmentObject var theme: Theme
@@ -43,7 +47,7 @@ struct SearchResultsListView: View {
         .padding(.bottom, (PlaybackManager.shared.currentEpisode() != nil) ? Constants.Values.miniPlayerOffset : 0)
         .ignoresSafeArea(.keyboard)
         .onAppear {
-            searchAnalyticsHelper.trackListShown()
+            searchAnalyticsHelper.trackListShown(displayMode)
         }
     }
 }

--- a/podcasts/New Search/Views/Results/SearchResultsView.swift
+++ b/podcasts/New Search/Views/Results/SearchResultsView.swift
@@ -4,6 +4,7 @@ import PocketCastsUtils
 
 struct SearchResultsView: View {
     @EnvironmentObject var theme: Theme
+    @EnvironmentObject var searchAnalyticsHelper: SearchAnalyticsHelper
 
     @ObservedObject var searchResults: SearchResultsModel
 
@@ -18,7 +19,7 @@ struct SearchResultsView: View {
         VStack(spacing: 0) {
             ThemedDivider()
 
-            NavigationLink(destination: InlineResultsView(searchResults: searchResults, searchHistory: searchHistory, showPodcasts: showPodcasts).setupDefaultEnvironment(), isActive: $showInlineResults) { EmptyView() }
+            NavigationLink(destination: InlineResultsView(searchResults: searchResults, searchHistory: searchHistory, showPodcasts: showPodcasts).setupDefaultEnvironment().environmentObject(searchAnalyticsHelper), isActive: $showInlineResults) { EmptyView() }
 
             List {
                 ThemeableListHeader(title: L10n.podcastsPlural, actionTitle: L10n.discoverShowAll) {

--- a/podcasts/New Search/Views/SearchView.swift
+++ b/podcasts/New Search/Views/SearchView.swift
@@ -5,6 +5,8 @@ class SearchVisibilityModel: ObservableObject {
 }
 
 struct SearchView: View {
+    @EnvironmentObject var searchAnalyticsHelper: SearchAnalyticsHelper
+
     @ObservedObject var displaySearch: SearchVisibilityModel
 
     let searchResults: SearchResultsModel
@@ -29,6 +31,6 @@ struct SearchView: View {
 struct SearchView_Previews: PreviewProvider {
     static var previews: some View {
         SearchView(displaySearch: SearchVisibilityModel(), searchResults: SearchResultsModel(),
-        searchHistory: SearchHistoryModel())
+                   searchHistory: SearchHistoryModel())
     }
 }

--- a/podcasts/PodcastListViewController+Search.swift
+++ b/podcasts/PodcastListViewController+Search.swift
@@ -143,7 +143,7 @@ extension PodcastListViewController: UIScrollViewDelegate, PCSearchBarDelegate {
         resultsControllerDelegate.performLocalSearch(searchTerm: searchTerm)
 
         debounce.call {
-            if !searchTerm.trim().isEmpty {
+            if !searchTerm.trim().isEmpty && !FeatureFlag.newSearch.enabled {
                 Analytics.track(.searchPerformed, properties: ["source": "podcasts_list"])
             }
         }

--- a/podcasts/PodcastListViewController+Search.swift
+++ b/podcasts/PodcastListViewController+Search.swift
@@ -133,6 +133,8 @@ extension PodcastListViewController: UIScrollViewDelegate, PCSearchBarDelegate {
                 self.searchResultsControler.clearSearch()
             }
         }
+
+        Analytics.track(.searchDismissed, properties: ["source": AnalyticsSource.podcastsList])
     }
 
     func searchWasCleared() {

--- a/podcasts/PodcastListViewController.swift
+++ b/podcasts/PodcastListViewController.swift
@@ -65,7 +65,7 @@ class PodcastListViewController: PCViewController, UIGestureRecognizerDelegate, 
     var searchController: PCSearchBarController!
 
     var searchResultsControler: PodcastListSearchResultsController!
-    lazy var newSearchResultsController = SearchResultsViewController()
+    lazy var newSearchResultsController = SearchResultsViewController(source: .podcastsList)
 
     var resultsControllerDelegate: SearchResultsDelegate {
         FeatureFlag.newSearch.enabled ? newSearchResultsController : searchResultsControler


### PR DESCRIPTION
| 📘 Project: #709 |
|:---:|

Add tracks to search history and search results.

## To test

### Before everything

1. Run the app
2. Go to Profile > Settings > Beta Features > enable `newSearch` and `tracksLogging`
3. Change the app Build Configuration to `Staging`
4. Login into an account with Plus, folders and subscribed podcasts
5. Grab a coffee or tea

### Search History

Before starting that, do a few searches, and tap on podcast and folders, then:

1. Tap on the search bar in Discover or Podcasts
2. ✅ `search_history_item_tapped` should be tracked with the correct source (discover or podcast_list), type (search_term/folder/podcast/episode) and uuid (if available)
3. Make sure to tap on search term, folder, podcast and episode
4. Remove any item (by tapping the "X")
5. ✅ `search_history_item_delete_button_tapped` should be tracked with the correct source (discover or podcast_list), type (search_term/folder/podcast/episode) and uuid (if available)
3. Make sure to try on search term, folder, podcast and episode
4. Tap on "Clear all"
5. `search_history_cleared` should be tracked with correct `source` (discover or podcast_list)

### Search results

1. Tap on the search bar in Discover or Podcasts
1. ✅ `search_shown` should be tracked with correct `source` (discover or podcast_list)
1. Search for any term
1. ✅ `search_performed` should be tracked with correct `source` (discover or podcast_list)
1. Turn off wi-fi
1. Perform a search
1. ✅ `search_failed` should be tracked with correct `source` (discover or podcast_list)
1. Turn on wi-fi
1. Search for something
1. Tap "Show all" on Podcasts
1. ✅ `search_list_shown` should be tracked with correct `source` (discover or podcast_list) and `displaying: podcasts`
1. Go back, tap "Show all" for Episodes
1. ✅ `search_list_shown` should be tracked with correct `source` (discover or podcast_list) and `displaying: episodes`

### Tapping search results

For the next step, make sure to perform your search from "Podcasts" so local results and folders are returned.

1. Search for something that will return a local podcast
1. Tap the local podcast
1. ✅ `search_result_tapped` should be tracked with correct `source` (discover or podcast_list), `uuid` and `type: podcast_local_result`
1. Search and tap on a folder
1. ✅ `search_result_tapped` should be tracked with correct `source` (discover or podcast_list), `uuid` and `type: folder`
1. Search and tap on a podcast you're not subscribed to
1. ✅ `search_result_tapped` should be tracked with correct `source` (discover or podcast_list), `uuid` and `type: podcast_remote_result`
1. Search and tap on an episode
1. ✅ `search_result_tapped` should be tracked with correct `source` (discover or podcast_list), `uuid` and `type: episode`
1. Test the same by tapping on "Show all" and making sure these events are triggered there

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
