### PR TITLE
Add pinyin sorting to podcast titles in Chinese

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Sorting/PodcastSorter.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Sorting/PodcastSorter.swift
@@ -9,11 +9,8 @@ public enum PodcastSorter {
      */
     public static func titleSort(title1: String, title2: String) -> Bool {
 
-        var convertedTitle1 = title1.trimmingThePrefix()
-        var convertedTitle2 = title2.trimmingThePrefix()
-
-        convertedTitle1 = convertToPinyinIfNeeded(convertedTitle1)
-        convertedTitle2 = convertToPinyinIfNeeded(convertedTitle2)
+        let convertedTitle1 = title1.trimmingThePrefix().convertToPinyinIfNeeded()
+        let convertedTitle2 = title2.trimmingThePrefix().convertToPinyinIfNeeded()
 
         return convertedTitle1.localizedLowercase.compare(convertedTitle2.localizedLowercase) == .orderedAscending
     }
@@ -37,25 +34,6 @@ public enum PodcastSorter {
     public static func dateAddedSort(date1: Date, date2: Date) -> Bool {
         return date1.compare(date2) == .orderedAscending
     }
-
-    /**
-     Converts Chinese characters to their Pinyin equivalent
-     - Returns Pinyin string
-     */
-    private static func convertToPinyinIfNeeded(_ string: String) -> String {
-        let range = NSRange(location: 0, length: string.utf16.count)
-        let regex = try! NSRegularExpression(pattern: "[\\u4e00-\\u9fff]+")
-        let hasChineseCharacter = regex.firstMatch(in: string, options: [], range: range) != nil
-
-        if hasChineseCharacter {
-            let mutableString = NSMutableString(string: string) as CFMutableString
-            CFStringTransform(mutableString, nil, kCFStringTransformToLatin, false)
-            CFStringTransform(mutableString, nil, kCFStringTransformStripDiacritics, false)
-            return mutableString as String
-        } else {
-            return string
-        }
-    }
 }
 
 private extension String {
@@ -65,5 +43,26 @@ private extension String {
         }
 
         return String(self[range.upperBound...])
+    }
+}
+
+/**
+ Converts Chinese characters to their Pinyin equivalent
+ - Returns Pinyin string
+ */
+extension String {
+    func convertToPinyinIfNeeded() -> String {
+        let range = NSRange(location: 0, length: self.utf16.count)
+        let regex = try! NSRegularExpression(pattern: "[\\u4e00-\\u9fff]+")
+        let hasChineseCharacter = regex.firstMatch(in: self, options: [], range: range) != nil
+
+        if hasChineseCharacter {
+            let mutableString = NSMutableString(string: self) as CFMutableString
+            CFStringTransform(mutableString, nil, kCFStringTransformToLatin, false)
+            CFStringTransform(mutableString, nil, kCFStringTransformStripDiacritics, false)
+            return mutableString as String
+        } else {
+            return self
+        }
     }
 }

--- a/Modules/Utils/Sources/PocketCastsUtils/Sorting/PodcastSorter.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Sorting/PodcastSorter.swift
@@ -8,8 +8,12 @@ public enum PodcastSorter {
      - Returns true when title1 is alphabetically before title2, false otherwise
      */
     public static func titleSort(title1: String, title2: String) -> Bool {
-        let convertedTitle1 = title1.trimmingThePrefix()
-        let convertedTitle2 = title2.trimmingThePrefix()
+
+        var convertedTitle1 = title1.trimmingThePrefix()
+        var convertedTitle2 = title2.trimmingThePrefix()
+
+        convertedTitle1 = convertToPinyinIfNeeded(convertedTitle1)
+        convertedTitle2 = convertToPinyinIfNeeded(convertedTitle2)
 
         return convertedTitle1.localizedLowercase.compare(convertedTitle2.localizedLowercase) == .orderedAscending
     }
@@ -32,6 +36,25 @@ public enum PodcastSorter {
      */
     public static func dateAddedSort(date1: Date, date2: Date) -> Bool {
         return date1.compare(date2) == .orderedAscending
+    }
+
+    /**
+     Converts Chinese characters to their Pinyin equivalent
+     - Returns Pinyin string
+     */
+    private static func convertToPinyinIfNeeded(_ string: String) -> String {
+        let range = NSRange(location: 0, length: string.utf16.count)
+        let regex = try! NSRegularExpression(pattern: "[\\u4e00-\\u9fff]+")
+        let hasChineseCharacter = regex.firstMatch(in: string, options: [], range: range) != nil
+
+        if hasChineseCharacter {
+            let mutableString = NSMutableString(string: string) as CFMutableString
+            CFStringTransform(mutableString, nil, kCFStringTransformToLatin, false)
+            CFStringTransform(mutableString, nil, kCFStringTransformStripDiacritics, false)
+            return mutableString as String
+        } else {
+            return string
+        }
     }
 }
 

--- a/Modules/Utils/Tests/PocketCastsUtilsTests/PodcastSorterTests.swift
+++ b/Modules/Utils/Tests/PocketCastsUtilsTests/PodcastSorterTests.swift
@@ -16,7 +16,12 @@ class PodcastSorterTests: XCTestCase {
             // emoji sorting
             ["B title", "🔚 A title"],
             ["🔥 A title", "🔥 B title"],
-            ["🔚 A title", "🔥 A title"]
+            ["🔚 A title", "🔥 A title"],
+            // Chinese to pinyin sorting: 昂 = áng, 奥 = ào, 备 = bèi
+            ["昂 áng title", "B title"],
+            ["昂 áng title", "奥 ào title"],
+            ["奥 ào title", "备 bèi title"],
+            ["B title", "备 bèi title"]
         ]
 
         tests.forEach {


### PR DESCRIPTION
Fixes #177 

On [#5464273-zd](https://woothemes.zendesk.com/agent/tickets/5464273) user reported incorrect alphabetical sorting of podcasts for the Chinese language.

![user-reported](https://user-images.githubusercontent.com/81433983/225174799-4aa4735c-d7a7-416a-bcc9-5fa57b2da593.jpg)

Added a method that compares strings to the [Unicode range for Chinese characters](https://en.wikipedia.org/wiki/CJK_Unified_Ideographs#CJK_Unified_Ideographs_blocks) (U+4E00 to U+9FFF) and determines if the string needs to be converted to pinyin prior to sorting.

## To Test

1. Add the following podcasts:
- https://podcasts.apple.com/no/podcast/%E5%88%AB%E4%BB%BB%E6%80%A7-be-a-dodo/id1504822434
- https://podcasts.apple.com/sg/podcast/%E5%86%85%E6%A0%B8%E6%81%90%E6%85%8C/id928916244
- https://podcasts.apple.com/us/podcast/%E5%8A%89%E8%BB%92%E7%9A%84how-to%E4%BA%BA%E7%94%9F%E5%AD%B8/id1547950387
- https://podcasts.apple.com/us/podcast/%E4%BC%90%E8%A6%81%E5%8E%BB%E7%AE%A1%E5%AE%83-storm%E5%B8%A6%E4%BD%A0%E8%A7%A3%E8%AF%BB%E7%94%9F%E6%B4%BB/id1327729926?l=zh

2. Go to the Podcasts tab
3. Sort by Name
4. Podcast list should mirror order by pinyin character, as reported by the customer
5. Add additional podcasts with titles in English to test that the sort order remains correct

![Pinyin-sorted-side](https://user-images.githubusercontent.com/81433983/225176380-ec39f63c-e2a1-4caf-b25c-d3c5e7abaa66.png)

## Checklist

- [✅] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [✅] I have considered adding unit tests for my changes.
- [] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
