### PR TITLE
Fix Auto Add to Up Next reset bug

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/PodcastDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/PodcastDataManager.swift
@@ -409,6 +409,31 @@ class PodcastDataManager {
         setOnAllPodcasts(value: autoAddToUpNext, propertyName: "autoAddToUpNext", subscribedOnly: true, dbQueue: dbQueue)
     }
 
+
+    /// TODO: Documentation
+    /// - Parameters:
+    ///   - value: <#value description#>
+    ///   - podcasts: <#podcasts description#>
+    ///   - dbQueue: <#dbQueue description#>
+    func updateAutoAddToUpNext(to value: AutoAddToUpNextSetting, for podcasts: [Podcast], in dbQueue: FMDatabaseQueue) {
+        dbQueue.inDatabase { db in
+            do {
+                let uuids = podcasts.map { $0.uuid }
+
+                let query = """
+                UPDATE \(DataManager.podcastTableName)
+                SET autoAddToUpNext = ?
+                AND uuid IN (\(DataHelper.convertArrayToInString(uuids)))
+                """
+                try db.executeUpdate(query, values: [value.rawValue])
+            } catch {
+                FileLog.shared.addMessage("PodcastDataManager.setOnAllPodcasts error: \(error)")
+            }
+        }
+
+        cachePodcasts(dbQueue: dbQueue)
+    }
+
     func setDownloadSettingForAllPodcasts(setting: AutoDownloadSetting, dbQueue: FMDatabaseQueue) {
         setOnAllPodcasts(value: setting.rawValue, propertyName: "autoDownloadSetting", subscribedOnly: true, dbQueue: dbQueue)
     }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -236,6 +236,15 @@ public class DataManager {
         podcastManager.saveAutoAddToUpNextForAllPodcasts(autoAddToUpNext: autoAddToUpNext, dbQueue: dbQueue)
     }
 
+
+    /// TODO: Documentation
+    /// - Parameters:
+    ///   - value: <#value description#>
+    ///   - podcasts: <#podcasts description#>
+    public func updateAutoAddToUpNext(to value: AutoAddToUpNextSetting, for podcasts: [Podcast]) {
+        podcastManager.updateAutoAddToUpNext(to: value, for: podcasts, in: dbQueue)
+    }
+
     public func setDownloadSettingForAllPodcasts(setting: AutoDownloadSetting) {
         podcastManager.setDownloadSettingForAllPodcasts(setting: setting, dbQueue: dbQueue)
     }

--- a/podcasts/AutoAddToUpNextViewController+PodcastSelect.swift
+++ b/podcasts/AutoAddToUpNextViewController+PodcastSelect.swift
@@ -9,12 +9,11 @@ extension AutoAddToUpNextViewController: PodcastSelectionDelegate {
 
         if selected {
             // Checks for existing AutoAddToUpNextSetting value before assigning a default value
-            allPodcasts.forEach {podcast in
-                if podcast.autoAddToUpNext == 0 {
-                    let status = AutoAddToUpNextSetting.addLast.rawValue
-                    DataManager.sharedManager.saveAutoAddToUpNext(podcastUuid: podcast.uuid, autoAddToUpNext: status)
-                }
+            let podcasts = allPodcasts.filter {
+                $0.isSubscribed() && $0.autoAddToUpNext == AutoAddToUpNextSetting.off.rawValue
             }
+
+            DataManager.sharedManager.updateAutoAddToUpNext(to: .addLast, for: podcasts)
         } else {
             setting = AutoAddToUpNextSetting.off.rawValue
             DataManager.sharedManager.saveAutoAddToUpNextForAllPodcasts(autoAddToUpNext: setting)

--- a/podcasts/AutoAddToUpNextViewController+PodcastSelect.swift
+++ b/podcasts/AutoAddToUpNextViewController+PodcastSelect.swift
@@ -3,9 +3,23 @@ import PocketCastsDataModel
 
 extension AutoAddToUpNextViewController: PodcastSelectionDelegate {
     func bulkSelectionChange(selected: Bool) {
-        let setting = selected ? AutoAddToUpNextSetting.addLast.rawValue : AutoAddToUpNextSetting.off.rawValue
-        DataManager.sharedManager.saveAutoAddToUpNextForAllPodcasts(autoAddToUpNext: setting)
+        var setting = Int32()
+
         let allPodcasts = DataManager.sharedManager.allPodcasts(includeUnsubscribed: false)
+
+        if selected {
+            // Checks for existing AutoAddToUpNextSetting value before assigning a default value
+            allPodcasts.forEach {podcast in
+                if podcast.autoAddToUpNext == 0 {
+                    let status = AutoAddToUpNextSetting.addLast.rawValue
+                    DataManager.sharedManager.saveAutoAddToUpNext(podcastUuid: podcast.uuid, autoAddToUpNext: status)
+                }
+            }
+        } else {
+            setting = AutoAddToUpNextSetting.off.rawValue
+            DataManager.sharedManager.saveAutoAddToUpNextForAllPodcasts(autoAddToUpNext: setting)
+        }
+
         allPodcasts.forEach { NotificationCenter.postOnMainThread(notification: Constants.Notifications.podcastUpdated, object: $0.uuid) }
 
         reloadDownloadedPodcasts()


### PR DESCRIPTION
Fixes #712 

When using the "Auto Add to Up Next" feature, there's a bug that occurs when choosing the Auto Add behavior. By default, podcasts selected for "Auto Add to Up Next" are podcasts at the bottom of the Up Next list. Users can change this behavior and choose podcasts to be added to the top of the Up Next list.

Users can also add all their podcasts to the Up Next lists using the Select All feature. The bug occurs when a user has all their podcasts selected to be added to Up Next. If the user deselects and re-selects a podcast on the list, all podcasts revert to the default configuration, which is to be added to the bottom of the Up Next list. 

This PR addresses this issue by keeping the individual podcasts as configured by the user, even when selecting and deselecting individual podcasts.

## To test

1. Subscribe to a few podcasts.
2. Tap Profile, then the Gear icon to go to Settings.
3. Tap Auto Add to Up Next menu
4. Tap the "0 Podcasts Chosen" menu
5. Select All podcasts and return to the previous menu
6. Change individual settings for a few podcasts to Add to Top
7. Tap the "# Podcasts Chosen" menu

![Flow - iPhone SE (2nd generation-side](https://user-images.githubusercontent.com/81433983/228139623-addb749c-015c-4eb0-ae7f-fed2fe3c1a4f.png)

8. Tap to deselect one podcast from the list, then tap to select again - on the current version, doing so resets all podcasts to Add to Bottom
9. Verify that this PR allows settings to remain

![Flow 2 - iPhone SE (2nd generation)](https://user-images.githubusercontent.com/81433983/228139974-6c469e40-148a-474e-a40b-7a0b694265be.png)

Note: The podcast that was deselected and reselected will be reset to Add to Bottom. This is intended behavior when an unselected podcast is first selected.

## Checklist

- [✅] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [✅] I have considered adding unit tests for my changes.
- [✅] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
