### PR TITLE
Update links to translations project

### DIFF
--- a/docs/localization.md
+++ b/docs/localization.md
@@ -6,7 +6,7 @@ On each build any new string added to the english localization of `Localizable.s
 
 When Strings are generated, they are converted from snake case to camel case and strings with an associated format are created as functions that will accept the passed in parameters and perform a type checking.
 
-During the release process, the `en.lproj/Localizable.strings` file is then uploaded to [GlotPress](https://translate.wordpress.org/projects/apps/ios/) for translation. Before the release build is finalized, all the translations are grabbed from GlotPress and saved back to the `Localizable.strings` files.
+During the release process, the `en.lproj/Localizable.strings` file is then uploaded to [GlotPress](https://translate.wordpress.com/projects/pocket-casts/ios/) for translation. Before the release build is finalized, all the translations are grabbed from GlotPress and saved back to the `Localizable.strings` files.
 
 ## Use Snake Cased Keys
 


### PR DESCRIPTION
I think the link to the translations project was wrong. After some digging I've found what I think it's the right project to link to.


## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
