### PR TITLE
Enabling autoscrolling of discover carousel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 7.35
 -----
-
+- Discover: Top carousel now scrolls automatically (#790)
 
 7.34
 -----

--- a/podcasts/FeatureFlag.swift
+++ b/podcasts/FeatureFlag.swift
@@ -56,7 +56,7 @@ enum FeatureFlag: String, CaseIterable {
         case .bookmarks:
             return false
         case .discoverFeaturedAutoScroll:
-            return false
+            return true
         }
     }
 }


### PR DESCRIPTION
Enabling auto scroll of Discover top carousel. 

## Checklist
1. Go to Discover
2. See the carousel auto scrolling

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
