### PR TITLE
Search Improvements: fix folders updating, history saving and duplicated podcasts

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/Search/PodcastSearchTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Search/PodcastSearchTask.swift
@@ -52,6 +52,10 @@ public struct PodcastFolderSearchResult: Codable, Hashable {
     public enum Kind: Codable {
         case podcast, folder
     }
+
+    static public func ==(lhs: PodcastFolderSearchResult, rhs: PodcastFolderSearchResult) -> Bool {
+        lhs.kind == rhs.kind && lhs.uuid == rhs.uuid
+    }
 }
 
 public class PodcastSearchTask {

--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -151,7 +151,7 @@ struct Constants {
         static let top5PodcastsListLink = "top5PodcastsListLink"
         static let shouldShowInitialOnboardingFlow = "shouldShowInitialOnboardingFlow"
 
-        static let searchHistoryEntried = "SearchHistoryEntries"
+        static let searchHistoryEntries = "SearchHistoryEntries"
     }
 
     enum Values {

--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -87,8 +87,11 @@ struct Constants {
         static let watchAutoDownloadSettingsChanged = NSNotification.Name(rawValue: "SJWatchAutoDownloadSettingsChanged")
 
         // folders
+        /// This is triggered many times whenever a folder is changed
         static let folderChanged = NSNotification.Name(rawValue: "SJFolderChanged")
         static let folderDeleted = NSNotification.Name(rawValue: "SJFolderDeleted")
+        /// This is triggered just once after a folder finishes editing
+        static let folderEdited = NSNotification.Name(rawValue: "SJFolderEdited")
 
         // End of Year
         static let profileSeen = NSNotification.Name(rawValue: "profileSeen")

--- a/podcasts/EditFolderView.swift
+++ b/podcasts/EditFolderView.swift
@@ -83,6 +83,7 @@ struct EditFolderView: View {
             }
             .onDisappear {
                 NotificationCenter.postOnMainThread(notification: Constants.Notifications.folderChanged, object: model.folderUuid)
+                NotificationCenter.postOnMainThread(notification: Constants.Notifications.folderEdited, object: model.folderUuid)
                 Analytics.track(.folderEditDismissed, properties: ["did_change_name": model.didChangeName, "did_change_color": model.didChangeColor])
             }
             .applyDefaultThemeOptions()

--- a/podcasts/New Search/Model/SearchHistoryModel.swift
+++ b/podcasts/New Search/Model/SearchHistoryModel.swift
@@ -113,10 +113,12 @@ class SearchHistoryModel: ObservableObject {
     }
 
     private func save() {
-        entries = Array(entries.prefix(maxNumberOfEntries))
+        let updatedEntries = Array(entries.prefix(maxNumberOfEntries))
+
         let encoder = JSONEncoder()
-        if let encoded = try? encoder.encode(entries) {
+        if let encoded = try? encoder.encode(updatedEntries) {
             defaults.set(encoded, forKey: Constants.UserDefaults.searchHistoryEntried)
+            entries = updatedEntries
         }
     }
 }

--- a/podcasts/New Search/Model/SearchHistoryModel.swift
+++ b/podcasts/New Search/Model/SearchHistoryModel.swift
@@ -65,10 +65,8 @@ class SearchHistoryModel: ObservableObject {
         // A folder was changed, update all folders inside the search history
         entries = entries.compactMap { entry in
             if entry.podcast?.kind == .folder, let uuid = entry.podcast?.uuid {
-                if let folder = DataManager.sharedManager.findFolder(uuid: uuid) {
-                    return SearchHistoryEntry(podcast: PodcastFolderSearchResult(from: folder))
-                } else {
-                    return nil
+                return DataManager.sharedManager.findFolder(uuid: uuid).map {
+                    SearchHistoryEntry(podcast: PodcastFolderSearchResult(from: $0))
                 }
             }
 

--- a/podcasts/New Search/Model/SearchHistoryModel.swift
+++ b/podcasts/New Search/Model/SearchHistoryModel.swift
@@ -93,6 +93,10 @@ class SearchHistoryModel: ObservableObject {
         add(entry: SearchHistoryEntry(podcast: podcast))
     }
 
+    func moveEntryToTop(_ entry: SearchHistoryEntry) {
+        add(entry: entry)
+    }
+
     func remove(entry: SearchHistoryEntry) {
         entries.removeAll(where: { $0 == entry })
 

--- a/podcasts/New Search/Model/SearchHistoryModel.swift
+++ b/podcasts/New Search/Model/SearchHistoryModel.swift
@@ -22,7 +22,7 @@ class SearchHistoryModel: ObservableObject {
     init(userDefaults: UserDefaults = UserDefaults.standard) {
         self.defaults = userDefaults
 
-        self.entries = userDefaults.data(forKey: "SearchHistoryEntries").flatMap {
+        self.entries = userDefaults.data(forKey: Constants.UserDefaults.searchHistoryEntries).flatMap {
             try? JSONDecoder().decode([SearchHistoryEntry].self, from: $0)
         } ?? []
 
@@ -117,7 +117,7 @@ class SearchHistoryModel: ObservableObject {
 
         let encoder = JSONEncoder()
         if let encoded = try? encoder.encode(updatedEntries) {
-            defaults.set(encoded, forKey: Constants.UserDefaults.searchHistoryEntried)
+            defaults.set(encoded, forKey: Constants.UserDefaults.searchHistoryEntries)
             entries = updatedEntries
         }
     }

--- a/podcasts/New Search/Model/SearchHistoryModel.swift
+++ b/podcasts/New Search/Model/SearchHistoryModel.swift
@@ -38,7 +38,7 @@ class SearchHistoryModel: ObservableObject {
             notificationCenter.publisher(for: ServerNotifications.subscriptionStatusChanged),
             notificationCenter.publisher(for: Constants.Notifications.folderChanged)
         )
-        .receive(on: RunLoop.main)
+        .debounce(for: .milliseconds(500), scheduler: RunLoop.main)
         .sink { [weak self] _ in
             self?.updateFolders()
         }

--- a/podcasts/New Search/Model/SearchHistoryModel.swift
+++ b/podcasts/New Search/Model/SearchHistoryModel.swift
@@ -36,7 +36,7 @@ class SearchHistoryModel: ObservableObject {
         // Listen for folder and subscription changes
         Publishers.Merge(
             notificationCenter.publisher(for: ServerNotifications.subscriptionStatusChanged),
-            notificationCenter.publisher(for: Constants.Notifications.folderChanged)
+            notificationCenter.publisher(for: Constants.Notifications.folderEdited)
         )
         .debounce(for: .milliseconds(500), scheduler: RunLoop.main)
         .sink { [weak self] _ in

--- a/podcasts/New Search/Model/SearchHistoryModel.swift
+++ b/podcasts/New Search/Model/SearchHistoryModel.swift
@@ -33,7 +33,13 @@ class SearchHistoryModel: ObservableObject {
     @objc private func updateFolders() {
         guard SubscriptionHelper.hasActiveSubscription() else {
             // User is not subscribed anymore, remove all folders from search history
-            entries = entries.filter { $0.podcast?.kind != .folder }
+            DispatchQueue.main.async { [weak self] in
+                guard let self else {
+                    return
+                }
+
+                self.entries = self.entries.filter { $0.podcast?.kind != .folder }
+            }
             save()
             return
         }

--- a/podcasts/New Search/SearchResultsViewController.swift
+++ b/podcasts/New Search/SearchResultsViewController.swift
@@ -4,7 +4,6 @@ import SwiftUI
 protocol SearchResultsDelegate {
     func clearSearch()
     func performLocalSearch(searchTerm: String)
-    func performRemoteSearch(searchTerm: String, completion: @escaping (() -> Void))
     func performSearch(searchTerm: String, triggeredByTimer: Bool, completion: @escaping (() -> Void))
 }
 
@@ -48,17 +47,14 @@ extension SearchResultsViewController: SearchResultsDelegate {
         searchResults.searchLocally(term: searchTerm)
     }
 
-    func performRemoteSearch(searchTerm: String, completion: @escaping (() -> Void)) {
-        displaySearch.isSearching = true
-        searchResults.search(term: searchTerm)
-        searchHistoryModel.add(searchTerm: searchTerm)
-        completion()
-    }
-
     func performSearch(searchTerm: String, triggeredByTimer: Bool, completion: @escaping (() -> Void)) {
         displaySearch.isSearching = true
         searchResults.search(term: searchTerm)
-        searchHistoryModel.add(searchTerm: searchTerm)
+
+        if !triggeredByTimer {
+            searchHistoryModel.add(searchTerm: searchTerm)
+        }
+
         completion()
     }
 }

--- a/podcasts/New Search/Views/History/SearchHistoryCell.swift
+++ b/podcasts/New Search/Views/History/SearchHistoryCell.swift
@@ -39,6 +39,7 @@ struct SearchHistoryCell: View {
                     NotificationCenter.postOnMainThread(notification: Constants.Notifications.podcastSearchRequest, object: searchTerm)
                 }
                 searchAnalyticsHelper.historyItemTapped(entry)
+                searchHistory.moveEntryToTop(entry)
             }) {
                 Rectangle()
                     .foregroundColor(.clear)

--- a/podcasts/New Search/Views/History/SearchHistoryView.swift
+++ b/podcasts/New Search/Views/History/SearchHistoryView.swift
@@ -9,13 +9,6 @@ struct SearchHistoryView: View {
     @EnvironmentObject var searchResults: SearchResultsModel
     @EnvironmentObject var displaySearch: SearchVisibilityModel
 
-    private var episode: Episode {
-        let episode = Episode()
-        episode.title = "Episode title"
-        episode.duration = 3600
-        return episode
-    }
-
     var body: some View {
         SearchListView {
             if !searchHistory.entries.isEmpty {

--- a/podcasts/PodcastListViewController+Search.swift
+++ b/podcasts/PodcastListViewController+Search.swift
@@ -153,6 +153,6 @@ extension PodcastListViewController: UIScrollViewDelegate, PCSearchBarDelegate {
     }
 
     func performSearch(searchTerm: String, triggeredByTimer: Bool, completion: @escaping (() -> Void)) {
-        resultsControllerDelegate.performRemoteSearch(searchTerm: searchTerm, completion: completion)
+        resultsControllerDelegate.performSearch(searchTerm: searchTerm, triggeredByTimer: triggeredByTimer, completion: completion)
     }
 }


### PR DESCRIPTION
| 📘 Project: #709 |
|:---:|

This PR fixes 3 issues:

1. Search history saving each letter of the search term
2. Folders updating and/or subscription expiring
3. Duplicated podcasts appearing when searching locally

## To test

### Before everything

1. Run the app
2. Go to Profile > Settings > Beta Features > enable `newSearch`

### Duplicated podcasts

1. Search for something like "hello"
1. Subscribe to the first podcast
1. Go to "Podcasts"
1. Search for "hello" again
1. ✅  The podcast you subscribed should not appear twice

### Search history

To behave like apps such as Instagram/Twitter/Facebook I changed how a search term is saved: it only happens if the user taps the "Search" button.

1. Search for something and do not tap "Search" (or, if in the simulator, do not type "return")
1. Dismiss the results
1. ✅ The term should not be added to the list
1. Repeat the search but this time type "Search" on the keyboard (or, if in the simulator, type "return" on your keyboard)
1. ✅ The term should be added to the history

### Folders

1. Make sure you're logged in to a Plus account
1. Create two folders
1. Search for those folders and tap on them, so they get added to the search history
1. Go to "Podcasts" and change the name of one folder
1. Open the search again
1. ✅ The folder should have the updated name
1. Go back to "Podcasts"
1. Delete this folder
1. Open the search
1. ✅ The folder should not be on the history
1. Go to the users web console and remove your Plus status (gift yourself `0.5` day)
1. Go back to the app and refresh it
1. Open the search history
1. ✅ Folders should not be on the history

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
