### PR TITLE
Search Improvements: enable new search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 -----
 - Updated sort order for Chinese podcast titles from Unicode-based to pinyin (#775)
 - Fixed and issue where the multi-selection header would overlap the search bar on certain devices depending on their screen size (#785)
-- Search: improved the search with a new visual and also searching for episodes (#796)
+- Search: improved the search with a new design and added the ability to search for episodes (#796)
 
 7.35
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 -----
 - Updated sort order for Chinese podcast titles from Unicode-based to pinyin (#775)
 - Fixed and issue where the multi-selection header would overlap the search bar on certain devices depending on their screen size (#785)
+- Search: improved the search with a new visual and also searching for episodes (#796)
 
 7.35
 -----

--- a/podcasts/FeatureFlag.swift
+++ b/podcasts/FeatureFlag.swift
@@ -52,7 +52,7 @@ enum FeatureFlag: String, CaseIterable {
         case .onboardingUpdates:
             return true
         case .newSearch:
-            return false
+            return true
         case .bookmarks:
             return false
         case .discoverFeaturedAutoScroll:


### PR DESCRIPTION
| 📘 Project: #709 |
|:---:|

Enable the new search

## To test

1. ✅ Search from Discover, the new search should be displayed
2. ✅ Search from Podcasts, the new search should be displayed

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
