### PR TITLE
Address some existing warnings and prevent future Xcode 14.3 ones 

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/General/TimedActionHelper.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/General/TimedActionHelper.swift
@@ -33,7 +33,7 @@ public class TimedActionHelper {
             DispatchQueue.main.sync { [weak self] in
                 guard let self else { return }
 
-                self.timer = Timer.scheduledTimer(timeInterval: time, target: self, selector: #selector(timerFired), userInfo: nil, repeats: false)
+                self.timer = Timer.scheduledTimer(timeInterval: time, target: self, selector: #selector(self.timerFired), userInfo: nil, repeats: false)
             }
         }
     }

--- a/Modules/Utils/Sources/PocketCastsUtils/General/TimedActionHelper.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/General/TimedActionHelper.swift
@@ -31,9 +31,9 @@ public class TimedActionHelper {
             timer = Timer.scheduledTimer(timeInterval: time, target: self, selector: #selector(timerFired), userInfo: nil, repeats: false)
         } else {
             DispatchQueue.main.sync { [weak self] in
-                guard let strongSelf = self else { return }
+                guard let self else { return }
 
-                strongSelf.timer = Timer.scheduledTimer(timeInterval: time, target: strongSelf, selector: #selector(timerFired), userInfo: nil, repeats: false)
+                self.timer = Timer.scheduledTimer(timeInterval: time, target: self, selector: #selector(timerFired), userInfo: nil, repeats: false)
             }
         }
     }

--- a/Pocket Casts Watch App Extension/EpisodeView.swift
+++ b/Pocket Casts Watch App Extension/EpisodeView.swift
@@ -94,8 +94,8 @@ struct EpisodeView: View {
                 }
             }
 
-            if viewModel.supportsPodcastNavigation, let podcast = viewModel.parentPodcast, let viewModel = PodcastEpisodeListViewModel(podcast: podcast) {
-                NavigationLink(destination: PodcastEpisodeListView(viewModel: viewModel)) {
+            if viewModel.supportsPodcastNavigation, let podcast = viewModel.parentPodcast  {
+                NavigationLink(destination: PodcastEpisodeListView(viewModel: .init(podcast: podcast))) {
                     EpisodeActionView(iconName: "episode_goto", title: L10n.goToPodcast)
                 }
             }

--- a/Pocket Casts Watch App Extension/EpisodeView.swift
+++ b/Pocket Casts Watch App Extension/EpisodeView.swift
@@ -94,7 +94,7 @@ struct EpisodeView: View {
                 }
             }
 
-            if viewModel.supportsPodcastNavigation, let podcast = viewModel.parentPodcast  {
+            if viewModel.supportsPodcastNavigation, let podcast = viewModel.parentPodcast {
                 NavigationLink(destination: PodcastEpisodeListView(viewModel: .init(podcast: podcast))) {
                     EpisodeActionView(iconName: "episode_goto", title: L10n.goToPodcast)
                 }

--- a/PocketCastsTests/Tests/End of Year/EndOfYearStoriesBuilderTests.swift
+++ b/PocketCastsTests/Tests/End of Year/EndOfYearStoriesBuilderTests.swift
@@ -186,7 +186,7 @@ class EndOfYearStoriesBuilderTests: XCTestCase {
         Settings.hasSyncedAll2022Episodes = false
 
         endOfYearManager.isFullListeningHistoryToReturn = false
-        let stories = await builder.build()
+        _ = await builder.build()
 
         XCTAssertTrue(syncCalled)
     }
@@ -199,7 +199,7 @@ class EndOfYearStoriesBuilderTests: XCTestCase {
         Settings.hasSyncedAll2022Episodes = true
 
         endOfYearManager.isFullListeningHistoryToReturn = false
-        let stories = await builder.build()
+        _ = await builder.build()
 
         XCTAssertFalse(syncCalled)
     }

--- a/Podfile
+++ b/Podfile
@@ -6,11 +6,21 @@ use_modular_headers!
 
 app_ios_deployment_target = Gem::Version.new('15.0')
 
+def kingfisher
+  # Any version compatible with 7.6, starting from 7.6.2 to ensure
+  # compatibility with Xcode 14.3.
+  #
+  # Notice that 7.6.2 is not necessarily the first version compatible with
+  # Xcode 14.3 but it was the latest version at the time we checked and so
+  # we are using it as the baseline.
+  pod 'Kingfisher', '~> 7.6', '>= 7.6.2'
+end
+
 def common_pods
   pod 'JLRoutes'
   pod 'google-cast-sdk-no-bluetooth', git: 'https://github.com/shiftyjelly/google-cast.git'
   pod 'MaterialComponents/BottomSheet'
-  pod 'Kingfisher'
+  kingfisher
 end
 
 target 'podcasts' do
@@ -25,7 +35,7 @@ end
 
 target 'Pocket Casts Watch App Extension' do
   platform :watchos, '6.0'
-  pod 'Kingfisher'
+  kingfisher
 end
 
 abstract_target 'CI' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
   - google-cast-sdk-no-bluetooth (1.0.0)
   - JLRoutes (2.1)
-  - Kingfisher (7.2.1)
+  - Kingfisher (7.6.2)
   - MaterialComponents/Availability (124.2.0)
   - MaterialComponents/BottomSheet (124.2.0):
     - MaterialComponents/Elevation
@@ -37,7 +37,7 @@ PODS:
 DEPENDENCIES:
   - google-cast-sdk-no-bluetooth (from `https://github.com/shiftyjelly/google-cast.git`)
   - JLRoutes
-  - Kingfisher
+  - Kingfisher (>= 7.6.2, ~> 7.6)
   - MaterialComponents/BottomSheet
   - SwiftGen (~> 6.0)
   - SwiftLint (~> 0.49)
@@ -62,11 +62,11 @@ CHECKOUT OPTIONS:
 SPEC CHECKSUMS:
   google-cast-sdk-no-bluetooth: fd144bf43bb76000a8e92b0410ae605937aa83bf
   JLRoutes: d755245322b94227662ea3e43492fdca94e05c5b
-  Kingfisher: 7c084bebf7d548c623ad41bcf765fb200efed369
+  Kingfisher: 6c5449c6450c5239166510ba04afe374a98afc4f
   MaterialComponents: 1a9b2d9d45b1601ae544de85089adc4c464306d4
   SwiftGen: a6d22010845f08fe18fbdf3a07a8e380fd22e0ea
   SwiftLint: 32ee33ded0636d0905ef6911b2b67bbaeeedafa5
 
-PODFILE CHECKSUM: 925e6346b7bb55351239c53d630c14b92d835bbc
+PODFILE CHECKSUM: 181a2570f509429a9b99ea44d4aa507f35d051eb
 
 COCOAPODS: 1.11.3

--- a/WidgetExtension/Up Next/UpNextMediumWidgetView.swift
+++ b/WidgetExtension/Up Next/UpNextMediumWidgetView.swift
@@ -71,13 +71,11 @@ struct MediumFilterView: View {
         GeometryReader { geometry in
             VStack(alignment: .leading, spacing: 0) {
                 HStack(alignment: .top) {
-                    if let filterName = filterName {
-                        Text(filterName)
-                            .font(.callout)
-                            .fontWeight(.regular)
-                            .foregroundColor(Color.secondary)
-                            .frame(height: 18)
-                    }
+                    Text(filterName)
+                        .font(.callout)
+                        .fontWeight(.regular)
+                        .foregroundColor(Color.secondary)
+                        .frame(height: 18)
                     Spacer()
                     Image("logo_red_small")
                         .frame(width: 28, height: 28)

--- a/podcasts/DownloadManager.swift
+++ b/podcasts/DownloadManager.swift
@@ -168,7 +168,6 @@ class DownloadManager: NSObject, FilePathProtocol {
         if episode.bufferedForStreaming(), autoDownloadStatus != AutoDownloadStatus.playerDownloadedForStreaming {
             let sourceUrl = URL(fileURLWithPath: streamingBufferPathForEpisode(episode))
             let destinationUrl = URL(fileURLWithPath: pathForEpisode(episode))
-            let fileManager = FileManager.default
             do {
                 try StorageManager.moveItem(at: sourceUrl, to: destinationUrl, options: .overwriteExisting)
 

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -1220,9 +1220,9 @@ class PlaybackManager: ServerPlaybackDelegate {
             updateTimer = Timer.scheduledTimer(timeInterval: updateTimerInterval, target: self, selector: #selector(progressTimerFired), userInfo: nil, repeats: true)
         } else {
             DispatchQueue.main.sync { [weak self] in
-                guard let strongSelf = self else { return }
+                guard let self else { return }
 
-                strongSelf.updateTimer = Timer.scheduledTimer(timeInterval: strongSelf.updateTimerInterval, target: strongSelf, selector: #selector(progressTimerFired), userInfo: nil, repeats: true)
+                self.updateTimer = Timer.scheduledTimer(timeInterval: self.updateTimerInterval, target: self, selector: #selector(progressTimerFired), userInfo: nil, repeats: true)
             }
         }
     }

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -1222,7 +1222,7 @@ class PlaybackManager: ServerPlaybackDelegate {
             DispatchQueue.main.sync { [weak self] in
                 guard let self else { return }
 
-                self.updateTimer = Timer.scheduledTimer(timeInterval: self.updateTimerInterval, target: self, selector: #selector(progressTimerFired), userInfo: nil, repeats: true)
+                self.updateTimer = Timer.scheduledTimer(timeInterval: self.updateTimerInterval, target: self, selector: #selector(self.progressTimerFired), userInfo: nil, repeats: true)
             }
         }
     }

--- a/podcasts/PlaybackQueue.swift
+++ b/podcasts/PlaybackQueue.swift
@@ -375,7 +375,7 @@ class PlaybackQueue: NSObject {
             DispatchQueue.main.sync { [weak self] () in
                 guard let self else { return }
 
-                self.syncTimer = Timer.scheduledTimer(timeInterval: self.syncTimerDelay, target: self, selector: #selector(syncTimerFired), userInfo: nil, repeats: false)
+                self.syncTimer = Timer.scheduledTimer(timeInterval: self.syncTimerDelay, target: self, selector: #selector(self.syncTimerFired), userInfo: nil, repeats: false)
             }
         }
     }

--- a/podcasts/PlaybackQueue.swift
+++ b/podcasts/PlaybackQueue.swift
@@ -373,9 +373,9 @@ class PlaybackQueue: NSObject {
             syncTimer = Timer.scheduledTimer(timeInterval: syncTimerDelay, target: self, selector: #selector(syncTimerFired), userInfo: nil, repeats: false)
         } else {
             DispatchQueue.main.sync { [weak self] () in
-                guard let strongSelf = self else { return }
+                guard let self else { return }
 
-                strongSelf.syncTimer = Timer.scheduledTimer(timeInterval: strongSelf.syncTimerDelay, target: strongSelf, selector: #selector(syncTimerFired), userInfo: nil, repeats: false)
+                self.syncTimer = Timer.scheduledTimer(timeInterval: self.syncTimerDelay, target: self, selector: #selector(syncTimerFired), userInfo: nil, repeats: false)
             }
         }
     }


### PR DESCRIPTION
This PR preemptively addresses code that will generated warnings in Xcode 14.3. While at it, I found a few more warnings which I don't think are new in Xcode 14.3 (but I didn't check by building in an older Xcode) and tackled them, too.

## To test
If CI is green, we should be good.

One thing that might be worth checking is image downloading. I had to update Kingfisher to the latest version to avoid a build failure in Xcode 14.3.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
