### PR TITLE
Fix some issues with handling share links

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1421,6 +1421,7 @@
 		C7B3C6142919F47A00054145 /* HorizontalScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7B3C6132919F47A00054145 /* HorizontalScrollView.swift */; };
 		C7B3C61B291AD05600054145 /* PlusLandingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7B3C61A291AD05600054145 /* PlusLandingView.swift */; };
 		C7B3C61D291AD0EA00054145 /* Onboarding.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C7B3C61C291AD0EA00054145 /* Onboarding.xcassets */; };
+		C7B7123A29DC98BD00965BF7 /* SFSafariViewController+Creation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7B7123929DC98BD00965BF7 /* SFSafariViewController+Creation.swift */; };
 		C7BF5E47290832FD00733C1E /* DiscoverCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7BF5E46290832FD00733C1E /* DiscoverCoordinator.swift */; };
 		C7BF5E4A29083B5300733C1E /* DiscoverCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7BF5E4929083B5300733C1E /* DiscoverCoordinatorTests.swift */; };
 		C7BF5E4D29083E2100733C1E /* PocketCastsServer in Frameworks */ = {isa = PBXBuildFile; productRef = C7BF5E4C29083E2100733C1E /* PocketCastsServer */; };
@@ -3038,6 +3039,7 @@
 		C7B3C6132919F47A00054145 /* HorizontalScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HorizontalScrollView.swift; sourceTree = "<group>"; };
 		C7B3C61A291AD05600054145 /* PlusLandingView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlusLandingView.swift; sourceTree = "<group>"; };
 		C7B3C61C291AD0EA00054145 /* Onboarding.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Onboarding.xcassets; sourceTree = "<group>"; };
+		C7B7123929DC98BD00965BF7 /* SFSafariViewController+Creation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SFSafariViewController+Creation.swift"; sourceTree = "<group>"; };
 		C7BF5E46290832FD00733C1E /* DiscoverCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverCoordinator.swift; sourceTree = "<group>"; };
 		C7BF5E4929083B5300733C1E /* DiscoverCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverCoordinatorTests.swift; sourceTree = "<group>"; };
 		C7C2391BA608F0CAB6E1D038 /* libPods-Pocket Casts Watch App Extension.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Pocket Casts Watch App Extension.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -6177,6 +6179,7 @@
 				8B484F0028D25D1E001AFA97 /* UIViewController+requestReview.swift */,
 				C7F4BABE28DB7F7C001C9785 /* DiscoverItem+Helper.swift */,
 				C7F87F0F2913242B00C15980 /* UIFont+FontStyle.swift */,
+				C7B7123929DC98BD00965BF7 /* SFSafariViewController+Creation.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -8136,6 +8139,7 @@
 				BD74F15327F28F6F00222785 /* HomeGridItem.swift in Sources */,
 				8BE85CAB28762C4900AEB5FF /* LegalAndMoreView.swift in Sources */,
 				BD780AE820049BFF00B5A442 /* PodcastViewController.swift in Sources */,
+				C7B7123A29DC98BD00965BF7 /* SFSafariViewController+Creation.swift in Sources */,
 				BD1B70C72359765D004DDD44 /* ThemeAwareScrollView.swift in Sources */,
 				BDCD1E7C244D630700B83602 /* LenticularViewController.swift in Sources */,
 				BDAE72D82138FB32002810A2 /* ActionIconButton.swift in Sources */,

--- a/podcasts/AppDelelgate+SiriShortcuts.swift
+++ b/podcasts/AppDelelgate+SiriShortcuts.swift
@@ -18,10 +18,21 @@ extension AppDelegate {
                 JLRoutes.routeURL(url)
             }
         } else if userActivity.activityType == NSUserActivityTypeBrowsingWeb {
-            guard let incomingURL = userActivity.webpageURL, let components = NSURLComponents(url: incomingURL, resolvingAgainstBaseURL: true), let path = components.path, let controller = SceneHelper.rootViewController(), path != "/get" else { return }
+            guard
+                let incomingURL = userActivity.webpageURL,
+                let components = NSURLComponents(url: incomingURL, resolvingAgainstBaseURL: true),
+                let path = components.path,
+                let controller = SceneHelper.rootViewController(),
+                path != "/get"
+            else { return }
 
-            FileLog.shared.addMessage("Opening universal link, path: \(path)")
-            openSharePath("social/share/show\(path)", controller: controller, onErrorOpen: incomingURL)
+            // Also pass any query params from the share URL to the server to allow support for episode position handling
+            // Ex: ?t=123
+            let query = components.query.map { "?\($0)" } ?? ""
+            let sharePath = "\(path)\(query)"
+
+            FileLog.shared.addMessage("Opening universal link, path: \(sharePath)")
+            openSharePath("social/share/show\(sharePath)", controller: controller, onErrorOpen: incomingURL)
         }
 
         guard let intent = userActivity.interaction?.intent else { return }

--- a/podcasts/CancelInfoViewController.swift
+++ b/podcasts/CancelInfoViewController.swift
@@ -83,10 +83,7 @@ class CancelInfoViewController: UIViewController, SFSafariViewControllerDelegate
 
     @IBAction func showMeTapped(_ sender: Any) {
         if let url = URL(string: ServerConstants.Urls.cancelSubscription) {
-            let config = SFSafariViewController.Configuration()
-            config.entersReaderIfAvailable = false
-
-            safariViewController = SFSafariViewController(url: url, configuration: config)
+            safariViewController = SFSafariViewController.controller(with: url)
             safariViewController?.delegate = self
             if let vc = safariViewController {
                 present(vc, animated: true)

--- a/podcasts/CancelInfoViewController.swift
+++ b/podcasts/CancelInfoViewController.swift
@@ -83,7 +83,7 @@ class CancelInfoViewController: UIViewController, SFSafariViewControllerDelegate
 
     @IBAction func showMeTapped(_ sender: Any) {
         if let url = URL(string: ServerConstants.Urls.cancelSubscription) {
-            safariViewController = SFSafariViewController.controller(with: url)
+            safariViewController = SFSafariViewController(with: url)
             safariViewController?.delegate = self
             if let vc = safariViewController {
                 present(vc, animated: true)

--- a/podcasts/ChaptersViewController+Table.swift
+++ b/podcasts/ChaptersViewController+Table.swift
@@ -33,11 +33,7 @@ extension ChaptersViewController: UITableViewDataSource, UITableViewDelegate, UI
                 if UserDefaults.standard.bool(forKey: Constants.UserDefaults.openLinksInExternalBrowser) {
                     UIApplication.shared.open(url, options: [:], completionHandler: nil)
                 } else {
-                    let config = SFSafariViewController.Configuration()
-                    config.entersReaderIfAvailable = true
-
-                    let vc = SFSafariViewController(url: url, configuration: config)
-                    self.present(vc, animated: true)
+                    self.present(SFSafariViewController.controller(with: url), animated: true)
                 }
             }
 

--- a/podcasts/ChaptersViewController+Table.swift
+++ b/podcasts/ChaptersViewController+Table.swift
@@ -33,7 +33,7 @@ extension ChaptersViewController: UITableViewDataSource, UITableViewDelegate, UI
                 if UserDefaults.standard.bool(forKey: Constants.UserDefaults.openLinksInExternalBrowser) {
                     UIApplication.shared.open(url, options: [:], completionHandler: nil)
                 } else {
-                    self.present(SFSafariViewController.controller(with: url), animated: true)
+                    self.present(SFSafariViewController(with: url), animated: true)
                 }
             }
 

--- a/podcasts/EpisodeDetailViewController+ShowNotes.swift
+++ b/podcasts/EpisodeDetailViewController+ShowNotes.swift
@@ -63,10 +63,12 @@ extension EpisodeDetailViewController: WKNavigationDelegate, SFSafariViewControl
             if UserDefaults.standard.bool(forKey: Constants.UserDefaults.openLinksInExternalBrowser), let url = navigationAction.request.url {
                 UIApplication.shared.open(url, options: [:], completionHandler: nil)
             } else if URLHelper.isValidScheme(navigationAction.request.url?.scheme) {
-                let config = SFSafariViewController.Configuration()
-                config.entersReaderIfAvailable = false
-                safariViewController = SFSafariViewController(url: navigationAction.request.url!, configuration: config)
+                safariViewController = navigationAction.request.url.flatMap {
+                    SFSafariViewController.controller(with: $0)
+                }
+
                 safariViewController?.delegate = self
+
                 NotificationCenter.postOnMainThread(notification: Constants.Notifications.openingNonOverlayableWindow)
                 present(safariViewController!, animated: true, completion: nil)
 

--- a/podcasts/EpisodeDetailViewController+ShowNotes.swift
+++ b/podcasts/EpisodeDetailViewController+ShowNotes.swift
@@ -64,7 +64,7 @@ extension EpisodeDetailViewController: WKNavigationDelegate, SFSafariViewControl
                 UIApplication.shared.open(url, options: [:], completionHandler: nil)
             } else if URLHelper.isValidScheme(navigationAction.request.url?.scheme) {
                 safariViewController = navigationAction.request.url.flatMap {
-                    SFSafariViewController.controller(with: $0)
+                    SFSafariViewController(with: $0)
                 }
 
                 safariViewController?.delegate = self

--- a/podcasts/ExpandedCollectionViewController.swift
+++ b/podcasts/ExpandedCollectionViewController.swift
@@ -103,10 +103,7 @@ class ExpandedCollectionViewController: PCViewController, CollectionHeaderLinkDe
         if UserDefaults.standard.bool(forKey: Constants.UserDefaults.openLinksInExternalBrowser) {
             UIApplication.shared.open(url, options: [:], completionHandler: nil)
         } else {
-            let config = SFSafariViewController.Configuration()
-            config.entersReaderIfAvailable = false
-            let safariViewController = SFSafariViewController(url: url, configuration: config)
-            present(safariViewController, animated: true, completion: nil)
+            present(SFSafariViewController.controller(with: url), animated: true, completion: nil)
         }
     }
 

--- a/podcasts/ExpandedCollectionViewController.swift
+++ b/podcasts/ExpandedCollectionViewController.swift
@@ -103,7 +103,7 @@ class ExpandedCollectionViewController: PCViewController, CollectionHeaderLinkDe
         if UserDefaults.standard.bool(forKey: Constants.UserDefaults.openLinksInExternalBrowser) {
             UIApplication.shared.open(url, options: [:], completionHandler: nil)
         } else {
-            present(SFSafariViewController.controller(with: url), animated: true, completion: nil)
+            present(SFSafariViewController(with: url), animated: true, completion: nil)
         }
     }
 

--- a/podcasts/ExpandedEpisodeListViewController.swift
+++ b/podcasts/ExpandedEpisodeListViewController.swift
@@ -111,11 +111,7 @@ class ExpandedEpisodeListViewController: PCViewController, UITableViewDelegate, 
         if UserDefaults.standard.bool(forKey: Constants.UserDefaults.openLinksInExternalBrowser) {
             UIApplication.shared.open(url, options: [:], completionHandler: nil)
         } else {
-            let config = SFSafariViewController.Configuration()
-            config.entersReaderIfAvailable = false
-            let safariViewController = SFSafariViewController(url: url, configuration: config)
-
-            present(safariViewController, animated: true, completion: nil)
+            present(SFSafariViewController.controller(with: url), animated: true, completion: nil)
         }
     }
 }

--- a/podcasts/ExpandedEpisodeListViewController.swift
+++ b/podcasts/ExpandedEpisodeListViewController.swift
@@ -111,7 +111,7 @@ class ExpandedEpisodeListViewController: PCViewController, UITableViewDelegate, 
         if UserDefaults.standard.bool(forKey: Constants.UserDefaults.openLinksInExternalBrowser) {
             UIApplication.shared.open(url, options: [:], completionHandler: nil)
         } else {
-            present(SFSafariViewController.controller(with: url), animated: true, completion: nil)
+            present(SFSafariViewController(with: url), animated: true, completion: nil)
         }
     }
 }

--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -127,7 +127,7 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
     func showInSafariViewController(urlString: String) {
         guard let url = URL(string: urlString) else { return }
 
-        let safariViewController = SFSafariViewController.controller(with: url)
+        let safariViewController = SFSafariViewController(with: url)
         topController().present(safariViewController, animated: true, completion: nil)
     }
 

--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -127,9 +127,7 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
     func showInSafariViewController(urlString: String) {
         guard let url = URL(string: urlString) else { return }
 
-        let config = SFSafariViewController.Configuration()
-        config.entersReaderIfAvailable = true
-        let safariViewController = SFSafariViewController(url: url, configuration: config)
+        let safariViewController = SFSafariViewController.controller(with: url)
         topController().present(safariViewController, animated: true, completion: nil)
     }
 

--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -171,11 +171,15 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
     }
 
     func navigateToPodcastInfo(_ podcastInfo: PodcastInfo) {
-        if let navController = selectedViewController as? UINavigationController {
+        appDelegate()?.miniPlayer()?.closeUpNextAndFullPlayer(completion: { [weak self] in
+            guard let navController = self?.selectedViewController as? UINavigationController else {
+                return
+            }
+
             navController.popToRootViewController(animated: false)
             let podcastController = PodcastViewController(podcastInfo: podcastInfo, existingImage: nil)
             navController.pushViewController(podcastController, animated: true)
-        }
+        })
     }
 
     func navigateTo(podcast searchResult: PodcastFolderSearchResult) {

--- a/podcasts/NowPlayingPlayerItemViewController.swift
+++ b/podcasts/NowPlayingPlayerItemViewController.swift
@@ -244,11 +244,7 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
         if UserDefaults.standard.bool(forKey: Constants.UserDefaults.openLinksInExternalBrowser) {
             UIApplication.shared.open(url, options: [:], completionHandler: nil)
         } else {
-            let config = SFSafariViewController.Configuration()
-            config.entersReaderIfAvailable = true
-
-            let vc = SFSafariViewController(url: url, configuration: config)
-            present(vc, animated: true)
+            present(SFSafariViewController.controller(with: url), animated: true)
         }
     }
 

--- a/podcasts/NowPlayingPlayerItemViewController.swift
+++ b/podcasts/NowPlayingPlayerItemViewController.swift
@@ -244,7 +244,7 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
         if UserDefaults.standard.bool(forKey: Constants.UserDefaults.openLinksInExternalBrowser) {
             UIApplication.shared.open(url, options: [:], completionHandler: nil)
         } else {
-            present(SFSafariViewController.controller(with: url), animated: true)
+            present(SFSafariViewController(with: url), animated: true)
         }
     }
 

--- a/podcasts/SFSafariViewController+Creation.swift
+++ b/podcasts/SFSafariViewController+Creation.swift
@@ -1,0 +1,21 @@
+import SafariServices
+
+extension SFSafariViewController {
+
+    /// Creates a SFSafariViewController with consistent config to be used in the app
+    static func controller(with url: URL, config: SFSafariViewController.Configuration = .appDefault) -> SFSafariViewController {
+        let controller = SFSafariViewController(url: url, configuration: config)
+        controller.dismissButtonStyle = .close
+
+        return controller
+    }
+}
+
+extension SFSafariViewController.Configuration {
+    static var appDefault: SFSafariViewController.Configuration {
+        let config = SFSafariViewController.Configuration()
+        config.entersReaderIfAvailable = false
+        config.barCollapsingEnabled = false
+        return config
+    }
+}

--- a/podcasts/SFSafariViewController+Creation.swift
+++ b/podcasts/SFSafariViewController+Creation.swift
@@ -3,11 +3,9 @@ import SafariServices
 extension SFSafariViewController {
 
     /// Creates a SFSafariViewController with consistent config to be used in the app
-    static func controller(with url: URL, config: SFSafariViewController.Configuration = .appDefault) -> SFSafariViewController {
-        let controller = SFSafariViewController(url: url, configuration: config)
-        controller.dismissButtonStyle = .close
-
-        return controller
+    convenience init(with url: URL, config: SFSafariViewController.Configuration = .appDefault) {
+        self.init(url: url, configuration: config)
+        dismissButtonStyle = .close
     }
 }
 

--- a/podcasts/ShowNotesPlayerItemViewController.swift
+++ b/podcasts/ShowNotesPlayerItemViewController.swift
@@ -200,7 +200,7 @@ class ShowNotesPlayerItemViewController: PlayerItemViewController, SFSafariViewC
             UIApplication.shared.open(url, options: [:], completionHandler: nil)
         } else {
             if URLHelper.isValidScheme(url.scheme) {
-                safariViewController = SFSafariViewController.controller(with: url)
+                safariViewController = SFSafariViewController(with: url)
                 safariViewController?.delegate = self
 
                 NotificationCenter.postOnMainThread(notification: Constants.Notifications.openingNonOverlayableWindow)

--- a/podcasts/ShowNotesPlayerItemViewController.swift
+++ b/podcasts/ShowNotesPlayerItemViewController.swift
@@ -200,10 +200,9 @@ class ShowNotesPlayerItemViewController: PlayerItemViewController, SFSafariViewC
             UIApplication.shared.open(url, options: [:], completionHandler: nil)
         } else {
             if URLHelper.isValidScheme(url.scheme) {
-                let config = SFSafariViewController.Configuration()
-                config.entersReaderIfAvailable = false
-                safariViewController = SFSafariViewController(url: url, configuration: config)
+                safariViewController = SFSafariViewController.controller(with: url)
                 safariViewController?.delegate = self
+
                 NotificationCenter.postOnMainThread(notification: Constants.Notifications.openingNonOverlayableWindow)
                 SceneHelper.rootViewController()?.present(safariViewController!, animated: true, completion: nil)
 


### PR DESCRIPTION
- Hides the mini player if we're loading a shared podcast
- Adds support for passing the time from the share URL to the server
  - Doesn't add support for playing back at that time yet.
- Disables hiding toolbar in the safari view controller
- Changes the 'Done' button to 'Close' in the safari view

I also updated all the scattered `SFSafariViewController` creation methods to use the new `SFSafariViewController.controller` extension so all controllers in the app will be consistent everywhere. 

## To test

### Query Param Passing
1. Launch the app 
2. Open the following link: https://pca.st/episode/d3d0a4a2-15e2-4fd7-a997-3515b37fbef4?t=1693.0
3. ✅ Verify you see a log for `Opening universal link, path: /episode/d3d0a4a2-15e2-4fd7-a997-3515b37fbef4?t=1693.0` and it includes the `t=`

### Loading a podcast with the player open
1. Play an episode and open the player
2. Open the following link: https://pca.st/podcast/6b59c010-3215-0136-fa7b-0fe84b59566d
3. ✅ Verify the player dismisses and the podcast is shown

### Safari Controller's

1. Open an episode 
4. Tap a link in the Show Notes
5. ✅ Verify the safari controller opens
6. ✅ Verify the button says 'Close'
7. Scroll down on the webpage 
8. ✅ Verify the top toolbar remains visible
9. Repeat the steps for the following places:
   - Play an episode, tap a link in its show notes from the player
   - Open a Guest List on Discover and tap the 'Why these' button
   - Tap the Terms of Use in the Privacy settings


## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
