### PR TITLE
Adds a HorizontalCarousel SwiftUI view

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1423,6 +1423,7 @@
 		C7B3C61B291AD05600054145 /* PlusLandingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7B3C61A291AD05600054145 /* PlusLandingView.swift */; };
 		C7B3C61D291AD0EA00054145 /* Onboarding.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C7B3C61C291AD0EA00054145 /* Onboarding.xcassets */; };
 		C7B7123A29DC98BD00965BF7 /* SFSafariViewController+Creation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7B7123929DC98BD00965BF7 /* SFSafariViewController+Creation.swift */; };
+		C7B7123C29DF49BC00965BF7 /* HorizontalCarousel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7B7123B29DF49BC00965BF7 /* HorizontalCarousel.swift */; };
 		C7BF5E47290832FD00733C1E /* DiscoverCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7BF5E46290832FD00733C1E /* DiscoverCoordinator.swift */; };
 		C7BF5E4A29083B5300733C1E /* DiscoverCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7BF5E4929083B5300733C1E /* DiscoverCoordinatorTests.swift */; };
 		C7BF5E4D29083E2100733C1E /* PocketCastsServer in Frameworks */ = {isa = PBXBuildFile; productRef = C7BF5E4C29083E2100733C1E /* PocketCastsServer */; };
@@ -3042,6 +3043,7 @@
 		C7B3C61A291AD05600054145 /* PlusLandingView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlusLandingView.swift; sourceTree = "<group>"; };
 		C7B3C61C291AD0EA00054145 /* Onboarding.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Onboarding.xcassets; sourceTree = "<group>"; };
 		C7B7123929DC98BD00965BF7 /* SFSafariViewController+Creation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SFSafariViewController+Creation.swift"; sourceTree = "<group>"; };
+		C7B7123B29DF49BC00965BF7 /* HorizontalCarousel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HorizontalCarousel.swift; sourceTree = "<group>"; };
 		C7BF5E46290832FD00733C1E /* DiscoverCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverCoordinator.swift; sourceTree = "<group>"; };
 		C7BF5E4929083B5300733C1E /* DiscoverCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverCoordinatorTests.swift; sourceTree = "<group>"; };
 		C7C2391BA608F0CAB6E1D038 /* libPods-Pocket Casts Watch App Extension.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Pocket Casts Watch App Extension.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -6258,6 +6260,7 @@
 				C7CA0558293E8918000E41BD /* HolographicEffect.swift */,
 				8B208A5229C933D300AEF951 /* MiniPlayerPaddingModifier.swift */,
 				8B208A5429C933F800AEF951 /* DismissKeyboardOnScroll.swift */,
+				C7B7123B29DF49BC00965BF7 /* HorizontalCarousel.swift */,
 			);
 			path = SwiftUI;
 			sourceTree = "<group>";
@@ -7827,6 +7830,7 @@
 				BDF09F041E669E16009E9845 /* BasePlayPauseButton.swift in Sources */,
 				407B21E72231F6A300B4E492 /* UploadedSettingsViewController.swift in Sources */,
 				BD339C5C2149E35600E655F9 /* VideoViewController+Controls.swift in Sources */,
+				C7B7123C29DF49BC00965BF7 /* HorizontalCarousel.swift in Sources */,
 				4041FE572181751F0089D4A1 /* SiriShortcutsManager.swift in Sources */,
 				4053CDFB214F374B001C92B1 /* ReleaseDateFilterOverlayController.swift in Sources */,
 				BD26AFD427BDFD18008CC973 /* Folder+Formatting.swift in Sources */,

--- a/podcasts/SwiftUI/HorizontalCarousel.swift
+++ b/podcasts/SwiftUI/HorizontalCarousel.swift
@@ -58,7 +58,7 @@ struct HorizontalCarousel<Content: View, T: Identifiable>: View {
     var body: some View {
         GeometryReader { proxy in
             let baseWidth = proxy.size.width - spacing
-            
+
             let peekAmount: Double = {
                 guard maxPages > 1 else {
                     return 0
@@ -100,8 +100,8 @@ struct HorizontalCarousel<Content: View, T: Identifiable>: View {
             HStack(spacing: spacing) {
                 ForEach(items) { item in
                     content(item)
-                        // Update each items width according to the calculated width above
-                        // We apply the spacing again to apply the trailing spacing
+                    // Update each items width according to the calculated width above
+                    // We apply the spacing again to apply the trailing spacing
                         .frame(width: itemWidth - spacing)
                 }
             }
@@ -109,10 +109,10 @@ struct HorizontalCarousel<Content: View, T: Identifiable>: View {
             // to make the entire thing spring around. To add more springyness up the damping
             .animation(.interpolatingSpring(stiffness: 350, damping: 30, initialVelocity: 10), value: gestureOffset)
             .offset(x: offsetX)
-            .gesture(
+            .highPriorityGesture(
                 DragGesture()
-                    // When the gesture is done, we use the predictedEnd calculate the next page based on the
-                    // gestures momentum
+                // When the gesture is done, we use the predictedEnd calculate the next page based on the
+                // gestures momentum
                     .onEnded { value in
                         let endIndex = calculateIndex(value.predictedEndTranslation, itemWidth: itemWidth)
 
@@ -124,7 +124,7 @@ struct HorizontalCarousel<Content: View, T: Identifiable>: View {
                         // Inform the listening of index changes while we're dragging
                         index = calculateIndex(value.translation, itemWidth: itemWidth)
                     }
-                    // Keep track of the gesture's offset so we can "scroll"
+                // Keep track of the gesture's offset so we can "scroll"
                     .updating($gestureOffset, body: { value, state, _ in
                         state = value.translation.width
                     })
@@ -137,9 +137,9 @@ struct HorizontalCarousel<Content: View, T: Identifiable>: View {
         let offset = (-translation.width / itemWidth).rounded()
 
         return (visibleIndex + Int(offset))
-            // Keep the next page within the page bounds
+        // Keep the next page within the page bounds
             .clamped(to: 0..<maxPages)
-            // Prevent the next page from being more than page item away
+        // Prevent the next page from being more than page item away
             .clamped(to: visibleIndex-1..<visibleIndex+1)
     }
 

--- a/podcasts/SwiftUI/HorizontalCarousel.swift
+++ b/podcasts/SwiftUI/HorizontalCarousel.swift
@@ -1,0 +1,253 @@
+import SwiftUI
+
+/// A horizontal carousel view with next item "peeking" support
+/// - `carouselItemsToDisplay` to change how many of the `items` will be displayed per page
+/// - `carouselItemSpacing` to adjust the spacing between the items
+/// - `carouselPeekAmount` to control how much (if any) of the next item on the next page should display
+/// Add the `currentIndex` binding to be notified when the page changes
+struct HorizontalCarousel<Content: View, T: Identifiable>: View {
+    /// Binding for the currently selected index
+    @Binding private var index: Int
+
+    /* Internal properties */
+    private var itemsToDisplay = 1
+    private var spacing: Double = 0
+    private var peekAmount: PeekAmount = .constant(10)
+
+    private let items: [T]
+    private let content: (T) -> Content
+
+    /// An offset amount set by the gesture used to move the items in the stack during a drag
+    @GestureState private var gestureOffset: Double = 0
+
+    /// Internal tracking of the visible index used to calculate the offset
+    @State private var visibleIndex = 0
+
+    init(currentIndex: Binding<Int>? = .constant(0), items: [T], @ViewBuilder content: @escaping (T) -> Content) {
+        self._index = currentIndex ?? .constant(0)
+        self.items = items
+        self.content = content
+    }
+
+    /// Sets the number of items to display per page
+    func carouselItemsToDisplay(_ value: Int) -> Self {
+        update { carousel in
+            carousel.itemsToDisplay = value.clamped(to: 0..<items.count)
+        }
+    }
+
+    /// Sets the spacing between each item and the leading/trailing margins
+    func carouselItemSpacing(_ value: CGFloat) -> Self {
+        update { carousel in
+            carousel.spacing = max(0, value)
+        }
+    }
+
+    /// The amount the next item to display
+    func carouselPeekAmount(_ value: PeekAmount) -> Self {
+        update { carousel in
+            carousel.peekAmount = value
+        }
+    }
+
+    /// The max total number of pages to be able to swipe through
+    private var maxPages: Int {
+        items.count - itemsToDisplay
+    }
+
+    var body: some View {
+        GeometryReader { proxy in
+            let baseWidth = proxy.size.width - spacing
+            
+            let peekAmount: Double = {
+                guard maxPages > 1 else {
+                    return 0
+                }
+
+                switch self.peekAmount {
+                case let .constant(value):
+                    return value
+
+                case let .percent(value):
+                    return baseWidth * value
+                }
+            }()
+
+            // Calculate the item size to be the width minus the trailing spacing and the trailing peek amount
+            let itemWidth = (baseWidth - peekAmount) / CGFloat(itemsToDisplay)
+
+            // The current X offset to apply to the HStack
+            // This is what gives the appearance of scrolling since it pairs with the drag gesture offset
+            // This uses negative values because we're moving the base X position to the left
+            let offsetX: CGFloat = {
+                let isLast = visibleIndex == maxPages
+
+                // Add the leading padding and calculate the current item offset
+                var x = spacing + (CGFloat(visibleIndex) * -itemWidth)
+
+                // If we're displaying the last item, then adjust the offset so we show the peek on the leading side
+                if isLast {
+                    x += peekAmount
+                }
+
+                // Apply the gesture offset so the view updates
+                x += gestureOffset
+
+                return x
+            }()
+
+            // The actual carousel
+            HStack(spacing: spacing) {
+                ForEach(items) { item in
+                    content(item)
+                        // Update each items width according to the calculated width above
+                        // We apply the spacing again to apply the trailing spacing
+                        .frame(width: itemWidth - spacing)
+                }
+            }
+            // Apply a little spring animation while gesturing so it doesn't feel so ... boring ... but not too much
+            // to make the entire thing spring around. To add more springyness up the damping
+            .animation(.interpolatingSpring(stiffness: 350, damping: 30, initialVelocity: 10), value: gestureOffset)
+            .offset(x: offsetX)
+            .gesture(
+                DragGesture()
+                    // When the gesture is done, we use the predictedEnd calculate the next page based on the
+                    // gestures momentum
+                    .onEnded { value in
+                        let endIndex = calculateIndex(value.predictedEndTranslation, itemWidth: itemWidth)
+
+                        // We're done animating so snap to the next index
+                        visibleIndex = endIndex
+                        index = endIndex
+                    }
+                    .onChanged { value in
+                        // Inform the listening of index changes while we're dragging
+                        index = calculateIndex(value.translation, itemWidth: itemWidth)
+                    }
+                    // Keep track of the gesture's offset so we can "scroll"
+                    .updating($gestureOffset, body: { value, state, _ in
+                        state = value.translation.width
+                    })
+            )
+        }
+    }
+
+    /// Calculate the current index based on the given translation and item widths
+    private func calculateIndex(_ translation: CGSize, itemWidth: CGFloat) -> Int {
+        let offset = (-translation.width / itemWidth).rounded()
+
+        return (visibleIndex + Int(offset))
+            // Keep the next page within the page bounds
+            .clamped(to: 0..<maxPages)
+            // Prevent the next page from being more than page item away
+            .clamped(to: visibleIndex-1..<visibleIndex+1)
+    }
+
+
+    /// Passes a mutable version of self to the block and returns the modified version
+    private func update(_ block: (inout Self) -> Void) -> Self {
+        var mutableSelf = self
+        block(&mutableSelf)
+        return mutableSelf
+    }
+
+    enum PeekAmount {
+        /// A static peek value
+        case constant(Double)
+
+        /// A dynamic value based off the total carousel width
+        /// A value between 0 and 1
+        /// Ex: 0.1 will have the peek take up 10% of the total carousel width
+        case percent(Double)
+    }
+}
+
+// MARK: - Preview
+
+struct HorizontalCarousel_Preview: PreviewProvider {
+    static var previews: some View {
+        ContainerView()
+    }
+
+    private struct ColorItem: Identifiable {
+        let color: Color
+        var id: String {
+            color.description
+        }
+    }
+
+    struct ContainerView: View {
+        @State var peek: CGFloat = 50
+        @State var spacing: CGFloat = 20
+        @State var items: CGFloat = 1
+        @State var isConstant: Bool = true
+
+        var body: some View {
+            let colors: [Color] = [.red, .orange, .yellow, .green, .blue, .purple, .pink]
+            let pages: [ColorItem] = colors.map { ColorItem(color: $0) }
+
+            VStack {
+                Spacer()
+
+                VStack {
+                    HStack {
+                        Text("Peek Type")
+                        Spacer()
+                        Button("Constant Amount") {
+                            isConstant = true
+                            peek = 10
+                        }
+                        .padding(5)
+                        .background((isConstant ? Color.blue : Color.clear).cornerRadius(10))
+                        .foregroundColor(isConstant ? Color.white : nil)
+
+                        Button("Percentage") {
+                            isConstant = false
+                            peek = 0.1
+                        }
+                        .padding(5)
+                        .background((!isConstant ? Color.blue : Color.clear).cornerRadius(10))
+                        .foregroundColor(!isConstant ? Color.white : nil)
+
+                    }
+                    HStack {
+                        Text("Peek Amount")
+                        if isConstant {
+                            Slider(value: $peek, in: 0...200)
+                        } else {
+                            Slider(value: $peek, in: 0...0.5)
+                        }
+                        Text("\(peek)")
+                    }
+
+                    HStack {
+                        Text("Item Spacing")
+                        Slider(value: $spacing, in: 0...50)
+                        Text("\(spacing)")
+                    }
+
+                    HStack {
+                        Text("Items Per Page")
+                        Slider(value: $items, in: 1...20)
+                        Text("\(Int(items))")
+                    }
+                }.padding()
+
+                HorizontalCarousel(items: pages) { item in
+                    Rectangle()
+                        .cornerRadius(5)
+                        .foregroundColor(item.color)
+                }
+                .carouselItemsToDisplay(Int(items))
+                .carouselItemSpacing(spacing)
+                .carouselPeekAmount(
+                    isConstant ? .constant(peek) : .percent(peek)
+                )
+                .frame(height: 200)
+
+                Spacer()
+            }
+            .frame(maxWidth: .infinity)
+        }
+    }
+}


### PR DESCRIPTION
Adds a horizontal carousel view for SwiftUI that supports peeking, displaying single or multiple items per page, with some extra configuration. 

## Demo Video

https://user-images.githubusercontent.com/793774/230473980-f6485ab9-4342-44c4-878f-c091985f3620.MP4


## To test

1. Open the HorizontalCarousel.swift view
2. Show the preview
3. ✅ Verify it works
4. Test on iOS 15
5. ✅ Verify it works

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
