### PR TITLE
Make author and title optional to avoid decoding issues

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/Search/PodcastSearchTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Search/PodcastSearchTask.swift
@@ -23,7 +23,7 @@ public struct PodcastFolderSearchResult: Codable, Hashable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.uuid = try container.decode(String.self, forKey: .uuid)
-        self.title = try container.decode(String.self, forKey: .title)
+        self.title = try? container.decode(String.self, forKey: .title)
         self.author = try? container.decode(String.self, forKey: .author)
         self.kind = (try? container.decodeIfPresent(Kind.self, forKey: .kind)) ?? .podcast
         self.isLocal = (try? container.decode(Bool.self, forKey: .isLocal)) ?? false

--- a/Modules/Server/Sources/PocketCastsServer/Public/Search/PodcastSearchTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Search/PodcastSearchTask.swift
@@ -71,7 +71,7 @@ public class PodcastSearchTask {
         let (data, _) = try await session.data(for: request!)
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = .convertFromSnakeCase
-        let envelope = try! decoder.decode(PodcastsSearchEnvelope.self, from: data)
+        let envelope = try decoder.decode(PodcastsSearchEnvelope.self, from: data)
         if let podcast = envelope.result.podcast {
             return [podcast]
         } else {

--- a/Modules/Server/Sources/PocketCastsServer/Public/Search/PodcastSearchTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Search/PodcastSearchTask.swift
@@ -30,15 +30,11 @@ public struct PodcastFolderSearchResult: Codable, Hashable {
     }
 
     public init?(from podcast: Podcast) {
-        if let title = podcast.title {
-            self.uuid = podcast.uuid
-            self.title = title
-            self.author = podcast.author
-            self.isLocal = true
-            self.kind = .podcast
-        } else {
-            return nil
-        }
+        self.uuid = podcast.uuid
+        self.title = podcast.title
+        self.author = podcast.author
+        self.isLocal = true
+        self.kind = .podcast
     }
 
     public init?(from folder: Folder) {

--- a/Modules/Server/Sources/PocketCastsServer/Public/Search/PodcastSearchTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Search/PodcastSearchTask.swift
@@ -16,7 +16,7 @@ struct PodcastsSearchEnvelopeResult: Decodable {
 public struct PodcastFolderSearchResult: Codable, Hashable {
     public let uuid: String
     public let title: String
-    public let author: String
+    public let author: String?
     public let kind: Kind
     public var isLocal: Bool?
 
@@ -24,16 +24,16 @@ public struct PodcastFolderSearchResult: Codable, Hashable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.uuid = try container.decode(String.self, forKey: .uuid)
         self.title = try container.decode(String.self, forKey: .title)
-        self.author = try container.decode(String.self, forKey: .author)
+        self.author = try? container.decode(String.self, forKey: .author)
         self.kind = (try? container.decodeIfPresent(Kind.self, forKey: .kind)) ?? .podcast
         self.isLocal = (try? container.decode(Bool.self, forKey: .isLocal)) ?? false
     }
 
     public init?(from podcast: Podcast) {
-        if let title = podcast.title, let author = podcast.author {
+        if let title = podcast.title {
             self.uuid = podcast.uuid
             self.title = title
-            self.author = author
+            self.author = podcast.author
             self.isLocal = true
             self.kind = .podcast
         } else {
@@ -71,7 +71,7 @@ public class PodcastSearchTask {
         let (data, _) = try await session.data(for: request!)
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = .convertFromSnakeCase
-        let envelope = try decoder.decode(PodcastsSearchEnvelope.self, from: data)
+        let envelope = try! decoder.decode(PodcastsSearchEnvelope.self, from: data)
         if let podcast = envelope.result.podcast {
             return [podcast]
         } else {

--- a/Modules/Server/Sources/PocketCastsServer/Public/Search/PodcastSearchTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Search/PodcastSearchTask.swift
@@ -15,7 +15,7 @@ struct PodcastsSearchEnvelopeResult: Decodable {
 
 public struct PodcastFolderSearchResult: Codable, Hashable {
     public let uuid: String
-    public let title: String
+    public let title: String?
     public let author: String?
     public let kind: Kind
     public var isLocal: Bool?

--- a/podcasts/New Search/Views/Results/PodcastCarouselView.swift
+++ b/podcasts/New Search/Views/Results/PodcastCarouselView.swift
@@ -110,7 +110,7 @@ struct PodcastResultCell: View {
                     Text(result.title)
                         .lineLimit(1)
                         .font(style: .subheadline, weight: .medium)
-                    Text(result.author)
+                    Text(result.authorToDisplay)
                         .lineLimit(1)
                         .font(size: 14, style: .subheadline, weight: .medium)
                         .foregroundColor(AppTheme.color(for: .primaryText02, theme: theme))

--- a/podcasts/New Search/Views/Results/PodcastCarouselView.swift
+++ b/podcasts/New Search/Views/Results/PodcastCarouselView.swift
@@ -107,7 +107,7 @@ struct PodcastResultCell: View {
 
             Button(action: { }) {
                 VStack(alignment: .leading, spacing: 2) {
-                    Text(result.title ?? "")
+                    Text(result.titleToDisplay)
                         .lineLimit(1)
                         .font(style: .subheadline, weight: .medium)
                     Text(result.authorToDisplay)

--- a/podcasts/New Search/Views/Results/PodcastCarouselView.swift
+++ b/podcasts/New Search/Views/Results/PodcastCarouselView.swift
@@ -107,7 +107,7 @@ struct PodcastResultCell: View {
 
             Button(action: { }) {
                 VStack(alignment: .leading, spacing: 2) {
-                    Text(result.title)
+                    Text(result.title ?? "")
                         .lineLimit(1)
                         .font(style: .subheadline, weight: .medium)
                     Text(result.authorToDisplay)

--- a/podcasts/New Search/Views/Results/SearchResultCell.swift
+++ b/podcasts/New Search/Views/Results/SearchResultCell.swift
@@ -54,7 +54,7 @@ struct SearchResultCell: View {
                                 .font(style: .subheadline, weight: .medium)
                                 .foregroundColor(AppTheme.color(for: .primaryText01, theme: theme))
                                 .lineLimit(2)
-                            Text(result.kind == .folder ? L10n.folder : result.author)
+                            Text(result.kind == .folder ? L10n.folder : result.authorToDisplay)
                                 .font(style: .caption, weight: .semibold)
                                 .foregroundColor(AppTheme.color(for: .primaryText02, theme: theme))
                                 .lineLimit(1)
@@ -72,5 +72,11 @@ struct SearchResultCell: View {
             }
             .padding(EdgeInsets(top: 12, leading: 8, bottom: 0, trailing: 0))
         }
+    }
+}
+
+extension PodcastFolderSearchResult {
+    var authorToDisplay: String {
+        author ?? ""
     }
 }

--- a/podcasts/New Search/Views/Results/SearchResultCell.swift
+++ b/podcasts/New Search/Views/Results/SearchResultCell.swift
@@ -50,7 +50,7 @@ struct SearchResultCell: View {
                                 .foregroundColor(AppTheme.color(for: .primaryText02, theme: theme))
                                 .lineLimit(1)
                         } else if let result {
-                            Text(result.title)
+                            Text(result.title ?? "")
                                 .font(style: .subheadline, weight: .medium)
                                 .foregroundColor(AppTheme.color(for: .primaryText01, theme: theme))
                                 .lineLimit(2)

--- a/podcasts/New Search/Views/Results/SearchResultCell.swift
+++ b/podcasts/New Search/Views/Results/SearchResultCell.swift
@@ -50,7 +50,7 @@ struct SearchResultCell: View {
                                 .foregroundColor(AppTheme.color(for: .primaryText02, theme: theme))
                                 .lineLimit(1)
                         } else if let result {
-                            Text(result.title ?? "")
+                            Text(result.titleToDisplay)
                                 .font(style: .subheadline, weight: .medium)
                                 .foregroundColor(AppTheme.color(for: .primaryText01, theme: theme))
                                 .lineLimit(2)
@@ -76,6 +76,10 @@ struct SearchResultCell: View {
 }
 
 extension PodcastFolderSearchResult {
+    var titleToDisplay: String {
+        title ?? ""
+    }
+
     var authorToDisplay: String {
         author ?? ""
     }

--- a/podcasts/PodcastImage.swift
+++ b/podcasts/PodcastImage.swift
@@ -12,6 +12,12 @@ struct PodcastImage: View {
 
     var body: some View {
         KFImage(ImageManager.sharedManager.podcastUrl(imageSize: size, uuid: uuid))
+            .placeholder { _ in
+                if let placeholder = ImageManager.sharedManager.placeHolderImage(size) {
+                    Image(uiImage: placeholder)
+                        .resizable()
+                }
+            }
             .resizable()
             .aspectRatio(1, contentMode: .fit)
             .accessibilityHidden(true)


### PR DESCRIPTION
Fixes search not returning results in case author is not available.

## To test

1. Run the app
2. Search for "Knifecast"
3. ✅ Podcasts results should appear

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
