### PR TITLE
Updates the podcast results scrollview on the new search to use the new HorizontalCarousel

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/Search/PodcastSearchTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Search/PodcastSearchTask.swift
@@ -58,6 +58,12 @@ public struct PodcastFolderSearchResult: Codable, Hashable {
     }
 }
 
+extension PodcastFolderSearchResult: Identifiable {
+    public var id: String {
+        uuid
+    }
+}
+
 public class PodcastSearchTask {
     private let session: URLSession
 

--- a/Modules/Utils/Sources/PocketCastsUtils/Extensions/Notification.Name+Publisher.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Extensions/Notification.Name+Publisher.swift
@@ -1,0 +1,14 @@
+import Combine
+import Foundation
+
+public extension NSNotification.Name {
+
+    /// Adds some simple to reduce boilerplate when converting a Notification.Name into a publisher
+    /// - Parameters:
+    ///   - center: The notification center to listen on
+    ///   - object: An optional object to listen on
+    /// - Returns: A new publisher on the given notification center
+    func publisher(in center: NotificationCenter = .default, object: AnyObject? = nil) -> NotificationCenter.Publisher {
+        center.publisher(for: self, object: object)
+    }
+}

--- a/podcasts/New Search/Views/Results/PodcastCarouselView.swift
+++ b/podcasts/New Search/Views/Results/PodcastCarouselView.swift
@@ -30,6 +30,11 @@ struct PodcastsCarouselView: View {
         UIScreen.main.bounds.width / Double(carouselItemsToDisplay)
     }
 
+    init() {
+        // Get the initial landscape value from the scene since UIDevice may not have the value yet
+        _isLandscape = State(initialValue: SceneHelper.foregroundActiveAppScene()?.interfaceOrientation.isLandscape ?? false)
+    }
+
     var body: some View {
         Group {
             if shouldShowLoadingActivity {

--- a/podcasts/New Search/Views/Results/PodcastCarouselView.swift
+++ b/podcasts/New Search/Views/Results/PodcastCarouselView.swift
@@ -53,10 +53,14 @@ struct PodcastsCarouselView: View {
                     PodcastResultCell(result: podcast)
                 }
                 .carouselPeekAmount(.constant(20))
-                .carouselItemSpacing(10)
-                .carouselItemsToDisplay(UIDevice.current.isiPad() ? 4 : 2)
-                .aspectRatio(UIDevice.current.isiPad() ? 4 : 1.75, contentMode: .fit)
-                .padding(.bottom, 10)
+                .carouselItemSpacing(16)
+                .carouselItemsToDisplay(carouselItemsToDisplay)
+
+                // Apply an aspect ratio to the carousel to auto adjust the height
+                // while maintaining the correct ratios for the items inside
+                .aspectRatio(Double(carouselItemsToDisplay) - Carousel.aspectRatio, contentMode: .fit)
+                .padding(.bottom, UIDevice.current.isiPad() ? 10 : 0)
+                .padding(.leading, 8)
 
             } else if !searchResults.isShowingLocalResultsOnly {
                 VStack(spacing: 2) {

--- a/podcasts/New Search/Views/Results/PodcastCarouselView.swift
+++ b/podcasts/New Search/Views/Results/PodcastCarouselView.swift
@@ -35,15 +35,15 @@ struct PodcastsCarouselView: View {
                     }
                 }
             } else if searchResults.podcasts.count > 0 {
-                ScrollView(.horizontal) {
-                    LazyHStack(spacing: 0) {
-                        ForEach(searchResults.podcasts, id: \.self) { podcast in
-                                PodcastResultCell(result: podcast)
-                                .padding(10)
-                                .frame(width: podcastCellWidth)
-                        }
-                    }
+                HorizontalCarousel(items: searchResults.podcasts) { podcast in
+                    PodcastResultCell(result: podcast)
                 }
+                .carouselPeekAmount(.constant(20))
+                .carouselItemSpacing(10)
+                .carouselItemsToDisplay(UIDevice.current.isiPad() ? 4 : 2)
+                .aspectRatio(UIDevice.current.isiPad() ? 4 : 1.75, contentMode: .fit)
+                .padding(.bottom, 10)
+
             } else if !searchResults.isShowingLocalResultsOnly {
                 VStack(spacing: 2) {
                     Text(L10n.discoverNoPodcastsFound)
@@ -60,7 +60,6 @@ struct PodcastsCarouselView: View {
             ThemedDivider()
                 .padding(.leading, 8)
         }
-        .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
         .background(AppTheme.color(for: .primaryUi02, theme: theme))
     }
 }

--- a/podcasts/New Search/Views/Results/PodcastCarouselView.swift
+++ b/podcasts/New Search/Views/Results/PodcastCarouselView.swift
@@ -62,6 +62,9 @@ struct PodcastsCarouselView: View {
                 .padding(.bottom, UIDevice.current.isiPad() ? 10 : 0)
                 .padding(.leading, 8)
 
+                // Set the id of the carousel to make sure the we reset the position when the search changes
+                .id(searchResults.podcasts.map { $0.id })
+
             } else if !searchResults.isShowingLocalResultsOnly {
                 VStack(spacing: 2) {
                     Text(L10n.discoverNoPodcastsFound)

--- a/podcasts/New Search/Views/Results/PodcastCarouselView.swift
+++ b/podcasts/New Search/Views/Results/PodcastCarouselView.swift
@@ -88,7 +88,7 @@ struct PodcastsCarouselView: View {
                 // Apply an aspect ratio to the carousel to auto adjust the height
                 // while maintaining the correct ratios for the items inside
                 .aspectRatio(Double(carouselItemsToDisplay) - Carousel.aspectRatio, contentMode: .fit)
-                .padding(.bottom, UIDevice.current.isiPad() ? 10 : 0)
+                .padding(.bottom, 10)
                 .padding(.leading, 8)
 
                 // Set the id of the carousel to make sure the we reset the position when the search changes

--- a/podcasts/New Search/Views/Results/PodcastCarouselView.swift
+++ b/podcasts/New Search/Views/Results/PodcastCarouselView.swift
@@ -49,8 +49,32 @@ struct PodcastsCarouselView: View {
                     }
                 }
             } else if searchResults.podcasts.count > 0 {
-                HorizontalCarousel(items: searchResults.podcasts) { podcast in
+                let fillerPodcast = Podcast.previewPodcast()
+
+                // If needed, fill the results with filler podcasts to make sure the sizing and positioning is consistent
+                let results: [PodcastFolderSearchResult] = {
+                    let results = searchResults.podcasts
+                    let minCount = carouselItemsToDisplay + 1 // + 1 to have a fake peeking item
+
+                    guard results.count < minCount else {
+                        return results
+                    }
+
+                    let diff = minCount - results.count
+
+                    let filler = PodcastFolderSearchResult(from: fillerPodcast).flatMap {
+                        Array(repeating: $0, count: diff)
+                    } ?? []
+
+                    return results + filler
+                }()
+
+                HorizontalCarousel(items: results) { podcast in
+                    let isFiller = podcast.uuid == fillerPodcast.uuid
+
                     PodcastResultCell(result: podcast)
+                        .opacity(isFiller ? 0 : 1)
+                        .allowsHitTesting(isFiller ? false : true)
                 }
                 .carouselPeekAmount(.constant(20))
                 .carouselItemSpacing(16)

--- a/podcasts/SwiftUI/DismissKeyboardOnScroll.swift
+++ b/podcasts/SwiftUI/DismissKeyboardOnScroll.swift
@@ -20,6 +20,6 @@ public struct DismissKeyboardOnScroll: ViewModifier {
 
     public func body(content: Content) -> some View {
         content
-            .highPriorityGesture(gesture)
+            .simultaneousGesture(gesture)
     }
 }

--- a/podcasts/SwiftUI/HorizontalCarousel.swift
+++ b/podcasts/SwiftUI/HorizontalCarousel.swift
@@ -101,6 +101,8 @@ struct HorizontalCarousel<Content: View, T: Identifiable>: View {
                         .frame(width: max(0, itemWidth - spacing))
                 }
             }
+            .frame(minWidth: proxy.size.width, alignment: .leading)
+
             // Apply a little spring animation while gesturing so it doesn't feel so ... boring ... but not too much
             // to make the entire thing spring around. To add more springyness up the damping
             .animation(.interpolatingSpring(stiffness: 350, damping: 30, initialVelocity: 10), value: gestureOffset)

--- a/podcasts/SwiftUI/HorizontalCarousel.swift
+++ b/podcasts/SwiftUI/HorizontalCarousel.swift
@@ -60,10 +60,6 @@ struct HorizontalCarousel<Content: View, T: Identifiable>: View {
             let baseWidth = proxy.size.width - spacing
 
             let peekAmount: Double = {
-                guard maxPages > 1 else {
-                    return 0
-                }
-
                 switch self.peekAmount {
                 case let .constant(value):
                     return value

--- a/podcasts/SwiftUI/HorizontalCarousel.swift
+++ b/podcasts/SwiftUI/HorizontalCarousel.swift
@@ -83,7 +83,7 @@ struct HorizontalCarousel<Content: View, T: Identifiable>: View {
                 let isLast = visibleIndex == maxPages
 
                 // Add the leading padding and calculate the current item offset
-                var x = spacing + (CGFloat(visibleIndex) * -itemWidth)
+                var x = (CGFloat(visibleIndex) * -itemWidth)
 
                 // If we're displaying the last item, then adjust the offset so we show the peek on the leading side
                 if isLast {

--- a/podcasts/SwiftUI/HorizontalCarousel.swift
+++ b/podcasts/SwiftUI/HorizontalCarousel.swift
@@ -139,6 +139,7 @@ struct HorizontalCarousel<Content: View, T: Identifiable>: View {
             // Keep the next page within the page bounds
             .clamped(to: 0..<maxPages)
             // Prevent the next page from being more than page item away
+            .clamped(to: visibleIndex-itemsToDisplay..<visibleIndex+itemsToDisplay)
     }
 
 

--- a/podcasts/SwiftUI/HorizontalCarousel.swift
+++ b/podcasts/SwiftUI/HorizontalCarousel.swift
@@ -92,13 +92,17 @@ struct HorizontalCarousel<Content: View, T: Identifiable>: View {
                 return x
             }()
 
+            let visibleFrame = proxy.frame(in: .global)
+
             // The actual carousel
             HStack(spacing: spacing) {
                 ForEach(items) { item in
-                    content(item)
-                        // Update each items width according to the calculated width above
-                        // We apply the spacing again to apply the trailing spacing
-                        .frame(width: max(0, itemWidth - spacing))
+                    // Lazy load the content to improve performance
+                    LazyLoadingView(visibleFrame: visibleFrame) {
+                        content(item)
+                    }
+                    // Update each items width according to the calculated width above
+                    .frame(width: max(0, itemWidth - spacing))
                 }
             }
             .frame(minWidth: proxy.size.width, alignment: .leading)

--- a/podcasts/SwiftUI/HorizontalCarousel.swift
+++ b/podcasts/SwiftUI/HorizontalCarousel.swift
@@ -100,9 +100,8 @@ struct HorizontalCarousel<Content: View, T: Identifiable>: View {
             HStack(spacing: spacing) {
                 ForEach(items) { item in
                     content(item)
-                    // Update each items width according to the calculated width above
-                    // We apply the spacing again to apply the trailing spacing
-                        .frame(width: itemWidth - spacing)
+                        // Update each items width according to the calculated width above
+                        // We apply the spacing again to apply the trailing spacing
                 }
             }
             // Apply a little spring animation while gesturing so it doesn't feel so ... boring ... but not too much
@@ -124,7 +123,7 @@ struct HorizontalCarousel<Content: View, T: Identifiable>: View {
                         // Inform the listening of index changes while we're dragging
                         index = calculateIndex(value.translation, itemWidth: itemWidth)
                     }
-                // Keep track of the gesture's offset so we can "scroll"
+                    // Keep track of the gesture's offset so we can "scroll"
                     .updating($gestureOffset, body: { value, state, _ in
                         state = value.translation.width
                     })
@@ -137,10 +136,9 @@ struct HorizontalCarousel<Content: View, T: Identifiable>: View {
         let offset = (-translation.width / itemWidth).rounded()
 
         return (visibleIndex + Int(offset))
-        // Keep the next page within the page bounds
+            // Keep the next page within the page bounds
             .clamped(to: 0..<maxPages)
-        // Prevent the next page from being more than page item away
-            .clamped(to: visibleIndex-1..<visibleIndex+1)
+            // Prevent the next page from being more than page item away
     }
 
 

--- a/podcasts/SwiftUI/HorizontalCarousel.swift
+++ b/podcasts/SwiftUI/HorizontalCarousel.swift
@@ -102,6 +102,7 @@ struct HorizontalCarousel<Content: View, T: Identifiable>: View {
                     content(item)
                         // Update each items width according to the calculated width above
                         // We apply the spacing again to apply the trailing spacing
+                        .frame(width: max(0, itemWidth - spacing))
                 }
             }
             // Apply a little spring animation while gesturing so it doesn't feel so ... boring ... but not too much

--- a/podcasts/SwiftUI/HorizontalCarousel.swift
+++ b/podcasts/SwiftUI/HorizontalCarousel.swift
@@ -57,7 +57,7 @@ struct HorizontalCarousel<Content: View, T: Identifiable>: View {
 
     var body: some View {
         GeometryReader { proxy in
-            let baseWidth = proxy.size.width - spacing
+            let baseWidth = proxy.size.width
 
             let peekAmount: Double = {
                 switch self.peekAmount {
@@ -83,7 +83,7 @@ struct HorizontalCarousel<Content: View, T: Identifiable>: View {
 
                 // If we're displaying the last item, then adjust the offset so we show the peek on the leading side
                 if isLast {
-                    x += peekAmount + spacing
+                    x += peekAmount
                 }
 
                 // Apply the gesture offset so the view updates
@@ -231,6 +231,9 @@ struct HorizontalCarousel_Preview: PreviewProvider {
             VStack {
                 Spacer()
 
+                Text("🎠 HorizontalCarousel.swift")
+                    .font(.title)
+                    .fontWeight(.bold)
                 VStack {
                     HStack {
                         Text("Peek Type")
@@ -286,6 +289,7 @@ struct HorizontalCarousel_Preview: PreviewProvider {
                     isConstant ? .constant(peek) : .percent(peek)
                 )
                 .frame(height: 200)
+                .padding(.leading, 20)
 
                 Spacer()
             }

--- a/podcasts/SwiftUI/HorizontalCarousel.swift
+++ b/podcasts/SwiftUI/HorizontalCarousel.swift
@@ -83,7 +83,7 @@ struct HorizontalCarousel<Content: View, T: Identifiable>: View {
 
                 // If we're displaying the last item, then adjust the offset so we show the peek on the leading side
                 if isLast {
-                    x += peekAmount
+                    x += peekAmount + spacing
                 }
 
                 // Apply the gesture offset so the view updates

--- a/podcasts/SwiftUI/HorizontalCarousel.swift
+++ b/podcasts/SwiftUI/HorizontalCarousel.swift
@@ -107,11 +107,13 @@ struct HorizontalCarousel<Content: View, T: Identifiable>: View {
             // to make the entire thing spring around. To add more springyness up the damping
             .animation(.interpolatingSpring(stiffness: 350, damping: 30, initialVelocity: 10), value: gestureOffset)
             .offset(x: offsetX)
+
+            // Use a highPriorityGesture to give this priority when enclosed in another view with gestures
             .highPriorityGesture(
                 DragGesture()
-                // When the gesture is done, we use the predictedEnd calculate the next page based on the
-                // gestures momentum
                     .onEnded { value in
+                        // When the gesture is done, we use the predictedEnd calculate the next page based on the
+                        // gestures momentum
                         let endIndex = calculateIndex(value.predictedEndTranslation, itemWidth: itemWidth)
 
                         // We're done animating so snap to the next index
@@ -122,8 +124,8 @@ struct HorizontalCarousel<Content: View, T: Identifiable>: View {
                         // Inform the listening of index changes while we're dragging
                         index = calculateIndex(value.translation, itemWidth: itemWidth)
                     }
-                    // Keep track of the gesture's offset so we can "scroll"
                     .updating($gestureOffset, body: { value, state, _ in
+                        // Keep track of the gesture's offset so we can "scroll"
                         state = value.translation.width
                     })
             )


### PR DESCRIPTION
This updates the search carousel with the new carousel and also makes some improvements to the HorizontalCarousel:
- Adds lazy loading of the items to prevent performance issues
- Allows swiping to a full next page instead of just to the next item

This also makes some other changes:
- Changes the dismiss keyboard gesture to a `simultaneousGesture` to prevent it from eating the carousels gesture
- Adds iPad portrait and landscape dynamic number of carousel items

I also made a helper extension to convert a `NSNotification.Name` to a publisher without the extra boilerplate

Also, I'll need to cherry pick this into `release/7.36` but am targeting trunk since the carousel was already there.

## Demo Video

https://user-images.githubusercontent.com/793774/230679351-c67a4941-76de-4015-a9e4-1a5edd3bc46f.mov

## To test

1. Launch the app
2. Search for some podcasts
3. ✅ Verify the search appears and looks good
4. Swipe between pages
5. ✅ Verify it goes to the next page
6. Swipe back, ✅ Verify it works
7. Swipe to the end
8. ✅ Verify that works
9. Search for something that will return a single result
   - I used local search for a single podcast item
11. ✅ Verify this also works
12. Tap on a podcast and ✅ verify it opens
13. With the keyboard open swipe and ✅ verify the board dismisses
14. Test both on the Podcast tab and Discover tab
15. Test on iPad Portrait and Landscape, iPhone SE and  iOS 15.5

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
