### PR TITLE
Update git s3 cache plugin to the latest version

### DIFF
--- a/.buildkite/cache_builder.yml
+++ b/.buildkite/cache_builder.yml
@@ -7,7 +7,7 @@
 common_params:
   - &common_plugins
     - automattic/a8c-ci-toolkit#2.13.0
-    - automattic/git-s3-cache#v1.1.3:
+    - automattic/git-s3-cache#1.1.4:
         bucket: a8c-repo-mirrors
         repo: automattic/pocket-casts-ios/
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,7 +3,7 @@ common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
     - automattic/a8c-ci-toolkit#2.13.0
-    - automattic/git-s3-cache#v1.1.3:
+    - automattic/git-s3-cache#1.1.4:
         bucket: a8c-repo-mirrors
         repo: automattic/pocket-casts-ios/
   # Common environment values to use with the `env` key.


### PR DESCRIPTION
What says in the title. This change is good to go as long as CI passes.