### PR TITLE
Carousel: Fix an issue where the next page animation could happen too fast

### DIFF
--- a/podcasts/SwiftUI/HorizontalCarousel.swift
+++ b/podcasts/SwiftUI/HorizontalCarousel.swift
@@ -13,6 +13,7 @@ struct HorizontalCarousel<Content: View, T: Identifiable>: View {
     private var itemsToDisplay = 1
     private var spacing: Double = 0
     private var peekAmount: PeekAmount = .constant(10)
+    private var swipeAnimation: Animation = .interpolatingSpring(stiffness: 350, damping: 30)
 
     private let items: [T]
     private let content: (T) -> Content
@@ -47,6 +48,13 @@ struct HorizontalCarousel<Content: View, T: Identifiable>: View {
     func carouselPeekAmount(_ value: PeekAmount) -> Self {
         update { carousel in
             carousel.peekAmount = value
+        }
+    }
+
+    /// Update the animation that occurs when swiping between pages
+    func carouselSwipeAnimation(_ value: Animation) -> Self {
+        update { carousel in
+            carousel.swipeAnimation = value
         }
     }
 
@@ -107,10 +115,9 @@ struct HorizontalCarousel<Content: View, T: Identifiable>: View {
             }
             .frame(minWidth: proxy.size.width, alignment: .leading)
 
-            // Apply a little spring animation while gesturing so it doesn't feel so ... boring ... but not too much
-            // to make the entire thing spring around. To add more springyness up the damping
-            .animation(.interpolatingSpring(stiffness: 350, damping: 30, initialVelocity: 10), value: gestureOffset)
-            .offset(x: offsetX)
+            // Animate the swiping / page changes
+            .animation(swipeAnimation, value: gestureOffset)
+            .animation(swipeAnimation, value: visibleIndex)
 
             // Use a highPriorityGesture to give this priority when enclosed in another view with gestures
             .highPriorityGesture(

--- a/podcasts/SwiftUI/HorizontalCarousel.swift
+++ b/podcasts/SwiftUI/HorizontalCarousel.swift
@@ -4,6 +4,7 @@ import SwiftUI
 /// - `carouselItemsToDisplay` to change how many of the `items` will be displayed per page
 /// - `carouselItemSpacing` to adjust the spacing between the items
 /// - `carouselPeekAmount` to control how much (if any) of the next item on the next page should display
+/// - `carouselSwipeAnimation` to change the swipe/page change animation
 /// Add the `currentIndex` binding to be notified when the page changes
 struct HorizontalCarousel<Content: View, T: Identifiable>: View {
     /// Binding for the currently selected index

--- a/podcasts/SwiftUI/HorizontalCarousel.swift
+++ b/podcasts/SwiftUI/HorizontalCarousel.swift
@@ -119,6 +119,8 @@ struct HorizontalCarousel<Content: View, T: Identifiable>: View {
             .animation(swipeAnimation, value: gestureOffset)
             .animation(swipeAnimation, value: visibleIndex)
 
+            .offset(x: dampenOffset(offsetX))
+
             // Use a highPriorityGesture to give this priority when enclosed in another view with gestures
             .highPriorityGesture(
                 DragGesture()
@@ -154,6 +156,17 @@ struct HorizontalCarousel<Content: View, T: Identifiable>: View {
             .clamped(to: visibleIndex-itemsToDisplay..<visibleIndex+itemsToDisplay)
     }
 
+    /// Dampens the offset for the first and last pages
+    private func dampenOffset(_ offset: Double) -> Double {
+        guard visibleIndex == 0 || visibleIndex == maxPages else {
+            return offset
+        }
+
+        // Scale the gesture offset down for the first and last items
+        let adjustedOffset = offset - (gestureOffset * 0.7)
+
+        return visibleIndex == 0 ? min(offset, adjustedOffset) : max(offset, adjustedOffset)
+    }
 
     /// Passes a mutable version of self to the block and returns the modified version
     private func update(_ block: (inout Self) -> Void) -> Self {


### PR DESCRIPTION
This adds the animation when changing the visibleIndex to prevent it from messing with the gesture offset animation and causing it to jump. 

This also:
- Allows the swipe animation to be configured
- Adds a damping effect for the first and last pages to reduce the effect of the gesture offset

## To test

1. Launch the app
2. Open the search
3. Swipe to the left
4. ✅ Verify it feels harder to swipe
5. Swipe to the last page, and swipe to the right
6. ✅ Verify it feels harder to swipe
7. ✅ Verify the swipe animation doesn't jump

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
