### PR TITLE
Use CI Toolkit SPM caching action

### DIFF
--- a/.buildkite/cache_builder.yml
+++ b/.buildkite/cache_builder.yml
@@ -6,7 +6,7 @@
 # Nodes with values to reuse in the pipeline.
 common_params:
   - &common_plugins
-    - automattic/a8c-ci-toolkit#2.13.0
+    - automattic/a8c-ci-toolkit#2.15.1
     - automattic/git-s3-cache#1.1.4:
         bucket: a8c-repo-mirrors
         repo: automattic/pocket-casts-ios/

--- a/.buildkite/commands/build.sh
+++ b/.buildkite/commands/build.sh
@@ -19,10 +19,8 @@ add_host_to_ssh_known_hosts 'github.com'
 export GIT_SSH_COMMAND="ssh -i $PRIVATE_REPO_FETCH_KEY -o IdentitiesOnly=yes"
 echo "Git SSH command is $GIT_SSH_COMMAND"
 
-# This is so Xcode use the built-in source control management, therefore using
-# the custom key we just set to fetch our private repos, otherwise it won't be
-# able to.
-sudo defaults write com.apple.dt.Xcode IDEPackageSupportUseBuiltinSCM YES
+echo "--- :swift: Installing Swift Package Manager Dependencies"
+install_swiftpm_dependencies
 
 echo "--- Setup Ruby tooling"
 

--- a/.buildkite/commands/release-build.sh
+++ b/.buildkite/commands/release-build.sh
@@ -1,5 +1,8 @@
 #!/bin/bash -eu
 
+echo "--- :swift: Installing Swift Package Manager Dependencies"
+install_swiftpm_dependencies
+
 echo "--- :rubygems: Setting up Gems"
 install_gems
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,7 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/a8c-ci-toolkit#2.13.0
+    - automattic/a8c-ci-toolkit#2.15.1
     - automattic/git-s3-cache#1.1.4:
         bucket: a8c-repo-mirrors
         repo: automattic/pocket-casts-ios/

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -4,7 +4,7 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/a8c-ci-toolkit#2.13.0
+    - automattic/a8c-ci-toolkit#2.15.1
     - automattic/git-s3-cache#v1.1.3:
         bucket: "a8c-repo-mirrors"
         repo: "automattic/pocket-casts-ios/"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -138,7 +138,8 @@ platform :ios do
 
     gym(
       scheme: 'pocketcasts',
-      include_bitcode: false      clean: true
+      include_bitcode: false,
+      clean: true
     )
     clean_build_artifacts
     sh(command: 'rm -fr ~/Library/Developer/Xcode/Archives/*')

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -11,7 +11,6 @@ APP_STORE_METADATA_FOLDER = File.join(FASTLANE_FOLDER, 'metadata')
 SECRETS_FOLDER = File.join(Dir.home, '.configure', 'pocketcasts-ios', 'secrets')
 ASC_KEY_PATH = File.join(SECRETS_FOLDER, 'app_store_connect_fastlane_api_key.json')
 VERSION_XCCONFIG_PATH = File.join(PROJECT_ROOT_FOLDER, 'config', 'Version.xcconfig')
-SPM_CACHE_FOLDER = File.join(PROJECT_ROOT_FOLDER, 'vendor', 'spm')
 RESOURCES_FOLDER = File.join(PROJECT_ROOT_FOLDER, 'podcasts', 'Resources')
 RELEASE_NOTES_SOURCE_PATH = File.join(PROJECT_ROOT_FOLDER, 'CHANGELOG.md')
 EXTRACTED_RELEASE_NOTES_PATH = File.join(RESOURCES_FOLDER, 'release_notes.txt')
@@ -122,14 +121,9 @@ platform :ios do
 
   desc 'Run the unit tests'
   lane :test do
-    load_ci_spm_cache
-
     run_tests(
-      scheme: 'pocketcasts',
-      cloned_source_packages_path: SPM_CACHE_FOLDER
+      scheme: 'pocketcasts'
     )
-
-    save_ci_spm_cache
   end
 
   desc 'Build the project only'
@@ -141,18 +135,13 @@ platform :ios do
     end
 
     configure_code_signing
-    load_ci_spm_cache
 
     gym(
       scheme: 'pocketcasts',
-      include_bitcode: false,
-      cloned_source_packages_path: SPM_CACHE_FOLDER,
-      clean: true
+      include_bitcode: false      clean: true
     )
     clean_build_artifacts
     sh(command: 'rm -fr ~/Library/Developer/Xcode/Archives/*')
-
-    save_ci_spm_cache
   end
 
   desc 'This lane downloads and configures the code signing certificates and profiles.'
@@ -907,25 +896,6 @@ inal copy, and try again.")
       project_slug: SENTRY_PROJECT_SLUG,
       dsym_path: symbols_path
     )
-  end
-
-  def load_ci_spm_cache
-    # Handling SPM caching for CI here for now to avoid having two sources of
-    # truth for what the cache key is. The alternative would be to call the
-    # save and restore cache commands in the CI pipeline and then duplicate the
-    # logic to get the key here.
-    sh(command: %(restore_cache "#{ci_spm_cache_key}")) if is_ci
-  end
-
-  def save_ci_spm_cache
-    sh(command: %(save_cache #{SPM_CACHE_FOLDER} "#{ci_spm_cache_key}")) if is_ci
-  end
-
-  def ci_spm_cache_key
-    UI.user_error! 'This function should be called from the Buildkite CI only!' unless is_ci
-
-    hash = sh(command: 'hash_file "../podcasts.xcworkspace/xcshareddata/swiftpm/Package.resolved"').rstrip
-    "$BUILDKITE_PIPELINE_SLUG-spm-cache-#{hash}"
   end
 
   def create_merge_release_branch


### PR DESCRIPTION
This PR uses the Swift Package Manager caching action from the CI Toolkit to replace the SPM caching mechanism that was added directly in the Fastfile. From the CI builds on this branch, it looks like it will only take 3-4 minutes to restore and use the SPM cache. 

## To test

You can verify that the action is working by looking at these Buildkite runs: 

Building the cache and uploading it: [#1](https://buildkite.com/automattic/pocket-casts-ios/builds/3381#01879154-c0ae-4ae8-8f3f-608651fad887/250)

Downloading and using the cache: [#1](https://buildkite.com/automattic/pocket-casts-ios/builds/3383#01879196-79ee-475a-98ba-0cce41c51658/248), [#2](https://buildkite.com/automattic/pocket-casts-ios/builds/3382#01879178-759d-46b0-8275-05edf30ad8f4/250)


## Checklist

- [X] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [X] I have considered adding unit tests for my changes.
- [X] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
