### PR TITLE
Load embedded artwork when streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 7.38
 -----
-
+- Embedded artwork: extract embedded artwork from episodes that are being streamed (#829)
 
 7.37
 -----

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -520,7 +520,6 @@
 		8B7298F829144EEC0059C077 /* PodcastCover.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B7298F729144EEC0059C077 /* PodcastCover.swift */; };
 		8B738F3128F5CBE0004E7526 /* StoriesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B738F3028F5CBE0004E7526 /* StoriesView.swift */; };
 		8B87C47C29F0129A00257B96 /* StreamingEpisodeArtwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B87C47B29F0129A00257B96 /* StreamingEpisodeArtwork.swift */; };
-		8B87C47D29F0129A00257B96 /* StreamingEpisodeArtwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B87C47B29F0129A00257B96 /* StreamingEpisodeArtwork.swift */; };
 		8B938E2B29BFB4F2008997B9 /* SearchAnalyticsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B938E2A29BFB4F2008997B9 /* SearchAnalyticsHelper.swift */; };
 		8B99197429A67A7100A5C81C /* SearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B99197329A67A7100A5C81C /* SearchView.swift */; };
 		8B99197729A686BA00A5C81C /* SearchResultsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B99197629A686BA00A5C81C /* SearchResultsView.swift */; };
@@ -8535,7 +8534,6 @@
 				BDD301931EFB9979004A9972 /* SessionManager.swift in Sources */,
 				BDE48A372410D4E300ECA6CA /* WatchNowPlayingHelper.swift in Sources */,
 				BDE48A1C2410D07300ECA6CA /* PlaybackProtocol.swift in Sources */,
-				8B87C47D29F0129A00257B96 /* StreamingEpisodeArtwork.swift in Sources */,
 				46666F0627D1289F00A141AA /* EpisodeAction.swift in Sources */,
 				40F8344C245028BE009FF284 /* WatchSyncManager+Autodownload.swift in Sources */,
 				46A2763D27C6ADAD0053557E /* SwiftUI+Constants.swift in Sources */,

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -519,6 +519,8 @@
 		8B723755291185B300FA8219 /* Analytics+story.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B723754291185B300FA8219 /* Analytics+story.swift */; };
 		8B7298F829144EEC0059C077 /* PodcastCover.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B7298F729144EEC0059C077 /* PodcastCover.swift */; };
 		8B738F3128F5CBE0004E7526 /* StoriesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B738F3028F5CBE0004E7526 /* StoriesView.swift */; };
+		8B87C47C29F0129A00257B96 /* StreamingEpisodeArtwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B87C47B29F0129A00257B96 /* StreamingEpisodeArtwork.swift */; };
+		8B87C47D29F0129A00257B96 /* StreamingEpisodeArtwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B87C47B29F0129A00257B96 /* StreamingEpisodeArtwork.swift */; };
 		8B938E2B29BFB4F2008997B9 /* SearchAnalyticsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B938E2A29BFB4F2008997B9 /* SearchAnalyticsHelper.swift */; };
 		8B99197429A67A7100A5C81C /* SearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B99197329A67A7100A5C81C /* SearchView.swift */; };
 		8B99197729A686BA00A5C81C /* SearchResultsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B99197629A686BA00A5C81C /* SearchResultsView.swift */; };
@@ -2163,6 +2165,7 @@
 		8B723754291185B300FA8219 /* Analytics+story.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Analytics+story.swift"; sourceTree = "<group>"; };
 		8B7298F729144EEC0059C077 /* PodcastCover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PodcastCover.swift; sourceTree = "<group>"; };
 		8B738F3028F5CBE0004E7526 /* StoriesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoriesView.swift; sourceTree = "<group>"; };
+		8B87C47B29F0129A00257B96 /* StreamingEpisodeArtwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamingEpisodeArtwork.swift; sourceTree = "<group>"; };
 		8B938E2A29BFB4F2008997B9 /* SearchAnalyticsHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchAnalyticsHelper.swift; sourceTree = "<group>"; };
 		8B99197329A67A7100A5C81C /* SearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchView.swift; sourceTree = "<group>"; };
 		8B99197629A686BA00A5C81C /* SearchResultsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultsView.swift; sourceTree = "<group>"; };
@@ -4578,6 +4581,7 @@
 			children = (
 				BD5294281B564417007A0B1D /* PlaybackItem.swift */,
 				BDB4E7D3240E3C7A005770E3 /* DefaultPlayer.swift */,
+				8B87C47B29F0129A00257B96 /* StreamingEpisodeArtwork.swift */,
 			);
 			name = "Default Player";
 			sourceTree = "<group>";
@@ -8014,6 +8018,7 @@
 				BD056F111F6F8CE800AF8260 /* MainTabBarController.swift in Sources */,
 				BD26AFD727BE09E8008CC973 /* EditFolderView.swift in Sources */,
 				BD585C232047B9A400AC842C /* SharedItemImporter.swift in Sources */,
+				8B87C47C29F0129A00257B96 /* StreamingEpisodeArtwork.swift in Sources */,
 				4041FEA1218AA5EC0089D4A1 /* SiriShortcutAddCell.swift in Sources */,
 				403D1AB42281C36100CE7C9B /* AccountViewController+TableView.swift in Sources */,
 				BDD5CA002303E8FA005E133C /* ThemeableUIButton.swift in Sources */,
@@ -8530,6 +8535,7 @@
 				BDD301931EFB9979004A9972 /* SessionManager.swift in Sources */,
 				BDE48A372410D4E300ECA6CA /* WatchNowPlayingHelper.swift in Sources */,
 				BDE48A1C2410D07300ECA6CA /* PlaybackProtocol.swift in Sources */,
+				8B87C47D29F0129A00257B96 /* StreamingEpisodeArtwork.swift in Sources */,
 				46666F0627D1289F00A141AA /* EpisodeAction.swift in Sources */,
 				40F8344C245028BE009FF284 /* WatchSyncManager+Autodownload.swift in Sources */,
 				46A2763D27C6ADAD0053557E /* SwiftUI+Constants.swift in Sources */,

--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -24,7 +24,6 @@ struct Constants {
         static let dimmingViewTapped = NSNotification.Name(rawValue: "SJDimViewTapped")
         static let downloadProgress = NSNotification.Name(rawValue: "SJDwnProg")
         static let podcastImageReCacheRequired = NSNotification.Name(rawValue: "PCPodcastImageReCacheRequired")
-        static let episodeEmbeddedArtworkLoaded = NSNotification.Name(rawValue: "PCEpisodeEmbeddedArtworkLoaded")
 
         static let skipTimesChanged = NSNotification.Name(rawValue: "SJSkipTimesChanged")
         static let subscribeRequestedFromCell = NSNotification.Name(rawValue: "SJSubscribeRequestFromCell")

--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -24,6 +24,7 @@ struct Constants {
         static let dimmingViewTapped = NSNotification.Name(rawValue: "SJDimViewTapped")
         static let downloadProgress = NSNotification.Name(rawValue: "SJDwnProg")
         static let podcastImageReCacheRequired = NSNotification.Name(rawValue: "PCPodcastImageReCacheRequired")
+        static let episodeEmbeddedArtworkLoaded = NSNotification.Name(rawValue: "PCEpisodeEmbeddedArtworkLoaded")
 
         static let skipTimesChanged = NSNotification.Name(rawValue: "SJSkipTimesChanged")
         static let subscribeRequestedFromCell = NSNotification.Name(rawValue: "SJSubscribeRequestFromCell")

--- a/podcasts/DefaultPlayer.swift
+++ b/podcasts/DefaultPlayer.swift
@@ -671,9 +671,10 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
     }
 
     func loadEmbeddedImage() {
-        let playerItem = player?.currentItem
-        if let asset = playerItem?.asset, let episodeUuid {
-            StreamingEpisodeArtwork.shared.loadEmbeddedImage(asset: asset, episodeUuid: episodeUuid)
+        guard let asset = player?.currentItem?.asset, let episodeUuid else {
+            return
         }
+
+        StreamingEpisodeArtwork.shared.loadEmbeddedImage(asset: asset, episodeUuid: episodeUuid)
     }
 }

--- a/podcasts/DefaultPlayer.swift
+++ b/podcasts/DefaultPlayer.swift
@@ -36,6 +36,10 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
     private var episodeUuid: String?
 
     #if !os(watchOS)
+        private lazy var streamingArtwork: StreamingEpisodeArtwork = {
+            StreamingEpisodeArtwork()
+        }()
+
         private var peakLimiter: AudioUnit?
         private var highPassFilter: AudioUnit?
         private var sampleCount: Float64 = 0
@@ -671,12 +675,12 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
     }
 
     func loadEmbeddedImage() {
+        #if !os(watchOS)
         guard let asset = player?.currentItem?.asset, let episodeUuid else {
             return
         }
 
-        #if !os(watchOS)
-        StreamingEpisodeArtwork.shared.loadEmbeddedImage(asset: asset, episodeUuid: episodeUuid)
+        streamingArtwork.loadEmbeddedImage(asset: asset, episodeUuid: episodeUuid)
         #endif
     }
 }

--- a/podcasts/DefaultPlayer.swift
+++ b/podcasts/DefaultPlayer.swift
@@ -33,6 +33,8 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
     private var playFailedObserver: NSObjectProtocol?
     private var playStalledObserver: NSObjectProtocol?
 
+    private var episodeUuid: String?
+
     #if !os(watchOS)
         private var peakLimiter: AudioUnit?
         private var highPassFilter: AudioUnit?
@@ -61,6 +63,8 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
         isWaitingForInitialPlayback = true
 
         player = AVPlayer(playerItem: playerItem)
+
+        episodeUuid = episode.uuid
 
         configurePlayer(videoPodcast: episode.videoPodcast())
     }
@@ -226,6 +230,8 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
         }
 
         if assetTrack == nil, player?.currentItem?.status == .readyToPlay, let tracks = player?.currentItem?.asset.tracks {
+            loadEmbeddedImage()
+
             for track in tracks {
                 if track.mediaType == AVMediaType.audio {
                     assetTrack = track
@@ -662,5 +668,12 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
 
     func hash(into hasher: inout Hasher) {
         hasher.combine(ObjectIdentifier(self))
+    }
+
+    func loadEmbeddedImage() {
+        let playerItem = player?.currentItem
+        if let asset = playerItem?.asset, let episodeUuid {
+            StreamingEpisodeArtwork.shared.loadEmbeddedImage(asset: asset, episodeUuid: episodeUuid)
+        }
     }
 }

--- a/podcasts/DefaultPlayer.swift
+++ b/podcasts/DefaultPlayer.swift
@@ -675,6 +675,8 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
             return
         }
 
+        #if !os(watchOS)
         StreamingEpisodeArtwork.shared.loadEmbeddedImage(asset: asset, episodeUuid: episodeUuid)
+        #endif
     }
 }

--- a/podcasts/ImageManager.swift
+++ b/podcasts/ImageManager.swift
@@ -226,8 +226,8 @@ class ImageManager {
             }
         }
 
-        if EmbeddedArtworkCache.shared.isCached(episodeUuid: episode.uuid) {
-            EmbeddedArtworkCache.shared.get(for: episode.uuid) { result in
+        if StreamingEpisodeArtwork.shared.isCached(episodeUuid: episode.uuid) {
+            StreamingEpisodeArtwork.shared.get(for: episode.uuid) { result in
                 switch result {
                 case .success(let imageCache):
                     imageView?.image = imageCache.image

--- a/podcasts/ImageManager.swift
+++ b/podcasts/ImageManager.swift
@@ -115,7 +115,7 @@ class ImageManager {
     }
 
     func loadImage(episode: BaseEpisode, imageView: UIImageView, size: PodcastThumbnailSize) {
-        if loadEmbeddedImageIfRequired(in: episode, into: imageView, completion: nil) {
+        if loadEmbeddedImageIfRequired(in: episode, into: imageView) {
             return
         }
 
@@ -183,7 +183,7 @@ class ImageManager {
     }
 
     func imageForEpisode(_ episode: BaseEpisode, size: PodcastThumbnailSize, completionHandler: @escaping ((UIImage?) -> Void)) {
-        if loadEmbeddedImageIfRequired(in: episode, into: nil, completion: { image in
+        if loadEmbeddedImageIfRequired(in: episode, completion: { image in
             completionHandler(image)
         }) {
             return
@@ -208,7 +208,7 @@ class ImageManager {
         }
     }
 
-    private func loadEmbeddedImageIfRequired(in episode: BaseEpisode, into imageView: UIImageView?, completion: ((UIImage?) -> Void)?) -> Bool {
+    private func loadEmbeddedImageIfRequired(in episode: BaseEpisode, into imageView: UIImageView? = nil, completion: ((UIImage?) -> Void)? = nil) -> Bool {
         // if the user has opted to use embedded artwork, try to load that
         guard Settings.loadEmbeddedImages else {
             return false

--- a/podcasts/ImageManager.swift
+++ b/podcasts/ImageManager.swift
@@ -226,7 +226,7 @@ class ImageManager {
             }
         }
 
-        if EmbeddedArtworkCache.shared.isCache(episodeUuid: episode.uuid) {
+        if EmbeddedArtworkCache.shared.isCached(episodeUuid: episode.uuid) {
             EmbeddedArtworkCache.shared.get(for: episode.uuid) { result in
                 switch result {
                 case .success(let imageCache):

--- a/podcasts/ImageManager.swift
+++ b/podcasts/ImageManager.swift
@@ -210,7 +210,7 @@ class ImageManager {
 
     private func loadEmbeddedImageIfRequired(in episode: BaseEpisode, into imageView: UIImageView?, completion: ((UIImage?) -> Void)?) -> Bool {
         // if the user has opted to use embedded artwork, try to load that
-        guard UserDefaults.standard.bool(forKey: Constants.UserDefaults.loadEmbeddedImages) else {
+        guard Settings.loadEmbeddedImages else {
             return false
         }
 

--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -143,6 +143,8 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
 
         addCustomObserver(Constants.Notifications.podcastImageReCacheRequired, selector: #selector(updateRequired))
 
+        addCustomObserver(Constants.Notifications.episodeEmbeddedArtworkLoaded, selector: #selector(updateRequired))
+
         addCustomObserver(Constants.Notifications.upNextQueueChanged, selector: #selector(upNextListChanged))
         addCustomObserver(Constants.Notifications.podcastDeleted, selector: #selector(upNextListChanged))
 

--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -143,7 +143,7 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
 
         addCustomObserver(Constants.Notifications.podcastImageReCacheRequired, selector: #selector(updateRequired))
 
-        addCustomObserver(Constants.Notifications.episodeEmbeddedArtworkLoaded, selector: #selector(updateRequired))
+        addCustomObserver(.episodeEmbeddedArtworkLoaded, selector: #selector(updateRequired))
 
         addCustomObserver(Constants.Notifications.upNextQueueChanged, selector: #selector(upNextListChanged))
         addCustomObserver(Constants.Notifications.podcastDeleted, selector: #selector(upNextListChanged))

--- a/podcasts/Notifications.swift
+++ b/podcasts/Notifications.swift
@@ -13,6 +13,9 @@ extension NSNotification.Name {
     /// When the updated onboarding flow dismisses
     static let onboardingFlowDidDismiss = NSNotification.Name("Onboarding.didDismiss")
 
+    /// When the episode artwork is loaded
+    static let episodeEmbeddedArtworkLoaded = NSNotification.Name(rawValue: "PCEpisodeEmbeddedArtworkLoaded")
+
     static let tableViewReorderWillBegin = NSNotification.Name("TableView.ReorderWillBegin")
     static let tableViewReorderDidEnd = NSNotification.Name("TableView.ReorderDidEnd")
 }

--- a/podcasts/NowPlayingPlayerItemViewController+Update.swift
+++ b/podcasts/NowPlayingPlayerItemViewController+Update.swift
@@ -13,7 +13,7 @@ extension NowPlayingPlayerItemViewController {
         addCustomObserver(Constants.Notifications.podcastChaptersDidUpdate, selector: #selector(update))
         addCustomObserver(Constants.Notifications.googleCastStatusChanged, selector: #selector(update))
         addCustomObserver(Constants.Notifications.playbackEffectsChanged, selector: #selector(update))
-        addCustomObserver(Constants.Notifications.episodeEmbeddedArtworkLoaded, selector: #selector(update))
+        addCustomObserver(.episodeEmbeddedArtworkLoaded, selector: #selector(update))
         addCustomObserver(Constants.Notifications.podcastChapterChanged, selector: #selector(updateChapterInfo))
         addCustomObserver(Constants.Notifications.episodeDownloaded, selector: #selector(update))
         addCustomObserver(Constants.Notifications.sleepTimerChanged, selector: #selector(sleepTimerUpdated))

--- a/podcasts/NowPlayingPlayerItemViewController+Update.swift
+++ b/podcasts/NowPlayingPlayerItemViewController+Update.swift
@@ -13,6 +13,7 @@ extension NowPlayingPlayerItemViewController {
         addCustomObserver(Constants.Notifications.podcastChaptersDidUpdate, selector: #selector(update))
         addCustomObserver(Constants.Notifications.googleCastStatusChanged, selector: #selector(update))
         addCustomObserver(Constants.Notifications.playbackEffectsChanged, selector: #selector(update))
+        addCustomObserver(Constants.Notifications.episodeEmbeddedArtworkLoaded, selector: #selector(update))
         addCustomObserver(Constants.Notifications.podcastChapterChanged, selector: #selector(updateChapterInfo))
         addCustomObserver(Constants.Notifications.episodeDownloaded, selector: #selector(update))
         addCustomObserver(Constants.Notifications.sleepTimerChanged, selector: #selector(sleepTimerUpdated))

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -77,7 +77,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         NotificationCenter.default.addObserver(self, selector: #selector(handleEpisodeDidDownload(_:)), name: Constants.Notifications.episodeDownloaded, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(updateExtraActions), name: Constants.Notifications.extraMediaSessionActionsChanged, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(updateNowPlayingInfo), name: Constants.Notifications.userEpisodeUpdated, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(updateAllNowPlayingData), name: Constants.Notifications.episodeEmbeddedArtworkLoaded, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(updateAllNowPlayingData), name: .episodeEmbeddedArtworkLoaded, object: nil)
 
         // run these on a background queue because some of them might call our singleton instance back, causing a crash because PlaybackManager.shared is called from the init method
         DispatchQueue.global().async {

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -77,6 +77,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         NotificationCenter.default.addObserver(self, selector: #selector(handleEpisodeDidDownload(_:)), name: Constants.Notifications.episodeDownloaded, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(updateExtraActions), name: Constants.Notifications.extraMediaSessionActionsChanged, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(updateNowPlayingInfo), name: Constants.Notifications.userEpisodeUpdated, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(updateAllNowPlayingData), name: Constants.Notifications.episodeEmbeddedArtworkLoaded, object: nil)
 
         // run these on a background queue because some of them might call our singleton instance back, causing a crash because PlaybackManager.shared is called from the init method
         DispatchQueue.global().async {
@@ -1352,7 +1353,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         chapterManager.parseChapters(episode: episode, duration: duration())
     }
 
-    private func updateAllNowPlayingData() {
+    @objc private func updateAllNowPlayingData() {
         guard let episode = currentEpisode() else {
             #if os(watchOS)
                 WatchNowPlayingHelper.clearNowPlayingInfo()

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -776,6 +776,14 @@ class Settings: NSObject {
         }
     }
 
+    // MARK: - Embedded Artwork
+
+    static var loadEmbeddedImages: Bool {
+        get {
+            UserDefaults.standard.bool(forKey: Constants.UserDefaults.loadEmbeddedImages)
+        }
+    }
+
     // MARK: - Variables that are loaded/changed through Firebase
 
     #if !os(watchOS)

--- a/podcasts/StreamingEpisodeArtwork.swift
+++ b/podcasts/StreamingEpisodeArtwork.swift
@@ -5,12 +5,16 @@ import Kingfisher
 class StreamingEpisodeArtwork {
     static let shared = StreamingEpisodeArtwork()
 
-    /// Extract a UIImage from a given asset
+    /// Extract a UIImage from a given asset if embedded artwork option is enabled.
     /// If an image is extracted, `episodeEmbeddedArtworkLoaded` notification is triggered
     /// - Parameters:
     ///   - asset: an AVAsset
     ///   - episodeUuid: the UUID of the current playing episode
     func loadEmbeddedImage(asset: AVAsset, episodeUuid: String) {
+        guard Settings.loadEmbeddedImages, !EmbeddedArtworkCache.shared.isCache(episodeUuid: episodeUuid) else {
+            return
+        }
+
         // If it's already loaded and cached, do nothing
         let metadata = asset.metadata
         for item in metadata {

--- a/podcasts/StreamingEpisodeArtwork.swift
+++ b/podcasts/StreamingEpisodeArtwork.swift
@@ -24,7 +24,6 @@ class StreamingEpisodeArtwork {
             return
         }
 
-        // If it's already loaded and cached, do nothing
         let metadata = asset.metadata
         for item in metadata {
             if let key = item.commonKey?.rawValue, key == "artwork" {

--- a/podcasts/StreamingEpisodeArtwork.swift
+++ b/podcasts/StreamingEpisodeArtwork.swift
@@ -1,0 +1,61 @@
+import Foundation
+import Kingfisher
+
+/// Extracts artwork from a streaming episode (if there's any)
+class StreamingEpisodeArtwork {
+    static let shared = StreamingEpisodeArtwork()
+
+    /// Extract a UIImage from a given asset
+    /// If an image is extracted, `episodeEmbeddedArtworkLoaded` notification is triggered
+    /// - Parameters:
+    ///   - asset: an AVAsset
+    ///   - episodeUuid: the UUID of the current playing episode
+    func loadEmbeddedImage(asset: AVAsset, episodeUuid: String) {
+        // If it's already loaded and cached, do nothing
+        let metadata = asset.metadata
+        for item in metadata {
+            if let key = item.commonKey?.rawValue, key == "artwork" {
+                if let imageData = item.value as? Data {
+                    let image = UIImage(data: imageData)
+
+                    if let image {
+                        EmbeddedArtworkCache.shared.set(for: episodeUuid, image: image) {
+                            NotificationCenter.postOnMainThread(notification: Constants.Notifications.episodeEmbeddedArtworkLoaded)
+                        }
+                    }
+
+                }
+            }
+        }
+    }
+}
+
+
+/// Saves the embedded artwork of a streaming episode
+class EmbeddedArtworkCache {
+    static let shared = EmbeddedArtworkCache()
+
+    private var subscribedPodcastsCache: ImageCache
+
+    private init() {
+        let path = (NSHomeDirectory() as NSString).appendingPathComponent("Documents/artworkv3")
+        let url = URL(fileURLWithPath: path)
+        subscribedPodcastsCache = try! ImageCache(name: "subscribedPodcastsCache", cacheDirectoryURL: url)
+        subscribedPodcastsCache.diskStorage.config.sizeLimit = UInt(400.megabytes)
+        subscribedPodcastsCache.diskStorage.config.expiration = .days(365)
+    }
+
+    func set(for episodeUuid: String, image: UIImage, completion: (() -> Void)?) {
+        subscribedPodcastsCache.store(image, forKey: episodeUuid) { _ in
+            completion?()
+        }
+    }
+
+    func get(for episodeUuid: String, completionHandler: ((Result<ImageCacheResult, KingfisherError>) -> Void)?) {
+        subscribedPodcastsCache.retrieveImage(forKey: episodeUuid, options: .none, completionHandler: completionHandler)
+    }
+
+    func isCache(episodeUuid: String) -> Bool {
+        subscribedPodcastsCache.isCached(forKey: episodeUuid)
+    }
+}

--- a/podcasts/StreamingEpisodeArtwork.swift
+++ b/podcasts/StreamingEpisodeArtwork.swift
@@ -5,13 +5,22 @@ import Kingfisher
 class StreamingEpisodeArtwork {
     static let shared = StreamingEpisodeArtwork()
 
+    private lazy var subscribedPodcastsCache: ImageCache = {
+        let path = (NSHomeDirectory() as NSString).appendingPathComponent("Documents/artworkv3")
+        let url = URL(fileURLWithPath: path)
+        subscribedPodcastsCache = try! ImageCache(name: "subscribedPodcastsCache", cacheDirectoryURL: url)
+        subscribedPodcastsCache.diskStorage.config.sizeLimit = UInt(400.megabytes)
+        subscribedPodcastsCache.diskStorage.config.expiration = .days(365)
+        return subscribedPodcastsCache
+    }()
+
     /// Extract a UIImage from a given asset if embedded artwork option is enabled.
     /// If an image is extracted, `episodeEmbeddedArtworkLoaded` notification is triggered
     /// - Parameters:
     ///   - asset: an AVAsset
     ///   - episodeUuid: the UUID of the current playing episode
     func loadEmbeddedImage(asset: AVAsset, episodeUuid: String) {
-        guard Settings.loadEmbeddedImages, !EmbeddedArtworkCache.shared.isCached(episodeUuid: episodeUuid) else {
+        guard Settings.loadEmbeddedImages, !isCached(episodeUuid: episodeUuid) else {
             return
         }
 
@@ -23,35 +32,13 @@ class StreamingEpisodeArtwork {
                     let image = UIImage(data: imageData)
 
                     if let image {
-                        EmbeddedArtworkCache.shared.set(for: episodeUuid, image: image) {
+                        set(for: episodeUuid, image: image) {
                             NotificationCenter.postOnMainThread(notification: Constants.Notifications.episodeEmbeddedArtworkLoaded)
                         }
                     }
 
                 }
             }
-        }
-    }
-}
-
-
-/// Saves the embedded artwork of a streaming episode
-class EmbeddedArtworkCache {
-    static let shared = EmbeddedArtworkCache()
-
-    private var subscribedPodcastsCache: ImageCache
-
-    private init() {
-        let path = (NSHomeDirectory() as NSString).appendingPathComponent("Documents/artworkv3")
-        let url = URL(fileURLWithPath: path)
-        subscribedPodcastsCache = try! ImageCache(name: "subscribedPodcastsCache", cacheDirectoryURL: url)
-        subscribedPodcastsCache.diskStorage.config.sizeLimit = UInt(400.megabytes)
-        subscribedPodcastsCache.diskStorage.config.expiration = .days(365)
-    }
-
-    func set(for episodeUuid: String, image: UIImage, completion: (() -> Void)?) {
-        subscribedPodcastsCache.store(image, forKey: episodeUuid) { _ in
-            completion?()
         }
     }
 
@@ -61,5 +48,11 @@ class EmbeddedArtworkCache {
 
     func isCached(episodeUuid: String) -> Bool {
         subscribedPodcastsCache.isCached(forKey: episodeUuid)
+    }
+
+    private func set(for episodeUuid: String, image: UIImage, completion: (() -> Void)?) {
+        subscribedPodcastsCache.store(image, forKey: episodeUuid) { _ in
+            completion?()
+        }
     }
 }

--- a/podcasts/StreamingEpisodeArtwork.swift
+++ b/podcasts/StreamingEpisodeArtwork.swift
@@ -3,7 +3,11 @@ import Kingfisher
 
 /// Extracts artwork from a streaming episode (if there's any)
 class StreamingEpisodeArtwork {
-    static let shared = StreamingEpisodeArtwork()
+    private let imageManager: ImageManager
+
+    init(imageManager: ImageManager = .sharedManager) {
+        self.imageManager = imageManager
+    }
 
     /// Extract a UIImage from a given asset if embedded artwork option is enabled.
     /// If an image is extracted, `episodeEmbeddedArtworkLoaded` notification is triggered
@@ -26,11 +30,11 @@ class StreamingEpisodeArtwork {
     }
 
     func isCached(episodeUuid: String) -> Bool {
-        ImageManager.sharedManager.subscribedPodcastsCache.isCached(forKey: episodeUuid)
+        imageManager.subscribedPodcastsCache.isCached(forKey: episodeUuid)
     }
 
     private func set(for episodeUuid: String, image: UIImage, completion: (() -> Void)?) {
-        ImageManager.sharedManager.subscribedPodcastsCache.store(image, forKey: episodeUuid) { _ in
+        imageManager.subscribedPodcastsCache.store(image, forKey: episodeUuid) { _ in
             completion?()
         }
     }

--- a/podcasts/StreamingEpisodeArtwork.swift
+++ b/podcasts/StreamingEpisodeArtwork.swift
@@ -11,7 +11,7 @@ class StreamingEpisodeArtwork {
     ///   - asset: an AVAsset
     ///   - episodeUuid: the UUID of the current playing episode
     func loadEmbeddedImage(asset: AVAsset, episodeUuid: String) {
-        guard Settings.loadEmbeddedImages, !EmbeddedArtworkCache.shared.isCache(episodeUuid: episodeUuid) else {
+        guard Settings.loadEmbeddedImages, !EmbeddedArtworkCache.shared.isCached(episodeUuid: episodeUuid) else {
             return
         }
 
@@ -59,7 +59,7 @@ class EmbeddedArtworkCache {
         subscribedPodcastsCache.retrieveImage(forKey: episodeUuid, options: .none, completionHandler: completionHandler)
     }
 
-    func isCache(episodeUuid: String) -> Bool {
+    func isCached(episodeUuid: String) -> Bool {
         subscribedPodcastsCache.isCached(forKey: episodeUuid)
     }
 }

--- a/podcasts/StreamingEpisodeArtwork.swift
+++ b/podcasts/StreamingEpisodeArtwork.swift
@@ -32,7 +32,7 @@ class StreamingEpisodeArtwork {
 
                     if let image {
                         set(for: episodeUuid, image: image) {
-                            NotificationCenter.postOnMainThread(notification: Constants.Notifications.episodeEmbeddedArtworkLoaded)
+                            NotificationCenter.postOnMainThread(notification: .episodeEmbeddedArtworkLoaded)
                         }
                     }
 

--- a/podcasts/StreamingEpisodeArtwork.swift
+++ b/podcasts/StreamingEpisodeArtwork.swift
@@ -5,15 +5,6 @@ import Kingfisher
 class StreamingEpisodeArtwork {
     static let shared = StreamingEpisodeArtwork()
 
-    private lazy var subscribedPodcastsCache: ImageCache = {
-        let path = (NSHomeDirectory() as NSString).appendingPathComponent("Documents/artworkv3")
-        let url = URL(fileURLWithPath: path)
-        subscribedPodcastsCache = try! ImageCache(name: "subscribedPodcastsCache", cacheDirectoryURL: url)
-        subscribedPodcastsCache.diskStorage.config.sizeLimit = UInt(400.megabytes)
-        subscribedPodcastsCache.diskStorage.config.expiration = .days(365)
-        return subscribedPodcastsCache
-    }()
-
     /// Extract a UIImage from a given asset if embedded artwork option is enabled.
     /// If an image is extracted, `episodeEmbeddedArtworkLoaded` notification is triggered
     /// - Parameters:
@@ -34,16 +25,12 @@ class StreamingEpisodeArtwork {
         }
     }
 
-    func get(for episodeUuid: String, completionHandler: ((Result<ImageCacheResult, KingfisherError>) -> Void)?) {
-        subscribedPodcastsCache.retrieveImage(forKey: episodeUuid, options: .none, completionHandler: completionHandler)
-    }
-
     func isCached(episodeUuid: String) -> Bool {
-        subscribedPodcastsCache.isCached(forKey: episodeUuid)
+        ImageManager.sharedManager.subscribedPodcastsCache.isCached(forKey: episodeUuid)
     }
 
     private func set(for episodeUuid: String, image: UIImage, completion: (() -> Void)?) {
-        subscribedPodcastsCache.store(image, forKey: episodeUuid) { _ in
+        ImageManager.sharedManager.subscribedPodcastsCache.store(image, forKey: episodeUuid) { _ in
             completion?()
         }
     }

--- a/podcasts/StreamingEpisodeArtwork.swift
+++ b/podcasts/StreamingEpisodeArtwork.swift
@@ -24,20 +24,13 @@ class StreamingEpisodeArtwork {
             return
         }
 
-        let metadata = asset.metadata
-        for item in metadata {
-            if let key = item.commonKey?.rawValue, key == "artwork" {
-                if let imageData = item.value as? Data {
-                    let image = UIImage(data: imageData)
+        let artworkItems = AVMetadataItem.metadataItems(from: asset.commonMetadata, filteredByIdentifier: .commonIdentifierArtwork)
+        let image = artworkItems.compactMap { $0.dataValue.flatMap { UIImage(data: $0) } }.first
 
-                    if let image {
-                        set(for: episodeUuid, image: image) {
-                            NotificationCenter.postOnMainThread(notification: .episodeEmbeddedArtworkLoaded)
-                        }
-                    }
+        guard let image else { return }
 
-                }
-            }
+        set(for: episodeUuid, image: image) {
+            NotificationCenter.postOnMainThread(notification: .episodeEmbeddedArtworkLoaded)
         }
     }
 


### PR DESCRIPTION
While we currently offer the "Use Embedded Artwork" option, it only works for downloaded episodes. This PR adds the capability to display artwork when streaming an episode (if there's any).

**This PR doesn't add the feature to display episode images contained in the feed.**

## To test

1. Run the app
2. Go to Settings > Appearance > enable "Use Embedded Artwork"
3. Search for a podcast that has embedded images in episode ("Tecnocast" is a good one)
4. Play the episode
5. ✅ After a bit, the image should change to show the embedded artwork
6. ✅ Check that this artwork is shown on the now playing widget
7. Run CarPlay simulator
8. ✅ Check that the image is reflected on CarPlay too

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
