### PR TITLE
Patron: update upgrade screen

### DIFF
--- a/podcasts/Onboarding/Models/PlusPricingInfoModel.swift
+++ b/podcasts/Onboarding/Models/PlusPricingInfoModel.swift
@@ -7,7 +7,7 @@ class PlusPricingInfoModel: ObservableObject {
     let purchaseHandler: IapHelper
 
     // Allow our views to get the necessary pricing information
-    let pricingInfo: PlusPricingInfo
+    @Published var pricingInfo: PlusPricingInfo
 
     /// Determines whether prices are available
     @Published var priceAvailability: PriceAvailablity
@@ -75,6 +75,7 @@ extension PlusPricingInfoModel {
     func loadPrices(_ completion: @escaping () -> Void) {
         if purchaseHandler.hasLoadedProducts {
             priceAvailability = .available
+            pricingInfo = Self.getPricingInfo(from: self.purchaseHandler)
             completion()
             return
         }
@@ -83,9 +84,13 @@ extension PlusPricingInfoModel {
 
         let notificationCenter = NotificationCenter.default
 
-        notificationCenter.addObserver(forName: ServerNotifications.iapProductsUpdated, object: nil, queue: .main) { _ in
+        notificationCenter.addObserver(forName: ServerNotifications.iapProductsUpdated, object: nil, queue: .main) { [weak self] _ in
+            guard let self else {
+                return
+            }
 
             self.priceAvailability = .available
+            self.pricingInfo = Self.getPricingInfo(from: self.purchaseHandler)
             completion()
         }
 

--- a/podcasts/Onboarding/Models/PlusPurchaseModel.swift
+++ b/podcasts/Onboarding/Models/PlusPurchaseModel.swift
@@ -117,8 +117,7 @@ private extension PlusPurchaseModel {
         let navigationController = parentController as? UINavigationController
         let controller = WelcomeViewModel.make(in: navigationController, displayType: .plus)
 
-        // Dismiss the current flow
-        parentController.dismiss(animated: true, completion: {
+        let presentNextBlock: () -> Void = {
             guard let navigationController else {
                 // Present the welcome flow
                 parentController.present(controller, animated: true)
@@ -127,7 +126,14 @@ private extension PlusPurchaseModel {
 
             // Reset the nav flow to only show the welcome controller
             navigationController.setViewControllers([controller], animated: true)
-        })
+        }
+
+        // Dismiss the current flow
+        if FeatureFlag.patron.enabled {
+            presentNextBlock()
+        } else {
+            parentController.dismiss(animated: true, completion: presentNextBlock)
+        }
     }
 }
 

--- a/podcasts/Onboarding/Models/PlusPurchaseModel.swift
+++ b/podcasts/Onboarding/Models/PlusPurchaseModel.swift
@@ -33,6 +33,10 @@ class PlusPurchaseModel: PlusPricingInfoModel, OnboardingModel {
         }
     }
 
+    func reset() {
+        state = .ready
+    }
+
     // MARK: - Triggers the purchase process
     func purchase(product: Constants.IapProducts) {
         guard purchaseHandler.buyProduct(identifier: product.rawValue) else {

--- a/podcasts/Onboarding/Plus/PlusButtonStyles.swift
+++ b/podcasts/Onboarding/Plus/PlusButtonStyles.swift
@@ -1,5 +1,49 @@
 import SwiftUI
 
+struct PlusOpaqueButtonStyle: ButtonStyle {
+    let isLoading: Bool
+    let plan: Constants.Plan
+
+    private var background: Color {
+        plan == .plus ? Color.plusBackgroundColor2 : Color.patronBackgroundColor
+    }
+
+    private var foregroundColor: Color {
+        plan == .plus ? .plusButtonFilledTextColor : Color.patronButtonFilledTextColor
+    }
+
+    init(isLoading: Bool = false, plan: Constants.Plan) {
+        self.isLoading = isLoading
+        self.plan = plan
+    }
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .applyButtonFont()
+            .frame(maxWidth: .infinity)
+            .padding()
+
+            .background(AnyView(background))
+            .foregroundColor(foregroundColor)
+
+            .cornerRadius(ViewConstants.buttonCornerRadius)
+            .applyButtonEffect(isPressed: configuration.isPressed)
+            .contentShape(Rectangle())
+            .overlay(
+                ZStack {
+                    if isLoading {
+                        Rectangle()
+                            .overlay(AnyView(background))
+                            .cornerRadius(ViewConstants.buttonCornerRadius)
+
+                        ProgressView()
+                            .progressViewStyle(CircularProgressViewStyle(tint: foregroundColor))
+                    }
+                }
+            )
+    }
+}
+
 struct PlusGradientFilledButtonStyle: ButtonStyle {
     let isLoading: Bool
     let plan: Constants.Plan
@@ -166,4 +210,5 @@ extension Color {
     static let plusBackgroundColor = Color(hex: "121212")
     static let plusLeftCircleColor = Color(hex: "ffd845")
     static let plusRightCircleColor = Color(hex: "ffb626")
+    static let plusBackgroundColor2 = Color(hex: "FFD846")
 }

--- a/podcasts/Onboarding/Plus/PlusLandingViewModel.swift
+++ b/podcasts/Onboarding/Plus/PlusLandingViewModel.swift
@@ -135,8 +135,9 @@ extension PlusLandingViewModel {
     @ViewBuilder
     private static func view(with viewModel: PlusLandingViewModel, purchaseModel: PlusPurchaseModel? = nil) -> some View {
         if FeatureFlag.patron.enabled, let purchaseModel {
-            UpgradeLandingView(purchaseModel: purchaseModel)
+            UpgradeLandingView()
                 .environmentObject(viewModel)
+                .environmentObject(purchaseModel)
                 .setupDefaultEnvironment()
         } else {
             PlusLandingView(viewModel: viewModel)

--- a/podcasts/Onboarding/Plus/PlusLandingViewModel.swift
+++ b/podcasts/Onboarding/Plus/PlusLandingViewModel.swift
@@ -116,8 +116,9 @@ private extension PlusLandingViewModel {
 extension PlusLandingViewModel {
     static func make(in navigationController: UINavigationController? = nil, from source: Source, continueUpgrade: Bool = false) -> UIViewController {
         let viewModel = PlusLandingViewModel(source: source, continueUpgrade: continueUpgrade)
+        let purchaseModel = FeatureFlag.patron.enabled ? PlusPurchaseModel() : nil
 
-        let view = Self.view(with: viewModel)
+        let view = Self.view(with: viewModel, purchaseModel: purchaseModel)
         let controller = PlusHostingViewController(rootView: view)
 
         controller.viewModel = viewModel
@@ -126,14 +127,15 @@ extension PlusLandingViewModel {
         // Create our own nav controller if we're not already going in one
         let navController = navigationController ?? UINavigationController(rootViewController: controller)
         viewModel.navigationController = navController
+        purchaseModel?.parentController = navController
 
         return (navigationController == nil) ? navController : controller
     }
 
     @ViewBuilder
-    private static func view(with viewModel: PlusLandingViewModel) -> some View {
-        if FeatureFlag.patron.enabled {
-            UpgradeLandingView()
+    private static func view(with viewModel: PlusLandingViewModel, purchaseModel: PlusPurchaseModel? = nil) -> some View {
+        if FeatureFlag.patron.enabled, let purchaseModel {
+            UpgradeLandingView(purchaseModel: purchaseModel)
                 .environmentObject(viewModel)
                 .setupDefaultEnvironment()
         } else {

--- a/podcasts/Onboarding/Plus/PlusLandingViewModel.swift
+++ b/podcasts/Onboarding/Plus/PlusLandingViewModel.swift
@@ -27,6 +27,18 @@ class PlusLandingViewModel: PlusPricingInfoModel, OnboardingModel {
         loadPricesAndContinue(plan: plan, selectedPrice: selectedPrice)
     }
 
+    func unlockTapped(ifLoggedIn: () -> Void) {
+        OnboardingFlow.shared.track(.plusPromotionUpgradeButtonTapped)
+
+        guard SyncManager.isUserLoggedIn() else {
+            let controller = LoginCoordinator.make(in: navigationController, fromUpgrade: true)
+            navigationController?.pushViewController(controller, animated: true)
+            return
+        }
+
+        ifLoggedIn()
+    }
+
     func didAppear() {
         OnboardingFlow.shared.track(.plusPromotionShown)
 

--- a/podcasts/Onboarding/Plus/PlusLandingViewModel.swift
+++ b/podcasts/Onboarding/Plus/PlusLandingViewModel.swift
@@ -60,6 +60,30 @@ class PlusLandingViewModel: PlusPricingInfoModel, OnboardingModel {
         pricingInfo.products.first(where: { $0.identifier == (frequency == .yearly ? tier.plan.yearly : tier.plan.monthly) })?.rawPrice ?? "?"
     }
 
+    func purchaseTitle(for tier: UpgradeTier, frequency: PlusPricingInfoModel.DisplayPrice) -> String {
+        guard let product = pricingInfo.products.first(where: { $0.identifier == (frequency == .yearly ? tier.plan.yearly : tier.plan.monthly) }) else {
+            return ""
+        }
+
+        if let _ = product.freeTrialDuration {
+            return L10n.plusStartMyFreeTrial
+        } else {
+            return tier.buttonLabel
+        }
+    }
+
+    func purchaseSubtitle(for tier: UpgradeTier, frequency: PlusPricingInfoModel.DisplayPrice) -> String {
+        guard let product = pricingInfo.products.first(where: { $0.identifier == (frequency == .yearly ? tier.plan.yearly : tier.plan.monthly) }) else {
+            return ""
+        }
+
+        if let freeTrialDuration = product.freeTrialDuration {
+            return L10n.plusStartTrialDurationPrice(freeTrialDuration, product.price)
+        } else {
+            return product.price
+        }
+    }
+
     private func loadPricesAndContinue(plan: Constants.Plan, selectedPrice: PlusPricingInfoModel.DisplayPrice) {
         loadPrices {
             switch self.priceAvailability {

--- a/podcasts/Onboarding/Plus/PlusLandingViewModel.swift
+++ b/podcasts/Onboarding/Plus/PlusLandingViewModel.swift
@@ -56,13 +56,9 @@ class PlusLandingViewModel: PlusPricingInfoModel, OnboardingModel {
         navigationController?.pushViewController(controller, animated: true)
     }
 
-    func price(for tier: UpgradeTier, frequency: PlusPricingInfoModel.DisplayPrice) -> String {
-        pricingInfo.products.first(where: { $0.identifier == (frequency == .yearly ? tier.plan.yearly : tier.plan.monthly) })?.rawPrice ?? "?"
-    }
-
     func purchaseTitle(for tier: UpgradeTier, frequency: PlusPricingInfoModel.DisplayPrice) -> String {
         guard let product = pricingInfo.products.first(where: { $0.identifier == (frequency == .yearly ? tier.plan.yearly : tier.plan.monthly) }) else {
-            return ""
+            return L10n.loading
         }
 
         if let _ = product.freeTrialDuration {

--- a/podcasts/Onboarding/Plus/PlusLandingViewModel.swift
+++ b/podcasts/Onboarding/Plus/PlusLandingViewModel.swift
@@ -61,7 +61,7 @@ class PlusLandingViewModel: PlusPricingInfoModel, OnboardingModel {
             return L10n.loading
         }
 
-        if let _ = product.freeTrialDuration {
+        if product.freeTrialDuration != nil {
             return L10n.plusStartMyFreeTrial
         } else {
             return tier.buttonLabel

--- a/podcasts/Onboarding/Plus/UpgradeLandingView.swift
+++ b/podcasts/Onboarding/Plus/UpgradeLandingView.swift
@@ -16,7 +16,7 @@ struct UpgradeLandingView: View {
 
     @State private var displayPrice: PlusPricingInfoModel.DisplayPrice = .yearly
 
-    @State private var shouldShowBottomGradient = false
+    @State private var contentIsScrollable = false
 
     @State private var purchaseButtonHeight: CGFloat = 0
 
@@ -68,8 +68,10 @@ struct UpgradeLandingView: View {
 
                                 FeaturesCarousel(currentIndex: $currentPage.animation(), currentPrice: $displayPrice, tiers: tiers)
 
-                                PageIndicatorView(numberOfItems: tiers.count, currentPage: currentPage)
-                                    .padding(.top, 27)
+                                if !isSmallScreen && !contentIsScrollable {
+                                    PageIndicatorView(numberOfItems: tiers.count, currentPage: currentPage)
+                                        .padding(.top, 27)
+                                }
 
                                 Spacer()
 
@@ -84,13 +86,13 @@ struct UpgradeLandingView: View {
                         }
                         .onPreferenceChange(ViewHeightKey.self) {
                             if $0 > reader.size.height {
-                                shouldShowBottomGradient = true
+                                contentIsScrollable = true
                             }
                         }
                     }
                 }
 
-                if shouldShowBottomGradient {
+                if contentIsScrollable {
                     ZStack {
                         VStack(spacing: 0) {
                             Spacer()

--- a/podcasts/Onboarding/Plus/UpgradeLandingView.swift
+++ b/podcasts/Onboarding/Plus/UpgradeLandingView.swift
@@ -43,12 +43,17 @@ struct UpgradeLandingView: View {
 
                         PageIndicatorView(numberOfItems: tiers.count, currentPage: currentPage)
                         .padding(.top, 27)
-
-                        Button(selectedTier.buttonLabel) {
-                            viewModel.unlockTapped(plan: selectedTier.plan, selectedPrice: displayPrice)
-                        }
-                        .buttonStyle(PlusGradientFilledButtonStyle(isLoading: false, plan: selectedTier.plan))
                     }
+                }
+
+                VStack {
+                    Spacer()
+
+                    Button(selectedTier.buttonLabel) {
+                        viewModel.unlockTapped(plan: selectedTier.plan, selectedPrice: displayPrice)
+                    }
+                    .buttonStyle(PlusGradientFilledButtonStyle(isLoading: false, plan: selectedTier.plan))
+                    .padding(.horizontal, 20)
                 }
             }
         }

--- a/podcasts/Onboarding/Plus/UpgradeLandingView.swift
+++ b/podcasts/Onboarding/Plus/UpgradeLandingView.swift
@@ -18,6 +18,10 @@ struct UpgradeLandingView: View {
 
     @State private var loadingPrices = true
 
+    private var selectedProduct: Constants.IapProducts {
+        displayPrice == .yearly ? selectedTier.plan.yearly : selectedTier.plan.monthly
+    }
+
     /// If this device has a small screen
     private var isSmallScreen: Bool {
         UIScreen.main.bounds.height <= 667
@@ -78,7 +82,7 @@ struct UpgradeLandingView: View {
                     )
                     let isLoading = (purchaseModel.state == .purchasing)
                     Button(action: {
-                        purchaseModel.purchase(product: selectedTier.plan.yearly)
+                        purchaseModel.purchase(product: selectedProduct)
                     }, label: {
                         VStack {
                             Text(viewModel.purchaseTitle(for: selectedTier, frequency: $displayPrice.wrappedValue))

--- a/podcasts/Onboarding/Plus/UpgradeLandingView.swift
+++ b/podcasts/Onboarding/Plus/UpgradeLandingView.swift
@@ -16,8 +16,6 @@ struct UpgradeLandingView: View {
 
     @State private var displayPrice: PlusPricingInfoModel.DisplayPrice = .yearly
 
-    @State private var loadingPrices = true
-
     private var selectedProduct: Constants.IapProducts {
         displayPrice == .yearly ? selectedTier.plan.yearly : selectedTier.plan.monthly
     }

--- a/podcasts/Onboarding/Plus/UpgradeLandingView.swift
+++ b/podcasts/Onboarding/Plus/UpgradeLandingView.swift
@@ -347,10 +347,13 @@ struct UpgradeCard: View {
         let privacyPolicy = ServerConstants.Urls.privacyPolicy
         let termsOfUse = ServerConstants.Urls.termsOfUse
 
-        Text(purchaseTerms[safe: 0] ?? "") +
-        Text(.init("[\(purchaseTerms[safe: 1] ?? "")](\(privacyPolicy))")).underline() +
-        Text(purchaseTerms[safe: 2] ?? "") +
-        Text(.init("[\(purchaseTerms[safe: 3] ?? "")](\(termsOfUse))")).underline()
+        Group {
+            Text(purchaseTerms[safe: 0] ?? "") +
+            Text(.init("[\(purchaseTerms[safe: 1] ?? "")](\(privacyPolicy))")).underline() +
+            Text(purchaseTerms[safe: 2] ?? "") +
+            Text(.init("[\(purchaseTerms[safe: 3] ?? "")](\(termsOfUse))")).underline()
+        }
+        .foregroundColor(.black)
     }
 }
 

--- a/podcasts/Onboarding/Plus/UpgradeLandingView.swift
+++ b/podcasts/Onboarding/Plus/UpgradeLandingView.swift
@@ -4,7 +4,7 @@ import PocketCastsServer
 struct UpgradeLandingView: View {
     @EnvironmentObject var viewModel: PlusLandingViewModel
 
-    private var purchaseModel: PlusPurchaseModel
+    @ObservedObject private var purchaseModel: PlusPurchaseModel
 
     private let tiers: [UpgradeTier] = [.plus, .patron]
 
@@ -72,6 +72,7 @@ struct UpgradeLandingView: View {
                 VStack {
                     Spacer()
 
+                    let isLoading = (purchaseModel.state == .purchasing)
                     Button(action: {
                         purchaseModel.purchase(product: selectedTier.plan.yearly)
                     }, label: {
@@ -83,7 +84,7 @@ struct UpgradeLandingView: View {
                         .transition(.opacity)
                         .id("plus_price" + selectedTier.title)
                     })
-                    .buttonStyle(PlusGradientFilledButtonStyle(isLoading: false, plan: selectedTier.plan))
+                    .buttonStyle(PlusGradientFilledButtonStyle(isLoading: isLoading, plan: selectedTier.plan))
                     .padding(.horizontal, 20)
                     .padding(.bottom, hasBottomSafeArea ? 0 : 16)
                 }

--- a/podcasts/Onboarding/Plus/UpgradeLandingView.swift
+++ b/podcasts/Onboarding/Plus/UpgradeLandingView.swift
@@ -168,7 +168,7 @@ private struct FeaturesCarousel: View {
 
     private enum Constants {
         static let peekAmount: Double = 20
-        static let spacing: Double = UIDevice.current.isiPad() ? 150 : 30
+        static let spacing: Double = 30
     }
 }
 

--- a/podcasts/Onboarding/Plus/UpgradeLandingView.swift
+++ b/podcasts/Onboarding/Plus/UpgradeLandingView.swift
@@ -322,7 +322,7 @@ struct UpgradeCard: View {
                     }
 
                     Group {
-                        Text("By continuing, you agree to ") + Text("[Privacy Policy](https://support.pocketcasts.com/article/privacy-policy/)").underline() + Text(" and ") + Text("[Terms and Conditions](https://support.pocketcasts.com/article/terms-of-use/)").underline()
+                        termsAndConditions
                     }
                     .font(style: .footnote).fixedSize(horizontal: false, vertical: true)
                     .tint(.black)
@@ -340,6 +340,12 @@ struct UpgradeCard: View {
         .shadow(color: .black.opacity(0.09), radius: 6, x: 0, y: 6)
         .shadow(color: .black.opacity(0.1), radius: 3, x: 0, y: 2)
         .shadow(color: .black.opacity(0.1), radius: 0, x: 0, y: 0)
+    }
+
+    @ViewBuilder
+    var termsAndConditions: some View {
+        let purchaseTerms = L10n.purchaseTerms("$", "$", "$", "$").components(separatedBy: "$")
+        Text(purchaseTerms[safe: 0] ?? "") + Text("[\(purchaseTerms[safe: 1] ?? "")](https://support.pocketcasts.com/article/privacy-policy/)").underline() + Text(purchaseTerms[safe: 2] ?? "") + Text("[\(purchaseTerms[safe: 3] ?? "")](https://support.pocketcasts.com/article/terms-of-use/)").underline()
     }
 }
 

--- a/podcasts/Onboarding/Plus/UpgradeLandingView.swift
+++ b/podcasts/Onboarding/Plus/UpgradeLandingView.swift
@@ -112,6 +112,7 @@ private struct FeaturesCarousel: View {
         .carouselPeekAmount(.constant(Constants.peekAmount))
         .carouselItemSpacing(Constants.spacing)
         .frame(height: calculatedCardHeight)
+        .padding(.leading, 30)
     }
 
     private enum Constants {

--- a/podcasts/Onboarding/Plus/UpgradeLandingView.swift
+++ b/podcasts/Onboarding/Plus/UpgradeLandingView.swift
@@ -37,68 +37,70 @@ struct UpgradeLandingView: View {
     }
 
     var body: some View {
-        VStack(spacing: 0) {
-            topBar
+        ZStack {
+            ForEach(tiers) { tier in
+                tier.background
+                    .opacity(selectedTier.id == tier.id ? 1 : 0)
+                    .ignoresSafeArea()
+            }
 
-            ZStack {
+            VStack(spacing: 0) {
+                topBar
 
-                ForEach(tiers) { tier in
-                    tier.background
-                        .opacity(selectedTier.id == tier.id ? 1 : 0)
-                        .ignoresSafeArea()
-                }
+                ZStack {
 
-                ScrollViewIfNeeded {
-                    VStack(spacing: 0) {
+                    ScrollViewIfNeeded {
+                        VStack(spacing: 0) {
 
-                        PlusLabel(selectedTier.header, for: .title2)
-                            .transition(.opacity)
-                            .id("plus_title" + selectedTier.header)
-                            .minimumScaleFactor(0.5)
-                            .lineLimit(2)
-                            .padding(.bottom, 16)
-                            .padding(.horizontal, 32)
+                            PlusLabel(selectedTier.header, for: .title2)
+                                .transition(.opacity)
+                                .id("plus_title" + selectedTier.header)
+                                .minimumScaleFactor(0.5)
+                                .lineLimit(2)
+                                .padding(.bottom, 16)
+                                .padding(.horizontal, 32)
 
-                        UpgradeRoundedSegmentedControl(selected: $displayPrice)
-                            .padding(.bottom, 24)
+                            UpgradeRoundedSegmentedControl(selected: $displayPrice)
+                                .padding(.bottom, 24)
 
-                        FeaturesCarousel(currentIndex: $currentPage.animation(), currentPrice: $displayPrice, tiers: tiers)
+                            FeaturesCarousel(currentIndex: $currentPage.animation(), currentPrice: $displayPrice, tiers: tiers)
 
-                        PageIndicatorView(numberOfItems: tiers.count, currentPage: currentPage)
-                        .padding(.top, 27)
+                            PageIndicatorView(numberOfItems: tiers.count, currentPage: currentPage)
+                            .padding(.top, 27)
 
-                        if isSmallScreen {
-                            Spacer()
+                            if isSmallScreen {
+                                Spacer()
+                            }
                         }
                     }
-                }
 
-                VStack {
-                    Spacer()
+                    VStack {
+                        Spacer()
 
-                    let hasError = Binding<Bool>(
-                        get: { self.purchaseModel.state == .failed },
-                        set: { _ in }
-                    )
-                    let isLoading = (purchaseModel.state == .purchasing)
-                    Button(action: {
-                        purchaseModel.purchase(product: selectedProduct)
-                    }, label: {
-                        VStack {
-                            Text(viewModel.purchaseTitle(for: selectedTier, frequency: $displayPrice.wrappedValue))
-                            Text(viewModel.purchaseSubtitle(for: selectedTier, frequency: $displayPrice.wrappedValue))
-                                .font(style: .subheadline)
-                        }
-                        .transition(.opacity)
-                        .id("plus_price" + selectedTier.title)
-                    })
-                    .buttonStyle(PlusGradientFilledButtonStyle(isLoading: isLoading, plan: selectedTier.plan))
-                    .padding(.horizontal, 20)
-                    .padding(.bottom, hasBottomSafeArea ? 0 : 16)
-                    .alert(isPresented: hasError) {
-                        Alert(
-                            title: Text(L10n.plusPurchaseFailed)
+                        let hasError = Binding<Bool>(
+                            get: { self.purchaseModel.state == .failed },
+                            set: { _ in }
                         )
+                        let isLoading = (purchaseModel.state == .purchasing)
+                        Button(action: {
+                            purchaseModel.purchase(product: selectedProduct)
+                        }, label: {
+                            VStack {
+                                Text(viewModel.purchaseTitle(for: selectedTier, frequency: $displayPrice.wrappedValue))
+                                Text(viewModel.purchaseSubtitle(for: selectedTier, frequency: $displayPrice.wrappedValue))
+                                    .font(style: .subheadline)
+                            }
+                            .transition(.opacity)
+                            .id("plus_price" + selectedTier.title)
+                        })
+                        .buttonStyle(PlusGradientFilledButtonStyle(isLoading: isLoading, plan: selectedTier.plan))
+                        .padding(.horizontal, 20)
+                        .padding(.bottom, hasBottomSafeArea ? 0 : 16)
+                        .alert(isPresented: hasError) {
+                            Alert(
+                                title: Text(L10n.plusPurchaseFailed)
+                            )
+                        }
                     }
                 }
             }
@@ -179,7 +181,7 @@ struct UpgradeTier: Identifiable {
     let buttonColor: Color
     let buttonForegroundColor: Color
     let features: [TierFeature]
-    let background: LinearGradient
+    let background: RadialGradient
 
     var id: String {
         tier.rawValue
@@ -205,7 +207,7 @@ extension UpgradeTier {
             TierFeature(iconName: "plus-feature-extra", title: L10n.plusFeatureThemesIcons),
             TierFeature(iconName: "plus-feature-love", title: L10n.plusFeatureGratitude)
         ],
-        background: LinearGradient(gradient: Gradient(colors: [Color(hex: "121212"), Color(hex: "121212"), Color(hex: "D4B43A"), Color(hex: "FFDE64")]), startPoint: .topLeading, endPoint: .bottomTrailing))
+                    background: RadialGradient(colors: [Color(hex: "FFDE64").opacity(0.5), Color(hex: "121212")], center: .leading, startRadius: 0, endRadius: 500))
     }
 
     static var patron: UpgradeTier {
@@ -218,7 +220,7 @@ extension UpgradeTier {
             TierFeature(iconName: "plus-feature-love", title: L10n.plusFeatureGratitude)
 
         ],
-        background: LinearGradient(gradient: Gradient(colors: [Color(hex: "121212"), Color(hex: "121212"), Color(hex: "9583F8"), Color(hex: "503ACC")]), startPoint: .topLeading, endPoint: .bottomTrailing))
+        background: RadialGradient(colors: [Color(hex: "503ACC").opacity(0.8), Color(hex: "121212")], center: .leading, startRadius: 0, endRadius: 500))
     }
 }
 

--- a/podcasts/Onboarding/Plus/UpgradeLandingView.swift
+++ b/podcasts/Onboarding/Plus/UpgradeLandingView.swift
@@ -14,6 +14,18 @@ struct UpgradeLandingView: View {
 
     @State private var displayPrice: PlusPricingInfoModel.DisplayPrice = .yearly
 
+    @State private var loadingPrices = true
+
+    /// If this device has a small screen
+    private var isSmallScreen: Bool {
+        UIScreen.main.bounds.height <= 667
+    }
+
+    /// If this device has a bottom safe area
+    private var hasBottomSafeArea: Bool {
+        (SceneHelper.connectedScene()?.windows.first(where: \.isKeyWindow)?.safeAreaInsets.bottom ?? 0) > 0
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             topBar
@@ -44,6 +56,10 @@ struct UpgradeLandingView: View {
 
                         PageIndicatorView(numberOfItems: tiers.count, currentPage: currentPage)
                         .padding(.top, 27)
+
+                        if isSmallScreen {
+                            Spacer()
+                        }
                     }
                 }
 
@@ -58,9 +74,12 @@ struct UpgradeLandingView: View {
                             Text(viewModel.purchaseSubtitle(for: selectedTier, frequency: $displayPrice.wrappedValue))
                                 .font(style: .subheadline)
                         }
+                        .transition(.opacity)
+                        .id("plus_price" + selectedTier.title)
                     })
                     .buttonStyle(PlusGradientFilledButtonStyle(isLoading: false, plan: selectedTier.plan))
                     .padding(.horizontal, 20)
+                    .padding(.bottom, hasBottomSafeArea ? 0 : 16)
                 }
             }
         }

--- a/podcasts/Onboarding/Plus/UpgradeLandingView.swift
+++ b/podcasts/Onboarding/Plus/UpgradeLandingView.swift
@@ -273,11 +273,11 @@ struct UpgradeCard: View {
                     Group {
                         Text("By continuing, you agree to ") + Text("[Privacy Policy](https://support.pocketcasts.com/article/privacy-policy/)").underline() + Text(" and ") + Text("[Terms and Conditions](https://support.pocketcasts.com/article/terms-of-use/)").underline()
                     }
-                    .font(style: .footnote)
+                    .font(style: .footnote).fixedSize(horizontal: false, vertical: true)
                     .tint(.black)
                     .opacity(0.64)
                 }
-                .padding(.bottom, 24)
+                .padding(.bottom, 0)
             }
             .padding(24)
 

--- a/podcasts/Onboarding/Plus/UpgradeLandingView.swift
+++ b/podcasts/Onboarding/Plus/UpgradeLandingView.swift
@@ -4,6 +4,8 @@ import PocketCastsServer
 struct UpgradeLandingView: View {
     @EnvironmentObject var viewModel: PlusLandingViewModel
 
+    private var purchaseModel: PlusPurchaseModel
+
     private let tiers: [UpgradeTier] = [.plus, .patron]
 
     private var selectedTier: UpgradeTier {
@@ -24,6 +26,10 @@ struct UpgradeLandingView: View {
     /// If this device has a bottom safe area
     private var hasBottomSafeArea: Bool {
         (SceneHelper.connectedScene()?.windows.first(where: \.isKeyWindow)?.safeAreaInsets.bottom ?? 0) > 0
+    }
+
+    init(purchaseModel: PlusPurchaseModel) {
+        self.purchaseModel = purchaseModel
     }
 
     var body: some View {
@@ -67,7 +73,7 @@ struct UpgradeLandingView: View {
                     Spacer()
 
                     Button(action: {
-                        viewModel.unlockTapped(plan: selectedTier.plan, selectedPrice: displayPrice)
+                        purchaseModel.purchase(product: selectedTier.plan.yearly)
                     }, label: {
                         VStack {
                             Text(viewModel.purchaseTitle(for: selectedTier, frequency: $displayPrice.wrappedValue))
@@ -320,6 +326,6 @@ struct UpgradeCard: View {
 
 struct UpgradeLandingView_Previews: PreviewProvider {
     static var previews: some View {
-        UpgradeLandingView().environmentObject(PlusLandingViewModel(source: .login))
+        UpgradeLandingView(purchaseModel: PlusPurchaseModel()).environmentObject(PlusLandingViewModel(source: .login))
     }
 }

--- a/podcasts/Onboarding/Plus/UpgradeLandingView.swift
+++ b/podcasts/Onboarding/Plus/UpgradeLandingView.swift
@@ -251,26 +251,7 @@ struct UpgradeCard: View {
                 }
                 .background(.black)
                 .cornerRadius(24)
-                .padding(.bottom, 10)
-
-                HStack {
-                    Text(viewModel.price(for: tier, frequency: currentPrice.wrappedValue))
-                        .font(style: .largeTitle, weight: .bold)
-                        .foregroundColor(.black)
-                    Text("/\(currentPrice.wrappedValue == .yearly ? L10n.year : L10n.month)")
-                        .font(style: .headline, weight: .bold)
-                        .foregroundColor(.black)
-                        .opacity(0.6)
-                        .padding(.top, 6)
-                }
-                .padding(.bottom, 8)
-
-                Text(tier.description)
-                    .font(style: .caption2, weight: .semibold)
-                    .fixedSize(horizontal: false, vertical: true)
-                    .foregroundColor(.black)
-                    .opacity(0.64)
-                    .padding(.bottom, 16)
+                .padding(.bottom, 16)
 
                 VStack(alignment: .leading, spacing: 12) {
                     ForEach(tier.features, id: \.self) { feature in

--- a/podcasts/Onboarding/Plus/UpgradeLandingView.swift
+++ b/podcasts/Onboarding/Plus/UpgradeLandingView.swift
@@ -43,6 +43,11 @@ struct UpgradeLandingView: View {
 
                         PageIndicatorView(numberOfItems: tiers.count, currentPage: currentPage)
                         .padding(.top, 27)
+
+                        Button(selectedTier.buttonLabel) {
+                            viewModel.unlockTapped(plan: selectedTier.plan, selectedPrice: displayPrice)
+                        }
+                        .buttonStyle(PlusGradientFilledButtonStyle(isLoading: false, plan: selectedTier.plan))
                     }
                 }
             }
@@ -279,11 +284,6 @@ struct UpgradeCard: View {
                     }
                 }
                 .padding(.bottom, 24)
-
-                Button(tier.buttonLabel) {
-                    viewModel.unlockTapped(plan: tier.plan, selectedPrice: currentPrice.wrappedValue)
-                }
-                .buttonStyle(PlusGradientFilledButtonStyle(isLoading: false, plan: tier.plan))
             }
             .padding(24)
 

--- a/podcasts/Onboarding/Plus/UpgradeLandingView.swift
+++ b/podcasts/Onboarding/Plus/UpgradeLandingView.swift
@@ -72,6 +72,10 @@ struct UpgradeLandingView: View {
                 VStack {
                     Spacer()
 
+                    let hasError = Binding<Bool>(
+                        get: { self.purchaseModel.state == .failed },
+                        set: { _ in }
+                    )
                     let isLoading = (purchaseModel.state == .purchasing)
                     Button(action: {
                         purchaseModel.purchase(product: selectedTier.plan.yearly)
@@ -87,6 +91,11 @@ struct UpgradeLandingView: View {
                     .buttonStyle(PlusGradientFilledButtonStyle(isLoading: isLoading, plan: selectedTier.plan))
                     .padding(.horizontal, 20)
                     .padding(.bottom, hasBottomSafeArea ? 0 : 16)
+                    .alert(isPresented: hasError) {
+                        Alert(
+                            title: Text(L10n.plusPurchaseFailed)
+                        )
+                    }
                 }
             }
         }

--- a/podcasts/Onboarding/Plus/UpgradeLandingView.swift
+++ b/podcasts/Onboarding/Plus/UpgradeLandingView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import PocketCastsServer
 
 struct UpgradeLandingView: View {
     @EnvironmentObject var viewModel: PlusLandingViewModel
@@ -268,6 +269,13 @@ struct UpgradeCard: View {
                                 .fixedSize(horizontal: false, vertical: true)
                         }
                     }
+
+                    Group {
+                        Text("By continuing, you agree to ") + Text("[Privacy Policy](https://support.pocketcasts.com/article/privacy-policy/)").underline() + Text(" and ") + Text("[Terms and Conditions](https://support.pocketcasts.com/article/terms-of-use/)").underline()
+                    }
+                    .font(style: .footnote)
+                    .tint(.black)
+                    .opacity(0.64)
                 }
                 .padding(.bottom, 24)
             }

--- a/podcasts/Onboarding/Plus/UpgradeLandingView.swift
+++ b/podcasts/Onboarding/Plus/UpgradeLandingView.swift
@@ -343,7 +343,14 @@ struct UpgradeCard: View {
     @ViewBuilder
     var termsAndConditions: some View {
         let purchaseTerms = L10n.purchaseTerms("$", "$", "$", "$").components(separatedBy: "$")
-        Text(purchaseTerms[safe: 0] ?? "") + Text("[\(purchaseTerms[safe: 1] ?? "")](https://support.pocketcasts.com/article/privacy-policy/)").underline() + Text(purchaseTerms[safe: 2] ?? "") + Text("[\(purchaseTerms[safe: 3] ?? "")](https://support.pocketcasts.com/article/terms-of-use/)").underline()
+
+        let privacyPolicy = ServerConstants.Urls.privacyPolicy
+        let termsOfUse = ServerConstants.Urls.termsOfUse
+
+        Text(purchaseTerms[safe: 0] ?? "") +
+        Text(.init("[\(purchaseTerms[safe: 1] ?? "")](\(privacyPolicy))")).underline() +
+        Text(purchaseTerms[safe: 2] ?? "") +
+        Text(.init("[\(purchaseTerms[safe: 3] ?? "")](\(termsOfUse))")).underline()
     }
 }
 

--- a/podcasts/Onboarding/Plus/UpgradeLandingView.swift
+++ b/podcasts/Onboarding/Plus/UpgradeLandingView.swift
@@ -29,7 +29,7 @@ struct UpgradeLandingView: View {
 
     /// If this device has a bottom safe area
     private var hasBottomSafeArea: Bool {
-        (SceneHelper.connectedScene()?.windows.first(where: \.isKeyWindow)?.safeAreaInsets.bottom ?? 0) > 0
+        !UIDevice.current.isiPad() && (SceneHelper.connectedScene()?.windows.first(where: \.isKeyWindow)?.safeAreaInsets.bottom ?? 0) > 0
     }
 
     init(purchaseModel: PlusPurchaseModel) {

--- a/podcasts/Onboarding/Plus/UpgradeLandingView.swift
+++ b/podcasts/Onboarding/Plus/UpgradeLandingView.swift
@@ -4,7 +4,7 @@ import PocketCastsServer
 struct UpgradeLandingView: View {
     @EnvironmentObject var viewModel: PlusLandingViewModel
 
-    @ObservedObject private var purchaseModel: PlusPurchaseModel
+    @EnvironmentObject private var purchaseModel: PlusPurchaseModel
 
     private let tiers: [UpgradeTier] = [.plus, .patron]
 
@@ -28,10 +28,6 @@ struct UpgradeLandingView: View {
     /// If this device has a bottom safe area
     private var hasBottomSafeArea: Bool {
         !UIDevice.current.isiPad() && (SceneHelper.connectedScene()?.windows.first(where: \.isKeyWindow)?.safeAreaInsets.bottom ?? 0) > 0
-    }
-
-    init(purchaseModel: PlusPurchaseModel) {
-        self.purchaseModel = purchaseModel
     }
 
     var body: some View {
@@ -357,6 +353,7 @@ struct UpgradeCard: View {
 
 struct UpgradeLandingView_Previews: PreviewProvider {
     static var previews: some View {
-        UpgradeLandingView(purchaseModel: PlusPurchaseModel()).environmentObject(PlusLandingViewModel(source: .login))
+        UpgradeLandingView().environmentObject(PlusLandingViewModel(source: .login))
+            .environmentObject(PlusPurchaseModel())
     }
 }

--- a/podcasts/Onboarding/Plus/UpgradeLandingView.swift
+++ b/podcasts/Onboarding/Plus/UpgradeLandingView.swift
@@ -81,7 +81,7 @@ struct UpgradeLandingView: View {
                             get: { self.purchaseModel.state == .failed },
                             set: { _ in }
                         )
-                        let isLoading = (purchaseModel.state == .purchasing)
+                        let isLoading = (purchaseModel.state == .purchasing) || (viewModel.priceAvailability == .loading)
                         Button(action: {
                             purchaseModel.purchase(product: selectedProduct)
                         }, label: {
@@ -106,6 +106,10 @@ struct UpgradeLandingView: View {
             }
         }
         .background(Color.plusBackgroundColor)
+        .onAppear {
+            // Ensure prices are loaded
+            viewModel.loadPrices { }
+        }
     }
 
     var topBar: some View {

--- a/podcasts/Onboarding/Plus/UpgradeLandingView.swift
+++ b/podcasts/Onboarding/Plus/UpgradeLandingView.swift
@@ -93,7 +93,7 @@ struct UpgradeLandingView: View {
                             .transition(.opacity)
                             .id("plus_price" + selectedTier.title)
                         })
-                        .buttonStyle(PlusGradientFilledButtonStyle(isLoading: isLoading, plan: selectedTier.plan))
+                        .buttonStyle(PlusOpaqueButtonStyle(isLoading: isLoading, plan: selectedTier.plan))
                         .padding(.horizontal, 20)
                         .padding(.bottom, hasBottomSafeArea ? 0 : 16)
                         .alert(isPresented: hasError) {
@@ -178,7 +178,6 @@ struct UpgradeTier: Identifiable {
     let header: String
     let description: String
     let buttonLabel: String
-    let buttonColor: Color
     let buttonForegroundColor: Color
     let features: [TierFeature]
     let background: RadialGradient
@@ -199,7 +198,7 @@ struct UpgradeTier: Identifiable {
 
 extension UpgradeTier {
     static var plus: UpgradeTier {
-        UpgradeTier(tier: .plus, iconName: "plusGold", title: "Plus", plan: .plus, header: L10n.plusMarketingTitle, description: L10n.accountDetailsPlusTitle, buttonLabel: L10n.plusSubscribeTo, buttonColor: Color(hex: "FFD846"), buttonForegroundColor: Color.plusButtonFilledTextColor, features: [
+        UpgradeTier(tier: .plus, iconName: "plusGold", title: "Plus", plan: .plus, header: L10n.plusMarketingTitle, description: L10n.accountDetailsPlusTitle, buttonLabel: L10n.plusSubscribeTo, buttonForegroundColor: Color.plusButtonFilledTextColor, features: [
             TierFeature(iconName: "plus-feature-desktop", title: L10n.plusMarketingDesktopAppsTitle),
             TierFeature(iconName: "plus-feature-folders", title: L10n.folders),
             TierFeature(iconName: "plus-feature-cloud", title: L10n.plusCloudStorageLimitFormat(10)),
@@ -211,7 +210,7 @@ extension UpgradeTier {
     }
 
     static var patron: UpgradeTier {
-        UpgradeTier(tier: .patron, iconName: "patron-heart", title: "Patron", plan: .patron, header: L10n.patronCallout, description: L10n.patronDescription, buttonLabel: L10n.patronSubscribeTo, buttonColor: Color.patronBackgroundColor, buttonForegroundColor: .white, features: [
+        UpgradeTier(tier: .patron, iconName: "patron-heart", title: "Patron", plan: .patron, header: L10n.patronCallout, description: L10n.patronDescription, buttonLabel: L10n.patronSubscribeTo, buttonForegroundColor: .white, features: [
             TierFeature(iconName: "patron-everything", title: L10n.patronFeatureEverythingInPlus),
             TierFeature(iconName: "patron-early-access", title: L10n.patronFeatureEarlyAccess),
             TierFeature(iconName: "plus-feature-cloud", title: L10n.plusCloudStorageLimitFormat(50)),

--- a/podcasts/Onboarding/Plus/UpgradeLandingView.swift
+++ b/podcasts/Onboarding/Plus/UpgradeLandingView.swift
@@ -146,7 +146,9 @@ struct UpgradeLandingView: View {
         )
         let isLoading = (purchaseModel.state == .purchasing) || (viewModel.priceAvailability == .loading)
         Button(action: {
-            purchaseModel.purchase(product: selectedProduct)
+            viewModel.unlockTapped {
+                purchaseModel.purchase(product: selectedProduct)
+            }
         }, label: {
             VStack {
                 Text(viewModel.purchaseTitle(for: selectedTier, frequency: $displayPrice.wrappedValue))
@@ -161,7 +163,10 @@ struct UpgradeLandingView: View {
         .padding(.bottom, hasBottomSafeArea ? 0 : 16)
         .alert(isPresented: hasError) {
             Alert(
-                title: Text(L10n.plusPurchaseFailed)
+                title: Text(L10n.plusPurchaseFailed),
+                dismissButton: .default(Text(L10n.ok)) {
+                    purchaseModel.reset()
+                }
             )
         }
     }

--- a/podcasts/Onboarding/Plus/UpgradeLandingView.swift
+++ b/podcasts/Onboarding/Plus/UpgradeLandingView.swift
@@ -50,9 +50,15 @@ struct UpgradeLandingView: View {
                 VStack {
                     Spacer()
 
-                    Button(selectedTier.buttonLabel) {
+                    Button(action: {
                         viewModel.unlockTapped(plan: selectedTier.plan, selectedPrice: displayPrice)
-                    }
+                    }, label: {
+                        VStack {
+                            Text(viewModel.purchaseTitle(for: selectedTier, frequency: $displayPrice.wrappedValue))
+                            Text(viewModel.purchaseSubtitle(for: selectedTier, frequency: $displayPrice.wrappedValue))
+                                .font(style: .subheadline)
+                        }
+                    })
                     .buttonStyle(PlusGradientFilledButtonStyle(isLoading: false, plan: selectedTier.plan))
                     .padding(.horizontal, 20)
                 }

--- a/podcasts/Onboarding/Plus/UpgradeLandingView.swift
+++ b/podcasts/Onboarding/Plus/UpgradeLandingView.swift
@@ -319,12 +319,10 @@ struct UpgradeCard: View {
                         }
                     }
 
-                    Group {
-                        termsAndConditions
-                    }
-                    .font(style: .footnote).fixedSize(horizontal: false, vertical: true)
-                    .tint(.black)
-                    .opacity(0.64)
+                    termsAndConditions
+                        .font(style: .footnote).fixedSize(horizontal: false, vertical: true)
+                        .tint(.black)
+                        .opacity(0.64)
                 }
                 .padding(.bottom, 0)
             }

--- a/podcasts/Onboarding/Plus/UpgradeLandingView.swift
+++ b/podcasts/Onboarding/Plus/UpgradeLandingView.swift
@@ -38,54 +38,50 @@ struct UpgradeLandingView: View {
                     .ignoresSafeArea()
             }
 
-            VStack(spacing: 0) {
-                topBar
+            ZStack {
+                VStack(spacing: 0) {
+                    topBar
 
-                Spacer()
+                    GeometryReader { reader in
+                        ScrollView {
+                            VStack(spacing: 0) {
+                                Spacer()
 
-                PlusLabel(selectedTier.header, for: .title2)
-                    .transition(.opacity)
-                    .id("plus_title" + selectedTier.header)
-                    .minimumScaleFactor(0.5)
-                    .lineLimit(2)
-                    .padding(.bottom, 16)
-                    .padding(.horizontal, 32)
+                                PlusLabel(selectedTier.header, for: .title2)
+                                    .transition(.opacity)
+                                    .id("plus_title" + selectedTier.header)
+                                    .minimumScaleFactor(0.5)
+                                    .lineLimit(2)
+                                    .padding(.bottom, 16)
+                                    .padding(.horizontal, 32)
 
-                UpgradeRoundedSegmentedControl(selected: $displayPrice)
-                    .padding(.bottom, 24)
+                                UpgradeRoundedSegmentedControl(selected: $displayPrice)
+                                    .padding(.bottom, 24)
 
-                FeaturesCarousel(currentIndex: $currentPage.animation(), currentPrice: $displayPrice, tiers: tiers)
+                                FeaturesCarousel(currentIndex: $currentPage.animation(), currentPrice: $displayPrice, tiers: tiers)
 
-                PageIndicatorView(numberOfItems: tiers.count, currentPage: currentPage)
-                .padding(.top, 27)
+                                PageIndicatorView(numberOfItems: tiers.count, currentPage: currentPage)
+                                    .padding(.top, 27)
 
-                Spacer()
+                                Spacer()
 
-                let hasError = Binding<Bool>(
-                    get: { self.purchaseModel.state == .failed },
-                    set: { _ in }
-                )
-                let isLoading = (purchaseModel.state == .purchasing) || (viewModel.priceAvailability == .loading)
-                Button(action: {
-                    purchaseModel.purchase(product: selectedProduct)
-                }, label: {
-                    VStack {
-                        Text(viewModel.purchaseTitle(for: selectedTier, frequency: $displayPrice.wrappedValue))
-                        Text(viewModel.purchaseSubtitle(for: selectedTier, frequency: $displayPrice.wrappedValue))
-                            .font(style: .subheadline)
+                                // Add an invisible purchase button to take into account if the content needs to scroll
+                                purchaseButton
+                                    .opacity(0)
+                                    .disabled(true)
+                            }
+                            .frame(minHeight: reader.size.height)
+                        }
                     }
-                    .transition(.opacity)
-                    .id("plus_price" + selectedTier.title)
-                })
-                .buttonStyle(PlusOpaqueButtonStyle(isLoading: isLoading, plan: selectedTier.plan))
-                .padding(.horizontal, 20)
-                .padding(.bottom, hasBottomSafeArea ? 0 : 16)
-                .alert(isPresented: hasError) {
-                    Alert(
-                        title: Text(L10n.plusPurchaseFailed)
-                    )
+                }
+
+                VStack(spacing: 0) {
+                    Spacer()
+
+                    purchaseButton
                 }
             }
+
         }
         .background(Color.plusBackgroundColor)
         .onAppear {
@@ -103,6 +99,34 @@ struct UpgradeLandingView: View {
             .foregroundColor(.white)
             .font(style: .body, weight: .medium)
             .padding()
+        }
+    }
+
+    @ViewBuilder
+    var purchaseButton: some View {
+        let hasError = Binding<Bool>(
+            get: { self.purchaseModel.state == .failed },
+            set: { _ in }
+        )
+        let isLoading = (purchaseModel.state == .purchasing) || (viewModel.priceAvailability == .loading)
+        Button(action: {
+            purchaseModel.purchase(product: selectedProduct)
+        }, label: {
+            VStack {
+                Text(viewModel.purchaseTitle(for: selectedTier, frequency: $displayPrice.wrappedValue))
+                Text(viewModel.purchaseSubtitle(for: selectedTier, frequency: $displayPrice.wrappedValue))
+                    .font(style: .subheadline)
+            }
+            .transition(.opacity)
+            .id("plus_price" + selectedTier.title)
+        })
+        .buttonStyle(PlusOpaqueButtonStyle(isLoading: isLoading, plan: selectedTier.plan))
+        .padding(.horizontal, 20)
+        .padding(.bottom, hasBottomSafeArea ? 0 : 16)
+        .alert(isPresented: hasError) {
+            Alert(
+                title: Text(L10n.plusPurchaseFailed)
+            )
         }
     }
 }
@@ -289,38 +313,28 @@ struct UpgradeCard: View {
                 .cornerRadius(24)
                 .padding(.bottom, 16)
 
-                ScrollView {
-                    VStack(alignment: .leading, spacing: 12) {
-                        ForEach(tier.features, id: \.self) { feature in
-                            HStack(spacing: 16) {
-                                Image(feature.iconName)
-                                    .renderingMode(.template)
-                                    .resizable()
-                                    .aspectRatio(contentMode: .fit)
-                                    .foregroundColor(.black)
-                                    .frame(width: 16, height: 16)
-                                Text(feature.title)
-                                    .font(size: 14, style: .subheadline, weight: .medium)
-                                    .foregroundColor(.black)
-                                    .fixedSize(horizontal: false, vertical: true)
-                            }
+                VStack(alignment: .leading, spacing: 12) {
+                    ForEach(tier.features, id: \.self) { feature in
+                        HStack(spacing: 16) {
+                            Image(feature.iconName)
+                                .renderingMode(.template)
+                                .resizable()
+                                .aspectRatio(contentMode: .fit)
+                                .foregroundColor(.black)
+                                .frame(width: 16, height: 16)
+                            Text(feature.title)
+                                .font(size: 14, style: .subheadline, weight: .medium)
+                                .foregroundColor(.black)
+                                .fixedSize(horizontal: false, vertical: true)
                         }
+                    }
 
-                        termsAndConditions
-                            .font(style: .footnote).fixedSize(horizontal: false, vertical: true)
-                            .tint(.black)
-                            .opacity(0.64)
-                    }.overlay(
-                        // Calculate the height of the card after it's been laid out
-                        GeometryReader { proxy in
-                            Action {
-                                calculatedCardHeight = proxy.size.height
-                            }
-                        }
-                    )
+                    termsAndConditions
+                        .font(style: .footnote).fixedSize(horizontal: false, vertical: true)
+                        .tint(.black)
+                        .opacity(0.64)
                 }
                 .padding(.bottom, 0)
-                .frame(maxHeight: calculatedCardHeight)
             }
             .padding(24)
 

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -1618,6 +1618,12 @@ internal enum L10n {
   internal static var plusSelectPaymentFrequency: String { return L10n.tr("Localizable", "plus_select_payment_frequency") }
   /// Skip
   internal static var plusSkip: String { return L10n.tr("Localizable", "plus_skip") }
+  /// Start my free trial
+  internal static var plusStartMyFreeTrial: String { return L10n.tr("Localizable", "plus_start_my_free_trial") }
+  /// Try %1$@, then %2$@
+  internal static func plusStartTrialDurationPrice(_ p1: Any, _ p2: Any) -> String {
+    return L10n.tr("Localizable", "plus_start_trial_duration_price", String(describing: p1), String(describing: p2))
+  }
   /// Subscribe to Plus
   internal static var plusSubscribeTo: String { return L10n.tr("Localizable", "plus_subscribe_to") }
   /// Your subscription is managed by the Apple App Store

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -1648,6 +1648,12 @@
 /* Label of a button to skip subscring to any plan */
 "plus_skip" = "Skip";
 
+/* Label of a button prompting the user to start free trial */
+"plus_start_my_free_trial" = "Start my free trial";
+
+/* Sublabel of a button informing the trial duration and the price after. Eg.: "Try 1 month, then $99.99 per year" */
+"plus_start_trial_duration_price" = "Try %1$@, then %2$@";
+
 /* Description of the Patron plan. Do not translate "Patron". */
 "patron_description" = "Become a Pocket Casts Patron and help us continue to deliver the best podcasting experience available.";
 


### PR DESCRIPTION
Updates the new upgrade screen to display prices right away and allow the purchase without the need to show the modal.

## To test

### Pre-testing setup:
1. Open the Xcode Project
3. Hit <kbd>Command</kbd>+<kbd>Shift</kbd>+<kbd>,</kbd> to open the Scheme editor
4. Click the options tab
5. Select the `Pocket Casts Configuration.storekit` file in the StoreKit configuration dropdown

### Test the current flow

1. Enable the `patron` flag in `FeatureFlag.swift`
2. Do a clean install of the app
3. Go through the whole onboarding process and buy any plan
4. ✅ Make sure you see the confetti screen at the end
5. Go to Settings > Developer > tap "Set to No Plus"
6. Go to Podcasts > tap the Folder button
7. Buy any plan
8. ✅ Make sure you see the confetti screen
9. On Xcode, go to Debug > StoreKit > Manage Transactions
10. Delete Everything
11. Display the `.sorekit` file on Xcode
12. Go to Editor > Fail Transactions > select any failure except the "unknown"
13. Re-run the app
13. Go to Settings > Developer > tap "Set to No Plus"
6. Go to Podcasts > tap the Folder button
7. Buy any plan
1. ✅ An error should be displayed

### Test messages

1. Open the `.storekit` file
2. Add free trial in all 4 available tiers, choose anything you want but make sure they're different
13. Re-run the app
13. Go to Settings > Developer > tap "Set to No Plus"
1. ✅ Make sure the correct prices and trial period are shown

### Different devices

Please test the screen on smaller devices and big devices.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
