### PR TITLE
Merge the pbxproj using the union strategy

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 CHANGELOG.md merge=union
 podcasts/Strings+Generated.swift linguist-generated
+*.pbxproj merge=union

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 CHANGELOG.md merge=union
-podcasts/Strings+Generated.swift linguist-generated
 *.pbxproj merge=union
+
+podcasts/Strings+Generated.swift linguist-generated


### PR DESCRIPTION
This prevents having to manually deal with most Xcode project merge conflicts by defaulting to the union merge strategy by default.

## To test
1. Switch to a branch with an Xcode project conflict
  - You can test using this [old branch](https://github.com/Automattic/pocket-casts-ios/tree/fix/ios-15-warnings)
2. Add the `*.pbxproj merge=union` to the .gitattributes
3. Commit the file on the test branch
4. Merge trunk into the branch
5. ✅ Verify you see `Auto-merging podcasts.xcodeproj/project.pbxproj`

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
