### PR TITLE
Add the content shape to the social button styles to make the entire button tappable

### DIFF
--- a/podcasts/Onboarding/Login/LoginButtonStyles.swift
+++ b/podcasts/Onboarding/Login/LoginButtonStyles.swift
@@ -26,7 +26,9 @@ struct SocialButtonStyle: ButtonStyle {
                     RoundedRectangle(cornerRadius: ViewConstants.buttonCornerRadius)
                         .stroke(strokeColor, style: StrokeStyle(lineWidth: 3))
                 }
-            ).cornerRadius(ViewConstants.buttonCornerRadius)
+            )
+            .cornerRadius(ViewConstants.buttonCornerRadius)
+            .contentShape(Rectangle())
             .applyButtonEffect(isPressed: configuration.isPressed)
     }
 }


### PR DESCRIPTION
Fixes #835 

Applies the `.contentShape(Rectangle())` to the button to allow the entire button to be tappable. 

## To test

1. Launch the app
2. Sign out if you're signed in
3. Open the sign in view
4. Tap on the side of the Apple and Google buttons
5. ✅ Verify you can tap them now

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
