### PR TITLE
Patron: update logged-out flow

### DIFF
--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -267,6 +267,15 @@ struct Constants {
                 }
             }
         }
+
+        enum PlanFrequency {
+            case yearly, monthly
+        }
+
+        struct ProductInfo {
+            let plan: Plan
+            let frequency: PlanFrequency
+        }
     #endif
 
     enum RemoteParams {

--- a/podcasts/Onboarding/LoginCoordinator.swift
+++ b/podcasts/Onboarding/LoginCoordinator.swift
@@ -202,7 +202,9 @@ extension LoginCoordinator: SyncSigninDelegate, CreateAccountDelegate {
         // Update the flow to make sure the correct analytics source is passed on
         OnboardingFlow.shared.updateAnalyticsSource(source == .login ? "login" : "account_created")
 
-        let controller = PlusLandingViewModel.make(in: navigationController, from: source, continueUpgrade: presentedFromUpgrade)
+        let controller = PlusLandingViewModel.make(in: navigationController,
+                                                   from: source,
+                                                   continuePurchasing: continuePurchasing)
         navigationController?.setViewControllers([controller], animated: true)
     }
 }

--- a/podcasts/Onboarding/LoginCoordinator.swift
+++ b/podcasts/Onboarding/LoginCoordinator.swift
@@ -6,7 +6,7 @@ import PocketCastsDataModel
 class LoginCoordinator: NSObject, OnboardingModel {
     weak var navigationController: UINavigationController? = nil
     let headerImages: [LoginHeaderImage]
-    var presentedFromUpgrade: Bool = false
+    var continuePurchasing: Constants.ProductInfo? = nil
 
     private var socialLogin: SocialLogin?
     private var socialAuthProvider: SocialAuthProvider?
@@ -160,7 +160,7 @@ extension LoginCoordinator: SyncSigninDelegate, CreateAccountDelegate {
             return
         }
 
-        let shouldDismiss = OnboardingFlow.shared.currentFlow.shouldDismiss || (SubscriptionHelper.hasActiveSubscription() && !presentedFromUpgrade)
+        let shouldDismiss = OnboardingFlow.shared.currentFlow.shouldDismiss || (SubscriptionHelper.hasActiveSubscription() && continuePurchasing == nil)
 
         if shouldDismiss {
             handleDismiss()
@@ -210,9 +210,9 @@ extension LoginCoordinator: SyncSigninDelegate, CreateAccountDelegate {
 // MARK: - Helpers
 
 extension LoginCoordinator {
-    static func make(in navigationController: UINavigationController? = nil, fromUpgrade: Bool = false) -> UIViewController {
+    static func make(in navigationController: UINavigationController? = nil, continuePurchasing: Constants.ProductInfo? = nil) -> UIViewController {
         let coordinator = LoginCoordinator()
-        coordinator.presentedFromUpgrade = fromUpgrade
+        coordinator.continuePurchasing = continuePurchasing
 
         let view = LoginLandingView(coordinator: coordinator)
         let controller = LoginLandingHostingController(rootView: view.setupDefaultEnvironment())

--- a/podcasts/Onboarding/Models/PlusAccountPromptViewModel.swift
+++ b/podcasts/Onboarding/Models/PlusAccountPromptViewModel.swift
@@ -29,7 +29,12 @@ private extension PlusAccountPromptViewModel {
         guard let parentController else { return }
         let controller = OnboardingFlow.shared.begin(flow: .plusAccountUpgrade, in: parentController, source: source.rawValue)
 
-        controller.presentModally(in: parentController)
+        guard FeatureFlag.patron.enabled else {
+            controller.presentModally(in: parentController)
+            return
+        }
+
+        parentController.present(controller, animated: true)
     }
 
     func showError() {

--- a/podcasts/Onboarding/Models/PlusPricingInfoModel.swift
+++ b/podcasts/Onboarding/Models/PlusPricingInfoModel.swift
@@ -64,10 +64,6 @@ class PlusPricingInfoModel: ObservableObject {
     enum PriceAvailablity {
         case unknown, available, loading, failed
     }
-
-    enum DisplayPrice {
-        case yearly, monthly
-    }
 }
 
 // MARK: - Price Loading

--- a/podcasts/Onboarding/Models/PlusPricingInfoModel.swift
+++ b/podcasts/Onboarding/Models/PlusPricingInfoModel.swift
@@ -68,11 +68,11 @@ class PlusPricingInfoModel: ObservableObject {
 
 // MARK: - Price Loading
 extension PlusPricingInfoModel {
-    func loadPrices(_ completion: @escaping () -> Void) {
+    func loadPrices(_ completion: (() -> Void)? = nil) {
         if purchaseHandler.hasLoadedProducts {
             priceAvailability = .available
             pricingInfo = Self.getPricingInfo(from: self.purchaseHandler)
-            completion()
+            completion?()
             return
         }
 
@@ -87,12 +87,12 @@ extension PlusPricingInfoModel {
 
             self.priceAvailability = .available
             self.pricingInfo = Self.getPricingInfo(from: self.purchaseHandler)
-            completion()
+            completion?()
         }
 
         notificationCenter.addObserver(forName: ServerNotifications.iapProductsFailed, object: nil, queue: .main) { _ in
             self.priceAvailability = .failed
-            completion()
+            completion?()
         }
 
         purchaseHandler.requestProductInfo()

--- a/podcasts/Onboarding/Models/PlusPurchaseModel.swift
+++ b/podcasts/Onboarding/Models/PlusPurchaseModel.swift
@@ -62,7 +62,7 @@ class PlusPurchaseModel: PlusPricingInfoModel, OnboardingModel {
 }
 
 extension PlusPurchaseModel {
-    static func make(in parentController: UIViewController?, plan: Constants.Plan, selectedPrice: PlusPricingInfoModel.DisplayPrice) -> UIViewController {
+    static func make(in parentController: UIViewController?, plan: Constants.Plan, selectedPrice: Constants.PlanFrequency) -> UIViewController {
         let viewModel = PlusPurchaseModel()
         viewModel.parentController = parentController
         viewModel.plan = plan

--- a/podcasts/Onboarding/OnboardingFlow.swift
+++ b/podcasts/Onboarding/OnboardingFlow.swift
@@ -23,7 +23,7 @@ struct OnboardingFlow {
             flowController = PlusPurchaseModel.make(in: controller, plan: .plus, selectedPrice: .yearly)
 
         case .plusAccountUpgradeNeedsLogin:
-            flowController = LoginCoordinator.make(in: navigationController, fromUpgrade: true)
+            flowController = LoginCoordinator.make(in: navigationController, continuePurchasing: .init(plan: .plus, frequency: .yearly))
 
         case .initialOnboarding, .loggedOut: fallthrough
         default:

--- a/podcasts/Onboarding/OnboardingFlow.swift
+++ b/podcasts/Onboarding/OnboardingFlow.swift
@@ -20,7 +20,13 @@ struct OnboardingFlow {
             flowController = PlusLandingViewModel.make(in: navigationController, from: .upsell)
 
         case .plusAccountUpgrade:
-            flowController = PlusPurchaseModel.make(in: controller, plan: .plus, selectedPrice: .yearly)
+            if FeatureFlag.patron.enabled {
+                // Only the upsell flow needs an unknown source
+                self.source = source ?? "unknown"
+                flowController = PlusLandingViewModel.make(in: navigationController, from: .upsell)
+            } else {
+                flowController = PlusPurchaseModel.make(in: controller, plan: .plus, selectedPrice: .yearly)
+            }
 
         case .plusAccountUpgradeNeedsLogin:
             flowController = LoginCoordinator.make(in: navigationController, continuePurchasing: .init(plan: .plus, frequency: .yearly))

--- a/podcasts/Onboarding/Plus/PlusLandingView.swift
+++ b/podcasts/Onboarding/Plus/PlusLandingView.swift
@@ -57,7 +57,7 @@ struct PlusLandingView: View {
                     // Buttons
                     VStack(alignment: .leading, spacing: 16) {
                         Button(L10n.plusButtonTitleUnlockAll) {
-                            viewModel.unlockTapped(selectedPrice: .yearly)
+                            viewModel.unlockTapped(.init(plan: .plus, frequency: .yearly))
                         }.buttonStyle(PlusGradientFilledButtonStyle(isLoading: viewModel.priceAvailability == .loading, plan: .plus))
 
                         Button(L10n.eoyNotNow) {

--- a/podcasts/Onboarding/Plus/PlusLandingViewModel.swift
+++ b/podcasts/Onboarding/Plus/PlusLandingViewModel.swift
@@ -143,7 +143,7 @@ extension PlusLandingViewModel {
         let navController = navigationController ?? UINavigationController(rootViewController: controller)
         viewModel.navigationController = navController
         viewModel.parentController = navController
-        
+
         return (navigationController == nil) ? navController : controller
     }
 

--- a/podcasts/Onboarding/Plus/PlusLandingViewModel.swift
+++ b/podcasts/Onboarding/Plus/PlusLandingViewModel.swift
@@ -11,6 +11,10 @@ class PlusLandingViewModel: PlusPricingInfoModel, OnboardingModel {
     @Published var currentPage: Int = 0
     @Published var displayPrice: DisplayPrice = .yearly
 
+    var hasAnyPreviouslySelectedPriceAndIsLoggedIn: Bool {
+        Self.previousSelectedPage != nil && Self.previousSelectedPrice != nil && SyncManager.isUserLoggedIn()
+    }
+
     static var previousSelectedPrice: DisplayPrice?
     static var previousSelectedPage: Int?
 

--- a/podcasts/Onboarding/Plus/PlusLandingViewModel.swift
+++ b/podcasts/Onboarding/Plus/PlusLandingViewModel.swift
@@ -80,7 +80,7 @@ class PlusLandingViewModel: PlusPurchaseModel {
         }
     }
 
-    func product(for plan: Constants.Plan, frequency: Constants.PlanFrequency) -> PlusProductPricingInfo? {
+    private func product(for plan: Constants.Plan, frequency: Constants.PlanFrequency) -> PlusProductPricingInfo? {
         pricingInfo.products.first(where: { $0.identifier == (frequency == .yearly ? plan.yearly : plan.monthly) })
     }
 
@@ -132,9 +132,8 @@ private extension PlusLandingViewModel {
 extension PlusLandingViewModel {
     static func make(in navigationController: UINavigationController? = nil, from source: Source, continuePurchasing: Constants.ProductInfo? = nil) -> UIViewController {
         let viewModel = PlusLandingViewModel(source: source, continuePurchasing: continuePurchasing)
-        let purchaseModel = FeatureFlag.patron.enabled ? PlusPurchaseModel() : nil
 
-        let view = Self.view(with: viewModel, purchaseModel: purchaseModel)
+        let view = Self.view(with: viewModel)
         let controller = PlusHostingViewController(rootView: view)
 
         controller.viewModel = viewModel
@@ -143,17 +142,16 @@ extension PlusLandingViewModel {
         // Create our own nav controller if we're not already going in one
         let navController = navigationController ?? UINavigationController(rootViewController: controller)
         viewModel.navigationController = navController
-        purchaseModel?.parentController = navController
-
+        viewModel.parentController = navController
+        
         return (navigationController == nil) ? navController : controller
     }
 
     @ViewBuilder
-    private static func view(with viewModel: PlusLandingViewModel, purchaseModel: PlusPurchaseModel? = nil) -> some View {
-        if FeatureFlag.patron.enabled, let purchaseModel {
+    private static func view(with viewModel: PlusLandingViewModel) -> some View {
+        if FeatureFlag.patron.enabled {
             UpgradeLandingView()
                 .environmentObject(viewModel)
-                .environmentObject(purchaseModel)
                 .setupDefaultEnvironment()
         } else {
             PlusLandingView(viewModel: viewModel)

--- a/podcasts/Onboarding/Plus/PlusLandingViewModel.swift
+++ b/podcasts/Onboarding/Plus/PlusLandingViewModel.swift
@@ -5,7 +5,7 @@ import SwiftUI
 class PlusLandingViewModel: PlusPricingInfoModel, OnboardingModel {
     weak var navigationController: UINavigationController? = nil
 
-    var continueUpgrade: Bool
+    var continuePurchasing: Constants.ProductInfo? = nil
     let source: Source
 
     @Published var currentPage: Int = 0
@@ -20,6 +20,8 @@ class PlusLandingViewModel: PlusPricingInfoModel, OnboardingModel {
 
     init(source: Source, continueUpgrade: Bool = false, purchaseHandler: IapHelper = .shared) {
         self.continueUpgrade = continueUpgrade
+    init(source: Source, continuePurchasing: Constants.ProductInfo? = nil, purchaseHandler: IapHelper = .shared) {
+        self.continuePurchasing = continuePurchasing
         self.source = source
 
         if let previousSelectedPage = Self.previousSelectedPage,

--- a/podcasts/Onboarding/Plus/PlusLandingViewModel.swift
+++ b/podcasts/Onboarding/Plus/PlusLandingViewModel.swift
@@ -2,7 +2,7 @@ import Foundation
 import PocketCastsServer
 import SwiftUI
 
-class PlusLandingViewModel: PlusPricingInfoModel, OnboardingModel {
+class PlusLandingViewModel: PlusPurchaseModel {
     weak var navigationController: UINavigationController? = nil
 
     var continuePurchasing: Constants.ProductInfo? = nil
@@ -40,6 +40,7 @@ class PlusLandingViewModel: PlusPricingInfoModel, OnboardingModel {
     }
 
     func didAppear() {
+    override func didAppear() {
         OnboardingFlow.shared.track(.plusPromotionShown)
 
         guard continueUpgrade else { return }
@@ -52,7 +53,7 @@ class PlusLandingViewModel: PlusPricingInfoModel, OnboardingModel {
         }
     }
 
-    func didDismiss(type: OnboardingDismissType) {
+    override func didDismiss(type: OnboardingDismissType) {
         guard type == .swipe else { return }
 
         OnboardingFlow.shared.track(.plusPromotionDismissed)

--- a/podcasts/Onboarding/Plus/PlusLandingViewModel.swift
+++ b/podcasts/Onboarding/Plus/PlusLandingViewModel.swift
@@ -8,9 +8,21 @@ class PlusLandingViewModel: PlusPricingInfoModel, OnboardingModel {
     var continueUpgrade: Bool
     let source: Source
 
+    @Published var currentPage: Int = 0
+    @Published var displayPrice: DisplayPrice = .yearly
+
+    static var previousSelectedPrice: DisplayPrice?
+    static var previousSelectedPage: Int?
+
     init(source: Source, continueUpgrade: Bool = false, purchaseHandler: IapHelper = .shared) {
         self.continueUpgrade = continueUpgrade
         self.source = source
+
+        if let previousSelectedPage = Self.previousSelectedPage,
+           let previousSelectedPrice = Self.previousSelectedPrice {
+            self.currentPage = previousSelectedPage
+            self.displayPrice = previousSelectedPrice
+        }
 
         super.init(purchaseHandler: purchaseHandler)
     }
@@ -47,7 +59,9 @@ class PlusLandingViewModel: PlusPricingInfoModel, OnboardingModel {
         // Don't continually show when the user dismisses
         continueUpgrade = false
 
-        self.loadPricesAndContinue(plan: .plus, selectedPrice: .yearly)
+        if !FeatureFlag.patron.enabled {
+            loadPricesAndContinue(plan: .plus, selectedPrice: .yearly)
+        }
     }
 
     func didDismiss(type: OnboardingDismissType) {

--- a/podcasts/Onboarding/Plus/PlusLandingViewModel.swift
+++ b/podcasts/Onboarding/Plus/PlusLandingViewModel.swift
@@ -8,27 +8,9 @@ class PlusLandingViewModel: PlusPricingInfoModel, OnboardingModel {
     var continuePurchasing: Constants.ProductInfo? = nil
     let source: Source
 
-    @Published var currentPage: Int = 0
-    @Published var displayPrice: DisplayPrice = .yearly
-
-    var hasAnyPreviouslySelectedPriceAndIsLoggedIn: Bool {
-        Self.previousSelectedPage != nil && Self.previousSelectedPrice != nil && SyncManager.isUserLoggedIn()
-    }
-
-    static var previousSelectedPrice: DisplayPrice?
-    static var previousSelectedPage: Int?
-
-    init(source: Source, continueUpgrade: Bool = false, purchaseHandler: IapHelper = .shared) {
-        self.continueUpgrade = continueUpgrade
     init(source: Source, continuePurchasing: Constants.ProductInfo? = nil, purchaseHandler: IapHelper = .shared) {
         self.continuePurchasing = continuePurchasing
         self.source = source
-
-        if let previousSelectedPage = Self.previousSelectedPage,
-           let previousSelectedPrice = Self.previousSelectedPrice {
-            self.currentPage = previousSelectedPage
-            self.displayPrice = previousSelectedPrice
-        }
 
         super.init(purchaseHandler: purchaseHandler)
     }

--- a/podcasts/Onboarding/Plus/PlusPurchaseModal.swift
+++ b/podcasts/Onboarding/Plus/PlusPurchaseModal.swift
@@ -18,7 +18,7 @@ struct PlusPurchaseModal: View {
 
     private var products: [PlusPricingInfoModel.PlusProductPricingInfo]
 
-    init(coordinator: PlusPurchaseModel, selectedPrice: PlusPricingInfoModel.DisplayPrice = .yearly) {
+    init(coordinator: PlusPurchaseModel, selectedPrice: Constants.PlanFrequency = .yearly) {
         self.coordinator = coordinator
 
         self.products = coordinator.pricingInfo.products.filter { coordinator.plan.products.contains($0.identifier) }

--- a/podcasts/Onboarding/Plus/UpgradeLandingView.swift
+++ b/podcasts/Onboarding/Plus/UpgradeLandingView.swift
@@ -121,6 +121,10 @@ struct UpgradeLandingView: View {
         .onAppear {
             // Ensure prices are loaded
             viewModel.loadPrices { }
+
+            if viewModel.hasAnyPreviouslySelectedPriceAndIsLoggedIn {
+                purchaseModel.purchase(product: selectedProduct)
+            }
         }
     }
 

--- a/podcasts/Onboarding/Plus/UpgradeLandingView.swift
+++ b/podcasts/Onboarding/Plus/UpgradeLandingView.swift
@@ -4,8 +4,6 @@ import PocketCastsServer
 struct UpgradeLandingView: View {
     @EnvironmentObject var viewModel: PlusLandingViewModel
 
-    @EnvironmentObject private var purchaseModel: PlusPurchaseModel
-
     private let tiers: [UpgradeTier] = [.plus, .patron]
 
     private var selectedTier: UpgradeTier {
@@ -141,15 +139,12 @@ struct UpgradeLandingView: View {
     @ViewBuilder
     var purchaseButton: some View {
         let hasError = Binding<Bool>(
-            get: { self.purchaseModel.state == .failed },
+            get: { self.viewModel.state == .failed },
             set: { _ in }
         )
-        let isLoading = (purchaseModel.state == .purchasing) || (viewModel.priceAvailability == .loading)
+        let isLoading = (viewModel.state == .purchasing) || (viewModel.priceAvailability == .loading)
         Button(action: {
-            viewModel.unlockTapped {
-                purchaseModel.purchase(product: selectedProduct)
-            }
-
+            viewModel.unlockTapped(.init(plan: selectedTier.plan, frequency: displayPrice))
         }, label: {
             VStack {
                 Text(viewModel.purchaseTitle(for: selectedTier, frequency: $displayPrice.wrappedValue))
@@ -166,7 +161,7 @@ struct UpgradeLandingView: View {
             Alert(
                 title: Text(L10n.plusPurchaseFailed),
                 dismissButton: .default(Text(L10n.ok)) {
-                    purchaseModel.reset()
+                    viewModel.reset()
                 }
             )
         }

--- a/podcasts/Onboarding/Plus/UpgradeLandingView.swift
+++ b/podcasts/Onboarding/Plus/UpgradeLandingView.swift
@@ -173,7 +173,7 @@ struct UpgradeLandingView: View {
 private struct FeaturesCarousel: View {
     let currentIndex: Binding<Int>
 
-    let currentPrice: Binding<PlusPricingInfoModel.DisplayPrice>
+    let currentPrice: Binding<Constants.PlanFrequency>
 
     let tiers: [UpgradeTier]
 
@@ -203,13 +203,13 @@ private struct FeaturesCarousel: View {
                     }
                 )
         }
-        .carouselPeekAmount(.constant(Constants.peekAmount))
-        .carouselItemSpacing(Constants.spacing)
+        .carouselPeekAmount(.constant(ViewConstants.peekAmount))
+        .carouselItemSpacing(ViewConstants.spacing)
         .frame(height: calculatedCardHeight)
         .padding(.leading, 30)
     }
 
-    private enum Constants {
+    private enum ViewConstants {
         static let peekAmount: Double = 20
         static let spacing: Double = 30
     }
@@ -273,9 +273,9 @@ extension UpgradeTier {
 // MARK: - Segmented Control
 
 struct UpgradeRoundedSegmentedControl: View {
-    @Binding private var selected: PlusPricingInfoModel.DisplayPrice
+    @Binding private var selected: Constants.PlanFrequency
 
-    init(selected: Binding<PlusPricingInfoModel.DisplayPrice>) {
+    init(selected: Binding<Constants.PlanFrequency>) {
         self._selected = selected
     }
 
@@ -330,7 +330,7 @@ struct UpgradeCard: View {
 
     let tier: UpgradeTier
 
-    let currentPrice: Binding<PlusPricingInfoModel.DisplayPrice>
+    let currentPrice: Binding<Constants.PlanFrequency>
 
     @State var calculatedCardHeight: CGFloat?
 
@@ -422,6 +422,5 @@ extension ViewHeightKey: ViewModifier {
 struct UpgradeLandingView_Previews: PreviewProvider {
     static var previews: some View {
         UpgradeLandingView().environmentObject(PlusLandingViewModel(source: .login))
-            .environmentObject(PlusPurchaseModel())
     }
 }

--- a/podcasts/Onboarding/Plus/UpgradeLandingView.swift
+++ b/podcasts/Onboarding/Plus/UpgradeLandingView.swift
@@ -9,15 +9,17 @@ struct UpgradeLandingView: View {
     private let tiers: [UpgradeTier] = [.plus, .patron]
 
     private var selectedTier: UpgradeTier {
-        tiers[viewModel.currentPage]
+        tiers[currentPage]
     }
 
     @State private var contentIsScrollable = false
 
     @State private var purchaseButtonHeight: CGFloat = 0
+    @State private var currentPage: Int = 0
+    @State private var displayPrice: Constants.PlanFrequency = .yearly
 
     private var selectedProduct: Constants.IapProducts {
-        viewModel.displayPrice == .yearly ? selectedTier.plan.yearly : selectedTier.plan.monthly
+        displayPrice == .yearly ? selectedTier.plan.yearly : selectedTier.plan.monthly
     }
 
     /// If this device has a small screen
@@ -59,13 +61,13 @@ struct UpgradeLandingView: View {
                                     .padding(.bottom, 16)
                                     .padding(.horizontal, 32)
 
-                                UpgradeRoundedSegmentedControl(selected: $viewModel.displayPrice)
+                                UpgradeRoundedSegmentedControl(selected: $displayPrice)
                                     .padding(.bottom, 24)
 
-                                FeaturesCarousel(currentIndex: $viewModel.currentPage.animation(), currentPrice: $viewModel.displayPrice, tiers: tiers)
+                                FeaturesCarousel(currentIndex: $currentPage.animation(), currentPrice: $displayPrice, tiers: tiers)
 
                                 if !isSmallScreen && !contentIsScrollable {
-                                    PageIndicatorView(numberOfItems: tiers.count, currentPage: viewModel.currentPage)
+                                    PageIndicatorView(numberOfItems: tiers.count, currentPage: currentPage)
                                         .padding(.top, 27)
                                 }
 
@@ -121,10 +123,6 @@ struct UpgradeLandingView: View {
         .onAppear {
             // Ensure prices are loaded
             viewModel.loadPrices { }
-
-            if viewModel.hasAnyPreviouslySelectedPriceAndIsLoggedIn {
-                purchaseModel.purchase(product: selectedProduct)
-            }
         }
     }
 
@@ -152,12 +150,10 @@ struct UpgradeLandingView: View {
                 purchaseModel.purchase(product: selectedProduct)
             }
 
-            PlusLandingViewModel.previousSelectedPrice = viewModel.displayPrice
-            PlusLandingViewModel.previousSelectedPage = viewModel.currentPage
         }, label: {
             VStack {
-                Text(viewModel.purchaseTitle(for: selectedTier, frequency: $viewModel.displayPrice.wrappedValue))
-                Text(viewModel.purchaseSubtitle(for: selectedTier, frequency: $viewModel.displayPrice.wrappedValue))
+                Text(viewModel.purchaseTitle(for: selectedTier, frequency: $displayPrice.wrappedValue))
+                Text(viewModel.purchaseSubtitle(for: selectedTier, frequency: $displayPrice.wrappedValue))
                     .font(style: .subheadline)
             }
             .transition(.opacity)

--- a/podcasts/Onboarding/Plus/UpgradeLandingView.swift
+++ b/podcasts/Onboarding/Plus/UpgradeLandingView.swift
@@ -120,7 +120,15 @@ struct UpgradeLandingView: View {
         .background(Color.plusBackgroundColor)
         .onAppear {
             // Ensure prices are loaded
-            viewModel.loadPrices { }
+            viewModel.loadPrices()
+
+            // Switch to the previously selected options if available
+            if let continuePurchasing = viewModel.continuePurchasing {
+                let index = tiers.firstIndex(where: { $0.plan == continuePurchasing.plan }) ?? 0
+
+                displayPrice = continuePurchasing.frequency
+                currentPage = index
+            }
         }
     }
 

--- a/podcasts/Onboarding/Plus/UpgradeLandingView.swift
+++ b/podcasts/Onboarding/Plus/UpgradeLandingView.swift
@@ -9,19 +9,15 @@ struct UpgradeLandingView: View {
     private let tiers: [UpgradeTier] = [.plus, .patron]
 
     private var selectedTier: UpgradeTier {
-        tiers[currentPage]
+        tiers[viewModel.currentPage]
     }
-
-    @State private var currentPage: Int = 0
-
-    @State private var displayPrice: PlusPricingInfoModel.DisplayPrice = .yearly
 
     @State private var contentIsScrollable = false
 
     @State private var purchaseButtonHeight: CGFloat = 0
 
     private var selectedProduct: Constants.IapProducts {
-        displayPrice == .yearly ? selectedTier.plan.yearly : selectedTier.plan.monthly
+        viewModel.displayPrice == .yearly ? selectedTier.plan.yearly : selectedTier.plan.monthly
     }
 
     /// If this device has a small screen
@@ -63,13 +59,13 @@ struct UpgradeLandingView: View {
                                     .padding(.bottom, 16)
                                     .padding(.horizontal, 32)
 
-                                UpgradeRoundedSegmentedControl(selected: $displayPrice)
+                                UpgradeRoundedSegmentedControl(selected: $viewModel.displayPrice)
                                     .padding(.bottom, 24)
 
-                                FeaturesCarousel(currentIndex: $currentPage.animation(), currentPrice: $displayPrice, tiers: tiers)
+                                FeaturesCarousel(currentIndex: $viewModel.currentPage.animation(), currentPrice: $viewModel.displayPrice, tiers: tiers)
 
                                 if !isSmallScreen && !contentIsScrollable {
-                                    PageIndicatorView(numberOfItems: tiers.count, currentPage: currentPage)
+                                    PageIndicatorView(numberOfItems: tiers.count, currentPage: viewModel.currentPage)
                                         .padding(.top, 27)
                                 }
 
@@ -151,10 +147,13 @@ struct UpgradeLandingView: View {
             viewModel.unlockTapped {
                 purchaseModel.purchase(product: selectedProduct)
             }
+
+            PlusLandingViewModel.previousSelectedPrice = viewModel.displayPrice
+            PlusLandingViewModel.previousSelectedPage = viewModel.currentPage
         }, label: {
             VStack {
-                Text(viewModel.purchaseTitle(for: selectedTier, frequency: $displayPrice.wrappedValue))
-                Text(viewModel.purchaseSubtitle(for: selectedTier, frequency: $displayPrice.wrappedValue))
+                Text(viewModel.purchaseTitle(for: selectedTier, frequency: $viewModel.displayPrice.wrappedValue))
+                Text(viewModel.purchaseSubtitle(for: selectedTier, frequency: $viewModel.displayPrice.wrappedValue))
                     .font(style: .subheadline)
             }
             .transition(.opacity)

--- a/podcasts/SettingsViewController.swift
+++ b/podcasts/SettingsViewController.swift
@@ -143,7 +143,11 @@ class SettingsViewController: PCViewController, UITableViewDataSource, UITableVi
         case .watch:
             navigationController?.pushViewController(WatchSettingsViewController(), animated: true)
         case .pocketCastsPlus:
-            navigationController?.present(OnboardingFlow.shared.begin(flow: .plusUpsell, source: "settings"), animated: true)
+            if FeatureFlag.patron.enabled {
+                navigationController?.present(OnboardingFlow.shared.begin(flow: .plusUpsell, source: "settings"), animated: true)
+            } else {
+                navigationController?.pushViewController(PlusDetailsViewController(), animated: true)
+            }
         case .privacy:
             navigationController?.pushViewController(PrivacySettingsViewController(), animated: true)
         case .developer:

--- a/podcasts/SettingsViewController.swift
+++ b/podcasts/SettingsViewController.swift
@@ -143,7 +143,7 @@ class SettingsViewController: PCViewController, UITableViewDataSource, UITableVi
         case .watch:
             navigationController?.pushViewController(WatchSettingsViewController(), animated: true)
         case .pocketCastsPlus:
-            navigationController?.pushViewController(PlusDetailsViewController(), animated: true)
+            navigationController?.present(OnboardingFlow.shared.begin(flow: .plusUpsell, source: "settings"), animated: true)
         case .privacy:
             navigationController?.pushViewController(PrivacySettingsViewController(), animated: true)
         case .developer:

--- a/podcasts/SwiftUI/HorizontalCarousel.swift
+++ b/podcasts/SwiftUI/HorizontalCarousel.swift
@@ -144,6 +144,10 @@ struct HorizontalCarousel<Content: View, T: Identifiable>: View {
                         state = value.translation.width
                     })
             )
+            // Update the internal visible index if the selection index changes
+            .onChange(of: index) { newValue in
+                visibleIndex = newValue
+            }
         }
     }
 

--- a/podcasts/SwiftUI/HorizontalCarousel.swift
+++ b/podcasts/SwiftUI/HorizontalCarousel.swift
@@ -27,6 +27,7 @@ struct HorizontalCarousel<Content: View, T: Identifiable>: View {
 
     init(currentIndex: Binding<Int>? = .constant(0), items: [T], @ViewBuilder content: @escaping (T) -> Content) {
         self._index = currentIndex ?? .constant(0)
+        self.visibleIndex = currentIndex?.wrappedValue ?? 0
         self.items = items
         self.content = content
     }
@@ -244,6 +245,7 @@ struct HorizontalCarousel_Preview: PreviewProvider {
         @State var spacing: CGFloat = 20
         @State var items: CGFloat = 1
         @State var isConstant: Bool = true
+        @State var currentIndex: Int = 2
 
         var body: some View {
             let colors: [Color] = [.red, .orange, .yellow, .green, .blue, .purple, .pink]
@@ -299,7 +301,7 @@ struct HorizontalCarousel_Preview: PreviewProvider {
                     }
                 }.padding()
 
-                HorizontalCarousel(items: pages) { item in
+                HorizontalCarousel(currentIndex: $currentIndex, items: pages) { item in
                     Rectangle()
                         .cornerRadius(5)
                         .foregroundColor(item.color)

--- a/podcasts/SwiftUI/HorizontalCarousel.swift
+++ b/podcasts/SwiftUI/HorizontalCarousel.swift
@@ -215,7 +215,10 @@ private struct LazyLoadingView<Content: View>: View {
                     Action {
                         var frame = visibleFrame
 
-                        // Expand the visible frame by 2 to load items that are currently off screen but may appear next
+                        // Take into account items that can be displayed before the current frame
+                        frame.origin.x = max(0, frame.origin.x - frame.size.width)
+
+                        // Expand the visible frame by 2 to load items that are currently off screen but may appear next or before
                         frame.size.width *= 2
 
                         // Calculate if this view is visible or not


### PR DESCRIPTION
Fixes the logged out flow for the new upgrade screen.

### Pre-testing setup:
1. Open the Xcode Project
3. Hit <kbd>Command</kbd>+<kbd>Shift</kbd>+<kbd>,</kbd> to open the Scheme editor
4. Click the options tab
5. Select the `Pocket Casts Configuration.storekit` file in the StoreKit configuration dropdown

### Test the current flow:

Before testing: Run the app, go to Profile > Settings > Beta Features > enable patron

#### From the upsell view

1. Go to Podcasts > tap the folder icon
2. Swipe to Patron and change it to monthly, tap "Subscribe to Patron"
3. Create an account
4. ✅ After creating an account you should be back to the upgrade screen and the modal IAP should appear right away, with the correct tier and payment recurrence. Also, the screen should reflect the changes of your previously selected product: correct card, page indicator and segment control.

#### From the Settings: Plus Item
1. Sign out if you're signed in
1. Go to the Profile tab
2. Tap the Settings cog in the top right corner
3. Tap Pocket Casts Plus
4. ✅ Verify you are brought to the new upgrade screen
5. Switch to Patron and Tap Monthly
6. Tap the Subscribe button
7. Login or create an account
8. ✅ Verify after you are brought to upgrade view and the purchase modal opens
9. Subscribe
7. ✅ Verify you are brought to the welcome view

#### From the account login:

1. Sign out if you're signed in
2. Go to the Profile tab
3. Tap the Set Up Account bubble
4. Login
5. ✅ Verify you are brought to the new upgrade view
6. Subscribe to a plan
7. ✅ Verify you are brought to the welcome view

### Test the old flow

1. Delete the account you just created
11. Go to Profile > Settings > Beta Features > disable patron
12. Test the flows described above
## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
