### PR TITLE
Fix playback speed label collapsed in German language

### DIFF
--- a/podcasts/EffectsViewController.xib
+++ b/podcasts/EffectsViewController.xib
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21678"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -99,7 +100,7 @@
                                     <rect key="frame" x="0.0" y="10" width="24" height="24"/>
                                     <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </imageView>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Speed" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7Mt-Tq-MwW" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" text="Speed" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="12" translatesAutoresizingMaskIntoConstraints="NO" id="7Mt-Tq-MwW" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
                                     <rect key="frame" x="44" y="11.5" width="52" height="21.5"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="18"/>
                                     <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
@@ -160,6 +161,7 @@
                                 <constraint firstAttribute="trailing" secondItem="ZiH-JO-EJn" secondAttribute="trailing" id="QsM-kr-nfF"/>
                                 <constraint firstItem="ZiH-JO-EJn" firstAttribute="leading" secondItem="OiT-SV-8zG" secondAttribute="trailing" constant="10" id="gp4-zR-gsp"/>
                                 <constraint firstItem="OiT-SV-8zG" firstAttribute="leading" secondItem="X9d-OS-tJn" secondAttribute="trailing" constant="10" id="jX1-Ba-n1v"/>
+                                <constraint firstItem="X9d-OS-tJn" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="7Mt-Tq-MwW" secondAttribute="trailing" constant="4" id="ug7-5u-o29"/>
                                 <constraint firstItem="7Mt-Tq-MwW" firstAttribute="centerY" secondItem="l8T-5d-1fK" secondAttribute="centerY" id="vgr-tS-BqN"/>
                                 <constraint firstItem="7Mt-Tq-MwW" firstAttribute="leading" secondItem="l8T-5d-1fK" secondAttribute="trailing" constant="20" id="wCK-VC-Hrq"/>
                                 <constraint firstAttribute="height" constant="44" id="xel-ni-y2Z"/>

--- a/podcasts/EffectsViewController.xib
+++ b/podcasts/EffectsViewController.xib
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21678"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -99,7 +100,7 @@
                                     <rect key="frame" x="0.0" y="10" width="24" height="24"/>
                                     <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </imageView>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Speed" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7Mt-Tq-MwW" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" text="Speed" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7Mt-Tq-MwW" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
                                     <rect key="frame" x="44" y="11.5" width="52" height="21.5"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="18"/>
                                     <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
@@ -156,6 +157,7 @@
                                 <constraint firstItem="l8T-5d-1fK" firstAttribute="centerY" secondItem="5iH-XX-TB6" secondAttribute="centerY" id="2kO-dn-1qy"/>
                                 <constraint firstItem="ZiH-JO-EJn" firstAttribute="centerY" secondItem="5iH-XX-TB6" secondAttribute="centerY" id="9n9-Io-6xx"/>
                                 <constraint firstItem="l8T-5d-1fK" firstAttribute="leading" secondItem="5iH-XX-TB6" secondAttribute="leading" id="Ens-YS-SOH"/>
+                                <constraint firstItem="X9d-OS-tJn" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="7Mt-Tq-MwW" secondAttribute="trailing" constant="4" id="LJ4-xc-sqt"/>
                                 <constraint firstItem="X9d-OS-tJn" firstAttribute="centerY" secondItem="OiT-SV-8zG" secondAttribute="centerY" id="QHV-jT-NMC"/>
                                 <constraint firstAttribute="trailing" secondItem="ZiH-JO-EJn" secondAttribute="trailing" id="QsM-kr-nfF"/>
                                 <constraint firstItem="ZiH-JO-EJn" firstAttribute="leading" secondItem="OiT-SV-8zG" secondAttribute="trailing" constant="10" id="gp4-zR-gsp"/>

--- a/podcasts/EffectsViewController.xib
+++ b/podcasts/EffectsViewController.xib
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21678"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -100,7 +99,7 @@
                                     <rect key="frame" x="0.0" y="10" width="24" height="24"/>
                                     <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </imageView>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" text="Speed" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7Mt-Tq-MwW" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Speed" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7Mt-Tq-MwW" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
                                     <rect key="frame" x="44" y="11.5" width="52" height="21.5"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="18"/>
                                     <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
@@ -157,7 +156,6 @@
                                 <constraint firstItem="l8T-5d-1fK" firstAttribute="centerY" secondItem="5iH-XX-TB6" secondAttribute="centerY" id="2kO-dn-1qy"/>
                                 <constraint firstItem="ZiH-JO-EJn" firstAttribute="centerY" secondItem="5iH-XX-TB6" secondAttribute="centerY" id="9n9-Io-6xx"/>
                                 <constraint firstItem="l8T-5d-1fK" firstAttribute="leading" secondItem="5iH-XX-TB6" secondAttribute="leading" id="Ens-YS-SOH"/>
-                                <constraint firstItem="X9d-OS-tJn" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="7Mt-Tq-MwW" secondAttribute="trailing" constant="4" id="LJ4-xc-sqt"/>
                                 <constraint firstItem="X9d-OS-tJn" firstAttribute="centerY" secondItem="OiT-SV-8zG" secondAttribute="centerY" id="QHV-jT-NMC"/>
                                 <constraint firstAttribute="trailing" secondItem="ZiH-JO-EJn" secondAttribute="trailing" id="QsM-kr-nfF"/>
                                 <constraint firstItem="ZiH-JO-EJn" firstAttribute="leading" secondItem="OiT-SV-8zG" secondAttribute="trailing" constant="10" id="gp4-zR-gsp"/>

--- a/podcasts/TimeStepperCell.xib
+++ b/podcasts/TimeStepperCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21678"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -24,7 +24,7 @@
                             <constraint firstAttribute="height" constant="24" id="mpO-kU-UDK"/>
                         </constraints>
                     </imageView>
-                    <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="253" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="Skip First" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="06e-3Z-E2J" userLabel="Main Label" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
+                    <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="253" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" text="Skip First" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="12" translatesAutoresizingMaskIntoConstraints="NO" id="06e-3Z-E2J" userLabel="Main Label" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
                         <rect key="frame" x="50" y="5" width="67.5" height="34"/>
                         <fontDescription key="fontDescription" type="system" pointSize="16"/>
                         <color key="textColor" red="0.1960784314" green="0.1960784314" blue="0.1960784314" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -47,7 +47,7 @@
                     <constraint firstItem="L5Q-aR-hdK" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="BoX-uy-x5a"/>
                     <constraint firstAttribute="bottom" secondItem="hII-1o-P5c" secondAttribute="bottom" id="C7N-sw-pCr"/>
                     <constraint firstItem="KNT-iD-vFj" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="ETk-sO-HNJ"/>
-                    <constraint firstItem="L5Q-aR-hdK" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="06e-3Z-E2J" secondAttribute="trailing" constant="-4" id="RKy-VE-koV"/>
+                    <constraint firstItem="L5Q-aR-hdK" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="06e-3Z-E2J" secondAttribute="trailing" constant="4" id="RKy-VE-koV"/>
                     <constraint firstItem="06e-3Z-E2J" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" priority="750" constant="16" id="U0p-Xm-Rhu"/>
                     <constraint firstAttribute="trailing" secondItem="hII-1o-P5c" secondAttribute="trailing" constant="8" id="UXv-qg-eP5"/>
                     <constraint firstItem="KNT-iD-vFj" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="Y7x-zG-bw0"/>

--- a/podcasts/TimeStepperCell.xib
+++ b/podcasts/TimeStepperCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21678"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -24,7 +24,7 @@
                             <constraint firstAttribute="height" constant="24" id="mpO-kU-UDK"/>
                         </constraints>
                     </imageView>
-                    <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="253" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" text="Skip First" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="06e-3Z-E2J" userLabel="Main Label" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
+                    <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="253" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="Skip First" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="06e-3Z-E2J" userLabel="Main Label" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
                         <rect key="frame" x="50" y="5" width="67.5" height="34"/>
                         <fontDescription key="fontDescription" type="system" pointSize="16"/>
                         <color key="textColor" red="0.1960784314" green="0.1960784314" blue="0.1960784314" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -47,7 +47,7 @@
                     <constraint firstItem="L5Q-aR-hdK" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="BoX-uy-x5a"/>
                     <constraint firstAttribute="bottom" secondItem="hII-1o-P5c" secondAttribute="bottom" id="C7N-sw-pCr"/>
                     <constraint firstItem="KNT-iD-vFj" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="ETk-sO-HNJ"/>
-                    <constraint firstItem="L5Q-aR-hdK" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="06e-3Z-E2J" secondAttribute="trailing" constant="4" id="RKy-VE-koV"/>
+                    <constraint firstItem="L5Q-aR-hdK" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="06e-3Z-E2J" secondAttribute="trailing" constant="-4" id="RKy-VE-koV"/>
                     <constraint firstItem="06e-3Z-E2J" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" priority="750" constant="16" id="U0p-Xm-Rhu"/>
                     <constraint firstAttribute="trailing" secondItem="hII-1o-P5c" secondAttribute="trailing" constant="8" id="UXv-qg-eP5"/>
                     <constraint firstItem="KNT-iD-vFj" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="Y7x-zG-bw0"/>

--- a/podcasts/TimeStepperCell.xib
+++ b/podcasts/TimeStepperCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21678"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -24,7 +24,7 @@
                             <constraint firstAttribute="height" constant="24" id="mpO-kU-UDK"/>
                         </constraints>
                     </imageView>
-                    <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="253" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="Skip First" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="06e-3Z-E2J" userLabel="Main Label" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
+                    <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="253" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" text="Skip First" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="06e-3Z-E2J" userLabel="Main Label" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
                         <rect key="frame" x="50" y="5" width="67.5" height="34"/>
                         <fontDescription key="fontDescription" type="system" pointSize="16"/>
                         <color key="textColor" red="0.1960784314" green="0.1960784314" blue="0.1960784314" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -47,7 +47,7 @@
                     <constraint firstItem="L5Q-aR-hdK" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="BoX-uy-x5a"/>
                     <constraint firstAttribute="bottom" secondItem="hII-1o-P5c" secondAttribute="bottom" id="C7N-sw-pCr"/>
                     <constraint firstItem="KNT-iD-vFj" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="ETk-sO-HNJ"/>
-                    <constraint firstItem="L5Q-aR-hdK" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="06e-3Z-E2J" secondAttribute="trailing" constant="-4" id="RKy-VE-koV"/>
+                    <constraint firstItem="L5Q-aR-hdK" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="06e-3Z-E2J" secondAttribute="trailing" constant="4" id="RKy-VE-koV"/>
                     <constraint firstItem="06e-3Z-E2J" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" priority="750" constant="16" id="U0p-Xm-Rhu"/>
                     <constraint firstAttribute="trailing" secondItem="hII-1o-P5c" secondAttribute="trailing" constant="8" id="UXv-qg-eP5"/>
                     <constraint firstItem="KNT-iD-vFj" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="Y7x-zG-bw0"/>


### PR DESCRIPTION
Fixes #836

Based on ticket #836, the `Speed` label is not appearing correctly in the playback settings when using the German language setting.
And I have also noticed that similar issue is present in the playback sheet, so I have fixed both of these problems.

### English

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/7476703/236717997-678cabdf-efea-40f4-bd7a-306db2642704.png" width="250" /> | <img src="https://user-images.githubusercontent.com/7476703/236717670-3ed52cf0-86f6-46d0-971c-76a0c997fd74.png" width="250" /> |
| <img src="https://user-images.githubusercontent.com/7476703/236718001-c8508edf-d523-4f76-a326-42a261b957a7.png" width="250" /> | <img src="https://user-images.githubusercontent.com/7476703/236717674-1c080433-6d2f-44c6-a63d-1e49919c7680.png" width="250" /> |

### German

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/7476703/236718102-0c957db4-eee9-4027-a1b7-5d668757b5a4.png" width="250" /> | <img src="https://user-images.githubusercontent.com/7476703/236717794-0e41b6b7-1e44-46b1-925b-5f2fa3eb238f.png" width="250" /> |
| <img src="https://user-images.githubusercontent.com/7476703/236718107-9db4d5b6-a060-4fc2-8e2b-a8f17104409a.png" width="250" /> | <img src="https://user-images.githubusercontent.com/7476703/236717796-00316ed9-2545-4aa4-8c3c-b8df25e240d5.png" width="250" /> |

## To test

- Change language settings to German in iOS settings
- Launch the app
- Open custom settings of a podcast and check the `Speed` label is not collapsed
- Play an episode
- Open playback effects modal sheet and checke the `Play Speed` label is not collapsed

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
