### PR TITLE
Profile Updates: Makes some views reusable, and makes some changes to reuse logic

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/ServerEnums.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/ServerEnums.swift
@@ -20,7 +20,7 @@ public enum SubscriptionFrequency: Int {
 }
 
 public enum SubscriptionType: Int {
-    case none = 0, plus = 1, supporter = 2
+    case none = 0, plus = 1, supporter = 2, patron = 3
 }
 
 public enum UpdateStatus: Int {

--- a/Modules/Server/Sources/PocketCastsServer/Public/StatsManager.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/StatsManager.swift
@@ -170,6 +170,15 @@ public class StatsManager {
         totalListeningTime() + timeForKey(ServerConstants.UserDefaults.statsListenedToServer)
     }
 
+    public func totalSavedTime() -> TimeInterval {
+        [
+            totalSkippedTimeInclusive(),
+            timeSavedVariableSpeedInclusive(),
+            timeSavedDynamicSpeedInclusive(),
+            totalAutoSkippedTimeInclusive()
+        ].reduce(0, +)
+    }
+
     public func totalSkippedTimeInclusive() -> TimeInterval {
         totalSkippedTime() + timeForKey(ServerConstants.UserDefaults.statsSkippedServer)
     }

--- a/Modules/Utils/Sources/PocketCastsUtils/Extensions/Double+formatTime.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Extensions/Double+formatTime.swift
@@ -44,3 +44,35 @@ extension Double {
         return DateComponentsFormatter.localizedString(from: components, unitsStyle: .short)?.replacingOccurrences(of: ",", with: "")
     }
 }
+
+extension Double {
+    public typealias TimeFormatValueType = (Double, TimeFormatUnit)
+
+    /// Converts a number of seconds to the nearest time value between: days, hours, minutes, and seconds
+    /// and returns the converted value and the closest unit
+    ///
+    /// For Example: 129600 will return 1.5 as the value and .day as the unit
+    public var timeFormatValues: TimeFormatValueType {
+        switch self {
+        case 1.day...:
+            return (scaleDown(value: self, by: 1.day), .day)
+
+        case 1.hour...:
+            return (scaleDown(value: self, by: 1.hour), .hour)
+
+        case 1.minute...:
+            return (scaleDown(value: self, by: 1.minute), .minute)
+
+        default:
+            return (scaleDown(value: self, by: 1.second), .second)
+        }
+    }
+
+    public enum TimeFormatUnit {
+        case day, hour, minute, second
+    }
+
+    private func scaleDown(value: Double, by amount: Double) -> Double {
+        ((value / amount) * 10.0).rounded() / 10.0
+    }
+}

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1374,6 +1374,7 @@
 		C7080C5D2923070200D7A432 /* PlusAccountUpgradePrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7080C5C2923070200D7A432 /* PlusAccountUpgradePrompt.swift */; };
 		C7080C5F29233BA000D7A432 /* PlusAccountPromptViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7080C5E29233BA000D7A432 /* PlusAccountPromptViewModel.swift */; };
 		C713D4FD2A05168B00A78468 /* Theme+AppColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D4FC2A05168B00A78468 /* Theme+AppColors.swift */; };
+		C713D4FF2A0519BE00A78468 /* ContentSizeGeometryReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D4FE2A0519BE00A78468 /* ContentSizeGeometryReader.swift */; };
 		C715EE0F2A0497DB0054A082 /* Theme+Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = C715EE0E2A0497DB0054A082 /* Theme+Color.swift */; };
 		C71C04C929243F7D00F2858A /* ImportViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71C04C829243F7D00F2858A /* ImportViewModel.swift */; };
 		C71C04CB2924403000F2858A /* ImportLandingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71C04CA2924403000F2858A /* ImportLandingView.swift */; };
@@ -3015,6 +3016,7 @@
 		C7080C5C2923070200D7A432 /* PlusAccountUpgradePrompt.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlusAccountUpgradePrompt.swift; sourceTree = "<group>"; };
 		C7080C5E29233BA000D7A432 /* PlusAccountPromptViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlusAccountPromptViewModel.swift; sourceTree = "<group>"; };
 		C713D4FC2A05168B00A78468 /* Theme+AppColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Theme+AppColors.swift"; sourceTree = "<group>"; };
+		C713D4FE2A0519BE00A78468 /* ContentSizeGeometryReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentSizeGeometryReader.swift; sourceTree = "<group>"; };
 		C715EE0E2A0497DB0054A082 /* Theme+Color.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Theme+Color.swift"; sourceTree = "<group>"; };
 		C71C04C829243F7D00F2858A /* ImportViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportViewModel.swift; sourceTree = "<group>"; };
 		C71C04CA2924403000F2858A /* ImportLandingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportLandingView.swift; sourceTree = "<group>"; };
@@ -6287,6 +6289,7 @@
 				C7CA0558293E8918000E41BD /* HolographicEffect.swift */,
 				C73CCBC829C590100075EFFD /* View+UIView.swift */,
 				8B208A5229C933D300AEF951 /* MiniPlayerPaddingModifier.swift */,
+				C713D4FE2A0519BE00A78468 /* ContentSizeGeometryReader.swift */,
 				8B208A5429C933F800AEF951 /* DismissKeyboardOnScroll.swift */,
 				C7B7123B29DF49BC00965BF7 /* HorizontalCarousel.swift */,
 				8B205C8029E84B6B0069BAF9 /* PageIndicatorView.swift */,

--- a/podcasts/Analytics/AnalyticsDescribable+Modules.swift
+++ b/podcasts/Analytics/AnalyticsDescribable+Modules.swift
@@ -41,6 +41,8 @@ extension SubscriptionType: AnalyticsDescribable {
             return "plus"
         case .supporter:
             return "supporter"
+        case .patron:
+            return "patron"
         }
     }
 }

--- a/podcasts/End of Year/Stories/EpilogueStory.swift
+++ b/podcasts/End of Year/Stories/EpilogueStory.swift
@@ -24,7 +24,7 @@ struct EpilogueStory: StoryView {
 
                 StoryLabelContainer(topPadding: 0, geometry: geometry) {
                     if visibility.isVisible {
-                        HolographicEffect(geometry: geometry) {
+                        HolographicEffect(parentSize: geometry.size) {
                             Image("heart")
                                 .renderingMode(.template)
                         }

--- a/podcasts/End of Year/Views/CircularProgressView.swift
+++ b/podcasts/End of Year/Views/CircularProgressView.swift
@@ -1,26 +1,81 @@
 import SwiftUI
-import PocketCastsServer
 
-struct CircularProgressView: View {
-    @ObservedObject private var model = SyncYearListeningProgress.shared
+/// Shows circular progress view that can count up (CountDirection.up) or count down (CountDirection.down)
+struct CircularProgressView<S: ShapeStyle>: View {
+    let value: Double
+    let stroke: S
+    let strokeWidth: Double
+    var direction: CountDirection = .up
+
+    private var from: Double {
+        switch direction {
+        case .up:
+            return 1 - value
+        case .down:
+            return 0
+        }
+    }
+
+    private var to: Double {
+        switch direction {
+        case .up:
+            return 1
+        case .down:
+            return value
+        }
+    }
 
     var body: some View {
-        ZStack {
-            Circle()
-                .stroke(
-                    Color.white.opacity(0.5),
-                    lineWidth: 6
-                )
-            Circle()
-                .trim(from: 0, to: model.progress)
-                .stroke(
-                    Color.white,
-                    style: StrokeStyle(
-                        lineWidth: 6,
-                        lineCap: .round
-                    )
-                )
-                .rotationEffect(.degrees(-90))
+        Circle()
+            .trim(from: from.clamped(to: 0..<1), to: to.clamped(to: 0..<1))
+            .stroke(
+                stroke,
+                style: .init(lineWidth: strokeWidth, lineCap: .round)
+            )
+            .rotationEffect(.degrees(-90))
+    }
+
+    enum CountDirection {
+        case up, down
+    }
+}
+
+struct CircularProgressView_Previews: PreviewProvider {
+    static var previews: some View {
+        PreviewContent()
+    }
+
+    struct PreviewContent: View {
+        @State var progress: Double = 0.5
+        @State var stroke: Double = 10
+        var body: some View {
+            VStack {
+                HStack(spacing: 20) {
+                    VStack(spacing: 10) {
+                        Text("Counting up")
+
+                        CircularProgressView(value: progress, stroke: Color.primary, strokeWidth: stroke)
+                    }
+
+                    VStack(spacing: 10) {
+                        Text("Counting down")
+
+                        CircularProgressView(value: progress, stroke: Color.primary, strokeWidth: stroke, direction: .down)
+                    }
+                }
+
+                HStack {
+                    Text("Progress")
+                    Slider(value: $progress, in: 0...1)
+                }
+
+                HStack {
+                    Text("Stroke Width")
+                    Slider(value: $stroke, in: 1...30)
+                }
+
+                Spacer()
+            }.padding()
         }
     }
 }

--- a/podcasts/End of Year/Views/StoriesView.swift
+++ b/podcasts/End of Year/Views/StoriesView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import PocketCastsServer
 
 struct StoriesView: View {
     @ObservedObject private var model: StoriesModel
@@ -60,7 +61,8 @@ struct StoriesView: View {
             Spacer()
 
             VStack(spacing: 15) {
-                CircularProgressView()
+                let progress = SyncYearListeningProgress.shared.progress
+                CircularProgressView(value: progress, stroke: Color.white, strokeWidth: 6)
                     .frame(width: 40, height: 40)
                 Text(L10n.loading)
                     .foregroundColor(.white)

--- a/podcasts/Onboarding/Plus/UpgradeLandingView.swift
+++ b/podcasts/Onboarding/Plus/UpgradeLandingView.swift
@@ -66,6 +66,7 @@ struct UpgradeLandingView: View {
 
                                 if !isSmallScreen && !contentIsScrollable {
                                     PageIndicatorView(numberOfItems: tiers.count, currentPage: currentPage)
+                                        .foregroundColor(.white)
                                         .padding(.top, 27)
                                 }
 

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -1395,6 +1395,8 @@ internal enum L10n {
   }
   /// Unsubscribing from all these podcasts will delete any downloaded files they have, are you sure?
   internal static var paidPodcastUnsubscribeMsg: String { return L10n.tr("Localizable", "paid_podcast_unsubscribe_msg") }
+  /// Patron
+  internal static var patron: String { return L10n.tr("Localizable", "patron") }
   /// Believe in what we’re doing and want to show your support?
   internal static var patronCallout: String { return L10n.tr("Localizable", "patron_callout") }
   /// Become a Pocket Casts Patron and help us continue to deliver the best podcasting experience available.
@@ -2617,6 +2619,10 @@ internal enum L10n {
   /// Subscription Cancelled %1$@ 
   internal static func subscriptionCancelledMsg(_ p1: Any) -> String {
     return L10n.tr("Localizable", "subscription_cancelled_msg", String(describing: p1))
+  }
+  /// Expires in %1$@
+  internal static func subscriptionExpiresIn(_ p1: Any) -> String {
+    return L10n.tr("Localizable", "subscription_expires_in", String(describing: p1))
   }
   /// Thanks for your support!
   internal static var subscriptionsThankYou: String { return L10n.tr("Localizable", "subscriptions_thank_you") }

--- a/podcasts/SwiftUI/ContentSizeGeometryReader.swift
+++ b/podcasts/SwiftUI/ContentSizeGeometryReader.swift
@@ -1,0 +1,64 @@
+import SwiftUI
+
+/// A GeometryReader wrapper view that calculates the size of the content and adjusts the
+///
+///
+/// The contentSizeUpdated to be informed of the new content size outside of SwiftUI
+///
+/// This can be used to dynamically change the height of a SwiftUI view that's being used in UIKit
+/// or use a GeometryReader without it taking up all the available space
+///
+struct ContentSizeGeometryReader<Content: View>: View {
+    let content: (GeometryProxy) -> Content
+    var contentSizeUpdated: ((CGSize) -> Void)? = nil
+
+    @State private var contentSize: CGSize = .zero
+
+    var body: some View {
+        GeometryReader { proxy in
+            ContentSizeReader(contentSize: $contentSize) {
+                content(proxy)
+            }
+        }
+        .frame(maxWidth: contentSize != .zero ? contentSize.width : nil)
+        .frame(maxHeight: contentSize != .zero ? contentSize.height : nil)
+        .onChange(of: contentSize) { newValue in
+            contentSizeUpdated?(newValue)
+        }
+    }
+}
+
+// MARK: - Previews
+
+struct ContentHeightView_Previews: PreviewProvider {
+    static var previews: some View {
+        PreviewContent()
+    }
+
+    struct PreviewContent: View {
+        var body: some View {
+            ZStack {
+                GeometryReader { proxy in
+                    VStack {
+                        Text("The geometry read is bound to \(String(describing: proxy.size))")
+
+                        Rectangle()
+                            .frame(width: 200, height: 200)
+                    }
+                }
+                .background(Color.red)
+
+                ContentSizeGeometryReader { proxy in
+                    VStack {
+                        Text("The geometry read is bound to \(String(describing: proxy.size))")
+                            .fixedSize(horizontal: false, vertical: true)
+                        Rectangle()
+                            .frame(width: 200, height: 200)
+                    }
+
+                }
+                .background(Color.blue)
+            }
+        }
+    }
+}

--- a/podcasts/SwiftUI/ContentSizeGeometryReader.swift
+++ b/podcasts/SwiftUI/ContentSizeGeometryReader.swift
@@ -1,12 +1,12 @@
 import SwiftUI
 
-/// A GeometryReader wrapper view that calculates the size of the content and adjusts the
+/// `ContentSizeGeometryReader` is a wrapper around a `GeometryReader` that adjusts itself to the size of its content,
+/// rather than taking up all the available space by default.
 ///
+/// Using .frame(maxWidth: .infinity) or .frame(maxHeight: .infinity) on the content view will expand the GeometryReader
+/// in a specific direction.
 ///
-/// The contentSizeUpdated to be informed of the new content size outside of SwiftUI
-///
-/// This can be used to dynamically change the height of a SwiftUI view that's being used in UIKit
-/// or use a GeometryReader without it taking up all the available space
+/// Set the `contentSizeUpdated` property to be informed of changes to the content size.
 ///
 struct ContentSizeGeometryReader<Content: View>: View {
     let content: (GeometryProxy) -> Content
@@ -40,7 +40,7 @@ struct ContentHeightView_Previews: PreviewProvider {
             ZStack {
                 GeometryReader { proxy in
                     VStack {
-                        Text("The geometry read is bound to \(String(describing: proxy.size))")
+                        Text("The GeometryReader is bound to \(String(describing: proxy.size))")
 
                         Rectangle()
                             .frame(width: 200, height: 200)
@@ -50,7 +50,7 @@ struct ContentHeightView_Previews: PreviewProvider {
 
                 ContentSizeGeometryReader { proxy in
                     VStack {
-                        Text("The geometry read is bound to \(String(describing: proxy.size))")
+                        Text("The GeometryReader is bound to \(String(describing: proxy.size))")
                             .fixedSize(horizontal: false, vertical: true)
                         Rectangle()
                             .frame(width: 200, height: 200)

--- a/podcasts/SwiftUI/PageIndicatorView.swift
+++ b/podcasts/SwiftUI/PageIndicatorView.swift
@@ -10,7 +10,6 @@ struct PageIndicatorView: View {
             ForEach(0 ..< numberOfItems, id: \.self) { itemIndex in
                 Circle()
                     .frame(width: 8, height: 8)
-                    .foregroundColor(.white)
                     .opacity(itemIndex == currentPage ? 1 : 0.5)
             }
         }

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -1615,6 +1615,8 @@
 /* Message informing the user when their Pocket Casts Plus subscription will expire. %1$@ is a placeholder for the expiration date. */
 "plus_subscription_expiration" = "PLUS EXPIRES IN %1$@";
 
+"subscription_expires_in" = "Expires in %1$@";
+
 /* Message informing the user that their Pocket Casts Plus subscription is managed by Google's system and needs to be managed there. */
 "plus_subscription_google" = "It looks like you subscribed to Pocket Casts Plus from an Android device";
 
@@ -1656,6 +1658,9 @@
 
 /* Description of the Patron plan. Do not translate "Patron". */
 "patron_description" = "Become a Pocket Casts Patron and help us continue to deliver the best podcasting experience available.";
+
+/* Name of the Patron plan. Do not translate "Patron". */
+"patron" = "Patron";
 
 /* Description of a Patron feature that gives user everything in Plus. */
 "patron_feature_everything_in_plus" = "Everything in Plus";


### PR DESCRIPTION
| 🛫 Depends on: https://github.com/Automattic/pocket-casts-ios/pull/848 |
|:---:|

This makes some logic and views reusable:
- Adds a Double extension to convert seconds to a formatted time and its closest unit, which will be used to calculate the stats on the profile
- Adds a `totalSavedTime` to the StatsManager to unify the logic
- Makes the CircularProgressView reusable with more customization options
- Removes the GeometryReader requirement from the HolographicEffect
- Adds some new strings
- Adds a new `ContentSizeGeometryReader` view which forces a GeometryProxy to be constrained to its content views size

## To test
No visible changes in the app but you can view the previews for to see how they work:
- CircularProgressView
- ContentSizeGeometryReader

The views will be used in the future PRs

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
