### PR TITLE
Remove starred as a default filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 7.39
 -----
-
+- Removed the starred filter from the list of default filters
 
 7.38
 -----

--- a/podcasts/PlaylistManager.swift
+++ b/podcasts/PlaylistManager.swift
@@ -55,28 +55,6 @@ class PlaylistManager {
             DataManager.sharedManager.save(filter: inProgress)
         }
 
-        // starred
-        existingUuid = "78EC673E-4C3A-4985-9D83-7A79C825A359"
-        existingFilter = DataManager.sharedManager.findFilter(uuid: existingUuid)
-        if existingFilter == nil {
-            let starred = EpisodeFilter()
-            starred.filterAllPodcasts = true
-            starred.filterAudioVideoType = AudioVideoFilter.all.rawValue
-            starred.sortPosition = 3
-            starred.playlistName = L10n.statusStarred
-            starred.filterDownloaded = true
-            starred.filterNotDownloaded = true
-            starred.filterUnplayed = true
-            starred.filterPartiallyPlayed = true
-            starred.filterFinished = true
-            starred.filterStarred = true
-            starred.uuid = existingUuid
-            starred.filterHours = 0
-            starred.customIcon = PlaylistIcon.yellowTop.rawValue
-            starred.syncStatus = SyncStatus.synced.rawValue
-            DataManager.sharedManager.save(filter: starred)
-        }
-
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.filterChanged)
     }
 


### PR DESCRIPTION
On a fresh install, one of the default filters is 'starred'. This change removes this filter so it matches Android. Having a starred filter in two places, on the 'Filters' and 'Profile' tab is confusing as they behave differently. As the Profile tab starred list includes episodes from unsubscribed podcasts, it's more useful there.

The reason for fixing this is one of our Automotive partners was confused by the two starred episode lists.

| iOS | Android |
| --- | --- |
| ![Simulator Screenshot - iPhone 14 Pro - 2023-05-10 at 14 06 45](https://github.com/Automattic/pocket-casts-ios/assets/308331/9771a2c0-26f4-4f8f-8017-853db4a91943) | ![Screenshot_20230510_141433](https://github.com/Automattic/pocket-casts-ios/assets/308331/ee160171-517c-4173-b8a1-4466b6b5d92a) |

iOS After
<img  width="300" src="https://github.com/Automattic/pocket-casts-ios/assets/308331/64561e43-4552-4fb7-a585-f5679e26837a" />

## To test

1. Clean install the app
2. Go to the 'Filters' tab
3. ✅ Verify the 'Starred' filter is not in the list