### PR TITLE
Ratings: Start loading ratings when the PodcastViewController is created

### DIFF
--- a/podcasts/PodcastHeadingTableCell.swift
+++ b/podcasts/PodcastHeadingTableCell.swift
@@ -329,7 +329,8 @@ class PodcastHeadingTableCell: ThemeableCell, SubscribeButtonDelegate, Expandabl
 
         roundedBorder.isHidden = nextEpisodeView.isHidden && scheduleView.isHidden && linkView.isHidden && authorView.isHidden
 
-        ratingView?.isHidden = !expanded && FeatureFlag.showRatings.enabled
+        let hasRating = delegate?.podcastRatingViewModel.rating != nil
+        ratingView?.isHidden = !FeatureFlag.showRatings.enabled || !hasRating || !expanded
     }
 
     private func setupButtons() {

--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -190,6 +190,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
         summaryExpanded = !podcast.isSubscribed() || (podcast.isPaid && podcast.licensing == PodcastLicensing.deleteEpisodesAfterExpiry.rawValue && (SubscriptionHelper.subscriptionForPodcast(uuid: podcast.uuid)?.isExpired() ?? false))
 
         AnalyticsHelper.podcastOpened(uuid: podcast.uuid)
+        podcastRatingViewModel.update(uuid: podcast.uuid)
 
         super.init(nibName: "PodcastViewController", bundle: nil)
     }
@@ -204,6 +205,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
         }
 
         if let uuid = podcastInfo.uuid {
+            podcastRatingViewModel.update(uuid: uuid)
             AnalyticsHelper.podcastOpened(uuid: uuid)
         }
 
@@ -263,6 +265,12 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+
+        // Load the ratings even if we've already started loading them to cover all other potential view states
+        // The view model will ignore extra calls
+        if let uuid = [podcast?.uuid, podcastInfo?.uuid].compactMap({ $0 }).first {
+            podcastRatingViewModel.update(uuid: uuid)
+        }
 
         updateColors()
     }


### PR DESCRIPTION
## Description

When the podcast view is created we'll start loading the ratings to make them available earlier than they were before. 

This also hides the rating view if there are no ratings available yet.

<details>
  <summary><h2>Demo Video</h2></summary>
  
https://github.com/Automattic/pocket-casts-ios/assets/793774/13ecda9b-86e7-44de-978a-2f4126802e71
  
</details>

## To test

1. Launch the app
2. Go to Profile > Cog > Beta Features > Enable showRatings
3. Go to the Discover tab
4. Tap on some podcasts
5. ✅ Verify the rating is hidden for podcasts that have no ratings
6. ✅ Verify the rating appears for podcasts with ratings
7. Tap back and tap on the podcast again
8. ✅ Verify the rating shows instantly


## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
