### PR TITLE
Patron: Improve the Account prompt states

### DIFF
--- a/Pocket Casts Configuration.storekit
+++ b/Pocket Casts Configuration.storekit
@@ -28,7 +28,12 @@
           "familyShareable" : false,
           "groupNumber" : 1,
           "internalID" : "C9B37131",
-          "introductoryOffer" : null,
+          "introductoryOffer" : {
+            "displayPrice" : "0.99",
+            "internalID" : "20314E17",
+            "paymentMode" : "free",
+            "subscriptionPeriod" : "P1M"
+          },
           "localizations" : [
             {
               "description" : "",

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1413,6 +1413,7 @@
 		C761300028E3BC090044C6C2 /* AnalyticsEpisodeHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7612FFE28E397A00044C6C2 /* AnalyticsEpisodeHelper.swift */; };
 		C761300B28E4CA4F0044C6C2 /* AnalyticsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C761300A28E4CA4E0044C6C2 /* AnalyticsCoordinator.swift */; };
 		C761300C28E4CAE90044C6C2 /* AnalyticsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C761300A28E4CA4E0044C6C2 /* AnalyticsCoordinator.swift */; };
+		C76400552A0EDFB90092A74B /* UserInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = C76400542A0EDFB90092A74B /* UserInfo.swift */; };
 		C791418D294CE32D00F1852B /* StorageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C791418C294CE32D00F1852B /* StorageManager.swift */; };
 		C791418E294CE33700F1852B /* StorageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C791418C294CE32D00F1852B /* StorageManager.swift */; };
 		C799373B2A095F6F0010DC64 /* ProfileInfoLabels.swift in Sources */ = {isa = PBXBuildFile; fileRef = C799373A2A095F6F0010DC64 /* ProfileInfoLabels.swift */; };
@@ -3080,6 +3081,7 @@
 		C75BB06729B954B100F2DF63 /* EpisodeLoadingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EpisodeLoadingController.swift; sourceTree = "<group>"; };
 		C7612FFE28E397A00044C6C2 /* AnalyticsEpisodeHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsEpisodeHelper.swift; sourceTree = "<group>"; };
 		C761300A28E4CA4E0044C6C2 /* AnalyticsCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnalyticsCoordinator.swift; sourceTree = "<group>"; };
+		C76400542A0EDFB90092A74B /* UserInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfo.swift; sourceTree = "<group>"; };
 		C791418C294CE32D00F1852B /* StorageManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageManager.swift; sourceTree = "<group>"; };
 		C799373A2A095F6F0010DC64 /* ProfileInfoLabels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileInfoLabels.swift; sourceTree = "<group>"; };
 		C79E1E3F28887549008524CB /* PlusUpgradeViewSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlusUpgradeViewSourceTests.swift; sourceTree = "<group>"; };
@@ -4829,6 +4831,7 @@
 		BD55C9F11FB9200C0084A7CB /* Profile */ = {
 			isa = PBXGroup;
 			children = (
+				C76400542A0EDFB90092A74B /* UserInfo.swift */,
 				C713D4EB2A04C8D700A78468 /* Profile - SwiftUI */,
 				BD5B79191783F9CF00A0F407 /* Settings */,
 				BD7516E01C0FC8180099F53E /* Downloads */,
@@ -8430,6 +8433,7 @@
 				40164A6E23E19C9A0043907B /* ProfileViewController+Promotion.swift in Sources */,
 				BDC8683223825933004C998F /* Interactor.swift in Sources */,
 				8B67A26929A7D8690076886D /* PodcastCarouselView.swift in Sources */,
+				C76400552A0EDFB90092A74B /* UserInfo.swift in Sources */,
 				46C3D556275EA6C400DDE116 /* DiscoverEpisodeViewModel.swift in Sources */,
 				BD054A7A1E3EDEB300D9195B /* SharedConstants.swift in Sources */,
 				C72CED36289DB8690017883A /* AppDelegate+Analytics.swift in Sources */,

--- a/podcasts/DeveloperMenu.swift
+++ b/podcasts/DeveloperMenu.swift
@@ -25,6 +25,7 @@ struct DeveloperMenu: View {
 
             Section {
                 Button("Set to No Plus") {
+                    ServerSettings.setIapUnverifiedPurchaseReceiptDate(nil)
                     SubscriptionHelper.setSubscriptionPaid(Int(0))
                     SubscriptionHelper.setSubscriptionPlatform(Int(0))
                     SubscriptionHelper.setSubscriptionExpiryDate(Date(timeIntervalSinceNow: 30.days).timeIntervalSince1970)
@@ -63,17 +64,58 @@ struct DeveloperMenu: View {
                     HapticsHelper.triggerSubscribedHaptic()
                 }
 
-                Button("Set to Lifetime") {
-                    SubscriptionHelper.setSubscriptionPaid(Int(1))
-                    SubscriptionHelper.setSubscriptionPlatform(Int(4))
-                    SubscriptionHelper.setSubscriptionExpiryDate(Date(timeIntervalSinceNow: 11 * 365.days).timeIntervalSince1970)
-                    SubscriptionHelper.setSubscriptionAutoRenewing(false)
-                    SubscriptionHelper.setSubscriptionGiftDays(Int(11 * 365.days))
-                    SubscriptionHelper.setSubscriptionFrequency(Int(0))
-                    SubscriptionHelper.setSubscriptionType(Int(1))
+                Group {
+                    Button("Set to 150 Gift Days") {
+                        SubscriptionHelper.setSubscriptionPaid(1)
+                        SubscriptionHelper.setSubscriptionPlatform(SubscriptionPlatform.gift.rawValue)
+                        SubscriptionHelper.setSubscriptionExpiryDate(Date(timeIntervalSinceNow: 150 * 1.days).timeIntervalSince1970)
+                        SubscriptionHelper.setSubscriptionAutoRenewing(false)
+                        SubscriptionHelper.setSubscriptionGiftDays(150)
+                        SubscriptionHelper.setSubscriptionFrequency(SubscriptionFrequency.none.rawValue)
+                        SubscriptionHelper.setSubscriptionType(SubscriptionType.plus.rawValue)
 
-                    NotificationCenter.postOnMainThread(notification: ServerNotifications.subscriptionStatusChanged)
-                    HapticsHelper.triggerSubscribedHaptic()
+                        NotificationCenter.postOnMainThread(notification: ServerNotifications.subscriptionStatusChanged)
+                        HapticsHelper.triggerSubscribedHaptic()
+                    }
+
+                    Button("Set to 150 Gift Days and Expiring in 1 day") {
+                        SubscriptionHelper.setSubscriptionPaid(1)
+                        SubscriptionHelper.setSubscriptionPlatform(SubscriptionPlatform.gift.rawValue)
+                        SubscriptionHelper.setSubscriptionExpiryDate(Date(timeIntervalSinceNow: 1.days).timeIntervalSince1970)
+                        SubscriptionHelper.setSubscriptionAutoRenewing(false)
+                        SubscriptionHelper.setSubscriptionGiftDays(150)
+                        SubscriptionHelper.setSubscriptionFrequency(SubscriptionFrequency.none.rawValue)
+                        SubscriptionHelper.setSubscriptionType(SubscriptionType.plus.rawValue)
+
+                        NotificationCenter.postOnMainThread(notification: ServerNotifications.subscriptionStatusChanged)
+                        HapticsHelper.triggerSubscribedHaptic()
+                    }
+
+                    Button("Set to 150 Gift Days and Expiring in 29 days") {
+                        SubscriptionHelper.setSubscriptionPaid(1)
+                        SubscriptionHelper.setSubscriptionPlatform(SubscriptionPlatform.gift.rawValue)
+                        SubscriptionHelper.setSubscriptionExpiryDate(Date(timeIntervalSinceNow: 30.days).timeIntervalSince1970)
+                        SubscriptionHelper.setSubscriptionAutoRenewing(false)
+                        SubscriptionHelper.setSubscriptionGiftDays(150)
+                        SubscriptionHelper.setSubscriptionFrequency(SubscriptionFrequency.none.rawValue)
+                        SubscriptionHelper.setSubscriptionType(SubscriptionType.plus.rawValue)
+
+                        NotificationCenter.postOnMainThread(notification: ServerNotifications.subscriptionStatusChanged)
+                        HapticsHelper.triggerSubscribedHaptic()
+                    }
+
+                    Button("Set to Lifetime") {
+                        SubscriptionHelper.setSubscriptionPaid(Int(1))
+                        SubscriptionHelper.setSubscriptionPlatform(Int(4))
+                        SubscriptionHelper.setSubscriptionExpiryDate(Date(timeIntervalSinceNow: 11 * 365.days).timeIntervalSince1970)
+                        SubscriptionHelper.setSubscriptionAutoRenewing(false)
+                        SubscriptionHelper.setSubscriptionGiftDays(Int(11 * 365.days))
+                        SubscriptionHelper.setSubscriptionFrequency(SubscriptionFrequency.none.rawValue)
+                        SubscriptionHelper.setSubscriptionType(SubscriptionType.plus.rawValue)
+
+                        NotificationCenter.postOnMainThread(notification: ServerNotifications.subscriptionStatusChanged)
+                        HapticsHelper.triggerSubscribedHaptic()
+                    }
                 }
 
                 VStack(alignment: .leading, spacing: 5) {
@@ -145,9 +187,10 @@ struct DeveloperMenu: View {
                 }
 
             } header: {
-                Text("Subscription Testing")
-            } footer: {
-                Text("⚠️ Temporary items only, the changes will only be active until the next server sync.")
+                VStack {
+                    Text("Subscription Testing")
+                    Text("⚠️ Temporary items only, the changes will only be active until the next server sync.")
+                }
             }
         }
     }

--- a/podcasts/Onboarding/Models/PlusAccountPromptViewModel.swift
+++ b/podcasts/Onboarding/Models/PlusAccountPromptViewModel.swift
@@ -4,6 +4,22 @@ class PlusAccountPromptViewModel: PlusPricingInfoModel {
     weak var parentController: UIViewController? = nil
     var source: Source = .unknown
 
+    let subscription: UserInfo.Subscription? = .init()
+
+    lazy var products: [PlusProductPricingInfo] = {
+        let productsToDisplay: [Constants.IapProducts] = {
+            guard FeatureFlag.patron.enabled else {
+                return [.yearly]
+            }
+
+            return subscription?.type == .patron ? [.patronYearly] : [.yearly, .patronYearly]
+        }()
+
+        return productsToDisplay.compactMap { product in
+            pricingInfo.products.first(where: { $0.identifier == product })
+        }
+    }()
+
     override init(purchaseHandler: IapHelper = .shared) {
         super.init(purchaseHandler: purchaseHandler)
 

--- a/podcasts/Onboarding/Models/PlusAccountPromptViewModel.swift
+++ b/podcasts/Onboarding/Models/PlusAccountPromptViewModel.swift
@@ -1,6 +1,8 @@
 import UIKit
 
-class PlusAccountPromptViewModel: PlusPurchaseModel {
+class PlusAccountPromptViewModel: PlusPricingInfoModel {
+    weak var parentController: UIViewController? = nil
+
     var source: Source = .unknown
 
     let subscription: UserInfo.Subscription? = .init()
@@ -53,13 +55,6 @@ private extension PlusAccountPromptViewModel {
         guard FeatureFlag.patron.enabled else {
             let controller = OnboardingFlow.shared.begin(flow: .plusAccountUpgrade, in: parentController, source: source.rawValue)
             controller.presentModally(in: parentController)
-            return
-        }
-
-        // If the user already has a subscription and we're prompting them to renew
-        // Then go straight to purchasing
-        if let product = product?.identifier, subscription?.isExpiring(product.subscriptionType) == true {
-            purchase(product: product)
             return
         }
 

--- a/podcasts/Onboarding/Models/PlusAccountPromptViewModel.swift
+++ b/podcasts/Onboarding/Models/PlusAccountPromptViewModel.swift
@@ -63,7 +63,8 @@ private extension PlusAccountPromptViewModel {
             ["product": Constants.ProductInfo(plan: $0.identifier.plan, frequency: .yearly)]
         }
 
-        let controller = OnboardingFlow.shared.begin(flow: .plusAccountUpgrade, in: parentController, source: source.rawValue, context: context)
+        let flow: OnboardingFlow.Flow = subscription?.isExpiring(.patron) == true ? .patronAccountUpgrade : .plusAccountUpgrade
+        let controller = OnboardingFlow.shared.begin(flow: flow, in: parentController, source: source.rawValue, context: context)
 
         parentController.present(controller, animated: true)
     }

--- a/podcasts/Onboarding/OnboardingFlow.swift
+++ b/podcasts/Onboarding/OnboardingFlow.swift
@@ -31,9 +31,11 @@ struct OnboardingFlow {
 
         case .patronAccountUpgrade:
             self.source = source ?? "unknown"
+            let config = PlusLandingViewModel.Config(products: [.patron], displayProduct: .init(plan: .patron, frequency: .yearly))
+
             flowController = PlusLandingViewModel.make(in: navigationController,
                                                        from: .upsell,
-                                                       config: .init(displayProduct: .init(plan: .patron, frequency: .yearly)))
+                                                       config: config)
 
         case .plusAccountUpgradeNeedsLogin:
             flowController = LoginCoordinator.make(in: navigationController, continuePurchasing: .init(plan: .plus, frequency: .yearly))

--- a/podcasts/Onboarding/Plus/Account Prompt/PlusAccountUpgradePrompt.swift
+++ b/podcasts/Onboarding/Plus/Account Prompt/PlusAccountUpgradePrompt.swift
@@ -94,11 +94,35 @@ struct PlusAccountUpgradePrompt: View {
     @ViewBuilder
     private func subscribeButton(for product: ProductInfo) -> some View {
         let plan = product.identifier.plan
+        let subscription = viewModel.subscription
+        let expiringPlus = subscription?.isExpiring(.plus) == true
 
         let label: String = {
             switch plan {
-            case .patron: return L10n.patronSubscribeTo
-            case .plus: return L10n.plusSubscribeTo
+            case .patron:
+                return {
+                    // Show the renew your sub title
+                    if subscription?.isExpiring(.patron) == true {
+                        return L10n.renewSubscription
+                    }
+
+                    // If the user has an expiring plus subscription show the 'Upgrade Account' title
+                    return expiringPlus ? L10n.upgradeAccount : L10n.patronSubscribeTo
+                }()
+
+            case .plus:
+                // Show 'Renew Sub' title if it's expiring
+                return {
+                    if expiringPlus {
+                        return L10n.renewSubscription
+                    }
+
+                    if product.freeTrialDuration != nil {
+                        return L10n.plusStartMyFreeTrial
+                    }
+
+                    return L10n.plusSubscribeTo
+                }()
             }
         }()
 
@@ -133,11 +157,6 @@ struct PlusAccountUpgradePrompt: View {
             .init(iconName: "patron-icons", title: L10n.patronFeatureProfileIcons)
         ]
     ]
-
-    // MARK: - Constants
-    private enum ViewConstants {
-        static let productsToDisplay: [Constants.IapProducts] = FeatureFlag.patron.enabled ? [.yearly, .patronYearly] : [.yearly]
-    }
 
     // MARK: - Model
     private struct Feature: Identifiable, Hashable {

--- a/podcasts/Onboarding/Plus/Account Prompt/PlusAccountUpgradePrompt.swift
+++ b/podcasts/Onboarding/Plus/Account Prompt/PlusAccountUpgradePrompt.swift
@@ -49,39 +49,60 @@ struct PlusAccountUpgradePrompt: View {
     @ViewBuilder
     func card(for product: ProductInfo, geometryProxy: GeometryProxy) -> some View {
         VStack(spacing: 16) {
-            HStack {
-                SubscriptionBadge(type: product.identifier.subscriptionType)
+            HStack(alignment: .top) {
+                VStack(alignment: .leading) {
+                    SubscriptionBadge(type: product.identifier.subscriptionType)
+                        .padding(.bottom, 10)
+
+                    productFeatures[product.identifier].map {
+                        ForEach($0) { feature in
+                            HStack(spacing: 10) {
+                                Image(feature.iconName)
+                                    .renderingMode(.template)
+                                    .resizable()
+                                    .aspectRatio(contentMode: .fit)
+                                    .frame(width: 16)
+                                    .foregroundColor(theme.primaryText01)
+
+                                Text(feature.title)
+                                    .fixedSize(horizontal: false, vertical: true)
+                                    .font(size: 14, style: .subheadline, weight: .medium)
+                                    .foregroundColor(theme.primaryText01)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                                Spacer()
+                            }.frame(maxWidth: .infinity)
+                        }
+                    }
+                }
 
                 Spacer()
 
-                HighlightedText(product.price)
-                    .highlight(product.rawPrice, { _ in
-                            .init(font: nil, weight: .bold, color: nil, backgroundColor: nil)
-                    })
-                    .font(style: .title2)
-                    .foregroundColor(theme.primaryText01)
-            }
+                VStack(alignment: .trailing) {
+                    if let freeTrial = product.freeTrialDuration {
+                        HighlightedText(L10n.plusFreeMembershipFormat(freeTrial).localizedLowercase)
+                            .highlight(freeTrial, { _ in
+                                    .init(weight: .bold)
+                            })
+                            .font(style: .title2)
+                            .foregroundColor(theme.primaryText01)
 
-            VStack(alignment: .leading) {
-                productFeatures[product.identifier].map {
-                    ForEach($0) { feature in
-                        HStack(spacing: 10) {
-                            Image(feature.iconName)
-                                .renderingMode(.template)
-                                .resizable()
-                                .aspectRatio(contentMode: .fit)
-                                .frame(width: 16)
-                                .foregroundColor(theme.primaryText01)
-
-                            Text(feature.title)
-                                .fixedSize(horizontal: false, vertical: true)
-                                .font(size: 14, style: .subheadline, weight: .medium)
-                                .foregroundColor(theme.primaryText01)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-
-                            Spacer()
-                        }.frame(maxWidth: .infinity)
+                        HighlightedText(L10n.pricingTermsAfterTrial(product.price))
+                            .highlight(product.rawPrice, { _ in
+                                    .init(weight: .bold)
+                            })
+                            .font(style: .body)
+                            .foregroundColor(theme.primaryText01)
+                    } else {
+                        HighlightedText(product.price)
+                            .highlight(product.rawPrice, { _ in
+                                    .init(weight: .bold)
+                            })
+                            .font(style: .title2)
+                            .foregroundColor(theme.primaryText01)
                     }
+
+                    Spacer()
                 }
             }
 

--- a/podcasts/Onboarding/Plus/Account Prompt/PlusAccountUpgradePrompt.swift
+++ b/podcasts/Onboarding/Plus/Account Prompt/PlusAccountUpgradePrompt.swift
@@ -17,10 +17,8 @@ struct PlusAccountUpgradePrompt: View {
 
     init(viewModel: PlusAccountPromptViewModel, contentSizeUpdated: ((CGSize) -> Void)? = nil) {
         self.viewModel = viewModel
+        self.products = viewModel.products
         self.contentSizeUpdated = contentSizeUpdated
-        self.products = ViewConstants.productsToDisplay.compactMap { product in
-            viewModel.pricingInfo.products.first(where: { $0.identifier == product })
-        }
     }
 
     var body: some View {

--- a/podcasts/Onboarding/Plus/PlusLandingViewModel.swift
+++ b/podcasts/Onboarding/Plus/PlusLandingViewModel.swift
@@ -5,12 +5,14 @@ import SwiftUI
 class PlusLandingViewModel: PlusPurchaseModel {
     weak var navigationController: UINavigationController? = nil
 
-    var displayProduct: Constants.ProductInfo? = nil
+    let displayedProducts: [UpgradeTier]
+    var initialProduct: Constants.ProductInfo? = nil
     var continuePurchasing: Constants.ProductInfo? = nil
     let source: Source
 
     init(source: Source, config: Config? = nil, purchaseHandler: IapHelper = .shared) {
-        self.displayProduct = config?.displayProduct
+        self.displayedProducts = config?.products ?? [.plus, .patron]
+        self.initialProduct = config?.displayProduct
         self.continuePurchasing = config?.continuePurchasing
         self.source = source
 
@@ -108,6 +110,7 @@ class PlusLandingViewModel: PlusPurchaseModel {
     }
 
     struct Config {
+        var products: [UpgradeTier]? = nil
         var displayProduct: Constants.ProductInfo? = nil
         var continuePurchasing: Constants.ProductInfo? = nil
     }

--- a/podcasts/Onboarding/Plus/UpgradeLandingView.swift
+++ b/podcasts/Onboarding/Plus/UpgradeLandingView.swift
@@ -18,15 +18,10 @@ struct UpgradeLandingView: View {
     init(viewModel: PlusLandingViewModel) {
         self.viewModel = viewModel
 
-        // Update the displayed products to hide ones the user is subscribed to
-        tiers = {
-            let type = SubscriptionHelper.hasActiveSubscription() ? SubscriptionHelper.subscriptionType() : .none
-
-            return [.plus, .patron].filter { $0.tier != type }
-        }()
+        tiers = viewModel.displayedProducts
 
         // Switch to the previously selected options if available
-        let displayProduct = [viewModel.continuePurchasing, viewModel.displayProduct].compactMap { $0 }.first
+        let displayProduct = [viewModel.continuePurchasing, viewModel.initialProduct].compactMap { $0 }.first
 
         if let displayProduct {
             let index = tiers.firstIndex(where: { $0.plan == displayProduct.plan }) ?? 0

--- a/podcasts/Profile - SwiftUI/Account/AccountHeaderView.swift
+++ b/podcasts/Profile - SwiftUI/Account/AccountHeaderView.swift
@@ -85,7 +85,7 @@ struct AccountHeaderView: View {
             return nil
         }
 
-        // If we're more than the max days (progress >= 1) then show the expirationd ate
+        // If we're more than the max days (progress >= 1) then show the expiration date
         guard expirationProgress < 1 else {
             let label = L10n.plusExpirationFormat(DateFormatHelper.sharedHelper.longLocalizedFormat(expirationDate))
             return Text(label)

--- a/podcasts/Profile - SwiftUI/Common Views/ProfileInfoLabels.swift
+++ b/podcasts/Profile - SwiftUI/Common Views/ProfileInfoLabels.swift
@@ -4,7 +4,7 @@ import SwiftUI
 struct ProfileInfoLabels: View {
     @EnvironmentObject var theme: Theme
 
-    let profile: ProfileDataViewModel.Profile
+    let profile: UserInfo.Profile
     var alignment: HorizontalAlignment = .center
     var spacing: Double = 0
 

--- a/podcasts/Profile - SwiftUI/Profile/ProfileHeaderView.swift
+++ b/podcasts/Profile - SwiftUI/Profile/ProfileHeaderView.swift
@@ -32,20 +32,22 @@ struct ProfileHeaderView: View {
                 .frame(width: Constants.imageSize, height: Constants.imageSize)
 
             // Show the patron badge
-            if let subscriptionType = viewModel.subscription?.type, subscriptionType == .patron {
-                SubscriptionBadge(type: subscriptionType)
-                    .padding(.top, -10)
-            }
+            if let subscription = viewModel.subscription {
+                if subscription.type == .patron {
+                    SubscriptionBadge(type: subscription.type)
+                        .padding(.top, -10)
+                }
 
-            // Display the expiration date if needed
-            if let expirationDate = viewModel.subscription?.expirationDate {
-                let time = TimeFormatter.shared.appleStyleTillString(date: expirationDate) ?? L10n.timeFormatNever
-                let message = L10n.subscriptionExpiresIn(time)
+                // Display the expiration date if needed
+                if subscription.expirationProgress < 1, let expirationDate = subscription.expirationDate {
+                    let time = TimeFormatter.shared.appleStyleTillString(date: expirationDate) ?? L10n.timeFormatNever
+                    let message = L10n.subscriptionExpiresIn(time)
 
-                Text(message.localizedUppercase)
-                    .font(style: .caption, weight: .semibold)
-                    .foregroundColor(theme.red)
-                    .padding(.top, Constants.spacing)
+                    Text(message.localizedUppercase)
+                        .font(style: .caption, weight: .semibold)
+                        .foregroundColor(theme.red)
+                        .padding(.top, Constants.spacing)
+                }
             }
         }
     }

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -1994,6 +1994,8 @@ internal enum L10n {
   internal static var removeFromUpNext: String { return L10n.tr("Localizable", "remove_from_up_next") }
   /// Remove Up Next
   internal static var removeUpNext: String { return L10n.tr("Localizable", "remove_up_next") }
+  /// Renew your Subscription
+  internal static var renewSubscription: String { return L10n.tr("Localizable", "renew_subscription") }
   /// Retry
   internal static var retry: String { return L10n.tr("Localizable", "retry") }
   /// Search

--- a/podcasts/UserInfo.swift
+++ b/podcasts/UserInfo.swift
@@ -1,0 +1,78 @@
+import Foundation
+import PocketCastsDataModel
+import PocketCastsServer
+
+struct UserInfo {
+    struct Profile {
+        let isLoggedIn: Bool
+        let displayName: String?
+        let email: String?
+
+        init(isLoggedIn: Bool = SyncManager.isUserLoggedIn(), email: String? = ServerSettings.syncingEmail(), displayName: String? = nil) {
+            self.isLoggedIn = isLoggedIn
+            self.email = isLoggedIn ? email : nil
+            self.displayName = isLoggedIn ? displayName : nil // Placeholder, Not available yet
+        }
+    }
+
+    struct Subscription {
+        let type: SubscriptionType
+        let expirationProgress: Double
+        let expirationDate: Date?
+
+        /// Returns nil if there is no subscription info to return
+        init?(loggedIn: Bool = SyncManager.isUserLoggedIn()) {
+            let hasSubscription = SubscriptionHelper.hasActiveSubscription()
+            let type = SubscriptionHelper.subscriptionType()
+
+            guard loggedIn, hasSubscription, type != .none else {
+                return nil
+            }
+
+            self.type = type
+
+            let maxDisplayTime = Constants.Limits.maxSubscriptionExpirySeconds
+
+            expirationDate = hasSubscription ? SubscriptionHelper.subscriptionRenewalDate() : nil
+
+            // Don't show the expiration label if we're outside of the max days
+            guard let expiration = SubscriptionHelper.timeToSubscriptionExpiry(), expiration <= maxDisplayTime else {
+                expirationProgress = hasSubscription ? 1 : 0
+                return
+            }
+
+            expirationProgress = (expiration / maxDisplayTime).clamped(to: 0..<1)
+        }
+
+        func isExpiring(_ type: SubscriptionType) -> Bool {
+            self.type == type && expirationProgress < 1
+        }
+    }
+
+    struct Stats {
+        /// The total number of podcasts the user is subscribed to
+        let podcastCount: Int
+
+        /// The total time the user has listened to podcasts
+        let listeningTime: Stat
+
+        /// The total time the user has saved from playback effects
+        let savedTime: Stat
+
+        init() {
+            podcastCount = DataManager.sharedManager.podcastCount()
+            listeningTime = .init(seconds: StatsManager.shared.totalListeningTimeInclusive())
+            savedTime = .init(seconds: StatsManager.shared.totalSavedTime())
+        }
+
+        struct Stat {
+            let seconds: TimeInterval
+            let formatValues: Double.TimeFormatValueType
+
+            init(seconds: TimeInterval) {
+                self.seconds = seconds
+                formatValues = seconds.timeFormatValues
+            }
+        }
+    }
+}

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -3652,3 +3652,6 @@
 
 /* Label describing the recent searches */
 "search_recent" = "Recent searches";
+
+/* Button label prompting the user to renew their subscription */
+"renew_subscription" = "Renew your Subscription";


### PR DESCRIPTION
This does the following:
- Fixes a bug where the prompt would show for non-lifetime gifts
- Adds free trial support to the prompt
- Provides more contextual button labeling
   - If the user has an expiring subscription the prompt button will now say: "Renew Subscription"
   - If the users plan is plus and it's expiring, the Patron label will say "Upgrade Account"
   - If the users plan is patron and it's expiring, then we'll only show patron in the prompt

## Screenshots

| Free Trial | Plus Expiring | Gift | Gift Expiring |
|:---:|:---:|:---:|:---:|
|<img src="https://github.com/Automattic/pocket-casts-ios/assets/793774/be456974-20e2-4aa6-8089-9ff306410f01" width="320" />|<img src="https://github.com/Automattic/pocket-casts-ios/assets/793774/5ea1e134-f7a0-404b-a3b7-c14ad5e748d8" width="320" />|<img src="https://github.com/Automattic/pocket-casts-ios/assets/793774/5ba3ed93-fe7f-4791-8338-3cd6bf73bf2a" width="320" />|<img src="https://github.com/Automattic/pocket-casts-ios/assets/793774/2cb7ccee-382e-4fbc-a58d-8a1ac2c6ace8" width="320" />|

| Plus Expiring - Patron Card | Patron Expiring |
|:---:|:---:|
<img src="https://github.com/Automattic/pocket-casts-ios/assets/793774/05898cbc-951b-4025-b1d5-be7260665178" width="320" />|<img src="https://github.com/Automattic/pocket-casts-ios/assets/793774/7120fdfe-050b-41c4-8cea-f29e3e1cb019" width="320" />|

## To Test
Before testing: Enable the Patron feature flag


### Gift Days
1. Launch the app
2. Sign into an account
3. Tap the Profile Tab > Cog > Developer
4. Tap 'Set to 150 Gift Days'
5. Go to Profile Tab > Account
6. ✅ Verify you only see the 'Upgrade Account' under Change Password
7. Go back to Developer, Tap 'Set to 150 gift days and expiring in 1 day'
8. Go back to the Account
9. ✅ Verify you now see the big prompt and the small Purple prompt from before is hidden
10. ✅ Verify the button reads "Renew" and the Patron one reads "Upgrade Account"
11. Go back to Developer, and set to lifetime
12. Go back to Account, ✅ verify you don't see the big prompt anymore

### Free Account
1. Go back to Developer, and Set to No Plus
2. Go back to Account
3. ✅ Verify you see the big prompt and the labels ready "Subscribe to Plus" and "Subscribe to Patron"

### Plus
1.  Go back to Developer, and Set to Paid Plus
2. Go back to the Account
5. ✅ Verify you don't see the big prompt
6. Go back to Developer, and Set to Active but cancelled: Plus
7. Go back to Account
8. ✅ Verify you see the big prompt

### Patron
1. Go back to Developer, and Set to Paid Patron
2. Go back to the Account
5. ✅ Verify you don't see the big prompt, or the 'Upgrade Account' item
6. Go back to Developer, and Set to Active but cancelled: Patron
7. Go back to Account
8. ✅ Verify you see the big prompt with patron as the only option and the button says 'Renew your subscription'

### Free Trials

1. Hit Command-Shift-Comma to open the scheme editor
2. Enable the StoreKit config
3. Launch the app
4. Follow the steps above and make sure you see the free trial states


## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
