### PR TITLE
Patron: Add Initial Server Support

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Private/API Tasks/SubscriptionStatusTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Private/API Tasks/SubscriptionStatusTask.swift
@@ -25,31 +25,37 @@ class SubscriptionStatusTask: ApiBaseTask {
                 SubscriptionHelper.setSubscriptionType(Int(status.type))
                 SubscriptionHelper.subscriptionTier = SubscriptionTier(rawValue: status.tier) ?? .none
 
-                var podcastSubscriptions = [PodcastSubscription]()
-
-                for subscription in status.subscriptions {
-                    if subscription.type == SubscriptionType.supporter.rawValue {
-                        for podcastUuids in subscription.podcasts {
-                            let podcastSubscription = PodcastSubscription(uuid: podcastUuids.userPodcastUuid, masterUuid: podcastUuids.masterPodcastUuid, bundleUuid: subscription.bundleUuid, frequency: Int(subscription.frequency), expiryDate: subscription.expiryDate.timeIntervalSince1970, autoRenewing: subscription.autoRenewing, platform: Int(subscription.platform))
-                            podcastSubscriptions.append(podcastSubscription)
-                        }
-                    }
-                }
-                if podcastSubscriptions.count > 0 {
-                    SubscriptionHelper.setSubscriptionPodcasts(podcastSubscriptions)
-                }
                 NotificationCenter.default.post(name: ServerNotifications.subscriptionStatusChanged, object: nil)
+
                 var expiryDateString = "nil"
                 if let expiryDate = SubscriptionHelper.subscriptionRenewalDate() {
                     expiryDateString = expiryDate.description
                 }
-                FileLog.shared.addMessage("Received subscription status paid : \(status.paid), platform : \(status.platform), frequency : \(status.frequency), giftDays : \(status.giftDays), expiryDate :  \(expiryDateString), supporterPodcasts : \(podcastSubscriptions.count)")
+                FileLog.shared.addMessage("Received subscription status paid : \(status.paid), platform : \(status.platform), frequency : \(status.frequency), giftDays : \(status.giftDays), expiryDate : \(expiryDateString)")
                 if originalSubscriptionStatus, !SubscriptionHelper.hasActiveSubscription() {
                     ServerConfig.shared.syncDelegate?.cleanupCloudOnlyFiles()
                 }
             }
         } catch {
             FileLog.shared.addMessage("SubscriptionStatusTask: Protobuf Encoding failed \(error.localizedDescription)")
+        }
+    }
+
+    /* Unused old code, leaving for now */
+    private func processPodcastSubscriptions(status: Api_SubscriptionsStatusResponse) {
+        var podcastSubscriptions = [PodcastSubscription]()
+
+        for subscription in status.subscriptions {
+            if subscription.type == SubscriptionType.supporter.rawValue {
+                for podcastUuids in subscription.podcasts {
+                    let podcastSubscription = PodcastSubscription(uuid: podcastUuids.userPodcastUuid, masterUuid: podcastUuids.masterPodcastUuid, bundleUuid: subscription.bundleUuid, frequency: Int(subscription.frequency), expiryDate: subscription.expiryDate.timeIntervalSince1970, autoRenewing: subscription.autoRenewing, platform: Int(subscription.platform))
+                    podcastSubscriptions.append(podcastSubscription)
+                }
+            }
+        }
+
+        if podcastSubscriptions.count > 0 {
+            SubscriptionHelper.setSubscriptionPodcasts(podcastSubscriptions)
         }
     }
 }

--- a/Modules/Server/Sources/PocketCastsServer/Private/API Tasks/SubscriptionStatusTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Private/API Tasks/SubscriptionStatusTask.swift
@@ -23,6 +23,8 @@ class SubscriptionStatusTask: ApiBaseTask {
                 SubscriptionHelper.setSubscriptionGiftDays(Int(status.giftDays))
                 SubscriptionHelper.setSubscriptionFrequency(Int(status.frequency))
                 SubscriptionHelper.setSubscriptionType(Int(status.type))
+                SubscriptionHelper.subscriptionTier = SubscriptionTier(rawValue: status.tier) ?? .none
+
                 var podcastSubscriptions = [PodcastSubscription]()
 
                 for subscription in status.subscriptions {

--- a/Modules/Server/Sources/PocketCastsServer/Private/Protobuffer/api.pb.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Private/Protobuffer/api.pb.swift
@@ -36,6 +36,8 @@ struct Api_UserChangeResponse {
 
   var message: String = String()
 
+  var messageID: String = String()
+
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
@@ -2437,11 +2439,41 @@ struct Api_SubscriptionResponse {
     set {_uniqueStorage()._eligible = newValue}
   }
 
+  var nextPayment: Api_PaymentResponse {
+    get {return _storage._nextPayment ?? Api_PaymentResponse()}
+    set {_uniqueStorage()._nextPayment = newValue}
+  }
+  /// Returns true if `nextPayment` has been explicitly set.
+  var hasNextPayment: Bool {return _storage._nextPayment != nil}
+  /// Clears the value of `nextPayment`. Subsequent reads from it will return its default value.
+  mutating func clearNextPayment() {_uniqueStorage()._nextPayment = nil}
+
+  var tier: String {
+    get {return _storage._tier}
+    set {_uniqueStorage()._tier = newValue}
+  }
+
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
 
   fileprivate var _storage = _StorageClass.defaultInstance
+}
+
+struct Api_PaymentResponse {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  var paymentDate: String = String()
+
+  var amount: Double = 0
+
+  var currency: String = String()
+
+  var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  init() {}
 }
 
 struct Api_PodcastPair {
@@ -2534,6 +2566,11 @@ struct Api_SubscriptionsStatusResponse {
   var webStatus: Int32 {
     get {return _storage._webStatus}
     set {_uniqueStorage()._webStatus = newValue}
+  }
+
+  var tier: String {
+    get {return _storage._tier}
+    set {_uniqueStorage()._tier = newValue}
   }
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -4558,6 +4595,20 @@ struct Api_VerifyEmailRequest {
   init() {}
 }
 
+struct Api_AuthorizeCallbackRequest {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  var idToken: String = String()
+
+  var state: String = String()
+
+  var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  init() {}
+}
+
 #if swift(>=5.5) && canImport(_Concurrency)
 extension Api_UserChangeResponse: @unchecked Sendable {}
 extension Api_UserResetPasswordRequest: @unchecked Sendable {}
@@ -4641,6 +4692,7 @@ extension Api_SubscriptionsPurchaseAppleRequest: @unchecked Sendable {}
 extension Api_SubscriptionsPurchaseWebRequest: @unchecked Sendable {}
 extension Api_SubscriptionsWebStatusResponse: @unchecked Sendable {}
 extension Api_SubscriptionResponse: @unchecked Sendable {}
+extension Api_PaymentResponse: @unchecked Sendable {}
 extension Api_PodcastPair: @unchecked Sendable {}
 extension Api_SubscriptionsStatusResponse: @unchecked Sendable {}
 extension Api_CancelUserSubscriptionRequest: @unchecked Sendable {}
@@ -4676,6 +4728,7 @@ extension Api_TokenLoginRequest: @unchecked Sendable {}
 extension Api_TokenLoginResponse: @unchecked Sendable {}
 extension Api_TokenErrorResponse: @unchecked Sendable {}
 extension Api_VerifyEmailRequest: @unchecked Sendable {}
+extension Api_AuthorizeCallbackRequest: @unchecked Sendable {}
 #endif  // swift(>=5.5) && canImport(_Concurrency)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
@@ -4687,6 +4740,7 @@ extension Api_UserChangeResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageI
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .same(proto: "success"),
     2: .same(proto: "message"),
+    3: .same(proto: "messageId"),
   ]
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -4697,6 +4751,7 @@ extension Api_UserChangeResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageI
       switch fieldNumber {
       case 1: try { try decoder.decodeSingularMessageField(value: &self._success) }()
       case 2: try { try decoder.decodeSingularStringField(value: &self.message) }()
+      case 3: try { try decoder.decodeSingularStringField(value: &self.messageID) }()
       default: break
       }
     }
@@ -4713,12 +4768,16 @@ extension Api_UserChangeResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageI
     if !self.message.isEmpty {
       try visitor.visitSingularStringField(value: self.message, fieldNumber: 2)
     }
+    if !self.messageID.isEmpty {
+      try visitor.visitSingularStringField(value: self.messageID, fieldNumber: 3)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: Api_UserChangeResponse, rhs: Api_UserChangeResponse) -> Bool {
     if lhs._success != rhs._success {return false}
     if lhs.message != rhs.message {return false}
+    if lhs.messageID != rhs.messageID {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -9217,6 +9276,8 @@ extension Api_SubscriptionResponse: SwiftProtobuf.Message, SwiftProtobuf._Messag
     15: .standard(proto: "bundle_uuid"),
     16: .same(proto: "podcasts"),
     17: .same(proto: "eligible"),
+    18: .standard(proto: "next_payment"),
+    19: .same(proto: "tier"),
   ]
 
   fileprivate class _StorageClass {
@@ -9236,6 +9297,8 @@ extension Api_SubscriptionResponse: SwiftProtobuf.Message, SwiftProtobuf._Messag
     var _bundleUuid: String = String()
     var _podcasts: [Api_PodcastPair] = []
     var _eligible: Bool = false
+    var _nextPayment: Api_PaymentResponse? = nil
+    var _tier: String = String()
 
     static let defaultInstance = _StorageClass()
 
@@ -9258,6 +9321,8 @@ extension Api_SubscriptionResponse: SwiftProtobuf.Message, SwiftProtobuf._Messag
       _bundleUuid = source._bundleUuid
       _podcasts = source._podcasts
       _eligible = source._eligible
+      _nextPayment = source._nextPayment
+      _tier = source._tier
     }
   }
 
@@ -9292,6 +9357,8 @@ extension Api_SubscriptionResponse: SwiftProtobuf.Message, SwiftProtobuf._Messag
         case 15: try { try decoder.decodeSingularStringField(value: &_storage._bundleUuid) }()
         case 16: try { try decoder.decodeRepeatedMessageField(value: &_storage._podcasts) }()
         case 17: try { try decoder.decodeSingularBoolField(value: &_storage._eligible) }()
+        case 18: try { try decoder.decodeSingularMessageField(value: &_storage._nextPayment) }()
+        case 19: try { try decoder.decodeSingularStringField(value: &_storage._tier) }()
         default: break
         }
       }
@@ -9352,6 +9419,12 @@ extension Api_SubscriptionResponse: SwiftProtobuf.Message, SwiftProtobuf._Messag
       if _storage._eligible != false {
         try visitor.visitSingularBoolField(value: _storage._eligible, fieldNumber: 17)
       }
+      try { if let v = _storage._nextPayment {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 18)
+      } }()
+      if !_storage._tier.isEmpty {
+        try visitor.visitSingularStringField(value: _storage._tier, fieldNumber: 19)
+      }
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -9377,10 +9450,56 @@ extension Api_SubscriptionResponse: SwiftProtobuf.Message, SwiftProtobuf._Messag
         if _storage._bundleUuid != rhs_storage._bundleUuid {return false}
         if _storage._podcasts != rhs_storage._podcasts {return false}
         if _storage._eligible != rhs_storage._eligible {return false}
+        if _storage._nextPayment != rhs_storage._nextPayment {return false}
+        if _storage._tier != rhs_storage._tier {return false}
         return true
       }
       if !storagesAreEqual {return false}
     }
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Api_PaymentResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  static let protoMessageName: String = _protobuf_package + ".PaymentResponse"
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .standard(proto: "payment_date"),
+    2: .same(proto: "amount"),
+    3: .same(proto: "currency"),
+  ]
+
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self.paymentDate) }()
+      case 2: try { try decoder.decodeSingularDoubleField(value: &self.amount) }()
+      case 3: try { try decoder.decodeSingularStringField(value: &self.currency) }()
+      default: break
+      }
+    }
+  }
+
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.paymentDate.isEmpty {
+      try visitor.visitSingularStringField(value: self.paymentDate, fieldNumber: 1)
+    }
+    if self.amount != 0 {
+      try visitor.visitSingularDoubleField(value: self.amount, fieldNumber: 2)
+    }
+    if !self.currency.isEmpty {
+      try visitor.visitSingularStringField(value: self.currency, fieldNumber: 3)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  static func ==(lhs: Api_PaymentResponse, rhs: Api_PaymentResponse) -> Bool {
+    if lhs.paymentDate != rhs.paymentDate {return false}
+    if lhs.amount != rhs.amount {return false}
+    if lhs.currency != rhs.currency {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -9440,6 +9559,7 @@ extension Api_SubscriptionsStatusResponse: SwiftProtobuf.Message, SwiftProtobuf.
     11: .same(proto: "type"),
     12: .same(proto: "index"),
     13: .same(proto: "webStatus"),
+    14: .same(proto: "tier"),
   ]
 
   fileprivate class _StorageClass {
@@ -9456,6 +9576,7 @@ extension Api_SubscriptionsStatusResponse: SwiftProtobuf.Message, SwiftProtobuf.
     var _type: Int32 = 0
     var _index: Int32 = 0
     var _webStatus: Int32 = 0
+    var _tier: String = String()
 
     static let defaultInstance = _StorageClass()
 
@@ -9475,6 +9596,7 @@ extension Api_SubscriptionsStatusResponse: SwiftProtobuf.Message, SwiftProtobuf.
       _type = source._type
       _index = source._index
       _webStatus = source._webStatus
+      _tier = source._tier
     }
   }
 
@@ -9506,6 +9628,7 @@ extension Api_SubscriptionsStatusResponse: SwiftProtobuf.Message, SwiftProtobuf.
         case 11: try { try decoder.decodeSingularInt32Field(value: &_storage._type) }()
         case 12: try { try decoder.decodeSingularInt32Field(value: &_storage._index) }()
         case 13: try { try decoder.decodeSingularInt32Field(value: &_storage._webStatus) }()
+        case 14: try { try decoder.decodeSingularStringField(value: &_storage._tier) }()
         default: break
         }
       }
@@ -9557,6 +9680,9 @@ extension Api_SubscriptionsStatusResponse: SwiftProtobuf.Message, SwiftProtobuf.
       if _storage._webStatus != 0 {
         try visitor.visitSingularInt32Field(value: _storage._webStatus, fieldNumber: 13)
       }
+      if !_storage._tier.isEmpty {
+        try visitor.visitSingularStringField(value: _storage._tier, fieldNumber: 14)
+      }
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -9579,6 +9705,7 @@ extension Api_SubscriptionsStatusResponse: SwiftProtobuf.Message, SwiftProtobuf.
         if _storage._type != rhs_storage._type {return false}
         if _storage._index != rhs_storage._index {return false}
         if _storage._webStatus != rhs_storage._webStatus {return false}
+        if _storage._tier != rhs_storage._tier {return false}
         return true
       }
       if !storagesAreEqual {return false}
@@ -12385,6 +12512,44 @@ extension Api_VerifyEmailRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageI
 
   static func ==(lhs: Api_VerifyEmailRequest, rhs: Api_VerifyEmailRequest) -> Bool {
     if lhs.verifyEmailToken != rhs.verifyEmailToken {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Api_AuthorizeCallbackRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  static let protoMessageName: String = _protobuf_package + ".AuthorizeCallbackRequest"
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .standard(proto: "id_token"),
+    2: .same(proto: "state"),
+  ]
+
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self.idToken) }()
+      case 2: try { try decoder.decodeSingularStringField(value: &self.state) }()
+      default: break
+      }
+    }
+  }
+
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.idToken.isEmpty {
+      try visitor.visitSingularStringField(value: self.idToken, fieldNumber: 1)
+    }
+    if !self.state.isEmpty {
+      try visitor.visitSingularStringField(value: self.state, fieldNumber: 2)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  static func ==(lhs: Api_AuthorizeCallbackRequest, rhs: Api_AuthorizeCallbackRequest) -> Bool {
+    if lhs.idToken != rhs.idToken {return false}
+    if lhs.state != rhs.state {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Modules/Server/Sources/PocketCastsServer/Public/ServerEnums.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/ServerEnums.swift
@@ -41,5 +41,18 @@ public enum SubscriptionType: Int {
 extension SubscriptionType: Comparable {
     public static func < (lhs: SubscriptionType, rhs: SubscriptionType) -> Bool {
         lhs.rawValue < rhs.rawValue
+// MARK: - SubscriptionTier
+public enum SubscriptionTier: String {
+    case none = "", plus = "Plus", patron = "Patron"
+}
+
+extension SubscriptionTier: Comparable {
+    private static var tierOrder: [Self] = [.none, .plus, .patron]
+
+    public static func < (lhs: SubscriptionTier, rhs: SubscriptionTier) -> Bool {
+        let lhsIndex = Self.tierOrder.firstIndex(of: lhs) ?? -1
+        let rhsIndex = Self.tierOrder.firstIndex(of: rhs) ?? -1
+
+        return lhsIndex < rhsIndex
     }
 }

--- a/Modules/Server/Sources/PocketCastsServer/Public/ServerEnums.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/ServerEnums.swift
@@ -40,7 +40,12 @@ public enum SubscriptionType: Int {
 
 // MARK: - SubscriptionTier
 public enum SubscriptionTier: String {
-    case none = "", plus = "Plus", patron = "Patron"
+    // The none state doesn't come from the server, but it instead may send an empty string
+    // This is used as the fallback value
+    case none = ""
+
+    // The values here come from the server and are case sensitive
+    case plus = "Plus", patron = "Patron"
 }
 
 extension SubscriptionTier: Comparable {

--- a/Modules/Server/Sources/PocketCastsServer/Public/ServerEnums.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/ServerEnums.swift
@@ -35,12 +35,9 @@ public enum AutoAddLimitReachedAction: Int32 {
 
 // MARK: - SubscriptionType
 public enum SubscriptionType: Int {
-    case none = 0, plus = 1, supporter = 2, patron = 3
+    case none = 0, plus = 1, supporter = 2
 }
 
-extension SubscriptionType: Comparable {
-    public static func < (lhs: SubscriptionType, rhs: SubscriptionType) -> Bool {
-        lhs.rawValue < rhs.rawValue
 // MARK: - SubscriptionTier
 public enum SubscriptionTier: String {
     case none = "", plus = "Plus", patron = "Patron"

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerConstants.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerConstants.swift
@@ -119,6 +119,7 @@ public enum ServerConstants {
         public static let subscriptionFrequency = "SJSubscriptionFrequency"
         static let subscriptionPodcasts = "SJSubscriptionPodcasts"
         static let subscriptionType = "SJSubscriptionType"
+        static let subscriptionTier = "SJSubscriptionTier"
         static let marketingOptInKey = "SJMarketingOptIn"
         static let marketingOptInNeedsSyncKey = "SJMarketingOptInNeedsSync"
         static let subscriptionGiftAcknowledgementNeedsSyncKey = "SJGiftAcknowledgementNeedsSync"

--- a/Modules/Server/Sources/PocketCastsServer/Public/SubscriptionHelper.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/SubscriptionHelper.swift
@@ -6,6 +6,24 @@ public class SubscriptionHelper: NSObject {
         hasActiveSubscription() ? subscriptionType() : .none
     }
 
+    /// Returns the users active subscription tier or .none if they don't currently have one
+    public static var activeSubscriptionTier: SubscriptionTier {
+        hasActiveSubscription() ? subscriptionTier : .none
+    }
+
+    /// The users subscription tier, or .none if there isn't one available
+    public static var subscriptionTier: SubscriptionTier {
+        set {
+            UserDefaults.standard.set(newValue.rawValue, forKey: ServerConstants.UserDefaults.subscriptionTier)
+        }
+
+        get {
+            UserDefaults.standard.string(forKey: ServerConstants.UserDefaults.subscriptionPaid).flatMap {
+                SubscriptionTier(rawValue: $0)
+            } ?? .none
+        }
+    }
+
     public class func hasActiveSubscription() -> Bool {
         let status = UserDefaults.standard.bool(forKey: ServerConstants.UserDefaults.subscriptionPaid)
         return status

--- a/Modules/Server/Sources/PocketCastsServer/Public/SubscriptionHelper.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/SubscriptionHelper.swift
@@ -18,7 +18,7 @@ public class SubscriptionHelper: NSObject {
         }
 
         get {
-            UserDefaults.standard.string(forKey: ServerConstants.UserDefaults.subscriptionPaid).flatMap {
+            UserDefaults.standard.string(forKey: ServerConstants.UserDefaults.subscriptionTier).flatMap {
                 SubscriptionTier(rawValue: $0)
             } ?? .none
         }

--- a/Modules/Server/Sources/PocketCastsServer/Public/SubscriptionHelper.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/SubscriptionHelper.swift
@@ -8,7 +8,23 @@ public class SubscriptionHelper: NSObject {
 
     /// Returns the users active subscription tier or .none if they don't currently have one
     public static var activeSubscriptionTier: SubscriptionTier {
-        hasActiveSubscription() ? subscriptionTier : .none
+        guard hasActiveSubscription() else {
+            return .none
+        }
+
+        let tier = subscriptionTier
+
+        // Fallback handling
+        // If the server isn't returning the subscription tier yet then the tier will be none
+        // If the user has an active subscription, and the tier is none, and their subscription type is plus
+        // Then fallback to returning plus as the tier
+        //
+        // This should be removed after the Patron server changes have been pushed to production
+        guard tier == .none, subscriptionType() == .plus else {
+            return tier
+        }
+
+        return .plus
     }
 
     /// The users subscription tier, or .none if there isn't one available

--- a/Modules/Server/Tests/PocketCastsServerTests/SubscriptionTierTests.swift
+++ b/Modules/Server/Tests/PocketCastsServerTests/SubscriptionTierTests.swift
@@ -1,0 +1,19 @@
+import Foundation
+@testable import PocketCastsServer
+import XCTest
+
+final class SubscriptionTierTests: XCTestCase {
+    func testSubscriptionNoneIsLessThanEverything() {
+        XCTAssertLessThan(SubscriptionTier.none, SubscriptionTier.plus)
+        XCTAssertLessThan(SubscriptionTier.none, SubscriptionTier.patron)
+    }
+
+    func testSubscriptionPlusIsLessThanPatron() {
+        XCTAssertLessThan(SubscriptionTier.plus, SubscriptionTier.patron)
+    }
+
+    func testSubscriptionPatronIsMoreThanEverythingElse() {
+        XCTAssertGreaterThan(SubscriptionTier.patron, SubscriptionTier.plus)
+        XCTAssertGreaterThan(SubscriptionTier.patron, SubscriptionTier.none)
+    }
+}

--- a/Pocket Casts Configuration.storekit
+++ b/Pocket Casts Configuration.storekit
@@ -91,7 +91,7 @@
               "locale" : "en_US"
             }
           ],
-          "productID" : "com.pocketcasts.patron.yearly",
+          "productID" : "com.pocketcasts.yearly.patron",
           "recurringSubscriptionPeriod" : "P1Y",
           "referenceName" : "Patron Yearly",
           "subscriptionGroupID" : "D129D5D3",
@@ -116,7 +116,7 @@
               "locale" : "en_US"
             }
           ],
-          "productID" : "com.pocketcasts.patron.monthly",
+          "productID" : "com.pocketcasts.monthly.patron",
           "recurringSubscriptionPeriod" : "P1M",
           "referenceName" : "Patron Monthly",
           "subscriptionGroupID" : "D129D5D3",

--- a/podcasts/AccountViewController.swift
+++ b/podcasts/AccountViewController.swift
@@ -94,7 +94,7 @@ class AccountViewController: UIViewController, ChangeEmailDelegate {
 
         // Show the 'Upgrade Account' if the user has an active subscription that isn't patron.
         // Hide the cell if we're already showing the big upgrade prompt
-        let upgradeRow = (FeatureFlag.patron.enabled && SubscriptionHelper.activeSubscriptionType < .patron && !isExpiring) ? TableRow.upgradeAccount : nil
+        let upgradeRow = (FeatureFlag.patron.enabled && SubscriptionHelper.activeSubscriptionTier < .patron && !isExpiring) ? TableRow.upgradeAccount : nil
 
         // Only accounts created with username/password can change email/password
         var accountOptions: [TableRow]

--- a/podcasts/Analytics/Adapters/Tracks/TracksAdapter.swift
+++ b/podcasts/Analytics/Adapters/Tracks/TracksAdapter.swift
@@ -66,6 +66,7 @@ class TracksAdapter: AnalyticsAdapter {
         let hasSubscription = subscriptionData.hasActiveSubscription()
         let platform = subscriptionData.subscriptionPlatform()
         let type = hasSubscription ? subscriptionData.subscriptionType() : .none
+        let tier = subscriptionData.subscriptionTier
         let frequency = hasSubscription ? subscriptionData.subscriptionFrequency() : .none
         let hasLifetime = subscriptionData.hasLifetimeGift()
 
@@ -77,6 +78,7 @@ class TracksAdapter: AnalyticsAdapter {
             "plus_has_subscription": hasSubscription,
             "plus_has_lifetime": hasLifetime,
             "plus_subscription_type": type.analyticsDescription,
+            "plus_subscription_tier": tier.analyticsDescription,
             "plus_subscription_platform": platform.analyticsDescription,
             "plus_subscription_frequency": frequency.analyticsDescription,
 

--- a/podcasts/Analytics/Adapters/Tracks/TracksSubscriptionData.swift
+++ b/podcasts/Analytics/Adapters/Tracks/TracksSubscriptionData.swift
@@ -8,6 +8,7 @@ protocol TracksSubscriptionData {
     func subscriptionType() -> SubscriptionType
     func subscriptionFrequency() -> SubscriptionFrequency
     func hasLifetimeGift() -> Bool
+    var subscriptionTier: SubscriptionTier { get }
 }
 
 /// Retrieves Pocket Casts specific data for use in tracks
@@ -22,6 +23,10 @@ struct PocketCastsTracksSubscriptionData: TracksSubscriptionData {
 
     func subscriptionType() -> SubscriptionType {
         SubscriptionHelper.subscriptionType()
+    }
+
+    var subscriptionTier: SubscriptionTier {
+        SubscriptionHelper.activeSubscriptionTier
     }
 
     func subscriptionFrequency() -> SubscriptionFrequency {

--- a/podcasts/Analytics/AnalyticsDescribable+Modules.swift
+++ b/podcasts/Analytics/AnalyticsDescribable+Modules.swift
@@ -41,8 +41,6 @@ extension SubscriptionType: AnalyticsDescribable {
             return "plus"
         case .supporter:
             return "supporter"
-        case .patron:
-            return "patron"
         }
     }
 }

--- a/podcasts/Analytics/AnalyticsDescribable+Modules.swift
+++ b/podcasts/Analytics/AnalyticsDescribable+Modules.swift
@@ -45,6 +45,19 @@ extension SubscriptionType: AnalyticsDescribable {
     }
 }
 
+extension SubscriptionTier: AnalyticsDescribable {
+    var analyticsDescription: String {
+        switch self {
+        case .none:
+            return "none"
+        case .plus:
+            return "plus"
+        case .patron:
+            return "patron"
+        }
+    }
+}
+
 extension AudioVideoFilter: AnalyticsDescribable {
     var analyticsDescription: String {
         switch self {

--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -229,8 +229,8 @@ struct Constants {
         enum IapProducts: String {
             case yearly = "com.pocketcasts.plus.yearly"
             case monthly = "com.pocketcasts.plus.monthly"
-            case patronYearly = "com.pocketcasts.patron.yearly"
-            case patronMonthly = "com.pocketcasts.patron.monthly"
+            case patronYearly = "com.pocketcasts.yearly.patron"
+            case patronMonthly = "com.pocketcasts.monthly.patron"
 
             var renewalPrompt: String {
                 switch self {

--- a/podcasts/DeveloperMenu.swift
+++ b/podcasts/DeveloperMenu.swift
@@ -31,9 +31,9 @@ struct DeveloperMenu: View {
                     SubscriptionHelper.setSubscriptionExpiryDate(Date(timeIntervalSinceNow: 30.days).timeIntervalSince1970)
                     SubscriptionHelper.setSubscriptionAutoRenewing(false)
                     SubscriptionHelper.setSubscriptionGiftDays(Int(0))
-                    SubscriptionHelper.setSubscriptionFrequency(Int(0))
-                    SubscriptionHelper.setSubscriptionType(Int(0))
-
+                    SubscriptionHelper.setSubscriptionFrequency(SubscriptionFrequency.none.rawValue)
+                    SubscriptionHelper.setSubscriptionType(SubscriptionType.none.rawValue)
+                    SubscriptionHelper.subscriptionTier = .none
                     NotificationCenter.postOnMainThread(notification: ServerNotifications.subscriptionStatusChanged)
                     HapticsHelper.triggerSubscribedHaptic()
                 }
@@ -44,8 +44,9 @@ struct DeveloperMenu: View {
                     SubscriptionHelper.setSubscriptionExpiryDate(Date(timeIntervalSinceNow: 30.days).timeIntervalSince1970)
                     SubscriptionHelper.setSubscriptionAutoRenewing(true)
                     SubscriptionHelper.setSubscriptionGiftDays(Int(0))
-                    SubscriptionHelper.setSubscriptionFrequency(Int(2))
-                    SubscriptionHelper.setSubscriptionType(Int(1))
+                    SubscriptionHelper.setSubscriptionFrequency(SubscriptionFrequency.monthly.rawValue)
+                    SubscriptionHelper.setSubscriptionType(SubscriptionType.plus.rawValue)
+                    SubscriptionHelper.subscriptionTier = .plus
 
                     NotificationCenter.postOnMainThread(notification: ServerNotifications.subscriptionStatusChanged)
                     HapticsHelper.triggerSubscribedHaptic()
@@ -57,8 +58,9 @@ struct DeveloperMenu: View {
                     SubscriptionHelper.setSubscriptionExpiryDate(Date(timeIntervalSinceNow: 30.days).timeIntervalSince1970)
                     SubscriptionHelper.setSubscriptionAutoRenewing(true)
                     SubscriptionHelper.setSubscriptionGiftDays(Int(0))
-                    SubscriptionHelper.setSubscriptionFrequency(Int(2))
-                    SubscriptionHelper.setSubscriptionType(Int(3))
+                    SubscriptionHelper.setSubscriptionFrequency(SubscriptionFrequency.monthly.rawValue)
+                    SubscriptionHelper.setSubscriptionType(SubscriptionType.plus.rawValue)
+                    SubscriptionHelper.subscriptionTier = .patron
 
                     NotificationCenter.postOnMainThread(notification: ServerNotifications.subscriptionStatusChanged)
                     HapticsHelper.triggerSubscribedHaptic()
@@ -73,6 +75,7 @@ struct DeveloperMenu: View {
                         SubscriptionHelper.setSubscriptionGiftDays(150)
                         SubscriptionHelper.setSubscriptionFrequency(SubscriptionFrequency.none.rawValue)
                         SubscriptionHelper.setSubscriptionType(SubscriptionType.plus.rawValue)
+                        SubscriptionHelper.subscriptionTier = .plus
 
                         NotificationCenter.postOnMainThread(notification: ServerNotifications.subscriptionStatusChanged)
                         HapticsHelper.triggerSubscribedHaptic()
@@ -86,6 +89,7 @@ struct DeveloperMenu: View {
                         SubscriptionHelper.setSubscriptionGiftDays(150)
                         SubscriptionHelper.setSubscriptionFrequency(SubscriptionFrequency.none.rawValue)
                         SubscriptionHelper.setSubscriptionType(SubscriptionType.plus.rawValue)
+                        SubscriptionHelper.subscriptionTier = .plus
 
                         NotificationCenter.postOnMainThread(notification: ServerNotifications.subscriptionStatusChanged)
                         HapticsHelper.triggerSubscribedHaptic()
@@ -99,6 +103,7 @@ struct DeveloperMenu: View {
                         SubscriptionHelper.setSubscriptionGiftDays(150)
                         SubscriptionHelper.setSubscriptionFrequency(SubscriptionFrequency.none.rawValue)
                         SubscriptionHelper.setSubscriptionType(SubscriptionType.plus.rawValue)
+                        SubscriptionHelper.subscriptionTier = .plus
 
                         NotificationCenter.postOnMainThread(notification: ServerNotifications.subscriptionStatusChanged)
                         HapticsHelper.triggerSubscribedHaptic()
@@ -112,6 +117,7 @@ struct DeveloperMenu: View {
                         SubscriptionHelper.setSubscriptionGiftDays(Int(11 * 365.days))
                         SubscriptionHelper.setSubscriptionFrequency(SubscriptionFrequency.none.rawValue)
                         SubscriptionHelper.setSubscriptionType(SubscriptionType.plus.rawValue)
+                        SubscriptionHelper.subscriptionTier = .plus
 
                         NotificationCenter.postOnMainThread(notification: ServerNotifications.subscriptionStatusChanged)
                         HapticsHelper.triggerSubscribedHaptic()
@@ -125,8 +131,9 @@ struct DeveloperMenu: View {
                         SubscriptionHelper.setSubscriptionExpiryDate(Date(timeIntervalSinceNow: 3.days).timeIntervalSince1970)
                         SubscriptionHelper.setSubscriptionAutoRenewing(false)
                         SubscriptionHelper.setSubscriptionGiftDays(Int(0))
-                        SubscriptionHelper.setSubscriptionFrequency(Int(0))
-                        SubscriptionHelper.setSubscriptionType(Int(1))
+                        SubscriptionHelper.setSubscriptionFrequency(SubscriptionFrequency.none.rawValue)
+                        SubscriptionHelper.setSubscriptionType(SubscriptionType.plus.rawValue)
+                        SubscriptionHelper.subscriptionTier = .plus
 
                         NotificationCenter.postOnMainThread(notification: ServerNotifications.subscriptionStatusChanged)
                         HapticsHelper.triggerSubscribedHaptic()
@@ -142,8 +149,9 @@ struct DeveloperMenu: View {
                         SubscriptionHelper.setSubscriptionExpiryDate(Date(timeIntervalSinceNow: 3.days).timeIntervalSince1970)
                         SubscriptionHelper.setSubscriptionAutoRenewing(false)
                         SubscriptionHelper.setSubscriptionGiftDays(Int(0))
-                        SubscriptionHelper.setSubscriptionFrequency(Int(0))
-                        SubscriptionHelper.setSubscriptionType(Int(3))
+                        SubscriptionHelper.setSubscriptionFrequency(SubscriptionFrequency.none.rawValue)
+                        SubscriptionHelper.setSubscriptionType(SubscriptionType.plus.rawValue)
+                        SubscriptionHelper.subscriptionTier = .patron
 
                         NotificationCenter.postOnMainThread(notification: ServerNotifications.subscriptionStatusChanged)
                         HapticsHelper.triggerSubscribedHaptic()
@@ -159,8 +167,9 @@ struct DeveloperMenu: View {
                         SubscriptionHelper.setSubscriptionExpiryDate(Date(timeIntervalSinceNow: (1.days * -1)).timeIntervalSince1970)
                         SubscriptionHelper.setSubscriptionAutoRenewing(false)
                         SubscriptionHelper.setSubscriptionGiftDays(Int(0))
-                        SubscriptionHelper.setSubscriptionFrequency(Int(0))
-                        SubscriptionHelper.setSubscriptionType(Int(0))
+                        SubscriptionHelper.setSubscriptionFrequency(SubscriptionFrequency.none.rawValue)
+                        SubscriptionHelper.setSubscriptionType(SubscriptionType.plus.rawValue)
+                        SubscriptionHelper.subscriptionTier = .plus
 
                         NotificationCenter.postOnMainThread(notification: ServerNotifications.subscriptionStatusChanged)
                         HapticsHelper.triggerSubscribedHaptic()
@@ -176,8 +185,9 @@ struct DeveloperMenu: View {
                         SubscriptionHelper.setSubscriptionExpiryDate(Date(timeIntervalSinceNow: (1.days * -1)).timeIntervalSince1970)
                         SubscriptionHelper.setSubscriptionAutoRenewing(false)
                         SubscriptionHelper.setSubscriptionGiftDays(Int(0))
-                        SubscriptionHelper.setSubscriptionFrequency(Int(0))
-                        SubscriptionHelper.setSubscriptionType(Int(3))
+                        SubscriptionHelper.setSubscriptionFrequency(SubscriptionFrequency.none.rawValue)
+                        SubscriptionHelper.setSubscriptionType(SubscriptionType.plus.rawValue)
+                        SubscriptionHelper.subscriptionTier = .patron
 
                         NotificationCenter.postOnMainThread(notification: ServerNotifications.subscriptionStatusChanged)
                         HapticsHelper.triggerSubscribedHaptic()

--- a/podcasts/IconSelectorCell.swift
+++ b/podcasts/IconSelectorCell.swift
@@ -189,11 +189,11 @@ enum IconType: Int, CaseIterable, AnalyticsDescribable {
 
     /// Whether the icon is unlocked for the users active subscription
     var isUnlocked: Bool {
-        SubscriptionHelper.activeSubscriptionType >= subscription
+        SubscriptionHelper.activeSubscriptionTier >= subscription
     }
 
     /// The minimum subscription level required to unlock the icon
-    var subscription: SubscriptionType {
+    var subscription: SubscriptionTier {
         switch self {
         case .patronChrome, .patronRound, .patronGlow, .patronDark:
             return .patron

--- a/podcasts/Onboarding/Models/PlusAccountPromptViewModel.swift
+++ b/podcasts/Onboarding/Models/PlusAccountPromptViewModel.swift
@@ -13,7 +13,7 @@ class PlusAccountPromptViewModel: PlusPricingInfoModel {
                 return [.yearly]
             }
 
-            return subscription?.type == .patron ? [.patronYearly] : [.yearly, .patronYearly]
+            return subscription?.tier == .patron ? [.patronYearly] : [.yearly, .patronYearly]
         }()
 
         return productsToDisplay.compactMap { product in

--- a/podcasts/Onboarding/Models/PlusPurchaseModel.swift
+++ b/podcasts/Onboarding/Models/PlusPurchaseModel.swift
@@ -152,6 +152,7 @@ private extension PlusPurchaseModel {
         SubscriptionHelper.setSubscriptionPaid(1)
         SubscriptionHelper.setSubscriptionPlatform(SubscriptionPlatform.iOS.rawValue)
         SubscriptionHelper.setSubscriptionAutoRenewing(true)
+        SubscriptionHelper.setSubscriptionType(SubscriptionType.plus.rawValue)
         SubscriptionHelper.subscriptionTier = purchasedProduct.subscriptionTier
 
         let currentDate = Date()

--- a/podcasts/Onboarding/Models/PlusPurchaseModel.swift
+++ b/podcasts/Onboarding/Models/PlusPurchaseModel.swift
@@ -152,7 +152,7 @@ private extension PlusPurchaseModel {
         SubscriptionHelper.setSubscriptionPaid(1)
         SubscriptionHelper.setSubscriptionPlatform(SubscriptionPlatform.iOS.rawValue)
         SubscriptionHelper.setSubscriptionAutoRenewing(true)
-        SubscriptionHelper.setSubscriptionType(purchasedProduct.subscriptionType.rawValue)
+        SubscriptionHelper.subscriptionTier = purchasedProduct.subscriptionTier
 
         let currentDate = Date()
         var dateComponent = DateComponents()

--- a/podcasts/Onboarding/Plus/Account Prompt/PlusAccountUpgradePrompt.swift
+++ b/podcasts/Onboarding/Plus/Account Prompt/PlusAccountUpgradePrompt.swift
@@ -51,7 +51,7 @@ struct PlusAccountUpgradePrompt: View {
         VStack(spacing: 16) {
             HStack(alignment: .top) {
                 VStack(alignment: .leading) {
-                    SubscriptionBadge(type: product.identifier.subscriptionType)
+                    SubscriptionBadge(tier: product.identifier.subscriptionTier)
                         .padding(.bottom, 10)
 
                     productFeatures[product.identifier].map {
@@ -189,7 +189,7 @@ struct PlusAccountUpgradePrompt: View {
 }
 
 extension Constants.IapProducts {
-    var subscriptionType: SubscriptionType {
+    var subscriptionTier: SubscriptionTier {
         switch self {
         case .monthly, .yearly:
             return .plus

--- a/podcasts/Onboarding/Plus/UpgradeLandingView.swift
+++ b/podcasts/Onboarding/Plus/UpgradeLandingView.swift
@@ -231,7 +231,7 @@ private struct FeaturesCarousel: View {
 // MARK: - Available plans
 
 struct UpgradeTier: Identifiable {
-    let tier: SubscriptionType
+    let tier: SubscriptionTier
     let iconName: String
     let title: String
     let plan: Constants.Plan
@@ -242,7 +242,7 @@ struct UpgradeTier: Identifiable {
     let features: [TierFeature]
     let background: RadialGradient
 
-    var id: Int {
+    var id: String {
         tier.rawValue
     }
 
@@ -346,7 +346,7 @@ struct UpgradeCard: View {
     var body: some View {
         VStack {
             VStack(alignment: .leading, spacing: 0) {
-                SubscriptionBadge(type: tier.tier)
+                SubscriptionBadge(tier: tier.tier)
                     .padding(.bottom, 16)
 
                 VStack(alignment: .leading, spacing: 12) {

--- a/podcasts/Profile - SwiftUI/Account/AccountHeaderView.swift
+++ b/podcasts/Profile - SwiftUI/Account/AccountHeaderView.swift
@@ -17,7 +17,7 @@ struct AccountHeaderView: View {
             VStack {
                 // Subscription badge
                 viewModel.subscription.map {
-                    SubscriptionBadge(type: $0.type)
+                    SubscriptionBadge(tier: $0.tier)
                         .padding(.bottom, Constants.padding.badgeBottom)
                 }
 

--- a/podcasts/Profile - SwiftUI/Common Views/SubscriptionBadge.swift
+++ b/podcasts/Profile - SwiftUI/Common Views/SubscriptionBadge.swift
@@ -8,13 +8,13 @@ import PocketCastsServer
 /// SubscriptionBadge(type: .patron, geometryProxy: geometryProxy)
 ///
 struct SubscriptionBadge: View {
-    let type: SubscriptionType
+    let tier: SubscriptionTier
 
     var body: some View {
-        let content = BadgeModel(type: type).map { render(with: $0) }
+        let content = BadgeModel(tier: tier).map { render(with: $0) }
 
         // Apply an extra effect to the patron badge
-        if type == .patron {
+        if tier == .patron {
             HolographicEffect(mode: .overlay) {
                 content
             }
@@ -48,8 +48,8 @@ struct SubscriptionBadge: View {
         let label: String
         let backgroundColor: Color
 
-        init?(type: SubscriptionType) {
-            switch type {
+        init?(tier: SubscriptionTier) {
+            switch tier {
             case .plus:
                 backgroundColor = .black
                 iconColor = Color(hex: "FFD846")
@@ -75,9 +75,9 @@ struct SubscriptionBadge_Preview: PreviewProvider {
         GeometryReader { proxy in
             VStack(alignment: .leading) {
                 HStack {
-                    SubscriptionBadge(type: .none) // Won't display
-                    SubscriptionBadge(type: .plus)
-                    SubscriptionBadge(type: .patron)
+                    SubscriptionBadge(tier: .none) // Won't display
+                    SubscriptionBadge(tier: .plus)
+                    SubscriptionBadge(tier: .patron)
                 }
             }
             .frame(maxWidth: .infinity)

--- a/podcasts/Profile - SwiftUI/Common Views/SubscriptionProfileImage.swift
+++ b/podcasts/Profile - SwiftUI/Common Views/SubscriptionProfileImage.swift
@@ -13,9 +13,9 @@ struct SubscriptionProfileImage: View {
     @ViewBuilder
     private func expirationProgressView() -> some View {
         if let subscription = viewModel.subscription {
-            let content = ExpirationProgress(subscriptionType: subscription.type, progress: subscription.expirationProgress)
+            let content = ExpirationProgress(tier: subscription.tier, progress: subscription.expirationProgress)
 
-            if subscription.type == .patron {
+            if subscription.tier == .patron {
                 HolographicEffect(mode: .overlay) {
                     content
                 }
@@ -28,11 +28,11 @@ struct SubscriptionProfileImage: View {
     private struct ExpirationProgress: View {
         @EnvironmentObject var theme: Theme
 
-        let subscriptionType: SubscriptionType
+        let tier: SubscriptionTier
         let progress: Double
 
         private var strokeColor: Color {
-            switch subscriptionType {
+            switch tier {
             case .plus:
                 return theme.plusPrimaryColor
             case .patron:

--- a/podcasts/Profile - SwiftUI/Profile/ProfileHeaderView.swift
+++ b/podcasts/Profile - SwiftUI/Profile/ProfileHeaderView.swift
@@ -33,8 +33,8 @@ struct ProfileHeaderView: View {
 
             // Show the patron badge
             if let subscription = viewModel.subscription {
-                if subscription.type == .patron {
-                    SubscriptionBadge(type: subscription.type)
+                if subscription.tier == .patron {
+                    SubscriptionBadge(tier: subscription.tier)
                         .padding(.top, -10)
                 }
 
@@ -69,7 +69,7 @@ struct ProfileHeaderView: View {
         .padding(.top, {
             guard
                 let subscription = viewModel.subscription,
-                subscription.type == .patron,
+                subscription.tier == .patron,
                 subscription.expirationDate != nil
             else {
                 return 0

--- a/podcasts/UserInfo.swift
+++ b/podcasts/UserInfo.swift
@@ -16,20 +16,20 @@ struct UserInfo {
     }
 
     struct Subscription {
-        let type: SubscriptionType
+        let tier: SubscriptionTier
         let expirationProgress: Double
         let expirationDate: Date?
 
         /// Returns nil if there is no subscription info to return
         init?(loggedIn: Bool = SyncManager.isUserLoggedIn()) {
             let hasSubscription = SubscriptionHelper.hasActiveSubscription()
-            let type = SubscriptionHelper.subscriptionType()
+            let tier = SubscriptionHelper.activeSubscriptionTier
 
-            guard loggedIn, hasSubscription, type != .none else {
+            guard loggedIn, hasSubscription, tier != .none else {
                 return nil
             }
 
-            self.type = type
+            self.tier = tier
 
             let maxDisplayTime = Constants.Limits.maxSubscriptionExpirySeconds
 
@@ -44,8 +44,8 @@ struct UserInfo {
             expirationProgress = (expiration / maxDisplayTime).clamped(to: 0..<1)
         }
 
-        func isExpiring(_ type: SubscriptionType) -> Bool {
-            self.type == type && expirationProgress < 1
+        func isExpiring(_ type: SubscriptionTier) -> Bool {
+            self.tier == type && expirationProgress < 1
         }
     }
 


### PR DESCRIPTION
This adds the initial support for the server changes which adds a new "Tier" field to the SubscriptionStatus request. 

This also replaces the usage of determining which level of subscription the user has from the SubscriptionType to the new SubscriptionTier. 

I also added a fallback to fill in the SubscriptionTier if the server isn't returning it yet so I can unify the usage of Tier while it's not readily available. 

## To test

**Note:** While the endpoint changes are available in staging they are not currently working yet. If you want to test the flow fully message me and I can setup an env for you to test.

1. Launch the app
2. Sign into an account with Plus
3. Go to the Profile tab
4. ✅ Verify your plus is recognized and displays the correct information
5. Tap Account
6. ✅ Verify plus is recognized and displays the correct information
7. Go to the Podcasts tab
8. ✅ Verify you can make a new folder
9. Use the Profile > Cog > Developer menu to switch to Paid Patron
10. Go back to the Profile tab
11. ✅ Verify the Patron status is reflected


## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
