### PR TITLE
Disables the ratings feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 7.39
 -----
 - Removed the starred filter from the list of default filters
-- Added the ability to see ratings for podcasts (#856)
 
 7.38
 -----

--- a/podcasts/FeatureFlag.swift
+++ b/podcasts/FeatureFlag.swift
@@ -66,7 +66,7 @@ enum FeatureFlag: String, CaseIterable {
         case .patron:
             return false
         case .showRatings:
-            return true
+            return false
         }
     }
 }


### PR DESCRIPTION
This adds the removed ratings feature flag, and removes it from the 7.39 change log.

## To test

1. Launch the app 
2. Go to Discover
3. Tap on podcasts
4. ✅ Verify the ratings do not appear
5. Go to your subscribed podcasts
6. Tap on one
7. Expand the details
8. ✅ Verify the rating does not appear

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
