### PR TITLE
Fix: Tracks Seeking Crash

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Extensions/Double+Extensions.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Extensions/Double+Extensions.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+extension Double {
+
+    /// Checks whether the value is not NaN or Infinite
+    public var isValid: Bool {
+        !self.isNaN && !self.isInfinite
+    }
+}

--- a/Modules/Utils/Sources/PocketCastsUtils/Extensions/Double+Extensions.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Extensions/Double+Extensions.swift
@@ -3,7 +3,7 @@ import Foundation
 extension Double {
 
     /// Checks whether the value is not NaN or Infinite
-    public var isValid: Bool {
+    public var isNumeric: Bool {
         !self.isNaN && !self.isInfinite
     }
 }

--- a/PocketCastsTests/Tests/Analytics/AnalyticsPlaybackHelperTests.swift
+++ b/PocketCastsTests/Tests/Analytics/AnalyticsPlaybackHelperTests.swift
@@ -12,4 +12,50 @@ class AnalyticsPlaybackHelperTests: XCTestCase {
             XCTAssertNil(AnalyticsPlaybackHelper.shared.currentSource)
         }
     }
+
+    func testSeekToDoesntCrashWithNanOrInfinite() {
+        let helper = AnalyticsPlaybackHelperMock()
+
+        // Forced Infinity
+        helper.seek(from: .infinity, to: .infinity, duration: .infinity)
+        XCTAssertNil(helper.lastEvent)
+
+        // Forced NaN check
+        helper.seek(from: .nan, to: .nan, duration: .nan)
+        XCTAssertNil(helper.lastEvent)
+
+        // Natural NaN check
+        helper.seek(from: 0, to: 0, duration: 0)
+        XCTAssertNil(helper.lastEvent)
+    }
+
+    func testSeekTracksValidValues() {
+        let helper = AnalyticsPlaybackHelperMock()
+
+        // 0%
+        helper.seek(from: 0, to: 0, duration: 10)
+        XCTAssertEqual(helper.lastEvent?.event, .playbackSeek)
+        XCTAssertEqual(helper.lastEvent?.properties?["seek_to_percent"] as? Int, 0)
+        XCTAssertEqual(helper.lastEvent?.properties?["seek_from_percent"] as? Int, 0)
+
+        // 50% / 100%
+        helper.seek(from: 10, to: 5, duration: 10)
+        XCTAssertEqual(helper.lastEvent?.properties?["seek_to_percent"] as? Int, 50)
+        XCTAssertEqual(helper.lastEvent?.properties?["seek_from_percent"] as? Int, 100)
+    }
+}
+
+// MARK: - AnalyticsPlaybackHelper Mock
+
+private class AnalyticsPlaybackHelperMock: AnalyticsPlaybackHelper {
+    var lastEvent: TrackEvent?
+
+    override func track(_ event: AnalyticsEvent, properties: [String: Any]? = nil) {
+        lastEvent = .init(event: event, properties: properties)
+    }
+
+    struct TrackEvent {
+        let event: AnalyticsEvent
+        let properties: [String: Any]?
+    }
 }

--- a/podcasts/Analytics/Helpers/AnalyticsPlaybackHelper.swift
+++ b/podcasts/Analytics/Helpers/AnalyticsPlaybackHelper.swift
@@ -1,4 +1,4 @@
-import UIKit
+import PocketCastsUtils
 
 /// Helper used to track playback
 class AnalyticsPlaybackHelper: AnalyticsCoordinator {
@@ -36,7 +36,8 @@ class AnalyticsPlaybackHelper: AnalyticsCoordinator {
         let from = (from / duration)
         let to = (to / duration)
 
-        guard !from.isNaN, !to.isNaN else { return }
+        // Validate the values are valid
+        guard from.isValid, to.isValid else { return }
 
         // Use percents to relativize the seeking across any duration episode
         let seekFrom = Int(from * 100)

--- a/podcasts/Analytics/Helpers/AnalyticsPlaybackHelper.swift
+++ b/podcasts/Analytics/Helpers/AnalyticsPlaybackHelper.swift
@@ -37,7 +37,7 @@ class AnalyticsPlaybackHelper: AnalyticsCoordinator {
         let to = (to / duration)
 
         // Validate the values are valid
-        guard from.isValid, to.isValid else { return }
+        guard from.isNumeric, to.isNumeric else { return }
 
         // Use percents to relativize the seeking across any duration episode
         let seekFrom = Int(from * 100)


### PR DESCRIPTION
This adds an additional check to prevent the following crash from happening:

`Fatal error: Double value cannot be converted to Int because it is either infinite or NaN`

## To test

I'm not sure exactly how to reproduce this but I added some Unit Tests for it so if the CI is 🟢  then we should be good. 

If you want to manually test you can do the following:

1. Open the PlaybackManager.swift in Xcode
2. Go to line 394
3. Replace it with `analyticsPlaybackHelper.seek(from: .infinity, to: .infinity, duration: .infinity)`
4. Run the app
5. Open the player
6. Seek to a different location
7. ✅ Verify it doesn't crash
8. Go back to line 394
9. Change it to `analyticsPlaybackHelper.seek(from: .nan, to: .nan, duration: .nan)`
10. Follow the steps again
11. ✅ Verify it doesn't crash


## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
