### PR TITLE
Tracks: Only track the application installed / updated events if protected data is available

### DIFF
--- a/podcasts/Analytics/AppLifecyleAnalytics.swift
+++ b/podcasts/Analytics/AppLifecyleAnalytics.swift
@@ -58,8 +58,8 @@ extension AppLifecycleAnalytics {
         //
         // If the app is launched "in the background" and protected data is enabled then the analytics won't
         // be enabled and we may miss some events.
+        // When the user opens the app directly the event will be tracked.
 
-        // When the user opens the app directly the event will be tracked. 
         guard UIApplication.shared.isProtectedDataAvailable else { return }
 
         let currentVersion = Settings.appVersion()

--- a/podcasts/Analytics/AppLifecyleAnalytics.swift
+++ b/podcasts/Analytics/AppLifecyleAnalytics.swift
@@ -54,6 +54,14 @@ extension AppLifecycleAnalytics {
 extension AppLifecycleAnalytics {
     /// Checks whether we need to track an app install or app update
     func checkApplicationInstalledOrUpgraded() {
+        // Don't check for install or upgrade if protected data isn't available yet
+        //
+        // If the app is launched "in the background" and protected data is enabled then the analytics won't
+        // be enabled and we may miss some events.
+
+        // When the user opens the app directly the event will be tracked. 
+        guard UIApplication.shared.isProtectedDataAvailable else { return }
+
         let currentVersion = Settings.appVersion()
 
         defer {


### PR DESCRIPTION
This adds a `UIApplication.shared.isProtectedDataAvailable` check before trying record the app installed/updated events. 

If the app somehow is launched in the background and `didFinishLaunchingWithOptions` is called but protected data isn't available then we'll save the latest app version in the user defaults but the analytics won't be setup so we don't record it. 

If that occurs, then we'll only record the events once the user relaunches the app.

## To test

Unfortunately there is not a way to test this since it only happens on app launch with protected data disabled. 

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
