### PR TITLE
Idea/712 auto add reset bug

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/PodcastDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/PodcastDataManager.swift
@@ -409,6 +409,31 @@ class PodcastDataManager {
         setOnAllPodcasts(value: autoAddToUpNext, propertyName: "autoAddToUpNext", subscribedOnly: true, dbQueue: dbQueue)
     }
 
+
+    /// TODO: Documentation
+    /// - Parameters:
+    ///   - value: <#value description#>
+    ///   - podcasts: <#podcasts description#>
+    ///   - dbQueue: <#dbQueue description#>
+    func updateAutoAddToUpNext(to value: AutoAddToUpNextSetting, for podcasts: [Podcast], in dbQueue: FMDatabaseQueue) {
+        dbQueue.inDatabase { db in
+            do {
+                let uuids = podcasts.map { $0.uuid }
+
+                let query = """
+                UPDATE \(DataManager.podcastTableName)
+                SET autoAddToUpNext = ?
+                AND uuid IN (\(DataHelper.convertArrayToInString(uuids)))
+                """
+                try db.executeUpdate(query, values: [value.rawValue])
+            } catch {
+                FileLog.shared.addMessage("PodcastDataManager.setOnAllPodcasts error: \(error)")
+            }
+        }
+
+        cachePodcasts(dbQueue: dbQueue)
+    }
+
     func setDownloadSettingForAllPodcasts(setting: AutoDownloadSetting, dbQueue: FMDatabaseQueue) {
         setOnAllPodcasts(value: setting.rawValue, propertyName: "autoDownloadSetting", subscribedOnly: true, dbQueue: dbQueue)
     }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -236,6 +236,15 @@ public class DataManager {
         podcastManager.saveAutoAddToUpNextForAllPodcasts(autoAddToUpNext: autoAddToUpNext, dbQueue: dbQueue)
     }
 
+
+    /// TODO: Documentation
+    /// - Parameters:
+    ///   - value: <#value description#>
+    ///   - podcasts: <#podcasts description#>
+    public func updateAutoAddToUpNext(to value: AutoAddToUpNextSetting, for podcasts: [Podcast]) {
+        podcastManager.updateAutoAddToUpNext(to: value, for: podcasts, in: dbQueue)
+    }
+
     public func setDownloadSettingForAllPodcasts(setting: AutoDownloadSetting) {
         podcastManager.setDownloadSettingForAllPodcasts(setting: setting, dbQueue: dbQueue)
     }

--- a/podcasts/AutoAddToUpNextViewController+PodcastSelect.swift
+++ b/podcasts/AutoAddToUpNextViewController+PodcastSelect.swift
@@ -9,12 +9,11 @@ extension AutoAddToUpNextViewController: PodcastSelectionDelegate {
 
         if selected {
             // Checks for existing AutoAddToUpNextSetting value before assigning a default value
-            allPodcasts.forEach {podcast in
-                if podcast.autoAddToUpNext == 0 {
-                    let status = AutoAddToUpNextSetting.addLast.rawValue
-                    DataManager.sharedManager.saveAutoAddToUpNext(podcastUuid: podcast.uuid, autoAddToUpNext: status)
-                }
+            let podcasts = allPodcasts.filter {
+                $0.isSubscribed() && $0.autoAddToUpNext == AutoAddToUpNextSetting.off.rawValue
             }
+
+            DataManager.sharedManager.updateAutoAddToUpNext(to: .addLast, for: podcasts)
         } else {
             setting = AutoAddToUpNextSetting.off.rawValue
             DataManager.sharedManager.saveAutoAddToUpNextForAllPodcasts(autoAddToUpNext: setting)


### PR DESCRIPTION
Fixes #

Tested the proposed method on this branch by adding 250 podcasts and using the Time Profiler to test db queries. It worked splendidly, reducing cache rebuild time from 494.0 ms to 2.0 ms 🙌🏼

Initial reset bug fix:

<img width="972" alt="Initial reset bug fix" src="https://github.com/Automattic/pocket-casts-ios/assets/81433983/093f9e2e-9002-4393-92de-c42ac8d737b7">

Bug  fix refactor:

<img width="972" alt="Bug fix refactor" src="https://github.com/Automattic/pocket-casts-ios/assets/81433983/a9d648ae-cc0d-4524-81b0-b80a7d2acdb9">

## To test

Test steps outlined here: 

https://github.com/Automattic/pocket-casts-ios/pull/788#issue-1643253163

## Checklist

- [✅] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [✅] I have considered adding unit tests for my changes.
- [Request to update, if needed] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.

Requesting merge with https://github.com/Automattic/pocket-casts-ios/pull/788 to create PR.