### PR TITLE
Specify public as the logging privacy to allow logs to show up in Xcode 15

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Logging/FileLog.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Logging/FileLog.swift
@@ -45,7 +45,7 @@ public class FileLog {
         guard let message = message, message.count > 0 else { return }
 
         // if it's important enough to log to file, write it to the debug console as well
-        Self.logger.log("\(message)")
+        Self.logger.log("\(message, privacy: .public)")
         let dateFormatter = DateFormatHelper.sharedHelper.localTimeJsonDateFormatter
         appendStringToLog("\(dateFormatter.string(from: Date())) \(message)\n")
     }


### PR DESCRIPTION
Xcode 15 has a new logging system and our logs don't show up. This applies the public privacy to ensure they appear correctly.

## To test

1. Run the app from Xcode 14
2. ✅ Verify the logs appear
3. Optional, run on Xcode 15
4. ✅ Verify the logs appear

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
