### PR TITLE
Bookmarks: Allow the player tabs to scroll instead of shrinking

### DIFF
--- a/podcasts/PlayerContainerViewController.xib
+++ b/podcasts/PlayerContainerViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22113.1" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22089"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -40,9 +40,9 @@
                             </connections>
                         </button>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="DY8-o1-Oqt" customClass="PlayerTabsView" customModule="podcasts" customModuleProvider="target">
-                            <rect key="frame" x="62" y="0.0" width="278" height="60"/>
+                            <rect key="frame" x="62" y="14" width="278" height="46"/>
                             <constraints>
-                                <constraint firstAttribute="height" constant="60" id="fvZ-1o-n3k"/>
+                                <constraint firstAttribute="height" constant="46" id="fvZ-1o-n3k"/>
                             </constraints>
                         </view>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" pointerInteraction="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HBu-bE-aeT" customClass="UpNextButton" customModule="podcasts" customModuleProvider="target">
@@ -86,7 +86,7 @@
                 <constraint firstAttribute="trailing" secondItem="tuk-fS-Mph" secondAttribute="trailing" id="jMd-Bl-UDQ"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-            <point key="canvasLocation" x="-2230" y="-36"/>
+            <point key="canvasLocation" x="-2643" y="-62"/>
         </view>
     </objects>
     <resources>

--- a/podcasts/PlayerTabsView.swift
+++ b/podcasts/PlayerTabsView.swift
@@ -238,6 +238,54 @@ class PlayerTabsView: UIScrollView {
     private enum TabConstants {
         static let titleFont = UIFont.systemFont(ofSize: 16, weight: .bold)
         static let spacing: CGFloat = 14
+// MARK: - Private: Scroll Fading
+
+private extension PlayerTabsView {
+    private class FadeOutLayer: CAGradientLayer {
+        enum FadePosition {
+            case leading, trailing
+        }
+
+        var fadePosition: FadePosition = .leading
+
+        init(fadePosition: FadePosition) {
+            self.fadePosition = fadePosition
+
+            super.init()
+
+            updateColors()
+
+            switch fadePosition {
+            case .leading:
+                startPoint = .init(x: 1, y: 0)
+                endPoint = .zero
+
+            case .trailing:
+                startPoint = .zero
+                endPoint = .init(x: 1, y: 0)
+            }
+        }
+
+        func updateColors() {
+            let color = PlayerColorHelper.playerBackgroundColor01()
+
+            colors = [
+                color.withAlphaComponent(0).cgColor,
+                color.cgColor
+            ]
+        }
+
+        override init(layer: Any) {
+            if let layer = layer as? Self {
+                fadePosition = layer.fadePosition
+            }
+
+            super.init(layer: layer)
+        }
+
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
     }
 }
 

--- a/podcasts/PlayerTabsView.swift
+++ b/podcasts/PlayerTabsView.swift
@@ -275,6 +275,8 @@ private extension PlayerTabsView {
         fadeTrailing.frame = .init(origin: .init(x: offset + bounds.width - TabConstants.fadeSize, y: 0), size: size)
         CATransaction.commit()
 
+        fadeLeading.opacity = contentOffset.x > 0 ? 1 : 0
+        fadeTrailing.opacity = (contentOffset.x + bounds.width) < contentSize.width ? 1 : 0
     }
 
     private class FadeOutLayer: CAGradientLayer {

--- a/podcasts/PlayerTabsView.swift
+++ b/podcasts/PlayerTabsView.swift
@@ -68,9 +68,7 @@ class PlayerTabsView: UIScrollView {
 
     weak var tabDelegate: PlayerTabDelegate?
 
-    private let lineHeight: CGFloat = 2
     private let lineLayer = CAShapeLayer()
-    private let lineOffset: CGFloat = 8
 
     private lazy var tabsStackView: UIStackView = {
         let stackView = UIStackView()
@@ -168,7 +166,7 @@ class PlayerTabsView: UIScrollView {
         lineLayer.fillColor = contrast01
         lineLayer.strokeColor = contrast01
 
-        lineLayer.path = UIBezierPath(rect: CGRect(x: 0, y: 0, width: 24, height: lineHeight)).cgPath
+        lineLayer.path = UIBezierPath(rect: CGRect(x: 0, y: 0, width: 24, height: TabConstants.lineHeight)).cgPath
         lineLayer.lineCap = CAShapeLayerLineCap.round
 
         layer.addSublayer(lineLayer)
@@ -242,22 +240,29 @@ class PlayerTabsView: UIScrollView {
     private func lineRectForTab(index: Int, ignoreLeadingTrailing: Bool = false) -> CGRect {
         guard let tab = tabsStackView.arrangedSubviews[safe: index] else { return CGRect.zero }
 
+        let height = TabConstants.lineHeight
+        let offset = TabConstants.lineOffset
+
         let tabRect = convert(tab.frame, from: tab.superview)
         if !ignoreLeadingTrailing, leadingEdgePullDistance > 0 || trailingEdgePullDistance > 0 {
             let width = tabRect.width - min(tabRect.width * 0.9, (leadingEdgePullDistance + trailingEdgePullDistance) / 3)
             if leadingEdgePullDistance > 0 {
-                return CGRect(x: tabRect.minX, y: tabRect.maxY - lineOffset, width: width, height: lineHeight)
+                return CGRect(x: tabRect.minX, y: tabRect.maxY - offset, width: width, height: height)
             } else {
-                return CGRect(x: tabRect.minX + (tabRect.width - width), y: tabRect.maxY - lineOffset, width: width, height: lineHeight)
+                return CGRect(x: tabRect.minX + (tabRect.width - width), y: tabRect.maxY - offset, width: width, height: height)
             }
         } else {
-            return CGRect(x: tabRect.minX, y: tabRect.maxY - lineOffset, width: tabRect.width, height: lineHeight)
+            return CGRect(x: tabRect.minX, y: tabRect.maxY - offset, width: tabRect.width, height: height)
         }
     }
 
     private enum TabConstants {
         static let titleFont = UIFont.systemFont(ofSize: 16, weight: .bold)
         static let spacing: CGFloat = 14
+
+        static let lineHeight: CGFloat = 2
+        static let lineOffset: CGFloat = 8
+
         static let fadeSize: CGFloat = 50
     }
 }

--- a/podcasts/PlayerTabsView.swift
+++ b/podcasts/PlayerTabsView.swift
@@ -114,6 +114,9 @@ class PlayerTabsView: UIScrollView {
 
     func themeDidChange() {
         updateTabs()
+
+        fadeLeading.updateColors()
+        fadeTrailing.updateColors()
     }
 
     var lastLayedOutWidth: CGFloat = 0

--- a/podcasts/PlayerTabsView.swift
+++ b/podcasts/PlayerTabsView.swift
@@ -15,7 +15,7 @@ enum PlayerTabs: Int {
         case .nowPlaying:
             return L10n.nowPlaying
         case .showNotes:
-            return L10n.playerShowNotesTitle
+            return FeatureFlag.bookmarks.enabled ? L10n.playerShowNotesTitle : L10n.showNotes
         case .chapters:
             return L10n.chapters
         }

--- a/podcasts/PlayerTabsView.swift
+++ b/podcasts/PlayerTabsView.swift
@@ -81,15 +81,22 @@ class PlayerTabsView: UIScrollView {
     }()
 
     func setup() {
+        showsVerticalScrollIndicator = false
+        showsHorizontalScrollIndicator = false
+        clipsToBounds = true
+
         configureLine()
         updateTabs()
 
         addSubview(tabsStackView)
         tabsStackView.translatesAutoresizingMaskIntoConstraints = false
+
         NSLayoutConstraint.activate([
-            tabsStackView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            tabsStackView.bottomAnchor.constraint(equalTo: bottomAnchor),
-            tabsStackView.topAnchor.constraint(equalTo: topAnchor, constant: 14)
+            tabsStackView.leadingAnchor.constraint(equalTo: contentLayoutGuide.leadingAnchor),
+            tabsStackView.trailingAnchor.constraint(equalTo: contentLayoutGuide.trailingAnchor),
+            tabsStackView.bottomAnchor.constraint(equalTo: contentLayoutGuide.bottomAnchor),
+            tabsStackView.topAnchor.constraint(equalTo: contentLayoutGuide.topAnchor),
+            tabsStackView.heightAnchor.constraint(equalTo: frameLayoutGuide.heightAnchor)
         ])
     }
 

--- a/podcasts/PlayerTabsView.swift
+++ b/podcasts/PlayerTabsView.swift
@@ -123,6 +123,8 @@ class PlayerTabsView: UIScrollView {
     override func layoutSubviews() {
         super.layoutSubviews()
 
+        updateFadeLayers()
+
         let currentWidth = bounds.width
         if lastLayedOutWidth == currentWidth { return }
 
@@ -263,6 +265,18 @@ class PlayerTabsView: UIScrollView {
 // MARK: - Private: Scroll Fading
 
 private extension PlayerTabsView {
+    private func updateFadeLayers() {
+        let offset = contentOffset.x
+        let size = CGSize(width: TabConstants.fadeSize, height: bounds.height)
+
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        fadeLeading.frame = .init(origin: .init(x: offset, y: 0), size: size)
+        fadeTrailing.frame = .init(origin: .init(x: offset + bounds.width - TabConstants.fadeSize, y: 0), size: size)
+        CATransaction.commit()
+
+    }
+
     private class FadeOutLayer: CAGradientLayer {
         enum FadePosition {
             case leading, trailing

--- a/podcasts/PlayerTabsView.swift
+++ b/podcasts/PlayerTabsView.swift
@@ -75,7 +75,7 @@ class PlayerTabsView: UIScrollView {
     private lazy var tabsStackView: UIStackView = {
         let stackView = UIStackView()
         stackView.axis = .horizontal
-        stackView.spacing = 14
+        stackView.spacing = TabConstants.spacing
 
         return stackView
     }()
@@ -118,35 +118,15 @@ class PlayerTabsView: UIScrollView {
     private func updateTabs() {
         tabsStackView.removeAllSubviews()
 
-        let widthAvailable = bounds.width
-
-        var fontSize: CGFloat = 16
-        var spacing: CGFloat = 14
-        var totalWidthRequired = widthAvailable
-
-        // not ideal, but here we figure out if our labels will fit, and if not we shrink the font and spacing by 1 until they do
-        while totalWidthRequired >= widthAvailable {
-            totalWidthRequired = 0
-            for tab in tabs {
-                let title = fontSize <= 14 ? tab.shortDescription : tab.description
-                totalWidthRequired += title.widthOfString(usingFont: UIFont.systemFont(ofSize: fontSize, weight: .bold))
-            }
-            totalWidthRequired += spacing * CGFloat(tabs.count - 1)
-
-            if totalWidthRequired >= widthAvailable {
-                fontSize -= 1
-                spacing -= 1
-            }
-        }
-
-        tabsStackView.spacing = spacing
         for (index, tab) in tabs.enumerated() {
             let button = UIButton(type: .custom)
             button.isPointerInteractionEnabled = true
-            button.titleLabel?.font = UIFont.systemFont(ofSize: fontSize, weight: .bold)
+            button.titleLabel?.font = TabConstants.titleFont
+
             let titleColor = index == currentTab ? ThemeColor.playerContrast01() : ThemeColor.playerContrast02()
             button.setTitleColor(titleColor, for: .normal)
-            let title = fontSize <= 14 ? tab.shortDescription : tab.description
+
+            let title = tab.description
             button.setTitle(title, for: .normal)
             button.tag = index
             button.addTarget(self, action: #selector(buttonTapped(_:)), for: .touchUpInside)

--- a/podcasts/PlayerTabsView.swift
+++ b/podcasts/PlayerTabsView.swift
@@ -15,7 +15,7 @@ enum PlayerTabs: Int {
         case .nowPlaying:
             return L10n.nowPlaying
         case .showNotes:
-            return L10n.showNotes
+            return L10n.playerShowNotesTitle
         case .chapters:
             return L10n.chapters
         }

--- a/podcasts/PlayerTabsView.swift
+++ b/podcasts/PlayerTabsView.swift
@@ -208,6 +208,9 @@ class PlayerTabsView: UIScrollView {
             UIView.transition(with: toTab, duration: Constants.Animation.defaultAnimationTime, options: .transitionCrossDissolve, animations: {
                 toTab.setTitleColor(ThemeColor.playerContrast01(), for: .normal)
             }, completion: nil)
+
+            // Scroll the button into view, but make sure it clears the fade
+            scrollRectToVisible(toTab.frame.insetBy(dx: -TabConstants.fadeSize, dy: 0), animated: true)
         }
 
         CATransaction.begin()
@@ -238,6 +241,10 @@ class PlayerTabsView: UIScrollView {
     private enum TabConstants {
         static let titleFont = UIFont.systemFont(ofSize: 16, weight: .bold)
         static let spacing: CGFloat = 14
+        static let fadeSize: CGFloat = 50
+    }
+}
+
 // MARK: - Private: Scroll Fading
 
 private extension PlayerTabsView {

--- a/podcasts/PlayerTabsView.swift
+++ b/podcasts/PlayerTabsView.swift
@@ -31,7 +31,7 @@ enum PlayerTabs: Int {
     }
 }
 
-class PlayerTabsView: UIView {
+class PlayerTabsView: UIScrollView {
     var tabs: [PlayerTabs] = [.nowPlaying] {
         didSet {
             updateTabs()

--- a/podcasts/PlayerTabsView.swift
+++ b/podcasts/PlayerTabsView.swift
@@ -80,6 +80,15 @@ class PlayerTabsView: UIScrollView {
         return stackView
     }()
 
+    // Fade Layers
+    private lazy var fadeLeading = {
+        FadeOutLayer(fadePosition: .leading)
+    }()
+
+    private lazy var fadeTrailing = {
+        FadeOutLayer(fadePosition: .trailing)
+    }()
+
     func setup() {
         showsVerticalScrollIndicator = false
         showsHorizontalScrollIndicator = false
@@ -98,6 +107,9 @@ class PlayerTabsView: UIScrollView {
             tabsStackView.topAnchor.constraint(equalTo: contentLayoutGuide.topAnchor),
             tabsStackView.heightAnchor.constraint(equalTo: frameLayoutGuide.heightAnchor)
         ])
+
+        layer.addSublayer(fadeLeading)
+        layer.addSublayer(fadeTrailing)
     }
 
     func themeDidChange() {

--- a/podcasts/PlayerTabsView.swift
+++ b/podcasts/PlayerTabsView.swift
@@ -254,6 +254,11 @@ class PlayerTabsView: UIScrollView {
             return CGRect(x: tabRect.minX, y: tabRect.maxY - lineOffset, width: tabRect.width, height: lineHeight)
         }
     }
+
+    private enum TabConstants {
+        static let titleFont = UIFont.systemFont(ofSize: 16, weight: .bold)
+        static let spacing: CGFloat = 14
+    }
 }
 
 // MARK: - Private: Analytics

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -1519,6 +1519,8 @@ internal enum L10n {
   internal static var playerRouteSelection: String { return L10n.tr("Localizable", "player_route_selection") }
   /// SHARE LINK TO
   internal static var playerShareHeader: String { return L10n.tr("Localizable", "player_share_header") }
+  /// Description
+  internal static var playerShowNotesTitle: String { return L10n.tr("Localizable", "player_show_notes_title") }
   /// Download Error
   internal static var playerUserEpisodeDownloadError: String { return L10n.tr("Localizable", "player_user_episode_download_error") }
   /// Playback Error

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -3721,3 +3721,6 @@
 
 /* A button label that informs the user to release a button press to finish */
 "patron_unlock_release" = "Release to Unlock";
+
+/* Title of a tab in the player that shows the episode description (show notes). */
+"player_show_notes_title" = "Description";


### PR DESCRIPTION
This changes the player tabs from shrinking if the labels wouldn't fit into the view width to instead scrolling the remaining items. 

This also adds a fade effect on the leading and trailing edges when there are more items to display in the scroll view.

## Screenshots

| No Scrolling | Scrolling Enabled | iPod Touch - No Scrolling | iPod Touch - Scrolling |
|:---:|:---:|:---:|:---:|
|<img src="https://github.com/Automattic/pocket-casts-ios/assets/793774/dfa6cf90-83ab-4661-a294-9d8f8cf24944" width="320" />|<img src="https://github.com/Automattic/pocket-casts-ios/assets/793774/0f7a0435-a3bd-43d7-81fe-65790e1e3b38" width="320" />|<img src="https://github.com/Automattic/pocket-casts-ios/assets/793774/43648543-d0ff-4470-9927-03eb41f3ddd8" width="320"/>|<img width="320" alt="Screenshot 2023-06-08 at 12 20 38 PM" src="https://github.com/Automattic/pocket-casts-ios/assets/793774/7567cdff-a05f-4276-a8ff-83d260593f24">


## Demo Videos
<details>
  <summary><strong>iPhone 14 Pro</strong></summary>

https://github.com/Automattic/pocket-casts-ios/assets/793774/54a597a0-0b68-41ba-98d8-4ced67de4f01

</details>


<details>
  <summary><strong>iPod Touch</strong></summary>

https://github.com/Automattic/pocket-casts-ios/assets/793774/b173475c-cb41-4042-8826-af6812987134

</details>

## To test

1. Launch the app on a larger device such as the iPhone 14 Pro
2. Play an episode of a podcast that doesn't have chapters
3. ✅ Verify the tabs at the top are fully visible and aren't scrollable
4. Swipe between pages on the player
5. ✅ Verify the tabs change correctly
6. Close the player and, Enable the Bookmarks Feature Flag
7. Play an episode with Chapters
    - Such as the first episode of: https://pca.st/pocketcast
8. ✅ Verify the tabs now scroll and a fade appears on the right side
9. Scroll to the chapters item
10. ✅ Verify the fade appears on the left, and the right side hides
11. Swipe between pages on the player
12. ✅ Verify The selected tab changes and fully scrolls into view if it's not visible
13. From the Now Playing tab
14. Tap the name of the chapter
15. ✅ Verify you are brought to the chapters view and the tab changes

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
