### PR TITLE
Bookmarks: Add a new tab to the player

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1425,9 +1425,10 @@
 		C741D9D228AD3D6C006CFBE7 /* Notifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7C4CAF228ABFD0900CFC8CF /* Notifications.swift */; };
 		C741D9D428ADBA23006CFBE7 /* AppLifecyleAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = C741D9D328ADBA23006CFBE7 /* AppLifecyleAnalytics.swift */; };
 		C750EF7F28E3475600E06BA9 /* AnalyticsDescribable+Modules.swift in Sources */ = {isa = PBXBuildFile; fileRef = C750EF7E28E3475600E06BA9 /* AnalyticsDescribable+Modules.swift */; };
-		C7540DE029AE645D00B77D54 /* UIFont+FontStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F87F0F2913242B00C15980 /* UIFont+FontStyle.swift */; };
+		C75274E22A3252180004DD15 /* BookmarksPlayerTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = C75274E12A3252180004DD15 /* BookmarksPlayerTab.swift */; };
 		C752F28A29D5F8F200681C33 /* StarRatingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C752F28929D5F8F100681C33 /* StarRatingView.swift */; };
 		C752F28C29D5F8FF00681C33 /* PodcastRatingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C752F28B29D5F8FF00681C33 /* PodcastRatingViewModel.swift */; };
+		C7540DE029AE645D00B77D54 /* UIFont+FontStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F87F0F2913242B00C15980 /* UIFont+FontStyle.swift */; };
 		C75BB06829B954B100F2DF63 /* EpisodeLoadingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C75BB06729B954B100F2DF63 /* EpisodeLoadingController.swift */; };
 		C7612FFF28E397A00044C6C2 /* AnalyticsEpisodeHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7612FFE28E397A00044C6C2 /* AnalyticsEpisodeHelper.swift */; };
 		C761300028E3BC090044C6C2 /* AnalyticsEpisodeHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7612FFE28E397A00044C6C2 /* AnalyticsEpisodeHelper.swift */; };
@@ -3120,6 +3121,7 @@
 		C741D9D328ADBA23006CFBE7 /* AppLifecyleAnalytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLifecyleAnalytics.swift; sourceTree = "<group>"; };
 		C746C9FCD5A79F9BA9776E01 /* libPods-PocketCastsTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-PocketCastsTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		C750EF7E28E3475600E06BA9 /* AnalyticsDescribable+Modules.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AnalyticsDescribable+Modules.swift"; sourceTree = "<group>"; };
+		C75274E12A3252180004DD15 /* BookmarksPlayerTab.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BookmarksPlayerTab.swift; sourceTree = "<group>"; };
 		C752F28929D5F8F100681C33 /* StarRatingView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StarRatingView.swift; sourceTree = "<group>"; };
 		C752F28B29D5F8FF00681C33 /* PodcastRatingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PodcastRatingViewModel.swift; sourceTree = "<group>"; };
 		C7547F77286F571900DC1C9E /* Pocket Casts Configuration.storekit */ = {isa = PBXFileReference; lastKnownFileType = text; path = "Pocket Casts Configuration.storekit"; sourceTree = "<group>"; };
@@ -4480,6 +4482,7 @@
 		BD2A49EE1701AA8500C2F192 /* User Interface */ = {
 			isa = PBXGroup;
 			children = (
+				C75274DF2A3252180004DD15 /* Bookmarks */,
 				C752F28829D5F8DA00681C33 /* Ratings */,
 				C7B3C618291AD03400054145 /* Onboarding */,
 				BD3E3C1B170404490066AE3D /* Common Components */,
@@ -6212,6 +6215,22 @@
 				C73CCBC829C590100075EFFD /* View+UIView.swift */,
 			);
 			path = SwiftUI;
+			sourceTree = "<group>";
+		};
+		C75274DF2A3252180004DD15 /* Bookmarks */ = {
+			isa = PBXGroup;
+			children = (
+				C75274E02A3252180004DD15 /* Player */,
+			);
+			path = Bookmarks;
+			sourceTree = "<group>";
+		};
+		C75274E02A3252180004DD15 /* Player */ = {
+			isa = PBXGroup;
+			children = (
+				C75274E12A3252180004DD15 /* BookmarksPlayerTab.swift */,
+			);
+			path = Player;
 			sourceTree = "<group>";
 		};
 		C752F28829D5F8DA00681C33 /* Ratings */ = {
@@ -8208,6 +8227,7 @@
 				4650F5C128ECC6D1006A5704 /* CrashLoggingDataProvider.swift in Sources */,
 				BD49DB811D5B052500813204 /* DestructiveButtonCell.swift in Sources */,
 				BDAA3CEF2122754700649F81 /* PlayerChapterCell.swift in Sources */,
+				C75274E22A3252180004DD15 /* BookmarksPlayerTab.swift in Sources */,
 				BD240C47231F475500FB2CDD /* PCSearchBarController+Scrolling.swift in Sources */,
 				BD0B68712203DC58002CCE3F /* EpisodeLimitPlaceholder.swift in Sources */,
 				4041FE99218A872B0089D4A1 /* SiriShortcutDisclosureCell.swift in Sources */,

--- a/podcasts/Bookmarks/Player/BookmarksPlayerTab.swift
+++ b/podcasts/Bookmarks/Player/BookmarksPlayerTab.swift
@@ -13,6 +13,8 @@ struct BookmarksPlayerTab: View {
     }
 }
 
+// MARK: - PlayerItemViewController Wrapper
+
 class BookmarksPlayerTabController: PlayerItemViewController {
     private let controller = ThemedHostingController(rootView: BookmarksPlayerTab())
 
@@ -31,6 +33,8 @@ class BookmarksPlayerTabController: PlayerItemViewController {
         addChild(controller)
     }
 }
+
+// MARK: - Previews
 
 struct BookmarksPlayerTab_Previews: PreviewProvider {
     static var previews: some View {

--- a/podcasts/Bookmarks/Player/BookmarksPlayerTab.swift
+++ b/podcasts/Bookmarks/Player/BookmarksPlayerTab.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+
+struct BookmarksPlayerTab: View {
+    @EnvironmentObject var theme: Theme
+
+    var body: some View {
+        ZStack {
+            Color.blue
+
+            Text("Hello!")
+                .foregroundStyle(Color.white)
+        }
+    }
+}
+
+class BookmarksPlayerTabController: PlayerItemViewController {
+    private let controller = ThemedHostingController(rootView: BookmarksPlayerTab())
+
+    override func loadView() {
+        self.view = controller.view.map {
+            let view = UIStackView(arrangedSubviews: [$0])
+            view.translatesAutoresizingMaskIntoConstraints = false
+            view.backgroundColor = .clear
+            return view
+        } ?? UIView()
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        addChild(controller)
+    }
+}
+
+struct BookmarksPlayerTab_Previews: PreviewProvider {
+    static var previews: some View {
+        BookmarksPlayerTab()
+            .setupDefaultEnvironment()
+    }
+}

--- a/podcasts/PlayerContainerViewController+Update.swift
+++ b/podcasts/PlayerContainerViewController+Update.swift
@@ -46,6 +46,11 @@ extension PlayerContainerViewController {
             tabsView.tabs += [.showNotes]
         }
 
+        if FeatureFlag.bookmarks.enabled {
+            tabsView.tabs += [.bookmarks]
+            addTab(bookmarksItem, previousTab: &previousTab)
+        }
+
         if shouldShowChapters {
             showingChapters = true
 

--- a/podcasts/PlayerContainerViewController+Update.swift
+++ b/podcasts/PlayerContainerViewController+Update.swift
@@ -22,9 +22,16 @@ extension PlayerContainerViewController {
 
         let shouldShowNotes = (playingEpisode is Episode)
         let shouldShowChapters = PlaybackManager.shared.chapterCount() > 0
+        let shouldShowBookmarks = FeatureFlag.bookmarks.enabled
 
         // check to see if the visible views are already configured correctly
-        if shouldShowNotes == showingNotes, shouldShowChapters == showingChapters { return }
+        if
+            shouldShowNotes == showingNotes,
+            shouldShowChapters == showingChapters,
+            shouldShowBookmarks == showingBookmarks
+        {
+            return
+        }
 
         mainScrollView.setContentOffset(CGPoint(x: 0, y: 0), animated: false)
         tabsView.currentTab = 0
@@ -42,19 +49,22 @@ extension PlayerContainerViewController {
 
         if shouldShowNotes {
             showingNotes = true
-            addTab(showNotesItem, previousTab: &previousTab)
             tabsView.tabs += [.showNotes]
+
+            addTab(showNotesItem, previousTab: &previousTab)
         }
 
-        if FeatureFlag.bookmarks.enabled {
+        if shouldShowBookmarks {
+            showingBookmarks = true
             tabsView.tabs += [.bookmarks]
+
             addTab(bookmarksItem, previousTab: &previousTab)
         }
 
         if shouldShowChapters {
             showingChapters = true
-
             tabsView.tabs += [.chapters]
+
             addTab(chaptersItem, previousTab: &previousTab)
         }
     }

--- a/podcasts/PlayerContainerViewController+Update.swift
+++ b/podcasts/PlayerContainerViewController+Update.swift
@@ -38,46 +38,19 @@ extension PlayerContainerViewController {
 
         tabsView.tabs = [.nowPlaying]
 
+        var previousTab: PlayerItemViewController = nowPlayingItem
+
         if shouldShowNotes {
             showingNotes = true
-            showNotesItem.willBeAddedToPlayer()
-            mainScrollView.addSubview(showNotesItem.view)
-            addChild(showNotesItem)
-
-            finalScrollViewConstraint?.isActive = false
-            let finalConstraint = showNotesItem.view.trailingAnchor.constraint(equalTo: mainScrollView.trailingAnchor)
-            NSLayoutConstraint.activate([
-                showNotesItem.view.leadingAnchor.constraint(equalTo: nowPlayingItem.view.trailingAnchor),
-                showNotesItem.view.topAnchor.constraint(equalTo: mainScrollView.topAnchor),
-                showNotesItem.view.bottomAnchor.constraint(equalTo: mainScrollView.bottomAnchor),
-                showNotesItem.view.widthAnchor.constraint(equalTo: mainScrollView.widthAnchor),
-                showNotesItem.view.heightAnchor.constraint(equalTo: mainScrollView.heightAnchor),
-                finalConstraint
-            ])
-            finalScrollViewConstraint = finalConstraint
-
+            addTab(showNotesItem, previousTab: &previousTab)
             tabsView.tabs += [.showNotes]
         }
 
         if shouldShowChapters {
             showingChapters = true
-            chaptersItem.willBeAddedToPlayer()
-            mainScrollView.addSubview(chaptersItem.view)
-            addChild(chaptersItem)
-
-            finalScrollViewConstraint?.isActive = false
-            let finalConstraint = chaptersItem.view.trailingAnchor.constraint(equalTo: mainScrollView.trailingAnchor)
-            NSLayoutConstraint.activate([
-                chaptersItem.view.leadingAnchor.constraint(equalTo: showingNotes ? showNotesItem.view.trailingAnchor : nowPlayingItem.view.trailingAnchor),
-                chaptersItem.view.topAnchor.constraint(equalTo: mainScrollView.topAnchor),
-                chaptersItem.view.bottomAnchor.constraint(equalTo: mainScrollView.bottomAnchor),
-                chaptersItem.view.widthAnchor.constraint(equalTo: mainScrollView.widthAnchor),
-                chaptersItem.view.heightAnchor.constraint(equalTo: mainScrollView.heightAnchor),
-                finalConstraint
-            ])
-            finalScrollViewConstraint = finalConstraint
 
             tabsView.tabs += [.chapters]
+            addTab(chaptersItem, previousTab: &previousTab)
         }
     }
 

--- a/podcasts/PlayerContainerViewController+Update.swift
+++ b/podcasts/PlayerContainerViewController+Update.swift
@@ -25,11 +25,9 @@ extension PlayerContainerViewController {
         let shouldShowBookmarks = FeatureFlag.bookmarks.enabled
 
         // check to see if the visible views are already configured correctly
-        if
-            shouldShowNotes == showingNotes,
+        if shouldShowNotes == showingNotes,
             shouldShowChapters == showingChapters,
-            shouldShowBookmarks == showingBookmarks
-        {
+            shouldShowBookmarks == showingBookmarks {
             return
         }
 

--- a/podcasts/PlayerContainerViewController+Update.swift
+++ b/podcasts/PlayerContainerViewController+Update.swift
@@ -80,4 +80,35 @@ extension PlayerContainerViewController {
             tabsView.tabs += [.chapters]
         }
     }
+
+    private func addTab(_ tab: PlayerItemViewController, previousTab: inout PlayerItemViewController) {
+        guard addTab(tab, after: previousTab) else { return }
+
+        previousTab = tab
+    }
+
+    @discardableResult
+    func addTab(_ tab: PlayerItemViewController, after afterTab: PlayerItemViewController? = nil) -> Bool {
+        guard let tabView = tab.view else { return false }
+
+        tab.willBeAddedToPlayer()
+        mainScrollView.addSubview(tabView)
+        addChild(tab)
+
+        let previousAnchor = afterTab?.view.map { $0.trailingAnchor } ?? mainScrollView.leadingAnchor
+
+        finalScrollViewConstraint?.isActive = false
+        let finalConstraint = tab.view.trailingAnchor.constraint(equalTo: mainScrollView.trailingAnchor)
+        NSLayoutConstraint.activate([
+            tabView.leadingAnchor.constraint(equalTo: previousAnchor),
+            tabView.topAnchor.constraint(equalTo: mainScrollView.topAnchor),
+            tabView.bottomAnchor.constraint(equalTo: mainScrollView.bottomAnchor),
+            tabView.widthAnchor.constraint(equalTo: mainScrollView.widthAnchor),
+            tabView.heightAnchor.constraint(equalTo: mainScrollView.heightAnchor),
+            finalConstraint
+        ])
+
+        finalScrollViewConstraint = finalConstraint
+        return true
+    }
 }

--- a/podcasts/PlayerContainerViewController.swift
+++ b/podcasts/PlayerContainerViewController.swift
@@ -51,6 +51,13 @@ class PlayerContainerViewController: SimpleNotificationsViewController, PlayerTa
         return item
     }()
 
+    lazy var bookmarksItem: BookmarksPlayerTabController = {
+        let item = BookmarksPlayerTabController()
+        item.view.translatesAutoresizingMaskIntoConstraints = false
+
+        return item
+    }()
+
     private lazy var upNextViewController = UpNextViewController(source: .player)
 
     @IBOutlet var closeBtn: ThemeableUIButton! {

--- a/podcasts/PlayerContainerViewController.swift
+++ b/podcasts/PlayerContainerViewController.swift
@@ -70,6 +70,8 @@ class PlayerContainerViewController: SimpleNotificationsViewController, PlayerTa
 
     var showingChapters = false
     var showingNotes = false
+    var showingBookmarks = false
+
     var finalScrollViewConstraint: NSLayoutConstraint?
 
     override func viewDidLoad() {

--- a/podcasts/PlayerTabsView.swift
+++ b/podcasts/PlayerTabsView.swift
@@ -20,7 +20,7 @@ enum PlayerTabs: Int {
         case .chapters:
             return L10n.chapters
         case .bookmarks:
-            return "Bookmarks"
+            return L10n.bookmarks
         }
     }
 }

--- a/podcasts/PlayerTabsView.swift
+++ b/podcasts/PlayerTabsView.swift
@@ -9,6 +9,7 @@ enum PlayerTabs: Int {
     case nowPlaying
     case showNotes
     case chapters
+    case bookmarks
 
     var description: String {
         switch self {
@@ -18,15 +19,8 @@ enum PlayerTabs: Int {
             return FeatureFlag.bookmarks.enabled ? L10n.playerShowNotesTitle : L10n.showNotes
         case .chapters:
             return L10n.chapters
-        }
-    }
-
-    var shortDescription: String {
-        switch self {
-        case .nowPlaying:
-            return L10n.nowPlayingShortTitle
-        default:
-            return description
+        case .bookmarks:
+            return "Bookmarks"
         }
     }
 }
@@ -42,14 +36,21 @@ class PlayerTabsView: UIScrollView {
         didSet {
             animateTabChange(fromIndex: oldValue, toIndex: currentTab)
 
-            if oldValue != currentTab, let tab = PlayerTabs(rawValue: currentTab) {
-                trackTabChanged(tab: tab)
+            guard oldValue != currentTab, let tab = PlayerTabs(rawValue: currentTab) else {
+                return
             }
 
-            if currentTab == 1 {
+            trackTabChanged(tab: tab)
+
+            switch tab {
+            case .nowPlaying:
+                break
+            case .showNotes:
                 AnalyticsHelper.playerShowNotesOpened()
-            } else if currentTab == 2 {
+            case .chapters:
                 AnalyticsHelper.chaptersOpened()
+            case .bookmarks: #warning("TODO: Bookmarks: Analytics")
+                break
             }
         }
     }
@@ -344,6 +345,8 @@ private extension PlayerTabsView {
             tabName = "show_notes"
         case .chapters:
             tabName = "chapters"
+        case .bookmarks:
+            tabName = "bookmarks"
         }
 
         Analytics.track(.playerTabSelected, properties: ["tab": tabName])

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -246,6 +246,8 @@ internal enum L10n {
   internal static var autoDownloadPromptFirst: String { return L10n.tr("Localizable", "auto_download_prompt_first") }
   /// Back
   internal static var back: String { return L10n.tr("Localizable", "back") }
+  /// Bookmarks
+  internal static var bookmarks: String { return L10n.tr("Localizable", "bookmarks") }
   /// Bottom
   internal static var bottom: String { return L10n.tr("Localizable", "bottom") }
   /// Bulk downloads are limited to %1$@.

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -3725,5 +3725,5 @@
 /* Title of a tab in the player that shows the episode description (show notes). */
 "player_show_notes_title" = "Description";
 
-/* Name of a feature called Bookmarks used in various places in the app */
+/* The plural name of a feature called Bookmarks, used in various places in the app */
 "bookmarks" = "Bookmarks";

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -3724,3 +3724,6 @@
 
 /* Title of a tab in the player that shows the episode description (show notes). */
 "player_show_notes_title" = "Description";
+
+/* Name of a feature called Bookmarks used in various places in the app */
+"bookmarks" = "Bookmarks";


### PR DESCRIPTION
| 🛫 Depends on: https://github.com/Automattic/pocket-casts-ios/pull/894 |
|:---:|

This adds a bookmarks placeholder tab to the player. 

## Screenshots
| Flag Disabled | Enabled |
|:---:|:---:|
|<img src="https://github.com/Automattic/pocket-casts-ios/assets/793774/121d2d4d-960b-45f0-8b64-57c6970d7076" width="320" />|<img src="https://github.com/Automattic/pocket-casts-ios/assets/793774/9bcfad0f-eadd-4ccf-bf4a-991ad6624de8" width="320" />|

## To test
1. Disable the bookmarks Feature Flag if its enabled
2. Play any episode
3. Open the full player
4. ✅ Verify you see Now Playing and Notes
5. Hide the player
6. Enable the bookmarks flag
7. Open the Player
8. ✅ Verify the bookmarks item appears
9. ✅ Verify tapping on it opens a placeholder view
10. ✅ Verify swiping between tabs works and opens the current view. 

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
