### PR TITLE
Bookmarks: Update the data structure

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/BookmarkDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/BookmarkDataManager.swift
@@ -66,7 +66,7 @@ public struct BookmarkDataManager {
         return selectBookmarks(where: whereColumns, values: values)
     }
 
-    /// A bookmark that represents a time range within an episode
+    /// A bookmark that represents a position in time within an episode
     public struct Bookmark {
         public let uuid: String
         public let createdDate: Date
@@ -125,7 +125,7 @@ public struct BookmarkDataManager {
 // MARK: - Private
 
 private extension BookmarkDataManager {
-    /// Looks for any existing bookmarks in an episode that have the same start/end timestampss
+    /// Looks for any existing bookmarks in an episode that have the same start time
     func existingBookmark(forEpisode episodeUuid: String, time: TimeInterval) -> Bookmark? {
         selectBookmarks(where: [.episode, .time],
                         values: [episodeUuid, time],

--- a/Modules/DataModel/Tests/PocketCastsDataModelTests/BookmarkDataManagerTests.swift
+++ b/Modules/DataModel/Tests/PocketCastsDataModelTests/BookmarkDataManagerTests.swift
@@ -30,13 +30,13 @@ final class BookmarkDataManagerTests: XCTestCase {
     }
 
     func testAddBookmarkSucceeds() {
-        XCTAssertNotNil(dataManager.add(episodeUuid: "episode-uuid", podcastUuid: "podcast-uuid", start: 1, end: 2))
+        XCTAssertNotNil(dataManager.add(episodeUuid: "episode-uuid", podcastUuid: "podcast-uuid", time: 1))
     }
 
     func testAddingEpisodeOnlyBookmarkSucceeds() {
         let episode = "episode-uuid"
 
-        let result = dataManager.add(episodeUuid: episode, podcastUuid: nil, start: 1, end: 2)
+        let result = dataManager.add(episodeUuid: episode, podcastUuid: nil, time: 1)
         XCTAssertNotNil(result)
         XCTAssertEqual(dataManager.bookmarks(forEpisode: episode).count, 1)
     }
@@ -44,34 +44,22 @@ final class BookmarkDataManagerTests: XCTestCase {
     func testAddingExistingBookmarkIsNotAdded() {
         let episode = "episode-uuid"
         let podcast = "podcast-uuid"
-        let start = 1.0
-        let end = 2.0
+        let time = 1.0
 
-        let firstUuid = dataManager.add(episodeUuid: episode, podcastUuid: podcast, start: start, end: end)
-        let secondUuid = dataManager.add(episodeUuid: episode, podcastUuid: podcast, start: start, end: end)
+        let firstUuid = dataManager.add(episodeUuid: episode, podcastUuid: podcast, time: time)
+        let secondUuid = dataManager.add(episodeUuid: episode, podcastUuid: podcast, time: time)
 
         XCTAssertEqual(firstUuid, secondUuid)
-    }
-
-    func testBookmarkModelReturnsCorrectTimeRange() {
-        let start = 1.0
-        let end = 2.0
-
-        let uuid = dataManager.add(episodeUuid: "episode-uuid", podcastUuid: "podcast-uuid", start: start, end: end)
-        let bookmark = dataManager.bookmark(for: uuid!)!
-
-        XCTAssertEqual(bookmark.timeRange.start, start)
-        XCTAssertEqual(bookmark.timeRange.end, end)
     }
 
     func testGettingAllBookmarksForPodcast() {
         let podcast = "podcast-uuid"
 
-        dataManager.add(episodeUuid: "episode-1", podcastUuid: podcast, start: 1, end: 2)
-        dataManager.add(episodeUuid: "episode-1", podcastUuid: podcast, start: 3, end: 4)
+        dataManager.add(episodeUuid: "episode-1", podcastUuid: podcast, time: 1)
+        dataManager.add(episodeUuid: "episode-1", podcastUuid: podcast, time: 3)
 
-        dataManager.add(episodeUuid: "episode-2", podcastUuid: podcast, start: 1, end: 2)
-        dataManager.add(episodeUuid: "episode-2", podcastUuid: podcast, start: 3, end: 4)
+        dataManager.add(episodeUuid: "episode-2", podcastUuid: podcast, time: 1)
+        dataManager.add(episodeUuid: "episode-2", podcastUuid: podcast, time: 3)
 
         let bookmarks = dataManager.bookmarks(forPodcast: podcast)
         XCTAssertEqual(bookmarks.count, 4)
@@ -80,11 +68,11 @@ final class BookmarkDataManagerTests: XCTestCase {
     func testGettingAllBookmarksForPodcastAndEpisode() {
         let podcast = "podcast-uuid"
 
-        dataManager.add(episodeUuid: "episode-1", podcastUuid: podcast, start: 1, end: 2)
-        dataManager.add(episodeUuid: "episode-1", podcastUuid: podcast, start: 3, end: 4)
+        dataManager.add(episodeUuid: "episode-1", podcastUuid: podcast, time: 1)
+        dataManager.add(episodeUuid: "episode-1", podcastUuid: podcast, time: 3)
 
-        dataManager.add(episodeUuid: "episode-2", podcastUuid: podcast, start: 1, end: 2)
-        dataManager.add(episodeUuid: "episode-2", podcastUuid: podcast, start: 3, end: 4)
+        dataManager.add(episodeUuid: "episode-2", podcastUuid: podcast, time: 1)
+        dataManager.add(episodeUuid: "episode-2", podcastUuid: podcast, time: 3)
 
         let bookmarks = dataManager.bookmarks(forPodcast: podcast, episodeUuid: "episode-2")
         XCTAssertEqual(bookmarks.count, 2)

--- a/podcasts/BookmarkManager.swift
+++ b/podcasts/BookmarkManager.swift
@@ -24,24 +24,16 @@ class BookmarkManager {
         return player
     }()
 
-    /// How long a bookmark clip is
-    /// TODO: Make configurable
-    private let clipLength = 1.minute
-
     /// Adds a new bookmark for an episode at the given time
     func add(to episode: BaseEpisode, at time: TimeInterval) {
         // If the episode has a podcast attached, also save that
         let podcastUuid: String? = (episode as? Episode)?.podcastUuid
 
-        // If someone is bookmarking a point in time, they probably want to remember the info leading up to the bookmark
-        // time, so calculate the start of the clip as X seconds before the bookmark time
-        let startTime = max(0, time - clipLength)
-
-        dataManager.add(episodeUuid: episode.uuid, podcastUuid: podcastUuid, start: startTime, end: time)
+        dataManager.add(episodeUuid: episode.uuid, podcastUuid: podcastUuid, time: time)
 
         playTone()
 
-        FileLog.shared.addMessage("[Bookmarks] Added bookmark for \(episode.displayableTitle()) from \(startTime) to \(time)")
+        FileLog.shared.addMessage("[Bookmarks] Added bookmark for \(episode.displayableTitle()) at \(time)")
     }
 
     /// Retrieves all the bookmarks for a episode


### PR DESCRIPTION
This updates the existing bookmarks data structure to match what was decided: 

```
Bookmark {
    bookmark_uuid: UUID,
    podcast_uuid: UUID,
    episode_uuid: UUID,
    time: Int,
    date_created: Timestamp
}
```

## To test

1. No code to test here but a 🟢 CI is good because of the tests

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
