### PR TITLE
Fix KingFisher from infinitely requesting the profile image when it returns 404

### DIFF
--- a/podcasts/Profile - SwiftUI/Common Views/ProfileImage.swift
+++ b/podcasts/Profile - SwiftUI/Common Views/ProfileImage.swift
@@ -10,8 +10,6 @@ struct ProfileImage: View {
         if let url {
             KFImage
                 .url(url, cacheKey: email)
-                .startLoadingBeforeViewAppear()
-                .cancelOnDisappear(true)
                 .placeholder { _ in defaultProfileView }
                 .resizable()
                 .aspectRatio(contentMode: .fill)


### PR DESCRIPTION
<img width="320" alt="Screenshot 2023-06-12 at 4 42 35 PM" src="https://github.com/Automattic/pocket-casts-ios/assets/793774/48140f85-c916-4533-985e-a791ec1b02e3">

I noticed when debugging another issue a bunch of requests to Gravatar when the user doesn't have a profile image. 

After some debugging it turns out that for some reason KingFisher will infinitely request the profile image when it returns 404 and the `startLoadingBeforeViewAppear` flag is set on the `KFImage`.

I've removed the `startLoadingBeforeViewAppear` flag which fixes this issue longer continually requests the image. I've also removed the `cancelOnDisappear` flag since I don't think it's needed.

## To test

1. Before applying the PR
2. Use Charles to inspect the traffic of either the simulator or a real device
3. Enable SSL Proxying on gravatar.com
4. Login to an account without a Gravatar profile
5. 💥 You should see a lot of requests now
6. Apply the PR
7. Run the app
8. ✅ Verify you no longer see all the requests


## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
