### PR TITLE
Inhibit warnings from CocoaPods libraries

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -4,6 +4,8 @@ source 'https://cdn.cocoapods.org/'
 
 use_modular_headers!
 
+inhibit_all_warnings!
+
 app_ios_deployment_target = Gem::Version.new('15.0')
 
 def kingfisher


### PR DESCRIPTION
Fixes N/A

This PR adds `inhibit_all_warnings!` setting to inhibit warnings from CocoaPods libraries.
https://guides.cocoapods.org/syntax/podfile.html#inhibit_all_warnings_bang

## To test

Run `pod install` and build the project.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
