### PR TITLE
Fix SmartLess not appearing in search results

### DIFF
--- a/podcasts/New Search/Views/Results/PodcastCarouselView.swift
+++ b/podcasts/New Search/Views/Results/PodcastCarouselView.swift
@@ -130,7 +130,7 @@ struct PodcastsCarouselView: View {
         let podcast = Podcast()
         podcast.title = ""
         podcast.author = ""
-        podcast.uuid = ""
+        podcast.uuid = UUID().uuidString
 
         return podcast
     }

--- a/podcasts/New Search/Views/Results/PodcastCarouselView.swift
+++ b/podcasts/New Search/Views/Results/PodcastCarouselView.swift
@@ -54,7 +54,7 @@ struct PodcastsCarouselView: View {
                     }
                 }
             } else if searchResults.podcasts.count > 0 {
-                let fillerPodcast = Podcast.previewPodcast()
+                let fillerPodcast = fillerPodcast()
 
                 // If needed, fill the results with filler podcasts to make sure the sizing and positioning is consistent
                 let results: [PodcastFolderSearchResult] = {
@@ -124,6 +124,15 @@ struct PodcastsCarouselView: View {
 
             UIDevice.current.endGeneratingDeviceOrientationNotifications()
         }
+    }
+
+    private func fillerPodcast() -> Podcast {
+        let podcast = Podcast()
+        podcast.title = ""
+        podcast.author = ""
+        podcast.uuid = ""
+
+        return podcast
     }
 
     private enum Carousel {


### PR DESCRIPTION
The SmartLess podcast is not showing the podcast carousel.

## To test

1. Run the app
2. Search for "smartless"
3. ✅ Check that the SmartLess podcast appears as the first result
4. Search for a feed (eg.: `https://feeds.megaphone.fm/WWO9257218156`)
5. ✅ A single podcast should appear correctly on the left side

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
