### PR TITLE
Episodes Autoplay: extract SQL queries to its own class

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -533,6 +533,7 @@
 		8BA55A1328CA7425002BECC5 /* XCTestCase+eventually.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA55A1228CA7425002BECC5 /* XCTestCase+eventually.swift */; };
 		8BA55A1528CA8FEB002BECC5 /* PrivacySettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA55A1428CA8FEB002BECC5 /* PrivacySettingsViewController.swift */; };
 		8BA55A1728CA92A7002BECC5 /* PrivacySettingsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8BA55A1628CA92A7002BECC5 /* PrivacySettingsViewController.xib */; };
+		8BAB27202A40B3340079E5B3 /* EpisodesDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BAB271F2A40B3340079E5B3 /* EpisodesDataManager.swift */; };
 		8BAB8B2F299ABC8200B8404C /* SearchResultsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BAB8B2E299ABC8200B8404C /* SearchResultsViewController.swift */; };
 		8BAD6E5E2975ADB800DB7259 /* GoogleSignIn in Frameworks */ = {isa = PBXBuildFile; productRef = 8BAD6E5D2975ADB800DB7259 /* GoogleSignIn */; };
 		8BAD6E612975AFAA00DB7259 /* GoogleSocialLogin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BAD6E602975AFAA00DB7259 /* GoogleSocialLogin.swift */; };
@@ -2239,6 +2240,7 @@
 		8BA55A1228CA7425002BECC5 /* XCTestCase+eventually.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+eventually.swift"; sourceTree = "<group>"; };
 		8BA55A1428CA8FEB002BECC5 /* PrivacySettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacySettingsViewController.swift; sourceTree = "<group>"; };
 		8BA55A1628CA92A7002BECC5 /* PrivacySettingsViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = PrivacySettingsViewController.xib; sourceTree = "<group>"; };
+		8BAB271F2A40B3340079E5B3 /* EpisodesDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EpisodesDataManager.swift; sourceTree = "<group>"; };
 		8BAB8B2E299ABC8200B8404C /* SearchResultsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultsViewController.swift; sourceTree = "<group>"; };
 		8BAD6E602975AFAA00DB7259 /* GoogleSocialLogin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleSocialLogin.swift; sourceTree = "<group>"; };
 		8BB1187E290C56F7009E3A39 /* CategoryPillar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryPillar.swift; sourceTree = "<group>"; };
@@ -5023,6 +5025,7 @@
 				BD583AF321AE5F9E0048D78D /* EpisodeDateHelper.swift */,
 				BDA681AA220D03930053BEEE /* UserEpisodeManager.swift */,
 				408F0B31227A6B540019584D /* IapHelper.swift */,
+				8BAB271F2A40B3340079E5B3 /* EpisodesDataManager.swift */,
 				40D9A4B0240746C30019E469 /* SignOutHelper.swift */,
 				4036B0A325240F5D00AE08E6 /* WidgetHelper.swift */,
 				BDDAE72B27F2E76B003741A1 /* FileTypeUtil.swift */,
@@ -8613,6 +8616,7 @@
 				BD43D9C01D52D423004077FA /* GoogleCastManager.swift in Sources */,
 				BDC3775C1C44CFFB001FD219 /* ListHeaderDelegate.swift in Sources */,
 				C72223D4292C918F006B3B55 /* OnboardingModel.swift in Sources */,
+				8BAB27202A40B3340079E5B3 /* EpisodesDataManager.swift in Sources */,
 				4029E3E02292686C0003BEEB /* ChangeEmailViewController.swift in Sources */,
 				4011B9432164641800661A7D /* EditFilterNameCell.swift in Sources */,
 				C7F4BAB528DA6BBB001C9785 /* BackgroundSignOutListener.swift in Sources */,

--- a/podcasts/DownloadsViewController.swift
+++ b/podcasts/DownloadsViewController.swift
@@ -177,7 +177,7 @@ class DownloadsViewController: PCViewController {
         operationQueue.addOperation { [weak self] in
             guard let strongSelf = self else { return }
 
-            let newData: [ArraySection<String, ListEpisode>] = strongSelf.episodesDataManager.get(.downloads)
+            let newData = strongSelf.episodesDataManager.downloadedEpisodes()
 
             DispatchQueue.main.sync {
                 strongSelf.downloadsTable.isHidden = (newData.count == 0)

--- a/podcasts/DownloadsViewController.swift
+++ b/podcasts/DownloadsViewController.swift
@@ -175,14 +175,14 @@ class DownloadsViewController: PCViewController {
 
     func reloadEpisodes() {
         operationQueue.addOperation { [weak self] in
-            guard let strongSelf = self else { return }
+            guard let self else { return }
 
-            let newData = strongSelf.episodesDataManager.downloadedEpisodes()
+            let newData = self.episodesDataManager.downloadedEpisodes()
 
             DispatchQueue.main.sync {
-                strongSelf.downloadsTable.isHidden = (newData.count == 0)
-                strongSelf.episodes = newData
-                strongSelf.downloadsTable.reloadData()
+                self.downloadsTable.isHidden = (newData.count == 0)
+                self.episodes = newData
+                self.downloadsTable.reloadData()
             }
         }
     }

--- a/podcasts/DownloadsViewController.swift
+++ b/podcasts/DownloadsViewController.swift
@@ -8,6 +8,8 @@ class DownloadsViewController: PCViewController {
     var episodes = [ArraySection<String, ListEpisode>]()
     var cellHeights: [IndexPath: CGFloat] = [:]
 
+    private let episodesDataManager = EpisodesDataManager()
+
     private lazy var operationQueue: OperationQueue = {
         let queue = OperationQueue()
         queue.maxConcurrentOperationCount = 1
@@ -172,17 +174,12 @@ class DownloadsViewController: PCViewController {
     }
 
     func reloadEpisodes() {
-        operationQueue.addOperation {
-            let query = "( (downloadTaskId IS NOT NULL OR episodeStatus = \(DownloadStatus.downloaded.rawValue) OR episodeStatus = \(DownloadStatus.waitingForWifi.rawValue)) OR (episodeStatus = \(DownloadStatus.downloadFailed.rawValue) AND lastDownloadAttemptDate > ?) ) ORDER BY lastDownloadAttemptDate DESC LIMIT 1000"
-            let arguments = [Date().weeksAgo(1)] as [Any]
+        operationQueue.addOperation { [weak self] in
+            guard let strongSelf = self else { return }
 
-            let newData = EpisodeTableHelper.loadSectionedEpisodes(tintColor: AppTheme.appTintColor(), query: query, arguments: arguments, episodeShortKey: { episode -> String in
-                episode.shortLastDownloadAttemptDate()
-            })
+            let newData: [ArraySection<String, ListEpisode>] = strongSelf.episodesDataManager.get(.downloads)
 
-            DispatchQueue.main.sync { [weak self] in
-                guard let strongSelf = self else { return }
-
+            DispatchQueue.main.sync {
                 strongSelf.downloadsTable.isHidden = (newData.count == 0)
                 strongSelf.episodes = newData
                 strongSelf.downloadsTable.reloadData()

--- a/podcasts/EpisodeTableHelper.swift
+++ b/podcasts/EpisodeTableHelper.swift
@@ -3,7 +3,7 @@ import Foundation
 import PocketCastsDataModel
 
 struct EpisodeTableHelper {
-    static func loadEpisodes(tintColor: UIColor, query: String, arguments: [Any]?) -> [ListEpisode] {
+    static func loadEpisodes(tintColor: UIColor = AppTheme.appTintColor(), query: String, arguments: [Any]?) -> [ListEpisode] {
         let loadedEpisodes = DataManager.sharedManager.findEpisodesWhere(customWhere: query, arguments: arguments)
 
         var newData = [ListEpisode]()
@@ -15,7 +15,7 @@ struct EpisodeTableHelper {
         return newData
     }
 
-    static func loadSectionedEpisodes(tintColor: UIColor, query: String, arguments: [Any]?, episodeShortKey: (Episode) -> String) -> [ArraySection<String, ListEpisode>] {
+    static func loadSectionedEpisodes(tintColor: UIColor = AppTheme.appTintColor(), query: String, arguments: [Any]?, episodeShortKey: (Episode) -> String) -> [ArraySection<String, ListEpisode>] {
         let loadedEpisodes = DataManager.sharedManager.findEpisodesWhere(customWhere: query, arguments: arguments)
 
         var previousSectionName = ""
@@ -41,7 +41,7 @@ struct EpisodeTableHelper {
         return newData
     }
 
-    static func loadSortedSectionedEpisodes(tintColor: UIColor, query: String, arguments: [Any]?, sectionComparator: (String, String) -> Bool, episodeShortKey: (Episode) -> String) -> [ArraySection<String, ListItem>] {
+    static func loadSortedSectionedEpisodes(tintColor: UIColor = AppTheme.appTintColor(), query: String, arguments: [Any]?, sectionComparator: (String, String) -> Bool, episodeShortKey: (Episode) -> String) -> [ArraySection<String, ListItem>] {
         let loadedEpisodes = DataManager.sharedManager.findEpisodesWhere(customWhere: query, arguments: arguments)
 
         var sections = [String: [ListEpisode]]()

--- a/podcasts/EpisodesDataManager.swift
+++ b/podcasts/EpisodesDataManager.swift
@@ -2,11 +2,11 @@ import PocketCastsDataModel
 import PocketCastsServer
 import DifferenceKit
 
-/// Returns a list of episodes for an specific section
-/// Depending on the section, it returns a DifferenceKit ArraySection
 class EpisodesDataManager {
     // MARK: - Podcast episodes list
 
+    /// Returns a podcasts episodes that are grouped by `PodcastGrouping`
+    /// Use `uuidsToFilter` to filter the episode UUIDs to only those in the array
     func episodes(for podcast: Podcast, uuidsToFilter: [String]? = nil) -> [ArraySection<String, ListItem>] {
         // the podcast page has a header, for simplicity in table animations, we add it here
         let searchHeader = ListHeader(headerTitle: L10n.search, isSectionHeader: true)

--- a/podcasts/EpisodesDataManager.swift
+++ b/podcasts/EpisodesDataManager.swift
@@ -2,16 +2,8 @@ import PocketCastsDataModel
 import PocketCastsServer
 import DifferenceKit
 
-/// Returns a list of episodes
+/// Returns a list of episodes for an specific section
 class EpisodesDataManager {
-    enum Section {
-        case podcast(Podcast, uuidsToFilter: [String]?)
-        case filter(EpisodeFilter)
-        case downloads
-        case listeningHistory
-        case starred
-    }
-
     // MARK: - Podcast episodes list
 
     func episodes(for podcast: Podcast, uuidsToFilter: [String]? = nil) -> [ArraySection<String, ListItem>] {

--- a/podcasts/EpisodesDataManager.swift
+++ b/podcasts/EpisodesDataManager.swift
@@ -7,6 +7,7 @@ class EpisodesDataManager {
         case podcast(Podcast, uuidsToFilter: [String]?)
         case filter(EpisodeFilter)
         case downloads
+        case listeningHistory
     }
 
     func get(_ section: Section) -> [ArraySection<String, ListItem>] {
@@ -31,6 +32,8 @@ class EpisodesDataManager {
         switch section {
         case .downloads:
             return downloadedEpisodes()
+        case .listeningHistory:
+            return listeningHistoryEpisodes()
         default:
             fatalError("[ArraySection<String, ListEpisode>] can't be returned for this section.")
         }
@@ -125,5 +128,16 @@ class EpisodesDataManager {
         })
 
         return newData
+    }
+
+    // MARK: - Listening History
+
+    func listeningHistoryEpisodes() -> [ArraySection<String, ListEpisode>] {
+        let query = "lastPlaybackInteractionDate IS NOT NULL AND lastPlaybackInteractionDate > 0 ORDER BY lastPlaybackInteractionDate DESC LIMIT 1000"
+
+        let oldData = self.episodes
+        return EpisodeTableHelper.loadSectionedEpisodes(tintColor: AppTheme.appTintColor(), query: query, arguments: nil, episodeShortKey: { episode -> String in
+            episode.shortLastPlaybackInteractionDate()
+        })
     }
 }

--- a/podcasts/EpisodesDataManager.swift
+++ b/podcasts/EpisodesDataManager.swift
@@ -12,17 +12,6 @@ class EpisodesDataManager {
         case starred
     }
 
-    func get(_ section: Section) -> [ArraySection<String, ListEpisode>] {
-        switch section {
-        case .downloads:
-            return downloadedEpisodes()
-        case .listeningHistory:
-            return listeningHistoryEpisodes()
-        default:
-            fatalError("[ArraySection<String, ListEpisode>] can't be returned for this section.")
-        }
-    }
-
     // MARK: - Podcast episodes list
 
     func episodes(for podcast: Podcast, uuidsToFilter: [String]? = nil) -> [ArraySection<String, ListItem>] {

--- a/podcasts/EpisodesDataManager.swift
+++ b/podcasts/EpisodesDataManager.swift
@@ -12,17 +12,6 @@ class EpisodesDataManager {
         case starred
     }
 
-    func get(_ section: Section) -> [ListEpisode] {
-        switch section {
-        case .filter(let filter):
-            return episodes(for: filter)
-        case .starred:
-            return starredEpisodes()
-        default:
-            fatalError("An array of ListEpisode can't be returned for this section.")
-        }
-    }
-
     func get(_ section: Section) -> [ArraySection<String, ListEpisode>] {
         switch section {
         case .downloads:

--- a/podcasts/EpisodesDataManager.swift
+++ b/podcasts/EpisodesDataManager.swift
@@ -3,6 +3,7 @@ import PocketCastsServer
 import DifferenceKit
 
 /// Returns a list of episodes for an specific section
+/// Depending on the section, it returns a DifferenceKit ArraySection
 class EpisodesDataManager {
     // MARK: - Podcast episodes list
 

--- a/podcasts/EpisodesDataManager.swift
+++ b/podcasts/EpisodesDataManager.swift
@@ -12,35 +12,34 @@ class EpisodesDataManager {
         let searchHeader = ListHeader(headerTitle: L10n.search, isSectionHeader: true)
         var newData = [ArraySection<String, ListItem>(model: searchHeader.headerTitle, elements: [searchHeader])]
 
-        let tintColor = AppTheme.appTintColor()
         let sortOrder = PodcastEpisodeSortOrder(rawValue: podcast.episodeSortOrder) ?? .newestToOldest
         switch podcast.podcastGrouping() {
         case .none:
-            let episodes = EpisodeTableHelper.loadEpisodes(tintColor: tintColor, query: createEpisodesQuery(podcast, uuidsToFilter: uuidsToFilter), arguments: nil)
+            let episodes = EpisodeTableHelper.loadEpisodes(query: createEpisodesQuery(podcast, uuidsToFilter: uuidsToFilter), arguments: nil)
             newData.append(ArraySection(model: "episodes", elements: episodes))
         case .season:
-            let groupedEpisodes = EpisodeTableHelper.loadSortedSectionedEpisodes(tintColor: AppTheme.appTintColor(), query: createEpisodesQuery(podcast, uuidsToFilter: uuidsToFilter), arguments: nil, sectionComparator: { name1, name2 -> Bool in
+            let groupedEpisodes = EpisodeTableHelper.loadSortedSectionedEpisodes(query: createEpisodesQuery(podcast, uuidsToFilter: uuidsToFilter), arguments: nil, sectionComparator: { name1, name2 -> Bool in
                 sortOrder == .newestToOldest ? name1.digits > name2.digits : name2.digits > name1.digits
             }, episodeShortKey: { episode -> String in
                 episode.seasonNumber > 0 ? L10n.podcastSeasonFormat(episode.seasonNumber.localized()) : L10n.podcastNoSeason
             })
             newData.append(contentsOf: groupedEpisodes)
         case .unplayed:
-            let groupedEpisodes = EpisodeTableHelper.loadSortedSectionedEpisodes(tintColor: AppTheme.appTintColor(), query: createEpisodesQuery(podcast, uuidsToFilter: uuidsToFilter), arguments: nil, sectionComparator: { name1, _ -> Bool in
+            let groupedEpisodes = EpisodeTableHelper.loadSortedSectionedEpisodes(query: createEpisodesQuery(podcast, uuidsToFilter: uuidsToFilter), arguments: nil, sectionComparator: { name1, _ -> Bool in
                 name1 == L10n.statusUnplayed
             }, episodeShortKey: { episode -> String in
                 episode.played() ? L10n.statusPlayed : L10n.statusUnplayed
             })
             newData.append(contentsOf: groupedEpisodes)
         case .downloaded:
-            let groupedEpisodes = EpisodeTableHelper.loadSortedSectionedEpisodes(tintColor: AppTheme.appTintColor(), query: createEpisodesQuery(podcast, uuidsToFilter: uuidsToFilter), arguments: nil, sectionComparator: { name1, _ -> Bool in
+            let groupedEpisodes = EpisodeTableHelper.loadSortedSectionedEpisodes(query: createEpisodesQuery(podcast, uuidsToFilter: uuidsToFilter), arguments: nil, sectionComparator: { name1, _ -> Bool in
                 name1 == L10n.statusDownloaded
             }, episodeShortKey: { (episode: Episode) -> String in
                 episode.downloaded(pathFinder: DownloadManager.shared) || episode.queued() || episode.downloading() ? L10n.statusDownloaded : L10n.statusNotDownloaded
             })
             newData.append(contentsOf: groupedEpisodes)
         case .starred:
-            let groupedEpisodes = EpisodeTableHelper.loadSortedSectionedEpisodes(tintColor: AppTheme.appTintColor(), query: createEpisodesQuery(podcast, uuidsToFilter: uuidsToFilter), arguments: nil, sectionComparator: { name1, _ -> Bool in
+            let groupedEpisodes = EpisodeTableHelper.loadSortedSectionedEpisodes(query: createEpisodesQuery(podcast, uuidsToFilter: uuidsToFilter), arguments: nil, sectionComparator: { name1, _ -> Bool in
                 name1 == L10n.statusStarred
             }, episodeShortKey: { episode -> String in
                 episode.keepEpisode ? L10n.statusStarred : L10n.statusNotStarred
@@ -89,7 +88,7 @@ class EpisodesDataManager {
         let query = "( (downloadTaskId IS NOT NULL OR episodeStatus = \(DownloadStatus.downloaded.rawValue) OR episodeStatus = \(DownloadStatus.waitingForWifi.rawValue)) OR (episodeStatus = \(DownloadStatus.downloadFailed.rawValue) AND lastDownloadAttemptDate > ?) ) ORDER BY lastDownloadAttemptDate DESC LIMIT 1000"
         let arguments = [Date().weeksAgo(1)] as [Any]
 
-        let newData = EpisodeTableHelper.loadSectionedEpisodes(tintColor: AppTheme.appTintColor(), query: query, arguments: arguments, episodeShortKey: { episode -> String in
+        let newData = EpisodeTableHelper.loadSectionedEpisodes(query: query, arguments: arguments, episodeShortKey: { episode -> String in
             episode.shortLastDownloadAttemptDate()
         })
 
@@ -101,7 +100,7 @@ class EpisodesDataManager {
     func listeningHistoryEpisodes() -> [ArraySection<String, ListEpisode>] {
         let query = "lastPlaybackInteractionDate IS NOT NULL AND lastPlaybackInteractionDate > 0 ORDER BY lastPlaybackInteractionDate DESC LIMIT 1000"
 
-        return EpisodeTableHelper.loadSectionedEpisodes(tintColor: AppTheme.appTintColor(), query: query, arguments: nil, episodeShortKey: { episode -> String in
+        return EpisodeTableHelper.loadSectionedEpisodes(query: query, arguments: nil, episodeShortKey: { episode -> String in
             episode.shortLastPlaybackInteractionDate()
         })
     }
@@ -110,7 +109,7 @@ class EpisodesDataManager {
 
     func starredEpisodes() -> [ListEpisode] {
         let query = "keepEpisode = 1 ORDER BY starredModified DESC LIMIT 1000"
-        return EpisodeTableHelper.loadEpisodes(tintColor: AppTheme.appTintColor(), query: query, arguments: nil)
+        return EpisodeTableHelper.loadEpisodes(query: query, arguments: nil)
     }
 
     // MARK: - Uploaded Files

--- a/podcasts/EpisodesDataManager.swift
+++ b/podcasts/EpisodesDataManager.swift
@@ -135,7 +135,6 @@ class EpisodesDataManager {
     func listeningHistoryEpisodes() -> [ArraySection<String, ListEpisode>] {
         let query = "lastPlaybackInteractionDate IS NOT NULL AND lastPlaybackInteractionDate > 0 ORDER BY lastPlaybackInteractionDate DESC LIMIT 1000"
 
-        let oldData = self.episodes
         return EpisodeTableHelper.loadSectionedEpisodes(tintColor: AppTheme.appTintColor(), query: query, arguments: nil, episodeShortKey: { episode -> String in
             episode.shortLastPlaybackInteractionDate()
         })

--- a/podcasts/EpisodesDataManager.swift
+++ b/podcasts/EpisodesDataManager.swift
@@ -8,6 +8,7 @@ class EpisodesDataManager {
         case filter(EpisodeFilter)
         case downloads
         case listeningHistory
+        case starred
     }
 
     func get(_ section: Section) -> [ArraySection<String, ListItem>] {
@@ -23,6 +24,8 @@ class EpisodesDataManager {
         switch section {
         case .filter(let filter):
             return episodes(for: filter)
+        case .starred:
+            return starredEpisodes()
         default:
             fatalError("An array of ListEpisode can't be returned for this section.")
         }
@@ -138,5 +141,12 @@ class EpisodesDataManager {
         return EpisodeTableHelper.loadSectionedEpisodes(tintColor: AppTheme.appTintColor(), query: query, arguments: nil, episodeShortKey: { episode -> String in
             episode.shortLastPlaybackInteractionDate()
         })
+    }
+
+    // MARK: - Starred
+
+    func starredEpisodes() -> [ListEpisode] {
+        let query = "keepEpisode = 1 ORDER BY starredModified DESC LIMIT 1000"
+        return EpisodeTableHelper.loadEpisodes(tintColor: AppTheme.appTintColor(), query: query, arguments: nil)
     }
 }

--- a/podcasts/EpisodesDataManager.swift
+++ b/podcasts/EpisodesDataManager.swift
@@ -12,15 +12,6 @@ class EpisodesDataManager {
         case starred
     }
 
-    func get(_ section: Section) -> [ArraySection<String, ListItem>] {
-        switch section {
-        case .podcast(let podcast, uuidsToFilter: let uuidsToFilter):
-            return episodes(for: podcast, uuidsToFilter: uuidsToFilter)
-        default:
-            fatalError("ArraySection<String, ListItem> can't be returned for this section.")
-        }
-    }
-
     func get(_ section: Section) -> [ListEpisode] {
         switch section {
         case .filter(let filter):

--- a/podcasts/EpisodesDataManager.swift
+++ b/podcasts/EpisodesDataManager.swift
@@ -5,12 +5,24 @@ import DifferenceKit
 class EpisodesDataManager {
     enum Section {
         case podcast(Podcast, uuidsToFilter: [String]?)
+        case filter(EpisodeFilter)
     }
 
     func get(_ section: Section) -> [ArraySection<String, ListItem>] {
         switch section {
         case .podcast(let podcast, uuidsToFilter: let uuidsToFilter):
             return episodes(for: podcast, uuidsToFilter: uuidsToFilter)
+        case .filter:
+            fatalError("ArraySection can't be returned for filters")
+        }
+    }
+
+    func get(_ section: Section) -> [ListEpisode] {
+        switch section {
+        case .podcast(_, uuidsToFilter: _):
+            fatalError("An array of ListEpisode can't be returned for a podcast")
+        case .filter(let filter):
+            return episodes(for: filter)
         }
     }
 
@@ -82,5 +94,13 @@ class EpisodesDataManager {
         }
 
         return "podcast_id = \(podcast.id) \(sortStr)"
+    }
+
+    // MARK: - Filters
+
+    func episodes(for filter: EpisodeFilter) -> [ListEpisode] {
+        let query = PlaylistHelper.queryFor(filter: filter, episodeUuidToAdd: filter.episodeUuidToAddToQueries(), limit: Constants.Limits.maxFilterItems)
+        let tintColor = filter.playlistColor()
+        return EpisodeTableHelper.loadEpisodes(tintColor: tintColor, query: query, arguments: nil)
     }
 }

--- a/podcasts/EpisodesDataManager.swift
+++ b/podcasts/EpisodesDataManager.swift
@@ -1,0 +1,86 @@
+import PocketCastsDataModel
+import DifferenceKit
+
+/// Returns a list of episodes
+class EpisodesDataManager {
+    enum Section {
+        case podcast(Podcast, uuidsToFilter: [String]?)
+    }
+
+    func get(_ section: Section) -> [ArraySection<String, ListItem>] {
+        switch section {
+        case .podcast(let podcast, uuidsToFilter: let uuidsToFilter):
+            return episodes(for: podcast, uuidsToFilter: uuidsToFilter)
+        }
+    }
+
+    // MARK: - Podcast episodes list
+
+    func episodes(for podcast: Podcast, uuidsToFilter: [String]? = nil) -> [ArraySection<String, ListItem>] {
+        // the podcast page has a header, for simplicity in table animations, we add it here
+        let searchHeader = ListHeader(headerTitle: L10n.search, isSectionHeader: true)
+        var newData = [ArraySection<String, ListItem>(model: searchHeader.headerTitle, elements: [searchHeader])]
+
+        let tintColor = AppTheme.appTintColor()
+        let sortOrder = PodcastEpisodeSortOrder(rawValue: podcast.episodeSortOrder) ?? .newestToOldest
+        switch podcast.podcastGrouping() {
+        case .none:
+            let episodes = EpisodeTableHelper.loadEpisodes(tintColor: tintColor, query: createEpisodesQuery(podcast, uuidsToFilter: uuidsToFilter), arguments: nil)
+            newData.append(ArraySection(model: "episodes", elements: episodes))
+        case .season:
+            let groupedEpisodes = EpisodeTableHelper.loadSortedSectionedEpisodes(tintColor: AppTheme.appTintColor(), query: createEpisodesQuery(podcast, uuidsToFilter: uuidsToFilter), arguments: nil, sectionComparator: { name1, name2 -> Bool in
+                sortOrder == .newestToOldest ? name1.digits > name2.digits : name2.digits > name1.digits
+            }, episodeShortKey: { episode -> String in
+                episode.seasonNumber > 0 ? L10n.podcastSeasonFormat(episode.seasonNumber.localized()) : L10n.podcastNoSeason
+            })
+            newData.append(contentsOf: groupedEpisodes)
+        case .unplayed:
+            let groupedEpisodes = EpisodeTableHelper.loadSortedSectionedEpisodes(tintColor: AppTheme.appTintColor(), query: createEpisodesQuery(podcast, uuidsToFilter: uuidsToFilter), arguments: nil, sectionComparator: { name1, _ -> Bool in
+                name1 == L10n.statusUnplayed
+            }, episodeShortKey: { episode -> String in
+                episode.played() ? L10n.statusPlayed : L10n.statusUnplayed
+            })
+            newData.append(contentsOf: groupedEpisodes)
+        case .downloaded:
+            let groupedEpisodes = EpisodeTableHelper.loadSortedSectionedEpisodes(tintColor: AppTheme.appTintColor(), query: createEpisodesQuery(podcast, uuidsToFilter: uuidsToFilter), arguments: nil, sectionComparator: { name1, _ -> Bool in
+                name1 == L10n.statusDownloaded
+            }, episodeShortKey: { (episode: Episode) -> String in
+                episode.downloaded(pathFinder: DownloadManager.shared) || episode.queued() || episode.downloading() ? L10n.statusDownloaded : L10n.statusNotDownloaded
+            })
+            newData.append(contentsOf: groupedEpisodes)
+        case .starred:
+            let groupedEpisodes = EpisodeTableHelper.loadSortedSectionedEpisodes(tintColor: AppTheme.appTintColor(), query: createEpisodesQuery(podcast, uuidsToFilter: uuidsToFilter), arguments: nil, sectionComparator: { name1, _ -> Bool in
+                name1 == L10n.statusStarred
+            }, episodeShortKey: { episode -> String in
+                episode.keepEpisode ? L10n.statusStarred : L10n.statusNotStarred
+            })
+            newData.append(contentsOf: groupedEpisodes)
+        }
+
+        return newData
+    }
+
+    func createEpisodesQuery(_ podcast: Podcast, uuidsToFilter: [String]? = nil) -> String {
+        let sortStr: String
+        let sortOrder = PodcastEpisodeSortOrder(rawValue: podcast.episodeSortOrder) ?? PodcastEpisodeSortOrder.newestToOldest
+        switch sortOrder {
+        case .newestToOldest:
+            sortStr = "ORDER BY publishedDate DESC, addedDate DESC"
+        case .oldestToNewest:
+            sortStr = "ORDER BY publishedDate ASC, addedDate ASC"
+        case .shortestToLongest:
+            sortStr = "ORDER BY duration ASC, addedDate"
+        case .longestToShortest:
+            sortStr = "ORDER BY duration DESC, addedDate"
+        }
+        if let uuids = uuidsToFilter {
+            let inClause = "(\(uuids.map { "'\($0)'" }.joined(separator: ",")))"
+            return "podcast_id = \(podcast.id) AND uuid IN \(inClause) \(sortStr)"
+        }
+        if !podcast.showArchived {
+            return "podcast_id = \(podcast.id) AND archived = 0 \(sortStr)"
+        }
+
+        return "podcast_id = \(podcast.id) \(sortStr)"
+    }
+}

--- a/podcasts/EpisodesDataManager.swift
+++ b/podcasts/EpisodesDataManager.swift
@@ -1,4 +1,5 @@
 import PocketCastsDataModel
+import PocketCastsServer
 import DifferenceKit
 
 /// Returns a list of episodes
@@ -148,5 +149,17 @@ class EpisodesDataManager {
     func starredEpisodes() -> [ListEpisode] {
         let query = "keepEpisode = 1 ORDER BY starredModified DESC LIMIT 1000"
         return EpisodeTableHelper.loadEpisodes(tintColor: AppTheme.appTintColor(), query: query, arguments: nil)
+    }
+
+    // MARK: - Uploaded Files
+
+    func uploadedEpisodes() -> [UserEpisode] {
+        let sortBy = UploadedSort(rawValue: Settings.userEpisodeSortBy()) ?? UploadedSort.newestToOldest
+
+        if SubscriptionHelper.hasActiveSubscription() {
+            return DataManager.sharedManager.allUserEpisodes(sortedBy: sortBy)
+        } else {
+            return DataManager.sharedManager.allUserEpisodesDownloaded(sortedBy: sortBy)
+        }
     }
 }

--- a/podcasts/ListeningHistoryViewController.swift
+++ b/podcasts/ListeningHistoryViewController.swift
@@ -117,7 +117,7 @@ class ListeningHistoryViewController: PCViewController {
             guard let self else { return }
 
             let oldData = self.episodes
-            let newData: [ArraySection<String, ListEpisode>] = self.episodesDataManager.get(.listeningHistory)
+            let newData = self.episodesDataManager.listeningHistoryEpisodes()
 
             DispatchQueue.main.sync {
                 self.listeningHistoryTable.isHidden = (newData.count == 0)

--- a/podcasts/ListeningHistoryViewController.swift
+++ b/podcasts/ListeningHistoryViewController.swift
@@ -8,6 +8,8 @@ class ListeningHistoryViewController: PCViewController {
     private let operationQueue = OperationQueue()
     var cellHeights: [IndexPath: CGFloat] = [:]
 
+    private let episodesDataManager = EpisodesDataManager()
+
     @IBOutlet var listeningHistoryTable: UITableView! {
         didSet {
             registerCells()
@@ -111,26 +113,22 @@ class ListeningHistoryViewController: PCViewController {
     }
 
     func refreshEpisodes(animated: Bool) {
-        operationQueue.addOperation {
-            let query = "lastPlaybackInteractionDate IS NOT NULL AND lastPlaybackInteractionDate > 0 ORDER BY lastPlaybackInteractionDate DESC LIMIT 1000"
+        operationQueue.addOperation { [weak self] in
+            guard let self else { return }
 
             let oldData = self.episodes
-            let newData = EpisodeTableHelper.loadSectionedEpisodes(tintColor: AppTheme.appTintColor(), query: query, arguments: nil, episodeShortKey: { episode -> String in
-                episode.shortLastPlaybackInteractionDate()
-            })
+            let newData: [ArraySection<String, ListEpisode>] = self.episodesDataManager.get(.listeningHistory)
 
-            DispatchQueue.main.sync { [weak self] in
-                guard let strongSelf = self else { return }
-
-                strongSelf.listeningHistoryTable.isHidden = (newData.count == 0)
+            DispatchQueue.main.sync {
+                self.listeningHistoryTable.isHidden = (newData.count == 0)
                 if animated {
                     let changeSet = StagedChangeset(source: oldData, target: newData)
-                    strongSelf.listeningHistoryTable.reload(using: changeSet, with: .none, setData: { data in
-                        strongSelf.episodes = data
+                    self.listeningHistoryTable.reload(using: changeSet, with: .none, setData: { data in
+                        self.episodes = data
                     })
                 } else {
-                    strongSelf.episodes = newData
-                    strongSelf.listeningHistoryTable.reloadData()
+                    self.episodes = newData
+                    self.listeningHistoryTable.reloadData()
                 }
             }
         }

--- a/podcasts/PlaylistRefreshOperation.swift
+++ b/podcasts/PlaylistRefreshOperation.swift
@@ -7,7 +7,7 @@ class PlaylistRefreshOperation: Operation {
     private let filter: EpisodeFilter
     private let completion: ([ListEpisode]) -> Void
 
-    init(episodesDataManager: EpisodesDataManager = EpisodesDataManager(), tableView: UITableView, filter: EpisodeFilter, completion: @escaping (([ListEpisode]) -> Void)) {
+    init(episodesDataManager: EpisodesDataManager = .init(), tableView: UITableView, filter: EpisodeFilter, completion: @escaping (([ListEpisode]) -> Void)) {
         self.episodesDataManager = episodesDataManager
         self.tableView = tableView
         self.filter = filter

--- a/podcasts/PlaylistRefreshOperation.swift
+++ b/podcasts/PlaylistRefreshOperation.swift
@@ -2,11 +2,13 @@ import Foundation
 import PocketCastsDataModel
 
 class PlaylistRefreshOperation: Operation {
+    private let episodesDataManager: EpisodesDataManager
     private let tableView: UITableView
     private let filter: EpisodeFilter
     private let completion: ([ListEpisode]) -> Void
 
-    init(tableView: UITableView, filter: EpisodeFilter, completion: @escaping (([ListEpisode]) -> Void)) {
+    init(episodesDataManager: EpisodesDataManager = EpisodesDataManager(), tableView: UITableView, filter: EpisodeFilter, completion: @escaping (([ListEpisode]) -> Void)) {
+        self.episodesDataManager = episodesDataManager
         self.tableView = tableView
         self.filter = filter
         self.completion = completion
@@ -18,9 +20,7 @@ class PlaylistRefreshOperation: Operation {
         autoreleasepool {
             if self.isCancelled { return }
 
-            let query = PlaylistHelper.queryFor(filter: filter, episodeUuidToAdd: filter.episodeUuidToAddToQueries(), limit: Constants.Limits.maxFilterItems)
-            let tintColor = filter.playlistColor()
-            let newData = EpisodeTableHelper.loadEpisodes(tintColor: tintColor, query: query, arguments: nil)
+            let newData: [ListEpisode] = episodesDataManager.get(.filter(filter))
 
             DispatchQueue.main.sync { [weak self] in
                 guard let strongSelf = self else { return }

--- a/podcasts/PlaylistRefreshOperation.swift
+++ b/podcasts/PlaylistRefreshOperation.swift
@@ -20,7 +20,7 @@ class PlaylistRefreshOperation: Operation {
         autoreleasepool {
             if self.isCancelled { return }
 
-            let newData: [ListEpisode] = episodesDataManager.get(.filter(filter))
+            let newData = episodesDataManager.episodes(for: filter)
 
             DispatchQueue.main.sync { [weak self] in
                 guard let strongSelf = self else { return }

--- a/podcasts/PodcastEpisodesRefreshOperation.swift
+++ b/podcasts/PodcastEpisodesRefreshOperation.swift
@@ -21,7 +21,7 @@ class PodcastEpisodesRefreshOperation: Operation {
         autoreleasepool {
             if self.isCancelled { return }
 
-            let newData = episodesDataManager.get(.podcast(podcast, uuidsToFilter: uuidsToFilter))
+            let newData: [ArraySection<String, ListItem>] = episodesDataManager.get(.podcast(podcast, uuidsToFilter: uuidsToFilter))
 
             if self.isCancelled { return }
             DispatchQueue.main.sync { [weak self] in

--- a/podcasts/PodcastEpisodesRefreshOperation.swift
+++ b/podcasts/PodcastEpisodesRefreshOperation.swift
@@ -3,11 +3,13 @@ import Foundation
 import PocketCastsDataModel
 
 class PodcastEpisodesRefreshOperation: Operation {
+    private let episodesDataManager: EpisodesDataManager
     private let podcast: Podcast
     private let uuidsToFilter: [String]?
     private let completion: (([ArraySection<String, ListItem>]) -> Void)?
 
-    init(podcast: Podcast, uuidsToFilter: [String]?, completion: (([ArraySection<String, ListItem>]) -> Void)?) {
+    init(episodesDataManager: EpisodesDataManager = EpisodesDataManager(), podcast: Podcast, uuidsToFilter: [String]?, completion: (([ArraySection<String, ListItem>]) -> Void)?) {
+        self.episodesDataManager = episodesDataManager
         self.podcast = podcast
         self.uuidsToFilter = uuidsToFilter
         self.completion = completion
@@ -19,45 +21,7 @@ class PodcastEpisodesRefreshOperation: Operation {
         autoreleasepool {
             if self.isCancelled { return }
 
-            // the podcast page has a header, for simplicity in table animations, we add it here
-            let searchHeader = ListHeader(headerTitle: L10n.search, isSectionHeader: true)
-            var newData = [ArraySection<String, ListItem>(model: searchHeader.headerTitle, elements: [searchHeader])]
-
-            let tintColor = AppTheme.appTintColor()
-            let sortOrder = PodcastEpisodeSortOrder(rawValue: podcast.episodeSortOrder) ?? .newestToOldest
-            switch podcast.podcastGrouping() {
-            case .none:
-                let episodes = EpisodeTableHelper.loadEpisodes(tintColor: tintColor, query: createEpisodesQuery(), arguments: nil)
-                newData.append(ArraySection(model: "episodes", elements: episodes))
-            case .season:
-                let groupedEpisodes = EpisodeTableHelper.loadSortedSectionedEpisodes(tintColor: AppTheme.appTintColor(), query: createEpisodesQuery(), arguments: nil, sectionComparator: { name1, name2 -> Bool in
-                    sortOrder == .newestToOldest ? name1.digits > name2.digits : name2.digits > name1.digits
-                }, episodeShortKey: { episode -> String in
-                    episode.seasonNumber > 0 ? L10n.podcastSeasonFormat(episode.seasonNumber.localized()) : L10n.podcastNoSeason
-                })
-                newData.append(contentsOf: groupedEpisodes)
-            case .unplayed:
-                let groupedEpisodes = EpisodeTableHelper.loadSortedSectionedEpisodes(tintColor: AppTheme.appTintColor(), query: createEpisodesQuery(), arguments: nil, sectionComparator: { name1, _ -> Bool in
-                    name1 == L10n.statusUnplayed
-                }, episodeShortKey: { episode -> String in
-                    episode.played() ? L10n.statusPlayed : L10n.statusUnplayed
-                })
-                newData.append(contentsOf: groupedEpisodes)
-            case .downloaded:
-                let groupedEpisodes = EpisodeTableHelper.loadSortedSectionedEpisodes(tintColor: AppTheme.appTintColor(), query: createEpisodesQuery(), arguments: nil, sectionComparator: { name1, _ -> Bool in
-                    name1 == L10n.statusDownloaded
-                }, episodeShortKey: { (episode: Episode) -> String in
-                    episode.downloaded(pathFinder: DownloadManager.shared) || episode.queued() || episode.downloading() ? L10n.statusDownloaded : L10n.statusNotDownloaded
-                })
-                newData.append(contentsOf: groupedEpisodes)
-            case .starred:
-                let groupedEpisodes = EpisodeTableHelper.loadSortedSectionedEpisodes(tintColor: AppTheme.appTintColor(), query: createEpisodesQuery(), arguments: nil, sectionComparator: { name1, _ -> Bool in
-                    name1 == L10n.statusStarred
-                }, episodeShortKey: { episode -> String in
-                    episode.keepEpisode ? L10n.statusStarred : L10n.statusNotStarred
-                })
-                newData.append(contentsOf: groupedEpisodes)
-            }
+            let newData = episodesDataManager.get(.podcast(podcast, uuidsToFilter: uuidsToFilter))
 
             if self.isCancelled { return }
             DispatchQueue.main.sync { [weak self] in
@@ -71,26 +35,6 @@ class PodcastEpisodesRefreshOperation: Operation {
     }
 
     func createEpisodesQuery() -> String {
-        let sortStr: String
-        let sortOrder = PodcastEpisodeSortOrder(rawValue: podcast.episodeSortOrder) ?? PodcastEpisodeSortOrder.newestToOldest
-        switch sortOrder {
-        case .newestToOldest:
-            sortStr = "ORDER BY publishedDate DESC, addedDate DESC"
-        case .oldestToNewest:
-            sortStr = "ORDER BY publishedDate ASC, addedDate ASC"
-        case .shortestToLongest:
-            sortStr = "ORDER BY duration ASC, addedDate"
-        case .longestToShortest:
-            sortStr = "ORDER BY duration DESC, addedDate"
-        }
-        if let uuids = uuidsToFilter {
-            let inClause = "(\(uuids.map { "'\($0)'" }.joined(separator: ",")))"
-            return "podcast_id = \(podcast.id) AND uuid IN \(inClause) \(sortStr)"
-        }
-        if !podcast.showArchived {
-            return "podcast_id = \(podcast.id) AND archived = 0 \(sortStr)"
-        }
-
-        return "podcast_id = \(podcast.id) \(sortStr)"
+        episodesDataManager.createEpisodesQuery(podcast, uuidsToFilter: uuidsToFilter)
     }
 }

--- a/podcasts/PodcastEpisodesRefreshOperation.swift
+++ b/podcasts/PodcastEpisodesRefreshOperation.swift
@@ -21,7 +21,7 @@ class PodcastEpisodesRefreshOperation: Operation {
         autoreleasepool {
             if self.isCancelled { return }
 
-            let newData: [ArraySection<String, ListItem>] = episodesDataManager.get(.podcast(podcast, uuidsToFilter: uuidsToFilter))
+            let newData = episodesDataManager.episodes(for: podcast, uuidsToFilter: uuidsToFilter)
 
             if self.isCancelled { return }
             DispatchQueue.main.sync { [weak self] in

--- a/podcasts/UploadedViewController.swift
+++ b/podcasts/UploadedViewController.swift
@@ -227,7 +227,7 @@ class UploadedViewController: PCViewController, UserEpisodeDetailProtocol {
     }
 
     func reloadLocalFiles() {
-        let uploadedEpisodes = episodesDataManager.uploadedEpisodes()
+        uploadedEpisodes = episodesDataManager.uploadedEpisodes()
         uploadsTable.isHidden = (uploadedEpisodes.count == 0)
 
         uploadsTable.reloadData()

--- a/podcasts/UploadedViewController.swift
+++ b/podcasts/UploadedViewController.swift
@@ -3,6 +3,8 @@ import PocketCastsServer
 import UIKit
 
 class UploadedViewController: PCViewController, UserEpisodeDetailProtocol {
+    private let episodesDataManager = EpisodesDataManager()
+
     @IBOutlet var uploadsTable: ThemeableTable! {
         didSet {
             uploadsTable.updateContentInset(multiSelectEnabled: false)
@@ -225,13 +227,7 @@ class UploadedViewController: PCViewController, UserEpisodeDetailProtocol {
     }
 
     func reloadLocalFiles() {
-        let sortBy = UploadedSort(rawValue: Settings.userEpisodeSortBy()) ?? UploadedSort.newestToOldest
-
-        if SubscriptionHelper.hasActiveSubscription() {
-            uploadedEpisodes = DataManager.sharedManager.allUserEpisodes(sortedBy: sortBy)
-        } else {
-            uploadedEpisodes = DataManager.sharedManager.allUserEpisodesDownloaded(sortedBy: sortBy)
-        }
+        let uploadedEpisodes = episodesDataManager.uploadedEpisodes()
         uploadsTable.isHidden = (uploadedEpisodes.count == 0)
 
         uploadsTable.reloadData()


### PR DESCRIPTION
This PR extracts the SQL queries that power the following screens:

* Podcast
* Filters
* Downloads
* Files
* Starred
* Listening History

This step is necessary for the autoplay, given we need a way to retrieve the same list of episodes so we can accurately play the next one.

No new features are added to this PR.

## To test

Ps.: you can use `trunk` or the main app running in another simulator/device so you can compare the list of episodes.

1. Run the app (I recommend running into on a logged account, with Filters, Downloaded files, Starred, etc)
2. Go to Discover and check any random podcast
3. ✅ The episodes should appear correctly
4. Do the same in your "Podcasts" tab
5. ✅ Check that episodes appear correctly
6. Go to "Profile" and tap "Downloads"
7. ✅ Check that episodes appear correctly
8. Go back to "Profile" and tap "Files"
9. ✅ Check that your files appear correctly
10. Go back to "Profile" and tap "Starred"
11. ✅ Check that your episodes appear correctly
12. Go back to "Profile" and tap "Listening History"
11. ✅ Check that your played episodes appear correctly

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
