### PR TITLE
Episodes Autoplay: add a new option in Settings

### DIFF
--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -154,6 +154,8 @@ struct Constants {
         static let top5PodcastsListLink = "top5PodcastsListLink"
         static let shouldShowInitialOnboardingFlow = "shouldShowInitialOnboardingFlow"
 
+        static let autoplay = "autoplay"
+
         static let searchHistoryEntries = "SearchHistoryEntries"
     }
 

--- a/podcasts/FeatureFlag.swift
+++ b/podcasts/FeatureFlag.swift
@@ -37,6 +37,9 @@ enum FeatureFlag: String, CaseIterable {
     /// Displaying podcast ratings
     case showRatings
 
+    /// New episodes autoplay if Up Next is empty
+    case autoplay
+
     var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -66,6 +69,8 @@ enum FeatureFlag: String, CaseIterable {
         case .patron:
             return false
         case .showRatings:
+            return false
+        case .autoplay:
             return false
         }
     }

--- a/podcasts/GeneralSettingsViewController.swift
+++ b/podcasts/GeneralSettingsViewController.swift
@@ -383,6 +383,8 @@ class GeneralSettingsViewController: UIViewController, UITableViewDelegate, UITa
             return L10n.settingsGeneralMultiSelectGestureSubtitle
         case [.publishChapterTitles]:
             return L10n.settingsGeneralPublishChapterTitlesSubtitle
+        case [.autoplay]:
+            return "Continue playing after an episode ends if Up Next is empty."
         default:
             return nil
         }

--- a/podcasts/GeneralSettingsViewController.swift
+++ b/podcasts/GeneralSettingsViewController.swift
@@ -366,9 +366,9 @@ class GeneralSettingsViewController: UIViewController, UITableViewDelegate, UITa
     }
 
     func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
-        guard let sectionItems = tableData[safe: section]?.last else { return nil }
+        let lastSectionItem = tableData[safe: section]?.last
 
-        switch sectionItems {
+        switch lastSectionItem {
         case .intelligentPlaybackResumption:
             return L10n.settingsGeneralSmartPlaybackSubtitle
         case .playUpNextOnTap:

--- a/podcasts/GeneralSettingsViewController.swift
+++ b/podcasts/GeneralSettingsViewController.swift
@@ -9,8 +9,8 @@ class GeneralSettingsViewController: UIViewController, UITableViewDelegate, UITa
 
     let debounce = Debounce(delay: Constants.defaultDebounceTime)
 
-    private enum TableRow { case skipForward, skipBack, remoteSkipChapters, keepScreenAwake, openPlayer, intelligentPlaybackResumption, defaultRowAction, extraMediaActions, defaultAddToUpNextSwipe, defaultGrouping, defaultArchive, playUpNextOnTap, legacyBluetooth, multiSelectGesture, openLinksInBrowser, publishChapterTitles }
-    private let tableData: [[TableRow]] = [[.defaultRowAction, .defaultGrouping, .defaultArchive, .defaultAddToUpNextSwipe, .openLinksInBrowser], [.skipForward, .skipBack, .keepScreenAwake, .openPlayer, .intelligentPlaybackResumption], [.playUpNextOnTap], [.remoteSkipChapters], [.extraMediaActions], [.legacyBluetooth], [.multiSelectGesture], [.publishChapterTitles]]
+    private enum TableRow { case skipForward, skipBack, remoteSkipChapters, keepScreenAwake, openPlayer, intelligentPlaybackResumption, defaultRowAction, extraMediaActions, defaultAddToUpNextSwipe, defaultGrouping, defaultArchive, playUpNextOnTap, legacyBluetooth, multiSelectGesture, openLinksInBrowser, publishChapterTitles, autoplay }
+    private var tableData: [[TableRow]] = [[.defaultRowAction, .defaultGrouping, .defaultArchive, .defaultAddToUpNextSwipe, .openLinksInBrowser], [.skipForward, .skipBack, .keepScreenAwake, .openPlayer, .intelligentPlaybackResumption], [.playUpNextOnTap], [.remoteSkipChapters], [.extraMediaActions], [.legacyBluetooth], [.multiSelectGesture], [.publishChapterTitles]]
 
     @IBOutlet var settingsTable: UITableView! {
         didSet {
@@ -27,6 +27,10 @@ class GeneralSettingsViewController: UIViewController, UITableViewDelegate, UITa
         title = L10n.settingsGeneral
 
         Analytics.track(.settingsGeneralShown)
+
+        if FeatureFlag.autoplay.enabled {
+            tableData.append([.autoplay])
+        }
     }
 
     // MARK: - UITableView Methods
@@ -221,6 +225,17 @@ class GeneralSettingsViewController: UIViewController, UITableViewDelegate, UITa
             let cell = tableView.dequeueReusableCell(withIdentifier: switchCellId, for: indexPath) as! SwitchCell
 
             cell.cellLabel.text = L10n.settingsGeneralPublishChapterTitles
+            cell.cellSwitch.isOn = Settings.publishChapterTitlesEnabled()
+
+            cell.cellSwitch.removeTarget(self, action: nil, for: UIControl.Event.valueChanged)
+            cell.cellSwitch.addTarget(self, action: #selector(publishChapterTitlesToggled(_:)), for: UIControl.Event.valueChanged)
+
+            return cell
+
+        case .autoplay:
+            let cell = tableView.dequeueReusableCell(withIdentifier: switchCellId, for: indexPath) as! SwitchCell
+
+            cell.cellLabel.text = "Continuous Playback"
             cell.cellSwitch.isOn = Settings.publishChapterTitlesEnabled()
 
             cell.cellSwitch.removeTarget(self, action: nil, for: UIControl.Event.valueChanged)

--- a/podcasts/GeneralSettingsViewController.swift
+++ b/podcasts/GeneralSettingsViewController.swift
@@ -108,8 +108,8 @@ class GeneralSettingsViewController: UIViewController, UITableViewDelegate, UITa
             cell.cellLabel.text = L10n.settingsGeneralRemoteSkipsChapters
             cell.cellSwitch.isOn = Settings.remoteSkipShouldSkipChapters()
 
-            cell.cellSwitch.removeTarget(self, action: nil, for: UIControl.Event.valueChanged)
-            cell.cellSwitch.addTarget(self, action: #selector(remoteSkipChanged(_:)), for: UIControl.Event.valueChanged)
+            cell.cellSwitch.removeTarget(self, action: nil, for: .valueChanged)
+            cell.cellSwitch.addTarget(self, action: #selector(remoteSkipChanged(_:)), for: .valueChanged)
 
             return cell
         case .keepScreenAwake:
@@ -118,8 +118,8 @@ class GeneralSettingsViewController: UIViewController, UITableViewDelegate, UITa
             cell.cellLabel.text = L10n.settingsGeneralKeepScreenAwake
             cell.cellSwitch.isOn = UserDefaults.standard.bool(forKey: Constants.UserDefaults.keepScreenOnWhilePlaying)
 
-            cell.cellSwitch.removeTarget(self, action: nil, for: UIControl.Event.valueChanged)
-            cell.cellSwitch.addTarget(self, action: #selector(screenLockToggled(_:)), for: UIControl.Event.valueChanged)
+            cell.cellSwitch.removeTarget(self, action: nil, for: .valueChanged)
+            cell.cellSwitch.addTarget(self, action: #selector(screenLockToggled(_:)), for: .valueChanged)
 
             return cell
         case .openLinksInBrowser:
@@ -128,8 +128,8 @@ class GeneralSettingsViewController: UIViewController, UITableViewDelegate, UITa
             cell.cellLabel.text = L10n.settingsGeneralOpenInBrowser
             cell.cellSwitch.isOn = UserDefaults.standard.bool(forKey: Constants.UserDefaults.openLinksInExternalBrowser)
 
-            cell.cellSwitch.removeTarget(self, action: nil, for: UIControl.Event.valueChanged)
-            cell.cellSwitch.addTarget(self, action: #selector(openLinksInBrowserToggled(_:)), for: UIControl.Event.valueChanged)
+            cell.cellSwitch.removeTarget(self, action: nil, for: .valueChanged)
+            cell.cellSwitch.addTarget(self, action: #selector(openLinksInBrowserToggled(_:)), for: .valueChanged)
 
             return cell
         case .openPlayer:
@@ -138,8 +138,8 @@ class GeneralSettingsViewController: UIViewController, UITableViewDelegate, UITa
             cell.cellLabel.text = L10n.settingsGeneralAutoOpenPlayer
             cell.cellSwitch.isOn = UserDefaults.standard.bool(forKey: Constants.UserDefaults.openPlayerAutomatically)
 
-            cell.cellSwitch.removeTarget(self, action: nil, for: UIControl.Event.valueChanged)
-            cell.cellSwitch.addTarget(self, action: #selector(openPlayerToggled(_:)), for: UIControl.Event.valueChanged)
+            cell.cellSwitch.removeTarget(self, action: nil, for: .valueChanged)
+            cell.cellSwitch.addTarget(self, action: #selector(openPlayerToggled(_:)), for: .valueChanged)
 
             return cell
         case .intelligentPlaybackResumption:
@@ -148,8 +148,8 @@ class GeneralSettingsViewController: UIViewController, UITableViewDelegate, UITa
             cell.cellLabel.text = L10n.settingsGeneralSmartPlayback
             cell.cellSwitch.isOn = UserDefaults.standard.bool(forKey: Constants.UserDefaults.intelligentPlaybackResumption)
 
-            cell.cellSwitch.removeTarget(self, action: nil, for: UIControl.Event.valueChanged)
-            cell.cellSwitch.addTarget(self, action: #selector(intelligentPlaybackResumptionToggled(_:)), for: UIControl.Event.valueChanged)
+            cell.cellSwitch.removeTarget(self, action: nil, for: .valueChanged)
+            cell.cellSwitch.addTarget(self, action: #selector(intelligentPlaybackResumptionToggled(_:)), for: .valueChanged)
 
             return cell
         case .defaultRowAction:
@@ -187,8 +187,8 @@ class GeneralSettingsViewController: UIViewController, UITableViewDelegate, UITa
             let cell = tableView.dequeueReusableCell(withIdentifier: switchCellId, for: indexPath) as! SwitchCell
             cell.cellLabel.text = L10n.settingsGeneralUpNextTap
             cell.cellSwitch.isOn = Settings.playUpNextOnTap()
-            cell.cellSwitch.removeTarget(self, action: nil, for: UIControl.Event.valueChanged)
-            cell.cellSwitch.addTarget(self, action: #selector(playUpNextOnTapToggled(_:)), for: UIControl.Event.valueChanged)
+            cell.cellSwitch.removeTarget(self, action: nil, for: .valueChanged)
+            cell.cellSwitch.addTarget(self, action: #selector(playUpNextOnTapToggled(_:)), for: .valueChanged)
 
             return cell
         case .extraMediaActions:
@@ -197,8 +197,8 @@ class GeneralSettingsViewController: UIViewController, UITableViewDelegate, UITa
             cell.cellLabel.text = L10n.settingsGeneralPlayBackActions
             cell.cellSwitch.isOn = Settings.extraMediaSessionActionsEnabled()
 
-            cell.cellSwitch.removeTarget(self, action: nil, for: UIControl.Event.valueChanged)
-            cell.cellSwitch.addTarget(self, action: #selector(extraMediaSessionActionsToggled(_:)), for: UIControl.Event.valueChanged)
+            cell.cellSwitch.removeTarget(self, action: nil, for: .valueChanged)
+            cell.cellSwitch.addTarget(self, action: #selector(extraMediaSessionActionsToggled(_:)), for: .valueChanged)
 
             return cell
         case .legacyBluetooth:
@@ -207,8 +207,8 @@ class GeneralSettingsViewController: UIViewController, UITableViewDelegate, UITa
             cell.cellLabel.text = L10n.settingsGeneralLegacyBluetooth
             cell.cellSwitch.isOn = Settings.legacyBluetoothModeEnabled()
 
-            cell.cellSwitch.removeTarget(self, action: nil, for: UIControl.Event.valueChanged)
-            cell.cellSwitch.addTarget(self, action: #selector(legacyBluetoothToggled(_:)), for: UIControl.Event.valueChanged)
+            cell.cellSwitch.removeTarget(self, action: nil, for: .valueChanged)
+            cell.cellSwitch.addTarget(self, action: #selector(legacyBluetoothToggled(_:)), for: .valueChanged)
 
             return cell
         case .multiSelectGesture:
@@ -217,8 +217,8 @@ class GeneralSettingsViewController: UIViewController, UITableViewDelegate, UITa
             cell.cellLabel.text = L10n.settingsGeneralMultiSelectGesture
             cell.cellSwitch.isOn = Settings.multiSelectGestureEnabled()
 
-            cell.cellSwitch.removeTarget(self, action: nil, for: UIControl.Event.valueChanged)
-            cell.cellSwitch.addTarget(self, action: #selector(multiSelectGestureToggled(_:)), for: UIControl.Event.valueChanged)
+            cell.cellSwitch.removeTarget(self, action: nil, for: .valueChanged)
+            cell.cellSwitch.addTarget(self, action: #selector(multiSelectGestureToggled(_:)), for: .valueChanged)
 
             return cell
         case .publishChapterTitles:
@@ -227,8 +227,8 @@ class GeneralSettingsViewController: UIViewController, UITableViewDelegate, UITa
             cell.cellLabel.text = L10n.settingsGeneralPublishChapterTitles
             cell.cellSwitch.isOn = Settings.publishChapterTitlesEnabled()
 
-            cell.cellSwitch.removeTarget(self, action: nil, for: UIControl.Event.valueChanged)
-            cell.cellSwitch.addTarget(self, action: #selector(publishChapterTitlesToggled(_:)), for: UIControl.Event.valueChanged)
+            cell.cellSwitch.removeTarget(self, action: nil, for: .valueChanged)
+            cell.cellSwitch.addTarget(self, action: #selector(publishChapterTitlesToggled(_:)), for: .valueChanged)
 
             return cell
 
@@ -238,8 +238,8 @@ class GeneralSettingsViewController: UIViewController, UITableViewDelegate, UITa
             cell.cellLabel.text = L10n.settingsGeneralAutoplay
             cell.cellSwitch.isOn = Settings.autoplay
 
-            cell.cellSwitch.removeTarget(self, action: nil, for: UIControl.Event.valueChanged)
-            cell.cellSwitch.addTarget(self, action: #selector(autoplayToggled(_:)), for: UIControl.Event.valueChanged)
+            cell.cellSwitch.removeTarget(self, action: nil, for: .valueChanged)
+            cell.cellSwitch.addTarget(self, action: #selector(autoplayToggled(_:)), for: .valueChanged)
 
             return cell
         }

--- a/podcasts/GeneralSettingsViewController.swift
+++ b/podcasts/GeneralSettingsViewController.swift
@@ -239,7 +239,7 @@ class GeneralSettingsViewController: UIViewController, UITableViewDelegate, UITa
             cell.cellSwitch.isOn = Settings.autoplay
 
             cell.cellSwitch.removeTarget(self, action: nil, for: UIControl.Event.valueChanged)
-            cell.cellSwitch.addTarget(self, action: #selector(publishChapterTitlesToggled(_:)), for: UIControl.Event.valueChanged)
+            cell.cellSwitch.addTarget(self, action: #selector(autoplayToggled(_:)), for: UIControl.Event.valueChanged)
 
             return cell
         }
@@ -476,6 +476,10 @@ class GeneralSettingsViewController: UIViewController, UITableViewDelegate, UITa
 
         PlaybackManager.shared.playerDidChangeNowPlayingInfo()
         Settings.trackValueToggled(.settingsGeneralPublishChapterTitlesToggled, enabled: sender.isOn)
+    }
+
+    @objc private func autoplayToggled(_ sender: UISwitch) {
+        Settings.autoplay = sender.isOn
     }
 
     override var preferredStatusBarStyle: UIStatusBarStyle {

--- a/podcasts/GeneralSettingsViewController.swift
+++ b/podcasts/GeneralSettingsViewController.swift
@@ -366,23 +366,26 @@ class GeneralSettingsViewController: UIViewController, UITableViewDelegate, UITa
     }
 
     func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
-        if section == 1 {
-            return L10n.settingsGeneralSmartPlaybackSubtitle
-        } else if section == 2 {
-            return Settings.playUpNextOnTap() ? L10n.settingsGeneralUpNextTapOnSubtitle : L10n.settingsGeneralUpNextTapOffSubtitle
-        } else if section == 3 {
-            return L10n.settingsGeneralRemoteSkipsChaptersSubtitle
-        } else if section == 4 {
-            return L10n.settingsGeneralPlayBackActionsSubtitle
-        } else if section == 5 {
-            return L10n.settingsGeneralLegacyBluetoothSubtitle
-        } else if section == 6 {
-            return L10n.settingsGeneralMultiSelectGestureSubtitle
-        } else if section == 7 {
-            return L10n.settingsGeneralPublishChapterTitlesSubtitle
-        }
+        guard let sectionItems = tableData[safe: section] else { return nil }
 
-        return nil
+        switch sectionItems {
+        case let section where section.contains(.intelligentPlaybackResumption):
+            return L10n.settingsGeneralSmartPlaybackSubtitle
+        case [.playUpNextOnTap]:
+            return Settings.playUpNextOnTap() ? L10n.settingsGeneralUpNextTapOnSubtitle : L10n.settingsGeneralUpNextTapOffSubtitle
+        case [.remoteSkipChapters]:
+            return L10n.settingsGeneralRemoteSkipsChaptersSubtitle
+        case [.extraMediaActions]:
+            return L10n.settingsGeneralPlayBackActionsSubtitle
+        case [.legacyBluetooth]:
+            return L10n.settingsGeneralLegacyBluetoothSubtitle
+        case [.multiSelectGesture]:
+            return L10n.settingsGeneralMultiSelectGestureSubtitle
+        case [.publishChapterTitles]:
+            return L10n.settingsGeneralPublishChapterTitlesSubtitle
+        default:
+            return nil
+        }
     }
 
     func tableView(_ tableView: UITableView, willDisplayFooterView view: UIView, forSection section: Int) {

--- a/podcasts/GeneralSettingsViewController.swift
+++ b/podcasts/GeneralSettingsViewController.swift
@@ -235,7 +235,7 @@ class GeneralSettingsViewController: UIViewController, UITableViewDelegate, UITa
         case .autoplay:
             let cell = tableView.dequeueReusableCell(withIdentifier: switchCellId, for: indexPath) as! SwitchCell
 
-            cell.cellLabel.text = "Continuous Playback"
+            cell.cellLabel.text = L10n.settingsGeneralAutoplay
             cell.cellSwitch.isOn = Settings.publishChapterTitlesEnabled()
 
             cell.cellSwitch.removeTarget(self, action: nil, for: UIControl.Event.valueChanged)
@@ -384,7 +384,7 @@ class GeneralSettingsViewController: UIViewController, UITableViewDelegate, UITa
         case [.publishChapterTitles]:
             return L10n.settingsGeneralPublishChapterTitlesSubtitle
         case [.autoplay]:
-            return "Continue playing after an episode ends if Up Next is empty."
+            return L10n.settingsGeneralAutoplaySubtitle
         default:
             return nil
         }

--- a/podcasts/GeneralSettingsViewController.swift
+++ b/podcasts/GeneralSettingsViewController.swift
@@ -236,7 +236,7 @@ class GeneralSettingsViewController: UIViewController, UITableViewDelegate, UITa
             let cell = tableView.dequeueReusableCell(withIdentifier: switchCellId, for: indexPath) as! SwitchCell
 
             cell.cellLabel.text = L10n.settingsGeneralAutoplay
-            cell.cellSwitch.isOn = Settings.publishChapterTitlesEnabled()
+            cell.cellSwitch.isOn = Settings.autoplay
 
             cell.cellSwitch.removeTarget(self, action: nil, for: UIControl.Event.valueChanged)
             cell.cellSwitch.addTarget(self, action: #selector(publishChapterTitlesToggled(_:)), for: UIControl.Event.valueChanged)

--- a/podcasts/GeneralSettingsViewController.swift
+++ b/podcasts/GeneralSettingsViewController.swift
@@ -366,24 +366,24 @@ class GeneralSettingsViewController: UIViewController, UITableViewDelegate, UITa
     }
 
     func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
-        guard let sectionItems = tableData[safe: section] else { return nil }
+        guard let sectionItems = tableData[safe: section]?.last else { return nil }
 
         switch sectionItems {
-        case let section where section.contains(.intelligentPlaybackResumption):
+        case .intelligentPlaybackResumption:
             return L10n.settingsGeneralSmartPlaybackSubtitle
-        case [.playUpNextOnTap]:
+        case .playUpNextOnTap:
             return Settings.playUpNextOnTap() ? L10n.settingsGeneralUpNextTapOnSubtitle : L10n.settingsGeneralUpNextTapOffSubtitle
-        case [.remoteSkipChapters]:
+        case .remoteSkipChapters:
             return L10n.settingsGeneralRemoteSkipsChaptersSubtitle
-        case [.extraMediaActions]:
+        case .extraMediaActions:
             return L10n.settingsGeneralPlayBackActionsSubtitle
-        case [.legacyBluetooth]:
+        case .legacyBluetooth:
             return L10n.settingsGeneralLegacyBluetoothSubtitle
-        case [.multiSelectGesture]:
+        case .multiSelectGesture:
             return L10n.settingsGeneralMultiSelectGestureSubtitle
-        case [.publishChapterTitles]:
+        case .publishChapterTitles:
             return L10n.settingsGeneralPublishChapterTitlesSubtitle
-        case [.autoplay]:
+        case .autoplay:
             return L10n.settingsGeneralAutoplaySubtitle
         default:
             return nil

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -784,6 +784,21 @@ class Settings: NSObject {
         }
     }
 
+    // MARK: - Autoplay
+
+    static var autoplay: Bool {
+        set {
+            UserDefaults.standard.set(newValue, forKey: Constants.UserDefaults.autoplay)
+        }
+        get {
+            guard let isEnabled = UserDefaults.standard.object(forKey: Constants.UserDefaults.autoplay) as? Bool else {
+                return true
+            }
+
+            return isEnabled
+        }
+    }
+
     // MARK: - Variables that are loaded/changed through Firebase
 
     #if !os(watchOS)

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -2268,6 +2268,10 @@ internal enum L10n {
   }
   /// Open Player Automatically
   internal static var settingsGeneralAutoOpenPlayer: String { return L10n.tr("Localizable", "settings_general_auto_open_player") }
+  /// Continuous Playback
+  internal static var settingsGeneralAutoplay: String { return L10n.tr("Localizable", "settings_general_autoplay") }
+  /// Continue playing after an episode ends if Up Next is empty.
+  internal static var settingsGeneralAutoplaySubtitle: String { return L10n.tr("Localizable", "settings_general_autoplay_subtitle") }
   /// DEFAULTS
   internal static var settingsGeneralDefaultsHeader: String { return L10n.tr("Localizable", "settings_general_defaults_header") }
   /// Podcast Episode Grouping

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -2270,7 +2270,7 @@ internal enum L10n {
   internal static var settingsGeneralAutoOpenPlayer: String { return L10n.tr("Localizable", "settings_general_auto_open_player") }
   /// Continuous Playback
   internal static var settingsGeneralAutoplay: String { return L10n.tr("Localizable", "settings_general_autoplay") }
-  /// Continue playing after an episode ends if Up Next is empty.
+  /// If your Up Next queue is empty, we'll play episodes from the same podcast or list you're currently listening to.
   internal static var settingsGeneralAutoplaySubtitle: String { return L10n.tr("Localizable", "settings_general_autoplay_subtitle") }
   /// DEFAULTS
   internal static var settingsGeneralDefaultsHeader: String { return L10n.tr("Localizable", "settings_general_defaults_header") }

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -2473,11 +2473,17 @@
 /* Setting toggle to modify how a tap is handled in the up next queue. */
 "settings_general_up_next_tap" = "Play Up Next On Tap";
 
+/* Setting toggle to modify if a new episode is played after the current one ends. */
+"settings_general_autoplay" = "Continuous Playback";
+
 /* Subtitle explaining the toggle to modify how a tap is handled in the up next queue. This is used when the toggle is off. */
 "settings_general_up_next_tap_off_subtitle" = "Tapping an episode in Up Next shows the actions page. Long press plays the episode. Turn on to switch these around.";
 
 /* Subtitle explaining the toggle to modify how a tap is handled in the up next queue. This is used when the toggle is on. */
 "settings_general_up_next_tap_on_subtitle" = "Tapping an episode in Up Next will play it. Long press shows episode options. Turn off to switch these around.";
+
+/* Subtitle explaining the toggle to modify if a new episode will be reproduced after the current one ends. */
+"settings_general_autoplay_subtitle" = "Continue playing after an episode ends if Up Next is empty.";
 
 /* Title for the menu that takes you to the global up next queue settings */
 "settings_global_settings" = "Global Settings";

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -2483,7 +2483,7 @@
 "settings_general_up_next_tap_on_subtitle" = "Tapping an episode in Up Next will play it. Long press shows episode options. Turn off to switch these around.";
 
 /* Subtitle explaining the toggle to modify if a new episode will be reproduced after the current one ends. */
-"settings_general_autoplay_subtitle" = "Continue playing after an episode ends if Up Next is empty.";
+"settings_general_autoplay_subtitle" = "If your Up Next queue is empty, we'll play episodes from the same podcast or list you're currently listening to.";
 
 /* Title for the menu that takes you to the global up next queue settings */
 "settings_global_settings" = "Global Settings";


### PR DESCRIPTION
This PR adds a feature flag and an option so the user can toggle on/off the Episodes Autoplay feature.

## To test

1. Run the app
2. Go to Profile > Settings > General and scroll all the way down
3. ✅ You should not see a continuous playback option
4. Go to Profile > Beta Features > enable `autoplay`
5. Then, go to Profile > Settings > General and scroll all the way down
6. ✅ You should see a "Continuous Playback" option toggle **on**
7. Disable the toggle, close the app, and reopen it again
8. Then, go to Profile > Settings > General and scroll all the way down
9. ✅ You should see a "Continuous Playback" option toggled **off**
10. Enable the toggle, close the app, and reopen it again
11. Then, go to Profile > Settings > General and scroll all the way down
12. ✅ You should see a "Continuous Playback" option toggled **on**

Ps.: check all the "General" footers. I did a small refactor on how they're displayed to allow us to move options easily.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
