### PR TITLE
Show the search bar by default on the podcasts tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 7.43
 -----
+- The search bar on the podcasts tab is now visible by default [#929]
 
 
 7.42

--- a/podcasts/PodcastListViewController+Search.swift
+++ b/podcasts/PodcastListViewController+Search.swift
@@ -37,7 +37,7 @@ extension PodcastListViewController: UIScrollViewDelegate, PCSearchBarDelegate {
         ])
         searchController.searchControllerTopConstant = topAnchor
 
-        searchController.setupScrollView(podcastsCollectionView, hideSearchInitially: !UIAccessibility.isVoiceOverRunning)
+        searchController.setupScrollView(podcastsCollectionView, hideSearchInitially: false)
         searchController.searchDebounce = Settings.podcastSearchDebounceTime()
         searchController.searchDelegate = self
 

--- a/podcasts/PodcastListViewController.swift
+++ b/podcasts/PodcastListViewController.swift
@@ -97,7 +97,6 @@ class PodcastListViewController: PCViewController, UIGestureRecognizerDelegate, 
         miniPlayerStatusDidChange()
         refreshGridItems()
         addEventObservers()
-        updateForVoiceOver()
         updateFolderButton()
 
         Analytics.track(.podcastsListShown, properties: [
@@ -158,8 +157,6 @@ class PodcastListViewController: PCViewController, UIGestureRecognizerDelegate, 
 
         addCustomObserver(Constants.Notifications.tappedOnSelectedTab, selector: #selector(checkForScrollTap(_:)))
         addCustomObserver(Constants.Notifications.searchRequested, selector: #selector(searchRequested))
-
-        addCustomObserver(UIAccessibility.voiceOverStatusDidChangeNotification, selector: #selector(updateForVoiceOver))
     }
 
     @objc private func subscriptionStatusDidChange() {
@@ -175,15 +172,6 @@ class PodcastListViewController: PCViewController, UIGestureRecognizerDelegate, 
         let leftButton = UIBarButtonItem(image: folderImage, style: .plain, target: self, action: #selector(createFolderTapped(_:)))
         leftButton.accessibilityLabel = L10n.folderCreateNew
         navigationItem.leftBarButtonItem = leftButton
-    }
-
-    @objc private func updateForVoiceOver() {
-        // if a user turns voice over on, show them the search field that's hidden behind a scroll
-        if UIAccessibility.isVoiceOverRunning {
-            if podcastsCollectionView.contentOffset.y == 0 {
-                podcastsCollectionView.contentOffset.y = -searchController.view.bounds.height
-            }
-        }
     }
 
     @objc private func checkForScrollTap(_ notification: Notification) {


### PR DESCRIPTION
This makes the search bar visible by default on the Podcasts tab.

## Screenshots
| No Podcasts | Podcasts |
|:---:|:---:|
|<img src="https://github.com/Automattic/pocket-casts-ios/assets/793774/4b5753c5-37e9-43a2-8393-ebaf007da49f" width="160" />|<img src="https://github.com/Automattic/pocket-casts-ios/assets/793774/e30ca7ad-27ae-4a80-b219-5e062feab96c" width="160" />|

## To test
1. Launch the app
2. Go to the Podcasts tab
3. ✅ Verify the search bar is visible
4. Scroll down the podcasts list
5. ✅ Verify the search bar is hidden as it did before
6. Install the app from fresh
7. Dismiss the login prompt
8. Open the Podcasts tab
9. ✅ Verify the search bar is visible
11. Enable VoiceOver
    - Open Settings.app > Accessibility > Toggle VoiceOver On
12. Navigate back to the app
13. ✅ Verify the search bar is still visible
14. With VoiceOver on, reinstall the app
15. Go to the Podcasts tab
16. ✅ Verify the search bar appears

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
