### PR TITLE
Fix #933 - Correct Chapter Durations If They Extend Past the Episode Length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 7.43
 -----
-
+- Correctly display chapter durations when the chapter info shows that it passes the end of the episode.
 
 7.42
 -----

--- a/podcasts/PodcastChapterParser.swift
+++ b/podcasts/PodcastChapterParser.swift
@@ -39,7 +39,7 @@ class PodcastChapterParser {
                         #endif
 
                         convertedChapter.startTime = chapter.time
-                        convertedChapter.duration = chapter.duration.seconds
+                        convertedChapter.duration = strongSelf.sanitise(chapterDuration: chapter.duration.seconds, usingChapterStart: chapter.time, episodeDuration: episodeDuration)
                         convertedChapter.isHidden = chapter.hidden
                         if !convertedChapter.isHidden {
                             convertedChapter.index = index
@@ -67,5 +67,11 @@ class PodcastChapterParser {
 
         // next see if the scheme is http or https, we don't support any others
         return scheme.caseInsensitiveCompare("http") == .orderedSame || scheme.caseInsensitiveCompare("https") == .orderedSame
+    }
+
+    private func sanitise(chapterDuration: TimeInterval, usingChapterStart chapterStart: CMTime, episodeDuration: TimeInterval) -> TimeInterval {
+        let sanitisedDuration = chapterStart.seconds + chapterDuration > episodeDuration ? episodeDuration - chapterStart.seconds : chapterDuration
+
+        return sanitisedDuration
     }
 }


### PR DESCRIPTION
Fixes #933 

When reading chapter information, sanitise it so that no chapter duration is past the episodes end time.

## To test

Playing [ATP episode 538](https://github.com/Automattic/pocket-casts-ios/issues/933) shows the correct chapter duration.

## Checklist

- [X] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [X] I have considered adding unit tests for my changes.
- [X] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
