### PR TITLE
Episodes Autoplay: enable it only for new users

### DIFF
--- a/podcasts/AppDelegate+Defaults.swift
+++ b/podcasts/AppDelegate+Defaults.swift
@@ -18,6 +18,7 @@ extension AppDelegate {
             Settings.setHomeFolderSortOrder(order: .dateAddedNewestToOldest)
             Settings.setMobileDataAllowed(true)
             Settings.shouldShowInitialOnboardingFlow = true
+            Settings.autoplay = true
             setWhatsNewAcknowledgeToLatest()
         }
 

--- a/podcasts/AppDelegate+Defaults.swift
+++ b/podcasts/AppDelegate+Defaults.swift
@@ -18,7 +18,9 @@ extension AppDelegate {
             Settings.setHomeFolderSortOrder(order: .dateAddedNewestToOldest)
             Settings.setMobileDataAllowed(true)
             Settings.shouldShowInitialOnboardingFlow = true
-            Settings.autoplay = true
+            if FeatureFlag.autoplay.enabled {
+                Settings.autoplay = true
+            }
             setWhatsNewAcknowledgeToLatest()
         }
 

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -797,11 +797,7 @@ class Settings: NSObject {
                 return false
             }
 
-            guard let isEnabled = UserDefaults.standard.object(forKey: Constants.UserDefaults.autoplay) as? Bool else {
-                return true
-            }
-
-            return isEnabled
+            return UserDefaults.standard.bool(forKey: Constants.UserDefaults.autoplay)
         }
     }
 


### PR DESCRIPTION
Enables Autoplay only for new users.

## To test

1. Run `trunk`
2. Run this branch
3. Go to Profile > Settings > Beta Features > turn on `autoplay`
4. Go back and tap "General", and scroll all the way down
5. ✅ Continuous Playback should be **off**
6. Delete the app
7. Run this branch
8. Go to Profile > Settings > Beta Features > turn on `autoplay`
4. Go back and tap "General", and scroll all the way down
5. ✅ Continuous Playback should be **on**

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
