### PR TITLE
Episodes Autoplay: add CarPlay support

### DIFF
--- a/podcasts/CarPlaySceneDelegate+Convert.swift
+++ b/podcasts/CarPlaySceneDelegate+Convert.swift
@@ -3,7 +3,7 @@ import Foundation
 import PocketCastsDataModel
 
 extension CarPlaySceneDelegate {
-    func convertToListItems(episodes: [BaseEpisode], showArtwork: Bool) -> [CPListItem] {
+    func convertToListItems(episodes: [BaseEpisode], showArtwork: Bool, playlist: AutoplayHelper.Playlist?) -> [CPListItem] {
         var items = [CPListItem]()
         for episode in episodes {
             let artwork = showArtwork ? CarPlayImageHelper.imageForEpisode(episode) : nil

--- a/podcasts/CarPlaySceneDelegate+Convert.swift
+++ b/podcasts/CarPlaySceneDelegate+Convert.swift
@@ -28,7 +28,7 @@ extension CarPlaySceneDelegate {
             item.isPlaying = PlaybackManager.shared.isNowPlayingEpisode(episodeUuid: episode.uuid)
 
             item.handler = { [weak self] _, completion in
-                self?.episodeTapped(episode)
+                self?.episodeTapped(episode, playlist: playlist)
                 completion()
             }
 

--- a/podcasts/CarPlaySceneDelegate+Interaction.swift
+++ b/podcasts/CarPlaySceneDelegate+Interaction.swift
@@ -141,7 +141,7 @@ extension CarPlaySceneDelegate {
             guard let self else { return nil }
 
             let episodes = episodeLoader()
-            let episodeItems = self.convertToListItems(episodes: episodes, showArtwork: showArtwork)
+            let episodeItems = self.convertToListItems(episodes: episodes, showArtwork: showArtwork, playlist: playlist)
             return [CPListSection(items: episodeItems)]
         }
 

--- a/podcasts/CarPlaySceneDelegate+Interaction.swift
+++ b/podcasts/CarPlaySceneDelegate+Interaction.swift
@@ -32,7 +32,7 @@ extension CarPlaySceneDelegate {
         }
     }
 
-    func episodeTapped(_ episode: BaseEpisode) {
+    func episodeTapped(_ episode: BaseEpisode, playlist: AutoplayHelper.Playlist? = nil) {
         AnalyticsPlaybackHelper.shared.currentSource = .carPlay
 
         defer {
@@ -51,6 +51,9 @@ extension CarPlaySceneDelegate {
 
         // Anything else, load the episode and start playing it
         PlaybackManager.shared.load(episode: episode, autoPlay: true, overrideUpNext: false)
+
+        // Store the playlist
+        AutoplayHelper.shared.playedFrom(playlist: playlist)
     }
 
     func listeningHistoryTapped() {

--- a/podcasts/CarPlaySceneDelegate+Tabs.swift
+++ b/podcasts/CarPlaySceneDelegate+Tabs.swift
@@ -80,7 +80,7 @@ extension CarPlaySceneDelegate {
 extension CarPlaySceneDelegate {
     private var downloadTabSections: [CPListSection] {
         let downloadedEpisodes = DataManager.sharedManager.findEpisodesWhere(customWhere: "episodeStatus == \(DownloadStatus.downloaded.rawValue) ORDER BY lastDownloadAttemptDate DESC LIMIT \(Constants.Limits.maxCarplayItems)", arguments: nil)
-        let items = convertToListItems(episodes: downloadedEpisodes, showArtwork: true)
+        let items = convertToListItems(episodes: downloadedEpisodes, showArtwork: true, playlist: .downloads)
 
         return [CPListSection(items: items)]
     }


### PR DESCRIPTION
Adds CarPlay support so that episodes played in CarPlay are autoplayed depending on whether the user started playing it.

## To test

1. Run this branch on a real phone and use the CarPlay Simulator
2. Make sure the `autoplay` Feature Flag is enabled and "Continuous Playback" is on (Profile > Settings > General > scroll all the way down)
3. make sure your Up Next is empty
3. Use the table below as a guide for testing:

| Play an episode from | What should happen after the current episode finishes |
| --------------------- | ------------------------------------------------------ |
| A podcast list | The next episode should play |
| A filter | The next episode in the filter should play |
| Downloads | The next downloaded episode should play |
| Listening History (under More) | Nothing should be played after the current episode finishes |
| Files (under More) | The next episode should play |

#### Not Empty Up Next

If your Up Next queue has items the next episode in Up Next queue should play after the current one ends.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
