### PR TITLE
Episodes Autoplay: add Watch (Phone source) support

### DIFF
--- a/Pocket Casts Watch App Extension/DownloadListView.swift
+++ b/Pocket Casts Watch App Extension/DownloadListView.swift
@@ -6,7 +6,7 @@ struct DownloadListView: View {
         ItemListContainer(isEmpty: viewModel.episodes.isEmpty, loading: viewModel.isLoading) {
             ScrollView {
                 LazyVStack {
-                    EpisodeListView(title: L10n.podcastsPlural.prefixSourceUnicode, showArtwork: true, episodes: $viewModel.episodes)
+                    EpisodeListView(title: L10n.podcastsPlural.prefixSourceUnicode, showArtwork: true, episodes: $viewModel.episodes, playlist: .downloads)
                 }
             }
         }

--- a/Pocket Casts Watch App Extension/EpisodeDetailsViewModel.swift
+++ b/Pocket Casts Watch App Extension/EpisodeDetailsViewModel.swift
@@ -123,7 +123,7 @@ class EpisodeDetailsViewModel: EpisodeViewModel {
     }
 
     func playPauseTapped() {
-        playSourceViewModel.playPauseTapped(withEpisode: episode)
+        playSourceViewModel.playPauseTapped(withEpisode: episode, playlist: playlist)
     }
 
     func handleEpisodeAction(_ action: EpisodeAction, wasConfirmed: Bool = false, dismiss: () -> Void) {

--- a/Pocket Casts Watch App Extension/EpisodeDetailsViewModel.swift
+++ b/Pocket Casts Watch App Extension/EpisodeDetailsViewModel.swift
@@ -10,6 +10,8 @@ class EpisodeDetailsViewModel: EpisodeViewModel {
     @Published var actions: [EpisodeAction] = []
     @Published var supportsPodcastNavigation = false
 
+    var playlist: AutoplayHelper.Playlist?
+
     var parentPodcast: Podcast? {
         (episode as? Episode)?.parentPodcast()
     }
@@ -31,7 +33,8 @@ class EpisodeDetailsViewModel: EpisodeViewModel {
         .eraseToAnyPublisher()
     }
 
-    override init(episode: BaseEpisode) {
+    init(episode: BaseEpisode, playlist: AutoplayHelper.Playlist?) {
+        self.playlist = playlist
         super.init(episode: episode)
 
         playbackChanged

--- a/Pocket Casts Watch App Extension/EpisodeListView.swift
+++ b/Pocket Casts Watch App Extension/EpisodeListView.swift
@@ -4,10 +4,11 @@ struct EpisodeListView: View {
     let title: String
     let showArtwork: Bool
     @Binding var episodes: [EpisodeRowViewModel]
+    let playlist: AutoplayHelper.Playlist?
 
     var body: some View {
         ForEach(episodes) { episodeViewModel in
-            NavigationLink(destination: EpisodeView(viewModel: EpisodeDetailsViewModel(episode: episodeViewModel.episode), listTitle: title)) {
+            NavigationLink(destination: EpisodeView(viewModel: EpisodeDetailsViewModel(episode: episodeViewModel.episode, playlist: playlist), listTitle: title)) {
                 EpisodeRow(viewModel: episodeViewModel, showArtwork: showArtwork)
                     .padding(-4)
             }
@@ -17,6 +18,6 @@ struct EpisodeListView: View {
 
 struct EpisodeListView_Previews: PreviewProvider {
     static var previews: some View {
-        EpisodeListView(title: "Test", showArtwork: true, episodes: .constant([]))
+        EpisodeListView(title: "Test", showArtwork: true, episodes: .constant([]), playlist: nil)
     }
 }

--- a/Pocket Casts Watch App Extension/EpisodeView.swift
+++ b/Pocket Casts Watch App Extension/EpisodeView.swift
@@ -108,7 +108,7 @@ struct EpisodeView: View {
 }
 
 struct EpisodeView_Previews: PreviewProvider {
-    static let testViewModel = EpisodeDetailsViewModel(episode: Episode())
+    static let testViewModel = EpisodeDetailsViewModel(episode: Episode(), playlist: nil)
     static var previews: some View {
         ForEach(PreviewDevice.previewDevices, id: \.rawValue) { device in
             EpisodeView(viewModel: testViewModel, listTitle: "Test")

--- a/Pocket Casts Watch App Extension/FilesListView.swift
+++ b/Pocket Casts Watch App Extension/FilesListView.swift
@@ -6,7 +6,7 @@ struct FilesListView: View {
         ItemListContainer(isEmpty: $viewModel.episodes.isEmpty, loading: viewModel.isLoading) {
             ScrollView {
                 LazyVStack {
-                    EpisodeListView(title: L10n.settingsFiles.prefixSourceUnicode, showArtwork: true, episodes: $viewModel.episodes)
+                    EpisodeListView(title: L10n.settingsFiles.prefixSourceUnicode, showArtwork: true, episodes: $viewModel.episodes, playlist: .files)
                 }
             }
             .withOrderPickerToolbar(selectedOption: viewModel.sortOrder, title: L10n.filesSort, supportsToolbar: viewModel.supportsSort) { option in

--- a/Pocket Casts Watch App Extension/FilterEpisodeListView.swift
+++ b/Pocket Casts Watch App Extension/FilterEpisodeListView.swift
@@ -28,7 +28,7 @@ struct FilterEpisodeListView: View {
     var body: some View {
         headerWithContent {
             ItemListContainer(isEmpty: $viewModel.episodes.isEmpty, loading: viewModel.isLoading) {
-                EpisodeListView(title: L10n.settingsFiles.prefixSourceUnicode, showArtwork: true, episodes: $viewModel.episodes)
+                EpisodeListView(title: L10n.settingsFiles.prefixSourceUnicode, showArtwork: true, episodes: $viewModel.episodes, playlist: .filter(uuid: viewModel.filter.uuid))
             }
         }
         .navigationTitle(L10n.filters.prefixSourceUnicode)

--- a/Pocket Casts Watch App Extension/NowPlayingContainerView.swift
+++ b/Pocket Casts Watch App Extension/NowPlayingContainerView.swift
@@ -49,7 +49,7 @@ struct NowPlayingContainerView: View {
             }.hidden()
 
             if let episode = viewModel.episode {
-                NavigationLink(destination: EpisodeView(viewModel: EpisodeDetailsViewModel(episode: episode), listTitle: L10n.nowPlaying), tag: .episodeDetails, selection: $presentedView) {
+                NavigationLink(destination: EpisodeView(viewModel: EpisodeDetailsViewModel(episode: episode, playlist: nil), listTitle: L10n.nowPlaying), tag: .episodeDetails, selection: $presentedView) {
                     EmptyView()
                 }.hidden()
             }

--- a/Pocket Casts Watch App Extension/NowPlayingViewModel.swift
+++ b/Pocket Casts Watch App Extension/NowPlayingViewModel.swift
@@ -127,7 +127,7 @@ class NowPlayingViewModel: ObservableObject {
 
     func playPauseTapped() {
         guard let episode = episode else { return }
-        playSource.playPauseTapped(withEpisode: episode)
+        playSource.playPauseTapped(withEpisode: episode, playlist: nil)
     }
 
     func markPlayed() {

--- a/Pocket Casts Watch App Extension/PhoneSourceViewModel.swift
+++ b/Pocket Casts Watch App Extension/PhoneSourceViewModel.swift
@@ -59,11 +59,11 @@ class PhoneSourceViewModel: PlaySourceViewModel {
         }
     }
 
-    func playPauseTapped(withEpisode episode: BaseEpisode) {
+    func playPauseTapped(withEpisode episode: BaseEpisode, playlist: AutoplayHelper.Playlist?) {
         if let currentEpisode = WatchDataManager.playingEpisode(), currentEpisode.uuid == episode.uuid {
             SessionManager.shared.togglePlayPause()
         } else {
-            SessionManager.shared.play(episode: episode)
+            SessionManager.shared.play(episode: episode, playlist: playlist)
         }
     }
 

--- a/Pocket Casts Watch App Extension/PlaySourceViewModel.swift
+++ b/Pocket Casts Watch App Extension/PlaySourceViewModel.swift
@@ -34,7 +34,7 @@ protocol PlaySourceViewModel {
     var volumeBoostAvailable: Bool { get }
     var volumeBoostEnabled: Bool { get set }
 
-    func playPauseTapped(withEpisode episode: BaseEpisode)
+    func playPauseTapped(withEpisode episode: BaseEpisode, playlist: AutoplayHelper.Playlist?)
     func skip(forward: Bool)
     func changeChapter(next: Bool)
 

--- a/Pocket Casts Watch App Extension/PodcastEpisodeListView.swift
+++ b/Pocket Casts Watch App Extension/PodcastEpisodeListView.swift
@@ -11,7 +11,7 @@ struct PodcastEpisodeListView: View {
         ScrollView {
             LazyVStack {
                 podcastInfo
-                EpisodeListView(title: L10n.podcastsPlural.prefixSourceUnicode, showArtwork: false, episodes: $viewModel.episodes)
+                EpisodeListView(title: L10n.podcastsPlural.prefixSourceUnicode, showArtwork: false, episodes: $viewModel.episodes, playlist: .podcast(uuid: viewModel.podcast.uuid))
             }
         }
         .navigationTitle(L10n.podcastsPlural.prefixSourceUnicode)

--- a/Pocket Casts Watch App Extension/SessionManager+Send.swift
+++ b/Pocket Casts Watch App Extension/SessionManager+Send.swift
@@ -16,7 +16,7 @@ extension SessionManager {
         if !WCSession.default.isReachable { return }
 
         let playEpisodeRequest = [WatchConstants.Messages.messageType: WatchConstants.Messages.PlayEpisodeRequest.type, WatchConstants.Messages.PlayEpisodeRequest.episodeUuid: episode.uuid,
-            WatchConstants.Messages.PlayEpisodeRequest.playlist: playlist as Any] as [String: Any]
+            WatchConstants.Messages.PlayEpisodeRequest.playlist: (try? JSONEncoder().encode(playlist)) as Any] as [String: Any]
         WCSession.default.sendMessage(playEpisodeRequest, replyHandler: nil)
     }
 

--- a/Pocket Casts Watch App Extension/SessionManager+Send.swift
+++ b/Pocket Casts Watch App Extension/SessionManager+Send.swift
@@ -12,10 +12,11 @@ extension SessionManager {
         sendResponseless(messageType: WatchConstants.Messages.MinorSyncableUpdate.type)
     }
 
-    func play(episode: BaseEpisode) {
+    func play(episode: BaseEpisode, playlist: AutoplayHelper.Playlist?) {
         if !WCSession.default.isReachable { return }
 
-        let playEpisodeRequest = [WatchConstants.Messages.messageType: WatchConstants.Messages.PlayEpisodeRequest.type, WatchConstants.Messages.PlayEpisodeRequest.episodeUuid: episode.uuid] as [String: Any]
+        let playEpisodeRequest = [WatchConstants.Messages.messageType: WatchConstants.Messages.PlayEpisodeRequest.type, WatchConstants.Messages.PlayEpisodeRequest.episodeUuid: episode.uuid,
+            WatchConstants.Messages.PlayEpisodeRequest.playlist: playlist as Any] as [String: Any]
         WCSession.default.sendMessage(playEpisodeRequest, replyHandler: nil)
     }
 

--- a/Pocket Casts Watch App Extension/UpNextView.swift
+++ b/Pocket Casts Watch App Extension/UpNextView.swift
@@ -8,7 +8,7 @@ struct UpNextView: View {
         ItemListContainer(isEmpty: viewModel.isEmpty, noItemsTitle: L10n.watchUpNextNoItemsTitle, noItemsSubtitle: L10n.watchUpNextNoItemsSubtitle) {
             List {
                 NowPlayingRow(isPlaying: $viewModel.isPlaying, podcastName: $viewModel.upNextTitle)
-                EpisodeListView(title: L10n.settingsFiles.prefixSourceUnicode, showArtwork: true, episodes: $viewModel.episodes)
+                EpisodeListView(title: L10n.settingsFiles.prefixSourceUnicode, showArtwork: true, episodes: $viewModel.episodes, playlist: nil)
                     .padding(.vertical, 10)
             }
             .listStyle(.plain)

--- a/Pocket Casts Watch App Extension/WatchSourceViewModel.swift
+++ b/Pocket Casts Watch App Extension/WatchSourceViewModel.swift
@@ -54,7 +54,7 @@ class WatchSourceViewModel: PlaySourceViewModel {
         set {} // This is intentionally a noop because this feature isn't supported on the Watch
     }
 
-    func playPauseTapped(withEpisode episode: BaseEpisode) {
+    func playPauseTapped(withEpisode episode: BaseEpisode, playlist: AutoplayHelper.Playlist?) {
         if PlaybackManager.shared.isNowPlayingEpisode(episodeUuid: episode.uuid) {
             PlaybackManager.shared.playPause()
         } else {

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -479,6 +479,7 @@
 		8B317BA728906CC200A26A13 /* TestingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B317BA628906CC200A26A13 /* TestingViewController.swift */; };
 		8B317BA92890704400A26A13 /* TestingScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8B317BA82890704400A26A13 /* TestingScreen.storyboard */; };
 		8B3654172926C13000FD7216 /* CircularProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B3654162926C13000FD7216 /* CircularProgressView.swift */; };
+		8B3C7CA52A4DE36000939DED /* AutoplayHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B472E012A4B83CE005905F4 /* AutoplayHelper.swift */; };
 		8B44446229785287007E0AA8 /* AppleSocialLogin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B44446129785287007E0AA8 /* AppleSocialLogin.swift */; };
 		8B44446429785947007E0AA8 /* SocialLogin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B44446329785947007E0AA8 /* SocialLogin.swift */; };
 		8B44446729785BD0007E0AA8 /* SocialLoginFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B44446629785BD0007E0AA8 /* SocialLoginFactory.swift */; };
@@ -8996,6 +8997,7 @@
 				C7CE415A28CBCFC200AD063E /* Analytics.swift in Sources */,
 				C7CE415C28CBD01F00AD063E /* String+Analytics.swift in Sources */,
 				46C7BB8827DA60E000CD6AE3 /* DownloadListView.swift in Sources */,
+				8B3C7CA52A4DE36000939DED /* AutoplayHelper.swift in Sources */,
 				BDD301951EFB9A4F004A9972 /* WatchDataManager.swift in Sources */,
 				46703E1427BEF79C00DD7998 /* PreviewHelpers.swift in Sources */,
 				BD38F252253FB0670016713B /* PlaybackCatchUpHelper.swift in Sources */,

--- a/podcasts/AutoplayHelper.swift
+++ b/podcasts/AutoplayHelper.swift
@@ -12,6 +12,7 @@ class AutoplayHelper {
         case starred
     }
 
+    #if !os(watchOS)
     static let shared = AutoplayHelper()
 
     private let userDefaults: UserDefaults
@@ -37,9 +38,7 @@ class AutoplayHelper {
 
     /// Saves the current playlist
     func playedFrom(playlist: Playlist?) {
-        #if !os(watchOS)
         save(selectedPlaylist: playlist)
-        #endif
     }
 
     /// Given the current episode UUID, checks if there's any
@@ -73,4 +72,5 @@ class AutoplayHelper {
         userDefaults.set(data, forKey: userDefaultsKey)
         FileLog.shared.addMessage("Autoplay: saving the latest playlist: \(playlist)")
     }
+    #endif
 }

--- a/podcasts/WatchConstants.swift
+++ b/podcasts/WatchConstants.swift
@@ -125,6 +125,7 @@ public enum WatchConstants {
         enum PlayEpisodeRequest {
             public static let type = "playEpisodeRequest"
             public static let episodeUuid = "uuid"
+            public static let playlist = "playlist"
         }
 
         enum PlayPauseRequest {


### PR DESCRIPTION
Adds Watch (Phone source) support so that episodes played using the Watch are autoplayed depending on whether the user started playing it.

## To test

1. Run this branch on a real phone paired with an Apple Watch
2. Make sure the `autoplay` Feature Flag is enabled and "Continuous Playback" is on (Profile > Settings > General > scroll all the way down)
3. Make sure your Up Next is empty
3. Use the table below as a guide for testing:

| Play an episode from | What should happen after the current episode finishes |
| --------------------- | ------------------------------------------------------ |
| Phone > Filters | The next episode in the filter should play |
| Phone > Downloads | The next downloaded episode should play |
| Phone > Files | The next episode should play |

#### Not Empty Up Next

If your Up Next queue has items the next episode in the Up Next queue should play after the current one finishes.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
