### PR TITLE
Episodes Autoplay: Tracks

### DIFF
--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -224,6 +224,8 @@ enum AnalyticsEvent: String {
     case playbackEffectTrimSilenceAmountChanged
     case playbackEffectVolumeBoostToggled
 
+    case playbackEpisodeAutoplayed
+
     // MARK: - Filters
 
     case filterListShown

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -461,6 +461,7 @@ enum AnalyticsEvent: String {
     case settingsGeneralLegacyBluetoothToggled
     case settingsGeneralMultiSelectGestureToggled
     case settingsGeneralPublishChapterTitlesToggled
+    case settingsGeneralAutoplayToggled
 
     // MARK: - Settings: Notifications
 

--- a/podcasts/GeneralSettingsViewController.swift
+++ b/podcasts/GeneralSettingsViewController.swift
@@ -480,6 +480,9 @@ class GeneralSettingsViewController: UIViewController, UITableViewDelegate, UITa
 
     @objc private func autoplayToggled(_ sender: UISwitch) {
         Settings.autoplay = sender.isOn
+
+
+        Settings.trackValueToggled(.settingsGeneralAutoplayToggled, enabled: sender.isOn)
     }
 
     override var preferredStatusBarStyle: UIStatusBarStyle {

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -1884,6 +1884,7 @@ class PlaybackManager: ServerPlaybackDelegate {
            let nextEpisode = AutoplayHelper.shared.nextEpisode(currentEpisodeUuid: episode.uuid) {
             FileLog.shared.addMessage("Autoplaying next episode: \(nextEpisode.displayableTitle())")
             queue.add(episode: nextEpisode, fireNotification: false)
+            Analytics.track(.playbackEpisodeAutoplayed, properties: ["episode_uuid": nextEpisode.uuid])
         } else {
             // Reset the latest played from
             AutoplayHelper.shared.playedFrom(playlist: nil)


### PR DESCRIPTION
Track the settings and when autoplay is triggered.

## To test

1. Go to Profile > Settings > Beta features > enable `autoplay` and `tracksLogging`
2. Go to Profile > Settings > General
3. Toggle "Autoplay" on/off
4. ✅ You should see `🔵 Tracked: settings_general_autoplay_toggled ["enabled": false]` and `🔵 Tracked: settings_general_autoplay_toggled ["enabled": true]` on the console
5. Leave it enabled
6. Clean your Up Next queue
7. Play any episode from a podcast or filter with more than 1 episode
8. Drag the scrubber all the way to the end
9. When the episode finishes and the next one starts you should see `🔵 Tracked: playback_episode_autoplayed ["episode_uuid": "c08e6e07-44e7-4062-9f98-f023fb69a3a3"]` logged, with the UUID being the UUID from the episode that just started playing

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
