### PR TITLE
What's New: add logic to show it

### DIFF
--- a/PocketCastsTests/Tests/Whats New/WhatsNewTests.swift
+++ b/PocketCastsTests/Tests/Whats New/WhatsNewTests.swift
@@ -37,4 +37,15 @@ class WhatsNewtests: XCTestCase {
 
         XCTAssertTrue(whatsNew.showIfNeeded())
     }
+
+    /// When opening the app for the first time, show nothing
+    func testDontShowWhenFirstOpening() {
+        let whatsNew = WhatsNew(
+            announcements: [.init(version: 7.41, image: "", title: "", message: "")],
+            previousOpenedVersion: nil,
+            currentVersion: 7.41
+        )
+
+        XCTAssertFalse(whatsNew.showIfNeeded())
+    }
 }

--- a/PocketCastsTests/Tests/Whats New/WhatsNewTests.swift
+++ b/PocketCastsTests/Tests/Whats New/WhatsNewTests.swift
@@ -48,4 +48,15 @@ class WhatsNewtests: XCTestCase {
 
         XCTAssertNil(whatsNew.viewControllerToShow())
     }
+
+    // If the announcement is for a futue version, don't show
+    func testDontShowWhenFutureVersion() {
+        let whatsNew = WhatsNew(
+            announcements: [.init(version: 7.50, image: "", title: "", message: "")],
+            previousOpenedVersion: 7.41,
+            currentVersion: 7.41
+        )
+
+        XCTAssertNil(whatsNew.viewControllerToShow())
+    }
 }

--- a/PocketCastsTests/Tests/Whats New/WhatsNewTests.swift
+++ b/PocketCastsTests/Tests/Whats New/WhatsNewTests.swift
@@ -83,6 +83,18 @@ class WhatsNewtests: XCTestCase {
 
         XCTAssertNotNil(whatsNew.viewControllerToShow())
     }
+
+    // If there's an announcement for the current hotfix and the user
+    // has opened this version yet, show what's new
+    func testDontShowWhatsNewForHotfix() {
+        let whatsNew = WhatsNew(
+            announcements: [.init(version: 7.42, image: "", title: "", message: "")],
+            previousOpenedVersion: 7.42,
+            currentVersion: "7.42.1".toDouble()
+        )
+
+        XCTAssertNil(whatsNew.viewControllerToShow())
+    }
 }
 
 extension String {

--- a/PocketCastsTests/Tests/Whats New/WhatsNewTests.swift
+++ b/PocketCastsTests/Tests/Whats New/WhatsNewTests.swift
@@ -49,7 +49,7 @@ class WhatsNewtests: XCTestCase {
         XCTAssertNil(whatsNew.viewControllerToShow())
     }
 
-    // If the announcement is for a futue version, don't show
+    // If the announcement is for a future version, don't show
     func testDontShowWhenFutureVersion() {
         let whatsNew = WhatsNew(
             announcements: [.init(version: 7.50, image: "", title: "", message: "")],

--- a/PocketCastsTests/Tests/Whats New/WhatsNewTests.swift
+++ b/PocketCastsTests/Tests/Whats New/WhatsNewTests.swift
@@ -71,4 +71,22 @@ class WhatsNewtests: XCTestCase {
 
         XCTAssertNil(whatsNew.viewControllerToShow())
     }
+
+    // If there's an announcement for the current hotfix and the user
+    // hasn't opened this version yet, show what's new
+    func testShowWhatsNewForHotfix() {
+        let whatsNew = WhatsNew(
+            announcements: [.init(version: 7.42, image: "", title: "", message: "")],
+            previousOpenedVersion: 7.41,
+            currentVersion: "7.42.1".toDouble()
+        )
+
+        XCTAssertNotNil(whatsNew.viewControllerToShow())
+    }
+}
+
+extension String {
+    func toDouble() -> Double {
+        (self as NSString).doubleValue
+    }
 }

--- a/PocketCastsTests/Tests/Whats New/WhatsNewTests.swift
+++ b/PocketCastsTests/Tests/Whats New/WhatsNewTests.swift
@@ -59,4 +59,16 @@ class WhatsNewtests: XCTestCase {
 
         XCTAssertNil(whatsNew.viewControllerToShow())
     }
+
+    // If there's an announcement for the current version but the user
+    // already opened it, show nothing
+    func testDontShowWhatsNewForTheCurrentOpenedVersion() {
+        let whatsNew = WhatsNew(
+            announcements: [.init(version: 7.41, image: "", title: "", message: "")],
+            previousOpenedVersion: 7.41,
+            currentVersion: 7.41
+        )
+
+        XCTAssertNil(whatsNew.viewControllerToShow())
+    }
 }

--- a/PocketCastsTests/Tests/Whats New/WhatsNewTests.swift
+++ b/PocketCastsTests/Tests/Whats New/WhatsNewTests.swift
@@ -12,7 +12,7 @@ class WhatsNewtests: XCTestCase {
             currentVersion: 7.40
         )
 
-        XCTAssertTrue(whatsNew.showIfNeeded())
+        XCTAssertNotNil(whatsNew.viewControllerToShow())
     }
 
     /// When just opening the same version, do nothing
@@ -23,7 +23,7 @@ class WhatsNewtests: XCTestCase {
             currentVersion: 7.40
         )
 
-        XCTAssertFalse(whatsNew.showIfNeeded())
+        XCTAssertNil(whatsNew.viewControllerToShow())
     }
 
     /// When upgrading from 7.37 to 7.42 and there's a "What's New"
@@ -35,7 +35,7 @@ class WhatsNewtests: XCTestCase {
             currentVersion: 7.42
         )
 
-        XCTAssertTrue(whatsNew.showIfNeeded())
+        XCTAssertNotNil(whatsNew.viewControllerToShow())
     }
 
     /// When opening the app for the first time, show nothing
@@ -46,6 +46,6 @@ class WhatsNewtests: XCTestCase {
             currentVersion: 7.41
         )
 
-        XCTAssertFalse(whatsNew.showIfNeeded())
+        XCTAssertNil(whatsNew.viewControllerToShow())
     }
 }

--- a/PocketCastsTests/Tests/Whats New/WhatsNewTests.swift
+++ b/PocketCastsTests/Tests/Whats New/WhatsNewTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+
+@testable import podcasts
+
+class WhatsNewtests: XCTestCase {
+    /// When upgrading from 7.39 to 7.40 and there's a "What's New"
+    /// for 7.40, show it
+    func testShowWhatsNew() {
+        let whatsNew = WhatsNew(
+            announcements: [.init(version: 7.40, image: "", title: "", message: "")],
+            previousOpenedVersion: 7.39,
+            currentVersion: 7.40
+        )
+
+        XCTAssertTrue(whatsNew.showIfNeeded())
+    }
+
+    /// When just opening the same version, do nothing
+    func testDontShowWhatsNew() {
+        let whatsNew = WhatsNew(
+            announcements: [.init(version: 7.39, image: "", title: "", message: "")],
+            previousOpenedVersion: 7.40,
+            currentVersion: 7.40
+        )
+
+        XCTAssertFalse(whatsNew.showIfNeeded())
+    }
+
+    /// When upgrading from 7.37 to 7.42 and there's a "What's New"
+    /// for 7.41, show it
+    func testShowWhatsNewEvenIfVersionDontMatch() {
+        let whatsNew = WhatsNew(
+            announcements: [.init(version: 7.41, image: "", title: "", message: "")],
+            previousOpenedVersion: 7.37,
+            currentVersion: 7.42
+        )
+
+        XCTAssertTrue(whatsNew.showIfNeeded())
+    }
+}

--- a/PocketCastsTests/Tests/Whats New/WhatsNewTests.swift
+++ b/PocketCastsTests/Tests/Whats New/WhatsNewTests.swift
@@ -8,8 +8,8 @@ class WhatsNewtests: XCTestCase {
     func testShowWhatsNew() {
         let whatsNew = WhatsNew(
             announcements: [.init(version: 7.40, image: "", title: "", message: "")],
-            previousOpenedVersion: 7.39,
-            currentVersion: 7.40
+            previousOpenedVersion: "7.39",
+            currentVersion: "7.40"
         )
 
         XCTAssertNotNil(whatsNew.viewControllerToShow())
@@ -19,8 +19,8 @@ class WhatsNewtests: XCTestCase {
     func testDontShowWhatsNew() {
         let whatsNew = WhatsNew(
             announcements: [.init(version: 7.39, image: "", title: "", message: "")],
-            previousOpenedVersion: 7.40,
-            currentVersion: 7.40
+            previousOpenedVersion: "7.40",
+            currentVersion: "7.40"
         )
 
         XCTAssertNil(whatsNew.viewControllerToShow())
@@ -31,8 +31,8 @@ class WhatsNewtests: XCTestCase {
     func testShowWhatsNewEvenIfVersionDontMatch() {
         let whatsNew = WhatsNew(
             announcements: [.init(version: 7.41, image: "", title: "", message: "")],
-            previousOpenedVersion: 7.37,
-            currentVersion: 7.42
+            previousOpenedVersion: "7.37",
+            currentVersion: "7.42"
         )
 
         XCTAssertNotNil(whatsNew.viewControllerToShow())
@@ -43,7 +43,7 @@ class WhatsNewtests: XCTestCase {
         let whatsNew = WhatsNew(
             announcements: [.init(version: 7.41, image: "", title: "", message: "")],
             previousOpenedVersion: nil,
-            currentVersion: 7.41
+            currentVersion: "7.41"
         )
 
         XCTAssertNil(whatsNew.viewControllerToShow())
@@ -53,8 +53,8 @@ class WhatsNewtests: XCTestCase {
     func testDontShowWhenFutureVersion() {
         let whatsNew = WhatsNew(
             announcements: [.init(version: 7.50, image: "", title: "", message: "")],
-            previousOpenedVersion: 7.41,
-            currentVersion: 7.41
+            previousOpenedVersion: "7.41",
+            currentVersion: "7.41"
         )
 
         XCTAssertNil(whatsNew.viewControllerToShow())
@@ -65,8 +65,8 @@ class WhatsNewtests: XCTestCase {
     func testDontShowWhatsNewForTheCurrentOpenedVersion() {
         let whatsNew = WhatsNew(
             announcements: [.init(version: 7.41, image: "", title: "", message: "")],
-            previousOpenedVersion: 7.41,
-            currentVersion: 7.41
+            previousOpenedVersion: "7.41",
+            currentVersion: "7.41"
         )
 
         XCTAssertNil(whatsNew.viewControllerToShow())
@@ -77,8 +77,8 @@ class WhatsNewtests: XCTestCase {
     func testShowWhatsNewForHotfix() {
         let whatsNew = WhatsNew(
             announcements: [.init(version: 7.42, image: "", title: "", message: "")],
-            previousOpenedVersion: 7.41,
-            currentVersion: "7.42.1".toDouble()
+            previousOpenedVersion: "7.41",
+            currentVersion: "7.42.1"
         )
 
         XCTAssertNotNil(whatsNew.viewControllerToShow())
@@ -89,8 +89,8 @@ class WhatsNewtests: XCTestCase {
     func testDontShowWhatsNewForHotfix() {
         let whatsNew = WhatsNew(
             announcements: [.init(version: 7.42, image: "", title: "", message: "")],
-            previousOpenedVersion: 7.42,
-            currentVersion: "7.42.1".toDouble()
+            previousOpenedVersion: "7.42",
+            currentVersion: "7.42.1"
         )
 
         XCTAssertNil(whatsNew.viewControllerToShow())

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -478,6 +478,8 @@
 		8B317BA528906CAB00A26A13 /* TestingSceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B317BA428906CAB00A26A13 /* TestingSceneDelegate.swift */; };
 		8B317BA728906CC200A26A13 /* TestingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B317BA628906CC200A26A13 /* TestingViewController.swift */; };
 		8B317BA92890704400A26A13 /* TestingScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8B317BA82890704400A26A13 /* TestingScreen.storyboard */; };
+		8B3295402A5333C900BDFA11 /* WhatsNew.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B32953F2A5333C900BDFA11 /* WhatsNew.swift */; };
+		8B3295432A5336DA00BDFA11 /* WhatsNewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B3295422A5336DA00BDFA11 /* WhatsNewTests.swift */; };
 		8B3654172926C13000FD7216 /* CircularProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B3654162926C13000FD7216 /* CircularProgressView.swift */; };
 		8B3C7CA52A4DE36000939DED /* AutoplayHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B472E012A4B83CE005905F4 /* AutoplayHelper.swift */; };
 		8B44446229785287007E0AA8 /* AppleSocialLogin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B44446129785287007E0AA8 /* AppleSocialLogin.swift */; };
@@ -2196,6 +2198,8 @@
 		8B317BA428906CAB00A26A13 /* TestingSceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestingSceneDelegate.swift; sourceTree = "<group>"; };
 		8B317BA628906CC200A26A13 /* TestingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestingViewController.swift; sourceTree = "<group>"; };
 		8B317BA82890704400A26A13 /* TestingScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = TestingScreen.storyboard; sourceTree = "<group>"; };
+		8B32953F2A5333C900BDFA11 /* WhatsNew.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhatsNew.swift; sourceTree = "<group>"; };
+		8B3295422A5336DA00BDFA11 /* WhatsNewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhatsNewTests.swift; sourceTree = "<group>"; };
 		8B3654162926C13000FD7216 /* CircularProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircularProgressView.swift; sourceTree = "<group>"; };
 		8B44446129785287007E0AA8 /* AppleSocialLogin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleSocialLogin.swift; sourceTree = "<group>"; };
 		8B44446329785947007E0AA8 /* SocialLogin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialLogin.swift; sourceTree = "<group>"; };
@@ -4027,6 +4031,22 @@
 			path = Helpers;
 			sourceTree = "<group>";
 		};
+		8B32953E2A5333B000BDFA11 /* Whats New */ = {
+			isa = PBXGroup;
+			children = (
+				8B32953F2A5333C900BDFA11 /* WhatsNew.swift */,
+			);
+			path = "Whats New";
+			sourceTree = "<group>";
+		};
+		8B3295412A5336C600BDFA11 /* Whats New */ = {
+			isa = PBXGroup;
+			children = (
+				8B3295422A5336DA00BDFA11 /* WhatsNewTests.swift */,
+			);
+			path = "Whats New";
+			sourceTree = "<group>";
+		};
 		8B47542C28D36D5800BC89F7 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
@@ -4037,6 +4057,7 @@
 				8B14E3B129BA43840069B6F2 /* New Search */,
 				8BF0BBCF28918B36006BBECF /* Podcasts */,
 				8BF1C61B2881F049007E80BF /* Folders */,
+				8B3295412A5336C600BDFA11 /* Whats New */,
 				2F63CE9428809E5A00A34B51 /* ThemeTests.swift */,
 				45ECEF8527E910FB00C65030 /* ShowNotesFormatterUtilsTests.swift */,
 				C79E1E3F28887549008524CB /* PlusUpgradeViewSourceTests.swift */,
@@ -4242,6 +4263,7 @@
 				8BE36DCA28734F7000E35313 /* DataModel */,
 				8BE36DCC28734F7000E35313 /* Server */,
 				8BE36DCB28734F7000E35313 /* Utils */,
+				8B32953E2A5333B000BDFA11 /* Whats New */,
 			);
 			name = Modules;
 			sourceTree = "<group>";
@@ -8152,6 +8174,7 @@
 				C7F4BAB728DA8666001C9785 /* BackgroundSignOutListenerTests.swift in Sources */,
 				8B484EFF28D257E2001AFA97 /* DataManagerMock.swift in Sources */,
 				8B484EF928D256F5001AFA97 /* Date+Ext.swift in Sources */,
+				8B3295432A5336DA00BDFA11 /* WhatsNewTests.swift in Sources */,
 				8B484EF728D23F06001AFA97 /* PlaybackTimeHelperTests.swift in Sources */,
 				45ECEF8627E910FB00C65030 /* ShowNotesFormatterUtilsTests.swift in Sources */,
 				2F63CE9528809E5B00A34B51 /* ThemeTests.swift in Sources */,
@@ -8505,6 +8528,7 @@
 				BD2F592A20468C6700AD3767 /* CustomObserver.swift in Sources */,
 				BDD62979200ECCBB00168DF7 /* EpisodeDetailViewController+ShowNotes.swift in Sources */,
 				BDD832AF214B8A8B0013D692 /* PCGoogleCastButton.swift in Sources */,
+				8B3295402A5333C900BDFA11 /* WhatsNew.swift in Sources */,
 				4573899A285BBAD500D4FE6C /* ColorSelectRow.swift in Sources */,
 				BD1C46D927B9DD8C00B1D8BB /* FolderGridCell.swift in Sources */,
 				BDD84CE327CC8EDE001C078B /* ChoosePodcastFolderView.swift in Sources */,

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -480,6 +480,7 @@
 		8B317BA92890704400A26A13 /* TestingScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8B317BA82890704400A26A13 /* TestingScreen.storyboard */; };
 		8B3295402A5333C900BDFA11 /* WhatsNew.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B32953F2A5333C900BDFA11 /* WhatsNew.swift */; };
 		8B3295432A5336DA00BDFA11 /* WhatsNewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B3295422A5336DA00BDFA11 /* WhatsNewTests.swift */; };
+		8B3295462A534E5A00BDFA11 /* Announcements.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B3295442A534CA800BDFA11 /* Announcements.swift */; };
 		8B3654172926C13000FD7216 /* CircularProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B3654162926C13000FD7216 /* CircularProgressView.swift */; };
 		8B3C7CA52A4DE36000939DED /* AutoplayHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B472E012A4B83CE005905F4 /* AutoplayHelper.swift */; };
 		8B44446229785287007E0AA8 /* AppleSocialLogin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B44446129785287007E0AA8 /* AppleSocialLogin.swift */; };
@@ -2200,6 +2201,7 @@
 		8B317BA82890704400A26A13 /* TestingScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = TestingScreen.storyboard; sourceTree = "<group>"; };
 		8B32953F2A5333C900BDFA11 /* WhatsNew.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhatsNew.swift; sourceTree = "<group>"; };
 		8B3295422A5336DA00BDFA11 /* WhatsNewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhatsNewTests.swift; sourceTree = "<group>"; };
+		8B3295442A534CA800BDFA11 /* Announcements.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Announcements.swift; sourceTree = "<group>"; };
 		8B3654162926C13000FD7216 /* CircularProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircularProgressView.swift; sourceTree = "<group>"; };
 		8B44446129785287007E0AA8 /* AppleSocialLogin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleSocialLogin.swift; sourceTree = "<group>"; };
 		8B44446329785947007E0AA8 /* SocialLogin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialLogin.swift; sourceTree = "<group>"; };
@@ -4034,6 +4036,7 @@
 		8B32953E2A5333B000BDFA11 /* Whats New */ = {
 			isa = PBXGroup;
 			children = (
+				8B3295442A534CA800BDFA11 /* Announcements.swift */,
 				8B32953F2A5333C900BDFA11 /* WhatsNew.swift */,
 			);
 			path = "Whats New";
@@ -8421,6 +8424,7 @@
 				BD83DE082068B7A100012C06 /* MiniPlayerViewController.swift in Sources */,
 				408ADBCA22B1D6A900E10AE6 /* OptionsPickerHelper.swift in Sources */,
 				BD22DF0B1BB7911F005FFA28 /* ShortcutManager.swift in Sources */,
+				8B3295462A534E5A00BDFA11 /* Announcements.swift in Sources */,
 				8B6B68E928F7527C0032BFFF /* StoryIndicator.swift in Sources */,
 				BDF15A421B54E088000EC323 /* EffectsPlayer.swift in Sources */,
 				BD2A8D701FD50AEA00EB485A /* SwipeActionsHelper.swift in Sources */,

--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -26,12 +26,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     private var backgroundSignOutListener: BackgroundSignOutListener?
 
+    var whatsNew: WhatsNew?
+
     // MARK: - App Lifecycle
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
         configureFirebase()
         TraceManager.shared.setup(handler: traceHandler)
         FileLog.shared.setup()
+
+        setupWhatsNew()
 
         setupSecrets()
         setupAnalytics()
@@ -355,5 +359,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
 
         backgroundSignOutListener = BackgroundSignOutListener(presentingViewController: rootController)
+    }
+
+    // MARK: What's New
+
+    private func setupWhatsNew() {
+        whatsNew = WhatsNew()
     }
 }

--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -63,6 +63,7 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
 
         endOfYear.showPromptBasedOnState(in: self)
         showInitialOnboardingIfNeeded()
+        showWhatsNewIfNeeded()
     }
 
     private func showInitialOnboardingIfNeeded() {
@@ -559,6 +560,14 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
         let giftDays = SubscriptionHelper.subscriptionGiftDays()
         let timeToSubscriptionExpiry = SubscriptionHelper.timeToSubscriptionExpiry() ?? 0
         if giftDays > 0, !promoFinishedAcknowledged, timeToSubscriptionExpiry < 0 { NavigationManager.sharedManager.navigateTo(NavigationManager.showPromotionFinishedPageKey, data: nil)
+        }
+    }
+
+    // MARK: - What's New
+
+    func showWhatsNewIfNeeded() {
+        if let whatsNewViewController = appDelegate()?.whatsNew?.viewControllerToShow() {
+            present(whatsNewViewController, animated: true)
         }
     }
 }

--- a/podcasts/Whats New/Announcements.swift
+++ b/podcasts/Whats New/Announcements.swift
@@ -4,7 +4,7 @@ struct Announcements {
     // Order is important.
     // In the case a user migrates to, let's say, 7.10 to 7.15 and
     // there were two announcements, the last one will be picked.
-    var announcements: [WhatsNewAnnouncement] = [
+    var announcements: [WhatsNew.Announcement] = [
         .init(
             version: 7.80,
             image: "",

--- a/podcasts/Whats New/Announcements.swift
+++ b/podcasts/Whats New/Announcements.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+struct Announcements {
+    // Order is important.
+    // In the case a user migrates to, let's say, 7.10 to 7.15 and
+    // there were two announcements, the last one will be picked.
+    var announcements: [WhatsNewAnnouncement] = [
+        .init(
+            version: 7.80,
+            image: "",
+            title: "",
+            message: ""
+        )
+    ]
+}

--- a/podcasts/Whats New/WhatsNew.swift
+++ b/podcasts/Whats New/WhatsNew.swift
@@ -20,6 +20,7 @@ class WhatsNew {
 
     func viewControllerToShow() -> UIViewController? {
         guard let previousOpenedVersion,
+              previousOpenedVersion != currentVersion,
               let announcement = announcements.last(where: { $0.version >= previousOpenedVersion && $0.version <= currentVersion }) else {
             return nil
         }

--- a/podcasts/Whats New/WhatsNew.swift
+++ b/podcasts/Whats New/WhatsNew.swift
@@ -12,7 +12,7 @@ class WhatsNew {
     let currentVersion: Double
     let previousOpenedVersion: Double?
 
-    init(announcements: [WhatsNewAnnouncement], previousOpenedVersion: Double?, currentVersion: Double) {
+    init(announcements: [WhatsNewAnnouncement] = Announcements().announcements, previousOpenedVersion: Double? = UserDefaults.standard.string(forKey: Constants.UserDefaults.lastRunVersion)?.toDouble(), currentVersion: Double = Settings.appVersion().toDouble()) {
         self.announcements = announcements
         self.previousOpenedVersion = previousOpenedVersion
         self.currentVersion = currentVersion
@@ -20,7 +20,7 @@ class WhatsNew {
 
     func viewControllerToShow() -> UIViewController? {
         guard let previousOpenedVersion,
-              let announcement = announcements.filter { $0.version >= previousOpenedVersion }.last else {
+              let announcement = announcements.filter { $0.version >= previousOpenedVersion && $0.version <= currentVersion }.last else {
             return nil
         }
 

--- a/podcasts/Whats New/WhatsNew.swift
+++ b/podcasts/Whats New/WhatsNew.swift
@@ -21,7 +21,7 @@ class WhatsNew {
     func viewControllerToShow() -> UIViewController? {
         guard let previousOpenedVersion,
               previousOpenedVersion != currentVersion,
-              let announcement = announcements.last(where: { $0.version >= previousOpenedVersion && $0.version <= currentVersion }) else {
+              let announcement = announcements.last(where: { $0.version > previousOpenedVersion && $0.version <= currentVersion }) else {
             return nil
         }
 

--- a/podcasts/Whats New/WhatsNew.swift
+++ b/podcasts/Whats New/WhatsNew.swift
@@ -18,12 +18,12 @@ class WhatsNew {
         self.currentVersion = currentVersion
     }
 
-    func showIfNeeded() -> Bool {
+    func viewControllerToShow() -> UIViewController? {
         guard let previousOpenedVersion,
               let announcement = announcements.filter { $0.version >= previousOpenedVersion }.last else {
-            return false
+            return nil
         }
 
-        return true
+        return UIViewController()
     }
 }

--- a/podcasts/Whats New/WhatsNew.swift
+++ b/podcasts/Whats New/WhatsNew.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+struct WhatsNewAnnouncement {
+    let version: Double
+    let image: String
+    let title: String
+    let message: String
+}
+
+class WhatsNew {
+    let announcements: [WhatsNewAnnouncement]
+    let currentVersion: Double
+    let previousOpenedVersion: Double
+
+    init(announcements: [WhatsNewAnnouncement], previousOpenedVersion: Double, currentVersion: Double) {
+        self.announcements = announcements
+        self.previousOpenedVersion = previousOpenedVersion
+        self.currentVersion = currentVersion
+    }
+
+    func showIfNeeded() -> Bool {
+        guard let announcement = announcements.filter { $0.version >= previousOpenedVersion }.last else {
+            return false
+        }
+
+        return true
+    }
+}

--- a/podcasts/Whats New/WhatsNew.swift
+++ b/podcasts/Whats New/WhatsNew.swift
@@ -12,10 +12,10 @@ class WhatsNew {
     let currentVersion: Double
     let previousOpenedVersion: Double?
 
-    init(announcements: [Announcement] = Announcements().announcements, previousOpenedVersion: Double? = UserDefaults.standard.string(forKey: Constants.UserDefaults.lastRunVersion)?.toDouble(), currentVersion: Double = Settings.appVersion().toDouble()) {
+    init(announcements: [Announcement] = Announcements().announcements, previousOpenedVersion: String? = UserDefaults.standard.string(forKey: Constants.UserDefaults.lastRunVersion), currentVersion: String = Settings.appVersion()) {
         self.announcements = announcements
-        self.previousOpenedVersion = previousOpenedVersion
-        self.currentVersion = currentVersion
+        self.previousOpenedVersion = previousOpenedVersion?.toDouble()
+        self.currentVersion = currentVersion.toDouble()
     }
 
     func viewControllerToShow() -> UIViewController? {

--- a/podcasts/Whats New/WhatsNew.swift
+++ b/podcasts/Whats New/WhatsNew.swift
@@ -10,16 +10,17 @@ struct WhatsNewAnnouncement {
 class WhatsNew {
     let announcements: [WhatsNewAnnouncement]
     let currentVersion: Double
-    let previousOpenedVersion: Double
+    let previousOpenedVersion: Double?
 
-    init(announcements: [WhatsNewAnnouncement], previousOpenedVersion: Double, currentVersion: Double) {
+    init(announcements: [WhatsNewAnnouncement], previousOpenedVersion: Double?, currentVersion: Double) {
         self.announcements = announcements
         self.previousOpenedVersion = previousOpenedVersion
         self.currentVersion = currentVersion
     }
 
     func showIfNeeded() -> Bool {
-        guard let announcement = announcements.filter { $0.version >= previousOpenedVersion }.last else {
+        guard let previousOpenedVersion,
+              let announcement = announcements.filter { $0.version >= previousOpenedVersion }.last else {
             return false
         }
 

--- a/podcasts/Whats New/WhatsNew.swift
+++ b/podcasts/Whats New/WhatsNew.swift
@@ -20,7 +20,7 @@ class WhatsNew {
 
     func viewControllerToShow() -> UIViewController? {
         guard let previousOpenedVersion,
-              let announcement = announcements.filter { $0.version >= previousOpenedVersion && $0.version <= currentVersion }.last else {
+              let announcement = announcements.last(where: { $0.version >= previousOpenedVersion && $0.version <= currentVersion }) else {
             return nil
         }
 

--- a/podcasts/Whats New/WhatsNew.swift
+++ b/podcasts/Whats New/WhatsNew.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-struct WhatsNewAnnouncement {
-    let version: Double
-    let image: String
-    let title: String
-    let message: String
-}
-
 class WhatsNew {
-    let announcements: [WhatsNewAnnouncement]
+    struct Announcement {
+        let version: Double
+        let image: String
+        let title: String
+        let message: String
+    }
+
+    let announcements: [Announcement]
     let currentVersion: Double
     let previousOpenedVersion: Double?
 
-    init(announcements: [WhatsNewAnnouncement] = Announcements().announcements, previousOpenedVersion: Double? = UserDefaults.standard.string(forKey: Constants.UserDefaults.lastRunVersion)?.toDouble(), currentVersion: Double = Settings.appVersion().toDouble()) {
+    init(announcements: [Announcement] = Announcements().announcements, previousOpenedVersion: Double? = UserDefaults.standard.string(forKey: Constants.UserDefaults.lastRunVersion)?.toDouble(), currentVersion: Double = Settings.appVersion().toDouble()) {
         self.announcements = announcements
         self.previousOpenedVersion = previousOpenedVersion
         self.currentVersion = currentVersion


### PR DESCRIPTION
Adds logic to show a new "What's New". We currently have code for the current What's New but this one differs in design and I'd like to have i18n as part of it. So reusing a few pieces of information we already have on the app I came up with this solution.

Designs are not part of this task and it will be covered in future tasks.

## To test

1. Review the code
2. Make sure CI is happy green

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
