### PR TITLE
What's New: add view

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -481,6 +481,7 @@
 		8B3295402A5333C900BDFA11 /* WhatsNew.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B32953F2A5333C900BDFA11 /* WhatsNew.swift */; };
 		8B3295432A5336DA00BDFA11 /* WhatsNewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B3295422A5336DA00BDFA11 /* WhatsNewTests.swift */; };
 		8B3295462A534E5A00BDFA11 /* Announcements.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B3295442A534CA800BDFA11 /* Announcements.swift */; };
+		8B3295492A5357A100BDFA11 /* WhatsNewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B3295472A53576600BDFA11 /* WhatsNewView.swift */; };
 		8B3654172926C13000FD7216 /* CircularProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B3654162926C13000FD7216 /* CircularProgressView.swift */; };
 		8B3C7CA52A4DE36000939DED /* AutoplayHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B472E012A4B83CE005905F4 /* AutoplayHelper.swift */; };
 		8B44446229785287007E0AA8 /* AppleSocialLogin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B44446129785287007E0AA8 /* AppleSocialLogin.swift */; };
@@ -2202,6 +2203,7 @@
 		8B32953F2A5333C900BDFA11 /* WhatsNew.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhatsNew.swift; sourceTree = "<group>"; };
 		8B3295422A5336DA00BDFA11 /* WhatsNewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhatsNewTests.swift; sourceTree = "<group>"; };
 		8B3295442A534CA800BDFA11 /* Announcements.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Announcements.swift; sourceTree = "<group>"; };
+		8B3295472A53576600BDFA11 /* WhatsNewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhatsNewView.swift; sourceTree = "<group>"; };
 		8B3654162926C13000FD7216 /* CircularProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircularProgressView.swift; sourceTree = "<group>"; };
 		8B44446129785287007E0AA8 /* AppleSocialLogin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleSocialLogin.swift; sourceTree = "<group>"; };
 		8B44446329785947007E0AA8 /* SocialLogin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialLogin.swift; sourceTree = "<group>"; };
@@ -4038,6 +4040,7 @@
 			children = (
 				8B3295442A534CA800BDFA11 /* Announcements.swift */,
 				8B32953F2A5333C900BDFA11 /* WhatsNew.swift */,
+				8B3295472A53576600BDFA11 /* WhatsNewView.swift */,
 			);
 			path = "Whats New";
 			sourceTree = "<group>";
@@ -8788,6 +8791,7 @@
 				C713D4F62A04C90500A78468 /* AccountHeaderView.swift in Sources */,
 				8B0EEDEA2900990D00075772 /* LongestEpisodeStory.swift in Sources */,
 				BD42E31A1B940AFF000EA14F /* DiscoverPodcastTableCell.swift in Sources */,
+				8B3295492A5357A100BDFA11 /* WhatsNewView.swift in Sources */,
 				8BFB434E2A1FFB4B00F3D409 /* StatusPageViewModel.swift in Sources */,
 				4006E31123A88AE600174DEB /* ExpandedCollectionViewController.swift in Sources */,
 				C72223D6292CAE92006B3B55 /* OnboardingFlow.swift in Sources */,

--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -566,8 +566,10 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
     // MARK: - What's New
 
     func showWhatsNewIfNeeded() {
+        guard let controller = view.window?.rootViewController else { return }
+
         if let whatsNewViewController = appDelegate()?.whatsNew?.viewControllerToShow() {
-            present(whatsNewViewController, animated: true)
+            controller.present(whatsNewViewController, animated: true)
         }
     }
 }

--- a/podcasts/Whats New/WhatsNew.swift
+++ b/podcasts/Whats New/WhatsNew.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SwiftUI
 
 struct WhatsNewAnnouncement {
     let version: Double
@@ -24,6 +25,11 @@ class WhatsNew {
             return nil
         }
 
-        return UIViewController()
+        let whatsNewViewController = ThemedHostingController(rootView: WhatsNewView())
+        whatsNewViewController.modalPresentationStyle = .overCurrentContext
+        whatsNewViewController.modalTransitionStyle = .crossDissolve
+        whatsNewViewController.view.backgroundColor = .init(red: 0, green: 0, blue: 0, alpha: 0.5)
+
+        return whatsNewViewController
     }
 }

--- a/podcasts/Whats New/WhatsNew.swift
+++ b/podcasts/Whats New/WhatsNew.swift
@@ -21,11 +21,11 @@ class WhatsNew {
 
     func viewControllerToShow() -> UIViewController? {
         guard let previousOpenedVersion,
-              let announcement = announcements.filter { $0.version >= previousOpenedVersion && $0.version <= currentVersion }.last else {
+              let announcement = announcements.filter({ $0.version >= previousOpenedVersion && $0.version <= currentVersion }).last else {
             return nil
         }
 
-        let whatsNewViewController = ThemedHostingController(rootView: WhatsNewView())
+        let whatsNewViewController = ThemedHostingController(rootView: WhatsNewView(announcement: announcement))
         whatsNewViewController.modalPresentationStyle = .overCurrentContext
         whatsNewViewController.modalTransitionStyle = .crossDissolve
         whatsNewViewController.view.backgroundColor = .init(red: 0, green: 0, blue: 0, alpha: 0.5)

--- a/podcasts/Whats New/WhatsNewView.swift
+++ b/podcasts/Whats New/WhatsNewView.swift
@@ -40,7 +40,7 @@ struct WhatsNewView: View {
                 .padding(.bottom)
         }
         .frame(width: 340)
-        .background(.white)
+        .background(theme.primaryUi01)
         .cornerRadius(5)
     }
 }

--- a/podcasts/Whats New/WhatsNewView.swift
+++ b/podcasts/Whats New/WhatsNewView.swift
@@ -31,7 +31,7 @@ struct WhatsNewView: View {
                 .foregroundColor(theme.primaryText01)
             Text(announcement.message)
                 .font(style: .subheadline)
-                .foregroundColor(theme.secondaryText02)
+                .foregroundStyle(theme.primaryText02)
                 .padding(.horizontal)
                 .padding(.bottom)
             Button("Enable it") {}

--- a/podcasts/Whats New/WhatsNewView.swift
+++ b/podcasts/Whats New/WhatsNewView.swift
@@ -25,10 +25,10 @@ struct WhatsNewView: View {
             VStack(spacing: 10) {
                 Text(announcement.title)
                     .font(style: .title3, weight: .bold)
-                    .foregroundColor(theme.primaryText01)
+                    .foregroundStyle(theme.primaryText01)
                 Text(announcement.message)
                     .font(style: .subheadline)
-                    .foregroundColor(theme.secondaryText02)
+                    .foregroundStyle(theme.secondaryText02)
                     .padding(.bottom)
                 Button("Enable it") { }
                     .buttonStyle(RoundedDarkButton(theme: theme))

--- a/podcasts/Whats New/WhatsNewView.swift
+++ b/podcasts/Whats New/WhatsNewView.swift
@@ -27,11 +27,13 @@ struct WhatsNewView: View {
             Text(announcement.title)
                 .font(style: .title3, weight: .bold)
                 .padding(.horizontal)
+                .padding(.top)
                 .foregroundColor(theme.primaryText01)
             Text(announcement.message)
                 .font(style: .subheadline)
                 .foregroundColor(theme.secondaryText02)
                 .padding(.horizontal)
+                .padding(.bottom)
             Button("Enable it") {}
                 .buttonStyle(RoundedDarkButton(theme: theme))
                 .padding(.horizontal)

--- a/podcasts/Whats New/WhatsNewView.swift
+++ b/podcasts/Whats New/WhatsNewView.swift
@@ -22,20 +22,18 @@ struct WhatsNewView: View {
                     .frame(width: 44, height: 44)
                 }
             }
-            Text(announcement.title)
-                .font(style: .title3, weight: .bold)
-                .padding(.horizontal)
-                .padding(.top)
-                .foregroundColor(theme.primaryText01)
-            Text(announcement.message)
-                .font(style: .subheadline)
-                .foregroundStyle(theme.primaryText02)
-                .padding(.horizontal)
-                .padding(.bottom)
-            Button("Enable it") {}
-                .buttonStyle(RoundedDarkButton(theme: theme))
-                .padding(.horizontal)
-                .padding(.bottom)
+            VStack(spacing: 10) {
+                Text(announcement.title)
+                    .font(style: .title3, weight: .bold)
+                    .foregroundColor(theme.primaryText01)
+                Text(announcement.message)
+                    .font(style: .subheadline)
+                    .foregroundColor(theme.secondaryText02)
+                    .padding(.bottom)
+                Button("Enable it") { }
+                    .buttonStyle(RoundedDarkButton(theme: theme))
+            }
+            .padding()
         }
         .frame(minWidth: 300, maxWidth: 340)
         .background(theme.primaryUi01)

--- a/podcasts/Whats New/WhatsNewView.swift
+++ b/podcasts/Whats New/WhatsNewView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct WhatsNewView: View {
-    var theme: Theme = .sharedTheme
+    @EnvironmentObject var theme: Theme
 
     var body: some View {
         VStack(spacing: 10) {

--- a/podcasts/Whats New/WhatsNewView.swift
+++ b/podcasts/Whats New/WhatsNewView.swift
@@ -18,7 +18,7 @@ struct WhatsNewView: View {
                     } label: {
                         ZStack {
                             Image("close")
-                                .foregroundColor(.white)
+                                .foregroundStyle(.white)
                         }
                         .frame(width: 44, height: 44)
                     }

--- a/podcasts/Whats New/WhatsNewView.swift
+++ b/podcasts/Whats New/WhatsNewView.swift
@@ -7,21 +7,19 @@ struct WhatsNewView: View {
 
     var body: some View {
         VStack(spacing: 10) {
-            ZStack(alignment: .top) {
+            ZStack(alignment: .topTrailing) {
                 Rectangle()
                     .frame(height: 195)
 
-                HStack {
-                    Spacer()
-                    Button {
-                        NavigationManager.sharedManager.dismissPresentedViewController()
-                    } label: {
-                        ZStack {
-                            Image("close")
-                                .foregroundStyle(.white)
-                        }
-                        .frame(width: 44, height: 44)
+                Spacer()
+                Button {
+                    NavigationManager.sharedManager.dismissPresentedViewController()
+                } label: {
+                    ZStack {
+                        Image("close")
+                            .foregroundStyle(.white)
                     }
+                    .frame(width: 44, height: 44)
                 }
             }
             Text(announcement.title)

--- a/podcasts/Whats New/WhatsNewView.swift
+++ b/podcasts/Whats New/WhatsNewView.swift
@@ -11,7 +11,6 @@ struct WhatsNewView: View {
                 Rectangle()
                     .frame(height: 195)
 
-                Spacer()
                 Button {
                     NavigationManager.sharedManager.dismissPresentedViewController()
                 } label: {
@@ -28,7 +27,7 @@ struct WhatsNewView: View {
                     .foregroundStyle(theme.primaryText01)
                 Text(announcement.message)
                     .font(style: .subheadline)
-                    .foregroundStyle(theme.secondaryText02)
+                    .foregroundStyle(theme.primaryText02)
                     .padding(.bottom)
                 Button("Enable it") { }
                     .buttonStyle(RoundedDarkButton(theme: theme))

--- a/podcasts/Whats New/WhatsNewView.swift
+++ b/podcasts/Whats New/WhatsNewView.swift
@@ -14,7 +14,7 @@ struct WhatsNewView: View {
                 HStack {
                     Spacer()
                     Button {
-
+                        NavigationManager.sharedManager.dismissPresentedViewController()
                     } label: {
                         ZStack {
                             Image("close")

--- a/podcasts/Whats New/WhatsNewView.swift
+++ b/podcasts/Whats New/WhatsNewView.swift
@@ -3,6 +3,8 @@ import SwiftUI
 struct WhatsNewView: View {
     @EnvironmentObject var theme: Theme
 
+    let announcement: WhatsNewAnnouncement
+
     var body: some View {
         VStack(spacing: 10) {
             ZStack(alignment: .top) {
@@ -22,11 +24,11 @@ struct WhatsNewView: View {
                     }
                 }
             }
-            Text("Autoplay is here!")
+            Text(announcement.title)
                 .font(style: .title3, weight: .bold)
                 .padding(.horizontal)
                 .foregroundColor(theme.primaryText01)
-            Text("If your Up Next queue is empty, Pocket Casts can autoplay episodes from the list you started playing it — either a specific podcast, a filter, downloaded episodes or your own files.")
+            Text(announcement.message)
                 .font(style: .subheadline)
                 .foregroundColor(theme.secondaryText02)
                 .padding(.horizontal)
@@ -43,7 +45,7 @@ struct WhatsNewView: View {
 
 struct WhatsNewView_Previews: PreviewProvider {
     static var previews: some View {
-        WhatsNewView()
+        WhatsNewView(announcement: .init(version: 7.20, image: "", title: "Autoplay is here!", message: "If your Up Next queue is empty, Pocket Casts can autoplay episodes from the list you started playing it — either a specific podcast, a filter, downloaded episodes or your own files."))
             .environmentObject(Theme(previewTheme: .light))
     }
 }

--- a/podcasts/Whats New/WhatsNewView.swift
+++ b/podcasts/Whats New/WhatsNewView.swift
@@ -39,9 +39,10 @@ struct WhatsNewView: View {
                 .padding(.horizontal)
                 .padding(.bottom)
         }
-        .frame(width: 340)
+        .frame(minWidth: 300, maxWidth: 340)
         .background(theme.primaryUi01)
         .cornerRadius(5)
+        .padding()
     }
 }
 

--- a/podcasts/Whats New/WhatsNewView.swift
+++ b/podcasts/Whats New/WhatsNewView.swift
@@ -1,0 +1,49 @@
+import SwiftUI
+
+struct WhatsNewView: View {
+    var theme: Theme = .sharedTheme
+
+    var body: some View {
+        VStack(spacing: 10) {
+            ZStack(alignment: .top) {
+                Rectangle()
+                    .frame(height: 195)
+
+                HStack {
+                    Spacer()
+                    Button {
+
+                    } label: {
+                        ZStack {
+                            Image("close")
+                                .foregroundColor(.white)
+                        }
+                        .frame(width: 44, height: 44)
+                    }
+                }
+            }
+            Text("Autoplay is here!")
+                .font(style: .title3, weight: .bold)
+                .padding(.horizontal)
+                .foregroundColor(theme.primaryText01)
+            Text("If your Up Next queue is empty, Pocket Casts can autoplay episodes from the list you started playing it — either a specific podcast, a filter, downloaded episodes or your own files.")
+                .font(style: .subheadline)
+                .foregroundColor(theme.secondaryText02)
+                .padding(.horizontal)
+            Button("Enable it") {}
+                .buttonStyle(RoundedDarkButton(theme: theme))
+                .padding(.horizontal)
+                .padding(.bottom)
+        }
+        .frame(width: 340)
+        .background(.white)
+        .cornerRadius(5)
+    }
+}
+
+struct WhatsNewView_Previews: PreviewProvider {
+    static var previews: some View {
+        WhatsNewView()
+            .environmentObject(Theme(previewTheme: .light))
+    }
+}


### PR DESCRIPTION
This PR adds the popup view structure for the new What's New. I've avoided adding logic for displaying images and stuff as I want to tackle those once we use it for the first time (next PR).

<img src="https://github.com/Automattic/pocket-casts-ios/assets/7040243/d783f6c9-52e8-4a0a-8808-45f5c6e4a8d2" width="300">

## To test

In order to test the popup appearing, change `WhatsNew.swift` method `viewControllerToShow()` to:

```swift
    func viewControllerToShow() -> UIViewController? {

        let whatsNewViewController = ThemedHostingController(rootView: WhatsNewView(announcement: .init(version: 7.20, image: "", title: "Autoplay is here!", message: "If your Up Next queue is empty, Pocket Casts can autoplay episodes from the list you started playing it — either a specific podcast, a filter, downloaded episodes or your own files.")))
        whatsNewViewController.modalPresentationStyle = .overCurrentContext
        whatsNewViewController.modalTransitionStyle = .crossDissolve
        whatsNewViewController.view.backgroundColor = .init(red: 0, green: 0, blue: 0, alpha: 0.5)

        return whatsNewViewController
    }
```

1. Run the app
2. ✅ The popup should appear
3. Tap "X"
4. ✅ It should be dismissed

You can test on multiple devices and with multiple themes.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
