### PR TITLE
Improve UI responsiveness of the Up Next view on the Apple Watch for large collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 7.49
 -----
-
+- Improves performance when opening a large Up Next queue in the Apple Watch [#950]
 
 7.48
 -----

--- a/Pocket Casts Watch App Extension/EpisodeRow.swift
+++ b/Pocket Casts Watch App Extension/EpisodeRow.swift
@@ -8,6 +8,13 @@ struct EpisodeRow: View {
     private let iconSize: CGFloat = 12
     private let artworkSize: CGFloat = 26
 
+    init(viewModel: EpisodeRowViewModel, showArtwork: Bool) {
+        // https://stackoverflow.com/questions/62635914/initialize-stateobject-with-a-parameter-in-swiftui
+        _viewModel = StateObject(wrappedValue: viewModel)
+        viewModel.hydrate()
+        self.showArtwork = showArtwork
+    }
+
     var body: some View {
         Group {
             if showArtwork {

--- a/Pocket Casts Watch App Extension/EpisodeRowViewModel.swift
+++ b/Pocket Casts Watch App Extension/EpisodeRowViewModel.swift
@@ -45,16 +45,16 @@ class EpisodeRowViewModel: EpisodeViewModel, Identifiable {
 
         let info: String
         let statusText: String?
-        switch episode.episodeStatus {
-        case DownloadStatus.downloaded.rawValue:
+        switch DownloadStatus(rawValue: episode.episodeStatus) {
+        case .downloaded:
             self.downloadStatusIconName = "episodedownloaded"
             info = episode.displayableTimeLeft()
             statusText = L10n.statusDownloaded
-        case DownloadStatus.downloading.rawValue:
+        case .downloading:
             self.downloadStatusIconName = nil
             info = episode.displayableInfo(includeSize: false)
             statusText = L10n.statusDownloading
-        case DownloadStatus.downloadFailed.rawValue:
+        case .downloadFailed:
             self.downloadStatusIconName = "downloadfailed"
             informationLabel = []
             accessibilityLabel = [L10n.downloadFailed]

--- a/Pocket Casts Watch App Extension/EpisodeRowViewModel.swift
+++ b/Pocket Casts Watch App Extension/EpisodeRowViewModel.swift
@@ -11,8 +11,15 @@ class EpisodeRowViewModel: EpisodeViewModel, Identifiable {
     @Published var downloadStatusIconName: String?
     @Published var isDownloading = false
 
-    override init(episode: BaseEpisode) {
-        super.init(episode: episode)
+    init(episode: BaseEpisode) {
+        super.init(episode: episode, skipHydration: true)
+    }
+
+    override func hydrate() {
+        if alreadyHydrated {
+            return
+        }
+        super.hydrate()
 
         updateProperties(episode: episode, downloadProgress: downloadProgress)
         Publishers.CombineLatest($episode, $downloadProgress)

--- a/Pocket Casts Watch App Extension/EpisodeViewModel.swift
+++ b/Pocket Casts Watch App Extension/EpisodeViewModel.swift
@@ -9,9 +9,20 @@ class EpisodeViewModel: ObservableObject {
 
     let playSourceViewModel = PlaySourceHelper.playSourceViewModel
     var cancellables = Set<AnyCancellable>()
+    var alreadyHydrated = false
 
-    init(episode: BaseEpisode) {
+    init(episode: BaseEpisode, skipHydration: Bool = false) {
         self.episode = episode
+        if !skipHydration {
+            hydrate()
+        }
+    }
+
+    func hydrate() {
+        if alreadyHydrated {
+            return
+        }
+        alreadyHydrated = true
         inUpNext = playSourceViewModel.inUpNext(forEpisode: episode)
 
         if episode.downloading() {


### PR DESCRIPTION
Hi folks! I'm learning Swift, and my most used app happens to be open-source, so it was a no-brainer to try this.

I have a large amount of episodes on my Up Next list (~800, I just put my whole library in there), and my Apple Watch S5 struggles when doing any operation with it. Opening the Up Next view takes about 3 seconds, in which the UI is completely frozen. So I gave Instruments a try and got to hacking. I can only test it in the Simulator (my watch doesn't pair with XCode for some reason), but with all these changes, opening Up Next should be instant. If these changes are implemented for the other lists (Podcast Episodes, Filters, Files), maybe the [limit of rows](https://github.com/Automattic/pocket-casts-ios/blob/297a81580766c13005a56bdf3cba758fb5971349/podcasts/Constants.swift#L192) on the Apple Watch can be removed altogether (fixing #191).

I'll explain what every commit does, in order:
- https://github.com/Automattic/pocket-casts-ios/pull/950/commits/39d81989178c930ea9c34239b2baab946dd46fa7: A quick refactor so other commits are smaller and more focused. Completely initializes the `EpisodeRowViewModel` object properties in the constructor instead of waiting for the main thread. Without this change, with the rest of the commits applied, you would see the rows "fill up" only when you stop scrolling on the list.
- https://github.com/Automattic/pocket-casts-ios/pull/950/commits/916b5ca36088df9d45758b6f11539b97c4eda135: Most of the time when rendering the Up Next view is spend initializing all of the `EpisodeRowViewModel`s. The initialization (I called it `hydration` but I'm not married to that, naming is hard) is now postponed until the last possible moment, when the row view is going to be rendered.
- ~https://github.com/Automattic/pocket-casts-ios/commit/5fb97b312c3c7c8481e250c57da03c666f566094: This extends the "hydration" concept to Episode/UserEpisode objects too. Instead of building 800+ Episode objects from database records, the Episode objects are created in a minimal way (just with the `uuid`), and they will be "filled" just in time as required. Strictly speaking, 800 calls to the database will be slower than a single big one, but those 800 calls will be spread through a large amount of time if the user decides to scroll through the whole list.~ _[Deferred to a future PR]_
- ~https://github.com/Automattic/pocket-casts-ios/commit/12153a12a89ded36bea2338b1d8ce7273fa7aec0: For all the code I could find that only reads the `uuid` of the Episode objects, I just changed the call to ask for the "bare-bones" dehydrated objects. I doubt there will be a dramatic speed difference, but why not.~ _[Deferred to a future PR]_

As an alternative, I have [another branch](https://github.com/DanReyLop/pocket-casts-ios/compare/update/upnext-performance...DanReyLop:pocket-casts-ios:try/upnext-performance-lazy-rowmodel-collection) with a different approach.  It involves having a custom collection of `EpisodeRowViewModel`s that will manage fetching the full Episode objects and building the view models. The result is the same, but I feel it's a bit more clunky. I don't like that `EpisodeStub` is a whole different object than `Episode`, for example. Let me know if you see more potential in that solution and I'll give it another think.

Let me know how do you prefer to proceed. Maybe it's worth it to add some comments here and there, and I haven't even checked if tests pass, but I wanted to put this in front of y'all in case you disagree fundamentally with those changes.

## To test

- Have a big Up Next list. Adding "WTF With Marc Marron" for example should get you there, it's nearly 1000 episodes.
- On your Apple Watch, do stuff on the Up Next view: open it, pick an episode and move it up top, pick an episode and start playing it, etc.
- On `trunk`, any of those operations would result in a ~3s freeze (maybe a bit less on newer Watches). With this PR, it should be near-instant.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
