### PR TITLE
Speed up checking if a podcast is in UpNext by caching a Set of all the UUIDs in UpNext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 7.44
 -----
 - Add a share action from the episode row [#966]
+- Speed up checking if a podcast is in UpNext, slightly improving app responsiveness [#951]
 
 7.43
 -----

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -60,6 +60,10 @@ public class DataManager {
         upNextManager.allUpNextPlaylistEpisodes(dbQueue: dbQueue)
     }
 
+    public func upNextPlayListContains(episodeUuid: String) -> Bool {
+        upNextManager.isEpisodePresent(uuid: episodeUuid, dbQueue: dbQueue)
+    }
+
     public func allUpNextEpisodes() -> [BaseEpisode] {
         let allUpNextEpisodes = upNextManager.allUpNextPlaylistEpisodes(dbQueue: dbQueue)
         if allUpNextEpisodes.count == 0 { return [BaseEpisode]() }

--- a/podcasts/PlaybackQueue.swift
+++ b/podcasts/PlaybackQueue.swift
@@ -241,13 +241,7 @@ class PlaybackQueue: NSObject {
     }
 
     func contains(episodeUuid: String) -> Bool {
-        let allEpisodes = DataManager.sharedManager.allUpNextPlaylistEpisodes()
-
-        for playlistEpisode in allEpisodes {
-            if playlistEpisode.episodeUuid == episodeUuid { return true }
-        }
-
-        return false
+        DataManager.sharedManager.upNextPlayListContains(episodeUuid: episodeUuid)
     }
 
     func allEpisodes(includeNowPlaying: Bool = true) -> [BaseEpisode] {


### PR DESCRIPTION
For every episode in the UpNext list, [this code](https://github.com/Automattic/pocket-casts-ios/blob/297a81580766c13005a56bdf3cba758fb5971349/Pocket%20Casts%20Watch%20App%20Extension/EpisodeViewModel.swift#L15) checks if it's in UpNext. That performs a linear search on an array of `PlaylistEpisode`s. This PR adds an auxiliary data structure (a `Set`) to speed up that check. The memory impact should be minimal because it only stores the UUIDs. This PR doesn't have a big impact if the rest of the proposed speed improvements are implemented, but it doesn't hurt.

## To test

- Have a big Up Next list. Adding "WTF With Marc Marron" for example should get you there, it's nearly 1000 episodes.
- On your Apple Watch, do stuff on the Up Next view: open it, pick an episode and move it up top, pick an episode and start playing it, etc.
- On this PR, those operations should freeze the watch UI for a bit less time than in `trunk`. It's more noticeable in a real watch than in the simulator.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
