### PR TITLE
Speed up merging the Episodes and UserEpisodes in UpNext

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -93,22 +93,20 @@ public class DataManager {
         if userEpisodes.isEmpty {
             return episodes
         }
+
         var convertedEpisodes = [BaseEpisode]()
         var episodeIndex = 0
         var userEpisodeIndex = 0
         for upNextEpisode in allUpNextEpisodes {
-            if let episode = episodes[safe: episodeIndex] {
-                if episode.uuid == upNextEpisode.episodeUuid {
-                    convertedEpisodes.append(episode)
-                    episodeIndex += 1
-                    continue
-                }
+            if let episode = episodes[safe: episodeIndex],
+               episode.uuid == upNextEpisode.episodeUuid {
+                convertedEpisodes.append(episode)
+                episodeIndex += 1
+                continue
             }
-            if let userEpisode = userEpisodes[safe: userEpisodeIndex] {
-                if userEpisode.uuid == upNextEpisode.episodeUuid {
-                    convertedEpisodes.append(userEpisode)
-                    userEpisodeIndex += 1
-                }
+            if let userEpisode = userEpisodes[safe: userEpisodeIndex], userEpisode.uuid == upNextEpisode.episodeUuid {
+                convertedEpisodes.append(userEpisode)
+                userEpisodeIndex += 1
             }
         }
 

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -90,6 +90,9 @@ public class DataManager {
         let userEpisodes = userEpisodeManager.allUpNextEpisodes(dbQueue: dbQueue)
 
         // this extra step is to make sure we return the episodes in the order they are in the up next list, which they won't be if there's both Episodes and UserEpisodes in Up Next
+        if userEpisodes.isEmpty {
+            return episodes
+        }
         var convertedEpisodes = [BaseEpisode]()
         var episodeIndex = 0
         var userEpisodeIndex = 0

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -91,10 +91,22 @@ public class DataManager {
 
         // this extra step is to make sure we return the episodes in the order they are in the up next list, which they won't be if there's both Episodes and UserEpisodes in Up Next
         var convertedEpisodes = [BaseEpisode]()
+        var episodeIndex = 0
+        var userEpisodeIndex = 0
         for upNextEpisode in allUpNextEpisodes {
-            guard let episode: BaseEpisode = episodes.first(where: { $0.uuid == upNextEpisode.episodeUuid }) ?? userEpisodes.first(where: { $0.uuid == upNextEpisode.episodeUuid }) else { continue }
-
-            convertedEpisodes.append(episode)
+            if let episode = episodes[safe: episodeIndex] {
+                if episode.uuid == upNextEpisode.episodeUuid {
+                    convertedEpisodes.append(episode)
+                    episodeIndex += 1
+                    continue
+                }
+            }
+            if let userEpisode = userEpisodes[safe: userEpisodeIndex] {
+                if userEpisode.uuid == upNextEpisode.episodeUuid {
+                    convertedEpisodes.append(userEpisode)
+                    userEpisodeIndex += 1
+                }
+            }
         }
 
         return convertedEpisodes


### PR DESCRIPTION
On the `allUpNextEpisodes()` function, the list of `Episode`s and `UserEpisode`s need to be merged, based on the order of a 3rd list (of `PlaylistEpisode`s). Both arrays are already sorted, so there's no need to do a full array scan for every insertion into the new list. The code is certainly not as elegant, but it's instant (as opposed to maybe 500ms on a real device). I'm open to rewriting it in a more "swift" way if you give me some pointers though.

## To test

- Have a big Up Next list. Adding "WTF With Marc Marron" for example should get you there, it's nearly 1000 episodes.
- On your Apple Watch, do stuff on the Up Next view: open it, pick an episode and move it up top, pick an episode and start playing it, etc.
- On this PR, those operations should freeze the watch UI for a bit less time than in `trunk`. It's more noticeable in a real watch than in the simulator.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
