### PR TITLE
Enable the ratings feature flag

### DIFF
--- a/podcasts/FeatureFlag.swift
+++ b/podcasts/FeatureFlag.swift
@@ -69,7 +69,7 @@ enum FeatureFlag: String, CaseIterable {
         case .patron:
             return false
         case .showRatings:
-            return false
+            return true
         case .autoplay:
             return false
         }


### PR DESCRIPTION
## To test

1. Launch the app
2. Go to the Discover section
3. Tap on a podcast in the trending
4. ✅ Verify the rating stars show

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
