### PR TITLE
What's New: tracks

### DIFF
--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -635,7 +635,7 @@ enum AnalyticsEvent: String {
     case patronWelcomeAppIconChanged
 
     // MARK: - What's New
-    case whatsnewDisplayed
+    case whatsnewShown
     case whatsnewDismissed
     case whatsnewConfirmButtonTapped
 

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -634,4 +634,9 @@ enum AnalyticsEvent: String {
     // MARK: - Patron
     case patronWelcomeAppIconChanged
 
+    // MARK: - What's New
+    case whatsnewDisplayed
+    case whatsnewDismissed
+    case whatsnewConfirmButtonTapped
+
 }

--- a/podcasts/Whats New/WhatsNew.swift
+++ b/podcasts/Whats New/WhatsNew.swift
@@ -22,11 +22,7 @@ class WhatsNew {
     }
 
     func viewControllerToShow() -> UIViewController? {
-        guard let previousOpenedVersion,
-              previousOpenedVersion != currentVersion,
-              let announcement = announcements.last(where: { $0.version > previousOpenedVersion && $0.version <= currentVersion }) else {
-            return nil
-        }
+        let announcement = announcements.last!
 
         let whatsNewViewController = ThemedHostingController(rootView: WhatsNewView(announcement: announcement))
         whatsNewViewController.modalPresentationStyle = .overCurrentContext

--- a/podcasts/Whats New/WhatsNew.swift
+++ b/podcasts/Whats New/WhatsNew.swift
@@ -22,7 +22,11 @@ class WhatsNew {
     }
 
     func viewControllerToShow() -> UIViewController? {
-        let announcement = announcements.last!
+        guard let previousOpenedVersion,
+              previousOpenedVersion != currentVersion,
+              let announcement = announcements.last(where: { $0.version > previousOpenedVersion && $0.version <= currentVersion }) else {
+            return nil
+        }
 
         let whatsNewViewController = ThemedHostingController(rootView: WhatsNewView(announcement: announcement))
         whatsNewViewController.modalPresentationStyle = .overCurrentContext

--- a/podcasts/Whats New/WhatsNewView.swift
+++ b/podcasts/Whats New/WhatsNewView.swift
@@ -43,7 +43,7 @@ struct WhatsNewView: View {
         .cornerRadius(5)
         .padding()
         .onAppear {
-            track(.whatsnewDisplayed)
+            track(.whatsnewShown)
         }
     }
 

--- a/podcasts/Whats New/WhatsNewView.swift
+++ b/podcasts/Whats New/WhatsNewView.swift
@@ -20,6 +20,8 @@ struct WhatsNewView: View {
                     .multilineTextAlignment(.center)
                     .padding(.bottom)
                 Button(announcement.buttonTitle) {
+                    track(.whatsnewConfirmButtonTapped)
+
                     announcement.action()
 
                     dismiss()
@@ -27,6 +29,7 @@ struct WhatsNewView: View {
                     .buttonStyle(RoundedButtonStyle(theme: theme))
                 Button(L10n.maybeLater) {
                     dismiss()
+                    track(.whatsnewDismissed)
                 }
                 .buttonStyle(SimpleTextButtonStyle(theme: theme, size: 16, textColor: .primaryInteractive01, style: .subheadline, weight: .medium))
                     .padding(.bottom, 5)
@@ -39,12 +42,19 @@ struct WhatsNewView: View {
         .background(theme.primaryUi01)
         .cornerRadius(5)
         .padding()
+        .onAppear {
+            track(.whatsnewDisplayed)
+        }
     }
 
     private func dismiss() {
         NavigationManager.sharedManager.dismissPresentedViewController()
 
         NotificationCenter.postOnMainThread(notification: .whatsNewDismissed)
+    }
+
+    private func track(_ event: AnalyticsEvent) {
+        Analytics.track(event, properties: ["version": "\(announcement.version)"])
     }
 }
 


### PR DESCRIPTION
Add tracks to the What's New.

## To test

### Setup

1. Run the app
2. Go to Profile > Settings > Beta Features > enable `tracksLogging`
3. Change `WhatsNew.viewControllerToShow()` to:

```swift
func viewControllerToShow() -> UIViewController? {
        let announcement = announcements.last!

        let whatsNewViewController = ThemedHostingController(rootView: WhatsNewView(announcement: announcement))
        whatsNewViewController.modalPresentationStyle = .overCurrentContext
        whatsNewViewController.modalTransitionStyle = .crossDissolve
        whatsNewViewController.view.backgroundColor = .init(red: 0, green: 0, blue: 0, alpha: 0.5)

        return whatsNewViewController
    }
```

### Testing

1. Re-run the app
2. ✅ When the What's New popup appears you should see a `🔵 Tracked: whatsnew_displayed ["version": "7.43"]` on the console
3. Tap "Maybe later"
4. ✅ You should see a `🔵 Tracked: whatsnew_dismissed ["version": "7.43"]` on the console
5. Re-run the app
6. This time, tap "Enable it now"
7. ✅ You should see a `🔵 Tracked: whatsnew_confirm_button_tapped ["version": "7.43"]` on the console

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
