### PR TITLE
Episode Swipe: add share action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 7.44
 -----
-
+- Add a share action from the episode row [#966]
 
 7.43
 -----

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -551,6 +551,7 @@
 		8BC7FF55290FF92400017779 /* StoriesProgressModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC7FF54290FF92400017779 /* StoriesProgressModel.swift */; };
 		8BCB22B228F47F44001A0315 /* EndOfYearModal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BCB22B128F47F44001A0315 /* EndOfYearModal.swift */; };
 		8BCB22B428F48282001A0315 /* EndOfYear.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BCB22B328F48282001A0315 /* EndOfYear.swift */; };
+		8BD256D22A5C7090006648BE /* SharingHelper+swipeButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BD256D12A5C7090006648BE /* SharingHelper+swipeButton.swift */; };
 		8BD5A4E42A1E844D00F473C6 /* StatusPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BD5A4E32A1E844D00F473C6 /* StatusPageView.swift */; };
 		8BD5A4FF2A1F96C200F473C6 /* AppIcon-Pride76x76@2x~ipad.png in Resources */ = {isa = PBXBuildFile; fileRef = 8BD5A4EE2A1F96BD00F473C6 /* AppIcon-Pride76x76@2x~ipad.png */; };
 		8BD5A5002A1F96C200F473C6 /* AppIcon-Pride83.5x83.5@2x~ipad.png in Resources */ = {isa = PBXBuildFile; fileRef = 8BD5A4EF2A1F96BD00F473C6 /* AppIcon-Pride83.5x83.5@2x~ipad.png */; };
@@ -2268,6 +2269,7 @@
 		8BC7FF54290FF92400017779 /* StoriesProgressModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoriesProgressModel.swift; sourceTree = "<group>"; };
 		8BCB22B128F47F44001A0315 /* EndOfYearModal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndOfYearModal.swift; sourceTree = "<group>"; };
 		8BCB22B328F48282001A0315 /* EndOfYear.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndOfYear.swift; sourceTree = "<group>"; };
+		8BD256D12A5C7090006648BE /* SharingHelper+swipeButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SharingHelper+swipeButton.swift"; sourceTree = "<group>"; };
 		8BD5A4E32A1E844D00F473C6 /* StatusPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusPageView.swift; sourceTree = "<group>"; };
 		8BD5A4EE2A1F96BD00F473C6 /* AppIcon-Pride76x76@2x~ipad.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "AppIcon-Pride76x76@2x~ipad.png"; sourceTree = "<group>"; };
 		8BD5A4EF2A1F96BD00F473C6 /* AppIcon-Pride83.5x83.5@2x~ipad.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "AppIcon-Pride83.5x83.5@2x~ipad.png"; sourceTree = "<group>"; };
@@ -5060,6 +5062,7 @@
 				BD47E7F91DD57F7B00C18EE7 /* ShowNotesFormatter.swift */,
 				45ECEF8727E9253900C65030 /* ShowNotesFormatterUtils.swift */,
 				BD7BCF101F6A4F110006E008 /* SharingHelper.swift */,
+				8BD256D12A5C7090006648BE /* SharingHelper+swipeButton.swift */,
 				BD7BCF121F6A4F920006E008 /* SharingItemProvider.swift */,
 				BDCE1D601FBC1C4100100A86 /* UrlHelper.swift */,
 				BDD6297E200EE26200168DF7 /* PlaybackActionHelper.swift */,
@@ -8752,6 +8755,7 @@
 				BDAE54CF230C063500330680 /* NoSearchResultsCell.swift in Sources */,
 				BDEC9AB52051197900088D76 /* BadgeSettingsViewController.swift in Sources */,
 				408529A3247C9A53007FE8AA /* PodcastSupporterCell.swift in Sources */,
+				8BD256D22A5C7090006648BE /* SharingHelper+swipeButton.swift in Sources */,
 				BDCD1E82244D636D00B83602 /* LenticularFilter.swift in Sources */,
 				8B9DEFD829071AD200075EAB /* MDCSwiftUIWrapper.swift in Sources */,
 				4006E31423AC453700174DEB /* ExpandedCollectionViewController+CollectionView.swift in Sources */,

--- a/podcasts/DownloadsViewController+Swipe.swift
+++ b/podcasts/DownloadsViewController+Swipe.swift
@@ -1,4 +1,5 @@
 import Foundation
+import PocketCastsDataModel
 import SwipeCellKit
 
 extension DownloadsViewController: SwipeTableViewCellDelegate, SwipeHandler {
@@ -45,4 +46,8 @@ extension DownloadsViewController: SwipeTableViewCellDelegate, SwipeHandler {
     }
 
     func deleteRequested(uuid: String) {} // we don't support this one
+
+    func share(episode: Episode, in indexPath: IndexPath) {
+        SharingHelper.shared.shareLinkTo(episode: episode, fromController: self, fromTableView: downloadsTable, at: indexPath)
+    }
 }

--- a/podcasts/DownloadsViewController+Swipe.swift
+++ b/podcasts/DownloadsViewController+Swipe.swift
@@ -47,7 +47,7 @@ extension DownloadsViewController: SwipeTableViewCellDelegate, SwipeHandler {
 
     func deleteRequested(uuid: String) {} // we don't support this one
 
-    func share(episode: Episode, in indexPath: IndexPath) {
+    func share(episode: Episode, at indexPath: IndexPath) {
         SharingHelper.shared.shareLinkTo(episode: episode, fromController: self, fromTableView: downloadsTable, at: indexPath)
     }
 }

--- a/podcasts/ListeningHistoryViewController+Swipe.swift
+++ b/podcasts/ListeningHistoryViewController+Swipe.swift
@@ -1,4 +1,5 @@
 import Foundation
+import PocketCastsDataModel
 import SwipeCellKit
 
 extension ListeningHistoryViewController: SwipeTableViewCellDelegate, SwipeHandler {
@@ -39,4 +40,8 @@ extension ListeningHistoryViewController: SwipeTableViewCellDelegate, SwipeHandl
     }
 
     func deleteRequested(uuid: String) {} // we don't support this one
+
+    func share(episode: Episode, in indexPath: IndexPath) {
+        SharingHelper.shared.shareLinkTo(episode: episode, fromController: self, fromTableView: listeningHistoryTable, at: indexPath)
+    }
 }

--- a/podcasts/ListeningHistoryViewController+Swipe.swift
+++ b/podcasts/ListeningHistoryViewController+Swipe.swift
@@ -41,7 +41,7 @@ extension ListeningHistoryViewController: SwipeTableViewCellDelegate, SwipeHandl
 
     func deleteRequested(uuid: String) {} // we don't support this one
 
-    func share(episode: Episode, in indexPath: IndexPath) {
+    func share(episode: Episode, at indexPath: IndexPath) {
         SharingHelper.shared.shareLinkTo(episode: episode, fromController: self, fromTableView: listeningHistoryTable, at: indexPath)
     }
 }

--- a/podcasts/PlaylistViewController+Swipe.swift
+++ b/podcasts/PlaylistViewController+Swipe.swift
@@ -47,7 +47,7 @@ extension PlaylistViewController: SwipeTableViewCellDelegate, SwipeHandler {
         true
     }
 
-    func share(episode: Episode, in indexPath: IndexPath) {
+    func share(episode: Episode, at indexPath: IndexPath) {
         SharingHelper.shared.shareLinkTo(episode: episode, fromController: self, fromTableView: tableView, at: indexPath)
     }
 }

--- a/podcasts/PlaylistViewController+Swipe.swift
+++ b/podcasts/PlaylistViewController+Swipe.swift
@@ -1,4 +1,5 @@
 import Foundation
+import PocketCastsDataModel
 import SwipeCellKit
 
 extension PlaylistViewController: SwipeTableViewCellDelegate, SwipeHandler {
@@ -44,5 +45,9 @@ extension PlaylistViewController: SwipeTableViewCellDelegate, SwipeHandler {
 
     func archivingRemovesFromList() -> Bool {
         true
+    }
+
+    func share(episode: Episode, in indexPath: IndexPath) {
+        SharingHelper.shared.shareLinkTo(episode: episode, fromController: self, fromTableView: tableView, at: indexPath)
     }
 }

--- a/podcasts/PodcastViewController+Swipe.swift
+++ b/podcasts/PodcastViewController+Swipe.swift
@@ -49,7 +49,7 @@ extension PodcastViewController: SwipeTableViewCellDelegate, SwipeHandler {
 
     func deleteRequested(uuid: String) {} // we don't support this one
 
-    func share(episode: Episode, in indexPath: IndexPath) {
+    func share(episode: Episode, at indexPath: IndexPath) {
         SharingHelper.shared.shareLinkTo(episode: episode, fromController: self, fromTableView: tableView(), at: indexPath)
     }
 }

--- a/podcasts/PodcastViewController+Swipe.swift
+++ b/podcasts/PodcastViewController+Swipe.swift
@@ -1,4 +1,5 @@
 import Foundation
+import PocketCastsDataModel
 import SwipeCellKit
 
 extension PodcastViewController: SwipeTableViewCellDelegate, SwipeHandler {
@@ -47,4 +48,8 @@ extension PodcastViewController: SwipeTableViewCellDelegate, SwipeHandler {
     }
 
     func deleteRequested(uuid: String) {} // we don't support this one
+
+    func share(episode: Episode, in indexPath: IndexPath) {
+        SharingHelper.shared.shareLinkTo(episode: episode, fromController: self, fromTableView: tableView(), at: indexPath)
+    }
 }

--- a/podcasts/SharingHelper+swipeButton.swift
+++ b/podcasts/SharingHelper+swipeButton.swift
@@ -4,6 +4,7 @@ import PocketCastsDataModel
 extension SharingHelper {
     func shareLinkTo(episode: Episode, fromController: UIViewController, fromTableView tableView: UITableView, at indexPath: IndexPath) {
         let source = tableView.swipeButton(forLabel: L10n.share, at: indexPath) ?? tableView
+        Analytics.track(.podcastShared, properties: ["type": "episode", "source": "episode_swipe_action"])
         shareLinkTo(episode: episode, shareTime: 0, fromController: fromController, sourceRect: source.bounds, sourceView: source)
     }
 }

--- a/podcasts/SharingHelper+swipeButton.swift
+++ b/podcasts/SharingHelper+swipeButton.swift
@@ -1,0 +1,25 @@
+import UIKit
+import PocketCastsDataModel
+
+extension SharingHelper {
+    func shareLinkTo(episode: Episode, fromController: UIViewController, fromTableView tableView: UITableView, at indexPath: IndexPath) {
+        let source = tableView.swipeButton(forLabel: L10n.share, at: indexPath) ?? tableView
+        shareLinkTo(episode: episode, shareTime: 0, fromController: fromController, sourceRect: source.bounds, sourceView: source)
+    }
+}
+
+private extension UITableView {
+    func swipeButton(forLabel label: String, at indexPath: IndexPath) -> UIView? {
+        cellForRow(at: indexPath)?.findViews(subclassOf: UIButton.self).first(where: { $0.accessibilityLabel == label })
+    }
+}
+
+private extension UIView {
+    func findViews<T: UIView>(subclassOf: T.Type) -> [T] {
+        return recursiveSubviews.compactMap { $0 as? T }
+    }
+
+    var recursiveSubviews: [UIView] {
+        return subviews + subviews.flatMap { $0.recursiveSubviews }
+    }
+}

--- a/podcasts/StarredViewController+Swipe.swift
+++ b/podcasts/StarredViewController+Swipe.swift
@@ -1,4 +1,5 @@
 import Foundation
+import PocketCastsDataModel
 import SwipeCellKit
 
 extension StarredViewController: SwipeTableViewCellDelegate, SwipeHandler {
@@ -45,4 +46,8 @@ extension StarredViewController: SwipeTableViewCellDelegate, SwipeHandler {
     }
 
     func deleteRequested(uuid: String) {} // we don't support this one
+
+    func share(episode: Episode, in indexPath: IndexPath) {
+        SharingHelper.shared.shareLinkTo(episode: episode, fromController: self, fromTableView: starredTable, at: indexPath)
+    }
 }

--- a/podcasts/StarredViewController+Swipe.swift
+++ b/podcasts/StarredViewController+Swipe.swift
@@ -47,7 +47,7 @@ extension StarredViewController: SwipeTableViewCellDelegate, SwipeHandler {
 
     func deleteRequested(uuid: String) {} // we don't support this one
 
-    func share(episode: Episode, in indexPath: IndexPath) {
+    func share(episode: Episode, at indexPath: IndexPath) {
         SharingHelper.shared.shareLinkTo(episode: episode, fromController: self, fromTableView: starredTable, at: indexPath)
     }
 }

--- a/podcasts/SwipeActionsHelper.swift
+++ b/podcasts/SwipeActionsHelper.swift
@@ -90,6 +90,14 @@ enum SwipeActionsHelper {
             tableSwipeActions.addAction(archiveAction)
         }
 
+        if !(episode is UserEpisode) {
+            let shareAction = TableSwipeAction(indexPath: indexPath, title: L10n.delete, removesFromList: false, backgroundColor: ThemeColor.support03(), icon: UIImage(named: "podcast-share"), tableView: tableView, handler: { _ -> Bool in
+                //            Self.performAction(.delete, handler: swipeHandler, willBeRemoved: true)
+                return true
+            })
+            tableSwipeActions.addAction(shareAction)
+        }
+
         return tableSwipeActions
     }
 

--- a/podcasts/SwipeActionsHelper.swift
+++ b/podcasts/SwipeActionsHelper.swift
@@ -7,6 +7,7 @@ protocol SwipeHandler: AnyObject {
     func archivingRemovesFromList() -> Bool
     func actionPerformed(willBeRemoved: Bool)
     func deleteRequested(uuid: String)
+    func share(episode: Episode, in: IndexPath)
 }
 
 enum SwipeActionsHelper {
@@ -90,9 +91,10 @@ enum SwipeActionsHelper {
             tableSwipeActions.addAction(archiveAction)
         }
 
-        if !(episode is UserEpisode) {
-            let shareAction = TableSwipeAction(indexPath: indexPath, title: L10n.delete, removesFromList: false, backgroundColor: ThemeColor.support03(), icon: UIImage(named: "podcast-share"), tableView: tableView, handler: { _ -> Bool in
-                    Self.performAction(.share, handler: swipeHandler, willBeRemoved: true)
+        if let episode = episode as? Episode {
+            let shareAction = TableSwipeAction(indexPath: indexPath, title: L10n.share, removesFromList: false, backgroundColor: ThemeColor.support03(), icon: UIImage(named: "podcast-share"), tableView: tableView, handler: { indexPath -> Bool in
+                    swipeHandler.share(episode: episode, in: indexPath)
+                    Self.performAction(.share, handler: swipeHandler, willBeRemoved: false)
                 return true
             })
             tableSwipeActions.addAction(shareAction)

--- a/podcasts/SwipeActionsHelper.swift
+++ b/podcasts/SwipeActionsHelper.swift
@@ -92,7 +92,7 @@ enum SwipeActionsHelper {
 
         if !(episode is UserEpisode) {
             let shareAction = TableSwipeAction(indexPath: indexPath, title: L10n.delete, removesFromList: false, backgroundColor: ThemeColor.support03(), icon: UIImage(named: "podcast-share"), tableView: tableView, handler: { _ -> Bool in
-                //            Self.performAction(.delete, handler: swipeHandler, willBeRemoved: true)
+                    Self.performAction(.share, handler: swipeHandler, willBeRemoved: true)
                 return true
             })
             tableSwipeActions.addAction(shareAction)
@@ -119,6 +119,7 @@ enum SwipeActionsHelper {
         case delete
         case unarchive
         case archive
+        case share
 
         var analyticsDescription: String {
             switch self {
@@ -134,6 +135,8 @@ enum SwipeActionsHelper {
                 return "unarchive"
             case .archive:
                 return "archive"
+            case .share:
+                return "share"
             }
         }
     }

--- a/podcasts/SwipeActionsHelper.swift
+++ b/podcasts/SwipeActionsHelper.swift
@@ -7,7 +7,7 @@ protocol SwipeHandler: AnyObject {
     func archivingRemovesFromList() -> Bool
     func actionPerformed(willBeRemoved: Bool)
     func deleteRequested(uuid: String)
-    func share(episode: Episode, in: IndexPath)
+    func share(episode: Episode, at: IndexPath)
 }
 
 enum SwipeActionsHelper {
@@ -93,7 +93,7 @@ enum SwipeActionsHelper {
 
         if let episode = episode as? Episode {
             let shareAction = TableSwipeAction(indexPath: indexPath, title: L10n.share, removesFromList: false, backgroundColor: ThemeColor.support03(), icon: UIImage(named: "podcast-share"), tableView: tableView, handler: { indexPath -> Bool in
-                    swipeHandler.share(episode: episode, in: indexPath)
+                    swipeHandler.share(episode: episode, at: indexPath)
                     Self.performAction(.share, handler: swipeHandler, willBeRemoved: false)
                 return true
             })

--- a/podcasts/UploadedViewController+Swipe.swift
+++ b/podcasts/UploadedViewController+Swipe.swift
@@ -45,5 +45,5 @@ extension UploadedViewController: SwipeTableViewCellDelegate, SwipeHandler {
         true
     }
 
-    func share(episode: Episode, in: IndexPath) { }
+    func share(episode: Episode, at: IndexPath) { }
 }

--- a/podcasts/UploadedViewController+Swipe.swift
+++ b/podcasts/UploadedViewController+Swipe.swift
@@ -44,4 +44,6 @@ extension UploadedViewController: SwipeTableViewCellDelegate, SwipeHandler {
     func archivingRemovesFromList() -> Bool {
         true
     }
+
+    func share(episode: Episode, in: IndexPath) { }
 }


### PR DESCRIPTION
Related to: https://github.com/Automattic/pocket-casts-ios/discussions/962

<img src="https://github.com/Automattic/pocket-casts-ios/assets/7040243/d9c3c37e-8bdb-4a0e-8303-75af3b61c624" width="300">

Adds a share episode action on the episodes row in the following screens:

- Podcast view
- Filters
- Downloads
- Listening history
- Starred

## To test

Before testing, make sure you have at least one filter with episodes, at least one downloaded episode, at least one starred episode, at least one listened to episode, and at least one uploaded file.

### Sharing

1. Run the app
2. Go to Discover and open any podcast
3. Swipe left and tap the share action
4. ✅ The share sheet should appear prompting you to share the link to the episode
5. Do the same from the following screens: filters, downloads, listening history and starred
6. Go to Files
7. ✅ Swipe left and you should not see the share action

Also, make sure to test on iPad and check that the share sheet correctly points to the share action button

### Events

1. Go to Settings > Beta Features > enable `tracksLogging`
2. Go to any of the aforementioned screens and swipe left
3. Tap share
4. ✅ You should see a `🔵 Tracked: episode_swipe_action_performed ["action": "share", "source": "??"]` logged (with `??` being the screen you performed the swipe on
5. ✅ You should also see a `🔵 Tracked: podcast_shared ["source": "episode_swipe_action", "type": "episode"]` logged


## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
