### PR TITLE
Multi selection: add share action

### DIFF
--- a/podcasts/Enumerations.swift
+++ b/podcasts/Enumerations.swift
@@ -426,4 +426,14 @@ enum MultiSelectAction: Int32, CaseIterable, AnalyticsDescribable {
             return "share"
         }
     }
+
+    func isVisible(with episodes: [BaseEpisode]) -> Bool {
+        switch self {
+        case .share:
+            return episodes.count > 1 && episodes.allSatisfy({ $0 is Episode })
+
+        default:
+            return true
+        }
+    }
 }

--- a/podcasts/Enumerations.swift
+++ b/podcasts/Enumerations.swift
@@ -320,7 +320,7 @@ enum PlayerAction: Int, CaseIterable, AnalyticsDescribable {
 }
 
 enum MultiSelectAction: Int32, CaseIterable, AnalyticsDescribable {
-    case playLast = 1, playNext, download, archive, markAsPlayed, star, moveToTop, moveToBottom, removeFromUpNext, unstar, unarchive, removeDownload, markAsUnplayed, delete
+    case playLast = 1, playNext, download, archive, share, markAsPlayed, star, moveToTop, moveToBottom, removeFromUpNext, unstar, unarchive, removeDownload, markAsUnplayed, delete
 
     func title() -> String {
         switch self {
@@ -352,6 +352,8 @@ enum MultiSelectAction: Int32, CaseIterable, AnalyticsDescribable {
             return L10n.multiSelectRemoveMarkUnplayed
         case .delete:
             return L10n.delete
+        case .share:
+            return L10n.share
         }
     }
 
@@ -385,6 +387,8 @@ enum MultiSelectAction: Int32, CaseIterable, AnalyticsDescribable {
             return "episode-remove-download"
         case .delete:
             return "episode-delete"
+        case .share:
+            return "podcast-share"
         }
     }
 
@@ -418,6 +422,8 @@ enum MultiSelectAction: Int32, CaseIterable, AnalyticsDescribable {
             return "remove_download"
         case .delete:
             return "delete"
+        case .share:
+            return "share"
         }
     }
 }

--- a/podcasts/Enumerations.swift
+++ b/podcasts/Enumerations.swift
@@ -430,7 +430,7 @@ enum MultiSelectAction: Int32, CaseIterable, AnalyticsDescribable {
     func isVisible(with episodes: [BaseEpisode]) -> Bool {
         switch self {
         case .share:
-            return episodes.count > 1 && episodes.allSatisfy({ $0 is Episode })
+            return episodes.count == 1 && episodes.allSatisfy({ $0 is Episode })
 
         default:
             return true

--- a/podcasts/Enumerations.swift
+++ b/podcasts/Enumerations.swift
@@ -320,7 +320,7 @@ enum PlayerAction: Int, CaseIterable, AnalyticsDescribable {
 }
 
 enum MultiSelectAction: Int32, CaseIterable, AnalyticsDescribable {
-    case playLast = 1, playNext, download, archive, share, markAsPlayed, star, moveToTop, moveToBottom, removeFromUpNext, unstar, unarchive, removeDownload, markAsUnplayed, delete
+    case playLast = 1, playNext, download, archive, markAsPlayed, star, moveToTop, moveToBottom, removeFromUpNext, unstar, unarchive, removeDownload, markAsUnplayed, delete, share
 
     func title() -> String {
         switch self {

--- a/podcasts/MultiSelectActionController.swift
+++ b/podcasts/MultiSelectActionController.swift
@@ -95,7 +95,7 @@ class MultiSelectActionController: UIViewController, UITableViewDelegate, UITabl
         updateColors()
         setPreferredSize(animated: false)
 
-        removeShareIfMultipleEpisodesAreSelected()
+        filterUnavailableActions()
 
         Analytics.track(.multiSelectViewOverflowMenuShown, properties: ["source": actionDelegate.multiSelectViewSource])
     }
@@ -237,7 +237,7 @@ class MultiSelectActionController: UIViewController, UITableViewDelegate, UITabl
     }
 
     @IBAction func doneTapped(_ sender: UIButton) {
-        removeShareIfMultipleEpisodesAreSelected()
+        filterUnavailableActions()
         setActionsFunc(orderedActions)
         delegate.actionOrderChanged()
         dismiss(animated: true, completion: nil)
@@ -272,10 +272,9 @@ class MultiSelectActionController: UIViewController, UITableViewDelegate, UITabl
         editButton.setTitleColor(AppTheme.colorForStyle(.primaryInteractive01, themeOverride: themeOverride), for: .normal)
     }
 
-    private func removeShareIfMultipleEpisodesAreSelected() {
-        if numSelectedEpisodes > 1 {
-            orderedActions = orderedActions.filter { $0 != .share }
-        }
+    private func filterUnavailableActions() {
+        let episodes = actionDelegate.multiSelectedBaseEpisodes()
+        orderedActions = orderedActions.filter { $0.isVisible(with: episodes) }
     }
 
     private func showAllActions() {

--- a/podcasts/MultiSelectActionController.swift
+++ b/podcasts/MultiSelectActionController.swift
@@ -279,11 +279,15 @@ class MultiSelectActionController: UIViewController, UITableViewDelegate, UITabl
 
     private func showAllActions() {
         orderedActions = originalActions
+        let shareableEpisodesCount = actionDelegate
+            .multiSelectedBaseEpisodes()
+            .filter { $0 is Episode }
+            .count
 
         // If a user already saved the actions, share will be
         // missing since was added later to the app.
-        // This ensures it's displayed.
-        if !orderedActions.contains(.share) {
+        // This ensures it's displayed except for user's files.
+        if !orderedActions.contains(.share) && shareableEpisodesCount > 0 {
             orderedActions.append(.share)
         }
     }

--- a/podcasts/MultiSelectActionController.swift
+++ b/podcasts/MultiSelectActionController.swift
@@ -79,6 +79,7 @@ class MultiSelectActionController: UIViewController, UITableViewDelegate, UITabl
         self.setActionsFunc = setActionsFunc
         self.themeOverride = themeOverride
         super.init(nibName: "MultiSelectActionController", bundle: nil)
+        filterUnavailableActions()
     }
 
     @available(*, unavailable)
@@ -94,8 +95,6 @@ class MultiSelectActionController: UIViewController, UITableViewDelegate, UITabl
         doneButton.isHidden = true
         updateColors()
         setPreferredSize(animated: false)
-
-        filterUnavailableActions()
 
         Analytics.track(.multiSelectViewOverflowMenuShown, properties: ["source": actionDelegate.multiSelectViewSource])
     }

--- a/podcasts/MultiSelectActionController.swift
+++ b/podcasts/MultiSelectActionController.swift
@@ -278,15 +278,14 @@ class MultiSelectActionController: UIViewController, UITableViewDelegate, UITabl
 
     private func showAllActions() {
         orderedActions = originalActions
-        let shareableEpisodesCount = actionDelegate
+        let hasOnlyShareableEpisodes = actionDelegate
             .multiSelectedBaseEpisodes()
-            .filter { $0 is Episode }
-            .count
+            .allSatisfy({ $0 is Episode })
 
         // If a user already saved the actions, share will be
         // missing since was added later to the app.
         // This ensures it's displayed except for user's files.
-        if !orderedActions.contains(.share) && shareableEpisodesCount > 0 {
+        if !orderedActions.contains(.share) && hasOnlyShareableEpisodes {
             orderedActions.append(.share)
         }
     }

--- a/podcasts/MultiSelectActionController.swift
+++ b/podcasts/MultiSelectActionController.swift
@@ -236,8 +236,8 @@ class MultiSelectActionController: UIViewController, UITableViewDelegate, UITabl
     }
 
     @IBAction func doneTapped(_ sender: UIButton) {
-        filterUnavailableActions()
         setActionsFunc(orderedActions)
+        filterUnavailableActions()
         delegate.actionOrderChanged()
         dismiss(animated: true, completion: nil)
         Analytics.track(.multiSelectViewOverflowMenuRearrangeFinished, properties: ["source": actionDelegate.multiSelectViewSource])

--- a/podcasts/MultiSelectFooterView.swift
+++ b/podcasts/MultiSelectFooterView.swift
@@ -64,16 +64,14 @@ class MultiSelectFooterView: UIView, MultiSelectActionOrderDelegate {
     @IBOutlet var activityIndicator: ThemeLoadingIndicator!
     private var rightAction: MultiSelectAction?
     private var leftAction: MultiSelectAction?
-    private var numberOfEpisodes: Int
+    private var numberOfEpisodes = 0
 
     override init(frame: CGRect) {
-        numberOfEpisodes = 0
         super.init(frame: frame)
         commonInit()
     }
 
     required init?(coder aDecoder: NSCoder) {
-        numberOfEpisodes = 0
         super.init(coder: aDecoder)
         commonInit()
     }

--- a/podcasts/MultiSelectFooterView.swift
+++ b/podcasts/MultiSelectFooterView.swift
@@ -64,13 +64,16 @@ class MultiSelectFooterView: UIView, MultiSelectActionOrderDelegate {
     @IBOutlet var activityIndicator: ThemeLoadingIndicator!
     private var rightAction: MultiSelectAction?
     private var leftAction: MultiSelectAction?
+    private var numberOfEpisodes: Int
 
     override init(frame: CGRect) {
+        numberOfEpisodes = 0
         super.init(frame: frame)
         commonInit()
     }
 
     required init?(coder aDecoder: NSCoder) {
+        numberOfEpisodes = 0
         super.init(coder: aDecoder)
         commonInit()
     }
@@ -102,6 +105,7 @@ class MultiSelectFooterView: UIView, MultiSelectActionOrderDelegate {
             return
         }
 
+        numberOfEpisodes = count
         isHidden = false
         selectedCountLabel.text = L10n.selectedCountFormat(count)
         selectedCountLabel.isHidden = false
@@ -145,12 +149,12 @@ class MultiSelectFooterView: UIView, MultiSelectActionOrderDelegate {
 
     @IBAction func rightActionTapped(_ sender: Any) {
         guard let delegate = delegate, let rightAction = rightAction else { return }
-        MultiSelectHelper.performAction(rightAction, actionDelegate: delegate)
+        MultiSelectHelper.performAction(rightAction, actionDelegate: delegate, view: rightActionButton)
     }
 
     @IBAction func leftActionTapped(_ sender: Any) {
         guard let delegate = delegate, let leftAction = leftAction else { return }
-        MultiSelectHelper.performAction(leftAction, actionDelegate: delegate)
+        MultiSelectHelper.performAction(leftAction, actionDelegate: delegate, view: leftActionButton)
     }
 
     @objc func handleThemeDidChange() {
@@ -167,8 +171,12 @@ class MultiSelectFooterView: UIView, MultiSelectActionOrderDelegate {
     }
 
     private func loadActions() {
-        let actions = getActionsFunc()
+        var actions = getActionsFunc()
         guard actions.count > 1, let actionDelegate = delegate else { return }
+
+        if numberOfEpisodes > 1 {
+            actions = actions.filter { $0 != .share }
+        }
 
         let newLeftAction = MultiSelectHelper.invertActionIfRequired(action: actions[0], actionDelegate: actionDelegate)
         if leftAction != newLeftAction {

--- a/podcasts/MultiSelectHelper.swift
+++ b/podcasts/MultiSelectHelper.swift
@@ -6,7 +6,7 @@ import PocketCastsUtils
 class MultiSelectHelper {
     // MARK: - Action Helpers
 
-    class func performAction(_ action: MultiSelectAction, actionDelegate: MultiSelectActionDelegate) {
+    class func performAction(_ action: MultiSelectAction, actionDelegate: MultiSelectActionDelegate, view: UIView? = nil) {
         AnalyticsEpisodeHelper.shared.currentSource = actionDelegate.multiSelectViewSource
 
         switch action {
@@ -38,6 +38,9 @@ class MultiSelectHelper {
             removeFromUpNext(actionDelegate: actionDelegate)
         case .delete:
             delete(actionDelegate: actionDelegate)
+        case .share:
+            share(actionDelegate: actionDelegate, view: view)
+            return
         }
     }
 
@@ -316,6 +319,21 @@ class MultiSelectHelper {
         }
         PlaybackManager.shared.bulkRemoveQueued(uuids: selectedUuids)
         actionDelegate.multiSelectActionCompleted()
+    }
+
+    private class func share(actionDelegate: MultiSelectActionDelegate, view: UIView?) {
+        guard let episode = actionDelegate.multiSelectedBaseEpisodes().first as? Episode else {
+            return
+        }
+
+        if let view {
+            SharingHelper.shared.shareLinkTo(episode: episode, shareTime: 0, fromController: actionDelegate.multiSelectPresentingViewController(), sourceRect: view.bounds, sourceView: view)
+        }
+
+        // If no view is provided, the app is sharing from the bottom sheet
+        if let view = actionDelegate.multiSelectPresentingViewController().view {
+            SharingHelper.shared.shareLinkTo(episode: episode, shareTime: 0, fromController: actionDelegate.multiSelectPresentingViewController(), sourceRect: view.bounds, sourceView: view, showArrow: false)
+        }
     }
 
     // MARK: - Selection Helpers

--- a/podcasts/MultiSelectHelper.swift
+++ b/podcasts/MultiSelectHelper.swift
@@ -326,6 +326,8 @@ class MultiSelectHelper {
             return
         }
 
+        Analytics.track(.podcastShared, properties: ["type": "episode", "source": "multi_select"])
+
         if let view {
             SharingHelper.shared.shareLinkTo(episode: episode, shareTime: 0, fromController: actionDelegate.multiSelectPresentingViewController(), sourceRect: view.bounds, sourceView: view)
         }

--- a/podcasts/MultiSelectHelper.swift
+++ b/podcasts/MultiSelectHelper.swift
@@ -328,14 +328,16 @@ class MultiSelectHelper {
 
         Analytics.track(.podcastShared, properties: ["type": "episode", "source": "multi_select"])
 
-        if let view {
-            SharingHelper.shared.shareLinkTo(episode: episode, shareTime: 0, fromController: actionDelegate.multiSelectPresentingViewController(), sourceRect: view.bounds, sourceView: view)
+        guard let sourceView = view ?? actionDelegate.multiSelectPresentingViewController().view else {
+            return
         }
 
-        // If no view is provided, the app is sharing from the bottom sheet
-        if let view = actionDelegate.multiSelectPresentingViewController().view {
-            SharingHelper.shared.shareLinkTo(episode: episode, shareTime: 0, fromController: actionDelegate.multiSelectPresentingViewController(), sourceRect: view.bounds, sourceView: view, showArrow: false)
-        }
+        SharingHelper.shared.shareLinkTo(episode: episode,
+                                         shareTime: 0,
+                                         fromController: actionDelegate.multiSelectPresentingViewController(),
+                                         sourceRect: sourceView.bounds,
+                                         sourceView: sourceView,
+                                         showArrow: view != nil)
     }
 
     // MARK: - Selection Helpers

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -597,13 +597,15 @@ class Settings: NSObject {
 
     private static let multiSelectActionsKey = "MultiSelectActions"
     class func multiSelectActions() -> [MultiSelectAction] {
+        let defaultActions: [MultiSelectAction] = [.playNext, .playLast, .download, .archive, .share, .markAsPlayed, .star]
         guard let savedInts = UserDefaults.standard.object(forKey: Settings.multiSelectActionsKey) as? [Int32] else {
-            return [.playNext, .playLast, .download, .archive, .share, .markAsPlayed, .star]
+            return defaultActions
         }
 
         let actions = savedInts.compactMap { MultiSelectAction(rawValue: $0) }
 
-        return actions
+        // Make sure new items are shown
+        return actions + defaultActions.filter { !actions.contains($0) }
     }
 
     class func updateMultiSelectActions(_ actions: [MultiSelectAction]) {

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -598,7 +598,7 @@ class Settings: NSObject {
     private static let multiSelectActionsKey = "MultiSelectActions"
     class func multiSelectActions() -> [MultiSelectAction] {
         guard let savedInts = UserDefaults.standard.object(forKey: Settings.multiSelectActionsKey) as? [Int32] else {
-            return [.playNext, .playLast, .download, .archive, .markAsPlayed, .star]
+            return [.playNext, .playLast, .download, .archive, .share, .markAsPlayed, .star]
         }
 
         let actions = savedInts.compactMap { MultiSelectAction(rawValue: $0) }

--- a/podcasts/SharingHelper.swift
+++ b/podcasts/SharingHelper.swift
@@ -91,7 +91,7 @@ class SharingHelper: NSObject {
         activityController.popoverPresentationController?.barButtonItem = barButtonItem
     }
 
-    func shareLinkTo(episode: Episode, shareTime: TimeInterval, fromController: UIViewController, sourceRect: CGRect, sourceView: UIView?) {
+    func shareLinkTo(episode: Episode, shareTime: TimeInterval, fromController: UIViewController, sourceRect: CGRect, sourceView: UIView?, showArrow: Bool = true) {
         activityController = createActivityController(episode: episode, shareTime: shareTime)
         activityController?.completionWithItemsHandler = { _, _, _, _ in
             NotificationCenter.postOnMainThread(notification: Constants.Notifications.closedNonOverlayableWindow)
@@ -105,6 +105,10 @@ class SharingHelper: NSObject {
         })
         activityController.popoverPresentationController?.sourceView = sourceView
         activityController.popoverPresentationController?.sourceRect = sourceRect
+
+        if !showArrow {
+            activityController.popoverPresentationController?.permittedArrowDirections = []
+        }
     }
 
     func createActivityController(episode: Episode, shareTime: TimeInterval) -> UIActivityViewController {


### PR DESCRIPTION
Finishes https://github.com/Automattic/pocket-casts-ios/discussions/962

This PR adds a new "Share" action to the multi episodes selection.

While the change seems simple, this section has a few things that I had to account for:

1. It's customizable
2. The first two items are displayed as the two buttons on the multi-selection UI;

A little demo:

https://github.com/Automattic/pocket-casts-ios/assets/7040243/c7cbcb55-57d0-4850-892a-25e84aa07442


## To test

### Showing the new option for previous users

1. Checkout and run `trunk`
2. Go to any podcast and long press any episode
3. Tap "..."
4. Tap "Edit"
5. Reorder and tap "Done"
6. Run this branch
7. Go to any podcast and long press an episode
8. Tap "..."
9. ✅ "Share" should appear

### Testing share action

1. Run this branch
2. Go to any podcast and long press a single episode
3. Tap "..."
4. Tap "Share"
5. ✅ The share sheet should appear
6. Dismiss it
7. Select more episodes
8. ✅ "Share" should not be available (only sharing a single episode is available)

### Reordering

1. Run this branch
2. Go to any podcast and long press a single episode
3. Tap "..."
4. Tap "Edit"
5. Move "Share" to be one of the first two actions
6. Tap "Done"
7. ✅ Share should be displayed on the action bar
8. Tap it
9. ✅ The share sheet should appear
10. Dismiss it
11. Select more episodes
12. ✅ The share button will be replaced by the next available action
13. Tap "..." and then "Edit"
14. Move "Share" to below
15. Tap "Done"
16. ✅ "Share" should not be available as you have multiple selected episodes

### Events

1. Run this branch
2. Go to Profile > Settings > Beta Features > enable `tracksLogging`
3. Go to any podcast and long press any episode
4. Tap Share
5. ✅ When showing the share sheet you should see a `🔵 Tracked: podcast_shared ["type": "episode", "source": "multi_select"]` log

### iPad

Please test the flows on iPad, given the way the share sheet appears is slightly different.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
