### PR TITLE
Autoplay: change What's New copy

### DIFF
--- a/fastlane/Frozen.strings
+++ b/fastlane/Frozen.strings
@@ -2487,7 +2487,7 @@
 "settings_general_up_next_tap_on_subtitle" = "Tapping an episode in Up Next will play it. Long press shows episode options. Turn off to switch these around.";
 
 /* Subtitle explaining the toggle to modify if a new episode will be reproduced after the current one ends. */
-"settings_general_autoplay_subtitle" = "If your Up Next queue is empty, we'll play episodes from the same podcast or list you're currently listening to.";
+"settings_general_autoplay_subtitle" = "If your Up Next Queue is empty and you start listening to an episode, Autoplay will keep playing episodes from that show or list.";
 
 /* Title for the menu that takes you to the global up next queue settings */
 "settings_global_settings" = "Global Settings";

--- a/fastlane/Frozen.strings
+++ b/fastlane/Frozen.strings
@@ -2487,7 +2487,7 @@
 "settings_general_up_next_tap_on_subtitle" = "Tapping an episode in Up Next will play it. Long press shows episode options. Turn off to switch these around.";
 
 /* Subtitle explaining the toggle to modify if a new episode will be reproduced after the current one ends. */
-"settings_general_autoplay_subtitle" = "If your Up Next Queue is empty and you start listening to an episode, Autoplay will keep playing episodes from that show or list.";
+"settings_general_autoplay_subtitle" = "If your Up Next queue is empty, we'll play episodes from the same podcast or list you're currently listening to.";
 
 /* Title for the menu that takes you to the global up next queue settings */
 "settings_global_settings" = "Global Settings";
@@ -3760,7 +3760,7 @@
 "announcement_autoplay_title" = "Autoplay is here!";
 
 /* Autoplay feature announcement description */
-"announcement_autoplay_description" = "Enable it and Pocket Casts will autoplay episodes from your current list, if your Up Next queue is empty.";
+"announcement_autoplay_description" = "If your Up Next queue is empty and you start listening to an episode, Autoplay will keep playing episodes from that show or list.";
 
 /* Button label for a feature that the user can enable */
 "enable_it_now" = "Enable it now";

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -150,7 +150,7 @@ internal enum L10n {
   internal static var addToUpNext: String { return L10n.tr("Localizable", "add_to_up_next") }
   /// After Playing
   internal static var afterPlaying: String { return L10n.tr("Localizable", "after_playing") }
-  /// Enable it and Pocket Casts will autoplay episodes from your current list, if your Up Next queue is empty.
+  /// If your Up Next queue is empty and you start listening to an episode, Autoplay will keep playing episodes from that show or list.
   internal static var announcementAutoplayDescription: String { return L10n.tr("Localizable", "announcement_autoplay_description") }
   /// Autoplay is here!
   internal static var announcementAutoplayTitle: String { return L10n.tr("Localizable", "announcement_autoplay_title") }
@@ -2284,7 +2284,7 @@ internal enum L10n {
   internal static var settingsGeneralAutoOpenPlayer: String { return L10n.tr("Localizable", "settings_general_auto_open_player") }
   /// Autoplay
   internal static var settingsGeneralAutoplay: String { return L10n.tr("Localizable", "settings_general_autoplay") }
-  /// If your Up Next queue is empty and you start listening to an episode, Autoplay will keep playing episodes from that show or list.
+  /// If your Up Next queue is empty, we'll play episodes from the same podcast or list you're currently listening to.
   internal static var settingsGeneralAutoplaySubtitle: String { return L10n.tr("Localizable", "settings_general_autoplay_subtitle") }
   /// DEFAULTS
   internal static var settingsGeneralDefaultsHeader: String { return L10n.tr("Localizable", "settings_general_defaults_header") }

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -2284,7 +2284,7 @@ internal enum L10n {
   internal static var settingsGeneralAutoOpenPlayer: String { return L10n.tr("Localizable", "settings_general_auto_open_player") }
   /// Autoplay
   internal static var settingsGeneralAutoplay: String { return L10n.tr("Localizable", "settings_general_autoplay") }
-  /// If your Up Next queue is empty, we'll play episodes from the same podcast or list you're currently listening to.
+  /// If your Up Next Queue is empty and you start listening to an episode, Autoplay will keep playing episodes from that show or list.
   internal static var settingsGeneralAutoplaySubtitle: String { return L10n.tr("Localizable", "settings_general_autoplay_subtitle") }
   /// DEFAULTS
   internal static var settingsGeneralDefaultsHeader: String { return L10n.tr("Localizable", "settings_general_defaults_header") }

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -2284,7 +2284,7 @@ internal enum L10n {
   internal static var settingsGeneralAutoOpenPlayer: String { return L10n.tr("Localizable", "settings_general_auto_open_player") }
   /// Autoplay
   internal static var settingsGeneralAutoplay: String { return L10n.tr("Localizable", "settings_general_autoplay") }
-  /// If your Up Next Queue is empty and you start listening to an episode, Autoplay will keep playing episodes from that show or list.
+  /// If your Up Next queue is empty and you start listening to an episode, Autoplay will keep playing episodes from that show or list.
   internal static var settingsGeneralAutoplaySubtitle: String { return L10n.tr("Localizable", "settings_general_autoplay_subtitle") }
   /// DEFAULTS
   internal static var settingsGeneralDefaultsHeader: String { return L10n.tr("Localizable", "settings_general_defaults_header") }

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -2483,7 +2483,7 @@
 "settings_general_up_next_tap_on_subtitle" = "Tapping an episode in Up Next will play it. Long press shows episode options. Turn off to switch these around.";
 
 /* Subtitle explaining the toggle to modify if a new episode will be reproduced after the current one ends. */
-"settings_general_autoplay_subtitle" = "If your Up Next Queue is empty and you start listening to an episode, Autoplay will keep playing episodes from that show or list.";
+"settings_general_autoplay_subtitle" = "If your Up Next queue is empty and you start listening to an episode, Autoplay will keep playing episodes from that show or list.";
 
 /* Title for the menu that takes you to the global up next queue settings */
 "settings_global_settings" = "Global Settings";

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -2483,7 +2483,7 @@
 "settings_general_up_next_tap_on_subtitle" = "Tapping an episode in Up Next will play it. Long press shows episode options. Turn off to switch these around.";
 
 /* Subtitle explaining the toggle to modify if a new episode will be reproduced after the current one ends. */
-"settings_general_autoplay_subtitle" = "If your Up Next queue is empty, we'll play episodes from the same podcast or list you're currently listening to.";
+"settings_general_autoplay_subtitle" = "If your Up Next Queue is empty and you start listening to an episode, Autoplay will keep playing episodes from that show or list.";
 
 /* Title for the menu that takes you to the global up next queue settings */
 "settings_global_settings" = "Global Settings";

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -2483,7 +2483,7 @@
 "settings_general_up_next_tap_on_subtitle" = "Tapping an episode in Up Next will play it. Long press shows episode options. Turn off to switch these around.";
 
 /* Subtitle explaining the toggle to modify if a new episode will be reproduced after the current one ends. */
-"settings_general_autoplay_subtitle" = "If your Up Next queue is empty and you start listening to an episode, Autoplay will keep playing episodes from that show or list.";
+"settings_general_autoplay_subtitle" = "If your Up Next queue is empty, we'll play episodes from the same podcast or list you're currently listening to.";
 
 /* Title for the menu that takes you to the global up next queue settings */
 "settings_global_settings" = "Global Settings";
@@ -3756,7 +3756,7 @@
 "announcement_autoplay_title" = "Autoplay is here!";
 
 /* Autoplay feature announcement description */
-"announcement_autoplay_description" = "Enable it and Pocket Casts will autoplay episodes from your current list, if your Up Next queue is empty.";
+"announcement_autoplay_description" = "If your Up Next queue is empty and you start listening to an episode, Autoplay will keep playing episodes from that show or list.";
 
 /* Button label for a feature that the user can enable */
 "enable_it_now" = "Enable it now";


### PR DESCRIPTION
Change the string that appear when announcing the new Autoplay feature.

<img src="https://github.com/Automattic/pocket-casts-ios/assets/7040243/14de7dd3-d55f-4ee9-be56-011c22753638" width="300">

## To test

### Setup

1. Change `WhatsNew.viewControllerToShow()` to:

```swift
func viewControllerToShow() -> UIViewController? {
        let announcement = announcements.last!

        let whatsNewViewController = ThemedHostingController(rootView: WhatsNewView(announcement: announcement))
        whatsNewViewController.modalPresentationStyle = .overCurrentContext
        whatsNewViewController.modalTransitionStyle = .crossDissolve
        whatsNewViewController.view.backgroundColor = .init(red: 0, green: 0, blue: 0, alpha: 0.5)

        return whatsNewViewController
    }
```

### Testing

1. Run the app
2. ✅ When the What's New popup appears you should see the new string

### Additional info

I manually ran `bundle exec fastlane generate_strings_file_for_glotpress` to update the file that is imported by GlotPress.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
