### PR TITLE
Adds the MultiSelectRow and ActionBarOverlayView views

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1520,6 +1520,7 @@
 		C7D813A92A0D575E007F715F /* AlternateAppIcons.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C7D813A82A0D575E007F715F /* AlternateAppIcons.xcassets */; };
 		C7D813AA2A0D57C2007F715F /* AlternateAppIcons.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C7D813A82A0D575E007F715F /* AlternateAppIcons.xcassets */; };
 		C7D854F328ADD98700877E87 /* AppLifecyleAnalyticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D854F228ADD98700877E87 /* AppLifecyleAnalyticsTests.swift */; };
+		C7D8AE572A5F6D2600C9EBAF /* ActionBarOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D8AE562A5F6D2600C9EBAF /* ActionBarOverlayView.swift */; };
 		C7DA8D272923DA4500C1B08B /* PlusPricingInfoModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7DA8D262923DA4500C1B08B /* PlusPricingInfoModel.swift */; };
 		C7DA8D2A2923DC6800C1B08B /* PlusAccountPromptTableCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7DA8D292923DC6800C1B08B /* PlusAccountPromptTableCell.swift */; };
 		C7E99EF82A5C807A00E7CBAF /* BookmarksPlayerTabController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7E99EF72A5C807A00E7CBAF /* BookmarksPlayerTabController.swift */; };
@@ -1528,6 +1529,7 @@
 		C7E99EFE2A5C918900E7CBAF /* NonBlockingLongPressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7E99EFD2A5C918900E7CBAF /* NonBlockingLongPressView.swift */; };
 		C7E99F002A5E099100E7CBAF /* MutliSelectListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7E99EFF2A5E099100E7CBAF /* MutliSelectListViewModel.swift */; };
 		C7E99F042A5E0FAB00E7CBAF /* ListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7E99F032A5E0FAB00E7CBAF /* ListViewModel.swift */; };
+		C7E99F092A5E105600E7CBAF /* MultiSelectRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7E99F082A5E105600E7CBAF /* MultiSelectRow.swift */; };
 		C7F0EEE7291D9A770007C148 /* LoginCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F0EEE6291D9A770007C148 /* LoginCoordinator.swift */; };
 		C7F2257F29145988001E4547 /* ShareableMetadataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F2257E29145988001E4547 /* ShareableMetadataProvider.swift */; };
 		C7F4BAB528DA6BBB001C9785 /* BackgroundSignOutListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F4BAB428DA6BBB001C9785 /* BackgroundSignOutListener.swift */; };
@@ -3219,6 +3221,7 @@
 		C7D8139F2A0D4BEE007F715F /* AppIcon-Patron-Dark-ipad-pro.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "AppIcon-Patron-Dark-ipad-pro.png"; sourceTree = "<group>"; };
 		C7D813A82A0D575E007F715F /* AlternateAppIcons.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = AlternateAppIcons.xcassets; sourceTree = "<group>"; };
 		C7D854F228ADD98700877E87 /* AppLifecyleAnalyticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLifecyleAnalyticsTests.swift; sourceTree = "<group>"; };
+		C7D8AE562A5F6D2600C9EBAF /* ActionBarOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionBarOverlayView.swift; sourceTree = "<group>"; };
 		C7DA8D262923DA4500C1B08B /* PlusPricingInfoModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlusPricingInfoModel.swift; sourceTree = "<group>"; };
 		C7DA8D292923DC6800C1B08B /* PlusAccountPromptTableCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlusAccountPromptTableCell.swift; sourceTree = "<group>"; };
 		C7E99EF72A5C807A00E7CBAF /* BookmarksPlayerTabController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksPlayerTabController.swift; sourceTree = "<group>"; };
@@ -3227,6 +3230,7 @@
 		C7E99EFD2A5C918900E7CBAF /* NonBlockingLongPressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonBlockingLongPressView.swift; sourceTree = "<group>"; };
 		C7E99EFF2A5E099100E7CBAF /* MutliSelectListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MutliSelectListViewModel.swift; sourceTree = "<group>"; };
 		C7E99F032A5E0FAB00E7CBAF /* ListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListViewModel.swift; sourceTree = "<group>"; };
+		C7E99F082A5E105600E7CBAF /* MultiSelectRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiSelectRow.swift; sourceTree = "<group>"; };
 		C7F0EEE6291D9A770007C148 /* LoginCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginCoordinator.swift; sourceTree = "<group>"; };
 		C7F2257E29145988001E4547 /* ShareableMetadataProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareableMetadataProvider.swift; sourceTree = "<group>"; };
 		C7F4BAB428DA6BBB001C9785 /* BackgroundSignOutListener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundSignOutListener.swift; sourceTree = "<group>"; };
@@ -6283,6 +6287,7 @@
 				C7BDECAA2A15310800BECF02 /* SwiftUI+Accessibility.swift */,
 				C784DE7C2A590866004D03E7 /* View+Buttonize.swift */,
 				C73CCBC829C590100075EFFD /* View+UIView.swift */,
+				C7D8AE562A5F6D2600C9EBAF /* ActionBarOverlayView.swift */,
 			);
 			path = SwiftUI;
 			sourceTree = "<group>";
@@ -6921,6 +6926,7 @@
 			isa = PBXGroup;
 			children = (
 				C7E99F032A5E0FAB00E7CBAF /* ListViewModel.swift */,
+				C7E99F082A5E105600E7CBAF /* MultiSelectRow.swift */,
 				C7E99EFF2A5E099100E7CBAF /* MutliSelectListViewModel.swift */,
 			);
 			path = "List View";
@@ -8487,6 +8493,7 @@
 				4086511B23B1CE8400D7585A /* CreateSiriShortcutCell.swift in Sources */,
 				8B68C1CF2942134300CF25C5 /* BetaMenu.swift in Sources */,
 				4053CE092159E477001C92B1 /* CreateFilterViewController.swift in Sources */,
+				C7D8AE572A5F6D2600C9EBAF /* ActionBarOverlayView.swift in Sources */,
 				BD86D94B217EB5060010FA1B /* FilterSelectionViewController.swift in Sources */,
 				40B26ABE213BB29200386173 /* FeaturedTableViewCell.swift in Sources */,
 				BD92323123629E1900C1E118 /* PlayerContainerViewController.swift in Sources */,
@@ -8644,6 +8651,7 @@
 				4041FE8D218A7DA60089D4A1 /* SiriShortcutEnabledCell.swift in Sources */,
 				BD5C39541B5E0A2A00C3A499 /* ShiftyLoadingAlert.swift in Sources */,
 				BD2D0AD3243C4138000B313A /* MainEpisodeActionView+Pointer.swift in Sources */,
+				C7E99F092A5E105600E7CBAF /* MultiSelectRow.swift in Sources */,
 				40164A5E23CC028D0043907B /* TourSpotlight.swift in Sources */,
 				8B472E022A4B83CE005905F4 /* AutoplayHelper.swift in Sources */,
 				BDA681AB220D03930053BEEE /* UserEpisodeManager.swift in Sources */,

--- a/podcasts/Common SwiftUI/List View/MultiSelectRow.swift
+++ b/podcasts/Common SwiftUI/List View/MultiSelectRow.swift
@@ -16,8 +16,8 @@ struct MultiSelectRow<Content: View>: View {
     /// Called when the selection toggle is tapped
     let onSelectionToggled: () -> Void
 
-    @ScaledMetricWithMaxSize(relativeTo: .body) private var multiSelectButtonSize = 24
-    @ScaledMetricWithMaxSize(relativeTo: .body) private var checkSize = 20
+    @ScaledMetricWithMaxSize(relativeTo: .body, maxSize: .xxLarge) private var multiSelectButtonSize = 24
+    @ScaledMetricWithMaxSize(relativeTo: .body, maxSize: .xxLarge) private var checkSize = 20
 
     private let style = Style()
 

--- a/podcasts/Common SwiftUI/List View/MultiSelectRow.swift
+++ b/podcasts/Common SwiftUI/List View/MultiSelectRow.swift
@@ -4,9 +4,16 @@ import SwiftUI
 ///
 /// See the [Preview](x-source-tag://MultiSelectRowPreview) for example usage
 struct MultiSelectRow<Content: View>: View {
-    let visible: Bool
+    /// Whether the row should display the select button in the row
+    let showSelectButton: Bool
+
+    /// Whether the select button should appear in its selected state
     let selected: Bool
+
+    /// The row content to wrap
     let content: () -> Content
+
+    /// Called when the selection toggle is tapped
     let onSelectionToggled: () -> Void
 
     @ScaledMetricWithMaxSize(relativeTo: .body) private var multiSelectButtonSize = 24
@@ -16,25 +23,29 @@ struct MultiSelectRow<Content: View>: View {
 
     var body: some View {
         HStack(spacing: 15) {
-            if visible {
+            if showSelectButton {
                 buttonView.buttonize {
                     onSelectionToggled()
                 } customize: { config in
                     config.label.applyButtonEffect(isPressed: config.isPressed)
                 }
-                .transition(.move(edge: .leading).combined(with: .opacity))
+                .accessibilityTransition(.move(edge: .leading).combined(with: .opacity))
             }
 
             content()
         }
     }
 
-    func rowStyle(tintColor: Color, checkColor: Color) -> Self {
+    /// Customizes the selection button colors
+    func selectButtonStyle(tintColor: Color, checkColor: Color) -> Self {
         style.tint = tintColor
         style.check = checkColor
         return self
     }
 
+    // MARK: - Private
+
+    /// The unselected select button
     private var buttonView: some View {
         Circle()
             .stroke(lineWidth: 2)
@@ -43,6 +54,7 @@ struct MultiSelectRow<Content: View>: View {
             .overlay(selectedView)
     }
 
+    /// The selected button state
     private var selectedView: some View {
         ZStack {
             Circle().fill(style.tint)
@@ -84,7 +96,7 @@ struct MultiSelectRow_Previews: PreviewProvider {
                     }
                 }.buttonStyle(.borderedProminent)
 
-                MultiSelectRow(visible: visible, selected: selected) {
+                MultiSelectRow(showSelectButton: visible, selected: selected) {
                     HStack {
                         Text("Hello World")
                     }
@@ -95,7 +107,7 @@ struct MultiSelectRow_Previews: PreviewProvider {
                         selected.toggle()
                     }
                 }
-                .rowStyle(tintColor: .black, checkColor: .white)
+                .selectButtonStyle(tintColor: .black, checkColor: .white)
                 .padding()
                 .background(Color.blue)
 

--- a/podcasts/Common SwiftUI/List View/MultiSelectRow.swift
+++ b/podcasts/Common SwiftUI/List View/MultiSelectRow.swift
@@ -1,0 +1,106 @@
+import SwiftUI
+
+/// A list view wrapper that can toggle a selection checkbox visible
+///
+/// See the [Preview](x-source-tag://MultiSelectRowPreview) for example usage
+struct MultiSelectRow<Content: View>: View {
+    let visible: Bool
+    let selected: Bool
+    let content: () -> Content
+    let onSelectionToggled: () -> Void
+
+    @ScaledMetricWithMaxSize(relativeTo: .body) private var multiSelectButtonSize = 24
+    @ScaledMetricWithMaxSize(relativeTo: .body) private var checkSize = 20
+
+    private let style = Style()
+
+    var body: some View {
+        HStack(spacing: 15) {
+            if visible {
+                buttonView.buttonize {
+                    onSelectionToggled()
+                } customize: { config in
+                    config.label.applyButtonEffect(isPressed: config.isPressed)
+                }
+                .transition(.move(edge: .leading).combined(with: .opacity))
+            }
+
+            content()
+        }
+    }
+
+    func rowStyle(tintColor: Color, checkColor: Color) -> Self {
+        style.tint = tintColor
+        style.check = checkColor
+        return self
+    }
+
+    private var buttonView: some View {
+        Circle()
+            .stroke(lineWidth: 2)
+            .fill(style.tint)
+            .frame(width: multiSelectButtonSize, height: multiSelectButtonSize)
+            .overlay(selectedView)
+    }
+
+    private var selectedView: some View {
+        ZStack {
+            Circle().fill(style.tint)
+
+            Image("discover_tick")
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(height: checkSize)
+                .foregroundStyle(style.check)
+        }
+        .opacity(selected ? 1 : 0)
+        .animation(.linear(duration: 0.1), value: selected)
+    }
+
+    private class Style {
+        var tint: Color = .white
+        var check: Color = .black
+    }
+}
+
+// MARK: - Previews
+
+/// - Tag: MultiSelectRowPreview
+
+struct MultiSelectRow_Previews: PreviewProvider {
+    static var previews: some View {
+        PreviewView()
+    }
+
+    private struct PreviewView: View {
+        @State private var visible = false
+        @State private var selected = false
+
+        var body: some View {
+            VStack(spacing: 20) {
+                Button("Toggle Visible") {
+                    withAnimation {
+                        visible.toggle()
+                    }
+                }.buttonStyle(.borderedProminent)
+
+                MultiSelectRow(visible: visible, selected: selected) {
+                    HStack {
+                        Text("Hello World")
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                } onSelectionToggled: {
+                    withAnimation {
+                        selected.toggle()
+                    }
+                }
+                .rowStyle(tintColor: .black, checkColor: .white)
+                .padding()
+                .background(Color.blue)
+
+            }
+            .frame(maxWidth: .infinity)
+        }
+    }
+}

--- a/podcasts/SwiftUI/ActionBarOverlayView.swift
+++ b/podcasts/SwiftUI/ActionBarOverlayView.swift
@@ -1,0 +1,157 @@
+import SwiftUI
+
+/// Displays an overlay view that displays text and icon only buttons
+///
+struct ActionBarOverlayView<Content: View>: View {
+    var visible: Bool
+    var title: String? = nil
+    let content: () -> Content
+    var actions: [Action] = []
+
+    private let style = Style()
+
+    @ScaledMetricWithMaxSize(relativeTo: .body) private var imageSize = 24
+
+    var body: some View {
+        ZStack(alignment: .bottom) {
+            content()
+
+            if visible {
+                HStack {
+                    // Show the title if needed
+                    title.map {
+                        Text($0)
+                            .font(style: .subheadline, weight: .medium)
+                            // Disable the animation so it doesn't fade when changed
+                            .animation(.none, value: $0)
+                    }
+
+                    Spacer()
+
+                    ForEach(actions) { action in
+                        if action.visible {
+                            actionButton(action)
+                        }
+                    }
+                }
+                .foregroundStyle(style.foregroundColor)
+                // Inner Padding
+                .padding(.vertical, ActionBarConstants.barPaddingVertical)
+                .padding(.horizontal, ActionBarConstants.barPaddingHorizontal)
+                .applyMaterial(tint: style.backgroundTint)
+                .cornerRadius(ActionBarConstants.radius)
+                // Outer Padding
+                .padding(.horizontal, ActionBarConstants.barPaddingHorizontal)
+            }
+        }
+        .accessibilityTransition(.opacity)
+        .animation(.linear(duration: 0.1), value: visible)
+        .padding(.bottom)
+    }
+
+    func barStyle(backgroundTint: Color, buttonColor: Color, foregroundColor: Color) -> Self {
+        style.backgroundTint = backgroundTint
+        style.buttonColor = buttonColor
+        style.foregroundColor = foregroundColor
+        return self
+    }
+
+    private func actionButton(_ action: Action) -> some View {
+        Button {
+            action.action()
+        } label: {
+            Image(action.imageName)
+                .renderingMode(.template)
+                .resizable()
+                .frame(width: imageSize, height: imageSize)
+                .padding(.vertical, ActionBarConstants.buttonPaddingVertical)
+                .padding(.horizontal, ActionBarConstants.buttonPaddingHorizontal)
+                .background(style.buttonColor)
+                .cornerRadius(.infinity)
+        }
+        .accessibilityLabel(action.title)
+        .opacity(action.visible ? 1 : 0)
+        .accessibilityAnimation(.linear(duration: 0.1), value: action.visible)
+    }
+
+    struct Action: Identifiable {
+        let imageName: String
+        let title: String
+        let visible: Bool
+        let action: () -> Void
+
+        init(imageName: String, title: String, visible: Bool = true, action: @escaping () -> Void) {
+            self.imageName = imageName
+            self.title = title
+            self.visible = visible
+            self.action = action
+        }
+
+        var id: String { title }
+    }
+
+    private class Style {
+        var backgroundTint: Color = .white
+        var buttonColor: Color = .white
+        var foregroundColor: Color = .black
+    }
+}
+
+private enum ActionBarConstants {
+    static let radius = 12.0
+    static let barPaddingVertical = 12.0
+    static let barPaddingHorizontal = 16.0
+    static let buttonPaddingHorizontal = 12.0
+    static let buttonPaddingVertical = 4.0
+}
+
+private extension View {
+    func applyMaterial(tint: Color) -> some View {
+        self
+            .background(.ultraThinMaterial)
+            .background(tint)
+            .environment(\.colorScheme, .dark)
+    }
+}
+
+/// - Tag: ActionBarOverlayViewPreview
+struct ActionBarOverlayView_Previews: PreviewProvider {
+    static var previews: some View {
+        PreviewView()
+    }
+
+    private struct PreviewView: View {
+        @State var visible = true
+        @State var showAction = true
+
+        var body: some View {
+            ActionBarOverlayView(visible: visible, title: "Hello World", content: {
+                VStack(spacing: 20) {
+                    Button("Toggle Action Bar") {
+                        withAnimation {
+                            visible.toggle()
+                        }
+                    }.buttonStyle(.bordered)
+
+                    Button("Toggle Action Visible") {
+                        withAnimation {
+                            showAction.toggle()
+                        }
+                    }.buttonStyle(.bordered)
+
+                    Spacer()
+                }.frame(maxWidth: .infinity)
+
+            }, actions: [
+                .init(imageName: "shelf_archive", title: "Archive", action: {
+                    print("one")
+                }),
+                .init(imageName: "shelf_delete", title: "Delete", visible: showAction, action: {
+                    print("two")
+                })
+            ])
+            .barStyle(backgroundTint: .secondary, buttonColor: .accentColor, foregroundColor: .primary)
+            .background(Color.primary.ignoresSafeArea())
+        }
+    }
+}

--- a/podcasts/SwiftUI/ActionBarOverlayView.swift
+++ b/podcasts/SwiftUI/ActionBarOverlayView.swift
@@ -115,6 +115,7 @@ private extension View {
 }
 
 /// - Tag: ActionBarOverlayViewPreview
+
 struct ActionBarOverlayView_Previews: PreviewProvider {
     static var previews: some View {
         PreviewView()

--- a/podcasts/SwiftUI/ActionBarOverlayView.swift
+++ b/podcasts/SwiftUI/ActionBarOverlayView.swift
@@ -53,7 +53,7 @@ struct ActionBarView<Style: ActionBarStyle>: View {
     /// The actions to display in the action bar, this can be omitted
     var actions: [Action] = []
 
-    @ScaledMetricWithMaxSize(relativeTo: .body) private var imageSize = 24
+    @ScaledMetricWithMaxSize(relativeTo: .body, maxSize: .xxLarge) private var imageSize = 24
 
     var body: some View {
         HStack {

--- a/podcasts/SwiftUI/ActionBarOverlayView.swift
+++ b/podcasts/SwiftUI/ActionBarOverlayView.swift
@@ -1,60 +1,106 @@
 import SwiftUI
 
-/// Displays an overlay view that displays text and icon only buttons
+/// Displays an overlay view that displays the ActionBarView at the bottom
 ///
-struct ActionBarOverlayView<Content: View>: View {
-    var visible: Bool
+struct ActionBarOverlayView<Content: View, Style: ActionBarStyle>: View {
+    /// Whether the action bar should appear in the view or not
+    var actionBarVisible: Bool
+
+    /// The label that appears in the action bar, this can be omitted
     var title: String? = nil
+
+    /// The ActionBarStyle to use
+    let style: Style
+
+    /// The view to display the action bar in, ideally this should be a full height view
     let content: () -> Content
-    var actions: [Action] = []
 
-    private let style = Style()
-
-    @ScaledMetricWithMaxSize(relativeTo: .body) private var imageSize = 24
+    /// The actions to display in the action bar
+    var actions: [ActionBarView<Style>.Action] = []
 
     var body: some View {
         ZStack(alignment: .bottom) {
             content()
 
-            if visible {
-                HStack {
-                    // Show the title if needed
-                    title.map {
-                        Text($0)
-                            .font(style: .subheadline, weight: .medium)
-                            // Disable the animation so it doesn't fade when changed
-                            .animation(.none, value: $0)
-                    }
-
-                    Spacer()
-
-                    ForEach(actions) { action in
-                        if action.visible {
-                            actionButton(action)
-                        }
-                    }
-                }
-                .foregroundStyle(style.foregroundColor)
-                // Inner Padding
-                .padding(.vertical, ActionBarConstants.barPaddingVertical)
-                .padding(.horizontal, ActionBarConstants.barPaddingHorizontal)
-                .applyMaterial(tint: style.backgroundTint)
-                .cornerRadius(ActionBarConstants.radius)
-                // Outer Padding
-                .padding(.horizontal, ActionBarConstants.barPaddingHorizontal)
+            if actionBarVisible {
+                ActionBarView(title: title, style: style, actions: actions)
             }
         }
         .accessibilityTransition(.opacity)
-        .animation(.linear(duration: 0.1), value: visible)
+        .animation(.linear(duration: 0.1), value: actionBarVisible)
         .padding(.bottom)
     }
+}
 
-    func barStyle(backgroundTint: Color, buttonColor: Color, foregroundColor: Color) -> Self {
-        style.backgroundTint = backgroundTint
-        style.buttonColor = buttonColor
-        style.foregroundColor = foregroundColor
-        return self
+// MARK: - ActionBarStyle
+
+/// Allows parent views to customize the colors of the action bar
+protocol ActionBarStyle {
+    var backgroundTint: Color { get }
+    var buttonColor: Color { get }
+    var foregroundColor: Color { get }
+}
+
+// MARK: - ActionBarView
+
+struct ActionBarView<Style: ActionBarStyle>: View {
+    /// The label that appears in the action bar, this can be omitted
+    var title: String? = nil
+
+    /// The ActionBarStyle to use
+    let style: Style
+
+    /// The actions to display in the action bar, this can be omitted
+    var actions: [Action] = []
+
+    @ScaledMetricWithMaxSize(relativeTo: .body) private var imageSize = 24
+
+    var body: some View {
+        HStack {
+            // Show the title if needed
+            title.map {
+                Text($0)
+                    .font(style: .subheadline, weight: .medium)
+                    // Disable the animation so it doesn't fade when changed
+                    .animation(.none, value: $0)
+            }
+
+            Spacer()
+
+            ForEach(actions) { action in
+                if action.visible {
+                    actionButton(action)
+                }
+            }
+        }
+        .foregroundStyle(style.foregroundColor)
+        // Inner Padding
+        .padding(.vertical, ActionBarConstants.barPaddingVertical)
+        .padding(.horizontal, ActionBarConstants.barPaddingHorizontal)
+        .applyMaterial(tint: style.backgroundTint)
+        .cornerRadius(ActionBarConstants.radius)
+        // Outer Padding
+        .padding(.horizontal, ActionBarConstants.barPaddingHorizontal)
     }
+
+    // MARK: - Action! 🎬
+    struct Action: Identifiable {
+        let imageName: String
+        let title: String
+        let visible: Bool
+        let action: () -> Void
+
+        init(imageName: String, title: String, visible: Bool = true, action: @escaping () -> Void) {
+            self.imageName = imageName
+            self.title = title
+            self.visible = visible
+            self.action = action
+        }
+
+        var id: String { title }
+    }
+
+    // MARK: - Private
 
     private func actionButton(_ action: Action) -> some View {
         Button {
@@ -72,28 +118,6 @@ struct ActionBarOverlayView<Content: View>: View {
         .accessibilityLabel(action.title)
         .opacity(action.visible ? 1 : 0)
         .accessibilityAnimation(.linear(duration: 0.1), value: action.visible)
-    }
-
-    struct Action: Identifiable {
-        let imageName: String
-        let title: String
-        let visible: Bool
-        let action: () -> Void
-
-        init(imageName: String, title: String, visible: Bool = true, action: @escaping () -> Void) {
-            self.imageName = imageName
-            self.title = title
-            self.visible = visible
-            self.action = action
-        }
-
-        var id: String { title }
-    }
-
-    private class Style {
-        var backgroundTint: Color = .white
-        var buttonColor: Color = .white
-        var foregroundColor: Color = .black
     }
 }
 
@@ -126,7 +150,7 @@ struct ActionBarOverlayView_Previews: PreviewProvider {
         @State var showAction = true
 
         var body: some View {
-            ActionBarOverlayView(visible: visible, title: "Hello World", content: {
+            ActionBarOverlayView(actionBarVisible: visible, title: "Hello World", style: PreviewStyle(), content: {
                 VStack(spacing: 20) {
                     Button("Toggle Action Bar") {
                         withAnimation {
@@ -151,8 +175,12 @@ struct ActionBarOverlayView_Previews: PreviewProvider {
                     print("two")
                 })
             ])
-            .barStyle(backgroundTint: .secondary, buttonColor: .accentColor, foregroundColor: .primary)
-            .background(Color.primary.ignoresSafeArea())
         }
+    }
+
+    private struct PreviewStyle: ActionBarStyle {
+        var backgroundTint: Color { .secondary }
+        var buttonColor: Color { .accentColor }
+        var foregroundColor: Color { .primary }
     }
 }

--- a/podcasts/UIFont+FontStyle.swift
+++ b/podcasts/UIFont+FontStyle.swift
@@ -153,6 +153,12 @@ private extension Font.TextStyle {
 }
 
 // MARK: - ScaledMetricWithMaxSize
+
+/// `ScaledMetricWithMaxSize` provides the same functionality as the [@ScaledMetric](https://developer.apple.com/documentation/swiftui/scaledmetric) property wrapper, however it also adds the ability to limit the maximum size of the value.
+///
+/// This allows you to create custom values that scale along with the dynamic text size, such as scaling an icon or padding.
+///
+///
 @propertyWrapper
 public struct ScaledMetricWithMaxSize<Value>: DynamicProperty where Value: BinaryFloatingPoint {
     @Environment(\.dynamicTypeSize) var dynamicTypeSize

--- a/podcasts/UIFont+FontStyle.swift
+++ b/podcasts/UIFont+FontStyle.swift
@@ -151,3 +151,61 @@ private extension Font.TextStyle {
         }
     }
 }
+
+// MARK: - ScaledMetricWithMaxSize
+@propertyWrapper
+public struct ScaledMetricWithMaxSize<Value>: DynamicProperty where Value: BinaryFloatingPoint {
+    @Environment(\.dynamicTypeSize) var dynamicTypeSize
+
+    private let baseValue: Value
+    private let textStyle: Font.TextStyle
+    private let maxTypeSize: DynamicTypeSize
+
+    public var wrappedValue: Value {
+        let size = min(dynamicTypeSize, maxTypeSize)
+        let metrics = UIFontMetrics(forTextStyle: textStyle.UIFontTextStyle)
+        let traits = UITraitCollection(preferredContentSizeCategory: size.UIContentSizeCategory)
+
+        return Value(metrics.scaledValue(for: Double(baseValue), compatibleWith: traits))
+    }
+
+    public init(wrappedValue: Value = .zero, relativeTo textStyle: Font.TextStyle, maxTypeSize: DynamicTypeSize = .xxLarge) {
+        self.baseValue = wrappedValue
+        self.textStyle = textStyle
+        self.maxTypeSize = maxTypeSize
+    }
+}
+
+private extension DynamicTypeSize {
+    var UIContentSizeCategory: UIContentSizeCategory {
+        switch self {
+        case .xSmall:
+            return .extraSmall
+        case .small:
+            return .small
+        case .medium:
+            return .medium
+        case .large:
+            return .large
+        case .xLarge:
+            return .extraLarge
+        case .xxLarge:
+            return .extraExtraLarge
+        case .xxxLarge:
+            return .extraExtraExtraLarge
+        case .accessibility1:
+            return .accessibilityMedium
+        case .accessibility2:
+            return .accessibilityLarge
+        case .accessibility3:
+            return .accessibilityExtraLarge
+        case .accessibility4:
+            return .accessibilityExtraExtraLarge
+        case .accessibility5:
+            return .accessibilityExtraExtraExtraLarge
+        @unknown default:
+            return .large
+        }
+    }
+}
+

--- a/podcasts/UIFont+FontStyle.swift
+++ b/podcasts/UIFont+FontStyle.swift
@@ -214,4 +214,3 @@ private extension DynamicTypeSize {
         }
     }
 }
-

--- a/podcasts/UIFont+FontStyle.swift
+++ b/podcasts/UIFont+FontStyle.swift
@@ -175,10 +175,10 @@ public struct ScaledMetricWithMaxSize<Value>: DynamicProperty where Value: Binar
         return Value(metrics.scaledValue(for: Double(baseValue), compatibleWith: traits))
     }
 
-    public init(wrappedValue: Value = .zero, relativeTo textStyle: Font.TextStyle, maxTypeSize: DynamicTypeSize = .xxLarge) {
+    public init(wrappedValue: Value = .zero, relativeTo textStyle: Font.TextStyle, maxSize: DynamicTypeSize) {
         self.baseValue = wrappedValue
         self.textStyle = textStyle
-        self.maxTypeSize = maxTypeSize
+        self.maxTypeSize = maxSize
     }
 }
 


### PR DESCRIPTION
| 🛫 Depends on: https://github.com/Automattic/pocket-casts-ios/pull/973 |
|:---:|

This adds the common MultiSelectRow and ActionBarOverlayView views, along with the `ScaledMetricWithMaxSize` property wrapper. 

`MultiSelectRow` is a list row wrapper that will display the selection checkbox, and inform the parent view when the selection changes. 

`ActionBarOverlayView` displays a simple overlay view with text and action buttons. 

`ScaledMetricWithMaxSize` provides the same functionality as the [@ScaledMetric](https://developer.apple.com/documentation/swiftui/scaledmetric) property wrapper, however it also adds the ability to limit the maximum size of the value.

## To test

Check the SwiftUI previews, and code review. 

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
