### PR TITLE
Bookmarks: Adds deleting of bookmarks from the list

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Bookmarks/BookmarkDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Bookmarks/BookmarkDataManager.swift
@@ -9,6 +9,8 @@ public struct BookmarkDataManager {
         self.dbQueue = dbQueue
     }
 
+    // MARK: - Adding
+
     /// Adds a new bookmark to the database
     /// - Parameters:
     ///   - episodeUuid: The UUID of the episode we're adding to
@@ -43,6 +45,8 @@ public struct BookmarkDataManager {
         return bookmarkUuid
     }
 
+    // MARK: - Retrieving
+
     /// Retrieves a single Bookmark for the given UUID
     public func bookmark(for uuid: String) -> Bookmark? {
         selectBookmarks(where: [.uuid], values: [uuid], limit: 1).first
@@ -64,6 +68,58 @@ public struct BookmarkDataManager {
         }
 
         return selectBookmarks(where: whereColumns, values: values)
+    }
+
+    /// Returns all the bookmarks in the database and optionally can also return deleted items
+    public func allBookmarks(includeDeleted: Bool) -> [Bookmark] {
+        selectBookmarks(where: [.deleted], values: [includeDeleted])
+    }
+
+    // MARK: - Deleting
+
+    /// Marks the bookmarks as deleted, but doesn't actually remove them from the database
+    public func remove(bookmarks: [Bookmark]) async -> Bool {
+        await withCheckedContinuation { continuation in
+            let uuids = bookmarks.map { "'\($0.uuid)'" }.joined(separator: ",")
+
+            let query = """
+            UPDATE \(Self.tableName)
+            SET \(Column.deleted) = 1
+            WHERE \(Column.uuid) IN (\(uuids))
+            """
+
+            dbQueue.inDatabase { db in
+                do {
+                    try db.executeUpdate(query, values: nil)
+                    continuation.resume(returning: true)
+                } catch {
+                    FileLog.shared.addMessage("BookmarkManager.remove failed: \(error)")
+                    continuation.resume(returning: false)
+                }
+            }
+        }
+    }
+
+    /// Permanently removes the bookmarks from the database
+    public func permanentlyDelete(bookmarks: [Bookmark]) async -> Bool {
+        await withCheckedContinuation { continuation in
+            let uuids = bookmarks.map { "'\($0.uuid)'" }.joined(separator: ",")
+
+            let query = """
+            DELETE FROM \(Self.tableName)
+            WHERE \(Column.uuid) IN (\(uuids))
+            """
+
+            dbQueue.inDatabase { db in
+                do {
+                    try db.executeUpdate(query, values: nil)
+                    continuation.resume(returning: true)
+                } catch {
+                    FileLog.shared.addMessage("BookmarkManager.remove failed: \(error)")
+                    continuation.resume(returning: false)
+                }
+            }
+        }
     }
 
     enum Column: String, CaseIterable, CustomStringConvertible {
@@ -99,6 +155,9 @@ private extension BookmarkDataManager {
         let selectColumns = Column.allCases.map { $0.rawValue }
         let whereString = whereColumns.map { "\($0.rawValue) = ?" }.joined(separator: " AND ")
 
+        // If the deleted column isn't specified, then by default exclude deleted items
+        let deleteString = whereColumns.contains(.deleted) ? "" : "AND \(Column.deleted) = 0"
+
         var results: [Bookmark] = []
 
         dbQueue.inDatabase { db in
@@ -107,6 +166,7 @@ private extension BookmarkDataManager {
                     SELECT \(selectColumns.columnString)
                     FROM \(Self.tableName)
                     WHERE \(whereString)
+                    \(deleteString)
                     ORDER BY \(Column.createdDate) DESC
                     \(limitQuery)
                 """

--- a/podcasts/BookmarkManager.swift
+++ b/podcasts/BookmarkManager.swift
@@ -8,6 +8,7 @@ class BookmarkManager {
 
     // Publishers
     let onBookmarkCreated = PassthroughSubject<(BaseEpisode, Bookmark), Never>()
+    let onBookmarksDeleted = PassthroughSubject<([Bookmark]), Never>()
 
     init(dataManager: BookmarkDataManager = DataManager.sharedManager.bookmarks) {
         self.dataManager = dataManager
@@ -49,6 +50,18 @@ class BookmarkManager {
     /// Retrieves all the bookmarks for a podcast
     func bookmarks(for podcast: Podcast) -> [Bookmark] {
         dataManager.bookmarks(forEpisode: podcast.uuid)
+    }
+
+    /// Removes an array of bookmarks
+    func remove(_ bookmarks: [Bookmark]) async -> Bool {
+        let success = await dataManager.remove(bookmarks: bookmarks)
+
+        // Inform any listeners
+        if success {
+            onBookmarksDeleted.send(bookmarks)
+        }
+
+        return success
     }
 }
 

--- a/podcasts/Bookmarks/List/BookmarkListViewModel.swift
+++ b/podcasts/Bookmarks/List/BookmarkListViewModel.swift
@@ -80,5 +80,12 @@ private extension BookmarkListViewModel {
     }
 
     func actuallyDelete(_ items: [Bookmark]) {
+        Task {
+            guard await bookmarkManager.remove(items) else {
+                return
+            }
+
+            reload()
+        }
     }
 }


### PR DESCRIPTION
This adds the ability to remove bookmarks when multi selecting in the bookmarks list

## Demo Video

https://github.com/Automattic/pocket-casts-ios/assets/793774/9b170e21-ced4-4fb7-89a1-0cb272edc427

## To test

1. Enable the Bookmarks Feature Flag by going to Profile > Cog > Beta Features > bookmarks
2. Open the Full Screen Player
3. Add multiple bookmarks at various places
4. Swipe to the bookmarks tab
5. Long press on a row
6. Tap the Delete item in the action bar
7. ✅ Verify the row is removed
8. Delete more than 1 item from various rows
9. ✅ Verify the view updates correctly
10. Delete all of the items
11. ✅ Verify you leave multi select mode and all of the items are removed

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
