### PR TITLE
Bookmarks: Add title field

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/Util/FMDatabaseQueue+Async.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/Util/FMDatabaseQueue+Async.swift
@@ -1,0 +1,42 @@
+import FMDB
+
+extension FMDatabaseQueue {
+
+    /// Asynchronously perform queries on an `FMDatabase` from a `FMDatabaseQueue`
+    /// The `inDatabase` call itself is a synchronous process but makes getting a return result harder due to the completion block. Using async you can retrieve the result in 1 line.
+    ///
+    /// Usage:
+    ///
+    ///     let result = await dbQueue.perform { try $0.executeQuery(...) }
+    ///     switch result {
+    ///         case .success:
+    ///             print("Yay")
+    ///         case .failure(let error):
+    ///             print("Uh oh", error)
+    ///
+    func perform<T>(_ action: (FMDatabase) throws -> T) async -> Result<T, Error> {
+        await withCheckedContinuation { continuation in
+            inDatabase { db in
+                do {
+                    continuation.resume(returning: .success(try action(db)))
+                } catch {
+                    continuation.resume(returning: .failure(error))
+                }
+            }
+        }
+    }
+
+    /// Helper async function perform `executeUpdate` from a database queue
+    func executeUpdate(_ query: String, values: [Any]? = nil) async -> Result<Void, Error> {
+        await perform { db in
+            try db.executeUpdate(query, values: values)
+        }
+    }
+
+    /// Helper async function perform `executeQuery` from a database queue
+    func executeQuery(_ query: String, values: [Any]? = nil) async -> Result<FMResultSet, Error> {
+        await perform { db in
+            try db.executeQuery(query, values: values)
+        }
+    }
+}

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Bookmarks/Bookmark.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Bookmarks/Bookmark.swift
@@ -3,9 +3,12 @@ import Foundation
 /// A bookmark that represents a position in time within an episode
 public struct Bookmark: Hashable {
     public let uuid: String
-    public let createdDate: Date
+    public let title: String
     public let time: TimeInterval
-    public let title: String?
+
+    public let created: Date
+    public let modified: Date
+
     public let episodeUuid: String
     public let podcastUuid: String?
 }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Bookmarks/BookmarkDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Bookmarks/BookmarkDataManager.swift
@@ -97,7 +97,7 @@ public struct BookmarkDataManager {
     }
 
     /// Returns all the bookmarks in the database and optionally can also return deleted items
-    public func allBookmarks(includeDeleted: Bool) -> [Bookmark] {
+    public func allBookmarks(includeDeleted: Bool = false) -> [Bookmark] {
         selectBookmarks(where: [.deleted], values: [includeDeleted])
     }
 

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Bookmarks/BookmarkDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Bookmarks/BookmarkDataManager.swift
@@ -124,7 +124,9 @@ public struct BookmarkDataManager {
 
     enum Column: String, CaseIterable, CustomStringConvertible {
         case uuid
+        case title
         case createdDate = "date_added"
+        case modifiedDate = "date_modified"
         case episode = "episode_uuid"
         case podcast = "podcast_uuid"
         case time
@@ -194,10 +196,12 @@ extension BookmarkDataManager {
         try db.executeUpdate("""
             CREATE TABLE IF NOT EXISTS \(Self.tableName) (
                 \(Column.uuid) varchar(40) NOT NULL,
+                \(Column.title) varchar(100) NOT NULL,
                 \(Column.episode) varchar(40) NOT NULL,
                 \(Column.podcast) varchar(40),
                 \(Column.time) real NOT NULL,
                 \(Column.createdDate) INTEGER NOT NULL,
+                \(Column.modifiedDate) INTEGER NOT NULL,
                 \(Column.deleted) int NOT NULL DEFAULT 0,
                 PRIMARY KEY (\(Column.uuid))
             );
@@ -215,20 +219,22 @@ private extension Bookmark {
     init?(from resultSet: FMResultSet) {
         guard
             let uuid = resultSet.string(for: .uuid),
+            let title = resultSet.string(for: .title),
             let createdDate = resultSet.date(for: .createdDate),
+            let modified = resultSet.date(for: .modifiedDate),
             let episode = resultSet.string(for: .episode),
             let time = resultSet.double(for: .time)
         else {
             return nil
         }
 
-        let title: String? = nil
         let podcast = resultSet.string(for: .podcast)
 
         self.init(uuid: uuid,
-                  createdDate: createdDate,
-                  time: time,
                   title: title,
+                  time: time,
+                  created: createdDate,
+                  modified: modified,
                   episodeUuid: episode,
                   podcastUuid: podcast)
     }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Bookmarks/BookmarkDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Bookmarks/BookmarkDataManager.swift
@@ -235,11 +235,8 @@ private extension Bookmark {
 }
 
 // MARK: - BookmarkDataManager.Column: FMResultSet Extension
-private extension FMResultSet {
-    func object(for column: BookmarkDataManager.Column) -> Any? {
-        object(forColumn: column.rawValue)
-    }
 
+private extension FMResultSet {
     func string(for column: BookmarkDataManager.Column) -> String? {
         string(forColumn: column.rawValue)
     }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Bookmarks/BookmarkDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Bookmarks/BookmarkDataManager.swift
@@ -50,6 +50,27 @@ public struct BookmarkDataManager {
         return bookmarkUuid
     }
 
+    // MARK: - Updating
+    @discardableResult
+    public func update(title: String, for bookmark: Bookmark, modified: Date = Date()) async -> Bool {
+        let query = """
+                UPDATE \(Self.tableName)
+                SET \(Column.title) = ?, \(Column.modifiedDate) = ?
+                WHERE \(Column.uuid) = ?
+                LIMIT 1
+                """
+
+        let result = await dbQueue.executeUpdate(query, values: [title, modified.timeIntervalSince1970, bookmark.uuid])
+
+        switch result {
+        case .success:
+            return true
+        case .failure(let failure):
+            FileLog.shared.addMessage("BookmarkManager.update failed: \(failure)")
+            return false
+        }
+    }
+
     // MARK: - Retrieving
 
     /// Retrieves a single Bookmark for the given UUID

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Bookmarks/BookmarkDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Bookmarks/BookmarkDataManager.swift
@@ -18,7 +18,7 @@ public struct BookmarkDataManager {
     ///   - time: The playback time for the bookmark
     ///   - transcription: A transcription of the clip if available
     @discardableResult
-    public func add(episodeUuid: String, podcastUuid: String?, time: TimeInterval) -> String? {
+    public func add(episodeUuid: String, podcastUuid: String?, time: TimeInterval, dateCreated: Date = Date()) -> String? {
         // Prevent adding more than 1 bookmark at the same place
         if let existing = existingBookmark(forEpisode: episodeUuid, time: time) {
             return existing.uuid
@@ -29,10 +29,10 @@ public struct BookmarkDataManager {
         dbQueue.inDatabase { db in
             do {
                 let uuid = UUID().uuidString.lowercased()
-                let now = Date().timeIntervalSince1970
+                let created = dateCreated.timeIntervalSince1970
 
                 let columns = Column.insertColumns
-                let values: [Any?] = [uuid, now, episodeUuid, podcastUuid, time]
+                let values: [Any?] = [uuid, created, episodeUuid, podcastUuid, time]
 
                 try db.insert(into: Self.tableName, columns: columns.map { $0.rawValue }, values: values)
 

--- a/Modules/DataModel/Tests/PocketCastsDataModelTests/BookmarkDataManagerTests.swift
+++ b/Modules/DataModel/Tests/PocketCastsDataModelTests/BookmarkDataManagerTests.swift
@@ -31,14 +31,13 @@ final class BookmarkDataManagerTests: XCTestCase {
 
     // MARK: - Adding
     func testAddBookmarkSucceeds() {
-        XCTAssertNotNil(dataManager.add(episodeUuid: "episode-uuid", podcastUuid: "podcast-uuid", time: 1))
+        XCTAssertNotNil(dataManager.add(episodeUuid: "episode-uuid", podcastUuid: "podcast-uuid", title: "Title", time: 1))
     }
 
     func testAddingEpisodeOnlyBookmarkSucceeds() {
         let episode = "episode-uuid"
 
-        let result = dataManager.add(episodeUuid: episode, podcastUuid: nil, time: 1)
-        XCTAssertNotNil(result)
+        addBookmark(episodeUuid: episode)
         XCTAssertEqual(dataManager.bookmarks(forEpisode: episode).count, 1)
     }
 
@@ -78,17 +77,57 @@ final class BookmarkDataManagerTests: XCTestCase {
     // MARK: - Data Validation
 
     func testBookmarkReturnsCorrectValues() {
+        let created = Date(timeIntervalSince1970: 0)
         let episode = "episode-uuid"
         let podcast = "podcast-uuid"
         let time: TimeInterval = 12345
-        let created = Date(timeIntervalSince1970: 0)
+        let title = "Hello World"
 
-        let bookmark = addBookmark(episodeUuid: episode, podcastUuid: podcast, time: time, created: created)
+        let bookmark = addBookmark(episodeUuid: episode, podcastUuid: podcast, title: title, time: time, created: created)
 
+        XCTAssertEqual(bookmark.created, created)
         XCTAssertEqual(bookmark.episodeUuid, episode)
+        XCTAssertEqual(bookmark.modified, created)
         XCTAssertEqual(bookmark.podcastUuid, podcast)
         XCTAssertEqual(bookmark.time, time)
-        XCTAssertEqual(bookmark.createdDate, created)
+        XCTAssertEqual(bookmark.title, title)
+    }
+
+    // MARK: - Updating
+
+    func testUpdatingTitleSucceeds() async {
+        let bookmark = addBookmark()
+
+        let success = await dataManager.update(title: "title2", for: bookmark)
+        XCTAssertTrue(success)
+    }
+
+    func testUpdatingTheTitleSaves() async {
+        let title1 = "First Title"
+        let title2 = "Second Title"
+        let modified = Date(timeIntervalSince1970: 10)
+
+        let bookmark = addBookmark(title: title1)
+
+        await dataManager.update(title: title2, for: bookmark, modified: modified)
+
+        let updatedBookmark = dataManager.bookmark(for: bookmark.uuid)
+        XCTAssertEqual(updatedBookmark?.title, title2)
+        XCTAssertEqual(updatedBookmark?.modified, modified)
+    }
+
+    func testUpdatingTitleEffectsOnlyOneBookmark() async {
+        let titles = ["a_title", "b_title", "c_title", "d_title"].sorted()
+
+        let bookmarks = titles.map { addBookmark(episodeUuid: $0, title: $0) }
+        let bookmarkToChange = 2
+        let title2 = "c_title_2"
+
+        await dataManager.update(title: title2, for: bookmarks[bookmarkToChange])
+
+        let updatedTitles = dataManager.allBookmarks().map { $0.title }.sorted()
+        XCTAssertNotEqual(titles, updatedTitles)
+        XCTAssertEqual(updatedTitles[bookmarkToChange], title2)
     }
 
     // MARK: - Deletion
@@ -125,8 +164,8 @@ final class BookmarkDataManagerTests: XCTestCase {
 
 private extension BookmarkDataManagerTests {
     @discardableResult
-    func addBookmark(episodeUuid: String = "episode-1", podcastUuid: String = "podcast-uuid", time: TimeInterval = 1, created: Date = .now) -> Bookmark {
-        dataManager.add(episodeUuid: episodeUuid, podcastUuid: podcastUuid, time: time, dateCreated: created).flatMap {
+    func addBookmark(episodeUuid: String = "episode-1", podcastUuid: String = "podcast-uuid", title: String = "Title", time: TimeInterval = 1, created: Date = .now) -> Bookmark {
+        dataManager.add(episodeUuid: episodeUuid, podcastUuid: podcastUuid, title: title, time: time, dateCreated: created).flatMap {
             dataManager.bookmark(for: $0)
         }!
     }

--- a/Modules/DataModel/Tests/PocketCastsDataModelTests/BookmarkDataManagerTests.swift
+++ b/Modules/DataModel/Tests/PocketCastsDataModelTests/BookmarkDataManagerTests.swift
@@ -30,6 +30,7 @@ final class BookmarkDataManagerTests: XCTestCase {
     }
 
     // MARK: - Adding
+
     func testAddBookmarkSucceeds() {
         XCTAssertNotNil(dataManager.add(episodeUuid: "episode-uuid", podcastUuid: "podcast-uuid", title: "Title", time: 1))
     }

--- a/Modules/DataModel/Tests/PocketCastsDataModelTests/BookmarkDataManagerTests.swift
+++ b/Modules/DataModel/Tests/PocketCastsDataModelTests/BookmarkDataManagerTests.swift
@@ -29,6 +29,7 @@ final class BookmarkDataManagerTests: XCTestCase {
         dbQueue.close()
     }
 
+    // MARK: - Adding
     func testAddBookmarkSucceeds() {
         XCTAssertNotNil(dataManager.add(episodeUuid: "episode-uuid", podcastUuid: "podcast-uuid", time: 1))
     }
@@ -42,24 +43,21 @@ final class BookmarkDataManagerTests: XCTestCase {
     }
 
     func testAddingExistingBookmarkIsNotAdded() {
-        let episode = "episode-uuid"
-        let podcast = "podcast-uuid"
-        let time = 1.0
-
-        let firstUuid = dataManager.add(episodeUuid: episode, podcastUuid: podcast, time: time)
-        let secondUuid = dataManager.add(episodeUuid: episode, podcastUuid: podcast, time: time)
+        let firstUuid = addBookmark()
+        let secondUuid = addBookmark()
 
         XCTAssertEqual(firstUuid, secondUuid)
     }
 
+    // MARK: - Retrieving
+
     func testGettingAllBookmarksForPodcast() {
         let podcast = "podcast-uuid"
 
-        dataManager.add(episodeUuid: "episode-1", podcastUuid: podcast, time: 1)
-        dataManager.add(episodeUuid: "episode-1", podcastUuid: podcast, time: 3)
-
-        dataManager.add(episodeUuid: "episode-2", podcastUuid: podcast, time: 1)
-        dataManager.add(episodeUuid: "episode-2", podcastUuid: podcast, time: 3)
+        ["episode-1", "episode-2"].forEach {
+            addBookmark(episodeUuid: $0, podcastUuid: podcast, time: 1)
+            addBookmark(episodeUuid: $0, podcastUuid: podcast, time: 3)
+        }
 
         let bookmarks = dataManager.bookmarks(forPodcast: podcast)
         XCTAssertEqual(bookmarks.count, 4)
@@ -68,42 +66,48 @@ final class BookmarkDataManagerTests: XCTestCase {
     func testGettingAllBookmarksForPodcastAndEpisode() {
         let podcast = "podcast-uuid"
 
-        dataManager.add(episodeUuid: "episode-1", podcastUuid: podcast, time: 1)
-        dataManager.add(episodeUuid: "episode-1", podcastUuid: podcast, time: 3)
-
-        dataManager.add(episodeUuid: "episode-2", podcastUuid: podcast, time: 1)
-        dataManager.add(episodeUuid: "episode-2", podcastUuid: podcast, time: 3)
+        ["episode-1", "episode-2"].forEach {
+            addBookmark(episodeUuid: $0, podcastUuid: podcast, time: 1)
+            addBookmark(episodeUuid: $0, podcastUuid: podcast, time: 3)
+        }
 
         let bookmarks = dataManager.bookmarks(forPodcast: podcast, episodeUuid: "episode-2")
         XCTAssertEqual(bookmarks.count, 2)
     }
 
+    // MARK: - Data Validation
+
+    func testBookmarkReturnsCorrectValues() {
+        let episode = "episode-uuid"
+        let podcast = "podcast-uuid"
+        let time: TimeInterval = 12345
+        let created = Date(timeIntervalSince1970: 0)
+
+        let bookmark = addBookmark(episodeUuid: episode, podcastUuid: podcast, time: time, created: created)
+
+        XCTAssertEqual(bookmark.episodeUuid, episode)
+        XCTAssertEqual(bookmark.podcastUuid, podcast)
+        XCTAssertEqual(bookmark.time, time)
+        XCTAssertEqual(bookmark.createdDate, created)
+    }
+
     // MARK: - Deletion
 
     func testRemovingBookmarksSucceeds() async {
-        let bookmark = dataManager.add(episodeUuid: "episode-1", podcastUuid: "podcast-uuid", time: 1).flatMap {
-            dataManager.bookmark(for: $0)
-        }!
-
+        let bookmark = addBookmark()
         let success = await dataManager.remove(bookmarks: [bookmark])
         XCTAssertTrue(success)
     }
 
     func testRemovedBookmarksArentReturned() async {
-        let bookmark = dataManager.add(episodeUuid: "episode-1", podcastUuid: "podcast-uuid", time: 1).flatMap {
-            dataManager.bookmark(for: $0)
-        }!
-
+        let bookmark = addBookmark()
         _ = await dataManager.remove(bookmarks: [bookmark])
 
         XCTAssertNil(dataManager.bookmark(for: bookmark.uuid))
     }
 
     func testAllBookmarksReturnsDeletedItems() async {
-        let bookmark = dataManager.add(episodeUuid: "episode-1", podcastUuid: "podcast-uuid", time: 1).flatMap {
-            dataManager.bookmark(for: $0)
-        }!
-
+        let bookmark = addBookmark()
         _ = await dataManager.remove(bookmarks: [bookmark])
         let allBookmarks = dataManager.allBookmarks(includeDeleted: true)
 
@@ -111,13 +115,19 @@ final class BookmarkDataManagerTests: XCTestCase {
     }
 
     func testBookmarkIsPermanentlyRemoved() async {
-        let bookmark = dataManager.add(episodeUuid: "episode-1", podcastUuid: "podcast-uuid", time: 1).flatMap {
-            dataManager.bookmark(for: $0)
-        }!
-
+        let bookmark = addBookmark()
         let success = await dataManager.permanentlyDelete(bookmarks: [bookmark])
         XCTAssertTrue(success)
 
         XCTAssertTrue(dataManager.allBookmarks(includeDeleted: true).isEmpty)
+    }
+}
+
+private extension BookmarkDataManagerTests {
+    @discardableResult
+    func addBookmark(episodeUuid: String = "episode-1", podcastUuid: String = "podcast-uuid", time: TimeInterval = 1, created: Date = .now) -> Bookmark {
+        dataManager.add(episodeUuid: episodeUuid, podcastUuid: podcastUuid, time: time, dateCreated: created).flatMap {
+            dataManager.bookmark(for: $0)
+        }!
     }
 }

--- a/podcasts/BookmarkManager.swift
+++ b/podcasts/BookmarkManager.swift
@@ -28,11 +28,11 @@ class BookmarkManager {
     }()
 
     /// Adds a new bookmark for an episode at the given time
-    func add(to episode: BaseEpisode, at time: TimeInterval) {
+    func add(to episode: BaseEpisode, at time: TimeInterval, title: String = L10n.bookmarkDefaultTitle) {
         // If the episode has a podcast attached, also save that
         let podcastUuid: String? = (episode as? Episode)?.podcastUuid
 
-        let uuid = dataManager.add(episodeUuid: episode.uuid, podcastUuid: podcastUuid, time: time)
+        let uuid = dataManager.add(episodeUuid: episode.uuid, podcastUuid: podcastUuid, title: title, time: time)
 
         // Inform the subscribers a bookmark was added
         uuid.flatMap { dataManager.bookmark(for: $0) }.map {

--- a/podcasts/Bookmarks/List/BookmarkRow.swift
+++ b/podcasts/Bookmarks/List/BookmarkRow.swift
@@ -17,14 +17,9 @@ struct BookmarkRow: View {
     init(bookmark: Bookmark) {
         self.bookmark = bookmark
 
-        let title = bookmark.title?.isEmpty == false ? bookmark.title : nil
-        let displayTime = TimeFormatter.shared.playTimeFormat(time: bookmark.time)
-
-        // Default to showing the display time if we don't have a title
-        self.title = title ?? displayTime
-        self.playButton = title == nil ? L10n.play : displayTime
-
-        self.subtitle = DateFormatter.localizedString(from: bookmark.createdDate,
+        self.title = bookmark.title
+        self.playButton = TimeFormatter.shared.playTimeFormat(time: bookmark.time)
+        self.subtitle = DateFormatter.localizedString(from: bookmark.created,
                                                       dateStyle: .medium,
                                                       timeStyle: .short)
     }

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -252,6 +252,8 @@ internal enum L10n {
   internal static var autoDownloadPromptFirst: String { return L10n.tr("Localizable", "auto_download_prompt_first") }
   /// Back
   internal static var back: String { return L10n.tr("Localizable", "back") }
+  /// Bookmark
+  internal static var bookmarkDefaultTitle: String { return L10n.tr("Localizable", "bookmark_default_title") }
   /// Are you sure you want to delete these bookmarks, there’s no way to undo it!
   internal static var bookmarkDeleteWarningBody: String { return L10n.tr("Localizable", "bookmark_delete_warning_body") }
   /// Delete Bookmarks?

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -3793,3 +3793,6 @@
 
 /* The body of an alert message asking the user if they want to continue with deleting the selected bookmarks */
 "bookmark_delete_warning_body" = "Are you sure you want to delete these bookmarks, there’s no way to undo it!";
+
+/* The default title to use for a bookmark */
+"bookmark_default_title" = "Bookmark";


### PR DESCRIPTION
- Adds the title and modified fields to the table and data structures
- Adds the ability to change the title from the data manager
- Add the default bookmark title

## Screenshot
<img src="https://github.com/Automattic/pocket-casts-ios/assets/793774/68424333-be0a-496e-8bb8-c656be8d1008" width="160" />

## To test

1. Ensure the CI is 🟢 
2. Enable the Bookmarks Feature Flag by going to Profile > Cog > Beta Features > bookmarks
3. If you have installed the debug build before, you will need to reinstall to get the database table changes. 
    - If you don't want to reinstall you can:
        1. Open `BookmarkDataManager`.swift` 
        2. Add a breakpoint on line 215
        4. Run the following in console: `po try? db.executeUpdate("DROP TABLE Bookmark", values: nil)`
3. Open the full screen player, and add the bookmark item to the shelf if it's not there already
5. Tap on the add bookmark item
6. Swipe to the Bookmarks tab
7. ✅ Verify you see 'Bookmark' as the title


## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
