### PR TITLE
Bookmarks: Fix a bug that prevented the Add Bookmark item from appearing

### DIFF
--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -561,15 +561,17 @@ class Settings: NSObject {
 
     private static let playerActionsKey = "PlayerActions"
     class func playerActions() -> [PlayerAction] {
+        let defaultActions = PlayerAction.allCases.filter { $0.isAvailable }
+
         guard let savedInts = UserDefaults.standard.object(forKey: Settings.playerActionsKey) as? [Int] else {
-            return PlayerAction.allCases.filter { $0.isAvailable }
+            return defaultActions
         }
 
         let playerActions = savedInts
             .compactMap { PlayerAction(rawValue: $0) }
             .filter { $0.isAvailable }
 
-        return playerActions
+        return playerActions + defaultActions.filter { !playerActions.contains($0) }
     }
 
     class func updatePlayerActions(_ actions: [PlayerAction]) {


### PR DESCRIPTION
This fixes a bug where the Add Bookmark player action wouldn't be added to the list of actions if the user has customized actions. 

## To test
1. Before running, reset your saved player actions with the bookmarks feature flag disabled
    - You can run `UserDefaults.standard.removeObject(forKey: "PlayerActions")` on app launch
2. Open the Full Screen player
3. Tap the ... icon
4. Then tap the Edit option
5. Customize the player actions
6. Enable the bookmarks Feature Flag
7. Go back to the player and show the actions list
8. ✅ 🚨 You should not see the Add Bookmark item
9. Run this PR
10. Go back to the player and show the actions list
11. ✅ The Add Bookmark item should now be visible

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
