### PR TITLE
Bookmarks: Add sorting to the list

### DIFF
--- a/Modules/DataModel/Tests/PocketCastsDataModelTests/BookmarkDataManagerTests.swift
+++ b/Modules/DataModel/Tests/PocketCastsDataModelTests/BookmarkDataManagerTests.swift
@@ -161,6 +161,43 @@ final class BookmarkDataManagerTests: XCTestCase {
 
         XCTAssertTrue(dataManager.allBookmarks(includeDeleted: true).isEmpty)
     }
+
+    // MARK: - Sorting
+    func testNewestToOldestSorting() {
+        let episode = "episode"
+
+        let ordered = [(0, 0), (1, 10), (2, 20), (3, 30)].map { values in
+            addBookmark(episodeUuid: episode, time: values.0, created: .init(timeIntervalSince1970: values.1))
+        }
+
+        let bookmarks = dataManager.bookmarks(forEpisode: episode, sorted: .newestToOldest)
+
+        XCTAssertEqual(ordered.reversed(), bookmarks)
+    }
+
+    func testOldestToNewestSorting() {
+        let episode = "episode"
+
+        let ordered = [(0, 0), (1, 10), (2, 20), (3, 30)].map { values in
+            addBookmark(episodeUuid: episode, time: values.0, created: .init(timeIntervalSince1970: values.1))
+        }
+
+        let bookmarks = dataManager.bookmarks(forEpisode: episode, sorted: .oldestToNewest)
+
+        XCTAssertEqual(ordered, bookmarks)
+    }
+
+    func testTimestampSorting() {
+        let episode = "episode"
+
+        let ordered = [(0, 24), (3600, 1), (7200, 123), (86400, 321)].map { values in
+            addBookmark(episodeUuid: episode, time: values.0, created: .init(timeIntervalSince1970: values.1))
+        }
+
+        let bookmarks = dataManager.bookmarks(forEpisode: episode, sorted: .timestamp)
+
+        XCTAssertEqual(ordered, bookmarks)
+    }
 }
 
 private extension BookmarkDataManagerTests {

--- a/podcasts/BookmarkManager.swift
+++ b/podcasts/BookmarkManager.swift
@@ -4,8 +4,6 @@ import PocketCastsUtils
 import Combine
 
 class BookmarkManager {
-    typealias SortOption = BookmarkDataManager.SortOption
-
     private let dataManager: BookmarkDataManager
 
     /// Called when a bookmark is created
@@ -56,13 +54,13 @@ class BookmarkManager {
     }
 
     /// Retrieves all the bookmarks for a episode
-    func bookmarks(for episode: BaseEpisode, sorted: SortOption = .newestToOldest) -> [Bookmark] {
-        dataManager.bookmarks(forEpisode: episode.uuid, sorted: sorted)
+    func bookmarks(for episode: BaseEpisode, sorted: BookmarkSortOption = .newestToOldest) -> [Bookmark] {
+        dataManager.bookmarks(forEpisode: episode.uuid, sorted: sorted.dataSortOption)
     }
 
     /// Retrieves all the bookmarks for a podcast
-    func bookmarks(for podcast: Podcast, sorted: SortOption = .newestToOldest) -> [Bookmark] {
-        dataManager.bookmarks(forEpisode: podcast.uuid, sorted: sorted)
+    func bookmarks(for podcast: Podcast, sorted: BookmarkSortOption = .newestToOldest) -> [Bookmark] {
+        dataManager.bookmarks(forEpisode: podcast.uuid, sorted: sorted.dataSortOption)
     }
 
     /// Removes an array of bookmarks
@@ -124,5 +122,18 @@ extension BookmarkManager {
 
         // Play
         tonePlayer?.play()
+    }
+}
+
+private extension BookmarkSortOption {
+    var dataSortOption: BookmarkDataManager.SortOption {
+        switch self {
+        case .newestToOldest:
+            return .newestToOldest
+        case .oldestToNewest:
+            return .oldestToNewest
+        case .timestamp:
+            return .timestamp
+        }
     }
 }

--- a/podcasts/BookmarkManager.swift
+++ b/podcasts/BookmarkManager.swift
@@ -4,6 +4,8 @@ import PocketCastsUtils
 import Combine
 
 class BookmarkManager {
+    typealias SortOption = BookmarkDataManager.SortOption
+
     private let dataManager: BookmarkDataManager
 
     /// Called when a bookmark is created
@@ -54,13 +56,13 @@ class BookmarkManager {
     }
 
     /// Retrieves all the bookmarks for a episode
-    func bookmarks(for episode: BaseEpisode) -> [Bookmark] {
-        dataManager.bookmarks(forEpisode: episode.uuid)
+    func bookmarks(for episode: BaseEpisode, sorted: SortOption = .newestToOldest) -> [Bookmark] {
+        dataManager.bookmarks(forEpisode: episode.uuid, sorted: sorted)
     }
 
     /// Retrieves all the bookmarks for a podcast
-    func bookmarks(for podcast: Podcast) -> [Bookmark] {
-        dataManager.bookmarks(forEpisode: podcast.uuid)
+    func bookmarks(for podcast: Podcast, sorted: SortOption = .newestToOldest) -> [Bookmark] {
+        dataManager.bookmarks(forEpisode: podcast.uuid, sorted: sorted)
     }
 
     /// Removes an array of bookmarks

--- a/podcasts/Bookmarks/List/BookmarkListViewModel.swift
+++ b/podcasts/Bookmarks/List/BookmarkListViewModel.swift
@@ -7,10 +7,18 @@ protocol BookmarkListRouter: AnyObject {
 }
 
 class BookmarkListViewModel: MultiSelectListViewModel<Bookmark> {
+    typealias BookmarkSettings = Constants.UserDefaults.bookmarks
+
     weak var router: BookmarkListRouter?
 
     private let bookmarkManager: BookmarkManager
     private var cancellables = Set<AnyCancellable>()
+
+    @Published private(set) var sortOption: BookmarkSortOption {
+        didSet {
+            BookmarkSettings.playerSort.save(sortOption)
+        }
+    }
 
     weak var episode: BaseEpisode? = nil {
         didSet {
@@ -20,6 +28,8 @@ class BookmarkListViewModel: MultiSelectListViewModel<Bookmark> {
 
     init(bookmarkManager: BookmarkManager) {
         self.bookmarkManager = bookmarkManager
+        self.sortOption = BookmarkSettings.playerSort.value
+
         super.init()
 
         addListeners()

--- a/podcasts/Bookmarks/List/BookmarkListViewModel.swift
+++ b/podcasts/Bookmarks/List/BookmarkListViewModel.swift
@@ -70,9 +70,11 @@ class BookmarkListViewModel: MultiSelectListViewModel<Bookmark> {
             }
             .store(in: &cancellables)
     }
+}
 
-    // MARK: - View Methods
+// MARK: - View Methods
 
+extension BookmarkListViewModel {
     func bookmarkPlayTapped(_ bookmark: Bookmark) {
         router?.bookmarkPlay(bookmark)
     }
@@ -84,6 +86,11 @@ class BookmarkListViewModel: MultiSelectListViewModel<Bookmark> {
         toggleMultiSelection()
     }
 
+    func sorted(by option: BookmarkSortOption) {
+        sortOption = option
+        reload()
+    }
+
     func deleteSelectedBookmarks() {
         guard numberOfSelectedItems > 0 else { return }
 
@@ -93,6 +100,39 @@ class BookmarkListViewModel: MultiSelectListViewModel<Bookmark> {
             self?.actuallyDelete(items)
             self?.toggleMultiSelection()
         }
+    }
+}
+
+// MARK: - More Menu
+
+extension BookmarkListViewModel {
+    func showMoreOptions() {
+        let optionPicker = OptionsPicker(title: nil)
+
+        optionPicker.addActions([
+            .init(label: L10n.selectBookmarks, icon: "option-multiselect") { [weak self] in
+                self?.toggleMultiSelection()
+            },
+            .init(label: L10n.sortBy, secondaryLabel: sortOption.label, icon: "podcast-sort") { [weak self] in
+                self?.showSortOptions()
+            }
+        ])
+
+        optionPicker.show(statusBarStyle: AppTheme.defaultStatusBarStyle())
+    }
+
+    func showSortOptions() {
+        let optionPicker = OptionsPicker(title: L10n.sortBy)
+
+        let options: [BookmarkSortOption] = [.newestToOldest, .oldestToNewest, .timestamp]
+
+        optionPicker.addActions(options.map({ option in
+            .init(label: option.label) { [weak self] in
+                self?.sorted(by: option)
+            }
+        }))
+
+        optionPicker.show(statusBarStyle: AppTheme.defaultStatusBarStyle())
     }
 }
 
@@ -119,6 +159,19 @@ private extension BookmarkListViewModel {
             }
 
             reload()
+        }
+    }
+}
+
+private extension BookmarkSortOption {
+    var label: String {
+        switch self {
+        case .newestToOldest:
+            return L10n.podcastsEpisodeSortNewestToOldest
+        case .oldestToNewest:
+            return L10n.podcastsEpisodeSortOldestToNewest
+        case .timestamp:
+            return L10n.sortOptionTimestamp
         }
     }
 }

--- a/podcasts/Bookmarks/List/BookmarkListViewModel.swift
+++ b/podcasts/Bookmarks/List/BookmarkListViewModel.swift
@@ -36,7 +36,7 @@ class BookmarkListViewModel: MultiSelectListViewModel<Bookmark> {
     }
 
     func reload() {
-        items = episode.map { bookmarkManager.bookmarks(for: $0) } ?? []
+        items = episode.map { bookmarkManager.bookmarks(for: $0, sorted: sortOption) } ?? []
     }
 
     /// Reload a single item from the list

--- a/podcasts/Bookmarks/List/BookmarkListViewModel.swift
+++ b/podcasts/Bookmarks/List/BookmarkListViewModel.swift
@@ -7,18 +7,20 @@ protocol BookmarkListRouter: AnyObject {
 }
 
 class BookmarkListViewModel: MultiSelectListViewModel<Bookmark> {
-    typealias BookmarkSettings = Constants.UserDefaults.bookmarks
+    typealias SortSetting = Constants.SettingValue<BookmarkSortOption>
 
     weak var router: BookmarkListRouter?
 
     private let bookmarkManager: BookmarkManager
     private var cancellables = Set<AnyCancellable>()
 
-    @Published private(set) var sortOption: BookmarkSortOption {
+    private var sortOption: BookmarkSortOption {
         didSet {
-            BookmarkSettings.playerSort.save(sortOption)
+            sortSettingValue.save(sortOption)
         }
     }
+
+    private let sortSettingValue: SortSetting
 
     weak var episode: BaseEpisode? = nil {
         didSet {
@@ -26,9 +28,10 @@ class BookmarkListViewModel: MultiSelectListViewModel<Bookmark> {
         }
     }
 
-    init(bookmarkManager: BookmarkManager) {
+    init(bookmarkManager: BookmarkManager, sortOption: SortSetting) {
         self.bookmarkManager = bookmarkManager
-        self.sortOption = BookmarkSettings.playerSort.value
+        self.sortSettingValue = sortOption
+        self.sortOption = sortOption.value
 
         super.init()
 

--- a/podcasts/Bookmarks/List/BookmarkRow.swift
+++ b/podcasts/Bookmarks/List/BookmarkRow.swift
@@ -41,6 +41,7 @@ struct BookmarkRow: View {
         // Display a highlight when tapped, or the row is selected
         .background((highlighted || selected) ? theme.playerContrast05 : nil)
         .animation(.linear, value: highlighted)
+        .animation(.default, value: viewModel.isMultiSelecting)
     }
 
     /// Displays a title and subtitle

--- a/podcasts/Bookmarks/Player/BookmarksPlayerTab.swift
+++ b/podcasts/Bookmarks/Player/BookmarksPlayerTab.swift
@@ -143,7 +143,7 @@ struct BookmarksPlayerTab: View {
 
 struct BookmarksPlayerTab_Previews: PreviewProvider {
     static var previews: some View {
-        BookmarksPlayerTab(viewModel: .init(bookmarkManager: .init()))
+        BookmarksPlayerTab(viewModel: .init(bookmarkManager: .init(), sortOption: .init("", defaultValue: .newestToOldest)))
             .setupDefaultEnvironment()
     }
 }

--- a/podcasts/Bookmarks/Player/BookmarksPlayerTab.swift
+++ b/podcasts/Bookmarks/Player/BookmarksPlayerTab.swift
@@ -37,7 +37,9 @@ struct BookmarksPlayerTab: View {
 
                 Spacer()
 
-                Image("more").foregroundStyle(theme.playerContrast01)
+                Image("more").foregroundStyle(theme.playerContrast01).buttonize {
+                    viewModel.showMoreOptions()
+                }
             }
             .opacity(viewModel.isMultiSelecting ? 0 : 1)
             .offset(y: viewModel.isMultiSelecting ? Constants.headerTransitionOffset : 0)

--- a/podcasts/Bookmarks/Player/BookmarksPlayerTabController.swift
+++ b/podcasts/Bookmarks/Player/BookmarksPlayerTabController.swift
@@ -14,7 +14,7 @@ class BookmarksPlayerTabController: PlayerItemViewController {
     init(bookmarkManager: BookmarkManager, playbackManager: PlaybackManager) {
         self.playbackManager = playbackManager
         self.bookmarkManager = bookmarkManager
-        let viewModel = BookmarkListViewModel(bookmarkManager: bookmarkManager)
+        let viewModel = BookmarkListViewModel(bookmarkManager: bookmarkManager, sortOption: Constants.UserDefaults.bookmarks.playerSort)
         self.viewModel = viewModel
         self.controller = ThemedHostingController(rootView: BookmarksPlayerTab(viewModel: viewModel))
 

--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -168,6 +168,8 @@ struct Constants {
 
         enum bookmarks {
             static let creationSound = SettingValue("bookmarks.creationSound", defaultValue: true)
+
+            static let playerSort = SettingValue("bookmarks.playerSort", defaultValue: BookmarkSortOption.newestToOldest)
         }
     }
 
@@ -414,4 +416,10 @@ enum HeadphoneControlAction: JSONCodable {
 
     /// Create a new bookmark for the currently playing episode
     case addBookmark
+}
+
+// MARK: - Bookmark Sorting
+
+enum BookmarkSortOption: JSONCodable {
+    case newestToOldest, oldestToNewest, timestamp
 }

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -2076,6 +2076,8 @@ internal enum L10n {
   internal static var selectAllAbove: String { return L10n.tr("Localizable", "select_all_above") }
   /// Select all below
   internal static var selectAllBelow: String { return L10n.tr("Localizable", "select_all_below") }
+  /// Select Bookmarks
+  internal static var selectBookmarks: String { return L10n.tr("Localizable", "select_bookmarks") }
   /// Select Episodes
   internal static var selectEpisodes: String { return L10n.tr("Localizable", "select_episodes") }
   /// %1$@ selected
@@ -2664,6 +2666,8 @@ internal enum L10n {
   internal static var sortBy: String { return L10n.tr("Localizable", "sort_by") }
   /// Sort Episodes
   internal static var sortEpisodes: String { return L10n.tr("Localizable", "sort_episodes") }
+  /// Timestamp
+  internal static var sortOptionTimestamp: String { return L10n.tr("Localizable", "sort_option_timestamp") }
   /// Speed
   internal static var speed: String { return L10n.tr("Localizable", "speed") }
   /// Star Episode

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -3808,3 +3808,9 @@
 
 /* Title of a button that allows the user to save their changes */
 "save_bookmark" = "Save Bookmark";
+
+/* Title of a menu prompt */
+"select_bookmarks" = "Select Bookmarks";
+
+/* Title of an option in a menu prompt */
+"sort_option_timestamp" = "Timestamp";


### PR DESCRIPTION
## Demo Video

https://github.com/Automattic/pocket-casts-ios/assets/793774/9d58ab62-af4b-4288-b2c3-9c0db668b61c

## To test

1. Enable the Bookmarks Feature Flag by going to Profile > Cog > Beta Features > bookmarks
2. Open the Full Screen Player
3. Swipe to the bookmarks list
4. Tap the <kbd>...</kbd> button
5. ✅ Verify you see an options menu with 2 options: Select Bookmarks, Sort By
6. ✅ Verify the default sort by option is newest to oldest
7. Tap on Select Bookmarks
8. ✅ Verify the view enters multi select mode
9. Tap Cancel, then tap the more (...) button again
10. Tap the sort by option
11. ✅ Verify a new options menu opens with 3 options: Newest to oldest, Oldest to Newest, and Timestamp
12. Tap on the oldest to newest
13. ✅ Verify the list is now sorted with the oldest bookmarks first
14. Open the sort menu again, choose timestamp
15. ✅ Verify the list is now sorted with the earliest timestamp at the top

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
