### PR TITLE
Bookmarks: Adds a way to customize the colors of the bookmark list

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1429,6 +1429,7 @@
 		C7318EA42A61E40800EAFA9C /* BookmarkEditTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7318EA32A61E40800EAFA9C /* BookmarkEditTitleView.swift */; };
 		C7318EA82A622AD000EAFA9C /* BookmarkEditTitleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7318EA72A622AD000EAFA9C /* BookmarkEditTitleViewController.swift */; };
 		C7318EAA2A624CB400EAFA9C /* BookmarkEditViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7318EA92A624CB400EAFA9C /* BookmarkEditViewModel.swift */; };
+		C7318EB72A62D75E00EAFA9C /* BookmarksTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7318EB62A62D75E00EAFA9C /* BookmarksTheme.swift */; };
 		C73215FB291EA13400AB1FE5 /* PlusPurchaseModal.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73215FA291EA13400AB1FE5 /* PlusPurchaseModal.swift */; };
 		C734A88E2938308F005E5B98 /* CommonStoryViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = C734A88D2938308F005E5B98 /* CommonStoryViews.swift */; };
 		C7360CB82A42128300456930 /* Bookmarks.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C7360CB72A42128300456930 /* Bookmarks.xcassets */; };
@@ -3153,6 +3154,7 @@
 		C7318EA32A61E40800EAFA9C /* BookmarkEditTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkEditTitleView.swift; sourceTree = "<group>"; };
 		C7318EA72A622AD000EAFA9C /* BookmarkEditTitleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkEditTitleViewController.swift; sourceTree = "<group>"; };
 		C7318EA92A624CB400EAFA9C /* BookmarkEditViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkEditViewModel.swift; sourceTree = "<group>"; };
+		C7318EB62A62D75E00EAFA9C /* BookmarksTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksTheme.swift; sourceTree = "<group>"; };
 		C73215FA291EA13400AB1FE5 /* PlusPurchaseModal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlusPurchaseModal.swift; sourceTree = "<group>"; };
 		C734A88D2938308F005E5B98 /* CommonStoryViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonStoryViews.swift; sourceTree = "<group>"; };
 		C7360CB72A42128300456930 /* Bookmarks.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Bookmarks.xcassets; sourceTree = "<group>"; };
@@ -6321,6 +6323,7 @@
 				C7318EA22A61E3FC00EAFA9C /* Editing */,
 				C7E99EF62A5C803B00E7CBAF /* List */,
 				C75274E02A3252180004DD15 /* Player */,
+				C7318EB62A62D75E00EAFA9C /* BookmarksTheme.swift */,
 			);
 			path = Bookmarks;
 			sourceTree = "<group>";
@@ -8960,6 +8963,7 @@
 				BD56102D200DA4BC002F2D53 /* Podcast+Formatting.swift in Sources */,
 				BD5294291B564417007A0B1D /* PlaybackItem.swift in Sources */,
 				8B99197429A67A7100A5C81C /* SearchView.swift in Sources */,
+				C7318EB72A62D75E00EAFA9C /* BookmarksTheme.swift in Sources */,
 				8B14E3AE29B8E71D0069B6F2 /* RoundedSubscribeButtonView.swift in Sources */,
 				BD6CABC927D18C0700C6D396 /* UnplayedSashOverlayView.swift in Sources */,
 				BDF15A441B54E155000EC323 /* PlaybackProtocol.swift in Sources */,

--- a/podcasts/Bookmarks/BookmarksTheme.swift
+++ b/podcasts/Bookmarks/BookmarksTheme.swift
@@ -1,0 +1,75 @@
+import SwiftUI
+import Combine
+
+protocol BookmarksStyle: ObservableObject {
+    associatedtype ActionStyle = ActionBarStyle
+
+    var background: Color { get }
+    var primaryText: Color { get }
+    var secondaryText: Color { get }
+    var tertiaryText: Color { get }
+    var divider: Color { get }
+    var rowHighlight: Color { get }
+    var rowSelected: Color { get }
+    var selectButtonStroke: Color { get }
+    var selectButton: Color { get }
+    var selectCheck: Color { get }
+    var playButtonText: Color { get }
+    var playButtonBackground: Color? { get }
+    var playButtonStroke: Color? { get }
+    var actionBarStyle: ActionStyle { get }
+}
+
+// MARK: - ThemeObserver
+
+class ThemeObserver: ObservableObject {
+    let theme: Theme = .sharedTheme
+    private var cancellables = Set<AnyCancellable>()
+
+    init() {
+        Constants.Notifications.themeChanged.publisher()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.objectWillChange.send()
+            }
+            .store(in: &cancellables)
+    }
+}
+
+// MARK: - Player Style
+
+class BookmarksPlayerTabStyle: ThemeObserver, BookmarksStyle {
+    var background: Color { theme.playerBackground01 }
+    var primaryText: Color { theme.playerContrast01 }
+    var secondaryText: Color { theme.playerContrast02 }
+    var tertiaryText: Color { theme.playerContrast02 }
+    var divider: Color { theme.playerContrast05 }
+    var rowHighlight: Color { theme.playerContrast05 }
+    var rowSelected: Color { rowHighlight }
+    var selectButton: Color { theme.playerContrast01 }
+    var selectButtonStroke: Color { theme.playerContrast01 }
+    var selectCheck: Color { theme.playerBackground01 }
+    var playButtonText: Color { theme.playerBackground01 }
+    var playButtonBackground: Color? { theme.playerContrast01 }
+    var playButtonStroke: Color? = nil
+    var actionBarStyle = PlayerActionBarStyle()
+}
+
+// MARK: - Default Themed Style
+
+class ThemedBookmarksStyle: ThemeObserver, BookmarksStyle {
+    var background: Color { theme.primaryUi01 }
+    var primaryText: Color { theme.primaryText01 }
+    var secondaryText: Color { theme.primaryText02 }
+    var tertiaryText: Color { theme.primaryText02 }
+    var divider: Color { theme.primaryUi05 }
+    var rowHighlight: Color { theme.primaryUi02Active }
+    var rowSelected: Color { theme.primaryUi02Selected }
+    var selectButtonStroke: Color { theme.primaryIcon02 }
+    var selectButton: Color { theme.primaryInteractive01 }
+    var selectCheck: Color { theme.primaryInteractive02 }
+    var playButtonText: Color { theme.primaryText01 }
+    var playButtonBackground: Color? { theme.primaryUi01 }
+    var playButtonStroke: Color? { theme.primaryText01 }
+    var actionBarStyle = ThemedActionBarStyle()
+}

--- a/podcasts/Bookmarks/Player/ActionBarStyles.swift
+++ b/podcasts/Bookmarks/Player/ActionBarStyles.swift
@@ -14,7 +14,11 @@ struct PlayerActionBarStyle: ActionBarStyle {
         theme.playerBackground01
     }
 
-    var foregroundColor: Color {
+    var titleColor: Color {
+        theme.playerContrast01
+    }
+
+    var iconColor: Color {
         theme.playerContrast01
     }
 }
@@ -22,5 +26,34 @@ struct PlayerActionBarStyle: ActionBarStyle {
 extension ActionBarStyle where Self == PlayerActionBarStyle {
     static var player: PlayerActionBarStyle {
         PlayerActionBarStyle()
+    }
+}
+
+// MARK: - ThemedActionBarStyle
+
+/// A style that should be used if the action bar appears in the full screen player
+struct ThemedActionBarStyle: ActionBarStyle {
+    @ObservedObject private var theme: Theme = .sharedTheme
+
+    var backgroundTint: Color {
+        theme.secondaryUi01
+    }
+
+    var buttonColor: Color {
+        theme.primaryInteractive01
+    }
+
+    var titleColor: Color {
+        theme.primaryText01
+    }
+
+    var iconColor: Color {
+        theme.primaryInteractive02
+    }
+}
+
+extension ActionBarStyle where Self == ThemedActionBarStyle {
+    static var themed: ThemedActionBarStyle {
+        ThemedActionBarStyle()
     }
 }

--- a/podcasts/Bookmarks/Player/BookmarksPlayerTab.swift
+++ b/podcasts/Bookmarks/Player/BookmarksPlayerTab.swift
@@ -4,7 +4,7 @@ import PocketCastsUtils
 
 struct BookmarksPlayerTab: View {
     @ObservedObject var viewModel: BookmarkListViewModel
-    @EnvironmentObject var theme: Theme
+    @ObservedObject var style: BookmarksPlayerTabStyle = .init()
 
     @State private var showShadow = false
 
@@ -23,7 +23,7 @@ struct BookmarksPlayerTab: View {
         }
         .environmentObject(viewModel)
         .padding(.bottom)
-        .background(theme.playerBackground01.ignoresSafeArea())
+        .background(style.background.ignoresSafeArea())
     }
 
     /// A static header view that displays the number of bookmarks and a ... more button
@@ -32,12 +32,12 @@ struct BookmarksPlayerTab: View {
         ZStack {
             HStack {
                 Text(L10n.bookmarkCount(viewModel.numberOfItems))
-                    .foregroundStyle(theme.playerContrast02)
+                    .foregroundStyle(style.secondaryText)
                     .font(size: 14, style: .subheadline)
 
                 Spacer()
 
-                Image("more").foregroundStyle(theme.playerContrast01).buttonize {
+                Image("more").foregroundStyle(style.primaryText).buttonize {
                     viewModel.showMoreOptions()
                 }
             }
@@ -66,7 +66,7 @@ struct BookmarksPlayerTab: View {
             }
         }
         .font(style: .body)
-        .foregroundStyle(theme.playerContrast01)
+        .foregroundStyle(style.primaryText)
         .opacity(viewModel.isMultiSelecting ? 1 : 0)
         .offset(y: viewModel.isMultiSelecting ? 0 : -Constants.headerTransitionOffset)
     }
@@ -76,7 +76,7 @@ struct BookmarksPlayerTab: View {
             ScrollViewWithContentOffset {
                 LazyVStack(spacing: 0) {
                     ForEach(viewModel.items) { bookmark in
-                        BookmarkRow(bookmark: bookmark)
+                        BookmarkRow(bookmark: bookmark, style: style)
 
                         if !viewModel.isLast(item: bookmark) {
                             divider
@@ -103,7 +103,7 @@ struct BookmarksPlayerTab: View {
         let title = L10n.selectedCountFormat(viewModel.numberOfSelectedItems)
         let editVisible = viewModel.numberOfSelectedItems == 1
 
-        ActionBarOverlayView(actionBarVisible: actionBarVisible, title: title, style: .player, content: {
+        ActionBarOverlayView(actionBarVisible: actionBarVisible, title: title, style: style.actionBarStyle, content: {
             content()
         }, actions: [
             .init(imageName: "folder-edit", title: L10n.edit, visible: editVisible, action: {
@@ -127,7 +127,7 @@ struct BookmarksPlayerTab: View {
 
     /// Styled divider view
     private var divider: some View {
-        Divider().background(theme.playerContrast05)
+        Divider().background(style.divider)
     }
 
     private enum Constants {

--- a/podcasts/Common SwiftUI/List View/MultiSelectRow.swift
+++ b/podcasts/Common SwiftUI/List View/MultiSelectRow.swift
@@ -37,9 +37,10 @@ struct MultiSelectRow<Content: View>: View {
     }
 
     /// Customizes the selection button colors
-    func selectButtonStyle(tintColor: Color, checkColor: Color) -> Self {
+    func selectButtonStyle(tintColor: Color, checkColor: Color, strokeColor: Color) -> Self {
         style.tint = tintColor
         style.check = checkColor
+        style.stroke = strokeColor
         return self
     }
 
@@ -48,8 +49,8 @@ struct MultiSelectRow<Content: View>: View {
     /// The unselected select button
     private var buttonView: some View {
         Circle()
-            .stroke(lineWidth: 2)
-            .fill(style.tint)
+            .inset(by: 1)
+            .stroke(style.stroke, lineWidth: 2)
             .frame(width: multiSelectButtonSize, height: multiSelectButtonSize)
             .overlay(selectedView)
     }
@@ -72,6 +73,7 @@ struct MultiSelectRow<Content: View>: View {
     private class Style {
         var tint: Color = .white
         var check: Color = .black
+        var stroke: Color = .white
     }
 }
 
@@ -107,7 +109,7 @@ struct MultiSelectRow_Previews: PreviewProvider {
                         selected.toggle()
                     }
                 }
-                .selectButtonStyle(tintColor: .black, checkColor: .white)
+                .selectButtonStyle(tintColor: .black, checkColor: .white, strokeColor: .black)
                 .padding()
                 .background(Color.blue)
 

--- a/podcasts/SwiftUI/ActionBarOverlayView.swift
+++ b/podcasts/SwiftUI/ActionBarOverlayView.swift
@@ -38,7 +38,8 @@ struct ActionBarOverlayView<Content: View, Style: ActionBarStyle>: View {
 protocol ActionBarStyle {
     var backgroundTint: Color { get }
     var buttonColor: Color { get }
-    var foregroundColor: Color { get }
+    var titleColor: Color { get }
+    var iconColor: Color { get }
 }
 
 // MARK: - ActionBarView
@@ -73,7 +74,7 @@ struct ActionBarView<Style: ActionBarStyle>: View {
                 }
             }
         }
-        .foregroundStyle(style.foregroundColor)
+        .foregroundStyle(style.titleColor)
         // Inner Padding
         .padding(.vertical, ActionBarConstants.barPaddingVertical)
         .padding(.horizontal, ActionBarConstants.barPaddingHorizontal)
@@ -114,6 +115,7 @@ struct ActionBarView<Style: ActionBarStyle>: View {
                 .padding(.horizontal, ActionBarConstants.buttonPaddingHorizontal)
                 .background(style.buttonColor)
                 .cornerRadius(.infinity)
+                .foregroundColor(style.iconColor)
         }
         .accessibilityLabel(action.title)
         .opacity(action.visible ? 1 : 0)
@@ -181,6 +183,7 @@ struct ActionBarOverlayView_Previews: PreviewProvider {
     private struct PreviewStyle: ActionBarStyle {
         var backgroundTint: Color { .secondary }
         var buttonColor: Color { .accentColor }
-        var foregroundColor: Color { .primary }
+        var titleColor: Color { .primary }
+        var iconColor: Color { .primary }
     }
 }


### PR DESCRIPTION
In preparation of this view being able to be reused elsewhere, this adds a way customize the colors. 

## To test

1. Enable the Bookmarks Feature Flag by going to Profile > Cog > Beta Features > bookmarks
2. Open the Full Screen Player
3. Swipe to the Bookmarks
4. ✅ Verify its still themed
5. Switch themes and reopen the view
6. ✅ Verify it updated
7. Open `BookmarksPlayerTab` and change the line 7 to: `@ObservedObject var style: ThemedBookmarksStyle = .init()`
8. Relaunch the app
9. Go to the bookmarks tab
10. ✅ Verify the elements are all different colors and match the normal episode list style


## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
