### PR TITLE
What's New: show it only once

### DIFF
--- a/PocketCastsTests/Tests/Whats New/WhatsNewTests.swift
+++ b/PocketCastsTests/Tests/Whats New/WhatsNewTests.swift
@@ -97,6 +97,20 @@ class WhatsNewtests: XCTestCase {
         XCTAssertNil(whatsNew.viewControllerToShow())
     }
 
+    // If the current What's New was shown, never show it again
+    // In theory, this setup should never happen, but we have
+    // reports of the popup appearing for every new beta
+    func testDontShowWhatsNewForSameBeta() {
+        let whatsNew = WhatsNew(
+            announcements: [announcement(version: 7.43)],
+            previousOpenedVersion: "7.42.0.0",
+            currentVersion: "7.44.0.0",
+            lastWhatsNewShown: 7.43
+        )
+
+        XCTAssertNil(whatsNew.viewControllerToShow())
+    }
+
     private func announcement(version: Double) -> WhatsNew.Announcement {
         return .init(version: version, header: { AnyView(EmptyView()) }, title: "", message: "", buttonTitle: "", action: {})
     }

--- a/PocketCastsTests/Tests/Whats New/WhatsNewTests.swift
+++ b/PocketCastsTests/Tests/Whats New/WhatsNewTests.swift
@@ -105,7 +105,7 @@ class WhatsNewtests: XCTestCase {
             announcements: [announcement(version: 7.43)],
             previousOpenedVersion: "7.42.0.0",
             currentVersion: "7.44.0.0",
-            lastWhatsNewShown: 7.43
+            lastWhatsNewShown: "7.43"
         )
 
         XCTAssertNil(whatsNew.viewControllerToShow())

--- a/PocketCastsTests/Tests/Whats New/WhatsNewTests.swift
+++ b/PocketCastsTests/Tests/Whats New/WhatsNewTests.swift
@@ -8,7 +8,7 @@ class WhatsNewtests: XCTestCase {
     /// for 7.40, show it
     func testShowWhatsNew() {
         let whatsNew = WhatsNew(
-            announcements: [announcement(version: 7.40)],
+            announcements: [announcement(version: "7.40")],
             previousOpenedVersion: "7.39",
             currentVersion: "7.40"
         )
@@ -19,7 +19,7 @@ class WhatsNewtests: XCTestCase {
     /// When just opening the same version, do nothing
     func testDontShowWhatsNew() {
         let whatsNew = WhatsNew(
-            announcements: [announcement(version: 7.39)],
+            announcements: [announcement(version: "7.39")],
             previousOpenedVersion: "7.40",
             currentVersion: "7.40"
         )
@@ -31,7 +31,7 @@ class WhatsNewtests: XCTestCase {
     /// for 7.41, show it
     func testShowWhatsNewEvenIfVersionDontMatch() {
         let whatsNew = WhatsNew(
-            announcements: [announcement(version: 7.41)],
+            announcements: [announcement(version: "7.41")],
             previousOpenedVersion: "7.37",
             currentVersion: "7.42"
         )
@@ -42,7 +42,7 @@ class WhatsNewtests: XCTestCase {
     /// When opening the app for the first time, show nothing
     func testDontShowWhenFirstOpening() {
         let whatsNew = WhatsNew(
-            announcements: [announcement(version: 7.41)],
+            announcements: [announcement(version: "7.41")],
             previousOpenedVersion: nil,
             currentVersion: "7.41"
         )
@@ -53,7 +53,7 @@ class WhatsNewtests: XCTestCase {
     // If the announcement is for a future version, don't show
     func testDontShowWhenFutureVersion() {
         let whatsNew = WhatsNew(
-            announcements: [announcement(version: 7.50)],
+            announcements: [announcement(version: "7.50")],
             previousOpenedVersion: "7.41",
             currentVersion: "7.41"
         )
@@ -65,7 +65,7 @@ class WhatsNewtests: XCTestCase {
     // already opened it, show nothing
     func testDontShowWhatsNewForTheCurrentOpenedVersion() {
         let whatsNew = WhatsNew(
-            announcements: [announcement(version: 7.41)],
+            announcements: [announcement(version: "7.41")],
             previousOpenedVersion: "7.41",
             currentVersion: "7.41"
         )
@@ -77,7 +77,7 @@ class WhatsNewtests: XCTestCase {
     // hasn't opened this version yet, show what's new
     func testShowWhatsNewForHotfix() {
         let whatsNew = WhatsNew(
-            announcements: [announcement(version: 7.42)],
+            announcements: [announcement(version: "7.42")],
             previousOpenedVersion: "7.41",
             currentVersion: "7.42.1"
         )
@@ -89,7 +89,7 @@ class WhatsNewtests: XCTestCase {
     // has opened this version yet, show what's new
     func testDontShowWhatsNewForHotfix() {
         let whatsNew = WhatsNew(
-            announcements: [announcement(version: 7.42)],
+            announcements: [announcement(version: "7.42")],
             previousOpenedVersion: "7.42",
             currentVersion: "7.42.1"
         )
@@ -102,7 +102,7 @@ class WhatsNewtests: XCTestCase {
     // reports of the popup appearing for every new beta
     func testDontShowWhatsNewForSameBeta() {
         let whatsNew = WhatsNew(
-            announcements: [announcement(version: 7.43)],
+            announcements: [announcement(version: "7.43")],
             previousOpenedVersion: "7.42.0.0",
             currentVersion: "7.44.0.0",
             lastWhatsNewShown: "7.43"
@@ -111,7 +111,7 @@ class WhatsNewtests: XCTestCase {
         XCTAssertNil(whatsNew.viewControllerToShow())
     }
 
-    private func announcement(version: Double) -> WhatsNew.Announcement {
+    private func announcement(version: String) -> WhatsNew.Announcement {
         return .init(version: version, header: { AnyView(EmptyView()) }, title: "", message: "", buttonTitle: "", action: {})
     }
 }

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -551,13 +551,13 @@ class Settings: NSObject {
 
 
     private static let lastWhatsNewShownKey = "LastWhatsNewShown"
-    class var lastWhatsNewShown: Double? {
+    class var lastWhatsNewShown: String? {
         set {
             UserDefaults.standard.set(newValue, forKey: lastWhatsNewShownKey)
         }
 
         get {
-            UserDefaults.standard.value(forKey: lastWhatsNewShownKey) as? Double
+            UserDefaults.standard.string(forKey: lastWhatsNewShownKey)
         }
     }
 

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -549,6 +549,18 @@ class Settings: NSObject {
         UserDefaults.standard.integer(forKey: whatsNewLastAcknowledgedKey)
     }
 
+
+    private static let lastWhatsNewShownKey = "LastWhatsNewShown"
+    class var lastWhatsNewShown: Double? {
+        set {
+            UserDefaults.standard.set(newValue, forKey: lastWhatsNewShownKey)
+        }
+
+        get {
+            UserDefaults.standard.value(forKey: lastWhatsNewShownKey) as? Double
+        }
+    }
+
     class func setShouldFollowSystemTheme(_ value: Bool) {
         UserDefaults.standard.set(value, forKey: Constants.UserDefaults.shouldFollowSystemThemeKey)
     }

--- a/podcasts/Whats New/Announcements.swift
+++ b/podcasts/Whats New/Announcements.swift
@@ -7,7 +7,7 @@ struct Announcements {
     // there were two announcements, the last one will be picked.
     var announcements: [WhatsNew.Announcement] = [
         .init(
-            version: 7.43,
+            version: "7.43",
             header: {
                 AnyView(AutoplayWhatsNewHeader())
             },

--- a/podcasts/Whats New/WhatsNew.swift
+++ b/podcasts/Whats New/WhatsNew.swift
@@ -14,17 +14,20 @@ class WhatsNew {
     let announcements: [Announcement]
     let currentVersion: Double
     let previousOpenedVersion: Double?
+    let lastWhatsNewShown: Double?
 
-    init(announcements: [Announcement] = Announcements().announcements, previousOpenedVersion: String? = UserDefaults.standard.string(forKey: Constants.UserDefaults.lastRunVersion), currentVersion: String = Settings.appVersion()) {
+    init(announcements: [Announcement] = Announcements().announcements, previousOpenedVersion: String? = UserDefaults.standard.string(forKey: Constants.UserDefaults.lastRunVersion), currentVersion: String = Settings.appVersion(), lastWhatsNewShown: Double? = Settings.lastWhatsNewShown) {
         self.announcements = announcements
         self.previousOpenedVersion = previousOpenedVersion?.toDouble()
         self.currentVersion = currentVersion.toDouble()
+        self.lastWhatsNewShown = lastWhatsNewShown
     }
 
     func viewControllerToShow() -> UIViewController? {
         guard let previousOpenedVersion,
               previousOpenedVersion != currentVersion,
-              let announcement = announcements.last(where: { $0.version > previousOpenedVersion && $0.version <= currentVersion }) else {
+              let announcement = announcements.last(where: { $0.version > previousOpenedVersion && $0.version <= currentVersion }),
+              announcement.version != lastWhatsNewShown else {
             return nil
         }
 

--- a/podcasts/Whats New/WhatsNew.swift
+++ b/podcasts/Whats New/WhatsNew.swift
@@ -14,9 +14,9 @@ class WhatsNew {
     let announcements: [Announcement]
     let currentVersion: Double
     let previousOpenedVersion: Double?
-    let lastWhatsNewShown: Double?
+    let lastWhatsNewShown: String?
 
-    init(announcements: [Announcement] = Announcements().announcements, previousOpenedVersion: String? = UserDefaults.standard.string(forKey: Constants.UserDefaults.lastRunVersion), currentVersion: String = Settings.appVersion(), lastWhatsNewShown: Double? = Settings.lastWhatsNewShown) {
+    init(announcements: [Announcement] = Announcements().announcements, previousOpenedVersion: String? = UserDefaults.standard.string(forKey: Constants.UserDefaults.lastRunVersion), currentVersion: String = Settings.appVersion(), lastWhatsNewShown: String? = Settings.lastWhatsNewShown) {
         self.announcements = announcements
         self.previousOpenedVersion = previousOpenedVersion?.toDouble()
         self.currentVersion = currentVersion.toDouble()
@@ -27,7 +27,7 @@ class WhatsNew {
         guard let previousOpenedVersion,
               previousOpenedVersion != currentVersion,
               let announcement = announcements.last(where: { $0.version > previousOpenedVersion && $0.version <= currentVersion }),
-              announcement.version != lastWhatsNewShown else {
+              "\(announcement.version)" != lastWhatsNewShown else {
             return nil
         }
 

--- a/podcasts/Whats New/WhatsNew.swift
+++ b/podcasts/Whats New/WhatsNew.swift
@@ -27,7 +27,7 @@ class WhatsNew {
         guard let previousOpenedVersion,
               previousOpenedVersion != currentVersion,
               let announcement = announcements.last(where: { $0.version > previousOpenedVersion && $0.version <= currentVersion }),
-              "\(announcement.version)" != lastWhatsNewShown else {
+              announcement.version != lastWhatsNewShown else {
             return nil
         }
 

--- a/podcasts/Whats New/WhatsNew.swift
+++ b/podcasts/Whats New/WhatsNew.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 class WhatsNew {
     struct Announcement {
-        let version: Double
+        let version: String
         let header: () -> AnyView
         let title: String
         let message: String
@@ -12,14 +12,14 @@ class WhatsNew {
     }
 
     let announcements: [Announcement]
-    let currentVersion: Double
-    let previousOpenedVersion: Double?
+    let currentVersion: String
+    let previousOpenedVersion: String?
     let lastWhatsNewShown: String?
 
     init(announcements: [Announcement] = Announcements().announcements, previousOpenedVersion: String? = UserDefaults.standard.string(forKey: Constants.UserDefaults.lastRunVersion), currentVersion: String = Settings.appVersion(), lastWhatsNewShown: String? = Settings.lastWhatsNewShown) {
         self.announcements = announcements
-        self.previousOpenedVersion = previousOpenedVersion?.toDouble()
-        self.currentVersion = currentVersion.toDouble()
+        self.previousOpenedVersion = previousOpenedVersion?.majorMinor
+        self.currentVersion = currentVersion.majorMinor
         self.lastWhatsNewShown = lastWhatsNewShown
     }
 
@@ -37,5 +37,21 @@ class WhatsNew {
         whatsNewViewController.view.backgroundColor = .init(red: 0, green: 0, blue: 0, alpha: 0.5)
 
         return whatsNewViewController
+    }
+}
+
+private extension String {
+    /// Given a semver string, ie.: "7.42", "7.43.0.1", "7.43.1"
+    /// returns it in the format of MAJOR.MINOR
+    /// Eg.: "7.43", "7.43.0.1" or "7.43.1" will return "7.43"
+    var majorMinor: String {
+        let splitVersion = split(separator: ".")
+
+        guard let major = splitVersion[safe: 0],
+              let minor = splitVersion[safe: 1] else {
+            return self
+        }
+
+        return "\(major).\(minor)"
     }
 }

--- a/podcasts/Whats New/WhatsNewView.swift
+++ b/podcasts/Whats New/WhatsNewView.swift
@@ -44,7 +44,7 @@ struct WhatsNewView: View {
         .padding()
         .onAppear {
             track(.whatsnewShown)
-            Settings.lastWhatsNewShown = "\(announcement.version)"
+            Settings.lastWhatsNewShown = announcement.version
         }
     }
 

--- a/podcasts/Whats New/WhatsNewView.swift
+++ b/podcasts/Whats New/WhatsNewView.swift
@@ -44,6 +44,7 @@ struct WhatsNewView: View {
         .padding()
         .onAppear {
             track(.whatsnewShown)
+            Settings.lastWhatsNewShown = announcement.version
         }
     }
 

--- a/podcasts/Whats New/WhatsNewView.swift
+++ b/podcasts/Whats New/WhatsNewView.swift
@@ -44,7 +44,7 @@ struct WhatsNewView: View {
         .padding()
         .onAppear {
             track(.whatsnewShown)
-            Settings.lastWhatsNewShown = announcement.version
+            Settings.lastWhatsNewShown = "\(announcement.version)"
         }
     }
 


### PR DESCRIPTION
While I'm unable to reproduce, we have reports of users in our beta that are being shown the "What's New" for every beta version.

This PR adds an additional flag to keep track of the latest announcement shown, and it never shows it again.

## To test

1. Code test
2. Check the unit test

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
