### PR TITLE
Share Extension: add it back and fix behavior

### DIFF
--- a/Share Extension/Info.plist
+++ b/Share Extension/Info.plist
@@ -6,18 +6,21 @@
 	<dict>
 		<key>NSExtensionAttributes</key>
 		<dict>
-			<key>NSExtensionActivationRule</key>
-			<dict>
-				<key>NSExtensionActivationAttachmentAttribute</key>
-				<dict>
-					<key>NSExtensionActivationAttachmentFileExtensions</key>
-					<array>
-						<string>opml</string>
-					</array>
-				</dict>
-				<key>NSExtensionActivationSupportsAttachmentsWithMaxCount</key>
-				<integer>1</integer>
-			</dict>
+            <key>NSExtensionActivationRule</key>
+            <string>SUBQUERY (
+                extensionItems,
+                $extensionItem,
+                SUBQUERY (
+                $extensionItem.attachments,
+                $attachment,
+                (
+                ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "unofficial.opml"
+                || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.opml"
+                || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "org.opml.opml"
+                )
+                ).@count == 1
+                ).@count == 1
+            </string>
 		</dict>
 		<key>NSExtensionMainStoryboard</key>
 		<string>MainInterface</string>

--- a/Share Extension/ShareViewController.swift
+++ b/Share Extension/ShareViewController.swift
@@ -1,22 +1,30 @@
 import UIKit
 import Social
 
-class ShareViewController: SLComposeServiceViewController {
+class ShareViewController: UIViewController {
 
-    override func isContentValid() -> Bool {
-        // Do validation of contentText and/or NSExtensionContext attachments here
-        return true
-    }
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
 
-    override func didSelectPost() {
-        // This is called after the user selects Post. Do the upload of contentText and/or NSExtensionContext attachments.
-        // Inform the host that we're done, so it un-blocks its UI. Note: Alternatively you could call super's -didSelectPost, which will similarly complete the extension context.
         self.extensionContext!.completeRequest(returningItems: [], completionHandler: nil)
+
+        redirectToHostApp()
     }
 
-    override func configurationItems() -> [Any]! {
-        // To add configuration options via table cells at the bottom of the sheet, return an array of SLComposeSheetConfigurationItem here.
-        return []
+    func redirectToHostApp() {
+        let url = URL(string: "pktc://item?id=20036169")
+        let selectorOpenURL = sel_registerName("openURL:")
+        let context = NSExtensionContext()
+        context.open(url! as URL, completionHandler: nil)
+
+        var responder = self as UIResponder?
+
+        while responder != nil {
+            if responder?.responds(to: selectorOpenURL) == true {
+                responder?.perform(selectorOpenURL, with: url)
+            }
+            responder = responder!.next
+        }
     }
 
 }

--- a/Share Extension/ShareViewController.swift
+++ b/Share Extension/ShareViewController.swift
@@ -7,20 +7,26 @@ class ShareViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
+        // Get the attachment
         let content = extensionContext?.inputItems.first as? NSExtensionItem
         guard let attachment = content?.attachments?.first as? NSItemProvider else {
             close()
             return
         }
 
+        // We only accept OPML files, and they need to conform to data identifier
+        // If we ever want to accept other files we need to change the Share Extension
+        // Info.plist
         if attachment.hasItemConformingToTypeIdentifier(UTType.data.identifier) {
 
+            // Request the OPML file URL
             attachment.loadItem(forTypeIdentifier: UTType.data.identifier, options: nil) { [weak self] data, error in
                 guard let url = data as? URL else {
                     self?.close()
                     return
                 }
 
+                // Convert the file to Data
                 guard let opmlData = try? Data(contentsOf: url) else {
                     self?.close()
                     return
@@ -28,6 +34,7 @@ class ShareViewController: UIViewController {
 
                 self?.close()
 
+                // Redirect to Pocket Casts sharing the OPML data encoded in Base64
                 self?.redirectToHostApp(opmlData.base64EncodedString())
             }
         }

--- a/Share Extension/ShareViewController.swift
+++ b/Share Extension/ShareViewController.swift
@@ -1,4 +1,5 @@
 import UIKit
+import UniformTypeIdentifiers
 import Social
 
 class ShareViewController: UIViewController {
@@ -6,16 +7,43 @@ class ShareViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        self.extensionContext!.completeRequest(returningItems: [], completionHandler: nil)
+        let content = extensionContext?.inputItems.first as? NSExtensionItem
+        guard let attachment = content?.attachments?.first as? NSItemProvider else {
+            close()
+            return
+        }
 
-        redirectToHostApp()
+        if attachment.hasItemConformingToTypeIdentifier(UTType.data.identifier) {
+
+            attachment.loadItem(forTypeIdentifier: UTType.data.identifier, options: nil) { [weak self] data, error in
+                guard let url = data as? URL else {
+                    return
+                }
+
+                let fileManager = FileManager.default
+                guard let container = fileManager.containerURL(forSecurityApplicationGroupIdentifier: "group.au.com.shiftyjelly.pocketcasts") else {
+                    return
+                }
+
+                let destURL = container.appendingPathComponent("opml.opml")
+
+                do { try FileManager.default.copyItem(at: url, to: destURL) } catch { }
+
+                self?.close()
+
+                self?.redirectToHostApp(destURL.absoluteString)
+            }
+        }
     }
 
-    func redirectToHostApp() {
-        let url = URL(string: "pktc://item?id=20036169")
+    func redirectToHostApp(_ url: String) {
+        guard let url = URL(string: "pktc://import-opml/\(url)") else {
+            return
+        }
+
         let selectorOpenURL = sel_registerName("openURL:")
         let context = NSExtensionContext()
-        context.open(url! as URL, completionHandler: nil)
+        context.open(url as URL, completionHandler: nil)
 
         var responder = self as UIResponder?
 
@@ -23,8 +51,12 @@ class ShareViewController: UIViewController {
             if responder?.responds(to: selectorOpenURL) == true {
                 responder?.perform(selectorOpenURL, with: url)
             }
-            responder = responder!.next
+            responder = responder?.next
         }
+    }
+
+    private func close() {
+        self.extensionContext?.completeRequest(returningItems: [], completionHandler: nil)
     }
 
 }

--- a/Share Extension/ShareViewController.swift
+++ b/Share Extension/ShareViewController.swift
@@ -17,27 +17,24 @@ class ShareViewController: UIViewController {
 
             attachment.loadItem(forTypeIdentifier: UTType.data.identifier, options: nil) { [weak self] data, error in
                 guard let url = data as? URL else {
+                    self?.close()
                     return
                 }
 
-                let fileManager = FileManager.default
-                guard let container = fileManager.containerURL(forSecurityApplicationGroupIdentifier: "group.au.com.shiftyjelly.pocketcasts") else {
+                guard let opmlData = try? Data(contentsOf: url) else {
+                    self?.close()
                     return
                 }
-
-                let destURL = container.appendingPathComponent("opml.opml")
-
-                do { try FileManager.default.copyItem(at: url, to: destURL) } catch { }
 
                 self?.close()
 
-                self?.redirectToHostApp(destURL.absoluteString)
+                self?.redirectToHostApp(opmlData.base64EncodedString())
             }
         }
     }
 
-    func redirectToHostApp(_ url: String) {
-        guard let url = URL(string: "pktc://import-opml/\(url)") else {
+    func redirectToHostApp(_ encodedOPML: String) {
+        guard let url = URL(string: "pktc://import-opml/\(encodedOPML)") else {
             return
         }
 

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -444,6 +444,7 @@
 		46FBD8B7276A874F00867746 /* Intents.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = 46FBD8B9276A874F00867746 /* Intents.intentdefinition */; settings = {ATTRIBUTES = (codegen, ); }; };
 		4A3C19F543779593E98EDA3C /* libPods-Pocket Casts Watch App Extension.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C7C2391BA608F0CAB6E1D038 /* libPods-Pocket Casts Watch App Extension.a */; };
 		8B0125682912A7AB00EC427A /* StoryShareableText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B0125672912A7AB00EC427A /* StoryShareableText.swift */; };
+		8B0845932A66C86C00742C2F /* Share Extension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 2F90990B2A4F88B00044FC55 /* Share Extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		8B087FC929DC976F0027EAE5 /* PodcastImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B087FC829DC976F0027EAE5 /* PodcastImage.swift */; };
 		8B087FCB29DE08460027EAE5 /* UpgradeLandingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B087FCA29DE08460027EAE5 /* UpgradeLandingView.swift */; };
 		8B0EEDE029003E8D00075772 /* ListeningTimeStory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B0EEDDF29003E8D00075772 /* ListeningTimeStory.swift */; };
@@ -1606,6 +1607,20 @@
 			remoteGlobalIDString = 462EE0C02702532E003D67DC;
 			remoteInfo = GenerateCredentials;
 		};
+		8B0845912A66C86500742C2F /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BDBD53E417019B290048C8C5 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = BD3A210C1E6CFC2400F42241;
+			remoteInfo = NotificationExtension;
+		};
+		8B0845942A66C86D00742C2F /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BDBD53E417019B290048C8C5 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 2F90990A2A4F88B00044FC55;
+			remoteInfo = "Share Extension";
+		};
 		BD3A21121E6CFC2400F42241 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BDBD53E417019B290048C8C5 /* Project object */;
@@ -1679,6 +1694,7 @@
 			dstSubfolderSpec = 13;
 			files = (
 				BDEFBA211E6D3C2300B9024B /* NotificationContent.appex in Embed App Extensions */,
+				8B0845932A66C86C00742C2F /* Share Extension.appex in Embed App Extensions */,
 				4090975B25235DFC00CED68C /* WidgetExtension.appex in Embed App Extensions */,
 				BD3A21141E6CFC2400F42241 /* NotificationExtension.appex in Embed App Extensions */,
 				403B5B2821813FFA00821A54 /* PodcastsIntents.appex in Embed App Extensions */,
@@ -7151,6 +7167,8 @@
 				403B5B2421813FFA00821A54 /* PBXTargetDependency */,
 				403B5B2721813FFA00821A54 /* PBXTargetDependency */,
 				4090975A25235DFC00CED68C /* PBXTargetDependency */,
+				8B0845922A66C86500742C2F /* PBXTargetDependency */,
+				8B0845952A66C86D00742C2F /* PBXTargetDependency */,
 			);
 			name = podcasts;
 			packageProductDependencies = (
@@ -9237,6 +9255,16 @@
 			isa = PBXTargetDependency;
 			target = 462EE0C02702532E003D67DC /* PreBuildActions */;
 			targetProxy = 46DB228A274EB52A0057D3DD /* PBXContainerItemProxy */;
+		};
+		8B0845922A66C86500742C2F /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = BD3A210C1E6CFC2400F42241 /* NotificationExtension */;
+			targetProxy = 8B0845912A66C86500742C2F /* PBXContainerItemProxy */;
+		};
+		8B0845952A66C86D00742C2F /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 2F90990A2A4F88B00044FC55 /* Share Extension */;
+			targetProxy = 8B0845942A66C86D00742C2F /* PBXContainerItemProxy */;
 		};
 		BD3A21131E6CFC2400F42241 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/podcasts/AppDelegate+UrlHandling.swift
+++ b/podcasts/AppDelegate+UrlHandling.swift
@@ -335,17 +335,21 @@ extension AppDelegate {
 
         // Import OMPL extension
         JLRoutes.global().addRoute("/import-opml/*") { [weak self] parameters -> Bool in
-            guard let strongSelf = self, let originalUrl = parameters[JLRouteURLKey] as? URL else { return false }
+            guard let self,
+                  let rootViewController = SceneHelper.rootViewController(),
+                  let documentsURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first,
+                  let originalUrl = parameters[JLRouteURLKey] as? URL else { return false }
 
-            let opmlURLString = originalUrl.absoluteString.replacingOccurrences(of: "pktc://import-opml/", with: "")
+            let encodedOPML = originalUrl.absoluteString.replacingOccurrences(of: "pktc://import-opml/", with: "")
 
-            guard let url = URL(string: opmlURLString) else {
+            guard let opmlData = Data(base64Encoded: encodedOPML) else {
                 return true
             }
 
-            PodcastManager.shared.importPodcastsFromOpml(url)
+            let fileURL = documentsURL.appendingPathComponent("import.opml")
+            try? opmlData.write(to: fileURL, options: .atomic)
 
-            return true
+            return self.handleOpenUrl(url: fileURL, rootViewController: rootViewController)
         }
     }
 

--- a/podcasts/AppDelegate+UrlHandling.swift
+++ b/podcasts/AppDelegate+UrlHandling.swift
@@ -332,6 +332,21 @@ extension AppDelegate {
             })
             return true
         }
+
+        // Import OMPL extension
+        JLRoutes.global().addRoute("/import-opml/*") { [weak self] parameters -> Bool in
+            guard let strongSelf = self, let originalUrl = parameters[JLRouteURLKey] as? URL else { return false }
+
+            let opmlURLString = originalUrl.absoluteString.replacingOccurrences(of: "pktc://import-opml/", with: "")
+
+            guard let url = URL(string: opmlURLString) else {
+                return true
+            }
+
+            PodcastManager.shared.importPodcastsFromOpml(url)
+
+            return true
+        }
     }
 
     func openSharePath(_ path: String, controller: UIViewController, onErrorOpen: URL?) {


### PR DESCRIPTION
1. Adds the share extension back
2. Fix the activation rule (thus not crashing the OS share sheet)
3. Handle the OPML import process

## To test

**📱 Note:** You should test this on a real device.

1. Build and run the app on your device
2. Reboot your device (this is important to re-run all the share extensions code)
3. Go to Photos and share any photo
4. ✅ The share sheet should contain your usual non-Apple apps
5. Open any other podcast app
6. Export the OPML file
7. ✅ When the share sheet appears you should see Pocket Casts
8. Tap on it
9. ✅ The app should open and import the podcasts

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
