### PR TITLE
Bookmarks: Show the toast message when a new bookmark is added

### DIFF
--- a/podcasts/Bookmarks/Editing/BookmarkEditTitleViewController.swift
+++ b/podcasts/Bookmarks/Editing/BookmarkEditTitleViewController.swift
@@ -3,10 +3,17 @@ import PocketCastsDataModel
 
 class BookmarkEditTitleViewController: ThemedHostingController<BookmarkEditTitleView> {
     private let viewModel: BookmarkEditViewModel
+    let onDismiss: (String) -> Void
+    let bookmark: Bookmark
 
-    init(manager: BookmarkManager, bookmark: Bookmark, state: BookmarkEditViewModel.EditState) {
+    init(manager: BookmarkManager,
+         bookmark: Bookmark,
+         state: BookmarkEditViewModel.EditState,
+         onDismiss: @escaping (String) -> Void) {
         let viewModel = BookmarkEditViewModel(manager: manager, bookmark: bookmark, state: state)
         self.viewModel = viewModel
+        self.bookmark = bookmark
+        self.onDismiss = onDismiss
 
         super.init(rootView: .init(viewModel: viewModel))
 
@@ -27,10 +34,11 @@ class BookmarkEditTitleViewController: ThemedHostingController<BookmarkEditTitle
 extension BookmarkEditTitleViewController: BookmarkEditRouter {
     func dismiss() {
         dismiss(animated: true)
+        onDismiss(bookmark.title)
     }
 
     func titleUpdated(title: String) {
-        print("Title updated!")
-        dismiss()
+        dismiss(animated: true)
+        onDismiss(title)
     }
 }

--- a/podcasts/Bookmarks/Editing/BookmarkEditTitleViewController.swift
+++ b/podcasts/Bookmarks/Editing/BookmarkEditTitleViewController.swift
@@ -4,7 +4,6 @@ import PocketCastsDataModel
 class BookmarkEditTitleViewController: ThemedHostingController<BookmarkEditTitleView> {
     private let viewModel: BookmarkEditViewModel
     let onDismiss: (String) -> Void
-    let bookmark: Bookmark
 
     init(manager: BookmarkManager,
          bookmark: Bookmark,
@@ -12,7 +11,6 @@ class BookmarkEditTitleViewController: ThemedHostingController<BookmarkEditTitle
          onDismiss: @escaping (String) -> Void) {
         let viewModel = BookmarkEditViewModel(manager: manager, bookmark: bookmark, state: state)
         self.viewModel = viewModel
-        self.bookmark = bookmark
         self.onDismiss = onDismiss
 
         super.init(rootView: .init(viewModel: viewModel))
@@ -34,7 +32,7 @@ class BookmarkEditTitleViewController: ThemedHostingController<BookmarkEditTitle
 extension BookmarkEditTitleViewController: BookmarkEditRouter {
     func dismiss() {
         dismiss(animated: true)
-        onDismiss(bookmark.title)
+        onDismiss(viewModel.originalTitle)
     }
 
     func titleUpdated(title: String) {

--- a/podcasts/Bookmarks/Player/BookmarksPlayerTabController.swift
+++ b/podcasts/Bookmarks/Player/BookmarksPlayerTabController.swift
@@ -94,7 +94,7 @@ class BookmarksPlayerTabController: PlayerItemViewController {
             self?.showBookmarksTab()
         }
 
-        Toast.show(message, actions: [action])
+        Toast.show(message, actions: [action], theme: .playerTheme)
     }
 
     private func showBookmarksTab() {

--- a/podcasts/Bookmarks/Player/BookmarksPlayerTabController.swift
+++ b/podcasts/Bookmarks/Player/BookmarksPlayerTabController.swift
@@ -77,8 +77,28 @@ class BookmarksPlayerTabController: PlayerItemViewController {
     }
 
     private func showBookmarkEdit(isNew: Bool, bookmark: Bookmark) {
-        let controller = BookmarkEditTitleViewController(manager: bookmarkManager, bookmark: bookmark, state: isNew ? .adding : .updating)
+        let controller = BookmarkEditTitleViewController(manager: bookmarkManager, bookmark: bookmark, state: isNew ? .adding : .updating, onDismiss: { [weak self] title in
+            self?.handleEditDismissed(isNew: isNew, title: title)
+        })
+
         present(controller, animated: true)
+    }
+
+    func handleEditDismissed(isNew: Bool, title: String) {
+        guard isNew else { return }
+
+        // If the title is still the default, we'll just show a 'Bookmark Added' message instead of displaying 'Bookmark "Bookmark" Added'.
+        let message = title == L10n.bookmarkDefaultTitle ? L10n.bookmarkAdded : L10n.bookmarkAddedNotification(title)
+
+        let action = Toast.Action(title: L10n.bookmarkAddedButtonTitle) { [weak self] in
+            self?.showBookmarksTab()
+        }
+
+        Toast.show(message, actions: [action])
+    }
+
+    private func showBookmarksTab() {
+        containerDelegate?.scrollToBookmarks()
     }
 
     // MARK: - Coder....

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -1906,17 +1906,7 @@ extension PlaybackManager {
             return
         }
 
-        #if DEBUG
-        #if !os(watchOS)
-        // For testing only, will be removed.
-        Toast.show("Bookmark 'Hello World' added", actions: [.init(title: "View", action: {
-            print("View Action")
-        })], theme: .playerTheme)
-        #endif
-        #else
         let currentTime = currentTime()
-
         bookmarkManager.add(to: episode, at: currentTime)
-        #endif
     }
 }

--- a/podcasts/PlayerContainerViewController.swift
+++ b/podcasts/PlayerContainerViewController.swift
@@ -137,6 +137,14 @@ class PlayerContainerViewController: SimpleNotificationsViewController, PlayerTa
         mainScrollView.scrollRectToVisible(scrollRect, animated: true)
     }
 
+    func scrollToBookmarks() {
+        guard let index = tabsView.tabs.firstIndex(of: .bookmarks) else { return }
+
+        tabsView.currentTab = index
+        let scrollRect = CGRect(x: CGFloat(index) * mainScrollView.frame.width, y: 0, width: mainScrollView.frame.width, height: mainScrollView.frame.height)
+        mainScrollView.scrollRectToVisible(scrollRect, animated: true)
+    }
+
     // MARK: - PlayerTabDelegate
 
     func didSwitchToTab(index: Int) {

--- a/podcasts/PlayerItemViewController.swift
+++ b/podcasts/PlayerItemViewController.swift
@@ -3,6 +3,7 @@ import UIKit
 protocol PlayerItemContainerDelegate: AnyObject {
     func scrollToCurrentChapter()
     func scrollToNowPlaying()
+    func scrollToBookmarks()
 }
 
 class PlayerItemViewController: SimpleNotificationsViewController {

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -254,6 +254,14 @@ internal enum L10n {
   internal static var autoDownloadPromptFirst: String { return L10n.tr("Localizable", "auto_download_prompt_first") }
   /// Back
   internal static var back: String { return L10n.tr("Localizable", "back") }
+  /// Bookmark added
+  internal static var bookmarkAdded: String { return L10n.tr("Localizable", "bookmark_added") }
+  /// View
+  internal static var bookmarkAddedButtonTitle: String { return L10n.tr("Localizable", "bookmark_added_button_title") }
+  /// Bookmark "%1$@" added
+  internal static func bookmarkAddedNotification(_ p1: Any) -> String {
+    return L10n.tr("Localizable", "bookmark_added_notification", String(describing: p1))
+  }
   /// Bookmark
   internal static var bookmarkDefaultTitle: String { return L10n.tr("Localizable", "bookmark_default_title") }
   /// Are you sure you want to delete these bookmarks, there’s no way to undo it!

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -3814,3 +3814,12 @@
 
 /* Title of an option in a menu prompt */
 "sort_option_timestamp" = "Timestamp";
+
+/* A message that appears after the user created a bookmark and %1$@ displays the title they choose for it. */
+"bookmark_added_notification" = "Bookmark \"%1$@\" added";
+
+/* A message that appears to inform the user their bookmark is added */
+"bookmark_added" = "Bookmark added";
+
+/* Title of a button that allows the user to view their bookmarks */
+"bookmark_added_button_title" = "View";


### PR DESCRIPTION
This displays the toast message after a bookmark is added, and adds the action to switch to the bookmarks tab.

## Demo Video

https://github.com/Automattic/pocket-casts-ios/assets/793774/fa071b3e-8fa1-463f-b642-26d5f4edc6bb

## To test

1. Enable the Bookmarks Feature Flag by going to Profile > Cog > Beta Features > bookmarks
2. Open the Full Screen Player
3. Tap the Add Bookmarks action
4. Edit the title, tap Save
5. ✅ Verify you see the toast message 
6. Tap the View button
7. ✅ Verify you are switched to the Bookmarks tab
8. Tap and hold on the bookmark
9. Tap the edit option in the action bar
10. Edit the title, tap save
11. ✅ Verify you do not see the toast


## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
