### PR TITLE
Bookmarks: Adds Empty State

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1453,6 +1453,8 @@
 		C761300B28E4CA4F0044C6C2 /* AnalyticsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C761300A28E4CA4E0044C6C2 /* AnalyticsCoordinator.swift */; };
 		C761300C28E4CAE90044C6C2 /* AnalyticsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C761300A28E4CA4E0044C6C2 /* AnalyticsCoordinator.swift */; };
 		C76400552A0EDFB90092A74B /* UserInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = C76400542A0EDFB90092A74B /* UserInfo.swift */; };
+		C76ECAC22A67612F00D9DB9E /* EmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C76ECAC12A67612F00D9DB9E /* EmptyStateView.swift */; };
+		C76ECAC42A67622900D9DB9E /* BookmarksEmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C76ECAC32A67622900D9DB9E /* BookmarksEmptyStateView.swift */; };
 		C784DE7B2A58CFA1004D03E7 /* ScrollViewWithContentOffset.swift in Sources */ = {isa = PBXBuildFile; fileRef = C784DE7A2A58CFA1004D03E7 /* ScrollViewWithContentOffset.swift */; };
 		C784DE7D2A590866004D03E7 /* View+Buttonize.swift in Sources */ = {isa = PBXBuildFile; fileRef = C784DE7C2A590866004D03E7 /* View+Buttonize.swift */; };
 		C791418D294CE32D00F1852B /* StorageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C791418C294CE32D00F1852B /* StorageManager.swift */; };
@@ -3185,6 +3187,8 @@
 		C7612FFE28E397A00044C6C2 /* AnalyticsEpisodeHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsEpisodeHelper.swift; sourceTree = "<group>"; };
 		C761300A28E4CA4E0044C6C2 /* AnalyticsCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnalyticsCoordinator.swift; sourceTree = "<group>"; };
 		C76400542A0EDFB90092A74B /* UserInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfo.swift; sourceTree = "<group>"; };
+		C76ECAC12A67612F00D9DB9E /* EmptyStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyStateView.swift; sourceTree = "<group>"; };
+		C76ECAC32A67622900D9DB9E /* BookmarksEmptyStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksEmptyStateView.swift; sourceTree = "<group>"; };
 		C784DE7A2A58CFA1004D03E7 /* ScrollViewWithContentOffset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollViewWithContentOffset.swift; sourceTree = "<group>"; };
 		C784DE7C2A590866004D03E7 /* View+Buttonize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Buttonize.swift"; sourceTree = "<group>"; };
 		C791418C294CE32D00F1852B /* StorageManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageManager.swift; sourceTree = "<group>"; };
@@ -6351,6 +6355,7 @@
 				C784DE7C2A590866004D03E7 /* View+Buttonize.swift */,
 				C73CCBC829C590100075EFFD /* View+UIView.swift */,
 				C7D8AE562A5F6D2600C9EBAF /* ActionBarOverlayView.swift */,
+				C76ECAC12A67612F00D9DB9E /* EmptyStateView.swift */,
 			);
 			path = SwiftUI;
 			sourceTree = "<group>";
@@ -7013,6 +7018,7 @@
 			children = (
 				C7DC401C2A67025D00883D03 /* Toast */,
 				C7E99F072A5E103A00E7CBAF /* List View */,
+				C76ECAC32A67622900D9DB9E /* BookmarksEmptyStateView.swift */,
 			);
 			path = "Common SwiftUI";
 			sourceTree = "<group>";
@@ -8574,6 +8580,7 @@
 				BDAA3CF321228A0D00649F81 /* ExpandCollapseButton.swift in Sources */,
 				407B9B72238B5D91008E7CA8 /* UpNextViewController+MultiSelectActions.swift in Sources */,
 				40422D96251AF10500C80BE4 /* BundlePodcastCell.swift in Sources */,
+				C76ECAC22A67612F00D9DB9E /* EmptyStateView.swift in Sources */,
 				8B317BA028906A8900A26A13 /* main.swift in Sources */,
 				BDC86830238251B0004C998F /* NowPlayingPlayerItemViewController+UpNextPan.swift in Sources */,
 				BD7BCF131F6A4F920006E008 /* SharingItemProvider.swift in Sources */,
@@ -8745,6 +8752,7 @@
 				BD69EBBC1CD1D383007F273B /* SocialsHelper.swift in Sources */,
 				BDEDCF7124627F02005910C1 /* CustomSegmentedControl.swift in Sources */,
 				BD2F592A20468C6700AD3767 /* CustomObserver.swift in Sources */,
+				C76ECAC42A67622900D9DB9E /* BookmarksEmptyStateView.swift in Sources */,
 				BDD62979200ECCBB00168DF7 /* EpisodeDetailViewController+ShowNotes.swift in Sources */,
 				BDD832AF214B8A8B0013D692 /* PCGoogleCastButton.swift in Sources */,
 				8B3295402A5333C900BDFA11 /* WhatsNew.swift in Sources */,

--- a/podcasts/Bookmarks/Player/BookmarksPlayerTab.swift
+++ b/podcasts/Bookmarks/Player/BookmarksPlayerTab.swift
@@ -14,21 +14,29 @@ struct BookmarksPlayerTab: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            if viewModel.items.isEmpty {
-                BookmarksEmptyStateView(style: .playerStyle)
-                Spacer()
-            } else {
-                headerView
-                divider
-
-                actionBarView {
-                    scrollView
-                }
-            }
+            viewModel.items.isEmpty ? emptyView : listView
         }
         .environmentObject(viewModel)
         .padding(.bottom)
         .background(style.background.ignoresSafeArea())
+    }
+
+    /// An empty state view that displays instructions
+    @ViewBuilder
+    private var emptyView: some View {
+        BookmarksEmptyStateView(style: .playerStyle)
+        Spacer()
+    }
+
+    /// The main content view that displays a list of bookmarks
+    @ViewBuilder
+    private var listView: some View {
+        headerView
+        divider
+
+        actionBarView {
+            scrollView
+        }
     }
 
     /// A static header view that displays the number of bookmarks and a ... more button

--- a/podcasts/Bookmarks/Player/BookmarksPlayerTab.swift
+++ b/podcasts/Bookmarks/Player/BookmarksPlayerTab.swift
@@ -14,7 +14,11 @@ struct BookmarksPlayerTab: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            viewModel.items.isEmpty ? emptyView : listView
+            if viewModel.items.isEmpty {
+                emptyView
+            } else {
+                listView
+            }
         }
         .environmentObject(viewModel)
         .padding(.bottom)

--- a/podcasts/Bookmarks/Player/BookmarksPlayerTab.swift
+++ b/podcasts/Bookmarks/Player/BookmarksPlayerTab.swift
@@ -14,11 +14,16 @@ struct BookmarksPlayerTab: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            headerView
-            divider
+            if viewModel.items.isEmpty {
+                BookmarksEmptyStateView(style: .playerStyle)
+                Spacer()
+            } else {
+                headerView
+                divider
 
-            actionBarView {
-                scrollView
+                actionBarView {
+                    scrollView
+                }
             }
         }
         .environmentObject(viewModel)

--- a/podcasts/Common SwiftUI/BookmarksEmptyStateView.swift
+++ b/podcasts/Common SwiftUI/BookmarksEmptyStateView.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+
+/// Displays the empty state view for the bookmarks
+struct BookmarksEmptyStateView<Style: EmptyStateViewStyle>: View {
+    @ObservedObject var style: Style
+
+    var body: some View {
+        EmptyStateView(title: L10n.noBookmarksTitle, message: L10n.noBookmarksMessage, actions: [
+            .init(title: L10n.noBookmarksButtonTitle, action: {
+
+                NavigationManager.sharedManager.navigateTo(NavigationManager.settingsHeadphoneKey)
+
+            })
+        ], style: style)
+    }
+}
+
+// MARK: - Styles
+
+class DefaultEmptyStateStyle: ThemeObserver, EmptyStateViewStyle {
+    var background: Color { theme.primaryUi01Active }
+    var title: Color { theme.primaryText01 }
+    var message: Color { theme.primaryText02 }
+    var button: Color { theme.primaryInteractive01 }
+}
+
+class PlayerEmptyStateStyle: ThemeObserver, EmptyStateViewStyle {
+    var background: Color { theme.playerContrast06 }
+    var title: Color { theme.playerContrast01 }
+    var message: Color { theme.playerContrast02 }
+    var button: Color { theme.playerContrast01 }
+}
+
+extension EmptyStateViewStyle where Self == PlayerEmptyStateStyle {
+    static var playerStyle: PlayerEmptyStateStyle {
+        PlayerEmptyStateStyle()
+    }
+}
+
+extension EmptyStateViewStyle where Self == DefaultEmptyStateStyle {
+    static var defaultStyle: DefaultEmptyStateStyle {
+        DefaultEmptyStateStyle()
+    }
+}
+
+// MARK: - Preview
+
+struct BookmarksEmptyStateView_Previews: PreviewProvider {
+    static var previews: some View {
+        BookmarksEmptyStateView(style: .playerStyle)
+    }
+}

--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -355,6 +355,15 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
         }
     }
 
+    func showHeadphoneSettings() {
+        switchToTab(.profile)
+        if let navController = selectedViewController as? UINavigationController {
+            navController.popToRootViewController(animated: false)
+            navController.pushViewController(SettingsViewController(), animated: false)
+            navController.pushViewController(HeadphoneSettingsViewController(), animated: true)
+        }
+    }
+
     func showSupporterSignIn(podcastInfo: PodcastInfo) {
         let supporterVC = SupporterGratitudeViewController(podcastInfo: podcastInfo)
         let controller = view.window?.rootViewController

--- a/podcasts/NavigationManager.swift
+++ b/podcasts/NavigationManager.swift
@@ -53,6 +53,7 @@ class NavigationManager {
 
     static let settingsAppearanceKey = "appearancePage"
     static let settingsProfileKey = "profilePage"
+    static let settingsHeadphoneKey = "headphoneSettings"
 
     static let endOfYearStories = "endOfYearStories"
     static let onboardingFlow = "onboardingFlow"
@@ -75,7 +76,7 @@ class NavigationManager {
 
     // MARK: - Navigation
 
-    func navigateTo(_ place: String, data: NSDictionary?) {
+    func navigateTo(_ place: String, data: NSDictionary? = nil) {
         performNavigation(place, data: data, animated: true)
     }
 
@@ -164,7 +165,11 @@ class NavigationManager {
             mainController?.showSettingsAppearance()
         } else if place == NavigationManager.settingsProfileKey {
             mainController?.showProfilePage()
-        } else if place == NavigationManager.showPromotionPageKey {
+        }
+        else if place == NavigationManager.settingsHeadphoneKey {
+            mainController?.showHeadphoneSettings()
+        }
+        else if place == NavigationManager.showPromotionPageKey {
             var promoCode: String?
             if let data = data, let promoString = data[NavigationManager.promotionInfoKey] as? String {
                 promoCode = promoString

--- a/podcasts/NavigationProtocol.swift
+++ b/podcasts/NavigationProtocol.swift
@@ -31,6 +31,7 @@ protocol NavigationProtocol: AnyObject {
     func showPromotionPage(promoCode: String?)
     func showPromotionFinishedAcknowledge()
     func showProfilePage()
+    func showHeadphoneSettings()
 
     func showSupporterSignIn(podcastInfo: PodcastInfo)
     func showSupporterSignIn(bundleUuid: String)

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -1360,6 +1360,12 @@ internal enum L10n {
   internal static func nextPaymentFormat(_ p1: Any) -> String {
     return L10n.tr("Localizable", "next_payment_format", String(describing: p1))
   }
+  /// Headphone settings
+  internal static var noBookmarksButtonTitle: String { return L10n.tr("Localizable", "no_bookmarks_button_title") }
+  /// You can save timestamps of episodes from the actions menu in the player or by configuring an action with your headphones.
+  internal static var noBookmarksMessage: String { return L10n.tr("Localizable", "no_bookmarks_message") }
+  /// No bookmarks yet
+  internal static var noBookmarksTitle: String { return L10n.tr("Localizable", "no_bookmarks_title") }
   /// None
   internal static var `none`: String { return L10n.tr("Localizable", "none") }
   /// You're not on WiFi

--- a/podcasts/SwiftUI/EmptyStateView.swift
+++ b/podcasts/SwiftUI/EmptyStateView.swift
@@ -1,0 +1,97 @@
+import SwiftUI
+
+protocol EmptyStateViewStyle: ObservableObject {
+    var background: Color { get }
+    var title: Color { get }
+    var message: Color { get }
+    var button: Color { get }
+}
+
+/// Displays an informative view when there are no items to display and can be customized to show a custom view instead
+/// of a text title.
+///
+/// The colors can be customized using EmptyStateViewStyle
+struct EmptyStateView<Title: View, Style: EmptyStateViewStyle>: View {
+    @ObservedObject var style: Style
+    let title: () -> Title
+    let message: String
+    let actions: [Action]
+
+    init(@ViewBuilder title: @escaping () -> Title, message: String, actions: [Action], style: Style) {
+        self.title = title
+        self.message = message
+        self.actions = actions
+        self.style = style
+    }
+
+    var body: some View {
+        VStack(spacing: EmptyConstants.spacing) {
+            title()
+                .font(style: .title2, weight: .bold)
+                .foregroundStyle(style.title)
+
+            Text(message)
+                .multilineTextAlignment(.center)
+                .font(style: .subheadline)
+                .foregroundStyle(style.message)
+
+            HStack {
+                ForEach(actions) { action in
+                    Button(action.title) {
+                        action.action()
+                    }.buttonStyle(ClickyButton())
+                }
+            }
+            .font(style: .subheadline, weight: .medium)
+            .foregroundStyle(style.button)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.horizontal, EmptyConstants.padding)
+        .padding(.vertical, EmptyConstants.verticalPadding)
+        .background(style.background)
+        .cornerRadius(EmptyConstants.cornerRadius)
+        .padding(EmptyConstants.padding)
+    }
+
+    struct Action: Identifiable {
+        let title: String
+        let action: () -> Void
+
+        var id: String { title }
+    }
+}
+
+private enum EmptyConstants {
+    static let cornerRadius = 4.0
+    static let padding = 16.0
+    static let verticalPadding = 24.0
+    static let spacing = 12.0
+}
+
+extension EmptyStateView where Title == Text {
+    init(title: String, message: String, actions: [Action], style: Style) {
+        self.message = message
+        self.actions = actions
+        self.title = {
+            Text(title)
+        }
+        self.style = style
+    }
+}
+
+struct EmptyStateView_Previews: PreviewProvider {
+    static var previews: some View {
+        EmptyStateView(title: "Hello World", message: "Hello how are you?", actions: [
+            .init(title: "Empty Action", action: {
+                print("Action!")
+            })
+        ], style: PreviewStyle())
+    }
+
+    private class PreviewStyle: EmptyStateViewStyle {
+        var background: Color { .black }
+        var title: Color { .white }
+        var message: Color { .white.opacity(0.8) }
+        var button: Color { .red }
+    }
+}

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -3823,3 +3823,12 @@
 
 /* Title of a button that allows the user to view their bookmarks */
 "bookmark_added_button_title" = "View";
+
+/* Title of a message informing the user they don't have any bookmarks yet */
+"no_bookmarks_title" = "No bookmarks yet";
+
+/* Subtitle of a message explaining how to add new bookmarks */
+"no_bookmarks_message" = "You can save timestamps of episodes from the actions menu in the player or by configuring an action with your headphones.";
+
+/* Title of a button that takes the user to the headphone settings */
+"no_bookmarks_button_title" = "Headphone settings";


### PR DESCRIPTION
This adds the empty state view when there are no bookmarks to display. This doesn't include the upgrade state yet, but I've written the code to be able to support that in the future. 


## Demo Video

https://github.com/Automattic/pocket-casts-ios/assets/793774/eda40f22-ea63-4783-b285-a073f0ef960c

## To test

1. Enable the Bookmarks Feature Flag by going to Profile > Cog > Beta Features > bookmarks
2. Play an episode that has no bookmarks
3. Open the Full Screen Player
4. Swipe to the Bookmarks tab
5. ✅ Verify you see the empty state view
6. Swipe to the now playing
7. Add a bookmark
8. Swipe back to the bookmarks tab
9. ✅ Verify the empty state is gone
10. Delete the bookmarks
11. ✅ Verify the empty state view shows

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
