### PR TITLE
Podcasts out of folders issue: add additional logs

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/PodcastDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/PodcastDataManager.swift
@@ -317,7 +317,7 @@ class PodcastDataManager {
 
     func save(podcast: Podcast, dbQueue: FMDatabaseQueue) {
         // Get the existing podcast to compare if folder is being changed
-        let existentPodcast = DataManager.sharedManager.findPodcast(uuid: podcast.uuid)
+        let existingPodcast = DataManager.sharedManager.findPodcast(uuid: podcast.uuid)
 
         dbQueue.inDatabase { db in
             do {
@@ -329,8 +329,8 @@ class PodcastDataManager {
                     try db.executeUpdate("UPDATE \(DataManager.podcastTableName) SET \(setStatement) WHERE id = ?", values: self.createValuesFrom(podcast: podcast, includeIdForWhere: true))
 
                     // If changing folder, log it
-                    if podcast.folderUuid != existentPodcast?.folderUuid {
-                        FileLog.shared.foldersIssue("PodcastDataManager: update \(podcast.title ?? "") folder from \(existentPodcast?.folderUuid ?? "nil") to \(podcast.folderUuid ?? "nil")")
+                    if podcast.folderUuid != existingPodcast?.folderUuid {
+                        FileLog.shared.foldersIssue("PodcastDataManager: update \(podcast.title ?? "") folder from \(existingPodcast?.folderUuid ?? "nil") to \(podcast.folderUuid ?? "nil")")
                     }
                 }
             } catch {

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+FullSync.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+FullSync.swift
@@ -91,7 +91,10 @@ extension SyncTask {
             if let addedDate = podcast.dateAdded {
                 localPodcast.addedDate = addedDate
             }
+
+            FileLog.shared.foldersIssue("SyncTask processPodcast: changing \(localPodcast.title ?? "") folder from \(localPodcast.folderUuid ?? "nil") to \(podcast.folderUuid ?? "nil")")
             localPodcast.folderUuid = podcast.folderUuid
+
             if let sortOrder = podcast.sortPosition {
                 localPodcast.sortOrder = sortOrder
             }

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
@@ -204,6 +204,7 @@ extension SyncTask {
         // if another device has deleted this folder, we need to delete it as well. No point in importing any of it's properties, so we return here as well
         if folderItem.isDeleted {
             DataManager.sharedManager.delete(folderUuid: folderUuid, markAsDeleted: false)
+            FileLog.shared.foldersIssue("SyncTask importFolder: delete folder \(folderUuid)")
 
             return
         }

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
@@ -117,6 +117,9 @@ extension SyncTask {
         }
         if podcastItem.hasFolderUuid {
             let folderUuid = podcastItem.folderUuid.value
+
+            FileLog.shared.addMessage("SyncTask importItem: \(podcast.title ?? "") folder to \(((folderUuid == DataConstants.homeGridFolderUuid) ? nil : folderUuid) ?? "nil")")
+
             podcast.folderUuid = (folderUuid == DataConstants.homeGridFolderUuid) ? nil : folderUuid
         }
         if podcastItem.hasSortPosition {

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
@@ -118,7 +118,7 @@ extension SyncTask {
         if podcastItem.hasFolderUuid {
             let folderUuid = podcastItem.folderUuid.value
 
-            FileLog.shared.addMessage("SyncTask importItem: \(podcast.title ?? "") folder to \(((folderUuid == DataConstants.homeGridFolderUuid) ? nil : folderUuid) ?? "nil")")
+            FileLog.shared.foldersIssue("SyncTask importItem: \(podcast.title ?? "") folder to \(((folderUuid == DataConstants.homeGridFolderUuid) ? nil : folderUuid) ?? "nil")")
 
             podcast.folderUuid = (folderUuid == DataConstants.homeGridFolderUuid) ? nil : folderUuid
         }

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask.swift
@@ -92,7 +92,7 @@ class SyncTask: ApiBaseTask {
 
                     // If server's folderUuid is `nil` then we don't change
                     if podcast.folderUuid?.isEmpty == false {
-                        FileLog.shared.addMessage("SyncTask performHomeGridRefresh: changing \(localPodcast.title ?? "") folder from \(localPodcast.folderUuid ?? "nil") to \(podcast.folderUuid ?? "nil")")
+                        FileLog.shared.foldersIssue("SyncTask performHomeGridRefresh: changing \(localPodcast.title ?? "") folder from \(localPodcast.folderUuid ?? "nil") to \(podcast.folderUuid ?? "nil")")
 
                         localPodcast.folderUuid = podcast.folderUuid
                     }

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask.swift
@@ -92,6 +92,8 @@ class SyncTask: ApiBaseTask {
 
                     // If server's folderUuid is `nil` then we don't change
                     if podcast.folderUuid?.isEmpty == false {
+                        FileLog.shared.addMessage("SyncTask performHomeGridRefresh: changing \(localPodcast.title ?? "") folder from \(localPodcast.folderUuid ?? "nil") to \(podcast.folderUuid ?? "nil")")
+
                         localPodcast.folderUuid = podcast.folderUuid
                     }
 

--- a/Modules/Utils/Sources/PocketCastsUtils/Logging/FileLog.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Logging/FileLog.swift
@@ -50,6 +50,16 @@ public class FileLog {
         appendStringToLog("\(dateFormatter.string(from: Date())) \(message)\n")
     }
 
+    // Just a shortcut for `addMessage` to be used specifically for
+    // the podcasts out of folders issue
+    // By doing so it will be easier to delete those logs once the issue is
+    // sorted.
+    //
+    // See: https://github.com/Automattic/pocket-casts-ios/issues/791
+    public func foldersIssue(_ message: String?) {
+        addMessage(message)
+    }
+
     public func loadLogFileAsString(completion: @escaping (String) -> Void) {
         logQueue.async { [weak self] in
             guard let self = self else { return }

--- a/podcasts/PodcastManager+Delete.swift
+++ b/podcasts/PodcastManager+Delete.swift
@@ -17,6 +17,7 @@ extension PodcastManager {
                 EpisodeManager.deleteDownloadedFiles(episode: episode)
             }
 
+            FileLog.shared.foldersIssue("PodcastManager delete: setting \(podcast.title ?? "") folder to nil")
             podcast.folderUuid = nil
             podcast.subscribed = 0
             podcast.autoArchiveEpisodeLimit = 0


### PR DESCRIPTION
Related to #791

While I've been unable to reproduce the podcasts out of folders issue I think that adding additional logs might help us to understand better the problem.

This basically adds additional logs in different parts of the code where a folder from a podcast is changed.

## To test

1. Run the app
2. Create a folder and add podcasts to it
3. Unsubscribe from podcasts
4. ✅ Go to Profile > Settings (top-right cog) > Help & Feedback > Get in touch > Get support > check your "Debug Logs" for the recently added logs

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
