### PR TITLE
Bookmarks: Add a way to access the bookmarks from the podcast details

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1456,6 +1456,7 @@
 		C76ECAC22A67612F00D9DB9E /* EmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C76ECAC12A67612F00D9DB9E /* EmptyStateView.swift */; };
 		C76ECAC42A67622900D9DB9E /* BookmarksEmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C76ECAC32A67622900D9DB9E /* BookmarksEmptyStateView.swift */; };
 		C76ECACE2A685FB300D9DB9E /* BookmarksListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C76ECACD2A685FB300D9DB9E /* BookmarksListView.swift */; };
+		C76ECAD62A69518800D9DB9E /* EpisodeBookmarksTabsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C76ECAD52A69518800D9DB9E /* EpisodeBookmarksTabsView.swift */; };
 		C784DE7B2A58CFA1004D03E7 /* ScrollViewWithContentOffset.swift in Sources */ = {isa = PBXBuildFile; fileRef = C784DE7A2A58CFA1004D03E7 /* ScrollViewWithContentOffset.swift */; };
 		C784DE7D2A590866004D03E7 /* View+Buttonize.swift in Sources */ = {isa = PBXBuildFile; fileRef = C784DE7C2A590866004D03E7 /* View+Buttonize.swift */; };
 		C791418D294CE32D00F1852B /* StorageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C791418C294CE32D00F1852B /* StorageManager.swift */; };
@@ -1552,6 +1553,7 @@
 		C7F4BAB528DA6BBB001C9785 /* BackgroundSignOutListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F4BAB428DA6BBB001C9785 /* BackgroundSignOutListener.swift */; };
 		C7F4BAB728DA8666001C9785 /* BackgroundSignOutListenerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F4BAB628DA8666001C9785 /* BackgroundSignOutListenerTests.swift */; };
 		C7F4BABF28DB7F7C001C9785 /* DiscoverItem+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F4BABE28DB7F7C001C9785 /* DiscoverItem+Helper.swift */; };
+		C7F605112A69C5AB00795F3C /* BookmarksPodcastListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F605102A69C5AB00795F3C /* BookmarksPodcastListView.swift */; };
 		C7FAFF5B294183AA00329B40 /* CancelConfirmationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7FAFF5A294183AA00329B40 /* CancelConfirmationView.swift */; };
 		C7FAFF5D2941844C00329B40 /* CancelConfirmationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7FAFF5C2941844C00329B40 /* CancelConfirmationViewModel.swift */; };
 		C7FAFF6A2942E78A00329B40 /* HighlightedText.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7FAFF682942E6A400329B40 /* HighlightedText.swift */; };
@@ -3191,6 +3193,7 @@
 		C76ECAC12A67612F00D9DB9E /* EmptyStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyStateView.swift; sourceTree = "<group>"; };
 		C76ECAC32A67622900D9DB9E /* BookmarksEmptyStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksEmptyStateView.swift; sourceTree = "<group>"; };
 		C76ECACD2A685FB300D9DB9E /* BookmarksListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksListView.swift; sourceTree = "<group>"; };
+		C76ECAD52A69518800D9DB9E /* EpisodeBookmarksTabsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EpisodeBookmarksTabsView.swift; sourceTree = "<group>"; };
 		C784DE7A2A58CFA1004D03E7 /* ScrollViewWithContentOffset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollViewWithContentOffset.swift; sourceTree = "<group>"; };
 		C784DE7C2A590866004D03E7 /* View+Buttonize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Buttonize.swift"; sourceTree = "<group>"; };
 		C791418C294CE32D00F1852B /* StorageManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageManager.swift; sourceTree = "<group>"; };
@@ -3273,6 +3276,7 @@
 		C7F4BAB428DA6BBB001C9785 /* BackgroundSignOutListener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundSignOutListener.swift; sourceTree = "<group>"; };
 		C7F4BAB628DA8666001C9785 /* BackgroundSignOutListenerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundSignOutListenerTests.swift; sourceTree = "<group>"; };
 		C7F4BABE28DB7F7C001C9785 /* DiscoverItem+Helper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DiscoverItem+Helper.swift"; sourceTree = "<group>"; };
+		C7F605102A69C5AB00795F3C /* BookmarksPodcastListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksPodcastListView.swift; sourceTree = "<group>"; };
 		C7F87F0F2913242B00C15980 /* UIFont+FontStyle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIFont+FontStyle.swift"; sourceTree = "<group>"; };
 		C7FAFF5A294183AA00329B40 /* CancelConfirmationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancelConfirmationView.swift; sourceTree = "<group>"; };
 		C7FAFF5C2941844C00329B40 /* CancelConfirmationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancelConfirmationViewModel.swift; sourceTree = "<group>"; };
@@ -5231,16 +5235,16 @@
 		BD6D417B200C555000CA8993 /* Cells */ = {
 			isa = PBXGroup;
 			children = (
-				BD6D417C200C557A00CA8993 /* PodcastHeadingTableCell.swift */,
-				BD6D417D200C557A00CA8993 /* PodcastHeadingTableCell.xib */,
-				BD0B68722203EFCC002CCE3F /* EpisodeLimitCell.swift */,
-				BD0B68732203EFCC002CCE3F /* EpisodeLimitCell.xib */,
 				409C793522387C0500386495 /* AllArchivedCell.swift */,
 				409C793622387C0500386495 /* AllArchivedCell.xib */,
-				BDAE54CD230C063500330680 /* NoSearchResultsCell.swift */,
-				BDAE54CE230C063500330680 /* NoSearchResultsCell.xib */,
 				4086511923B1CE8400D7585A /* CreateSiriShortcutCell.swift */,
 				4086511A23B1CE8400D7585A /* CreateSiriShortcutCell.xib */,
+				BD0B68722203EFCC002CCE3F /* EpisodeLimitCell.swift */,
+				BD0B68732203EFCC002CCE3F /* EpisodeLimitCell.xib */,
+				BDAE54CD230C063500330680 /* NoSearchResultsCell.swift */,
+				BDAE54CE230C063500330680 /* NoSearchResultsCell.xib */,
+				BD6D417C200C557A00CA8993 /* PodcastHeadingTableCell.swift */,
+				BD6D417D200C557A00CA8993 /* PodcastHeadingTableCell.xib */,
 			);
 			name = Cells;
 			sourceTree = "<group>";
@@ -5396,6 +5400,7 @@
 				BD3311A0202171EF00863A15 /* EpisodeListSearchController.xib */,
 				40AE73B321F00DFA00F77ACE /* SubscribeButton.swift */,
 				40AE73B121F00AFD00F77ACE /* SubscribeButton.xib */,
+				C76ECAD52A69518800D9DB9E /* EpisodeBookmarksTabsView.swift */,
 			);
 			name = "Podcast Page";
 			sourceTree = "<group>";
@@ -6369,6 +6374,7 @@
 				C7318EA22A61E3FC00EAFA9C /* Editing */,
 				C7E99EF62A5C803B00E7CBAF /* List */,
 				C75274E02A3252180004DD15 /* Player */,
+				C7F6050F2A69C59000795F3C /* Podcast */,
 			);
 			path = Bookmarks;
 			sourceTree = "<group>";
@@ -7036,6 +7042,14 @@
 			path = "List View";
 			sourceTree = "<group>";
 		};
+		C7F6050F2A69C59000795F3C /* Podcast */ = {
+			isa = PBXGroup;
+			children = (
+				C7F605102A69C5AB00795F3C /* BookmarksPodcastListView.swift */,
+			);
+			path = Podcast;
+			sourceTree = "<group>";
+		};
 		C7FAFF592941839A00329B40 /* Cancel */ = {
 			isa = PBXGroup;
 			children = (
@@ -7266,10 +7280,10 @@
 				BDBD53E817019B2A0048C8C5 /* Sources */,
 				BDBD53E917019B2A0048C8C5 /* Frameworks */,
 				BDBD53EA17019B2A0048C8C5 /* Resources */,
-				C716FF45296F2BE3006B787D /* Modify Plist */,
 				BD5231EA1E3EDA6A000F0D38 /* Embed App Extensions */,
 				BDD3018A1EFB9356004A9972 /* Embed Watch Content */,
 				40BF0B3F241F55FE003E3ABD /* Embed Frameworks */,
+				C716FF45296F2BE3006B787D /* Modify Plist */,
 				CD7B4456FFD51509B59727FB /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
@@ -8946,6 +8960,7 @@
 				404BB868231361A6006FE8A9 /* WhatsNewLinkButton.swift in Sources */,
 				BDBA7F2C1DA51B440080EBAC /* NotificationsHelper.swift in Sources */,
 				BD907DA621533243004D7C02 /* PodcastEffectsViewController.swift in Sources */,
+				C76ECAD62A69518800D9DB9E /* EpisodeBookmarksTabsView.swift in Sources */,
 				BD44E36D20937D9C008BD7F0 /* PodcastChapterParser.swift in Sources */,
 				BDE954E9236684E300CEB6DA /* ChaptersViewController.swift in Sources */,
 				BDF7BDD21CA2248E0045AB6D /* StatsTopCell.swift in Sources */,
@@ -9020,6 +9035,7 @@
 				BD78A1D71FBACD4800048EB2 /* SmartInvertImageView.swift in Sources */,
 				BD03DF8C1CACDB75005A127E /* ButtonCell.swift in Sources */,
 				BD340FC521AF897400EAB091 /* PodcastArchiveViewController.swift in Sources */,
+				C7F605112A69C5AB00795F3C /* BookmarksPodcastListView.swift in Sources */,
 				BD9657582468FAA600873BB5 /* CastToViewController.swift in Sources */,
 				4085299F247C9682007FE8AA /* SupporterContributionsViewController.swift in Sources */,
 				BDB165E0208078D5007B57CD /* DownloadManager+URLSessionDelegate.swift in Sources */,

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -7283,10 +7283,10 @@
 				BDBD53E817019B2A0048C8C5 /* Sources */,
 				BDBD53E917019B2A0048C8C5 /* Frameworks */,
 				BDBD53EA17019B2A0048C8C5 /* Resources */,
+				C716FF45296F2BE3006B787D /* Modify Plist */,
 				BD5231EA1E3EDA6A000F0D38 /* Embed App Extensions */,
 				BDD3018A1EFB9356004A9972 /* Embed Watch Content */,
 				40BF0B3F241F55FE003E3ABD /* Embed Frameworks */,
-				C716FF45296F2BE3006B787D /* Modify Plist */,
 				CD7B4456FFD51509B59727FB /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (

--- a/podcasts/Bookmarks/Podcast/BookmarksPodcastListView.swift
+++ b/podcasts/Bookmarks/Podcast/BookmarksPodcastListView.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+
+struct BookmarksPodcastListView: View {
+    var body: some View {
+        ZStack {
+            Color.blue
+            Text("COMING SOON")
+        }
+        .ignoresSafeArea()
+    }
+}

--- a/podcasts/EpisodeBookmarksTabsView.swift
+++ b/podcasts/EpisodeBookmarksTabsView.swift
@@ -3,13 +3,14 @@ import SwiftUI
 /// Displays a fake set of tabs that allows the user to open the bookmarks view from the podcast list
 struct EpisodeBookmarksTabsView: View {
     @EnvironmentObject var theme: Theme
-    
+
     weak var delegate: PodcastActionsDelegate?
-    
+
     var body: some View {
         HStack(spacing: 12) {
-            Text(L10n.episodes).applyStyle(theme: theme)
-            
+            Text(L10n.episodes)
+                .applyStyle(theme: theme, highlighted: true)
+
             Text(L10n.bookmarks)
                 .buttonize {
                     delegate?.showBookmarks()
@@ -18,27 +19,32 @@ struct EpisodeBookmarksTabsView: View {
                         .applyStyle(theme: theme)
                         .applyButtonEffect(isPressed: config.isPressed)
                 }
-            
+
             Spacer()
         }
         .font(style: .subheadline, weight: .medium)
     }
 }
 
-struct EpisodeBookmarksTabsView_Previews: PreviewProvider {
-    static var previews: some View {
-        EpisodeBookmarksTabsView()
-            .setupDefaultEnvironment()
-    }
-}
+// MARK: - View Extension
 
 private extension View {
-    func applyStyle(theme: Theme) -> some View {
+    func applyStyle(theme: Theme, highlighted: Bool = false) -> some View {
         self
             .contentShape(Rectangle())
             .padding(.vertical, 8)
             .padding(.horizontal, 12)
-            .foregroundColor(theme.primaryText02)
+            .foregroundColor(highlighted ? theme.primaryUi01 : theme.primaryText02)
+            .background(highlighted ? theme.primaryText01 : nil)
             .cornerRadius(8)
+    }
+}
+
+// MARK: - Previews
+
+struct EpisodeBookmarksTabsView_Previews: PreviewProvider {
+    static var previews: some View {
+        EpisodeBookmarksTabsView()
+            .setupDefaultEnvironment()
     }
 }

--- a/podcasts/EpisodeBookmarksTabsView.swift
+++ b/podcasts/EpisodeBookmarksTabsView.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+
+/// Displays a fake set of tabs that allows the user to open the bookmarks view from the podcast list
+struct EpisodeBookmarksTabsView: View {
+    @EnvironmentObject var theme: Theme
+    
+    weak var delegate: PodcastActionsDelegate?
+    
+    var body: some View {
+        HStack(spacing: 12) {
+            Text(L10n.episodes).applyStyle(theme: theme)
+            
+            Text(L10n.bookmarks)
+                .buttonize {
+                    delegate?.showBookmarks()
+                } customize: { config in
+                    config.label
+                        .applyStyle(theme: theme)
+                        .applyButtonEffect(isPressed: config.isPressed)
+                }
+            
+            Spacer()
+        }
+        .font(style: .subheadline, weight: .medium)
+    }
+}
+
+struct EpisodeBookmarksTabsView_Previews: PreviewProvider {
+    static var previews: some View {
+        EpisodeBookmarksTabsView()
+            .setupDefaultEnvironment()
+    }
+}
+
+private extension View {
+    func applyStyle(theme: Theme) -> some View {
+        self
+            .contentShape(Rectangle())
+            .padding(.vertical, 8)
+            .padding(.horizontal, 12)
+            .foregroundColor(theme.primaryText02)
+            .cornerRadius(8)
+    }
+}

--- a/podcasts/PCHostingController.swift
+++ b/podcasts/PCHostingController.swift
@@ -39,6 +39,11 @@ class ThemedHostingController<Content>: ModifedHostingController<Content, Themed
         super.init(rootView: rootView, modifier: ThemedEnvironment(theme: theme))
     }
 
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .clear
+    }
+
     @MainActor required dynamic init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }

--- a/podcasts/PodcastHeadingTableCell.swift
+++ b/podcasts/PodcastHeadingTableCell.swift
@@ -157,7 +157,28 @@ class PodcastHeadingTableCell: ThemeableCell, SubscribeButtonDelegate, Expandabl
     override func setSelected(_ selected: Bool, animated: Bool) {}
     override func setHighlighted(_ highlighted: Bool, animated: Bool) {}
 
-    func populateFrom(tintColor: UIColor?, delegate: PodcastActionsDelegate) {
+    @IBOutlet var bookmarkTabsView: UIStackView!
+    private var tabsViewController: ThemedHostingController<EpisodeBookmarksTabsView>? = nil
+
+    private func addBookmarksTabViewIfNeeded(parentController: UIViewController) {
+        guard FeatureFlag.bookmarks.enabled else {
+            bookmarkTabsView.removeAllSubviews()
+            return
+        }
+
+        guard tabsViewController == nil else { return }
+
+        bookmarkTabsView.removeAllSubviews()
+        let controller = ThemedHostingController(rootView: EpisodeBookmarksTabsView(delegate: delegate))
+
+        bookmarkTabsView.addArrangedSubview(controller.view)
+        parentController.addChild(controller)
+        controller.didMove(toParent: parentController)
+
+        tabsViewController = controller
+    }
+
+    func populateFrom(tintColor: UIColor?, delegate: PodcastActionsDelegate, parentController: UIViewController) {
         self.delegate = delegate
 
         guard let podcast = delegate.displayedPodcast() else { return }
@@ -173,6 +194,8 @@ class PodcastHeadingTableCell: ThemeableCell, SubscribeButtonDelegate, Expandabl
 
         expandButton.tintColor = ThemeColor.contrast03()
         link.textColor = tintColor
+
+        addBookmarksTabViewIfNeeded(parentController: parentController)
 
         if podcast.isPaid {
             supporterView.isHidden = false

--- a/podcasts/PodcastHeadingTableCell.swift
+++ b/podcasts/PodcastHeadingTableCell.swift
@@ -166,7 +166,12 @@ class PodcastHeadingTableCell: ThemeableCell, SubscribeButtonDelegate, Expandabl
             return
         }
 
-        guard tabsViewController == nil else { return }
+        // Make sure the view reappears
+        if let tabsViewController {
+            tabsViewController.removeFromParent()
+            tabsViewController.didMove(toParent: parentController)
+            return
+        }
 
         bookmarkTabsView.removeAllSubviews()
         let controller = ThemedHostingController(rootView: EpisodeBookmarksTabsView(delegate: delegate))
@@ -194,8 +199,6 @@ class PodcastHeadingTableCell: ThemeableCell, SubscribeButtonDelegate, Expandabl
 
         expandButton.tintColor = ThemeColor.contrast03()
         link.textColor = tintColor
-
-        addBookmarksTabViewIfNeeded(parentController: parentController)
 
         if podcast.isPaid {
             supporterView.isHidden = false
@@ -259,6 +262,8 @@ class PodcastHeadingTableCell: ThemeableCell, SubscribeButtonDelegate, Expandabl
             delegate.podcastRatingViewModel.update(uuid: podcast.uuid)
             addRatingIfNeeded()
         }
+
+        addBookmarksTabViewIfNeeded(parentController: parentController)
     }
 
     private lazy var ratingView: UIView? = {

--- a/podcasts/PodcastHeadingTableCell.swift
+++ b/podcasts/PodcastHeadingTableCell.swift
@@ -343,10 +343,22 @@ class PodcastHeadingTableCell: ThemeableCell, SubscribeButtonDelegate, Expandabl
         }
 
         contentView.removeConstraint(contentViewBottomConstraint)
-        if expanded {
-            contentViewBottomConstraint = NSLayoutConstraint(item: contentView, attribute: .bottom, relatedBy: NSLayoutConstraint.Relation.equal, toItem: extraContentStackView, attribute: .bottom, multiplier: 1, constant: 0)
+
+        // When bookmarks are enabled we need to align to the tabs view with different values
+        if FeatureFlag.bookmarks.enabled {
+            if let bookmarkTabsView {
+                if expanded {
+                    contentViewBottomConstraint = NSLayoutConstraint(item: bookmarkTabsView, attribute: .top, relatedBy: NSLayoutConstraint.Relation.equal, toItem: extraContentStackView, attribute: .bottom, multiplier: 1, constant: 16)
+                } else {
+                    contentViewBottomConstraint = NSLayoutConstraint(item: bookmarkTabsView, attribute: .top, relatedBy: NSLayoutConstraint.Relation.equal, toItem: topSectionView, attribute: .bottom, multiplier: 1, constant: -1)
+                }
+            }
         } else {
-            contentViewBottomConstraint = NSLayoutConstraint(item: contentView, attribute: .bottom, relatedBy: NSLayoutConstraint.Relation.equal, toItem: topSectionView, attribute: .bottom, multiplier: 1, constant: -10)
+            if expanded {
+                contentViewBottomConstraint = NSLayoutConstraint(item: contentView, attribute: .bottom, relatedBy: NSLayoutConstraint.Relation.equal, toItem: extraContentStackView, attribute: .bottom, multiplier: 1, constant: 0)
+            } else {
+                contentViewBottomConstraint = NSLayoutConstraint(item: contentView, attribute: .bottom, relatedBy: NSLayoutConstraint.Relation.equal, toItem: topSectionView, attribute: .bottom, multiplier: 1, constant: -10)
+            }
         }
         contentView.addConstraint(contentViewBottomConstraint)
 

--- a/podcasts/PodcastHeadingTableCell.xib
+++ b/podcasts/PodcastHeadingTableCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22138.1" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22113"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -371,6 +371,19 @@
                             </stackView>
                         </subviews>
                     </stackView>
+                    <stackView opaque="NO" contentMode="scaleToFill" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="xfv-Do-H5F">
+                        <rect key="frame" x="16" y="486" width="362" height="34"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="DoX-hV-o5P">
+                                <rect key="frame" x="0.0" y="0.0" width="362" height="34"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="filled" title="Button"/>
+                            </button>
+                        </subviews>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="34" id="ATk-yp-3C3"/>
+                        </constraints>
+                    </stackView>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="wsF-Lm-vdp">
                         <rect key="frame" x="0.0" y="-400" width="394" height="400"/>
                         <color key="backgroundColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -384,6 +397,7 @@
                     <constraint firstItem="CHK-bP-kvy" firstAttribute="top" secondItem="Ypx-au-SZl" secondAttribute="top" constant="-1" id="1tc-5M-dSk"/>
                     <constraint firstItem="wsF-Lm-vdp" firstAttribute="bottom" secondItem="H2p-sc-9uM" secondAttribute="top" id="2dG-uE-lim"/>
                     <constraint firstAttribute="bottom" secondItem="TeM-KI-UI1" secondAttribute="bottom" constant="20" symbolic="YES" id="2yS-PS-SWG"/>
+                    <constraint firstItem="xfv-Do-H5F" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="3zp-hz-mvr"/>
                     <constraint firstItem="wsF-Lm-vdp" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="6vs-0u-f4Y"/>
                     <constraint firstAttribute="trailing" secondItem="6JF-62-6gD" secondAttribute="trailing" id="9Jv-G8-Era"/>
                     <constraint firstAttribute="trailing" secondItem="sd5-XC-dXM" secondAttribute="trailing" id="GUJ-1l-6Uk"/>
@@ -395,7 +409,9 @@
                     <constraint firstItem="sd5-XC-dXM" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="VCV-mi-83g"/>
                     <constraint firstAttribute="trailing" secondItem="wsF-Lm-vdp" secondAttribute="trailing" id="aMd-TM-fXj"/>
                     <constraint firstItem="jf0-QS-TJi" firstAttribute="centerY" secondItem="6JF-62-6gD" secondAttribute="centerY" id="b59-OP-gRA"/>
+                    <constraint firstAttribute="bottom" secondItem="xfv-Do-H5F" secondAttribute="bottom" constant="6" id="bBU-Qa-Zaa"/>
                     <constraint firstItem="5S4-8c-Ssa" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="bhl-hO-mdd"/>
+                    <constraint firstAttribute="trailingMargin" secondItem="xfv-Do-H5F" secondAttribute="trailing" id="dQp-hQ-LdM"/>
                     <constraint firstItem="6JF-62-6gD" firstAttribute="bottom" secondItem="sd5-XC-dXM" secondAttribute="bottom" id="jpI-F1-Zhq"/>
                     <constraint firstItem="CHK-bP-kvy" firstAttribute="bottom" secondItem="Ypx-au-SZl" secondAttribute="bottom" constant="-1" id="kd8-Nr-Cur"/>
                     <constraint firstItem="TeM-KI-UI1" firstAttribute="top" secondItem="5S4-8c-Ssa" secondAttribute="bottom" id="nel-K1-cL3"/>
@@ -409,6 +425,7 @@
             <connections>
                 <outlet property="author" destination="k55-Wk-FMM" id="tNR-lH-xgT"/>
                 <outlet property="authorView" destination="v18-FN-11C" id="faS-yl-UZU"/>
+                <outlet property="bookmarkTabsView" destination="xfv-Do-H5F" id="EyA-yR-0cF"/>
                 <outlet property="bottomAuthorSpacer" destination="d5Y-gS-EgE" id="KBI-Fm-Fsr"/>
                 <outlet property="categoryDescriptionSpacer" destination="SGH-Lz-9LI" id="VmT-TR-elg"/>
                 <outlet property="contentViewBottomConstraint" destination="2yS-PS-SWG" id="dJC-uS-1Bg"/>
@@ -452,7 +469,7 @@
                 <outlet property="topSectionHeightConstraint" destination="Uzk-YX-q2W" id="wZr-U0-VlD"/>
                 <outlet property="topSectionView" destination="5S4-8c-Ssa" id="pjS-pW-Y38"/>
             </connections>
-            <point key="canvasLocation" x="-3651" y="-1120"/>
+            <point key="canvasLocation" x="-3592" y="-1116"/>
         </tableViewCell>
     </objects>
     <resources>
@@ -468,10 +485,10 @@
         <image name="support-heart-outline" width="24" height="24"/>
         <image name="supporter-heart-large" width="19" height="16"/>
         <systemColor name="systemIndigoColor">
-            <color red="0.34509803921568627" green="0.33725490196078434" blue="0.83921568627450982" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.34509803919999998" green="0.33725490200000002" blue="0.83921568629999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemPinkColor">
-            <color red="1" green="0.17647058823529413" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="1" green="0.1764705882" blue="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/podcasts/PodcastViewController+TableData.swift
+++ b/podcasts/PodcastViewController+TableData.swift
@@ -62,7 +62,7 @@ extension PodcastViewController: UITableViewDataSource, UITableViewDelegate {
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         if indexPath.section == PodcastViewController.headerSection {
             let cell = tableView.dequeueReusableCell(withIdentifier: PodcastViewController.headerCellId, for: indexPath) as! PodcastHeadingTableCell
-            cell.populateFrom(tintColor: podcast?.iconTintColor(), delegate: self)
+            cell.populateFrom(tintColor: podcast?.iconTintColor(), delegate: self, parentController: self)
             cell.buttonsEnabled = !isMultiSelectEnabled
             return cell
         }

--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -37,6 +37,7 @@ protocol PodcastActionsDelegate: AnyObject {
     func enableMultiSelect()
 
     var podcastRatingViewModel: PodcastRatingViewModel { get }
+    func showBookmarks()
 }
 
 class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, SyncSigninDelegate, MultiSelectActionDelegate {
@@ -877,6 +878,11 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
         let hostingController = PCHostingController(rootView: chooseFolderView.environmentObject(Theme.sharedTheme))
 
         present(hostingController, animated: true, completion: nil)
+    }
+
+    func showBookmarks() {
+        let controller = ThemedHostingController(rootView: BookmarksPodcastListView())
+        present(controller, animated: true)
     }
 
     // MARK: - Long press actions


### PR DESCRIPTION
| 🎨 Designs: [Figma](https://www.figma.com/file/Io7PCz1H1hmOgEE9eljoYW/Bookmarks?type=design&node-id=2033-33461&mode=dev) |
|:---:|

This adds the bookmarks tab button to the podcast details view. 

## Demo Video

https://github.com/Automattic/pocket-casts-ios/assets/793774/4b797571-f227-4e80-8163-a50d1262f463

## To test

1. Launch the app with the bookmarks feature flag enabled
2. Go to the podcasts list and select a podcast
3. ✅ Verify you see the Episodes / Bookmarks "Tab" buttons
4. Tap on the Bookmarks button
5. ✅ Verify the bookmarks placeholder screen is presented
6. Swipe to dismiss it
7. Expand the podcasts details
8. ✅ Verify the tabs appear correctly
9. Go to Profile > Cog > Beta Features
10. Disable Bookmarks
11. Reopen a podcast details view
12. ✅ Verify the tabs don't appear


## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
