### PR TITLE
Bookmarks: Adds a reusable SwiftUI SearchField view

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1459,6 +1459,7 @@
 		C76ECAD62A69518800D9DB9E /* EpisodeBookmarksTabsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C76ECAD52A69518800D9DB9E /* EpisodeBookmarksTabsView.swift */; };
 		C784DE7B2A58CFA1004D03E7 /* ScrollViewWithContentOffset.swift in Sources */ = {isa = PBXBuildFile; fileRef = C784DE7A2A58CFA1004D03E7 /* ScrollViewWithContentOffset.swift */; };
 		C784DE7D2A590866004D03E7 /* View+Buttonize.swift in Sources */ = {isa = PBXBuildFile; fileRef = C784DE7C2A590866004D03E7 /* View+Buttonize.swift */; };
+		C7891DC82A6AFE26009DA661 /* SearchField.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7891DC72A6AFE26009DA661 /* SearchField.swift */; };
 		C791418D294CE32D00F1852B /* StorageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C791418C294CE32D00F1852B /* StorageManager.swift */; };
 		C791418E294CE33700F1852B /* StorageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C791418C294CE32D00F1852B /* StorageManager.swift */; };
 		C799373B2A095F6F0010DC64 /* ProfileInfoLabels.swift in Sources */ = {isa = PBXBuildFile; fileRef = C799373A2A095F6F0010DC64 /* ProfileInfoLabels.swift */; };
@@ -3197,6 +3198,7 @@
 		C76ECAD52A69518800D9DB9E /* EpisodeBookmarksTabsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EpisodeBookmarksTabsView.swift; sourceTree = "<group>"; };
 		C784DE7A2A58CFA1004D03E7 /* ScrollViewWithContentOffset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollViewWithContentOffset.swift; sourceTree = "<group>"; };
 		C784DE7C2A590866004D03E7 /* View+Buttonize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Buttonize.swift"; sourceTree = "<group>"; };
+		C7891DC72A6AFE26009DA661 /* SearchField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchField.swift; sourceTree = "<group>"; };
 		C791418C294CE32D00F1852B /* StorageManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageManager.swift; sourceTree = "<group>"; };
 		C799373A2A095F6F0010DC64 /* ProfileInfoLabels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileInfoLabels.swift; sourceTree = "<group>"; };
 		C79E1E3F28887549008524CB /* PlusUpgradeViewSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlusUpgradeViewSourceTests.swift; sourceTree = "<group>"; };
@@ -6365,6 +6367,7 @@
 				C73CCBC829C590100075EFFD /* View+UIView.swift */,
 				C7D8AE562A5F6D2600C9EBAF /* ActionBarOverlayView.swift */,
 				C76ECAC12A67612F00D9DB9E /* EmptyStateView.swift */,
+				C7891DC72A6AFE26009DA661 /* SearchField.swift */,
 			);
 			path = SwiftUI;
 			sourceTree = "<group>";
@@ -8881,6 +8884,7 @@
 				BD9D923C21342CC50070D4FD /* ListEpisode.swift in Sources */,
 				BDF4D30F2175AA830086463E /* StarredViewController+Table.swift in Sources */,
 				C73CCBC929C590100075EFFD /* View+UIView.swift in Sources */,
+				C7891DC82A6AFE26009DA661 /* SearchField.swift in Sources */,
 				C761300B28E4CA4F0044C6C2 /* AnalyticsCoordinator.swift in Sources */,
 				BDE292E423680D6100A4EEAE /* EffectsViewController.swift in Sources */,
 				BD907DAE21537B51004D7C02 /* SiriSettingsViewController.swift in Sources */,

--- a/podcasts/SwiftUI/SearchField.swift
+++ b/podcasts/SwiftUI/SearchField.swift
@@ -1,0 +1,113 @@
+import SwiftUI
+
+struct SearchField: View {
+    @ObservedObject var theme: SearchTheme = .init()
+
+    /// The search text binding
+    @Binding var text: String
+
+    var showsCancelButton: Bool = true
+
+    /// The placeholder text to display when the field is empty
+    var placeholder: String = L10n.search
+
+    /// Keeps track of whether the search field has focus or not
+    @FocusState private var isFocused: Bool
+
+    /// Whether we should show the cancel button, we keep this separate to ensure animations
+    @State private var isCancelVisible = false
+
+    /// If the control is `.disable(true)` or not. We'll fade out the search and remove any focus
+    @Environment(\.isEnabled) private var isEnabled
+
+    /// The scaled icon size
+    @ScaledMetricWithMaxSize(relativeTo: .subheadline, maxSize: .xxLarge) private var iconSize = 16.0
+
+    var body: some View {
+        // We use 2 stacks here to have the cancel button appear outside the background
+        HStack {
+            HStack(spacing: SearchFieldConstants.padding) {
+                Image("custom_search")
+                    .renderingMode(.template)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: iconSize, height: iconSize)
+                    .foregroundStyle(theme.placeholder)
+
+                let prompt = Text(placeholder).foregroundColor(theme.placeholder)
+
+                TextField(placeholder, text: $text, prompt: prompt)
+                    .foregroundColor(theme.text)
+                    .focused($isFocused)
+                    .padding(.vertical, SearchFieldConstants.padding)
+
+                if !text.isEmpty {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(theme.placeholder)
+                        .buttonize {
+                            text = ""
+                        }
+                }
+            }
+            .padding(.horizontal, SearchFieldConstants.padding)
+            .background(theme.background)
+            .cornerRadius(SearchFieldConstants.cornerRadius)
+            .font(size: 14, style: .subheadline, weight: .medium)
+
+            // Show the cancel button
+            if showsCancelButton && isCancelVisible {
+                Button(L10n.cancel) {
+                    withAnimation {
+                        text = ""
+                        isFocused = false
+                    }
+                }
+                .font(size: 14, style: .subheadline)
+                .foregroundStyle(theme.cancel)
+                .transition(
+                    .move(edge: .trailing)
+                    .combined(with: .opacity)
+                    .animation(.linear(duration: 0.1))
+                )
+            }
+        }
+        // Fade the view out a bit if it's disabled
+        .opacity(isEnabled ? 1 : 0.8)
+
+        // Animate the shows cancel button in or out
+        .onChange(of: isFocused) { newValue in
+            withAnimation {
+                isCancelVisible = newValue
+            }
+        }
+        // If the disabled state changes, then remove focus from the field
+        .onChange(of: isEnabled) { newValue in
+            guard newValue else { return }
+
+            isFocused = false
+        }
+    }
+
+    class SearchTheme: ThemeObserver {
+        var background: Color {
+            theme.primaryField01
+        }
+
+        var placeholder: Color {
+            theme.primaryField03
+        }
+
+        var text: Color {
+            theme.primaryText01
+        }
+
+        var cancel: Color {
+            theme.primaryInteractive01
+        }
+    }
+}
+
+private enum SearchFieldConstants {
+    static let padding = 8.0
+    static let cornerRadius = 8.0
+}

--- a/podcasts/SwiftUI/SearchField.swift
+++ b/podcasts/SwiftUI/SearchField.swift
@@ -111,3 +111,18 @@ private enum SearchFieldConstants {
     static let padding = 8.0
     static let cornerRadius = 8.0
 }
+
+struct SearchFieldView_Preview: PreviewProvider {
+    static var previews: some View {
+        PreviewView()
+            .setupDefaultEnvironment()
+    }
+
+    private struct PreviewView: View {
+        @State var title: String = ""
+
+        var body: some View {
+            SearchField(text: $title).padding()
+        }
+    }
+}

--- a/podcasts/SwiftUI/SearchField.swift
+++ b/podcasts/SwiftUI/SearchField.swift
@@ -1,5 +1,27 @@
 import SwiftUI
 
+/// A SwiftUI TextField that mimics the functionality of a UISearchTextField
+/// SwiftUI has the [`.searchable(text:)`](https://developer.apple.com/documentation/swiftui/adding-a-search-interface-to-your-app) modifier
+/// but unfortunately that only works if your view is wrapped in a `NavigationStack` or `NavigationSplitView`.
+///
+/// You can use the [`disabled(_:)`](https://developer.apple.com/documentation/swiftui/view/disabled(_:)) modifier to disable the field
+///
+/// Usage:
+///
+///     struct MyView: View {
+///         @State var text: String = ""
+///
+///         var body: View {
+///             VStack {
+///                 SearchField($text)
+///                 TheRestOfTheOwl()
+///             }
+///             .padding()
+///         }
+///     }
+///
+/// The colors of the `SearchField` can be customized by subclassing the `SearchTheme` and passing it in
+///
 struct SearchField: View {
     @ObservedObject var theme: SearchTheme = .init()
 
@@ -111,6 +133,8 @@ private enum SearchFieldConstants {
     static let padding = 8.0
     static let cornerRadius = 8.0
 }
+
+// MARK: - Previews
 
 struct SearchFieldView_Preview: PreviewProvider {
     static var previews: some View {


### PR DESCRIPTION
This adds a SwiftUI search field view that mimics the functionality of a UISearchTextField. 
SwiftUI has the [`.searchable(text:)`](https://developer.apple.com/documentation/swiftui/adding-a-search-interface-to-your-app) modifier but unfortunately that only works if your view is wrapped in a `NavigationStack` or `NavigationSplitView`.

This removes that requirement. 

## To test
Code Review + Run the preview.

Note: The preview doesn't properly reflect the keyboard states. This can be more fully tested in a later PR.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
