### PR TITLE
Bookmarks: Remove the bookmarks empty tab view if the flag is disabled

### DIFF
--- a/podcasts/PodcastHeadingTableCell.swift
+++ b/podcasts/PodcastHeadingTableCell.swift
@@ -163,6 +163,7 @@ class PodcastHeadingTableCell: ThemeableCell, SubscribeButtonDelegate, Expandabl
     private func addBookmarksTabViewIfNeeded(parentController: UIViewController) {
         guard FeatureFlag.bookmarks.enabled else {
             bookmarkTabsView.removeAllSubviews()
+            bookmarkTabsView.isHidden = true
             return
         }
 
@@ -181,6 +182,7 @@ class PodcastHeadingTableCell: ThemeableCell, SubscribeButtonDelegate, Expandabl
         controller.didMove(toParent: parentController)
 
         tabsViewController = controller
+        bookmarkTabsView.isHidden = false
     }
 
     func populateFrom(tintColor: UIColor?, delegate: PodcastActionsDelegate, parentController: UIViewController) {


### PR DESCRIPTION
This fixes an issue that prevents the folder, settings, subscribe/unsubscribe buttons from being tapped. 

## To test

1. Disable the bookmarks feature flag
2. Open the podcast details
3. ✅ Verify you can tap the folder, settings, subscribe button
4. Enable the bookmarks flag
5. ✅ Verify the bookmarks bar appears and the icons are still tappable


## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
