### PR TITLE
Bookmarks: Fixes an iOS 15 issue when adding a hosting controller as a child

### DIFF
--- a/podcasts/FakeNavViewController.swift
+++ b/podcasts/FakeNavViewController.swift
@@ -85,6 +85,15 @@ class FakeNavViewController: PCViewController, UIScrollViewDelegate {
         if !navigationTitleSetOnScroll { fakeNavTitle.text = navTitle }
     }
 
+    override func addChild(_ childController: UIViewController) {
+        super.addChild(childController)
+
+        /// Hide the child nav bar on the next run loop since this doesn't have any effect if called immediately
+        DispatchQueue.main.asyncAfter(deadline: .now()) {
+            childController.navigationController?.setNavigationBarHidden(true, animated: false)
+        }
+    }
+
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
 

--- a/podcasts/PCHostingController.swift
+++ b/podcasts/PCHostingController.swift
@@ -50,6 +50,8 @@ class ThemedHostingController<Content>: ModifedHostingController<Content, Themed
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
+        // We don't set this if the flag isn't true because there's a weird bug that
+        // will hide the nav bar even if this is false.
         guard navBarHidden else { return }
 
         navigationController?.navigationBar.isHidden = true

--- a/podcasts/PCHostingController.swift
+++ b/podcasts/PCHostingController.swift
@@ -35,9 +35,6 @@ class ModifedHostingController<Content: View, Modifier: ViewModifier>: UIHosting
 /// }
 class ThemedHostingController<Content>: ModifedHostingController<Content, ThemedEnvironment> where Content: View {
 
-    /// Hides the navigation bar when set to true
-    var navBarHidden: Bool = false
-
     init(rootView: Content, theme: Theme = Theme.sharedTheme) {
         super.init(rootView: rootView, modifier: ThemedEnvironment(theme: theme))
     }
@@ -45,16 +42,6 @@ class ThemedHostingController<Content>: ModifedHostingController<Content, Themed
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .clear
-    }
-
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-
-        // We don't set this if the flag isn't true because there's a weird bug that
-        // will hide the nav bar even if this is false.
-        guard navBarHidden else { return }
-
-        navigationController?.navigationBar.isHidden = true
     }
 
     @MainActor required dynamic init?(coder aDecoder: NSCoder) {

--- a/podcasts/PCHostingController.swift
+++ b/podcasts/PCHostingController.swift
@@ -35,6 +35,9 @@ class ModifedHostingController<Content: View, Modifier: ViewModifier>: UIHosting
 /// }
 class ThemedHostingController<Content>: ModifedHostingController<Content, ThemedEnvironment> where Content: View {
 
+    /// Hides the navigation bar when set to true
+    var navBarHidden: Bool = false
+
     init(rootView: Content, theme: Theme = Theme.sharedTheme) {
         super.init(rootView: rootView, modifier: ThemedEnvironment(theme: theme))
     }
@@ -42,6 +45,14 @@ class ThemedHostingController<Content>: ModifedHostingController<Content, Themed
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .clear
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        guard navBarHidden else { return }
+
+        navigationController?.navigationBar.isHidden = true
     }
 
     @MainActor required dynamic init?(coder aDecoder: NSCoder) {

--- a/podcasts/PodcastHeadingTableCell.swift
+++ b/podcasts/PodcastHeadingTableCell.swift
@@ -170,6 +170,7 @@ class PodcastHeadingTableCell: ThemeableCell, SubscribeButtonDelegate, Expandabl
         // Make sure the view reappears
         if let tabsViewController {
             tabsViewController.removeFromParent()
+            parentController.addChild(tabsViewController)
             tabsViewController.didMove(toParent: parentController)
             return
         }
@@ -177,9 +178,6 @@ class PodcastHeadingTableCell: ThemeableCell, SubscribeButtonDelegate, Expandabl
         bookmarkTabsView.removeAllSubviews()
         let controller = ThemedHostingController(rootView: EpisodeBookmarksTabsView(delegate: delegate))
 
-        // on iOS 15 there is a bug that shows the nav bar when the controller is added as a child
-        // This prevents that from happening.
-        controller.navBarHidden = true
         bookmarkTabsView.addArrangedSubview(controller.view)
         parentController.addChild(controller)
         controller.didMove(toParent: parentController)

--- a/podcasts/PodcastHeadingTableCell.swift
+++ b/podcasts/PodcastHeadingTableCell.swift
@@ -177,6 +177,9 @@ class PodcastHeadingTableCell: ThemeableCell, SubscribeButtonDelegate, Expandabl
         bookmarkTabsView.removeAllSubviews()
         let controller = ThemedHostingController(rootView: EpisodeBookmarksTabsView(delegate: delegate))
 
+        // on iOS 15 there is a bug that shows the nav bar when the controller is added as a child
+        // This prevents that from happening.
+        controller.navBarHidden = true
         bookmarkTabsView.addArrangedSubview(controller.view)
         parentController.addChild(controller)
         controller.didMove(toParent: parentController)


### PR DESCRIPTION
There's a bug on iOS 15 that causes the nav bar to appear when adding a hosting controller as a child controller. 

This fixes it by adding a flag to hide the nav bar in will appear. 

## Screenshots

| Before | After |
|:---:|:---:|
|<img width="320" src="https://github.com/Automattic/pocket-casts-ios/assets/793774/8538dedf-4db8-42ba-8d4d-1818384ca66f">|<img width="320" src="https://github.com/Automattic/pocket-casts-ios/assets/793774/0d81d8f2-8ba5-4f04-a575-a9d0adf0f4ac">|

| iPad Before | iPad After |
|:---:|:---:|
|<img width="320" src="https://github.com/Automattic/pocket-casts-ios/assets/793774/74761ef1-02a8-48b7-beee-1ff83ab1c3d4">|<img width="320" src="https://github.com/Automattic/pocket-casts-ios/assets/793774/5cb22b17-ad65-4c10-800a-8bc03e354d2f">|


## To test

1. Launch the app on iOS 15
2. Enable the Bookmarks Feature Flag
3. Go to the Discover tab
4. Tap on any podcast
5. ✅ Verify the nav bar isn't shown at the top
6. Tap back
7. ✅ Verify the Discover nav bar is still shown
8. Do the same from the Podcasts tab
6. Relaunch the app on iOS 16
7. ✅ Repeat the steps, and verify everything works as intended

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
