### PR TITLE
Bookmarks: Shows the bookmarks for user files

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1471,6 +1471,7 @@
 		C7891DCE2A6B2C0F009DA661 /* SearchableListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7891DCD2A6B2C0F009DA661 /* SearchableListViewModel.swift */; };
 		C791418D294CE32D00F1852B /* StorageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C791418C294CE32D00F1852B /* StorageManager.swift */; };
 		C791418E294CE33700F1852B /* StorageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C791418C294CE32D00F1852B /* StorageManager.swift */; };
+		C797D7C32A7A13AA004D7419 /* BookmarkCardTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C797D7C22A7A13AA004D7419 /* BookmarkCardTitleView.swift */; };
 		C799373B2A095F6F0010DC64 /* ProfileInfoLabels.swift in Sources */ = {isa = PBXBuildFile; fileRef = C799373A2A095F6F0010DC64 /* ProfileInfoLabels.swift */; };
 		C79E1E4028887549008524CB /* PlusUpgradeViewSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79E1E3F28887549008524CB /* PlusUpgradeViewSourceTests.swift */; };
 		C7A110E6291EF2DF00887A90 /* PlusLandingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A110E5291EF2DF00887A90 /* PlusLandingViewModel.swift */; };
@@ -3234,6 +3235,7 @@
 		C7891DC92A6B080F009DA661 /* BookmarksPodcastListController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksPodcastListController.swift; sourceTree = "<group>"; };
 		C7891DCD2A6B2C0F009DA661 /* SearchableListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchableListViewModel.swift; sourceTree = "<group>"; };
 		C791418C294CE32D00F1852B /* StorageManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageManager.swift; sourceTree = "<group>"; };
+		C797D7C22A7A13AA004D7419 /* BookmarkCardTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkCardTitleView.swift; sourceTree = "<group>"; };
 		C799373A2A095F6F0010DC64 /* ProfileInfoLabels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileInfoLabels.swift; sourceTree = "<group>"; };
 		C79E1E3F28887549008524CB /* PlusUpgradeViewSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlusUpgradeViewSourceTests.swift; sourceTree = "<group>"; };
 		C7A110E5291EF2DF00887A90 /* PlusLandingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlusLandingViewModel.swift; sourceTree = "<group>"; };
@@ -7075,6 +7077,7 @@
 				C7221A672A6AD80B004AAE00 /* BookmarkPodcastListViewModel.swift */,
 				C781EA422A6B7BF9001DBFCC /* BookmarkRowViewModel.swift */,
 				C7252E112A718AD600E7D3C0 /* BookmarkListRouter.swift */,
+				C797D7C22A7A13AA004D7419 /* BookmarkCardTitleView.swift */,
 			);
 			path = List;
 			sourceTree = "<group>";
@@ -8910,6 +8913,7 @@
 				BDD62981200EEA6700168DF7 /* SimpleNotificationsViewController.swift in Sources */,
 				BD4BBFA41D223AA9001BEE4D /* Settings.swift in Sources */,
 				400AB2FD220BA3050003EE21 /* UploadedViewController.swift in Sources */,
+				C797D7C32A7A13AA004D7419 /* BookmarkCardTitleView.swift in Sources */,
 				BD2B50B0201077150099B79D /* PodcastSettingsViewController+Table.swift in Sources */,
 				4007B053230E3115008DDCF5 /* WhatsNewPageView.swift in Sources */,
 				BDCF3C8024283B0F005B6933 /* ListeningHistoryViewController+Swipe.swift in Sources */,

--- a/podcasts/Bookmarks/Episode/BookmarkEpisodeListController.swift
+++ b/podcasts/Bookmarks/Episode/BookmarkEpisodeListController.swift
@@ -9,7 +9,7 @@ class BookmarkEpisodeListController: ThemedHostingController<BookmarkEpisodeList
 
     private var cancellables = Set<AnyCancellable>()
 
-    init(episode: BaseEpisode,
+    init(episode: BaseEpisode, displayMode: BookmarkEpisodeListView.DisplayMode = .list,
          bookmarkManager: BookmarkManager = PlaybackManager.shared.bookmarkManager,
          playbackManager: PlaybackManager = .shared) {
 
@@ -20,7 +20,7 @@ class BookmarkEpisodeListController: ThemedHostingController<BookmarkEpisodeList
                                                       bookmarkManager: bookmarkManager,
                                                       sortOption: Constants.UserDefaults.bookmarks.podcastSort)
 
-        super.init(rootView: BookmarkEpisodeListView(viewModel: viewModel))
+        super.init(rootView: BookmarkEpisodeListView(viewModel: viewModel, displayMode: displayMode))
 
         viewModel.router = self
     }

--- a/podcasts/Bookmarks/Episode/BookmarkEpisodeListView.swift
+++ b/podcasts/Bookmarks/Episode/BookmarkEpisodeListView.swift
@@ -2,9 +2,39 @@ import SwiftUI
 
 struct BookmarkEpisodeListView: View {
     @ObservedObject var viewModel: BookmarkEpisodeListViewModel
+    @ObservedObject var style = ThemedBookmarksStyle()
+    var displayMode: DisplayMode = .list
 
     var body: some View {
-        BookmarksListView(viewModel: viewModel, style: ThemedBookmarksStyle(), showMoreInHeader: false)
-            .padding(.top, 16)
+        if displayMode == .list {
+            BookmarksListView(viewModel: viewModel, style: style, showMoreInHeader: false)
+                .padding(.top, 16)
+        } else {
+            VStack(spacing: BookmarkListConstants.padding) {
+                headerView
+                BookmarksListView(viewModel: viewModel, style: style, showMultiSelectInHeader: false)
+            }
+            .background(style.background.ignoresSafeArea())
+        }
+    }
+
+    private var headerView: some View {
+        VStack(spacing: Constants.padding) {
+            ZStack {
+                BookmarkCardTitleView(viewModel: viewModel, style: style)
+                BookmarkListMultiSelectHeaderView(viewModel: viewModel, style: style)
+            }
+            .animation(.linear(duration: 0.2), value: viewModel.isMultiSelecting)
+        }
+        .padding(.top, Constants.padding)
+        .padding(.horizontal, BookmarkListConstants.padding)
+    }
+
+    private enum Constants {
+        static let padding = 14.0
+    }
+
+    enum DisplayMode {
+        case list, standalone
     }
 }

--- a/podcasts/Bookmarks/List/BookmarkCardTitleView.swift
+++ b/podcasts/Bookmarks/List/BookmarkCardTitleView.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+
+/// Displays a title bar view with a dismiss button
+struct BookmarkCardTitleView<Style: BookmarksStyle>: View {
+    @ObservedObject var viewModel: BookmarkListViewModel
+    @ObservedObject var style: Style
+
+    var body: some View {
+        ZStack(alignment: .leading) {
+            HStack {
+                Spacer()
+
+                Text(L10n.bookmarks)
+                    .font(style: .headline, weight: .semibold)
+
+                Spacer()
+            }
+
+            Image("episode-close")
+                .renderingMode(.template)
+                .padding(5)
+                .buttonize {
+                    viewModel.dismiss()
+                }
+        }
+        .foregroundStyle(style.primaryText)
+        .opacity(viewModel.isMultiSelecting ? 0 : 1)
+        .offset(y: viewModel.isMultiSelecting ? BookmarkListConstants.headerTransitionOffset : 0)
+    }
+}

--- a/podcasts/Bookmarks/List/BookmarkListViewModel.swift
+++ b/podcasts/Bookmarks/List/BookmarkListViewModel.swift
@@ -37,6 +37,10 @@ class BookmarkListViewModel: SearchableListViewModel<Bookmark> {
 
     func reload() { }
 
+    func dismiss() {
+        router?.dismissBookmarksList()
+    }
+
     /// Reload a single item from the list
     func refresh(bookmark: Bookmark) {
         guard let index = items.firstIndex(of: bookmark) else { return }

--- a/podcasts/Bookmarks/List/BookmarkPodcastListViewModel.swift
+++ b/podcasts/Bookmarks/List/BookmarkPodcastListViewModel.swift
@@ -39,8 +39,4 @@ class BookmarkPodcastListViewModel: BookmarkListViewModel {
             }
             .store(in: &cancellables)
     }
-
-    func dismiss() {
-        router?.dismissBookmarksList()
-    }
 }

--- a/podcasts/Bookmarks/Podcast/BookmarksPodcastListView.swift
+++ b/podcasts/Bookmarks/Podcast/BookmarksPodcastListView.swift
@@ -16,7 +16,7 @@ struct BookmarksPodcastListView: View {
     private var headerView: some View {
         VStack(spacing: Constants.padding) {
             ZStack {
-                titleView
+                BookmarkCardTitleView(viewModel: viewModel, style: style)
                 BookmarkListMultiSelectHeaderView(viewModel: viewModel, style: style)
             }
             .animation(.linear(duration: 0.2), value: viewModel.isMultiSelecting)

--- a/podcasts/Bookmarks/Podcast/BookmarksPodcastListView.swift
+++ b/podcasts/Bookmarks/Podcast/BookmarksPodcastListView.swift
@@ -27,30 +27,6 @@ struct BookmarksPodcastListView: View {
         .padding(.horizontal, BookmarkListConstants.padding)
     }
 
-    /// Shows the faux navigation bar with the dismiss button and title
-    private var titleView: some View {
-        ZStack(alignment: .leading) {
-            HStack {
-                Spacer()
-
-                Text(L10n.bookmarks)
-                    .font(style: .headline, weight: .semibold)
-
-                Spacer()
-            }
-
-            Image("episode-close")
-                .renderingMode(.template)
-                .padding(5)
-                .buttonize {
-                    viewModel.dismiss()
-                }
-        }
-        .foregroundStyle(style.primaryText)
-        .opacity(viewModel.isMultiSelecting ? 0 : 1)
-        .offset(y: viewModel.isMultiSelecting ? BookmarkListConstants.headerTransitionOffset : 0)
-    }
-
     @ViewBuilder
     private var searchField: some View {
         if viewModel.isSearching || !viewModel.bookmarks.isEmpty {

--- a/podcasts/UserEpisodeDetailViewController+Table.swift
+++ b/podcasts/UserEpisodeDetailViewController+Table.swift
@@ -68,6 +68,12 @@ extension UserEpisodeDetailViewController: UITableViewDelegate, UITableViewDataS
             cell.titleLabel.style = .primaryText01
             cell.actionImage?.image = UIImage(named: "cancel")
             cell.actionImage?.tintColor = ThemeColor.primaryIcon01()
+
+        case .bookmarks:
+            cell.titleLabel.text = L10n.bookmarks
+            cell.titleLabel.style = .primaryText01
+            cell.actionImage?.image = UIImage(named: "bookmarks-shelf-overflow-icon")
+            cell.actionImage?.tintColor = ThemeColor.primaryIcon01()
         }
         return cell
     }
@@ -76,6 +82,10 @@ extension UserEpisodeDetailViewController: UITableViewDelegate, UITableViewDataS
         let tableRow = tableData()[indexPath.row]
 
         switch tableRow {
+        case .bookmarks:
+            delegate?.showBookmarks(userEpisode: episode)
+            animateOut()
+
         case .download:
             Analytics.track(.userFileDetailOptionTapped, properties: ["option": "download"])
             PlaybackActionHelper.download(episodeUuid: episode.uuid)
@@ -147,6 +157,10 @@ extension UserEpisodeDetailViewController: UITableViewDelegate, UITableViewDataS
 
     private func tableData() -> [TableRow] {
         var data: [TableRow] = [.upNext, .markAsPlayed, .editDetails, .delete]
+
+        if FeatureFlag.bookmarks.enabled {
+            data.insert(.bookmarks, at: 2)
+        }
 
         if episode.queued() || episode.downloading() || episode.waitingForWifi() {
             data.insert(.cancelDownload, at: 3)

--- a/podcasts/UserEpisodeDetailViewController.swift
+++ b/podcasts/UserEpisodeDetailViewController.swift
@@ -10,6 +10,13 @@ protocol UserEpisodeDetailProtocol: AnyObject {
     func showBookmarks(userEpisode: UserEpisode)
 }
 
+extension UserEpisodeDetailProtocol where Self: UIViewController {
+    func showBookmarks(userEpisode: UserEpisode) {
+        let controller = BookmarkEpisodeListController(episode: userEpisode, displayMode: .standalone)
+        present(controller, animated: true)
+    }
+}
+
 class UserEpisodeDetailViewController: UIViewController {
     @IBOutlet var containerView: ThemeableView! {
         didSet {

--- a/podcasts/UserEpisodeDetailViewController.swift
+++ b/podcasts/UserEpisodeDetailViewController.swift
@@ -7,6 +7,7 @@ protocol UserEpisodeDetailProtocol: AnyObject {
     func showDeleteConfirmation(userEpisode: UserEpisode)
     func showUpgradeRequired()
     func userEpisodeDetailClosed()
+    func showBookmarks(userEpisode: UserEpisode)
 }
 
 class UserEpisodeDetailViewController: UIViewController {
@@ -91,9 +92,9 @@ class UserEpisodeDetailViewController: UIViewController {
 
     private var window: UIWindow?
     private static let containerHeightWithError: CGFloat = 534
-    private static let containerHeightWithoutError: CGFloat = 410
+    private static let containerHeightWithoutError: CGFloat = 430
 
-    enum TableRow { case download, removeFromCloud, upload, upNext, markAsPlayed, editDetails, delete, cancelUpload, cancelDownload }
+    enum TableRow { case download, bookmarks, removeFromCloud, upload, upNext, markAsPlayed, editDetails, delete, cancelUpload, cancelDownload }
     let actionCellId = "UserEpisodeActionCell"
 
     // MARK: - Init

--- a/podcasts/UserEpisodeDetailViewController.xib
+++ b/podcasts/UserEpisodeDetailViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21678"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -51,7 +51,7 @@
                     <rect key="frame" x="0.0" y="257" width="375" height="410"/>
                     <subviews>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5vT-2y-mAd" customClass="ThemeableSelectionView" customModule="podcasts" customModuleProvider="target">
-                            <rect key="frame" x="16" y="-84" width="343" height="100"/>
+                            <rect key="frame" x="16" y="-108" width="343" height="100"/>
                             <subviews>
                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="yield" translatesAutoresizingMaskIntoConstraints="NO" id="UDO-V9-Plg">
                                     <rect key="frame" x="13" y="14" width="24" height="24"/>
@@ -87,13 +87,13 @@
                             </constraints>
                         </view>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="A user episode" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mS3-CC-CaQ" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                            <rect key="frame" x="88" y="40" width="271" height="21.5"/>
+                            <rect key="frame" x="88" y="16" width="271" height="21.5"/>
                             <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="18"/>
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="3MH-20-muf">
-                            <rect key="frame" x="88" y="66.5" width="271" height="17"/>
+                            <rect key="frame" x="88" y="42.5" width="271" height="17"/>
                             <subviews>
                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="upnext" translatesAutoresizingMaskIntoConstraints="NO" id="Ov1-M8-SNF">
                                     <rect key="frame" x="0.0" y="0.0" width="16" height="16"/>
@@ -149,10 +149,10 @@
                             </subviews>
                         </stackView>
                         <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" scrollEnabled="NO" style="plain" separatorStyle="none" rowHeight="52" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="blI-8r-cU7" customClass="ThemeableTable" customModule="podcasts" customModuleProvider="target">
-                            <rect key="frame" x="0.0" y="114" width="375" height="296"/>
+                            <rect key="frame" x="0.0" y="90" width="375" height="320"/>
                             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <constraints>
-                                <constraint firstAttribute="height" constant="296" id="iV3-Ps-eju"/>
+                                <constraint firstAttribute="height" constant="320" id="iV3-Ps-eju"/>
                             </constraints>
                             <connections>
                                 <outlet property="dataSource" destination="-1" id="iu4-Su-7sV"/>
@@ -160,7 +160,7 @@
                             </connections>
                         </tableView>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9yI-6F-r4n" customClass="PodcastImageView" customModule="podcasts" customModuleProvider="target">
-                            <rect key="frame" x="16" y="40" width="56" height="56"/>
+                            <rect key="frame" x="16" y="16" width="56" height="56"/>
                             <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="56" id="e8l-gA-y6B"/>
@@ -168,14 +168,14 @@
                             </constraints>
                         </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lvd-qJ-KlQ" customClass="ThemeableView" customModule="podcasts" customModuleProvider="target">
-                            <rect key="frame" x="0.0" y="112" width="375" height="1"/>
+                            <rect key="frame" x="0.0" y="88" width="375" height="1"/>
                             <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="1" id="sLD-9L-gBG"/>
                             </constraints>
                         </view>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="LuC-fC-pKT" customClass="PlayPauseButton" customModule="podcasts" customModuleProvider="target">
-                            <rect key="frame" x="295" y="80.5" width="64" height="64"/>
+                            <rect key="frame" x="295" y="56.5" width="64" height="64"/>
                             <constraints>
                                 <constraint firstAttribute="width" constant="64" id="bzQ-fR-GYs"/>
                                 <constraint firstAttribute="height" constant="64" id="gNn-RO-knN"/>
@@ -219,6 +219,7 @@
                     </constraints>
                 </view>
             </subviews>
+            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <constraints>
                 <constraint firstItem="rPk-NC-Zbc" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="4af-x7-FjX"/>
@@ -230,7 +231,6 @@
                 <constraint firstItem="rPk-NC-Zbc" firstAttribute="bottom" secondItem="blI-8r-cU7" secondAttribute="bottom" id="i7y-Cs-8Mg"/>
                 <constraint firstAttribute="trailing" secondItem="bbX-qh-cTr" secondAttribute="trailing" id="tBD-i1-T7e"/>
             </constraints>
-            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <point key="canvasLocation" x="138" y="153"/>
         </view>
     </objects>


### PR DESCRIPTION
| 🛫 Depends on: #1017  |
|:---:|

This adds the ability to view the bookmarks for a user file. 

## Demo Video

https://github.com/Automattic/pocket-casts-ios/assets/793774/4723607a-0552-4ab2-8c29-e24cb2ecc51c

## To test

1. Launch the app
2. Enable the Bookmarks feature flag
3. Add a user file
4. Play the user file and add some bookmarks
5. Go to Profile > Files
6. ✅ Verify you see the bookmark indicator on the episode cell
7. Tap the episode
8. ✅ Verify you see the bookmarks item
9. Tap it
10. ✅ Verify you see the episode bookmarks and the view works
11. Dismiss the bookmarks
12. Add the user file to the queue, but not the playing episode
13. Open the queue
14. Tap the file
15. ✅ Verify you see the bookmarks item
16. Tap it
17. ✅ Verify the bookmarks view opens
18. Dismiss the view
19. Go to the Podcast details and tap on any episode
20. Swipe to the bookmarks tab
21. ✅ Verify the view still appears correctly

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
