### PR TITLE
PlaybackManager: remove lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 7.45
 -----
-
+- Attempt to fix a crash when switching episodes [1019]
 
 7.44
 -----

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -52,8 +52,6 @@ class PlaybackManager: ServerPlaybackDelegate {
     private var playersToCleanUp = [AnyHashable]()
     private let playerCleanupQueue: DispatchQueue
 
-    private let playerCreateDestroyLock = NSObject()
-
     private let catchUpHelper = PlaybackCatchUpHelper()
 
     private let analyticsPlaybackHelper = AnalyticsPlaybackHelper.shared
@@ -130,9 +128,6 @@ class PlaybackManager: ServerPlaybackDelegate {
     }
 
     func load(episode: BaseEpisode, autoPlay: Bool, overrideUpNext: Bool, saveCurrentEpisode: Bool = true, completion: (() -> Void)? = nil) {
-        objc_sync_enter(playerCreateDestroyLock)
-        defer { objc_sync_exit(playerCreateDestroyLock) }
-
         FileLog.shared.addMessage("Loading \(episode.displayableTitle()) with UUID \(episode.uuid) autoPlay \(autoPlay)")
 
         let episodeIsChanging = episode.uuid != currentEpisode()?.uuid
@@ -519,9 +514,6 @@ class PlaybackManager: ServerPlaybackDelegate {
         guard let nextEpisode = queue.episodeAt(index: 0) else { return }
 
         FileLog.shared.addMessage("Play Next Episode \(nextEpisode.displayableTitle())")
-
-        objc_sync_enter(playerCreateDestroyLock)
-        defer { objc_sync_exit(playerCreateDestroyLock) }
 
         queue.removeTopEpisode(fireNotification: false)
         chapterManager.clearChapterInfo()
@@ -1081,9 +1073,6 @@ class PlaybackManager: ServerPlaybackDelegate {
     }
 
     private func cleanupCurrentPlayer(permanent: Bool) {
-        objc_sync_enter(playerCreateDestroyLock)
-        defer { objc_sync_exit(playerCreateDestroyLock) }
-
         haveCalledPlayerLoad = false
         seekingTo = PlaybackManager.notSeeking
         FileLog.shared.addMessage("cleanupCurrentPlayer permanent? \(permanent)")


### PR DESCRIPTION
Our top crash seems to be related to a deadlock with the players. In order to easily reproduce that:

1. Go to `trunk`
2. Run the app
3. Clean your Up Next queue
4. Download and add an episode to your Up Next queue
5. Add a non-downloaded to your Up Next queue (after the downloaded episode)
6. Go offline
7. Play the download episode
8. Move the scrubber til the end
9. 💥 The app should freeze due to a deadlock

This happens while changing from `EffectsPlayer` to `DefaultPlayer`. Given there's no connectivity the lock is never released somehow and the whole app freezes.

## Additional context

With the help of @emilylaguna we were able to check why this check was added in the first place:

1. It seems that there was a crash because `loadEpisode` was called twice
2. A test of calling `loadEpisode` 100 times was added — which crashes the app right away
3. The locks were then added to the code preventing the crash from happening

Although I don't have access to the original test, I did the same and removed the locks. To my surprise, there wasn't any crash.

However, a few times I was able to see a `EXC BAD_ACCESS` happening on iOS 15. I then reduced the number of calls to 10 (given that 100 is an exaggeration of the issue) and wasn't unable to see the crash.

I believe we can remove the locks (as did in this PR) and monitor this during the beta period — I wonder whether any other possible crash that might happen due to this change will have fewer occurrences compared to what we have today.

## To test

1. Make sure you have at least one episode in your Up Next queue
1. In the `AppDelegate.swift` `didFinishLaunchingWithOptions` method add this just before the `return true`:

```swift
        Array(0...10).forEach { index in
            DispatchQueue.init(label: "\(index)-thread").asyncAfter(deadline: .now() + 1) {
                print("$$ Executing at \(CFAbsoluteTimeGetCurrent()) \(Thread.current)\n")
                if let firstEpisodeInUpNext = DataManager.sharedManager.episodeInUpNextAt(index: 0) {
                    PlaybackManager.shared.load(episode: firstEpisodeInUpNext, autoPlay: true, overrideUpNext: false)
                }
            }
        }
```

This will create 10 threads loading the first episode of your Up Next queue.

2. Run the app
3. ✅ The app should not crash
4. Download the episode and re-run the app
5. ✅ The app should not crash ¶

¶ This is in order to test both `DefaultPlayer` and also `EffectsPlayer`.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
