### PR TITLE
What's New: ensure last shown version is saved

### DIFF
--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -553,7 +553,8 @@ class Settings: NSObject {
     private static let lastWhatsNewShownKey = "LastWhatsNewShown"
     class var lastWhatsNewShown: String? {
         set {
-            UserDefaults.standard.set(newValue, forKey: lastWhatsNewShownKey)
+            UserDefaults.standard.setValue(newValue, forKey: lastWhatsNewShownKey)
+            UserDefaults.standard.synchronize()
         }
 
         get {


### PR DESCRIPTION
We still have a few reports of the What's New appearing over and over for some users: https://www.reddit.com/r/pocketcasts/comments/15fun5s/auto_play_is_here_pop_up_wont_go_away_it_keeps/

This PR makes a simple change based on some context found in this SO thread: https://stackoverflow.com/questions/41302015/userdefaults-is-not-saved-with-swift

1. Change `set` to `setValue`
2. Perform a `synchronize`

## To test

1. Delete the app from your simulator/device
1. First, install the version without Autoplay: `git checkout 7.42`
2. Run the app
3. Checkout this branch: `git checkout task/change_how_whats_new_version_is_saved`
4. Run the app
5. ✅ What's New should appear
6. Re-run it again
7. ✅ Autoplay shouldn't appear
8. Delete the app from your simulator/device
9. Checkout 7.43: `git checkout 7.43`
9. Run the app
10. Checkout this branch: `git checkout task/change_how_whats_new_version_is_saved`
11. Run the app
12. ✅ The What's New shouldn't appear

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
