### PR TITLE
Bookmarks: Adds importing of bookmarks from the server

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -29,6 +29,7 @@ public class DataManager {
 
     public static let sharedManager = DataManager()
 
+    /// Creates a DataManager using a queue that is persisted to a local SQLIte file
     public convenience init() {
         DataManager.ensureDbFolderExists()
 
@@ -38,14 +39,16 @@ public class DataManager {
         self.init(dbQueue: dbQueue)
     }
 
-    public init(dbQueue: FMDatabaseQueue, closeQueue: Bool = true) {
+    /// Creates a DataManager using the given `FMDatabaseQueue`.
+    /// If `shouldCloseQueueAfterSetup` is true, `dbQueue.close()` is called after the schema is created, otherwise the queue is left open.
+    public init(dbQueue: FMDatabaseQueue, shouldCloseQueueAfterSetup: Bool = true) {
         self.dbQueue = dbQueue
 
         dbQueue.inDatabase { db in
             DatabaseHelper.setup(db: db)
         }
 
-        if closeQueue {
+        if shouldCloseQueueAfterSetup {
             // "You don't need to close it during the app lifecycle, unless you modify the schema." Since the above method can modify the schema, we do that here as recommended by the author of FMDB
             dbQueue.close()
         }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -29,16 +29,26 @@ public class DataManager {
 
     public static let sharedManager = DataManager()
 
-    public init() {
+    public convenience init() {
         DataManager.ensureDbFolderExists()
 
         let flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FILEPROTECTION_NONE
-        dbQueue = FMDatabaseQueue(path: DataManager.pathToDb(), flags: flags)!
+        let dbQueue = FMDatabaseQueue(path: DataManager.pathToDb(), flags: flags)!
+
+        self.init(dbQueue: dbQueue)
+    }
+
+    public init(dbQueue: FMDatabaseQueue, closeQueue: Bool = true) {
+        self.dbQueue = dbQueue
+
         dbQueue.inDatabase { db in
             DatabaseHelper.setup(db: db)
         }
-        // "You don't need to close it during the app lifecycle, unless you modify the schema." Since the above method can modify the schema, we do that here as recommended by the author of FMDB
-        dbQueue.close()
+
+        if closeQueue {
+            // "You don't need to close it during the app lifecycle, unless you modify the schema." Since the above method can modify the schema, we do that here as recommended by the author of FMDB
+            dbQueue.close()
+        }
 
         // closing it above won't affect these calls, since they will re-open it
         podcastManager.setup(dbQueue: dbQueue)

--- a/Modules/DataModel/Tests/PocketCastsDataModelTests/BookmarkDataManagerTests.swift
+++ b/Modules/DataModel/Tests/PocketCastsDataModelTests/BookmarkDataManagerTests.swift
@@ -150,7 +150,7 @@ final class BookmarkDataManagerTests: XCTestCase {
     func testUpdatingTitleSucceeds() async {
         let bookmark = addBookmark()
 
-        let success = await dataManager.update(title: "title2", for: bookmark)
+        let success = await dataManager.update(bookmark: bookmark, title: "title2")
         XCTAssertTrue(success)
     }
 
@@ -161,7 +161,7 @@ final class BookmarkDataManagerTests: XCTestCase {
 
         let bookmark = addBookmark(title: title1)
 
-        await dataManager.update(title: title2, for: bookmark, modified: modified)
+        await dataManager.update(bookmark: bookmark, title: title2, modified: modified)
 
         let updatedBookmark = dataManager.bookmark(for: bookmark.uuid)
         XCTAssertEqual(updatedBookmark?.title, title2)
@@ -175,7 +175,7 @@ final class BookmarkDataManagerTests: XCTestCase {
         let bookmarkToChange = 2
         let title2 = "c_title_2"
 
-        await dataManager.update(title: title2, for: bookmarks[bookmarkToChange])
+        await dataManager.update(bookmark: bookmarks[bookmarkToChange], title: title2)
 
         let updatedTitles = dataManager.allBookmarks().map { $0.title }.sorted()
         XCTAssertNotEqual(titles, updatedTitles)

--- a/Modules/Server/Sources/PocketCastsServer/Private/API Tasks/ApiBaseTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Private/API Tasks/ApiBaseTask.swift
@@ -7,6 +7,13 @@ class ApiBaseTask: Operation {
     private let isoDateFormatter = ISO8601DateFormatter()
     let apiVersion = "2"
 
+    let dataManager: DataManager
+
+    init(dataManager: DataManager = .sharedManager) {
+        self.dataManager = dataManager
+        super.init()
+    }
+
     override func main() {
         autoreleasepool {
             runTaskSynchronously()

--- a/Modules/Server/Tests/PocketCastsServerTests/SyncTaskTests+BookmarkImport.swift
+++ b/Modules/Server/Tests/PocketCastsServerTests/SyncTaskTests+BookmarkImport.swift
@@ -24,12 +24,12 @@ final class SyncTaskTests_BookmarkImport: XCTestCase {
         let time = 86400.0
         let created = Date(timeIntervalSince1970: 456)
 
-        let apiBookmark = Api_SyncUserBookmark.forTesting(uuid: uuid,
-                                                          episode: episode,
-                                                          podcast: podcast,
-                                                          title: title,
-                                                          time: time,
-                                                          created: created)
+        let apiBookmark = Api_SyncUserBookmark(uuid: uuid,
+                                               episode: episode,
+                                               podcast: podcast,
+                                               title: title,
+                                               time: time,
+                                               created: created)
 
         await syncTask.importBookmark(apiBookmark)
 
@@ -46,7 +46,7 @@ final class SyncTaskTests_BookmarkImport: XCTestCase {
     }
 
     func testNonexistingDeletedBookmarkIsNotAdded() async {
-        let apiBookmark = Api_SyncUserBookmark.forTesting(uuid: "nope", isDeleted: true)
+        let apiBookmark = Api_SyncUserBookmark(uuid: "nope", isDeleted: true)
 
         await syncTask.importBookmark(apiBookmark)
 
@@ -84,12 +84,12 @@ final class SyncTaskTests_BookmarkImport: XCTestCase {
         let updatedTime = 321.0
         let updatedDate = Date.init(timeIntervalSince1970: 99999)
 
-        let apiBookmark = Api_SyncUserBookmark.forTesting(uuid: uuid,
-                                                          episode: bookmark.episodeUuid,
-                                                          podcast: bookmark.podcastUuid,
-                                                          title: updatedTitle,
-                                                          time: updatedTime,
-                                                          created: updatedDate)
+        let apiBookmark = Api_SyncUserBookmark(uuid: uuid,
+                                               episode: bookmark.episodeUuid,
+                                               podcast: bookmark.podcastUuid,
+                                               title: updatedTitle,
+                                               time: updatedTime,
+                                               created: updatedDate)
 
         await syncTask.importBookmark(apiBookmark)
 
@@ -117,7 +117,11 @@ final class SyncTaskTests_BookmarkImport: XCTestCase {
 
 private extension SyncTaskTests_BookmarkImport {
     @discardableResult
-    func addBookmark(episodeUuid: String = "episode-1", podcastUuid: String = "podcast-uuid", title: String = "Title", time: TimeInterval = 1, created: Date = .now) -> Bookmark {
+    func addBookmark(episodeUuid: String = "episode-1",
+                     podcastUuid: String = "podcast-uuid",
+                     title: String = "Title",
+                     time: TimeInterval = 1,
+                     created: Date = .now) -> Bookmark {
         bookmarkManager.add(episodeUuid: episodeUuid, podcastUuid: podcastUuid, title: title, time: time, dateCreated: created).flatMap {
             bookmarkManager.bookmark(for: $0)
         }!
@@ -129,7 +133,13 @@ private extension Api_SyncUpdateResponse {
         var response = Api_SyncUpdateResponse()
 
         for i in 0..<count {
-            let bookmark = Api_SyncUserBookmark.forTesting(uuid: "uuid_\(i)", episode: "episode_\(i)", podcast: "podcast_\(i)", title: "title_\(i)", time: TimeInterval(i), created: .init(timeIntervalSince1970: TimeInterval(i)), isDeleted: i < deletedCount)
+            let bookmark = Api_SyncUserBookmark(uuid: "uuid_\(i)",
+                                                episode: "episode_\(i)",
+                                                podcast: "podcast_\(i)",
+                                                title: "title_\(i)",
+                                                time: TimeInterval(i),
+                                                created: .init(timeIntervalSince1970: TimeInterval(i)),
+                                                isDeleted: i < deletedCount)
 
             var record = Api_Record()
             record.record = .bookmark(bookmark)
@@ -144,38 +154,37 @@ private extension Api_SyncUpdateResponse {
 
 private extension Api_SyncUserBookmark {
     static func fromBookmark(_ bookmark: Bookmark, isDeleted: Bool? = nil) -> Self {
-        return forTesting(uuid: bookmark.uuid,
-                          episode: bookmark.episodeUuid,
-                          podcast: bookmark.podcastUuid,
-                          title: bookmark.title,
-                          time: bookmark.time,
-                          created: bookmark.created,
-                          isDeleted: isDeleted)
+        return .init(uuid: bookmark.uuid,
+                     episode: bookmark.episodeUuid,
+                     podcast: bookmark.podcastUuid,
+                     title: bookmark.title,
+                     time: bookmark.time,
+                     created: bookmark.created,
+                     isDeleted: isDeleted)
     }
 
-    static func forTesting(uuid: String,
-                           episode: String = "episode",
-                           podcast: String? = nil,
-                           title: String = "Title",
-                           time: TimeInterval = 1234,
-                           created: Date = Date(),
-                           isDeleted: Bool? = nil) -> Self {
-        var apiBookmark = Api_SyncUserBookmark()
-        apiBookmark.bookmarkUuid = uuid
-        apiBookmark.episodeUuid = episode
+    init(uuid: String,
+         episode: String = "episode",
+         podcast: String? = nil,
+         title: String = "Title",
+         time: TimeInterval = 1234,
+         created: Date = Date(),
+         isDeleted: Bool? = nil) {
+        self.init()
+
+        bookmarkUuid = uuid
+        episodeUuid = episode
 
         if let podcast {
-            apiBookmark.podcastUuid = podcast
+            podcastUuid = podcast
         }
 
-        apiBookmark.title.value = title
-        apiBookmark.time.value = Int32(time)
-        apiBookmark.createdAt = .init(date: created)
+        self.title.value = title
+        self.time.value = Int32(time)
+        createdAt = .init(date: created)
 
         if let isDeleted {
-            apiBookmark.isDeleted.value = isDeleted
+            self.isDeleted.value = isDeleted
         }
-
-        return apiBookmark
     }
 }

--- a/Modules/Server/Tests/PocketCastsServerTests/SyncTaskTests+BookmarkImport.swift
+++ b/Modules/Server/Tests/PocketCastsServerTests/SyncTaskTests+BookmarkImport.swift
@@ -9,7 +9,7 @@ final class SyncTaskTests_BookmarkImport: XCTestCase {
     private var syncTask: SyncTask!
 
     override func setUp() {
-        dataManager = DataManager(dbQueue: FMDatabaseQueue(), closeQueue: false)
+        dataManager = DataManager(dbQueue: FMDatabaseQueue(), shouldCloseQueueAfterSetup: false)
         bookmarkManager = dataManager.bookmarks
         syncTask = SyncTask(dataManager: dataManager)
     }

--- a/Modules/Server/Tests/PocketCastsServerTests/SyncTaskTests+BookmarkImport.swift
+++ b/Modules/Server/Tests/PocketCastsServerTests/SyncTaskTests+BookmarkImport.swift
@@ -1,0 +1,181 @@
+@testable import PocketCastsServer
+import PocketCastsDataModel
+import FMDB
+import XCTest
+
+final class SyncTaskTests_BookmarkImport: XCTestCase {
+    private var dataManager: DataManager!
+    private var bookmarkManager: BookmarkDataManager!
+    private var syncTask: SyncTask!
+
+    override func setUp() {
+        dataManager = DataManager(dbQueue: FMDatabaseQueue(), closeQueue: false)
+        bookmarkManager = dataManager.bookmarks
+        syncTask = SyncTask(dataManager: dataManager)
+    }
+
+    // MARK: - Importing a single bookmark
+
+    func testNonexistingBookmarkIsAdded() async {
+        let uuid = UUID().uuidString
+        let episode = UUID().uuidString
+        let podcast = UUID().uuidString
+        let title = "Hello World"
+        let time = 86400.0
+        let created = Date(timeIntervalSince1970: 456)
+
+        let apiBookmark = Api_SyncUserBookmark.forTesting(uuid: uuid,
+                                                          episode: episode,
+                                                          podcast: podcast,
+                                                          title: title,
+                                                          time: time,
+                                                          created: created)
+
+        await syncTask.importBookmark(apiBookmark)
+
+        XCTAssertEqual(bookmarkManager.allBookmarks().count, 1)
+
+        let bookmark = bookmarkManager.bookmark(for: uuid)
+
+        XCTAssertNotNil(bookmark)
+        XCTAssertEqual(created, bookmark?.created)
+        XCTAssertEqual(episode, bookmark?.episodeUuid)
+        XCTAssertEqual(podcast, bookmark?.podcastUuid)
+        XCTAssertEqual(time, bookmark?.time)
+        XCTAssertEqual(title, bookmark?.title)
+    }
+
+    func testNonexistingDeletedBookmarkIsNotAdded() async {
+        let apiBookmark = Api_SyncUserBookmark.forTesting(uuid: "nope", isDeleted: true)
+
+        await syncTask.importBookmark(apiBookmark)
+
+        XCTAssertNil(bookmarkManager.bookmark(for: "nope"))
+    }
+
+    func testExistingBookmarkGetsDeleted() async {
+        // Add some bookmarks to the local db
+        addBookmark(time: 1)
+        let bookmark = addBookmark(time: 2)
+        addBookmark(time: 3)
+        addBookmark(time: 4)
+
+        // Delete the bookmark from the API data
+        let apiBookmark = Api_SyncUserBookmark.fromBookmark(bookmark, isDeleted: true)
+        await syncTask.importBookmark(apiBookmark)
+
+        // Ensure the bookmark was deleted
+        let bookmarks = bookmarkManager.allBookmarks(sorted: .timestamp)
+        XCTAssertEqual(bookmarks.count, 3)
+
+        // Ensure the correct bookmark was removed
+        XCTAssertEqual(bookmarks.map(\.time), [1, 3, 4])
+    }
+
+    func testExistingBookmarkGetsUpdated() async {
+        // Add some bookmarks to the local db
+        addBookmark(time: 1)
+        let bookmark = addBookmark(time: 2)
+        addBookmark(time: 3)
+        addBookmark(time: 4)
+
+        let uuid = bookmark.uuid
+        let updatedTitle = "hello"
+        let updatedTime = 321.0
+        let updatedDate = Date.init(timeIntervalSince1970: 99999)
+
+        let apiBookmark = Api_SyncUserBookmark.forTesting(uuid: uuid,
+                                                          episode: bookmark.episodeUuid,
+                                                          podcast: bookmark.podcastUuid,
+                                                          title: updatedTitle,
+                                                          time: updatedTime,
+                                                          created: updatedDate)
+
+        await syncTask.importBookmark(apiBookmark)
+
+        // Ensure no bookmarks were deleted
+        XCTAssertEqual(bookmarkManager.allBookmarks().count, 4)
+
+        // Verify the updated data is saved
+        let dbBookmark = bookmarkManager.bookmark(for: uuid)
+        XCTAssertNotNil(bookmark)
+        XCTAssertEqual(updatedDate, dbBookmark?.created)
+        XCTAssertEqual(updatedTime, dbBookmark?.time)
+        XCTAssertEqual(updatedTitle, dbBookmark?.title)
+    }
+
+    // MARK: - Server Data Processed
+
+    func testProcessServerDataParsesBookmarksCorrectly() {
+        let count = 2000
+        let deletedCount = 321
+        syncTask.processServerData(response: .bookmarkResponse(count: count, deletedCount: deletedCount))
+
+        XCTAssertEqual(bookmarkManager.allBookmarks().count, count - deletedCount)
+    }
+}
+
+private extension SyncTaskTests_BookmarkImport {
+    @discardableResult
+    func addBookmark(episodeUuid: String = "episode-1", podcastUuid: String = "podcast-uuid", title: String = "Title", time: TimeInterval = 1, created: Date = .now) -> Bookmark {
+        bookmarkManager.add(episodeUuid: episodeUuid, podcastUuid: podcastUuid, title: title, time: time, dateCreated: created).flatMap {
+            bookmarkManager.bookmark(for: $0)
+        }!
+    }
+}
+
+private extension Api_SyncUpdateResponse {
+    static func bookmarkResponse(count: Int, deletedCount: Int = 0) -> Self {
+        var response = Api_SyncUpdateResponse()
+
+        for i in 0..<count {
+            let bookmark = Api_SyncUserBookmark.forTesting(uuid: "uuid_\(i)", episode: "episode_\(i)", podcast: "podcast_\(i)", title: "title_\(i)", time: TimeInterval(i), created: .init(timeIntervalSince1970: TimeInterval(i)), isDeleted: i < deletedCount)
+
+            var record = Api_Record()
+            record.record = .bookmark(bookmark)
+            record.bookmark = bookmark
+
+            response.records.append(record)
+        }
+
+        return response
+    }
+}
+
+private extension Api_SyncUserBookmark {
+    static func fromBookmark(_ bookmark: Bookmark, isDeleted: Bool? = nil) -> Self {
+        return forTesting(uuid: bookmark.uuid,
+                          episode: bookmark.episodeUuid,
+                          podcast: bookmark.podcastUuid,
+                          title: bookmark.title,
+                          time: bookmark.time,
+                          created: bookmark.created,
+                          isDeleted: isDeleted)
+    }
+
+    static func forTesting(uuid: String,
+                           episode: String = "episode",
+                           podcast: String? = nil,
+                           title: String = "Title",
+                           time: TimeInterval = 1234,
+                           created: Date = Date(),
+                           isDeleted: Bool? = nil) -> Self {
+        var apiBookmark = Api_SyncUserBookmark()
+        apiBookmark.bookmarkUuid = uuid
+        apiBookmark.episodeUuid = episode
+
+        if let podcast {
+            apiBookmark.podcastUuid = podcast
+        }
+
+        apiBookmark.title.value = title
+        apiBookmark.time.value = Int32(time)
+        apiBookmark.createdAt = .init(date: created)
+
+        if let isDeleted {
+            apiBookmark.isDeleted.value = isDeleted
+        }
+
+        return apiBookmark
+    }
+}

--- a/podcasts/BookmarkManager.swift
+++ b/podcasts/BookmarkManager.swift
@@ -81,7 +81,7 @@ class BookmarkManager {
     /// Updates the bookmark with the given title, emits `onBookmarkChanged` on success
     @discardableResult
     func update(title: String, for bookmark: Bookmark) async -> Bool {
-        await dataManager.update(title: title, for: bookmark).when(true) {
+        await dataManager.update(bookmark: bookmark, title: title).when(true) {
             onBookmarkChanged.send(.init(uuid: bookmark.uuid, change: .title(title)))
         }
     }


### PR DESCRIPTION
This adds the foundation to import bookmarks that are sent from the server. Along with making the SyncTask testable to verify the bookmarks are being imported as expected. 

🚨 **Heads Up:** I realized too late that I was copying the folderIssue file log. I fixed this in a later PR.

## To test

There aren't any visible changes to test, so a 🟢 CI is great. However this does change the data manager and sync task a bit so in addition to that and a code review we should also verify:

1. There are no errors being displayed in console about the database
2. The data remains intact after running
3. Syncing works as expected


## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
