### PR TITLE
Bookmarks: Updates the database schema for syncing

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Bookmarks/Bookmark.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Bookmarks/Bookmark.swift
@@ -8,13 +8,15 @@ public struct Bookmark: Hashable {
     public let time: TimeInterval
 
     public let created: Date
-    public let modified: Date
 
     public let episodeUuid: String
     public let podcastUuid: String?
 
     public var episode: BaseEpisode? = nil
     public var podcast: Podcast? = nil
+
+    public var titleModified: Date? = nil
+    public var deletedModified: Date? = nil
 
     // `BaseEpisode` and `Podcast` don't conform to Hashable, so instead we implement it manually to ignore those properties
     public func hash(into hasher: inout Hasher) {
@@ -24,6 +26,8 @@ public struct Bookmark: Hashable {
         hasher.combine(created)
         hasher.combine(episodeUuid)
         hasher.combine(podcastUuid)
+        hasher.combine(titleModified)
+        hasher.combine(deletedModified)
     }
 
     public static func == (lhs: Bookmark, rhs: Bookmark) -> Bool {
@@ -45,7 +49,6 @@ extension PreviewProvider {
                  title: title,
                  time: time,
                  created: created,
-                 modified: Date(),
                  episodeUuid: "episode",
                  podcastUuid: "podcast")
     }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Bookmarks/BookmarkDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Bookmarks/BookmarkDataManager.swift
@@ -52,19 +52,21 @@ public struct BookmarkDataManager {
 
     // MARK: - Updating
     @discardableResult
-    public func update(bookmark: Bookmark, title: String, time: TimeInterval? = nil, created: Date? = nil, modified: Date? = Date()) async -> Bool {
+    public func update(bookmark: Bookmark, title: String, time: TimeInterval? = nil, created: Date? = nil, modified: Date? = Date(), syncStatus: SyncStatus = .notSynced) async -> Bool {
         let updateColumns = [
             "\(Column.title) = ?",
             time.map { _ in "\(Column.time) = ?" },
             created.map { _ in "\(Column.createdDate) = ?" },
-            modified.map { _ in "\(Column.modifiedDate) = ?" },
+            "\(Column.titleModifiedDate) = ?",
+            "\(Column.syncStatus) = ?",
         ].compactMap { $0 }
 
         let values: [Any?] = [
             title,
             time,
             created,
-            modified,
+            modified ?? Date(),
+            syncStatus.rawValue,
             bookmark.uuid
         ]
 

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Bookmarks/BookmarkDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Bookmarks/BookmarkDataManager.swift
@@ -274,12 +274,14 @@ extension BookmarkDataManager {
             CREATE TABLE IF NOT EXISTS \(Self.tableName) (
                 \(Column.uuid) varchar(40) NOT NULL,
                 \(Column.title) varchar(100) NOT NULL,
+                \(Column.titleModifiedDate) INTEGER,
                 \(Column.episode) varchar(40) NOT NULL,
                 \(Column.podcast) varchar(40),
                 \(Column.time) real NOT NULL,
                 \(Column.createdDate) INTEGER NOT NULL,
-                \(Column.modifiedDate) INTEGER NOT NULL,
                 \(Column.deleted) int NOT NULL DEFAULT 0,
+                \(Column.deletedModifiedDate) INTEGER,
+                \(Column.syncStatus) int NOT NULL DEFAULT 0,
                 PRIMARY KEY (\(Column.uuid))
             );
         """, values: nil)
@@ -306,14 +308,17 @@ private extension Bookmark {
         }
 
         let podcast = resultSet.string(for: .podcast)
+        let titleModified = resultSet.date(for: .titleModifiedDate)
+        let deletedModified = resultSet.date(for: .deletedModifiedDate)
 
         self.init(uuid: uuid,
                   title: title,
                   time: time,
                   created: createdDate,
-                  modified: modified,
                   episodeUuid: episode,
-                  podcastUuid: podcast)
+                  podcastUuid: podcast,
+                  titleModified: titleModified,
+                  deletedModified: deletedModified)
     }
 }
 

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Bookmarks/BookmarkDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Bookmarks/BookmarkDataManager.swift
@@ -18,7 +18,7 @@ public struct BookmarkDataManager {
     ///   - time: The playback time for the bookmark
     ///   - transcription: A transcription of the clip if available
     @discardableResult
-    public func add(uuid: String? = nil, episodeUuid: String, podcastUuid: String?, title: String, time: TimeInterval, dateCreated: Date = Date()) -> String? {
+    public func add(uuid: String? = nil, episodeUuid: String, podcastUuid: String?, title: String, time: TimeInterval, dateCreated: Date = Date(), syncStatus: SyncStatus = .notSynced) -> String? {
         // Prevent adding more than 1 bookmark at the same place
         guard existingBookmark(forEpisode: episodeUuid, time: time) == nil else {
             return nil
@@ -33,11 +33,11 @@ public struct BookmarkDataManager {
 
                 let columns: [Column] = [
                     .uuid, .title, .time,
-                    .createdDate, .modifiedDate,
-                    .episode, .podcast
+                    .createdDate, .titleModifiedDate,
+                    .episode, .podcast, .syncStatus
                 ]
 
-                let values: [Any?] = [uuid, title, time, created, created, episodeUuid, podcastUuid]
+                let values: [Any?] = [uuid, title, time, created, created, episodeUuid, podcastUuid, syncStatus.rawValue]
 
                 try db.insert(into: Self.tableName, columns: columns.map { $0.rawValue }, values: values)
 

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Bookmarks/BookmarkDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Bookmarks/BookmarkDataManager.swift
@@ -317,7 +317,6 @@ private extension Bookmark {
             let uuid = resultSet.string(for: .uuid),
             let title = resultSet.string(for: .title),
             let createdDate = resultSet.date(for: .createdDate),
-            let modified = resultSet.date(for: .modifiedDate),
             let episode = resultSet.string(for: .episode),
             let time = resultSet.double(for: .time)
         else {

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Bookmarks/BookmarkDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Bookmarks/BookmarkDataManager.swift
@@ -142,6 +142,11 @@ public struct BookmarkDataManager {
         return count
     }
 
+    /// Returns all the bookmarks in the database that have the syncStatus of `notSynced`
+    public func bookmarksToSync() -> [Bookmark] {
+        selectBookmarks(where: [.syncStatus], values: [SyncStatus.notSynced.rawValue], allowDeleted: true)
+    }
+
     // MARK: - Deleting
 
     /// Marks the bookmarks as deleted, but doesn't actually remove them from the database

--- a/Modules/DataModel/Tests/PocketCastsDataModelTests/BookmarkDataManagerTests.swift
+++ b/Modules/DataModel/Tests/PocketCastsDataModelTests/BookmarkDataManagerTests.swift
@@ -139,7 +139,7 @@ final class BookmarkDataManagerTests: XCTestCase {
 
         XCTAssertEqual(bookmark.created, created)
         XCTAssertEqual(bookmark.episodeUuid, episode)
-        XCTAssertEqual(bookmark.modified, created)
+        XCTAssertEqual(bookmark.titleModified, created)
         XCTAssertEqual(bookmark.podcastUuid, podcast)
         XCTAssertEqual(bookmark.time, time)
         XCTAssertEqual(bookmark.title, title)
@@ -165,7 +165,7 @@ final class BookmarkDataManagerTests: XCTestCase {
 
         let updatedBookmark = dataManager.bookmark(for: bookmark.uuid)
         XCTAssertEqual(updatedBookmark?.title, title2)
-        XCTAssertEqual(updatedBookmark?.modified, modified)
+        XCTAssertEqual(updatedBookmark?.titleModified, modified)
     }
 
     func testUpdatingTitleEffectsOnlyOneBookmark() async {
@@ -197,12 +197,14 @@ final class BookmarkDataManagerTests: XCTestCase {
         XCTAssertNil(dataManager.bookmark(for: bookmark.uuid))
     }
 
-    func testAllBookmarksReturnsDeletedItems() async {
-        let bookmark = addBookmark()
-        _ = await dataManager.remove(bookmarks: [bookmark])
-        let allBookmarks = dataManager.allBookmarks(includeDeleted: true)
+    func testAllBookmarksAlsoReturnsDeletedItems() async {
+        let bookmarkNotDeleted = addBookmark(time: 1)
+        let bookmark = addBookmark(time: 2)
 
-        XCTAssertEqual([bookmark.uuid], allBookmarks.map(\.uuid))
+        _ = await dataManager.remove(bookmarks: [bookmark])
+        let allBookmarks = dataManager.allBookmarks(includeDeleted: true, sorted: .timestamp)
+
+        XCTAssertEqual([bookmarkNotDeleted.uuid, bookmark.uuid], allBookmarks.map(\.uuid))
     }
 
     func testBookmarkIsPermanentlyRemoved() async {
@@ -249,12 +251,61 @@ final class BookmarkDataManagerTests: XCTestCase {
 
         XCTAssertEqual(ordered, bookmarks)
     }
+
+    // MARK: - Syncing
+    func testBookmarksToSyncReturnsOnlyItemsThatNeedSyncing() {
+        let count = 10
+
+        for i in 0..<count {
+            addBookmark(time: TimeInterval(i))
+        }
+
+        addBookmark(time: TimeInterval(999), syncStatus: .synced)
+
+        let unsyncedBookmarks = dataManager.bookmarksToSync()
+        XCTAssertEqual(unsyncedBookmarks.count, count)
+    }
+
+    func testUpdatingTitleMarksAsNotSynced() async {
+        addBookmark(time: TimeInterval(123), syncStatus: .synced)
+
+        let bookmark = addBookmark(time: TimeInterval(999), syncStatus: .synced)
+        await dataManager.update(bookmark: bookmark, title: "New Title")
+
+        XCTAssertEqual(dataManager.bookmarksToSync().count, 1)
+    }
+
+    func testUpdatingTitleUpdatesTheModifiedDate() async {
+        let created = Date(timeIntervalSince1970: 1234)
+        let bookmark = addBookmark(time: TimeInterval(999), created: created, syncStatus: .synced)
+        await dataManager.update(bookmark: bookmark, title: "New Title")
+
+        let updatedBookmark = dataManager.bookmark(for: bookmark.uuid)
+
+        XCTAssertNotEqual(updatedBookmark?.titleModified, created)
+    }
+
+    func testUpdatingWithSyncStatusSetsCorrectly() async {
+        addBookmark(time: TimeInterval(123), syncStatus: .synced)
+        let bookmark = addBookmark(time: TimeInterval(999))
+        await dataManager.update(bookmark: bookmark, title: "New Title", syncStatus: .synced)
+
+        XCTAssertEqual(dataManager.bookmarksToSync().count, 0)
+    }
+
+    func testDeletingUpdatesSyncStatus() async {
+        addBookmark(time: TimeInterval(123), syncStatus: .synced)
+        let bookmark = addBookmark(time: TimeInterval(999), syncStatus: .synced)
+        _ = await dataManager.remove(bookmarks: [bookmark])
+
+        XCTAssertEqual(dataManager.bookmarksToSync().count, 1)
+    }
 }
 
 private extension BookmarkDataManagerTests {
     @discardableResult
-    func addBookmark(episodeUuid: String = "episode-1", podcastUuid: String = "podcast-uuid", title: String = "Title", time: TimeInterval = 1, created: Date = .now) -> Bookmark {
-        dataManager.add(episodeUuid: episodeUuid, podcastUuid: podcastUuid, title: title, time: time, dateCreated: created).flatMap {
+    func addBookmark(episodeUuid: String = "episode-1", podcastUuid: String = "podcast-uuid", title: String = "Title", time: TimeInterval = 1, created: Date = .now, syncStatus: SyncStatus = .notSynced) -> Bookmark {
+        dataManager.add(episodeUuid: episodeUuid, podcastUuid: podcastUuid, title: title, time: time, dateCreated: created, syncStatus: syncStatus).flatMap {
             dataManager.bookmark(for: $0)
         }!
     }


### PR DESCRIPTION
This adds the title and delete modified dates, and a sync status field, and removes the general `modified` field, and updates the references to update the title/deleted modified. 

I also updated the tests, and added more to verify its all working.

## To test
**Note:** You'll need to reinstall the app or delete the bookmarks table

There are no visible changes, so a 🟢 CI and a code review should suffice.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
