### PR TITLE
Bookmark: Adds incremental syncing of bookmarks

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Bookmarks/Bookmark.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Bookmarks/Bookmark.swift
@@ -15,8 +15,10 @@ public struct Bookmark: Hashable {
     public var episode: BaseEpisode? = nil
     public var podcast: Podcast? = nil
 
+    // For syncing
     public var titleModified: Date? = nil
     public var deletedModified: Date? = nil
+    public var deleted: Bool = false
 
     // `BaseEpisode` and `Podcast` don't conform to Hashable, so instead we implement it manually to ignore those properties
     public func hash(into hasher: inout Hasher) {

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Bookmarks/BookmarkDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Bookmarks/BookmarkDataManager.swift
@@ -142,6 +142,8 @@ public struct BookmarkDataManager {
         return count
     }
 
+    // MARK: - Syncing
+
     /// Returns all the bookmarks in the database that have the syncStatus of `notSynced`
     public func bookmarksToSync() -> [Bookmark] {
         selectBookmarks(where: [.syncStatus], values: [SyncStatus.notSynced.rawValue], allowDeleted: true)
@@ -173,6 +175,7 @@ public struct BookmarkDataManager {
     }
 
     /// Permanently removes the bookmarks from the database
+    @discardableResult
     public func permanentlyDelete(bookmarks: [Bookmark]) async -> Bool {
         await withCheckedContinuation { continuation in
             let uuids = bookmarks.map { "'\($0.uuid)'" }.joined(separator: ",")
@@ -317,7 +320,6 @@ private extension Bookmark {
             let uuid = resultSet.string(for: .uuid),
             let title = resultSet.string(for: .title),
             let createdDate = resultSet.date(for: .createdDate),
-            let modified = resultSet.date(for: .modifiedDate),
             let episode = resultSet.string(for: .episode),
             let time = resultSet.double(for: .time)
         else {
@@ -327,6 +329,7 @@ private extension Bookmark {
         let podcast = resultSet.string(for: .podcast)
         let titleModified = resultSet.date(for: .titleModifiedDate)
         let deletedModified = resultSet.date(for: .deletedModifiedDate)
+        let deleted = resultSet.bool(for: .deleted) ?? false
 
         self.init(uuid: uuid,
                   title: title,
@@ -335,7 +338,8 @@ private extension Bookmark {
                   episodeUuid: episode,
                   podcastUuid: podcast,
                   titleModified: titleModified,
-                  deletedModified: deletedModified)
+                  deletedModified: deletedModified,
+                  deleted: deleted)
     }
 }
 
@@ -352,5 +356,9 @@ private extension FMResultSet {
 
     func double(for column: BookmarkDataManager.Column) -> Double? {
         double(forColumn: column.rawValue)
+    }
+
+    func bool(for column: BookmarkDataManager.Column) -> Bool? {
+        bool(forColumn: column.rawValue)
     }
 }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -25,6 +25,11 @@ public class DataManager {
     public let autoAddCandidates: AutoAddCandidatesDataManager
     public let bookmarks: BookmarkDataManager
 
+    /// Internal feature flag the app can set because the modules don't have access
+    /// to FeatureFlag.
+    /// TODO: Remove this after the flag is enabled
+    public var bookmarksEnabled: Bool = false
+
     private let dbQueue: FMDatabaseQueue
 
     public static let sharedManager = DataManager()

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+LocalChanges.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+LocalChanges.swift
@@ -132,6 +132,13 @@ extension SyncTask {
         return filterRecords
     }
 
+    /// Retrieve any bookmarks that need to be sent to the server
+    func changedBookmarks() -> [Api_Record]? {
+        dataManager.bookmarks.bookmarksToSync()
+            .map { .init(bookmark: $0) }
+            .nilIfEmpty()
+    }
+
     func changedStats() -> Api_Record? {
         let timeSavedDynamicSpeed = convertStat(StatsManager.shared.timeSavedDynamicSpeed())
         let totalSkippedTime = convertStat(StatsManager.shared.totalSkippedTime())

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+LocalChanges.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+LocalChanges.swift
@@ -167,3 +167,45 @@ extension SyncTask {
         return Int64(stat)
     }
 }
+
+// MARK: - Bookmark Helpers
+
+private extension Api_Record {
+    init(bookmark: Bookmark) {
+        self.init()
+
+        self.bookmark = .init(bookmark: bookmark)
+    }
+}
+
+private extension Api_SyncUserBookmark {
+    init(bookmark: Bookmark) {
+        self.init()
+
+        self.bookmarkUuid = bookmark.uuid
+        self.episodeUuid = bookmark.episodeUuid
+        self.podcastUuid = bookmark.podcastUuid ?? ""
+        self.time.value = .init(bookmark.time)
+        self.createdAt = .init(date: bookmark.created)
+
+        bookmark.deletedModified.map {
+            self.isDeletedModified = .init(date: $0)
+            self.isDeleted.value = bookmark.deleted
+        }
+
+        bookmark.titleModified.map {
+            self.titleModified = .init(date: $0)
+            self.title.value = bookmark.title
+        }
+    }
+}
+
+extension SwiftProtobuf.Google_Protobuf_Int64Value {
+    init(date: Date) {
+        self.init()
+
+        // The server uses `Instant.ofEpochMilli` when converting the date which expects the time value to be in
+        // milliseconds. So we'll * 1000 to convert the time stamp
+        self.value = .init(date.timeIntervalSince1970 * 1000)
+    }
+}

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
@@ -341,7 +341,8 @@ extension SyncTask {
                                                     podcastUuid: apiBookmark.podcastUuid,
                                                     title: apiBookmark.title.value,
                                                     time: Double(apiBookmark.time.value),
-                                                    dateCreated: apiBookmark.createdAt.date)
+                                                    dateCreated: apiBookmark.createdAt.date,
+                                                    syncStatus: .synced)
 
                 if addedUuid == nil {
                     FileLog.shared.foldersIssue("SyncTask: Import Bookmark Failed: Could not add non existent bookmark. API data: \(apiBookmark.logDescription)")
@@ -369,7 +370,7 @@ extension SyncTask {
             return
         }
 
-        await bookmarkManager.update(bookmark: existingBookmark, title: title, time: time, created: created).when(false) {
+        await bookmarkManager.update(bookmark: existingBookmark, title: title, time: time, created: created, syncStatus: .synced).when(false) {
             FileLog.shared.foldersIssue("SyncTask: Update Bookmark Failed. API Data: \(apiBookmark.logDescription)")
         }
     }

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask.swift
@@ -245,6 +245,10 @@ class SyncTask: ApiBaseTask {
         }
         if let statsChanges = changedStats() {
             records.append(statsChanges)
+
+        if let bookmarks = changedBookmarks() {
+            records += bookmarks
+            FileLog.shared.addMessage("SyncTask: Number of changed bookmarks: \(bookmarks.count)")
         }
 
         FileLog.shared.addMessage("SyncTask: sending \(records.count) changed items to the server")

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask.swift
@@ -245,6 +245,7 @@ class SyncTask: ApiBaseTask {
         }
         if let statsChanges = changedStats() {
             records.append(statsChanges)
+        }
 
         if dataManager.bookmarksEnabled, let bookmarks = changedBookmarks() {
             records += bookmarks

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask.swift
@@ -246,7 +246,7 @@ class SyncTask: ApiBaseTask {
         if let statsChanges = changedStats() {
             records.append(statsChanges)
 
-        if let bookmarks = changedBookmarks() {
+        if dataManager.bookmarksEnabled, let bookmarks = changedBookmarks() {
             records += bookmarks
             FileLog.shared.addMessage("SyncTask: Number of changed bookmarks: \(bookmarks.count)")
         }

--- a/Modules/Server/Tests/PocketCastsServerTests/SyncTaskTests+BookmarkImport.swift
+++ b/Modules/Server/Tests/PocketCastsServerTests/SyncTaskTests+BookmarkImport.swift
@@ -10,6 +10,7 @@ final class SyncTaskTests_BookmarkImport: XCTestCase {
 
     override func setUp() {
         dataManager = DataManager(dbQueue: FMDatabaseQueue(), shouldCloseQueueAfterSetup: false)
+        dataManager.bookmarksEnabled = true
         bookmarkManager = dataManager.bookmarks
         syncTask = SyncTask(dataManager: dataManager)
     }
@@ -112,6 +113,13 @@ final class SyncTaskTests_BookmarkImport: XCTestCase {
         syncTask.processServerData(response: .bookmarkResponse(count: count, deletedCount: deletedCount))
 
         XCTAssertEqual(bookmarkManager.allBookmarks().count, count - deletedCount)
+    }
+
+    func testBookmarksArentSyncedIfFeatureFlagIsOff() {
+        dataManager.bookmarksEnabled = false
+        syncTask.processServerData(response: .bookmarkResponse(count: 20, deletedCount: 4))
+
+        XCTAssertEqual(bookmarkManager.allBookmarks().count, 0)
     }
 }
 

--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -55,6 +55,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         setupRoutes()
 
+        DataManager.sharedManager.bookmarksEnabled = FeatureFlag.bookmarks.enabled
+
         ServerConfig.shared.syncDelegate = ServerSyncManager.shared
         ServerConfig.shared.playbackDelegate = PlaybackManager.shared
         checkDefaults()


### PR DESCRIPTION
This adds sending and importing of bookmarks during an incremental sync. 

I also added an internal feature flag to use to prevent sending/importing bookmarks in production. This isn't ideal, but it should work for now. 

I also replaced `foldersIssue` with `addMessage` 🤦‍♀️ 

> **🚨 Heads Up:** Syncing of bookmarks on a user file doesn't work on the server yet. 

## To test

1. Switch your environment to staging
2. Enable the Bookmarks feature flag
   - Restart the app if you did
3. Add some bookmarks to podcasts
4. Go to the Profile tab
5. Pull to refresh to sync
6. ✅ Verify you see `SyncTask: Number of changed bookmarks: {X}` where X is the number of bookmarks you added that are unsync'd
7. ✅ Verify you also see `SyncTask: Found X bookmarks to import` where X is the number of bookmarks you sent to be sync'd
    - The other processes also do this, I'm not entirely sure why we need to reimport the data that we just sync'd. 
8. Open the podcast/episode you added bookmarks to
9. ✅ Verify all your bookmarks are still there and their titles are correct
10. In a simulator or on a different device run this branch, enable the flag, etc
11. If you just signed in, perform another pull to refresh to perform the incremental sync
12. ✅ Verify you see the bookmarks from your other device 
13. Edit one of the titles
14. Delete one of the bookmarks
15. On your second device perform another sync
16. Check your bookmarks again
17. ✅ Verify the title is updated
18. ✅ Verify the deleted item is removed


## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
