### PR TITLE
Bookmarks: Adds Full Syncing

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Bookmarks/BookmarkDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Bookmarks/BookmarkDataManager.swift
@@ -149,6 +149,23 @@ public struct BookmarkDataManager {
         selectBookmarks(where: [.syncStatus], values: [SyncStatus.notSynced.rawValue], allowDeleted: true)
     }
 
+    @discardableResult
+    public func markAllBookmarksAsSynced() async -> Bool {
+        let query = """
+        UPDATE \(Self.tableName)
+        SET \(Column.syncStatus) = ?
+        """
+
+        let result = await dbQueue.executeUpdate(query, values: [SyncStatus.synced])
+        switch result {
+        case .success:
+            return true
+        case .failure(let error):
+            FileLog.shared.addMessage("BookmarkManager.markAllBookmarksAsSynced failed: \(error)")
+            return false
+        }
+    }
+
     // MARK: - Deleting
 
     /// Marks the bookmarks as deleted, but doesn't actually remove them from the database

--- a/Modules/Server/Sources/PocketCastsServer/Private/API Tasks/RetrieveBookmarksTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Private/API Tasks/RetrieveBookmarksTask.swift
@@ -1,0 +1,48 @@
+import Foundation
+import PocketCastsDataModel
+import PocketCastsUtils
+import SwiftProtobuf
+
+class RetrieveBookmarksTask: ApiBaseTask {
+    typealias BookmarkRetrievedHandler = ([Api_BookmarkResponse]?) -> Void
+
+    let onBookmarksRetrieved: BookmarkRetrievedHandler
+
+    init(onBookmarksRetrieved: @escaping BookmarkRetrievedHandler, dataManager: DataManager = .sharedManager) {
+        self.onBookmarksRetrieved = onBookmarksRetrieved
+        super.init(dataManager: dataManager)
+    }
+
+    override func apiTokenAcquired(token: String) {
+        let url = ServerConstants.Urls.api() + "user/bookmark/list"
+
+        guard let data = try? Api_BookmarkRequest().serializedData() else {
+            failed("Could not create Api_BookmarkRequest")
+            return
+        }
+
+        let (response, httpStatus) = postToServer(url: url, token: token, data: data)
+
+        guard let response, httpStatus == ServerConstants.HttpConstants.ok else {
+            failed("Retrieve bookmarks received an invalid response: Status: \(httpStatus) - Response: \(String(describing: (response as? NSData)))")
+
+            return
+        }
+
+        parse(response: response)
+    }
+
+    private func parse(response: Data) {
+        do {
+            let bookmarksResponse = try Api_BookmarksResponse(serializedData: response)
+            onBookmarksRetrieved(bookmarksResponse.bookmarks.nilIfEmpty())
+        } catch {
+            failed("Decoding BookmarksResponse failed \(error.localizedDescription)")
+        }
+    }
+
+    private func failed(_ message: String) {
+        FileLog.shared.addMessage(message)
+        onBookmarksRetrieved(nil)
+    }
+}

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+FullSync.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+FullSync.swift
@@ -115,3 +115,54 @@ extension SyncTask {
         _ = dispatchGroup.wait(timeout: .now() + 30.seconds)
     }
 }
+
+// MARK: - Bookmarks
+
+extension SyncTask {
+    /// Fully imports the server bookmarks and replaces the existing data if there is any available
+    func processServerBookmarks(_ bookmarks: [Api_BookmarkResponse]) {
+        let semaphore = DispatchSemaphore(value: 0)
+
+        Task {
+            let bookmarkManager = dataManager.bookmarks
+
+            // Set all the bookmarks as synced
+            await bookmarkManager.markAllBookmarksAsSynced()
+
+            for apiBookmark in bookmarks {
+                await bookmarkManager.remove(apiBookmark: apiBookmark).when(false) {
+                    FileLog.shared.addMessage("SyncTask: Process Server Bookmarks - Could not delete existing bookmark: \(apiBookmark.bookmarkUuid)")
+                }
+
+                // Add the incoming bookmark to the database
+                bookmarkManager.add(from: apiBookmark).when(.none) {
+                    FileLog.shared.addMessage("SyncTask: Process Server Bookmarks - Could not add bookmark: \(String(describing: try? apiBookmark.jsonString()))")
+                }
+            }
+
+            semaphore.signal()
+        }
+
+        semaphore.wait()
+    }
+}
+
+private extension BookmarkDataManager {
+    func add(from apiBookmark: Api_BookmarkResponse) -> String? {
+        add(uuid: apiBookmark.bookmarkUuid,
+            episodeUuid: apiBookmark.episodeUuid,
+            podcastUuid: apiBookmark.podcastUuid,
+            title: apiBookmark.title,
+            time: .init(apiBookmark.time),
+            dateCreated: apiBookmark.createdAt.date,
+            syncStatus: .synced)
+    }
+
+    func remove(apiBookmark: Api_BookmarkResponse) async -> Bool? {
+        guard let bookmark = bookmark(for: apiBookmark.bookmarkUuid) else {
+            return nil
+        }
+
+        return await permanentlyDelete(bookmarks: [bookmark])
+    }
+}

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+LocalChanges.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+LocalChanges.swift
@@ -191,7 +191,7 @@ private extension Api_SyncUserBookmark {
 
         self.bookmarkUuid = bookmark.uuid
         self.episodeUuid = bookmark.episodeUuid
-        self.podcastUuid = bookmark.podcastUuid ?? ""
+        self.podcastUuid = bookmark.podcastUuid ?? DataConstants.userEpisodeFakePodcastId
         self.time.value = .init(bookmark.time)
         self.createdAt = .init(date: bookmark.created)
 

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
@@ -340,9 +340,12 @@ extension SyncTask {
         // Add the bookmark if it's not in the database
         guard let existingBookmark = bookmarkManager.bookmark(for: apiBookmark.bookmarkUuid) else {
             if !apiBookmark.shouldDelete {
+                // If the podcast is for a user episode then we default to nil
+                let podcastUuid = apiBookmark.podcastUuid == DataConstants.userEpisodeFakePodcastId ? nil : apiBookmark.podcastUuid
+
                 let addedUuid = bookmarkManager.add(uuid: apiBookmark.bookmarkUuid,
                                                     episodeUuid: apiBookmark.episodeUuid,
-                                                    podcastUuid: apiBookmark.podcastUuid,
+                                                    podcastUuid: podcastUuid,
                                                     title: apiBookmark.title.value,
                                                     time: Double(apiBookmark.time.value),
                                                     dateCreated: apiBookmark.createdAt.date,

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask.swift
@@ -160,6 +160,15 @@ class SyncTask: ApiBaseTask {
         }
         retrieveFiltersTask.runTaskSynchronously()
 
+        if dataManager.bookmarksEnabled {
+            // Retrieve all the bookmarks
+            RetrieveBookmarksTask { bookmarks in
+                guard let bookmarks else { return }
+
+                self.processServerBookmarks(bookmarks)
+            }.runTaskSynchronously()
+        }
+
         UserDefaults.standard.set(lastSyncDate, forKey: ServerConstants.UserDefaults.lastModifiedServerDate)
 
         status = .successNewData

--- a/Modules/Server/Tests/PocketCastsServerTests/SyncTaskTests+BookmarkImport.swift
+++ b/Modules/Server/Tests/PocketCastsServerTests/SyncTaskTests+BookmarkImport.swift
@@ -123,6 +123,7 @@ final class SyncTaskTests_BookmarkImport: XCTestCase {
     }
 
     // MARK: - Full Sync
+
     func testFullSyncMarksAllAsSynced() {
         let bookmarks = [
             addBookmark(time: 1),

--- a/Modules/Server/Tests/PocketCastsServerTests/SyncTaskTests+BookmarkImport.swift
+++ b/Modules/Server/Tests/PocketCastsServerTests/SyncTaskTests+BookmarkImport.swift
@@ -113,12 +113,87 @@ final class SyncTaskTests_BookmarkImport: XCTestCase {
 
         XCTAssertEqual(bookmarkManager.allBookmarks().count, count - deletedCount)
     }
+
+    // MARK: - Full Sync
+    func testFullSyncMarksAllAsSynced() {
+        let bookmarks = [
+            addBookmark(time: 1),
+            addBookmark(time: 2),
+            addBookmark(time: 3)
+        ]
+
+        let server = bookmarks.map {
+            Api_BookmarkResponse.fromBookmark($0)
+        }
+
+        syncTask.processServerBookmarks(server)
+
+        XCTAssertEqual(bookmarkManager.bookmarksToSync().count, 0)
+    }
+
+    func testFullSyncReplacesExistingUUIDs() {
+        let bookmarks = [
+            addBookmark(time: 1),
+            addBookmark(time: 2),
+            addBookmark(time: 3)
+        ]
+
+        let newTitle = "NEW TITLE"
+        let created = Date(timeIntervalSince1970: 4321)
+
+        let server = bookmarks.map {
+            Api_BookmarkResponse.forTesting(uuid: $0.uuid, episode: $0.episodeUuid, podcast: $0.podcastUuid, title: newTitle, time: $0.time, created: created)
+        }
+
+        syncTask.processServerBookmarks(server)
+
+        let allBookmarks = bookmarkManager.allBookmarks()
+
+        XCTAssertEqual(allBookmarks.map(\.title), Array.init(repeating: newTitle, count: bookmarks.count))
+        XCTAssertEqual(allBookmarks.map(\.created), Array.init(repeating: created, count: bookmarks.count))
+    }
+
+    func testFullSyncImportsDataCorrectly() {
+        let serverData: [Api_BookmarkResponse] = [
+            .forTesting(uuid: "one", episode: "two", podcast: "three", title: "four", time: 5, created: .init(timeIntervalSince1970: 6)),
+            .forTesting(uuid: "seven", episode: "eight", podcast: "nine", title: "ten", time: 11, created: .init(timeIntervalSince1970: 12)),
+            .forTesting(uuid: "thirteen", episode: "fourteen", podcast: "fifteen", title: "sixteen", time: 17, created: .init(timeIntervalSince1970: 18))
+        ]
+
+        syncTask.processServerBookmarks(serverData)
+
+        let allBookmarks = bookmarkManager.allBookmarks(sorted: .timestamp)
+
+        XCTAssertEqual(allBookmarks.count, serverData.count)
+        XCTAssertEqual(allBookmarks.map(\.uuid), ["one", "seven", "thirteen"])
+        XCTAssertEqual(allBookmarks.map(\.title), ["four", "ten", "sixteen"])
+        XCTAssertEqual(allBookmarks.map(\.episodeUuid), ["two", "eight", "fourteen"])
+        XCTAssertEqual(allBookmarks.map(\.podcastUuid), ["three", "nine", "fifteen"])
+        XCTAssertEqual(allBookmarks.map(\.time), [5, 11, 17])
+        XCTAssertEqual(allBookmarks.map(\.created), [.init(timeIntervalSince1970: 6), .init(timeIntervalSince1970: 12), .init(timeIntervalSince1970: 18)])
+    }
+
+    func testFullSyncIgnoresExistingItems() {
+        addBookmark(time: 1)
+        addBookmark(time: 2)
+        addBookmark(time: 3)
+
+        let serverData: [Api_BookmarkResponse] = [
+            .forTesting(uuid: "one", episode: "two", podcast: "three", title: "four", time: 5, created: .init(timeIntervalSince1970: 6)),
+            .forTesting(uuid: "seven", episode: "eight", podcast: "nine", title: "ten", time: 11, created: .init(timeIntervalSince1970: 12)),
+            .forTesting(uuid: "thirteen", episode: "fourteen", podcast: "fifteen", title: "sixteen", time: 17, created: .init(timeIntervalSince1970: 18))
+        ]
+
+        syncTask.processServerBookmarks(serverData)
+
+        XCTAssertEqual( bookmarkManager.allBookmarks().count, 6)
+    }
 }
 
 private extension SyncTaskTests_BookmarkImport {
     @discardableResult
-    func addBookmark(episodeUuid: String = "episode-1", podcastUuid: String = "podcast-uuid", title: String = "Title", time: TimeInterval = 1, created: Date = .now) -> Bookmark {
-        bookmarkManager.add(episodeUuid: episodeUuid, podcastUuid: podcastUuid, title: title, time: time, dateCreated: created).flatMap {
+    func addBookmark(episodeUuid: String = "episode-1", podcastUuid: String = "podcast-uuid", title: String = "Title", time: TimeInterval = 1, created: Date = .now, syncStatus: SyncStatus = .notSynced) -> Bookmark {
+        bookmarkManager.add(episodeUuid: episodeUuid, podcastUuid: podcastUuid, title: title, time: time, dateCreated: created, syncStatus: syncStatus).flatMap {
             bookmarkManager.bookmark(for: $0)
         }!
     }
@@ -178,4 +253,37 @@ private extension Api_SyncUserBookmark {
 
         return apiBookmark
     }
+}
+
+private extension Api_BookmarkResponse {
+    static func forTesting(uuid: String,
+                           episode: String = "episode",
+                           podcast: String? = nil,
+                           title: String = "Title",
+                           time: TimeInterval = 1234,
+                           created: Date = Date()) -> Self {
+        var apiBookmark = Api_BookmarkResponse()
+        apiBookmark.bookmarkUuid = uuid
+        apiBookmark.episodeUuid = episode
+
+        if let podcast {
+            apiBookmark.podcastUuid = podcast
+        }
+
+        apiBookmark.title = title
+        apiBookmark.time = Int32(time)
+        apiBookmark.createdAt = .init(date: created)
+
+        return apiBookmark
+    }
+
+    static func fromBookmark(_ bookmark: Bookmark) -> Self {
+        return forTesting(uuid: bookmark.uuid,
+                          episode: bookmark.episodeUuid,
+                          podcast: bookmark.podcastUuid,
+                          title: bookmark.title,
+                          time: bookmark.time,
+                          created: bookmark.created)
+    }
+
 }


### PR DESCRIPTION
This adds syncing of bookmarks during the first full sync. 

## To test

1. Open up the FeatureFlag file
2. Set the bookmarks value to true
3. Run the app
4. Add some bookmarks to an episode
5. Perform an incremental sync by pulling to refresh
6. Delete the app
7. Reinstall it and sign back in
8. Wait for the full sync to be completed
9. Go to the episode 
10. ✅ Verify all your bookmarks are there

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
