### PR TITLE
Bookmarks: Migrates the Remote Skips Chapters setting to Headphone Controls

### DIFF
--- a/podcasts/AppDelegate+Defaults.swift
+++ b/podcasts/AppDelegate+Defaults.swift
@@ -109,6 +109,21 @@ extension AppDelegate {
             }
         }
 
+        // With the addition of bookmarks we have added a new headphone controls setting that this is being migrated to
+        // This will check if the user has the old Remote Skips Chapters preference enabled, and will move that setting
+        // by setting both the previous and next track actions to the change chapter action.
+        performUpdateIfRequired(updateKey: "MigrateRemoteSkipsChaptersToHeadphoneControls") {
+            let key = "RemoteChapterSkip"
+
+            UserDefaults.standard.bool(forKey: key).when(true) {
+                Settings.headphonesNextAction = .nextChapter
+                Settings.headphonesPreviousAction = .previousChapter
+
+                // Remove the setting
+                UserDefaults.standard.removeObject(forKey: key)
+            }
+        }
+
         defaults.synchronize()
     }
 

--- a/podcasts/AppDelegate+Defaults.swift
+++ b/podcasts/AppDelegate+Defaults.swift
@@ -115,7 +115,7 @@ extension AppDelegate {
         performUpdateIfRequired(updateKey: "MigrateRemoteSkipsChaptersToHeadphoneControls") {
             let key = "RemoteChapterSkip"
 
-            UserDefaults.standard.bool(forKey: key).when(true) {
+            if UserDefaults.standard.bool(forKey: key) {
                 Settings.headphonesNextAction = .nextChapter
                 Settings.headphonesPreviousAction = .previousChapter
 

--- a/podcasts/GeneralSettingsViewController.swift
+++ b/podcasts/GeneralSettingsViewController.swift
@@ -9,8 +9,8 @@ class GeneralSettingsViewController: UIViewController, UITableViewDelegate, UITa
 
     let debounce = Debounce(delay: Constants.defaultDebounceTime)
 
-    private enum TableRow { case skipForward, skipBack, remoteSkipChapters, keepScreenAwake, openPlayer, intelligentPlaybackResumption, defaultRowAction, extraMediaActions, defaultAddToUpNextSwipe, defaultGrouping, defaultArchive, playUpNextOnTap, legacyBluetooth, multiSelectGesture, openLinksInBrowser, publishChapterTitles, autoplay }
-    private var tableData: [[TableRow]] = [[.defaultRowAction, .defaultGrouping, .defaultArchive, .defaultAddToUpNextSwipe, .openLinksInBrowser], [.skipForward, .skipBack, .keepScreenAwake, .openPlayer, .intelligentPlaybackResumption], [.playUpNextOnTap], [.remoteSkipChapters], [.extraMediaActions], [.legacyBluetooth], [.multiSelectGesture], [.publishChapterTitles]]
+    private enum TableRow { case skipForward, skipBack, keepScreenAwake, openPlayer, intelligentPlaybackResumption, defaultRowAction, extraMediaActions, defaultAddToUpNextSwipe, defaultGrouping, defaultArchive, playUpNextOnTap, legacyBluetooth, multiSelectGesture, openLinksInBrowser, publishChapterTitles, autoplay }
+    private var tableData: [[TableRow]] = [[.defaultRowAction, .defaultGrouping, .defaultArchive, .defaultAddToUpNextSwipe, .openLinksInBrowser], [.skipForward, .skipBack, .keepScreenAwake, .openPlayer, .intelligentPlaybackResumption], [.playUpNextOnTap], [.extraMediaActions], [.legacyBluetooth], [.multiSelectGesture], [.publishChapterTitles]]
 
     @IBOutlet var settingsTable: UITableView! {
         didSet {
@@ -112,16 +112,6 @@ class GeneralSettingsViewController: UIViewController, UITableViewDelegate, UITa
                     Settings.trackValueChanged(.settingsGeneralSkipBackChanged, value: value)
                 }
             }
-
-            return cell
-        case .remoteSkipChapters:
-            let cell = tableView.dequeueReusableCell(withIdentifier: switchCellId, for: indexPath) as! SwitchCell
-
-            cell.cellLabel.text = L10n.settingsGeneralRemoteSkipsChapters
-            cell.cellSwitch.isOn = Settings.remoteSkipShouldSkipChapters()
-
-            cell.cellSwitch.removeTarget(self, action: nil, for: .valueChanged)
-            cell.cellSwitch.addTarget(self, action: #selector(remoteSkipChanged(_:)), for: .valueChanged)
 
             return cell
         case .keepScreenAwake:
@@ -385,8 +375,6 @@ class GeneralSettingsViewController: UIViewController, UITableViewDelegate, UITa
             return L10n.settingsGeneralSmartPlaybackSubtitle
         case .playUpNextOnTap:
             return Settings.playUpNextOnTap() ? L10n.settingsGeneralUpNextTapOnSubtitle : L10n.settingsGeneralUpNextTapOffSubtitle
-        case .remoteSkipChapters:
-            return L10n.settingsGeneralRemoteSkipsChaptersSubtitle
         case .extraMediaActions:
             return L10n.settingsGeneralPlayBackActionsSubtitle
         case .legacyBluetooth:
@@ -461,10 +449,6 @@ class GeneralSettingsViewController: UIViewController, UITableViewDelegate, UITa
 
     @objc private func extraMediaSessionActionsToggled(_ sender: UISwitch) {
         Settings.setExtraMediaSessionActionsEnabled(sender.isOn)
-    }
-
-    @objc private func remoteSkipChanged(_ sender: UISwitch) {
-        Settings.setRemoteSkipShouldSkipChapters(sender.isOn)
     }
 
     @objc private func openPlayerToggled(_ sender: UISwitch) {

--- a/podcasts/HeadphoneSettingsViewController.swift
+++ b/podcasts/HeadphoneSettingsViewController.swift
@@ -165,6 +165,9 @@ class HeadphoneSettingsViewController: PCTableViewController {
 
 private extension HeadphoneSettingsViewController {
     private func showPicker(_ title: String, _ options: [HeadphoneControlAction], currentValue: HeadphoneControlAction, onChange: @escaping ((HeadphoneControlAction) -> Void)) {
+        // Hide the add bookmark item if the flag is off
+        let options = FeatureFlag.bookmarks.enabled ? options : options.filter { $0 != .addBookmark }
+
         let picker = OptionsPicker(title: title)
         picker.addActions(options.map { option in
             OptionAction(label: option.displayableTitle, icon: option.iconName, selected: currentValue == option) {

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -341,18 +341,6 @@ class Settings: NSObject {
         UserDefaults.standard.set(adjustedTime, forKey: "CustomSleepTime")
     }
 
-    // MARK: - Chapter skipping
-
-    private static let remoteChapterSkipKey = "RemoteChapterSkip"
-    class func remoteSkipShouldSkipChapters() -> Bool {
-        UserDefaults.standard.bool(forKey: remoteChapterSkipKey)
-    }
-
-    class func setRemoteSkipShouldSkipChapters(_ value: Bool) {
-        UserDefaults.standard.set(value, forKey: remoteChapterSkipKey)
-        Settings.trackValueToggled(.settingsGeneralRemoteSkipsChaptersToggled, enabled: value)
-    }
-
     // MARK: - CarPlay/Lock Screen actions
 
     private static let mediaSessionActionsKey = "MediaSessionActions"

--- a/podcasts/SettingsViewController.swift
+++ b/podcasts/SettingsViewController.swift
@@ -22,9 +22,6 @@ class SettingsViewController: PCViewController, UITableViewDataSource, UITableVi
             case .pocketCastsPlus:
                 return !SubscriptionHelper.hasActiveSubscription()
 
-            case .headphoneControls:
-                return FeatureFlag.bookmarks.enabled
-
             default:
                 return true
             }


### PR DESCRIPTION
This removes the Remote Skips Chapters setting, and migrates it over to the Headphone Controls. 

When the app launches for the first time after updating we'll check to see if the remote skips chapters setting is on, if its we'll update the headphone controls settings to reflect their original option. 

This also updates the next/prev track commands to use the new headphone actions. 

## To test

1. Before updating
2. Enable the Remote Skips Chapters setting in General
3. Launch this PR
4. Disable the bookmarks feature flag if its enable
Go to Profile > Cog > Headphone Controls
5. ✅ Verify the next action shows next chapter
6. ✅ Verify the previous action shows previous chapter
7. Play a podcast with chapters
8. Using headphones or a remote use the next track action 
9. ✅ Verify you are brought to the next chapter
10. Perform the previous track action
11. ✅ Verify you are brought to the previous chapter
12. Open the Headphone Controls
13. Tap on each action
14. ✅ Verify you do not see the add bookmark option
15. Change to the Skip Back and Skip Forward options
16. Use the previous and next track actions
17. ✅ Verify you are skipped forward in the correct direction
18. Enable the Bookmarks feature flag
19. Go to the Headphone Controls
20. Change one of the actions to add bookmark
21. Perform that action
22. ✅ Verify a bookmark was created

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
