### PR TITLE
Bookmarks: Improve some interactions when creating a bookmark from headphones

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1522,6 +1522,7 @@
 		C7CE415A28CBCFC200AD063E /* Analytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7AF5790289D87CF0089E435 /* Analytics.swift */; };
 		C7CE415B28CBD00A00AD063E /* AnalyticsEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = C72CED2C289DA14F0017883A /* AnalyticsEvent.swift */; };
 		C7CE415C28CBD01F00AD063E /* String+Analytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = C72CED2E289DA1650017883A /* String+Analytics.swift */; };
+		C7D5E7F12A8BF3150039F4A1 /* UIViewController+Presenting.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D5E7F02A8BF3150039F4A1 /* UIViewController+Presenting.swift */; };
 		C7D6551428E5153200AD7174 /* Debounce.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D6551328E5153200AD7174 /* Debounce.swift */; };
 		C7D6551528E5153200AD7174 /* Debounce.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D6551328E5153200AD7174 /* Debounce.swift */; };
 		C7D6551628E5450600AD7174 /* AnalyticsDescribable+Modules.swift in Sources */ = {isa = PBXBuildFile; fileRef = C750EF7E28E3475600E06BA9 /* AnalyticsDescribable+Modules.swift */; };
@@ -3276,6 +3277,7 @@
 		C7C4F9B52A4BAD57002822DD /* HeadphoneSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeadphoneSettingsViewController.swift; sourceTree = "<group>"; };
 		C7C4F9BE2A4CC359002822DD /* PCTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PCTableViewController.swift; sourceTree = "<group>"; };
 		C7CA0558293E8918000E41BD /* HolographicEffect.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HolographicEffect.swift; sourceTree = "<group>"; };
+		C7D5E7F02A8BF3150039F4A1 /* UIViewController+Presenting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Presenting.swift"; sourceTree = "<group>"; };
 		C7D6551328E5153200AD7174 /* Debounce.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Debounce.swift; sourceTree = "<group>"; };
 		C7D813782A0D4B89007F715F /* AppIcon-Patron-Chrome-iphone@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "AppIcon-Patron-Chrome-iphone@2x.png"; sourceTree = "<group>"; };
 		C7D813792A0D4B89007F715F /* AppIcon-Patron-Chrome-ipad-pro.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "AppIcon-Patron-Chrome-ipad-pro.png"; sourceTree = "<group>"; };
@@ -6299,6 +6301,7 @@
 				C7F4BABE28DB7F7C001C9785 /* DiscoverItem+Helper.swift */,
 				C7F87F0F2913242B00C15980 /* UIFont+FontStyle.swift */,
 				C7B7123929DC98BD00965BF7 /* SFSafariViewController+Creation.swift */,
+				C7D5E7F02A8BF3150039F4A1 /* UIViewController+Presenting.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -9036,6 +9039,7 @@
 				BD907DA621533243004D7C02 /* PodcastEffectsViewController.swift in Sources */,
 				C76ECAD62A69518800D9DB9E /* EpisodeBookmarksTabsView.swift in Sources */,
 				BD44E36D20937D9C008BD7F0 /* PodcastChapterParser.swift in Sources */,
+				C7D5E7F12A8BF3150039F4A1 /* UIViewController+Presenting.swift in Sources */,
 				BDE954E9236684E300CEB6DA /* ChaptersViewController.swift in Sources */,
 				BDF7BDD21CA2248E0045AB6D /* StatsTopCell.swift in Sources */,
 				BDA7A0A624C6BBA600ADA8AA /* SecondaryLabel.swift in Sources */,

--- a/podcasts/Bookmarks/Player/BookmarksPlayerTabController.swift
+++ b/podcasts/Bookmarks/Player/BookmarksPlayerTabController.swift
@@ -73,6 +73,13 @@ class BookmarksPlayerTabController: PlayerItemViewController {
     }
 
     private func handleBookmarkCreated(bookmark: Bookmark) {
+        // Prevent the add bookmark window from opening if the app isn't active
+        // We also prevent it from opening while connected to CarPlay to not distract anyone, and in my testing the app state is always
+        // true while connected to CarPlay, even if it's in the background
+        guard UIApplication.shared.applicationState == .active, !SceneHelper.isConnectedToCarPlay else {
+            return
+        }
+
         showBookmarkEdit(isNew: true, bookmark: bookmark)
     }
 

--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -593,6 +593,7 @@ private extension MainTabBarController {
     // Shows a toast notification when a bookmark is created and we're not in the full screen player
     func addBookmarkCreatedToastHandler() {
         let bookmarkManager = PlaybackManager.shared.bookmarkManager
+
         bookmarkManager.onBookmarkCreated
             .receive(on: RunLoop.main)
             .filter { event in
@@ -601,7 +602,7 @@ private extension MainTabBarController {
                 && NavigationManager.sharedManager.miniPlayer?.playerOpenState == .closed
             }
             .compactMap { event in
-                PlaybackManager.shared.bookmarkManager.bookmark(for: event.uuid)
+                bookmarkManager.bookmark(for: event.uuid)
             }
             .sink { [weak self] bookmark in
                 self?.showToast(for: bookmark)
@@ -622,7 +623,7 @@ private extension MainTabBarController {
                 self?.handleBookmarkTitleUpdated(updatedTitle: updatedTitle)
             })
 
-            self?.present(controller, animated: true)
+            self?.presentFromRootController(controller)
         }
 
         Toast.show(message, actions: [action], theme: .playerTheme)
@@ -637,8 +638,10 @@ private extension MainTabBarController {
     }
 
     func showBookmarksInPlayer() {
-        NavigationManager.sharedManager.miniPlayer?.openFullScreenPlayer {
-            NavigationManager.sharedManager.miniPlayer?.fullScreenPlayer?.scrollToBookmarks()
+        dismissIfNeeded {
+            NavigationManager.sharedManager.miniPlayer?.openFullScreenPlayer {
+                NavigationManager.sharedManager.miniPlayer?.fullScreenPlayer?.scrollToBookmarks()
+            }
         }
     }
 }

--- a/podcasts/MiniPlayerViewController+Positioning.swift
+++ b/podcasts/MiniPlayerViewController+Positioning.swift
@@ -37,7 +37,7 @@ extension MiniPlayerViewController {
         })
     }
 
-    func openFullScreenPlayer() {
+    func openFullScreenPlayer(completion: (() -> Void)? = nil) {
         guard PlaybackManager.shared.currentEpisode() != nil else { return }
 
         if playerOpenState == .open || playerOpenState == .animating { return }
@@ -56,6 +56,7 @@ extension MiniPlayerViewController {
             self.rootViewController()?.setNeedsStatusBarAppearanceUpdate()
             self.rootViewController()?.setNeedsUpdateOfHomeIndicatorAutoHidden()
             AnalyticsHelper.nowPlayingOpened()
+            completion?()
         }
     }
 

--- a/podcasts/SceneHelper.swift
+++ b/podcasts/SceneHelper.swift
@@ -9,6 +9,12 @@ class SceneHelper {
         }.first
     }
 
+    static var isConnectedToCarPlay: Bool {
+        UIApplication.shared.connectedScenes.contains(where: {
+            $0 is CPTemplateApplicationScene
+        })
+    }
+
     class func newMainScreenWindow() -> UIWindow {
         if let scene = connectedScene() {
             return UIWindow(windowScene: scene)

--- a/podcasts/SceneHelper.swift
+++ b/podcasts/SceneHelper.swift
@@ -1,5 +1,6 @@
 import PocketCastsUtils
 import UIKit
+import CarPlay
 
 class SceneHelper {
     class func connectedScene() -> UIWindowScene? {

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -272,6 +272,10 @@ internal enum L10n {
   internal static var bookmarkSearchNoResultsMessage: String { return L10n.tr("Localizable", "bookmark_search_no_results_message") }
   /// No bookmarks found
   internal static var bookmarkSearchNoResultsTitle: String { return L10n.tr("Localizable", "bookmark_search_no_results_title") }
+  /// Bookmark "%1$@" updated
+  internal static func bookmarkUpdatedNotification(_ p1: Any) -> String {
+    return L10n.tr("Localizable", "bookmark_updated_notification", String(describing: p1))
+  }
   /// Bookmarks
   internal static var bookmarks: String { return L10n.tr("Localizable", "bookmarks") }
   /// %1$@ bookmarks

--- a/podcasts/UIViewController+Presenting.swift
+++ b/podcasts/UIViewController+Presenting.swift
@@ -1,0 +1,29 @@
+import UIKit
+
+extension UIViewController {
+    /// Presents the given view controller from the root view controller, or the currently presented view controller if there is one.
+    func presentFromRootController(_ controller: UIViewController, animated: Bool = true, completion: (() -> Void)? = nil) {
+        guard let presentingController = presentedViewController ?? SceneHelper.rootViewController() else {
+            completion?()
+            return
+        }
+
+        presentingController.present(controller, animated: animated, completion: completion)
+    }
+
+    /// Dismisses the presented controller if there is one, then calls the completion block
+    /// - Parameters:
+    ///   - sourceController: The source controller to dismiss from. This defaults to `self` if its nil.
+    ///   - animated: Whether to animate the dismiss or not
+    ///   - completion: The optional completion block to call after the view is dismissed.
+    func dismissIfNeeded(sourceController: UIViewController? = nil, animated: Bool = true, completion: (() -> Void)? = nil) {
+        let sourceController = sourceController ?? self
+
+        guard sourceController.presentedViewController != nil else {
+            completion?()
+            return
+        }
+
+        sourceController.dismiss(animated: animated, completion: completion)
+    }
+}

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -3818,6 +3818,9 @@
 /* A message that appears after the user created a bookmark and %1$@ displays the title they choose for it. */
 "bookmark_added_notification" = "Bookmark \"%1$@\" added";
 
+/* A message that appears after the user updates a bookmark and %1$@ displays the title they choose for it. */
+"bookmark_updated_notification" = "Bookmark \"%1$@\" updated";
+
 /* A message that appears to inform the user their bookmark is added */
 "bookmark_added" = "Bookmark added";
 


### PR DESCRIPTION
This fixes some odd UI issues when the edit title action appears while in the background by disabling showing of update bookmark title view if the app is not active, or if connected to CarPlay. 

I've disabled this while connected to CarPlay for a couple reasons:
- It could be distracting for someone who is driving
- In my testing being connected to CarPlay has made it show the app always appears active no matter what. 

This also adds some visual feedback in the form of a toast when the user makes a bookmark and the full screen is not open. This toast gives the user the option to update the title of the bookmark, and then opens the edit title view, if they update the title we then show another toast confirming their change with the option to view it in the fullscreen player. 

## Demo Video

https://github.com/Automattic/pocket-casts-ios/assets/793774/a94d83a4-43dd-4146-8960-4f10d552d4eb

## To test

1. Connect some headphones to your device
2. Enable the bookmarks feature flag
3. Enable the headphone controls so one of the actions is add bookmark
4. Open the full screen player
5. Move the app into the background
6. Use the headphones to add a bookmark
7. ✅ Verify you see a log indicating a bookmark was created
8. Open the app
9. ✅ Verify the edit title screen is not open
10. Dismiss the full screen player
11. Use the add bookmark action again
12. ✅ Verify you see a toast that the bookmark was created
13. Tap the Change title action
14. ✅ Verify the edit controller opens
15. Update the title
16. ✅ Verify you see a 'Bookmark X updated' toast where X is the new title of the bookmark
17. Repeat the steps while connected to CarPlay.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
