### PR TITLE
Share Extension: copy files through shared group container

### DIFF
--- a/Share Extension/Share Extension.entitlements
+++ b/Share Extension/Share Extension.entitlements
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.au.com.shiftyjelly.pocketcasts</string>
+	</array>
+</dict>
 </plist>

--- a/Share Extension/ShareViewController.swift
+++ b/Share Extension/ShareViewController.swift
@@ -26,7 +26,7 @@ class ShareViewController: UIViewController {
 
                 // Save the file to the shared group directory
                 let fileManager = FileManager.default
-                guard let container = fileManager.containerURL(forSecurityApplicationGroupIdentifier: "group.au.com.shiftyjelly.pocketcasts") else {
+                guard let container = fileManager.containerURL(forSecurityApplicationGroupIdentifier: SharedConstants.GroupUserDefaults.groupContainerId) else {
                     return
                 }
 

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -550,6 +550,7 @@
 		8BAD6E612975AFAA00DB7259 /* GoogleSocialLogin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BAD6E602975AFAA00DB7259 /* GoogleSocialLogin.swift */; };
 		8BB1187F290C56F7009E3A39 /* CategoryPillar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB1187E290C56F7009E3A39 /* CategoryPillar.swift */; };
 		8BB11881290C5720009E3A39 /* CategoriesContrastingColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB11880290C5720009E3A39 /* CategoriesContrastingColor.swift */; };
+		8BB2E58B2A8AA02E00E93088 /* SharedConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD054A791E3EDEB300D9195B /* SharedConstants.swift */; };
 		8BB55E3A28FEEE99001D1766 /* StoryShareableProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB55E3928FEEE99001D1766 /* StoryShareableProvider.swift */; };
 		8BC7FF55290FF92400017779 /* StoriesProgressModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC7FF54290FF92400017779 /* StoriesProgressModel.swift */; };
 		8BCB22B228F47F44001A0315 /* EndOfYearModal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BCB22B128F47F44001A0315 /* EndOfYearModal.swift */; };
@@ -8373,6 +8374,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8BB2E58B2A8AA02E00E93088 /* SharedConstants.swift in Sources */,
 				2F90990E2A4F88B10044FC55 /* ShareViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/podcasts/AppDelegate+UrlHandling.swift
+++ b/podcasts/AppDelegate+UrlHandling.swift
@@ -337,17 +337,13 @@ extension AppDelegate {
         JLRoutes.global().addRoute("/import-opml/*") { [weak self] parameters -> Bool in
             guard let self,
                   let rootViewController = SceneHelper.rootViewController(),
-                  let documentsURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first,
                   let originalUrl = parameters[JLRouteURLKey] as? URL else { return false }
 
-            let encodedOPML = originalUrl.absoluteString.replacingOccurrences(of: "pktc://import-opml/", with: "")
+            let opmlURLString = originalUrl.absoluteString.replacingOccurrences(of: "pktc://import-opml/", with: "")
 
-            guard let opmlData = Data(base64Encoded: encodedOPML) else {
+            guard let fileURL = URL(string: opmlURLString) else {
                 return true
             }
-
-            let fileURL = documentsURL.appendingPathComponent("import.opml")
-            try? opmlData.write(to: fileURL, options: .atomic)
 
             return self.handleOpenUrl(url: fileURL, rootViewController: rootViewController)
         }


### PR DESCRIPTION
In the original #989 we were "transmitting" the OPML file to Pocket Casts by encoding it to Base 64. This was not the correct behavior but we were missing the right permissions on the certificates to do "the correct way" at the time.

Now that this is fixed we can copy the file to the shared group container and just read it on the app, without any hack stuff.

This also fixes an issue with some OPML files not being able to import.

## To test

1. Run the app
2. [Import this file](https://a8c.slack.com/archives/C02A333D8LQ/p1691728449019899) to Pocket Casts
3. ✅ The app should open, the import process should start and be successful

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
