### PR TITLE
Player did not see an IO cycle: attempt to fix the crash by removing locks

### DIFF
--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -271,7 +271,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             Constants.RemoteParams.episodeSearchDebounceMs: NSNumber(value: Constants.RemoteParams.episodeSearchDebounceMsDefault),
             Constants.RemoteParams.podcastSearchDebounceMs: NSNumber(value: Constants.RemoteParams.podcastSearchDebounceMsDefault),
             Constants.RemoteParams.customStorageLimitGB: NSNumber(value: Constants.RemoteParams.customStorageLimitGBDefault),
-            Constants.RemoteParams.endOfYearRequireAccount: NSNumber(value: Constants.RemoteParams.endOfYearRequireAccountDefault)
+            Constants.RemoteParams.endOfYearRequireAccount: NSNumber(value: Constants.RemoteParams.endOfYearRequireAccountDefault),
+            Constants.RemoteParams.lockEffectsPlayer: NSNumber(value: Constants.RemoteParams.lockEffectsPlayerDefault)
         ])
 
         remoteConfig.fetch(withExpirationDuration: 2.hour) { [weak self] status, _ in

--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -312,6 +312,9 @@ struct Constants {
 
         static let endOfYearRequireAccount = "end_of_year_require_account"
         static let endOfYearRequireAccountDefault: Bool = true
+
+        static let lockEffectsPlayer = "lock_effects_player"
+        static let lockEffectsPlayerDefault: Bool = false
     }
 
     static let defaultDebounceTime: TimeInterval = 0.5

--- a/podcasts/EffectsPlayer.swift
+++ b/podcasts/EffectsPlayer.swift
@@ -37,7 +37,7 @@ class EffectsPlayer: PlaybackProtocol, Hashable {
     private var lastSeekTime = 0 as TimeInterval
 
     // this lock is to avoid race conditions where you're destroying the player while in the middle of setting it up (since the play method does its work asynchronously)
-    private let playerLock = NSObject()
+    private let playerLock = NSLock()
 
     // MARK: - PlaybackProtocol Impl
 
@@ -63,7 +63,7 @@ class EffectsPlayer: PlaybackProtocol, Hashable {
         DispatchQueue.global().async { [weak self] in
             guard let strongSelf = self, let episode = strongSelf.episode else { return }
 
-            objc_sync_enter(strongSelf.playerLock)
+            strongSelf.playerLock.lock()
 
             strongSelf.engine = AVAudioEngine()
             strongSelf.player = AVAudioPlayerNode()
@@ -100,7 +100,7 @@ class EffectsPlayer: PlaybackProtocol, Hashable {
                     DataManager.sharedManager.saveFrameCount(episode: episode, frameCount: strongSelf.cachedFrameCount)
                 }
             } catch {
-                objc_sync_exit(strongSelf.playerLock)
+                strongSelf.playerLock.unlock()
                 PlaybackManager.shared.playbackDidFail(logMessage: error.localizedDescription, userMessage: nil)
                 return
             }
@@ -132,13 +132,13 @@ class EffectsPlayer: PlaybackProtocol, Hashable {
                 strongSelf.engine?.prepare()
                 try strongSelf.engine?.start()
             } catch {
-                objc_sync_exit(strongSelf.playerLock)
+                strongSelf.playerLock.unlock()
                 PlaybackManager.shared.playbackDidFail(logMessage: error.localizedDescription, userMessage: nil)
                 return
             }
             // there seem to be cases where the above call succeeds but the engine isn't actually started. Handle that here
             if !(strongSelf.engine?.isRunning ?? false) {
-                objc_sync_exit(strongSelf.playerLock)
+                strongSelf.playerLock.unlock()
                 FileLog.shared.addMessage("EffectsPlayer: engine reported not running, calling playbackDidFail")
                 PlaybackManager.shared.playbackDidFail(logMessage: "AVAudioEngine reported not running", userMessage: nil)
                 return
@@ -146,7 +146,7 @@ class EffectsPlayer: PlaybackProtocol, Hashable {
 
             strongSelf.player?.play()
 
-            objc_sync_exit(strongSelf.playerLock)
+            strongSelf.playerLock.unlock()
 
             completion?()
 
@@ -235,8 +235,8 @@ class EffectsPlayer: PlaybackProtocol, Hashable {
     }
 
     func endPlayback(permanent: Bool) {
-        objc_sync_enter(playerLock)
-        defer { objc_sync_exit(playerLock) }
+        playerLock.lock()
+        defer { playerLock.unlock() }
 
         shouldKeepPlaying.value = false
         aboutToPlay.value = false

--- a/podcasts/EffectsPlayer.swift
+++ b/podcasts/EffectsPlayer.swift
@@ -37,7 +37,9 @@ class EffectsPlayer: PlaybackProtocol, Hashable {
     private var lastSeekTime = 0 as TimeInterval
 
     // this lock is to avoid race conditions where you're destroying the player while in the middle of setting it up (since the play method does its work asynchronously)
-    private let playerLock = NSLock()
+    private lazy var playerLock: NSLock? = {
+        NSLock()
+    }()
 
     // MARK: - PlaybackProtocol Impl
 
@@ -63,7 +65,7 @@ class EffectsPlayer: PlaybackProtocol, Hashable {
         DispatchQueue.global().async { [weak self] in
             guard let strongSelf = self, let episode = strongSelf.episode else { return }
 
-            strongSelf.playerLock.lock()
+            strongSelf.playerLock?.lock()
 
             strongSelf.engine = AVAudioEngine()
             strongSelf.player = AVAudioPlayerNode()
@@ -100,7 +102,7 @@ class EffectsPlayer: PlaybackProtocol, Hashable {
                     DataManager.sharedManager.saveFrameCount(episode: episode, frameCount: strongSelf.cachedFrameCount)
                 }
             } catch {
-                strongSelf.playerLock.unlock()
+                strongSelf.playerLock?.unlock()
                 PlaybackManager.shared.playbackDidFail(logMessage: error.localizedDescription, userMessage: nil)
                 return
             }
@@ -132,13 +134,13 @@ class EffectsPlayer: PlaybackProtocol, Hashable {
                 strongSelf.engine?.prepare()
                 try strongSelf.engine?.start()
             } catch {
-                strongSelf.playerLock.unlock()
+                strongSelf.playerLock?.unlock()
                 PlaybackManager.shared.playbackDidFail(logMessage: error.localizedDescription, userMessage: nil)
                 return
             }
             // there seem to be cases where the above call succeeds but the engine isn't actually started. Handle that here
             if !(strongSelf.engine?.isRunning ?? false) {
-                strongSelf.playerLock.unlock()
+                strongSelf.playerLock?.unlock()
                 FileLog.shared.addMessage("EffectsPlayer: engine reported not running, calling playbackDidFail")
                 PlaybackManager.shared.playbackDidFail(logMessage: "AVAudioEngine reported not running", userMessage: nil)
                 return
@@ -146,7 +148,7 @@ class EffectsPlayer: PlaybackProtocol, Hashable {
 
             strongSelf.player?.play()
 
-            strongSelf.playerLock.unlock()
+            strongSelf.playerLock?.unlock()
 
             completion?()
 
@@ -235,8 +237,8 @@ class EffectsPlayer: PlaybackProtocol, Hashable {
     }
 
     func endPlayback(permanent: Bool) {
-        playerLock.lock()
-        defer { playerLock.unlock() }
+        playerLock?.lock()
+        defer { playerLock?.unlock() }
 
         shouldKeepPlaying.value = false
         aboutToPlay.value = false

--- a/podcasts/EffectsPlayer.swift
+++ b/podcasts/EffectsPlayer.swift
@@ -38,7 +38,7 @@ class EffectsPlayer: PlaybackProtocol, Hashable {
 
     // this lock is to avoid race conditions where you're destroying the player while in the middle of setting it up (since the play method does its work asynchronously)
     private lazy var playerLock: NSLock? = {
-        NSLock()
+        Settings.lockEffectsPlayer ? NSLock() : nil
     }()
 
     // MARK: - PlaybackProtocol Impl

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -871,6 +871,11 @@ class Settings: NSObject {
             return remote.boolValue
         }
 
+        static var lockEffectsPlayer: Bool {
+            let remote = RemoteConfig.remoteConfig().configValue(forKey: Constants.RemoteParams.lockEffectsPlayer)
+            return remote.boolValue
+        }
+
         private class func remoteMsToTime(key: String) -> TimeInterval {
             let remoteMs = RemoteConfig.remoteConfig().configValue(forKey: key)
 


### PR DESCRIPTION
Based on the crash reports we've seen so far our top crash "Player did not see an IO cycle" seems to be happening because of a deadlock. Also, on iOS 17 this crash seems way worse.

This is an attempt to fix it by removing the locks in `EffectsPlayer` and observing the results. I also added this change behind a remote feature flag so we can enable/disable the locks without doing an app release. In case anything goes wrong, we can simply revert it.

## To test

First, configure the environment:

1. Go to `AppDelegate.swift`, locate the `configureFirebase` method, and change `2.hour` to `30.seconds`.
2. Then, on `EffectsPlayer.swift` add a breakpoint on line `68`.
3. Finally, download some episodes

### Testing the flag changing

1. Run the app
2. Hit play on any downloaded episode
3. When the breakpoint is hit, type `po strongSelf.playerLock` on the console
4. ✅ The returned value should be `nil`
5. Go to Firebase Console
6. Change `lock_effects_player` to `true` and publish the changes
7. Re-run the app
8. Play any downloaded episode
3. When the breakpoint is hit, type `po strongSelf.playerLock` on the console
4. ✅ The returned value should be **NOT** `nil`
4. Go to Firebase Console
6. Change `lock_effects_player` to `false` and publish the changes

### Testing the player without locks

It's better to test that on a real device.

1. Run the app
2. ✅ Make sure `Settings.lockEffectsPlayer` is `false`
3. Play any downloaded episode
4. Connect a Bluetooth earphone
5. ✅ Episode should keep playing on Bluetooth
6. Remove the Bluetooth device
7. ✅ Episode should pause
8. Connect to CarPlay
9. Play a downloaded episode
10. Open Maps and set any route
11. ✅ When Maps announce a route or information the episode should pause and resume after the announcement ends
12. Go back to your phone
13. Play/pause the episode a few times (to trigger player creation/destruction)
14. ✅ Everything should work as expected

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
