### PR TITLE
Bookmarks: Fix swipe to dismiss on the episode detail view

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Extensions/UI/DismissableNestedScrollView.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Extensions/UI/DismissableNestedScrollView.swift
@@ -1,0 +1,10 @@
+#if !os(watchOS)
+import UIKit
+
+/// A UIScrollView subclass that allows the swipe to dismiss in a presented view when its contained in a parent UIScrollView
+public class DismissableNestedScrollView: UIScrollView, UIGestureRecognizerDelegate {
+    public override func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        return (contentOffset.y + contentInset.top) - panGestureRecognizer.translation(in: self).y > 0
+    }
+}
+#endif

--- a/podcasts/EpisodeDetailViewController.xib
+++ b/podcasts/EpisodeDetailViewController.xib
@@ -49,10 +49,10 @@
             <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" directionalLockEnabled="YES" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tmT-f0-kSM" userLabel="Container Scroll View" customClass="PagedUIScrollView" customModule="PocketCastsUtils">
+                <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" directionalLockEnabled="YES" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" delaysContentTouches="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tmT-f0-kSM" userLabel="Container Scroll View" customClass="PagedUIScrollView" customModule="PocketCastsUtils">
                     <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                     <subviews>
-                        <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" directionalLockEnabled="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ffa-0D-OU4" userLabel="Content Scroll View">
+                        <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" directionalLockEnabled="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ffa-0D-OU4" userLabel="Content Scroll View" customClass="DismissableNestedScrollView" customModule="PocketCastsUtils">
                             <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                             <subviews>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="SYi-ag-GDK" userLabel="Top Section">


### PR DESCRIPTION
This fixes an issue reported on the beta slack where the episode detail can't be swiped to be dismissed anymore. 

This is happening because the episode detail view has been wrapped in a parent UIScrollView to support the tabs which is interfering with the interactive dismiss. 

This PR fixes the issue by adding a new UIScrollView subclass called `DismissableNestedScrollView` that prevents the panning gesture from triggering if the scroll view would be scrolled past the top offset. 

This means the container scrollview's gesture is triggered instead, which correctly calls the UIPresentationController's internal methods to dismiss the view. 

## Demo Videos

### Default system swipe to dismiss

https://github.com/Automattic/pocket-casts-ios/assets/793774/bc8a013d-7b88-4e03-b99e-ffc323b8b900

### Swipe to dismiss introduce in this PR

https://github.com/Automattic/pocket-casts-ios/assets/793774/e80a4da9-4619-44b9-8413-c1689f8c9637

## To test

1. Launch the app
2. Disable the bookmarks feature flag if it's enabled
3. Open any episode detail view
4. Swipe down
5. ✅ Verify the interactive dismiss is engaged, and swiping down fully dismisses the view
6. Open the episode detail again
7. Scroll up a small amount, then scroll back down to dismiss
8. ✅ Verify the view **does not** start dismissing
   - This is the default system behavior
9. Stop dragging, then swipe to dismiss from the top again
10. ✅ Verify it dismisses
11. Enable the bookmarks feature flag
12. Open the episode details again
13. ✅ Verify you can swipe to dismiss
14. ✅ Verify you can still swipe to the next page

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
