### PR TITLE
Bookmarks: Locks the settings and other UI actions

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Bookmarks/BookmarkDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Bookmarks/BookmarkDataManager.swift
@@ -86,8 +86,8 @@ public struct BookmarkDataManager {
     // MARK: - Retrieving
 
     /// Retrieves a single Bookmark for the given UUID
-    public func bookmark(for uuid: String) -> Bookmark? {
-        selectBookmarks(where: [.uuid], values: [uuid], limit: 1).first
+    public func bookmark(for uuid: String, allowDeleted: Bool = false) -> Bookmark? {
+        selectBookmarks(where: [.uuid], values: [uuid], limit: 1, allowDeleted: allowDeleted).first
     }
 
     /// Retrieves all the Bookmarks for an episode

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Bookmarks/BookmarkDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Bookmarks/BookmarkDataManager.swift
@@ -19,11 +19,6 @@ public struct BookmarkDataManager {
     ///   - transcription: A transcription of the clip if available
     @discardableResult
     public func add(uuid: String? = nil, episodeUuid: String, podcastUuid: String?, title: String, time: TimeInterval, dateCreated: Date = Date(), syncStatus: SyncStatus = .notSynced) -> String? {
-        // Prevent adding more than 1 bookmark at the same place
-        guard existingBookmark(forEpisode: episodeUuid, time: time) == nil else {
-            return nil
-        }
-
         var bookmarkUuid: String? = nil
 
         dbQueue.inDatabase { db in

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Bookmarks/BookmarkDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Bookmarks/BookmarkDataManager.swift
@@ -217,7 +217,7 @@ public struct BookmarkDataManager {
     // MARK: - Sortings
 
     public enum SortOption {
-        case newestToOldest, oldestToNewest, timestamp
+        case newestToOldest, oldestToNewest, timestamp, episode
 
         var queryString: String {
             switch self {
@@ -225,7 +225,7 @@ public struct BookmarkDataManager {
                 return "ORDER BY \(Column.createdDate) DESC"
             case .oldestToNewest:
                 return "ORDER BY \(Column.createdDate) ASC"
-            case .timestamp:
+            case .timestamp, .episode:
                 return "ORDER BY \(Column.time) ASC"
             }
         }

--- a/Modules/DataModel/Tests/PocketCastsDataModelTests/BookmarkDataManagerTests.swift
+++ b/Modules/DataModel/Tests/PocketCastsDataModelTests/BookmarkDataManagerTests.swift
@@ -42,24 +42,6 @@ final class BookmarkDataManagerTests: XCTestCase {
         XCTAssertEqual(dataManager.bookmarks(forEpisode: episode).count, 1)
     }
 
-    func testAddingABookmarkAtTheSameTimeAsAnotherDoesntGetAdded() {
-        let title = "Title 1"
-        let date = Date(timeIntervalSince1970: 321)
-        let time = 9876.0
-
-        let first = dataManager.add(episodeUuid: "episode-uuid", podcastUuid: "podcast-uuid", title: title, time: time, dateCreated: date)
-
-        let second = dataManager.add(episodeUuid: "episode-uuid", podcastUuid: "podcast-uuid", title: "Title 2", time: 9876, dateCreated: Date())
-
-        XCTAssertNil(second)
-
-        // Verify stored data was not modified
-        let bookmark = dataManager.bookmark(for: first!)
-        XCTAssertEqual(title, bookmark?.title)
-        XCTAssertEqual(time, bookmark?.time)
-        XCTAssertEqual(date, bookmark?.created)
-    }
-
     // MARK: - Retrieving
 
     func testGettingAllBookmarksForPodcast() {

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+FullSync.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+FullSync.swift
@@ -159,7 +159,7 @@ private extension BookmarkDataManager {
     }
 
     func remove(apiBookmark: Api_BookmarkResponse) async -> Bool? {
-        guard let bookmark = bookmark(for: apiBookmark.bookmarkUuid) else {
+        guard let bookmark = bookmark(for: apiBookmark.bookmarkUuid, allowDeleted: true) else {
             return nil
         }
 

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
@@ -338,7 +338,7 @@ extension SyncTask {
         let bookmarkManager = dataManager.bookmarks
 
         // Add the bookmark if it's not in the database
-        guard let existingBookmark = bookmarkManager.bookmark(for: apiBookmark.bookmarkUuid) else {
+        guard let existingBookmark = bookmarkManager.bookmark(for: apiBookmark.bookmarkUuid, allowDeleted: true) else {
             if !apiBookmark.shouldDelete {
                 let addedUuid = bookmarkManager.add(uuid: apiBookmark.bookmarkUuid,
                                                     episodeUuid: apiBookmark.episodeUuid,

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask.swift
@@ -218,6 +218,12 @@ class SyncTask: ApiBaseTask {
             DataManager.sharedManager.markAllEpisodeFiltersSynced()
             DataManager.sharedManager.markAllFoldersSynced()
 
+            if dataManager.bookmarksEnabled {
+                Task {
+                    await dataManager.bookmarks.markAllBookmarksAsSynced()
+                }
+            }
+
             let response = try Api_SyncUpdateResponse(serializedData: responseData)
             processServerData(response: response)
 

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1468,6 +1468,8 @@
 		C7811D842A9009A800FC68B4 /* Settings+Unlockable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7811D822A90090700FC68B4 /* Settings+Unlockable.swift */; };
 		C7811D862A90247B00FC68B4 /* Unlockable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7811D852A90247B00FC68B4 /* Unlockable.swift */; };
 		C7811D872A90248C00FC68B4 /* Unlockable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7811D852A90247B00FC68B4 /* Unlockable.swift */; };
+		C7811D892A90334200FC68B4 /* Unlockable+Bookmarks.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7811D882A90334200FC68B4 /* Unlockable+Bookmarks.swift */; };
+		C7811D8A2A90334200FC68B4 /* Unlockable+Bookmarks.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7811D882A90334200FC68B4 /* Unlockable+Bookmarks.swift */; };
 		C781EA412A6B72AE001DBFCC /* SearchableListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C781EA402A6B72AE001DBFCC /* SearchableListViewModelTests.swift */; };
 		C781EA432A6B7BF9001DBFCC /* BookmarkRowViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C781EA422A6B7BF9001DBFCC /* BookmarkRowViewModel.swift */; };
 		C784DE7B2A58CFA1004D03E7 /* ScrollViewWithContentOffset.swift in Sources */ = {isa = PBXBuildFile; fileRef = C784DE7A2A58CFA1004D03E7 /* ScrollViewWithContentOffset.swift */; };
@@ -3239,6 +3241,7 @@
 		C76ECAD52A69518800D9DB9E /* EpisodeBookmarksTabsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EpisodeBookmarksTabsView.swift; sourceTree = "<group>"; };
 		C7811D822A90090700FC68B4 /* Settings+Unlockable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Settings+Unlockable.swift"; sourceTree = "<group>"; };
 		C7811D852A90247B00FC68B4 /* Unlockable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Unlockable.swift; sourceTree = "<group>"; };
+		C7811D882A90334200FC68B4 /* Unlockable+Bookmarks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Unlockable+Bookmarks.swift"; sourceTree = "<group>"; };
 		C781EA402A6B72AE001DBFCC /* SearchableListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchableListViewModelTests.swift; sourceTree = "<group>"; };
 		C781EA422A6B7BF9001DBFCC /* BookmarkRowViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkRowViewModel.swift; sourceTree = "<group>"; };
 		C784DE7A2A58CFA1004D03E7 /* ScrollViewWithContentOffset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollViewWithContentOffset.swift; sourceTree = "<group>"; };
@@ -6474,8 +6477,9 @@
 		C7811D812A9008F500FC68B4 /* Unlockable */ = {
 			isa = PBXGroup;
 			children = (
-				C7811D852A90247B00FC68B4 /* Unlockable.swift */,
 				C7811D822A90090700FC68B4 /* Settings+Unlockable.swift */,
+				C7811D852A90247B00FC68B4 /* Unlockable.swift */,
+				C7811D882A90334200FC68B4 /* Unlockable+Bookmarks.swift */,
 			);
 			path = Unlockable;
 			sourceTree = "<group>";
@@ -8825,6 +8829,7 @@
 				BD27B8C72756F4C9007A0EA7 /* Styles.swift in Sources */,
 				8B484F0228D25DB5001AFA97 /* UIViewController+requestReview.swift in Sources */,
 				8B6B68E528F744520032BFFF /* StoriesDataSource.swift in Sources */,
+				C7811D892A90334200FC68B4 /* Unlockable+Bookmarks.swift in Sources */,
 				406C6854216AC9EF0004E249 /* PodcastFilterSelectionCell.swift in Sources */,
 				BD5945291D8A7F1700020B12 /* IncomingShareListViewController.swift in Sources */,
 				BDEC9AB720511F8900088D76 /* SettingsOptionsViewController.swift in Sources */,
@@ -9391,6 +9396,7 @@
 				BDE48A292410D27300ECA6CA /* BaseEpisode+Formatting.swift in Sources */,
 				4633FEC127D7E6B700996077 /* EpisodeRow.swift in Sources */,
 				468A0FBE27D68B1A00F800C8 /* EpisodeActionView.swift in Sources */,
+				C7811D8A2A90334200FC68B4 /* Unlockable+Bookmarks.swift in Sources */,
 				8B68C1D429421B4700CF25C5 /* FeatureFlagOverrideStore.swift in Sources */,
 				46C843B927E373B100D1DBF3 /* NowPlayingImage.swift in Sources */,
 				BD74F15827F2955D00222785 /* FolderView.swift in Sources */,

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1464,6 +1464,10 @@
 		C76ECAC42A67622900D9DB9E /* BookmarksEmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C76ECAC32A67622900D9DB9E /* BookmarksEmptyStateView.swift */; };
 		C76ECACE2A685FB300D9DB9E /* BookmarksListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C76ECACD2A685FB300D9DB9E /* BookmarksListView.swift */; };
 		C76ECAD62A69518800D9DB9E /* EpisodeBookmarksTabsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C76ECAD52A69518800D9DB9E /* EpisodeBookmarksTabsView.swift */; };
+		C7811D832A90090700FC68B4 /* Settings+Unlockable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7811D822A90090700FC68B4 /* Settings+Unlockable.swift */; };
+		C7811D842A9009A800FC68B4 /* Settings+Unlockable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7811D822A90090700FC68B4 /* Settings+Unlockable.swift */; };
+		C7811D862A90247B00FC68B4 /* Unlockable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7811D852A90247B00FC68B4 /* Unlockable.swift */; };
+		C7811D872A90248C00FC68B4 /* Unlockable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7811D852A90247B00FC68B4 /* Unlockable.swift */; };
 		C781EA412A6B72AE001DBFCC /* SearchableListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C781EA402A6B72AE001DBFCC /* SearchableListViewModelTests.swift */; };
 		C781EA432A6B7BF9001DBFCC /* BookmarkRowViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C781EA422A6B7BF9001DBFCC /* BookmarkRowViewModel.swift */; };
 		C784DE7B2A58CFA1004D03E7 /* ScrollViewWithContentOffset.swift in Sources */ = {isa = PBXBuildFile; fileRef = C784DE7A2A58CFA1004D03E7 /* ScrollViewWithContentOffset.swift */; };
@@ -3233,6 +3237,8 @@
 		C76ECAC32A67622900D9DB9E /* BookmarksEmptyStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksEmptyStateView.swift; sourceTree = "<group>"; };
 		C76ECACD2A685FB300D9DB9E /* BookmarksListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksListView.swift; sourceTree = "<group>"; };
 		C76ECAD52A69518800D9DB9E /* EpisodeBookmarksTabsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EpisodeBookmarksTabsView.swift; sourceTree = "<group>"; };
+		C7811D822A90090700FC68B4 /* Settings+Unlockable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Settings+Unlockable.swift"; sourceTree = "<group>"; };
+		C7811D852A90247B00FC68B4 /* Unlockable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Unlockable.swift; sourceTree = "<group>"; };
 		C781EA402A6B72AE001DBFCC /* SearchableListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchableListViewModelTests.swift; sourceTree = "<group>"; };
 		C781EA422A6B7BF9001DBFCC /* BookmarkRowViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkRowViewModel.swift; sourceTree = "<group>"; };
 		C784DE7A2A58CFA1004D03E7 /* ScrollViewWithContentOffset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollViewWithContentOffset.swift; sourceTree = "<group>"; };
@@ -4628,6 +4634,7 @@
 		BD2A49E31701A66E00C2F192 /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				C7811D812A9008F500FC68B4 /* Unlockable */,
 				C7BDECAC2A15311000BECF02 /* Haptics */,
 				C74887782919DC7B00EBC926 /* SwiftUI */,
 				C7AF578F289D7F1E0089E435 /* Analytics */,
@@ -6462,6 +6469,15 @@
 				8BA55A0C28CA4540002BECC5 /* AnalyticsPlaybackHelper.swift */,
 			);
 			path = Helpers;
+			sourceTree = "<group>";
+		};
+		C7811D812A9008F500FC68B4 /* Unlockable */ = {
+			isa = PBXGroup;
+			children = (
+				C7811D852A90247B00FC68B4 /* Unlockable.swift */,
+				C7811D822A90090700FC68B4 /* Settings+Unlockable.swift */,
+			);
+			path = Unlockable;
 			sourceTree = "<group>";
 		};
 		C799373C2A0963420010DC64 /* Account */ = {
@@ -8886,6 +8902,7 @@
 				466DE3F6278794D50046F722 /* EpisodeListTableViewCell.swift in Sources */,
 				BD056F111F6F8CE800AF8260 /* MainTabBarController.swift in Sources */,
 				BD26AFD727BE09E8008CC973 /* EditFolderView.swift in Sources */,
+				C7811D832A90090700FC68B4 /* Settings+Unlockable.swift in Sources */,
 				BD585C232047B9A400AC842C /* SharedItemImporter.swift in Sources */,
 				8B87C47C29F0129A00257B96 /* StreamingEpisodeArtwork.swift in Sources */,
 				4041FEA1218AA5EC0089D4A1 /* SiriShortcutAddCell.swift in Sources */,
@@ -8903,6 +8920,7 @@
 				BDB1E4FE1B8C5C2B009AD30F /* CategorySummaryViewController.swift in Sources */,
 				BD1C46E027B9E6F600B1D8BB /* HomeGridListItem.swift in Sources */,
 				BD542C20240382A100F35D26 /* EpisodeFilter+Formatting.swift in Sources */,
+				C7811D862A90247B00FC68B4 /* Unlockable.swift in Sources */,
 				BDB5F0CF2045296200437669 /* PodcastGridCell.swift in Sources */,
 				BD6FADF024C1625D009F3183 /* PlusDetailsViewController.swift in Sources */,
 				C7AF7B912925E5CD002F0025 /* PlusHostingViewController.swift in Sources */,
@@ -9398,6 +9416,7 @@
 				C761300C28E4CAE90044C6C2 /* AnalyticsCoordinator.swift in Sources */,
 				BDEF20A62435AA780000ABB2 /* ColorManager.swift in Sources */,
 				4670303827D7B5CF00844CED /* PodcastEpisodeListViewModel.swift in Sources */,
+				C7811D842A9009A800FC68B4 /* Settings+Unlockable.swift in Sources */,
 				BDE48A2E2410D3E700ECA6CA /* ShowNotesUpdater.swift in Sources */,
 				468F800F27D0042900E6D764 /* BaseEpisode+Display.swift in Sources */,
 				BDE48A322410D44900ECA6CA /* ChapterInfo.swift in Sources */,
@@ -9436,6 +9455,7 @@
 				463538F426F2413400BA9D35 /* Strings+L10n.swift in Sources */,
 				BDE48A1F2410D09900ECA6CA /* DownloadManager.swift in Sources */,
 				468F800D27CFCFB500E6D764 /* PlaySourceViewModel.swift in Sources */,
+				C7811D872A90248C00FC68B4 /* Unlockable.swift in Sources */,
 				40541471243603D300431FD5 /* SourceInterfaceController.swift in Sources */,
 				46B5DFD227EA2705006FC2ED /* NowPlayingEmptyView.swift in Sources */,
 				BDC063D1246A626E00208446 /* DownloadManager+SessionManagement.swift in Sources */,

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1470,6 +1470,8 @@
 		C7811D872A90248C00FC68B4 /* Unlockable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7811D852A90247B00FC68B4 /* Unlockable.swift */; };
 		C7811D892A90334200FC68B4 /* Unlockable+Bookmarks.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7811D882A90334200FC68B4 /* Unlockable+Bookmarks.swift */; };
 		C7811D8A2A90334200FC68B4 /* Unlockable+Bookmarks.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7811D882A90334200FC68B4 /* Unlockable+Bookmarks.swift */; };
+		C7811D8C2A90491000FC68B4 /* Bookmarks+Analytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7811D8B2A90491000FC68B4 /* Bookmarks+Analytics.swift */; };
+		C7811D8D2A90491000FC68B4 /* Bookmarks+Analytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7811D8B2A90491000FC68B4 /* Bookmarks+Analytics.swift */; };
 		C781EA412A6B72AE001DBFCC /* SearchableListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C781EA402A6B72AE001DBFCC /* SearchableListViewModelTests.swift */; };
 		C781EA432A6B7BF9001DBFCC /* BookmarkRowViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C781EA422A6B7BF9001DBFCC /* BookmarkRowViewModel.swift */; };
 		C784DE7B2A58CFA1004D03E7 /* ScrollViewWithContentOffset.swift in Sources */ = {isa = PBXBuildFile; fileRef = C784DE7A2A58CFA1004D03E7 /* ScrollViewWithContentOffset.swift */; };
@@ -3242,6 +3244,7 @@
 		C7811D822A90090700FC68B4 /* Settings+Unlockable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Settings+Unlockable.swift"; sourceTree = "<group>"; };
 		C7811D852A90247B00FC68B4 /* Unlockable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Unlockable.swift; sourceTree = "<group>"; };
 		C7811D882A90334200FC68B4 /* Unlockable+Bookmarks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Unlockable+Bookmarks.swift"; sourceTree = "<group>"; };
+		C7811D8B2A90491000FC68B4 /* Bookmarks+Analytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bookmarks+Analytics.swift"; sourceTree = "<group>"; };
 		C781EA402A6B72AE001DBFCC /* SearchableListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchableListViewModelTests.swift; sourceTree = "<group>"; };
 		C781EA422A6B7BF9001DBFCC /* BookmarkRowViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkRowViewModel.swift; sourceTree = "<group>"; };
 		C784DE7A2A58CFA1004D03E7 /* ScrollViewWithContentOffset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollViewWithContentOffset.swift; sourceTree = "<group>"; };
@@ -6441,6 +6444,7 @@
 				C7E99EF62A5C803B00E7CBAF /* List */,
 				C75274E02A3252180004DD15 /* Player */,
 				C7F6050F2A69C59000795F3C /* Podcast */,
+				C7811D8B2A90491000FC68B4 /* Bookmarks+Analytics.swift */,
 			);
 			path = Bookmarks;
 			sourceTree = "<group>";
@@ -8879,6 +8883,7 @@
 				40FE395F229CF424004526CD /* UserEpisode+Formatting.swift in Sources */,
 				BD14CCD61D7D2BCE00DB4547 /* SharePublishViewController.swift in Sources */,
 				C713D4FB2A04C90500A78468 /* SubscriptionBadge.swift in Sources */,
+				C7811D8C2A90491000FC68B4 /* Bookmarks+Analytics.swift in Sources */,
 				46737E6A272B2EEC00739C3E /* ReadOnlyTextView.swift in Sources */,
 				4011B93B2164546E00661A7D /* FilterEditOptionsViewController.swift in Sources */,
 				4051A5762281A9DD00C13C12 /* AccountActionCell.swift in Sources */,
@@ -9468,6 +9473,7 @@
 				BDE48A212410D0A300ECA6CA /* DownloadProgress.swift in Sources */,
 				467DF6EA26E10AFB00AC290C /* Strings+Generated.swift in Sources */,
 				46D88ABC27DFDB5B00F3BC43 /* FilesListView.swift in Sources */,
+				C7811D8D2A90491000FC68B4 /* Bookmarks+Analytics.swift in Sources */,
 				BDD301931EFB9979004A9972 /* SessionManager.swift in Sources */,
 				BDE48A372410D4E300ECA6CA /* WatchNowPlayingHelper.swift in Sources */,
 				BDE48A1C2410D07300ECA6CA /* PlaybackProtocol.swift in Sources */,

--- a/podcasts/Analytics/Analytics.swift
+++ b/podcasts/Analytics/Analytics.swift
@@ -26,6 +26,17 @@ class Analytics {
     }
 }
 
+// MARK: - Analytics + Source
+
+extension Analytics {
+    static func track(_ event: AnalyticsEvent, source: Any, properties: [AnyHashable: Any]? = nil) {
+        var sourceProperties = properties ?? [:]
+        sourceProperties.updateValue(source, forKey: "source")
+
+        track(event, properties: sourceProperties)
+    }
+}
+
 // MARK: - Opt out/in
 
 extension Analytics {

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -644,7 +644,7 @@ enum AnalyticsEvent: String {
     // MARK: - Bookmarks
     case bookmarkCreated
     case bookmarkUpdateTitle
-    case bookmarkUpgradeButtonTapped
+    case bookmarksUpgradeButtonTapped
     case bookmarksEmptyGoToHeadphoneSettings
     case bookmarkPlayTapped
     case bookmarksSortByChanged

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -639,4 +639,12 @@ enum AnalyticsEvent: String {
     case whatsnewDismissed
     case whatsnewConfirmButtonTapped
 
+    // MARK: - Bookmarks
+    case bookmarkCreated
+    case bookmarkUpdateTitle
+    case bookmarkUpgradeButtonTapped
+    case bookmarksEmptyGoToHeadphoneSettings
+    case bookmarkPlayTapped
+    case bookmarksSortByChanged
+    case bookmarkDeleted
 }

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -395,6 +395,7 @@ enum AnalyticsEvent: String {
     case episodeDetailShowNotesLinkTapped
     case episodeDetailPodcastNameTapped
     case episodeDetailDismissed
+    case episodeDetailTabChanged
 
     // MARK: - Multi Select View
 

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -266,6 +266,7 @@ enum AnalyticsEvent: String {
     case podcastScreenToggleSummary
     case podcastsScreenSortOrderChanged
     case podcastsScreenEpisodeGroupingChanged
+    case podcastsScreenTabTapped
 
     // MARK: - App Store Review Request
 

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -647,4 +647,10 @@ enum AnalyticsEvent: String {
     case bookmarkPlayTapped
     case bookmarksSortByChanged
     case bookmarkDeleted
+
+    // MARK: - Headphone Controls
+    case settingsHeadphoneControlsShown
+    case settingsHeadphoneControlsNextChanged
+    case settingsHeadphoneControlsPreviousChanged
+    case settingsHeadphoneControlsBookmarkSoundToggled
 }

--- a/podcasts/Analytics/Helpers/AnalyticsCoordinator.swift
+++ b/podcasts/Analytics/Helpers/AnalyticsCoordinator.swift
@@ -43,6 +43,7 @@ enum AnalyticsSource: String, AnalyticsDescribable {
     case videoPlayerSkipForwardLongPress = "video_player_skip_forward_long_press"
     case playbackFailed = "playback_failed"
     case watch
+    case bookmarks
     case unknown
 
     var analyticsDescription: String { rawValue }

--- a/podcasts/Analytics/Helpers/AnalyticsCoordinator.swift
+++ b/podcasts/Analytics/Helpers/AnalyticsCoordinator.swift
@@ -43,7 +43,7 @@ enum AnalyticsSource: String, AnalyticsDescribable {
     case videoPlayerSkipForwardLongPress = "video_player_skip_forward_long_press"
     case playbackFailed = "playback_failed"
     case watch
-    case bookmarks
+    case bookmark
     case unknown
 
     var analyticsDescription: String { rawValue }

--- a/podcasts/BookmarkManager.swift
+++ b/podcasts/BookmarkManager.swift
@@ -155,6 +155,8 @@ private extension BookmarkSortOption {
             return .oldestToNewest
         case .timestamp:
             return .timestamp
+        case .episode:
+            return .episode
         }
     }
 }

--- a/podcasts/Bookmarks/Bookmarks+Analytics.swift
+++ b/podcasts/Bookmarks/Bookmarks+Analytics.swift
@@ -25,6 +25,8 @@ extension BookmarkSortOption: AnalyticsDescribable {
             return "date_added_oldest_to_newest"
         case .timestamp:
             return "timestamp"
+        case .episode:
+            return "episode"
         }
     }
 }

--- a/podcasts/Bookmarks/Bookmarks+Analytics.swift
+++ b/podcasts/Bookmarks/Bookmarks+Analytics.swift
@@ -28,3 +28,20 @@ extension BookmarkSortOption: AnalyticsDescribable {
         }
     }
 }
+
+extension HeadphoneControlAction: AnalyticsDescribable {
+    var analyticsDescription: String {
+        switch self {
+        case .skipBack:
+            return "skip_back"
+        case .skipForward:
+            return "skip_forward"
+        case .previousChapter:
+            return "previous_chapter"
+        case .nextChapter:
+            return "next_chapter"
+        case .addBookmark:
+            return "add_bookmark"
+        }
+    }
+}

--- a/podcasts/Bookmarks/Bookmarks+Analytics.swift
+++ b/podcasts/Bookmarks/Bookmarks+Analytics.swift
@@ -25,8 +25,6 @@ extension BookmarkSortOption: AnalyticsDescribable {
             return "date_added_oldest_to_newest"
         case .timestamp:
             return "timestamp"
-        case .episode:
-            return "episode"
         }
     }
 }

--- a/podcasts/Bookmarks/Bookmarks+Analytics.swift
+++ b/podcasts/Bookmarks/Bookmarks+Analytics.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+// MARK: - Source
+
+enum BookmarkAnalyticsSource: String, AnalyticsDescribable {
+    case podcasts = "podcast_screen"
+    case episodes = "episode_details"
+    case player
+    case files
+    case headphones
+
+    case unknown
+
+    var analyticsDescription: String {
+        rawValue
+    }
+}
+
+extension BookmarkSortOption: AnalyticsDescribable {
+    var analyticsDescription: String {
+        switch self {
+        case .newestToOldest:
+            return "date_added_newest_to_oldest"
+        case .oldestToNewest:
+            return "date_added_oldest_to_newest"
+        case .timestamp:
+            return "timestamp"
+        case .episode:
+            return "episode"
+        }
+    }
+}

--- a/podcasts/Bookmarks/Editing/BookmarkEditTitleViewController.swift
+++ b/podcasts/Bookmarks/Editing/BookmarkEditTitleViewController.swift
@@ -5,7 +5,7 @@ class BookmarkEditTitleViewController: ThemedHostingController<BookmarkEditTitle
     private let viewModel: BookmarkEditViewModel
     let onDismiss: ((String) -> Void)?
 
-    var source: BookmarkAnalyticsSource? = nil {
+    var source: BookmarkAnalyticsSource = .unknown {
         didSet {
             viewModel.analyticsSource = source
         }

--- a/podcasts/Bookmarks/Editing/BookmarkEditTitleViewController.swift
+++ b/podcasts/Bookmarks/Editing/BookmarkEditTitleViewController.swift
@@ -5,6 +5,12 @@ class BookmarkEditTitleViewController: ThemedHostingController<BookmarkEditTitle
     private let viewModel: BookmarkEditViewModel
     let onDismiss: ((String) -> Void)?
 
+    var source: BookmarkAnalyticsSource? = nil {
+        didSet {
+            viewModel.analyticsSource = source
+        }
+    }
+
     init(manager: BookmarkManager,
          bookmark: Bookmark,
          state: BookmarkEditViewModel.EditState,

--- a/podcasts/Bookmarks/Editing/BookmarkEditViewModel.swift
+++ b/podcasts/Bookmarks/Editing/BookmarkEditViewModel.swift
@@ -23,7 +23,7 @@ class BookmarkEditViewModel: ObservableObject {
     private let bookmarkManager: BookmarkManager
     private let bookmark: Bookmark
 
-    var analyticsSource: BookmarkAnalyticsSource? = nil
+    var analyticsSource: BookmarkAnalyticsSource = .unknown
 
     init(manager: BookmarkManager, bookmark: Bookmark, state: EditState) {
         self.bookmarkManager = manager
@@ -56,6 +56,10 @@ class BookmarkEditViewModel: ObservableObject {
             let title = String(title.trim().prefix(maxTitleLength))
 
             await bookmarkManager.update(title: title.isEmpty ? placeholder : title, for: bookmark)
+
+            if editState == .updating {
+                Analytics.track(.bookmarkUpdateTitle, source: analyticsSource)
+            }
 
             await MainActor.run {
                 router?.titleUpdated(title: title)

--- a/podcasts/Bookmarks/Editing/BookmarkEditViewModel.swift
+++ b/podcasts/Bookmarks/Editing/BookmarkEditViewModel.swift
@@ -23,6 +23,8 @@ class BookmarkEditViewModel: ObservableObject {
     private let bookmarkManager: BookmarkManager
     private let bookmark: Bookmark
 
+    var analyticsSource: BookmarkAnalyticsSource? = nil
+
     init(manager: BookmarkManager, bookmark: Bookmark, state: EditState) {
         self.bookmarkManager = manager
         self.bookmark = bookmark

--- a/podcasts/Bookmarks/Episode/BookmarkEpisodeListController.swift
+++ b/podcasts/Bookmarks/Episode/BookmarkEpisodeListController.swift
@@ -16,9 +16,12 @@ class BookmarkEpisodeListController: ThemedHostingController<BookmarkEpisodeList
         self.bookmarkManager = bookmarkManager
         self.playbackManager = playbackManager
 
-        self.viewModel = BookmarkEpisodeListViewModel(episode: episode,
+        let viewModel = BookmarkEpisodeListViewModel(episode: episode,
                                                       bookmarkManager: bookmarkManager,
                                                       sortOption: Constants.UserDefaults.bookmarks.podcastSort)
+        viewModel.analyticsSource = (episode is Episode) ? .episodes : .files
+
+        self.viewModel = viewModel
 
         super.init(rootView: BookmarkEpisodeListView(viewModel: viewModel, displayMode: displayMode))
 

--- a/podcasts/Bookmarks/Episode/BookmarkEpisodeListController.swift
+++ b/podcasts/Bookmarks/Episode/BookmarkEpisodeListController.swift
@@ -46,7 +46,7 @@ extension BookmarkEpisodeListController: BookmarkListRouter {
                                                          bookmark: bookmark,
                                                          state: .updating)
 
-        controller.source = .episodes
+        controller.source = viewModel.analyticsSource
 
         present(controller, animated: true)
     }

--- a/podcasts/Bookmarks/Episode/BookmarkEpisodeListController.swift
+++ b/podcasts/Bookmarks/Episode/BookmarkEpisodeListController.swift
@@ -37,7 +37,7 @@ class BookmarkEpisodeListController: ThemedHostingController<BookmarkEpisodeList
 
 extension BookmarkEpisodeListController: BookmarkListRouter {
     func bookmarkPlay(_ bookmark: Bookmark) {
-        playbackManager.playBookmark(bookmark)
+        playbackManager.playBookmark(bookmark, source: .episodes)
         dismiss(animated: true)
     }
 
@@ -45,6 +45,8 @@ extension BookmarkEpisodeListController: BookmarkListRouter {
         let controller = BookmarkEditTitleViewController(manager: bookmarkManager,
                                                          bookmark: bookmark,
                                                          state: .updating)
+
+        controller.source = .episodes
 
         present(controller, animated: true)
     }

--- a/podcasts/Bookmarks/Episode/BookmarkEpisodeListController.swift
+++ b/podcasts/Bookmarks/Episode/BookmarkEpisodeListController.swift
@@ -37,7 +37,7 @@ class BookmarkEpisodeListController: ThemedHostingController<BookmarkEpisodeList
 
 extension BookmarkEpisodeListController: BookmarkListRouter {
     func bookmarkPlay(_ bookmark: Bookmark) {
-        playbackManager.playBookmark(bookmark, source: .episodes)
+        playbackManager.playBookmark(bookmark, source: viewModel.analyticsSource)
         dismiss(animated: true)
     }
 

--- a/podcasts/Bookmarks/List/BookmarkEpisodeListViewModel.swift
+++ b/podcasts/Bookmarks/List/BookmarkEpisodeListViewModel.swift
@@ -2,7 +2,7 @@ import Combine
 import PocketCastsDataModel
 
 class BookmarkEpisodeListViewModel: BookmarkListViewModel {
-    weak var episode: BaseEpisode? = nil {
+    var episode: BaseEpisode? = nil {
         didSet {
             reload()
         }

--- a/podcasts/Bookmarks/List/BookmarkEpisodeListViewModel.swift
+++ b/podcasts/Bookmarks/List/BookmarkEpisodeListViewModel.swift
@@ -16,11 +16,12 @@ class BookmarkEpisodeListViewModel: BookmarkListViewModel {
     }
 
     override func reload() {
-        guard feature.isUnlocked else {
+        guard feature.isUnlocked, let episode else {
             items = []
             return
         }
-        items = episode.map { bookmarkManager.bookmarks(for: $0, sorted: sortOption) } ?? []
+
+        items = bookmarkManager.bookmarks(for: episode, sorted: sortOption)
     }
 
     override func addListeners() {

--- a/podcasts/Bookmarks/List/BookmarkListViewModel.swift
+++ b/podcasts/Bookmarks/List/BookmarkListViewModel.swift
@@ -109,6 +109,8 @@ extension BookmarkListViewModel {
     }
 
     func openHeadphoneSettings() {
+        Analytics.track(.bookmarksEmptyGoToHeadphoneSettings, source: analyticsSource)
+
         router?.dismissBookmarksList()
         NavigationManager.sharedManager.navigateTo(NavigationManager.settingsHeadphoneKey)
     }

--- a/podcasts/Bookmarks/List/BookmarkListViewModel.swift
+++ b/podcasts/Bookmarks/List/BookmarkListViewModel.swift
@@ -10,6 +10,9 @@ class BookmarkListViewModel: SearchableListViewModel<Bookmark> {
 
     var sortOption: BookmarkSortOption {
         didSet {
+            Analytics.track(.bookmarksSortByChanged, source: analyticsSource, properties: [
+                "sort_order": sortOption
+            ])
             sortSettingValue.save(sortOption)
         }
     }

--- a/podcasts/Bookmarks/List/BookmarkListViewModel.swift
+++ b/podcasts/Bookmarks/List/BookmarkListViewModel.swift
@@ -26,6 +26,7 @@ class BookmarkListViewModel: SearchableListViewModel<Bookmark> {
     private let sortSettingValue: SortSetting
 
     let feature: PaidFeature = .bookmarks
+    var analyticsSource: BookmarkAnalyticsSource = .unknown
 
     init(bookmarkManager: BookmarkManager, sortOption: SortSetting) {
         self.bookmarkManager = bookmarkManager

--- a/podcasts/Bookmarks/List/BookmarkListViewModel.swift
+++ b/podcasts/Bookmarks/List/BookmarkListViewModel.swift
@@ -17,6 +17,10 @@ class BookmarkListViewModel: SearchableListViewModel<Bookmark> {
         }
     }
 
+    var availableSortOptions: [BookmarkSortOption] {
+        [.newestToOldest, .oldestToNewest, .timestamp]
+    }
+
     var bookmarks: [Bookmark] {
         isSearching ? filteredItems : items
     }
@@ -137,9 +141,7 @@ extension BookmarkListViewModel {
     func showSortOptions() {
         let optionPicker = OptionsPicker(title: L10n.sortBy)
 
-        let options: [BookmarkSortOption] = [.newestToOldest, .oldestToNewest, .timestamp]
-
-        optionPicker.addActions(options.map({ option in
+        optionPicker.addActions(availableSortOptions.map({ option in
             .init(label: option.label) { [weak self] in
                 self?.sorted(by: option)
             }
@@ -186,6 +188,8 @@ private extension BookmarkSortOption {
             return L10n.podcastsEpisodeSortOldestToNewest
         case .timestamp:
             return L10n.sortOptionTimestamp
+        case .episode:
+            return L10n.episode
         }
     }
 }

--- a/podcasts/Bookmarks/List/BookmarkListViewModel.swift
+++ b/podcasts/Bookmarks/List/BookmarkListViewModel.swift
@@ -171,6 +171,7 @@ private extension BookmarkListViewModel {
                 return
             }
 
+            Analytics.track(.bookmarkDeleted, source: analyticsSource)
             reload()
         }
     }

--- a/podcasts/Bookmarks/List/BookmarkPodcastListViewModel.swift
+++ b/podcasts/Bookmarks/List/BookmarkPodcastListViewModel.swift
@@ -17,12 +17,18 @@ class BookmarkPodcastListViewModel: BookmarkListViewModel {
     }
 
     override func reload() {
-        guard feature.isUnlocked else {
+        guard feature.isUnlocked, let podcast else {
             items = []
             return
         }
 
-        items = podcast.map { bookmarkManager.bookmarks(for: $0, sorted: sortOption).includeEpisodes() } ?? []
+        var items = bookmarkManager.bookmarks(for: podcast, sorted: sortOption).includeEpisodes()
+
+        if sortOption == .episode {
+            items.sortByNewestEpisodeAndBookmarkTimestamp()
+        }
+
+        self.items = items
     }
 
     override func refresh(bookmark: Bookmark) {
@@ -45,5 +51,31 @@ class BookmarkPodcastListViewModel: BookmarkListViewModel {
                 self?.reload()
             }
             .store(in: &cancellables)
+    }
+}
+
+private extension BaseEpisode {
+    var sortDate: Date? {
+        publishedDate ?? addedDate
+    }
+}
+
+private extension Array where Element == Bookmark {
+    /// Sorts the array by episodes release date, and the bookmarks timestamp
+    mutating func sortByNewestEpisodeAndBookmarkTimestamp() {
+        sort(by: {
+            let timestampAsc = $0.time < $1.time
+
+            guard let date1 = $0.episode?.sortDate, let date2 = $1.episode?.sortDate else {
+                return timestampAsc
+            }
+
+            // We're grouping by the episode date, so default to using the timestamp sort if the dates are equal
+            if date1 == date2 {
+                return timestampAsc
+            }
+
+            return date1 > date2
+        })
     }
 }

--- a/podcasts/Bookmarks/List/BookmarkPodcastListViewModel.swift
+++ b/podcasts/Bookmarks/List/BookmarkPodcastListViewModel.swift
@@ -4,6 +4,10 @@ import PocketCastsDataModel
 class BookmarkPodcastListViewModel: BookmarkListViewModel {
     var podcast: Podcast?
 
+    override var availableSortOptions: [BookmarkSortOption] {
+        [.newestToOldest, .oldestToNewest, .episode]
+    }
+
     init(podcast: Podcast, bookmarkManager: BookmarkManager, sortOption: BookmarkListViewModel.SortSetting) {
         self.podcast = podcast
 

--- a/podcasts/Bookmarks/List/BookmarksListView.swift
+++ b/podcasts/Bookmarks/List/BookmarksListView.swift
@@ -46,7 +46,7 @@ struct BookmarksListView<ListStyle: BookmarksStyle>: View {
     @ViewBuilder
     private var emptyView: some View {
         if !feature.isUnlocked {
-            BookmarksLockedStateView(style: style.emptyStyle, feature: feature)
+            BookmarksLockedStateView(style: style.emptyStyle, feature: feature, source: viewModel.analyticsSource)
         }
         else if !viewModel.isSearching {
             BookmarksEmptyStateView(style: style.emptyStyle)

--- a/podcasts/Bookmarks/Player/BookmarksPlayerTabController.swift
+++ b/podcasts/Bookmarks/Player/BookmarksPlayerTabController.swift
@@ -17,10 +17,8 @@ class BookmarksPlayerTabController: PlayerItemViewController {
 
         self.playbackManager = playbackManager
         self.bookmarkManager = bookmarkManager
-        let viewModel = BookmarkEpisodeListViewModel(bookmarkManager: bookmarkManager, sortOption: Constants.UserDefaults.bookmarks.playerSort)
         self.viewModel = viewModel
         self.controller = ThemedHostingController(rootView: BookmarksPlayerTab(viewModel: viewModel))
-
         super.init(nibName: nil, bundle: nil)
 
         viewModel.router = self
@@ -91,6 +89,8 @@ class BookmarksPlayerTabController: PlayerItemViewController {
             self?.handleEditDismissed(isNew: isNew, title: title)
         })
 
+        controller.source = .player
+
         present(controller, animated: true)
     }
 
@@ -123,7 +123,7 @@ extension BookmarksPlayerTabController: BookmarkListRouter {
     func bookmarkPlay(_ bookmark: Bookmark) {
         containerDelegate?.scrollToNowPlaying()
 
-        playbackManager.playBookmark(bookmark)
+        playbackManager.playBookmark(bookmark, source: .player)
     }
 
     func bookmarkEdit(_ bookmark: Bookmark) {

--- a/podcasts/Bookmarks/Player/BookmarksPlayerTabController.swift
+++ b/podcasts/Bookmarks/Player/BookmarksPlayerTabController.swift
@@ -89,7 +89,7 @@ class BookmarksPlayerTabController: PlayerItemViewController {
             self?.handleEditDismissed(isNew: isNew, title: title)
         })
 
-        controller.source = .player
+        controller.source = viewModel.analyticsSource
 
         present(controller, animated: true)
     }

--- a/podcasts/Bookmarks/Player/BookmarksPlayerTabController.swift
+++ b/podcasts/Bookmarks/Player/BookmarksPlayerTabController.swift
@@ -12,6 +12,9 @@ class BookmarksPlayerTabController: PlayerItemViewController {
     private var cancellables = Set<AnyCancellable>()
 
     init(bookmarkManager: BookmarkManager, playbackManager: PlaybackManager) {
+        let viewModel = BookmarkEpisodeListViewModel(bookmarkManager: bookmarkManager, sortOption: Constants.UserDefaults.bookmarks.playerSort)
+        viewModel.analyticsSource = .player
+
         self.playbackManager = playbackManager
         self.bookmarkManager = bookmarkManager
         let viewModel = BookmarkEpisodeListViewModel(bookmarkManager: bookmarkManager, sortOption: Constants.UserDefaults.bookmarks.playerSort)

--- a/podcasts/Bookmarks/Podcast/BookmarksPodcastListController.swift
+++ b/podcasts/Bookmarks/Podcast/BookmarksPodcastListController.swift
@@ -35,12 +35,13 @@ class BookmarksPodcastListController: ThemedHostingController<BookmarksPodcastLi
 
 extension BookmarksPodcastListController: BookmarkListRouter {
     func bookmarkPlay(_ bookmark: Bookmark) {
-        playbackManager.playBookmark(bookmark)
+        playbackManager.playBookmark(bookmark, source: viewModel.analyticsSource)
         dismiss(animated: true)
     }
 
     func bookmarkEdit(_ bookmark: Bookmark) {
         let controller = BookmarkEditTitleViewController(manager: bookmarkManager, bookmark: bookmark, state: .updating)
+        controller.source = viewModel.analyticsSource
 
         present(controller, animated: true)
     }

--- a/podcasts/Bookmarks/Podcast/BookmarksPodcastListController.swift
+++ b/podcasts/Bookmarks/Podcast/BookmarksPodcastListController.swift
@@ -15,9 +15,12 @@ class BookmarksPodcastListController: ThemedHostingController<BookmarksPodcastLi
         self.playbackManager = playbackManager
 
         let sortOption = Constants.UserDefaults.bookmarks.podcastSort
-        self.viewModel = BookmarkPodcastListViewModel(podcast: podcast,
+        let viewModel = BookmarkPodcastListViewModel(podcast: podcast,
                                                       bookmarkManager: bookmarkManager,
                                                       sortOption: sortOption)
+        viewModel.analyticsSource = .podcasts
+
+        self.viewModel = viewModel
         super.init(rootView: .init(viewModel: viewModel))
 
         viewModel.router = self

--- a/podcasts/Common SwiftUI/BookmarksLockedStateView.swift
+++ b/podcasts/Common SwiftUI/BookmarksLockedStateView.swift
@@ -85,8 +85,7 @@ private class BookmarksUpgradeViewModel: PlusAccountPromptViewModel {
     override func showModal(for product: PlusPricingInfoModel.PlusProductPricingInfo? = nil) {
         guard let parentController = SceneHelper.rootViewController() else { return }
 
-        let controller = feature.upgradeController(source: "bookmarks_locked_state")
-        parentController.presentFromRootController(controller)
+        feature.presentUpgradeController(from: parentController, source: "bookmarks_locked_state")
     }
 
     private func product(for tier: SubscriptionTier) -> PlusProductPricingInfo? {

--- a/podcasts/Common SwiftUI/BookmarksLockedStateView.swift
+++ b/podcasts/Common SwiftUI/BookmarksLockedStateView.swift
@@ -65,6 +65,7 @@ struct BookmarksLockedStateView<Style: EmptyStateViewStyle>: View {
 
 private class BookmarksUpgradeViewModel: PlusAccountPromptViewModel {
     let feature: PaidFeature
+    let bookmarksSource: BookmarkAnalyticsSource
 
     init(feature: PaidFeature, source: BookmarkAnalyticsSource) {
         self.feature = feature
@@ -81,6 +82,7 @@ private class BookmarksUpgradeViewModel: PlusAccountPromptViewModel {
     }
 
     func upgradeTapped() {
+        Analytics.track(.bookmarkUpgradeButtonTapped, source: bookmarksSource)
         upgradeTapped(with: product(for: feature.tier))
     }
 

--- a/podcasts/Common SwiftUI/BookmarksLockedStateView.swift
+++ b/podcasts/Common SwiftUI/BookmarksLockedStateView.swift
@@ -82,14 +82,14 @@ private class BookmarksUpgradeViewModel: PlusAccountPromptViewModel {
     }
 
     func upgradeTapped() {
-        Analytics.track(.bookmarkUpgradeButtonTapped, source: bookmarksSource)
+        Analytics.track(.bookmarksUpgradeButtonTapped, source: bookmarksSource)
         upgradeTapped(with: product(for: feature.tier))
     }
 
     override func showModal(for product: PlusPricingInfoModel.PlusProductPricingInfo? = nil) {
         guard let parentController = SceneHelper.rootViewController() else { return }
 
-        feature.presentUpgradeController(from: parentController, source: bookmarksSource.analyticsDescription)
+        feature.presentUpgradeController(from: parentController, source: "bookmarks_locked")
     }
 
     private func product(for tier: SubscriptionTier) -> PlusProductPricingInfo? {

--- a/podcasts/Common SwiftUI/BookmarksLockedStateView.swift
+++ b/podcasts/Common SwiftUI/BookmarksLockedStateView.swift
@@ -6,9 +6,10 @@ struct BookmarksLockedStateView<Style: EmptyStateViewStyle>: View {
     @ObservedObject var style: Style
     @StateObject private var upgradeModel: BookmarksUpgradeViewModel
 
-    init(style: Style, feature: PaidFeature) {
+    init(style: Style, feature: PaidFeature, source: BookmarkAnalyticsSource) {
         self.style = style
-        _upgradeModel = .init(wrappedValue: .init(feature: feature))
+
+        _upgradeModel = .init(wrappedValue: .init(feature: feature, source: source))
     }
 
     private var message: String {
@@ -65,8 +66,9 @@ struct BookmarksLockedStateView<Style: EmptyStateViewStyle>: View {
 private class BookmarksUpgradeViewModel: PlusAccountPromptViewModel {
     let feature: PaidFeature
 
-    init(feature: PaidFeature) {
+    init(feature: PaidFeature, source: BookmarkAnalyticsSource) {
         self.feature = feature
+        self.bookmarksSource = source
         super.init()
     }
 

--- a/podcasts/Common SwiftUI/BookmarksLockedStateView.swift
+++ b/podcasts/Common SwiftUI/BookmarksLockedStateView.swift
@@ -89,7 +89,7 @@ private class BookmarksUpgradeViewModel: PlusAccountPromptViewModel {
     override func showModal(for product: PlusPricingInfoModel.PlusProductPricingInfo? = nil) {
         guard let parentController = SceneHelper.rootViewController() else { return }
 
-        feature.presentUpgradeController(from: parentController, source: "bookmarks_locked_state")
+        feature.presentUpgradeController(from: parentController, source: bookmarksSource.analyticsDescription)
     }
 
     private func product(for tier: SubscriptionTier) -> PlusProductPricingInfo? {

--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -422,5 +422,5 @@ enum HeadphoneControlAction: JSONCodable {
 // MARK: - Bookmark Sorting
 
 enum BookmarkSortOption: JSONCodable {
-    case newestToOldest, oldestToNewest, timestamp
+    case newestToOldest, oldestToNewest, timestamp, episode
 }

--- a/podcasts/EpisodeDetailViewController.swift
+++ b/podcasts/EpisodeDetailViewController.swift
@@ -538,12 +538,21 @@ class EpisodeDetailViewController: FakeNavViewController, UIDocumentInteractionC
         Analytics.track(.episodeDetailDismissed, properties: ["source": viewSource])
     }
 
-    private enum Tab: Int {
+    private enum Tab: Int, AnalyticsDescribable {
         case details, bookmarks
 
         // Allow comparing against a raw int to the enum
         static func == (lhs: Int, rhs: Self) -> Bool {
             Tab(rawValue: lhs) == rhs
+        }
+
+        var analyticsDescription: String {
+            switch self {
+            case .details:
+                return "details"
+            case .bookmarks:
+                return "bookmarks"
+            }
         }
     }
 }
@@ -653,6 +662,8 @@ private extension EpisodeDetailViewController {
     private func didSwitchToTab(_ tab: Tab, animated: Bool = true) {
         currentTab = tab
         tabViewModel?.selectTabIndex(tab.rawValue)
+
+        Analytics.track(.episodeDetailTabChanged, properties: ["value": tab])
 
         guard animated else {
             updateRightButtons()

--- a/podcasts/EpisodeDetailViewController.swift
+++ b/podcasts/EpisodeDetailViewController.swift
@@ -660,10 +660,12 @@ private extension EpisodeDetailViewController {
     }
 
     private func didSwitchToTab(_ tab: Tab, animated: Bool = true) {
+        if currentTab != tab {
+            Analytics.track(.episodeDetailTabChanged, properties: ["value": tab])
+        }
+
         currentTab = tab
         tabViewModel?.selectTabIndex(tab.rawValue)
-
-        Analytics.track(.episodeDetailTabChanged, properties: ["value": tab])
 
         guard animated else {
             updateRightButtons()

--- a/podcasts/HeadphoneSettingsViewController.swift
+++ b/podcasts/HeadphoneSettingsViewController.swift
@@ -196,7 +196,7 @@ private extension HeadphoneSettingsViewController {
 
         let picker = OptionsPicker(title: title)
         picker.addActions(options.map { option in
-            OptionAction(label: option.displayableTitle, icon: option.iconName, selected: currentValue == option) {
+            OptionAction(label: option.displayableTitle, icon: option.iconName, tintIcon: false, selected: currentValue == option) {
                 onChange(option)
             }
         })
@@ -223,7 +223,6 @@ private extension HeadphoneControlAction {
     }
 
     var iconName: String? {
-        // placeholder for the future
-        return nil
+        isUnlocked ? nil : "plusGold24"
     }
 }

--- a/podcasts/HeadphoneSettingsViewController.swift
+++ b/podcasts/HeadphoneSettingsViewController.swift
@@ -15,6 +15,7 @@ class HeadphoneSettingsViewController: PCTableViewController {
         super.viewDidLoad()
 
         title = L10n.settingsHeadphoneControls
+        Analytics.track(.settingsHeadphoneControlsShown)
     }
 
     override var customCellTypes: [ReusableTableCell.Type] {
@@ -108,6 +109,7 @@ class HeadphoneSettingsViewController: PCTableViewController {
 
     private func updateBookmarkSoundEnabled(_ enabled: Bool) {
         Settings.playBookmarkCreationSound = enabled
+        Settings.trackValueToggled(.settingsHeadphoneControlsBookmarkSoundToggled, enabled: enabled)
 
         // Play a preview of the sound if the user has enabled the option
         if enabled {
@@ -122,9 +124,11 @@ class HeadphoneSettingsViewController: PCTableViewController {
         let action = { [weak self] in
             switch row {
             case .previousAction:
+                Settings.trackValueChanged(.settingsHeadphoneControlsPreviousChanged, value: selection)
                 Settings.headphonesPreviousAction = selection
 
             case .nextAction:
+                Settings.trackValueChanged(.settingsHeadphoneControlsNextChanged, value: selection)
                 Settings.headphonesNextAction = selection
 
             default: break

--- a/podcasts/HeadphoneSettingsViewController.swift
+++ b/podcasts/HeadphoneSettingsViewController.swift
@@ -149,8 +149,7 @@ class HeadphoneSettingsViewController: PCTableViewController {
             .sink { unlocked() }
             .store(in: &cancellables)
 
-        let controller = feature.upgradeController(source: "headphone_settings")
-        present(controller, animated: true)
+        feature.presentUpgradeController(from: self, source: "headphone_settings")
     }
 
     // MARK: - Data Struct

--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -623,6 +623,8 @@ private extension MainTabBarController {
                 self?.handleBookmarkTitleUpdated(updatedTitle: updatedTitle)
             })
 
+            controller.source = .headphones
+
             self?.presentFromRootController(controller)
         }
 

--- a/podcasts/NowPlayingPlayerItemViewController+Shelf.swift
+++ b/podcasts/NowPlayingPlayerItemViewController+Shelf.swift
@@ -216,6 +216,11 @@ extension NowPlayingPlayerItemViewController: NowPlayingActionsDelegate {
     }
 
     func bookmarkTapped() {
+        guard PaidFeature.bookmarks.isUnlocked else {
+            let controller = PaidFeature.bookmarks.upgradeController(source: "shelf")
+            presentFromRootController(controller)
+            return
+        }
         PlaybackManager.shared.bookmark()
     }
 

--- a/podcasts/NowPlayingPlayerItemViewController+Shelf.swift
+++ b/podcasts/NowPlayingPlayerItemViewController+Shelf.swift
@@ -216,7 +216,7 @@ extension NowPlayingPlayerItemViewController: NowPlayingActionsDelegate {
     }
 
     func bookmarkTapped() {
-        PlaybackManager.shared.bookmark()
+        PlaybackManager.shared.bookmark(source: .player)
     }
 
     // MARK: - Player Actions

--- a/podcasts/NowPlayingPlayerItemViewController+Shelf.swift
+++ b/podcasts/NowPlayingPlayerItemViewController+Shelf.swift
@@ -216,14 +216,6 @@ extension NowPlayingPlayerItemViewController: NowPlayingActionsDelegate {
     }
 
     func bookmarkTapped() {
-        let feature = PaidFeature.bookmarks
-
-        guard feature.isUnlocked else {
-            let controller = feature.upgradeController(source: "shelf_action")
-            presentFromRootController(controller)
-            return
-        }
-
         PlaybackManager.shared.bookmark()
     }
 
@@ -274,7 +266,14 @@ extension NowPlayingPlayerItemViewController: NowPlayingActionsDelegate {
     }
 
     @objc private func bookmarkTapped(_ sender: UIButton) {
-        shelfButtonTapped(.addBookmark)
+        let action = PlayerAction.addBookmark
+        shelfButtonTapped(action)
+
+        guard action.isUnlocked else {
+            action.paidFeature?.presentUpgradeController(from: self, source: "shelf")
+            return
+        }
+
         bookmarkTapped()
     }
 

--- a/podcasts/NowPlayingPlayerItemViewController+Shelf.swift
+++ b/podcasts/NowPlayingPlayerItemViewController+Shelf.swift
@@ -216,11 +216,14 @@ extension NowPlayingPlayerItemViewController: NowPlayingActionsDelegate {
     }
 
     func bookmarkTapped() {
-        guard PaidFeature.bookmarks.isUnlocked else {
-            let controller = PaidFeature.bookmarks.upgradeController(source: "shelf")
+        let feature = PaidFeature.bookmarks
+
+        guard feature.isUnlocked else {
+            let controller = feature.upgradeController(source: "shelf_action")
             presentFromRootController(controller)
             return
         }
+
         PlaybackManager.shared.bookmark()
     }
 

--- a/podcasts/NowPlayingPlayerItemViewController+Shelf.swift
+++ b/podcasts/NowPlayingPlayerItemViewController+Shelf.swift
@@ -270,7 +270,7 @@ extension NowPlayingPlayerItemViewController: NowPlayingActionsDelegate {
         shelfButtonTapped(action)
 
         guard action.isUnlocked else {
-            action.paidFeature?.presentUpgradeController(from: self, source: "shelf")
+            action.paidFeature?.presentUpgradeController(from: self, source: "bookmarks_shelf_action")
             return
         }
 

--- a/podcasts/OptionAction.swift
+++ b/podcasts/OptionAction.swift
@@ -9,18 +9,21 @@ class OptionAction {
     var destructive = false
     var outline = false
     var onOffAction = false
+    var tintIcon: Bool = true
 
-    init(label: String, secondaryLabel: String? = nil, icon: String? = nil, selected: Bool = false, action: @escaping (() -> Void)) {
+    init(label: String, secondaryLabel: String? = nil, icon: String? = nil, tintIcon: Bool = true, selected: Bool = false, action: @escaping (() -> Void)) {
         self.label = label
         self.secondaryLabel = secondaryLabel
         self.icon = icon
+        self.tintIcon = tintIcon
         self.action = action
         self.selected = false
     }
 
-    init(label: String, icon: String, selected: Bool, onOffAction: Bool, action: @escaping (() -> Void)) {
+    init(label: String, icon: String, tintIcon: Bool = true, selected: Bool, onOffAction: Bool, action: @escaping (() -> Void)) {
         self.label = label
         self.icon = icon
+        self.tintIcon = tintIcon
         self.action = action
         self.onOffAction = onOffAction
         self.selected = selected

--- a/podcasts/PaidFeature.swift
+++ b/podcasts/PaidFeature.swift
@@ -72,6 +72,11 @@ extension PaidFeature {
         OnboardingFlow.shared.begin(flow: upgradeFlow, source: source)
     }
 
+    /// Presents the `upgradeController` from the given view controller
+    func presentUpgradeController(from controller: UIViewController, source: String) {
+        controller.presentFromRootController(upgradeController(source: source))
+    }
+
     private var upgradeFlow: OnboardingFlow.Flow {
         switch tier {
         case .patron:

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -1936,6 +1936,10 @@ extension PlaybackManager {
     func playBookmark(_ bookmark: Bookmark, source: BookmarkAnalyticsSource) {
         guard bookmarksEnabled else { return }
 
+        Analytics.track(.bookmarkPlayTapped, source: source)
+
+        analyticsPlaybackHelper.currentSource = .bookmarks
+
         // If we're already the now playing episode, then just seek to the bookmark time
         if isNowPlayingEpisode(episodeUuid: bookmark.episodeUuid) {
             seekTo(time: bookmark.time, startPlaybackAfterSeek: true)

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -1882,7 +1882,7 @@ private extension PlaybackManager {
     func handleRemoteAction(_ action: HeadphoneControlAction) {
         switch action {
         case .addBookmark:
-            bookmark()
+            bookmark(source: .headphones)
 
         case .previousChapter:
             guard let chapter = chapterManager.previousVisibleChapter() else { fallthrough }
@@ -1928,6 +1928,12 @@ extension PlaybackManager {
 
         let currentTime = currentTime()
         bookmarkManager.add(to: episode, at: currentTime)
+
+        Analytics.track(.bookmarkCreated, source: source, properties: [
+            "episode_uuid": episode.uuid,
+            "podcast_uuid": (episode as? Episode)?.podcastUuid ?? "user_file",
+            "time": Int(currentTime)
+        ])
     }
 
     /// Plays the given bookmark

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -1917,11 +1917,12 @@ private extension PlaybackManager {
 // MARK: - Bookmarks
 
 extension PlaybackManager {
+    private var bookmarksEnabled: Bool {
+        FeatureFlag.bookmarks.enabled && PaidFeature.bookmarks.isUnlocked
+    }
+
     func bookmark() {
-        guard
-            FeatureFlag.bookmarks.enabled,
-            let episode = currentEpisode()
-        else {
+        guard bookmarksEnabled, let episode = currentEpisode() else {
             return
         }
 
@@ -1933,6 +1934,8 @@ extension PlaybackManager {
     /// - if the episode is not currently playing we'll load it and then play at the bookmark time
     /// - if the episode is playing, we trigger a seek to the bookmark time
     func playBookmark(_ bookmark: Bookmark) {
+        guard bookmarksEnabled else { return }
+
         // If we're already the now playing episode, then just seek to the bookmark time
         if isNowPlayingEpisode(episodeUuid: bookmark.episodeUuid) {
             seekTo(time: bookmark.time, startPlaybackAfterSeek: true)

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -1921,7 +1921,7 @@ extension PlaybackManager {
         FeatureFlag.bookmarks.enabled && PaidFeature.bookmarks.isUnlocked
     }
 
-    func bookmark() {
+    func bookmark(source: BookmarkAnalyticsSource) {
         guard bookmarksEnabled, let episode = currentEpisode() else {
             return
         }
@@ -1933,7 +1933,7 @@ extension PlaybackManager {
     /// Plays the given bookmark
     /// - if the episode is not currently playing we'll load it and then play at the bookmark time
     /// - if the episode is playing, we trigger a seek to the bookmark time
-    func playBookmark(_ bookmark: Bookmark) {
+    func playBookmark(_ bookmark: Bookmark, source: BookmarkAnalyticsSource) {
         guard bookmarksEnabled else { return }
 
         // If we're already the now playing episode, then just seek to the bookmark time

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -1944,7 +1944,7 @@ extension PlaybackManager {
 
         Analytics.track(.bookmarkPlayTapped, source: source)
 
-        analyticsPlaybackHelper.currentSource = .bookmarks
+        analyticsPlaybackHelper.currentSource = .bookmark
 
         // If we're already the now playing episode, then just seek to the bookmark time
         if isNowPlayingEpisode(episodeUuid: bookmark.episodeUuid) {

--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -913,6 +913,8 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
     func showBookmarks() {
         guard let podcast else { return }
 
+        Analytics.track(.podcastsScreenTabTapped, properties: ["value": "bookmarks"])
+
         let controller = BookmarksPodcastListController(podcast: podcast)
         present(controller, animated: true)
     }

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -810,7 +810,7 @@ class Settings: NSObject {
 
     static var headphonesPreviousAction: HeadphoneControlAction {
         get {
-            Constants.UserDefaults.headphones.previousAction.value
+            Constants.UserDefaults.headphones.previousAction.unlockedValue
         }
 
         set {
@@ -820,7 +820,7 @@ class Settings: NSObject {
 
     static var headphonesNextAction: HeadphoneControlAction {
         get {
-            Constants.UserDefaults.headphones.nextAction.value
+            Constants.UserDefaults.headphones.nextAction.unlockedValue
         }
 
         set {

--- a/podcasts/ShelfActionsViewController+Table.swift
+++ b/podcasts/ShelfActionsViewController+Table.swift
@@ -72,6 +72,11 @@ extension ShelfActionsViewController: UITableViewDelegate, UITableViewDataSource
         Analytics.track(.playerShelfActionTapped, properties: ["action": action.analyticsDescription, "from": "overflow_menu"])
 
         dismiss(animated: true) {
+            guard action.isUnlocked else {
+                action.paidFeature?.presentUpgradeController(from: self, source: "overflow_menu")
+                return
+            }
+
             switch action {
             case .starEpisode:
                 self.playerActionsDelegate?.starEpisodeTapped()

--- a/podcasts/SimpleActionView.swift
+++ b/podcasts/SimpleActionView.swift
@@ -31,7 +31,14 @@ class SimpleActionView: UIView {
         addSubview(label)
 
         let iconTintColor = action.destructive ? AppTheme.destructiveTextColor(for: themeOverride) : AppTheme.colorForStyle(iconTintStyle, themeOverride: themeOverride)
-        if let icon = action.icon, let image = UIImage(named: icon)?.tintedImage(iconTintColor) {
+
+        var image = action.icon.flatMap { UIImage(named: $0) }
+
+        if action.tintIcon {
+            image = image?.tintedImage(iconTintColor)
+        }
+
+        if let image {
             let imageView = UIImageView(image: image)
             imageView.translatesAutoresizingMaskIntoConstraints = false
             addSubview(imageView)

--- a/podcasts/Unlockable/Settings+Unlockable.swift
+++ b/podcasts/Unlockable/Settings+Unlockable.swift
@@ -14,16 +14,3 @@ extension Constants.SettingValue: Unlockable {
         isUnlocked ? value : defaultValue
     }
 }
-
-// MARK: - HeadphoneControlAction + Bookmarks
-
-extension HeadphoneControlAction: Unlockable {
-    var paidFeature: PaidFeature? {
-        switch self {
-        case .addBookmark:
-            return .bookmarks
-        default:
-            return nil
-        }
-    }
-}

--- a/podcasts/Unlockable/Settings+Unlockable.swift
+++ b/podcasts/Unlockable/Settings+Unlockable.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+// MARK: - SettingValue
+
+/// This adds support for `Unlockable` `SettingValue`'s and provides a way for callers to retrieve the easily get the
+/// setting value which defaults to `defaultValue` if the feature is locked.
+extension Constants.SettingValue: Unlockable {
+    var paidFeature: PaidFeature? {
+        (value as? Unlockable)?.paidFeature
+    }
+
+    /// Defaults to returning the default value if the setting is not unlocked
+    var unlockedValue: Value {
+        isUnlocked ? value : defaultValue
+    }
+}
+
+// MARK: - HeadphoneControlAction + Bookmarks
+
+extension HeadphoneControlAction: Unlockable {
+    var paidFeature: PaidFeature? {
+        switch self {
+        case .addBookmark:
+            return .bookmarks
+        default:
+            return nil
+        }
+    }
+}

--- a/podcasts/Unlockable/Unlockable+Bookmarks.swift
+++ b/podcasts/Unlockable/Unlockable+Bookmarks.swift
@@ -1,4 +1,4 @@
-import UIKit
+import Foundation
 
 // MARK: - HeadphoneControlAction
 

--- a/podcasts/Unlockable/Unlockable+Bookmarks.swift
+++ b/podcasts/Unlockable/Unlockable+Bookmarks.swift
@@ -1,12 +1,15 @@
 import Foundation
 
+/// Defines the feature in this file that can be unlocked
+private let UnlockableFeature = PaidFeature.bookmarks
+
 // MARK: - HeadphoneControlAction
 
 extension HeadphoneControlAction: Unlockable {
     var paidFeature: PaidFeature? {
         switch self {
         case .addBookmark:
-            return .bookmarks
+            return UnlockableFeature
         default:
             return nil
         }
@@ -19,7 +22,7 @@ extension PlayerAction: Unlockable {
     var paidFeature: PaidFeature? {
         switch self {
         case .addBookmark:
-            return .bookmarks
+            return UnlockableFeature
         default:
             return nil
         }

--- a/podcasts/Unlockable/Unlockable+Bookmarks.swift
+++ b/podcasts/Unlockable/Unlockable+Bookmarks.swift
@@ -1,0 +1,27 @@
+import UIKit
+
+// MARK: - HeadphoneControlAction
+
+extension HeadphoneControlAction: Unlockable {
+    var paidFeature: PaidFeature? {
+        switch self {
+        case .addBookmark:
+            return .bookmarks
+        default:
+            return nil
+        }
+    }
+}
+
+// MARK: - PlayerAction
+
+extension PlayerAction: Unlockable {
+    var paidFeature: PaidFeature? {
+        switch self {
+        case .addBookmark:
+            return .bookmarks
+        default:
+            return nil
+        }
+    }
+}

--- a/podcasts/Unlockable/Unlockable.swift
+++ b/podcasts/Unlockable/Unlockable.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+/// Unlockable Protocol: Represents an item that is connected to a `PaidFeature` and can be unlocked with a subscription tier.
+/// Callers can check the `isUnlocked` property to determine whether the user can access it. By default this checked `paidFeature.isUnlocked`
+/// but can be customized to suit each options needs.
+protocol Unlockable {
+    /// Whether the feature is unlocked
+    var isUnlocked: Bool { get }
+
+    /// Returns the `PaidFeature` that the locked item is tied to
+    var paidFeature: PaidFeature? { get }
+}
+
+/// Provides the default isUnlocked functionality
+extension Unlockable {
+    var isUnlocked: Bool {
+        paidFeature?.isUnlocked ?? true
+    }
+}


### PR DESCRIPTION
| 🎨 Designs: [Figma](https://www.figma.com/file/Io7PCz1H1hmOgEE9eljoYW/Bookmarks?type=design&node-id=2099-32855&mode=dev) |
|:---:|

This locks the player shelf action and the headphone settings

- Headphone Settings
- Shelf Action
- Overflow Menu

### Things to note
- If the user no longer has access to bookmarks, but has the Add Bookmark headphone action selected then the setting will fallback to defaultValue set on the `SettingValue`. 
- If the user upgrades after tapping the Add Bookmark setting, then we will automatically change the setting to the add bookmark option. 
   - I didn't do this with the other places because it felt less contextual (ie: they tap add bookmark on the shelf, then 30 - 45 seconds later they finish the upgrade process and then we make a bookmark that isn't really near where they started the process at)

### 🔓 Unlockable
This also aims to reduce duplicated code, and make it easier to define an unlockable option by adding the `Unlockable` protocol. When an item adheres to Unlockable it defines which `PaidFeature` it can be unlocked with, and callers can check the `isUnlocked` property to determine if it's unlocked. 

Along with that, I added all of the Unlockable settings for Bookmarks in a the `Unlockable+Bookmarks` file to increase the visibility of which items are available with bookmarks.

## To test

**Note**: Enable the Bookmarks + Patron feature flags

1. Launch the app in the signed out state
10. Open the Full Screen player
11. Tap the Overflow icon (...)
12. Tap the Add Bookmark item
13. ✅ Verify the upsell opens
14. Dismiss it
15. Tap the Edit button and move the item into the shelf actions
16. Dismiss the overflow menu
17. Tap the shelf action
18. ✅ Verify you see the upsell
19. Dismiss it
2. Go to the Profile Tab > Settings Cog
3. Swipe down to the Headphone Controls option
4. Tap the previous action
5. ✅ Verify you see the Add Bookmark item with the Plus icon next to it
6. ✅ Verify tapping it opens the plus upsell
7. Dismiss it
8. Tap the next action
9. ✅ Verify the action is locked, and tapping it opens the upsell
10. Purchase the upgrade, and dismiss the app icon unlock view
11. ✅ Verify the setting action that was selected is now set to 'Add Bookmark'

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
