### PR TITLE
Bookmarks: Add episode sort to the podcast list

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Bookmarks/BookmarkDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Bookmarks/BookmarkDataManager.swift
@@ -86,8 +86,8 @@ public struct BookmarkDataManager {
     // MARK: - Retrieving
 
     /// Retrieves a single Bookmark for the given UUID
-    public func bookmark(for uuid: String) -> Bookmark? {
-        selectBookmarks(where: [.uuid], values: [uuid], limit: 1).first
+    public func bookmark(for uuid: String, allowDeleted: Bool = false) -> Bookmark? {
+        selectBookmarks(where: [.uuid], values: [uuid], limit: 1, allowDeleted: allowDeleted).first
     }
 
     /// Retrieves all the Bookmarks for an episode

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Bookmarks/BookmarkDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Bookmarks/BookmarkDataManager.swift
@@ -19,11 +19,6 @@ public struct BookmarkDataManager {
     ///   - transcription: A transcription of the clip if available
     @discardableResult
     public func add(uuid: String? = nil, episodeUuid: String, podcastUuid: String?, title: String, time: TimeInterval, dateCreated: Date = Date(), syncStatus: SyncStatus = .notSynced) -> String? {
-        // Prevent adding more than 1 bookmark at the same place
-        guard existingBookmark(forEpisode: episodeUuid, time: time) == nil else {
-            return nil
-        }
-
         var bookmarkUuid: String? = nil
 
         dbQueue.inDatabase { db in

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Bookmarks/BookmarkDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Bookmarks/BookmarkDataManager.swift
@@ -217,7 +217,7 @@ public struct BookmarkDataManager {
     // MARK: - Sortings
 
     public enum SortOption {
-        case newestToOldest, oldestToNewest, timestamp
+        case newestToOldest, oldestToNewest, timestamp, episode
 
         var queryString: String {
             switch self {
@@ -225,7 +225,7 @@ public struct BookmarkDataManager {
                 return "ORDER BY \(Column.createdDate) DESC"
             case .oldestToNewest:
                 return "ORDER BY \(Column.createdDate) ASC"
-            case .timestamp:
+            case .timestamp, .episode:
                 return "ORDER BY \(Column.time) ASC"
             }
         }

--- a/Modules/DataModel/Tests/PocketCastsDataModelTests/BookmarkDataManagerTests.swift
+++ b/Modules/DataModel/Tests/PocketCastsDataModelTests/BookmarkDataManagerTests.swift
@@ -42,24 +42,6 @@ final class BookmarkDataManagerTests: XCTestCase {
         XCTAssertEqual(dataManager.bookmarks(forEpisode: episode).count, 1)
     }
 
-    func testAddingABookmarkAtTheSameTimeAsAnotherDoesntGetAdded() {
-        let title = "Title 1"
-        let date = Date(timeIntervalSince1970: 321)
-        let time = 9876.0
-
-        let first = dataManager.add(episodeUuid: "episode-uuid", podcastUuid: "podcast-uuid", title: title, time: time, dateCreated: date)
-
-        let second = dataManager.add(episodeUuid: "episode-uuid", podcastUuid: "podcast-uuid", title: "Title 2", time: 9876, dateCreated: Date())
-
-        XCTAssertNil(second)
-
-        // Verify stored data was not modified
-        let bookmark = dataManager.bookmark(for: first!)
-        XCTAssertEqual(title, bookmark?.title)
-        XCTAssertEqual(time, bookmark?.time)
-        XCTAssertEqual(date, bookmark?.created)
-    }
-
     // MARK: - Retrieving
 
     func testGettingAllBookmarksForPodcast() {

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+FullSync.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+FullSync.swift
@@ -159,7 +159,7 @@ private extension BookmarkDataManager {
     }
 
     func remove(apiBookmark: Api_BookmarkResponse) async -> Bool? {
-        guard let bookmark = bookmark(for: apiBookmark.bookmarkUuid) else {
+        guard let bookmark = bookmark(for: apiBookmark.bookmarkUuid, allowDeleted: true) else {
             return nil
         }
 

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
@@ -338,7 +338,7 @@ extension SyncTask {
         let bookmarkManager = dataManager.bookmarks
 
         // Add the bookmark if it's not in the database
-        guard let existingBookmark = bookmarkManager.bookmark(for: apiBookmark.bookmarkUuid) else {
+        guard let existingBookmark = bookmarkManager.bookmark(for: apiBookmark.bookmarkUuid, allowDeleted: true) else {
             if !apiBookmark.shouldDelete {
                 let addedUuid = bookmarkManager.add(uuid: apiBookmark.bookmarkUuid,
                                                     episodeUuid: apiBookmark.episodeUuid,

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask.swift
@@ -218,6 +218,12 @@ class SyncTask: ApiBaseTask {
             DataManager.sharedManager.markAllEpisodeFiltersSynced()
             DataManager.sharedManager.markAllFoldersSynced()
 
+            if dataManager.bookmarksEnabled {
+                Task {
+                    await dataManager.bookmarks.markAllBookmarksAsSynced()
+                }
+            }
+
             let response = try Api_SyncUpdateResponse(serializedData: responseData)
             processServerData(response: response)
 

--- a/podcasts/BookmarkManager.swift
+++ b/podcasts/BookmarkManager.swift
@@ -155,6 +155,8 @@ private extension BookmarkSortOption {
             return .oldestToNewest
         case .timestamp:
             return .timestamp
+        case .episode:
+            return .episode
         }
     }
 }

--- a/podcasts/Bookmarks/Bookmarks+Analytics.swift
+++ b/podcasts/Bookmarks/Bookmarks+Analytics.swift
@@ -25,6 +25,8 @@ extension BookmarkSortOption: AnalyticsDescribable {
             return "date_added_oldest_to_newest"
         case .timestamp:
             return "timestamp"
+        case .episode:
+            return "episode"
         }
     }
 }

--- a/podcasts/Bookmarks/List/BookmarkEpisodeListViewModel.swift
+++ b/podcasts/Bookmarks/List/BookmarkEpisodeListViewModel.swift
@@ -16,11 +16,12 @@ class BookmarkEpisodeListViewModel: BookmarkListViewModel {
     }
 
     override func reload() {
-        guard feature.isUnlocked else {
+        guard feature.isUnlocked, let episode else {
             items = []
             return
         }
-        items = episode.map { bookmarkManager.bookmarks(for: $0, sorted: sortOption) } ?? []
+
+        items = bookmarkManager.bookmarks(for: episode, sorted: sortOption)
     }
 
     override func addListeners() {

--- a/podcasts/Bookmarks/List/BookmarkListViewModel.swift
+++ b/podcasts/Bookmarks/List/BookmarkListViewModel.swift
@@ -17,6 +17,10 @@ class BookmarkListViewModel: SearchableListViewModel<Bookmark> {
         }
     }
 
+    var availableSortOptions: [BookmarkSortOption] {
+        [.newestToOldest, .oldestToNewest, .timestamp]
+    }
+
     var bookmarks: [Bookmark] {
         isSearching ? filteredItems : items
     }
@@ -137,9 +141,7 @@ extension BookmarkListViewModel {
     func showSortOptions() {
         let optionPicker = OptionsPicker(title: L10n.sortBy)
 
-        let options: [BookmarkSortOption] = [.newestToOldest, .oldestToNewest, .timestamp]
-
-        optionPicker.addActions(options.map({ option in
+        optionPicker.addActions(availableSortOptions.map({ option in
             .init(label: option.label) { [weak self] in
                 self?.sorted(by: option)
             }
@@ -186,6 +188,8 @@ private extension BookmarkSortOption {
             return L10n.podcastsEpisodeSortOldestToNewest
         case .timestamp:
             return L10n.sortOptionTimestamp
+        case .episode:
+            return L10n.episode
         }
     }
 }

--- a/podcasts/Bookmarks/List/BookmarkPodcastListViewModel.swift
+++ b/podcasts/Bookmarks/List/BookmarkPodcastListViewModel.swift
@@ -17,12 +17,18 @@ class BookmarkPodcastListViewModel: BookmarkListViewModel {
     }
 
     override func reload() {
-        guard feature.isUnlocked else {
+        guard feature.isUnlocked, let podcast else {
             items = []
             return
         }
 
-        items = podcast.map { bookmarkManager.bookmarks(for: $0, sorted: sortOption).includeEpisodes() } ?? []
+        var items = bookmarkManager.bookmarks(for: podcast, sorted: sortOption).includeEpisodes()
+
+        if sortOption == .episode {
+            items.sortByNewestEpisodeAndBookmarkTimestamp()
+        }
+
+        self.items = items
     }
 
     override func refresh(bookmark: Bookmark) {
@@ -45,5 +51,31 @@ class BookmarkPodcastListViewModel: BookmarkListViewModel {
                 self?.reload()
             }
             .store(in: &cancellables)
+    }
+}
+
+private extension BaseEpisode {
+    var sortDate: Date? {
+        publishedDate ?? addedDate
+    }
+}
+
+private extension Array where Element == Bookmark {
+    /// Sorts the array by episodes release date, and the bookmarks timestamp
+    mutating func sortByNewestEpisodeAndBookmarkTimestamp() {
+        sort(by: {
+            let timestampAsc = $0.time < $1.time
+
+            guard let date1 = $0.episode?.sortDate, let date2 = $1.episode?.sortDate else {
+                return timestampAsc
+            }
+
+            // We're grouping by the episode date, so default to using the timestamp sort if the dates are equal
+            if date1 == date2 {
+                return timestampAsc
+            }
+
+            return date1 > date2
+        })
     }
 }

--- a/podcasts/Bookmarks/List/BookmarkPodcastListViewModel.swift
+++ b/podcasts/Bookmarks/List/BookmarkPodcastListViewModel.swift
@@ -4,6 +4,10 @@ import PocketCastsDataModel
 class BookmarkPodcastListViewModel: BookmarkListViewModel {
     var podcast: Podcast?
 
+    override var availableSortOptions: [BookmarkSortOption] {
+        [.newestToOldest, .oldestToNewest, .episode]
+    }
+
     init(podcast: Podcast, bookmarkManager: BookmarkManager, sortOption: BookmarkListViewModel.SortSetting) {
         self.podcast = podcast
 

--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -422,5 +422,5 @@ enum HeadphoneControlAction: JSONCodable {
 // MARK: - Bookmark Sorting
 
 enum BookmarkSortOption: JSONCodable {
-    case newestToOldest, oldestToNewest, timestamp
+    case newestToOldest, oldestToNewest, timestamp, episode
 }


### PR DESCRIPTION
| 🎨 Designs: [Figma](https://www.figma.com/file/Io7PCz1H1hmOgEE9eljoYW/Bookmarks?type=design&node-id=2033-34278&mode=dev) |
|:---:|

Replaces the timestamp sort option on the podcast list with episode sort. Episode sort will sort the bookmarks so:
   - The bookmarks for the most recent episodes are displayed first
   - The bookmarks for each episode are ordered ascending by timestamp

## To test

**Note:** Enable the bookmarks, patron, and tracksLogging feature flags

1. Launch the app
2. Tap on the Podcasts tab
3. Tap on a podcast with bookmarks
4. Tap the `...` option
5. Tap Sort by
6. ✅ Verify you now see `Episode` as an option
7. Tap it
8. ✅ Verify you see `🔵 Tracked: bookmarks_sort_by_changed ["sort_order": "episode", "source": "podcast_screen"]`
9. ✅ Verify the bookmarks are sorted by:
   - The bookmarks for the most recent episodes are displayed first
   - The bookmarks for each episode are ordered ascending by timestamp

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
