### PR TITLE
Bookmarks: Fixes an error that can happen when syncing bookmarks

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Bookmarks/BookmarkDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Bookmarks/BookmarkDataManager.swift
@@ -86,8 +86,8 @@ public struct BookmarkDataManager {
     // MARK: - Retrieving
 
     /// Retrieves a single Bookmark for the given UUID
-    public func bookmark(for uuid: String) -> Bookmark? {
-        selectBookmarks(where: [.uuid], values: [uuid], limit: 1).first
+    public func bookmark(for uuid: String, allowDeleted: Bool = false) -> Bookmark? {
+        selectBookmarks(where: [.uuid], values: [uuid], limit: 1, allowDeleted: allowDeleted).first
     }
 
     /// Retrieves all the Bookmarks for an episode

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Bookmarks/BookmarkDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Bookmarks/BookmarkDataManager.swift
@@ -19,11 +19,6 @@ public struct BookmarkDataManager {
     ///   - transcription: A transcription of the clip if available
     @discardableResult
     public func add(uuid: String? = nil, episodeUuid: String, podcastUuid: String?, title: String, time: TimeInterval, dateCreated: Date = Date(), syncStatus: SyncStatus = .notSynced) -> String? {
-        // Prevent adding more than 1 bookmark at the same place
-        guard existingBookmark(forEpisode: episodeUuid, time: time) == nil else {
-            return nil
-        }
-
         var bookmarkUuid: String? = nil
 
         dbQueue.inDatabase { db in

--- a/Modules/DataModel/Tests/PocketCastsDataModelTests/BookmarkDataManagerTests.swift
+++ b/Modules/DataModel/Tests/PocketCastsDataModelTests/BookmarkDataManagerTests.swift
@@ -42,24 +42,6 @@ final class BookmarkDataManagerTests: XCTestCase {
         XCTAssertEqual(dataManager.bookmarks(forEpisode: episode).count, 1)
     }
 
-    func testAddingABookmarkAtTheSameTimeAsAnotherDoesntGetAdded() {
-        let title = "Title 1"
-        let date = Date(timeIntervalSince1970: 321)
-        let time = 9876.0
-
-        let first = dataManager.add(episodeUuid: "episode-uuid", podcastUuid: "podcast-uuid", title: title, time: time, dateCreated: date)
-
-        let second = dataManager.add(episodeUuid: "episode-uuid", podcastUuid: "podcast-uuid", title: "Title 2", time: 9876, dateCreated: Date())
-
-        XCTAssertNil(second)
-
-        // Verify stored data was not modified
-        let bookmark = dataManager.bookmark(for: first!)
-        XCTAssertEqual(title, bookmark?.title)
-        XCTAssertEqual(time, bookmark?.time)
-        XCTAssertEqual(date, bookmark?.created)
-    }
-
     // MARK: - Retrieving
 
     func testGettingAllBookmarksForPodcast() {

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+FullSync.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+FullSync.swift
@@ -159,7 +159,7 @@ private extension BookmarkDataManager {
     }
 
     func remove(apiBookmark: Api_BookmarkResponse) async -> Bool? {
-        guard let bookmark = bookmark(for: apiBookmark.bookmarkUuid) else {
+        guard let bookmark = bookmark(for: apiBookmark.bookmarkUuid, allowDeleted: true) else {
             return nil
         }
 

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
@@ -338,7 +338,7 @@ extension SyncTask {
         let bookmarkManager = dataManager.bookmarks
 
         // Add the bookmark if it's not in the database
-        guard let existingBookmark = bookmarkManager.bookmark(for: apiBookmark.bookmarkUuid) else {
+        guard let existingBookmark = bookmarkManager.bookmark(for: apiBookmark.bookmarkUuid, allowDeleted: true) else {
             if !apiBookmark.shouldDelete {
                 let addedUuid = bookmarkManager.add(uuid: apiBookmark.bookmarkUuid,
                                                     episodeUuid: apiBookmark.episodeUuid,

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask.swift
@@ -218,6 +218,12 @@ class SyncTask: ApiBaseTask {
             DataManager.sharedManager.markAllEpisodeFiltersSynced()
             DataManager.sharedManager.markAllFoldersSynced()
 
+            if dataManager.bookmarksEnabled {
+                Task {
+                    await dataManager.bookmarks.markAllBookmarksAsSynced()
+                }
+            }
+
             let response = try Api_SyncUpdateResponse(serializedData: responseData)
             processServerData(response: response)
 


### PR DESCRIPTION
This fixes some errors that I've seen while testing syncing:
- ` Unknown error calling sqlite3_step (19: UNIQUE constraint failed: Bookmark.uuid) rs`
  - This was happening while doing a full sync where some of the local bookmarks were marked as deleted, and when we tried to import the incoming one we would think the bookmark wasn't in our local database but it was. 
  - `SyncTask: Process Server Bookmarks - Could not add bookmark:`
      - This was triggered when importing existing bookmarks at the same timestamp on an episode as another in our local database. Since the `existingBookmark` check would return nil, the process thought it failed. I've removed that check to fix this .

## To test

I'm not entirely sure how to get into a state to reproduce these because it requires some data on the server to be in a specific state and your local device to also be in a state. 

I would try deleting some local bookmarks, logging out and back in to trigger full sync, and verifying you don't see any errors during syncing. 


## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
