### PR TITLE
EffectsPlayer: add different setup mechanisms

### DIFF
--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -275,7 +275,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             Constants.RemoteParams.episodeSearchDebounceMs: NSNumber(value: Constants.RemoteParams.episodeSearchDebounceMsDefault),
             Constants.RemoteParams.podcastSearchDebounceMs: NSNumber(value: Constants.RemoteParams.podcastSearchDebounceMsDefault),
             Constants.RemoteParams.customStorageLimitGB: NSNumber(value: Constants.RemoteParams.customStorageLimitGBDefault),
-            Constants.RemoteParams.endOfYearRequireAccount: NSNumber(value: Constants.RemoteParams.endOfYearRequireAccountDefault)
+            Constants.RemoteParams.endOfYearRequireAccount: NSNumber(value: Constants.RemoteParams.endOfYearRequireAccountDefault),
+            Constants.RemoteParams.effectsPlayerStrategy: NSNumber(value: Constants.RemoteParams.effectsPlayerStrategyDefault)
         ])
 
         remoteConfig.fetch(withExpirationDuration: 2.hour) { [weak self] status, _ in

--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -275,8 +275,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             Constants.RemoteParams.episodeSearchDebounceMs: NSNumber(value: Constants.RemoteParams.episodeSearchDebounceMsDefault),
             Constants.RemoteParams.podcastSearchDebounceMs: NSNumber(value: Constants.RemoteParams.podcastSearchDebounceMsDefault),
             Constants.RemoteParams.customStorageLimitGB: NSNumber(value: Constants.RemoteParams.customStorageLimitGBDefault),
-            Constants.RemoteParams.endOfYearRequireAccount: NSNumber(value: Constants.RemoteParams.endOfYearRequireAccountDefault),
-            Constants.RemoteParams.lockEffectsPlayer: NSNumber(value: Constants.RemoteParams.lockEffectsPlayerDefault)
+            Constants.RemoteParams.endOfYearRequireAccount: NSNumber(value: Constants.RemoteParams.endOfYearRequireAccountDefault)
         ])
 
         remoteConfig.fetch(withExpirationDuration: 2.hour) { [weak self] status, _ in

--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -312,6 +312,9 @@ struct Constants {
 
         static let endOfYearRequireAccount = "end_of_year_require_account"
         static let endOfYearRequireAccountDefault: Bool = true
+
+        static let effectsPlayerStrategy = "effects_player_strategy"
+        static let effectsPlayerStrategyDefault: Int = 1
     }
 
     static let defaultDebounceTime: TimeInterval = 0.5

--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -312,9 +312,6 @@ struct Constants {
 
         static let endOfYearRequireAccount = "end_of_year_require_account"
         static let endOfYearRequireAccountDefault: Bool = true
-
-        static let lockEffectsPlayer = "lock_effects_player"
-        static let lockEffectsPlayerDefault: Bool = false
     }
 
     static let defaultDebounceTime: TimeInterval = 0.5

--- a/podcasts/EffectsPlayer.swift
+++ b/podcasts/EffectsPlayer.swift
@@ -150,7 +150,7 @@ class EffectsPlayer: PlaybackProtocol, Hashable {
                 return
             }
 
-            strongSelf.playAndRetryIfNeeded()
+            strongSelf.playAndFallbackIfNeeded()
 
             strongSelf.playerLock.unlock()
 
@@ -198,6 +198,18 @@ class EffectsPlayer: PlaybackProtocol, Hashable {
 
         if !failedToStart {
             Self.attemptNumber = 1
+        }
+    }
+
+    /// Try to play. If it fails, fallback to DefaultPlayer
+    func playAndFallbackIfNeeded() {
+        do {
+            try SJCommonUtils.catchException {
+                self.player?.play()
+            }
+        } catch {
+            self.playerLock.unlock()
+            PlaybackManager.shared.playbackDidFail(logMessage: error.localizedDescription, userMessage: nil, fallbackToDefaultPlayer: true)
         }
     }
 

--- a/podcasts/EffectsPlayer.swift
+++ b/podcasts/EffectsPlayer.swift
@@ -156,7 +156,16 @@ class EffectsPlayer: PlaybackProtocol, Hashable {
                 return
             }
 
-            strongSelf.playAndFallbackIfNeeded()
+            switch Settings.effectsPlayerStrategy {
+            case .normalPlay:
+                strongSelf.normalPlay()
+            case .playAndRetryIfNeeded:
+                strongSelf.playAndRetryIfNeeded()
+            case .playAndFallbackIfNeeded:
+                strongSelf.playAndFallbackIfNeeded()
+            default:
+                strongSelf.normalPlay()
+            }
 
             strongSelf.playerLock.unlock()
 

--- a/podcasts/EffectsPlayer.swift
+++ b/podcasts/EffectsPlayer.swift
@@ -4,6 +4,12 @@ import PocketCastsDataModel
 import PocketCastsUtils
 import UIKit
 
+enum EffectsPlayerStrategy: Int {
+    case normalPlay = 1
+    case playAndRetryIfNeeded = 2
+    case playAndFallbackIfNeeded = 3
+}
+
 class EffectsPlayer: PlaybackProtocol, Hashable {
     private static let targetVolumeDbGain = 15.0 as Float
 

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -859,6 +859,11 @@ class Settings: NSObject {
             return remote.boolValue
         }
 
+        static var effectsPlayerStrategy: EffectsPlayerStrategy? {
+            let remote = RemoteConfig.remoteConfig().configValue(forKey: Constants.RemoteParams.effectsPlayerStrategy)
+            return EffectsPlayerStrategy(rawValue: remote.numberValue.intValue)
+        }
+
         private class func remoteMsToTime(key: String) -> TimeInterval {
             let remoteMs = RemoteConfig.remoteConfig().configValue(forKey: key)
 

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -859,11 +859,6 @@ class Settings: NSObject {
             return remote.boolValue
         }
 
-        static var lockEffectsPlayer: Bool {
-            let remote = RemoteConfig.remoteConfig().configValue(forKey: Constants.RemoteParams.lockEffectsPlayer)
-            return remote.boolValue
-        }
-
         private class func remoteMsToTime(key: String) -> TimeInterval {
             let remoteMs = RemoteConfig.remoteConfig().configValue(forKey: key)
 


### PR DESCRIPTION
This PR adds 3 different ways of setting up the `EffectsPlayer`:

1. The current one. It just calls `play` on `player` and if it crashes, it crashes
2. A retry mechanism. The player attempts to create and play itself three times, in the third time if it fails it crashes
3. A fallback mechanism. If the player creation/play fails, it falls back to `DefaultPlayer`

Which mechanism will be used is controlled by a remote feature flag, allowing us to test different scenarios without deploying a new app version.

Also part of this PR, I removed the old remote feature flag code for removing the `EffectsPlayer` lock as this didn't have any effect.

## To test

First, configure the environment:

1. Go to `AppDelegate.swift`, locate the `configureFirebase` method, and change `2.hour` to `30.seconds`.
3. Comment (or remove) `EffectsPlayer.swift` lines `143` to `157` (by doing this the engine won't start thus the playback will fail)
2. Download some episodes or add Files

### Normal play

Go to Firebase Console and change `effects_player_strategy` feature flag value to `1` and publish it.

1. Run the app
2. Play a downloaded episode or local file
3. ✅ The app should crash

### Retrying three times

Go to Firebase Console and change `effects_player_strategy` feature flag value to `2` and publish it.

1. Run the app
2. Play a downloaded episode or local file
3. ✅ The app should crash
4. Check the logs, you should see three `Loading <episode title>`, and for the first two you should see something like `EffectsPlayer: failed to start playback`

### Falling back to DefaultsPlayer

Go to Firebase Console and change `effects_player_strategy` feature flag value to `3` and publish it.

1. Run the app
2. Play a downloaded episode or local file
3. ✅ The episode should play
4. Check the logs and you should see `Playback Failed, attempting to fallback to: DefaultPlayer`

### Changing remote feature flag to 2

Go to Firebase Console and change `effects_player_strategy` feature flag value to `2` and publish it.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
