### PR TITLE
Autoplay: add missing tracks

### DIFF
--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -224,11 +224,9 @@ enum AnalyticsEvent: String {
     case playbackEffectTrimSilenceAmountChanged
     case playbackEffectVolumeBoostToggled
 
-    case playbackEpisodeAutoplayed
-
     // MARK: - Autoplay
+    case playbackEpisodeAutoplayed
     case autoplayStarted
-    case autoplayStopped
     case autoplayFinishedLastEpisode
 
     // MARK: - Filters

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -226,6 +226,11 @@ enum AnalyticsEvent: String {
 
     case playbackEpisodeAutoplayed
 
+    // MARK: - Autoplay
+    case autoplayStarted
+    case autoplayStopped
+    case autoplayFinishedLastEpisode
+
     // MARK: - Filters
 
     case filterListShown

--- a/podcasts/AutoplayHelper.swift
+++ b/podcasts/AutoplayHelper.swift
@@ -4,12 +4,27 @@ import PocketCastsUtils
 
 /// Reponsible for handling the Autoplay of episodes
 class AutoplayHelper {
-    enum Playlist: Codable {
+    enum Playlist: Codable, AnalyticsDescribable {
         case podcast(uuid: String)
         case filter(uuid: String)
         case downloads
         case files
         case starred
+
+        var analyticsDescription: String {
+            switch self {
+            case .podcast(uuid: _):
+                return "podcast"
+            case .filter(uuid: _):
+                return "filter"
+            case .downloads:
+                return "downloads"
+            case .files:
+                return "files"
+            case .starred:
+                return "starred"
+            }
+        }
     }
 
     #if !os(watchOS)
@@ -71,6 +86,7 @@ class AutoplayHelper {
 
         userDefaults.set(data, forKey: userDefaultsKey)
         FileLog.shared.addMessage("Autoplay: saving the latest playlist: \(playlist)")
+        Analytics.track(.autoplayStarted, properties: ["source": playlist])
     }
     #endif
 }

--- a/podcasts/AutoplayHelper.swift
+++ b/podcasts/AutoplayHelper.swift
@@ -57,6 +57,12 @@ class AutoplayHelper {
     /// Saves the current playlist
     func playedFrom(playlist: Playlist?) {
         save(selectedPlaylist: playlist)
+
+        // We always save the playlist no matter if Up Next is empty or not
+        // However this event should be fired only if the Up Next is empty.
+        if Settings.autoplay && upNextQueue.upNextCount() == 0 {
+            Analytics.track(.autoplayStarted, properties: ["source": playlist ?? "unknown"])
+        }
     }
 
     /// Given the current episode UUID, checks if there's any
@@ -89,12 +95,6 @@ class AutoplayHelper {
 
         userDefaults.set(data, forKey: userDefaultsKey)
         FileLog.shared.addMessage("Autoplay: saving the latest playlist: \(playlist)")
-
-        // We always save the playlist no matter if Up Next is empty or not
-        // However this event should be fired only if the Up Next is empty.
-        if upNextQueue.upNextCount() == 0 {
-            Analytics.track(.autoplayStarted, properties: ["source": playlist])
-        }
     }
     #endif
 }

--- a/podcasts/AutoplayHelper.swift
+++ b/podcasts/AutoplayHelper.swift
@@ -33,6 +33,7 @@ class AutoplayHelper {
     private let userDefaults: UserDefaults
     private let userDefaultsKey = "playlist"
     private let episodesDataManager: EpisodesDataManager
+    private let upNextQueue: PlaybackQueue
 
     /// Returns the latest playlist that the user played an episode from
     var lastPlaylist: Playlist? {
@@ -46,9 +47,11 @@ class AutoplayHelper {
     }
 
     init(userDefaults: UserDefaults = UserDefaults.standard,
-         episodesDataManager: EpisodesDataManager = EpisodesDataManager()) {
+         episodesDataManager: EpisodesDataManager = EpisodesDataManager(),
+         queue: PlaybackQueue = PlaybackQueue()) {
         self.userDefaults = userDefaults
         self.episodesDataManager = episodesDataManager
+        self.upNextQueue = queue
     }
 
     /// Saves the current playlist
@@ -86,7 +89,12 @@ class AutoplayHelper {
 
         userDefaults.set(data, forKey: userDefaultsKey)
         FileLog.shared.addMessage("Autoplay: saving the latest playlist: \(playlist)")
-        Analytics.track(.autoplayStarted, properties: ["source": playlist])
+
+        // We always save the playlist no matter if Up Next is empty or not
+        // However this event should be fired only if the Up Next is empty.
+        if upNextQueue.upNextCount() == 0 {
+            Analytics.track(.autoplayStarted, properties: ["source": playlist])
+        }
     }
     #endif
 }

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -1858,6 +1858,8 @@ class PlaybackManager: ServerPlaybackDelegate {
         } else {
             // Reset the latest played from
             AutoplayHelper.shared.playedFrom(playlist: nil)
+
+            Analytics.track(.autoplayFinishedLastEpisode)
         }
         #endif
     }

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -1850,17 +1850,21 @@ class PlaybackManager: ServerPlaybackDelegate {
         // If Autoplay is enabled we check if there's another episode to play
         if Settings.autoplay,
            queue.upNextCount() == 0,
-           let episode = currentEpisode(),
-           let nextEpisode = AutoplayHelper.shared.nextEpisode(currentEpisodeUuid: episode.uuid) {
-            FileLog.shared.addMessage("Autoplaying next episode: \(nextEpisode.displayableTitle())")
-            queue.add(episode: nextEpisode, fireNotification: false)
-            Analytics.track(.playbackEpisodeAutoplayed, properties: ["episode_uuid": nextEpisode.uuid])
-        } else {
-            // Reset the latest played from
-            AutoplayHelper.shared.playedFrom(playlist: nil)
+           let episode = currentEpisode() {
 
-            Analytics.track(.autoplayFinishedLastEpisode)
+            if let nextEpisode = AutoplayHelper.shared.nextEpisode(currentEpisodeUuid: episode.uuid) {
+                FileLog.shared.addMessage("Autoplaying next episode: \(nextEpisode.displayableTitle())")
+                queue.add(episode: nextEpisode, fireNotification: false)
+                Analytics.track(.playbackEpisodeAutoplayed, properties: ["episode_uuid": nextEpisode.uuid])
+                return
+            } else {
+                Analytics.track(.autoplayFinishedLastEpisode)
+            }
+
         }
+
+        // Nothing to autoplay or Up Next has items, reset the latest played from
+        AutoplayHelper.shared.playedFrom(playlist: nil)
         #endif
     }
 


### PR DESCRIPTION
Adds two tracks that were added on the web:

* `autoplay_started`: whenever an autoplay session starts
* `autoplay_finished_last_episode`: when the last episode of a playlist finishes playing

## To test

1. Run the app
2. Go to Profile > Settings > Beta Features > enable `tracksLogging`
3. Clean your Up Next if there's any item (long press the miniplayer > "Close and Clear Up Next")
4. Play an episode from any place
5. ✅ You should see a log like: `🔵 Tracked: autoplay_started ["source": "SOURCE"]` (with SOURCE being `podcast`, `filter`, `downloads`, `files` or `starred`)
6. Play an episode from any playlist or podcast with less than 5 episodes (Discover has the "House of R")
7. Move the scrubber to the end until you finish all episodes
8. ✅ After the last one, you should see a log `🔵 Tracked: autoplay_finished_last_episode`

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
