### PR TITLE
Always specify the bookmark modified values when syncing

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+LocalChanges.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+LocalChanges.swift
@@ -195,15 +195,11 @@ private extension Api_SyncUserBookmark {
         self.time.value = .init(bookmark.time)
         self.createdAt = .init(date: bookmark.created)
 
-        bookmark.deletedModified.map {
-            self.isDeletedModified = .init(date: $0)
-            self.isDeleted.value = bookmark.deleted
-        }
+        self.isDeleted.value = bookmark.deleted
+        self.isDeletedModified = .init(date: bookmark.deletedModified ?? bookmark.created)
 
-        bookmark.titleModified.map {
-            self.titleModified = .init(date: $0)
-            self.title.value = bookmark.title
-        }
+        self.title.value = bookmark.title
+        self.titleModified = .init(date: bookmark.titleModified ?? bookmark.created)
     }
 }
 


### PR DESCRIPTION
| 📘 Part of: #1061 |
|:---:|

Bookmarks that are created from iOS were not displaying in the Android app because the `deleted` value would be received as null which does not pass the [validation check on Android](https://github.com/Automattic/pocket-casts-android/blob/16e17f99bd57be7c60d9e9968c6419b1a3d0ede0/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/update/SyncUpdateResponseParser.kt#L209). 

This fixes that by always specifying the deleted value and the deleted modified value. 

## To test

1. Run the app on iOS and Android
2. Sign into the same account
3. Add some bookmarks on iOS
4. Sync
5. Sync on Android
6. Open the bookmarks list on Android
7. ✅ Verify the iOS created bookmark appears

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
