### PR TITLE
Bookmarks: Refresh the user files when bookmarks change

### DIFF
--- a/podcasts/BookmarkManager.swift
+++ b/podcasts/BookmarkManager.swift
@@ -123,8 +123,13 @@ class BookmarkManager {
             let items: [Info]
 
             struct Info {
+                /// The uuid of the deleted bookmark
                 let uuid: String
+
+                /// The uuid of the episode the bookmark was removed from
                 let episode: String
+
+                /// The uuid of the podcast the bookmark was removed from, if available
                 let podcast: String?
             }
         }

--- a/podcasts/Bookmarks/List/BookmarkListViewModel.swift
+++ b/podcasts/Bookmarks/List/BookmarkListViewModel.swift
@@ -1,5 +1,6 @@
 import Combine
 import PocketCastsDataModel
+import PocketCastsServer
 
 class BookmarkListViewModel: SearchableListViewModel<Bookmark> {
     typealias SortSetting = Constants.SettingValue<BookmarkSortOption>
@@ -69,6 +70,13 @@ class BookmarkListViewModel: SearchableListViewModel<Bookmark> {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] bookmark in
                 self?.refresh(bookmark: bookmark)
+            }
+            .store(in: &cancellables)
+
+        ServerNotifications.syncCompleted.publisher()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] bookmark in
+                self?.reload()
             }
             .store(in: &cancellables)
 

--- a/podcasts/PlayerTabsView.swift
+++ b/podcasts/PlayerTabsView.swift
@@ -49,7 +49,7 @@ class PlayerTabsView: UIScrollView {
                 AnalyticsHelper.playerShowNotesOpened()
             case .chapters:
                 AnalyticsHelper.chaptersOpened()
-            case .bookmarks: #warning("TODO: Bookmarks: Analytics")
+            case .bookmarks:
                 break
             }
         }


### PR DESCRIPTION
| 📘 Part of: #1061 |
|:---:|

This fixes the issue where the bookmark indicator would not appear/disappear if a bookmark was created/deleted. 

This also reloads the other bookmark lists when a sync completes to make sure any sync'd bookmarks also appear.

## To test

Note: Enable the Bookmarks and Patron feature flag. Activate Patron to unlock bookmarks

1. Launch the app
2. Add a user file if you don't have one
3. Go to Profile > Files to view the list
4. Tap Play
5. Open the Player
6. Tap the 'Add Bookmark' shelf action
7. Dismiss the player
8. ✅ Verify the bookmark icon appears for the file
9. Tap on the file
10. Tap Bookmarks
11. Tap and hold the bookmark, and delete it
12. Dismiss the bookmarks view
13. ✅ Verify the bookmark icon is removed

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
