### PR TITLE
Bookmarks: Update the edit title view theme

### DIFF
--- a/podcasts/Bookmarks/Editing/BookmarkEditTitleViewController.swift
+++ b/podcasts/Bookmarks/Editing/BookmarkEditTitleViewController.swift
@@ -19,7 +19,8 @@ class BookmarkEditTitleViewController: ThemedHostingController<BookmarkEditTitle
         self.viewModel = viewModel
         self.onDismiss = onDismiss
 
-        super.init(rootView: .init(viewModel: viewModel))
+        let theme = BookmarkEditTheme(episode: manager.episode(for: bookmark))
+        super.init(rootView: .init(viewModel: viewModel, theme: theme))
 
         viewModel.router = self
     }

--- a/podcasts/Bookmarks/Editing/BookmarkEditViewModel.swift
+++ b/podcasts/Bookmarks/Editing/BookmarkEditViewModel.swift
@@ -16,6 +16,7 @@ class BookmarkEditViewModel: ObservableObject {
     /// Localized Strings
     let headerTitle: String
     let headerSubTitle: String
+    let saveButtonTitle: String
     let placeholder: String = L10n.bookmarkDefaultTitle
 
     @Published var didAppear = false
@@ -35,9 +36,11 @@ class BookmarkEditViewModel: ObservableObject {
         case .adding:
             headerTitle = L10n.addBookmark
             headerSubTitle = L10n.addBookmarkSubtitle
+            saveButtonTitle = L10n.saveBookmark
         case .updating:
             headerTitle = L10n.changeBookmarkTitle
             headerSubTitle = L10n.changeBookmarkSubtitle
+            saveButtonTitle = L10n.changeBookmarkTitle
         }
     }
 

--- a/podcasts/PlayerColorHelper.swift
+++ b/podcasts/PlayerColorHelper.swift
@@ -2,74 +2,83 @@ import Foundation
 import PocketCastsDataModel
 
 struct PlayerColorHelper {
-    static func playerBackgroundColor01() -> UIColor {
-        guard let podcastBackgroundColor = backgroundColorForPlayingEpisode() else { return UIColor.black }
+    static func playerBackgroundColor01(for theme: Theme.ThemeType = Theme.sharedTheme.activeTheme,
+                                        episode: BaseEpisode? = PlaybackManager.shared.currentEpisode()) -> UIColor {
+        guard let podcastBackgroundColor = backgroundColor(for: episode) else { return UIColor.black }
 
-        return ThemeColor.playerBackground01(podcastColor: podcastBackgroundColor)
+        return ThemeColor.playerBackground01(podcastColor: podcastBackgroundColor, for: theme)
     }
 
-    static func playerBackgroundColor02() -> UIColor {
-        guard let podcastBackgroundColor = backgroundColorForPlayingEpisode() else { return UIColor.black }
+    static func playerBackgroundColor02(for theme: Theme.ThemeType = Theme.sharedTheme.activeTheme,
+                                        episode: BaseEpisode? = PlaybackManager.shared.currentEpisode()) -> UIColor {
+        guard let podcastBackgroundColor = backgroundColor(for: episode) else { return UIColor.black }
 
-        return ThemeColor.playerBackground02(podcastColor: podcastBackgroundColor)
+        return ThemeColor.playerBackground02(podcastColor: podcastBackgroundColor, for: theme)
     }
 
-    static func playerHighlightColor01(for theme: Theme.ThemeType) -> UIColor {
-        guard let podcastColor = themeTintForPlayingEpisode(for: theme) else { return UIColor.white }
+    static func playerHighlightColor01(for theme: Theme.ThemeType,
+                                       episode: BaseEpisode? = PlaybackManager.shared.currentEpisode()) -> UIColor {
+        guard let podcastColor = tint(for: episode, with: theme) else { return UIColor.white }
 
         return ThemeColor.playerHighlight01(podcastColor: podcastColor)
     }
 
-    static func playerHighlightColor02(for theme: Theme.ThemeType) -> UIColor {
-        guard let podcastColor = themeTintForPlayingEpisode(for: theme) else { return UIColor.white }
+    static func playerHighlightColor02(for theme: Theme.ThemeType,
+                                       episode: BaseEpisode? = PlaybackManager.shared.currentEpisode()) -> UIColor {
+        guard let podcastColor = tint(for: episode, with: theme) else { return UIColor.white }
 
         return ThemeColor.playerHighlight02(podcastColor: podcastColor)
     }
 
-    static func playerHighlightColor06(for theme: Theme.ThemeType) -> UIColor {
-        guard let podcastColor = themeTintForPlayingEpisode(for: theme) else { return UIColor.white }
+    static func playerHighlightColor06(for theme: Theme.ThemeType,
+                                       episode: BaseEpisode? = PlaybackManager.shared.currentEpisode()) -> UIColor {
+        guard let podcastColor = tint(for: episode, with: theme) else { return UIColor.white }
 
         return ThemeColor.playerHighlight06(podcastColor: podcastColor)
     }
 
-    static func playerHighlightColor07(for theme: Theme.ThemeType) -> UIColor {
-        guard let podcastColor = themeTintForPlayingEpisode(for: theme) else { return UIColor.white }
+    static func playerHighlightColor07(for theme: Theme.ThemeType,
+                                       episode: BaseEpisode? = PlaybackManager.shared.currentEpisode()) -> UIColor {
+        guard let podcastColor = tint(for: episode, with: theme) else { return UIColor.white }
 
         return ThemeColor.playerHighlight07(podcastColor: podcastColor)
     }
 
-    static func podcastInteractive03(for theme: Theme.ThemeType) -> UIColor {
-        guard let podcastColor = themeTintForPlayingEpisode(for: theme) else { return UIColor.white }
+    static func podcastInteractive03(for theme: Theme.ThemeType,
+                                     episode: BaseEpisode? = PlaybackManager.shared.currentEpisode()) -> UIColor {
+        guard let podcastColor = tint(for: episode, with: theme) else { return UIColor.white }
 
         return ThemeColor.podcastInteractive03(podcastColor: podcastColor)
     }
 
-    static func podcastInteractive04(for theme: Theme.ThemeType) -> UIColor {
-        guard let podcastColor = themeTintForPlayingEpisode(for: theme) else { return UIColor.white }
+    static func podcastInteractive04(for theme: Theme.ThemeType,
+                                     episode: BaseEpisode? = PlaybackManager.shared.currentEpisode()) -> UIColor {
+        guard let podcastColor = tint(for: episode, with: theme) else { return UIColor.white }
 
         return ThemeColor.podcastInteractive04(podcastColor: podcastColor)
     }
 
-    static func podcastInteractive05(for theme: Theme.ThemeType) -> UIColor {
-        guard let podcastColor = themeTintForPlayingEpisode(for: theme) else { return UIColor.white }
+    static func podcastInteractive05(for theme: Theme.ThemeType,
+                                     episode: BaseEpisode? = PlaybackManager.shared.currentEpisode()) -> UIColor {
+        guard let podcastColor = tint(for: episode, with: theme) else { return UIColor.white }
 
         return ThemeColor.podcastInteractive05(podcastColor: podcastColor)
     }
 
-    private static func themeTintForPlayingEpisode(for theme: Theme.ThemeType) -> UIColor? {
-        if let episode = PlaybackManager.shared.currentEpisode() as? UserEpisode {
-            return episode.imageColor > 0 ? AppTheme.userEpisodeColor(number: Int(episode.imageColor)) : AppTheme.userEpisodeNoArtworkColor()
+    private static func tint(for episode: BaseEpisode?, with theme: Theme.ThemeType) -> UIColor? {
+        if let userEpisode = episode as? UserEpisode {
+            return userEpisode.imageColor > 0 ? AppTheme.userEpisodeColor(number: Int(userEpisode.imageColor)) : AppTheme.userEpisodeNoArtworkColor()
         }
 
-        guard let episode = PlaybackManager.shared.currentEpisode() as? Episode, let parentPodcast = episode.parentPodcast() else {
+        guard let parentPodcast = (episode as? Episode)?.parentPodcast() else {
             return nil
         }
 
         return theme.isDark ? ColorManager.darkThemeTintForPodcast(parentPodcast) : ColorManager.lightThemeTintForPodcast(parentPodcast)
     }
 
-    private static func backgroundColorForPlayingEpisode() -> UIColor? {
-        guard let episode = PlaybackManager.shared.currentEpisode() as? Episode, let parentPodcast = episode.parentPodcast() else {
+    private static func backgroundColor(for episode: BaseEpisode?) -> UIColor? {
+        guard let parentPodcast = (episode as? Episode)?.parentPodcast() else {
             return nil
         }
 


### PR DESCRIPTION
| 📘 Part of: #1061 |
|:---:|

This fixes the issue where the button and accent colors on the edit title view were incorrect. 

This also does a bit of refactoring to allow injecting of an episode into the PlayerColorHelper methods, and the edit title view will use the colors of the bookmark episode rather than always using the player colors.

| Before | After |
|:---:|:---:|
|<img src="https://github.com/Automattic/pocket-casts-ios/assets/793774/e7a63f68-43d5-437e-932b-36d0327e93cf" width="320" />|<img src="https://github.com/Automattic/pocket-casts-ios/assets/793774/dfcaa130-6d52-4238-9182-26188883a308" width="320" />|

## To test

Note: Enable the bookmarks and patron feature flags. Activate bookmarks. 

1. Launch the app
4. Open the full screen player
5. ✅ Verify the theme still look the same
2. Create a new bookmark
3. ✅ Verify the button and text field accent colors look good and have good contrast


## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
