### PR TITLE
Bookmarks: Update the player tab style

### DIFF
--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -224,6 +224,8 @@ struct Constants {
         static let bottomCardAnimationTime = 0.2 as TimeInterval
         static let playerDragLineFadeTime = 0.6 as TimeInterval
         static let multiSelectStatusDelayTime = 0.8 as TimeInterval
+
+        static let playerTabSwitch: TimeInterval = 0.2
     }
 
     #if !os(watchOS)

--- a/podcasts/PlayerContainerViewController+Scroll.swift
+++ b/podcasts/PlayerContainerViewController+Scroll.swift
@@ -6,15 +6,6 @@ extension PlayerContainerViewController: UIScrollViewDelegate {
             if !scrollView.isTracking, !scrollView.isDragging { return } // ignore programmatic scroll
 
             let xOffset = scrollView.contentOffset.x
-            if xOffset < 0 {
-                tabsView.leadingEdgePullDistance = -xOffset
-            } else if xOffset > maxScrollWidth() {
-                tabsView.trailingEdgePullDistance = xOffset - maxScrollWidth()
-            } else if tabsView.leadingEdgePullDistance != 0 || tabsView.trailingEdgePullDistance != 0 {
-                tabsView.leadingEdgePullDistance = 0
-                tabsView.trailingEdgePullDistance = 0
-            }
-
             let currentTab = Int(round(xOffset / scrollView.bounds.width))
             if currentTab == tabsView.currentTab { return }
             tabsView.currentTab = currentTab
@@ -24,18 +15,5 @@ extension PlayerContainerViewController: UIScrollViewDelegate {
             // this is a secondary child scroll view, pass it on to our gesture handler code
             handleScrollViewDidScroll(scrollView: scrollView)
         }
-    }
-
-    func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>) {
-        let endPoint = targetContentOffset.pointee
-
-        if (endPoint.x == 0 && tabsView.leadingEdgePullDistance > 0) || (endPoint.x == maxScrollWidth() && tabsView.trailingEdgePullDistance > 0) {
-            tabsView.animateBackToNonCompressed()
-        }
-    }
-
-    private func maxScrollWidth() -> CGFloat {
-        let tabCount = tabsView.tabs.count
-        return CGFloat(max(1, tabCount - 1)) * view.bounds.width
     }
 }

--- a/podcasts/PlayerContainerViewController.swift
+++ b/podcasts/PlayerContainerViewController.swift
@@ -122,34 +122,25 @@ class PlayerContainerViewController: SimpleNotificationsViewController, PlayerTa
     // MARK: - PlayerItemContainerDelegate
 
     func scrollToCurrentChapter() {
-        guard let chapterTabIndex = tabsView.tabs.firstIndex(of: .chapters) else { return }
-
-        tabsView.currentTab = chapterTabIndex
-        let scrollRect = CGRect(x: CGFloat(chapterTabIndex) * mainScrollView.frame.width, y: 0, width: mainScrollView.frame.width, height: mainScrollView.frame.height)
-        mainScrollView.scrollRectToVisible(scrollRect, animated: true)
+        guard scroll(to: .chapters) else {
+            return
+        }
 
         chaptersItem.scrollToCurrentlyPlayingChapter(animated: false)
     }
 
     func scrollToNowPlaying() {
-        tabsView.currentTab = 0
-        let scrollRect = CGRect(x: 0, y: 0, width: mainScrollView.frame.width, height: mainScrollView.frame.height)
-        mainScrollView.scrollRectToVisible(scrollRect, animated: true)
+        scroll(to: .nowPlaying)
     }
 
     func scrollToBookmarks() {
-        guard let index = tabsView.tabs.firstIndex(of: .bookmarks) else { return }
-
-        tabsView.currentTab = index
-        let scrollRect = CGRect(x: CGFloat(index) * mainScrollView.frame.width, y: 0, width: mainScrollView.frame.width, height: mainScrollView.frame.height)
-        mainScrollView.scrollRectToVisible(scrollRect, animated: true)
+        scroll(to: .bookmarks)
     }
 
     // MARK: - PlayerTabDelegate
 
     func didSwitchToTab(index: Int) {
-        let scrollWidth = mainScrollView.bounds.width
-        mainScrollView.setContentOffset(CGPoint(x: CGFloat(index) * scrollWidth, y: 0), animated: true)
+        scroll(to: index)
     }
 
     private func setupObservers() {
@@ -236,5 +227,30 @@ class PlayerContainerViewController: SimpleNotificationsViewController, PlayerTa
 
     @objc func handleAppWillBecomeActive() {
         didSwitchToTab(index: tabsView.currentTab)
+    }
+}
+
+private extension PlayerContainerViewController {
+    @discardableResult
+    func scroll(to tab: PlayerTabs) -> Bool {
+        guard let index = tabsView.tabs.firstIndex(of: tab) else {
+            return false
+        }
+
+        scroll(to: index)
+
+        return true
+    }
+
+    func scroll(to index: Int) {
+        if tabsView.currentTab != index {
+            tabsView.currentTab = index
+        }
+
+        let offset = CGFloat(index) * mainScrollView.frame.width
+
+        UIView.animate(withDuration: Constants.Animation.playerTabSwitch) {
+            self.mainScrollView.setContentOffset(.init(x: offset, y: 0), animated: false)
+        }
     }
 }

--- a/podcasts/PlayerContainerViewController.xib
+++ b/podcasts/PlayerContainerViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22113.1" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22089"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21678"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -40,9 +40,9 @@
                             </connections>
                         </button>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="DY8-o1-Oqt" customClass="PlayerTabsView" customModule="podcasts" customModuleProvider="target">
-                            <rect key="frame" x="62" y="14" width="278" height="46"/>
+                            <rect key="frame" x="62" y="18" width="278" height="40"/>
                             <constraints>
-                                <constraint firstAttribute="height" constant="46" id="fvZ-1o-n3k"/>
+                                <constraint firstAttribute="height" constant="40" placeholder="YES" id="fvZ-1o-n3k"/>
                             </constraints>
                         </view>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" pointerInteraction="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HBu-bE-aeT" customClass="UpNextButton" customModule="podcasts" customModuleProvider="target">
@@ -60,12 +60,12 @@
                     <constraints>
                         <constraint firstAttribute="bottom" secondItem="n9H-5y-Rbm" secondAttribute="bottom" id="75X-MC-iuO"/>
                         <constraint firstAttribute="trailing" secondItem="HBu-bE-aeT" secondAttribute="trailing" constant="10" id="A5g-u0-D5V"/>
+                        <constraint firstItem="DY8-o1-Oqt" firstAttribute="centerY" secondItem="HBu-bE-aeT" secondAttribute="centerY" constant="2" id="Igm-ry-DNo"/>
                         <constraint firstItem="DY8-o1-Oqt" firstAttribute="leading" secondItem="n9H-5y-Rbm" secondAttribute="trailing" constant="4" id="LZm-RF-qiW"/>
                         <constraint firstItem="HBu-bE-aeT" firstAttribute="leading" secondItem="DY8-o1-Oqt" secondAttribute="trailing" constant="20" id="OYA-T1-dGq"/>
                         <constraint firstAttribute="bottom" secondItem="HBu-bE-aeT" secondAttribute="bottom" constant="2" id="QvH-py-N3Q"/>
                         <constraint firstAttribute="height" constant="60" id="c5W-M4-Gcb"/>
                         <constraint firstItem="n9H-5y-Rbm" firstAttribute="leading" secondItem="tuk-fS-Mph" secondAttribute="leading" constant="14" id="liR-iX-SIQ"/>
-                        <constraint firstAttribute="bottom" secondItem="DY8-o1-Oqt" secondAttribute="bottom" id="w1r-S2-cMD"/>
                     </constraints>
                 </view>
                 <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" directionalLockEnabled="YES" pagingEnabled="YES" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jyM-S1-fQW" customClass="RegionCancellingScrollView" customModule="podcasts" customModuleProvider="target">

--- a/podcasts/PlayerTabsView.swift
+++ b/podcasts/PlayerTabsView.swift
@@ -62,6 +62,9 @@ class PlayerTabsView: UIScrollView {
     private lazy var tabsStackView: UIStackView = {
         let stackView = UIStackView()
         stackView.axis = .horizontal
+        stackView.distribution = .fillProportionally
+        stackView.alignment = .fill
+
         stackView.spacing = TabConstants.spacing
 
         return stackView
@@ -122,18 +125,11 @@ class PlayerTabsView: UIScrollView {
         tabsStackView.removeAllSubviews()
 
         for (index, tab) in tabs.enumerated() {
-            let button = UIButton(type: .custom)
-            button.isPointerInteractionEnabled = true
-            button.titleLabel?.font = TabConstants.titleFont
-
-            let titleColor = index == currentTab ? ThemeColor.playerContrast01() : ThemeColor.playerContrast02()
-            button.setTitleColor(titleColor, for: .normal)
-
-            let title = tab.description
-            button.setTitle(title, for: .normal)
+            let button = PlayerTabButton(title: tab.description)
+            button.isSelected = index == currentTab
             button.tag = index
+            button.isPointerInteractionEnabled = true
             button.addTarget(self, action: #selector(buttonTapped(_:)), for: .touchUpInside)
-
             tabsStackView.addArrangedSubview(button)
         }
 
@@ -141,43 +137,40 @@ class PlayerTabsView: UIScrollView {
     }
 
     @objc private func buttonTapped(_ sender: UIButton) {
-        let tabIndex = sender.tag
-
-        currentTab = tabIndex
+        currentTab = sender.tag
         tabDelegate?.didSwitchToTab(index: currentTab)
     }
 
     private func animateTabChange(fromIndex: Int, toIndex: Int) {
+        let animationDuration = Constants.Animation.playerTabSwitch
 
         // text color animation
         if let fromTab = tabsStackView.arrangedSubviews[safe: fromIndex] as? UIButton {
-            UIView.transition(with: fromTab, duration: Constants.Animation.defaultAnimationTime, options: .transitionCrossDissolve, animations: {
-                fromTab.setTitleColor(ThemeColor.playerContrast02(), for: .normal)
-            }, completion: nil)
+            UIView.transition(with: fromTab, duration: animationDuration, options: .transitionCrossDissolve, animations: {
+                fromTab.isSelected = false
+            })
         }
 
         if let toTab = tabsStackView.arrangedSubviews[safe: toIndex] as? UIButton {
-            UIView.transition(with: toTab, duration: Constants.Animation.defaultAnimationTime, options: .transitionCrossDissolve, animations: {
-                toTab.setTitleColor(ThemeColor.playerContrast01(), for: .normal)
-            }, completion: nil)
+            UIView.transition(with: toTab, duration: animationDuration, options: .transitionCrossDissolve, animations: {
+                toTab.isSelected = true
+            })
 
             // Scroll the button into view, but make sure it clears the fade
             scrollRectToVisible(toTab.frame.insetBy(dx: -TabConstants.fadeSize, dy: 0), animated: true)
         }
     }
+}
 
 
+private enum TabConstants {
+    static let titleFont = UIFont.systemFont(ofSize: 15, weight: .semibold)
+    static let spacing: CGFloat = 0
 
+    static let lineHeight: CGFloat = 2
+    static let lineOffset: CGFloat = 8
 
-    private enum TabConstants {
-        static let titleFont = UIFont.systemFont(ofSize: 16, weight: .bold)
-        static let spacing: CGFloat = 14
-
-        static let lineHeight: CGFloat = 2
-        static let lineOffset: CGFloat = 8
-
-        static let fadeSize: CGFloat = 50
-    }
+    static let fadeSize: CGFloat = 50
 }
 
 // MARK: - Private: Scroll Fading

--- a/podcasts/PlayerTabsView.swift
+++ b/podcasts/PlayerTabsView.swift
@@ -264,3 +264,63 @@ private extension PlayerTabsView {
         Analytics.track(.playerTabSelected, properties: ["tab": tabName])
     }
 }
+
+/// A button subclass that applies the tab button style
+private class PlayerTabButton: UIButton {
+    let title: String
+
+    init(title: String) {
+        self.title = title
+        super.init(frame: .zero)
+
+        configuration = .plain()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func updateConfiguration() {
+        let background: UIColor
+        let text: UIColor
+
+        var config = UIButton.Configuration.plain()
+        config.automaticallyUpdateForSelection = true
+
+        switch state {
+
+        case .selected, [.selected, .highlighted]:
+            background = ThemeColor.playerContrast05()
+            text = ThemeColor.playerContrast01()
+
+        case .highlighted:
+            background = ThemeColor.playerContrast05().withAlphaComponent(0.1)
+            text = ThemeColor.playerContrast01()
+
+        default:
+            background = .clear
+            text = ThemeColor.playerContrast02()
+        }
+
+        config.contentInsets = .init(top: 8, leading: 12, bottom: 8, trailing: 12)
+
+        config.attributedTitle = {
+            var attributedTitle = AttributedString(title)
+            attributedTitle.font = TabConstants.titleFont
+            attributedTitle.foregroundColor = text
+            return attributedTitle
+        }()
+
+        config.background = {
+            var config = UIBackgroundConfiguration.clear()
+            config.backgroundColor = .clear
+            return config
+        }()
+
+        // Background isn't animatable, so we'll default to using the layer
+        layer.backgroundColor = background.cgColor
+        layer.cornerRadius = 8
+
+        self.configuration = config
+    }
+}

--- a/podcasts/PlayerTabsView.swift
+++ b/podcasts/PlayerTabsView.swift
@@ -154,10 +154,9 @@ class PlayerTabsView: UIScrollView {
         if let toTab = tabsStackView.arrangedSubviews[safe: toIndex] as? UIButton {
             UIView.transition(with: toTab, duration: animationDuration, options: .transitionCrossDissolve, animations: {
                 toTab.isSelected = true
+                // Scroll the button into view, but make sure it clears the fade
+                self.scrollRectToVisible(toTab.frame.insetBy(dx: -TabConstants.fadeSize, dy: 0), animated: false)
             })
-
-            // Scroll the button into view, but make sure it clears the fade
-            scrollRectToVisible(toTab.frame.insetBy(dx: -TabConstants.fadeSize, dy: 0), animated: true)
         }
     }
 }

--- a/podcasts/PlayerTabsView.swift
+++ b/podcasts/PlayerTabsView.swift
@@ -154,6 +154,7 @@ class PlayerTabsView: UIScrollView {
         if let toTab = tabsStackView.arrangedSubviews[safe: toIndex] as? UIButton {
             UIView.transition(with: toTab, duration: animationDuration, options: .transitionCrossDissolve, animations: {
                 toTab.isSelected = true
+
                 // Scroll the button into view, but make sure it clears the fade
                 self.scrollRectToVisible(toTab.frame.insetBy(dx: -TabConstants.fadeSize, dy: 0), animated: false)
             })

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -1581,7 +1581,7 @@ internal enum L10n {
   internal static var playerRouteSelection: String { return L10n.tr("Localizable", "player_route_selection") }
   /// SHARE LINK TO
   internal static var playerShareHeader: String { return L10n.tr("Localizable", "player_share_header") }
-  /// Description
+  /// Details
   internal static var playerShowNotesTitle: String { return L10n.tr("Localizable", "player_show_notes_title") }
   /// Download Error
   internal static var playerUserEpisodeDownloadError: String { return L10n.tr("Localizable", "player_user_episode_download_error") }

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -3744,7 +3744,7 @@
 "support_watch_help_send_without_log" = "Send without Watch logs";
 
 /* Title of a tab in the player that shows the episode description (show notes). */
-"player_show_notes_title" = "Description";
+"player_show_notes_title" = "Details";
 
 /* The plural name of a feature called Bookmarks, used in various places in the app */
 "bookmarks" = "Bookmarks";


### PR DESCRIPTION
| 📘 Part of: #1061 | 🎨 Designs: [Figma](https://www.figma.com/file/Io7PCz1H1hmOgEE9eljoYW/Bookmarks?type=design&node-id=2032-51568&mode=dev) |
|:---:|:---:|

- Updates the player tab design
- Renames the show notes tab to 'Details' when bookmarks are enabled
- Speeds up the tab switch animation 

## Screenshots
| iPhone | iPad | iPod |
|:---:|:---:|:---:|
|<img src="https://github.com/Automattic/pocket-casts-ios/assets/793774/529a9434-bef5-4e25-8849-49ee84d8315c" height="320" />|<img src="https://github.com/Automattic/pocket-casts-ios/assets/793774/2e07db0c-ed2b-44f5-8d82-d1a1c4a8666e" height="320" />|<img src="https://github.com/Automattic/pocket-casts-ios/assets/793774/e53aca02-a46f-477f-9fc4-221b0ba314cd" height="320" />|

## To test

1. Launch the app
2. Play any episode
3. Open the full screen player
4. ✅ Verify the player tabs look good
5. Tab on each of the tabs
6. ✅ Verify the selected tab switches and the content animates to the tab content
7. Swipe between pages
8. ✅ Verify the selected tab updates
9. Test on iPad, and small devices

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
