### PR TITLE
Bookmarks: Shows the edit screen if the bookmark that was created already existed at the current time

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Bookmarks/BookmarkDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Bookmarks/BookmarkDataManager.swift
@@ -9,6 +9,13 @@ public struct BookmarkDataManager {
         self.dbQueue = dbQueue
     }
 
+    /// Looks for any existing bookmarks in an episode that have the same start time
+    public func existingBookmark(forEpisode episodeUuid: String, time: TimeInterval) -> Bookmark? {
+        selectBookmarks(where: [.episode, .time],
+                        values: [episodeUuid, time],
+                        limit: 1).first
+    }
+
     // MARK: - Adding
 
     /// Adds a new bookmark to the database
@@ -249,13 +256,6 @@ public struct BookmarkDataManager {
 // MARK: - Private
 
 private extension BookmarkDataManager {
-    /// Looks for any existing bookmarks in an episode that have the same start time
-    func existingBookmark(forEpisode episodeUuid: String, time: TimeInterval) -> Bookmark? {
-        selectBookmarks(where: [.episode, .time],
-                        values: [episodeUuid, time],
-                        limit: 1).first
-    }
-
     func selectBookmarks(where whereColumns: [Column] = [], values: [Any] = [], limit: Int = 0, sorted: SortOption = .newestToOldest, allowDeleted: Bool = false) -> [Bookmark] {
         let limitQuery = limit != 0 ? "LIMIT \(limit)" : ""
 

--- a/podcasts/BookmarkManager.swift
+++ b/podcasts/BookmarkManager.swift
@@ -44,6 +44,11 @@ class BookmarkManager {
         // If the episode has a podcast attached, also save that
         let podcastUuid: String? = (episode as? Episode)?.podcastUuid
 
+        if let existing = dataManager.existingBookmark(forEpisode: episode.uuid, time: time) {
+            onBookmarkCreated.send(.init(uuid: existing.uuid, episode: episode.uuid, podcast: podcastUuid, isDuplicate: true))
+            return existing
+        }
+
         return dataManager.add(episodeUuid: episode.uuid, podcastUuid: podcastUuid, title: title, time: time).flatMap {
             FileLog.shared.addMessage("[Bookmarks] Added bookmark for \(episode.displayableTitle()) at \(time)")
 
@@ -103,6 +108,9 @@ class BookmarkManager {
 
             /// The uuid of the podcast the bookmark was added to, if available
             let podcast: String?
+
+            /// Whether the bookmark that is being created already existed for the current time
+            var isDuplicate: Bool = false
         }
 
         struct Changed {


### PR DESCRIPTION
| 📘 Part of: #1061 |
|:---:|

## To test

1. Enable the bookmarks and patron feature flags
2. Open the full screen player
3. Pause the episode
4. Tap the Add Bookmark option
5. ✅ You should see the 'Add Bookmark' screen
6. Dismiss it
7. Tap the 'Add Bookmark' item again
8. ✅ You should see the edit bookmark screen

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
