### PR TITLE
Bookmarks: Misc fixes

### DIFF
--- a/podcasts/Bookmarks/Episode/BookmarkEpisodeListController.swift
+++ b/podcasts/Bookmarks/Episode/BookmarkEpisodeListController.swift
@@ -18,7 +18,7 @@ class BookmarkEpisodeListController: ThemedHostingController<BookmarkEpisodeList
 
         let viewModel = BookmarkEpisodeListViewModel(episode: episode,
                                                       bookmarkManager: bookmarkManager,
-                                                      sortOption: Constants.UserDefaults.bookmarks.podcastSort)
+                                                      sortOption: Constants.UserDefaults.bookmarks.episodeSort)
         viewModel.analyticsSource = (episode is Episode) ? .episodes : .files
 
         self.viewModel = viewModel

--- a/podcasts/Bookmarks/Episode/BookmarkEpisodeListController.swift
+++ b/podcasts/Bookmarks/Episode/BookmarkEpisodeListController.swift
@@ -38,7 +38,6 @@ class BookmarkEpisodeListController: ThemedHostingController<BookmarkEpisodeList
 extension BookmarkEpisodeListController: BookmarkListRouter {
     func bookmarkPlay(_ bookmark: Bookmark) {
         playbackManager.playBookmark(bookmark, source: viewModel.analyticsSource)
-        dismiss(animated: true)
     }
 
     func bookmarkEdit(_ bookmark: Bookmark) {

--- a/podcasts/Bookmarks/List/BookmarkListViewModel.swift
+++ b/podcasts/Bookmarks/List/BookmarkListViewModel.swift
@@ -140,9 +140,10 @@ extension BookmarkListViewModel {
 
     func showSortOptions() {
         let optionPicker = OptionsPicker(title: L10n.sortBy)
+        let currentSort = sortOption
 
         optionPicker.addActions(availableSortOptions.map({ option in
-            .init(label: option.label) { [weak self] in
+                .init(label: option.label, selected: option == currentSort) { [weak self] in
                 self?.sorted(by: option)
             }
         }))

--- a/podcasts/Bookmarks/Player/BookmarksPlayerTabController.swift
+++ b/podcasts/Bookmarks/Player/BookmarksPlayerTabController.swift
@@ -123,8 +123,6 @@ class BookmarksPlayerTabController: PlayerItemViewController {
 
 extension BookmarksPlayerTabController: BookmarkListRouter {
     func bookmarkPlay(_ bookmark: Bookmark) {
-        containerDelegate?.scrollToNowPlaying()
-
         playbackManager.playBookmark(bookmark, source: .player)
     }
 

--- a/podcasts/Bookmarks/Podcast/BookmarksPodcastListController.swift
+++ b/podcasts/Bookmarks/Podcast/BookmarksPodcastListController.swift
@@ -36,7 +36,6 @@ class BookmarksPodcastListController: ThemedHostingController<BookmarksPodcastLi
 extension BookmarksPodcastListController: BookmarkListRouter {
     func bookmarkPlay(_ bookmark: Bookmark) {
         playbackManager.playBookmark(bookmark, source: viewModel.analyticsSource)
-        dismiss(animated: true)
     }
 
     func bookmarkEdit(_ bookmark: Bookmark) {

--- a/podcasts/Common SwiftUI/BookmarksLockedStateView.swift
+++ b/podcasts/Common SwiftUI/BookmarksLockedStateView.swift
@@ -74,11 +74,11 @@ private class BookmarksUpgradeViewModel: PlusAccountPromptViewModel {
     }
 
     var upgradeLabel: String {
-        guard let product = product(for: feature.tier) else {
-            return L10n.upgradeAccount
+        guard product(for: feature.tier)?.freeTrialDuration != nil else {
+            return L10n.upgradeToPlan(feature.tier == .patron ? L10n.patron : L10n.pocketCastsPlusShort)
         }
 
-        return upgradeLabel(for: product)
+        return L10n.startFreeTrial
     }
 
     func upgradeTapped() {

--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -171,6 +171,7 @@ struct Constants {
 
             static let playerSort = SettingValue("bookmarks.playerSort", defaultValue: BookmarkSortOption.newestToOldest)
             static let podcastSort = SettingValue("bookmarks.podcastSort", defaultValue: BookmarkSortOption.newestToOldest)
+            static let episodeSort = SettingValue("bookmarks.episodeSort", defaultValue: BookmarkSortOption.newestToOldest)
         }
     }
 

--- a/podcasts/Enumerations.swift
+++ b/podcasts/Enumerations.swift
@@ -168,8 +168,17 @@ enum PlaylistIcon: Int32 {
          redTop, blueTop, greenTop, purpleTop, yellowTop
 }
 
-enum PlayerAction: Int, CaseIterable, AnalyticsDescribable {
+enum PlayerAction: Int, AnalyticsDescribable {
     case effects = 1, sleepTimer, routePicker, starEpisode, shareEpisode, goToPodcast, chromecast, markPlayed, archive, addBookmark
+
+    /// Specify default actions and their order
+    static var defaultActions: [PlayerAction] {
+        [
+            .effects, .sleepTimer, .routePicker, .starEpisode,
+            .shareEpisode, .goToPodcast, .chromecast, .markPlayed,
+            .addBookmark, .archive
+        ]
+    }
 
     func title(episode: BaseEpisode? = nil) -> String {
         switch self {

--- a/podcasts/HeadphoneSettingsViewController.swift
+++ b/podcasts/HeadphoneSettingsViewController.swift
@@ -34,13 +34,15 @@ class HeadphoneSettingsViewController: PCTableViewController {
         let section = visibleSections[indexPath.section]
         let row = section.rows[indexPath.row]
 
+        let actions: [HeadphoneControlAction] = [.skipForward, .nextChapter, .skipBack, .previousChapter, .addBookmark]
+
         switch row {
         case .nextAction:
-            showPicker(L10n.settingsNextAction, [.skipForward, .nextChapter, .addBookmark], currentValue: Settings.headphonesNextAction) { [weak self] in
+            showPicker(L10n.settingsNextAction, actions, currentValue: Settings.headphonesNextAction) { [weak self] in
                 self?.headphoneOptionChanged(to: $0, for: row)
             }
         case .previousAction:
-            showPicker(L10n.settingsPreviousAction, [.skipBack, .previousChapter, .addBookmark], currentValue: Settings.headphonesPreviousAction) { [weak self] in
+            showPicker(L10n.settingsPreviousAction, actions, currentValue: Settings.headphonesPreviousAction) { [weak self] in
                 self?.headphoneOptionChanged(to: $0, for: row)
             }
         case .bookmarkSound:

--- a/podcasts/OptionAction.swift
+++ b/podcasts/OptionAction.swift
@@ -17,7 +17,7 @@ class OptionAction {
         self.icon = icon
         self.tintIcon = tintIcon
         self.action = action
-        self.selected = false
+        self.selected = selected
     }
 
     init(label: String, icon: String, tintIcon: Bool = true, selected: Bool, onOffAction: Bool, action: @escaping (() -> Void)) {

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -562,7 +562,7 @@ class Settings: NSObject {
 
     private static let playerActionsKey = "PlayerActions"
     class func playerActions() -> [PlayerAction] {
-        let defaultActions = PlayerAction.allCases.filter { $0.isAvailable }
+        let defaultActions = PlayerAction.defaultActions.filter { $0.isAvailable }
 
         guard let savedInts = UserDefaults.standard.object(forKey: Settings.playerActionsKey) as? [Int] else {
             return defaultActions

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -2704,6 +2704,8 @@ internal enum L10n {
   internal static var starEpisode: String { return L10n.tr("Localizable", "star_episode") }
   /// Star
   internal static var starEpisodeShort: String { return L10n.tr("Localizable", "star_episode_short") }
+  /// Start Free Trial
+  internal static var startFreeTrial: String { return L10n.tr("Localizable", "start_free_trial") }
   /// You've listened for %1$@. %2$@
   internal static func statsAccessibilityListenHistoryFormat(_ p1: Any, _ p2: Any) -> String {
     return L10n.tr("Localizable", "stats_accessibility_listen_history_format", String(describing: p1), String(describing: p2))
@@ -2860,6 +2862,10 @@ internal enum L10n {
   internal static var upNextEmptyTitle: String { return L10n.tr("Localizable", "up_next_empty_title") }
   /// Upgrade Account
   internal static var upgradeAccount: String { return L10n.tr("Localizable", "upgrade_account") }
+  /// Upgrade to %1$@
+  internal static func upgradeToPlan(_ p1: Any) -> String {
+    return L10n.tr("Localizable", "upgrade_to_plan", String(describing: p1))
+  }
   /// Title (A-Z)
   internal static var uploadSortAlpha: String { return L10n.tr("Localizable", "upload_sort_alpha") }
   /// Volume Boost

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -3850,3 +3850,9 @@
 
 /* A message informing the user a feature is locked. %1$@ is the name of the tier (Plus or Patron) */
 "boomarks_locked_message" = "Unlock this feature and many more with Pocket Casts %1$@ and save timestamps of your favorite episodes.";
+
+/* A button title that prompts the user to upgrade their plan. %1$@ is the name of the tier (Plus or Patron) */
+"upgrade_to_plan" = "Upgrade to %1$@";
+
+/* A button title that prompts the user upgrade to redeem a free trial */
+"start_free_trial" = "Start Free Trial";


### PR DESCRIPTION
| 📘 Part of: #1061 |
|:---:|

- When tapping play on a bookmark we stay on the same screen
- Updates the bookmarks locked button title
- Changes the default player action order to show bookmarks second from the bottom
- Allows selecting of any headphone action for both options
- Stores the sort option on a "per list" basis

## To test

**When tapping play on a bookmark we stay on the same screen**:
1. Launch the app
2. Open the full screen player
3. Switch to the bookmarks tab
4. Tap on the play button
5. ✅ Verify the bookmark plays, and you stay on the same screen
6. Dismiss the full screen player
7. Go to a podcast with bookmarks
8. Tap the Bookmarks tab item
9. Tap Play
10. ✅ Verify the bookmark plays and you stay on the same screen
11. Dismiss the view
12. Tap on the episode with bookmarks
13. Switch to the Bookmarks tab
14. Tap Play
15. ✅ Verify the bookmark plays and you stay on the same screen

**Updates the bookmarks locked button title**:
1. If you have bookmarks unlocked, go to Profile > Cog > Developer > Set to no plus
2. Open the full screen player
3. Switch to the bookmarks tab
4. ✅ Verify the upgrade button says 'Upgrade to Patron'
5. Open PaidFeature.swift, on line 16, change .patron to .plus
6. Restart the app
7. Open any bookmarks view
8. ✅ Verify the upgrade button says 'Start Free Trial'

**Changes the default player action order to show bookmarks second from the bottom**:
1. If you have customized the player actions
   - Open Settings.swift, put a breakpoint on line 567
   - Run the app, and open the full screen player
   - When the breakpoint hits, type `po UserDefaults.standard.removeObject(forKey: Settings.playerActionsKey)` in the debugger console
   - Continue running, and remove the breakpoint
2. Open the full screen player
3. Tap the `...` button
4. ✅ Verify you see Add Bookmark second from the bottom

**Allows selecting of any headphone action for both options**:

1. Go to Profile > Cog > Headphone Controls
2. Tap on the Previous Action
3. ✅ Verify you see all the direction options available
4. Switch through the options and ✅ verify each one option is persisted
5. Repeat for Next Action

**Stores the sort option on a "per list" basis**:

1. Open the full screen player
2. Switch to the bookmarks tab
3. Tap the `...` button
4. Change the sort option to timestamp
5. Dismiss the view
6. Go to a podcast with bookmarks, tap the Bookmarks tab
7. Tap the `...` button
9. Change the sort option to episode
10. Dismiss the view
11. Tap the episode with bookmarks
12. Go to the bookmarks tab
13. Tap the `...` button
14. Change the sort option to oldest to newest
15. Go back to the player and open the sort menu
16. ✅ Verify it's still set to timestamp
17. Go back to the podcast and open the sort menu
18. ✅ Verify it's still set to episode
19. Go back to the episode and open the sort menu
20. ✅ Verify its still set to oldest to newest

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
