### PR TITLE
Fix the unsupported use warnings when showing or hiding the full screen player

### DIFF
--- a/podcasts/MiniPlayerViewController+Positioning.swift
+++ b/podcasts/MiniPlayerViewController+Positioning.swift
@@ -45,10 +45,12 @@ extension MiniPlayerViewController {
         playerOpenState = .animating
         aboutToDisplayFullScreenPlayer()
         view.superview?.layoutIfNeeded()
+        fullScreenPlayer?.beginAppearanceTransition(true, animated: true)
         UIView.animate(withDuration: 0.7, delay: 0, usingSpringWithDamping: 0.94, initialSpringVelocity: 0.7, options: UIView.AnimationOptions.curveEaseIn, animations: { () in
             self.moveToHiddenTopPosition()
             self.fullScreenPlayer?.view.moveTo(y: 0)
         }) { _ in
+            self.fullScreenPlayer?.endAppearanceTransition()
             self.view.isHidden = true
             self.moveToHiddenTopPosition() // call this again in case the animation block wasn't called. It's ok to call this twice
             self.playerOpenState = .open
@@ -66,8 +68,9 @@ extension MiniPlayerViewController {
             return
         }
 
+        fullScreenPlayer?.beginAppearanceTransition(false, animated: true)
         playerOpenState = .animating
-        DispatchQueue.main.async { () in
+        DispatchQueue.main.async {
             guard let parentView = self.view.superview else { return }
 
             let isSomethingPlaying = PlaybackManager.shared.currentEpisode() != nil
@@ -79,6 +82,8 @@ extension MiniPlayerViewController {
                 self.fullScreenPlayer?.view.moveTo(y: parentViewHeight)
             }, completion: { _ in
                 self.moveToShownPosition() // call this again in case the animation block wasn't called. It's ok to call this twice
+                self.fullScreenPlayer?.endAppearanceTransition()
+
                 self.finishedWithFullScreenPlayer()
                 self.playerOpenState = .closed
                 completion?()

--- a/podcasts/MiniPlayerViewController+Positioning.swift
+++ b/podcasts/MiniPlayerViewController+Positioning.swift
@@ -49,7 +49,6 @@ extension MiniPlayerViewController {
             self.moveToHiddenTopPosition()
             self.fullScreenPlayer?.view.moveTo(y: 0)
         }) { _ in
-            self.fullScreenPlayer?.viewDidAppear(true)
             self.view.isHidden = true
             self.moveToHiddenTopPosition() // call this again in case the animation block wasn't called. It's ok to call this twice
             self.playerOpenState = .open

--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -86,7 +86,6 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
         }
 
         fullScreenPlayer?.view.frame = CGRect(x: 0, y: startingYPos, width: viewSize.width, height: viewSize.height)
-        fullScreenPlayer?.viewWillAppear(false)
 
         // prevent swipe to go back while the player is open
         rootNavController()?.interactivePopGestureRecognizer?.isEnabled = false
@@ -98,7 +97,6 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
         if fullScreenPlayer?.presentedViewController != nil {
             fullScreenPlayer?.dismiss(animated: false, completion: nil)
         }
-        fullScreenPlayer?.viewWillDisappear(false)
 
         // there's a bug in iOS where because the player is added as a child controller to the tab bar, the tab bar adds it as a tab
         // that would be fine, except if we call fullScreenPlayer.removeFromParent() it removes the controller but not the tab, so here we drop it manually
@@ -111,7 +109,6 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
         rootViewController()?.setNeedsStatusBarAppearanceUpdate()
         rootViewController()?.setNeedsUpdateOfHomeIndicatorAutoHidden()
         fullScreenPlayer?.view.removeFromSuperview()
-        fullScreenPlayer?.viewDidDisappear(false)
         fullScreenPlayer = nil
 
         // re-enable the disabled swipe back gesture


### PR DESCRIPTION
Fixes #599

This replaces the manual calls to viewWillAppear/Disappear and viewDidAppear/Disappear with [`beginAppearanceTransition`](https://developer.apple.com/documentation/uikit/uiviewcontroller/1621387-beginappearancetransition) and [`endAppearanceTransition`](https://developer.apple.com/documentation/uikit/uiviewcontroller/1621503-endappearancetransition). 

## To test

1. Open PlayerContainerViewController.swift in Xcode
2. Locate the viewDidAppear and viewDidDisappear methods
3. Put a breakpoint on each of them
4. Run the app
5. Open the full screen player
6. ✅ Verify the viewDidAppear breakpoint is hit
7. ✅ Verify there are no logs about the unsupported use of the view methods
8. Dismiss the full screen player
9. ✅ Verify the viewDidDisappear breakpoint is hit
7. ✅ Verify there are no logs about the unsupported use of the view methods

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
