### PR TITLE
Add Headphone Controls to the release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Added import support for audio and movie files [#1039]
 - Adds a new show notes endpoint [#1033]
 - Show episode artwork from the feed if "Use Embedded Artwork" is enabled [#1033]
+- Adds a new Headphone Controls section in the settings [#1027]
+- Moves the Remote Skips Chapters setting in the General section to Headphone Controls [#1027]
 
 7.45
 -----


### PR DESCRIPTION
Adds the addition of the Headphone Controls section in the release notes: https://github.com/Automattic/pocket-casts-ios/pull/1027

## To test

1. Read the release notes

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
