### PR TITLE
Episode Artwork: enable only on TestFlight builds

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/Cache/CacheServerHandler.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Cache/CacheServerHandler.swift
@@ -15,6 +15,8 @@ public class CacheServerHandler {
 
     public static var newShowNotesEndpoint: Bool = false
 
+    public static var episodeFeedArtwork: Bool = false
+
     public init() {
         showNotesUrlCache = URLCache(memoryCapacity: 1.megabytes, diskCapacity: 10.megabytes, diskPath: "show_notes")
         colorsUrlsCache = URLCache(memoryCapacity: 400.kilobytes, diskCapacity: 5.megabytes, diskPath: "colors")
@@ -60,7 +62,7 @@ public class CacheServerHandler {
     // MARK: - Episode Artwork
 
     public func loadEpisodeArtworkUrl(podcastUuid: String, episodeUuid: String, completion: ((String?) -> Void)?) {
-        guard Self.newShowNotesEndpoint else {
+        guard Self.newShowNotesEndpoint, Self.episodeFeedArtwork else {
             completion?(nil)
             return
         }

--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -54,6 +54,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         GoogleCastManager.sharedManager.setup()
 
         CacheServerHandler.newShowNotesEndpoint = FeatureFlag.newShowNotesEndpoint.enabled
+        CacheServerHandler.episodeFeedArtwork = FeatureFlag.episodeFeedArtwork.enabled
 
         setupRoutes()
 

--- a/podcasts/FeatureFlag.swift
+++ b/podcasts/FeatureFlag.swift
@@ -51,10 +51,6 @@ enum FeatureFlag: String, CaseIterable {
             return overriddenValue
         }
 
-        if availableOnlyOnTestFlight && !FeatureFlag.isTestFlight {
-            return false
-        }
-
         switch self {
         case .freeTrialsEnabled:
             return true
@@ -85,17 +81,7 @@ enum FeatureFlag: String, CaseIterable {
         case .newShowNotesEndpoint:
             return true
         case .episodeFeedArtwork:
-            return true
-        }
-    }
-
-    /// Whether the feature should be available only in TestFlight
-    private var availableOnlyOnTestFlight: Bool {
-        switch self {
-        case .episodeFeedArtwork:
-            return true
-        default:
-            return false
+            return Self.isTestFlight ? true : false
         }
     }
 }

--- a/podcasts/FeatureFlag.swift
+++ b/podcasts/FeatureFlag.swift
@@ -43,9 +43,16 @@ enum FeatureFlag: String, CaseIterable {
     /// Enable the new show notes endpoint plus embedded episode artwork
     case newShowNotesEndpoint
 
+    /// Enable retrieving episode artwork from the RSS feed
+    case episodeFeedArtwork
+
     var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
+        }
+
+        if availableOnlyOnTestFlight && !FeatureFlag.isTestFlight {
+            return false
         }
 
         switch self {
@@ -77,6 +84,18 @@ enum FeatureFlag: String, CaseIterable {
             return true
         case .newShowNotesEndpoint:
             return true
+        case .episodeFeedArtwork:
+            return true
+        }
+    }
+
+    /// Whether the feature should be available only in TestFlight
+    private var availableOnlyOnTestFlight: Bool {
+        switch self {
+        case .episodeFeedArtwork:
+            return true
+        default:
+            return false
         }
     }
 }
@@ -89,4 +108,6 @@ extension FeatureFlag: OverrideableFlag {
     var canOverride: Bool {
         true
     }
+
+    private static let isTestFlight = Bundle.main.appStoreReceiptURL?.lastPathComponent == "sandboxReceipt"
 }


### PR DESCRIPTION
Until this feature has cross-platform parity we'll have it enabled only on TestFlight.

## To test

I'm really not sure how we can test that without doing a release on TestFlight. 🤷 

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
