### PR TITLE
Bookmarks: Allow specifying different values when beta testing

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/General/BuildEnvironment.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/General/BuildEnvironment.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// Describes the type of build environment the app is running in.
+/// Use `BuildEnvironment.current` to get the environment for the current running build.
+public enum BuildEnvironment {
+    /// From Xcode, or another DEBUG build
+    case debug
+
+    /// A release build from TestFlight
+    case testFlight
+
+    /// A release build from the AppStore
+    case appStore
+
+    /// Returns the `BuildEnvironment` for the current build
+    public static var current: BuildEnvironment {
+        #if DEBUG || STAGING
+        return .debug
+        #else
+        // https://stackoverflow.com/a/26113597/257949
+        if Bundle.main.appStoreReceiptURL?.lastPathComponent == "sandboxReceipt" {
+            return .testFlight
+        }
+
+        return .appStore
+        #endif
+    }
+}

--- a/Modules/Utils/Sources/PocketCastsUtils/General/BuildEnvironment.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/General/BuildEnvironment.swift
@@ -13,7 +13,13 @@ public enum BuildEnvironment {
     case appStore
 
     /// Returns the `BuildEnvironment` for the current build
-    public static var current: BuildEnvironment {
+    public static var current: BuildEnvironment = .determineCurrentEnvironment
+
+    /// Determines the current environment by:
+    /// - If the DEBUG or STAGING preprocessor macros are set, return `.debug`
+    /// - If the `appStoreReceiptURL` is `sandboxReceipt` return `.beta`
+    /// - For anything else, return `.appStore`
+    private static var determineCurrentEnvironment: BuildEnvironment {
         #if DEBUG || STAGING
         return .debug
         #else

--- a/PocketCastsTests/Tests/Utilities/PaidFeatureTests.swift
+++ b/PocketCastsTests/Tests/Utilities/PaidFeatureTests.swift
@@ -88,6 +88,30 @@ final class PaidFeatureTests: XCTestCase {
         XCTAssertTrue(feature.isUnlocked)
     }
 
+    // MARK: - Beta Testing
+
+    func testPatronFeatureWithBetaPlusIsUnlockedInBeta() {
+        let feature = PaidFeature(tier: .patron,
+                                  betaTier: .plus,
+                                  subscriptionHelper: subscriptionHelper,
+                                  buildEnvironment: .testFlight)
+
+        subscriptionHelper.userHasPlusSubscription()
+
+        XCTAssertTrue(feature.isUnlocked)
+    }
+
+    func testPatronFeatureWithBetaPlusIsLockedForAppStore() {
+        let feature = PaidFeature(tier: .patron,
+                                  betaTier: .plus,
+                                  subscriptionHelper: subscriptionHelper,
+                                  buildEnvironment: .appStore)
+
+        subscriptionHelper.userHasPlusSubscription()
+
+        XCTAssertFalse(feature.isUnlocked)
+    }
+
     // MARK: - Private
     private func freeFeature() -> PaidFeature {
         feature(tier: .none)

--- a/podcasts/PaidFeature.swift
+++ b/podcasts/PaidFeature.swift
@@ -1,5 +1,6 @@
 import Combine
 import PocketCastsServer
+import PocketCastsUtils
 import SwiftUI
 
 // MARK: - Features
@@ -13,7 +14,7 @@ import SwiftUI
 ///     2. Check the unlock state using `PaidFeature.hello.isUnlocked`
 ///
 extension PaidFeature {
-    static var bookmarks: PaidFeature = .init(tier: .patron)
+    static var bookmarks: PaidFeature = .init(tier: .patron, betaTier: .plus)
 }
 
 /// A `PaidFeature` represents a feature that is unlocked with a subscription tier, and is considered to be unlocked if the tier
@@ -41,9 +42,20 @@ class PaidFeature: ObservableObject {
 
     private var cancellables = Set<AnyCancellable>()
 
-    /// Creates a new paid feature with the minimum `unlockTier`.
-    init(tier: SubscriptionTier, subscriptionHelper: SubscriptionHelper = .shared) {
-        self.tier = tier
+    /// Creates a new paid feature with a minimum tier
+    /// - Parameters:
+    ///   - tier: The minimum tier required to unlock
+    ///   - betaTier: The minimum tier required when running in the app beta
+    init(tier: SubscriptionTier,
+         betaTier: SubscriptionTier? = nil,
+         subscriptionHelper: SubscriptionHelper = .shared,
+         buildEnvironment: BuildEnvironment = .current) {
+        if let betaTier, buildEnvironment == .testFlight {
+            self.tier = betaTier
+        } else {
+            self.tier = tier
+        }
+
         self.subscriptionHelper = subscriptionHelper
 
         addListeners()


### PR DESCRIPTION
This adds a way to specify different tiers for a feature during beta testing. 

This also adds the `BuildEnvironment` enum that describes the type environment the app is currently running in. 

## To test

Note: Enable the Bookmarks and Patron feature flags

1. Launch the app
2. Go to Profile Tab > Cog > Developer > Set No Plus
3. Go to full screen player > Bookmarks tab
4. ✅ Verify you see Upgrade to Patron
5. In Xcode, open `BuildEnvironment.swift`
6. Remove lines 17 - 19, and 26 (removing the if check)
7. Run the app on a real device
   - When testing on a real device the `appStoreReceiptURL` returns the `sandboxReceipt` value which is what we use to check if it's TestFlight.
9. Go to Profile Tab > Cog > Developer > Set No Plus
10. Go to the full screen player > Bookmarks tab
11. ✅ Verify you see Upgrade to Plus

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
