### PR TITLE
iOS 17 widgets: adapt margins and background

### DIFF
--- a/WidgetExtension/App Icon/AppIconWidget.swift
+++ b/WidgetExtension/App Icon/AppIconWidget.swift
@@ -22,10 +22,20 @@ struct AppIconWidgetEntryView: View {
     var body: some View {
         ZStack {
             Color.black
+                .clipShape(Circle())
             Image("logo-transparent-medium")
                 .resizable()
                 .frame(width: 55, height: 55)
         }
         .widgetURL(URL(string: "pktc://last_opened"))
+        .clearBackground()
+    }
+}
+
+@available(iOSApplicationExtension 17.0, *)
+struct Previews_AppIconWidgetEntryView_Previews: PreviewProvider {
+    static var previews: some View {
+        AppIconWidgetEntryView(entry: StaticEntry(date: Date()))
+            .previewContext(WidgetPreviewContext(family: .accessoryCircular))
     }
 }

--- a/WidgetExtension/Common/View+clearBackground.swift
+++ b/WidgetExtension/Common/View+clearBackground.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+
+extension View {
+    func clearBackground() -> some View {
+        if #available(iOSApplicationExtension 17.0, *) {
+            return self.containerBackground(.clear, for: .widget)
+        } else {
+            return self
+        }
+    }
+}

--- a/WidgetExtension/Common/Widget+contentMarginsDisabled.swift
+++ b/WidgetExtension/Common/Widget+contentMarginsDisabled.swift
@@ -1,0 +1,12 @@
+import WidgetKit
+import SwiftUI
+
+extension WidgetConfiguration {
+    func contentMarginsDisabledIfAvailable() -> some WidgetConfiguration {
+        if #available(iOSApplicationExtension 17.0, *) {
+            return self.contentMarginsDisabled()
+        } else {
+            return self
+        }
+    }
+}

--- a/WidgetExtension/Now Playing/NowPlayingEntryView.swift
+++ b/WidgetExtension/Now Playing/NowPlayingEntryView.swift
@@ -47,14 +47,12 @@ struct NowPlayingWidgetEntryView: View {
                 }
             }
             .widgetURL(URL(string: "pktc://last_opened"))
-            .clearBackground()
         } else {
             ZStack {
                 Image(CommonWidgetHelper.loadAppIconName())
                     .resizable()
             }
             .widgetURL(URL(string: "pktc://last_opened"))
-            .clearBackground()
         }
     }
 }

--- a/WidgetExtension/Now Playing/NowPlayingEntryView.swift
+++ b/WidgetExtension/Now Playing/NowPlayingEntryView.swift
@@ -45,12 +45,16 @@ struct NowPlayingWidgetEntryView: View {
                         .padding(EdgeInsets(top: 0, leading: 16, bottom: 16, trailing: 16))
                         .layoutPriority(1)
                 }
-            }.widgetURL(URL(string: "pktc://last_opened"))
+            }
+            .widgetURL(URL(string: "pktc://last_opened"))
+            .clearBackground()
         } else {
             ZStack {
                 Image(CommonWidgetHelper.loadAppIconName())
                     .resizable()
-            }.widgetURL(URL(string: "pktc://last_opened"))
+            }
+            .widgetURL(URL(string: "pktc://last_opened"))
+            .clearBackground()
         }
     }
 }

--- a/WidgetExtension/Now Playing/NowPlayingWidget.swift
+++ b/WidgetExtension/Now Playing/NowPlayingWidget.swift
@@ -6,7 +6,7 @@ struct NowPlayingWidget: Widget {
         StaticConfiguration(kind: "Now_Playing_Widget", provider: NowPlayingProvider()) { entry in
             NowPlayingWidgetEntryView(entry: entry)
         }
-        .contentMarginsDisabled()
+        .contentMarginsDisabledIfAvailable()
         .configurationDisplayName(L10n.nowPlaying)
         .description(L10n.widgetsNowPlayingDesc)
         .supportedFamilies([.systemSmall])

--- a/WidgetExtension/Now Playing/NowPlayingWidget.swift
+++ b/WidgetExtension/Now Playing/NowPlayingWidget.swift
@@ -5,6 +5,7 @@ struct NowPlayingWidget: Widget {
     var body: some WidgetConfiguration {
         StaticConfiguration(kind: "Now_Playing_Widget", provider: NowPlayingProvider()) { entry in
             NowPlayingWidgetEntryView(entry: entry)
+                .clearBackground()
         }
         .contentMarginsDisabledIfAvailable()
         .configurationDisplayName(L10n.nowPlaying)

--- a/WidgetExtension/Now Playing/NowPlayingWidget.swift
+++ b/WidgetExtension/Now Playing/NowPlayingWidget.swift
@@ -6,6 +6,7 @@ struct NowPlayingWidget: Widget {
         StaticConfiguration(kind: "Now_Playing_Widget", provider: NowPlayingProvider()) { entry in
             NowPlayingWidgetEntryView(entry: entry)
         }
+        .contentMarginsDisabled()
         .configurationDisplayName(L10n.nowPlaying)
         .description(L10n.widgetsNowPlayingDesc)
         .supportedFamilies([.systemSmall])

--- a/WidgetExtension/Up Next/UpNextLargeWidgetView.swift
+++ b/WidgetExtension/Up Next/UpNextLargeWidgetView.swift
@@ -77,7 +77,8 @@ struct LargeUpNextWidgetView: View {
                         .frame(width: .infinity, height: .infinity, alignment: .center)
                     }
                 }
-            })
+            }
+            .clearBackground())
     }
 }
 

--- a/WidgetExtension/Up Next/UpNextLockScreenWidget.swift
+++ b/WidgetExtension/Up Next/UpNextLockScreenWidget.swift
@@ -16,7 +16,7 @@ struct UpNextLockScreenWidget: Widget {
     }
 }
 
-@available(iOSApplicationExtension 16.0, *)
+@available(iOS 16.0, *)
 struct UpNextLockScreenWidgetEntryView: View {
     @State var entry: UpNextProvider.Entry
     @Environment(\.widgetFamily) private var family
@@ -71,6 +71,7 @@ struct UpNextCircularWidgetView: View {
             }
         }
         .widgetURL(URL(string: widgetURL))
+        .clearBackground()
     }
 }
 
@@ -129,12 +130,14 @@ struct UpNextRectangularWidgetView: View {
                     .fontWeight(.medium)
                     .foregroundColor(Color.secondary)
             }
-        }.widgetURL(URL(string: widgetURL))
+        }
+        .widgetURL(URL(string: widgetURL))
+        .clearBackground()
     }
 }
 
 @available(iOSApplicationExtension 16.0, *)
-struct Previews_UpNextLockScreenWidget_Previews: PreviewProvider {
+struct UpNextLockScreenWidget_Previews: PreviewProvider {
     static var previews: some View {
         UpNextLockScreenWidgetEntryView(entry: UpNextEntry(date: Date(), isPlaying: false, upNextEpisodesCount: 18))
             .previewContext(WidgetPreviewContext(family: .accessoryCircular))

--- a/WidgetExtension/Up Next/UpNextMediumWidgetView.swift
+++ b/WidgetExtension/Up Next/UpNextMediumWidgetView.swift
@@ -92,7 +92,9 @@ struct MediumFilterView: View {
                     Spacer()
                         .frame(minHeight: 42, maxHeight: 56)
                 }
-            }.padding(geometry.size.height > 155 ? 16 : 12)
+            }
+            .padding(geometry.size.height > 155 ? 16 : 12)
+            .clearBackground()
         }
     }
 }

--- a/WidgetExtension/Up Next/UpNextWidget.swift
+++ b/WidgetExtension/Up Next/UpNextWidget.swift
@@ -6,6 +6,7 @@ struct UpNextWidget: Widget {
         StaticConfiguration(kind: "Up_Next_Widget", provider: UpNextProvider()) { entry in
             UpNextWidgetEntryView(entry: entry)
         }
+        .contentMarginsDisabledIfAvailable()
         .configurationDisplayName(L10n.upNext)
         .description("See what’s playing now, and what’s coming Up Next.")
         .supportedFamilies([.systemMedium, .systemLarge])

--- a/WidgetExtension/Up Next/UpNextWidget.swift
+++ b/WidgetExtension/Up Next/UpNextWidget.swift
@@ -5,6 +5,7 @@ struct UpNextWidget: Widget {
     var body: some WidgetConfiguration {
         StaticConfiguration(kind: "Up_Next_Widget", provider: UpNextProvider()) { entry in
             UpNextWidgetEntryView(entry: entry)
+                .clearBackground()
         }
         .contentMarginsDisabledIfAvailable()
         .configurationDisplayName(L10n.upNext)

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -523,6 +523,7 @@
 		8B6B68E528F744520032BFFF /* StoriesDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6B68E428F744520032BFFF /* StoriesDataSource.swift */; };
 		8B6B68E728F74A010032BFFF /* StoriesModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6B68E628F74A010032BFFF /* StoriesModel.swift */; };
 		8B6B68E928F7527C0032BFFF /* StoryIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6B68E828F7527C0032BFFF /* StoryIndicator.swift */; };
+		8B7065A32AB0D5D200FE04CB /* View+clearBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B7065A22AB0D5D200FE04CB /* View+clearBackground.swift */; };
 		8B71828A28CF651D00B98F04 /* NowPlayingLockScreenWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B71828928CF651D00B98F04 /* NowPlayingLockScreenWidget.swift */; };
 		8B71828D28CF68E800B98F04 /* AppIconWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B71828C28CF68E800B98F04 /* AppIconWidget.swift */; };
 		8B71828F28CF6ED900B98F04 /* StaticWidgetProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B71828E28CF6ED900B98F04 /* StaticWidgetProvider.swift */; };
@@ -2318,6 +2319,7 @@
 		8B6B68E428F744520032BFFF /* StoriesDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoriesDataSource.swift; sourceTree = "<group>"; };
 		8B6B68E628F74A010032BFFF /* StoriesModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoriesModel.swift; sourceTree = "<group>"; };
 		8B6B68E828F7527C0032BFFF /* StoryIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoryIndicator.swift; sourceTree = "<group>"; };
+		8B7065A22AB0D5D200FE04CB /* View+clearBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+clearBackground.swift"; sourceTree = "<group>"; };
 		8B71828928CF651D00B98F04 /* NowPlayingLockScreenWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowPlayingLockScreenWidget.swift; sourceTree = "<group>"; };
 		8B71828C28CF68E800B98F04 /* AppIconWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconWidget.swift; sourceTree = "<group>"; };
 		8B71828E28CF6ED900B98F04 /* StaticWidgetProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaticWidgetProvider.swift; sourceTree = "<group>"; };
@@ -4992,6 +4994,7 @@
 			children = (
 				4075C2AD252C06DE001C280A /* ArtworkViews.swift */,
 				4090978625236B0400CED68C /* CommonWidgetHelper.swift */,
+				8B7065A22AB0D5D200FE04CB /* View+clearBackground.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -8471,6 +8474,7 @@
 				BD422ECA2684195E0078B799 /* UpNextWidgetEntryView.swift in Sources */,
 				BD422EC426840EDD0078B799 /* WidgetData.swift in Sources */,
 				8B71829128CF755D00B98F04 /* UpNextLockScreenWidget.swift in Sources */,
+				8B7065A32AB0D5D200FE04CB /* View+clearBackground.swift in Sources */,
 				BD422ED226841BF10078B799 /* HungryForMoreView.swift in Sources */,
 				4031466D252568970085E76B /* WidgetEpisode.swift in Sources */,
 				4075C2AE252C06DE001C280A /* ArtworkViews.swift in Sources */,

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -524,6 +524,7 @@
 		8B6B68E728F74A010032BFFF /* StoriesModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6B68E628F74A010032BFFF /* StoriesModel.swift */; };
 		8B6B68E928F7527C0032BFFF /* StoryIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6B68E828F7527C0032BFFF /* StoryIndicator.swift */; };
 		8B7065A32AB0D5D200FE04CB /* View+clearBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B7065A22AB0D5D200FE04CB /* View+clearBackground.swift */; };
+		8B7065A52AB0E14200FE04CB /* Widget+contentMarginsDisabled.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B7065A42AB0E14200FE04CB /* Widget+contentMarginsDisabled.swift */; };
 		8B71828A28CF651D00B98F04 /* NowPlayingLockScreenWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B71828928CF651D00B98F04 /* NowPlayingLockScreenWidget.swift */; };
 		8B71828D28CF68E800B98F04 /* AppIconWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B71828C28CF68E800B98F04 /* AppIconWidget.swift */; };
 		8B71828F28CF6ED900B98F04 /* StaticWidgetProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B71828E28CF6ED900B98F04 /* StaticWidgetProvider.swift */; };
@@ -2320,6 +2321,7 @@
 		8B6B68E628F74A010032BFFF /* StoriesModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoriesModel.swift; sourceTree = "<group>"; };
 		8B6B68E828F7527C0032BFFF /* StoryIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoryIndicator.swift; sourceTree = "<group>"; };
 		8B7065A22AB0D5D200FE04CB /* View+clearBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+clearBackground.swift"; sourceTree = "<group>"; };
+		8B7065A42AB0E14200FE04CB /* Widget+contentMarginsDisabled.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Widget+contentMarginsDisabled.swift"; sourceTree = "<group>"; };
 		8B71828928CF651D00B98F04 /* NowPlayingLockScreenWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowPlayingLockScreenWidget.swift; sourceTree = "<group>"; };
 		8B71828C28CF68E800B98F04 /* AppIconWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconWidget.swift; sourceTree = "<group>"; };
 		8B71828E28CF6ED900B98F04 /* StaticWidgetProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaticWidgetProvider.swift; sourceTree = "<group>"; };
@@ -4995,6 +4997,7 @@
 				4075C2AD252C06DE001C280A /* ArtworkViews.swift */,
 				4090978625236B0400CED68C /* CommonWidgetHelper.swift */,
 				8B7065A22AB0D5D200FE04CB /* View+clearBackground.swift */,
+				8B7065A42AB0E14200FE04CB /* Widget+contentMarginsDisabled.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -8485,6 +8488,7 @@
 				BD422ECE2684198B0078B799 /* UpNextLargeWidgetView.swift in Sources */,
 				BD422EC8268416050078B799 /* UpNextEntry.swift in Sources */,
 				467DF6EB26E10AFD00AC290C /* Strings+Generated.swift in Sources */,
+				8B7065A52AB0E14200FE04CB /* Widget+contentMarginsDisabled.swift in Sources */,
 				4036B06E25240CC600AE08E6 /* SharedConstants.swift in Sources */,
 				467BB04726CC07C900A73BAF /* Constants.swift in Sources */,
 				8B71828A28CF651D00B98F04 /* NowPlayingLockScreenWidget.swift in Sources */,


### PR DESCRIPTION
This PR:

* Adjust widget margins for iOS 17
* Adjust widget background for iOS 17

It doesn't add any new widgets or new functionality. This will be added in a follow-up PR.

This change is necessary so we can release a new beta build. Without these changes the widget content don't appear, and, a message saying "Please adopt containerBackground API" appear in its place.

Ps.: the code can be vastly improved for that. But I'll add interactivity and work on displaying the widgets accordingly in a subsequent PR and also refactor these changes a bit.

<img src="https://github.com/Automattic/pocket-casts-ios/assets/7040243/dc44efbf-6866-4a59-a9b0-a09aa0ffd085" width="500">

## To test

1. ✅ Run the app on the iOS 17 iPad simulator
2. Add all widgets in the lock screen (landscape)
3. ✅ Make sure they look good
4. Add all widgets in the apps dashboard
5. ✅ Make sure they look good
6. Run the app on an iOS 16 device/simulator
7. Make sure the widgets appear correctly

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
