### PR TITLE
iOS 17 Now Playing widget: adapt it for StandBy and iPad lock screen

### DIFF
--- a/WidgetExtension/Common/ArtworkViews.swift
+++ b/WidgetExtension/Common/ArtworkViews.swift
@@ -2,28 +2,38 @@ import SwiftUI
 
 struct LargeArtworkView: View {
     @State var imageData: Data?
+
+    var showShadow: Bool = true
+
     var body: some View {
         ZStack {
-            Rectangle()
-                .foregroundColor(Color.nowPlayingShadowColor)
-                .aspectRatio(1, contentMode: .fit)
-                .frame(maxHeight: 74)
-                .cornerRadius(9)
-                .secondaryShadow()
+            if showShadow {
+                Rectangle()
+                    .foregroundColor(Color.nowPlayingShadowColor)
+                    .aspectRatio(1, contentMode: .fit)
+                    .frame(maxHeight: 74)
+                    .cornerRadius(9)
+                    .secondaryShadow()
+            }
+
             if let imageData = imageData, let uiImage = UIImage(data: imageData) {
                 Image(uiImage: uiImage)
                     .resizable()
                     .aspectRatio(1, contentMode: .fit)
                     .frame(maxHeight: 74)
                     .cornerRadius(8)
-                    .artworkShadow()
+                    .if(showShadow) { view in
+                        view.artworkShadow()
+                    }
             } else {
                 Image("no-podcast-artwork")
                     .resizable()
                     .aspectRatio(1, contentMode: .fit)
                     .frame(maxHeight: 74)
                     .cornerRadius(8)
-                    .artworkShadow()
+                    .if(showShadow) { view in
+                        view.artworkShadow()
+                    }
             }
         }
     }

--- a/WidgetExtension/Now Playing/NowPlayingEntryView.swift
+++ b/WidgetExtension/Now Playing/NowPlayingEntryView.swift
@@ -1,8 +1,11 @@
 import Foundation
+import WidgetKit
 import SwiftUI
 
 struct NowPlayingWidgetEntryView: View {
     @State var entry: NowPlayingProvider.Entry
+
+    @Environment(\.showsWidgetContainerBackground) var showsWidgetBackground
 
     var body: some View {
         if let playingEpisode = entry.episode {
@@ -11,7 +14,7 @@ struct NowPlayingWidgetEntryView: View {
                     HStack(alignment: .top) {
                         if #available(iOS 17, *) {
                             Toggle(isOn: entry.isPlaying, intent: PlayEpisodeIntent(episodeUuid: playingEpisode.episodeUuid)) {
-                                LargeArtworkView(imageData: playingEpisode.imageData)
+                                LargeArtworkView(imageData: playingEpisode.imageData, showShadow: showsWidgetBackground)
                             }
                             .toggleStyle(WidgetPlayToggleStyle())
                         } else {
@@ -20,12 +23,14 @@ struct NowPlayingWidgetEntryView: View {
                         Spacer()
                         Image("logo-transparent")
                             .frame(width: 28, height: 28)
-                    }.padding(EdgeInsets(top: 16, leading: 16, bottom: 0, trailing: 16))
+                    }.padding(topPadding)
                         .background(
                             VStack {
-                                Rectangle()
-                                    .fill(Color(UIColor(hex: playingEpisode.podcastColor)).opacity(0.85))
-                                    .frame(height: 0.667 * geometry.size.height, alignment: .top)
+                                if showsWidgetBackground {
+                                    Rectangle()
+                                        .fill(Color(UIColor(hex: playingEpisode.podcastColor)).opacity(0.85))
+                                        .frame(height: 0.667 * geometry.size.height, alignment: .top)
+                                }
                                 Spacer()
                             })
                 }
@@ -36,30 +41,101 @@ struct NowPlayingWidgetEntryView: View {
                     .lineLimit(2)
                     .frame(height: 38, alignment: .center)
                     .layoutPriority(1)
-                    .padding(EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16))
+                    .padding(episodeTitlePadding)
 
                 if entry.isPlaying {
                     Text(L10n.nowPlaying.localizedUppercase)
                         .font(.caption2)
                         .fontWeight(.medium)
                         .foregroundColor(Color.secondary)
-                        .padding(EdgeInsets(top: 0, leading: 16, bottom: 16, trailing: 16))
+                        .padding(bottomTextPadding)
                 } else {
                     Text(L10n.podcastTimeLeft(CommonWidgetHelper.durationString(duration: playingEpisode.duration)).localizedUppercase)
                         .font(.caption2)
                         .fontWeight(.medium)
                         .foregroundColor(Color.secondary)
-                        .padding(EdgeInsets(top: 0, leading: 16, bottom: 16, trailing: 16))
+                        .padding(bottomTextPadding)
                         .layoutPriority(1)
                 }
             }
             .widgetURL(URL(string: "pktc://last_opened"))
+            .clearBackground()
+            .if(!showsWidgetBackground) { view in
+                view
+                    .padding(.top)
+                    .padding(.bottom)
+            }
+        } else if !showsWidgetBackground {
+            nothingPlaying
         } else {
             ZStack {
                 Image(CommonWidgetHelper.loadAppIconName())
                     .resizable()
             }
             .widgetURL(URL(string: "pktc://last_opened"))
+            .clearBackground()
+        }
+    }
+
+    private var nothingPlaying: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            GeometryReader { geometry in
+                HStack(alignment: .top) {
+                    LargeArtworkView()
+                        .opacity(0.5)
+                    Spacer()
+                    Image("logo-transparent")
+                        .frame(width: 28, height: 28)
+                }.padding(topPadding)
+            }
+            Text(L10n.widgetsDiscoverPromptTitle)
+                .font(.footnote)
+                .fontWeight(.semibold)
+                .foregroundColor(Color.primary)
+                .lineLimit(2)
+                .frame(height: 38, alignment: .center)
+                .layoutPriority(1)
+                .padding(episodeTitlePadding)
+
+            Text(L10n.widgetsDiscoverPromptMsg)
+                .font(.caption2)
+                .fontWeight(.medium)
+                .foregroundColor(Color.secondary)
+                .padding(bottomTextPadding)
+                .layoutPriority(1)
+        }
+        .widgetURL(URL(string: "pktc://discover"))
+        .clearBackground()
+        .if(!showsWidgetBackground) { view in
+            view
+                .padding(.top)
+                .padding(.bottom)
+        }
+    }
+
+    private var topPadding: EdgeInsets {
+        showsWidgetBackground ? EdgeInsets(top: 16, leading: 16, bottom: 0, trailing: 16) : EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0)
+    }
+
+    private var episodeTitlePadding: EdgeInsets {
+        showsWidgetBackground ? EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16) : EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0)
+    }
+
+    private var bottomTextPadding: EdgeInsets {
+        showsWidgetBackground ? EdgeInsets(top: 0, leading: 16, bottom: 16, trailing: 16) : EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0)
+    }
+}
+
+struct NowPlayingEntryView_Previews: PreviewProvider {
+    static var previews: some View {
+        Group {
+            NowPlayingWidgetEntryView(entry: .init(date: Date(), episode: WidgetEpisode(commonItem: CommonUpNextItem.init(episodeUuid: "foo", imageUrl: "", episodeTitle: "foo", podcastName: "foo", podcastColor: "#999999", duration: 400, isPlaying: true)), isPlaying: true))
+                .previewContext(WidgetPreviewContext(family: .systemSmall))
+                .previewDisplayName("Episode Playing")
+
+            NowPlayingWidgetEntryView(entry: .init(date: Date(), episode: nil, isPlaying: true))
+                .previewContext(WidgetPreviewContext(family: .systemSmall))
+                .previewDisplayName("Nothing Playing")
         }
     }
 }

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -558,6 +558,8 @@
 		8BC060092AB1FA0D00A4FEC6 /* PlayEpisodeIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC060072AB1FA0400A4FEC6 /* PlayEpisodeIntent.swift */; };
 		8BC0600B2AB1FB8100A4FEC6 /* AppPlayEpisodeIntentExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC0600A2AB1FB8100A4FEC6 /* AppPlayEpisodeIntentExtension.swift */; };
 		8BC0600E2AB2219700A4FEC6 /* WidgetPlayEpisodeIntentExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC0600C2AB2218300A4FEC6 /* WidgetPlayEpisodeIntentExtension.swift */; };
+		8BC060102AB35D0D00A4FEC6 /* View+if.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC0600F2AB35D0D00A4FEC6 /* View+if.swift */; };
+		8BC060112AB35D1200A4FEC6 /* View+if.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC0600F2AB35D0D00A4FEC6 /* View+if.swift */; };
 		8BC7FF55290FF92400017779 /* StoriesProgressModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC7FF54290FF92400017779 /* StoriesProgressModel.swift */; };
 		8BCB22B228F47F44001A0315 /* EndOfYearModal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BCB22B128F47F44001A0315 /* EndOfYearModal.swift */; };
 		8BCB22B428F48282001A0315 /* EndOfYear.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BCB22B328F48282001A0315 /* EndOfYear.swift */; };
@@ -2355,6 +2357,7 @@
 		8BC060072AB1FA0400A4FEC6 /* PlayEpisodeIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayEpisodeIntent.swift; sourceTree = "<group>"; };
 		8BC0600A2AB1FB8100A4FEC6 /* AppPlayEpisodeIntentExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppPlayEpisodeIntentExtension.swift; sourceTree = "<group>"; };
 		8BC0600C2AB2218300A4FEC6 /* WidgetPlayEpisodeIntentExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetPlayEpisodeIntentExtension.swift; sourceTree = "<group>"; };
+		8BC0600F2AB35D0D00A4FEC6 /* View+if.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+if.swift"; sourceTree = "<group>"; };
 		8BC7FF54290FF92400017779 /* StoriesProgressModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoriesProgressModel.swift; sourceTree = "<group>"; };
 		8BCB22B128F47F44001A0315 /* EndOfYearModal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndOfYearModal.swift; sourceTree = "<group>"; };
 		8BCB22B328F48282001A0315 /* EndOfYear.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndOfYear.swift; sourceTree = "<group>"; };
@@ -6452,6 +6455,7 @@
 				C7D8AE562A5F6D2600C9EBAF /* ActionBarOverlayView.swift */,
 				C76ECAC12A67612F00D9DB9E /* EmptyStateView.swift */,
 				C7891DC72A6AFE26009DA661 /* SearchField.swift */,
+				8BC0600F2AB35D0D00A4FEC6 /* View+if.swift */,
 			);
 			path = SwiftUI;
 			sourceTree = "<group>";
@@ -8488,6 +8492,7 @@
 				BD422EC426840EDD0078B799 /* WidgetData.swift in Sources */,
 				8B71829128CF755D00B98F04 /* UpNextLockScreenWidget.swift in Sources */,
 				8B7065A32AB0D5D200FE04CB /* View+clearBackground.swift in Sources */,
+				8BC060112AB35D1200A4FEC6 /* View+if.swift in Sources */,
 				BD422ED226841BF10078B799 /* HungryForMoreView.swift in Sources */,
 				4031466D252568970085E76B /* WidgetEpisode.swift in Sources */,
 				4075C2AE252C06DE001C280A /* ArtworkViews.swift in Sources */,
@@ -8823,6 +8828,7 @@
 				BD96575E2469053600873BB5 /* GoogleCastCell.swift in Sources */,
 				C71C04C929243F7D00F2858A /* ImportViewModel.swift in Sources */,
 				8B9D459C28F9A6260034219E /* TopFivePodcastsStory.swift in Sources */,
+				8BC060102AB35D0D00A4FEC6 /* View+if.swift in Sources */,
 				BDD3018C1EFB94C9004A9972 /* WatchManager.swift in Sources */,
 				C7BF5E47290832FD00733C1E /* DiscoverCoordinator.swift in Sources */,
 				BDD40A181FA1ABF500A53AE1 /* PCNavigationController.swift in Sources */,

--- a/podcasts/SwiftUI/View+if.swift
+++ b/podcasts/SwiftUI/View+if.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+extension View {
+    /// Applies the given transform if the given condition evaluates to `true`.
+    /// - Parameters:
+    ///   - condition: The condition to evaluate.
+    ///   - transform: The transform to apply to the source `View`.
+    /// - Returns: Either the original `View` or the modified `View` if the condition is `true`.
+    @ViewBuilder func `if`<Content: View>(_ condition: Bool, transform: (Self) -> Content) -> some View {
+        if condition {
+            transform(self)
+        } else {
+            self
+        }
+    }
+}

--- a/podcasts/WidgetHelper.swift
+++ b/podcasts/WidgetHelper.swift
@@ -148,7 +148,7 @@ class WidgetHelper {
         var imageUrl = ""
 
         if let episode = episode as? Episode {
-            imageUrl = ServerHelper.image(podcastUuid: episode.parentIdentifier(), size: 130)
+            imageUrl = ServerHelper.image(podcastUuid: episode.parentIdentifier(), size: 340)
         } else if let userEpisode = episode as? UserEpisode {
             imageUrl = userEpisodeImageString(userEpisode)
         }


### PR DESCRIPTION
This PR adapts the Now Playing widget for:

1. iPad landscape lockscreen: it doesn't display the background
2. StandBy: it doesn't show background and improve how items are shown
3. StandBy not playing: instead of the huge Pocket Casts icon we show a message that opens Discover

#### iPad lockscreen

<img src="https://github.com/Automattic/pocket-casts-ios/assets/7040243/dced9775-ba6b-4ea4-898f-854be728e97c" width="500">

#### StandBy

| Playing | Now Playing |
| ------- | ------------ |
| ![IMG_0064](https://github.com/Automattic/pocket-casts-ios/assets/7040243/d3a0996b-be92-4fc0-adb7-c60fb88fd030) | ![IMG_0065](https://github.com/Automattic/pocket-casts-ios/assets/7040243/6b193962-3398-41c4-98d9-2a14705bfd6a) |

## To test

1. Run the app (device or simulator)
2. Add the Now Playing on the StandBy screen (if you're using phone, put it on charge and move it to be in landscape, on simulator just go to Features > Show StandBy)
3. ✅  If something is playing, interact with the play or pause button and see that it works
4. Go to Pocket Casts, tap and hold on the miniplayer and tap "Close And Clear Up Next"
5. Go back to StandBy mode
6. Tap it
7. ✅ You should go to Discover
8. Run the app on iPad
9. Add the Now Playing widget to the landscape lock screen
10. Check that it looks good

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
