### PR TITLE
Updates cloud storage to use the remote value

### DIFF
--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -311,7 +311,7 @@ struct Constants {
         static let episodeSearchDebounceMsDefault: Double = 800
 
         static let customStorageLimitGB = "custom_storage_limit_gb"
-        static let customStorageLimitGBDefault: Int = 10
+        static let customStorageLimitGBDefault: Int = 20
 
         static let endOfYearRequireAccount = "end_of_year_require_account"
         static let endOfYearRequireAccountDefault: Bool = true

--- a/podcasts/Onboarding/Plus/Account Prompt/PlusAccountUpgradePrompt.swift
+++ b/podcasts/Onboarding/Plus/Account Prompt/PlusAccountUpgradePrompt.swift
@@ -135,7 +135,7 @@ struct PlusAccountUpgradePrompt: View {
         .yearly: [
             .init(iconName: "plus-feature-desktop", title: L10n.plusMarketingDesktopAppsTitle),
             .init(iconName: "plus-feature-folders", title: L10n.folders),
-            .init(iconName: "plus-feature-cloud", title: L10n.plusCloudStorageLimitFormat(Constants.RemoteParams.customStorageLimitGBDefault.localized())),
+            .init(iconName: "plus-feature-cloud", title: L10n.plusCloudStorageLimit),
             .init(iconName: "plus-feature-watch", title: L10n.plusMarketingWatchPlaybackTitle),
             .init(iconName: "plus-feature-themes", title: L10n.plusMarketingThemesIconsTitle)
         ],

--- a/podcasts/Onboarding/Plus/PlusLandingView.swift
+++ b/podcasts/Onboarding/Plus/PlusLandingView.swift
@@ -80,7 +80,7 @@ struct PlusLandingView: View {
                     title: L10n.folders,
                     description: L10n.plusMarketingUpdatedFoldersDescription),
         PlusFeature(iconName: "plus-feature-cloud",
-                    title: L10n.plusCloudStorageLimitFormat(Constants.RemoteParams.customStorageLimitGBDefault.localized()),
+                    title: L10n.plusCloudStorageLimit,
                     description: L10n.plusMarketingUpdatedCloudStorageDescription),
         PlusFeature(iconName: "plus-feature-watch",
                     title: L10n.plusMarketingWatchPlaybackTitle,

--- a/podcasts/Onboarding/Plus/UpgradeLandingView.swift
+++ b/podcasts/Onboarding/Plus/UpgradeLandingView.swift
@@ -257,7 +257,7 @@ extension UpgradeTier {
         UpgradeTier(tier: .plus, iconName: "plusGold", title: "Plus", plan: .plus, header: L10n.plusMarketingTitle, description: L10n.accountDetailsPlusTitle, buttonLabel: L10n.plusSubscribeTo, buttonForegroundColor: Color.plusButtonFilledTextColor, features: [
             TierFeature(iconName: "plus-feature-desktop", title: L10n.plusMarketingDesktopAppsTitle),
             TierFeature(iconName: "plus-feature-folders", title: L10n.folders),
-            TierFeature(iconName: "plus-feature-cloud", title: L10n.plusCloudStorageLimitFormat(10)),
+            TierFeature(iconName: "plus-feature-cloud", title: L10n.plusCloudStorageLimit),
             TierFeature(iconName: "plus-feature-watch", title: L10n.plusMarketingWatchPlaybackTitle),
             TierFeature(iconName: "plus-feature-extra", title: L10n.plusFeatureThemesIcons),
             TierFeature(iconName: "plus-feature-love", title: L10n.plusFeatureGratitude)

--- a/podcasts/PlusFeaturesView.swift
+++ b/podcasts/PlusFeaturesView.swift
@@ -63,6 +63,6 @@ class PlusFeaturesView: UIView {
     }
 
     private func configureLabels() {
-        customStorageLabel.text = L10n.plusCloudStorageLimitFormat(Constants.RemoteParams.customStorageLimitGBDefault.localized())
+        customStorageLabel.text = L10n.plusCloudStorageLimit
     }
 }

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -863,6 +863,10 @@ class Settings: NSObject {
             return EffectsPlayerStrategy(rawValue: remote.numberValue.intValue)
         }
 
+        static var plusCloudStorageLimit: Int {
+            RemoteConfig.remoteConfig().configValue(forKey: Constants.RemoteParams.customStorageLimitGB).numberValue.intValue
+        }
+
         private class func remoteMsToTime(key: String) -> TimeInterval {
             let remoteMs = RemoteConfig.remoteConfig().configValue(forKey: key)
 
@@ -880,3 +884,11 @@ extension Settings {
         Analytics.track(event, properties: ["enabled": enabled])
     }
 }
+
+#if !os(watchOS)
+extension L10n {
+    static var plusCloudStorageLimit: String {
+        plusCloudStorageLimitFormat(Settings.plusCloudStorageLimit.localized())
+    }
+}
+#endif


### PR DESCRIPTION
| 🚨 Targets Frozen Branch |
|:---:|

Updates the references cloud storage references to retrieve the remote value.

## To test

1. Launch the app
2. Sign out if you're signed in
3. Go to the Podcasts tab
4. Tap on the folders button
5. Swipe to the cloud storage card
6. ✅ Verify you see 20 GB
7. Sign into an account without plus
8. Go to the Profile tab
9. Tap the Account button
10. ✅ Verify you see 20 GB listed in the cloud storage item

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
