### PR TITLE
Display an alert if the user is purchasing in the beta

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Private/API Tasks/PurchaseReceiptTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Private/API Tasks/PurchaseReceiptTask.swift
@@ -18,6 +18,9 @@ class PurchaseReceiptTask: ApiBaseTask {
             return
         }
 
+        FileLog.shared.addMessage("PurchaseReceiptTask: Receipt URL: \(receiptUrl)")
+        FileLog.shared.addMessage("PurchaseReceiptTask: iapUnverifiedPurchaseReceiptDate: \(String(describing: ServerSettings.iapUnverifiedPurchaseReceiptDate()))")
+
         let receiptString = receiptData.base64EncodedString()
         var updateRequest = Api_SubscriptionsPurchaseAppleRequest()
         updateRequest.receipt = receiptString

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1537,6 +1537,7 @@
 		C7CE415A28CBCFC200AD063E /* Analytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7AF5790289D87CF0089E435 /* Analytics.swift */; };
 		C7CE415B28CBD00A00AD063E /* AnalyticsEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = C72CED2C289DA14F0017883A /* AnalyticsEvent.swift */; };
 		C7CE415C28CBD01F00AD063E /* String+Analytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = C72CED2E289DA1650017883A /* String+Analytics.swift */; };
+		C7D1CC112AB3B444008463FC /* SubscriptionTier+L10n.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D1CC102AB3B443008463FC /* SubscriptionTier+L10n.swift */; };
 		C7D5E7F12A8BF3150039F4A1 /* UIViewController+Presenting.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D5E7F02A8BF3150039F4A1 /* UIViewController+Presenting.swift */; };
 		C7D6551428E5153200AD7174 /* Debounce.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D6551328E5153200AD7174 /* Debounce.swift */; };
 		C7D6551528E5153200AD7174 /* Debounce.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D6551328E5153200AD7174 /* Debounce.swift */; };
@@ -3302,6 +3303,7 @@
 		C7C4F9B52A4BAD57002822DD /* HeadphoneSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeadphoneSettingsViewController.swift; sourceTree = "<group>"; };
 		C7C4F9BE2A4CC359002822DD /* PCTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PCTableViewController.swift; sourceTree = "<group>"; };
 		C7CA0558293E8918000E41BD /* HolographicEffect.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HolographicEffect.swift; sourceTree = "<group>"; };
+		C7D1CC102AB3B443008463FC /* SubscriptionTier+L10n.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SubscriptionTier+L10n.swift"; sourceTree = "<group>"; };
 		C7D5E7F02A8BF3150039F4A1 /* UIViewController+Presenting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Presenting.swift"; sourceTree = "<group>"; };
 		C7D6551328E5153200AD7174 /* Debounce.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Debounce.swift; sourceTree = "<group>"; };
 		C7D813782A0D4B89007F715F /* AppIcon-Patron-Chrome-iphone@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "AppIcon-Patron-Chrome-iphone@2x.png"; sourceTree = "<group>"; };
@@ -6329,6 +6331,7 @@
 				BD2CB3E22418B48600E2D762 /* ArrayExtension.swift */,
 				463538AA26E814B300BA9D35 /* DataModel+Strings.swift */,
 				463538AD26E8F4AE00BA9D35 /* Server+Strings.swift */,
+				C7D1CC102AB3B443008463FC /* SubscriptionTier+L10n.swift */,
 				46851BB62790D5E00065C8B2 /* PodcastCollectionColors+Helpers.swift */,
 				8B484F0028D25D1E001AFA97 /* UIViewController+requestReview.swift */,
 				C7F4BABE28DB7F7C001C9785 /* DiscoverItem+Helper.swift */,
@@ -8650,6 +8653,7 @@
 				401EBA6923725C6400899F93 /* UpNextNowPlayingCell.swift in Sources */,
 				C7DC40202A6702A600883D03 /* ToastView.swift in Sources */,
 				C7DA8D2A2923DC6800C1B08B /* PlusAccountPromptTableCell.swift in Sources */,
+				C7D1CC112AB3B444008463FC /* SubscriptionTier+L10n.swift in Sources */,
 				409BF82524906EC10015097B /* PodcastViewController+MultiSelect.swift in Sources */,
 				C7DA8D272923DA4500C1B08B /* PlusPricingInfoModel.swift in Sources */,
 				C7BDECB52A15327000BECF02 /* PatronUnlockButton.swift in Sources */,

--- a/podcasts/IapHelper.swift
+++ b/podcasts/IapHelper.swift
@@ -20,6 +20,9 @@ class IapHelper: NSObject, SKProductsRequestDelegate {
     /// Prevent multiple eligibility requests from being performed
     private var isCheckingEligibility = false
 
+    /// Whether purchasing is allowed in the current environment or not
+    var canMakePurchases = BuildEnvironment.current != .testFlight
+
     override init() {
         super.init()
 

--- a/podcasts/IapHelper.swift
+++ b/podcasts/IapHelper.swift
@@ -211,6 +211,7 @@ private extension IapHelper {
     private func addSubscriptionNotifications() {
         NotificationCenter.default.addObserver(forName: ServerNotifications.subscriptionStatusChanged, object: nil, queue: .main) { [weak self] _ in
             self?.updateTrialEligibility()
+            self?.requestProductInfo()
         }
     }
 

--- a/podcasts/Onboarding/Models/PlusPurchaseModel.swift
+++ b/podcasts/Onboarding/Models/PlusPurchaseModel.swift
@@ -68,7 +68,7 @@ class PlusPurchaseModel: PlusPricingInfoModel, OnboardingModel {
 
         alert.addAction(.init(title: L10n.ok, style: .cancel))
 
-        presentingViewController.present(alert, animated: true, completion: nil)
+        presentingViewController.presentFromRootController(alert)
     }
 
     // Our internal state

--- a/podcasts/Onboarding/Models/PlusPurchaseModel.swift
+++ b/podcasts/Onboarding/Models/PlusPurchaseModel.swift
@@ -68,7 +68,8 @@ class PlusPurchaseModel: PlusPricingInfoModel, OnboardingModel {
 
         alert.addAction(.init(title: L10n.ok, style: .cancel))
 
-        presentingViewController.presentFromRootController(alert)
+        let controller = (presentingViewController.presentedViewController ?? presentingViewController)
+        controller.present(alert, animated: true)
     }
 
     // Our internal state

--- a/podcasts/Onboarding/Models/PlusPurchaseModel.swift
+++ b/podcasts/Onboarding/Models/PlusPurchaseModel.swift
@@ -39,6 +39,11 @@ class PlusPurchaseModel: PlusPricingInfoModel, OnboardingModel {
 
     // MARK: - Triggers the purchase process
     func purchase(product: Constants.IapProducts) {
+        guard purchaseHandler.canMakePurchases else {
+            showPurchaseDisabledAlert(product: product)
+            return
+        }
+
         guard purchaseHandler.buyProduct(identifier: product.rawValue) else {
             handlePurchaseFailed(error: nil)
             return
@@ -48,6 +53,22 @@ class PlusPurchaseModel: PlusPricingInfoModel, OnboardingModel {
 
         purchasedProduct = product
         state = .purchasing
+    }
+
+    func showPurchaseDisabledAlert(product: Constants.IapProducts) {
+        guard let presentingViewController = parentController ?? SceneHelper.rootViewController() else {
+            return
+        }
+
+        let displayName = product.subscriptionTier.displayName
+
+        let alert = UIAlertController(title: L10n.betaThankYou,
+                                      message: L10n.betaPurchaseDisabled(displayName),
+                                      preferredStyle: .alert)
+
+        alert.addAction(.init(title: L10n.ok, style: .cancel))
+
+        presentingViewController.present(alert, animated: true, completion: nil)
     }
 
     // Our internal state

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -254,6 +254,12 @@ internal enum L10n {
   internal static var autoDownloadPromptFirst: String { return L10n.tr("Localizable", "auto_download_prompt_first") }
   /// Back
   internal static var back: String { return L10n.tr("Localizable", "back") }
+  /// Please download Pocket Casts from the App Store to purchase %1$@.
+  internal static func betaPurchaseDisabled(_ p1: Any) -> String {
+    return L10n.tr("Localizable", "beta_purchase_disabled", String(describing: p1))
+  }
+  /// Thank you for beta testing!
+  internal static var betaThankYou: String { return L10n.tr("Localizable", "beta_thank_you") }
   /// Bookmark added
   internal static var bookmarkAdded: String { return L10n.tr("Localizable", "bookmark_added") }
   /// View

--- a/podcasts/SubscriptionTier+L10n.swift
+++ b/podcasts/SubscriptionTier+L10n.swift
@@ -1,0 +1,21 @@
+import PocketCastsServer
+
+extension SubscriptionTier {
+    /// Pocket Casts Plus, or Patron
+    var displayName: String {
+        switch self {
+        case .patron: L10n.patron
+        case .plus: L10n.pocketCastsPlus
+        case .none: L10n.pocketCastsPlus
+        }
+    }
+
+    /// Plus, or Patron
+    var displayNameShort: String {
+        switch self {
+        case .patron: L10n.patron
+        case .plus: L10n.pocketCastsShort
+        case .none: L10n.pocketCastsShort
+        }
+    }
+}

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -3860,5 +3860,5 @@
 /* Title of a message thanking the user for being a beta tester */
 "beta_thank_you" = "Thank you for beta testing!";
 
-/* Message of an alert that informs the user purchasing is disabled in the beta. 'Pocket Casts' is treated as a proper noun and hasn't been localized in other places of the app. */
+/* Message of an alert that informs the user purchasing is disabled in the beta. 'Pocket Casts' is treated as a proper noun and hasn't been localized in other places of the app. %1$@ is the name of the tier (Plus or Patron)*/
 "beta_purchase_disabled" = "Please download Pocket Casts from the App Store to purchase %1$@.";

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -3856,3 +3856,9 @@
 
 /* A button title that prompts the user upgrade to redeem a free trial */
 "start_free_trial" = "Start Free Trial";
+
+/* Title of a message thanking the user for being a beta tester */
+"beta_thank_you" = "Thank you for beta testing!";
+
+/* Message of an alert that informs the user purchasing is disabled in the beta. 'Pocket Casts' is treated as a proper noun and hasn't been localized in other places of the app. */
+"beta_purchase_disabled" = "Please download Pocket Casts from the App Store to purchase %1$@.";


### PR DESCRIPTION
We have been getting reports from users with active subscriptions from the App Store version that have had their purchase receipt overridden 

This aims to prevent that by disabling test purchases in the beta, and displaying an alert to the user instructing them to purchase using the App Store version. 

This also adds some debug logs to try and figure out what's going on.

## To test

1. Launch the app
2. Sign into an account without plus or sign out if you're signed in
3. Go to the Podcasts tab
4. Tap the Folders icon
5. Tap the purchase button
6. ✅ Verify you see the purchase dialog
7. Open `BuildEnvironment.swift`
8. Change line 24 from `return .debug` to `return .testFlight`
9. Launch the app again
10. Repeat the steps above
11. ✅ Verify you see an alert instructing you to purchase on the App Store
12. Dismiss the view
13. Change the BuildEnvironment to `.appStore`
14. ✅ Verify you are able to purchase again

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
