### PR TITLE
Folder issue: add more logs

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
@@ -139,7 +139,7 @@ extension SyncTask {
         if podcastItem.hasFolderUuid {
             let folderUuid = podcastItem.folderUuid.value
 
-            FileLog.shared.foldersIssue("SyncTask importItem: \(podcast.title ?? "") folder to \(((folderUuid == DataConstants.homeGridFolderUuid) ? nil : folderUuid) ?? "nil")")
+            FileLog.shared.foldersIssue("SyncTask importItem: \(podcast.title ?? "") changing folder from \(podcast.folderUuid ?? "nil") to \(((folderUuid == DataConstants.homeGridFolderUuid) ? nil : folderUuid) ?? "nil")")
 
             podcast.folderUuid = (folderUuid == DataConstants.homeGridFolderUuid) ? nil : folderUuid
         }

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask.swift
@@ -248,18 +248,23 @@ class SyncTask: ApiBaseTask {
         var records = [Api_Record]()
         if let podcastChanges = changedPodcasts() {
             records += podcastChanges
+            FileLog.shared.foldersIssue("SyncTask: Number of changed podcasts: \(podcastChanges.count)")
         }
         if let episodeChanges = changedEpisodes(for: episodesToSync) {
             records += episodeChanges
+            FileLog.shared.foldersIssue("SyncTask: Number of changed episodes: \(episodeChanges.count)")
         }
         if let filterChanges = changedFilters() {
             records += filterChanges
+            FileLog.shared.foldersIssue("SyncTask: Number of changed filters: \(filterChanges.count)")
         }
         if let folderChanges = changedFolders() {
             records += folderChanges
+            FileLog.shared.foldersIssue("SyncTask: Number of changed folders: \(folderChanges.count)")
         }
         if let statsChanges = changedStats() {
             records.append(statsChanges)
+            FileLog.shared.foldersIssue("SyncTask: sending stats changes")
         }
 
         if dataManager.bookmarksEnabled, let bookmarks = changedBookmarks() {

--- a/Modules/Utils/Sources/PocketCastsUtils/Logging/FileLog.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Logging/FileLog.swift
@@ -58,7 +58,7 @@ public class FileLog {
     // See: https://github.com/Automattic/pocket-casts-ios/issues/791
     public func foldersIssue(_ message: String?) {
         guard let message else { return }
-    
+
         addMessage("[Folders] \(message)")
     }
 

--- a/Modules/Utils/Sources/PocketCastsUtils/Logging/FileLog.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Logging/FileLog.swift
@@ -57,6 +57,8 @@ public class FileLog {
     //
     // See: https://github.com/Automattic/pocket-casts-ios/issues/791
     public func foldersIssue(_ message: String?) {
+        guard let message else { return }
+    
         addMessage("[Folders] \(message)")
     }
 

--- a/Modules/Utils/Sources/PocketCastsUtils/Logging/FileLog.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Logging/FileLog.swift
@@ -57,7 +57,7 @@ public class FileLog {
     //
     // See: https://github.com/Automattic/pocket-casts-ios/issues/791
     public func foldersIssue(_ message: String?) {
-        addMessage(message)
+        addMessage("[Folders] \(message)")
     }
 
     public func loadLogFileAsString(completion: @escaping (String) -> Void) {


### PR DESCRIPTION
This PR adds more logs so we can try to identify better the issue with podcasts being removed from folders.

## To test

1. Run the app
2. If logged out, log in
2. Subscribe to a new podcast
3. Go to Profile > scroll down > tap "Refresh Now"
4. Check that you see additional logs such as `[Folders] SyncTask: Number of changed podcasts: 1`

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
