### PR TITLE
Fix the bookmarks indicator icon always appearing for archived episodes

### DIFF
--- a/podcasts/EpisodeCell.swift
+++ b/podcasts/EpisodeCell.swift
@@ -168,7 +168,7 @@ class EpisodeCell: ThemeableSwipeCell, MainEpisodeActionViewDelegate {
         populate(progressOnly: false)
     }
 
-    
+
     /// Determines whether the bookmark indicator icon should appear
     private var showBookmarksIcon: Bool {
         FeatureFlag.bookmarks.enabled && PaidFeature.bookmarks.isUnlocked && episode?.hasBookmarks == true
@@ -193,10 +193,10 @@ class EpisodeCell: ThemeableSwipeCell, MainEpisodeActionViewDelegate {
             } else {
                 uploadStatusIndicator.isHidden = true
             }
-            
+
             // Since this calls out to the DB we'll cache the value here so later calls don't hit it again
             let showBookmarksIcon = self.showBookmarksIcon
-            
+
             // Setup the bookmarks icon
             bookmarkIcon.image = UIImage(named: "bookmark-icon-episode")
             bookmarkIcon.tintColor = mainTintColor

--- a/podcasts/EpisodeCell.swift
+++ b/podcasts/EpisodeCell.swift
@@ -168,6 +168,12 @@ class EpisodeCell: ThemeableSwipeCell, MainEpisodeActionViewDelegate {
         populate(progressOnly: false)
     }
 
+    
+    /// Determines whether the bookmark indicator icon should appear
+    private var showBookmarksIcon: Bool {
+        FeatureFlag.bookmarks.enabled && PaidFeature.bookmarks.isUnlocked && episode?.hasBookmarks == true
+    }
+
     private func populate(progressOnly: Bool) {
         guard let episode = episode else { return }
 
@@ -180,15 +186,6 @@ class EpisodeCell: ThemeableSwipeCell, MainEpisodeActionViewDelegate {
             upNextIndicator.isHidden = !PlaybackManager.shared.inUpNext(episode: episode)
             upNextIndicator.tintColor = ThemeColor.support01()
 
-            let showBookmarksIcon = FeatureFlag.bookmarks.enabled && PaidFeature.bookmarks.isUnlocked
-            if showBookmarksIcon {
-                bookmarkIcon.image = UIImage(named: "bookmark-icon-episode")
-                bookmarkIcon.tintColor = mainTintColor
-                bookmarkIcon.isHidden = !episode.hasBookmarks
-            } else {
-                bookmarkIcon.isHidden = true
-            }
-
             var uploadFailed = false
             if let userEpisode = episode as? UserEpisode {
                 uploadStatusIndicator.isHidden = !userEpisode.uploaded()
@@ -196,6 +193,14 @@ class EpisodeCell: ThemeableSwipeCell, MainEpisodeActionViewDelegate {
             } else {
                 uploadStatusIndicator.isHidden = true
             }
+            
+            // Since this calls out to the DB we'll cache the value here so later calls don't hit it again
+            let showBookmarksIcon = self.showBookmarksIcon
+            
+            // Setup the bookmarks icon
+            bookmarkIcon.image = UIImage(named: "bookmark-icon-episode")
+            bookmarkIcon.tintColor = mainTintColor
+            bookmarkIcon.isHidden = !showBookmarksIcon
 
             let hideStatus = !episode.archived && !episode.downloaded(pathFinder: DownloadManager.shared) && !episode.downloadFailed() && !uploadFailed && !episode.playbackError()
             if !hideStatus {
@@ -205,6 +210,8 @@ class EpisodeCell: ThemeableSwipeCell, MainEpisodeActionViewDelegate {
                 } else if episode.downloaded(pathFinder: DownloadManager.shared) {
                     statusImage = UIImage(named: "list_downloaded")
                 } else {
+                    // To show the archive and bookmark indicator in the correct places we show the bookmark indicator
+                    // in the status image, and move the archive icon into the bookmarks place.
                     if showBookmarksIcon {
                         statusImage = UIImage(named: "bookmark-icon-episode")?.tintedImage(mainTintColor ?? ThemeColor.primaryIcon02())
                         bookmarkIcon.image = UIImage(named: "list_archived")?.tintedImage(ThemeColor.primaryIcon02())


### PR DESCRIPTION
This fixes a bug where if the feature is enabled then the icon will always appear for archived episodes. 

Thanks for reporting this @rviljoen! 

## To test

1. Launch the app
2. Enable the bookmarks feature flag
3. Go to a Podcast without bookmarks
4. Archive an episode
5. ✅ Verify you don't see the bookmarks indicator
6. Unarchive the episode
7. Play it
8. Add a bookmark
9. ✅ Verify you see the indicator
10. Archive it again
11. ✅ Verify you see the icon still

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
