### PR TITLE
Bookmarks: Fixes the save button title color

### DIFF
--- a/podcasts/Bookmarks/Editing/BookmarkEditTitleView.swift
+++ b/podcasts/Bookmarks/Editing/BookmarkEditTitleView.swift
@@ -202,7 +202,7 @@ class BookmarkEditTheme: ThemeObserver {
     var textFieldUnderline: Color { theme.playerContrast05 }
 
     var saveButton: Color {
-        background.luminance() < 0.5 ? .white : .black
+        saveButtonBackground.luminance() < 0.5 ? .white : .black
     }
 
     var saveButtonBackground: Color {


### PR DESCRIPTION
The save button was checking the luminance of the view background color to determine the foreground color of the save button. 

This updates it to check the `saveButtonBackground` instead. 

| Before | After |
|:---:|:---:|
|<img src="https://github.com/Automattic/pocket-casts-ios/assets/793774/6792b8b4-f0c7-4a51-a0a9-7d0b661a14bc" width="320" />|<img src="https://github.com/Automattic/pocket-casts-ios/assets/793774/3ce8040a-58a3-4670-88fb-421a70eaf34a" width="320" />|

## To test

1. Enable the bookmarks feature flag
2. Launch the app
3. Go to Discover -> Strike Force Five
4. Play an episode
5. Tap the Add Bookmark item
6. ✅ Verify the save button color is readable
7. Play episodes from other podcasts and verify the save button color is legible

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
