### PR TITLE
Fix accessibility grouping on profile header view

### DIFF
--- a/podcasts/Profile - SwiftUI/Profile/ProfileHeaderView.swift
+++ b/podcasts/Profile - SwiftUI/Profile/ProfileHeaderView.swift
@@ -182,6 +182,7 @@ struct ProfileHeaderView: View {
                         .foregroundColor(theme.primaryText02)
                 }
                 .frame(maxWidth: .infinity)
+                .accessibilityElement(children: .combine)
             }
         }
 


### PR DESCRIPTION
When using voiceover, values were not read together with their corresponding labels on profile header stats which made it confusing for voiceover users.

## To test

1. Turn voiceover on
2. Launch the app
3. Go to profile tab
4. Use swipe gestures to navigate through the profile screen

Now, values like number of podcasts should be read "0 podcasts" all at once instead of needing to swipe through the numbers and keep swiping to reach the labels below the numbers.