### PR TITLE
Disables the patron feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 7.48
 -----
-- Enables Patron: [#1104] [Internal]
 
 7.47
 -----

--- a/podcasts/FeatureFlag.swift
+++ b/podcasts/FeatureFlag.swift
@@ -73,7 +73,7 @@ enum FeatureFlag: String, CaseIterable {
         case .discoverFeaturedAutoScroll:
             return true
         case .patron:
-            return true
+            return false
         case .showRatings:
             return true
         case .autoplay:


### PR DESCRIPTION
Reverts the changes from #1104 

## To test

1. CI is 🟢
2. Launch the app
3. Sign into an account without Plus
4. Go to the upgrade screens and verify you do not see Patron listed
5. Go through the Purchase flow
6. ✅ Verify it works and Plus is unlocked



## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
