### PR TITLE
Fix the player tabs not rendering correctly for some languages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 7.48
 -----
 - Fix importing podcasts route [#1091]
+- Fixes an issue where the player tabs may not render correctly [#1119]
 
 7.47
 -----

--- a/podcasts/PlayerTabsView.swift
+++ b/podcasts/PlayerTabsView.swift
@@ -132,6 +132,11 @@ class PlayerTabsView: UIScrollView {
             button.addTarget(self, action: #selector(buttonTapped(_:)), for: .touchUpInside)
             tabsStackView.addArrangedSubview(button)
         }
+        
+        // Add an empty view to make sure the sizes are calculated correctly when there is a longer first item
+        let empty = UIView()
+        empty.isUserInteractionEnabled = false
+        tabsStackView.addArrangedSubview(UIView())
 
         layoutIfNeeded()
     }

--- a/podcasts/PlayerTabsView.swift
+++ b/podcasts/PlayerTabsView.swift
@@ -132,7 +132,7 @@ class PlayerTabsView: UIScrollView {
             button.addTarget(self, action: #selector(buttonTapped(_:)), for: .touchUpInside)
             tabsStackView.addArrangedSubview(button)
         }
-        
+
         // Add an empty view to make sure the sizes are calculated correctly when there is a longer first item
         let empty = UIView()
         empty.isUserInteractionEnabled = false


### PR DESCRIPTION
This fixes an rendering issue where if the name of the now playing tab is longer the system may not render the tabs correctly. 

The fix for this was to add an empty `UIView` at the end of the Stack View which causes the tabs to be properly sized and render correctly. 

## Screenshots

| Italian | English | German | Chinese |
|:---:|:---:|:---:|:---:|
|<img src="https://github.com/Automattic/pocket-casts-ios/assets/793774/6309e529-d969-42fa-af3f-612746cea864" width="320" />|<img src="https://github.com/Automattic/pocket-casts-ios/assets/793774/50076f52-73fa-4fcd-bda7-cdbc4d29be34" width="320" />|<img src="https://github.com/Automattic/pocket-casts-ios/assets/793774/b7166bfd-59da-4746-8fc1-62d470b2727c" width="320" />|<img src="https://github.com/Automattic/pocket-casts-ios/assets/793774/6309e529-d969-42fa-af3f-612746cea864" width="320" />|<img src="https://github.com/Automattic/pocket-casts-ios/assets/793774/5bd1cb58-0104-46fa-818e-84474c0e499b" width="320" />|

## To test
1. Launch the app on iOS 17
2. Open the full screen player
3. ✅ Verify the tabs render correctly
4. Repeat for Italian, German, Russian, and other languages
5. Repeat for iOS 16, and iPad

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
