### PR TITLE
Update the player tab colors when the episode changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 7.48
 -----
 - Fix importing podcasts route [#1091]
+- Fixes the player tab scroll indicator colors [#1120]
 
 7.47
 -----

--- a/podcasts/PlayerContainerViewController+Update.swift
+++ b/podcasts/PlayerContainerViewController+Update.swift
@@ -20,6 +20,9 @@ extension PlayerContainerViewController {
     private func updateAvailableTabs() {
         guard let playingEpisode = PlaybackManager.shared.currentEpisode() else { return }
 
+        // Update the colors when the episode changes
+        tabsView.themeDidChange()
+
         let shouldShowNotes = (playingEpisode is Episode)
         let shouldShowChapters = PlaybackManager.shared.chapterCount() > 0
         let shouldShowBookmarks = FeatureFlag.bookmarks.enabled


### PR DESCRIPTION
Fixes #1117 

This updates the theme colors of the tabs when updating the available tabs to make sure the fade colors appear correctly for the current episode.

## Video

https://github.com/Automattic/pocket-casts-ios/assets/793774/28bc97be-2a3c-4b83-a928-d3610cff4d89


## To test

1. Add some items to your up next
2. Play an episode
3. Open the full screen player
4. Tap the up next icon
5. Change the current episode to one from a different podcast
6. Dismiss the up next
7. ✅ Verify the fade color is correct


## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
