### PR TITLE
Fixes Play / Pause not working on the Now Playing widget with user-added files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix importing podcasts route [#1091]
 - Fixes the player tab scroll indicator colors [#1120]
 - Fixes an issue where the player tabs may not render correctly [#1119]
+- Fixes the play/pause on interactive widgets not working for user files [#1123]
 
 7.47
 -----

--- a/podcasts/Analytics/Helpers/AnalyticsCoordinator.swift
+++ b/podcasts/Analytics/Helpers/AnalyticsCoordinator.swift
@@ -44,6 +44,7 @@ enum AnalyticsSource: String, AnalyticsDescribable {
     case playbackFailed = "playback_failed"
     case watch
     case bookmark
+    case interactiveWidget = "interactive_widget"
     case unknown
 
     var analyticsDescription: String { rawValue }

--- a/podcasts/AppPlayEpisodeIntentExtension.swift
+++ b/podcasts/AppPlayEpisodeIntentExtension.swift
@@ -11,6 +11,7 @@ extension PlayEpisodeIntent {
             return
         }
 
+        AnalyticsPlaybackHelper.shared.currentSource = .interactiveWidget
         let current = PlaybackManager.shared.currentEpisode()
 
         if current?.uuid == podcastEpisode.uuid {

--- a/podcasts/AppPlayEpisodeIntentExtension.swift
+++ b/podcasts/AppPlayEpisodeIntentExtension.swift
@@ -6,7 +6,7 @@ extension PlayEpisodeIntent {
     func intentPlayback(_ episodeUuid: String) {
         FileLog.shared.addMessage("PlayEpisodeIntent called for episode \(episodeUuid)")
 
-        guard let podcastEpisode = DataManager.sharedManager.findEpisode(uuid: episodeUuid) else {
+        guard let podcastEpisode = DataManager.sharedManager.findBaseEpisode(uuid: episodeUuid) else {
             FileLog.shared.addMessage("PlayEpisodeIntent error: episode not found")
             return
         }


### PR DESCRIPTION
Fixes #1114

## To test

1. Run the app
2. Add any interactive widget
3. Go to Profile > Files > add a file
4. Play it
5. Go to the widget
6. Tap play/pause
7. ✅ Verify it works

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
