### PR TITLE
Utility: Adds mapFirst method on Sequence

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Extensions/Sequence+Extensions.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Extensions/Sequence+Extensions.swift
@@ -14,14 +14,14 @@ import Foundation
 ///     }
 ///
 ///  After:
-///     coolData.mapFirst(where: { $0.someValue })
+///     coolData.mapFirst { $0.someValue }
 ///
 public extension Sequence {
     /// Finds the first non-`nil` transformed element in the sequence if available.
     /// - Parameter transform: A closure that accepts an element of this
     ///   sequence as its argument and returns an optional value.
     /// - Returns: The first non-`nil` result of `transform` or nil if there are none.
-    func mapFirst<U>(where transform: (Element) throws -> U?) rethrows -> U? {
+    func mapFirst<U>(_ transform: (Element) throws -> U?) rethrows -> U? {
         for element in self {
             guard let result = try transform(element) else {
                 continue

--- a/Modules/Utils/Sources/PocketCastsUtils/Extensions/Sequence+Extensions.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Extensions/Sequence+Extensions.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+// MARK: - mapFirst
+
+/// `mapFirst` iterates over the sequence to find the first non-nil value as the result of the `transform`.
+///  Before:
+///
+///     let coolData = [Cool(), Cool(), Cool(), ...]
+///
+///     for data in coolData {
+///         if let value data.someValue {
+///             return value
+///         }
+///     }
+///
+///  After:
+///     coolData.mapFirst(where: { $0.someValue })
+///
+public extension Sequence {
+    /// Finds the first non-`nil` transformed element in the sequence if available.
+    /// - Parameter transform: A closure that accepts an element of this
+    ///   sequence as its argument and returns an optional value.
+    /// - Returns: The first non-`nil` result of `transform` or nil if there are none.
+    func mapFirst<U>(where transform: (Element) throws -> U?) rethrows -> U? {
+        for element in self {
+            guard let result = try transform(element) else {
+                continue
+            }
+
+            return result
+        }
+
+        return nil
+    }
+}

--- a/Modules/Utils/Tests/PocketCastsUtilsTests/SequenceExtensionsTest.swift
+++ b/Modules/Utils/Tests/PocketCastsUtilsTests/SequenceExtensionsTest.swift
@@ -1,0 +1,60 @@
+import Foundation
+import PocketCastsUtils
+import XCTest
+
+final class SequenceExtensionsTest: XCTestCase {
+    private let count = 50000
+
+    func testMapFirstReturnsCorrectValue() {
+        let nonNilValue = Int.random(in: 0..<count)
+
+        // Fill the array with only a single non-nil value
+        var data: [MapFirstTestStruct] = []
+        for i in 0..<count {
+            if i == nonNilValue {
+                data.append(.init(value: "🍃 Yahaha! You found me!"))
+            } else {
+                data.append(.init(value: nil))
+            }
+        }
+
+        XCTAssertEqual(data.mapFirst(where: { $0.value }), data[nonNilValue].value)
+    }
+
+    func testMapFirstTransformIsCalledOnlyUntilNonNilValueIsFound() {
+        let data = [
+            MapFirstTestStruct(value: nil),
+            MapFirstTestStruct(value: "One"),
+            MapFirstTestStruct(value: "2"),
+            MapFirstTestStruct(value: "3")
+        ]
+
+        var count = 0
+        let _ = data.mapFirst(where: {
+            count += 1
+            return $0.value
+        })
+
+        XCTAssertEqual(count, 2)
+    }
+
+    func testMapFirstReturnsFirstNonNilValue() {
+        let nonNilValue = Int.random(in: 0..<count)
+        // Fill the array with multiple non-nil values to ensure only the first is returned
+        var data: [MapFirstTestStruct] = []
+        for i in 0..<count {
+            if i >= nonNilValue {
+                data.append(.init(value: "🍃 Yahaha! You found me! \(i)"))
+                continue
+            }
+
+            data.append(.init(value: nil))
+        }
+
+        XCTAssertEqual(data.mapFirst(where: { $0.value }), data[nonNilValue].value)
+    }
+}
+
+private struct MapFirstTestStruct {
+    let value: String?
+}

--- a/Modules/Utils/Tests/PocketCastsUtilsTests/SequenceExtensionsTest.swift
+++ b/Modules/Utils/Tests/PocketCastsUtilsTests/SequenceExtensionsTest.swift
@@ -18,7 +18,7 @@ final class SequenceExtensionsTest: XCTestCase {
             }
         }
 
-        XCTAssertEqual(data.mapFirst(where: { $0.value }), data[nonNilValue].value)
+        XCTAssertEqual(data.mapFirst({ $0.value }), data[nonNilValue].value)
     }
 
     func testMapFirstTransformIsCalledOnlyUntilNonNilValueIsFound() {
@@ -30,10 +30,10 @@ final class SequenceExtensionsTest: XCTestCase {
         ]
 
         var count = 0
-        let _ = data.mapFirst(where: {
+        let _ = data.mapFirst {
             count += 1
             return $0.value
-        })
+        }
 
         XCTAssertEqual(count, 2)
     }
@@ -51,7 +51,7 @@ final class SequenceExtensionsTest: XCTestCase {
             data.append(.init(value: nil))
         }
 
-        XCTAssertEqual(data.mapFirst(where: { $0.value }), data[nonNilValue].value)
+        XCTAssertEqual(data.mapFirst({ $0.value }), data[nonNilValue].value)
     }
 }
 


### PR DESCRIPTION
| 🛫 Depends on: #1088  |
|:---:|

This adds a utility extension for `mapFirst` which will iterate over the sequence applying the `transform` and returns the first non-nil result. 

### Examples
Before: 

```
func neat(data: [Cool]) -> COOOL? {
  for item in coolData { 
     if let value = item.coolValue {
        return value
     } 
  }
  
  return nil
}

```

After:

```
func neat(data: [Cool]) -> COOOL? {
    data.mapFirst { $0.coolValue }
}
```


This can also be used similar to compactMap to find the first non-nil value in a sequence:

```
let values = [nil, nil, nil, "Oh hey!", "there", "how", "are", "you?"]
values.mapFirst { $0 }
```

## To test

1. 🟢 CI
2. 👁️ 👁️ Code review

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
