### PR TITLE
Podcasts: fix space between nav bar and content for all devices

### DIFF
--- a/podcasts/FakeNavViewController.swift
+++ b/podcasts/FakeNavViewController.swift
@@ -126,7 +126,7 @@ class FakeNavViewController: PCViewController, UIScrollViewDelegate {
     }
 
     func navBarHeight(window: UIWindow) -> CGFloat {
-        fakeNavHeight.constant - UIUtil.statusBarHeight(in: window)
+        fakeNavHeight.constant - window.safeAreaInsets.top
     }
 
     func addGoogleCastBtn() {

--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -240,7 +240,6 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
         addGoogleCastBtn()
         loadPodcastInfo()
         updateColors()
-        updateTopConstraintForiPhone14Pro()
 
         NotificationCenter.default.addObserver(self, selector: #selector(podcastUpdated(_:)), name: Constants.Notifications.podcastUpdated, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(folderChanged(_:)), name: Constants.Notifications.folderChanged, object: nil)
@@ -272,26 +271,6 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
                 self?.upNextChanged()
             })
             .store(in: &cancellables)
-    }
-
-    private func updateTopConstraintForiPhone14Pro() {
-        // Retrieve the name of the device
-        var deviceName = UIDeviceHardware.platformString()
-
-        #if targetEnvironment(simulator)
-        // If we're running in the simulator, grab the model that we're simulating
-        if let simulatorIdentifier = ProcessInfo.processInfo.environment["SIMULATOR_MODEL_IDENTIFIER"] {
-            deviceName = UIDeviceHardware.platformString(forType: simulatorIdentifier)
-        }
-        #endif
-
-        if deviceName.startsWith(string: "iPhone 14 Pro") {
-            // On iPhone 14 Pro and iPhone 14 Pro Max there's a space
-            // between the nav bar and the content
-            // Here we change the table top constraint to take into account that
-            // See: https://github.com/Automattic/pocket-casts-ios/issues/327
-            episodesTableTopConstraint.constant = -5
-        }
     }
 
     override func viewWillAppear(_ animated: Bool) {


### PR DESCRIPTION
With the introduction of iPhone 14 Pro and 14 Pro Max, we had an issue in which white lines appeared when archiving/unarchiving episodes or toggling/untoggling the header: https://github.com/Automattic/pocket-casts-ios/pull/328

iPhone 15 was released and guess what? The bug is back, baby!

The fix was specific to iPhone 14 Pro and 14 Pro Max so it's not working anymore. However this time I was able to find the culprit, so it should be fixed for **all devices** and we don't handle it specifically for one or another.

## To test

1. Run the app on iPhone 15
2. Go to a podcast > toggle and untoggle the information header (by tapping the cover)
3. ✅ You should not see a white line at the top while the content is resized
4. Repeat these steps with iPhone 15 Pro, 15 Pro Max, 14, 14 Pro, iPad and any other device you can think of

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
