### PR TITLE
Adds a remote feature flag for Patron

### DIFF
--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -292,6 +292,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     private func updatePatronRemoteFeatureFlag() {
+        #if !DEBUG
         do {
             try FeatureFlagOverrideStore().override(FeatureFlag.patron, withValue: Settings.patronEnabled)
 
@@ -300,6 +301,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         } catch {
             FileLog.shared.addMessage("Failed to set the patron remote feature flag: \(error)")
         }
+        #endif
     }
 
     private func updateEndOfYearRemoteValue() {

--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -277,7 +277,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             Constants.RemoteParams.podcastSearchDebounceMs: NSNumber(value: Constants.RemoteParams.podcastSearchDebounceMsDefault),
             Constants.RemoteParams.customStorageLimitGB: NSNumber(value: Constants.RemoteParams.customStorageLimitGBDefault),
             Constants.RemoteParams.endOfYearRequireAccount: NSNumber(value: Constants.RemoteParams.endOfYearRequireAccountDefault),
-            Constants.RemoteParams.effectsPlayerStrategy: NSNumber(value: Constants.RemoteParams.effectsPlayerStrategyDefault)
+            Constants.RemoteParams.effectsPlayerStrategy: NSNumber(value: Constants.RemoteParams.effectsPlayerStrategyDefault),
+            Constants.RemoteParams.patronEnabled: NSNumber(value: Constants.RemoteParams.patronEnabledDefault)
         ])
 
         remoteConfig.fetch(withExpirationDuration: 2.hour) { [weak self] status, _ in
@@ -285,7 +286,19 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 remoteConfig.activate(completion: nil)
 
                 self?.updateEndOfYearRemoteValue()
+                self?.updatePatronRemoteFeatureFlag()
             }
+        }
+    }
+
+    private func updatePatronRemoteFeatureFlag() {
+        do {
+            try FeatureFlagOverrideStore().override(FeatureFlag.patron, withValue: Settings.patronEnabled)
+
+            // If the flag is off and we're turning it on we won't have the product info yet so we'll ask for them again
+            IapHelper.shared.requestProductInfoIfNeeded()
+        } catch {
+            FileLog.shared.addMessage("Failed to set the patron remote feature flag: \(error)")
         }
     }
 

--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -318,6 +318,9 @@ struct Constants {
 
         static let effectsPlayerStrategy = "effects_player_strategy"
         static let effectsPlayerStrategyDefault: Int = 1
+
+        static let patronEnabled = "add_patron_enabled"
+        static let patronEnabledDefault = true
     }
 
     static let defaultDebounceTime: TimeInterval = 0.5

--- a/podcasts/IapHelper.swift
+++ b/podcasts/IapHelper.swift
@@ -20,6 +20,9 @@ class IapHelper: NSObject, SKProductsRequestDelegate {
     /// Prevent multiple eligibility requests from being performed
     private var isCheckingEligibility = false
 
+    /// Prevent multiple product requests from being performed
+    private var isRequestingProducts = false
+
     /// Whether purchasing is allowed in the current environment or not
     var canMakePurchases = BuildEnvironment.current != .testFlight
 
@@ -29,7 +32,19 @@ class IapHelper: NSObject, SKProductsRequestDelegate {
         addSubscriptionNotifications()
     }
 
+    /// Requests the product info if we're not checking already, and the products we have already are different
+    func requestProductInfoIfNeeded() {
+        let isMissingProducts = productsArray.isEmpty || productsArray.map { $0.productIdentifier } == productIdentifiers.map { $0.rawValue }
+
+        guard isMissingProducts, !isRequestingProducts else {
+            return
+        }
+
+        requestProductInfo()
+    }
+
     func requestProductInfo() {
+        isRequestingProducts = true
         let request = SKProductsRequest(productIdentifiers: Set(productIdentifiers.map { $0.rawValue }))
         request.delegate = self
         request.start()
@@ -102,6 +117,8 @@ class IapHelper: NSObject, SKProductsRequestDelegate {
     // MARK: SKProductReuqestDelelgate
 
     func productsRequest(_ request: SKProductsRequest, didReceive response: SKProductsResponse) {
+        defer { isRequestingProducts = false }
+
         if response.products.count > 0 {
             productsArray = response.products
 
@@ -120,6 +137,7 @@ class IapHelper: NSObject, SKProductsRequestDelegate {
     }
 
     public func request(_ request: SKRequest, didFailWithError error: Error) {
+        defer { isRequestingProducts = false }
         FileLog.shared.addMessage("IAPHelper Failed to load list of products \(error.localizedDescription)")
         NotificationCenter.postOnMainThread(notification: ServerNotifications.iapProductsFailed)
         clearRequestAndHandler()
@@ -211,7 +229,7 @@ private extension IapHelper {
     private func addSubscriptionNotifications() {
         NotificationCenter.default.addObserver(forName: ServerNotifications.subscriptionStatusChanged, object: nil, queue: .main) { [weak self] _ in
             self?.updateTrialEligibility()
-            self?.requestProductInfo()
+            self?.requestProductInfoIfNeeded()
         }
     }
 

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -867,6 +867,10 @@ class Settings: NSObject {
             RemoteConfig.remoteConfig().configValue(forKey: Constants.RemoteParams.customStorageLimitGB).numberValue.intValue
         }
 
+        static var patronEnabled: Bool {
+            RemoteConfig.remoteConfig().configValue(forKey: Constants.RemoteParams.patronEnabled).boolValue
+        }
+
         private class func remoteMsToTime(key: String) -> TimeInterval {
             let remoteMs = RemoteConfig.remoteConfig().configValue(forKey: key)
 


### PR DESCRIPTION
This adds a remote config value that allows the Patron feature flag to be controlled remotely using Firebase.

This makes use of the `FeatureFlagOverrideStore` to save the remote value without needing to replace every reference in the app with a "remote" value.  

I also disabled this for debug builds to prevent the flag from being overridden during development. 

## To test

1. Before launching open AppDelegate and:
   - Remove the `#if !DEBUG` check on line 295
   - Change 2.hour to 30.seconds on line 284
2. Launch the app
3. Sign out or sign into a non plus account
4. Go to the Podcasts tab
5. Tap on the folders button
6. ✅ Verify Patron is not enabled
7. Go to Firebase and change the `add_patron_enabled` value for iOS to true
8. Relaunch the app
9. Go to the Podcasts tab -> Folders button
10. ✅ Verify Patron is now enabled
11. ✅ Verify the correct pricing loads in

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
