### PR TITLE
Moves the Patron cloud storage value to remote config

### DIFF
--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -278,7 +278,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             Constants.RemoteParams.customStorageLimitGB: NSNumber(value: Constants.RemoteParams.customStorageLimitGBDefault),
             Constants.RemoteParams.endOfYearRequireAccount: NSNumber(value: Constants.RemoteParams.endOfYearRequireAccountDefault),
             Constants.RemoteParams.effectsPlayerStrategy: NSNumber(value: Constants.RemoteParams.effectsPlayerStrategyDefault),
-            Constants.RemoteParams.patronEnabled: NSNumber(value: Constants.RemoteParams.patronEnabledDefault)
+            Constants.RemoteParams.patronEnabled: NSNumber(value: Constants.RemoteParams.patronEnabledDefault),
+            Constants.RemoteParams.patronCloudStorageGB: NSNumber(value: Constants.RemoteParams.patronCloudStorageGBDefault)
         ])
 
         remoteConfig.fetch(withExpirationDuration: 2.hour) { [weak self] status, _ in

--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -321,6 +321,9 @@ struct Constants {
 
         static let patronEnabled = "add_patron_enabled"
         static let patronEnabledDefault = true
+
+        static let patronCloudStorageGB = "patron_custom_storage_limit_gb"
+        static let patronCloudStorageGBDefault = 100
     }
 
     static let defaultDebounceTime: TimeInterval = 0.5

--- a/podcasts/Onboarding/Plus/Account Prompt/PlusAccountUpgradePrompt.swift
+++ b/podcasts/Onboarding/Plus/Account Prompt/PlusAccountUpgradePrompt.swift
@@ -143,7 +143,7 @@ struct PlusAccountUpgradePrompt: View {
         .patronYearly: [
             .init(iconName: "patron-everything", title: L10n.patronFeatureEverythingInPlus),
             .init(iconName: "patron-early-access", title: L10n.patronFeatureEarlyAccess),
-            .init(iconName: "plus-feature-cloud", title: L10n.plusCloudStorageLimitFormat(100)),
+            .init(iconName: "plus-feature-cloud", title: L10n.patronCloudStorageLimit),
             .init(iconName: "patron-badge", title: L10n.patronFeatureProfileBadge),
             .init(iconName: "patron-icons", title: L10n.patronFeatureProfileIcons)
         ]

--- a/podcasts/Onboarding/Plus/UpgradeLandingView.swift
+++ b/podcasts/Onboarding/Plus/UpgradeLandingView.swift
@@ -269,7 +269,7 @@ extension UpgradeTier {
         UpgradeTier(tier: .patron, iconName: "patron-heart", title: "Patron", plan: .patron, header: L10n.patronCallout, description: L10n.patronDescription, buttonLabel: L10n.patronSubscribeTo, buttonForegroundColor: .white, features: [
             TierFeature(iconName: "patron-everything", title: L10n.patronFeatureEverythingInPlus),
             TierFeature(iconName: "patron-early-access", title: L10n.patronFeatureEarlyAccess),
-            TierFeature(iconName: "plus-feature-cloud", title: L10n.plusCloudStorageLimitFormat(100)),
+            TierFeature(iconName: "plus-feature-cloud", title: L10n.patronCloudStorageLimit),
             TierFeature(iconName: "patron-badge", title: L10n.patronFeatureProfileBadge),
             TierFeature(iconName: "patron-icons", title: L10n.patronFeatureProfileIcons),
             TierFeature(iconName: "plus-feature-love", title: L10n.plusFeatureGratitude)

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -871,6 +871,10 @@ class Settings: NSObject {
             RemoteConfig.remoteConfig().configValue(forKey: Constants.RemoteParams.patronEnabled).boolValue
         }
 
+        static var patronCloudStorageLimit: Int {
+            RemoteConfig.remoteConfig().configValue(forKey: Constants.RemoteParams.patronCloudStorageGB).numberValue.intValue
+        }
+
         private class func remoteMsToTime(key: String) -> TimeInterval {
             let remoteMs = RemoteConfig.remoteConfig().configValue(forKey: key)
 
@@ -893,6 +897,10 @@ extension Settings {
 extension L10n {
     static var plusCloudStorageLimit: String {
         plusCloudStorageLimitFormat(Settings.plusCloudStorageLimit.localized())
+    }
+
+    static var patronCloudStorageLimit: String {
+        plusCloudStorageLimitFormat(Settings.patronCloudStorageLimit.localized())
     }
 }
 #endif


### PR DESCRIPTION
This moves the Patron cloud storage value to be remotely configured.

## To test

1. Before launching open AppDelegate and:
   - Change 2.hour to 30.seconds on line 285
2. Launch the app
3. Sign out or sign into a non plus account
4. Go to the Podcasts tab
5. Tap on the folders button
6. Swipe to the Patron item
7. ✅ Verify the cloud storage value is 100
8. Go to Firebase and change the `patron_custom_storage_limit_gb` value for iOS to 101
9. Relaunch the app
10. Go to the Podcasts tab -> Folders button
11. Swipe to Patron
12. ✅ Verify you see 101
13. Go to Profile > Account
14. Swipe to Patron
15. ✅ Verify you see 101
16. Remember to reset the remote value when done.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
