### PR TITLE
Fix TracksLogging crash

### DIFF
--- a/podcasts/Analytics/Adapters/Tracks/TracksAdapter.swift
+++ b/podcasts/Analytics/Adapters/Tracks/TracksAdapter.swift
@@ -36,6 +36,7 @@ class TracksAdapter: AnalyticsAdapter {
 
     deinit {
         notificationCenter.removeObserver(self)
+        tracksService.clearQueuedEvents()
     }
 
     init(userDefaults: UserDefaults = .standard,
@@ -50,7 +51,7 @@ class TracksAdapter: AnalyticsAdapter {
         tracksService.eventNamePrefix = TracksConfig.prefix
         tracksService.authenticatedUserTypeKey = TracksConfig.userKey
 
-        TracksLogging.delegate = TracksAdapterLoggingDelegate()
+        TracksLogging.delegate = TracksAdapterLoggingDelegate.shared
 
         // Setup the rest of the properties
         updateUserProperties()
@@ -123,7 +124,8 @@ private extension TracksAdapter {
 // MARK: - TracksLoggingDelegate
 
 private class TracksAdapterLoggingDelegate: NSObject, TracksLoggingDelegate {
-    static let logger = Logger()
+    static let shared = TracksAdapterLoggingDelegate()
+    private static let logger = Logger()
 
     func logError(_ str: String) {
         Self.logger.error("\(str)")

--- a/podcasts/Analytics/Adapters/Tracks/TracksAdapter.swift
+++ b/podcasts/Analytics/Adapters/Tracks/TracksAdapter.swift
@@ -36,7 +36,6 @@ class TracksAdapter: AnalyticsAdapter {
 
     deinit {
         notificationCenter.removeObserver(self)
-        tracksService.clearQueuedEvents()
     }
 
     init(userDefaults: UserDefaults = .standard,

--- a/podcasts/Analytics/Analytics.swift
+++ b/podcasts/Analytics/Analytics.swift
@@ -4,13 +4,18 @@ class Analytics {
     static let shared = Analytics()
     private var adapters: [AnalyticsAdapter]?
 
+    // Whether we have adapters registered or not
+    var adaptersRegistered: Bool = false
+
     static func register(adapters: [AnalyticsAdapter]) {
         Self.shared.adapters = adapters
+        shared.adaptersRegistered = true
     }
 
     /// Unregisters all the registered adapters, disabling analytics
     static func unregister() {
         Self.shared.adapters = nil
+        shared.adaptersRegistered = false
     }
 
     /// Convenience method to call Analytics.shared.track*

--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -38,6 +38,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         setupWhatsNew()
 
         setupSecrets()
+        addAnalyticsObservers()
         setupAnalytics()
         appLifecycleAnalytics.checkApplicationInstalledOrUpgraded()
 

--- a/podcasts/FeatureFlag.swift
+++ b/podcasts/FeatureFlag.swift
@@ -4,9 +4,6 @@ enum FeatureFlag: String, CaseIterable {
     /// Whether we should detect and show the free trial UI
     case freeTrialsEnabled
 
-    /// Whether the Tracks analytics are enabled
-    case tracks
-
     /// Whether logging of Tracks events in console are enabled
     case tracksLogging
 
@@ -53,8 +50,6 @@ enum FeatureFlag: String, CaseIterable {
 
         switch self {
         case .freeTrialsEnabled:
-            return true
-        case .tracks:
             return true
         case .tracksLogging:
             return false


### PR DESCRIPTION
This attempt to fix one of our top crashes which is a EXC_BAD_ACCESS when TracksLogging tries to read the delegate property.

This applies the following fixes:
- Switches to using a singleton `TracksAdapterLoggingDelegate` that is passed to `TracksLogging.delegate`
- Fixes a bug that was causing the analytics adapters to be recreated whenever the `UIApplication.protectedDataDidBecomeAvailableNotification` notification was fired


## To test

1. Open Profile > Beta Features > Enable Tracks Logging
2. Launch the app
3. ✅ Verify you see the events being logged in console
4. Open AppDelegate+Analytics and put a breakpoint on line 15
5. Lock your device and wait about 10 seconds
6. Unlock your device
7. ✅ Verify the breakpoint is not hit
8. Relaunch the app
9. ✅ Verify the breakpoint is hit
10. Go to Profile > Privacy > Disable analytics
11. Tap around
12. ✅ Verify you do not see any events being logged
13. Lock your device and wait about 10 seconds
14. Unlock your device
15. ✅ Verify the breakpoint is not hit
16. Relaunch the app
17. ✅ Verify the breakpoint is not hit
18. Tap around and verify you do not see any events being logged
19. Enable analytics again
20. ✅ Verify you see events being logged

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
