### PR TITLE
EOY 2023: top podcast story

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
@@ -5,12 +5,12 @@ import PocketCastsUtils
 class EndOfYearDataManager {
     /// The date to start calculating results from
     /// The data will start from 00:00:00 (midnight) the users device time
-    private let startDate = "2022-01-01"
+    private let startDate = "2023-01-01"
 
     /// The date to stop including results from
     /// This is set to the day after the final day we want to include in the results to make sure we include the full
     /// day up to midnight
-    private let endDate = "2023-01-01"
+    private let endDate = "2024-01-01"
 
     private lazy var listenedEpisodesThisYear = """
                                             lastPlaybackInteractionDate IS NOT NULL AND lastPlaybackInteractionDate BETWEEN strftime('%s', '\(startDate)') and strftime('%s', '\(endDate)')

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncYearListeningHistoryTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncYearListeningHistoryTask.swift
@@ -173,7 +173,7 @@ class PodcastExistsHelper {
 
 public class YearListeningHistory {
     public static func sync() -> Bool {
-        let syncYearListeningHistory = SyncYearListeningHistoryTask(year: 2022)
+        let syncYearListeningHistory = SyncYearListeningHistoryTask(year: 2023)
 
         syncYearListeningHistory.start()
 

--- a/podcasts/End of Year/Stories/EndOfYearStoriesDataSource.swift
+++ b/podcasts/End of Year/Stories/EndOfYearStoriesDataSource.swift
@@ -23,7 +23,7 @@ class EndOfYearStoriesDataSource: StoriesDataSource {
         case .numberOfPodcastsAndEpisodesListened:
             return ListenedNumbersStory(listenedNumbers: data.listenedNumbers, podcasts: data.top10Podcasts)
         case .topOnePodcast:
-            return TopOnePodcastStory(topPodcast: data.topPodcasts[0])
+            return TopOnePodcastStory(podcasts: data.topPodcasts)
         case .topFivePodcasts:
             return TopFivePodcastsStory(podcasts: data.topPodcasts.map { $0.podcast })
         case .longestEpisode:

--- a/podcasts/End of Year/Stories/TopOnePodcastStory.swift
+++ b/podcasts/End of Year/Stories/TopOnePodcastStory.swift
@@ -54,7 +54,7 @@ struct TopOnePodcastStory: ShareableStory {
                         .offset(x: geometry.size.width * 0.4, y: -geometry.size.height * 0.11)
                         .opacity(0.2)
 
-                    PodcastCover(podcastUuid: topPodcast.podcast.uuid)
+                    PodcastCover(podcastUuid: topPodcast.podcast.uuid, higherQuality: true)
                         .frame(width: geometry.size.width * 0.7, height: geometry.size.width * 0.7)
                 }
                 .padding(.top, geometry.size.height * 0.09)

--- a/podcasts/End of Year/Stories/TopOnePodcastStory.swift
+++ b/podcasts/End of Year/Stories/TopOnePodcastStory.swift
@@ -27,18 +27,37 @@ struct TopOnePodcastStory: ShareableStory {
             PodcastCoverContainer(geometry: geometry) {
                 StoryLabelContainer(geometry: geometry) {
                     let title = podcast.title ?? ""
-                    let author = podcast.author ?? ""
                     StoryLabel(L10n.eoyStoryTopPodcast(title), for: .title, geometry: geometry)
 
                     let time = topPodcast.totalPlayedTime.storyTimeDescription
-                    let count = L10n.eoyStoryListenedToEpisodesText(topPodcast.numberOfPlayedEpisodes)
                     StoryLabel(L10n.eoyStoryTopPodcastSubtitle(topPodcast.numberOfPlayedEpisodes, time), for: .subtitle, color: Color(hex: "8F97A4"), geometry: geometry)
                 }
 
                 ZStack {
+                    podcastCover(1)
+                        .frame(width: geometry.size.width * 0.3, height: geometry.size.width * 0.3)
+                        .offset(x: -geometry.size.width * 0.53, y: -geometry.size.height * 0.15)
+                        .opacity(0.3)
+
+                    podcastCover(2)
+                        .frame(width: geometry.size.width * 0.25, height: geometry.size.width * 0.25)
+                        .offset(x: -geometry.size.width * 0.3, y: geometry.size.height * 0.2)
+                        .opacity(0.5)
+
+                    podcastCover(3)
+                        .frame(width: geometry.size.width * 0.32, height: geometry.size.width * 0.32)
+                        .offset(x: geometry.size.width * 0.3, y: geometry.size.height * 0.23)
+                        .opacity(0.5)
+
+                    podcastCover(4)
+                        .frame(width: geometry.size.width * 0.2, height: geometry.size.width * 0.2)
+                        .offset(x: geometry.size.width * 0.4, y: -geometry.size.height * 0.11)
+                        .opacity(0.2)
+
                     PodcastCover(podcastUuid: topPodcast.podcast.uuid)
                         .frame(width: geometry.size.width * 0.7, height: geometry.size.width * 0.7)
                 }
+                .padding(.top, geometry.size.height * 0.09)
             }.background(
                 ZStack(alignment: .bottom) {
                     Color.black
@@ -77,6 +96,6 @@ struct TopOnePodcastStory: ShareableStory {
 
 struct TopOnePodcastStory_Previews: PreviewProvider {
     static var previews: some View {
-        TopOnePodcastStory(podcasts: [TopPodcast(podcast: Podcast.previewPodcast(), numberOfPlayedEpisodes: 10, totalPlayedTime: 3600)])
+        TopOnePodcastStory(podcasts: [TopPodcast(podcast: Podcast.previewPodcast(), numberOfPlayedEpisodes: 10, totalPlayedTime: 3600), TopPodcast(podcast: Podcast.previewPodcast(), numberOfPlayedEpisodes: 10, totalPlayedTime: 3600)])
     }
 }

--- a/podcasts/End of Year/Stories/TopOnePodcastStory.swift
+++ b/podcasts/End of Year/Stories/TopOnePodcastStory.swift
@@ -7,7 +7,11 @@ struct TopOnePodcastStory: ShareableStory {
 
     let identifier: String = "top_one_podcast"
 
-    let topPodcast: TopPodcast
+    let podcasts: [TopPodcast]
+
+    var topPodcast: TopPodcast {
+        podcasts[0]
+    }
 
     var backgroundColor: Color {
         Color(topPodcast.podcast.bgColor())
@@ -21,20 +25,38 @@ struct TopOnePodcastStory: ShareableStory {
         let podcast = topPodcast.podcast
         GeometryReader { geometry in
             PodcastCoverContainer(geometry: geometry) {
-                PodcastStackView(podcasts: [podcast], geometry: geometry)
-
                 StoryLabelContainer(geometry: geometry) {
                     let title = podcast.title ?? ""
                     let author = podcast.author ?? ""
-                    StoryLabel(L10n.eoyStoryTopPodcast("\n" + title, author), highlighting: [title, author], for: .title)
+                    StoryLabel(L10n.eoyStoryTopPodcast(title), for: .title, geometry: geometry)
 
                     let time = topPodcast.totalPlayedTime.storyTimeDescription
                     let count = L10n.eoyStoryListenedToEpisodesText(topPodcast.numberOfPlayedEpisodes)
-                    StoryLabel(L10n.eoyStoryTopPodcastSubtitle(topPodcast.numberOfPlayedEpisodes, time), highlighting: [time, count], for: .subtitle)
-                        .opacity(0.8)
+                    StoryLabel(L10n.eoyStoryTopPodcastSubtitle(topPodcast.numberOfPlayedEpisodes, time), for: .subtitle, color: Color(hex: "8F97A4"), geometry: geometry)
                 }
-            }
-        }.background(DynamicBackgroundView(podcast: podcast))
+
+                ZStack {
+                    PodcastCover(podcastUuid: topPodcast.podcast.uuid)
+                        .frame(width: geometry.size.width * 0.7, height: geometry.size.width * 0.7)
+                }
+            }.background(
+                ZStack(alignment: .bottom) {
+                    Color.black
+
+                    StoryGradient()
+                    .offset(x: -geometry.size.width * 0.8, y: geometry.size.height * 0.25)
+                }
+            )
+        }
+    }
+
+    @ViewBuilder
+    func podcastCover(_ index: Int) -> some View {
+        if let topPodcast = podcasts[safe: index] {
+            PodcastCover(podcastUuid: topPodcast.podcast.uuid)
+        } else {
+            EmptyView()
+        }
     }
 
     func onAppear() {
@@ -55,6 +77,6 @@ struct TopOnePodcastStory: ShareableStory {
 
 struct TopOnePodcastStory_Previews: PreviewProvider {
     static var previews: some View {
-        TopOnePodcastStory(topPodcast: TopPodcast(podcast: Podcast.previewPodcast(), numberOfPlayedEpisodes: 10, totalPlayedTime: 3600))
+        TopOnePodcastStory(podcasts: [TopPodcast(podcast: Podcast.previewPodcast(), numberOfPlayedEpisodes: 10, totalPlayedTime: 3600)])
     }
 }

--- a/podcasts/End of Year/Stories/Views/PodcastCover.swift
+++ b/podcasts/End of Year/Stories/Views/PodcastCover.swift
@@ -44,7 +44,7 @@ struct PodcastCover: View {
                 }
             }
             .opacity(image != nil ? 1 : 0.2)
-            .blendMode(!renderForSharing && image != nil ? .multiply : .normal)
+            .blendMode(.multiply)
 
             ImageView(image: image)
                 .cornerRadius(big ? 8 : 4)

--- a/podcasts/End of Year/Stories/Views/PodcastCover.swift
+++ b/podcasts/End of Year/Stories/Views/PodcastCover.swift
@@ -7,20 +7,17 @@ struct PodcastCover: View {
     let podcastUuid: String
 
     /// Whether this is a big cover, in which shadows should be bigger
-    let big: Bool
+    var big: Bool = false
 
     /// The color of the view the cover will appear on
     /// Prevents a flickering issue on dark backgrounds
-    let viewBackgroundStyle: ThemeStyle?
+    var viewBackgroundStyle: ThemeStyle? = nil
+
+    /// If the artwork needs a bigger image with higher quality
+    var higherQuality: Bool = false
 
     @State private var image: UIImage?
     @Environment(\.renderForSharing) var renderForSharing: Bool
-
-    init(podcastUuid: String, big: Bool = false, viewBackgroundStyle: ThemeStyle? = nil) {
-        self.podcastUuid = podcastUuid
-        self.big = big
-        self.viewBackgroundStyle = viewBackgroundStyle
-    }
 
     private var rectangleColor: Color? {
         if let viewBackgroundStyle {
@@ -65,7 +62,8 @@ struct PodcastCover: View {
 
     private func loadImage() {
         image = nil
-        KingfisherManager.shared.retrieveImage(with: ServerHelper.imageUrl(podcastUuid: podcastUuid, size: 280)) { result in
+        let size = higherQuality ? 680 : 280
+        KingfisherManager.shared.retrieveImage(with: ServerHelper.imageUrl(podcastUuid: podcastUuid, size: size)) { result in
             switch result {
             case .success(let result):
                 image = result.image

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -804,9 +804,9 @@ internal enum L10n {
   internal static var eoyStoryTopCategories: String { return L10n.tr("Localizable", "eoy_story_top_categories") }
   /// My most listened to podcast categories
   internal static var eoyStoryTopCategoriesShareText: String { return L10n.tr("Localizable", "eoy_story_top_categories_share_text") }
-  /// Your top podcast was %1$@ by %2$@
-  internal static func eoyStoryTopPodcast(_ p1: Any, _ p2: Any) -> String {
-    return L10n.tr("Localizable", "eoy_story_top_podcast", String(describing: p1), String(describing: p2))
+  /// %1$@ was your most listened show in 2023
+  internal static func eoyStoryTopPodcast(_ p1: Any) -> String {
+    return L10n.tr("Localizable", "eoy_story_top_podcast", String(describing: p1))
   }
   /// My favorite podcast of 2022! %1$@
   internal static func eoyStoryTopPodcastShareText(_ p1: Any) -> String {

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -3525,7 +3525,7 @@
 "eoy_story_listened_to_numbers_share_text" = "I listened to %1$@ different podcasts and %2$@ episodes in 2022";
 
 /* Title for the story that display the most listened podcast by the user this year. %1$@ is a placeholder for the podcast title and %2$@ is a placeholder for the author. */
-"eoy_story_top_podcast" = "Your top podcast was %1$@ by %2$@";
+"eoy_story_top_podcast" = "%1$@ was your most listened show in 2023";
 
 /* Subtitle for the story that display the most listened podcast by the user this year. %1$@ is a placeholder for the number of episodes and %2$@ is a placeholder for the listened time. */
 "eoy_story_top_podcast_subtitle" = "You listened to %1$@ episodes for a total of %2$@";


### PR DESCRIPTION
| 📘 Part of: #1142 | 🎨 Designs: [Figma](https://www.figma.com/file/lH66LwxxgG8btQ8NrM0ldx/End-of-Year?type=design&node-id=1599-20385&mode=design) |
|:---:|:---:|

Adds the 2023 visual for the Top Show Story.

**Animations are not part of this task and will be tackled later.**

<img src="https://github.com/Automattic/pocket-casts-ios/assets/7040243/32a69472-9b4a-450b-9666-5123c5a9df65" width="300">

## To test

1. Make sure you're logged in into an account that has a few episodes listened
2. Go to Profile > Settings > Beta Features > enable `endOfYear`
3. Go back to Profile
4. Tap the EOY image
5. Skip to the third story
5. ✅ Check that the story looks good
6. Tap "Share this story" > Save Image
7. Go to Photos
8. ✅ The story image asset should be the last one on Photos and should have the images appearing correctly

Please test on a big device (iPhone 15 Pro Max, for example), normal device (iPhone 15), and a smaller device (iPod touch).

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
