### PR TITLE
EOY 2023: top five podcasts story

### DIFF
--- a/podcasts/End of Year/EndOfYearStoriesBuilder.swift
+++ b/podcasts/End of Year/EndOfYearStoriesBuilder.swift
@@ -9,10 +9,10 @@ enum EndOfYearStory: CaseIterable {
     case intro
     case numberOfPodcastsAndEpisodesListened
     case topOnePodcast
+    case topFivePodcasts
     case listeningTime
     case listenedCategories
     case topCategories
-    case topFivePodcasts
     case longestEpisode
     case epilogue
 }

--- a/podcasts/End of Year/Stories/EndOfYearStoriesDataSource.swift
+++ b/podcasts/End of Year/Stories/EndOfYearStoriesDataSource.swift
@@ -25,7 +25,7 @@ class EndOfYearStoriesDataSource: StoriesDataSource {
         case .topOnePodcast:
             return TopOnePodcastStory(podcasts: data.topPodcasts)
         case .topFivePodcasts:
-            return TopFivePodcastsStory(podcasts: data.topPodcasts.map { $0.podcast })
+            return TopFivePodcastsStory(topPodcasts: data.topPodcasts)
         case .longestEpisode:
             return LongestEpisodeStory(episode: data.longestEpisode, podcast: data.longestEpisodePodcast)
         case .epilogue:

--- a/podcasts/End of Year/Stories/TopFivePodcastsStory.swift
+++ b/podcasts/End of Year/Stories/TopFivePodcastsStory.swift
@@ -18,7 +18,7 @@ struct TopFivePodcastsStory: ShareableStory {
                 }
 
                 let headerSpacing = geometry.size.height * 0.054
-                let size = round(max(geometry.size.height * 0.099, 60))
+                let size = round(geometry.size.height * 0.09)
 
                 VStack(spacing: geometry.size.height * 0.03) {
                     ForEach(0...4, id: \.self) {
@@ -45,6 +45,7 @@ struct TopFivePodcastsStory: ShareableStory {
                 .font(.custom("DM Sans", size: 18))
                 .fontWeight(.semibold)
                 .foregroundColor(Color(hex: "8F97A4"))
+                .frame(width: size * 0.2)
 
                 if let podcast = podcasts[safe: index] {
                     PodcastCover(podcastUuid: podcast.uuid)
@@ -56,12 +57,14 @@ struct TopFivePodcastsStory: ShareableStory {
 
             VStack(alignment: .leading, spacing: 4) {
                 Text(podcasts[safe: index]?.title ?? "")
-                    .font(.system(size: 16, weight: .bold))
+                    .font(.custom("DM Sans", size: 18))
+                    .fontWeight(.semibold)
                     .foregroundColor(.white)
 
                 Text(podcasts[safe: index]?.author ?? "")
-                    .font(.system(size: 12, weight: .semibold))
-                    .foregroundColor(.white)
+                    .font(.custom("DM Sans", size: 14))
+                    .fontWeight(.semibold)
+                    .foregroundColor(Color(hex: "8F97A4"))
                     .lineLimit(2)
                     .opacity(0.8)
             }

--- a/podcasts/End of Year/Stories/TopFivePodcastsStory.swift
+++ b/podcasts/End of Year/Stories/TopFivePodcastsStory.swift
@@ -12,28 +12,39 @@ struct TopFivePodcastsStory: ShareableStory {
     var body: some View {
         GeometryReader { geometry in
             PodcastCoverContainer(geometry: geometry) {
+                StoryLabelContainer(geometry: geometry) {
+                    StoryLabel(L10n.eoyStoryTopPodcastsTitle, for: .title, geometry: geometry)
+                    StoryLabel(L10n.eoyStoryTopPodcastsSubtitle, for: .subtitle, color: Color(hex: "8F97A4"), geometry: geometry)
+                }
+
                 let headerSpacing = geometry.size.height * 0.054
                 let size = round(max(geometry.size.height * 0.099, 60))
 
-                VStack(spacing: headerSpacing) {
-                    StoryLabel(L10n.eoyStoryTopPodcasts, for: .title2)
-                        .opacity(0.8)
-                    VStack(spacing: geometry.size.height * 0.03) {
-                        ForEach(0...4, id: \.self) {
-                            topPodcastRow($0, size: size)
-                        }
-                    }.padding([.leading, .trailing], 35)
+                VStack(spacing: geometry.size.height * 0.03) {
+                    ForEach(0...4, id: \.self) {
+                        topPodcastRow($0, size: size)
+                    }
                 }
-            }.background(DynamicBackgroundView(podcast: podcasts[0]))
+                .padding([.leading, .trailing], 35)
+                .padding(.top, headerSpacing)
+            }.background(
+                ZStack(alignment: .bottom) {
+                    Color.black
+
+                    StoryGradient()
+                    .offset(x: geometry.size.width * 0.7, y: -geometry.size.height * 0.7)
+                }
+            )
         }
     }
 
     @ViewBuilder
     func topPodcastRow(_ index: Int, size: Double) -> some View {
         HStack(spacing: 16) {
-            Text("\(index + 1).")
-                .font(.system(size: 18, weight: .medium))
-                .foregroundColor(.white)
+            Text("\(index + 1)")
+                .font(.custom("DM Sans", size: 18))
+                .fontWeight(.semibold)
+                .foregroundColor(Color(hex: "8F97A4"))
 
                 if let podcast = podcasts[safe: index] {
                     PodcastCover(podcastUuid: podcast.uuid)

--- a/podcasts/End of Year/Stories/TopFivePodcastsStory.swift
+++ b/podcasts/End of Year/Stories/TopFivePodcastsStory.swift
@@ -22,7 +22,7 @@ struct TopFivePodcastsStory: ShareableStory {
 
                 VStack(spacing: geometry.size.height * 0.03) {
                     ForEach(0...4, id: \.self) {
-                        topPodcastRow($0, size: size)
+                        topPodcastRow($0, size: size, geometry: geometry)
                     }
                 }
                 .padding([.leading, .trailing], 35)
@@ -39,10 +39,10 @@ struct TopFivePodcastsStory: ShareableStory {
     }
 
     @ViewBuilder
-    func topPodcastRow(_ index: Int, size: Double) -> some View {
+    func topPodcastRow(_ index: Int, size: Double, geometry: GeometryProxy) -> some View {
         HStack(spacing: 16) {
             Text("\(index + 1)")
-                .font(.custom("DM Sans", size: 18))
+                .font(.custom("DM Sans", size: geometry.size.height * 0.025))
                 .fontWeight(.semibold)
                 .foregroundColor(Color(hex: "8F97A4"))
                 .frame(width: size * 0.2)
@@ -57,12 +57,12 @@ struct TopFivePodcastsStory: ShareableStory {
 
             VStack(alignment: .leading, spacing: 4) {
                 Text(topPodcasts[safe: index]?.podcast.title ?? "")
-                    .font(.custom("DM Sans", size: 18))
+                    .font(.custom("DM Sans", size: geometry.size.height * 0.024))
                     .fontWeight(.semibold)
                     .foregroundColor(.white)
 
                 Text(topPodcasts[safe: index]?.totalPlayedTime.storyTimeDescription ?? "")
-                    .font(.custom("DM Sans", size: 14))
+                    .font(.custom("DM Sans", size: geometry.size.height * 0.018))
                     .fontWeight(.semibold)
                     .foregroundColor(Color(hex: "8F97A4"))
                     .lineLimit(2)

--- a/podcasts/End of Year/Stories/TopFivePodcastsStory.swift
+++ b/podcasts/End of Year/Stories/TopFivePodcastsStory.swift
@@ -61,7 +61,7 @@ struct TopFivePodcastsStory: ShareableStory {
                     .fontWeight(.semibold)
                     .foregroundColor(.white)
 
-                Text(topPodcasts[safe: index]?.podcast.author ?? "")
+                Text(topPodcasts[safe: index]?.totalPlayedTime.storyTimeDescription ?? "")
                     .font(.custom("DM Sans", size: 14))
                     .fontWeight(.semibold)
                     .foregroundColor(Color(hex: "8F97A4"))

--- a/podcasts/End of Year/Stories/TopFivePodcastsStory.swift
+++ b/podcasts/End of Year/Stories/TopFivePodcastsStory.swift
@@ -3,7 +3,7 @@ import PocketCastsServer
 import PocketCastsDataModel
 
 struct TopFivePodcastsStory: ShareableStory {
-    let podcasts: [Podcast]
+    let topPodcasts: [TopPodcast]
 
     let identifier: String = "top_five_podcast"
 
@@ -47,7 +47,7 @@ struct TopFivePodcastsStory: ShareableStory {
                 .foregroundColor(Color(hex: "8F97A4"))
                 .frame(width: size * 0.2)
 
-                if let podcast = podcasts[safe: index] {
+                if let podcast = topPodcasts[safe: index]?.podcast {
                     PodcastCover(podcastUuid: podcast.uuid)
                         .frame(width: size, height: size)
                 } else {
@@ -56,12 +56,12 @@ struct TopFivePodcastsStory: ShareableStory {
                 }
 
             VStack(alignment: .leading, spacing: 4) {
-                Text(podcasts[safe: index]?.title ?? "")
+                Text(topPodcasts[safe: index]?.podcast.title ?? "")
                     .font(.custom("DM Sans", size: 18))
                     .fontWeight(.semibold)
                     .foregroundColor(.white)
 
-                Text(podcasts[safe: index]?.author ?? "")
+                Text(topPodcasts[safe: index]?.podcast.author ?? "")
                     .font(.custom("DM Sans", size: 14))
                     .fontWeight(.semibold)
                     .foregroundColor(Color(hex: "8F97A4"))
@@ -73,7 +73,7 @@ struct TopFivePodcastsStory: ShareableStory {
             .frame(maxHeight: size)
             Spacer()
         }
-        .opacity(podcasts[safe: index] != nil ? 1 : 0)
+        .opacity(topPodcasts[safe: index]?.podcast != nil ? 1 : 0)
     }
 
     func onAppear() {
@@ -87,13 +87,13 @@ struct TopFivePodcastsStory: ShareableStory {
     func sharingAssets() -> [Any] {
         [
             StoryShareableProvider.new(AnyView(self)),
-            StoryShareableText(L10n.eoyStoryTopPodcastsShareText("%1$@"), podcasts: podcasts)
+            StoryShareableText(L10n.eoyStoryTopPodcastsShareText("%1$@"), podcasts: topPodcasts.map { $0.podcast })
         ]
     }
 }
 
 struct DummyStory_Previews: PreviewProvider {
     static var previews: some View {
-        TopFivePodcastsStory(podcasts: [Podcast.previewPodcast(), Podcast.previewPodcast(), Podcast.previewPodcast(), Podcast.previewPodcast(), Podcast.previewPodcast()])
+        TopFivePodcastsStory(topPodcasts: [TopPodcast(podcast: Podcast.previewPodcast(), numberOfPlayedEpisodes: 10, totalPlayedTime: 3600), TopPodcast(podcast: Podcast.previewPodcast(), numberOfPlayedEpisodes: 10, totalPlayedTime: 3600), TopPodcast(podcast: Podcast.previewPodcast(), numberOfPlayedEpisodes: 10, totalPlayedTime: 3600), TopPodcast(podcast: Podcast.previewPodcast(), numberOfPlayedEpisodes: 10, totalPlayedTime: 3600), TopPodcast(podcast: Podcast.previewPodcast(), numberOfPlayedEpisodes: 10, totalPlayedTime: 3600)])
     }
 }

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -824,6 +824,10 @@ internal enum L10n {
   internal static func eoyStoryTopPodcastsShareText(_ p1: Any) -> String {
     return L10n.tr("Localizable", "eoy_story_top_podcasts_share_text", String(describing: p1))
   }
+  /// This is your top 5 most listened to in 2023
+  internal static var eoyStoryTopPodcastsSubtitle: String { return L10n.tr("Localizable", "eoy_story_top_podcasts_subtitle") }
+  /// And you were big on these shows too!
+  internal static var eoyStoryTopPodcastsTitle: String { return L10n.tr("Localizable", "eoy_story_top_podcasts_title") }
   /// Your Year in Podcasts
   internal static var eoyTitle: String { return L10n.tr("Localizable", "eoy_title") }
   /// View My 2022

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -3536,6 +3536,12 @@
 /* Title for the story showing the top podcasts for the user in the current year. */
 "eoy_story_top_podcasts" = "Your Top Podcasts";
 
+/* Title for the story showing the top podcasts for the user in the current year. */
+"eoy_story_top_podcasts_title" = "And you were big on these shows too!";
+
+/* Subtitle for the story showing the top podcasts for the user in the current year. */
+"eoy_story_top_podcasts_subtitle" = "This is your top 5 most listened to in 2023";
+
 /* Text that appear when someone share the top 5 podcasts of the year story to Twitter. %1$@ is a link to the list of the top podcasts. */
 "eoy_story_top_podcasts_share_text" = "My top podcasts of the year! %1$@";
 


### PR DESCRIPTION
| 📘 Part of: #1142 | 🎨 Designs: [Figma](https://www.figma.com/file/lH66LwxxgG8btQ8NrM0ldx/End-of-Year?type=design&node-id=1599-20385&mode=design) |
|:---:|:---:|

Adds the 2023 visual for the Top Podcasts Story.

**Animations are not part of this task and will be tackled later.**

<img src="https://github.com/Automattic/pocket-casts-ios/assets/7040243/7ba5bc7f-92f7-4089-a394-ae49e09d5538" width="300">

## To test

1. Make sure you're logged in to an account that has a few episodes listened
2. Go to Profile > Settings > Beta Features > enable `endOfYear`
3. Go back to Profile
4. Tap the EOY image
5. Skip to the fourth story
5. ✅ Check that the story looks good
6. Tap "Share this story" > Save Image
7. Go to Photos
8. ✅ The story image asset should be the last one on Photos and should have your top five podcasts

Please test on a big device (iPhone 15 Pro Max, for example), a normal device (iPhone 15), and a smaller device (iPod touch).

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
