### PR TITLE
Bookmarks: Add a way to specify a feature is in early access

### DIFF
--- a/podcasts/PaidFeature.swift
+++ b/podcasts/PaidFeature.swift
@@ -37,6 +37,11 @@ class PaidFeature: ObservableObject {
     /// The minimum subscription level required to unlock this feature
     let tier: SubscriptionTier
 
+    /// Whether the feature is in its early access period or not.
+    /// 
+    /// Internally this doesn't change anything with the feature, but allows the app to check its state and display different UI if needed.
+    let inEarlyAccess: Bool
+
     /// The static class to use to check for the active subscription.
     private let subscriptionHelper: SubscriptionHelper
 
@@ -46,8 +51,10 @@ class PaidFeature: ObservableObject {
     /// - Parameters:
     ///   - tier: The minimum tier required to unlock
     ///   - betaTier: The minimum tier required when running in the app beta
+    ///   - inEarlyAccess: Whether this feature is in its early access period or not.
     init(tier: SubscriptionTier,
          betaTier: SubscriptionTier? = nil,
+         inEarlyAccess: Bool = false,
          subscriptionHelper: SubscriptionHelper = .shared,
          buildEnvironment: BuildEnvironment = .current) {
         if let betaTier, buildEnvironment == .testFlight {
@@ -56,6 +63,7 @@ class PaidFeature: ObservableObject {
             self.tier = tier
         }
 
+        self.inEarlyAccess = inEarlyAccess
         self.subscriptionHelper = subscriptionHelper
 
         addListeners()

--- a/podcasts/PaidFeature.swift
+++ b/podcasts/PaidFeature.swift
@@ -34,7 +34,7 @@ class PaidFeature: ObservableObject {
     let tier: SubscriptionTier
 
     /// Whether the feature is in its early access period or not.
-    /// 
+    ///
     /// Internally this doesn't change anything with the feature, but allows the app to check its state and display different UI if needed.
     let inEarlyAccess: Bool
 

--- a/podcasts/PaidFeature.swift
+++ b/podcasts/PaidFeature.swift
@@ -107,3 +107,33 @@ extension PaidFeature {
     }
 }
 #endif
+
+
+// MARK: - Private: Feature State Helpers
+
+private extension PaidFeature {
+    /// A `PaidFeature` that is currently in early access.
+    ///
+    /// - Available to Patron users on the AppStore
+    /// - Available to Plus users during beta
+    /// - Has the `inEarlyAccess` flag set to True
+    static var inEarlyAccess: PaidFeature {
+        .init(tier: .patron, betaTier: .plus, inEarlyAccess: true)
+    }
+
+    /// A `PaidFeature` that is available to Patron subscribers.
+    ///
+    /// - Available to Patron users on the AppStore and Beta.
+    /// - The `inEarlyAccess` flag is set to False
+    static var patronFeature: PaidFeature {
+        .init(tier: .patron)
+    }
+
+    /// A `PaidFeature` that is available to Plus and Patron subscribers.
+    ///
+    /// - Available to Plus and Patron users on the AppStore and Beta.
+    /// - The `inEarlyAccess` flag is set to False
+    static var plusFeature: PaidFeature {
+        .init(tier: .plus)
+    }
+}

--- a/podcasts/PaidFeature.swift
+++ b/podcasts/PaidFeature.swift
@@ -5,16 +5,12 @@ import SwiftUI
 
 // MARK: - Features
 
-/// To add a new feature:
-///     1. Add a new static var for the feature name and tier it should be unlocked with
-///
-///     Template:
-///         static var <#FeatureName#>: PaidFeature = .init(tier: <#Tier#>)
-///
-///     2. Check the unlock state using `PaidFeature.hello.isUnlocked`
-///
 extension PaidFeature {
-    static var bookmarks: PaidFeature = .init(tier: .patron, betaTier: .plus)
+    static var bookmarks: PaidFeature = .inEarlyAccess
+
+    // When the feature leaves early access, it will switch to being a Plus feature
+    // Adding this here to make it easier to uncomment
+    // static var bookmarks: PaidFeature = .plusFeature
 }
 
 /// A `PaidFeature` represents a feature that is unlocked with a subscription tier, and is considered to be unlocked if the tier


### PR DESCRIPTION
| 📘 Part of: #1061 |
|:---:|

This adds a new `inEarlyAccess` flag to the PaidFeature to signify when a feature is in the early access period or not. Internally this does not change how the PaidFeature works, but it allows the app to be able to show different UI for a feature in early access or not. 

I decided to add a new flag instead of adding a check for `tier != betaTier` to give us more flexibility in how the flag is used, and make it more explicit when a feature is in this period or not. 

One downfall to adding the flag is the initializer got a bit long and could potentially make it more difficult when trying to quickly grok the state of a feature. To help with this I added 3 new "states" that we can use: `.inEarlyAccess`, `.patronFeature`, and `.plusFeature`.  Each of these just return a PaidFeature initializer with the flags set. 

I also opted to return a new instance of PaidFeature for each of them in case in the future we need compare the features. 

## To test

1. Enable the Bookmarks feature flag
2. Launch the app, sign into a Plus account
3. Open a podcast detail page
4. Tap on Bookmarks
5. ✅ Verify you see it locked for Patron
6. In Xcode, open BuildEnvironment
7. Change line 24 to `.testFlight`
8. Launch the app
9. Open the podcast detail page
10. Tap Bookmarks
11. ✅ Verify its unlocked now

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
