### PR TITLE
Bookmarks: Adds early access what's new logic

### DIFF
--- a/PocketCastsTests/Tests/Whats New/WhatsNewTests.swift
+++ b/PocketCastsTests/Tests/Whats New/WhatsNewTests.swift
@@ -140,7 +140,7 @@ class WhatsNewtests: XCTestCase {
     }
 
     private func announcement(version: String, isEnabled: Bool = true) -> WhatsNew.Announcement {
-        return .init(version: version, header: { AnyView(EmptyView()) }, title: "", message: "", buttonTitle: "", action: {}, isEnabled: isEnabled)
+        return .init(version: version, header: AnyView(EmptyView()), title: "", message: "", buttonTitle: "", action: {}, isEnabled: isEnabled)
     }
 }
 

--- a/PocketCastsTests/Tests/Whats New/WhatsNewTests.swift
+++ b/PocketCastsTests/Tests/Whats New/WhatsNewTests.swift
@@ -121,6 +121,26 @@ class WhatsNewtests: XCTestCase {
 
         XCTAssertNil(whatsNew.viewControllerToShow())
     }
+
+    // If there are multiple announcements in the list, we should only show the last one
+    func testShowOnlyTheLastAnnouncement() {
+        let lastAnnouncement = announcement(version: "7.12")
+
+        let whatsNew = WhatsNew(
+            announcements: [
+                announcement(version: "7.10"),
+                announcement(version: "7.11"),
+                lastAnnouncement
+            ],
+            previousOpenedVersion: "7.00",
+            currentVersion: "7.40"
+        )
+
+        XCTAssertEqual(whatsNew.visibleAnnouncement?.version, lastAnnouncement.version)
+    }
+
+    private func announcement(version: String, isEnabled: Bool = true) -> WhatsNew.Announcement {
+        return .init(version: version, header: { AnyView(EmptyView()) }, title: "", message: "", buttonTitle: "", action: {}, isEnabled: isEnabled)
     }
 }
 

--- a/PocketCastsTests/Tests/Whats New/WhatsNewTests.swift
+++ b/PocketCastsTests/Tests/Whats New/WhatsNewTests.swift
@@ -111,8 +111,16 @@ class WhatsNewtests: XCTestCase {
         XCTAssertNil(whatsNew.viewControllerToShow())
     }
 
-    private func announcement(version: String) -> WhatsNew.Announcement {
-        return .init(version: version, header: { AnyView(EmptyView()) }, title: "", message: "", buttonTitle: "", action: {})
+    // Don't show any announcements that are disabled even if the other conditions are true
+    func testDontShowDisabledAnnouncements() {
+        let whatsNew = WhatsNew(
+            announcements: [announcement(version: "7.40", isEnabled: false)],
+            previousOpenedVersion: "7.39",
+            currentVersion: "7.40"
+        )
+
+        XCTAssertNil(whatsNew.viewControllerToShow())
+    }
     }
 }
 

--- a/podcasts/Whats New/Announcements.swift
+++ b/podcasts/Whats New/Announcements.swift
@@ -53,7 +53,7 @@ struct Announcements {
 
         // TODO: Update with the real content
         let announcement = WhatsNew.Announcement(
-            version: "7.50",
+            version: "99.99",
             header: {
                 AnyView(AutoplayWhatsNewHeader().onAppear {
                     // Record when someone sees the full announcement while in early access so we don't show it again

--- a/podcasts/Whats New/Announcements.swift
+++ b/podcasts/Whats New/Announcements.swift
@@ -71,6 +71,34 @@ struct Announcements {
 
         announcements.append(announcement)
     }
+
+    /// When bookmarks is out of early access we'll show the announcement to everyone
+    /// but don't show it to people who already saw the full announcement when it was in early access
+    /// This is a placeholder for now.
+    /**
+    mutating func addBookmarksReleaseAnnouncement() {
+        guard
+            FeatureFlag.bookmarks.enabled, !PaidFeature.bookmarks.inEarlyAccess,
+            !UserDefaults.standard.bool(forKey: "WhatsNew.Bookmarks.EarlyAccess.Seen")
+        else {
+            return
+        }
+
+        // TODO: Update with the real content
+        let announcement = WhatsNew.Announcement(
+            version: "99.99",
+            header: {
+                AnyView(AutoplayWhatsNewHeader())
+            },
+            title: "Normal Title",
+            message: "Bookmarks Message",
+            buttonTitle: "Action Button",
+            action: { }
+        )
+
+        announcements.append(announcement)
+    }
+     */
 }
 
 class AnnouncementFlow {

--- a/podcasts/Whats New/Announcements.swift
+++ b/podcasts/Whats New/Announcements.swift
@@ -1,5 +1,7 @@
 import Foundation
 import SwiftUI
+import PocketCastsServer
+import PocketCastsUtils
 
 struct Announcements {
     // Order is important.
@@ -21,6 +23,54 @@ struct Announcements {
             }
         )
     ]
+
+    init() {
+        addBookmarksEarlyAccessAnnouncement()
+    }
+
+    /// Add the bookmarks announcement when in Early Access.
+    ///
+    /// Since the beta and App Store binaries are the same we'll dynamically determine:
+    /// - If we're in beta we'll show a "join beta testing" message for Plus and Patron
+    /// - If we're in production we'll show the regular announcement for Patron
+    ///
+    /// If not we don't show the what's new at all.
+    mutating func addBookmarksEarlyAccessAnnouncement() {
+        guard FeatureFlag.bookmarks.enabled, PaidFeature.bookmarks.inEarlyAccess else { return }
+
+        let activeTier = SubscriptionHelper.activeTier
+        let environment = BuildEnvironment.current
+        let isBeta = environment == .testFlight
+
+        // Check to determine if we are showing the announcement
+        let shouldShowInBeta = isBeta && activeTier > .none
+        let shouldShowInRelease = !isBeta && activeTier == .patron
+
+        // Don't add the announcement if we're not showing it
+        guard shouldShowInBeta || shouldShowInRelease else { return }
+
+        let title = isBeta ? "Beta Title" : "Normal Title"
+
+        // TODO: Update with the real content
+        let announcement = WhatsNew.Announcement(
+            version: "7.50",
+            header: {
+                AnyView(AutoplayWhatsNewHeader().onAppear {
+                    // Record when someone sees the full announcement while in early access so we don't show it again
+                    // to them when we move to full release.
+                    if shouldShowInRelease {
+                        UserDefaults.standard.setValue(true, forKey: "WhatsNew.Bookmarks.EarlyAccess.Seen")
+                    }
+                })
+            },
+            title: title,
+            message: "Bookmarks Message",
+            buttonTitle: "Action Button",
+            action: { }
+        )
+
+        announcements.append(announcement)
+    }
 }
 
 class AnnouncementFlow {

--- a/podcasts/Whats New/Announcements.swift
+++ b/podcasts/Whats New/Announcements.swift
@@ -11,9 +11,7 @@ struct Announcements {
         // Autoplay
         .init(
             version: "7.43",
-            header: {
-                AnyView(AutoplayWhatsNewHeader())
-            },
+            header: AnyView(AutoplayWhatsNewHeader()),
             title: L10n.announcementAutoplayTitle,
             message: L10n.announcementAutoplayDescription,
             buttonTitle: L10n.enableItNow,
@@ -21,14 +19,15 @@ struct Announcements {
                 AnnouncementFlow.shared.isShowingAutoplayOption = true
 
                 NavigationManager.sharedManager.navigateTo(NavigationManager.settingsProfileKey, data: nil)
-            }
+            },
+            isEnabled: true
         ),
 
         // Bookmarks Early Access: Beta
         // Show only in TestFlight, for Plus and Patron
         .init(
             version: "99.99",
-            header: { AnyView(EmptyView()) },
+            header: AnyView(EmptyView()),
             title: "Early Access Beta Title",
             message: "Message",
             buttonTitle: "Button",
@@ -40,10 +39,10 @@ struct Announcements {
         // Show when not in beta, for Patron only
         .init(
             version: "99.99",
-            header: { AnyView(EmptyView().onAppear {
+            header: AnyView(EmptyView().onAppear {
                 // Record when someone sees the full announcement while in early access so we don't show it again to them when we move to full release.
                 UserDefaults.standard.setValue(true, forKey: "WhatsNew.Bookmarks.EarlyAccess.Seen")
-            }) },
+            }),
             title: "Early Access Normal Title",
             message: "Message",
             buttonTitle: "Button",
@@ -55,7 +54,7 @@ struct Announcements {
         // Show for everyone, except those who saw the `Early Access: Release` announcement
         .init(
             version: "99.99",
-            header: { AnyView(EmptyView()) },
+            header: AnyView(EmptyView()),
             title: "Release Title",
             message: "Message",
             buttonTitle: "Button",

--- a/podcasts/Whats New/Announcements.swift
+++ b/podcasts/Whats New/Announcements.swift
@@ -8,6 +8,7 @@ struct Announcements {
     // In the case a user migrates to, let's say, 7.10 to 7.15 and
     // there were two announcements, the last one will be picked.
     var announcements: [WhatsNew.Announcement] = [
+        // Autoplay
         .init(
             version: "7.43",
             header: {
@@ -21,84 +22,47 @@ struct Announcements {
 
                 NavigationManager.sharedManager.navigateTo(NavigationManager.settingsProfileKey, data: nil)
             }
+        ),
+
+        // Bookmarks Early Access: Beta
+        // Show only in TestFlight, for Plus and Patron
+        .init(
+            version: "99.99",
+            header: { AnyView(EmptyView()) },
+            title: "Early Access Beta Title",
+            message: "Message",
+            buttonTitle: "Button",
+            action: {},
+            isEnabled: PaidFeature.bookmarks.inEarlyAccess && BuildEnvironment.current == .testFlight && SubscriptionHelper.activeTier > .none
+        ),
+
+        // Bookmarks Early Access: Release
+        // Show when not in beta, for Patron only
+        .init(
+            version: "99.99",
+            header: { AnyView(EmptyView().onAppear {
+                // Record when someone sees the full announcement while in early access so we don't show it again to them when we move to full release.
+                UserDefaults.standard.setValue(true, forKey: "WhatsNew.Bookmarks.EarlyAccess.Seen")
+            }) },
+            title: "Early Access Normal Title",
+            message: "Message",
+            buttonTitle: "Button",
+            action: {},
+            isEnabled: PaidFeature.bookmarks.inEarlyAccess && BuildEnvironment.current != .testFlight && SubscriptionHelper.activeTier == .patron
+        ),
+
+        // Bookmarks: Full Release
+        // Show for everyone, except those who saw the `Early Access: Release` announcement
+        .init(
+            version: "99.99",
+            header: { AnyView(EmptyView()) },
+            title: "Release Title",
+            message: "Message",
+            buttonTitle: "Button",
+            action: {},
+            isEnabled: !PaidFeature.bookmarks.inEarlyAccess && !UserDefaults.standard.bool(forKey: "WhatsNew.Bookmarks.EarlyAccess.Seen")
         )
     ]
-
-    init() {
-        addBookmarksEarlyAccessAnnouncement()
-    }
-
-    /// Add the bookmarks announcement when in Early Access.
-    ///
-    /// Since the beta and App Store binaries are the same we'll dynamically determine:
-    /// - If we're in beta we'll show a "join beta testing" message for Plus and Patron
-    /// - If we're in production we'll show the regular announcement for Patron
-    ///
-    /// If not we don't show the what's new at all.
-    mutating func addBookmarksEarlyAccessAnnouncement() {
-        guard FeatureFlag.bookmarks.enabled, PaidFeature.bookmarks.inEarlyAccess else { return }
-
-        let activeTier = SubscriptionHelper.activeTier
-        let environment = BuildEnvironment.current
-        let isBeta = environment == .testFlight
-
-        // Check to determine if we are showing the announcement
-        let shouldShowInBeta = isBeta && activeTier > .none
-        let shouldShowInRelease = !isBeta && activeTier == .patron
-
-        // Don't add the announcement if we're not showing it
-        guard shouldShowInBeta || shouldShowInRelease else { return }
-
-        let title = isBeta ? "Beta Title" : "Normal Title"
-
-        // TODO: Update with the real content
-        let announcement = WhatsNew.Announcement(
-            version: "99.99",
-            header: {
-                AnyView(AutoplayWhatsNewHeader().onAppear {
-                    // Record when someone sees the full announcement while in early access so we don't show it again
-                    // to them when we move to full release.
-                    if shouldShowInRelease {
-                        UserDefaults.standard.setValue(true, forKey: "WhatsNew.Bookmarks.EarlyAccess.Seen")
-                    }
-                })
-            },
-            title: title,
-            message: "Bookmarks Message",
-            buttonTitle: "Action Button",
-            action: { }
-        )
-
-        announcements.append(announcement)
-    }
-
-    /// When bookmarks is out of early access we'll show the announcement to everyone
-    /// but don't show it to people who already saw the full announcement when it was in early access
-    /// This is a placeholder for now.
-    /**
-    mutating func addBookmarksReleaseAnnouncement() {
-        guard
-            FeatureFlag.bookmarks.enabled, !PaidFeature.bookmarks.inEarlyAccess,
-            !UserDefaults.standard.bool(forKey: "WhatsNew.Bookmarks.EarlyAccess.Seen")
-        else {
-            return
-        }
-
-        // TODO: Update with the real content
-        let announcement = WhatsNew.Announcement(
-            version: "99.99",
-            header: {
-                AnyView(AutoplayWhatsNewHeader())
-            },
-            title: "Normal Title",
-            message: "Bookmarks Message",
-            buttonTitle: "Action Button",
-            action: { }
-        )
-
-        announcements.append(announcement)
-    }
-     */
 }
 
 class AnnouncementFlow {

--- a/podcasts/Whats New/WhatsNew.swift
+++ b/podcasts/Whats New/WhatsNew.swift
@@ -9,7 +9,22 @@ class WhatsNew {
         let message: String
         let buttonTitle: String
         let action: () -> Void
-        var isEnabled: Bool = true
+        let isEnabled: () -> Bool
+
+        init(version: String,
+             header: @autoclosure @escaping () -> AnyView,
+             title: String, message: String,
+             buttonTitle: String,
+             action: @escaping () -> Void,
+             isEnabled: @autoclosure @escaping () -> Bool) {
+            self.version = version
+            self.header = header
+            self.title = title
+            self.message = message
+            self.buttonTitle = buttonTitle
+            self.action = action
+            self.isEnabled = isEnabled
+        }
     }
 
     let announcements: [Announcement]
@@ -51,7 +66,7 @@ class WhatsNew {
         // - the target version is not before the last opened version, and not for a future version
         return announcements
             .last(where: {
-                $0.isEnabled &&
+                $0.isEnabled() &&
                 $0.version != lastWhatsNewShown &&
                 $0.version.inRange(of: previousOpenedVersion, upper: currentVersion)
             })

--- a/podcasts/Whats New/WhatsNew.swift
+++ b/podcasts/Whats New/WhatsNew.swift
@@ -9,6 +9,7 @@ class WhatsNew {
         let message: String
         let buttonTitle: String
         let action: () -> Void
+        var isEnabled: Bool = true
     }
 
     let announcements: [Announcement]

--- a/podcasts/Whats New/WhatsNew.swift
+++ b/podcasts/Whats New/WhatsNew.swift
@@ -25,10 +25,7 @@ class WhatsNew {
     }
 
     func viewControllerToShow() -> UIViewController? {
-        guard let previousOpenedVersion,
-              previousOpenedVersion != currentVersion,
-              let announcement = announcements.last(where: { $0.version > previousOpenedVersion && $0.version <= currentVersion }),
-              announcement.version != lastWhatsNewShown else {
+        guard let announcement = visibleAnnouncement else {
             return nil
         }
 

--- a/podcasts/Whats New/WhatsNew.swift
+++ b/podcasts/Whats New/WhatsNew.swift
@@ -55,4 +55,9 @@ private extension String {
 
         return "\(major).\(minor)"
     }
+
+    /// Returns whether the version is above the `lower` and equal to or below the `upper` bounds
+    func inRange(of lower: String, upper: String) -> Bool {
+        self > lower && self <= upper
+    }
 }

--- a/podcasts/Whats New/WhatsNew.swift
+++ b/podcasts/Whats New/WhatsNew.swift
@@ -39,6 +39,26 @@ class WhatsNew {
 
         return whatsNewViewController
     }
+
+    /// Returns the announcement to be displayed if one is available
+    var visibleAnnouncement: Announcement? {
+        // Don't show any announcements if this is the first run of the app,
+        // or if we've already checked the what's new for this version
+        guard let previousOpenedVersion, previousOpenedVersion != currentVersion else {
+            return nil
+        }
+
+        // Find the last announcement that:
+        // - is enabled
+        // - has not been shown already
+        // - the target version is not before the last opened version, and not for a future version
+        return announcements
+            .last(where: {
+                $0.isEnabled &&
+                $0.version != lastWhatsNewShown &&
+                $0.version.inRange(of: previousOpenedVersion, upper: currentVersion)
+            })
+    }
 }
 
 private extension String {


### PR DESCRIPTION
| 📘 Part of: #1061 |
|:---:|

This adds the logic the display the what's new while the feature is in early access:
- If we're in beta we'll show a "join beta testing" message for Plus and Patron
- If we're in production we'll show the regular announcement for Patron

This also adds a flag that's stored in the user defaults to prevent showing the full announcement to people who already saw it while it was in early access.

**Note:** This doesn't add the design or real text yet. 

## To test

**Before running do the following:**
   1. Enable the Bookmarks feature flag
   2. Open Announcements.swift, and change the bookmarks announcement versions from `99.99` to `7.50`

The easiest way to test is by changing the values in the WhatsNew initializer so the WhatsNew will always be displayed:

```     
self.announcements = announcements
self.previousOpenedVersion = "7.49"
self.currentVersion = "7.50"
self.lastWhatsNewShown = "7.43"
```

### Early Access: What's New is shown for Patron when not in beta:
1. Launch the app
2. ✅ You should not see the What's New
3. Sign into an account with Patron, or use the developer menu Paid Patron option
4. Restart the app
5. ✅ Verify you see the What's New with the "Normal Title"

### Early Access: What's New is shown for Plus and above when in beta:
1. In Xcode, open BuildEnvironment.swift, change line 24 to `.testFlight`
2. Sign into free account
3. Restart the app
4. ✅ Verify you do not see the what's new
5. Sign into a Plus account
6. Restart the app
7. ✅ Verify you see the What's New with the "Beta Title"
8. Sign into a Patron account
9. Restart the app
10. ✅ Verify you see the What's New with the "Beta Title"

### Full Release: Don't show the announcement to people who saw it already
1. In Xcode, open PaidFeature, and change line 9 from `.inEarlyAccess` to `.plusFeature`
2. Restart the app
3. ✅ You should not see the what's new because the flag was set to true in the first testing step
4. In Xcode, run `UserDefaults.standard.setValue(nil, forKey: "WhatsNew.Bookmarks.EarlyAccess.Seen")`
5. Restart the app
6. ✅ You should now see the what's new with the "Release Title"

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
