### PR TITLE
Playback 2023: show total listening time

### DIFF
--- a/podcasts/End of Year/Stories/ListeningTimeStory.swift
+++ b/podcasts/End of Year/Stories/ListeningTimeStory.swift
@@ -11,39 +11,147 @@ struct ListeningTimeStory: ShareableStory {
 
     let podcasts: [Podcast]
 
+    var numberOfBalls: Int {
+        Int(listeningTime.firstNumber) ?? 0 > 100 ? 10 : 7
+    }
+
+    var numberOfLines: Int {
+        var linesSlashBalls = (Double(listeningTime.firstNumber) ?? 1) / Double(numberOfBalls)
+        linesSlashBalls.round(.up)
+        return Int(linesSlashBalls)
+    }
+
     var body: some View {
         GeometryReader { geometry in
-            VStack(spacing: 0) {
-                StoryLabelContainer(topPadding: geometry.size.height * Constants.topPadding, geometry: geometry) {
-                    let time = listeningTime.storyTimeDescription
-                    if NSLocale.isCurrentLanguageEnglish {
-                        StoryLabel(L10n.eoyStoryListenedToUpdated("\n\(time)\n"), highlighting: [time], for: .title)
-                    } else {
-                        StoryLabel(L10n.eoyStoryListenedTo("\n\(time)\n"), highlighting: [time], for: .title)
-                    }
-                    StoryLabel(FunMessage.timeSecsToFunnyText(listeningTime), for: .subtitle)
-                        .opacity(0.8)
+            PodcastCoverContainer(geometry: geometry) {
+                StoryLabelContainer(geometry: geometry) {
+                    StoryLabel(L10n.eoyStoryListenedToTitle, for: .title, geometry: geometry)
+                    StoryLabel(L10n.eoyStoryListenedToSubtitle, for: .subtitle, color: Color(hex: "8F97A4"), geometry: geometry)
                 }
 
                 // Podcast images angled to fill the width of the view
                 let size = 0.30 * geometry.size.height
 
-                HStack(spacing: 20) {
-                    ForEach(Constants.displayedPodcasts, id: \.self) {
-                        podcastCover($0, size: size)
-                    }
+                ContentSizeGeometryReader { listeningTimeReader in
+                    Text(listeningTime.firstNumber)
+                        .font(.custom("DM Sans", size: geometry.size.height * 0.4))
+                        .fontWeight(.light)
+                        .frame(width: geometry.size.width - 70)
+                        .scaledToFill()
+                        .minimumScaleFactor(0.5)
+                        .lineLimit(1)
+                        .foregroundColor(.white)
+                        .padding([.leading, .trailing], 35)
+                        .padding(.bottom, -listeningTimeReader.size.height * 0.2)
                 }
-                .applyPodcastCoverPerspective()
-                .padding(.top)
-            }.frame(width: geometry.size.width)
-        }.background(DynamicBackgroundView(podcast: podcasts[0]))
-    }
 
-    @ViewBuilder
-    func podcastCover(_ index: Int, size: Double) -> some View {
-        let podcast = podcasts[safe: index] ?? podcasts[0]
-        PodcastCover(podcastUuid: podcast.uuid)
-            .frame(width: size, height: size)
+                StoryLabel(listeningTime.subtitle, for: .subtitle, color: Color(hex: "8F97A4"), geometry: geometry)
+                    .padding(.bottom, geometry.size.height * 0.025)
+
+
+//                VStack(alignment: .leading) {
+//                    ForEach(0..<numberOfLines, id: \.self) { _ in
+//                        LinearGradient(
+//                                                    stops: [
+//                                                    Gradient.Stop(color: Color(red: 0.25, green: 0.11, blue: 0.92), location: 0.00),
+//                                                    Gradient.Stop(color: Color(red: 0.68, green: 0.89, blue: 0.86), location: 0.24),
+//                                                    Gradient.Stop(color: Color(red: 0.87, green: 0.91, blue: 0.53), location: 0.50),
+//                                                    Gradient.Stop(color: Color(red: 0.91, green: 0.35, blue: 0.26), location: 0.76),
+//                                                    Gradient.Stop(color: Color(red: 0.1, green: 0.1, blue: 0.1), location: 1.00),
+//                                                    ],
+//                                                    startPoint: UnitPoint(x: 0, y: 0),
+//                                                    endPoint: UnitPoint(x: 1.22, y: 1.25)
+//                                                    )
+//                        .mask(
+//                            HStack(alignment: .top) {
+//                                Group {
+//                                    Circle()
+//                                    Circle()
+//                                    Circle()
+//                                    Circle()
+//                                    Circle()
+//                                    Circle()
+//                                    Circle()
+//                                }
+//                                .frame(width: geometry.size.height * 0.055)
+//                            }
+//                        )
+//                    }
+//                }
+//                .padding([.leading, .trailing], 18)
+
+                let maxArea = CGSize(width: geometry.size.width, height: geometry.size.height * 0.3)
+                let number = Double(listeningTime.firstNumber) ?? 0
+                let eachBallSquareArea = Double(maxArea.width * maxArea.height) / number
+                let numberOfBallsPerLine = max(7, (maxArea.width / eachBallSquareArea.squareRoot()).rounded(.up))
+                let numberOfLines = min((number / numberOfBallsPerLine).rounded(.up), max(1, (maxArea.height / eachBallSquareArea.squareRoot()).rounded(.up)))
+                let ballCalculatedWidth = maxArea.width / numberOfBallsPerLine
+                let ballCalculatedHeight = maxArea.height / numberOfLines
+                let ballPadding = min(ballCalculatedWidth, ballCalculatedHeight) * 0.05
+                let ballFinalWidth = min(ballCalculatedWidth, ballCalculatedHeight) - 4 * ballPadding
+                // The width of the days displayed as balls that the user didn't listened to podcasts
+                let missingDaysWidth = ((((numberOfLines * numberOfBallsPerLine) * 86400) - listeningTime) / 86400) * (ballFinalWidth + (2 * ballPadding))
+                let ballTotalArea = min(ballCalculatedWidth, ballCalculatedHeight)
+                let daysArea = CGSize(width: numberOfBallsPerLine * ballTotalArea, height: numberOfLines * ballTotalArea)
+
+                VStack(spacing: 0) {
+                    ForEach(0..<Int(numberOfLines), id: \.self) { _ in
+                        HStack(spacing: 0) {
+                            ForEach(0..<Int(numberOfBallsPerLine), id: \.self) { _ in
+                                Circle()
+                                    .foregroundStyle(.white)
+                                    .frame(width: ballFinalWidth, height: ballFinalWidth)
+                                    .padding(.all, ballPadding)
+                            }
+                        }
+                    }
+                    .opacity(0)
+                }
+                .background(
+                    ZStack(alignment: .bottomTrailing) {
+                        LinearGradient(
+                            stops: [
+                                Gradient.Stop(color: Color(red: 0.25, green: 0.11, blue: 0.92), location: 0.00),
+                                Gradient.Stop(color: Color(red: 0.68, green: 0.89, blue: 0.86), location: 0.24),
+                                Gradient.Stop(color: Color(red: 0.87, green: 0.91, blue: 0.53), location: 0.50),
+                                Gradient.Stop(color: Color(red: 0.91, green: 0.35, blue: 0.26), location: 0.76),
+                                Gradient.Stop(color: Color(red: 0.1, green: 0.1, blue: 0.1), location: 1.00),
+                            ],
+                            startPoint: UnitPoint(x: 0, y: 0),
+                            endPoint: UnitPoint(x: 1.22, y: 1.25)
+                        )
+
+                        Rectangle()
+                            .foregroundStyle(Color(hex: "8F97A4"))
+                            .frame(width: missingDaysWidth, height: ballFinalWidth + 2 * ballPadding)
+                    }
+                    .mask (
+                        VStack(spacing: 0) {
+                            ForEach(0..<Int(numberOfLines), id: \.self) { _ in
+                                HStack(spacing: 0) {
+                                    ForEach(0..<Int(numberOfBallsPerLine), id: \.self) { _ in
+                                        Circle()
+                                            .foregroundStyle(.white)
+                                            .frame(width: ballFinalWidth, height: ballFinalWidth)
+                                            .padding(.all, ballPadding)
+                                    }
+                                }
+                            }
+                        }
+                    )
+
+                )
+
+            }
+            .background(
+                ZStack(alignment: .bottom) {
+                    Color.black
+
+                    StoryGradient()
+                    .offset(x: -geometry.size.width * 0.8, y: geometry.size.height * 0.25)
+                }
+            )
+        }
     }
 
     func onAppear() {
@@ -74,22 +182,18 @@ struct ListeningTimeStory: ShareableStory {
     }
 }
 
-/// Always return the same funny message
-struct FunMessage {
-    static var message: String?
+private extension Double {
+    var firstNumber: String {
+        storyTimeDescription.components(separatedBy: "\u{00a0}").first ?? ""
+    }
 
-    static func timeSecsToFunnyText(_ timeInSeconds: Double) -> String {
-        guard let message = Self.message else {
-            Self.message = FunnyTimeConverter.timeSecsToFunnyText(timeInSeconds)
-            return Self.message ?? ""
-        }
-
-        return message
+    var subtitle: String {
+        storyTimeDescription.components(separatedBy: "\u{00a0}").dropFirst().joined(separator: "\u{00a0}")
     }
 }
 
 struct ListeningTimeStory_Previews: PreviewProvider {
     static var previews: some View {
-        ListeningTimeStory(listeningTime: 100, podcasts: [Podcast.previewPodcast(), Podcast.previewPodcast(), Podcast.previewPodcast()])
+        ListeningTimeStory(listeningTime: 22000000, podcasts: [Podcast.previewPodcast(), Podcast.previewPodcast(), Podcast.previewPodcast()])
     }
 }

--- a/podcasts/End of Year/Stories/ListeningTimeStory.swift
+++ b/podcasts/End of Year/Stories/ListeningTimeStory.swift
@@ -19,9 +19,10 @@ struct ListeningTimeStory: ShareableStory {
                     StoryLabel(L10n.eoyStoryListenedToSubtitle, for: .subtitle, color: Color(hex: "8F97A4"), geometry: geometry)
                 }
 
+                let fontSize = Int(listeningTime.firstNumber) ?? 0 <= 21 ? 0.4 : 0.3
                 ContentSizeGeometryReader { listeningTimeReader in
                     Text(listeningTime.firstNumber)
-                        .font(.custom("DM Sans", size: geometry.size.height * 0.4))
+                        .font(.custom("DM Sans", size: geometry.size.height * fontSize))
                         .fontWeight(.regular)
                         .frame(width: geometry.size.width - 70)
                         .scaledToFill()

--- a/podcasts/End of Year/Stories/ListeningTimeStory.swift
+++ b/podcasts/End of Year/Stories/ListeningTimeStory.swift
@@ -19,22 +19,23 @@ struct ListeningTimeStory: ShareableStory {
                     StoryLabel(L10n.eoyStoryListenedToSubtitle, for: .subtitle, color: Color(hex: "8F97A4"), geometry: geometry)
                 }
 
-                let fontSize = Int(listeningTime.firstNumber) ?? 0 <= 21 ? 0.4 : 0.3
-                ContentSizeGeometryReader { listeningTimeReader in
-                    Text(listeningTime.firstNumber)
-                        .font(.custom("DM Sans", size: geometry.size.height * fontSize))
-                        .fontWeight(.regular)
-                        .frame(width: geometry.size.width - 70)
-                        .scaledToFill()
-                        .minimumScaleFactor(0.5)
-                        .lineLimit(1)
-                        .foregroundColor(.white)
-                        .padding([.leading, .trailing], 35)
-                        .padding(.bottom, -listeningTimeReader.size.height * 0.2)
-                }
-
-                StoryLabel(listeningTime.subtitle, for: .subtitle, color: Color(hex: "8F97A4"), geometry: geometry)
-                    .padding(.bottom, geometry.size.height * 0.025)
+                // We treat numbers below 21 differently, as there's much more space available
+                let maxHeight = Int(listeningTime.firstNumber) ?? 0 <= 21 ? 0.5 : 0.35
+                let subtitleTopPadding = (Int(listeningTime.firstNumber) ?? 0 <= 21 ? 0.35 : 0.25)
+                Text(listeningTime.firstNumber)
+                    .font(.custom("DM Sans", size: geometry.size.height * 0.4))
+                    .fontWeight(.regular)
+                    .frame(width: geometry.size.width - 70)
+                    .frame(maxHeight: geometry.size.height * maxHeight)
+                    .scaledToFill()
+                    .minimumScaleFactor(0.5)
+                    .lineLimit(1)
+                    .foregroundColor(.white)
+                    .padding([.leading, .trailing], 35)
+                    .overlay {
+                        StoryLabel(listeningTime.subtitle, for: .subtitle, color: Color(hex: "8F97A4"), geometry: geometry)
+                            .padding(.top, geometry.size.height * subtitleTopPadding)
+                    }
 
                 Spacer()
 
@@ -163,6 +164,6 @@ private extension Double {
 
 struct ListeningTimeStory_Previews: PreviewProvider {
     static var previews: some View {
-        ListeningTimeStory(listeningTime: 8600000, podcasts: [Podcast.previewPodcast(), Podcast.previewPodcast(), Podcast.previewPodcast()])
+        ListeningTimeStory(listeningTime: 109000, podcasts: [Podcast.previewPodcast(), Podcast.previewPodcast(), Podcast.previewPodcast()])
     }
 }

--- a/podcasts/End of Year/Stories/ListeningTimeStory.swift
+++ b/podcasts/End of Year/Stories/ListeningTimeStory.swift
@@ -103,16 +103,7 @@ struct CircleDays: View {
         // The content is repeated on the background so the gradient
         // can have the exact same size as the circles.
         VStack(spacing: 0) {
-            ForEach(0..<Int(numberOfLines), id: \.self) { _ in
-                HStack(spacing: 0) {
-                    ForEach(0..<Int(numberOfBallsPerLine), id: \.self) { _ in
-                        Circle()
-                            .foregroundStyle(.white)
-                            .frame(width: ballFinalWidth, height: ballFinalWidth)
-                            .padding(.all, ballPadding)
-                    }
-                }
-            }
+            circles(numberOfLines: numberOfLines, numberOfBallsPerLine: numberOfBallsPerLine, ballWidth: ballFinalWidth, ballPadding: ballPadding)
             .opacity(0)
         }
         .background(
@@ -135,20 +126,24 @@ struct CircleDays: View {
             }
             .mask (
                 VStack(spacing: 0) {
-                    ForEach(0..<Int(numberOfLines), id: \.self) { _ in
-                        HStack(spacing: 0) {
-                            ForEach(0..<Int(numberOfBallsPerLine), id: \.self) { _ in
-                                Circle()
-                                    .foregroundStyle(.white)
-                                    .frame(width: ballFinalWidth, height: ballFinalWidth)
-                                    .padding(.all, ballPadding)
-                            }
-                        }
-                    }
+                    circles(numberOfLines: numberOfLines, numberOfBallsPerLine: numberOfBallsPerLine, ballWidth: ballFinalWidth, ballPadding: ballPadding)
                 }
             )
 
         )
+    }
+
+    func circles(numberOfLines: Double, numberOfBallsPerLine: Double, ballWidth: Double, ballPadding: Double) -> some View {
+        ForEach(0..<Int(numberOfLines), id: \.self) { _ in
+            HStack(spacing: 0) {
+                ForEach(0..<Int(numberOfBallsPerLine), id: \.self) { _ in
+                    Circle()
+                        .foregroundStyle(.white)
+                        .frame(width: ballWidth, height: ballWidth)
+                        .padding(.all, ballPadding)
+                }
+            }
+        }
     }
 }
 

--- a/podcasts/End of Year/Stories/ListeningTimeStory.swift
+++ b/podcasts/End of Year/Stories/ListeningTimeStory.swift
@@ -120,6 +120,7 @@ struct CircleDays: View {
                     endPoint: UnitPoint(x: 1.22, y: 1.25)
                 )
 
+                // Fill the non-listened days
                 Rectangle()
                     .foregroundStyle(Color(hex: "8F97A4"))
                     .frame(width: missingDaysWidth, height: ballFinalWidth + 2 * ballPadding)

--- a/podcasts/End of Year/Stories/ListeningTimeStory.swift
+++ b/podcasts/End of Year/Stories/ListeningTimeStory.swift
@@ -29,13 +29,10 @@ struct ListeningTimeStory: ShareableStory {
                     StoryLabel(L10n.eoyStoryListenedToSubtitle, for: .subtitle, color: Color(hex: "8F97A4"), geometry: geometry)
                 }
 
-                // Podcast images angled to fill the width of the view
-                let size = 0.30 * geometry.size.height
-
                 ContentSizeGeometryReader { listeningTimeReader in
                     Text(listeningTime.firstNumber)
                         .font(.custom("DM Sans", size: geometry.size.height * 0.4))
-                        .fontWeight(.light)
+                        .fontWeight(.regular)
                         .frame(width: geometry.size.width - 70)
                         .scaledToFill()
                         .minimumScaleFactor(0.5)
@@ -48,40 +45,10 @@ struct ListeningTimeStory: ShareableStory {
                 StoryLabel(listeningTime.subtitle, for: .subtitle, color: Color(hex: "8F97A4"), geometry: geometry)
                     .padding(.bottom, geometry.size.height * 0.025)
 
-
-//                VStack(alignment: .leading) {
-//                    ForEach(0..<numberOfLines, id: \.self) { _ in
-//                        LinearGradient(
-//                                                    stops: [
-//                                                    Gradient.Stop(color: Color(red: 0.25, green: 0.11, blue: 0.92), location: 0.00),
-//                                                    Gradient.Stop(color: Color(red: 0.68, green: 0.89, blue: 0.86), location: 0.24),
-//                                                    Gradient.Stop(color: Color(red: 0.87, green: 0.91, blue: 0.53), location: 0.50),
-//                                                    Gradient.Stop(color: Color(red: 0.91, green: 0.35, blue: 0.26), location: 0.76),
-//                                                    Gradient.Stop(color: Color(red: 0.1, green: 0.1, blue: 0.1), location: 1.00),
-//                                                    ],
-//                                                    startPoint: UnitPoint(x: 0, y: 0),
-//                                                    endPoint: UnitPoint(x: 1.22, y: 1.25)
-//                                                    )
-//                        .mask(
-//                            HStack(alignment: .top) {
-//                                Group {
-//                                    Circle()
-//                                    Circle()
-//                                    Circle()
-//                                    Circle()
-//                                    Circle()
-//                                    Circle()
-//                                    Circle()
-//                                }
-//                                .frame(width: geometry.size.height * 0.055)
-//                            }
-//                        )
-//                    }
-//                }
-//                .padding([.leading, .trailing], 18)
+                Spacer()
 
                 let maxArea = CGSize(width: geometry.size.width, height: geometry.size.height * 0.3)
-                let number = Double(listeningTime.firstNumber) ?? 0
+                let number = Double(listeningTime / 86400).rounded(.up)
                 let eachBallSquareArea = Double(maxArea.width * maxArea.height) / number
                 let numberOfBallsPerLine = max(7, (maxArea.width / eachBallSquareArea.squareRoot()).rounded(.up))
                 let numberOfLines = min((number / numberOfBallsPerLine).rounded(.up), max(1, (maxArea.height / eachBallSquareArea.squareRoot()).rounded(.up)))
@@ -92,7 +59,6 @@ struct ListeningTimeStory: ShareableStory {
                 // The width of the days displayed as balls that the user didn't listened to podcasts
                 let missingDaysWidth = ((((numberOfLines * numberOfBallsPerLine) * 86400) - listeningTime) / 86400) * (ballFinalWidth + (2 * ballPadding))
                 let ballTotalArea = min(ballCalculatedWidth, ballCalculatedHeight)
-                let daysArea = CGSize(width: numberOfBallsPerLine * ballTotalArea, height: numberOfLines * ballTotalArea)
 
                 VStack(spacing: 0) {
                     ForEach(0..<Int(numberOfLines), id: \.self) { _ in
@@ -142,6 +108,11 @@ struct ListeningTimeStory: ShareableStory {
 
                 )
 
+                Spacer()
+
+                Rectangle()
+                    .frame(height: geometry.size.height * 0.1)
+                    .opacity(0)
             }
             .background(
                 ZStack(alignment: .bottom) {
@@ -194,6 +165,6 @@ private extension Double {
 
 struct ListeningTimeStory_Previews: PreviewProvider {
     static var previews: some View {
-        ListeningTimeStory(listeningTime: 22000000, podcasts: [Podcast.previewPodcast(), Podcast.previewPodcast(), Podcast.previewPodcast()])
+        ListeningTimeStory(listeningTime: 5000000, podcasts: [Podcast.previewPodcast(), Podcast.previewPodcast(), Podcast.previewPodcast()])
     }
 }

--- a/podcasts/End of Year/Stories/ListeningTimeStory.swift
+++ b/podcasts/End of Year/Stories/ListeningTimeStory.swift
@@ -98,7 +98,6 @@ struct CircleDays: View {
 
         // The width of the days displayed as balls that the user didn't listened to podcasts
         let missingDaysWidth = ((((numberOfLines * numberOfBallsPerLine) * 86400) - listeningTime) / 86400) * (ballFinalWidth + (2 * ballPadding))
-        let ballTotalArea = min(ballCalculatedWidth, ballCalculatedHeight)
 
         // The content is repeated on the background so the gradient
         // can have the exact same size as the circles.

--- a/podcasts/End of Year/Stories/ListeningTimeStory.swift
+++ b/podcasts/End of Year/Stories/ListeningTimeStory.swift
@@ -16,6 +16,7 @@ struct ListeningTimeStory: ShareableStory {
             PodcastCoverContainer(geometry: geometry) {
                 StoryLabelContainer(geometry: geometry) {
                     StoryLabel(L10n.eoyStoryListenedToTitle, for: .title, geometry: geometry)
+                        .fixedSize(horizontal: false, vertical: true)
                     StoryLabel(L10n.eoyStoryListenedToSubtitle, for: .subtitle, color: Color(hex: "8F97A4"), geometry: geometry)
                 }
 

--- a/podcasts/End of Year/Stories/ListeningTimeStory.swift
+++ b/podcasts/End of Year/Stories/ListeningTimeStory.swift
@@ -11,16 +11,6 @@ struct ListeningTimeStory: ShareableStory {
 
     let podcasts: [Podcast]
 
-    var numberOfBalls: Int {
-        Int(listeningTime.firstNumber) ?? 0 > 100 ? 10 : 7
-    }
-
-    var numberOfLines: Int {
-        var linesSlashBalls = (Double(listeningTime.firstNumber) ?? 1) / Double(numberOfBalls)
-        linesSlashBalls.round(.up)
-        return Int(linesSlashBalls)
-    }
-
     var body: some View {
         GeometryReader { geometry in
             PodcastCoverContainer(geometry: geometry) {
@@ -47,66 +37,7 @@ struct ListeningTimeStory: ShareableStory {
 
                 Spacer()
 
-                let maxArea = CGSize(width: geometry.size.width, height: geometry.size.height * 0.3)
-                let number = Double(listeningTime / 86400).rounded(.up)
-                let eachBallSquareArea = Double(maxArea.width * maxArea.height) / number
-                let numberOfBallsPerLine = max(7, (maxArea.width / eachBallSquareArea.squareRoot()).rounded(.up))
-                let numberOfLines = min((number / numberOfBallsPerLine).rounded(.up), max(1, (maxArea.height / eachBallSquareArea.squareRoot()).rounded(.up)))
-                let ballCalculatedWidth = maxArea.width / numberOfBallsPerLine
-                let ballCalculatedHeight = maxArea.height / numberOfLines
-                let ballPadding = min(ballCalculatedWidth, ballCalculatedHeight) * 0.05
-                let ballFinalWidth = min(ballCalculatedWidth, ballCalculatedHeight) - 4 * ballPadding
-                // The width of the days displayed as balls that the user didn't listened to podcasts
-                let missingDaysWidth = ((((numberOfLines * numberOfBallsPerLine) * 86400) - listeningTime) / 86400) * (ballFinalWidth + (2 * ballPadding))
-                let ballTotalArea = min(ballCalculatedWidth, ballCalculatedHeight)
-
-                VStack(spacing: 0) {
-                    ForEach(0..<Int(numberOfLines), id: \.self) { _ in
-                        HStack(spacing: 0) {
-                            ForEach(0..<Int(numberOfBallsPerLine), id: \.self) { _ in
-                                Circle()
-                                    .foregroundStyle(.white)
-                                    .frame(width: ballFinalWidth, height: ballFinalWidth)
-                                    .padding(.all, ballPadding)
-                            }
-                        }
-                    }
-                    .opacity(0)
-                }
-                .background(
-                    ZStack(alignment: .bottomTrailing) {
-                        LinearGradient(
-                            stops: [
-                                Gradient.Stop(color: Color(red: 0.25, green: 0.11, blue: 0.92), location: 0.00),
-                                Gradient.Stop(color: Color(red: 0.68, green: 0.89, blue: 0.86), location: 0.24),
-                                Gradient.Stop(color: Color(red: 0.87, green: 0.91, blue: 0.53), location: 0.50),
-                                Gradient.Stop(color: Color(red: 0.91, green: 0.35, blue: 0.26), location: 0.76),
-                                Gradient.Stop(color: Color(red: 0.1, green: 0.1, blue: 0.1), location: 1.00),
-                            ],
-                            startPoint: UnitPoint(x: 0, y: 0),
-                            endPoint: UnitPoint(x: 1.22, y: 1.25)
-                        )
-
-                        Rectangle()
-                            .foregroundStyle(Color(hex: "8F97A4"))
-                            .frame(width: missingDaysWidth, height: ballFinalWidth + 2 * ballPadding)
-                    }
-                    .mask (
-                        VStack(spacing: 0) {
-                            ForEach(0..<Int(numberOfLines), id: \.self) { _ in
-                                HStack(spacing: 0) {
-                                    ForEach(0..<Int(numberOfBallsPerLine), id: \.self) { _ in
-                                        Circle()
-                                            .foregroundStyle(.white)
-                                            .frame(width: ballFinalWidth, height: ballFinalWidth)
-                                            .padding(.all, ballPadding)
-                                    }
-                                }
-                            }
-                        }
-                    )
-
-                )
+                CircleDays(proxy: geometry, listeningTime: listeningTime)
 
                 Spacer()
 
@@ -139,17 +70,84 @@ struct ListeningTimeStory: ShareableStory {
             StoryShareableText(L10n.eoyStoryListenedToShareText(listeningTime.storyTimeDescriptionForSharing))
         ]
     }
+}
 
-    private enum Constants {
-        /// The podcasts that are displayed on the view, the middle is your top 10 podcast
-        static let displayedPodcasts = [1, 0, 2]
-        static let coverSize = 180.0
+/// Given a GeometryProxy and a Double listening time it
+/// returns a view filled with circles representing days of listening.
+///
+/// The minimum amount of circles is 7.
+///
+/// The algorithm takes a `maxArea` and calculates how many balls it
+/// can fill there. However the returned `View` might be bigger or smaller,
+/// the area just give it some constraints to calculate values.
+struct CircleDays: View {
+    let proxy: GeometryProxy
+    let listeningTime: Double
 
-        static let spaceBetweenLabels = 22.0
-        static let labelHorizontalPadding = 35.0
+    var body: some View {
+        let maxArea = CGSize(width: proxy.size.width, height: proxy.size.height * 0.3)
+        let number = Double(listeningTime / 86400).rounded(.up)
+        let eachBallSquareArea = Double(maxArea.width * maxArea.height) / number
+        let numberOfBallsPerLine = max(7, (maxArea.width / eachBallSquareArea.squareRoot()).rounded(.up))
+        let numberOfLines = min((number / numberOfBallsPerLine).rounded(.up), max(1, (maxArea.height / eachBallSquareArea.squareRoot()).rounded(.up)))
+        let ballCalculatedWidth = maxArea.width / numberOfBallsPerLine
+        let ballCalculatedHeight = maxArea.height / numberOfLines
+        let ballPadding = min(ballCalculatedWidth, ballCalculatedHeight) * 0.05
+        let ballFinalWidth = min(ballCalculatedWidth, ballCalculatedHeight) - 4 * ballPadding
 
-        /// Top padding is a percent calculated using the height of the view
-        static let topPadding = 0.158
+        // The width of the days displayed as balls that the user didn't listened to podcasts
+        let missingDaysWidth = ((((numberOfLines * numberOfBallsPerLine) * 86400) - listeningTime) / 86400) * (ballFinalWidth + (2 * ballPadding))
+        let ballTotalArea = min(ballCalculatedWidth, ballCalculatedHeight)
+
+        // The content is repeated on the background so the gradient
+        // can have the exact same size as the circles.
+        VStack(spacing: 0) {
+            ForEach(0..<Int(numberOfLines), id: \.self) { _ in
+                HStack(spacing: 0) {
+                    ForEach(0..<Int(numberOfBallsPerLine), id: \.self) { _ in
+                        Circle()
+                            .foregroundStyle(.white)
+                            .frame(width: ballFinalWidth, height: ballFinalWidth)
+                            .padding(.all, ballPadding)
+                    }
+                }
+            }
+            .opacity(0)
+        }
+        .background(
+            ZStack(alignment: .bottomTrailing) {
+                LinearGradient(
+                    stops: [
+                        Gradient.Stop(color: Color(red: 0.25, green: 0.11, blue: 0.92), location: 0.00),
+                        Gradient.Stop(color: Color(red: 0.68, green: 0.89, blue: 0.86), location: 0.24),
+                        Gradient.Stop(color: Color(red: 0.87, green: 0.91, blue: 0.53), location: 0.50),
+                        Gradient.Stop(color: Color(red: 0.91, green: 0.35, blue: 0.26), location: 0.76),
+                        Gradient.Stop(color: Color(red: 0.1, green: 0.1, blue: 0.1), location: 1.00),
+                    ],
+                    startPoint: UnitPoint(x: 0, y: 0),
+                    endPoint: UnitPoint(x: 1.22, y: 1.25)
+                )
+
+                Rectangle()
+                    .foregroundStyle(Color(hex: "8F97A4"))
+                    .frame(width: missingDaysWidth, height: ballFinalWidth + 2 * ballPadding)
+            }
+            .mask (
+                VStack(spacing: 0) {
+                    ForEach(0..<Int(numberOfLines), id: \.self) { _ in
+                        HStack(spacing: 0) {
+                            ForEach(0..<Int(numberOfBallsPerLine), id: \.self) { _ in
+                                Circle()
+                                    .foregroundStyle(.white)
+                                    .frame(width: ballFinalWidth, height: ballFinalWidth)
+                                    .padding(.all, ballPadding)
+                            }
+                        }
+                    }
+                }
+            )
+
+        )
     }
 }
 
@@ -165,6 +163,6 @@ private extension Double {
 
 struct ListeningTimeStory_Previews: PreviewProvider {
     static var previews: some View {
-        ListeningTimeStory(listeningTime: 5000000, podcasts: [Podcast.previewPodcast(), Podcast.previewPodcast(), Podcast.previewPodcast()])
+        ListeningTimeStory(listeningTime: 8600000, podcasts: [Podcast.previewPodcast(), Podcast.previewPodcast(), Podcast.previewPodcast()])
     }
 }

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -776,6 +776,10 @@ internal enum L10n {
   internal static func eoyStoryListenedToShareText(_ p1: Any) -> String {
     return L10n.tr("Localizable", "eoy_story_listened_to_share_text", String(describing: p1))
   }
+  /// We hope you loved every minute of it!
+  internal static var eoyStoryListenedToSubtitle: String { return L10n.tr("Localizable", "eoy_story_listened_to_subtitle") }
+  /// This was your total time listening to podcasts
+  internal static var eoyStoryListenedToTitle: String { return L10n.tr("Localizable", "eoy_story_listened_to_title") }
   /// This year, you spent %1$@ listening to podcasts
   internal static func eoyStoryListenedToUpdated(_ p1: Any) -> String {
     return L10n.tr("Localizable", "eoy_story_listened_to_updated", String(describing: p1))

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -3497,6 +3497,12 @@
 /* String telling the user how much time they listened to podcasts in 2022, %1$@ is a placeholder for the amount of time. */
 "eoy_story_listened_to" = "In 2022, you spent %1$@ listening to podcasts";
 
+/* Title of the listening time Story. */
+"eoy_story_listened_to_title" = "This was your total time listening to podcasts";
+
+/* Title of the listening time Story. */
+"eoy_story_listened_to_subtitle" = "We hope you loved every minute of it!";
+
 /* String telling the user how much time they listened to podcasts in 2022, %1$@ is a placeholder for the amount of time. */
 "eoy_story_listened_to_updated" = "This year, you spent %1$@ listening to podcasts";
 


### PR DESCRIPTION
| 📘 Part of: #1142 | 🎨 Designs: [Figma](https://www.figma.com/file/lH66LwxxgG8btQ8NrM0ldx/End-of-Year?type=design&node-id=1599-20385&mode=design) |
|:---:|:---:|

Adds the 2023 visual for the Total Listening Time Story.

**Animations are not part of this task and will be tackled later.**

| Just a few | Something | Crazy user |
| ---------- | ----------- | ----------- |
| ![Simulator Screenshot - iPhone 15 - 2023-10-12 at 16 25 31](https://github.com/Automattic/pocket-casts-ios/assets/7040243/6f79509e-0de6-4989-b982-9c0e4bb0327b) | ![Simulator Screenshot - iPhone 15 - 2023-10-12 at 16 26 01](https://github.com/Automattic/pocket-casts-ios/assets/7040243/e4e6c3d8-50a7-420c-9eed-bdacaef5af9c) | ![Simulator Screenshot - iPhone 15 - 2023-10-12 at 16 27 37](https://github.com/Automattic/pocket-casts-ios/assets/7040243/6033a498-bfa2-46ec-9d46-be4da19fc234) |

## To test

1. Make sure you're logged in to an account that has a few episodes listened
2. Go to Profile > Settings > Beta Features > enable `endOfYear`
3. Go back to Profile
4. Tap the EOY image
5. Skip to the sixth story
5. ✅ Check that the story looks good, that it shows your total listening time and that the circles matches it correctly
6. Tap "Share this story" > Save Image
7. Go to Photos
8. ✅ The story image asset should be the last one on Photos and should have your total listening time
9. Stop the app
10. Go to `EndOfYearStoriesDataSource` and change `return ListeningTimeStory(listeningTime: data.listeningTime, podcasts: data.top10Podcasts)` to `return ListeningTimeStory(listeningTime: 200000, podcasts: data.top10Podcasts)`
11. Run it again
12. ✅ Check the story and the circles
13. Stop the app, increment one zero in `listeningTime` and run it again
14. ✅ Check the story and the circles
15. Repeat the steps above a few times, manipulating the listeningTime so you can test that the displayed circles are correct

Please test on a big device (iPhone 15 Pro Max, for example), a normal device (iPhone 15), and a smaller device (iPod touch).

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
