### PR TITLE
Bookmarks: Update the upgrade message text

### DIFF
--- a/podcasts/Common SwiftUI/BookmarksLockedStateView.swift
+++ b/podcasts/Common SwiftUI/BookmarksLockedStateView.swift
@@ -13,17 +13,27 @@ struct BookmarksLockedStateView<Style: EmptyStateViewStyle>: View {
     }
 
     private var message: String {
+        let feature = upgradeModel.feature
+
         let tierName: String
-        switch upgradeModel.feature.tier {
+        var secondaryTierName: String? = nil
+
+        switch feature.tier {
         case .patron:
             tierName = L10n.patron
+            secondaryTierName = feature.inEarlyAccess ? L10n.pocketCastsPlusShort : nil
         case .plus:
             tierName = L10n.pocketCastsPlusShort
         case .none:
             tierName = L10n.pocketCastsPlusShort
         }
 
-        return L10n.boomarksLockedMessage(tierName)
+        // Show the regular unlock message if there isn't a secondary early access tier to display
+        guard let secondaryTierName else {
+            return L10n.bookmarksLockedMessage(tierName).preventWidows()
+        }
+
+        return L10n.bookmarksEarlyAccessLockedMessage(tierName, secondaryTierName).preventWidows()
     }
 
     var body: some View {

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -296,6 +296,10 @@ internal enum L10n {
   }
   /// 1 bookmark
   internal static var bookmarksCountSingular: String { return L10n.tr("Localizable", "bookmarks_count_singular") }
+  /// Unlock this feature and many more with Pocket Casts %1$@ and save timestamps of your favorite episodes. Available for %2$@ subscribers soon.
+  internal static func boomarksEarlyAccessLockedMessage(_ p1: Any, _ p2: Any) -> String {
+    return L10n.tr("Localizable", "boomarks_early_access_locked_message", String(describing: p1), String(describing: p2))
+  }
   /// Unlock this feature and many more with Pocket Casts %1$@ and save timestamps of your favorite episodes.
   internal static func boomarksLockedMessage(_ p1: Any) -> String {
     return L10n.tr("Localizable", "boomarks_locked_message", String(describing: p1))

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -297,12 +297,12 @@ internal enum L10n {
   /// 1 bookmark
   internal static var bookmarksCountSingular: String { return L10n.tr("Localizable", "bookmarks_count_singular") }
   /// Unlock this feature and many more with Pocket Casts %1$@ and save timestamps of your favorite episodes. Available for %2$@ subscribers soon.
-  internal static func boomarksEarlyAccessLockedMessage(_ p1: Any, _ p2: Any) -> String {
-    return L10n.tr("Localizable", "boomarks_early_access_locked_message", String(describing: p1), String(describing: p2))
+  internal static func bookmarksEarlyAccessLockedMessage(_ p1: Any, _ p2: Any) -> String {
+    return L10n.tr("Localizable", "bookmarks_early_access_locked_message", String(describing: p1), String(describing: p2))
   }
   /// Unlock this feature and many more with Pocket Casts %1$@ and save timestamps of your favorite episodes.
-  internal static func boomarksLockedMessage(_ p1: Any) -> String {
-    return L10n.tr("Localizable", "boomarks_locked_message", String(describing: p1))
+  internal static func bookmarksLockedMessage(_ p1: Any) -> String {
+    return L10n.tr("Localizable", "bookmarks_locked_message", String(describing: p1))
   }
   /// Bottom
   internal static var bottom: String { return L10n.tr("Localizable", "bottom") }

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -3861,10 +3861,10 @@
 "episode_details_title" = "Details";
 
 /* A message informing the user a feature is locked. %1$@ is the name of the tier (Plus or Patron) */
-"boomarks_locked_message" = "Unlock this feature and many more with Pocket Casts %1$@ and save timestamps of your favorite episodes.";
+"bookmarks_locked_message" = "Unlock this feature and many more with Pocket Casts %1$@ and save timestamps of your favorite episodes.";
 
 /* A message informing the user a feature is locked while in early access. %1$@ and %2$@ are the names of the tier (Plus or Patron) */
-"boomarks_early_access_locked_message" = "Unlock this feature and many more with Pocket Casts %1$@ and save timestamps of your favorite episodes. Available for %2$@ subscribers soon.";
+"bookmarks_early_access_locked_message" = "Unlock this feature and many more with Pocket Casts %1$@ and save timestamps of your favorite episodes. Available for %2$@ subscribers soon.";
 
 /* A button title that prompts the user to upgrade their plan. %1$@ is the name of the tier (Plus or Patron) */
 "upgrade_to_plan" = "Upgrade to %1$@";

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -3863,6 +3863,9 @@
 /* A message informing the user a feature is locked. %1$@ is the name of the tier (Plus or Patron) */
 "boomarks_locked_message" = "Unlock this feature and many more with Pocket Casts %1$@ and save timestamps of your favorite episodes.";
 
+/* A message informing the user a feature is locked while in early access. %1$@ and %2$@ are the names of the tier (Plus or Patron) */
+"boomarks_early_access_locked_message" = "Unlock this feature and many more with Pocket Casts %1$@ and save timestamps of your favorite episodes. Available for %2$@ subscribers soon.";
+
 /* A button title that prompts the user to upgrade their plan. %1$@ is the name of the tier (Plus or Patron) */
 "upgrade_to_plan" = "Upgrade to %1$@";
 


### PR DESCRIPTION
| 📘 Part of: #1061 | 🎨 [Designs](https://www.figma.com/file/Io7PCz1H1hmOgEE9eljoYW/Bookmarks?type=design&node-id=3689-30106&mode=dev) |
|:---:|:---:|

This updates the inline upgrade message to display info about early access. 

| Early Access: Locked | Not Early Access |
|:---:|:---:|
|<img src="https://github.com/Automattic/pocket-casts-ios/assets/793774/6ee4c0f9-164f-429a-a02d-3716dcbcbe2b" width="320" />|<img src="https://github.com/Automattic/pocket-casts-ios/assets/793774/0ccdbe82-bdfd-4088-87fc-f35f454b7cc0" width="320" />|


## To test

Enable the Bookmarks and Patron feature flags before starting. 

1. Sign into an account with Plus or no subscription
2. Launch the app
3. Go to the Podcasts tab, and tap on any podcast
4. Tap on the Bookmarks tab
5. ✅ Verify you see the upgrade message that mentions it will be available for Plus soon
6. In Xcode, open PaidFeature, and change line 9 from `.inEarlyAccess` to `.plusFeature`
7. Sign into an account with no subscription
8. Relaunch the app
9. Open the bookmarks tab again
10. ✅ Verify you see the normal upgrade message


## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
