### PR TITLE
Playback 2023: year over year listening time story

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
@@ -16,6 +16,10 @@ class EndOfYearDataManager {
                                             lastPlaybackInteractionDate IS NOT NULL AND lastPlaybackInteractionDate BETWEEN strftime('%s', '\(startDate)') and strftime('%s', '\(endDate)')
                                            """
 
+    private lazy var listenedEpisodesPreviousYear = """
+                                            lastPlaybackInteractionDate IS NOT NULL AND lastPlaybackInteractionDate BETWEEN strftime('%s', '2021-01-01') and strftime('%s', '"2023-01-01"')
+                                           """
+
     /// If the user is eligible to see End of Year stats
     ///
     /// All it's needed is a single episode listened for more than 5 minutes.
@@ -318,6 +322,32 @@ class EndOfYearDataManager {
 
         return numberOfItemsInListeningHistory
     }
+
+    /// Returns the approximate listening time for the current year
+    func yearOverYearListeningTime(dbQueue: FMDatabaseQueue) -> YearOverYearListeningTime {
+        var listeningTimeThisYear: Double = 0
+        var listeningTimePreviousYear: Double = 0
+
+        dbQueue.inDatabase { db in
+            do {
+                let query = "SELECT DISTINCT \(DataManager.episodeTableName).uuid, SUM(playedUpTo) as totalPlayedTime from \(DataManager.episodeTableName) WHERE \(listenedEpisodesThisYear) UNION SELECT DISTINCT \(DataManager.episodeTableName).uuid, SUM(playedUpTo) as totalPlayedTime from \(DataManager.episodeTableName) WHERE \(listenedEpisodesPreviousYear)"
+                let resultSet = try db.executeQuery(query, values: nil)
+                defer { resultSet.close() }
+
+                if resultSet.next() {
+                    listeningTimeThisYear = resultSet.double(forColumn: "totalPlayedTime")
+                }
+
+                if resultSet.next() {
+                    listeningTimePreviousYear = resultSet.double(forColumn: "totalPlayedTime")
+                }
+            } catch {
+                FileLog.shared.addMessage("EndOfYearDataManager.listeningTime error: \(error)")
+            }
+        }
+
+        return YearOverYearListeningTime(totalPlayedTimeThisYear: listeningTimeThisYear, totalPlayedTimeLastYear: listeningTimePreviousYear)
+    }
 }
 
 public struct ListenedCategory {
@@ -367,7 +397,7 @@ public struct YearOverYearListeningTime {
     public let totalPlayedTimeLastYear: Double
 
     public var percentage: Double {
-        let nonRoundendPercentage = ((100 * totalPlayedTimeThisYear) / totalPlayedTimeLastYear)
+        let nonRoundendPercentage = ((100 * totalPlayedTimeThisYear) / totalPlayedTimeLastYear) - 100
         return (nonRoundendPercentage.rounded() * 100) / 100
     }
 

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
@@ -395,15 +395,12 @@ public struct ListenedNumbers {
 public struct YearOverYearListeningTime {
     public let totalPlayedTimeThisYear: Double
     public let totalPlayedTimeLastYear: Double
-
-    public var percentage: Double {
-        let nonRoundendPercentage = ((100 * totalPlayedTimeThisYear) / totalPlayedTimeLastYear) - 100
-        return (nonRoundendPercentage.rounded() * 100) / 100
-    }
+    public let percentage: Double
 
     public init(totalPlayedTimeThisYear: Double, totalPlayedTimeLastYear: Double) {
         self.totalPlayedTimeThisYear = totalPlayedTimeThisYear
         self.totalPlayedTimeLastYear = totalPlayedTimeLastYear
+        self.percentage = (((totalPlayedTimeThisYear - totalPlayedTimeLastYear) / totalPlayedTimeLastYear) * 100).rounded()
     }
 }
 

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
@@ -362,6 +362,21 @@ public struct ListenedNumbers {
     }
 }
 
+public struct YearOverYearListeningTime {
+    public let totalPlayedTimeThisYear: Double
+    public let totalPlayedTimeLastYear: Double
+
+    public var percentage: Double {
+        let nonRoundendPercentage = ((100 * totalPlayedTimeThisYear) / totalPlayedTimeLastYear)
+        return (nonRoundendPercentage.rounded() * 100) / 100
+    }
+
+    public init(totalPlayedTimeThisYear: Double, totalPlayedTimeLastYear: Double) {
+        self.totalPlayedTimeThisYear = totalPlayedTimeThisYear
+        self.totalPlayedTimeLastYear = totalPlayedTimeLastYear
+    }
+}
+
 public struct TopPodcast {
     public let podcast: Podcast
     public let numberOfPlayedEpisodes: Int

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
@@ -330,7 +330,7 @@ class EndOfYearDataManager {
 
         dbQueue.inDatabase { db in
             do {
-                let query = "SELECT DISTINCT \(DataManager.episodeTableName).uuid, SUM(playedUpTo) as totalPlayedTime from \(DataManager.episodeTableName) WHERE \(listenedEpisodesThisYear) UNION SELECT DISTINCT \(DataManager.episodeTableName).uuid, SUM(playedUpTo) as totalPlayedTime from \(DataManager.episodeTableName) WHERE \(listenedEpisodesPreviousYear)"
+                let query = "SELECT DISTINCT \(DataManager.episodeTableName).uuid, SUM(playedUpTo) as totalPlayedTime from \(DataManager.episodeTableName) WHERE \(listenedEpisodesThisYear) UNION ALL SELECT DISTINCT \(DataManager.episodeTableName).uuid, SUM(playedUpTo) as totalPlayedTime from \(DataManager.episodeTableName) WHERE \(listenedEpisodesPreviousYear)"
                 let resultSet = try db.executeQuery(query, values: nil)
                 defer { resultSet.close() }
 

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
@@ -17,7 +17,7 @@ class EndOfYearDataManager {
                                            """
 
     private lazy var listenedEpisodesPreviousYear = """
-                                            lastPlaybackInteractionDate IS NOT NULL AND lastPlaybackInteractionDate BETWEEN strftime('%s', '2021-01-01') and strftime('%s', '"2023-01-01"')
+                                            lastPlaybackInteractionDate IS NOT NULL AND lastPlaybackInteractionDate BETWEEN strftime('%s', '2022-01-01') and strftime('%s', '2023-01-01')
                                            """
 
     /// If the user is eligible to see End of Year stats

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -953,4 +953,8 @@ public extension DataManager {
     func episodesThatExist(uuids: [String]) -> [String] {
         endOfYearManager.episodesThatExist(dbQueue: dbQueue, uuids: uuids)
     }
+
+    func yearOverYearListeningTime() -> YearOverYearListeningTime {
+        endOfYearManager.yearOverYearListeningTime(dbQueue: dbQueue)
+    }
 }

--- a/PocketCastsTests/Mocks/EndOfYearManagerMock.swift
+++ b/PocketCastsTests/Mocks/EndOfYearManagerMock.swift
@@ -16,6 +16,8 @@ class EndOfYearManagerMock: EndOfYearDataManager {
 
     var isFullListeningHistoryToReturn = false
 
+    var yearOverYearToReturn: YearOverYearListeningTime?
+
     override func listeningTime(dbQueue: FMDatabaseQueue) -> Double? {
         listeningTimeToReturn
     }
@@ -38,5 +40,9 @@ class EndOfYearManagerMock: EndOfYearDataManager {
 
     override func isFullListeningHistory(dbQueue: FMDatabaseQueue) -> Bool {
         return isFullListeningHistoryToReturn
+    }
+
+    override func yearOverYearListeningTime(dbQueue: FMDatabaseQueue) -> YearOverYearListeningTime {
+        return yearOverYearToReturn ?? YearOverYearListeningTime(totalPlayedTimeThisYear: 0, totalPlayedTimeLastYear: 0)
     }
 }

--- a/PocketCastsTests/Tests/End of Year/EndOfYearStoriesBuilderTests.swift
+++ b/PocketCastsTests/Tests/End of Year/EndOfYearStoriesBuilderTests.swift
@@ -190,6 +190,7 @@ class EndOfYearStoriesBuilderTests: XCTestCase {
         let stories = await builder.build()
 
         XCTAssertEqual(endOfYearManager.yearOverYearToReturn?.percentage, 53.0)
+        XCTAssertNotNil(stories.1.yearOverYearListeningTime)
     }
 
     func testSyncWhenNeeded() async {

--- a/PocketCastsTests/Tests/End of Year/EndOfYearStoriesBuilderTests.swift
+++ b/PocketCastsTests/Tests/End of Year/EndOfYearStoriesBuilderTests.swift
@@ -189,7 +189,7 @@ class EndOfYearStoriesBuilderTests: XCTestCase {
 
         let stories = await builder.build()
 
-        XCTAssertFalse(stories.0.contains(.yearOverYearListeningTime))
+        XCTAssertTrue(stories.0.contains(.yearOverYearListeningTime))
         XCTAssertEqual(endOfYearManager.yearOverYearToReturn?.percentage, 53.0)
         XCTAssertNotNil(stories.1.yearOverYearListeningTime)
     }

--- a/PocketCastsTests/Tests/End of Year/EndOfYearStoriesBuilderTests.swift
+++ b/PocketCastsTests/Tests/End of Year/EndOfYearStoriesBuilderTests.swift
@@ -189,6 +189,7 @@ class EndOfYearStoriesBuilderTests: XCTestCase {
 
         let stories = await builder.build()
 
+        XCTAssertFalse(stories.0.contains(.yearOverYearListeningTime))
         XCTAssertEqual(endOfYearManager.yearOverYearToReturn?.percentage, 53.0)
         XCTAssertNotNil(stories.1.yearOverYearListeningTime)
     }

--- a/PocketCastsTests/Tests/End of Year/EndOfYearStoriesBuilderTests.swift
+++ b/PocketCastsTests/Tests/End of Year/EndOfYearStoriesBuilderTests.swift
@@ -177,6 +177,21 @@ class EndOfYearStoriesBuilderTests: XCTestCase {
         XCTAssertNil(stories.1.longestEpisodePodcast)
     }
 
+    func testReturnYearOverYearListeningTime() async {
+        let endOfYearManager = EndOfYearManagerMock()
+        let dataManager = DataManagerMock(endOfYearManager: endOfYearManager)
+        let builder = EndOfYearStoriesBuilder(dataManager: dataManager)
+
+        endOfYearManager.yearOverYearToReturn = YearOverYearListeningTime(
+            totalPlayedTimeThisYear: 153,
+            totalPlayedTimeLastYear: 100
+        )
+
+        let stories = await builder.build()
+
+        XCTAssertEqual(endOfYearManager.yearOverYearToReturn?.percentage, 53.0)
+    }
+
     func testSyncWhenNeeded() async {
         var syncCalled = false
         let endOfYearManager = EndOfYearManagerMock()

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -604,6 +604,7 @@
 		8BF0BBD92891AFB5006BBECF /* PodcastBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BF0BBD82891AFB5006BBECF /* PodcastBuilder.swift */; };
 		8BF0BBDB2891B038006BBECF /* FolderBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BF0BBDA2891B038006BBECF /* FolderBuilder.swift */; };
 		8BF1C61D2881F05D007E80BF /* FolderModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BF1C61C2881F05D007E80BF /* FolderModelTests.swift */; };
+		8BF9CC0C2ADDA90F004E9B65 /* YearOverYearStory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BF9CC0B2ADDA90F004E9B65 /* YearOverYearStory.swift */; };
 		8BFB434E2A1FFB4B00F3D409 /* StatusPageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BFB434D2A1FFB4B00F3D409 /* StatusPageViewModel.swift */; };
 		BD001B892174260B00504DD3 /* FilterManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD001B882174260B00504DD3 /* FilterManager.swift */; };
 		BD00CB2B24BD20CD00A10257 /* TimeStepperCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD00CB2924BD20CD00A10257 /* TimeStepperCell.swift */; };
@@ -2388,6 +2389,7 @@
 		8BF0BBD82891AFB5006BBECF /* PodcastBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PodcastBuilder.swift; sourceTree = "<group>"; };
 		8BF0BBDA2891B038006BBECF /* FolderBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FolderBuilder.swift; sourceTree = "<group>"; };
 		8BF1C61C2881F05D007E80BF /* FolderModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FolderModelTests.swift; sourceTree = "<group>"; };
+		8BF9CC0B2ADDA90F004E9B65 /* YearOverYearStory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YearOverYearStory.swift; sourceTree = "<group>"; };
 		8BFB434D2A1FFB4B00F3D409 /* StatusPageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusPageViewModel.swift; sourceTree = "<group>"; };
 		8F94CEC98B0A0E0B35578196 /* Pods-Today Extension.ad hoc.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Today Extension.ad hoc.xcconfig"; path = "Pods/Target Support Files/Pods-Today Extension/Pods-Today Extension.ad hoc.xcconfig"; sourceTree = "<group>"; };
 		9A9517324EFFD2C905890193 /* Pods-podcasts.appstore.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-podcasts.appstore.xcconfig"; path = "Pods/Target Support Files/Pods-podcasts/Pods-podcasts.appstore.xcconfig"; sourceTree = "<group>"; };
@@ -4325,6 +4327,7 @@
 				8BB1187D290C56D1009E3A39 /* TopCategoriesStory */,
 				8B0EEDE729008B6300075772 /* TopOnePodcastStory.swift */,
 				8B4D7949290876C200F4A56F /* DynamicBackgroundView.swift */,
+				8BF9CC0B2ADDA90F004E9B65 /* YearOverYearStory.swift */,
 			);
 			path = Stories;
 			sourceTree = "<group>";
@@ -9077,6 +9080,7 @@
 				BD03DF881CACD9AB005A127E /* DownloadedFilesViewController.swift in Sources */,
 				BDB0C5C3231F74D60071FBA2 /* PCSearchBarController+Search.swift in Sources */,
 				BD7BCF111F6A4F110006E008 /* SharingHelper.swift in Sources */,
+				8BF9CC0C2ADDA90F004E9B65 /* YearOverYearStory.swift in Sources */,
 				BDF15A3E1B54E053000EC323 /* PlaybackManager.swift in Sources */,
 				BD40987C1B9ED731007F36BD /* SynchronizedAudioStack.swift in Sources */,
 				BD77E9031B9D2CF600DC4ADF /* AngularProgressIndicator.swift in Sources */,

--- a/podcasts/End of Year/EndOfYearStoriesBuilder.swift
+++ b/podcasts/End of Year/EndOfYearStoriesBuilder.swift
@@ -95,6 +95,14 @@ class EndOfYearStoriesBuilder {
                 stories.append(.longestEpisode)
             }
 
+            // Year over year listening time
+            let yearOverYearListeningTime = dataManager.yearOverYearListeningTime()
+            if yearOverYearListeningTime.totalPlayedTimeThisYear != 0 ||
+                yearOverYearListeningTime.totalPlayedTimeLastYear != 0 {
+                data.yearOverYearListeningTime = yearOverYearListeningTime
+//                stories.append(.longestEpisode)
+            }
+
             continuation.resume(returning: (stories, data))
         }
     }
@@ -115,4 +123,6 @@ class EndOfYearStoriesData {
     var longestEpisodePodcast: Podcast!
 
     var top10Podcasts: [Podcast] = []
+
+    var yearOverYearListeningTime: YearOverYearListeningTime!
 }

--- a/podcasts/End of Year/EndOfYearStoriesBuilder.swift
+++ b/podcasts/End of Year/EndOfYearStoriesBuilder.swift
@@ -13,6 +13,7 @@ enum EndOfYearStory: CaseIterable {
     case topCategories
     case listeningTime
     case longestEpisode
+    case yearOverYearListeningTime
     case epilogue
 }
 
@@ -100,7 +101,7 @@ class EndOfYearStoriesBuilder {
             if yearOverYearListeningTime.totalPlayedTimeThisYear != 0 ||
                 yearOverYearListeningTime.totalPlayedTimeLastYear != 0 {
                 data.yearOverYearListeningTime = yearOverYearListeningTime
-//                stories.append(.longestEpisode)
+                stories.append(.yearOverYearListeningTime)
             }
 
             continuation.resume(returning: (stories, data))

--- a/podcasts/End of Year/Stories/EndOfYearStoriesDataSource.swift
+++ b/podcasts/End of Year/Stories/EndOfYearStoriesDataSource.swift
@@ -26,6 +26,8 @@ class EndOfYearStoriesDataSource: StoriesDataSource {
             return TopFivePodcastsStory(topPodcasts: data.topPodcasts)
         case .longestEpisode:
             return LongestEpisodeStory(episode: data.longestEpisode, podcast: data.longestEpisodePodcast)
+        case .yearOverYearListeningTime:
+            return YearOverYearStory(yearOverYearListeningTime: data.yearOverYearListeningTime)
         case .epilogue:
             return EpilogueStory()
         }

--- a/podcasts/End of Year/Stories/EndOfYearStoriesDataSource.swift
+++ b/podcasts/End of Year/Stories/EndOfYearStoriesDataSource.swift
@@ -27,7 +27,7 @@ class EndOfYearStoriesDataSource: StoriesDataSource {
         case .longestEpisode:
             return LongestEpisodeStory(episode: data.longestEpisode, podcast: data.longestEpisodePodcast)
         case .yearOverYearListeningTime:
-            return YearOverYearStory(yearOverYearListeningTime: data.yearOverYearListeningTime)
+            return YearOverYearStory(data: data.yearOverYearListeningTime)
         case .epilogue:
             return EpilogueStory()
         }

--- a/podcasts/End of Year/Stories/YearOverYearStory.swift
+++ b/podcasts/End of Year/Stories/YearOverYearStory.swift
@@ -86,7 +86,7 @@ struct YearOverYearStory: ShareableStory {
                                 .font(.custom("DM Sans", size: geometry.size.height * 0.09).weight(.medium))
                                 .foregroundColor(.white)
 
-                                Text("10 days 2 hours")
+                                Text(yearOverYearListeningTime.totalPlayedTimeLastYear.storyTimeDescription)
                                 .font(.custom("DM Sans", size: geometry.size.height * 0.018).weight(.semibold))
                                 .foregroundColor(.white)
                             }
@@ -133,7 +133,7 @@ struct YearOverYearStory: ShareableStory {
                                 .font(.custom("DM Sans", size: geometry.size.height * 0.09).weight(.medium))
                                 .foregroundColor(.white)
 
-                                Text("10 days 2 hours")
+                                Text(yearOverYearListeningTime.totalPlayedTimeThisYear.storyTimeDescription)
                                 .font(.custom("DM Sans", size: geometry.size.height * 0.018).weight(.semibold))
                                 .foregroundColor(.white)
                             }

--- a/podcasts/End of Year/Stories/YearOverYearStory.swift
+++ b/podcasts/End of Year/Stories/YearOverYearStory.swift
@@ -7,7 +7,7 @@ struct YearOverYearStory: ShareableStory {
 
     let identifier: String = "year_over_year"
 
-    let listeningPercentage = 10.3
+    let listeningPercentage = 7.5
 
     var title: String {
         switch listeningPercentage {
@@ -16,7 +16,7 @@ struct YearOverYearStory: ShareableStory {
         case _ where listeningPercentage < 0:
             return L10n.eoyYearOverYearTitleWentDown
         default:
-            return L10n.eoyYearOverYearTitleFlat("\(listeningPercentage)%")
+            return L10n.eoyYearOverYearTitleFlat
         }
     }
 
@@ -35,24 +35,87 @@ struct YearOverYearStory: ShareableStory {
         GeometryReader { geometry in
             PodcastCoverContainer(geometry: geometry) {
                 StoryLabelContainer(geometry: geometry) {
+                    SubscriptionBadge(tier: .plus, displayMode: .gradient, foregroundColor: .black)
                     StoryLabel(title, for: .title, geometry: geometry)
                     StoryLabel(subtitle, for: .subtitle, color: Color(hex: "8F97A4"), geometry: geometry)
                 }
+                .padding(.bottom, geometry.size.height * 0.06)
 
                 Spacer()
 
-                Rectangle()
-                    .frame(height: geometry.size.height * 0.1)
-                    .opacity(0)
-            }
-            .background(
                 ZStack(alignment: .bottom) {
-                    Color.black
+                    HStack(spacing: 0) {
+                        ZStack(alignment: .top) {
+                            Rectangle()
+                                .foregroundColor(.clear)
+                                .background(
+                                    LinearGradient(
+                                    stops: [
+                                    Gradient.Stop(color: Color(red: 0.31, green: 0.31, blue: 0.31), location: 0.00),
+                                    Gradient.Stop(color: .black.opacity(0), location: 1.00),
+                                    ],
+                                    startPoint: UnitPoint(x: 0.5, y: 0),
+                                    endPoint: UnitPoint(x: 0.5, y: 1)
+                                    )
+                                )
 
-                    StoryGradient()
-                    .offset(x: -geometry.size.width * 0.8, y: geometry.size.height * 0.25)
+                            VStack(alignment: .leading) {
+                                Text("2022")
+                                .font(.custom("DM Sans", size: geometry.size.height * 0.09).weight(.medium))
+                                .foregroundColor(.white)
+
+                                Text("10 days 2 hours")
+                                .font(.custom("DM Sans", size: geometry.size.height * 0.018).weight(.semibold))
+                                .foregroundColor(.white)
+                            }
+                            .opacity(0.5)
+                        }
+
+                        ZStack(alignment: .top) {
+                            Rectangle()
+                                .foregroundColor(.clear)
+                                .background(
+                                    LinearGradient(
+                                    stops: [
+                                    Gradient.Stop(color: Color(red: 0.25, green: 0.11, blue: 0.92), location: 0.00),
+                                    Gradient.Stop(color: Color(red: 0.68, green: 0.89, blue: 0.86), location: 0.24),
+                                    Gradient.Stop(color: Color(red: 0.87, green: 0.91, blue: 0.53), location: 0.50),
+                                    Gradient.Stop(color: Color(red: 0.91, green: 0.35, blue: 0.26), location: 0.74),
+                                    Gradient.Stop(color: Color(red: 0.1, green: 0.1, blue: 0.1), location: 1.00),
+                                    ],
+                                    startPoint: UnitPoint(x: 0.8, y: 1.27),
+                                    endPoint: UnitPoint(x: 0.76, y: -0.44)
+                                    )
+                                )
+
+                            VStack(alignment: .leading) {
+                                Text("2023")
+                                .font(.custom("DM Sans", size: geometry.size.height * 0.09).weight(.medium))
+                                .foregroundColor(.white)
+
+                                Text("10 days 2 hours")
+                                .font(.custom("DM Sans", size: geometry.size.height * 0.018).weight(.semibold))
+                                .foregroundColor(.white)
+                            }
+                        }
+                    }
+
+                    Rectangle()
+                      .foregroundColor(.clear)
+                      .frame(width: 393, height: geometry.size.height * 0.35)
+                      .background(
+                        LinearGradient(
+                          stops: [
+                            Gradient.Stop(color: .black.opacity(0), location: 0.00),
+                            Gradient.Stop(color: .black, location: 1.00),
+                          ],
+                          startPoint: UnitPoint(x: 0.5, y: 0.05),
+                          endPoint: UnitPoint(x: 0.5, y: 0.89)
+                        )
+                      )
                 }
-            )
+            }
+            .background(.black)
         }
     }
 

--- a/podcasts/End of Year/Stories/YearOverYearStory.swift
+++ b/podcasts/End of Year/Stories/YearOverYearStory.swift
@@ -75,98 +75,20 @@ struct YearOverYearStory: ShareableStory {
 
                     GeometryReader { proxy in
                         HStack(alignment: .bottom, spacing: 0) {
-                            ZStack(alignment: .top) {
-                                Rectangle()
-                                    .foregroundColor(.clear)
-                                    .background(
-                                        VStack {
-                                            Spacer()
-                                            Rectangle()
-                                              .foregroundColor(.clear)
-                                              .frame(height: geometry.size.height * 0.35)
-                                              .background(
-                                                LinearGradient(
-                                                  stops: [
-                                                    Gradient.Stop(color: .black.opacity(0), location: 0.00),
-                                                    Gradient.Stop(color: .black, location: 1.00),
-                                                  ],
-                                                  startPoint: UnitPoint(x: 0.5, y: 0.05),
-                                                  endPoint: UnitPoint(x: 0.5, y: 0.89)
-                                                )
-                                              )
-                                        }
-                                    )
-                                    .background(
-                                        LinearGradient(
-                                        stops: [
-                                        Gradient.Stop(color: Color(red: 0.31, green: 0.31, blue: 0.31), location: 0.00),
-                                        Gradient.Stop(color: .black.opacity(0), location: 1.00),
-                                        ],
-                                        startPoint: UnitPoint(x: 0.5, y: 0),
-                                        endPoint: UnitPoint(x: 0.5, y: 1)
-                                        )
-                                    )
-
-                                VStack(alignment: .leading) {
-                                    Text("2022")
-                                    .font(.custom("DM Sans", size: geometry.size.height * 0.09).weight(.medium))
-                                    .foregroundColor(.white)
-
-                                    Text(yearOverYearListeningTime.totalPlayedTimeLastYear.storyTimeDescription)
-                                    .font(.custom("DM Sans", size: geometry.size.height * 0.018).weight(.semibold))
-                                    .padding(.top, -geometry.size.height * 0.08)
-                                    .foregroundColor(.white)
-                                }
-                                .opacity(0.5)
-                            }
+                            bar(
+                                title: "2022",
+                                subtitle: yearOverYearListeningTime.totalPlayedTimeLastYear.storyTimeDescription,
+                                geometry: geometry,
+                                barStyle: .grey
+                            )
                             .frame(height: leftBarPercentageSize * proxy.size.height)
 
-                            ZStack(alignment: .top) {
-                                Rectangle()
-                                    .foregroundColor(.clear)
-                                    .background(
-                                        VStack {
-                                            Spacer()
-                                            Rectangle()
-                                              .foregroundColor(.clear)
-                                              .frame(height: geometry.size.height * 0.35)
-                                              .background(
-                                                LinearGradient(
-                                                  stops: [
-                                                    Gradient.Stop(color: .black.opacity(0), location: 0.00),
-                                                    Gradient.Stop(color: .black, location: 1.00),
-                                                  ],
-                                                  startPoint: UnitPoint(x: 0.5, y: 0.05),
-                                                  endPoint: UnitPoint(x: 0.5, y: 0.89)
-                                                )
-                                              )
-                                        }
-                                    )
-                                    .background(
-                                        LinearGradient(
-                                        stops: [
-                                        Gradient.Stop(color: Color(red: 0.25, green: 0.11, blue: 0.92), location: 0.00),
-                                        Gradient.Stop(color: Color(red: 0.68, green: 0.89, blue: 0.86), location: 0.24),
-                                        Gradient.Stop(color: Color(red: 0.87, green: 0.91, blue: 0.53), location: 0.50),
-                                        Gradient.Stop(color: Color(red: 0.91, green: 0.35, blue: 0.26), location: 0.74),
-                                        Gradient.Stop(color: Color(red: 0.1, green: 0.1, blue: 0.1), location: 1.00),
-                                        ],
-                                        startPoint: UnitPoint(x: 0.8, y: 1.27),
-                                        endPoint: UnitPoint(x: 0.76, y: -0.44)
-                                        )
-                                    )
-
-                                VStack(alignment: .leading) {
-                                    Text("2023")
-                                    .font(.custom("DM Sans", size: geometry.size.height * 0.09).weight(.medium))
-                                    .foregroundColor(.white)
-
-                                    Text(yearOverYearListeningTime.totalPlayedTimeThisYear.storyTimeDescription)
-                                    .font(.custom("DM Sans", size: geometry.size.height * 0.018).weight(.semibold))
-                                    .padding(.top, -geometry.size.height * 0.08)
-                                    .foregroundColor(.white)
-                                }
-                            }
+                            bar(
+                                title: "2023",
+                                subtitle: yearOverYearListeningTime.totalPlayedTimeThisYear.storyTimeDescription,
+                                geometry: geometry,
+                                barStyle: .rainbow
+                            )
                             .frame(height: rightBarPercentageSize * proxy.size.height)
 
                         }
@@ -176,6 +98,78 @@ struct YearOverYearStory: ShareableStory {
             }
             .background(.black)
         }
+    }
+
+    private func bar(title: String, subtitle: String, geometry: GeometryProxy, barStyle: BarStyle) -> some View {
+        ZStack(alignment: .top) {
+            Rectangle()
+                .foregroundColor(.clear)
+                .background(
+                    VStack {
+                        Spacer()
+                        Rectangle()
+                          .foregroundColor(.clear)
+                          .frame(height: geometry.size.height * 0.35)
+                          .background(
+                            LinearGradient(
+                              stops: [
+                                Gradient.Stop(color: .black.opacity(0), location: 0.00),
+                                Gradient.Stop(color: .black, location: 1.00),
+                              ],
+                              startPoint: UnitPoint(x: 0.5, y: 0.05),
+                              endPoint: UnitPoint(x: 0.5, y: 0.89)
+                            )
+                          )
+                    }
+                )
+                .background(
+                    gradient(for: barStyle)
+                )
+
+            VStack(alignment: .leading) {
+                Text(title)
+                .font(.custom("DM Sans", size: geometry.size.height * 0.09).weight(.medium))
+                .foregroundColor(.white)
+
+                Text(subtitle)
+                .font(.custom("DM Sans", size: geometry.size.height * 0.018).weight(.semibold))
+                .padding(.top, -geometry.size.height * 0.08)
+                .foregroundColor(.white)
+            }
+            .opacity(barStyle == .grey ? 0.5 : 1)
+        }
+    }
+
+    @ViewBuilder
+    private func gradient(for barStyle: BarStyle) -> some View {
+        switch barStyle {
+        case .grey:
+            LinearGradient(
+                stops: [
+                    Gradient.Stop(color: Color(red: 0.31, green: 0.31, blue: 0.31), location: 0.00),
+                    Gradient.Stop(color: .black.opacity(0), location: 1.00),
+                ],
+                startPoint: UnitPoint(x: 0.5, y: 0),
+                endPoint: UnitPoint(x: 0.5, y: 1)
+            )
+        case .rainbow:
+            LinearGradient(
+                stops: [
+                    Gradient.Stop(color: Color(red: 0.25, green: 0.11, blue: 0.92), location: 0.00),
+                    Gradient.Stop(color: Color(red: 0.68, green: 0.89, blue: 0.86), location: 0.24),
+                    Gradient.Stop(color: Color(red: 0.87, green: 0.91, blue: 0.53), location: 0.50),
+                    Gradient.Stop(color: Color(red: 0.91, green: 0.35, blue: 0.26), location: 0.74),
+                    Gradient.Stop(color: Color(red: 0.1, green: 0.1, blue: 0.1), location: 1.00),
+                ],
+                startPoint: UnitPoint(x: 0.8, y: 1.27),
+                endPoint: UnitPoint(x: 0.76, y: -0.44)
+            )
+        }
+    }
+
+    private enum BarStyle {
+        case grey
+        case rainbow
     }
 
     func onAppear() {

--- a/podcasts/End of Year/Stories/YearOverYearStory.swift
+++ b/podcasts/End of Year/Stories/YearOverYearStory.swift
@@ -7,14 +7,15 @@ struct YearOverYearStory: ShareableStory {
 
     let identifier: String = "year_over_year"
 
-    let listeningPercentage = 7.5
+    let yearOverYearListeningTime: YearOverYearListeningTime
 
     let subscriptionTier: SubscriptionTier = .plus
 
     var title: String {
+        let listeningPercentage = yearOverYearListeningTime.percentage
         switch listeningPercentage {
         case _ where listeningPercentage > 10:
-            return L10n.eoyYearOverYearTitleWentUp("\(listeningPercentage)%")
+            return L10n.eoyYearOverYearTitleWentUp("\(listeningPercentage.clean)%")
         case _ where listeningPercentage < 0:
             return L10n.eoyYearOverYearTitleWentDown
         default:
@@ -23,6 +24,7 @@ struct YearOverYearStory: ShareableStory {
     }
 
     var subtitle: String {
+        let listeningPercentage = yearOverYearListeningTime.percentage
         switch listeningPercentage {
         case _ where listeningPercentage > 10:
             return L10n.eoyYearOverYearSubtitleWentUp
@@ -137,8 +139,14 @@ struct YearOverYearStory: ShareableStory {
     }
 }
 
+private extension Double {
+    var clean: String {
+       return self.truncatingRemainder(dividingBy: 1) == 0 ? String(format: "%.0f", self) : String(self)
+    }
+}
+
 struct YearOverYearStory_Previews: PreviewProvider {
     static var previews: some View {
-        YearOverYearStory()
+        YearOverYearStory(yearOverYearListeningTime: YearOverYearListeningTime(totalPlayedTimeThisYear: 200, totalPlayedTimeLastYear: 100))
     }
 }

--- a/podcasts/End of Year/Stories/YearOverYearStory.swift
+++ b/podcasts/End of Year/Stories/YearOverYearStory.swift
@@ -7,12 +7,12 @@ struct YearOverYearStory: ShareableStory {
 
     let identifier: String = "year_over_year"
 
-    let yearOverYearListeningTime: YearOverYearListeningTime
+    let data: YearOverYearListeningTime
 
     let subscriptionTier: SubscriptionTier = SubscriptionHelper.subscriptionTier
 
     var title: String {
-        let listeningPercentage = yearOverYearListeningTime.percentage
+        let listeningPercentage = data.percentage
         switch listeningPercentage {
         case _ where listeningPercentage == .infinity:
             return L10n.eoyYearOverYearTitleSkyrocketed
@@ -26,7 +26,7 @@ struct YearOverYearStory: ShareableStory {
     }
 
     var subtitle: String {
-        let listeningPercentage = yearOverYearListeningTime.percentage
+        let listeningPercentage = data.percentage
         switch listeningPercentage {
         case _ where listeningPercentage > 10:
             return L10n.eoyYearOverYearSubtitleWentUp
@@ -38,20 +38,20 @@ struct YearOverYearStory: ShareableStory {
     }
 
     var leftBarPercentageSize: Double {
-        let percentage = yearOverYearListeningTime.percentage
+        let percentage = data.percentage
         if percentage == .infinity {
             return 0.2
         } else if percentage > 0 {
-            return max(yearOverYearListeningTime.totalPlayedTimeLastYear / yearOverYearListeningTime.totalPlayedTimeThisYear, minimumBarPercentage)
+            return max(data.totalPlayedTimeLastYear / data.totalPlayedTimeThisYear, minimumBarPercentage)
         }
 
         return 1
     }
 
     var rightBarPercentageSize: Double {
-        let percentage = yearOverYearListeningTime.percentage
+        let percentage = data.percentage
         if percentage < 0 {
-            return max(yearOverYearListeningTime.totalPlayedTimeThisYear / yearOverYearListeningTime.totalPlayedTimeLastYear, minimumBarPercentage)
+            return max(data.totalPlayedTimeThisYear / data.totalPlayedTimeLastYear, minimumBarPercentage)
         }
 
         return 1
@@ -77,7 +77,7 @@ struct YearOverYearStory: ShareableStory {
                         HStack(alignment: .bottom, spacing: 0) {
                             bar(
                                 title: "2022",
-                                subtitle: yearOverYearListeningTime.totalPlayedTimeLastYear.storyTimeDescription,
+                                subtitle: data.totalPlayedTimeLastYear.storyTimeDescription,
                                 geometry: geometry,
                                 barStyle: .grey
                             )
@@ -85,7 +85,7 @@ struct YearOverYearStory: ShareableStory {
 
                             bar(
                                 title: "2023",
-                                subtitle: yearOverYearListeningTime.totalPlayedTimeThisYear.storyTimeDescription,
+                                subtitle: data.totalPlayedTimeThisYear.storyTimeDescription,
                                 geometry: geometry,
                                 barStyle: .rainbow
                             )
@@ -196,16 +196,16 @@ private extension Double {
 
 struct YearOverYearStory_Previews: PreviewProvider {
     static var previews: some View {
-        YearOverYearStory(yearOverYearListeningTime: YearOverYearListeningTime(totalPlayedTimeThisYear: 200, totalPlayedTimeLastYear: 400))
+        YearOverYearStory(data: YearOverYearListeningTime(totalPlayedTimeThisYear: 200, totalPlayedTimeLastYear: 400))
             .previewDisplayName("Went down")
 
-        YearOverYearStory(yearOverYearListeningTime: YearOverYearListeningTime(totalPlayedTimeThisYear: 200, totalPlayedTimeLastYear: 130))
+        YearOverYearStory(data: YearOverYearListeningTime(totalPlayedTimeThisYear: 200, totalPlayedTimeLastYear: 130))
             .previewDisplayName("Went up")
 
-        YearOverYearStory(yearOverYearListeningTime: YearOverYearListeningTime(totalPlayedTimeThisYear: 140, totalPlayedTimeLastYear: 130))
+        YearOverYearStory(data: YearOverYearListeningTime(totalPlayedTimeThisYear: 140, totalPlayedTimeLastYear: 130))
             .previewDisplayName("Stayed same")
 
-        YearOverYearStory(yearOverYearListeningTime: YearOverYearListeningTime(totalPlayedTimeThisYear: 140, totalPlayedTimeLastYear: 0))
+        YearOverYearStory(data: YearOverYearListeningTime(totalPlayedTimeThisYear: 140, totalPlayedTimeLastYear: 0))
             .previewDisplayName("No listening time for past year")
     }
 }

--- a/podcasts/End of Year/Stories/YearOverYearStory.swift
+++ b/podcasts/End of Year/Stories/YearOverYearStory.swift
@@ -7,7 +7,7 @@ struct YearOverYearStory: ShareableStory {
 
     let identifier: String = "year_over_year"
 
-    let data: YearOverYearListeningTime
+    var data: YearOverYearListeningTime
 
     let subscriptionTier: SubscriptionTier = SubscriptionHelper.subscriptionTier
 

--- a/podcasts/End of Year/Stories/YearOverYearStory.swift
+++ b/podcasts/End of Year/Stories/YearOverYearStory.swift
@@ -1,0 +1,79 @@
+import SwiftUI
+import PocketCastsServer
+import PocketCastsDataModel
+
+struct YearOverYearStory: ShareableStory {
+    var duration: TimeInterval = 5.seconds
+
+    let identifier: String = "year_over_year"
+
+    let listeningPercentage = 10.3
+
+    var title: String {
+        switch listeningPercentage {
+        case _ where listeningPercentage > 10:
+            return L10n.eoyYearOverYearTitleWentUp("\(listeningPercentage)%")
+        case _ where listeningPercentage < 0:
+            return L10n.eoyYearOverYearTitleWentDown
+        default:
+            return L10n.eoyYearOverYearTitleFlat("\(listeningPercentage)%")
+        }
+    }
+
+    var subtitle: String {
+        switch listeningPercentage {
+        case _ where listeningPercentage > 10:
+            return L10n.eoyYearOverYearSubtitleWentUp
+        case _ where listeningPercentage < 0:
+            return L10n.eoyYearOverYearSubtitleWentDown
+        default:
+            return L10n.eoyYearOverYearSubtitleFlat
+        }
+    }
+
+    var body: some View {
+        GeometryReader { geometry in
+            PodcastCoverContainer(geometry: geometry) {
+                StoryLabelContainer(geometry: geometry) {
+                    StoryLabel(title, for: .title, geometry: geometry)
+                    StoryLabel(subtitle, for: .subtitle, color: Color(hex: "8F97A4"), geometry: geometry)
+                }
+
+                Spacer()
+
+                Rectangle()
+                    .frame(height: geometry.size.height * 0.1)
+                    .opacity(0)
+            }
+            .background(
+                ZStack(alignment: .bottom) {
+                    Color.black
+
+                    StoryGradient()
+                    .offset(x: -geometry.size.width * 0.8, y: geometry.size.height * 0.25)
+                }
+            )
+        }
+    }
+
+    func onAppear() {
+        Analytics.track(.endOfYearStoryShown, story: identifier)
+    }
+
+    func willShare() {
+        Analytics.track(.endOfYearStoryShare, story: identifier)
+    }
+
+    func sharingAssets() -> [Any] {
+        [
+            StoryShareableProvider.new(AnyView(self)),
+            StoryShareableText("Shareable text")
+        ]
+    }
+}
+
+struct YearOverYearStory_Previews: PreviewProvider {
+    static var previews: some View {
+        YearOverYearStory()
+    }
+}

--- a/podcasts/End of Year/Stories/YearOverYearStory.swift
+++ b/podcasts/End of Year/Stories/YearOverYearStory.swift
@@ -14,6 +14,8 @@ struct YearOverYearStory: ShareableStory {
     var title: String {
         let listeningPercentage = yearOverYearListeningTime.percentage
         switch listeningPercentage {
+        case _ where listeningPercentage == .infinity:
+            return L10n.eoyYearOverYearTitleSkyrocketed
         case _ where listeningPercentage > 10:
             return L10n.eoyYearOverYearTitleWentUp("\(listeningPercentage.clean)%")
         case _ where listeningPercentage < 0:
@@ -199,5 +201,15 @@ private extension Double {
 struct YearOverYearStory_Previews: PreviewProvider {
     static var previews: some View {
         YearOverYearStory(yearOverYearListeningTime: YearOverYearListeningTime(totalPlayedTimeThisYear: 200, totalPlayedTimeLastYear: 400))
+            .previewDisplayName("Went down")
+
+        YearOverYearStory(yearOverYearListeningTime: YearOverYearListeningTime(totalPlayedTimeThisYear: 200, totalPlayedTimeLastYear: 130))
+            .previewDisplayName("Went up")
+
+        YearOverYearStory(yearOverYearListeningTime: YearOverYearListeningTime(totalPlayedTimeThisYear: 140, totalPlayedTimeLastYear: 130))
+            .previewDisplayName("Stayed same")
+
+        YearOverYearStory(yearOverYearListeningTime: YearOverYearListeningTime(totalPlayedTimeThisYear: 140, totalPlayedTimeLastYear: 0))
+            .previewDisplayName("No listening time for past year")
     }
 }

--- a/podcasts/End of Year/Stories/YearOverYearStory.swift
+++ b/podcasts/End of Year/Stories/YearOverYearStory.swift
@@ -9,6 +9,8 @@ struct YearOverYearStory: ShareableStory {
 
     let listeningPercentage = 7.5
 
+    let subscriptionTier: SubscriptionTier = .plus
+
     var title: String {
         switch listeningPercentage {
         case _ where listeningPercentage > 10:
@@ -35,7 +37,7 @@ struct YearOverYearStory: ShareableStory {
         GeometryReader { geometry in
             PodcastCoverContainer(geometry: geometry) {
                 StoryLabelContainer(geometry: geometry) {
-                    SubscriptionBadge(tier: .plus, displayMode: .gradient, foregroundColor: .black)
+                    SubscriptionBadge(tier: subscriptionTier, displayMode: .gradient, foregroundColor: .black)
                     StoryLabel(title, for: .title, geometry: geometry)
                     StoryLabel(subtitle, for: .subtitle, color: Color(hex: "8F97A4"), geometry: geometry)
                 }

--- a/podcasts/End of Year/Stories/YearOverYearStory.swift
+++ b/podcasts/End of Year/Stories/YearOverYearStory.swift
@@ -44,7 +44,7 @@ struct YearOverYearStory: ShareableStory {
                 Spacer()
 
                 ZStack(alignment: .bottom) {
-                    HStack(spacing: 0) {
+                    HStack(alignment: .bottom, spacing: 0) {
                         ZStack(alignment: .top) {
                             Rectangle()
                                 .foregroundColor(.clear)

--- a/podcasts/End of Year/Stories/YearOverYearStory.swift
+++ b/podcasts/End of Year/Stories/YearOverYearStory.swift
@@ -189,7 +189,7 @@ struct YearOverYearStory: ShareableStory {
     func sharingAssets() -> [Any] {
         [
             StoryShareableProvider.new(AnyView(self)),
-            StoryShareableText("Shareable text")
+            StoryShareableText(L10n.eoyYearOverShareText)
         ]
     }
 }

--- a/podcasts/End of Year/Stories/YearOverYearStory.swift
+++ b/podcasts/End of Year/Stories/YearOverYearStory.swift
@@ -35,6 +35,26 @@ struct YearOverYearStory: ShareableStory {
         }
     }
 
+    var leftBarPercentageSize: Double {
+        let percentage = yearOverYearListeningTime.percentage
+        if percentage == .infinity {
+            return 0.2
+        } else if percentage > 0 {
+            return max(yearOverYearListeningTime.totalPlayedTimeLastYear / yearOverYearListeningTime.totalPlayedTimeThisYear, 0.35)
+        }
+
+        return 1
+    }
+
+    var rightBarPercentageSize: Double {
+        let percentage = yearOverYearListeningTime.percentage
+        if percentage < 0 {
+            return max(yearOverYearListeningTime.totalPlayedTimeThisYear / yearOverYearListeningTime.totalPlayedTimeLastYear, 0.35)
+        }
+
+        return 1
+    }
+
     var body: some View {
         GeometryReader { geometry in
             PodcastCoverContainer(geometry: geometry) {
@@ -48,98 +68,104 @@ struct YearOverYearStory: ShareableStory {
                 Spacer()
 
                 ZStack(alignment: .bottom) {
-                    HStack(alignment: .bottom, spacing: 0) {
-                        ZStack(alignment: .top) {
-                            Rectangle()
-                                .foregroundColor(.clear)
-                                .background(
-                                    VStack {
-                                        Spacer()
-                                        Rectangle()
-                                          .foregroundColor(.clear)
-                                          .frame(height: geometry.size.height * 0.35)
-                                          .background(
-                                            LinearGradient(
-                                              stops: [
-                                                Gradient.Stop(color: .black.opacity(0), location: 0.00),
-                                                Gradient.Stop(color: .black, location: 1.00),
-                                              ],
-                                              startPoint: UnitPoint(x: 0.5, y: 0.05),
-                                              endPoint: UnitPoint(x: 0.5, y: 0.89)
-                                            )
-                                          )
-                                    }
-                                )
-                                .background(
-                                    LinearGradient(
-                                    stops: [
-                                    Gradient.Stop(color: Color(red: 0.31, green: 0.31, blue: 0.31), location: 0.00),
-                                    Gradient.Stop(color: .black.opacity(0), location: 1.00),
-                                    ],
-                                    startPoint: UnitPoint(x: 0.5, y: 0),
-                                    endPoint: UnitPoint(x: 0.5, y: 1)
+
+                    GeometryReader { proxy in
+                        HStack(alignment: .bottom, spacing: 0) {
+                            ZStack(alignment: .top) {
+                                Rectangle()
+                                    .foregroundColor(.clear)
+                                    .background(
+                                        VStack {
+                                            Spacer()
+                                            Rectangle()
+                                              .foregroundColor(.clear)
+                                              .frame(height: geometry.size.height * 0.35)
+                                              .background(
+                                                LinearGradient(
+                                                  stops: [
+                                                    Gradient.Stop(color: .black.opacity(0), location: 0.00),
+                                                    Gradient.Stop(color: .black, location: 1.00),
+                                                  ],
+                                                  startPoint: UnitPoint(x: 0.5, y: 0.05),
+                                                  endPoint: UnitPoint(x: 0.5, y: 0.89)
+                                                )
+                                              )
+                                        }
                                     )
-                                )
-
-                            VStack(alignment: .leading) {
-                                Text("2022")
-                                .font(.custom("DM Sans", size: geometry.size.height * 0.09).weight(.medium))
-                                .foregroundColor(.white)
-
-                                Text(yearOverYearListeningTime.totalPlayedTimeLastYear.storyTimeDescription)
-                                .font(.custom("DM Sans", size: geometry.size.height * 0.018).weight(.semibold))
-                                .foregroundColor(.white)
-                            }
-                            .opacity(0.5)
-                        }
-
-                        ZStack(alignment: .top) {
-                            Rectangle()
-                                .foregroundColor(.clear)
-                                .background(
-                                    VStack {
-                                        Spacer()
-                                        Rectangle()
-                                          .foregroundColor(.clear)
-                                          .frame(height: geometry.size.height * 0.35)
-                                          .background(
-                                            LinearGradient(
-                                              stops: [
-                                                Gradient.Stop(color: .black.opacity(0), location: 0.00),
-                                                Gradient.Stop(color: .black, location: 1.00),
-                                              ],
-                                              startPoint: UnitPoint(x: 0.5, y: 0.05),
-                                              endPoint: UnitPoint(x: 0.5, y: 0.89)
-                                            )
-                                          )
-                                    }
-                                )
-                                .background(
-                                    LinearGradient(
-                                    stops: [
-                                    Gradient.Stop(color: Color(red: 0.25, green: 0.11, blue: 0.92), location: 0.00),
-                                    Gradient.Stop(color: Color(red: 0.68, green: 0.89, blue: 0.86), location: 0.24),
-                                    Gradient.Stop(color: Color(red: 0.87, green: 0.91, blue: 0.53), location: 0.50),
-                                    Gradient.Stop(color: Color(red: 0.91, green: 0.35, blue: 0.26), location: 0.74),
-                                    Gradient.Stop(color: Color(red: 0.1, green: 0.1, blue: 0.1), location: 1.00),
-                                    ],
-                                    startPoint: UnitPoint(x: 0.8, y: 1.27),
-                                    endPoint: UnitPoint(x: 0.76, y: -0.44)
+                                    .background(
+                                        LinearGradient(
+                                        stops: [
+                                        Gradient.Stop(color: Color(red: 0.31, green: 0.31, blue: 0.31), location: 0.00),
+                                        Gradient.Stop(color: .black.opacity(0), location: 1.00),
+                                        ],
+                                        startPoint: UnitPoint(x: 0.5, y: 0),
+                                        endPoint: UnitPoint(x: 0.5, y: 1)
+                                        )
                                     )
-                                )
 
-                            VStack(alignment: .leading) {
-                                Text("2023")
-                                .font(.custom("DM Sans", size: geometry.size.height * 0.09).weight(.medium))
-                                .foregroundColor(.white)
+                                VStack(alignment: .leading) {
+                                    Text("2022")
+                                    .font(.custom("DM Sans", size: geometry.size.height * 0.09).weight(.medium))
+                                    .foregroundColor(.white)
 
-                                Text(yearOverYearListeningTime.totalPlayedTimeThisYear.storyTimeDescription)
-                                .font(.custom("DM Sans", size: geometry.size.height * 0.018).weight(.semibold))
-                                .foregroundColor(.white)
+                                    Text(yearOverYearListeningTime.totalPlayedTimeLastYear.storyTimeDescription)
+                                    .font(.custom("DM Sans", size: geometry.size.height * 0.018).weight(.semibold))
+                                    .foregroundColor(.white)
+                                }
+                                .opacity(0.5)
                             }
-                        }
+                            .frame(height: leftBarPercentageSize * proxy.size.height)
 
+                            ZStack(alignment: .top) {
+                                Rectangle()
+                                    .foregroundColor(.clear)
+                                    .background(
+                                        VStack {
+                                            Spacer()
+                                            Rectangle()
+                                              .foregroundColor(.clear)
+                                              .frame(height: geometry.size.height * 0.35)
+                                              .background(
+                                                LinearGradient(
+                                                  stops: [
+                                                    Gradient.Stop(color: .black.opacity(0), location: 0.00),
+                                                    Gradient.Stop(color: .black, location: 1.00),
+                                                  ],
+                                                  startPoint: UnitPoint(x: 0.5, y: 0.05),
+                                                  endPoint: UnitPoint(x: 0.5, y: 0.89)
+                                                )
+                                              )
+                                        }
+                                    )
+                                    .background(
+                                        LinearGradient(
+                                        stops: [
+                                        Gradient.Stop(color: Color(red: 0.25, green: 0.11, blue: 0.92), location: 0.00),
+                                        Gradient.Stop(color: Color(red: 0.68, green: 0.89, blue: 0.86), location: 0.24),
+                                        Gradient.Stop(color: Color(red: 0.87, green: 0.91, blue: 0.53), location: 0.50),
+                                        Gradient.Stop(color: Color(red: 0.91, green: 0.35, blue: 0.26), location: 0.74),
+                                        Gradient.Stop(color: Color(red: 0.1, green: 0.1, blue: 0.1), location: 1.00),
+                                        ],
+                                        startPoint: UnitPoint(x: 0.8, y: 1.27),
+                                        endPoint: UnitPoint(x: 0.76, y: -0.44)
+                                        )
+                                    )
+
+                                VStack(alignment: .leading) {
+                                    Text("2023")
+                                    .font(.custom("DM Sans", size: geometry.size.height * 0.09).weight(.medium))
+                                    .foregroundColor(.white)
+
+                                    Text(yearOverYearListeningTime.totalPlayedTimeThisYear.storyTimeDescription)
+                                    .font(.custom("DM Sans", size: geometry.size.height * 0.018).weight(.semibold))
+                                    .foregroundColor(.white)
+                                }
+                            }
+                            .frame(height: rightBarPercentageSize * proxy.size.height)
+
+                        }
                     }
+
                 }
             }
             .background(.black)
@@ -170,6 +196,6 @@ private extension Double {
 
 struct YearOverYearStory_Previews: PreviewProvider {
     static var previews: some View {
-        YearOverYearStory(yearOverYearListeningTime: YearOverYearListeningTime(totalPlayedTimeThisYear: 200, totalPlayedTimeLastYear: 100))
+        YearOverYearStory(yearOverYearListeningTime: YearOverYearListeningTime(totalPlayedTimeThisYear: 200, totalPlayedTimeLastYear: 400))
     }
 }

--- a/podcasts/End of Year/Stories/YearOverYearStory.swift
+++ b/podcasts/End of Year/Stories/YearOverYearStory.swift
@@ -9,7 +9,7 @@ struct YearOverYearStory: ShareableStory {
 
     let yearOverYearListeningTime: YearOverYearListeningTime
 
-    let subscriptionTier: SubscriptionTier = .plus
+    let subscriptionTier: SubscriptionTier = SubscriptionHelper.subscriptionTier
 
     var title: String {
         let listeningPercentage = yearOverYearListeningTime.percentage

--- a/podcasts/End of Year/Stories/YearOverYearStory.swift
+++ b/podcasts/End of Year/Stories/YearOverYearStory.swift
@@ -53,6 +53,24 @@ struct YearOverYearStory: ShareableStory {
                             Rectangle()
                                 .foregroundColor(.clear)
                                 .background(
+                                    VStack {
+                                        Spacer()
+                                        Rectangle()
+                                          .foregroundColor(.clear)
+                                          .frame(height: geometry.size.height * 0.35)
+                                          .background(
+                                            LinearGradient(
+                                              stops: [
+                                                Gradient.Stop(color: .black.opacity(0), location: 0.00),
+                                                Gradient.Stop(color: .black, location: 1.00),
+                                              ],
+                                              startPoint: UnitPoint(x: 0.5, y: 0.05),
+                                              endPoint: UnitPoint(x: 0.5, y: 0.89)
+                                            )
+                                          )
+                                    }
+                                )
+                                .background(
                                     LinearGradient(
                                     stops: [
                                     Gradient.Stop(color: Color(red: 0.31, green: 0.31, blue: 0.31), location: 0.00),
@@ -79,6 +97,24 @@ struct YearOverYearStory: ShareableStory {
                             Rectangle()
                                 .foregroundColor(.clear)
                                 .background(
+                                    VStack {
+                                        Spacer()
+                                        Rectangle()
+                                          .foregroundColor(.clear)
+                                          .frame(height: geometry.size.height * 0.35)
+                                          .background(
+                                            LinearGradient(
+                                              stops: [
+                                                Gradient.Stop(color: .black.opacity(0), location: 0.00),
+                                                Gradient.Stop(color: .black, location: 1.00),
+                                              ],
+                                              startPoint: UnitPoint(x: 0.5, y: 0.05),
+                                              endPoint: UnitPoint(x: 0.5, y: 0.89)
+                                            )
+                                          )
+                                    }
+                                )
+                                .background(
                                     LinearGradient(
                                     stops: [
                                     Gradient.Stop(color: Color(red: 0.25, green: 0.11, blue: 0.92), location: 0.00),
@@ -102,21 +138,8 @@ struct YearOverYearStory: ShareableStory {
                                 .foregroundColor(.white)
                             }
                         }
-                    }
 
-                    Rectangle()
-                      .foregroundColor(.clear)
-                      .frame(width: 393, height: geometry.size.height * 0.35)
-                      .background(
-                        LinearGradient(
-                          stops: [
-                            Gradient.Stop(color: .black.opacity(0), location: 0.00),
-                            Gradient.Stop(color: .black, location: 1.00),
-                          ],
-                          startPoint: UnitPoint(x: 0.5, y: 0.05),
-                          endPoint: UnitPoint(x: 0.5, y: 0.89)
-                        )
-                      )
+                    }
                 }
             }
             .background(.black)

--- a/podcasts/End of Year/Stories/YearOverYearStory.swift
+++ b/podcasts/End of Year/Stories/YearOverYearStory.swift
@@ -42,7 +42,7 @@ struct YearOverYearStory: ShareableStory {
         if percentage == .infinity {
             return 0.2
         } else if percentage > 0 {
-            return max(yearOverYearListeningTime.totalPlayedTimeLastYear / yearOverYearListeningTime.totalPlayedTimeThisYear, 0.4)
+            return max(yearOverYearListeningTime.totalPlayedTimeLastYear / yearOverYearListeningTime.totalPlayedTimeThisYear, minimumBarPercentage)
         }
 
         return 1
@@ -51,11 +51,13 @@ struct YearOverYearStory: ShareableStory {
     var rightBarPercentageSize: Double {
         let percentage = yearOverYearListeningTime.percentage
         if percentage < 0 {
-            return max(yearOverYearListeningTime.totalPlayedTimeThisYear / yearOverYearListeningTime.totalPlayedTimeLastYear, 0.4)
+            return max(yearOverYearListeningTime.totalPlayedTimeThisYear / yearOverYearListeningTime.totalPlayedTimeLastYear, minimumBarPercentage)
         }
 
         return 1
     }
+
+    private let minimumBarPercentage: Double = 0.4
 
     var body: some View {
         GeometryReader { geometry in

--- a/podcasts/End of Year/Stories/YearOverYearStory.swift
+++ b/podcasts/End of Year/Stories/YearOverYearStory.swift
@@ -40,7 +40,7 @@ struct YearOverYearStory: ShareableStory {
         if percentage == .infinity {
             return 0.2
         } else if percentage > 0 {
-            return max(yearOverYearListeningTime.totalPlayedTimeLastYear / yearOverYearListeningTime.totalPlayedTimeThisYear, 0.35)
+            return max(yearOverYearListeningTime.totalPlayedTimeLastYear / yearOverYearListeningTime.totalPlayedTimeThisYear, 0.4)
         }
 
         return 1
@@ -49,7 +49,7 @@ struct YearOverYearStory: ShareableStory {
     var rightBarPercentageSize: Double {
         let percentage = yearOverYearListeningTime.percentage
         if percentage < 0 {
-            return max(yearOverYearListeningTime.totalPlayedTimeThisYear / yearOverYearListeningTime.totalPlayedTimeLastYear, 0.35)
+            return max(yearOverYearListeningTime.totalPlayedTimeThisYear / yearOverYearListeningTime.totalPlayedTimeLastYear, 0.4)
         }
 
         return 1
@@ -110,6 +110,7 @@ struct YearOverYearStory: ShareableStory {
 
                                     Text(yearOverYearListeningTime.totalPlayedTimeLastYear.storyTimeDescription)
                                     .font(.custom("DM Sans", size: geometry.size.height * 0.018).weight(.semibold))
+                                    .padding(.top, -geometry.size.height * 0.08)
                                     .foregroundColor(.white)
                                 }
                                 .opacity(0.5)
@@ -158,6 +159,7 @@ struct YearOverYearStory: ShareableStory {
 
                                     Text(yearOverYearListeningTime.totalPlayedTimeThisYear.storyTimeDescription)
                                     .font(.custom("DM Sans", size: geometry.size.height * 0.018).weight(.semibold))
+                                    .padding(.top, -geometry.size.height * 0.08)
                                     .foregroundColor(.white)
                                 }
                             }

--- a/podcasts/End of Year/Stories/YearOverYearStory.swift
+++ b/podcasts/End of Year/Stories/YearOverYearStory.swift
@@ -12,28 +12,26 @@ struct YearOverYearStory: ShareableStory {
     let subscriptionTier: SubscriptionTier = SubscriptionHelper.subscriptionTier
 
     var title: String {
-        let listeningPercentage = data.percentage
-        switch listeningPercentage {
-        case _ where listeningPercentage == .infinity:
-            return L10n.eoyYearOverYearTitleSkyrocketed
-        case _ where listeningPercentage > 10:
-            return L10n.eoyYearOverYearTitleWentUp("\(listeningPercentage.clean)%")
-        case _ where listeningPercentage < 0:
-            return L10n.eoyYearOverYearTitleWentDown
+        switch data.percentage {
+        case .infinity:
+            L10n.eoyYearOverYearTitleSkyrocketed
+        case 10...:
+            L10n.eoyYearOverYearTitleWentUp("\(data.percentage.clean)%")
+        case ...0:
+            L10n.eoyYearOverYearTitleWentDown
         default:
-            return L10n.eoyYearOverYearTitleFlat
+            L10n.eoyYearOverYearTitleFlat
         }
     }
 
     var subtitle: String {
-        let listeningPercentage = data.percentage
-        switch listeningPercentage {
-        case _ where listeningPercentage > 10:
-            return L10n.eoyYearOverYearSubtitleWentUp
-        case _ where listeningPercentage < 0:
-            return L10n.eoyYearOverYearSubtitleWentDown
+        switch data.percentage {
+        case 10...:
+            L10n.eoyYearOverYearSubtitleWentUp
+        case ...0:
+            L10n.eoyYearOverYearSubtitleWentDown
         default:
-            return L10n.eoyYearOverYearSubtitleFlat
+            L10n.eoyYearOverYearSubtitleFlat
         }
     }
 

--- a/podcasts/Profile - SwiftUI/Common Views/SubscriptionBadge.swift
+++ b/podcasts/Profile - SwiftUI/Common Views/SubscriptionBadge.swift
@@ -10,6 +10,7 @@ import PocketCastsServer
 struct SubscriptionBadge: View {
     let tier: SubscriptionTier
     var displayMode: DisplayMode = .black
+    var foregroundColor: Color? = nil
 
     /// The base of the font the label should use
     var fontSize: Double = 14
@@ -35,11 +36,11 @@ struct SubscriptionBadge: View {
                 .resizable()
                 .aspectRatio(contentMode: .fill)
                 .frame(width: 12, height: 12)
-                .foregroundColor(model.iconColor)
+                .foregroundColor(foregroundColor ?? model.iconColor)
 
             Text(model.label)
                 .font(size: fontSize, style: .subheadline, weight: .semibold)
-                .foregroundColor(.white)
+                .foregroundColor(foregroundColor ?? .white)
         }
         .padding(.horizontal, 10)
         .padding(.vertical, 6)

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -855,10 +855,8 @@ internal enum L10n {
   internal static var eoyYearOverYearSubtitleWentDown: String { return L10n.tr("Localizable", "eoy_year_over_year_subtitle_went_down") }
   /// Ready to top it in 2024?
   internal static var eoyYearOverYearSubtitleWentUp: String { return L10n.tr("Localizable", "eoy_year_over_year_subtitle_went_up") }
-  /// Compared to 2022, your listening time went up a whopping %1$@%
-  internal static func eoyYearOverYearTitleFlat(_ p1: Any) -> String {
-    return L10n.tr("Localizable", "eoy_year_over_year_title_flat", String(describing: p1))
-  }
+  /// Compared to 2022, your listening time stayed pretty consistent
+  internal static var eoyYearOverYearTitleFlat: String { return L10n.tr("Localizable", "eoy_year_over_year_title_flat") }
   /// Compared to 2022, your listening time went down a little
   internal static var eoyYearOverYearTitleWentDown: String { return L10n.tr("Localizable", "eoy_year_over_year_title_went_down") }
   /// Compared to 2022, your listening time went up a whopping %1$@%

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -857,6 +857,8 @@ internal enum L10n {
   internal static var eoyYearOverYearSubtitleWentUp: String { return L10n.tr("Localizable", "eoy_year_over_year_subtitle_went_up") }
   /// Compared to 2022, your listening time stayed pretty consistent
   internal static var eoyYearOverYearTitleFlat: String { return L10n.tr("Localizable", "eoy_year_over_year_title_flat") }
+  /// Compared to 2022, your listening time skyrocketed!
+  internal static var eoyYearOverYearTitleSkyrocketed: String { return L10n.tr("Localizable", "eoy_year_over_year_title_skyrocketed") }
   /// Compared to 2022, your listening time went down a little
   internal static var eoyYearOverYearTitleWentDown: String { return L10n.tr("Localizable", "eoy_year_over_year_title_went_down") }
   /// Compared to 2022, your listening time went up a whopping %1$@%

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -849,6 +849,8 @@ internal enum L10n {
   internal static var eoyTitle: String { return L10n.tr("Localizable", "eoy_title") }
   /// View My 2022
   internal static var eoyViewYear: String { return L10n.tr("Localizable", "eoy_view_year") }
+  /// My 2023 listening time compared to 2022
+  internal static var eoyYearOverShareText: String { return L10n.tr("Localizable", "eoy_year_over_share_text") }
   /// And they say consistency is the key to success... or something like that!
   internal static var eoyYearOverYearSubtitleFlat: String { return L10n.tr("Localizable", "eoy_year_over_year_subtitle_flat") }
   /// Aaaah... there’s a life to be lived, right?

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -849,6 +849,22 @@ internal enum L10n {
   internal static var eoyTitle: String { return L10n.tr("Localizable", "eoy_title") }
   /// View My 2022
   internal static var eoyViewYear: String { return L10n.tr("Localizable", "eoy_view_year") }
+  /// And they say consistency is the key to success... or something like that!
+  internal static var eoyYearOverYearSubtitleFlat: String { return L10n.tr("Localizable", "eoy_year_over_year_subtitle_flat") }
+  /// Aaaah... there’s a life to be lived, right?
+  internal static var eoyYearOverYearSubtitleWentDown: String { return L10n.tr("Localizable", "eoy_year_over_year_subtitle_went_down") }
+  /// Ready to top it in 2024?
+  internal static var eoyYearOverYearSubtitleWentUp: String { return L10n.tr("Localizable", "eoy_year_over_year_subtitle_went_up") }
+  /// Compared to 2022, your listening time went up a whopping %1$@%
+  internal static func eoyYearOverYearTitleFlat(_ p1: Any) -> String {
+    return L10n.tr("Localizable", "eoy_year_over_year_title_flat", String(describing: p1))
+  }
+  /// Compared to 2022, your listening time went down a little
+  internal static var eoyYearOverYearTitleWentDown: String { return L10n.tr("Localizable", "eoy_year_over_year_title_went_down") }
+  /// Compared to 2022, your listening time went up a whopping %1$@%
+  internal static func eoyYearOverYearTitleWentUp(_ p1: Any) -> String {
+    return L10n.tr("Localizable", "eoy_year_over_year_title_went_up", String(describing: p1))
+  }
   /// Episode
   internal static var episode: String { return L10n.tr("Localizable", "episode") }
   /// %1$@ episodes

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -3611,6 +3611,9 @@
 /* Label of a button to share the current story (similar to Instagram stories) */
 "eoy_share" = "Share this story";
 
+/* Title of the story when this year's listening time is way bigger than previous year. */
+"eoy_year_over_year_title_skyrocketed" = "Compared to 2022, your listening time skyrocketed!";
+
 /* Title of the story when this year's listening time is bigger than previous year. %1$@ is the percentage */
 "eoy_year_over_year_title_went_up" = "Compared to 2022, your listening time went up a whopping %1$@%";
 

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -3611,6 +3611,24 @@
 /* Label of a button to share the current story (similar to Instagram stories) */
 "eoy_share" = "Share this story";
 
+/* Title of the story when this year's listening time is bigger than previous year. %1$@ is the percentage */
+"eoy_year_over_year_title_went_up" = "Compared to 2022, your listening time went up a whopping %1$@%";
+
+/* Subtitle of the story that compares year listening time when this year's listening time is bigger than last's year */
+"eoy_year_over_year_subtitle_went_up" = "Ready to top it in 2024?";
+
+/* Title of the story when this year's listening time is almost the same as the previous year. %1$@ is the percentage */
+"eoy_year_over_year_title_flat" = "Compared to 2022, your listening time went up a whopping %1$@%";
+
+/* Subtitle of the story that compares year listening time when this year's listening time is almost the same as last's year */
+"eoy_year_over_year_subtitle_flat" = "And they say consistency is the key to success... or something like that!";
+
+/* Title of the story when this year's listening time is less than the previous year. %1$@ is the percentage */
+"eoy_year_over_year_title_went_down" = "Compared to 2022, your listening time went down a little";
+
+/* Subtitle of the story that compares year listening time when this year's listening time is less than last's year */
+"eoy_year_over_year_subtitle_went_down" = "Aaaah... there’s a life to be lived, right?";
+
 /* Title of the view displayed after a user successfully upgrades to plus */
 "welcome_plus_title" = "Thank you, now let's get you listening!";
 

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -3632,6 +3632,9 @@
 /* Subtitle of the story that compares year listening time when this year's listening time is less than last's year */
 "eoy_year_over_year_subtitle_went_down" = "Aaaah... there’s a life to be lived, right?";
 
+/* Text for when a user shares the story comparing the 2022 and 2023 listening time. */
+"eoy_year_over_share_text" = "My 2023 listening time compared to 2022";
+
 /* Title of the view displayed after a user successfully upgrades to plus */
 "welcome_plus_title" = "Thank you, now let's get you listening!";
 

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -3618,7 +3618,7 @@
 "eoy_year_over_year_subtitle_went_up" = "Ready to top it in 2024?";
 
 /* Title of the story when this year's listening time is almost the same as the previous year. %1$@ is the percentage */
-"eoy_year_over_year_title_flat" = "Compared to 2022, your listening time went up a whopping %1$@%";
+"eoy_year_over_year_title_flat" = "Compared to 2022, your listening time stayed pretty consistent";
 
 /* Subtitle of the story that compares year listening time when this year's listening time is almost the same as last's year */
 "eoy_year_over_year_subtitle_flat" = "And they say consistency is the key to success... or something like that!";


### PR DESCRIPTION
| 📘 Part of: #1142 | 🎨 Designs: [Figma](https://www.figma.com/file/lH66LwxxgG8btQ8NrM0ldx/End-of-Year?type=design&node-id=1599-20385&mode=design) |
|:---:|:---:|

Adds the 2023 visual for the Year Over Year Listening Time Story.

<img src="https://github.com/Automattic/pocket-casts-ios/assets/7040243/12e9b332-cffe-47f8-9406-8820ced3e4e8" width="300">

**This doesn't tackle syncing 2022 listening history.**

## To test

## Different states

1. Go to `YearOverYearstory.swift`
2. Preview the view
3. ✅ Go over all the cases and check that their match the designs
4. You can also play with the numbers to see if the bars/title updates accordingly

## Story appearing

1. Make sure you're logged in to an account that has a few episodes listened
2. Go to Profile > Settings > Beta Features > enable `endOfYear`
3. Go back to Profile
4. Tap the EOY image
5. Skip to the penultimate story
5. ✅ Check that the story looks good compared to the design
6. Tap "Share this story" > Save Image
8. Go to Photos
9. ✅ The story image asset should be the last one in Photos
10. Give yourself Plus (Settings > Developer > Set to Paid Plus)
11. ✅ Check the story again, it should show a Plus badge
10. Give yourself Patron (Settings > Developer > Set to Paid Patron)
11. ✅ Check the story again, it should show a Patron badge

Please test on a big device (iPhone 15 Pro Max, for example), a normal device (iPhone 15), and a smaller device (iPod touch).

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
