### PR TITLE
Playback 2023: add a mechanism to skip "Plus stories" in sequence

### DIFF
--- a/PocketCastsTests/Tests/End of Year/StoriesModelTests.swift
+++ b/PocketCastsTests/Tests/End of Year/StoriesModelTests.swift
@@ -65,6 +65,80 @@ class StoriesModelTests: XCTestCase {
 
         XCTAssertEqual(dataSource.didCallStoryForWithStoryNumber, 0)
     }
+
+    // MARK: - Plus stories
+
+    /// If a user has a non-paid account we want to show only the first Plus story
+    /// and skip all the following ones to the next non-Plus story.
+    /// This way they don't see the same upsell multiple times.
+    func testSkipToFirstNonPlusStoryIfFreeUser() {
+        let model = StoriesModel(dataSource: MockStoriesWithPlusDataSource(),
+                                 configuration: StoriesConfiguration(),
+                                 activeTier: .none)
+        model.start()
+        _ = model.story(index: 0)
+
+        model.next()
+
+        eventually(timeout: 0.1) {
+            XCTAssertEqual(model.currentStory, 3)
+        }
+    }
+
+
+    /// If a user has a non-paid account and they want to go to the previous story
+    /// and it's a plus story, we want to show the first Plus story only.
+    /// This way they don't see the same upsell multiple times.
+    func testReturnToFirstPlusStoryIfFreeUser() {
+        let model = StoriesModel(dataSource: MockStoriesWithPlusDataSource(),
+                                 configuration: StoriesConfiguration(),
+                                 activeTier: .none)
+        model.start()
+        _ = model.story(index: 0)
+
+        model.next()
+        model.previous()
+
+        eventually(timeout: 0.1) {
+            XCTAssertEqual(model.currentStory, 0)
+        }
+    }
+
+    /// If the user is paid, don't skip
+    func testDontSkipToFirstNonPlusStoryIfPatronUser() {
+        let model = StoriesModel(dataSource: MockStoriesWithPlusDataSource(),
+                                 configuration: StoriesConfiguration(),
+                                 activeTier: .plus)
+        model.start()
+        _ = model.story(index: 0)
+
+        model.next()
+
+        eventually(timeout: 0.1) {
+            XCTAssertEqual(model.currentStory, 1)
+        }
+    }
+
+
+    /// If the user is paid, don't return to the first plus story
+    /// Instead, just go back normally.
+    func testDontReturnToFirstPlusStoryIfPatronUser() {
+        let model = StoriesModel(dataSource: MockStoriesWithPlusDataSource(),
+                                 configuration: StoriesConfiguration(),
+                                 activeTier: .patron)
+        model.start()
+        _ = model.story(index: 0)
+
+        model.next()
+        model.next()
+        model.next()
+        model.currentStory = 3
+        model.previous()
+
+        eventually(timeout: 0.1) {
+            XCTAssertEqual(model.currentStory, 2)
+        }
+    }
 }
 
 class MockStoriesDataSource: StoriesDataSource {
@@ -92,6 +166,37 @@ class MockStoriesDataSource: StoriesDataSource {
     }
 }
 
+class MockStoriesWithPlusDataSource: StoriesDataSource {
+    var numberOfStories: Int = 4
+
+    var didCallStoryForWithStoryNumber: Int?
+
+    func story(for storyNumber: Int) -> any StoryView {
+        didCallStoryForWithStoryNumber = storyNumber
+
+        switch storyNumber {
+        case 0:
+            return MockedPlusStory()
+        case 1:
+            return MockedPlusStory()
+        case 2:
+            return MockedPlusStory()
+        case 3:
+            return MockedStory()
+        default:
+            return MockedStoryTwo()
+        }
+    }
+
+    func shareableStory(for storyNumber: Int) -> (any ShareableStory)? {
+        nil
+    }
+
+    func isReady() async -> Bool {
+        true
+    }
+}
+
 struct MockedStory: StoryView {
     var duration: TimeInterval = 5 * 60
 
@@ -104,6 +209,18 @@ struct MockedStory: StoryView {
 
 struct MockedStoryTwo: StoryView {
     var duration: TimeInterval = 5 * 60
+
+    var body: some View {
+        ZStack {
+            Color.yellow
+        }
+    }
+}
+
+struct MockedPlusStory: StoryView {
+    var duration: TimeInterval = 5 * 60
+
+    var plusOnly = true
 
     var body: some View {
         ZStack {

--- a/podcasts/End of Year/StoriesDataSource.swift
+++ b/podcasts/End of Year/StoriesDataSource.swift
@@ -46,6 +46,9 @@ protocol Story {
     /// A string that identifies the story
     var identifier: String { get }
 
+    /// If the story is available only for Plus users
+    var plusOnly: Bool { get }
+
     /// Called when the story actually appears.
     ///
     /// If you use SwiftUI `onAppear` together with preload
@@ -59,6 +62,10 @@ protocol Story {
 extension Story {
     var identifier: String {
         "unknown"
+    }
+
+    var plusOnly: Bool {
+        false
     }
 
     func onAppear() {}


### PR DESCRIPTION
| 📘 Part of: #1142 |
|:---:|

This PR adds a mechanism to:

1. Set which stories are Plus or not;
2. Skip a bunch of Plus stories in sequence for a non-paid user;
3. Skip a bunch of Plus stories in sequence for a non-paid user when going to previous stories

Basically — given the "Plus stories" will have an upsell, we don't want users to see the same story multiple times. So we just display it once, whether is going to next stories or previous one.

## To test

Before testing, Add `let plusOnly = true` in `CompletionRateStory`, `LongestEpisodeStory` and `YearOverYearStory`.

Then:

1. Run the app
2. Go to Profile > Settings > Developer > Set to No Plus
3. Let the stories run (don't tap to skip to the next or to the previous one)
4. ✅ After the "Longest Episode" story is show, it should skip to the last one
5. Tap to go to the previous story
6. ✅ It should go back to the "Longest Episode" (skipping completion rate and year over year)
7. On the "Longest Episode", tap to go next
8. ✅ It should go to the last story
9. Exit the stories
10. Go to Profile > Settings > Developer > Set to Paid Plus
11. Repeat the testing steps
12. ✅ However, all stories should show (no stories will be skipped)
13. Go to Profile > Settings > Developer > Set to Paid Patron
14. ✅ All stories should show (no stories will be skipped)

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
