### PR TITLE
Remove unneeded env vars from Fastfile

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -121,7 +121,8 @@ before_all do
 end
 
 platform :ios do
-  # This explicit timeout helps resolve Xcode build errors
+  # This explicit timeout is necessary for the `xcodebuild -showBuildSettings` call to succeed in CI.
+  # See https://buildkite.com/automattic/pocket-casts-ios/builds/4875#018b7eea-e8d7-40a1-8ce5-515dd8feafce/666-805
   ENV['FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT'] = '120'
 
   desc 'Run the unit tests'

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -121,12 +121,7 @@ before_all do
 end
 
 platform :ios do
-  # Unfortunately, release toolkit still relies on certain settings being set in the environment
-  ENV['PROJECT_NAME'] = 'podcasts'
-  ENV['PROJECT_ROOT_FOLDER'] = "#{PROJECT_ROOT_FOLDER}/"
-  ENV['PUBLIC_CONFIG_FILE'] = VERSION_XCCONFIG_PATH
-  ENV['GHHELPER_REPO'] = GHHELPER_REPO
-
+  # This explicit timeout helps resolve Xcode build errors
   ENV['FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT'] = '120'
 
   desc 'Run the unit tests'


### PR DESCRIPTION
## Summary of changes:

This PR removes several unneeded environment variables:
- `PROJECT_ROOT_FOLDER` - The only action used by PCiOS that uses this one is[`ios_update_release_notes`](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_update_release_notes.rb) Release Toolkit action. PCiOS already sets an explicit path for that action, so the env var isn't needed.
- `PROJECT_NAME` - This env var is used by Android apps in a path like `PROJECT_ROOT_FOLDER/PROJECT_NAME/build.gradle`, but it's not currently used by any iOS actions. I don't know if that was different in the past, but it's not needed at all now. 
- `PUBLIC_CONFIG_FILE` - This is used by [`ios_get_build_version.rb`](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_get_build_version.rb), and the `update_xc_configs` method in [`ios_version_helper`](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_version_helper.rb) but none of those actions are used by PCiOS anymore after the recent versioning changes: https://github.com/Automattic/pocket-casts-ios/pull/1137
- `GHHELPER_REPO` - This env var isn't used by any actions in the Release Toolkit or anywhere else by PCiOS. 