### PR TITLE
Use DefaultPlayer instead of EffectsPlayer for downloaded files when trim silence is disabled

### DIFF
--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -1083,7 +1083,7 @@ class PlaybackManager: ServerPlaybackDelegate {
                 return possiblePlayers // for Google Cast, only the Google Cast player is allowed
             }
 
-        if !playingOverAirplay(), !currEpisode.videoPodcast(), (currEpisode.downloaded(pathFinder: DownloadManager.shared) && effects().trimSilence != .off) || currEpisode.bufferedForStreaming() {
+            if !playingOverAirplay(), !currEpisode.videoPodcast(), (currEpisode.downloaded(pathFinder: DownloadManager.shared) && effects().trimSilence != .off) || currEpisode.bufferedForStreaming() {
                 possiblePlayers.append(EffectsPlayer.self)
             }
         #endif

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -1083,7 +1083,7 @@ class PlaybackManager: ServerPlaybackDelegate {
                 return possiblePlayers // for Google Cast, only the Google Cast player is allowed
             }
 
-            if !playingOverAirplay(), !currEpisode.videoPodcast(), currEpisode.downloaded(pathFinder: DownloadManager.shared) || currEpisode.bufferedForStreaming() {
+        if !playingOverAirplay(), !currEpisode.videoPodcast(), (currEpisode.downloaded(pathFinder: DownloadManager.shared) && effects().trimSilence != .off) || currEpisode.bufferedForStreaming() {
                 possiblePlayers.append(EffectsPlayer.self)
             }
         #endif


### PR DESCRIPTION
Fixes #1184 

For downloaded episodes, only use EffectsPlayer if trim silence is enabled, else use DefaultPlayer (which can already handle  Speed and Volume Boost)

## To test
1. Run current build
2. Download episode
3. Play episode with no effects applied
4. Notice that EffectsPlayer is used (can be seen in device log file)
5. Apply change and repeat steps above
6. Notice that DefaultPlayer is now used
7. Enable trim silence
8. Notice that app switches to EffectsPlayer
9. Disable trim silence
10. Notice that app switches back to DefaultPlayer
11. Enable and disable other effect settings (Speed and Volume Boost) as well to ensure that everything works

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
