### PR TITLE
Disable new show notes and RSS artwork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 7.51
 -----
-
+- Improvements on battery consumption when trim silence is not enabled [#1186]
 
 7.50
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 7.51
 -----
 - Improvements on battery consumption when trim silence is not enabled [#1186]
+- TestFlight: Disable new show notes endpoint and custom RSS artwork due to memory issues
 
 7.50
 -----

--- a/podcasts/FeatureFlag.swift
+++ b/podcasts/FeatureFlag.swift
@@ -74,9 +74,9 @@ enum FeatureFlag: String, CaseIterable {
         case .autoplay:
             return true
         case .newShowNotesEndpoint:
-            return true
+            return false
         case .episodeFeedArtwork:
-            return Self.isTestFlight ? true : false
+            return false // To be enabled, newShowNotesEndpoint needs to be too
         }
     }
 }


### PR DESCRIPTION
Unfortunately, we've been seeing some crashes related to the way we retrieve the new show notes. This PR disables it so we can measure and see if this is really an issue.

Also, given the RSS artwork depends on the new show notes, it has also been disabled.

## To test

1. Run the app
2. ✅ Make sure the show notes loads correctly

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
