### PR TITLE
Playback 2023: Tracks

### DIFF
--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -607,6 +607,7 @@ enum AnalyticsEvent: String {
     case endOfYearStoryShare
     case endOfYearStoryShared
     case endOfYearProfileCardTapped
+    case endOfYearUpsellShown
 
     // MARK: - Welcome View
 

--- a/podcasts/End of Year/Stories/CompletionRateStory.swift
+++ b/podcasts/End of Year/Stories/CompletionRateStory.swift
@@ -5,7 +5,7 @@ import PocketCastsDataModel
 struct CompletionRateStory: ShareableStory {
     var duration: TimeInterval = 5.seconds
 
-    let identifier: String = "year_over_year"
+    let identifier: String = "completion_rate"
 
     let plusOnly = true
 

--- a/podcasts/End of Year/Stories/Views/PaidStoryWallView.swift
+++ b/podcasts/End of Year/Stories/Views/PaidStoryWallView.swift
@@ -39,6 +39,9 @@ struct PaidStoryWallView: View {
             .allowsHitTesting(false)
             .ignoresSafeArea(edges: [.top, .bottom])
         )
+        .onAppear {
+            Analytics.track(.endOfYearUpsellShown)
+        }
     }
 }
 

--- a/podcasts/End of Year/StoriesModel.swift
+++ b/podcasts/End of Year/StoriesModel.swift
@@ -100,7 +100,13 @@ class StoriesModel: ObservableObject {
 
     func story(index: Int) -> AnyView {
         let story = dataSource.story(for: index)
-        story.onAppear()
+
+        // Only trigger onAppear if the story is not plus or user is paid
+        // Otherwise, the paywall appears in front of the story
+        if !story.plusOnly || isPaidUser() {
+            story.onAppear()
+        }
+
         currentStoryIdentifier = story.identifier
         currentStoryIsPlus = story.plusOnly
         return AnyView(story)


### PR DESCRIPTION
| 📘 Part of: #1142 |
|:---:|

* Fix tracks for completion rate
* Add event when showing the stories upsell

## To test

1. Make sure you're logged in to an account that has a few episodes listened to this year and last year
1. In Xcode, enable the StoreKit configuration (Edit Scheme > Run > StoreKit Config)
2. Go to Profile > Settings > Beta Features > enable `endOfYear`
3. Go to Profile > Settings > Developer > Set to No Plus
3. Open stories
4. Go to the 8th story
5. ✅ Check that `end_of_year_upsell_shown` is tracked and `end_of_year_story_shown ["story": "year_over_year"]` **is not**
6. Tap "Start your Free Trial"
7. Purchase
8. ✅ Check that `end_of_year_story_shown ["story": "year_over_year"]` is shown

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
