### PR TITLE
Bookmarks: Enables the What's New

### DIFF
--- a/podcasts/NowPlayingPlayerItemViewController+Shelf.swift
+++ b/podcasts/NowPlayingPlayerItemViewController+Shelf.swift
@@ -221,7 +221,7 @@ extension NowPlayingPlayerItemViewController: NowPlayingActionsDelegate {
 
     // MARK: - Player Actions
 
-    @objc private func overflowTapped() {
+    @objc func overflowTapped() {
         let shelfController = ShelfActionsViewController()
         shelfController.playerActionsDelegate = self
         let bottomSheet = MDCBottomSheetController(contentViewController: shelfController)

--- a/podcasts/NowPlayingPlayerItemViewController.swift
+++ b/podcasts/NowPlayingPlayerItemViewController.swift
@@ -175,7 +175,7 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        
+
         // Show the overflow menu
         if FeatureFlag.bookmarks.enabled, AnnouncementFlow.shared.bookmarksFlow == .player {
             overflowTapped()

--- a/podcasts/NowPlayingPlayerItemViewController.swift
+++ b/podcasts/NowPlayingPlayerItemViewController.swift
@@ -173,6 +173,15 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
         routePicker.delegate = self
     }
 
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        // Show the overflow menu
+        if FeatureFlag.bookmarks.enabled, AnnouncementFlow.shared.bookmarksFlow == .player {
+            overflowTapped()
+        }
+    }
+
     private var lastBoundsAdjustedFor = CGRect.zero
 
     var analyticsSource: AnalyticsSource {

--- a/podcasts/ProfileViewController.swift
+++ b/podcasts/ProfileViewController.swift
@@ -351,11 +351,16 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
             navigationController?.pushViewController(generalSettingsViewController, animated: true)
         }
 
-        if AnnouncementFlow.shared.isShowingBookmarksOption {
-            let controller = HeadphoneSettingsViewController()
-            navigationController?.pushViewController(controller, animated: true)
-            AnnouncementFlow.shared.isShowingBookmarksOption = false
-        }
+        showHeadphoneControlsFromWhatsNew()
+    }
+
+    // Pushes to the headphone controls if shown from the what's new
+    private func showHeadphoneControlsFromWhatsNew() {
+        guard AnnouncementFlow.shared.bookmarksFlow == .profile else { return }
+
+        let controller = HeadphoneSettingsViewController()
+        navigationController?.pushViewController(controller, animated: true)
+        AnnouncementFlow.shared.bookmarksFlow = .none
     }
 }
 

--- a/podcasts/ShelfActionsViewController.swift
+++ b/podcasts/ShelfActionsViewController.swift
@@ -61,6 +61,12 @@ class ShelfActionsViewController: UIViewController {
         NotificationCenter.default.addObserver(self, selector: #selector(updateColors), name: Constants.Notifications.themeChanged, object: nil)
     }
 
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        highlightAddBookmarksIfNeeded()
+    }
+
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
@@ -145,5 +151,23 @@ class ShelfActionsViewController: UIViewController {
 
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         .portrait
+    }
+}
+
+private extension ShelfActionsViewController {
+    /// Highlights the bookmarks row when triggered from the what's new
+    func highlightAddBookmarksIfNeeded() {
+        guard FeatureFlag.bookmarks.enabled, AnnouncementFlow.shared.bookmarksFlow == .player else {
+            return
+        }
+
+        defer { AnnouncementFlow.shared.bookmarksFlow = .none }
+
+        // Find the index of the row
+        guard let index = extraActions.firstIndex(of: .addBookmark) else {
+            return
+        }
+
+        actionsTable.selectRow(at: .init(row: index, section: 0), animated: true, scrollPosition: .middle)
     }
 }

--- a/podcasts/Whats New/Announcements.swift
+++ b/podcasts/Whats New/Announcements.swift
@@ -79,5 +79,9 @@ class AnnouncementFlow {
     static let shared = AnnouncementFlow()
 
     var isShowingAutoplayOption = false
-    var isShowingBookmarksOption = false
+    var bookmarksFlow: BookmarksFlow = .none
+
+    enum BookmarksFlow {
+        case none, player, profile
+    }
 }

--- a/podcasts/Whats New/Announcements.swift
+++ b/podcasts/Whats New/Announcements.swift
@@ -28,7 +28,7 @@ struct Announcements {
         // Bookmarks Early Access: Beta
         // Show only in TestFlight, for Plus and Patron
         .init(
-            version: "99.99",
+            version: "7.52",
             header: AnyView(BookmarksWhatsNewHeader()),
             title: L10n.announcementBookmarksTitleBeta,
             message: L10n.announcementBookmarksDescription,
@@ -43,7 +43,7 @@ struct Announcements {
         // Bookmarks Early Access: Release
         // Show when not in beta, for Patron only
         .init(
-            version: "99.99",
+            version: "7.52",
             header: AnyView(BookmarksWhatsNewHeader().onAppear {
                 // Record when someone sees the full announcement while in early access so we don't show it again to them when we move to full release.
                 bookmarksViewModel.markAsSeen()

--- a/podcasts/Whats New/BookmarksAnnouncement.swift
+++ b/podcasts/Whats New/BookmarksAnnouncement.swift
@@ -93,15 +93,15 @@ class BookmarkAnnouncementViewModel {
             return
         }
 
-        AnnouncementFlow.shared.isShowingBookmarksOption = true
-
         // Show the player
         if PlaybackManager.shared.currentEpisode() != nil {
+            AnnouncementFlow.shared.bookmarksFlow = .player
             NavigationManager.sharedManager.miniPlayer?.openFullScreenPlayer()
             return
         }
 
         // Show the headphone controls
+        AnnouncementFlow.shared.bookmarksFlow = .profile
         NavigationManager.sharedManager.navigateTo(NavigationManager.settingsProfileKey, data: nil)
     }
 


### PR DESCRIPTION
Enables Bookmarks Early Access What's New for 7.52, and enables highlighting of the Add Bookmark item for the Try it Now action.

## Demos

<details>
  <summary><h3>Try it Now Action</h3></summary>
 
https://github.com/Automattic/pocket-casts-ios/assets/793774/8c16f535-90da-4008-91ca-cca9165fea2c
</details>


<details>
  <summary><h3>Enable it now Action</h3></summary>
 
https://github.com/Automattic/pocket-casts-ios/assets/793774/96961da2-d503-4de1-88f8-6a4bd8a6771a

</details>

## To test

**Before running do the following:**
   1. Enable the Bookmarks feature flag

2. The easiest way to test is by changing the values in the WhatsNew initializer so the WhatsNew will always be displayed:

```     
self.announcements = announcements
self.previousOpenedVersion = "7.51"
self.currentVersion = "7.52"
self.lastWhatsNewShown = "7.43"
```

### Beta: Playing an episode
1. In Xcode, open BuildEnvironment.swift, change line 24 to `.testFlight`
2. Sign into a Plus or Patron account
3. Play any episode
4. Relaunch the app
5. ✅ Verify you see the Join Beta message with the Try it Now action
6. Tap the Try it Now button
7. ✅ Verify the full screen player and overflow menu open, and the Add Bookmark item is highlighted
8. Dismiss the overflow menu, and open it again
9. ✅ Verify the Add Bookmark item is not selected again
10. Dismiss the player, and reopen it
11. ✅ Verify the overflow menu doesn't open again
12. Go to the Profile tab, ✅ Verify nothing happens

### Beta: No Playing Episode
1. In Xcode, open BuildEnvironment.swift, change line 24 to `.testFlight`
2. Sign into a Plus or Patron account
3. Clear any playing episode
4. Relaunch the app
5. ✅ Verify you see the Join Beta message with the Enable it Now action
6. Tap the Enable button
7. ✅ Verify you are brought to the headphone controls setting
8. Tap back, and change tabs, then tap the Profile tab again
9. ✅ Verify nothing happens


### Early Access AppStore Patron
1. In Xcode, open BuildEnvironment.swift, change line 24 to `.appStore`
2. Sign into a Patron account
4. Relaunch the app
5. ✅ Verify you see the Bookmarks Are Here message with the Patron badge
6. Repeat the steps from above to test the Playing Episode and No Playing episode actions



### Early Access AppStore Plus
1. In Xcode, open BuildEnvironment.swift, change line 24 to `.appStore`
2. Sign into a Plus account
4. Relaunch the app
5. ✅ Verify you do not see the Whats New

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
