### PR TITLE
Enables the bookmarks feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 7.52
 -----
-
+- Enables Bookmarks for Early Access: [#1202]
 
 7.51
 -----

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseHelper.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseHelper.swift
@@ -645,9 +645,7 @@ class DatabaseHelper {
             }
         }
 
-        #if DEBUG
-        #warning("TODO: Remove the debug check once the FeatureFlag is enabled")
-        if schemaVersion < 999 {
+        if schemaVersion < 42 {
             do {
                 try BookmarkDataManager.createTable(in: db)
 
@@ -657,7 +655,6 @@ class DatabaseHelper {
                 return
             }
         }
-        #endif
 
         db.commit()
     }

--- a/podcasts/FeatureFlag.swift
+++ b/podcasts/FeatureFlag.swift
@@ -64,7 +64,7 @@ enum FeatureFlag: String, CaseIterable {
         case .newSearch:
             return true
         case .bookmarks:
-            return false
+            return true
         case .discoverFeaturedAutoScroll:
             return true
         case .patron:


### PR DESCRIPTION
Enables the bookmarks feature flag, and removes the DEBUG check for creating the bookmarks database table. 

## To test

### Clean Install
1. Delete the app
2. Run this PR
6. ✅ Verify you **do not** see any database errors
7. Play an episode
8. Open the full screen player
9. Tap the overflow menu
10. Tap Add Bookmark
11. Tap Save Bookmark
12. Tap the Bookmarks tab
13. ✅ Verify the new bookmark appears

### Update from App Store Build
1. Delete the app and clean install the App Store build
4. Sign into an account with Patron
5. Install the app from this PR
6. ✅ Verify you **do not** see any database errors
7. Play an episode
8. Open the full screen player
9. Tap the overflow menu
10. Tap Add Bookmark
11. Tap Save Bookmark
12. Tap the Bookmarks tab
13. ✅ Verify the new bookmark appears

### Update from TestFlight build
1. Delete the app and clean install the TestFlight build
4. Sign into an account with Patron
5. Install the app from this PR
6. ✅ Verify you **do not** see any database errors
7. Play an episode
8. Open the full screen player
9. Tap the overflow menu
10. Tap Add Bookmark
11. Tap Save Bookmark
12. Tap the Bookmarks tab
13. ✅ Verify the new bookmark appears

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
