### PR TITLE
Patron: change product IDs

### DIFF
--- a/Pocket Casts Configuration.storekit
+++ b/Pocket Casts Configuration.storekit
@@ -73,7 +73,7 @@
           ],
           "displayPrice" : "39.99",
           "familyShareable" : false,
-          "groupNumber" : 1,
+          "groupNumber" : 2,
           "internalID" : "C9B37131",
           "introductoryOffer" : {
             "displayPrice" : "0.99",
@@ -103,7 +103,7 @@
           ],
           "displayPrice" : "3.99",
           "familyShareable" : false,
-          "groupNumber" : 1,
+          "groupNumber" : 2,
           "internalID" : "267218F7",
           "introductoryOffer" : null,
           "localizations" : [

--- a/Pocket Casts Configuration.storekit
+++ b/Pocket Casts Configuration.storekit
@@ -7,7 +7,54 @@
 
   ],
   "settings" : {
-
+    "_failTransactionsEnabled" : false,
+    "_storeKitErrors" : [
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Load Products"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Purchase"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Verification"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "App Store Sync"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Subscription Status"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "App Transaction"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Manage Subscriptions Sheet"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Refund Request Sheet"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Offer Code Redeem Sheet"
+      }
+    ]
   },
   "subscriptionGroups" : [
     {
@@ -91,7 +138,7 @@
               "locale" : "en_US"
             }
           ],
-          "productID" : "com.pocketcasts.yearly.patron",
+          "productID" : "com.pocketcasts.patron_yearly",
           "recurringSubscriptionPeriod" : "P1Y",
           "referenceName" : "Patron Yearly",
           "subscriptionGroupID" : "D129D5D3",
@@ -116,7 +163,7 @@
               "locale" : "en_US"
             }
           ],
-          "productID" : "com.pocketcasts.monthly.patron",
+          "productID" : "com.pocketcasts.patron_monthly",
           "recurringSubscriptionPeriod" : "P1M",
           "referenceName" : "Patron Monthly",
           "subscriptionGroupID" : "D129D5D3",
@@ -126,7 +173,7 @@
     }
   ],
   "version" : {
-    "major" : 2,
+    "major" : 3,
     "minor" : 0
   }
 }

--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -252,8 +252,8 @@ struct Constants {
         enum IapProducts: String {
             case yearly = "com.pocketcasts.plus.yearly"
             case monthly = "com.pocketcasts.plus.monthly"
-            case patronYearly = "com.pocketcasts.yearly.patron"
-            case patronMonthly = "com.pocketcasts.monthly.patron"
+            case patronYearly = "com.pocketcasts.patron_yearly"
+            case patronMonthly = "com.pocketcasts.patron_monthly"
 
             var renewalPrompt: String {
                 switch self {


### PR DESCRIPTION
This PR changes Patron product IDs so they are all inside the same group.

## To test

1. Open the Xcode Project
3. Hit <kbd>Command</kbd>+<kbd>Shift</kbd>+<kbd>,</kbd> to open the Scheme editor
4. Click the options tab
5. Select the `Pocket Casts Configuration.storekit` file in the StoreKit configuration dropdown
6. ✅ Go over the Plus/Patron purchase and everything should work

Ps.: E2E tests will be done once this is on TestFlight and changes deployed to prod.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
