### PR TITLE
Playback 2023: fix hanging loading the episodes

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncYearListeningHistoryTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncYearListeningHistoryTask.swift
@@ -95,6 +95,9 @@ class SyncYearListeningHistoryTask: ApiBaseTask {
                 performRequest(yearToSync: year, token: token, shouldSync: true)
             } else {
                 success = true
+
+                // If there are no episodes to sync we leave the dispatch group
+                totalEpisodesDispatchGroup.leave()
             }
         } catch {
             print("SyncYearListeningHistory had issues decoding protobuf \(error.localizedDescription)")

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncYearListeningHistoryTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncYearListeningHistoryTask.swift
@@ -31,36 +31,21 @@ public class SyncYearListeningProgress: ObservableObject {
 class SyncYearListeningHistoryTask: ApiBaseTask {
     private var token: String?
 
-    private let yearsToSync: [Int32]
-
-    private var totalEpisodesDispatchGroup = DispatchGroup()
+    private let yearToSync: Int32
 
     var success: Bool = false
 
-    init(years: [Int32]) {
-        self.yearsToSync = years
+    init(year: Int32) {
+        self.yearToSync = year
     }
 
     override func apiTokenAcquired(token: String) {
         self.token = token
 
-        // Sync multiple years in parallel so it's faster
-        let dispatchGroup = DispatchGroup()
-        yearsToSync.forEach { yearToSync in
-            totalEpisodesDispatchGroup.enter()
-            dispatchGroup.enter()
-
-            DispatchQueue.global(qos: .userInitiated).async {
-                self.performRequest(yearToSync: yearToSync, token: token, shouldSync: false)
-
-                dispatchGroup.leave()
-            }
-        }
-
-        dispatchGroup.wait()
+        performRequest(token: token, shouldSync: false)
     }
 
-    private func performRequest(yearToSync: Int32, token: String, shouldSync: Bool) {
+    private func performRequest(token: String, shouldSync: Bool) {
         var dataToSync = Api_YearHistoryRequest()
         dataToSync.version = apiVersion
         dataToSync.year = yearToSync
@@ -72,9 +57,9 @@ class SyncYearListeningHistoryTask: ApiBaseTask {
             let (response, httpStatus) = postToServer(url: url, token: token, data: data)
             if let response, httpStatus == ServerConstants.HttpConstants.ok {
                 if !shouldSync {
-                    compareNumberOfEpisodes(year: yearToSync, serverData: response)
+                    compareNumberOfEpisodes(serverData: response)
                 } else {
-                    syncMissingEpisodes(year: yearToSync, serverData: response)
+                    syncMissingEpisodes(serverData: response)
                 }
             } else {
                 print("SyncYearListeningHistory Unable to sync with server got status \(httpStatus)")
@@ -84,33 +69,30 @@ class SyncYearListeningHistoryTask: ApiBaseTask {
         }
     }
 
-    private func compareNumberOfEpisodes(year: Int32, serverData: Data) {
+    private func compareNumberOfEpisodes(serverData: Data) {
         do {
             let response = try Api_YearHistoryResponse(serializedData: serverData)
 
-            let localNumberOfEpisodes = DataManager.sharedManager.numberOfEpisodes(year: year)
+            let localNumberOfEpisodes = DataManager.sharedManager.numberOfEpisodes(year: yearToSync)
 
             if response.count > localNumberOfEpisodes, let token {
                 print("SyncYearListeningHistory: \(Int(response.count) - localNumberOfEpisodes) episodes missing, adding them...")
-                performRequest(yearToSync: year, token: token, shouldSync: true)
+                performRequest(token: token, shouldSync: true)
             } else {
                 success = true
-
-                // If there are no episodes to sync we leave the dispatch group
-                totalEpisodesDispatchGroup.leave()
             }
         } catch {
             print("SyncYearListeningHistory had issues decoding protobuf \(error.localizedDescription)")
         }
     }
 
-    private func syncMissingEpisodes(year: Int32, serverData: Data) {
+    private func syncMissingEpisodes(serverData: Data) {
         do {
             let response = try Api_YearHistoryResponse(serializedData: serverData)
 
             // on watchOS, we don't show history, so we also don't process server changes we only want to push changes up, not down
             #if !os(watchOS)
-            updateEpisodes(year: year, updates: response.history.changes)
+            updateEpisodes(updates: response.history.changes)
             #endif
 
             success = true
@@ -119,20 +101,15 @@ class SyncYearListeningHistoryTask: ApiBaseTask {
         }
     }
 
-    private func updateEpisodes(year: Int32, updates: [Api_HistoryChange]) {
+    private func updateEpisodes(updates: [Api_HistoryChange]) {
         var podcastsToUpdate: Set<String> = []
 
         // Get the list of missing episodes in the database
         let uuids = updates.map { $0.episode }
-        let episodesThatExist = DataManager.sharedManager.episodesThatExist(year: year, uuids: uuids)
+        let episodesThatExist = DataManager.sharedManager.episodesThatExist(year: yearToSync, uuids: uuids)
         let missingEpisodes = updates.filter { !episodesThatExist.contains($0.episode) }
 
         SyncYearListeningProgress.shared.episodesToSync += Double(missingEpisodes.count)
-
-        totalEpisodesDispatchGroup.leave()
-
-        // Wait until we have the total number of episodes to be synced
-        totalEpisodesDispatchGroup.wait()
 
         let dispatchGroup = DispatchGroup()
 
@@ -203,11 +180,26 @@ class PodcastExistsHelper {
 
 public class YearListeningHistory {
     public static func sync() -> Bool {
+        var syncResults: [Bool] = []
         let yearsToSync: [Int32] = SubscriptionHelper.hasActiveSubscription() ? [2023, 2022] : [2023]
-        let syncYearListeningHistory = SyncYearListeningHistoryTask(years: yearsToSync)
 
-        syncYearListeningHistory.start()
+        let dispatchGroup = DispatchGroup()
+        yearsToSync.forEach { yearToSync in
+            dispatchGroup.enter()
 
-        return syncYearListeningHistory.success
+            DispatchQueue.global(qos: .userInitiated).async {
+                let syncYearListeningHistory = SyncYearListeningHistoryTask.init(year: yearToSync)
+
+                syncYearListeningHistory.start()
+
+                syncResults.append(syncYearListeningHistory.success)
+
+                dispatchGroup.leave()
+            }
+        }
+
+        dispatchGroup.wait()
+
+        return syncResults.allSatisfy { $0 == true }
     }
 }

--- a/podcasts/End of Year/Stories/EpilogueStory.swift
+++ b/podcasts/End of Year/Stories/EpilogueStory.swift
@@ -77,13 +77,15 @@ struct EpilogueStory: ShareableStory {
                     .onAppear(perform: prepareHaptics)
                 )
 
-                VStack {
-                    Spacer()
-                    HStack {
+                if !renderForSharing {
+                    VStack {
                         Spacer()
-                        Image("logo")
-                            .padding(.bottom, geometry.size.height * 0.06)
-                        Spacer()
+                        HStack {
+                            Spacer()
+                            Image("logo")
+                                .padding(.bottom, geometry.size.height * 0.06)
+                            Spacer()
+                        }
                     }
                 }
             }


### PR DESCRIPTION
| 📘 Part of: #1142 |
|:---:|

There's a bug that can occur if the user has no episodes to sync.

The sync code ends up on `totalEpisodesDispatchGroup.wait()` and it will never leave. That's why I didn't handle the case where there are no episodes to sync. 🤡 

## To test

1. Do a clean install
1. Log in to an account that has a few episodes listened this year and last year
3. Go to Profile and tap the End of Year card
4. ✅ Your data should load correctly

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
