### PR TITLE
Playback 2023: tweak parallax on the intro story

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Extensions/ComparableExtension.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Extensions/ComparableExtension.swift
@@ -4,4 +4,8 @@ public extension Comparable {
     func clamped(to limits: Range<Self>) -> Self {
         min(max(self, limits.lowerBound), limits.upperBound)
     }
+
+    func betweenOrClamped(to limits: Range<Self>) -> Self {
+        self > limits.lowerBound && self < limits.upperBound ? self : self.clamped(to: limits)
+    }
 }

--- a/podcasts/End of Year/Stories/IntroStory.swift
+++ b/podcasts/End of Year/Stories/IntroStory.swift
@@ -103,9 +103,11 @@ private struct TwentyThreeParallaxModifier: ViewModifier {
     var rollMultiplier: Double = 4
     var pitchMultiplier: Double = 40
 
+    private let rollAndPitchBoundary = -1.4..<1.5
+
     func body(content: Content) -> some View {
-        let roll = manager.roll.betweenOrClamped(to: -1.4..<1.5) * 10
-        let pitch = manager.pitch.betweenOrClamped(to: -1.4..<1.5)
+        let roll = manager.roll.betweenOrClamped(to: rollAndPitchBoundary) * 10
+        let pitch = manager.pitch.betweenOrClamped(to: rollAndPitchBoundary)
         return content
             .offset(x: roll * rollMultiplier, y: pitch * pitchMultiplier)
             .onAppear() {

--- a/podcasts/End of Year/Stories/IntroStory.swift
+++ b/podcasts/End of Year/Stories/IntroStory.swift
@@ -106,7 +106,7 @@ private struct TwentyThreeParallaxModifier: ViewModifier {
     private let rollAndPitchBoundary = -1.4..<1.5
 
     func body(content: Content) -> some View {
-        let roll = manager.roll.betweenOrClamped(to: rollAndPitchBoundary) * 10
+        let roll = manager.roll.betweenOrClamped(to: rollAndPitchBoundary) * 7
         let pitch = manager.pitch.betweenOrClamped(to: rollAndPitchBoundary)
         return content
             .offset(x: roll * rollMultiplier, y: pitch * pitchMultiplier)

--- a/podcasts/End of Year/Stories/IntroStory.swift
+++ b/podcasts/End of Year/Stories/IntroStory.swift
@@ -99,14 +99,14 @@ struct IntroStory: ShareableStory {
 
 private struct TwentyThreeParallaxModifier: ViewModifier {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    @StateObject var manager: MotionManager = .init()
+    @StateObject var manager: MotionManager = .init(relativeToWhenStarting: true)
     var rollMultiplier: Double = 4
     var pitchMultiplier: Double = 40
 
     func body(content: Content) -> some View {
-        let roll = manager.roll * 10
-        let pitch = manager.pitch
-        content
+        let roll = manager.roll.betweenOrClamped(to: -1.4..<1.5) * 10
+        let pitch = manager.pitch.betweenOrClamped(to: -1.4..<1.5)
+        return content
             .offset(x: roll * rollMultiplier, y: pitch * pitchMultiplier)
             .onAppear() {
                 if !reduceMotion {

--- a/podcasts/SwiftUI/Motion.swift
+++ b/podcasts/SwiftUI/Motion.swift
@@ -72,9 +72,6 @@ class MotionManager: ObservableObject {
 
                 self.pitch = pitch - (initialPitch ?? 0)
                 self.roll = roll - (initialRoll ?? 0)
-
-                print("$$ \(self.pitch) \(self.roll)")
-                print("$$ \(self.roll > -2 && self.roll < 2 && self.pitch > -2 && self.pitch < 2))")
             }
         }
 


### PR DESCRIPTION
| 📘 Part of: #1142 |
|:---:|

This PR makes two changes to the parallax effect:

1. It calculates the pitch/roll based on the initial value. This means that the "2023" won't jump on the screen as previously;
2. It defines a boundary so the pitch and roll values will always be between -1.4 and 1.4. This is because tilting aggressively can sometimes cause the numbers to "jump"

## To test

Test using a real device.

1. Log in to an account that has a few episodes listened this year and last year
2. Make sure yo have your device fully on the vertical
3. Go to Profile and tap the End of Year card
4. ✅ Notice that the numbers don't jump
5. Tilt your device and the numbers should follow
6. Go to the next story and back
7. ✅ The numbers won't jump

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
