### PR TITLE
Bookmarks: Some design improvements

### DIFF
--- a/podcasts/Bookmarks/Episode/EpisodeDetailTabView.swift
+++ b/podcasts/Bookmarks/Episode/EpisodeDetailTabView.swift
@@ -64,7 +64,8 @@ struct EpisodeDetailTabView: View {
 
                 Spacer()
             }
-            .font(style: .subheadline, weight: .medium)
+            .font(.subheadline.weight(.medium))
+            .environment(\.dynamicTypeSize, .large)
         }
         .padding(.leading, isSmallScreen ? 0 : 10)
     }

--- a/podcasts/Bookmarks/Player/BookmarksPlayerTab.swift
+++ b/podcasts/Bookmarks/Player/BookmarksPlayerTab.swift
@@ -7,7 +7,6 @@ struct BookmarksPlayerTab: View {
 
     var body: some View {
         BookmarksListView(viewModel: viewModel, style: BookmarksPlayerTabStyle())
-            .padding(.bottom)
     }
 }
 

--- a/podcasts/EpisodeBookmarksTabsView.swift
+++ b/podcasts/EpisodeBookmarksTabsView.swift
@@ -22,7 +22,8 @@ struct EpisodeBookmarksTabsView: View {
 
             Spacer()
         }
-        .font(style: .subheadline, weight: .medium)
+        .font(.subheadline.weight(.medium))
+        .environment(\.dynamicTypeSize, .large)
     }
 }
 

--- a/podcasts/SwiftUI/ActionBarOverlayView.swift
+++ b/podcasts/SwiftUI/ActionBarOverlayView.swift
@@ -27,8 +27,10 @@ struct ActionBarOverlayView<Content: View, Style: ActionBarStyle>: View {
                     .padding(.bottom)
             }
         }
+        .padding(.bottom)
         .accessibilityTransition(.opacity)
         .animation(.linear(duration: 0.1), value: actionBarVisible)
+        .ignoresSafeArea()
     }
 }
 


### PR DESCRIPTION
This disables the font scaling on the podcast and episode bookmarks tab because the rest of those views don't support scaling. 

This also fixes an issue where the player bookmarks list had a lot of extra padding. 

| Before | After |
|:---:|:---:|
|<img src="https://github.com/Automattic/pocket-casts-ios/assets/793774/cf1982a6-af6b-48c1-816e-66ce55853978" width="320" />|<img src="https://github.com/Automattic/pocket-casts-ios/assets/793774/373a44eb-b208-407a-bdd5-5a1b7a3fe61c" width="320" />|


## To test

1. Launch the app and open the full screen player
2. Add lots of bookmarks
3. Swipe to the bookmarks tab
4. ✅ Verify there isn't a huge gap at the bottom
5. Press and hold on a bookmark
6. ✅ Verify it also doesn't have lots of padding
7. Go to the Podcasts bookmarks, and episode bookmarks and verify it still looks good and the action bar doesn't have any padding issues

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
