### PR TITLE
Bookmarks: fix colors when opening from Up Next

### DIFF
--- a/podcasts/Bookmarks/BookmarksTheme.swift
+++ b/podcasts/Bookmarks/BookmarksTheme.swift
@@ -81,7 +81,7 @@ class ThemedBookmarksStyle: ThemeObserver, BookmarksStyle {
 // MARK: - Override Themed Style
 class OverrideThemedBookmarksStyle: ThemedBookmarksStyle {
     private var overrideTheme: Theme.ThemeType
-    private lazy var overridenEmptyStyle: DefaultEmptyStateStyle = OverrideEmptyStateStyle(overrideTheme: overrideTheme)
+    private lazy var overrideEmptyStyle: DefaultEmptyStateStyle = OverrideEmptyStateStyle(overrideTheme: overrideTheme)
 
     init(overrideTheme: Theme.ThemeType) {
         self.overrideTheme = overrideTheme
@@ -105,7 +105,7 @@ class OverrideThemedBookmarksStyle: ThemedBookmarksStyle {
     }
     override var emptyStyle: DefaultEmptyStateStyle {
         set { }
-        get { overridenEmptyStyle }
+        get { overrideEmptyStyle }
     }
 }
 

--- a/podcasts/Bookmarks/BookmarksTheme.swift
+++ b/podcasts/Bookmarks/BookmarksTheme.swift
@@ -77,3 +77,47 @@ class ThemedBookmarksStyle: ThemeObserver, BookmarksStyle {
     var actionBarStyle = ThemedActionBarStyle()
     var emptyStyle = DefaultEmptyStateStyle()
 }
+
+// MARK: - Override Themed Style
+class OverrideThemedBookmarksStyle: ThemedBookmarksStyle {
+    private var overrideTheme: Theme.ThemeType
+    private lazy var overridenEmptyStyle: DefaultEmptyStateStyle = OverrideEmptyStateStyle(overrideTheme: overrideTheme)
+
+    init(overrideTheme: Theme.ThemeType) {
+        self.overrideTheme = overrideTheme
+    }
+
+    override var background: Color { Color(ThemeColor.primaryUi01(for: overrideTheme)) }
+    override var primaryText: Color { Color(ThemeColor.primaryText01(for: overrideTheme)) }
+    override var secondaryText: Color { Color(ThemeColor.primaryText02(for: overrideTheme)) }
+    override var tertiaryText: Color { Color(ThemeColor.primaryText02(for: overrideTheme)) }
+    override var divider: Color { Color(ThemeColor.primaryUi05(for: overrideTheme)) }
+    override var rowHighlight: Color { Color(ThemeColor.primaryUi02Active(for: overrideTheme)) }
+    override var rowSelected: Color { Color(ThemeColor.primaryUi02Selected(for: overrideTheme)) }
+    override var selectButtonStroke: Color { Color(ThemeColor.primaryIcon02(for: overrideTheme)) }
+    override var selectButton: Color { Color(ThemeColor.primaryInteractive01(for: overrideTheme)) }
+    override var selectCheck: Color { Color(ThemeColor.primaryInteractive02(for: overrideTheme)) }
+    override var playButtonText: Color { Color(ThemeColor.primaryText01(for: overrideTheme)) }
+    override var playButtonBackground: Color? { Color(ThemeColor.primaryUi01(for: overrideTheme)) }
+    override var playButtonStroke: Color? {
+        set { }
+        get { Color(ThemeColor.primaryText01(for: overrideTheme)) }
+    }
+    override var emptyStyle: DefaultEmptyStateStyle {
+        set { }
+        get { overridenEmptyStyle }
+    }
+}
+
+class OverrideEmptyStateStyle: DefaultEmptyStateStyle {
+    var overrideTheme: Theme.ThemeType
+
+    init(overrideTheme: Theme.ThemeType) {
+        self.overrideTheme = overrideTheme
+    }
+
+    override var background: Color { Color(ThemeColor.primaryUi01Active(for: overrideTheme)) }
+    override var title: Color { Color(ThemeColor.primaryText01(for: overrideTheme)) }
+    override var message: Color { Color(ThemeColor.primaryText02(for: overrideTheme)) }
+    override var button: Color { Color(ThemeColor.primaryInteractive01(for: overrideTheme)) }
+}

--- a/podcasts/Bookmarks/Episode/BookmarkEpisodeListController.swift
+++ b/podcasts/Bookmarks/Episode/BookmarkEpisodeListController.swift
@@ -11,7 +11,7 @@ class BookmarkEpisodeListController: ThemedHostingController<BookmarkEpisodeList
 
     init(episode: BaseEpisode, displayMode: BookmarkEpisodeListView.DisplayMode = .list,
          bookmarkManager: BookmarkManager = PlaybackManager.shared.bookmarkManager,
-         playbackManager: PlaybackManager = .shared) {
+         playbackManager: PlaybackManager = .shared, themeOverride: Theme.ThemeType? = nil) {
 
         self.bookmarkManager = bookmarkManager
         self.playbackManager = playbackManager
@@ -23,7 +23,11 @@ class BookmarkEpisodeListController: ThemedHostingController<BookmarkEpisodeList
 
         self.viewModel = viewModel
 
-        super.init(rootView: BookmarkEpisodeListView(viewModel: viewModel, displayMode: displayMode))
+        if let themeOverride {
+            super.init(rootView: BookmarkEpisodeListView(viewModel: viewModel, style: OverrideThemedBookmarksStyle(overrideTheme: themeOverride), displayMode: displayMode))
+        } else {
+            super.init(rootView: BookmarkEpisodeListView(viewModel: viewModel, displayMode: displayMode))
+        }
 
         viewModel.router = self
     }

--- a/podcasts/EpisodeDetailViewController.swift
+++ b/podcasts/EpisodeDetailViewController.swift
@@ -19,7 +19,7 @@ class EpisodeDetailViewController: FakeNavViewController, UIDocumentInteractionC
     private lazy var bookmarksController: BookmarkEpisodeListController? = {
         guard FeatureFlag.bookmarks.enabled else { return nil }
 
-        return BookmarkEpisodeListController(episode: episode)
+        return BookmarkEpisodeListController(episode: episode, themeOverride: themeOverride)
     }()
 
     @IBOutlet var podcastImage: PodcastImageView!


### PR DESCRIPTION
There's a small issue that happens when the Bookmarks are opened from Up Next. This PR fixes this.

## To test

1. Run the app
2. Make sure you are using a Light theme and the simulator is on light mode (Profile > Settings > Appearance > Light Theme should be "Default Light")
3. Go to any podcast (you can use F1: Beyond the Grid) and a few episodes to Up Next
3. Add one or more Bookmarks to the current playing episode
4. Open Up Next, play any other episode
5. Open Up Next again
6. Tap the episode you added Bookmarks > then tap Bookmarks
7. ✅ The colors should be correct
8. Go back to Up Next
9. Tap an episode without Bookmarks
10. ✅ The colors should be correct

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
