### PR TITLE
Bookmarks: Ensure the whats new handler is called from the profile tab

### DIFF
--- a/podcasts/ProfileViewController.swift
+++ b/podcasts/ProfileViewController.swift
@@ -124,7 +124,7 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
             NotificationCenter.postOnMainThread(notification: Constants.Notifications.profileSeen)
         }
 
-        showGeneralSettingsIfNeeded()
+        whatsNewDismissed()
     }
 
     override func viewDidDisappear(_ animated: Bool) {


### PR DESCRIPTION
If the user sees the whats new and they don't have anything playing or in their up next, tapping the Enable button may not push to the headphone settings if the profile tab isn't active. 

## To test
Before testing: To force open the what's new, open WhatsNew.swift and change the init code to:

```
        self.announcements = announcements
        self.previousOpenedVersion = "7.51"
        self.currentVersion = currentVersion.majorMinor
        self.lastWhatsNewShown = "7.40"
```

1. Launch the app and clear your now playing and up next
2. Sign into a Patron account
3. Tap the Podcasts tab
4. Relaunch the app using this PR
5. The whats new should open
7. Tap the Enable it now button
8. ✅ Verify the profile tab opens and the headphone controls opens
9. Go back and tap the Profile tab
10. Relaunch the app
11. Tap the Enable button again in the whats new
12. ✅ Verify the headphone controls opens 
13. Play an episode
15. Relaunch the app
16. Tap the Try it Now button
17. ✅ Verify the Player opens and shows the Add Bookmark item
18. Dismiss and go to the Profile tab
19. ✅ Verify nothing happens
20. Clear the WhatsNew.swift changes
21. Relaunch the app
22. ✅ Verify the WhatsNew does not appear

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
