### PR TITLE
Playback: small fixes for next year

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncYearListeningHistoryTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncYearListeningHistoryTask.swift
@@ -167,9 +167,14 @@ class SyncYearListeningHistoryTask: ApiBaseTask {
 class PodcastExistsHelper {
     static let shared = PodcastExistsHelper()
 
-    var checkedUuidsThatExist: [String] = []
+    private var checkedUuidsThatExist: [String] = []
+
+    private var lock = NSLock()
 
     func exists(uuid: String) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+
         if checkedUuidsThatExist.contains(uuid) {
             return true
         }

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -851,7 +851,7 @@ internal enum L10n {
   }
   /// Your Top Podcasts
   internal static var eoyStoryTopPodcasts: String { return L10n.tr("Localizable", "eoy_story_top_podcasts") }
-  /// My top podcasts of 2022
+  /// My top podcasts of the year!
   internal static var eoyStoryTopPodcastsListTitle: String { return L10n.tr("Localizable", "eoy_story_top_podcasts_list_title") }
   /// My top podcasts of the year! %1$@
   internal static func eoyStoryTopPodcastsShareText(_ p1: Any) -> String {

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -3564,7 +3564,7 @@
 "eoy_story_top_podcasts_share_text" = "My top podcasts of the year! %1$@";
 
 /* Title of a list of podcasts created containing the user's top 5 podcasts of 2022. */
-"eoy_story_top_podcasts_list_title" = "My top podcasts of 2022";
+"eoy_story_top_podcasts_list_title" = "My top podcasts of the year!";
 
 /* Title for the story showing the longest episode listened for the user in the current year. %1$@ is a placeholder for the episode title and %2$@ is a placeholder for the podcast title. */
 "eoy_story_longest_episode" = "The longest episode you listened to was %1$@";


### PR DESCRIPTION
* Changes the title of the created top podcasts lists to not contain the year (so we don't run into the issue of it saying 2022 as it happened this year)
* Adds a lock in PodcastExistsHelper to prevent data race conditions¶

¶ Ideally the sync of podcasts should be rewritten to use async/await and get rid of those manual thread manipulations/locks. However, it's good to have this in place so this won't cause crashes.

## To test

1. Change `EndOfYearStoriesBuilder.swift` if in line 44 to be `if true` (forcing the sync to always happen)
2. Run a clean install of the app
3. Check your stories
4. ✅ It should display normally
5. On your top five podcasts story, tap share
6. ✅ Check that the created lists contain the title "My top podcasts of the year!"

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
