### PR TITLE
Folders issue: prevent the watch app from syncing folder changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 -----
 - Moves Bookmarks out of Early Access: [#1224]
 - Makes the player transition faster, smoother and with a new effect [#1090]
+- Attempts to fix podcast being removed from their folders [#1239]
 
 7.52
 -----

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+LocalChanges.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+LocalChanges.swift
@@ -17,7 +17,13 @@ extension SyncTask {
             podcastRecord.isDeleted.value = !podcast.isSubscribed()
             podcastRecord.subscribed.value = podcast.isSubscribed()
             podcastRecord.sortPosition.value = podcast.sortOrder
+
+            // There's a bug on the watch app that resets all users folders
+            // Since the watch don't use folders at all, it shouldn't sync
+            #if !os(watchOS)
             podcastRecord.folderUuid.value = podcast.folderUuid ?? DataConstants.homeGridFolderUuid
+            #endif
+
             if let addedDate = podcast.addedDate {
                 podcastRecord.dateAdded = Google_Protobuf_Timestamp(date: addedDate)
             }


### PR DESCRIPTION
Attempt to fix #791

We have a high suspicion that the watch app is causing the folder issue. While the exact reasons are still not very clear to me, this PR adds a change that prevents the watch from sending any folder changes.

## To test

You need an account with Plus.

1. Put a breakpoint on SyncTask+LocalChanges.swift line 24
2. Run the iPhone app
3. Add or remove any podcast to a folder
4. Go to Profile > tap "Refresh Now"
5. ✅ The breakpoint is hit, meaning that there are no changes in how the sync on the iOS app works
6. Go to `PodcastDataManager` and change the line 245 to `if true {`
7. Run the watch app
8. Tap "Refresh Data" (on the main screen)
9. ✅ The breakpoint should not be hit

If you're interested in testing that not sending the folder information is fine, comment on the `SyncTask+LocalChanges.swift` line 24 then:

1. Run the iOS app
2. Change any podcast/folder (add or remove from a folder)
3. Move podcasts order (tap and hold and then move it)
4. Go to Profile > tap "Refresh Now"
5. ✅ All the changes should persist EXCEPT the folder changes

## Additional information

It seems that, somehow, the watch app is executing the full sync. While this isn't a problem per-se, the full sync has a code that resets all folder information, [you can see it here](https://github.com/Automattic/pocket-casts-ios/blob/trunk/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift#L860).

What I believe is happening is a "sync race condition" in which the folder information is reset, the podcast is marked as unsynced, and before the folder information is correctly added again to the podcast another sync sends the changed podcast to the server.

This is a logic that we can (and probably should) refactor — we should not allow an entry on the database to be in a "temporary state" as this temporary state might get synced to the server. But given the small cost of such a change like the one in this PR and the benefit that we can start testing it as soon as possible, it seems it worths giving that a try.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
