### PR TITLE
Bookmarks: Show the Bookmarks player tab after Chapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 7.53
 -----
 - Moves Bookmarks out of Early Access: [#1224]
+- Shows the Bookmarks tab after Chapters [#1240]
 - Makes the player transition faster, smoother and with a new effect [#1090]
 
 7.52

--- a/podcasts/PlayerContainerViewController+Update.swift
+++ b/podcasts/PlayerContainerViewController+Update.swift
@@ -55,18 +55,18 @@ extension PlayerContainerViewController {
             addTab(showNotesItem, previousTab: &previousTab)
         }
 
-        if shouldShowBookmarks {
-            showingBookmarks = true
-            tabsView.tabs += [.bookmarks]
-
-            addTab(bookmarksItem, previousTab: &previousTab)
-        }
-
         if shouldShowChapters {
             showingChapters = true
             tabsView.tabs += [.chapters]
 
             addTab(chaptersItem, previousTab: &previousTab)
+        }
+
+        if shouldShowBookmarks {
+            showingBookmarks = true
+            tabsView.tabs += [.bookmarks]
+
+            addTab(bookmarksItem, previousTab: &previousTab)
         }
     }
 


### PR DESCRIPTION
| 🔗  Internal Ref: p1701267305022489/1701225559.781909-slack-C055BDMU095 |
|:---:|

Changes the order of the player tabs to show the Bookmarks tab after Chapters.

## To test

1. Launch the app
2. Play a podcast with chapters like https://pca.st/kfyb6kvc
3. Open the full screen player
4. ✅ Verify the order of the tabs is: Now Playing, Details, Chapters, Bookmarks

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.