### PR TITLE
Presentation: fix Playback 2023, About, Sonos and List

### DIFF
--- a/podcasts/AboutView.swift
+++ b/podcasts/AboutView.swift
@@ -112,7 +112,7 @@ struct AboutView: View {
     }
 
     private func openShareApp() {
-        guard let controller = SceneHelper.rootViewController()?.presentedViewController else { return }
+        guard let controller = SceneHelper.rootViewController() else { return }
 
         SharingHelper.shared.shareLinkToApp(fromController: controller)
     }

--- a/podcasts/AboutView.swift
+++ b/podcasts/AboutView.swift
@@ -112,7 +112,7 @@ struct AboutView: View {
     }
 
     private func openShareApp() {
-        guard let controller = SceneHelper.rootViewController() else { return }
+        guard let controller = FeatureFlag.newPlayerTransition.enabled ? SceneHelper.rootViewController() : SceneHelper.rootViewController()?.presentedViewController else { return }
 
         SharingHelper.shared.shareLinkToApp(fromController: controller)
     }

--- a/podcasts/End of Year/EndOfYear.swift
+++ b/podcasts/End of Year/EndOfYear.swift
@@ -100,7 +100,7 @@ struct EndOfYear {
     }
 
     func share(assets: [Any], storyIdentifier: String = "unknown", onDismiss: (() -> Void)? = nil) {
-        let presenter = SceneHelper.rootViewController()?.presentedViewController
+        let presenter = SceneHelper.rootViewController()
 
         let fakeViewController = FakeViewController()
         fakeViewController.onDismiss = onDismiss

--- a/podcasts/End of Year/EndOfYear.swift
+++ b/podcasts/End of Year/EndOfYear.swift
@@ -100,7 +100,7 @@ struct EndOfYear {
     }
 
     func share(assets: [Any], storyIdentifier: String = "unknown", onDismiss: (() -> Void)? = nil) {
-        let presenter = SceneHelper.rootViewController()
+        let presenter = FeatureFlag.newPlayerTransition.enabled ? SceneHelper.rootViewController() : SceneHelper.rootViewController()?.presentedViewController
 
         let fakeViewController = FakeViewController()
         fakeViewController.onDismiss = onDismiss

--- a/podcasts/End of Year/Stories/Views/PaidStoryWallView.swift
+++ b/podcasts/End of Year/Stories/Views/PaidStoryWallView.swift
@@ -15,7 +15,7 @@ struct PaidStoryWallView: View {
                 .padding(.bottom, geometry.size.height * 0.06)
 
                 Button(model.pricingInfo.hasFreeTrial ? L10n.eoyStartYourFreeTrial : L10n.upgradeToPlan(L10n.pocketCastsPlusShort)) {
-                    guard let storiesViewController = SceneHelper.rootViewController()?.presentedViewController else {
+                    guard let storiesViewController = SceneHelper.rootViewController() else {
                         return
                     }
 

--- a/podcasts/End of Year/Stories/Views/PaidStoryWallView.swift
+++ b/podcasts/End of Year/Stories/Views/PaidStoryWallView.swift
@@ -15,7 +15,7 @@ struct PaidStoryWallView: View {
                 .padding(.bottom, geometry.size.height * 0.06)
 
                 Button(model.pricingInfo.hasFreeTrial ? L10n.eoyStartYourFreeTrial : L10n.upgradeToPlan(L10n.pocketCastsPlusShort)) {
-                    guard let storiesViewController = SceneHelper.rootViewController() else {
+                    guard let storiesViewController = FeatureFlag.newPlayerTransition.enabled ? SceneHelper.rootViewController() : SceneHelper.rootViewController()?.presentedViewController else {
                         return
                     }
 

--- a/podcasts/UIViewController+Presenting.swift
+++ b/podcasts/UIViewController+Presenting.swift
@@ -2,7 +2,7 @@ import UIKit
 
 extension UIViewController {
     var topMostPresentedViewController: UIViewController? {
-        guard UIApplication.shared.applicationState == .active else {
+        guard UIApplication.shared.applicationState != .background else {
             return nil
         }
 


### PR DESCRIPTION
With the player transition recent changes, we shouldn't access `presentedViewController` directly anymore.

This code removes that fixing presenting screens on Playback 2023 and About.

## To test

1. Run the app
2. Set yourself as Not Paid
2. Check your Playback 2023
3. Tap "Share story" in any story
4. ✅ The share sheet should appear
5. Dismiss it
6. Go to the 8th story
7. Tap "Start your free trial"
8. ✅ The upgrade screen should appear
9. Dismiss it, then dismiss the stories
10. Go to Settings
11. Tap About
12. Tap "Share With Friends"
13. ✅ The share sheet should appear
14. Open Safari
15. Paste the following URL: `pktc://applink/sonos/testing`
16. ✅ Sonos screen should appear
17. Open on Safari a list (ie.: https://lists.pocketcasts.com/3dc4100e-9b3c-466f-93b7-917fc582e923)
18. Tap "Open list in Pocket Casts"
19. ✅ A list should appear

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
