### PR TITLE
Issue 17 – Buffer Logs to Reduce Filesystem Writes

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/General/DispatchQueueing.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/General/DispatchQueueing.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+protocol DispatchQueueing: AnyObject {
+    func async(execute work: @escaping @convention(block) () -> Void)
+}
+
+extension DispatchQueue: DispatchQueueing {
+    func async(execute work: @escaping @convention(block) () -> Void) {
+        async(group: nil, qos: qos, flags: [], execute: work)
+    }
+}

--- a/Modules/Utils/Sources/PocketCastsUtils/Logging/FileLog.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Logging/FileLog.swift
@@ -88,6 +88,7 @@ public final class FileLog {
     }
 
     public func loadLogFileAsString(completion: @escaping (String) -> Void) {
+        forceFlush()
         logQueue.async {
             let mainFileContents: String
             do {

--- a/Modules/Utils/Sources/PocketCastsUtils/Logging/FileLog.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Logging/FileLog.swift
@@ -83,6 +83,8 @@ public final class FileLog {
     }
 
     public func forceFlush() {
+        guard !logBuffer.isEmpty else { return }
+        
         logger?.debug("\(Self.self) forcibly flushing to disk.")
         writeLogBufferToDisk()
     }

--- a/Modules/Utils/Sources/PocketCastsUtils/Logging/FileLog.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Logging/FileLog.swift
@@ -2,14 +2,32 @@ import Combine
 import Foundation
 import os
 
-public class FileLog {
+public final class FileLog {
     public enum LogError: Error {
         case logCanceled
         case logGenerationFailed
     }
 
-    public static let shared = FileLog()
-    private static let logger = Logger()
+    public static let shared: FileLog = {
+        let logger = Logger()
+
+        let logFileWriter = LogFileWriter(
+            writingToFileAtPath: LogFilePaths.mainLogFilePath,
+            loggingTo: logger
+        )
+
+        let fileRotator = FileRotator(
+            targetFilePath: LogFilePaths.mainLogFilePath,
+            backupFilePath: LogFilePaths.backupLogFilePath,
+            loggingTo: logger
+        )
+
+        return FileLog(
+            logPersistence: logFileWriter,
+            logRotator: fileRotator,
+            loggingTo: logger
+        )
+    }()
 
     #if os(watchOS)
         private let maxFileSize = 25.kilobytes
@@ -17,37 +35,46 @@ public class FileLog {
         private let maxFileSize = 100.kilobytes
     #endif
 
-    private lazy var logDirectory: String = {
-        let directory = (NSHomeDirectory() as NSString).appendingPathComponent("Documents/debug_log")
+    private let bufferThreshold: UInt
+    private let logPersistence: PersistentTextWriting
+    private let logRotator: FileRotating
+    private let logger: Logger?
 
-        return directory
-    }()
+    private lazy var entries: [LogEntry] = [] {
+        didSet {
+            if entries.count >= bufferThreshold {
+                writeLogBufferToDisk()
+            }
+        }
+    }
+    private let logQueue: DispatchQueueing
 
-    private lazy var mainLogFilePath: String = logDirectory + "/main.log"
-
-    private lazy var backupLogFilePath: String = logDirectory + "/old.log"
-
-    public lazy var watchUploadLog: String = self.logDirectory + "/uploadWatchDebug.log"
-
-    public lazy var debugUploadLog: String = self.logDirectory + "/uploadDebug.log"
-
-    private let logQueue = DispatchQueue(label: "au.com.pocketcasts.LogQueue")
+    init(
+        logPersistence: PersistentTextWriting,
+        logRotator: FileRotating,
+        writeQueue: DispatchQueueing = DispatchQueue(label: "au.com.pocketcasts.LogQueue", qos: .background),
+        bufferThreshold: UInt = 100,
+        loggingTo logger: Logger? = nil
+    ) {
+        self.logPersistence = logPersistence
+        self.logRotator = logRotator
+        self.logQueue = writeQueue
+        self.bufferThreshold = bufferThreshold
+        self.logger = logger
+    }
 
     public func setup() {
         let fileManager = FileManager.default
         do {
-            try fileManager.createDirectory(atPath: logDirectory, withIntermediateDirectories: true, attributes: nil)
-            // SJCommonUtils.setDontBackupFlag(URL(fileURLWithPath: logDirectory))
+            try fileManager.createDirectory(atPath: LogFilePaths.logDirectory, withIntermediateDirectories: true, attributes: nil)
         } catch {}
     }
 
-    public func addMessage(_ message: String?) {
-        guard let message = message, message.count > 0 else { return }
-
+    public func addMessage(_ message: String) {
         // if it's important enough to log to file, write it to the debug console as well
-        Self.logger.log("\(message, privacy: .public)")
-        let dateFormatter = DateFormatHelper.sharedHelper.localTimeJsonDateFormatter
-        appendStringToLog("\(dateFormatter.string(from: Date())) \(message)\n")
+        logger?.log("\(message, privacy: .public)")
+
+        entries.append(LogEntry(message))
     }
 
     // Just a shortcut for `addMessage` to be used specifically for
@@ -62,20 +89,36 @@ public class FileLog {
         addMessage("[Folders] \(message)")
     }
 
-    public func loadLogFileAsString(completion: @escaping (String) -> Void) {
-        logQueue.async { [weak self] in
-            guard let self = self else { return }
+    public func forceFlush() {
+        logger?.log("\(Self.self) forcibly flushing to disk.")
+        writeLogBufferToDisk()
+    }
 
+    private func writeLogBufferToDisk() {
+        let logTimestampFormatter = DateFormatHelper.sharedHelper.localTimeJsonDateFormatter
+        let newLogChunk = entries.reduce(into: "") { resultChunk, logEntry in
+            let formattedTimestamp = logTimestampFormatter.string(from: logEntry.timestamp)
+            let logLine = "\(formattedTimestamp) \(logEntry.message)\n"
+
+            resultChunk.append(logLine)
+        }
+
+        entries.removeAll(keepingCapacity: true)
+        appendStringToLog(newLogChunk)
+    }
+
+    public func loadLogFileAsString(completion: @escaping (String) -> Void) {
+        logQueue.async {
             let mainFileContents: String
             do {
-                mainFileContents = try String(contentsOfFile: self.mainLogFilePath)
+                mainFileContents = try String(contentsOfFile: LogFilePaths.mainLogFilePath)
             } catch {
                 mainFileContents = "Main log is empty"
             }
 
             let secondaryFileContents: String
             do {
-                secondaryFileContents = try String(contentsOfFile: self.backupLogFilePath)
+                secondaryFileContents = try String(contentsOfFile: LogFilePaths.backupLogFilePath)
             } catch {
                 secondaryFileContents = ""
             }
@@ -86,7 +129,7 @@ public class FileLog {
 
     // Creates a merged file from `mainLogFilePath` and `backupLogFilePath` to be used for enquing the file upload.
     public func logFileForUpload() -> AnyPublisher<String, Error> {
-        let file = debugUploadLog
+        let file = LogFilePaths.debugUploadLog
 
         return Future { [unowned self] promise in
             self.loadLogFileAsString { result in
@@ -102,36 +145,13 @@ public class FileLog {
         .eraseToAnyPublisher()
     }
 
-    private func appendStringToLog(_ line: String) {
+    private func appendStringToLog(_ logUpdate: String) {
         let trace = TraceManager.shared.beginTracing(eventName: "FILE_LOG_WRITE_MESSAGE_TO_FILE")
-        logQueue.async { [weak self] in
+        logQueue.async { [logRotator, logPersistence, logUpdate, maxFileSize] in
             defer { TraceManager.shared.endTracing(trace: trace) }
-            guard let self = self, let dataToWrite = line.data(using: .utf8) else { return }
 
-            let fileManager = FileManager.default
-            do {
-                // check that the main log file isn't too big, if it is, write it into the backup location
-                if fileManager.fileExists(atPath: self.mainLogFilePath) {
-                    let fileDict = try fileManager.attributesOfItem(atPath: self.mainLogFilePath)
-                    let fileSizeInBytes = fileDict[.size] as? UInt64 ?? 0
-                    if fileSizeInBytes > self.maxFileSize {
-                        do { try fileManager.removeItem(atPath: self.backupLogFilePath) } catch {} // this one will throw if the file doesn't exist, which is perfectly fine
-                        try fileManager.moveItem(atPath: self.mainLogFilePath, toPath: self.backupLogFilePath)
-                    }
-                }
-
-                if let fileHandle = FileHandle(forWritingAtPath: self.mainLogFilePath) {
-                    defer {
-                        fileHandle.closeFile()
-                    }
-                    fileHandle.seekToEndOfFile()
-                    fileHandle.write(dataToWrite)
-                } else {
-                    try line.write(toFile: self.mainLogFilePath, atomically: true, encoding: String.Encoding.utf8)
-                }
-            } catch {
-                print("Unable to write to file")
-            }
+            logRotator.rotateFile(ifSizeExceeds: maxFileSize)
+            logPersistence.write(logUpdate)
         }
     }
 }

--- a/Modules/Utils/Sources/PocketCastsUtils/Logging/FileLog.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Logging/FileLog.swift
@@ -129,12 +129,8 @@ public final class FileLog {
     }
 
     private func writeLogBufferToDisk() {
-        let logTimestampFormatter = DateFormatHelper.sharedHelper.localTimeJsonDateFormatter
         let newLogChunk = logBuffer.reduce(into: "") { resultChunk, logEntry in
-            let formattedTimestamp = logTimestampFormatter.string(from: logEntry.timestamp)
-            let logLine = "\(formattedTimestamp) \(logEntry.message)\n"
-
-            resultChunk.append(logLine)
+            resultChunk.append("\(logEntry.formattedForLog)\n")
         }
 
         logBuffer.removeAll(keepingCapacity: true)

--- a/Modules/Utils/Sources/PocketCastsUtils/Logging/FileLog.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Logging/FileLog.swift
@@ -41,6 +41,8 @@ public final class FileLog {
     private let logQueue: DispatchQueueing
     private let logger: Logger?
 
+    private var filePathCreated = false
+
     private lazy var logBuffer: [LogEntry] = [] {
         didSet {
             if logBuffer.count >= bufferThreshold {
@@ -61,13 +63,6 @@ public final class FileLog {
         self.logQueue = writeQueue
         self.bufferThreshold = bufferThreshold
         self.logger = logger
-    }
-
-    public func setup() {
-        let fileManager = FileManager.default
-        do {
-            try fileManager.createDirectory(atPath: LogFilePaths.logDirectory, withIntermediateDirectories: true, attributes: nil)
-        } catch {}
     }
 
     public func addMessage(_ message: String) {

--- a/Modules/Utils/Sources/PocketCastsUtils/Logging/FileLog.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Logging/FileLog.swift
@@ -41,8 +41,6 @@ public final class FileLog {
     private let logQueue: DispatchQueueing
     private let logger: Logger?
 
-    private var filePathCreated = false
-
     private lazy var logBuffer: [LogEntry] = [] {
         didSet {
             if logBuffer.count >= bufferThreshold {

--- a/Modules/Utils/Sources/PocketCastsUtils/Logging/FileRotating.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Logging/FileRotating.swift
@@ -1,0 +1,51 @@
+import Foundation
+import OSLog
+
+protocol FileRotating {
+    func rotateFile(ifSizeExceeds: Int)
+}
+
+struct FileRotator: FileRotating {
+
+    private let fileManager: FileManager
+    private let targetFilePath: String
+    private let backupFilePath: String
+    private let logger: Logger?
+
+    init(fileManager: FileManager = .default, targetFilePath: String, backupFilePath: String, loggingTo logger: Logger? = nil) {
+        self.fileManager = fileManager
+        self.targetFilePath = targetFilePath
+        self.backupFilePath = backupFilePath
+        self.logger = logger
+    }
+
+    func rotateFile(ifSizeExceeds maxFileSizeInBytes: Int) {
+        guard fileManager.fileExists(atPath: targetFilePath) else {
+            logger?.debug("Attempted to rotate file at <\(targetFilePath)> but no such file exists. Aborting.")
+            return
+        }
+
+        let fileSizeInBytes: UInt64
+        do {
+            let fileDict = try fileManager.attributesOfItem(atPath: targetFilePath)
+            fileSizeInBytes = (fileDict[.size] as? UInt64) ?? 0
+        } catch {
+            logger?.debug("Failed to retrieve attributes of file at path <\(targetFilePath)>. Error: \(error)")
+            return
+        }
+
+        guard fileSizeInBytes > maxFileSizeInBytes else {
+            // File is small enough that it doesn't need to be rotated.
+            return
+        }
+
+        do { try fileManager.removeItem(atPath: LogFilePaths.backupLogFilePath) }
+        catch { /* The file doesn't exist, which is perfectly fine */ }
+
+        do {
+            try fileManager.moveItem(atPath: targetFilePath, toPath: backupFilePath)
+        } catch {
+            logger?.error("Failed to rotate file at path <\(targetFilePath)> by moving it to <\(backupFilePath)>. Error: \(error)")
+        }
+    }
+}

--- a/Modules/Utils/Sources/PocketCastsUtils/Logging/LogEntry.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Logging/LogEntry.swift
@@ -2,8 +2,22 @@ import Foundation
 
 struct LogEntry {
 
+    // MARK: - Public Properties
+
     let message: String
     let timestamp: Date
+
+    var formattedForLog: String {
+        "\(formatter.string(from: timestamp)) \(message)"
+    }
+
+    // MARK: - Private Properties
+
+    private var formatter: DateFormatter {
+        DateFormatHelper.sharedHelper.localTimeJsonDateFormatter
+    }
+
+    // MARK: - Initializers
 
     init(_ message: String) {
         self.message = message

--- a/Modules/Utils/Sources/PocketCastsUtils/Logging/LogEntry.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Logging/LogEntry.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+struct LogEntry {
+
+    let message: String
+    let timestamp: Date
+
+    init(_ message: String) {
+        self.message = message
+        self.timestamp = Date() // Now
+    }
+}

--- a/Modules/Utils/Sources/PocketCastsUtils/Logging/LogFilePaths.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Logging/LogFilePaths.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+public enum LogFilePaths {
+
+    public static var watchUploadLog: String { logDirectory + "/uploadWatchDebug.log" }
+
+    public static var debugUploadLog: String { logDirectory + "/uploadDebug.log" }
+
+    static var mainLogFilePath: String { logDirectory + "/main.log" }
+
+    static var backupLogFilePath: String { logDirectory + "/old.log" }
+
+    static var logDirectory: String {
+        let directory = (NSHomeDirectory() as NSString).appendingPathComponent("Documents/debug_log")
+        return directory
+    }
+}

--- a/Modules/Utils/Sources/PocketCastsUtils/Logging/PersistentTextWriting.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Logging/PersistentTextWriting.swift
@@ -1,0 +1,44 @@
+import Foundation
+import OSLog
+
+protocol PersistentTextWriting {
+    func write(_ text: String)
+}
+
+struct LogFileWriter: PersistentTextWriting {
+
+    private let targetFilePath: String
+    private let encoding: String.Encoding
+    private let logger: Logger?
+
+    init(writingToFileAtPath targetFilePath: String, encodingTextAs encoding: String.Encoding = .utf8, loggingTo logger: Logger? = nil) {
+        self.encoding = encoding
+        self.logger = logger
+        self.targetFilePath = targetFilePath
+    }
+
+    func write(_ text: String) {
+        guard let encodedText = text.data(using: encoding) else {
+            return
+        }
+
+        guard let fileHandle = FileHandle(forWritingAtPath: targetFilePath) else {
+            do { try text.write(toFile: targetFilePath, atomically: true, encoding: encoding) }
+            catch { logger?.debug("Unable to write to file. Error: \(error)") }
+            return
+        }
+
+        do {
+            try fileHandle.seekToEnd()
+            fileHandle.write(encodedText)
+        } catch {
+            logger?.error("Failed to seek to end of file at path <\(targetFilePath)>. Error: \(error)")
+        }
+
+        do {
+            try fileHandle.close()
+        } catch {
+            logger?.warning("Failed to close file handle to file at path <\(targetFilePath)>. Must likely the handle is already closed or is not a filesystem file. Error: \(error)")
+        }
+    }
+}

--- a/Modules/Utils/Sources/PocketCastsUtils/Logging/PersistentTextWriting.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Logging/PersistentTextWriting.swift
@@ -9,22 +9,33 @@ struct LogFileWriter: PersistentTextWriting {
 
     private let targetFilePath: String
     private let encoding: String.Encoding
+    private let fileManager: FileManager
     private let logger: Logger?
 
-    init(writingToFileAtPath targetFilePath: String, encodingTextAs encoding: String.Encoding = .utf8, loggingTo logger: Logger? = nil) {
+    init(
+        writingToFileAtPath targetFilePath: String,
+        encodingTextAs encoding: String.Encoding = .utf8,
+        fileManager: FileManager = .default,
+        loggingTo logger: Logger? = nil
+    ) {
         self.encoding = encoding
         self.logger = logger
+        self.fileManager = fileManager
         self.targetFilePath = targetFilePath
     }
 
     func write(_ text: String) {
-        guard let encodedText = text.data(using: encoding) else {
+        guard let fileHandle = FileHandle(forWritingAtPath: targetFilePath) else {
+            do {
+                try text.write(toFile: targetFilePath, atomically: true, encoding: encoding)
+            }
+            catch {
+                handle(fileHandleWriteError: error, encounteredWriting: text)
+            }
             return
         }
 
-        guard let fileHandle = FileHandle(forWritingAtPath: targetFilePath) else {
-            do { try text.write(toFile: targetFilePath, atomically: true, encoding: encoding) }
-            catch { logger?.debug("Unable to write to file. Error: \(error)") }
+        guard let encodedText = text.data(using: encoding) else {
             return
         }
 
@@ -40,5 +51,36 @@ struct LogFileWriter: PersistentTextWriting {
         } catch {
             logger?.warning("Failed to close file handle to file at path <\(targetFilePath)>. Must likely the handle is already closed or is not a filesystem file. Error: \(error)")
         }
+    }
+
+    private func handle(fileHandleWriteError: any Error, encounteredWriting textToWrite: String) {
+        let fileHandleWriteError = fileHandleWriteError as NSError
+
+        guard fileHandleWriteError.domain == NSCocoaErrorDomain else {
+            logger?.debug("Unable to write to file. Error: \(fileHandleWriteError)")
+            return
+        }
+
+        switch fileHandleWriteError.code {
+        case NSFileNoSuchFileError:
+            logger?.debug("Attempted to write to log file but directory structure for <\(targetFilePath)> appears not to exist. Creating it.")
+            do {
+                try createDirectoryStructure(for: targetFilePath)
+                write(textToWrite) // Error successfully addressed, retry the log write.
+            } catch {
+                logger?.error("Failed to create directory structure for logs at <\(targetFilePath)>. Error: \(error)")
+            }
+
+        default:
+            logger?.debug("Unable to write to file. Error: \(fileHandleWriteError)")
+        }
+    }
+
+    private func createDirectoryStructure(for filePath: String) throws {
+        try fileManager.createDirectory(
+            atPath: filePath,
+            withIntermediateDirectories: true,
+            attributes: nil
+        )
     }
 }

--- a/Modules/Utils/Sources/PocketCastsUtils/Logging/PersistentTextWriting.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Logging/PersistentTextWriting.swift
@@ -77,8 +77,12 @@ struct LogFileWriter: PersistentTextWriting {
     }
 
     private func createDirectoryStructure(for filePath: String) throws {
+        let filePathComponents = filePath.split(separator: "/")
+        let directoryPathComponenets = filePathComponents.dropLast()
+        let directoryPath = directoryPathComponenets.joined(separator: "/")
+
         try fileManager.createDirectory(
-            atPath: filePath,
+            atPath: directoryPath,
             withIntermediateDirectories: true,
             attributes: nil
         )

--- a/Modules/Utils/Tests/PocketCastsUtilsTests/General/SerialDispatchMock.swift
+++ b/Modules/Utils/Tests/PocketCastsUtilsTests/General/SerialDispatchMock.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+@testable import PocketCastsUtils
+
+final class SerialDispatchMock: DispatchQueueing {
+    func async(execute work: @escaping @convention(block) () -> Void) {
+        work()
+    }
+}

--- a/Modules/Utils/Tests/PocketCastsUtilsTests/Logging/FileLogTests.swift
+++ b/Modules/Utils/Tests/PocketCastsUtilsTests/Logging/FileLogTests.swift
@@ -1,0 +1,113 @@
+import XCTest
+
+@testable import PocketCastsUtils
+
+final class FileLogTests: XCTestCase {
+
+    func testLogFlushedWhenThresholdReached() {
+        // GIVEN that we have a FileLog with a buffer threshold of 3...
+        let fileWriteSpy = LogPersistenceSpy()
+        let bufferThreshold: UInt = 3
+        let fileLog = FileLog(
+            logPersistence: fileWriteSpy,
+            logRotator: LogRotatorStub(),
+            writeQueue: SerialDispatchMock(),
+            bufferThreshold: bufferThreshold
+        )
+
+        // WHEN we write three log messages...
+        for messageNum in 1...bufferThreshold {
+            fileLog.addMessage("Log Message \(messageNum)")
+        }
+
+        // THEN the log messages have been flushed to file persistence.
+        XCTAssertTrue(fileWriteSpy.textWrittenToLog)
+        XCTAssertEqual(fileWriteSpy.writeCount, 1)
+    }
+
+    func testLogNotFlushedBeforeThresholdReached() {
+        // GIVEN that we have a FileLog with a buffer threshold of 2...
+        let fileWriteSpy = LogPersistenceSpy()
+        let fileLog = FileLog(
+            logPersistence: fileWriteSpy,
+            logRotator: LogRotatorStub(),
+            writeQueue: SerialDispatchMock(),
+            bufferThreshold: 2
+        )
+
+        // WHEN we write only one log message...
+        fileLog.addMessage("Log Message")
+
+        // THEN the log is not flushed to persistence as the threshold was not reached.
+        XCTAssertFalse(fileWriteSpy.textWrittenToLog)
+        XCTAssertEqual(fileWriteSpy.writeCount, 0)
+    }
+
+    func testFileRotationRequestedWhenFlushing() {
+        // GIVEN that we have a FileLog with a low threshold...
+        let rotationSpy = LogRotationSpy()
+        let fileLog = FileLog(
+            logPersistence: LogPersistenceStub(),
+            logRotator: rotationSpy,
+            writeQueue: SerialDispatchMock(),
+            bufferThreshold: 1
+        )
+
+        // WHEN we exceed the buffer threshold and trigger the log to be flushed...
+        fileLog.addMessage("Log Message")
+
+        // THEN file rotation is requested.
+        XCTAssertTrue(rotationSpy.rotationRequested)
+    }
+
+    func testFlushedMessagesSeperatedByNewlines() {
+        // GIVEN that we have a FileLog with a low threshold...
+        let fileWriteSpy = LogPersistenceSpy()
+        let bufferThreshold: UInt = 3
+        let fileLog = FileLog(
+            logPersistence: fileWriteSpy,
+            logRotator: LogRotatorStub(),
+            writeQueue: SerialDispatchMock(),
+            bufferThreshold: bufferThreshold
+        )
+
+        // WHEN we write enough messages to trigger a flush...
+        for messageNum in 1...bufferThreshold {
+            fileLog.addMessage("Log Message \(messageNum)")
+        }
+
+        // THEN the flushed messages are seperated by newlines.
+        XCTAssertTrue(fileWriteSpy.textWrittenToLog)
+        XCTAssertNotNil(fileWriteSpy.lastWrittenChunk)
+        let lineCount = fileWriteSpy.lastWrittenChunk!.split(separator: "\n").count
+        XCTAssertEqual(lineCount, 3)
+    }
+
+    func testForceFlushFlushesRegardlessOfNumberOfBufferedMessages() {
+        // GIVEN that we have a FileLog with a high threshold...
+        let fileWriteSpy = LogPersistenceSpy()
+        let bufferThreshold: UInt = 10
+        let fileLog = FileLog(
+            logPersistence: fileWriteSpy,
+            logRotator: LogRotatorStub(),
+            writeQueue: SerialDispatchMock(),
+            bufferThreshold: bufferThreshold
+        )
+
+        // AND the number of buffered messages is below the threshold...
+        let halfBufferThreshold = (bufferThreshold / 2)
+        for messageNum in 1...halfBufferThreshold {
+            fileLog.addMessage("Log Message \(messageNum)")
+        }
+
+        // WHEN we force the FileLog to flush...
+        fileLog.forceFlush()
+
+        // THEN all of the buffered messages are flushed despite being below the threshold.
+        XCTAssertTrue(fileWriteSpy.textWrittenToLog)
+        XCTAssertEqual(fileWriteSpy.writeCount, 1)
+        let linesWrittenCount = fileWriteSpy.lastWrittenChunk!.split(separator: "\n").count
+        XCTAssertEqual(UInt(linesWrittenCount), halfBufferThreshold)
+    }
+
+}

--- a/Modules/Utils/Tests/PocketCastsUtilsTests/Logging/LogPersistenceSpy.swift
+++ b/Modules/Utils/Tests/PocketCastsUtilsTests/Logging/LogPersistenceSpy.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+@testable import PocketCastsUtils
+
+final class LogPersistenceSpy: PersistentTextWriting {
+
+    private(set) var textWrittenToLog = false
+    private(set) var writeCount: UInt = 0
+    private(set) var lastWrittenChunk: String?
+
+    func write(_ text: String) {
+        textWrittenToLog = true
+        writeCount += 1
+        lastWrittenChunk = text
+    }
+
+}

--- a/Modules/Utils/Tests/PocketCastsUtilsTests/Logging/LogPersistenceStub.swift
+++ b/Modules/Utils/Tests/PocketCastsUtilsTests/Logging/LogPersistenceStub.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+@testable import PocketCastsUtils
+
+final class LogPersistenceStub: PersistentTextWriting {
+
+    func write(_ text: String) {
+        // No operation
+    }
+
+}

--- a/Modules/Utils/Tests/PocketCastsUtilsTests/Logging/LogRotationSpy.swift
+++ b/Modules/Utils/Tests/PocketCastsUtilsTests/Logging/LogRotationSpy.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+@testable import PocketCastsUtils
+
+final class LogRotationSpy: FileRotating {
+
+    private(set) var rotationRequested = false
+
+    func rotateFile(ifSizeExceeds: Int) {
+        rotationRequested = true
+    }
+}

--- a/Modules/Utils/Tests/PocketCastsUtilsTests/Logging/LogRotatorStub.swift
+++ b/Modules/Utils/Tests/PocketCastsUtilsTests/Logging/LogRotatorStub.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+@testable import PocketCastsUtils
+
+struct LogRotatorStub: FileRotating {
+    func rotateFile(ifSizeExceeds: Int) {
+        // No operation
+    }
+}

--- a/Pocket Casts Watch App Extension/WatchSyncManager.swift
+++ b/Pocket Casts Watch App Extension/WatchSyncManager.swift
@@ -25,8 +25,6 @@ class WatchSyncManager {
     }
 
     func setup() {
-        FileLog.shared.setup()
-
         let defaults = UserDefaults.standard
 
         // check to see that this app has a unique ID, if not create one

--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -103,6 +103,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func handleEnterBackground() {
         scheduleNextBackgroundRefresh()
+        FileLog.shared.forceFlush()
 
         UserDefaults.standard.set(Date(), forKey: Constants.UserDefaults.lastAppCloseDate)
         badgeHelper.updateBadge()

--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -33,7 +33,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
         configureFirebase()
         TraceManager.shared.setup(handler: traceHandler)
-        FileLog.shared.setup()
 
         setupWhatsNew()
 

--- a/podcasts/AutoplayHelper.swift
+++ b/podcasts/AutoplayHelper.swift
@@ -13,9 +13,9 @@ class AutoplayHelper {
 
         var analyticsDescription: String {
             switch self {
-            case .podcast(uuid: _):
+            case .podcast:
                 return "podcast"
-            case .filter(uuid: _):
+            case .filter:
                 return "filter"
             case .downloads:
                 return "downloads"

--- a/podcasts/Zendesk/FileLog+FileUpload.swift
+++ b/podcasts/Zendesk/FileLog+FileUpload.swift
@@ -49,7 +49,7 @@ extension FileLog: EventLoggingDelegate {
                     promise(.success(nil))
                     return
                 }
-                let file = self.watchUploadLog
+                let file = LogFilePaths.watchUploadLog
                 do {
                     try wearableLog.write(toFile: file, atomically: true, encoding: String.Encoding.utf8)
                 } catch {
@@ -79,7 +79,7 @@ extension FileLog: EventLoggingDelegate {
     // MARK: - EventLoggingDelegate
 
     public var shouldUploadLogFiles: Bool {
-        FileManager.default.fileExists(atPath: debugUploadLog) || FileManager.default.fileExists(atPath: watchUploadLog)
+        FileManager.default.fileExists(atPath: LogFilePaths.debugUploadLog) || FileManager.default.fileExists(atPath: LogFilePaths.watchUploadLog)
     }
 
     public func didFinishUploadingLog(_ log: LogFile) {


### PR DESCRIPTION
Fixes #17 

This is a partial fix for [Issue 17 Battery Usage](https://github.com/Automattic/pocket-casts-ios/issues/17). I don't have access to the performance data from Apple but implemented the `FileLog` buffering described in the issue.

There are three primary changes to the `FileLog`.

The first and most significant change is that we no longer write each log message to the filesystem each time that `addMessage(_ message: String)` is called. Instead we store the log entry in a `logBuffer` collection. Each time that we reach a number of log messages specified in the `init` (defaults to 100) we batch write the cached log entries to the log file. We also forcibly flush the cache when the app enters the background.

The second change is the delegation of the log file rotation and the log writing to separate protocols `FileRotating` and `PersistentTextWriting` respectively. While the abstraction is nice this has mostly been done to implement unit tests for the `FileLog` to ensure that its flushing the log buffer.

The final change is that we no longer invoke `FileLog.shared.setup()` at app start. Instead the `LogFileWriter` that implements `PersistentTextWriting` in production will create the directories in which we store the logs if writing to the log fails with `NSFileNoSuchFileError`.

## To test

1. Navigate around the app and start a podcast to generate log entries.
2. Tap the Profile tab
3. Tap the gear to access Settings
4. Scroll to the bottom and tap Help & Feedback
5. Scroll to the bottom and tap Get in touch
6. Tap Get Support
7. Tap Attached Logs at the bottom
8. Verify that Debug Logs contains the expected log output such as for the podcast that was started

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
