### PR TITLE
Fix episodes not showing up on the app

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Podcast.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Podcast.swift
@@ -56,7 +56,7 @@ public class Podcast: NSObject, Identifiable {
 
     // if set to true, all podcast episodes will be refreshed in the next sync
     // useful for when episodes are missing
-    public var forceRefreshEpisodes: Bool = false
+    public var forceRefreshEpisodeFrom: String? = nil
 
     public func autoDownloadOn() -> Bool {
         autoDownloadSetting == AutoDownloadSetting.latest.rawValue

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Podcast.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Podcast.swift
@@ -54,8 +54,8 @@ public class Podcast: NSObject, Identifiable {
     // transient not saved to database
     public var cachedUnreadCount = 0
 
-    // if set to true, all podcast episodes will be refreshed in the next sync
-    // useful for when episodes are missing
+    // if set to an episode UUID, all podcast episodes after the given
+    // UUID will be updated
     public var forceRefreshEpisodeFrom: String? = nil
 
     public func autoDownloadOn() -> Bool {

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Podcast.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Podcast.swift
@@ -54,6 +54,10 @@ public class Podcast: NSObject, Identifiable {
     // transient not saved to database
     public var cachedUnreadCount = 0
 
+    // if set to true, all podcast episodes will be refreshed in the next sync
+    // useful for when episodes are missing
+    public var forceRefreshEpisodes: Bool = false
+
     public func autoDownloadOn() -> Bool {
         autoDownloadSetting == AutoDownloadSetting.latest.rawValue
     }

--- a/Modules/Server/Sources/PocketCastsServer/Public/Refresh/MainServerHandler.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Refresh/MainServerHandler.swift
@@ -237,7 +237,7 @@ public class MainServerHandler {
         var jsonRequest = jsonWithStandardParams(uniqueId: uniqueId)
         jsonRequest["push_sound"].string = "11" // for legacy reasons, this is always the push sound we send, since it's no longer configurable
         jsonRequest["podcasts"].string = podcasts.map(\.uuid).joined(separator: ",")
-        jsonRequest["last_episodes"].string = podcasts.map { $0.forceRefreshEpisodes ? "" : $0.latestEpisodeUuid ?? "" }.joined(separator: ",")
+        jsonRequest["last_episodes"].string = podcasts.map { $0.forceRefreshEpisodeFrom ?? $0.latestEpisodeUuid ?? "" }.joined(separator: ",")
         jsonRequest["push_messages_on"].string = podcasts.map { (pushEnabled && $0.pushEnabled) ? "1" : "0" }.joined()
         if let pushToken = ServerSettings.pushToken() {
             jsonRequest["push_token"].string = pushToken

--- a/Modules/Server/Sources/PocketCastsServer/Public/Refresh/MainServerHandler.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Refresh/MainServerHandler.swift
@@ -237,7 +237,7 @@ public class MainServerHandler {
         var jsonRequest = jsonWithStandardParams(uniqueId: uniqueId)
         jsonRequest["push_sound"].string = "11" // for legacy reasons, this is always the push sound we send, since it's no longer configurable
         jsonRequest["podcasts"].string = podcasts.map(\.uuid).joined(separator: ",")
-        jsonRequest["last_episodes"].string = podcasts.map { $0.latestEpisodeUuid ?? "" }.joined(separator: ",")
+        jsonRequest["last_episodes"].string = podcasts.map { $0.forceRefreshEpisodes ? "" : $0.latestEpisodeUuid ?? "" }.joined(separator: ",")
         jsonRequest["push_messages_on"].string = podcasts.map { (pushEnabled && $0.pushEnabled) ? "1" : "0" }.joined()
         if let pushToken = ServerSettings.pushToken() {
             jsonRequest["push_token"].string = pushToken

--- a/Modules/Server/Sources/PocketCastsServer/Public/Refresh/RefreshManager.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Refresh/RefreshManager.swift
@@ -42,6 +42,7 @@ public class RefreshManager {
                 guard let episodes = ApiServerHandler.shared.retrieveEpisodeTaskSynchronouusly(podcastUuid: podcast.uuid) else { return }
 
                 DataManager.sharedManager.saveBulkEpisodeSyncInfo(episodes: DataConverter.convert(syncInfoEpisodes: episodes))
+                podcast.forceRefreshEpisodeFrom = nil
             }
         }
     }

--- a/Modules/Server/Sources/PocketCastsServer/Public/Refresh/RefreshManager.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Refresh/RefreshManager.swift
@@ -65,7 +65,6 @@ public class RefreshManager {
 
     private func refresh(podcasts: [Podcast], completion: (() -> Void)? = nil) {
         UserDefaults.standard.set(Date(), forKey: ServerConstants.UserDefaults.lastRefreshStartTime)
-        let podcasts = podcasts
 
         DispatchQueue.global().async {
             MainServerHandler.shared.refresh(podcasts: podcasts) { [weak self] refreshResponse in

--- a/Modules/Server/Sources/PocketCastsServer/Public/Refresh/RefreshManager.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Refresh/RefreshManager.swift
@@ -35,8 +35,8 @@ public class RefreshManager {
     ///
     /// Note that this will force all the episodes to be updated.
     /// - Parameter podcast: a `Podcast` object
-    public func refresh(podcast: Podcast) {
-        podcast.forceRefreshEpisodes = true
+    public func refresh(podcast: Podcast, from episodeUuid: String) {
+        podcast.forceRefreshEpisodeFrom = episodeUuid
         refresh(podcasts: [podcast]) {
             if SyncManager.isUserLoggedIn() {
                 guard let episodes = ApiServerHandler.shared.retrieveEpisodeTaskSynchronouusly(podcastUuid: podcast.uuid) else { return }

--- a/Modules/Server/Sources/PocketCastsServer/Public/ServerPodcastManager+Update.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/ServerPodcastManager+Update.swift
@@ -185,7 +185,7 @@ extension ServerPodcastManager {
         // If there are episode missing that are not the recent ones this mean that
         // likely this show changed the episodes dates. This might lead to some
         // episodes never being added, so we add them here
-        if missingEpisodesThatIsNotTheLatestOnes, let latestAvailableEpisodeUuid {
+        if addMissingEpisodes, missingEpisodesThatIsNotTheLatestOnes, let latestAvailableEpisodeUuid {
             FileLog.shared.addMessage("[ServerPodcastManager] Updating \(podcast.title ?? "") from episode UUID \(latestAvailableEpisodeUuid)")
             RefreshManager.shared.refresh(podcast: podcast, from: latestAvailableEpisodeUuid)
         }

--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -282,6 +282,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             Constants.RemoteParams.patronEnabled: NSNumber(value: Constants.RemoteParams.patronEnabledDefault),
             Constants.RemoteParams.patronCloudStorageGB: NSNumber(value: Constants.RemoteParams.patronCloudStorageGBDefault),
             Constants.RemoteParams.bookmarksEnabled: NSNumber(value: Constants.RemoteParams.bookmarksEnabledDefault),
+            Constants.RemoteParams.addMissingEpisodes: NSNumber(value: Constants.RemoteParams.addMissingEpisodesDefault),
         ])
 
         remoteConfig.fetch(withExpirationDuration: 2.hour) { [weak self] status, _ in

--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -328,6 +328,9 @@ struct Constants {
 
         static let bookmarksEnabled = "bookmarks_enabled"
         static let bookmarksEnabledDefault = true
+
+        static let addMissingEpisodes = "add_missing_episodes"
+        static let addMissingEpisodesDefault: Bool = true
     }
 
     static let defaultDebounceTime: TimeInterval = 0.5

--- a/podcasts/PodcastViewController+NetworkLoad.swift
+++ b/podcasts/PodcastViewController+NetworkLoad.swift
@@ -24,7 +24,7 @@ extension PodcastViewController {
 
     func checkIfPodcastNeedsUpdating() {
         guard let podcast = podcast else { return }
-        ServerPodcastManager.shared.updatePodcastIfRequired(podcast: podcast) { [weak self] updated in
+        ServerPodcastManager.shared.updatePodcastIfRequired(podcast: podcast, addMissingEpisodes: true) { [weak self] updated in
             if updated {
                 self?.loadLocalEpisodes(podcast: podcast, animated: true)
             }

--- a/podcasts/PodcastViewController+NetworkLoad.swift
+++ b/podcasts/PodcastViewController+NetworkLoad.swift
@@ -24,7 +24,8 @@ extension PodcastViewController {
 
     func checkIfPodcastNeedsUpdating() {
         guard let podcast = podcast else { return }
-        ServerPodcastManager.shared.updatePodcastIfRequired(podcast: podcast, addMissingEpisodes: true) { [weak self] updated in
+        let addMissingEpisodes = Settings.addMissingEpisodes
+        ServerPodcastManager.shared.updatePodcastIfRequired(podcast: podcast, addMissingEpisodes: addMissingEpisodes) { [weak self] updated in
             if updated {
                 self?.loadLocalEpisodes(podcast: podcast, animated: true)
             }

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -869,6 +869,11 @@ class Settings: NSObject {
             return remote.boolValue
         }
 
+        static var addMissingEpisodes: Bool {
+            let remote = RemoteConfig.remoteConfig().configValue(forKey: Constants.RemoteParams.addMissingEpisodes)
+            return remote.boolValue
+        }
+
         static var effectsPlayerStrategy: EffectsPlayerStrategy? {
             let remote = RemoteConfig.remoteConfig().configValue(forKey: Constants.RemoteParams.effectsPlayerStrategy)
             return EffectsPlayerStrategy(rawValue: remote.numberValue.intValue)


### PR DESCRIPTION
We have an issue on iOS that prevents episodes from appearing if:

1. A user is subscribed to the podcast
2. The podcast author change the dates of the episodes (this can happen)

The app ends up in a state where episodes are not added but it does have the latest episode. This causes those "in-between" episodes never to be added.

## To test

Preferably, it would be good to have a database with this state. If you don't have one, please ping me.

1. Open the app
2. Go to a podcast that had the dates changed ([it seems that this almost always happens with this one](https://pca.st/k09G))
3. ✅ The missing episodes should be added and their states will be synced

## Additional information

The additional update made in this fix will happen only if:

1. The episode has missing episodes that are not the latest ones. This means that there are "holes": missing episodes that are in between already added episodes;
2. It just syncs enough to get the missing episodes

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
