### PR TITLE
Bookmarks: Fix the bookmark player tab appearing in the wrong location

### DIFF
--- a/podcasts/PlayerContainerViewController+Update.swift
+++ b/podcasts/PlayerContainerViewController+Update.swift
@@ -44,6 +44,10 @@ extension PlayerContainerViewController {
         chaptersItem.view.removeFromSuperview()
         showingChapters = false
 
+        bookmarksItem.removeFromParent()
+        bookmarksItem.view.removeFromSuperview()
+        showingBookmarks = false
+
         tabsView.tabs = [.nowPlaying]
 
         var previousTab: PlayerItemViewController = nowPlayingItem


### PR DESCRIPTION
This fixes a small bug where the bookmark tab may appear in the incorrect spot when switching between a custom file and podcast episode. 

## Demo Video

https://github.com/Automattic/pocket-casts-ios/assets/793774/dcd7aac6-7a6f-425d-832d-cf9abf0efe7c


## To test

1. Launch the app
2. Play a podcast episode
3. Add a custom file to your up next
4. Open the full screen player
5. Verify you see the Now Playing, Details, and Bookmarks tabs
6. ✅ Swipe between them and verify they appear in the correct spot
7. Open your Up Next from the player
8. Play the custom file
9. Your up next
10. ✅ Verify you see the Now Playing and Bookmarks tabs
12. ✅ Swipe between them and verify they appear in the correct spot
13. Open your up next and switch back to the podcast episode
14. ✅ Verify you see the Now Playing, Details, and Bookmarks tab
16. ✅ Swipe between them and verify they appear in the correct spot


## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
