### PR TITLE
Tooling: ensure "Releases" is added as a Label for each release-related PR

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -391,22 +391,14 @@ platform :ios do
 
     # TODO: move this to a GH action
     UI.message('Opening PR to merge changes to trunk...')
-    github_api(
-      server_url: 'https://api.github.com',
+    create_pull_request(
       api_token: ENV.fetch('GITHUB_TOKEN'),
-      http_method: 'POST',
-      path: "/repos/#{GHHELPER_REPO}/pulls",
-      body: {
-        title: "#{app_version} Release: Merge changes from #{build_version} into `trunk`",
-        body: "Merge changes from #{app_version} (#{build_version}) to `trunk`.\n\n## To test\n\n- Ensure the build is 🟢\n- The code changes here were tested in their own PRs",
-        head: options[:beta_release] ? merge_branch_name : release_branch_name,
-        base: 'trunk'
-      },
-      error_handlers: {
-        '*' => proc do |_result|
-          UI.important("⚠️ Couldn't open the PR to merge changes to trunk. Please do it manually.")
-        end
-      }
+      repo: GHHELPER_REPO,
+      title: "#{app_version} Release: Merge changes from #{build_version} into `trunk`",
+      body: "Merge changes from #{app_version} (#{build_version}) to `trunk`.\n\n## To test\n\n- Ensure the build is 🟢\n- The code changes here were tested in their own PRs",
+      head: options[:beta_release] ? merge_branch_name : release_branch_name,
+      base: 'trunk',
+      labels: ["Releases"]
     )
 
     UI.message('Sending message to Slack...')

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -398,7 +398,7 @@ platform :ios do
       body: "Merge changes from #{app_version} (#{build_version}) to `trunk`.\n\n## To test\n\n- Ensure the build is 🟢\n- The code changes here were tested in their own PRs",
       head: options[:beta_release] ? merge_branch_name : release_branch_name,
       base: 'trunk',
-      labels: ["Releases"]
+      labels: ['Releases']
     )
 
     UI.message('Sending message to Slack...')


### PR DESCRIPTION
With the addition of Dangermattic, the release builds are failing due to lacking Labels.

This changes the `Fastfile` so labels are added.

`trunk` needs to be updated but there will be a merge conflict next time we're merging beta changes to there and I'll fix it.

## To test

Just a code review is enough.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
