### PR TITLE
Add theme support to the Up Next

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 7.54
 -----
 - Fixes star functionality on native Now Playing widgets (lock screen and control centre) for iOS 17.1 and later [#1195]
+- Adds theme support to the Up Next [#1265]
 
 7.53
 -----

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -487,6 +487,7 @@ enum AnalyticsEvent: String {
     case settingsAppearanceAppIconChanged
     case settingsAppearanceRefreshAllArtworkTapped
     case settingsAppearanceUseEmbeddedArtworkToggled
+    case settingsAppearanceUseDarkUpNextToggled
 
     // MARK: - Settings: Auto Archive
 

--- a/podcasts/AppDelegate+Defaults.swift
+++ b/podcasts/AppDelegate+Defaults.swift
@@ -21,6 +21,10 @@ extension AppDelegate {
             if FeatureFlag.autoplay.enabled {
                 Settings.autoplay = true
             }
+
+            // Disable dark up next theme for new users
+            Settings.darkUpNextTheme = false
+
             setWhatsNewAcknowledgeToLatest()
         }
 

--- a/podcasts/AppearanceViewController.swift
+++ b/podcasts/AppearanceViewController.swift
@@ -10,7 +10,7 @@ class AppearanceViewController: SimpleNotificationsViewController, UITableViewDa
     private let plusLockedInfoCellId = "PlusLockedCell"
 
     private enum TableRow {
-        case themeOption, lightTheme, darkTheme, appIcon, refreshArtwork, embeddedArtwork, plusCallout
+        case themeOption, lightTheme, darkTheme, appIcon, refreshArtwork, embeddedArtwork, plusCallout, darkUpNextTheme
     }
 
     private var tableData = [[TableRow]]()
@@ -106,6 +106,16 @@ class AppearanceViewController: SimpleNotificationsViewController, UITableViewDa
             cell.cellSwitch.addTarget(self, action: #selector(shouldFollowSystemThemeToggled(_:)), for: UIControl.Event.valueChanged)
 
             return cell
+
+        case .darkUpNextTheme:
+            let cell = tableView.dequeueReusableCell(withIdentifier: switchCellId, for: indexPath) as! SwitchCell
+            cell.cellLabel.text = L10n.settingsUpNextDarkModeTitle
+            cell.cellSwitch.isOn = Settings.darkUpNextTheme
+            cell.cellSwitch.removeTarget(self, action: nil, for: .valueChanged)
+            cell.cellSwitch.addTarget(self, action: #selector(darkUpNextToggled(_:)), for: .valueChanged)
+
+            return cell
+
         case .lightTheme:
             let cell = tableView.dequeueReusableCell(withIdentifier: disclosureCellId, for: indexPath) as! DisclosureCell
             cell.cellLabel.text = Settings.shouldFollowSystemTheme() ? L10n.appearanceLightTheme : L10n.appearanceThemeHeader
@@ -207,11 +217,13 @@ class AppearanceViewController: SimpleNotificationsViewController, UITableViewDa
     }
 
     func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
-        let firstItem = tableData[section][0]
-
-        if firstItem == .refreshArtwork { return L10n.appearanceEmbeddedArtworkSubtitle }
-
-        return nil
+        switch tableData[section][0] {
+        case .refreshArtwork:
+            L10n.appearanceEmbeddedArtworkSubtitle
+        case .darkUpNextTheme:
+            L10n.settingsUpNextDarkModeFooter
+        default: nil
+        }
     }
 
     func tableView(_ tableView: UITableView, willDisplayFooterView view: UIView, forSection section: Int) {
@@ -229,6 +241,9 @@ class AppearanceViewController: SimpleNotificationsViewController, UITableViewDa
     }
 
     // MARK: - Actions
+    @objc private func darkUpNextToggled(_ sender: UISwitch) {
+        Settings.darkUpNextTheme = sender.isOn
+    }
 
     @objc private func shouldFollowSystemThemeToggled(_ sender: UISwitch) {
         Settings.setShouldFollowSystemTheme(sender.isOn)
@@ -251,9 +266,9 @@ class AppearanceViewController: SimpleNotificationsViewController, UITableViewDa
     private func updateTableAndData() {
         var newTableData: [[TableRow]]
         if Settings.shouldFollowSystemTheme() {
-            newTableData = [[.themeOption, .lightTheme, .darkTheme], [.appIcon], [.refreshArtwork, .embeddedArtwork]]
+            newTableData = [[.themeOption, .lightTheme, .darkTheme], [.appIcon], [.refreshArtwork, .embeddedArtwork], [.darkUpNextTheme]]
         } else {
-            newTableData = [[.themeOption, .lightTheme], [.appIcon], [.refreshArtwork, .embeddedArtwork]]
+            newTableData = [[.themeOption, .lightTheme], [.appIcon], [.refreshArtwork, .embeddedArtwork], [.darkUpNextTheme]]
         }
 
         if !SubscriptionHelper.hasActiveSubscription(), !Settings.plusInfoDismissedOnAppearance() {

--- a/podcasts/AppearanceViewController.swift
+++ b/podcasts/AppearanceViewController.swift
@@ -198,18 +198,20 @@ class AppearanceViewController: SimpleNotificationsViewController, UITableViewDa
     }
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        let firstItem = tableData[section][0]
         let headerFrame = CGRect(x: 0, y: 0, width: 0, height: Constants.Values.tableSectionHeaderHeight)
 
-        if firstItem == .themeOption {
+        switch tableData[section][0] {
+        case .themeOption:
             return SettingsTableHeader(frame: headerFrame, title: L10n.appearanceThemeHeader)
-        } else if firstItem == .appIcon {
+        case .appIcon:
             return SettingsTableHeader(frame: headerFrame, title: L10n.appearanceAppIconHeader)
-        } else if firstItem == .refreshArtwork {
+        case .refreshArtwork:
             return SettingsTableHeader(frame: headerFrame, title: L10n.appearanceArtworkHeader)
+        case .darkUpNextTheme:
+            return SettingsTableHeader(frame: headerFrame, title: L10n.upNext)
+        default:
+            return nil
         }
-
-        return nil
     }
 
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {

--- a/podcasts/AppearanceViewController.swift
+++ b/podcasts/AppearanceViewController.swift
@@ -245,6 +245,7 @@ class AppearanceViewController: SimpleNotificationsViewController, UITableViewDa
     // MARK: - Actions
     @objc private func darkUpNextToggled(_ sender: UISwitch) {
         Settings.darkUpNextTheme = sender.isOn
+        Settings.trackValueToggled(.settingsAppearanceUseDarkUpNextToggled, enabled: sender.isOn)
     }
 
     @objc private func shouldFollowSystemThemeToggled(_ sender: UISwitch) {

--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -174,6 +174,10 @@ struct Constants {
             static let podcastSort = SettingValue("bookmarks.podcastSort", defaultValue: BookmarkSortOption.newestToOldest)
             static let episodeSort = SettingValue("bookmarks.episodeSort", defaultValue: BookmarkSortOption.newestToOldest)
         }
+
+        enum appearance {
+            static let darkUpNextTheme = SettingValue("appearance.darkUpNextTheme", defaultValue: true)
+        }
     }
 
     enum Values {

--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -322,7 +322,7 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
         upNextViewController = UpNextViewController(source: source)
         guard let upNextController = upNextViewController else { return }
 
-        let navWrapper = SJUIUtils.navController(for: upNextController, navStyle: .secondaryUi01, titleStyle: .playerContrast01, iconStyle: .playerContrast01, themeOverride: .dark)
+        let navWrapper = SJUIUtils.navController(for: upNextController, iconStyle: .secondaryText01, themeOverride: upNextController.themeOverride)
         navWrapper.modalPresentationStyle = .formSheet
         rootViewController()?.present(navWrapper, animated: true, completion: nil)
     }

--- a/podcasts/NothingUpNextCell.swift
+++ b/podcasts/NothingUpNextCell.swift
@@ -12,14 +12,14 @@ class NothingUpNextCell: ThemeableCell {
 
     @IBOutlet var messageBackground: ThemeableView! {
         didSet {
-            messageBackground.style = .playerContrast06
+            messageBackground.style = .primaryUi06
             messageBackground.layer.cornerRadius = 8
         }
     }
 
     @IBOutlet var headingLabel: ThemeableLabel! {
         didSet {
-            headingLabel.style = .playerContrast01
+            headingLabel.style = .primaryText01
             headingLabel.themeOverride = themeOverride
             headingLabel.text = L10n.upNextEmptyTitle
         }
@@ -27,7 +27,7 @@ class NothingUpNextCell: ThemeableCell {
 
     @IBOutlet var descriptionLabel: ThemeableLabel! {
         didSet {
-            descriptionLabel.style = .playerContrast02
+            descriptionLabel.style = .primaryText02
             descriptionLabel.themeOverride = themeOverride
             descriptionLabel.text = L10n.upNextEmptyDescription
         }

--- a/podcasts/NowPlayingPlayerItemViewController.swift
+++ b/podcasts/NowPlayingPlayerItemViewController.swift
@@ -149,7 +149,7 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
     private lazy var upNextController = UpNextViewController(source: .nowPlaying)
 
     lazy var upNextViewController: UIViewController = {
-        let controller = SJUIUtils.navController(for: upNextController, navStyle: .secondaryUi01, titleStyle: .playerContrast01, iconStyle: .playerContrast01, themeOverride: .dark)
+        let controller = SJUIUtils.navController(for: upNextController, iconStyle: .secondaryText01, themeOverride: upNextController.themeOverride)
         controller.modalPresentationStyle = .pageSheet
 
         return controller

--- a/podcasts/PlayerCell.swift
+++ b/podcasts/PlayerCell.swift
@@ -2,42 +2,34 @@ import PocketCastsDataModel
 import SwipeCellKit
 import UIKit
 
-class PlayerCell: SwipeTableViewCell {
-    var themeOverride: Theme.ThemeType? {
+class PlayerCell: ThemeableSwipeCell {
+    override var themeOverride: Theme.ThemeType? {
         didSet {
-            updateColor()
+            super.updateColor()
             episodeTitle.themeOverride = themeOverride
             episodeInfo.themeOverride = themeOverride
             dayName.themeOverride = themeOverride
+            dividerView.themeOverride = themeOverride
         }
     }
-
-    var style: ThemeStyle = .primaryUi02 {
-        didSet {
-            updateColor()
-        }
-    }
-
-    var selectedStyle: ThemeStyle = .primaryUi02Active
-    var iconStyle: ThemeStyle = .primaryIcon02
 
     @IBOutlet var podcastImage: PodcastImageView!
     @IBOutlet var episodeTitle: ThemeableLabel! {
         didSet {
-            episodeTitle.style = .playerContrast01
+            episodeTitle.style = .primaryText01
         }
     }
 
     @IBOutlet var episodeInfo: ThemeableLabel! {
         didSet {
-            episodeInfo.style = .playerContrast03
+            episodeInfo.style = .primaryText02
         }
     }
 
     @IBOutlet var downloadedIndicator: UIImageView!
     @IBOutlet var dayName: ThemeableLabel! {
         didSet {
-            dayName.style = .playerContrast03
+            dayName.style = .primaryText02
         }
     }
 
@@ -49,7 +41,6 @@ class PlayerCell: SwipeTableViewCell {
 
     @IBOutlet var selectView: UIView! {
         didSet {
-            selectView.layer.borderColor = AppTheme.colorForStyle(.playerContrast01, themeOverride: themeOverride).cgColor
             selectView.layer.borderWidth = 0
             selectView.layer.cornerRadius = 12
         }
@@ -57,8 +48,7 @@ class PlayerCell: SwipeTableViewCell {
 
     @IBOutlet var dividerView: ThemeableView! {
         didSet {
-            dividerView.style = .playerContrast05
-            dividerView.themeOverride = themeOverride
+            dividerView.style = .primaryUi05
         }
     }
 
@@ -69,8 +59,9 @@ class PlayerCell: SwipeTableViewCell {
     var showTick = false {
         didSet {
             selectTickImageView.isHidden = !showTick
-            selectView.backgroundColor = showTick ? AppTheme.colorForStyle(.playerContrast01, themeOverride: themeOverride) : AppTheme.colorForStyle(.primaryUi04, themeOverride: themeOverride)
-            selectTickImageView.tintColor = AppTheme.colorForStyle(.primaryUi04, themeOverride: themeOverride)
+            selectView.backgroundColor = showTick ? AppTheme.colorForStyle(.primaryInteractive01, themeOverride: themeOverride) : AppTheme.colorForStyle(.primaryUi04, themeOverride: themeOverride)
+            selectView.layer.borderWidth = showTick ? 0 : 2
+            selectTickImageView.tintColor = AppTheme.colorForStyle(.primaryInteractive02, themeOverride: themeOverride)
 
             selectView.accessibilityLabel = showTick ? L10n.accessibilityDeselectEpisode : L10n.accessibilitySelectEpisode
         }
@@ -84,8 +75,6 @@ class PlayerCell: SwipeTableViewCell {
         NotificationCenter.default.addObserver(self, selector: #selector(updateCellForDownloadProgressChange), name: Constants.Notifications.downloadProgress, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(updateCellForDownloadStatusChange(_:)), name: Constants.Notifications.episodeDownloaded, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(updateCellForDownloadStatusChange(_:)), name: Constants.Notifications.episodeDownloadStatusChanged, object: nil)
-
-        overrideUserInterfaceStyle = .dark
     }
 
     override func addSubview(_ view: UIView) {
@@ -193,22 +182,6 @@ class PlayerCell: SwipeTableViewCell {
         }
     }
 
-    override func setHighlighted(_ highlighted: Bool, animated: Bool) {
-        setHighlightedState(highlighted)
-    }
-
-    override func setSelected(_ selected: Bool, animated: Bool) {
-        setHighlightedState(selected)
-    }
-
-    private func setHighlightedState(_ highlighted: Bool) {
-        if highlighted {
-            updateBgColor(AppTheme.colorForStyle(selectedStyle, themeOverride: themeOverride))
-        } else {
-            updateBgColor(AppTheme.colorForStyle(style, themeOverride: themeOverride))
-        }
-    }
-
     override func setEditing(_ editing: Bool, animated: Bool) {
         // Show the reordering control but not the native selection view (editControl)
         // In iOS13+ the tableView is in editing mode but the cell is not
@@ -220,12 +193,6 @@ class PlayerCell: SwipeTableViewCell {
 
         showTick = false
         setSelected(false, animated: false)
-    }
-
-    func updateColor() {
-        updateBgColor(AppTheme.colorForStyle(style, themeOverride: themeOverride))
-        accessoryView?.tintColor = AppTheme.colorForStyle(iconStyle, themeOverride: themeOverride)
-        tintColor = AppTheme.colorForStyle(iconStyle, themeOverride: themeOverride)
     }
 
     private func updateBgColor(_ color: UIColor) {
@@ -259,6 +226,14 @@ class PlayerCell: SwipeTableViewCell {
                 setHighlightedState(false)
             }
         }
+    }
+
+    override func handleThemeDidChange() {
+        selectView.layer.borderColor = AppTheme.colorForStyle(.primaryIcon02, themeOverride: themeOverride).cgColor
+        selectView.backgroundColor = showTick ? AppTheme.colorForStyle(.primaryInteractive01, themeOverride: themeOverride) : AppTheme.colorForStyle(.primaryUi04, themeOverride: themeOverride)
+        selectView.layer.borderWidth = showTick ? 0 : 2
+        selectTickImageView.tintColor = AppTheme.colorForStyle(.primaryInteractive02, themeOverride: themeOverride)
+
     }
 }
 

--- a/podcasts/PlayerCell.swift
+++ b/podcasts/PlayerCell.swift
@@ -234,6 +234,9 @@ class PlayerCell: ThemeableSwipeCell {
         selectView.layer.borderWidth = showTick ? 0 : 2
         selectTickImageView.tintColor = AppTheme.colorForStyle(.primaryInteractive02, themeOverride: themeOverride)
 
+        // Update the reorder control color
+        let activeTheme = themeOverride ?? Theme.sharedTheme.activeTheme
+        overrideUserInterfaceStyle = activeTheme.isDark ? .dark : .light
     }
 }
 

--- a/podcasts/PlayerContainerViewController.swift
+++ b/podcasts/PlayerContainerViewController.swift
@@ -125,7 +125,7 @@ class PlayerContainerViewController: SimpleNotificationsViewController, PlayerTa
     }
 
     @objc private func showUpNext() {
-        let navController = SJUIUtils.navController(for: upNextViewController, navStyle: .secondaryUi01, titleStyle: .playerContrast01, iconStyle: .playerContrast01, themeOverride: .dark)
+        let navController = SJUIUtils.navController(for: upNextViewController, iconStyle: .secondaryText01, themeOverride: upNextViewController.themeOverride)
         present(navController, animated: true, completion: nil)
     }
 

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -849,6 +849,16 @@ class Settings: NSObject {
         }
     }
 
+    static var darkUpNextTheme: Bool {
+        get {
+            Constants.UserDefaults.appearance.darkUpNextTheme.value
+        }
+
+        set {
+            Constants.UserDefaults.appearance.darkUpNextTheme.save(newValue)
+        }
+    }
+
     // MARK: - Variables that are loaded/changed through Firebase
 
     #if !os(watchOS)

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -2600,6 +2600,10 @@ internal enum L10n {
   internal static var settingsTrimLevel: String { return L10n.tr("Localizable", "settings_trim_level") }
   /// Trim Silence
   internal static var settingsTrimSilence: String { return L10n.tr("Localizable", "settings_trim_silence") }
+  /// When enabled the Up Next will always use the dark theme, or will match the current theme when disabled.
+  internal static var settingsUpNextDarkModeFooter: String { return L10n.tr("Localizable", "settings_up_next_dark_mode_footer") }
+  /// Use Dark Up Next Theme
+  internal static var settingsUpNextDarkModeTitle: String { return L10n.tr("Localizable", "settings_up_next_dark_mode_title") }
   /// Automatically add new episodes to Up Next. New episodes will stop being added when Up Next reaches %1$@.
   internal static func settingsUpNextLimit(_ p1: Any) -> String {
     return L10n.tr("Localizable", "settings_up_next_limit", String(describing: p1))

--- a/podcasts/ThemeableSwipeCell.swift
+++ b/podcasts/ThemeableSwipeCell.swift
@@ -49,7 +49,7 @@ class ThemeableSwipeCell: SwipeTableViewCell {
         handleThemeDidChange()
     }
 
-    private func setHighlightedState(_ highlighted: Bool) {
+    func setHighlightedState(_ highlighted: Bool) {
         if highlighted {
             updateBgColor(AppTheme.colorForStyle(selectedStyle, themeOverride: themeOverride))
         } else {

--- a/podcasts/UpNextNowPlayingCell.swift
+++ b/podcasts/UpNextNowPlayingCell.swift
@@ -134,21 +134,38 @@ class UpNextNowPlayingCell: ThemeableCell {
 
         let activeTheme = themeOverride ?? Theme.sharedTheme.activeTheme
 
-        roundedBackgroundView.style = switch activeTheme {
-        case .extraDark, .contrastDark: .primaryUi05
-        case .contrastLight: .primaryUi05
-        default: .primaryUi02
+        // Rounded background
+        if activeTheme.isDark {
+            roundedBackgroundView.style = .playerContrast06
+        } else {
+            roundedBackgroundView.style = activeTheme == .contrastLight ? .primaryUi05 : .primaryUi02
         }
 
-        progressView.backgroundColor = switch activeTheme {
-        case .rosé, .radioactive:
-            AppTheme.colorForStyle(.primaryIcon02Selected, themeOverride: themeOverride).withAlphaComponent(0.1)
-        default:
-            (activeTheme.isDark ? UIColor.white : UIColor.black).withAlphaComponent(0.1)
+        // Progress view
+        if activeTheme == .rosé {
+            progressView.backgroundColor = AppTheme.colorForStyle(.primaryIcon02Selected, themeOverride: themeOverride).withAlphaComponent(0.1)
+        } else if activeTheme.isDark {
+            progressView.backgroundColor = AppTheme.colorForStyle(.playerContrast06, themeOverride: themeOverride).withAlphaComponent(0.1)
+        } else {
+            progressView.backgroundColor = .black.withAlphaComponent(0.1)
         }
+
+        // Disclosure icon
+        switch activeTheme {
+        case .dark:
+            disclosureImageView.backgroundColor = AppTheme.colorForStyle(.primaryInteractive02)
+            disclosureImageView.tintColor = nil
+
+        case .contrastLight, .contrastDark:
+            disclosureImageView.backgroundColor = AppTheme.colorForStyle(.primaryInteractive01, themeOverride: themeOverride)
+            disclosureImageView.tintColor = AppTheme.colorForStyle(.primaryInteractive02, themeOverride: themeOverride)
+
+        default:
+            disclosureImageView.backgroundColor = AppTheme.colorForStyle(.primaryUi05, themeOverride: themeOverride)
+            disclosureImageView.tintColor = AppTheme.colorForStyle(.primaryInteractive01, themeOverride: themeOverride)
+        }
+
         disclosureImageView.layer.cornerRadius = 12
-        disclosureImageView.backgroundColor = AppTheme.colorForStyle(.primaryUi05, themeOverride: themeOverride)
-        disclosureImageView.tintColor = AppTheme.colorForStyle(.primaryInteractive01, themeOverride: themeOverride)
     }
 
     func updateDownloadStatus() {

--- a/podcasts/UpNextNowPlayingCell.swift
+++ b/podcasts/UpNextNowPlayingCell.swift
@@ -9,25 +9,18 @@ class UpNextNowPlayingCell: ThemeableCell {
             episodeTitle.themeOverride = themeOverride
             dateLabel.themeOverride = themeOverride
             timeRemainingLabel.themeOverride = themeOverride
+            roundedBackgroundView.themeOverride = themeOverride
         }
     }
 
-    @IBOutlet var roundedBackgroundView: ThemeableView! {
-        didSet {
-            roundedBackgroundView.style = .playerContrast06
-        }
-    }
+    @IBOutlet var roundedBackgroundView: ThemeableView!
 
-    @IBOutlet var progressView: UIView! {
-        didSet {
-            progressView.backgroundColor = AppTheme.colorForStyle(.playerContrast06, themeOverride: themeOverride).withAlphaComponent(0.1)
-        }
-    }
+    @IBOutlet var progressView: UIView!
 
     @IBOutlet var podcastImage: PodcastImageView!
     @IBOutlet var dateLabel: ThemeableLabel! {
         didSet {
-            dateLabel.style = .playerContrast02
+            dateLabel.style = .primaryText02
         }
     }
 
@@ -40,22 +33,17 @@ class UpNextNowPlayingCell: ThemeableCell {
 
     @IBOutlet var timeRemainingLabel: ThemeableLabel! {
         didSet {
-            timeRemainingLabel.style = .playerContrast03
+            timeRemainingLabel.style = .primaryText02
         }
     }
 
     @IBOutlet var episodeTitle: ThemeableLabel! {
         didSet {
-            episodeTitle.style = .playerContrast01
+            episodeTitle.style = .primaryText01
         }
     }
 
-    @IBOutlet var disclosureImageView: UIImageView! {
-        didSet {
-            disclosureImageView.layer.cornerRadius = 12
-            disclosureImageView.backgroundColor = ThemeColor.primaryInteractive02()
-        }
-    }
+    @IBOutlet var disclosureImageView: UIImageView!
 
     @IBOutlet var playingAnimationView: NowPlayingAnimationView!
 
@@ -65,6 +53,8 @@ class UpNextNowPlayingCell: ThemeableCell {
 
     override func awakeFromNib() {
         super.awakeFromNib()
+        style = .primaryUi04
+
         NotificationCenter.default.addObserver(self, selector: #selector(progressUpdated), name: Constants.Notifications.playbackProgress, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(updatePlayingAnimation), name: Constants.Notifications.playbackPaused, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(updatePlayingAnimation), name: Constants.Notifications.playbackStarted, object: nil)
@@ -88,7 +78,7 @@ class UpNextNowPlayingCell: ThemeableCell {
             podcastImage.setUserEpisode(uuid: episode.uuid, size: .list)
         }
 
-        EpisodeDateHelper.setDate(episode: episode, on: dateLabel, tintColor: ThemeColor.playerContrast02(for: themeOverride))
+        EpisodeDateHelper.setDate(episode: episode, on: dateLabel, tintColor: ThemeColor.primaryText02(for: themeOverride))
 
         if let dateText = dateLabel.text {
             dateLabel.accessibilityLabel = L10n.queueNowPlayingAccessibility(dateText)
@@ -140,8 +130,14 @@ class UpNextNowPlayingCell: ThemeableCell {
     }
 
     override func handleThemeDidChange() {
-        disclosureImageView.backgroundColor = ThemeColor.primaryInteractive02()
-        progressView.backgroundColor = AppTheme.colorForStyle(.playerContrast06, themeOverride: themeOverride).withAlphaComponent(0.1)
+        super.handleThemeDidChange()
+
+        let activeTheme = themeOverride ?? Theme.sharedTheme.activeTheme
+        roundedBackgroundView.style = .primaryUi02
+        progressView.backgroundColor = (activeTheme.isDark ? UIColor.white : UIColor.black).withAlphaComponent(0.1)
+        disclosureImageView.layer.cornerRadius = 12
+        disclosureImageView.backgroundColor = AppTheme.colorForStyle(.primaryUi05, themeOverride: themeOverride)
+        disclosureImageView.tintColor = AppTheme.colorForStyle(.primaryInteractive01, themeOverride: themeOverride)
     }
 
     func updateDownloadStatus() {

--- a/podcasts/UpNextNowPlayingCell.swift
+++ b/podcasts/UpNextNowPlayingCell.swift
@@ -133,13 +133,19 @@ class UpNextNowPlayingCell: ThemeableCell {
         super.handleThemeDidChange()
 
         let activeTheme = themeOverride ?? Theme.sharedTheme.activeTheme
+
         roundedBackgroundView.style = switch activeTheme {
         case .extraDark, .contrastDark: .primaryUi05
         case .contrastLight: .primaryUi05
         default: .primaryUi02
         }
 
-        progressView.backgroundColor = (activeTheme.isDark ? UIColor.white : UIColor.black).withAlphaComponent(0.1)
+        progressView.backgroundColor = switch activeTheme {
+        case .rosé, .radioactive:
+            AppTheme.colorForStyle(.primaryIcon02Selected, themeOverride: themeOverride).withAlphaComponent(0.1)
+        default:
+            (activeTheme.isDark ? UIColor.white : UIColor.black).withAlphaComponent(0.1)
+        }
         disclosureImageView.layer.cornerRadius = 12
         disclosureImageView.backgroundColor = AppTheme.colorForStyle(.primaryUi05, themeOverride: themeOverride)
         disclosureImageView.tintColor = AppTheme.colorForStyle(.primaryInteractive01, themeOverride: themeOverride)

--- a/podcasts/UpNextNowPlayingCell.swift
+++ b/podcasts/UpNextNowPlayingCell.swift
@@ -133,7 +133,12 @@ class UpNextNowPlayingCell: ThemeableCell {
         super.handleThemeDidChange()
 
         let activeTheme = themeOverride ?? Theme.sharedTheme.activeTheme
-        roundedBackgroundView.style = .primaryUi02
+        roundedBackgroundView.style = switch activeTheme {
+        case .extraDark, .contrastDark: .primaryUi05
+        case .contrastLight: .primaryUi05
+        default: .primaryUi02
+        }
+
         progressView.backgroundColor = (activeTheme.isDark ? UIColor.white : UIColor.black).withAlphaComponent(0.1)
         disclosureImageView.layer.cornerRadius = 12
         disclosureImageView.backgroundColor = AppTheme.colorForStyle(.primaryUi05, themeOverride: themeOverride)

--- a/podcasts/UpNextViewController.swift
+++ b/podcasts/UpNextViewController.swift
@@ -95,7 +95,7 @@ class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
 
     init(source: UpNextViewSource, themeOverride: Theme.ThemeType? = nil) {
         self.source = source
-        self.themeOverride = themeOverride
+        self.themeOverride = Settings.darkUpNextTheme ? .dark : themeOverride
 
         super.init(nibName: nil, bundle: nil)
     }

--- a/podcasts/UpNextViewController.swift
+++ b/podcasts/UpNextViewController.swift
@@ -15,11 +15,7 @@ class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
 
     enum sections: Int { case nowPlayingSection = 0, upNextSection }
 
-    var themeOverride: Theme.ThemeType {
-        if Theme.isDarkTheme() { return Theme.sharedTheme.activeTheme }
-
-        return .dark
-    }
+    var themeOverride: Theme.ThemeType? = nil
 
     var isMultiSelectEnabled = false {
         didSet {
@@ -97,8 +93,10 @@ class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
 
     let source: UpNextViewSource
 
-    init(source: UpNextViewSource) {
+    init(source: UpNextViewSource, themeOverride: Theme.ThemeType? = nil) {
         self.source = source
+        self.themeOverride = themeOverride
+
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -132,12 +130,12 @@ class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
         remainingLabel.adjustsFontSizeToFitWidth = true
         remainingLabel.minimumScaleFactor = 0.8
         remainingLabel.numberOfLines = 2
-        remainingLabel.style = .playerContrast02
+        remainingLabel.style = .primaryText02
         remainingLabel.themeOverride = themeOverride
 
         clearQueueButton.setTitle(L10n.queueClearQueue, for: .normal)
-        clearQueueButton.setTitleColor(AppTheme.colorForStyle(.playerContrast01, themeOverride: themeOverride), for: .normal)
-        clearQueueButton.setTitleColor(AppTheme.colorForStyle(.playerContrast05, themeOverride: themeOverride), for: .disabled)
+        clearQueueButton.setTitleColor(AppTheme.colorForStyle(.primaryText02, themeOverride: themeOverride), for: .normal)
+        clearQueueButton.setTitleColor(AppTheme.colorForStyle(.primaryText02, themeOverride: themeOverride).withAlphaComponent(0.5), for: .disabled)
         clearQueueButton.titleLabel?.font = UIFont.systemFont(ofSize: 13, weight: .bold)
         clearQueueButton.addTarget(self, action: #selector(clearQueueTapped), for: .touchUpInside)
     }
@@ -168,7 +166,7 @@ class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
         if queueCount <= Constants.Limits.upNextClearWithoutWarning {
             performClearAll()
         } else {
-            let clearOptions = OptionsPicker(title: nil, themeOverride: .dark)
+            let clearOptions = OptionsPicker(title: nil, themeOverride: themeOverride)
             let actionLabel = L10n.queueClearEpisodeQueuePlural(queueCount.localized())
             let clearAllAction = OptionAction(label: actionLabel, icon: nil, action: { [weak self] in
                 self?.performClearAll()

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -3958,3 +3958,9 @@
 
 /* Message of an alert that informs the user purchasing is disabled in the beta. 'Pocket Casts' is treated as a proper noun and hasn't been localized in other places of the app. %1$@ is the name of the tier (Plus or Patron)*/
 "beta_purchase_disabled" = "Please download Pocket Casts from the App Store to purchase %1$@.";
+
+/* Title of a setting that lets the user use dark mode for the up next */
+"settings_up_next_dark_mode_title" = "Use Dark Up Next Theme";
+
+/* Description explaining to the user what up next dark mode means. */
+"settings_up_next_dark_mode_footer" = "When enabled the Up Next will always use the dark theme, or will match the current theme when disabled.";


### PR DESCRIPTION
This adds theme support to the Up Next, and also adds a setting to allow users to override the theme and have the up next default to dark mode. 

The up next will use the dark mode for existing users, and will use the current them for new users. 


## Screenshots

| Light | Dark | Light Contrast | Dark Contrast | Extra Dark |
|:---:|:---:|:---:|:---:|:---:|
|<img src="https://github.com/Automattic/pocket-casts-ios/assets/793774/34cd66ba-def3-4e9c-9e10-676fc5d506fc" width="100" />|<img src="https://github.com/Automattic/pocket-casts-ios/assets/793774/300bd258-8f4c-4107-bb2d-aa197a9d40ed" width="100" />|<img src="https://github.com/Automattic/pocket-casts-ios/assets/793774/f157d8bc-e5d8-4f80-8247-52d270f0574f" width="100" />|<img src="https://github.com/Automattic/pocket-casts-ios/assets/793774/8d5c75c1-5e7f-4d53-b344-2c0271f844e0" width="100" />|<img src="https://github.com/Automattic/pocket-casts-ios/assets/793774/c8d4b2a4-fb99-441f-939d-542cedf502b4" width="100" />|

| Radioactive | Electric | Rose | Classic | Indigo |
|:---:|:---:|:---:|:---:|:---:|
|<img src="https://github.com/Automattic/pocket-casts-ios/assets/793774/be2853e1-e923-486e-a234-af6e727f1cc4" width="100" />|<img src="https://github.com/Automattic/pocket-casts-ios/assets/793774/1425a661-6e7e-4d0d-b714-f7a0b6fb31a0" width="100" />|<img src="https://github.com/Automattic/pocket-casts-ios/assets/793774/dc9fcd5f-4490-4112-b378-b87e1e94d92f" width="100" />|<img src="https://github.com/Automattic/pocket-casts-ios/assets/793774/faba1622-ee90-47b8-b7dd-703f8783c700" width="100" />|<img src="https://github.com/Automattic/pocket-casts-ios/assets/793774/0f59bf60-5e02-4e90-a1f5-0c9182cd0f66" width="100" />|

## To test

### Dark mode is used for existing users
1. Launch the app in an existing install
2. Add some items to you up next
3. Open the Up Next
4. ✅ Verify it is using the dark theme
5. Open the Full Screen player
6. Tap the Up Next
7. ✅ Verify it is using the dark theme
8. Dismiss the player
9. Tap Profile > Cog > Appearance
10. Swipe down to the Up Next section
11. Disable the option
12. Open the Up Next
13. ✅ Verify it is now using your current theme

### Current theme is used for new users
1. Launch the app in fresh install
2. Add some items to you up next
3. Open the Up Next
4. ✅ Verify it is using the current theme
5. Open the Full Screen player
6. Tap the Up Next
7. ✅ Verify it is using the current theme
8. Dismiss the player
9. Tap Profile > Cog > Appearance
10. Swipe down to the Up Next section
11. Enable the option
12. Open the Up Next
13. ✅ Verify it is now using the dark theme

### Themes look good
1. Launch the app 
2. Disable the Use Dark Mode Setting
3. Play an episode so it's about half way but have no items in your up next
4. Open the Up Next
5. ✅ Verify all of the labels, and now playing progress are legible in each theme
6. Add some items to your up next
7. ✅ Verify all of the labels, icons, and colors are legible in each theme
8. Enter multi select mode
9. ✅ Verify all of the check marks are legible in each theme


### Settings Analytics
1. Launch the app
11. Tap Profile > Cog > Beta Features > Enable Tracks Logging
12. Go back
13. Tap Appearance
14. Swipe down to the Up Next section
15. Toggle the option
16. ✅ Verify you see: `🔵 Tracked: settings_appearance_use_dark_up_next_toggled ["enabled": {Enabled}]` where {Enabled} is the state of the switch




## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
