### PR TITLE
Remove the freeTrialsEnabled feature flag

### DIFF
--- a/podcasts/AnalyticsHelper.swift
+++ b/podcasts/AnalyticsHelper.swift
@@ -318,7 +318,7 @@ class AnalyticsHelper {
             ]
 
             // Log that a free trial was used
-            if IapHelper.shared.isEligibleForFreeTrial(), product.introductoryPrice?.paymentMode == .freeTrial {
+            if IapHelper.shared.isEligibleForTrial, product.introductoryPrice?.paymentMode == .freeTrial {
                 parameters[AnalyticsParameterCoupon] = "FREE_TRIAL"
             }
 

--- a/podcasts/FeatureFlag.swift
+++ b/podcasts/FeatureFlag.swift
@@ -1,9 +1,6 @@
 import Foundation
 
 enum FeatureFlag: String, CaseIterable {
-    /// Whether we should detect and show the free trial UI
-    case freeTrialsEnabled
-
     /// Whether logging of Tracks events in console are enabled
     case tracksLogging
 
@@ -52,8 +49,6 @@ enum FeatureFlag: String, CaseIterable {
         }
 
         switch self {
-        case .freeTrialsEnabled:
-            return true
         case .tracksLogging:
             return false
         case .firebaseLogging:

--- a/podcasts/IapHelper.swift
+++ b/podcasts/IapHelper.swift
@@ -15,7 +15,7 @@ class IapHelper: NSObject, SKProductsRequestDelegate {
     private var productsRequest: SKProductsRequest?
 
     /// Whether or not the user is eligible for a free trial
-    private (set) var isEligibleForTrial = Constants.Values.freeTrialDefaultValue
+    private(set) var isEligibleForTrial = Constants.Values.freeTrialDefaultValue
 
     /// Prevent multiple eligibility requests from being performed
     private var isCheckingEligibility = false


### PR DESCRIPTION
Removes the `freeTrialsEnabled` feature flag. 

## To test

1. Launch the app
2. Sign into a non plus account
3. Tap the Podcasts tab
4. Tap the Folder icon
5. ✅ Verify you see the free trial for Plus yearly

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
