### PR TITLE
Player transition: small tweaks

### DIFF
--- a/podcasts/MiniPlayerToFullPlayerAnimator.swift
+++ b/podcasts/MiniPlayerToFullPlayerAnimator.swift
@@ -16,7 +16,7 @@ class MiniPlayerToFullPlayerAnimator: NSObject, UIViewControllerAnimatedTransiti
     // An assumed "normal" velocity from a pan gesture
     private let normalVelocity: CGFloat = 2500
 
-    // When presenting the player, duration is always 0.25
+    // When presenting the player, duration is always the same
     // However, if the view is being dismissed we take into account
     // the velocity of the swipe down gesture to carry it
     // An agressive swipe down will make the view to be dismissed faster.

--- a/podcasts/MiniPlayerToFullPlayerAnimator.swift
+++ b/podcasts/MiniPlayerToFullPlayerAnimator.swift
@@ -11,18 +11,18 @@ class MiniPlayerToFullPlayerAnimator: NSObject, UIViewControllerAnimatedTransiti
     private let dismissVelocity: CGFloat
 
     // The max duration that the transition can last
-    private let maxDismissDuration: TimeInterval = 0.28
+    private let maxDismissDuration: TimeInterval = 0.2
 
     // An assumed "normal" velocity from a pan gesture
     private let normalVelocity: CGFloat = 2500
 
-    // When presenting the player, duration is always 0.35
+    // When presenting the player, duration is always 0.25
     // However, if the view is being dismissed we take into account
     // the velocity of the swipe down gesture to carry it
     // An agressive swipe down will make the view to be dismissed faster.
     private var duration: TimeInterval {
         guard !isPresenting || dismissVelocity != 0 else {
-            return 0.35
+            return 0.3
         }
 
         return min((normalVelocity * maxDismissDuration) / dismissVelocity, maxDismissDuration)


### PR DESCRIPTION
* Fixes a bad merge adding back code that shouldn't be removed: we track the dismissal speed gesture and apply to the dismissal animation
* We also check for how quick the dismiss gesture is. If it's too quick (bigger than a `1000`) we dismiss the player

The tests and changes were done pairing with @david-gonzalez-a8c 

## To test

1. Run this PR on a real device
2. Play with showing/dismissing the player
3. ✅ The animations should feel natural

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
