### PR TITLE
Removes the discoverFeaturedAutoScroll feature flag

### DIFF
--- a/podcasts/FeatureFlag.swift
+++ b/podcasts/FeatureFlag.swift
@@ -22,9 +22,6 @@ enum FeatureFlag: String, CaseIterable {
     /// Bookmarks / Highlights
     case bookmarks
 
-    /// Auto scrolls Discover Featured carousel
-    case discoverFeaturedAutoScroll
-
     /// Patron
     case patron
 
@@ -62,8 +59,6 @@ enum FeatureFlag: String, CaseIterable {
         case .newSearch:
             return true
         case .bookmarks:
-            return true
-        case .discoverFeaturedAutoScroll:
             return true
         case .patron:
             return true

--- a/podcasts/ThemeableCollectionView.swift
+++ b/podcasts/ThemeableCollectionView.swift
@@ -37,10 +37,6 @@ class ThemeableCollectionView: UICollectionView, AutoScrollCollectionViewDelegat
     var timer: Timer?
 
     func initializeAutoScrollTimer() {
-        guard FeatureFlag.discoverFeaturedAutoScroll.enabled else {
-            return
-        }
-
         timer = Timer.scheduledTimer(timeInterval: 3.0, target: self, selector: #selector(scrolltoNextItem), userInfo: nil, repeats: true)
     }
 


### PR DESCRIPTION
Removes the `discoverFeaturedAutoScroll` feature flag

## To test

1. Launch the app
2. Go to the Discover tab
3. ✅ Verify the feature section auto scrolls

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
