### PR TITLE
Cleanup: onboardingUpdates feature flag

### DIFF
--- a/podcasts/FeatureFlag.swift
+++ b/podcasts/FeatureFlag.swift
@@ -13,9 +13,6 @@ enum FeatureFlag: String, CaseIterable {
     /// Adds the Sign In With Apple options to the login flow
     case signInWithApple
 
-    /// Displays the new onboarding view updates
-    case onboardingUpdates
-
     /// Bookmarks / Highlights
     case bookmarks
 
@@ -50,8 +47,6 @@ enum FeatureFlag: String, CaseIterable {
         case .endOfYear:
             return true
         case .signInWithApple:
-            return true
-        case .onboardingUpdates:
             return true
         case .bookmarks:
             return true

--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -295,12 +295,6 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
         // If we're already presenting a view, then present from that view if possible
         let presentingController = presentedViewController ?? view.window?.rootViewController
 
-        guard FeatureFlag.onboardingUpdates.enabled else {
-            let upgradeVC = UpgradeRequiredViewController(upgradeRootViewController: upgradeRootViewController, source: source)
-            presentingController?.present(SJUIUtils.popupNavController(for: upgradeVC), animated: true, completion: nil)
-            return
-        }
-
         let controller = OnboardingFlow.shared.begin(flow: flow, source: source.rawValue, context: context)
         presentingController?.present(controller, animated: true, completion: nil)
     }

--- a/podcasts/PlusDetailsViewController.swift
+++ b/podcasts/PlusDetailsViewController.swift
@@ -142,7 +142,7 @@ class PlusDetailsViewController: PCViewController {
         }
     }
 
-    private func handleUpgrade() {
+    @IBAction func upgradeTapped(_ sender: Any) {
         let source = PlusAccountPromptViewModel.Source.plusDetails
         if SyncManager.isUserLoggedIn() {
             let model = PlusAccountPromptViewModel()
@@ -151,24 +151,6 @@ class PlusDetailsViewController: PCViewController {
             model.upgradeTapped()
         } else {
             present(OnboardingFlow.shared.begin(flow: .plusAccountUpgradeNeedsLogin, source: source.rawValue), animated: true)
-        }
-
-        Analytics.track(.settingsPlusUpgradeButtonTapped)
-    }
-
-    @IBAction func upgradeTapped(_ sender: Any) {
-        guard !FeatureFlag.onboardingUpdates.enabled else {
-            handleUpgrade()
-            return
-        }
-        if SyncManager.isUserLoggedIn() {
-            let newSubscription = NewSubscription(isNewAccount: false, iap_identifier: "")
-            let termsVC = TermsViewController(newSubscription: newSubscription)
-            present(SJUIUtils.popupNavController(for: termsVC), animated: true, completion: nil)
-        } else {
-            let profileIntroViewController = ProfileIntroViewController()
-            profileIntroViewController.upgradeRootViewController = self
-            present(SJUIUtils.popupNavController(for: profileIntroViewController), animated: true)
         }
 
         Analytics.track(.settingsPlusUpgradeButtonTapped)

--- a/podcasts/ProfileViewController.swift
+++ b/podcasts/ProfileViewController.swift
@@ -158,10 +158,6 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
         navigationController?.pushViewController(settingsController, animated: true)
     }
 
-    func showProfileSetupController() {
-        NavigationManager.sharedManager.navigateTo(NavigationManager.onboardingFlow, data: ["flow": OnboardingFlow.Flow.loggedOut])
-    }
-
     private func showAccountController() {
         let accountVC = AccountViewController()
         navigationController?.pushViewController(accountVC, animated: true)

--- a/podcasts/ProfileViewController.swift
+++ b/podcasts/ProfileViewController.swift
@@ -159,14 +159,7 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
     }
 
     func showProfileSetupController() {
-        if FeatureFlag.onboardingUpdates.enabled {
-            NavigationManager.sharedManager.navigateTo(NavigationManager.onboardingFlow, data: ["flow": OnboardingFlow.Flow.loggedOut])
-            return
-        }
-
-        let profileIntroController = ProfileIntroViewController()
-        let navController = SJUIUtils.popupNavController(for: profileIntroController)
-        present(navController, animated: true, completion: nil)
+        NavigationManager.sharedManager.navigateTo(NavigationManager.onboardingFlow, data: ["flow": OnboardingFlow.Flow.loggedOut])
     }
 
     private func showAccountController() {


### PR DESCRIPTION
This removes the onboardingUpdates feature flag. 

## To test
1. Install the app from fresh
2. ✅ Verify you see the new onboarding flow
3. Dismiss it
4. Go to the Podcasts tab
5. Tap the folders icon
6. ✅ Verify you see the new onboarding flow
7. Dismiss it

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
