### PR TITLE
Cleanup: Removes the signInWithApple feature flag

### DIFF
--- a/podcasts/FeatureFlag.swift
+++ b/podcasts/FeatureFlag.swift
@@ -10,9 +10,6 @@ enum FeatureFlag: String, CaseIterable {
     /// Whether End Of Year feature is enabled
     case endOfYear
 
-    /// Adds the Sign In With Apple options to the login flow
-    case signInWithApple
-
     /// Bookmarks / Highlights
     case bookmarks
 
@@ -45,8 +42,6 @@ enum FeatureFlag: String, CaseIterable {
         case .firebaseLogging:
             return false
         case .endOfYear:
-            return true
-        case .signInWithApple:
             return true
         case .bookmarks:
             return true

--- a/podcasts/Onboarding/Login/LoginLandingView.swift
+++ b/podcasts/Onboarding/Login/LoginLandingView.swift
@@ -22,11 +22,6 @@ private struct LoginLandingContent: View {
     /// Determines if we should compact the view for smaller devices such as the iPhone SE / iPhone 12 Mini
     private var smallHeight: Bool { deviceHeight < 700 }
 
-    /// Reduce the header height to allow the buttons to fit for larger size categories
-    private var useSmallHeader: Bool {
-        smallHeight && sizeCategory > .extraLarge
-    }
-
     let coordinator: LoginCoordinator
 
     init(coordinator: LoginCoordinator) {

--- a/podcasts/Onboarding/Login/LoginLandingView.swift
+++ b/podcasts/Onboarding/Login/LoginLandingView.swift
@@ -16,7 +16,6 @@ private struct LoginLandingContent: View {
     @EnvironmentObject var theme: Theme
     @Environment(\.sizeCategory) var sizeCategory
 
-    @ProportionalValue(with: .height) var calculatedHeaderHeightLarge: Double
     @ProportionalValue(with: .height) var calculatedHeaderHeightSmall: Double
     @ProportionalValue(with: .height) var deviceHeight = 1
 
@@ -25,23 +24,13 @@ private struct LoginLandingContent: View {
 
     /// Reduce the header height to allow the buttons to fit for larger size categories
     private var useSmallHeader: Bool {
-        (smallHeight && sizeCategory > .extraLarge) || FeatureFlag.signInWithApple.enabled
+        smallHeight && sizeCategory > .extraLarge
     }
 
     let coordinator: LoginCoordinator
 
     init(coordinator: LoginCoordinator) {
         self.coordinator = coordinator
-
-        // Find the value that will appear the lowest, and use that to calculate the
-        // "total view height" since the actual view height doesn't account correctly
-        calculatedHeaderHeightLarge = {
-            let maxModel = largeHeaderModels.max {
-                $0.y < $1.y
-            }
-
-            return maxModel?.y ?? 0
-        }()
 
         // Calculate the header height for the small header too
         calculatedHeaderHeightSmall = {
@@ -149,12 +138,7 @@ private struct LoginLandingContent: View {
     /// Return the models to use in the header and allow them to be
     /// swapped out dynamically
     var calculatedModels: [CoverModel] {
-        var models: [CoverModel]
-        if useSmallHeader {
-            models = smallHeaderModels
-        } else {
-            models = largeHeaderModels
-        }
+        var models: [CoverModel] = smallHeaderModels
 
         // Map the models to images
         for i in 0..<models.count {
@@ -165,8 +149,7 @@ private struct LoginLandingContent: View {
     }
 
     var loginHeaderHeight: Double {
-        let height = useSmallHeader ? calculatedHeaderHeightSmall : calculatedHeaderHeightLarge
-        return height + (smallHeight ? Config.topPaddingSmallDevice : Config.topPadding)
+        calculatedHeaderHeightSmall + (smallHeight ? Config.topPaddingSmallDevice : Config.topPadding)
     }
 
 }
@@ -349,20 +332,16 @@ private struct SocialLoginButtons: View {
     let coordinator: LoginCoordinator
 
     var body: some View {
-        if !FeatureFlag.signInWithApple.enabled {
-            EmptyView()
-        } else {
-            ForEach(SocialAuthProvider.allCases, id: \.self) { provider in
-                switch provider {
-                case .apple:
-                    Button(L10n.socialSignInContinueWithApple) {
-                        coordinator.signIn(with: provider)
-                    }.buttonStyle(SocialButtonStyle(imageName: AppTheme.socialIconAppleImageName()))
-                case .google:
-                    Button(L10n.socialSignInContinueWithGoogle) {
-                        coordinator.signIn(with: provider)
-                    }.buttonStyle(SocialButtonStyle(imageName: AppTheme.socialIconGoogleImageName()))
-                }
+        ForEach(SocialAuthProvider.allCases, id: \.self) { provider in
+            switch provider {
+            case .apple:
+                Button(L10n.socialSignInContinueWithApple) {
+                    coordinator.signIn(with: provider)
+                }.buttonStyle(SocialButtonStyle(imageName: AppTheme.socialIconAppleImageName()))
+            case .google:
+                Button(L10n.socialSignInContinueWithGoogle) {
+                    coordinator.signIn(with: provider)
+                }.buttonStyle(SocialButtonStyle(imageName: AppTheme.socialIconGoogleImageName()))
             }
         }
     }


### PR DESCRIPTION
- Removes the signInWithApple feature flag
- Updates the LoginLandingView to remove references to it

## To test

1. Launch the app
2. Sign out if you're signed in
3. Go to Profile
4. Tap the Setup Account button
5. ✅ Verify you still see the social login buttons
6. ✅ Verify the view looks the same

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
