### PR TITLE
Cleanup: Remove autoplay feature flag

### DIFF
--- a/podcasts/AppDelegate+Defaults.swift
+++ b/podcasts/AppDelegate+Defaults.swift
@@ -18,9 +18,7 @@ extension AppDelegate {
             Settings.setHomeFolderSortOrder(order: .dateAddedNewestToOldest)
             Settings.setMobileDataAllowed(true)
             Settings.shouldShowInitialOnboardingFlow = true
-            if FeatureFlag.autoplay.enabled {
-                Settings.autoplay = true
-            }
+            Settings.autoplay = true
 
             // Disable dark up next theme for new users
             Settings.darkUpNextTheme = false

--- a/podcasts/FeatureFlag.swift
+++ b/podcasts/FeatureFlag.swift
@@ -19,9 +19,6 @@ enum FeatureFlag: String, CaseIterable {
     /// Displaying podcast ratings
     case showRatings
 
-    /// New episodes autoplay if Up Next is empty
-    case autoplay
-
     /// Enable the new show notes endpoint plus embedded episode artwork
     case newShowNotesEndpoint
 
@@ -48,8 +45,6 @@ enum FeatureFlag: String, CaseIterable {
         case .patron:
             return true
         case .showRatings:
-            return true
-        case .autoplay:
             return true
         case .newShowNotesEndpoint:
             return false

--- a/podcasts/GeneralSettingsViewController.swift
+++ b/podcasts/GeneralSettingsViewController.swift
@@ -10,7 +10,7 @@ class GeneralSettingsViewController: UIViewController, UITableViewDelegate, UITa
     let debounce = Debounce(delay: Constants.defaultDebounceTime)
 
     private enum TableRow { case skipForward, skipBack, keepScreenAwake, openPlayer, intelligentPlaybackResumption, defaultRowAction, extraMediaActions, defaultAddToUpNextSwipe, defaultGrouping, defaultArchive, playUpNextOnTap, legacyBluetooth, multiSelectGesture, openLinksInBrowser, publishChapterTitles, autoplay }
-    private var tableData: [[TableRow]] = [[.defaultRowAction, .defaultGrouping, .defaultArchive, .defaultAddToUpNextSwipe, .openLinksInBrowser], [.skipForward, .skipBack, .keepScreenAwake, .openPlayer, .intelligentPlaybackResumption], [.playUpNextOnTap], [.extraMediaActions], [.legacyBluetooth], [.multiSelectGesture], [.publishChapterTitles]]
+    private var tableData: [[TableRow]] = [[.defaultRowAction, .defaultGrouping, .defaultArchive, .defaultAddToUpNextSwipe, .openLinksInBrowser], [.skipForward, .skipBack, .keepScreenAwake, .openPlayer, .intelligentPlaybackResumption], [.playUpNextOnTap], [.extraMediaActions], [.legacyBluetooth], [.multiSelectGesture], [.publishChapterTitles], [.autoplay]]
 
     @IBOutlet var settingsTable: UITableView! {
         didSet {
@@ -27,10 +27,6 @@ class GeneralSettingsViewController: UIViewController, UITableViewDelegate, UITa
         title = L10n.settingsGeneral
 
         Analytics.track(.settingsGeneralShown)
-
-        if FeatureFlag.autoplay.enabled {
-            tableData.append([.autoplay])
-        }
     }
 
     override func viewDidAppear(_ animated: Bool) {

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -797,11 +797,7 @@ class Settings: NSObject {
             UserDefaults.standard.set(newValue, forKey: Constants.UserDefaults.autoplay)
         }
         get {
-            guard FeatureFlag.autoplay.enabled else {
-                return false
-            }
-
-            return UserDefaults.standard.bool(forKey: Constants.UserDefaults.autoplay)
+            UserDefaults.standard.bool(forKey: Constants.UserDefaults.autoplay)
         }
     }
 


### PR DESCRIPTION
Removes the autoplay feature flag

## To test

1. Fresh install the app
2. Go to Profile Tab > Cog > General
3. Swipe down to the bottom
4. ✅ Verify the Autoplay preferences is visible
5. ✅ Verify it is checked by default
6. Change the value
7. Reopen the General settings
8. ✅ Verify the autoplay setting shows the updated value

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
