### PR TITLE
Cleanup: Removes the showRatings feature flag

### DIFF
--- a/podcasts/FeatureFlag.swift
+++ b/podcasts/FeatureFlag.swift
@@ -16,9 +16,6 @@ enum FeatureFlag: String, CaseIterable {
     /// Patron
     case patron
 
-    /// Displaying podcast ratings
-    case showRatings
-
     /// Enable the new show notes endpoint plus embedded episode artwork
     case newShowNotesEndpoint
 
@@ -43,8 +40,6 @@ enum FeatureFlag: String, CaseIterable {
         case .bookmarks:
             return true
         case .patron:
-            return true
-        case .showRatings:
             return true
         case .newShowNotesEndpoint:
             return false

--- a/podcasts/PodcastHeadingTableCell.swift
+++ b/podcasts/PodcastHeadingTableCell.swift
@@ -261,10 +261,8 @@ class PodcastHeadingTableCell: ThemeableCell, SubscribeButtonDelegate, Expandabl
             layoutIfNeeded()
         }
 
-        if FeatureFlag.showRatings.enabled {
-            delegate.podcastRatingViewModel.update(uuid: podcast.uuid)
-            addRatingIfNeeded()
-        }
+        delegate.podcastRatingViewModel.update(uuid: podcast.uuid)
+        addRatingIfNeeded()
 
         addBookmarksTabViewIfNeeded(parentController: parentController)
     }
@@ -373,7 +371,7 @@ class PodcastHeadingTableCell: ThemeableCell, SubscribeButtonDelegate, Expandabl
         roundedBorder.isHidden = nextEpisodeView.isHidden && scheduleView.isHidden && linkView.isHidden && authorView.isHidden
 
         let hasRating = delegate?.podcastRatingViewModel.rating != nil
-        ratingView?.isHidden = !FeatureFlag.showRatings.enabled || !hasRating || !expanded
+        ratingView?.isHidden = !hasRating || !expanded
     }
 
     private func setupButtons() {


### PR DESCRIPTION
Removes the `showRatings` feature flag

## To test

1. Launch the app
2. Go to a podcast detail page
3. ✅ Verify you still see the rating

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
