### PR TITLE
Logs: use `actor` to avoid data race conditions

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Logging/LogEntry.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Logging/LogEntry.swift
@@ -19,8 +19,8 @@ struct LogEntry {
 
     // MARK: - Initializers
 
-    init(_ message: String) {
+    init(_ message: String, timestamp: Date) {
         self.message = message
-        self.timestamp = Date() // Now
+        self.timestamp = timestamp
     }
 }

--- a/Modules/Utils/Tests/PocketCastsUtilsTests/General/SerialDispatchMock.swift
+++ b/Modules/Utils/Tests/PocketCastsUtilsTests/General/SerialDispatchMock.swift
@@ -1,9 +1,0 @@
-import Foundation
-
-@testable import PocketCastsUtils
-
-final class SerialDispatchMock: DispatchQueueing {
-    func async(execute work: @escaping @convention(block) () -> Void) {
-        work()
-    }
-}

--- a/Modules/Utils/Tests/PocketCastsUtilsTests/Logging/FileLogTests.swift
+++ b/Modules/Utils/Tests/PocketCastsUtilsTests/Logging/FileLogTests.swift
@@ -11,7 +11,6 @@ final class FileLogTests: XCTestCase {
         let fileLog = FileLog(
             logPersistence: fileWriteSpy,
             logRotator: LogRotatorStub(),
-            writeQueue: SerialDispatchMock(),
             bufferThreshold: bufferThreshold
         )
 
@@ -31,7 +30,6 @@ final class FileLogTests: XCTestCase {
         let fileLog = FileLog(
             logPersistence: fileWriteSpy,
             logRotator: LogRotatorStub(),
-            writeQueue: SerialDispatchMock(),
             bufferThreshold: 2
         )
 
@@ -49,7 +47,6 @@ final class FileLogTests: XCTestCase {
         let fileLog = FileLog(
             logPersistence: LogPersistenceStub(),
             logRotator: rotationSpy,
-            writeQueue: SerialDispatchMock(),
             bufferThreshold: 1
         )
 
@@ -67,7 +64,6 @@ final class FileLogTests: XCTestCase {
         let fileLog = FileLog(
             logPersistence: fileWriteSpy,
             logRotator: LogRotatorStub(),
-            writeQueue: SerialDispatchMock(),
             bufferThreshold: bufferThreshold
         )
 
@@ -90,7 +86,6 @@ final class FileLogTests: XCTestCase {
         let fileLog = FileLog(
             logPersistence: fileWriteSpy,
             logRotator: LogRotatorStub(),
-            writeQueue: SerialDispatchMock(),
             bufferThreshold: bufferThreshold
         )
 

--- a/Modules/Utils/Tests/PocketCastsUtilsTests/Logging/LogBufferTests.swift
+++ b/Modules/Utils/Tests/PocketCastsUtilsTests/Logging/LogBufferTests.swift
@@ -78,31 +78,31 @@ final class LogBufferTests: XCTestCase {
         let lineCount = fileWriteSpy.lastWrittenChunk!.split(separator: "\n").count
         XCTAssertEqual(lineCount, 3)
     }
-//
-//    func testForceFlushFlushesRegardlessOfNumberOfBufferedMessages() {
-//        // GIVEN that we have a FileLog with a high threshold...
-//        let fileWriteSpy = LogPersistenceSpy()
-//        let bufferThreshold: UInt = 10
-//        let fileLog = FileLog(
-//            logPersistence: fileWriteSpy,
-//            logRotator: LogRotatorStub(),
-//            bufferThreshold: bufferThreshold
-//        )
-//
-//        // AND the number of buffered messages is below the threshold...
-//        let halfBufferThreshold = (bufferThreshold / 2)
-//        for messageNum in 1...halfBufferThreshold {
-//            fileLog.addMessage("Log Message \(messageNum)")
-//        }
-//
-//        // WHEN we force the FileLog to flush...
-//        fileLog.forceFlush()
-//
-//        // THEN all of the buffered messages are flushed despite being below the threshold.
-//        XCTAssertTrue(fileWriteSpy.textWrittenToLog)
-//        XCTAssertEqual(fileWriteSpy.writeCount, 1)
-//        let linesWrittenCount = fileWriteSpy.lastWrittenChunk!.split(separator: "\n").count
-//        XCTAssertEqual(UInt(linesWrittenCount), halfBufferThreshold)
-//    }
+
+    func testForceFlushFlushesRegardlessOfNumberOfBufferedMessages() async {
+        // GIVEN that we have a FileLog with a high threshold...
+        let fileWriteSpy = LogPersistenceSpy()
+        let bufferThreshold: UInt = 10
+        let fileLog = LogBuffer(
+            logPersistence: fileWriteSpy,
+            logRotator: LogRotatorStub(),
+            bufferThreshold: bufferThreshold
+        )
+
+        // AND the number of buffered messages is below the threshold...
+        let halfBufferThreshold = (bufferThreshold / 2)
+        for messageNum in 1...halfBufferThreshold {
+            await fileLog.append("Log Message \(messageNum)", date: Date())
+        }
+
+        // WHEN we force the FileLog to flush...
+        await fileLog.forceFlush()
+
+        // THEN all of the buffered messages are flushed despite being below the threshold.
+        XCTAssertTrue(fileWriteSpy.textWrittenToLog)
+        XCTAssertEqual(fileWriteSpy.writeCount, 1)
+        let linesWrittenCount = fileWriteSpy.lastWrittenChunk!.split(separator: "\n").count
+        XCTAssertEqual(UInt(linesWrittenCount), halfBufferThreshold)
+    }
 
 }

--- a/Modules/Utils/Tests/PocketCastsUtilsTests/Logging/LogBufferTests.swift
+++ b/Modules/Utils/Tests/PocketCastsUtilsTests/Logging/LogBufferTests.swift
@@ -4,11 +4,11 @@ import XCTest
 
 final class LogBufferTests: XCTestCase {
 
-    func testLogFlushedWhenThresholdReached() {
+    func testLogFlushedWhenThresholdReached() async {
         // GIVEN that we have a FileLog with a buffer threshold of 3...
         let fileWriteSpy = LogPersistenceSpy()
         let bufferThreshold: UInt = 3
-        let fileLog = FileLog(
+        let fileLog = LogBuffer(
             logPersistence: fileWriteSpy,
             logRotator: LogRotatorStub(),
             bufferThreshold: bufferThreshold
@@ -16,7 +16,7 @@ final class LogBufferTests: XCTestCase {
 
         // WHEN we write three log messages...
         for messageNum in 1...bufferThreshold {
-            fileLog.addMessage("Log Message \(messageNum)")
+            await fileLog.append("Log Message \(messageNum)", date: Date())
         }
 
         // THEN the log messages have been flushed to file persistence.
@@ -24,85 +24,85 @@ final class LogBufferTests: XCTestCase {
         XCTAssertEqual(fileWriteSpy.writeCount, 1)
     }
 
-    func testLogNotFlushedBeforeThresholdReached() {
-        // GIVEN that we have a FileLog with a buffer threshold of 2...
-        let fileWriteSpy = LogPersistenceSpy()
-        let fileLog = FileLog(
-            logPersistence: fileWriteSpy,
-            logRotator: LogRotatorStub(),
-            bufferThreshold: 2
-        )
-
-        // WHEN we write only one log message...
-        fileLog.addMessage("Log Message")
-
-        // THEN the log is not flushed to persistence as the threshold was not reached.
-        XCTAssertFalse(fileWriteSpy.textWrittenToLog)
-        XCTAssertEqual(fileWriteSpy.writeCount, 0)
-    }
-
-    func testFileRotationRequestedWhenFlushing() {
-        // GIVEN that we have a FileLog with a low threshold...
-        let rotationSpy = LogRotationSpy()
-        let fileLog = FileLog(
-            logPersistence: LogPersistenceStub(),
-            logRotator: rotationSpy,
-            bufferThreshold: 1
-        )
-
-        // WHEN we exceed the buffer threshold and trigger the log to be flushed...
-        fileLog.addMessage("Log Message")
-
-        // THEN file rotation is requested.
-        XCTAssertTrue(rotationSpy.rotationRequested)
-    }
-
-    func testFlushedMessagesSeperatedByNewlines() {
-        // GIVEN that we have a FileLog with a low threshold...
-        let fileWriteSpy = LogPersistenceSpy()
-        let bufferThreshold: UInt = 3
-        let fileLog = FileLog(
-            logPersistence: fileWriteSpy,
-            logRotator: LogRotatorStub(),
-            bufferThreshold: bufferThreshold
-        )
-
-        // WHEN we write enough messages to trigger a flush...
-        for messageNum in 1...bufferThreshold {
-            fileLog.addMessage("Log Message \(messageNum)")
-        }
-
-        // THEN the flushed messages are seperated by newlines.
-        XCTAssertTrue(fileWriteSpy.textWrittenToLog)
-        XCTAssertNotNil(fileWriteSpy.lastWrittenChunk)
-        let lineCount = fileWriteSpy.lastWrittenChunk!.split(separator: "\n").count
-        XCTAssertEqual(lineCount, 3)
-    }
-
-    func testForceFlushFlushesRegardlessOfNumberOfBufferedMessages() {
-        // GIVEN that we have a FileLog with a high threshold...
-        let fileWriteSpy = LogPersistenceSpy()
-        let bufferThreshold: UInt = 10
-        let fileLog = FileLog(
-            logPersistence: fileWriteSpy,
-            logRotator: LogRotatorStub(),
-            bufferThreshold: bufferThreshold
-        )
-
-        // AND the number of buffered messages is below the threshold...
-        let halfBufferThreshold = (bufferThreshold / 2)
-        for messageNum in 1...halfBufferThreshold {
-            fileLog.addMessage("Log Message \(messageNum)")
-        }
-
-        // WHEN we force the FileLog to flush...
-        fileLog.forceFlush()
-
-        // THEN all of the buffered messages are flushed despite being below the threshold.
-        XCTAssertTrue(fileWriteSpy.textWrittenToLog)
-        XCTAssertEqual(fileWriteSpy.writeCount, 1)
-        let linesWrittenCount = fileWriteSpy.lastWrittenChunk!.split(separator: "\n").count
-        XCTAssertEqual(UInt(linesWrittenCount), halfBufferThreshold)
-    }
+//    func testLogNotFlushedBeforeThresholdReached() {
+//        // GIVEN that we have a FileLog with a buffer threshold of 2...
+//        let fileWriteSpy = LogPersistenceSpy()
+//        let fileLog = FileLog(
+//            logPersistence: fileWriteSpy,
+//            logRotator: LogRotatorStub(),
+//            bufferThreshold: 2
+//        )
+//
+//        // WHEN we write only one log message...
+//        fileLog.addMessage("Log Message")
+//
+//        // THEN the log is not flushed to persistence as the threshold was not reached.
+//        XCTAssertFalse(fileWriteSpy.textWrittenToLog)
+//        XCTAssertEqual(fileWriteSpy.writeCount, 0)
+//    }
+//
+//    func testFileRotationRequestedWhenFlushing() {
+//        // GIVEN that we have a FileLog with a low threshold...
+//        let rotationSpy = LogRotationSpy()
+//        let fileLog = FileLog(
+//            logPersistence: LogPersistenceStub(),
+//            logRotator: rotationSpy,
+//            bufferThreshold: 1
+//        )
+//
+//        // WHEN we exceed the buffer threshold and trigger the log to be flushed...
+//        fileLog.addMessage("Log Message")
+//
+//        // THEN file rotation is requested.
+//        XCTAssertTrue(rotationSpy.rotationRequested)
+//    }
+//
+//    func testFlushedMessagesSeperatedByNewlines() {
+//        // GIVEN that we have a FileLog with a low threshold...
+//        let fileWriteSpy = LogPersistenceSpy()
+//        let bufferThreshold: UInt = 3
+//        let fileLog = FileLog(
+//            logPersistence: fileWriteSpy,
+//            logRotator: LogRotatorStub(),
+//            bufferThreshold: bufferThreshold
+//        )
+//
+//        // WHEN we write enough messages to trigger a flush...
+//        for messageNum in 1...bufferThreshold {
+//            fileLog.addMessage("Log Message \(messageNum)")
+//        }
+//
+//        // THEN the flushed messages are seperated by newlines.
+//        XCTAssertTrue(fileWriteSpy.textWrittenToLog)
+//        XCTAssertNotNil(fileWriteSpy.lastWrittenChunk)
+//        let lineCount = fileWriteSpy.lastWrittenChunk!.split(separator: "\n").count
+//        XCTAssertEqual(lineCount, 3)
+//    }
+//
+//    func testForceFlushFlushesRegardlessOfNumberOfBufferedMessages() {
+//        // GIVEN that we have a FileLog with a high threshold...
+//        let fileWriteSpy = LogPersistenceSpy()
+//        let bufferThreshold: UInt = 10
+//        let fileLog = FileLog(
+//            logPersistence: fileWriteSpy,
+//            logRotator: LogRotatorStub(),
+//            bufferThreshold: bufferThreshold
+//        )
+//
+//        // AND the number of buffered messages is below the threshold...
+//        let halfBufferThreshold = (bufferThreshold / 2)
+//        for messageNum in 1...halfBufferThreshold {
+//            fileLog.addMessage("Log Message \(messageNum)")
+//        }
+//
+//        // WHEN we force the FileLog to flush...
+//        fileLog.forceFlush()
+//
+//        // THEN all of the buffered messages are flushed despite being below the threshold.
+//        XCTAssertTrue(fileWriteSpy.textWrittenToLog)
+//        XCTAssertEqual(fileWriteSpy.writeCount, 1)
+//        let linesWrittenCount = fileWriteSpy.lastWrittenChunk!.split(separator: "\n").count
+//        XCTAssertEqual(UInt(linesWrittenCount), halfBufferThreshold)
+//    }
 
 }

--- a/Modules/Utils/Tests/PocketCastsUtilsTests/Logging/LogBufferTests.swift
+++ b/Modules/Utils/Tests/PocketCastsUtilsTests/Logging/LogBufferTests.swift
@@ -8,7 +8,7 @@ final class LogBufferTests: XCTestCase {
         // GIVEN that we have a FileLog with a buffer threshold of 3...
         let fileWriteSpy = LogPersistenceSpy()
         let bufferThreshold: UInt = 3
-        let fileLog = LogBuffer(
+        let logBuffer = LogBuffer(
             logPersistence: fileWriteSpy,
             logRotator: LogRotatorStub(),
             bufferThreshold: bufferThreshold
@@ -16,7 +16,7 @@ final class LogBufferTests: XCTestCase {
 
         // WHEN we write three log messages...
         for messageNum in 1...bufferThreshold {
-            await fileLog.append("Log Message \(messageNum)", date: Date())
+            await logBuffer.append("Log Message \(messageNum)", date: Date())
         }
 
         // THEN the log messages have been flushed to file persistence.
@@ -27,14 +27,14 @@ final class LogBufferTests: XCTestCase {
     func testLogNotFlushedBeforeThresholdReached() async {
         // GIVEN that we have a FileLog with a buffer threshold of 2...
         let fileWriteSpy = LogPersistenceSpy()
-        let fileLog = LogBuffer(
+        let logBuffer = LogBuffer(
             logPersistence: fileWriteSpy,
             logRotator: LogRotatorStub(),
             bufferThreshold: 2
         )
 
         // WHEN we write only one log message...
-        await fileLog.append("Log Message", date: Date())
+        await logBuffer.append("Log Message", date: Date())
 
         // THEN the log is not flushed to persistence as the threshold was not reached.
         XCTAssertFalse(fileWriteSpy.textWrittenToLog)
@@ -44,14 +44,14 @@ final class LogBufferTests: XCTestCase {
     func testFileRotationRequestedWhenFlushing() async {
         // GIVEN that we have a FileLog with a low threshold...
         let rotationSpy = LogRotationSpy()
-        let fileLog = LogBuffer(
+        let logBuffer = LogBuffer(
             logPersistence: LogPersistenceStub(),
             logRotator: rotationSpy,
             bufferThreshold: 1
         )
 
         // WHEN we exceed the buffer threshold and trigger the log to be flushed...
-        await fileLog.append("Log Message", date: Date())
+        await logBuffer.append("Log Message", date: Date())
 
         // THEN file rotation is requested.
         XCTAssertTrue(rotationSpy.rotationRequested)
@@ -61,7 +61,7 @@ final class LogBufferTests: XCTestCase {
         // GIVEN that we have a FileLog with a low threshold...
         let fileWriteSpy = LogPersistenceSpy()
         let bufferThreshold: UInt = 3
-        let fileLog = LogBuffer(
+        let logBuffer = LogBuffer(
             logPersistence: fileWriteSpy,
             logRotator: LogRotatorStub(),
             bufferThreshold: bufferThreshold
@@ -69,7 +69,7 @@ final class LogBufferTests: XCTestCase {
 
         // WHEN we write enough messages to trigger a flush...
         for messageNum in 1...bufferThreshold {
-            await fileLog.append("Log Message \(messageNum)", date: Date())
+            await logBuffer.append("Log Message \(messageNum)", date: Date())
         }
 
         // THEN the flushed messages are seperated by newlines.
@@ -83,7 +83,7 @@ final class LogBufferTests: XCTestCase {
         // GIVEN that we have a FileLog with a high threshold...
         let fileWriteSpy = LogPersistenceSpy()
         let bufferThreshold: UInt = 10
-        let fileLog = LogBuffer(
+        let logBuffer = LogBuffer(
             logPersistence: fileWriteSpy,
             logRotator: LogRotatorStub(),
             bufferThreshold: bufferThreshold
@@ -92,11 +92,11 @@ final class LogBufferTests: XCTestCase {
         // AND the number of buffered messages is below the threshold...
         let halfBufferThreshold = (bufferThreshold / 2)
         for messageNum in 1...halfBufferThreshold {
-            await fileLog.append("Log Message \(messageNum)", date: Date())
+            await logBuffer.append("Log Message \(messageNum)", date: Date())
         }
 
         // WHEN we force the FileLog to flush...
-        await fileLog.forceFlush()
+        await logBuffer.forceFlush()
 
         // THEN all of the buffered messages are flushed despite being below the threshold.
         XCTAssertTrue(fileWriteSpy.textWrittenToLog)

--- a/Modules/Utils/Tests/PocketCastsUtilsTests/Logging/LogBufferTests.swift
+++ b/Modules/Utils/Tests/PocketCastsUtilsTests/Logging/LogBufferTests.swift
@@ -2,7 +2,7 @@ import XCTest
 
 @testable import PocketCastsUtils
 
-final class FileLogTests: XCTestCase {
+final class LogBufferTests: XCTestCase {
 
     func testLogFlushedWhenThresholdReached() {
         // GIVEN that we have a FileLog with a buffer threshold of 3...

--- a/Modules/Utils/Tests/PocketCastsUtilsTests/Logging/LogBufferTests.swift
+++ b/Modules/Utils/Tests/PocketCastsUtilsTests/Logging/LogBufferTests.swift
@@ -40,22 +40,22 @@ final class LogBufferTests: XCTestCase {
         XCTAssertFalse(fileWriteSpy.textWrittenToLog)
         XCTAssertEqual(fileWriteSpy.writeCount, 0)
     }
-//
-//    func testFileRotationRequestedWhenFlushing() {
-//        // GIVEN that we have a FileLog with a low threshold...
-//        let rotationSpy = LogRotationSpy()
-//        let fileLog = FileLog(
-//            logPersistence: LogPersistenceStub(),
-//            logRotator: rotationSpy,
-//            bufferThreshold: 1
-//        )
-//
-//        // WHEN we exceed the buffer threshold and trigger the log to be flushed...
-//        fileLog.addMessage("Log Message")
-//
-//        // THEN file rotation is requested.
-//        XCTAssertTrue(rotationSpy.rotationRequested)
-//    }
+
+    func testFileRotationRequestedWhenFlushing() async {
+        // GIVEN that we have a FileLog with a low threshold...
+        let rotationSpy = LogRotationSpy()
+        let fileLog = LogBuffer(
+            logPersistence: LogPersistenceStub(),
+            logRotator: rotationSpy,
+            bufferThreshold: 1
+        )
+
+        // WHEN we exceed the buffer threshold and trigger the log to be flushed...
+        await fileLog.append("Log Message", date: Date())
+
+        // THEN file rotation is requested.
+        XCTAssertTrue(rotationSpy.rotationRequested)
+    }
 //
 //    func testFlushedMessagesSeperatedByNewlines() {
 //        // GIVEN that we have a FileLog with a low threshold...

--- a/Modules/Utils/Tests/PocketCastsUtilsTests/Logging/LogBufferTests.swift
+++ b/Modules/Utils/Tests/PocketCastsUtilsTests/Logging/LogBufferTests.swift
@@ -24,22 +24,22 @@ final class LogBufferTests: XCTestCase {
         XCTAssertEqual(fileWriteSpy.writeCount, 1)
     }
 
-//    func testLogNotFlushedBeforeThresholdReached() {
-//        // GIVEN that we have a FileLog with a buffer threshold of 2...
-//        let fileWriteSpy = LogPersistenceSpy()
-//        let fileLog = FileLog(
-//            logPersistence: fileWriteSpy,
-//            logRotator: LogRotatorStub(),
-//            bufferThreshold: 2
-//        )
-//
-//        // WHEN we write only one log message...
-//        fileLog.addMessage("Log Message")
-//
-//        // THEN the log is not flushed to persistence as the threshold was not reached.
-//        XCTAssertFalse(fileWriteSpy.textWrittenToLog)
-//        XCTAssertEqual(fileWriteSpy.writeCount, 0)
-//    }
+    func testLogNotFlushedBeforeThresholdReached() async {
+        // GIVEN that we have a FileLog with a buffer threshold of 2...
+        let fileWriteSpy = LogPersistenceSpy()
+        let fileLog = LogBuffer(
+            logPersistence: fileWriteSpy,
+            logRotator: LogRotatorStub(),
+            bufferThreshold: 2
+        )
+
+        // WHEN we write only one log message...
+        await fileLog.append("Log Message", date: Date())
+
+        // THEN the log is not flushed to persistence as the threshold was not reached.
+        XCTAssertFalse(fileWriteSpy.textWrittenToLog)
+        XCTAssertEqual(fileWriteSpy.writeCount, 0)
+    }
 //
 //    func testFileRotationRequestedWhenFlushing() {
 //        // GIVEN that we have a FileLog with a low threshold...

--- a/Modules/Utils/Tests/PocketCastsUtilsTests/Logging/LogBufferTests.swift
+++ b/Modules/Utils/Tests/PocketCastsUtilsTests/Logging/LogBufferTests.swift
@@ -56,28 +56,28 @@ final class LogBufferTests: XCTestCase {
         // THEN file rotation is requested.
         XCTAssertTrue(rotationSpy.rotationRequested)
     }
-//
-//    func testFlushedMessagesSeperatedByNewlines() {
-//        // GIVEN that we have a FileLog with a low threshold...
-//        let fileWriteSpy = LogPersistenceSpy()
-//        let bufferThreshold: UInt = 3
-//        let fileLog = FileLog(
-//            logPersistence: fileWriteSpy,
-//            logRotator: LogRotatorStub(),
-//            bufferThreshold: bufferThreshold
-//        )
-//
-//        // WHEN we write enough messages to trigger a flush...
-//        for messageNum in 1...bufferThreshold {
-//            fileLog.addMessage("Log Message \(messageNum)")
-//        }
-//
-//        // THEN the flushed messages are seperated by newlines.
-//        XCTAssertTrue(fileWriteSpy.textWrittenToLog)
-//        XCTAssertNotNil(fileWriteSpy.lastWrittenChunk)
-//        let lineCount = fileWriteSpy.lastWrittenChunk!.split(separator: "\n").count
-//        XCTAssertEqual(lineCount, 3)
-//    }
+
+    func testFlushedMessagesSeperatedByNewlines() async {
+        // GIVEN that we have a FileLog with a low threshold...
+        let fileWriteSpy = LogPersistenceSpy()
+        let bufferThreshold: UInt = 3
+        let fileLog = LogBuffer(
+            logPersistence: fileWriteSpy,
+            logRotator: LogRotatorStub(),
+            bufferThreshold: bufferThreshold
+        )
+
+        // WHEN we write enough messages to trigger a flush...
+        for messageNum in 1...bufferThreshold {
+            await fileLog.append("Log Message \(messageNum)", date: Date())
+        }
+
+        // THEN the flushed messages are seperated by newlines.
+        XCTAssertTrue(fileWriteSpy.textWrittenToLog)
+        XCTAssertNotNil(fileWriteSpy.lastWrittenChunk)
+        let lineCount = fileWriteSpy.lastWrittenChunk!.split(separator: "\n").count
+        XCTAssertEqual(lineCount, 3)
+    }
 //
 //    func testForceFlushFlushesRegardlessOfNumberOfBufferedMessages() {
 //        // GIVEN that we have a FileLog with a high threshold...


### PR DESCRIPTION
Follow-up to #1249

In #1249 @mylesbarros changed how we manage logs to reduce filesystem writes.

One side-effect of this change is some crashes caused by data race conditions, as discovered by @emilylaguna — given many different threads can write logs at the same time.

You can easily reproduce that on `trunk` by using this chunk of code:

```swift
let queue = OperationQueue()
queue.maxConcurrentOperationCount = 5

for i in 0..<2000 {
    queue.addOperation {
        print("$$ Message: \(i)")
        FileLog.shared.addMessage("Message: \(i)")
    }
}
queue.waitUntilAllOperationsAreFinished()
```

This PR changes `FileLog` by wrapping most of the write/read/storage on a new `actor` called `LogBuffer` — ensuring only one caller can interact with it. This also removes the need to have `DispatchQueue`.

Another change is that the messages are ordered according to their timestamp. This happens because given we're now using an `actor` messages will not necessarily be added in the correct order.

## To test

1. Try the chunk of code provided above, the app should not crash
2. Interact with the app as usual
1. Navigate around the app and start a podcast to generate log entries.
2. Tap the Profile tab
3. Tap the gear to access Settings
4. Scroll to the bottom and tap Help & Feedback
5. Scroll to the bottom and tap Get in touch
6. Tap Get Support
7. Tap Attached Logs at the bottom
8. Verify that Debug Logs contain the expected log output such as for the podcast that was started

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
