### PR TITLE
Cache the EndOfYear.isEligible value

### DIFF
--- a/podcasts/End of Year/EndOfYear.swift
+++ b/podcasts/End of Year/EndOfYear.swift
@@ -194,7 +194,6 @@ extension EndOfYear {
             notifications.forEach { notificationCenter.removeObserver($0) }
         }
 
-
         var isEligible = false
 
         private let updateQueue = OperationQueue()

--- a/podcasts/End of Year/EndOfYear.swift
+++ b/podcasts/End of Year/EndOfYear.swift
@@ -195,7 +195,6 @@ extension EndOfYear {
 
         var isEligible = false
 
-        private let updateQueue = OperationQueue()
         private let notificationCenter: NotificationCenter
         private var notifications: [NSObjectProtocol] = []
 
@@ -222,7 +221,7 @@ extension EndOfYear {
             ]
 
             self.notifications = notifications.map {
-                notificationCenter.addObserver(forName: $0, object: nil, queue: updateQueue) { [weak self] notification in
+                notificationCenter.addObserver(forName: $0, object: nil, queue: .main) { [weak self] notification in
                     self?.update()
                 }
             }
@@ -235,7 +234,7 @@ extension EndOfYear {
 
             // Let others know this changed
             if didChange {
-                NotificationCenter.postOnMainThread(notification: EndOfYear.eoyEligibilityDidChange)
+                notificationCenter.post(name: EndOfYear.eoyEligibilityDidChange, object: nil)
             }
         }
     }

--- a/podcasts/End of Year/EndOfYear.swift
+++ b/podcasts/End of Year/EndOfYear.swift
@@ -10,10 +10,10 @@ enum EndOfYearPresentationSource: String {
 }
 
 struct EndOfYear {
-    static var isEligible: Bool { eligibilityChecker.isEligible }
+    static var isEligible: Bool { eligibilityChecker?.isEligible ?? false }
 
     // Setup the eligibility checker
-    private static let eligibilityChecker: EligibilityChecker = .init()
+    private static let eligibilityChecker: EligibilityChecker? = .init()
 
     /// Internal state machine to determine how we should react to login changes
     /// and when to show the modal vs go directly to the stories
@@ -186,6 +186,8 @@ private class FakeViewController: UIViewController {
 }
 
 extension EndOfYear {
+    static let eoyEligibilityDidChange = NSNotification.Name(rawValue: "eoyEligibilityDidChange")
+
     private class EligibilityChecker {
         deinit {
             notifications.forEach { notificationCenter.removeObserver($0) }
@@ -232,6 +234,9 @@ extension EndOfYear {
             let didChange = isEligible != self.isEligible
             self.isEligible = isEligible
 
+            // Let others know this changed
+            if didChange {
+                NotificationCenter.postOnMainThread(notification: EndOfYear.eoyEligibilityDidChange)
             }
         }
     }

--- a/podcasts/End of Year/EndOfYear.swift
+++ b/podcasts/End of Year/EndOfYear.swift
@@ -137,6 +137,7 @@ struct EndOfYear {
         // shown to show it again.
         if Self.state == .showModalIfNeeded {
             Settings.endOfYearModalHasBeenShown = false
+            Self.eligibilityChecker?.update()
             return
         }
 

--- a/podcasts/End of Year/EndOfYear.swift
+++ b/podcasts/End of Year/EndOfYear.swift
@@ -190,7 +190,7 @@ extension EndOfYear {
 
     private class EligibilityChecker {
         deinit {
-            notifications.forEach { notificationCenter.removeObserver($0) }
+            stopListening()
         }
 
         var isEligible = false
@@ -227,14 +227,20 @@ extension EndOfYear {
             }
         }
 
-        func update() {
-            let isEligible = DataManager.sharedManager.isEligibleForEndOfYearStories()
-            let didChange = isEligible != self.isEligible
-            self.isEligible = isEligible
+        private func stopListening() {
+            notifications.forEach { notificationCenter.removeObserver($0) }
+            notifications.removeAll()
+        }
+
+        private func update() {
+            isEligible = DataManager.sharedManager.isEligibleForEndOfYearStories()
 
             // Let others know this changed
-            if didChange {
+            if isEligible {
                 notificationCenter.post(name: EndOfYear.eoyEligibilityDidChange, object: nil)
+
+                // We don't need to check eligibility anymore
+                stopListening()
             }
         }
     }

--- a/podcasts/End of Year/EndOfYear.swift
+++ b/podcasts/End of Year/EndOfYear.swift
@@ -10,10 +10,10 @@ enum EndOfYearPresentationSource: String {
 }
 
 struct EndOfYear {
-    // We'll calculate this just once
-    static var isEligible: Bool {
-        FeatureFlag.endOfYear.enabled && DataManager.sharedManager.isEligibleForEndOfYearStories()
-    }
+    static var isEligible: Bool { eligibilityChecker.isEligible }
+
+    // Setup the eligibility checker
+    private static let eligibilityChecker: EligibilityChecker = .init()
 
     /// Internal state machine to determine how we should react to login changes
     /// and when to show the modal vs go directly to the stories
@@ -182,5 +182,11 @@ private class FakeViewController: UIViewController {
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         onDismiss?()
+    }
+}
+
+extension EndOfYear {
+    private class EligibilityChecker {
+        var isEligible = false
     }
 }

--- a/podcasts/End of Year/EndOfYear.swift
+++ b/podcasts/End of Year/EndOfYear.swift
@@ -12,7 +12,7 @@ enum EndOfYearPresentationSource: String {
 struct EndOfYear {
     static var isEligible: Bool { eligibilityChecker?.isEligible ?? false }
 
-    // Setup the eligibility checker
+    // Eligibility checker to manage the `isEligible` state
     private static let eligibilityChecker: EligibilityChecker? = .init()
 
     /// Internal state machine to determine how we should react to login changes

--- a/podcasts/End of Year/EndOfYear.swift
+++ b/podcasts/End of Year/EndOfYear.swift
@@ -137,7 +137,6 @@ struct EndOfYear {
         // shown to show it again.
         if Self.state == .showModalIfNeeded {
             Settings.endOfYearModalHasBeenShown = false
-            Self.eligibilityChecker?.update()
             return
         }
 

--- a/podcasts/ProfileViewController.swift
+++ b/podcasts/ProfileViewController.swift
@@ -112,6 +112,7 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
         addCustomObserver(.userLoginDidChange, selector: #selector(handleDataChangedNotification))
         addCustomObserver(.serverUserWillBeSignedOut, selector: #selector(handleDataChangedNotification))
         addCustomObserver(.whatsNewDismissed, selector: #selector(whatsNewDismissed))
+        addCustomObserver(EndOfYear.eoyEligibilityDidChange, selector: #selector(handleDataChangedNotification))
 
         addCustomObserver(Constants.Notifications.tappedOnSelectedTab, selector: #selector(checkForScrollTap(_:)))
         if promoRedeemedMessage != nil {


### PR DESCRIPTION
This adds a `EligibilityChecker` class to manage the `isEligible` value. It will update the value when:
- A sync is completed
- The user signs in
- The playback was paused, ended, or changed

Doing this prevents `DataManager.sharedManager.isEligibleForEndOfYearStories` from being called too often from places like the ProfileViewController. 

A future PR will address how the `ProfileViewController` is update the values to reduce the calls.

## To test

1. Fresh install the app
2. ✅ Verify you do not see the card on the profile tab
3. Sign into an account that is eligible for Playback 2023
4. ✅ Verify the prompt appears after signing in
5. ✅ Verify you see the card on the profile tab
6. Fresh install the app again
7. Play and finish an episode
8. Go to the Profile tab
9. ✅ Verify you see the Playback card
10. Relaunch the app
11. ✅ Verify you see the prompt


## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
