### PR TITLE
Player transition: fix a freeze when dismissing

### DIFF
--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -367,6 +367,13 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
     }
 
     func showHeadphoneSettings() {
+        let state = NavigationManager.sharedManager.miniPlayer?.playerOpenState
+
+        // Dismiss any presented views if the player is not already open/dismissing since it will dismiss itself
+        if state != .open, state != .animating {
+            dismissPresentedViewController()
+        }
+
         switchToTab(.profile)
         if let navController = selectedViewController as? UINavigationController {
             navController.popToRootViewController(animated: false)

--- a/podcasts/MiniPlayerViewController+Positioning.swift
+++ b/podcasts/MiniPlayerViewController+Positioning.swift
@@ -54,8 +54,6 @@ extension MiniPlayerViewController {
 
             playerOpenState = .animating
 
-            fullScreenPlayer.modalPresentationStyle = .overCurrentContext
-
             presentFromRootController(fullScreenPlayer, animated: true) {
                 self.playerOpenState = .open
                 self.rootViewController()?.setNeedsStatusBarAppearanceUpdate()

--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -109,6 +109,10 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
             fullScreenPlayer?.view.removeFromSuperview()
             fullScreenPlayer = nil
 
+            // When there are a stack of VCs the player might not dismiss as expected
+            // Here we ensure it is correctly dismissed
+            SceneHelper.rootViewController()?.dismiss(animated: true)
+
             // update the mini player on full screen player close
             playbackStateDidChange()
             playbackProgressDidChange()


### PR DESCRIPTION
There is a specific case that happens when the player is dismissed and is presenting other views. For some reason, this makes the transition view never disappear blocking any user interaction.

This PR ensures the player is dismissed when it should

## To test

1. Run the app
2. Have more than one item on your Up Next
3. Open the player
4. Tap the "Up Next" icon
5. Tap the episode that is not playing
6. Go to Bookmarks
7. Tap "Headphone settings"
8. ✅ You should be able to interact normally with the app

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
