### PR TITLE
Fix a crash when exporting the database on an iPad

### DIFF
--- a/podcasts/DatabaseExport.swift
+++ b/podcasts/DatabaseExport.swift
@@ -4,60 +4,17 @@ import PocketCastsUtils
 
 class DatabaseExport {
     private let fileManager = FileManager.default
-    private var loadingAlert: ShiftyLoadingAlert?
 
     /// The resulting file name of the zip file
     private let exportName = "Pocket Casts Export"
 
-    /// ZIPs the users SQLite database and shows a share dialog for them to share it with us
-    func exportDatabase(from controller: UIViewController, completion: @escaping () -> Void) {
-        loadingAlert = ShiftyLoadingAlert(title: L10n.exportingDatabase)
-        loadingAlert?.showAlert(controller, hasProgress: false, completion: { [weak self] in
-            self?.export { url in
-                self?.share(url: url, from: controller, completion: completion)
-            }
-        })
-    }
-
-    /// Open the resulting zip file in the share sheet, or show an error
-    private func share(url: URL?, from controller: UIViewController, completion: @escaping () -> Void) {
-        loadingAlert?.hideAlert(false)
-        loadingAlert = nil
-
-        guard let url else {
-            SJUIUtils.showAlert(title: L10n.settingsExportError, message: nil, from: controller)
-            return
-        }
-
-        // Share the file
-        let shareSheet = UIActivityViewController(activityItems: [url], applicationActivities: nil)
-        shareSheet.completionWithItemsHandler = { [weak self] _, _, _, _ in
-            // Attempt to cleanup the temporary file
-            self?.cleanup(url: url)
-
-            completion()
-        }
-
-        controller.present(shareSheet, animated: true, completion: nil)
-    }
-
-    /// Attempt to remove the temporary export directory and files
-    private func cleanup(url: URL) {
-        do {
-            try fileManager.removeItem(at: url.deletingLastPathComponent())
-        } catch {
-            FileLog.shared.addMessage("[Export] Could not cleanup file: \(error)")
-        }
-    }
-
     /// Create a zip of the database and prefrences
-    private func export(_ handler: @escaping (URL?) -> Void) {
-        DispatchQueue.global(qos: .userInitiated).async {
-            guard let exportFolder = self.prepareFiles() else {
-                handler(nil)
-                return
-            }
+    func export() async -> URL? {
+        guard let exportFolder = self.prepareFiles() else {
+            return nil
+        }
 
+        return await withCheckedContinuation { continutation in
             let coordinator = NSFileCoordinator()
 
             // The file coordinate will zip the export folder for us
@@ -68,14 +25,21 @@ class DatabaseExport {
                     let tempURL = exportFolder.appendingPathComponent("\(self.exportName).zip")
                     try self.fileManager.moveItem(at: zipURL, to: tempURL)
 
-                    DispatchQueue.main.async {
-                        handler(tempURL)
-                    }
+                    continutation.resume(returning: tempURL)
                 } catch {
                     FileLog.shared.addMessage("[Export] Could not generate zip file: \(error)")
-                    handler(nil)
+                    continutation.resume(returning: nil)
                 }
             }
+        }
+    }
+
+    /// Attempt to remove the temporary export directory and files
+    func cleanup(url: URL) {
+        do {
+            try fileManager.removeItem(at: url.deletingLastPathComponent())
+        } catch {
+            FileLog.shared.addMessage("[Export] Could not cleanup file: \(error)")
         }
     }
 

--- a/podcasts/DatabaseExport.swift
+++ b/podcasts/DatabaseExport.swift
@@ -3,10 +3,14 @@ import PocketCastsDataModel
 import PocketCastsUtils
 
 class DatabaseExport {
-    private let fileManager = FileManager.default
-
     /// The resulting file name of the zip file
-    private let exportName = "Pocket Casts Export"
+    let exportName: String
+
+    init(exportName: String = "Pocket Casts Export") {
+        self.exportName = exportName
+    }
+
+    private let fileManager = FileManager.default
 
     /// Create a zip of the database and prefrences
     func export() async -> URL? {


### PR DESCRIPTION
When trying to export the database on an iPad the app will crash.  This is because the `popoverPresentationController` source values weren't set. 

While fixing this I realized I put too much of the UI work in the `DatabaseExport` class so I refactored it to:
- Move the UI work from the DatabaseExport into the View Controller
- Replaced the completion blocks with async functions

## To test

1. Launch the app on iPad
2. Go to the Profile tab > Help & Feedback
3. Tap the ... in the top right corner
4. Tap Export Database
5. ✅ Verify the database is exported
6. Add the resulting file to the Files app
7. Open the Files app and tap on the .zip file
8. ✅ Verify it unzips
9. Test the changes on iPhone

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
