### PR TITLE
Player transition: disable

### DIFF
--- a/podcasts/FeatureFlag.swift
+++ b/podcasts/FeatureFlag.swift
@@ -81,7 +81,7 @@ enum FeatureFlag: String, CaseIterable {
         case .episodeFeedArtwork:
             return false // To be enabled, newShowNotesEndpoint needs to be too
         case .newPlayerTransition:
-            return true
+            return false
         }
     }
 }


### PR DESCRIPTION
When the app is in the background and the player dismisses, the app becomes unresponsive because there's a `UITransitionView` on top of everything that doesn't go away.

## To test

1. Run the app
2. Make sure you have a clean Up Next and that Autoplay is off
3. Play any episode
4. Open the full player
6. Put the app in background
7. Finish the episode
8. Reopen the app
10. ✅ Interact with the app and everything should work normally

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
