### PR TITLE
Player Transition: Fix the player not dismissing correctly when in the background

### DIFF
--- a/podcasts/FeatureFlag.swift
+++ b/podcasts/FeatureFlag.swift
@@ -46,7 +46,7 @@ enum FeatureFlag: String, CaseIterable {
         case .episodeFeedArtwork:
             return false // To be enabled, newShowNotesEndpoint needs to be too
         case .newPlayerTransition:
-            return false
+            return true
         }
     }
 }

--- a/podcasts/MiniPlayerToFullPlayerAnimator.swift
+++ b/podcasts/MiniPlayerToFullPlayerAnimator.swift
@@ -149,7 +149,7 @@ class MiniPlayerToFullPlayerAnimator: NSObject, UIViewControllerAnimatedTransiti
             toView.frame = toFrame
             toView.layer.opacity = self.isPresenting ? 1 : 0
         } completion: { completed in
-            transitionContext.completeTransition(completed)
+            transitionContext.completeTransition(true)
         }
 
         // MARK: - Background and Mini Player

--- a/podcasts/MiniPlayerViewController+Positioning.swift
+++ b/podcasts/MiniPlayerViewController+Positioning.swift
@@ -95,7 +95,7 @@ extension MiniPlayerViewController {
         guard !FeatureFlag.newPlayerTransition.enabled else {
             playerOpenState = .animating
 
-            fullScreenPlayer?.dismiss(animated: true) {
+            rootViewController()?.dismiss(animated: true) {
                 self.finishedWithFullScreenPlayer()
                 self.playerOpenState = .closed
                 Analytics.track(.playerDismissed)

--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -110,8 +110,8 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
             fullScreenPlayer = nil
 
             // When there are a stack of VCs the player might not dismiss as expected
-            // Here we ensure it is correctly dismissed
-            SceneHelper.rootViewController()?.dismiss(animated: true)
+            // Here we ensure everything is correctly dismissed
+            rootViewController()?.dismiss(animated: UIApplication.shared.applicationState == .active)
 
             // update the mini player on full screen player close
             playbackStateDidChange()

--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -109,10 +109,6 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
             fullScreenPlayer?.view.removeFromSuperview()
             fullScreenPlayer = nil
 
-            // When there are a stack of VCs the player might not dismiss as expected
-            // Here we ensure everything is correctly dismissed
-            rootViewController()?.dismiss(animated: UIApplication.shared.applicationState == .active)
-
             // update the mini player on full screen player close
             playbackStateDidChange()
             playbackProgressDidChange()

--- a/podcasts/PlayerContainerViewController.swift
+++ b/podcasts/PlayerContainerViewController.swift
@@ -99,14 +99,6 @@ class PlayerContainerViewController: SimpleNotificationsViewController, PlayerTa
         if !FeatureFlag.newPlayerTransition.enabled {
             Analytics.track(.playerShown)
         }
-    override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
-        // When the app is not active, dismissing it animated causes
-        // the `UITransitionView` to never disappear, blocking any gesture
-        // with the app.
-        let animated = UIApplication.shared.applicationState == .active
-        super.dismiss(animated: animated, completion: completion)
-    }
-
     }
 
     override func viewDidDisappear(_ animated: Bool) {

--- a/podcasts/PlayerContainerViewController.swift
+++ b/podcasts/PlayerContainerViewController.swift
@@ -99,6 +99,14 @@ class PlayerContainerViewController: SimpleNotificationsViewController, PlayerTa
         if !FeatureFlag.newPlayerTransition.enabled {
             Analytics.track(.playerShown)
         }
+    override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
+        // When the app is not active, dismissing it animated causes
+        // the `UITransitionView` to never disappear, blocking any gesture
+        // with the app.
+        let animated = UIApplication.shared.applicationState == .active
+        super.dismiss(animated: animated, completion: completion)
+    }
+
     }
 
     override func viewDidDisappear(_ animated: Bool) {


### PR DESCRIPTION
This fixes an issue where the `UITransitionView` would stay open if the player was dismissed while in the background, or the device was locked. 

## To test

### Background dismiss
1. Run the app
2. Make sure you have a clean Up Next and that Autoplay is off
3. Play any episode
4. Open the full player
6. Put the app in background
7. Finish the episode
8. Reopen the app
10. ✅ Interact with the app and everything should work normally

### Background dismiss with multiple presented views
1. Run the app
2. Make sure you have a clean Up Next and that Autoplay is off
3. Play any episode
4. Open the full player
5. Open the Up next
6. Put the app in background
7. Finish the episode
8. Reopen the app
10. ✅ Interact with the app and everything should work normally

### Dismissing multiple presented views
1. Run the app
2. Have more than one item on your Up Next
3. Open the player
4. Tap the "Up Next" icon
6. Tap the episode that is not playing
7. Go to Bookmarks
8. Tap "Headphone settings"
9. ✅ You should be able to interact normally with the app

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
