### PR TITLE
Player transition: add remote feature flag

### DIFF
--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -283,6 +283,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             Constants.RemoteParams.patronCloudStorageGB: NSNumber(value: Constants.RemoteParams.patronCloudStorageGBDefault),
             Constants.RemoteParams.bookmarksEnabled: NSNumber(value: Constants.RemoteParams.bookmarksEnabledDefault),
             Constants.RemoteParams.addMissingEpisodes: NSNumber(value: Constants.RemoteParams.addMissingEpisodesDefault),
+            Constants.RemoteParams.newPlayerTransition: NSNumber(value: Constants.RemoteParams.newPlayerTransitionDefault),
         ])
 
         remoteConfig.fetch(withExpirationDuration: 2.hour) { [weak self] status, _ in

--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -302,10 +302,17 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             try FeatureFlagOverrideStore().override(FeatureFlag.patron, withValue: Settings.patronEnabled)
             try FeatureFlagOverrideStore().override(FeatureFlag.bookmarks, withValue: Settings.remoteBookmarksEnabled)
 
+            if FeatureFlag.newPlayerTransition.enabled != Settings.newPlayerTransition {
+                // If the player transition changes we dismiss the full screen player
+                // Otherwise this might lead to crashes or weird behavior
+                appDelegate()?.miniPlayer()?.closeFullScreenPlayer()
+                try FeatureFlagOverrideStore().override(FeatureFlag.newPlayerTransition, withValue: Settings.newPlayerTransition)
+            }
+
             // If the flag is off and we're turning it on we won't have the product info yet so we'll ask for them again
             IapHelper.shared.requestProductInfoIfNeeded()
         } catch {
-            FileLog.shared.addMessage("Failed to set the patron remote feature flag: \(error)")
+            FileLog.shared.addMessage("Failed to set remote feature flag: \(error)")
         }
         #endif
     }

--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -335,6 +335,9 @@ struct Constants {
 
         static let addMissingEpisodes = "add_missing_episodes"
         static let addMissingEpisodesDefault: Bool = true
+
+        static let newPlayerTransition = "new_player_transition"
+        static let newPlayerTransitionDefault: Bool = true
     }
 
     static let defaultDebounceTime: TimeInterval = 0.5

--- a/podcasts/MiniPlayerToFullPlayerAnimator.swift
+++ b/podcasts/MiniPlayerToFullPlayerAnimator.swift
@@ -205,3 +205,9 @@ class MiniPlayerToFullPlayerAnimator: NSObject, UIViewControllerAnimatedTransiti
         case dismissing
     }
 }
+
+extension FeatureFlag {
+    var isNewTransitionEnabled: Bool {
+        FeatureFlag.newPlayerTransition.enabled && Settings.newPlayerTransition
+    }
+}

--- a/podcasts/MiniPlayerToFullPlayerAnimator.swift
+++ b/podcasts/MiniPlayerToFullPlayerAnimator.swift
@@ -205,9 +205,3 @@ class MiniPlayerToFullPlayerAnimator: NSObject, UIViewControllerAnimatedTransiti
         case dismissing
     }
 }
-
-extension FeatureFlag {
-    var isNewTransitionEnabled: Bool {
-        FeatureFlag.newPlayerTransition.enabled && Settings.newPlayerTransition
-    }
-}

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -880,6 +880,11 @@ class Settings: NSObject {
             return remote.boolValue
         }
 
+        static var newPlayerTransition: Bool {
+            let remote = RemoteConfig.remoteConfig().configValue(forKey: Constants.RemoteParams.newPlayerTransition)
+            return remote.boolValue
+        }
+
         static var effectsPlayerStrategy: EffectsPlayerStrategy? {
             let remote = RemoteConfig.remoteConfig().configValue(forKey: Constants.RemoteParams.effectsPlayerStrategy)
             return EffectsPlayerStrategy(rawValue: remote.numberValue.intValue)


### PR DESCRIPTION
This PR puts the new player transition behind a remote feature flag.

## To test

Go to `AppDelegate` and inside `updateRemoteFeatureFlags` remove the conditional macros.

1. Do a clean install of the app
2. Play something, tap on the miniplayer
3. ✅ Ensure the new transition is on
4. Delete the app
5. Go to Firebase console and and change `new_player_transition` to`false`, publish changes
6. Re-run the app
7. Play something, tap on the miniplayer
8. ✅ Ensure the transition is the old one
9. Go to Firebase console and revert `new_player_transition` to `true`, publish changes


## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
