### PR TITLE
Player: do not allow landscape on the player

### DIFF
--- a/podcasts/PlayerContainerViewController.swift
+++ b/podcasts/PlayerContainerViewController.swift
@@ -129,6 +129,13 @@ class PlayerContainerViewController: SimpleNotificationsViewController, PlayerTa
         present(navController, animated: true, completion: nil)
     }
 
+    // MARK: - Orientation
+
+    // we implement this here to lock all views (except presented modal VCs to portrait)
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        .portrait
+    }
+
     // MARK: - PlayerItemContainerDelegate
 
     func scrollToCurrentChapter() {


### PR DESCRIPTION
A user shared this feedback on the Beta Slack that the player can be put on landscape. This is due to changing how the player is presented, this PR fixes this issue.

## To test

1. Run the app
2. Open the full player
3. Move the device to landscape
4. ✅ The player should remain in portrait

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
