### PR TITLE
Player: add a spring animation when dismissing

### DIFF
--- a/podcasts/MiniPlayerToFullPlayerAnimator.swift
+++ b/podcasts/MiniPlayerToFullPlayerAnimator.swift
@@ -174,6 +174,17 @@ class MiniPlayerToFullPlayerAnimator: NSObject, UIViewControllerAnimatedTransiti
 
             // MARK: - Artwork animation
 
+            // We fade from the big artwork to the miniplayer snapshot to ensure
+            // a smooth transition. DispatchQueue is needed because delay conflicts
+            // with snapshotView(afterScreenUpdates: true) (yes...)
+            if !isPresenting {
+                DispatchQueue.main.async {
+                    UIView.animate(withDuration: self.duration * 0.3, delay: self.duration * 0.7, options: .curveEaseOut) { [self] in
+                        artwork.layer.opacity = self.isPresenting ? 1 : 0
+                    }
+                }
+            }
+
             animate(withDuration: duration) { [self] in
                 artwork.frame = self.isPresenting ? fullPlayerArtworkFrame : miniPlayerArtworkFrame
                 artwork.layer.cornerRadius = self.isPresenting ? fullPlayerArtwork.layer.cornerRadius : miniPlayerArtwork.imageView!.layer.cornerRadius

--- a/podcasts/MiniPlayerToFullPlayerAnimator.swift
+++ b/podcasts/MiniPlayerToFullPlayerAnimator.swift
@@ -95,8 +95,7 @@ class MiniPlayerToFullPlayerAnimator: NSObject, UIViewControllerAnimatedTransiti
             case .presenting:
                 return containerView.frame
             case .dismissing:
-                var toFrame = fromViewController.view.frame
-                return toFrame
+                return fromViewController.view.frame
             }
         }()
 
@@ -124,10 +123,7 @@ class MiniPlayerToFullPlayerAnimator: NSObject, UIViewControllerAnimatedTransiti
         if !isVideoPodcast {
 
             // Calculate initial and final frame for the artwork
-            let fullPlayerArtworkFrame: CGRect = {
-                var fullPlayerArtworkFrame = fullPlayerArtwork.superview?.convert(fullPlayerArtwork.frame, to: nil) ?? .zero
-                return fullPlayerArtworkFrame
-            }()
+            let fullPlayerArtworkFrame: CGRect = fullPlayerArtwork.superview?.convert(fullPlayerArtwork.frame, to: nil) ?? .zero
 
             let miniPlayerArtworkFrame = miniPlayerArtwork.superview?.convert(miniPlayerArtwork.frame, to: nil) ?? .zero
             let miniPlayerArtworkWithShadowFrame = miniPlayerArtwork.superview?.superview?.convert(miniPlayerArtwork.superview?.frame ?? .zero, to: nil) ?? .zero

--- a/podcasts/MiniPlayerToFullPlayerAnimator.swift
+++ b/podcasts/MiniPlayerToFullPlayerAnimator.swift
@@ -71,6 +71,16 @@ class MiniPlayerToFullPlayerAnimator: NSObject, UIViewControllerAnimatedTransiti
             return
         }
 
+        // MARK: - Tab bar
+
+        // When dismissing, add the tab bar so the miniplayer appear behind it (not in front)
+        if !isPresenting,
+           let tabBar = (toViewController.presentingViewController as? MainTabBarController)?.tabBar,
+           let tabBarSnapshot = tabBar.snapshotView(afterScreenUpdates: true) {
+            containerView.addSubview(tabBarSnapshot)
+            tabBarSnapshot.frame = tabBar.frame
+        }
+
         // MARK: - Full Player
 
         /// The player initial frame

--- a/podcasts/MiniPlayerToFullPlayerAnimator.swift
+++ b/podcasts/MiniPlayerToFullPlayerAnimator.swift
@@ -137,8 +137,7 @@ class MiniPlayerToFullPlayerAnimator: NSObject, UIViewControllerAnimatedTransiti
         if !isPresenting,
            let tabBar = (toViewController.presentingViewController as? MainTabBarController)?.tabBar,
            let tabBarSnapshot = tabBar.snapshotView(afterScreenUpdates: true) {
-            tabBarSnapshot.layer.borderWidth = 1.0 / UIScreen.main.scale
-            tabBarSnapshot.layer.borderColor = UITabBarAppearance().shadowColor?.cgColor
+            tabBarSnapshot.layer.drawTopBorder()
             containerView.addSubview(tabBarSnapshot)
             containerView.sendSubviewToBack(tabBarSnapshot)
             tabBarSnapshot.frame = tabBar.frame
@@ -290,5 +289,14 @@ class MiniPlayerToFullPlayerAnimator: NSObject, UIViewControllerAnimatedTransiti
     enum Transition {
         case presenting
         case dismissing
+    }
+}
+
+extension CALayer {
+    func drawTopBorder() {
+        let border = CALayer()
+        border.frame = CGRect(x: 0, y: 0, width: frame.width, height: 1.0 / UIScreen.main.scale)
+        border.backgroundColor = UITabBarAppearance().shadowColor?.cgColor
+        addSublayer(border)
     }
 }

--- a/podcasts/MiniPlayerToFullPlayerAnimator.swift
+++ b/podcasts/MiniPlayerToFullPlayerAnimator.swift
@@ -198,8 +198,8 @@ class MiniPlayerToFullPlayerAnimator: NSObject, UIViewControllerAnimatedTransiti
         backgroundTransitionView.backgroundColor = fromColor
         backgroundTransitionView.frame = backgroundFromFrame
 
-        toView?.frame = fromFrame
         toView?.layer.opacity = isPresenting ? 0 : 1
+        toView?.frame = .init(x: 0, y: 0, width: fromFrame.width, height: fromFrame.height)
 
         fromViewController.view.layer.opacity = isPresenting ? 1 : 0
 
@@ -217,9 +217,6 @@ class MiniPlayerToFullPlayerAnimator: NSObject, UIViewControllerAnimatedTransiti
 
             // Background
             backgroundTransitionView.frame = backgroundToFrame
-
-            // Player
-            toView?.frame = self.isPresenting ? backgroundToFrame : .init(x: backgroundToFrame.origin.x, y: backgroundToFrame.origin.y, width: backgroundToFrame.width, height: toFrame.height)
 
             // Miniplayer
             miniPlayerSnapshotView?.layer.opacity = self.isPresenting ? 0 : 1

--- a/podcasts/MiniPlayerToFullPlayerAnimator.swift
+++ b/podcasts/MiniPlayerToFullPlayerAnimator.swift
@@ -202,7 +202,7 @@ class MiniPlayerToFullPlayerAnimator: NSObject, UIViewControllerAnimatedTransiti
 
         // MARK: - Background and Mini Player
 
-        let backgroundTransitionView = UIView()
+        let backgroundTransitionView = MiniPlayerBackingView()
         containerView.addSubview(backgroundTransitionView)
         containerView.sendSubviewToBack(backgroundTransitionView)
 

--- a/podcasts/MiniPlayerToFullPlayerAnimator.swift
+++ b/podcasts/MiniPlayerToFullPlayerAnimator.swift
@@ -215,8 +215,11 @@ class MiniPlayerToFullPlayerAnimator: NSObject, UIViewControllerAnimatedTransiti
         // MARK: - Mini Player animation
 
         miniPlayerSnapshotView?.layer.opacity = isPresenting ? 1 : 0
+        fromViewController.view.layer.opacity = isPresenting ? 1 : 0
         animate(withDuration: duration) {
             miniPlayerSnapshotView?.layer.opacity = self.isPresenting ? 0 : 1
+        } completion: { _ in
+            self.fromViewController.view.layer.opacity = 1
         }
     }
 

--- a/podcasts/MiniPlayerToFullPlayerAnimator.swift
+++ b/podcasts/MiniPlayerToFullPlayerAnimator.swift
@@ -270,7 +270,7 @@ class MiniPlayerToFullPlayerAnimator: NSObject, UIViewControllerAnimatedTransiti
             // Mass is reduced accordingly to speed. This prevents the miniplayer from boucing really hard if the speed is high
             let mass = -springVelocity > 20 ? 3 / log2(-springVelocity) : 1
             let timingParameters = UISpringTimingParameters(mass: mass, stiffness: 400, damping: 30, initialVelocity: CGVector(dx: -springVelocity, dy: springVelocity))
-            let animator = UIViewPropertyAnimator(duration: 0.2, timingParameters: timingParameters)
+            let animator = UIViewPropertyAnimator(duration: duration, timingParameters: timingParameters)
             animator.addCompletion { position in
                 switch position {
                 case .end:

--- a/podcasts/MiniPlayerToFullPlayerAnimator.swift
+++ b/podcasts/MiniPlayerToFullPlayerAnimator.swift
@@ -169,6 +169,7 @@ class MiniPlayerToFullPlayerAnimator: NSObject, UIViewControllerAnimatedTransiti
 
         // Add a snapshot of the miniplayer and full player
         let miniPlayerSnapshotView = fromViewController.view.snapshotView(afterScreenUpdates: true)
+        miniPlayerSnapshotView?.layer.opacity = isPresenting ? 1 : 0
         backgroundTransitionView.addSubview(toView ?? UIView())
         backgroundTransitionView.addSubview(miniPlayerSnapshotView ?? UIView())
         playerView.isHidden = true
@@ -195,7 +196,6 @@ class MiniPlayerToFullPlayerAnimator: NSObject, UIViewControllerAnimatedTransiti
         toView?.frame = fromFrame
         toView?.layer.opacity = isPresenting ? 0 : 1
 
-        miniPlayerSnapshotView?.layer.opacity = isPresenting ? 1 : 0
         fromViewController.view.layer.opacity = isPresenting ? 1 : 0
 
         let tabBarFrame = tabBar?.frame ?? .zero

--- a/podcasts/MiniPlayerToFullPlayerAnimator.swift
+++ b/podcasts/MiniPlayerToFullPlayerAnimator.swift
@@ -213,7 +213,6 @@ class MiniPlayerToFullPlayerAnimator: NSObject, UIViewControllerAnimatedTransiti
 
         let backgroundFromFrame = isPresenting ? miniplayerFrame : backgroundTransitionInitialFrame
         let backgroundToFrame = isPresenting ? toFrame : miniplayerFrame
-        print("@@ \(backgroundToFrame) **")
 
         // Add a snapshot of the miniplayer
         let miniPlayerSnapshotView = fromViewController.view.snapshotView(afterScreenUpdates: true)
@@ -263,7 +262,7 @@ class MiniPlayerToFullPlayerAnimator: NSObject, UIViewControllerAnimatedTransiti
         if isPresenting {
             UIView.animate(withDuration: duration, delay: 0, options: .curveEaseInOut, animations: animations, completion: completion)
         } else {
-            let timingParameters = UISpringTimingParameters(mass: 1, stiffness: 400, damping: 30, initialVelocity: CGVector(dx: 0, dy: springVelocity))
+            let timingParameters = UISpringTimingParameters(mass: 1, stiffness: 400, damping: 30, initialVelocity: CGVector(dx: -springVelocity, dy: springVelocity))
             let animator = UIViewPropertyAnimator(duration: duration, timingParameters: timingParameters)
             animator.addCompletion { position in
                 switch position {

--- a/podcasts/MiniPlayerToFullPlayerAnimator.swift
+++ b/podcasts/MiniPlayerToFullPlayerAnimator.swift
@@ -141,13 +141,6 @@ class MiniPlayerToFullPlayerAnimator: NSObject, UIViewControllerAnimatedTransiti
             artwork?.frame = isPresenting ? miniPlayerArtworkFrame : fullPlayerArtworkFrame
             artwork?.layer.cornerRadius = isPresenting ? miniPlayerArtwork.imageView!.layer.cornerRadius : fullPlayerArtwork.layer.cornerRadius
             artwork?.layer.masksToBounds = true
-
-            // If it has artwork, hide the original ones
-            if artwork?.image != nil {
-                fullPlayerArtwork.layer.opacity = 0
-                miniPlayerArtwork.layer.opacity = 0
-            }
-
         }
 
         // MARK: - Background and Mini Player
@@ -189,6 +182,12 @@ class MiniPlayerToFullPlayerAnimator: NSObject, UIViewControllerAnimatedTransiti
         containerView.addSubview(tabBarSnapshot ?? UIView())
 
         // MARK: - Animations
+
+        // If it has artwork, hide the original ones
+        if artwork?.image != nil {
+            fullPlayerArtwork.layer.opacity = 0
+            miniPlayerArtwork.layer.opacity = 0
+        }
 
         backgroundTransitionView.backgroundColor = fromColor
         backgroundTransitionView.frame = backgroundFromFrame

--- a/podcasts/MiniPlayerToFullPlayerAnimator.swift
+++ b/podcasts/MiniPlayerToFullPlayerAnimator.swift
@@ -139,7 +139,7 @@ class MiniPlayerToFullPlayerAnimator: NSObject, UIViewControllerAnimatedTransiti
 
             // MARK: - Artwork animation
 
-            UIView.animate(withDuration: duration, delay: 0, options: isPresenting ? .curveEaseInOut : .curveEaseOut) { [self] in
+            animate(withDuration: duration) { [self] in
                 artwork.frame = self.isPresenting ? fullPlayerArtworkFrame : miniPlayerArtworkFrame
                 artwork.layer.cornerRadius = self.isPresenting ? fullPlayerArtwork.layer.cornerRadius : miniPlayerArtwork.imageView!.layer.cornerRadius
             } completion: { completed in
@@ -155,7 +155,7 @@ class MiniPlayerToFullPlayerAnimator: NSObject, UIViewControllerAnimatedTransiti
 
         toView.frame = fromFrame
         toView.layer.opacity = isPresenting ? 0 : 1
-        UIView.animate(withDuration: duration, delay: 0, options: isPresenting ? .curveEaseInOut : .curveEaseOut) {
+        animate(withDuration: duration) {
             toView.frame = toFrame
             toView.layer.opacity = self.isPresenting ? 1 : 0
         } completion: { completed in
@@ -195,7 +195,7 @@ class MiniPlayerToFullPlayerAnimator: NSObject, UIViewControllerAnimatedTransiti
         backgroundTransitionView.backgroundColor = fromColor
         backgroundTransitionView.frame = backgroundFromFrame
 
-        UIView.animate(withDuration: duration, delay: 0, options: isPresenting ? .curveEaseInOut : .curveEaseOut) {
+        animate(withDuration: duration) {
             backgroundTransitionView.backgroundColor = toColor
             backgroundTransitionView.frame = backgroundToFrame
         } completion: { completed in
@@ -205,7 +205,7 @@ class MiniPlayerToFullPlayerAnimator: NSObject, UIViewControllerAnimatedTransiti
         // MARK: - Mini Player animation
 
         miniPlayerSnapshotView?.layer.opacity = isPresenting ? 1 : 0
-        UIView.animate(withDuration: isPresenting ? 0.1 : duration, delay: 0, options: .curveEaseInOut) {
+        animate(withDuration: duration) {
             miniPlayerSnapshotView?.layer.opacity = self.isPresenting ? 0 : 1
         }
     }

--- a/podcasts/MiniPlayerToFullPlayerAnimator.swift
+++ b/podcasts/MiniPlayerToFullPlayerAnimator.swift
@@ -71,30 +71,6 @@ class MiniPlayerToFullPlayerAnimator: NSObject, UIViewControllerAnimatedTransiti
             return
         }
 
-        // MARK: - Mini player artwork + shadow
-
-        let miniPlayerArtworkFrame = miniPlayerArtwork.superview?.convert(miniPlayerArtwork.frame, to: nil) ?? .zero
-
-        // We need a mini player artwork snapshot when dismissing
-        // to ensure a smooth transition and that the shadows are
-        // displayed
-        let miniPlayerArtworkSnapshot: UIView? = {
-            guard !isPresenting else {
-                return nil
-            }
-
-            let toSnapshot = UIView()
-            toSnapshot.frame = miniPlayerArtworkFrame
-            let coverWithShadow = PodcastImageView()
-            coverWithShadow.setImageManually(image: fullPlayerArtwork.image, size: .list)
-            toSnapshot.addSubview(coverWithShadow)
-
-            // Padding is added so the shadow appears in the snapshot
-            coverWithShadow.anchorToAllSidesOf(view: toSnapshot, padding: 2)
-
-            return toSnapshot.snapshotView(afterScreenUpdates: true)
-        }()
-
         // MARK: - Full Player
 
         /// The player initial frame
@@ -157,6 +133,20 @@ class MiniPlayerToFullPlayerAnimator: NSObject, UIViewControllerAnimatedTransiti
                 return fullPlayerArtworkFrame
             }()
 
+            let miniPlayerArtworkFrame = miniPlayerArtwork.superview?.convert(miniPlayerArtwork.frame, to: nil) ?? .zero
+            let miniPlayerArtworkWithShadowFrame = miniPlayerArtwork.superview?.superview?.convert(miniPlayerArtwork.superview?.frame ?? .zero, to: nil) ?? .zero
+
+            // We need a mini player artwork snapshot when dismissing
+            // to ensure a smooth transition and that the shadows are
+            // displayed
+            let miniPlayerArtworkSnapshot: UIView? = {
+                guard !isPresenting else {
+                    return nil
+                }
+
+                return miniPlayerArtwork.superview?.snapshotView(afterScreenUpdates: false)
+            }()
+
             if let miniPlayerArtworkSnapshot {
                 containerView.addSubview(miniPlayerArtworkSnapshot)
                 miniPlayerArtworkSnapshot.frame = isPresenting ? miniPlayerArtworkFrame : fullPlayerArtworkFrame
@@ -194,7 +184,7 @@ class MiniPlayerToFullPlayerAnimator: NSObject, UIViewControllerAnimatedTransiti
                 artwork.layer.cornerRadius = self.isPresenting ? fullPlayerArtwork.layer.cornerRadius : miniPlayerArtwork.imageView!.layer.cornerRadius
 
                 // snapshot has its frame changed to account for the shadow
-                miniPlayerArtworkSnapshot?.frame = self.isPresenting ? fullPlayerArtworkFrame : CGRect(x: miniPlayerArtworkFrame.origin.x - 2, y: miniPlayerArtworkFrame.origin.y - 2, width: miniPlayerArtworkFrame.width + 4, height: miniPlayerArtworkFrame.height + 4)
+                miniPlayerArtworkSnapshot?.frame = self.isPresenting ? fullPlayerArtworkFrame : miniPlayerArtworkWithShadowFrame
             } completion: { completed in
                 artwork.removeFromSuperview()
 

--- a/podcasts/MiniPlayerToFullPlayerAnimator.swift
+++ b/podcasts/MiniPlayerToFullPlayerAnimator.swift
@@ -264,8 +264,10 @@ class MiniPlayerToFullPlayerAnimator: NSObject, UIViewControllerAnimatedTransiti
         if isPresenting {
             UIView.animate(withDuration: duration, delay: 0, options: .curveEaseInOut, animations: animations, completion: completion)
         } else {
-            let timingParameters = UISpringTimingParameters(mass: 1, stiffness: 400, damping: 30, initialVelocity: CGVector(dx: -springVelocity, dy: springVelocity))
-            let animator = UIViewPropertyAnimator(duration: duration, timingParameters: timingParameters)
+            // Mass is reduced accordingly to speed. This prevents the miniplayer from boucing really hard if the speed is high
+            let mass = -springVelocity > 20 ? 3 / log2(-springVelocity) : 1
+            let timingParameters = UISpringTimingParameters(mass: mass, stiffness: 400, damping: 30, initialVelocity: CGVector(dx: -springVelocity, dy: springVelocity))
+            let animator = UIViewPropertyAnimator(duration: 0.2, timingParameters: timingParameters)
             animator.addCompletion { position in
                 switch position {
                 case .end:

--- a/podcasts/MiniPlayerToFullPlayerAnimator.swift
+++ b/podcasts/MiniPlayerToFullPlayerAnimator.swift
@@ -34,7 +34,7 @@ class MiniPlayerToFullPlayerAnimator: NSObject, UIViewControllerAnimatedTransiti
             return 0.3
         }
 
-        return min((normalVelocity * maxDismissDuration) / dismissVelocity, maxDismissDuration)
+        return 0.2
     }
 
     // Initialize with an empty UIView to avoid optional code
@@ -220,11 +220,14 @@ class MiniPlayerToFullPlayerAnimator: NSObject, UIViewControllerAnimatedTransiti
         backgroundTransitionView.frame = backgroundFromFrame
 
         animate(withDuration: duration) {
-            backgroundTransitionView.backgroundColor = toColor
             backgroundTransitionView.frame = backgroundToFrame
         } completion: { completed in
             backgroundTransitionView.removeFromSuperview()
             transitionContext.completeTransition(true)
+        }
+
+        UIView.animate(withDuration: duration, delay: 0, options: isPresenting ? .curveEaseInOut : .curveEaseOut) { [self] in
+            backgroundTransitionView.backgroundColor = toColor
         }
 
         // MARK: - Player animation
@@ -237,9 +240,12 @@ class MiniPlayerToFullPlayerAnimator: NSObject, UIViewControllerAnimatedTransiti
             } else {
                 toView.frame = .init(x: backgroundToFrame.origin.x, y: backgroundToFrame.origin.y, width: backgroundToFrame.width, height: toFrame.height)
             }
-            toView.layer.opacity = self.isPresenting ? 1 : 0
         } completion: { completed in
             transitionContext.completeTransition(true)
+        }
+
+        UIView.animate(withDuration: duration, delay: 0, options: isPresenting ? .curveEaseInOut : .curveEaseOut) { [self] in
+            toView.layer.opacity = self.isPresenting ? 1 : 0
         }
 
         // MARK: - Mini Player animation

--- a/podcasts/MiniPlayerToFullPlayerAnimator.swift
+++ b/podcasts/MiniPlayerToFullPlayerAnimator.swift
@@ -152,10 +152,8 @@ class MiniPlayerToFullPlayerAnimator: NSObject, UIViewControllerAnimatedTransiti
             // a smooth transition. DispatchQueue is needed because delay conflicts
             // with snapshotView(afterScreenUpdates: true) (yes...)
             if !isPresenting {
-                DispatchQueue.main.async {
-                    UIView.animate(withDuration: self.duration * 0.3, delay: self.duration * 0.7, options: .curveEaseOut) { [self] in
-                        artwork.layer.opacity = self.isPresenting ? 1 : 0
-                    }
+                UIView.animate(withDuration: self.duration * 0.3, delay: self.duration * 0.7, options: .curveEaseOut) { [self] in
+                    artwork.layer.opacity = self.isPresenting ? 1 : 0
                 }
             }
 

--- a/podcasts/MiniPlayerToFullPlayerAnimator.swift
+++ b/podcasts/MiniPlayerToFullPlayerAnimator.swift
@@ -137,6 +137,8 @@ class MiniPlayerToFullPlayerAnimator: NSObject, UIViewControllerAnimatedTransiti
         if !isPresenting,
            let tabBar = (toViewController.presentingViewController as? MainTabBarController)?.tabBar,
            let tabBarSnapshot = tabBar.snapshotView(afterScreenUpdates: true) {
+            tabBarSnapshot.layer.borderWidth = 1.0 / UIScreen.main.scale
+            tabBarSnapshot.layer.borderColor = UITabBarAppearance().shadowColor?.cgColor
             containerView.addSubview(tabBarSnapshot)
             containerView.sendSubviewToBack(tabBarSnapshot)
             tabBarSnapshot.frame = tabBar.frame

--- a/podcasts/MiniPlayerToFullPlayerAnimator.swift
+++ b/podcasts/MiniPlayerToFullPlayerAnimator.swift
@@ -105,18 +105,6 @@ class MiniPlayerToFullPlayerAnimator: NSObject, UIViewControllerAnimatedTransiti
         toViewController.view.setNeedsLayout()
         toViewController.view.layoutIfNeeded()
 
-        // MARK: - Tab bar
-
-        // When dismissing, add the tab bar so the miniplayer appear behind it (not in front)
-        if !isPresenting,
-           let tabBar = (toViewController.presentingViewController as? MainTabBarController)?.tabBar,
-           let tabBarSnapshot = tabBar.snapshotView(afterScreenUpdates: true) {
-            tabBarSnapshot.layer.drawTopBorder()
-            containerView.addSubview(tabBarSnapshot)
-            containerView.sendSubviewToBack(tabBarSnapshot)
-            tabBarSnapshot.frame = tabBar.frame
-        }
-
         // MARK: - Artwork
 
         // Artwork is not animated if it's a video podcast
@@ -226,7 +214,7 @@ class MiniPlayerToFullPlayerAnimator: NSObject, UIViewControllerAnimatedTransiti
             transitionContext.completeTransition(true)
         }
 
-        UIView.animate(withDuration: duration, delay: 0, options: isPresenting ? .curveEaseInOut : .curveEaseOut) { [self] in
+        UIView.animate(withDuration: duration, delay: 0, options: isPresenting ? .curveEaseInOut : .curveEaseOut) {
             backgroundTransitionView.backgroundColor = toColor
         }
 
@@ -256,6 +244,23 @@ class MiniPlayerToFullPlayerAnimator: NSObject, UIViewControllerAnimatedTransiti
             miniPlayerSnapshotView?.layer.opacity = self.isPresenting ? 0 : 1
         } completion: { _ in
             self.fromViewController.view.layer.opacity = 1
+        }
+
+        // MARK: - Tab bar
+
+        // When dismissing, add the tab bar so the miniplayer appear behind it (not in front)
+        if let tabBar = (toViewController.presentingViewController as? MainTabBarController)?.tabBar,
+           let tabBarSnapshot = tabBar.snapshotView(afterScreenUpdates: true) {
+            tabBar.isHidden = true
+            tabBarSnapshot.layer.drawTopBorder()
+            containerView.addSubview(tabBarSnapshot)
+            tabBarSnapshot.frame = isPresenting ? tabBar.frame : .init(x: tabBar.frame.origin.x, y: tabBar.frame.origin.y + tabBar.frame.height, width: tabBar.frame.width, height: tabBar.frame.height)
+
+            UIView.animate(withDuration: duration, delay: 0, options: isPresenting ? .curveEaseInOut : .curveEaseOut) {
+                tabBarSnapshot.frame = !self.isPresenting ? tabBar.frame : .init(x: tabBar.frame.origin.x, y: tabBar.frame.origin.y + tabBar.frame.height, width: tabBar.frame.width, height: tabBar.frame.height)
+            } completion: { _ in
+                tabBar.isHidden = false
+            }
         }
     }
 

--- a/podcasts/MiniPlayerToFullPlayerAnimator.swift
+++ b/podcasts/MiniPlayerToFullPlayerAnimator.swift
@@ -16,6 +16,8 @@ class MiniPlayerToFullPlayerAnimator: NSObject, UIViewControllerAnimatedTransiti
     // An assumed "normal" velocity from a pan gesture
     private let normalVelocity: CGFloat = 2500
 
+    private let fullPlayerYPosition: CGFloat
+
     // When presenting the player, duration is always the same
     // However, if the view is being dismissed we take into account
     // the velocity of the swipe down gesture to carry it
@@ -40,13 +42,14 @@ class MiniPlayerToFullPlayerAnimator: NSObject, UIViewControllerAnimatedTransiti
         PlaybackManager.shared.currentEpisode()?.videoPodcast() ?? false
     }
 
-    init?(fromViewController: UIViewController, toViewController: UIViewController, transition: Transition, miniPlayerArtwork: PodcastImageView, fullPlayerArtwork: UIImageView, dismissVelocity: CGFloat = 0) {
+    init?(fromViewController: UIViewController, toViewController: UIViewController, transition: Transition, miniPlayerArtwork: PodcastImageView, fullPlayerArtwork: UIImageView, dismissVelocity: CGFloat = 0, fullPlayerYPosition: CGFloat = 0) {
         self.fromViewController = fromViewController
         self.toViewController = toViewController
         self.transition = transition
         self.miniPlayerArtwork = miniPlayerArtwork
         self.fullPlayerArtwork = fullPlayerArtwork
         self.dismissVelocity = dismissVelocity
+        self.fullPlayerYPosition = fullPlayerYPosition
     }
 
     func transitionDuration(using transitionContext: UIViewControllerContextTransitioning?) -> TimeInterval {

--- a/podcasts/MiniPlayerToFullPlayerAnimator.swift
+++ b/podcasts/MiniPlayerToFullPlayerAnimator.swift
@@ -94,8 +94,10 @@ class MiniPlayerToFullPlayerAnimator: NSObject, UIViewControllerAnimatedTransiti
         }()
 
         // Add the full player and do a layout pass to avoid issues
+        // If presenting, we do this out of the screen to avoid the view briefly appearing
+        let playerRenderingFrame = isPresenting ? .init(x: 0, y: 0 + containerView.frame.height, width: containerView.frame.width, height: containerView.frame.height) : fromFrame
         containerView.addSubview(playerView)
-        playerView.frame = isPresenting ? containerView.frame : fromFrame
+        playerView.frame = playerRenderingFrame
         playerView.setNeedsLayout()
         playerView.layoutIfNeeded()
 
@@ -112,7 +114,10 @@ class MiniPlayerToFullPlayerAnimator: NSObject, UIViewControllerAnimatedTransiti
         var artwork: UIImageView?
 
         // Calculate initial and final frame for the artwork
-        let fullPlayerArtworkFrame: CGRect = fullPlayerArtwork.superview?.convert(fullPlayerArtwork.frame, to: nil) ?? .zero
+        var fullPlayerArtworkFrame: CGRect = fullPlayerArtwork.superview?.convert(fullPlayerArtwork.frame, to: nil) ?? .zero
+        if isPresenting {
+            fullPlayerArtworkFrame.origin.y -= containerView.frame.height
+        }
 
         let miniPlayerArtworkFrame = miniPlayerArtwork.superview?.convert(miniPlayerArtwork.frame, to: nil) ?? .zero
         let miniPlayerArtworkWithShadowFrame = miniPlayerArtwork.superview?.superview?.convert(miniPlayerArtwork.superview?.frame ?? .zero, to: nil) ?? .zero
@@ -225,6 +230,7 @@ class MiniPlayerToFullPlayerAnimator: NSObject, UIViewControllerAnimatedTransiti
             artwork?.removeFromSuperview()
             backgroundTransitionView.removeFromSuperview()
 
+            playerView.frame = self.isPresenting ? self.containerView.frame : playerView.frame
             playerView.isHidden = false
 
             self.fromViewController.view.layer.opacity = 1

--- a/podcasts/MiniPlayerToFullPlayerAnimator.swift
+++ b/podcasts/MiniPlayerToFullPlayerAnimator.swift
@@ -10,12 +10,6 @@ class MiniPlayerToFullPlayerAnimator: NSObject, UIViewControllerAnimatedTransiti
 
     private let dismissVelocity: CGFloat
 
-    // The max duration that the transition can last
-    private let maxDismissDuration: TimeInterval = 0.2
-
-    // An assumed "normal" velocity from a pan gesture
-    private let normalVelocity: CGFloat = 2500
-
     private let fullPlayerYPosition: CGFloat
 
     // Spring velocity is defined by pan gesture velocity / distance

--- a/podcasts/MiniPlayerViewController+TransitionDelegate.swift
+++ b/podcasts/MiniPlayerViewController+TransitionDelegate.swift
@@ -6,7 +6,7 @@ extension MiniPlayerViewController: UIViewControllerTransitioningDelegate {
             return nil
         }
 
-        return MiniPlayerToFullPlayerAnimator(fromViewController: self, toViewController: dismissed, transition: .dismissing, miniPlayerArtwork: podcastArtwork, fullPlayerArtwork: fullPlayer.nowPlayingItem.episodeImage, dismissVelocity: fullPlayer.dismissVelocity)
+        return MiniPlayerToFullPlayerAnimator(fromViewController: self, toViewController: dismissed, transition: .dismissing, miniPlayerArtwork: podcastArtwork, fullPlayerArtwork: fullPlayer.nowPlayingItem.episodeImage, dismissVelocity: fullPlayer.dismissVelocity, fullPlayerYPosition: fullPlayer.finalYPositionWhenDismissing)
     }
 
     func animationController(forPresented presented: UIViewController, presenting: UIViewController, source: UIViewController) -> UIViewControllerAnimatedTransitioning? {

--- a/podcasts/MiniPlayerViewController.xib
+++ b/podcasts/MiniPlayerViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16086"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -13,7 +13,7 @@
                 <outlet property="mainView" destination="rTj-uk-yNW" id="ZLL-0J-RYU"/>
                 <outlet property="playPauseBtn" destination="CjL-4C-tuh" id="Y8g-6z-ZoN"/>
                 <outlet property="playbackProgressView" destination="aWD-bx-vF2" id="vpI-fM-bgO"/>
-                <outlet property="podcastArtwork" destination="Bqa-eT-t3r" id="THy-P0-Dp8"/>
+                <outlet property="podcastArtwork" destination="tJx-CO-hRe" id="Kzl-ZM-bdq"/>
                 <outlet property="skipBackBtn" destination="92g-6h-Yd9" id="i61-v9-wgd"/>
                 <outlet property="skipFwdBtn" destination="JHq-wc-GDV" id="Pkp-0D-lfF"/>
                 <outlet property="upNextBtn" destination="nTH-nm-IG6" id="QNQ-hP-BL6"/>
@@ -28,15 +28,30 @@
                 <view clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rTj-uk-yNW" userLabel="Main View" customClass="MiniPlayerBackingView" customModule="podcasts" customModuleProvider="target">
                     <rect key="frame" x="0.0" y="0.0" width="325" height="65"/>
                     <subviews>
-                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Bqa-eT-t3r" customClass="PodcastImageView" customModule="podcasts" customModuleProvider="target">
-                            <rect key="frame" x="8" y="5.5" width="52" height="52"/>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Bqa-eT-t3r">
+                            <rect key="frame" x="8" y="3.5" width="56" height="56"/>
+                            <subviews>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="tJx-CO-hRe" customClass="PodcastImageView" customModule="podcasts" customModuleProvider="target">
+                                    <rect key="frame" x="2" y="2" width="52" height="52"/>
+                                    <accessibility key="accessibilityConfiguration" hint="Tap to open full size player" label="Player">
+                                        <accessibilityTraits key="traits" button="YES"/>
+                                        <bool key="isElement" value="YES"/>
+                                    </accessibility>
+                                    <constraints>
+                                        <constraint firstAttribute="height" constant="52" id="dnA-Im-DKw"/>
+                                        <constraint firstAttribute="width" constant="52" id="nch-ve-CD6"/>
+                                    </constraints>
+                                </view>
+                            </subviews>
                             <accessibility key="accessibilityConfiguration" hint="Tap to open full size player" label="Player">
                                 <accessibilityTraits key="traits" button="YES"/>
                                 <bool key="isElement" value="YES"/>
                             </accessibility>
                             <constraints>
-                                <constraint firstAttribute="height" constant="52" id="2cu-pH-twC"/>
-                                <constraint firstAttribute="width" constant="52" id="hQL-XX-9K1"/>
+                                <constraint firstAttribute="height" constant="56" id="2cu-pH-twC"/>
+                                <constraint firstItem="tJx-CO-hRe" firstAttribute="centerY" secondItem="Bqa-eT-t3r" secondAttribute="centerY" id="WJ7-YG-L41"/>
+                                <constraint firstItem="tJx-CO-hRe" firstAttribute="centerX" secondItem="Bqa-eT-t3r" secondAttribute="centerX" id="gaR-1g-5bG"/>
+                                <constraint firstAttribute="width" constant="56" id="hQL-XX-9K1"/>
                             </constraints>
                         </view>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" pointerInteraction="YES" translatesAutoresizingMaskIntoConstraints="NO" id="92g-6h-Yd9" userLabel="Skip Back">
@@ -93,6 +108,7 @@
                             </constraints>
                         </view>
                     </subviews>
+                    <viewLayoutGuide key="safeArea" id="AxG-ti-suk"/>
                     <accessibility key="accessibilityConfiguration">
                         <accessibilityTraits key="traits" button="YES"/>
                         <bool key="isElement" value="NO"/>
@@ -112,9 +128,9 @@
                         <constraint firstItem="CjL-4C-tuh" firstAttribute="centerY" secondItem="Bqa-eT-t3r" secondAttribute="centerY" id="hcs-EK-GcX"/>
                         <constraint firstItem="aWD-bx-vF2" firstAttribute="leading" secondItem="rTj-uk-yNW" secondAttribute="leading" id="yRh-2G-2xp"/>
                     </constraints>
-                    <viewLayoutGuide key="safeArea" id="AxG-ti-suk"/>
                 </view>
             </subviews>
+            <viewLayoutGuide key="safeArea" id="rNg-cs-ZaL"/>
             <constraints>
                 <constraint firstAttribute="bottom" secondItem="rTj-uk-yNW" secondAttribute="bottom" id="4a5-HO-sPI"/>
                 <constraint firstItem="rTj-uk-yNW" firstAttribute="leading" secondItem="1" secondAttribute="leading" id="UhX-sK-Mo9"/>
@@ -123,7 +139,6 @@
             </constraints>
             <nil key="simulatedStatusBarMetrics"/>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-            <viewLayoutGuide key="safeArea" id="rNg-cs-ZaL"/>
             <point key="canvasLocation" x="-1146" y="-201"/>
         </view>
     </objects>

--- a/podcasts/MiniPlayerViewController.xib
+++ b/podcasts/MiniPlayerViewController.xib
@@ -29,10 +29,10 @@
                     <rect key="frame" x="0.0" y="0.0" width="325" height="65"/>
                     <subviews>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Bqa-eT-t3r">
-                            <rect key="frame" x="8" y="3.5" width="56" height="56"/>
+                            <rect key="frame" x="8" y="2.5" width="58" height="58"/>
                             <subviews>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="tJx-CO-hRe" customClass="PodcastImageView" customModule="podcasts" customModuleProvider="target">
-                                    <rect key="frame" x="2" y="2" width="52" height="52"/>
+                                    <rect key="frame" x="3" y="3" width="52" height="52"/>
                                     <accessibility key="accessibilityConfiguration" hint="Tap to open full size player" label="Player">
                                         <accessibilityTraits key="traits" button="YES"/>
                                         <bool key="isElement" value="YES"/>
@@ -48,10 +48,10 @@
                                 <bool key="isElement" value="YES"/>
                             </accessibility>
                             <constraints>
-                                <constraint firstAttribute="height" constant="56" id="2cu-pH-twC"/>
+                                <constraint firstAttribute="height" constant="58" id="2cu-pH-twC"/>
                                 <constraint firstItem="tJx-CO-hRe" firstAttribute="centerY" secondItem="Bqa-eT-t3r" secondAttribute="centerY" id="WJ7-YG-L41"/>
                                 <constraint firstItem="tJx-CO-hRe" firstAttribute="centerX" secondItem="Bqa-eT-t3r" secondAttribute="centerX" id="gaR-1g-5bG"/>
-                                <constraint firstAttribute="width" constant="56" id="hQL-XX-9K1"/>
+                                <constraint firstAttribute="width" constant="58" id="hQL-XX-9K1"/>
                             </constraints>
                         </view>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" pointerInteraction="YES" translatesAutoresizingMaskIntoConstraints="NO" id="92g-6h-Yd9" userLabel="Skip Back">

--- a/podcasts/PlayerContainerViewController+Gestures.swift
+++ b/podcasts/PlayerContainerViewController+Gestures.swift
@@ -36,6 +36,7 @@ extension PlayerContainerViewController: UIGestureRecognizerDelegate {
                 dismissVelocity = velocity.y
 
                 if closing {
+                    finalYPositionWhenDismissing = touchPoint.y - initialTouchPoint.y
                     miniPlayer.closeFullScreenPlayer()
                 } else {
                     UIView.animate(withDuration: 0.2, animations: {

--- a/podcasts/PlayerContainerViewController.swift
+++ b/podcasts/PlayerContainerViewController.swift
@@ -81,6 +81,9 @@ class PlayerContainerViewController: SimpleNotificationsViewController, PlayerTa
     /// The velocity in which the player was dismissed
     var dismissVelocity: CGFloat = 0
 
+    /// The final yPosition when dismissing
+    var finalYPositionWhenDismissing: CGFloat = 0
+
     override func viewDidLoad() {
         super.viewDidLoad()
         view.accessibilityViewIsModal = true


### PR DESCRIPTION
This PR adds a spring animation when dismissing the player.

Besides the spring, there are additional changes:

1. All animations are now grouped into 3 animation blocks, instead of many different ones;
2. We do a setup phase (in which we position the views, take snapshot, etc) and only then animate (this was mixed before)
3. Given we were presenting the full player view itself, a lot of constraint warnings were shown. Now we snapshot it and use the snapshot instead
4. These changes makes the transition way smoother
5. The mass of the spring is reduced if the spring's initial velocity is too high. This is done to prevent the mini player from jumping too high.

### Normal speed
https://github.com/Automattic/pocket-casts-ios/assets/7040243/4fef0624-a302-4a2b-9c78-6546b98ff90e

### Slow speed

https://github.com/Automattic/pocket-casts-ios/assets/7040243/db561686-c23d-4753-a3e3-57806f1b1bbe

## To test

1. Open the player
2. Dismiss the player
3. ✅ The dismiss should be followed by a spring animation

Please test on multiple devices, light/dark mode.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
