### PR TITLE
Only show 'Cancel Subscription' button for renewing subscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 7.55
 -----
-
+- Only show 'Cancel Subscription' button on Account Profile if the user has an active, renewing subscription [#1032]
 
 7.54
 -----

--- a/podcasts/AccountViewController.swift
+++ b/podcasts/AccountViewController.swift
@@ -107,7 +107,7 @@ class AccountViewController: UIViewController, ChangeEmailDelegate {
         if SubscriptionHelper.hasActiveSubscription() {
             var newTableRows: [[TableRow]] = [accountOptions, [.privacyPolicy, .termsOfUse], [.logout], [.deleteAccount]]
 
-            if SubscriptionHelper.activeSubscriptionType != .none {
+            if SubscriptionHelper.hasRenewingSubscription() {
                 newTableRows[0].append(.cancelSubscription)
             }
 


### PR DESCRIPTION
Fixes #1032 

The Cancel Subscription button is currently shown for all active subscriptions, including lifetime. This PR updates the logic to only show the cancel button for renewing subscriptions.

## To test
1. Settings->Developer->Set to Lifetime
2. Open Account page and notice that cancel button is present
3. Apply the change in this PR and repeat steps. Cancel button should no longer be visible.
4. Repeat test with other subscription types (plus, patron) and ensure that cancel button is correctly shown.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
