### PR TITLE
Now Playing Scrubber Accessibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Adds a button to export the database and preferences from the Help & Feedback view [#1257]
 - Fixes star functionality on native Now Playing widgets (lock screen and control centre) for iOS 17.1 and later [#1195]
 - Adds theme support to the Up Next [#1265]
+- Now Playing scrubber is now interactive with Accessibility VoiceOver enabled [#1318]
 
 7.53
 -----

--- a/podcasts/NowPlayingPlayerItemViewController.swift
+++ b/podcasts/NowPlayingPlayerItemViewController.swift
@@ -119,6 +119,8 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
 
     @IBOutlet var timeSlider: TimeSlider! {
         didSet {
+            timeSlider.accessibilityLabel = L10n.accessibilityEpisodePlayback
+            timeSlider.accessibilityHint = L10n.accessibilityEpisodePlaybackHint
             timeSlider.delegate = self
         }
     }

--- a/podcasts/NowPlayingPlayerItemViewController.xib
+++ b/podcasts/NowPlayingPlayerItemViewController.xib
@@ -202,7 +202,7 @@
                                     <subviews>
                                         <view opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="v3N-m7-an0" customClass="TimeSlider" customModule="podcasts" customModuleProvider="target">
                                             <rect key="frame" x="10" y="-45" width="394" height="80"/>
-                                            <accessibility key="accessibilityConfiguration" hint="Swipe up or down with one finger to adjust the value" label="Episode Position">
+                                            <accessibility key="accessibilityConfiguration">
                                                 <accessibilityTraits key="traits" adjustable="YES"/>
                                                 <bool key="isElement" value="YES"/>
                                             </accessibility>

--- a/podcasts/NowPlayingPlayerItemViewController.xib
+++ b/podcasts/NowPlayingPlayerItemViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22155" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22131"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -202,9 +202,9 @@
                                     <subviews>
                                         <view opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="v3N-m7-an0" customClass="TimeSlider" customModule="podcasts" customModuleProvider="target">
                                             <rect key="frame" x="10" y="-45" width="394" height="80"/>
-                                            <accessibility key="accessibilityConfiguration" label=" Time Slider">
-                                                <accessibilityTraits key="traits" none="YES"/>
-                                                <bool key="isElement" value="NO"/>
+                                            <accessibility key="accessibilityConfiguration" hint="Swipe up or down with one finger to adjust the value" label="Episode Position">
+                                                <accessibilityTraits key="traits" adjustable="YES"/>
+                                                <bool key="isElement" value="YES"/>
                                             </accessibility>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="80" id="seG-rc-zHm"/>
@@ -212,12 +212,18 @@
                                         </view>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" text="00:00" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="BjS-kB-x8Y" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
                                             <rect key="frame" x="30" y="27" width="35" height="14.5"/>
+                                            <accessibility key="accessibilityConfiguration">
+                                                <bool key="isElement" value="NO"/>
+                                            </accessibility>
                                             <fontDescription key="fontDescription" type="system" weight="medium" pointSize="12"/>
                                             <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" text="00:00" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1nY-hc-503" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
                                             <rect key="frame" x="349" y="27" width="35" height="14.5"/>
+                                            <accessibility key="accessibilityConfiguration">
+                                                <bool key="isElement" value="NO"/>
+                                            </accessibility>
                                             <fontDescription key="fontDescription" type="system" weight="medium" pointSize="12"/>
                                             <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <nil key="highlightedColor"/>

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -40,6 +40,10 @@ internal enum L10n {
   internal static var accessibilityDisabled: String { return L10n.tr("Localizable", "accessibility_disabled") }
   /// Dismiss
   internal static var accessibilityDismiss: String { return L10n.tr("Localizable", "accessibility_dismiss") }
+  /// Episode Playback
+  internal static var accessibilityEpisodePlayback: String { return L10n.tr("Localizable", "accessibility_episode_playback") }
+  /// Swipe up or down with one finger to adjust the value
+  internal static var accessibilityEpisodePlaybackHint: String { return L10n.tr("Localizable", "accessibility_episode_playback_hint") }
   /// Tap to hide filter details
   internal static var accessibilityHideFilterDetails: String { return L10n.tr("Localizable", "accessibility_hide_filter_details") }
   /// Double tap to star episode
@@ -53,6 +57,10 @@ internal enum L10n {
   /// %1$@ percent completed
   internal static func accessibilityPercentCompleteFormat(_ p1: Any) -> String {
     return L10n.tr("Localizable", "accessibility_percent_complete_format", String(describing: p1))
+  }
+  /// %1$@ of %2$@
+  internal static func accessibilityPlaybackProgress(_ p1: Any, _ p2: Any) -> String {
+    return L10n.tr("Localizable", "accessibility_playback_progress", String(describing: p1), String(describing: p2))
   }
   /// Playback speed %1$@ times
   internal static func accessibilityPlayerEffectsPlaybackSpeed(_ p1: Any) -> String {

--- a/podcasts/TimeSlider.swift
+++ b/podcasts/TimeSlider.swift
@@ -50,7 +50,7 @@ class TimeSlider: UIView {
         get {
             let current = currentTime.accessibilityValue()
             let total = totalDuration.accessibilityValue()
-            return "\(current) of \(total)"
+            return L10n.accessibilityPlaybackProgress(current, total)
         }
         set {
             // No-op

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -55,6 +55,15 @@
 /* A common string used throughout the app. An accessibility label to direct the user to sort and option menus. */
 "accessibility_sort_and_options" = "Sort and Options";
 
+/* Accessibility label for episode playback progress scrubber */
+"accessibility_playback_progress" = "%1$@ of %2$@";
+
+/* Accessibility label for episode playback scrubber */
+"accessibility_episode_playback" = "Episode Playback";
+
+/* Accessibility hint for episode playback scrubber */
+"accessibility_episode_playback_hint" = "Swipe up or down with one finger to adjust the value";
+
 /* Prompt to allow the user to update the email associated to their account. */
 "account_change_email" = "Change Email";
 


### PR DESCRIPTION
Fixes #1315

* Enables accessibility for the Time Slider
* Adds accessibility value for the current playback progress
* Adds `increment`/`decrement` methods to handle Voice Over interactions
* Adds a linear equation converter to scale scrub skip interval as episode duration lengthens

### Linear equation based on episode length

After checking the behavior of Apple Podcasts and Apple Music, I determined that both apps scrub variable amounts depending on the track length (so you aren't stuck swiping 50 times to get through an episode). I based the coefficient and constant values to replicate roughly the skip values I found in those apps. These can be adjusted based on our own testing but I think it's a good start. Finer adjustments can be made using the 45 second skip buttons.

### Demo

https://github.com/Automattic/pocket-casts-ios/assets/3250/d53b4dd0-0ac5-46d8-99f3-9110aa1b2e99

## To test

* Navigate to the Now Playing screen
* Enable Voice Over (using Siri is easiest)
* Swipe through controls
* Verify that scrubber is read with text "Episode Playback, <x minutes, x seconds current time> of <x minutes, x seconds duration>"
* Swipe up or down to scrub forwards or backwards respectively
* Verify that playback position is properly adjusted

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
