### PR TITLE
Cleanup: remove patron feature flag.

### DIFF
--- a/podcasts/AccountViewController.swift
+++ b/podcasts/AccountViewController.swift
@@ -94,7 +94,7 @@ class AccountViewController: UIViewController, ChangeEmailDelegate {
 
         // Show the 'Upgrade Account' if the user has an active subscription that isn't patron.
         // Hide the cell if we're already showing the big upgrade prompt
-        let upgradeRow = (FeatureFlag.patron.enabled && SubscriptionHelper.activeTier == .plus && !isExpiring) ? TableRow.upgradeAccount : nil
+        let upgradeRow = (SubscriptionHelper.activeTier == .plus && !isExpiring) ? TableRow.upgradeAccount : nil
 
         // Only accounts created with username/password can change email/password
         var accountOptions: [TableRow]

--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -278,8 +278,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             Constants.RemoteParams.podcastSearchDebounceMs: NSNumber(value: Constants.RemoteParams.podcastSearchDebounceMsDefault),
             Constants.RemoteParams.customStorageLimitGB: NSNumber(value: Constants.RemoteParams.customStorageLimitGBDefault),
             Constants.RemoteParams.endOfYearRequireAccount: NSNumber(value: Constants.RemoteParams.endOfYearRequireAccountDefault),
-            Constants.RemoteParams.effectsPlayerStrategy: NSNumber(value: Constants.RemoteParams.effectsPlayerStrategyDefault),
-            Constants.RemoteParams.patronEnabled: NSNumber(value: Constants.RemoteParams.patronEnabledDefault),
+            Constants.RemoteParams.effectsPlayerStrategy: NSNumber(value: Constants.RemoteParams.effectsPlayerStrategyDefault),            
             Constants.RemoteParams.patronCloudStorageGB: NSNumber(value: Constants.RemoteParams.patronCloudStorageGBDefault),
             Constants.RemoteParams.bookmarksEnabled: NSNumber(value: Constants.RemoteParams.bookmarksEnabledDefault),
             Constants.RemoteParams.addMissingEpisodes: NSNumber(value: Constants.RemoteParams.addMissingEpisodesDefault),
@@ -299,7 +298,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     private func updateRemoteFeatureFlags() {
         #if !DEBUG
         do {
-            try FeatureFlagOverrideStore().override(FeatureFlag.patron, withValue: Settings.patronEnabled)
             try FeatureFlagOverrideStore().override(FeatureFlag.bookmarks, withValue: Settings.remoteBookmarksEnabled)
 
             if FeatureFlag.newPlayerTransition.enabled != Settings.newPlayerTransition {

--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -324,9 +324,6 @@ struct Constants {
         static let effectsPlayerStrategy = "effects_player_strategy"
         static let effectsPlayerStrategyDefault: Int = 1
 
-        static let patronEnabled = "add_patron_enabled"
-        static let patronEnabledDefault = true
-
         static let patronCloudStorageGB = "patron_custom_storage_limit_gb"
         static let patronCloudStorageGBDefault = 100
 

--- a/podcasts/FeatureFlag.swift
+++ b/podcasts/FeatureFlag.swift
@@ -13,9 +13,6 @@ enum FeatureFlag: String, CaseIterable {
     /// Bookmarks / Highlights
     case bookmarks
 
-    /// Patron
-    case patron
-
     /// Enable the new show notes endpoint plus embedded episode artwork
     case newShowNotesEndpoint
 
@@ -38,8 +35,6 @@ enum FeatureFlag: String, CaseIterable {
         case .endOfYear:
             return true
         case .bookmarks:
-            return true
-        case .patron:
             return true
         case .newShowNotesEndpoint:
             return false

--- a/podcasts/IapHelper.swift
+++ b/podcasts/IapHelper.swift
@@ -8,7 +8,7 @@ class IapHelper: NSObject, SKProductsRequestDelegate {
     static let shared = IapHelper()
 
     private var productIdentifiers: [Constants.IapProducts] {
-        FeatureFlag.patron.enabled ? [.monthly, .yearly, .patronMonthly, .patronYearly] : [.monthly, .yearly]
+        [.monthly, .yearly, .patronMonthly, .patronYearly]
     }
     private var productsArray = [SKProduct]()
     private var requestedPurchase: String!

--- a/podcasts/IconSelectorCell.swift
+++ b/podcasts/IconSelectorCell.swift
@@ -19,7 +19,7 @@ enum IconType: Int, CaseIterable, AnalyticsDescribable {
 
     static var availableIcons: [IconType] {
         Self.allCases.filter {
-            $0.subscription <= (FeatureFlag.patron.enabled ? .patron : .plus)
+            $0.subscription <= .patron
         }
     }
 

--- a/podcasts/Onboarding/Models/PlusAccountPromptViewModel.swift
+++ b/podcasts/Onboarding/Models/PlusAccountPromptViewModel.swift
@@ -9,10 +9,6 @@ class PlusAccountPromptViewModel: PlusPricingInfoModel {
 
     lazy var products: [PlusProductPricingInfo] = {
         let productsToDisplay: [Constants.IapProducts] = {
-            guard FeatureFlag.patron.enabled else {
-                return [.yearly]
-            }
-
             return subscription?.tier == .patron ? [.patronYearly] : [.yearly, .patronYearly]
         }()
 
@@ -82,12 +78,6 @@ class PlusAccountPromptViewModel: PlusPricingInfoModel {
 
     func showModal(for product: PlusProductPricingInfo? = nil) {
         guard let parentController else { return }
-
-        guard FeatureFlag.patron.enabled else {
-            let controller = OnboardingFlow.shared.begin(flow: .plusAccountUpgrade, in: parentController, source: source.rawValue)
-            controller.presentModally(in: parentController)
-            return
-        }
 
         // Set the initial product to display on the upsell
         let context: OnboardingFlow.Context? = product.map {

--- a/podcasts/Onboarding/Models/PlusPricingInfoModel.swift
+++ b/podcasts/Onboarding/Models/PlusPricingInfoModel.swift
@@ -19,12 +19,8 @@ class PlusPricingInfoModel: ObservableObject {
     }
 
     private static func getPricingInfo(from purchaseHandler: IapHelper) -> PlusPricingInfo {
-        var products: [Constants.IapProducts]
-        if FeatureFlag.patron.enabled {
-            products = [.yearly, .monthly, .patronYearly, .patronMonthly]
-        } else {
-            products = [.yearly, .monthly]
-        }
+        let products: [Constants.IapProducts] = [.yearly, .monthly, .patronYearly, .patronMonthly]
+
         var pricing: [PlusProductPricingInfo] = []
 
         for product in products {

--- a/podcasts/Onboarding/Models/PlusPurchaseModel.swift
+++ b/podcasts/Onboarding/Models/PlusPurchaseModel.swift
@@ -141,19 +141,14 @@ private extension PlusPurchaseModel {
         guard let parentController else { return }
 
         if OnboardingFlow.shared.currentFlow.shouldDismissAfterPurchase {
-            if FeatureFlag.patron.enabled {
-                parentController.dismiss(animated: true)
-            } else {
-                parentController.presentingViewController?.dismiss(animated: true)
-            }
-
+            parentController.dismiss(animated: true)
             return
         }
 
         let navigationController = parentController as? UINavigationController
 
         let controller: UIViewController
-        if FeatureFlag.patron.enabled, SubscriptionHelper.activeTier == .patron {
+        if SubscriptionHelper.activeTier == .patron {
             controller = PatronWelcomeViewModel.make(in: navigationController)
         } else {
             controller = WelcomeViewModel.make(in: navigationController, displayType: .plus)
@@ -170,12 +165,8 @@ private extension PlusPurchaseModel {
             navigationController.setViewControllers([controller], animated: true)
         }
 
-        // Dismiss the current flow
-        if FeatureFlag.patron.enabled {
-            presentNextBlock()
-        } else {
-            parentController.dismiss(animated: true, completion: presentNextBlock)
-        }
+        // Dismiss the current flow        
+        presentNextBlock()
     }
 }
 

--- a/podcasts/Onboarding/OnboardingFlow.swift
+++ b/podcasts/Onboarding/OnboardingFlow.swift
@@ -22,12 +22,8 @@ struct OnboardingFlow {
             flowController = upgradeController(in: navigationController, context: context)
 
         case .plusAccountUpgrade:
-            if FeatureFlag.patron.enabled {
-                self.source = source ?? "unknown"
-                flowController = upgradeController(in: navigationController, context: context)
-            } else {
-                flowController = PlusPurchaseModel.make(in: controller, plan: .plus, selectedPrice: .yearly)
-            }
+            self.source = source ?? "unknown"
+            flowController = upgradeController(in: navigationController, context: context)            
 
         case .patronAccountUpgrade:
             self.source = source ?? "unknown"

--- a/podcasts/Onboarding/Plus/PlusLandingViewModel.swift
+++ b/podcasts/Onboarding/Plus/PlusLandingViewModel.swift
@@ -118,22 +118,13 @@ class PlusLandingViewModel: PlusPurchaseModel {
 
 private extension PlusLandingViewModel {
     func showModal(product: Constants.ProductInfo) {
-        if FeatureFlag.patron.enabled {
-            guard let product = self.product(for: product.plan, frequency: product.frequency) else {
-                state = .failed
-                return
-            }
-
-            purchase(product: product.identifier)
+        guard let product = self.product(for: product.plan, frequency: product.frequency) else {
+            state = .failed
             return
         }
 
-        guard let navigationController else { return }
-
-        let controller = PlusPurchaseModel.make(in: navigationController,
-                                                plan: product.plan,
-                                                selectedPrice: product.frequency)
-        controller.presentModally(in: navigationController)
+        purchase(product: product.identifier)
+        return
     }
 
     func showError() {
@@ -161,12 +152,7 @@ extension PlusLandingViewModel {
 
     @ViewBuilder
     private static func view(with viewModel: PlusLandingViewModel) -> some View {
-        if FeatureFlag.patron.enabled {
-            UpgradeLandingView(viewModel: viewModel)
-                .setupDefaultEnvironment()
-        } else {
-            PlusLandingView(viewModel: viewModel)
-                .setupDefaultEnvironment()
-        }
+        UpgradeLandingView(viewModel: viewModel)
+            .setupDefaultEnvironment()
     }
 }

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -892,11 +892,7 @@ class Settings: NSObject {
 
         static var plusCloudStorageLimit: Int {
             RemoteConfig.remoteConfig().configValue(forKey: Constants.RemoteParams.customStorageLimitGB).numberValue.intValue
-        }
-
-        static var patronEnabled: Bool {
-            RemoteConfig.remoteConfig().configValue(forKey: Constants.RemoteParams.patronEnabled).boolValue
-        }
+        }        
 
         static var patronCloudStorageLimit: Int {
             RemoteConfig.remoteConfig().configValue(forKey: Constants.RemoteParams.patronCloudStorageGB).numberValue.intValue

--- a/podcasts/SettingsViewController.swift
+++ b/podcasts/SettingsViewController.swift
@@ -179,11 +179,7 @@ class SettingsViewController: PCViewController, UITableViewDataSource, UITableVi
         case .watch:
             navigationController?.pushViewController(WatchSettingsViewController(), animated: true)
         case .pocketCastsPlus:
-            if FeatureFlag.patron.enabled {
-                navigationController?.present(OnboardingFlow.shared.begin(flow: .plusUpsell, source: "settings"), animated: true)
-            } else {
-                navigationController?.pushViewController(PlusDetailsViewController(), animated: true)
-            }
+            navigationController?.present(OnboardingFlow.shared.begin(flow: .plusUpsell, source: "settings"), animated: true)            
         case .privacy:
             navigationController?.pushViewController(PrivacySettingsViewController(), animated: true)
         case .developer:


### PR DESCRIPTION
Fixes #1304 

This remove the patron feature flag and code branching associated with it.

## To test

 - Start the Pocket Cast app

### Test with a new user
 - Logout
 - Go to Profile -> Setup Account
 - Sign In
 - Check that the options to sign up to Plus and Patron show up
 - Skip the onboarding user
 - Go to Profile -> Account
 - Check that on the top you see a page view that allows you to sign up to Plus or Patron

| 1 | 2 | 3 | 4 |
| - | - | - | - |
| ![Simulator Screenshot - iPhone 15 Pro - 2024-01-03 at 16 33 48](https://github.com/Automattic/pocket-casts-ios/assets/651601/0bd406ee-9d3f-427a-91a7-f1d8e15093d0) | ![Simulator Screenshot - iPhone 15 Pro - 2024-01-03 at 16 32 08](https://github.com/Automattic/pocket-casts-ios/assets/651601/759a56c6-3a94-4afc-bbe9-71d63e5168dc) | ![Simulator Screenshot - iPhone 15 Pro - 2024-01-03 at 16 16 15](https://github.com/Automattic/pocket-casts-ios/assets/651601/aa266239-02a2-4ad1-a9bd-06d673d9a301) | ![Simulator Screenshot - iPhone 15 Pro - 2024-01-03 at 16 16 11](https://github.com/Automattic/pocket-casts-ios/assets/651601/d66d5d05-de02-4519-8e48-f442aabc20be) |


### Test with a user that has a Plus account
 - Go to Profile -> Account -> Upgrade Account
 - Check that the Patron upgrade page shows up correctly


## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
