### PR TITLE
Remove code coverage

### DIFF
--- a/PocketCastsTests/UnitTests.xctestplan
+++ b/PocketCastsTests/UnitTests.xctestplan
@@ -13,6 +13,7 @@
     }
   ],
   "defaultOptions" : {
+    "codeCoverage" : false,
     "environmentVariableEntries" : [
       {
         "key" : "BUILDKITE_ANALYTICS_TOKEN",


### PR DESCRIPTION
Code coverage (#1167) is affecting building the app to a real device:

<img width="268" alt="Screenshot 2024-01-12 at 14 55 38" src="https://github.com/Automattic/pocket-casts-ios/assets/7040243/3d14e4a7-a59b-4dca-919b-1c5285a4742f">

This [thread on SF mentions adding a linker flag](https://stackoverflow.com/questions/58127940/undefined-symbols-llvm-profile-runtime) fixes the issue. However, I'm not entirely sure of the implications of that and all the other flag changes to hardcoded ones.

Since code coverage metrics are not extensively used yet and not being able to build to a device is a blocker I'm disabling code coverage for the moment.

## To test

1. Run this branch on a real device
2. ✅ The build should succeed

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
