### PR TITLE
Move Upgrade Card features under badge + free trial

### DIFF
--- a/podcasts/Onboarding/Plus/Account Prompt/PlusAccountUpgradePrompt.swift
+++ b/podcasts/Onboarding/Plus/Account Prompt/PlusAccountUpgradePrompt.swift
@@ -51,8 +51,37 @@ struct PlusAccountUpgradePrompt: View {
         VStack(spacing: 16) {
             HStack(alignment: .top) {
                 VStack(alignment: .leading) {
-                    SubscriptionBadge(tier: product.identifier.subscriptionTier)
-                        .padding(.bottom, 10)
+                    HStack(alignment: .top) {
+                        SubscriptionBadge(tier: product.identifier.subscriptionTier)
+                            .padding(.bottom, 10)
+                        Spacer()
+                        VStack(alignment: .trailing) {
+                            if let freeTrial = product.freeTrialDuration {
+                                HighlightedText(L10n.plusFreeMembershipFormat(freeTrial).localizedLowercase)
+                                    .highlight(freeTrial, { _ in
+                                            .init(weight: .bold)
+                                    })
+                                    .font(style: .title2)
+                                    .foregroundColor(theme.primaryText01)
+
+                                HighlightedText(L10n.pricingTermsAfterTrial(product.price))
+                                    .highlight(product.rawPrice, { _ in
+                                            .init(weight: .bold)
+                                    })
+                                    .font(style: .body)
+                                    .foregroundColor(theme.primaryText01)
+                            } else {
+                                HighlightedText(product.price)
+                                    .highlight(product.rawPrice, { _ in
+                                            .init(weight: .bold)
+                                    })
+                                    .font(style: .title2)
+                                    .foregroundColor(theme.primaryText01)
+                            }
+
+                            Spacer()
+                        }
+                    }
 
                     productFeatures[product.identifier].map {
                         ForEach($0) { feature in
@@ -74,35 +103,6 @@ struct PlusAccountUpgradePrompt: View {
                             }.frame(maxWidth: .infinity)
                         }
                     }
-                }
-
-                Spacer()
-
-                VStack(alignment: .trailing) {
-                    if let freeTrial = product.freeTrialDuration {
-                        HighlightedText(L10n.plusFreeMembershipFormat(freeTrial).localizedLowercase)
-                            .highlight(freeTrial, { _ in
-                                    .init(weight: .bold)
-                            })
-                            .font(style: .title2)
-                            .foregroundColor(theme.primaryText01)
-
-                        HighlightedText(L10n.pricingTermsAfterTrial(product.price))
-                            .highlight(product.rawPrice, { _ in
-                                    .init(weight: .bold)
-                            })
-                            .font(style: .body)
-                            .foregroundColor(theme.primaryText01)
-                    } else {
-                        HighlightedText(product.price)
-                            .highlight(product.rawPrice, { _ in
-                                    .init(weight: .bold)
-                            })
-                            .font(style: .title2)
-                            .foregroundColor(theme.primaryText01)
-                    }
-
-                    Spacer()
                 }
             }
 


### PR DESCRIPTION
Fixes #1346

Widens horizontal width for features in Upgrade cards

| Before | After |
| ------ | ----- |
| <img width="300" src="https://github.com/Automattic/pocket-casts-ios/assets/3250/19a749c6-d091-4038-978f-8816a2d43a6a"/> | <img width="300" src="https://github.com/Automattic/pocket-casts-ios/assets/3250/845d2c79-a844-4572-bcd4-cd13b9e1e753"/> | 
| <img width="300" src="https://github.com/Automattic/pocket-casts-ios/assets/3250/e1198525-ded4-4d55-94d9-ffcb14cee320"/> | <img width="300" src="https://github.com/Automattic/pocket-casts-ios/assets/3250/0b5f76c0-6531-404f-b2e2-236fa72a2129"/> |

## To test

1. Go to Profile > Account
2. Check Upgrade feature cells

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary. **I don't think this qualifies. It's a minor layout change.**
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
