### PR TITLE
Fix tap on tab bar to display search

### DIFF
--- a/podcasts/DiscoverViewController.swift
+++ b/podcasts/DiscoverViewController.swift
@@ -83,7 +83,7 @@ class DiscoverViewController: PCViewController {
         guard let index = notification.object as? Int, index == tabBarItem.tag else { return }
 
         let defaultOffset = -PCSearchBarController.defaultHeight - view.safeAreaInsets.top
-        if mainScrollView.contentOffset.y.rounded() > defaultOffset.rounded() {
+        if mainScrollView.contentOffset.y.rounded(.down) > defaultOffset.rounded(.down) {
             mainScrollView.setContentOffset(CGPoint(x: 0, y: defaultOffset), animated: true)
         } else {
             searchController.searchTextField.becomeFirstResponder()

--- a/podcasts/DiscoverViewController.swift
+++ b/podcasts/DiscoverViewController.swift
@@ -83,7 +83,7 @@ class DiscoverViewController: PCViewController {
         guard let index = notification.object as? Int, index == tabBarItem.tag else { return }
 
         let defaultOffset = -PCSearchBarController.defaultHeight - view.safeAreaInsets.top
-        if mainScrollView.contentOffset.y > defaultOffset {
+        if mainScrollView.contentOffset.y.rounded() > defaultOffset.rounded() {
             mainScrollView.setContentOffset(CGPoint(x: 0, y: defaultOffset), animated: true)
         } else {
             searchController.searchTextField.becomeFirstResponder()

--- a/podcasts/PodcastListViewController.swift
+++ b/podcasts/PodcastListViewController.swift
@@ -173,7 +173,7 @@ class PodcastListViewController: PCViewController, UIGestureRecognizerDelegate, 
 
     @objc private func checkForScrollTap(_ notification: Notification) {
         let topOffset = -PCSearchBarController.defaultHeight - view.safeAreaInsets.top
-        if let index = notification.object as? Int, index == tabBarItem.tag, podcastsCollectionView.contentOffset.y.rounded() > topOffset.rounded() {
+        if let index = notification.object as? Int, index == tabBarItem.tag, podcastsCollectionView.contentOffset.y.rounded(.down) > topOffset.rounded(.down) {
             podcastsCollectionView.setContentOffset(CGPoint(x: 0, y: topOffset), animated: true)
         } else {
             searchController.searchTextField.becomeFirstResponder()

--- a/podcasts/PodcastListViewController.swift
+++ b/podcasts/PodcastListViewController.swift
@@ -172,9 +172,11 @@ class PodcastListViewController: PCViewController, UIGestureRecognizerDelegate, 
     }
 
     @objc private func checkForScrollTap(_ notification: Notification) {
-        let topOffset = view.safeAreaInsets.top
-        if let index = notification.object as? Int, index == tabBarItem.tag, podcastsCollectionView.contentOffset.y > -topOffset {
-            podcastsCollectionView.setContentOffset(CGPoint(x: 0, y: -topOffset), animated: true)
+        let topOffset = -PCSearchBarController.defaultHeight - view.safeAreaInsets.top
+        if let index = notification.object as? Int, index == tabBarItem.tag, podcastsCollectionView.contentOffset.y.rounded() > topOffset.rounded() {
+            podcastsCollectionView.setContentOffset(CGPoint(x: 0, y: topOffset), animated: true)
+        } else {
+            searchController.searchTextField.becomeFirstResponder()
         }
     }
 


### PR DESCRIPTION
Fixes #1345

Due to a change on iOS, the tap on the tab bar to display search stopped working on iPhone.

This happened because the value returned by `view.safeAreaInsets.top` is slightly different than before: `97.66666666666667` instead of `97.66666666666666`. This makes the `if` never succeed thus never showing the search. I just rounded the numbers to avoid this issue.

I'm targeting the frozen branch since it's a small fix.

## To test

1. Run the app on a device/simulator with the Dynamic Island
2. Go to DIscover
3. Scroll down
4. Tap "Discover" on the tab bar
5. ✅ Discover section should scroll to the top
6. Tap it again
7. ✅ The Discover search should appear
8. Dismiss it and go to "Podcasts"
9. Scroll down
10. Tap "Podcasts" on the tab bar
11. ✅ Podcasts will scroll to the top with the search bar visible
12. Tap "Podcasts" again
13. ✅ Podcasts search should appear

Repeat these tests on iPhone SE and iPad.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
