### PR TITLE
Player transition: another attempt on fixing freezing issues

### DIFF
--- a/podcasts/MiniPlayerToFullPlayerAnimator.swift
+++ b/podcasts/MiniPlayerToFullPlayerAnimator.swift
@@ -61,7 +61,7 @@ class MiniPlayerToFullPlayerAnimator: NSObject, UIViewControllerAnimatedTransiti
         containerView = transitionContext.containerView
 
         guard let playerView = toViewController.view else {
-            transitionContext.completeTransition(false)
+            transitionContext.completeTransition(true)
             return
         }
 


### PR DESCRIPTION
Back in December we had an issue that was blocking the UI when dismissing the player: #1288

However, we're still receiving a few reports of the issue happening:

1. https://www.reddit.com/r/pocketcasts/comments/196l8l8/ui_freezing_after_a_couple_of_minutes/
2. I'm also in contact with a user that reported this through TestFlight feedback

Last time, completing the transition without returning `true` was causing the `UITransitionView` to never goes away. I believe this might be happening when the `toViewController.view` is `nil`, so I changed it.

Unfortunately, I haven't been able to reproduce the issue.

## To test

1. To simulate the issue, go to `MiniPlayerToFullPlayerAnimator.swift` and before `guard let playerView = toViewController.view else {` add:

```swift
        if !isPresenting {
            transitionContext.completeTransition(false)
            return
        }
```

2. Then, open the full player
3. Dismiss it
4. 💥 Check that you can't interact with the UI anymore
5. Stop the app
6. Change the completeTransition to return true in the code you added: `transitionContext.completeTransition(true)`
7. Run the app
8. Open the full player
9. Dismiss it
10. ✅ You should be able to interact with the app

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
