### PR TITLE
Dynamic type podcasts

### DIFF
--- a/PocketCastsUITests/PocketCastsUITests.swift
+++ b/PocketCastsUITests/PocketCastsUITests.swift
@@ -1,0 +1,98 @@
+//
+//  PocketCastsUITests.swift
+//  PocketCastsUITests
+//
+//  Created by Brandon Titus on 1/8/24.
+//  Copyright © 2024 Shifty Jelly. All rights reserved.
+//
+
+import XCTest
+
+final class PocketCastsUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+
+        // We want all errors to be reported from accessibility audit
+        continueAfterFailure = true
+
+        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testPodcastsTab() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        let tab = app.tab(.podcasts)
+        guard tab.waitForExistence(timeout: 20.0) else { return }
+
+        tab.tap()
+
+        try app.performAccessibilityAudit(for: .dynamicType)
+    }
+
+    func testFiltersTab() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        let tab = app.tab(.filter)
+        guard tab.waitForExistence(timeout: 0.5) else { return }
+
+        tab.tap()
+
+        try app.performAccessibilityAudit(for: .dynamicType)
+    }
+
+    func testDiscoverTab() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        let tab = app.tab(.discover)
+        guard tab.waitForExistence(timeout: 0.5) else { return }
+
+        tab.tap()
+
+        try app.performAccessibilityAudit(for: .dynamicType)
+    }
+
+    func testProfileTab() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        let tab = app.tab(.profile)
+        guard tab.waitForExistence(timeout: 0.5) else { return }
+
+        tab.tap()
+
+        try app.performAccessibilityAudit(for: .dynamicType)
+    }
+
+    func testNowPlayingScreen() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        let playButton = app.buttons["Player"]
+        guard playButton.waitForExistence(timeout: 0.5) else { return }
+
+        playButton.tap()
+
+        try app.performAccessibilityAudit(for: .dynamicType)
+    }
+}
+
+extension XCUIApplication {
+    enum PocketCastsTab: String {
+        case podcasts = "Podcasts"
+        case filter = "Filter"
+        case discover = "Discover"
+        case profile = "Profile"
+    }
+
+    func tab(_ tab: PocketCastsTab) -> XCUIElement {
+        tabBars.firstMatch.buttons[tab.rawValue]
+    }
+}

--- a/PocketCastsUITests/PocketCastsUITests.swift
+++ b/PocketCastsUITests/PocketCastsUITests.swift
@@ -32,7 +32,35 @@ final class PocketCastsUITests: XCTestCase {
 
         tab.tap()
 
-        try app.performAccessibilityAudit(for: .dynamicType)
+        try app.performAccessibilityAudit(for: .dynamicType) { issue in
+            if issue.element?.identifier.hasPrefix("GridCell") == true {
+                return false
+            }
+
+            return true
+        }
+    }
+
+    func testPodcastsListView() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        let tab = app.tab(.podcasts)
+        guard tab.waitForExistence(timeout: 20.0) else { return }
+        tab.tap()
+
+        let actionsButton = app.buttons["More actions"]
+        guard actionsButton.waitForExistence(timeout: 20.0) else { return }
+        actionsButton.tap()
+
+        let listButton = app.buttons["List"]
+        guard listButton.waitForExistence(timeout: 20.0) else { return }
+        listButton.tap()
+
+        let dismiss = app.buttons["Dismiss"]
+        dismiss.tap()
+
+        try app.performAccessibilityAudit()
     }
 
     func testFiltersTab() throws {

--- a/PocketCastsUITests/PocketCastsUITestsLaunchTests.swift
+++ b/PocketCastsUITests/PocketCastsUITestsLaunchTests.swift
@@ -1,0 +1,33 @@
+//
+//  PocketCastsUITestsLaunchTests.swift
+//  PocketCastsUITests
+//
+//  Created by Brandon Titus on 1/8/24.
+//  Copyright © 2024 Shifty Jelly. All rights reserved.
+//
+
+import XCTest
+
+final class PocketCastsUITestsLaunchTests: XCTestCase {
+
+    override class var runsForEachTargetApplicationUIConfiguration: Bool {
+        true
+    }
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    func testLaunch() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        // Insert steps here to perform after app launch but before taking a screenshot,
+        // such as logging into a test account or navigating somewhere in the app
+
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = "Launch Screen"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}

--- a/UITests.xctestplan
+++ b/UITests.xctestplan
@@ -1,0 +1,24 @@
+{
+  "configurations" : [
+    {
+      "id" : "2BB9E4CD-AE7A-42AC-AD4A-4A006E45D86B",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:podcasts.xcodeproj",
+        "identifier" : "F5D46F752B4CBA52006B1D8B",
+        "name" : "PocketCastsUITests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/UITests.xctestplan
+++ b/UITests.xctestplan
@@ -13,6 +13,9 @@
   },
   "testTargets" : [
     {
+      "skippedTests" : [
+        "PocketCastsUITestsLaunchTests"
+      ],
       "target" : {
         "containerPath" : "container:podcasts.xcodeproj",
         "identifier" : "F5D46F752B4CBA52006B1D8B",

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1591,6 +1591,8 @@
 		E3F37446291F0DD1005916ED /* Chapters.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3F37445291F0DD1005916ED /* Chapters.swift */; };
 		E3F37447291F0DD1005916ED /* Chapters.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3F37445291F0DD1005916ED /* Chapters.swift */; };
 		F5E431D62B50888500A71DB3 /* PlusLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5E431D52B50888500A71DB3 /* PlusLabel.swift */; };
+		F5D46F792B4CBA52006B1D8B /* PocketCastsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5D46F782B4CBA52006B1D8B /* PocketCastsUITests.swift */; };
+		F5D46F7B2B4CBA52006B1D8B /* PocketCastsUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5D46F7A2B4CBA52006B1D8B /* PocketCastsUITestsLaunchTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1698,6 +1700,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = BDEFBA131E6D3C2300B9024B;
 			remoteInfo = NotificationContent;
+		};
+		F5D46F7C2B4CBA52006B1D8B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BDBD53E417019B290048C8C5 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = BDBD53EB17019B2A0048C8C5;
+			remoteInfo = podcasts;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -3353,6 +3362,10 @@
 		F5E431D52B50888500A71DB3 /* PlusLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlusLabel.swift; sourceTree = "<group>"; };
 		FF57373B2B4EB5B100F511C7 /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
 		FF57373C2B4EB5B100F511C7 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		F5D46F762B4CBA52006B1D8B /* PocketCastsUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PocketCastsUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		F5D46F782B4CBA52006B1D8B /* PocketCastsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PocketCastsUITests.swift; sourceTree = "<group>"; };
+		F5D46F7A2B4CBA52006B1D8B /* PocketCastsUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PocketCastsUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		F5D46F822B4CBABF006B1D8B /* UITests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = UITests.xctestplan; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -3470,6 +3483,13 @@
 			files = (
 				BDEFBA171E6D3C2300B9024B /* UserNotificationsUI.framework in Frameworks */,
 				BDEFBA151E6D3C2300B9024B /* UserNotifications.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F5D46F732B4CBA52006B1D8B /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -5737,6 +5757,7 @@
 				46AFC23527AB19CE004B026F /* Screenshot Automation Watch */,
 				45ECEF7C27E910E300C65030 /* PocketCastsTests */,
 				2F90990C2A4F88B10044FC55 /* Share Extension */,
+				F5D46F772B4CBA52006B1D8B /* PocketCastsUITests */,
 				BDBD53EE17019B2A0048C8C5 /* Frameworks */,
 				BDBD53ED17019B2A0048C8C5 /* Products */,
 				0AEDA899EF3BB3B8C0034C76 /* Pods */,
@@ -5758,6 +5779,7 @@
 				46AFC23427AB19CE004B026F /* Screenshot Automation Watch.xctest */,
 				45ECEF7B27E910E300C65030 /* PocketCastsTests.xctest */,
 				2F90990B2A4F88B00044FC55 /* Share Extension.appex */,
+				F5D46F762B4CBA52006B1D8B /* PocketCastsUITests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -7211,6 +7233,16 @@
 			path = Chapters;
 			sourceTree = "<group>";
 		};
+		F5D46F772B4CBA52006B1D8B /* PocketCastsUITests */ = {
+			isa = PBXGroup;
+			children = (
+				F5D46F822B4CBABF006B1D8B /* UITests.xctestplan */,
+				F5D46F782B4CBA52006B1D8B /* PocketCastsUITests.swift */,
+				F5D46F7A2B4CBA52006B1D8B /* PocketCastsUITestsLaunchTests.swift */,
+			);
+			path = PocketCastsUITests;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -7483,6 +7515,24 @@
 			productReference = BDEFBA141E6D3C2300B9024B /* NotificationContent.appex */;
 			productType = "com.apple.product-type.app-extension";
 		};
+		F5D46F752B4CBA52006B1D8B /* PocketCastsUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F5D46F812B4CBA53006B1D8B /* Build configuration list for PBXNativeTarget "PocketCastsUITests" */;
+			buildPhases = (
+				F5D46F722B4CBA52006B1D8B /* Sources */,
+				F5D46F732B4CBA52006B1D8B /* Frameworks */,
+				F5D46F742B4CBA52006B1D8B /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				F5D46F7D2B4CBA52006B1D8B /* PBXTargetDependency */,
+			);
+			name = PocketCastsUITests;
+			productName = PocketCastsUITests;
+			productReference = F5D46F762B4CBA52006B1D8B /* PocketCastsUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -7490,7 +7540,7 @@
 			isa = PBXProject;
 			attributes = {
 				CLASSPREFIX = SJ;
-				LastSwiftUpdateCheck = 1430;
+				LastSwiftUpdateCheck = 1500;
 				LastUpgradeCheck = 1330;
 				ORGANIZATIONNAME = "Shifty Jelly";
 				TargetAttributes = {
@@ -7570,6 +7620,10 @@
 						LastSwiftMigration = 1000;
 						ProvisioningStyle = Manual;
 					};
+					F5D46F752B4CBA52006B1D8B = {
+						CreatedOnToolsVersion = 15.0.1;
+						TestTargetID = BDBD53EB17019B2A0048C8C5;
+					};
 				};
 			};
 			buildConfigurationList = BDBD53E717019B290048C8C5 /* Build configuration list for PBXProject "podcasts" */;
@@ -7623,6 +7677,7 @@
 				46AFC23327AB19CE004B026F /* Screenshot Automation Watch */,
 				45ECEF7A27E910E300C65030 /* PocketCastsTests */,
 				2F90990A2A4F88B00044FC55 /* Share Extension */,
+				F5D46F752B4CBA52006B1D8B /* PocketCastsUITests */,
 			);
 		};
 /* End PBXProject section */
@@ -8217,6 +8272,13 @@
 				BDEED1561EB07C7D003FE87D /* Assets.xcassets in Resources */,
 				BDEFBA1D1E6D3C2300B9024B /* MainInterface.storyboard in Resources */,
 				8B10E78828D9094500702C54 /* GoogleService-Info.plist in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F5D46F742B4CBA52006B1D8B /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -9490,6 +9552,15 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		F5D46F722B4CBA52006B1D8B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F5D46F792B4CBA52006B1D8B /* PocketCastsUITests.swift in Sources */,
+				F5D46F7B2B4CBA52006B1D8B /* PocketCastsUITestsLaunchTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -9567,6 +9638,11 @@
 			isa = PBXTargetDependency;
 			target = BDEFBA131E6D3C2300B9024B /* NotificationContent */;
 			targetProxy = BDEFBA1F1E6D3C2300B9024B /* PBXContainerItemProxy */;
+		};
+		F5D46F7D2B4CBA52006B1D8B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = BDBD53EB17019B2A0048C8C5 /* podcasts */;
+			targetProxy = F5D46F7C2B4CBA52006B1D8B /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -11167,6 +11243,121 @@
 			};
 			name = Release;
 		};
+		F5D46F7E2B4CBA53006B1D8B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = au.com.shiftyjelly.podcasts.PocketCastsUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = "30883187-573f-4897-a47e-b5451773b23d";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = podcasts;
+			};
+			name = Debug;
+		};
+		F5D46F7F2B4CBA53006B1D8B /* Staging */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = au.com.shiftyjelly.podcasts.PocketCastsUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = "30883187-573f-4897-a47e-b5451773b23d";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = podcasts;
+			};
+			name = Staging;
+		};
+		F5D46F802B4CBA53006B1D8B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = au.com.shiftyjelly.podcasts.PocketCastsUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = "30883187-573f-4897-a47e-b5451773b23d";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = podcasts;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -11306,6 +11497,16 @@
 				BDEFBA221E6D3C2300B9024B /* Debug */,
 				BD69A01D2266A9E400168459 /* Staging */,
 				BDEFBA231E6D3C2300B9024B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		F5D46F812B4CBA53006B1D8B /* Build configuration list for PBXNativeTarget "PocketCastsUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F5D46F7E2B4CBA53006B1D8B /* Debug */,
+				F5D46F7F2B4CBA53006B1D8B /* Staging */,
+				F5D46F802B4CBA53006B1D8B /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/podcasts.xcodeproj/xcshareddata/xcschemes/NotificationContent.xcscheme
+++ b/podcasts.xcodeproj/xcshareddata/xcschemes/NotificationContent.xcscheme
@@ -72,6 +72,17 @@
                ReferencedContainer = "container:podcasts.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F5D46F752B4CBA52006B1D8B"
+               BuildableName = "PocketCastsUITests.xctest"
+               BlueprintName = "PocketCastsUITests"
+               ReferencedContainer = "container:podcasts.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/podcasts.xcodeproj/xcshareddata/xcschemes/NotificationExtension.xcscheme
+++ b/podcasts.xcodeproj/xcshareddata/xcschemes/NotificationExtension.xcscheme
@@ -72,6 +72,17 @@
                ReferencedContainer = "container:podcasts.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F5D46F752B4CBA52006B1D8B"
+               BuildableName = "PocketCastsUITests.xctest"
+               BlueprintName = "PocketCastsUITests"
+               ReferencedContainer = "container:podcasts.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/podcasts.xcodeproj/xcshareddata/xcschemes/PodcastsIntents.xcscheme
+++ b/podcasts.xcodeproj/xcshareddata/xcschemes/PodcastsIntents.xcscheme
@@ -63,6 +63,17 @@
                ReferencedContainer = "container:podcasts.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F5D46F752B4CBA52006B1D8B"
+               BuildableName = "PocketCastsUITests.xctest"
+               BlueprintName = "PocketCastsUITests"
+               ReferencedContainer = "container:podcasts.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/podcasts.xcodeproj/xcshareddata/xcschemes/PodcastsIntentsUI.xcscheme
+++ b/podcasts.xcodeproj/xcshareddata/xcschemes/PodcastsIntentsUI.xcscheme
@@ -53,6 +53,17 @@
                ReferencedContainer = "container:podcasts.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F5D46F752B4CBA52006B1D8B"
+               BuildableName = "PocketCastsUITests.xctest"
+               BlueprintName = "PocketCastsUITests"
+               ReferencedContainer = "container:podcasts.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/podcasts.xcodeproj/xcshareddata/xcschemes/Screenshot Automation.xcscheme
+++ b/podcasts.xcodeproj/xcshareddata/xcschemes/Screenshot Automation.xcscheme
@@ -63,6 +63,17 @@
                ReferencedContainer = "container:podcasts.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F5D46F752B4CBA52006B1D8B"
+               BuildableName = "PocketCastsUITests.xctest"
+               BlueprintName = "PocketCastsUITests"
+               ReferencedContainer = "container:podcasts.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction
@@ -92,15 +103,6 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "4694FA5F2799C80300E9CF70"
-            BuildableName = "Screenshot Automation.xctest"
-            BlueprintName = "Screenshot Automation"
-            ReferencedContainer = "container:podcasts.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/podcasts.xcodeproj/xcshareddata/xcschemes/Today Extension.xcscheme
+++ b/podcasts.xcodeproj/xcshareddata/xcschemes/Today Extension.xcscheme
@@ -72,6 +72,17 @@
                ReferencedContainer = "container:podcasts.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F5D46F752B4CBA52006B1D8B"
+               BuildableName = "PocketCastsUITests.xctest"
+               BlueprintName = "PocketCastsUITests"
+               ReferencedContainer = "container:podcasts.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/podcasts.xcodeproj/xcshareddata/xcschemes/WidgetExtension.xcscheme
+++ b/podcasts.xcodeproj/xcshareddata/xcschemes/WidgetExtension.xcscheme
@@ -53,6 +53,17 @@
                ReferencedContainer = "container:podcasts.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F5D46F752B4CBA52006B1D8B"
+               BuildableName = "PocketCastsUITests.xctest"
+               BlueprintName = "PocketCastsUITests"
+               ReferencedContainer = "container:podcasts.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/podcasts.xcodeproj/xcshareddata/xcschemes/pocketcasts.xcscheme
+++ b/podcasts.xcodeproj/xcshareddata/xcschemes/pocketcasts.xcscheme
@@ -41,6 +41,9 @@
             reference = "container:PocketCastsTests/UnitTests.xctestplan"
             default = "YES">
          </TestPlanReference>
+         <TestPlanReference
+            reference = "container:UITests.xctestplan">
+         </TestPlanReference>
       </TestPlans>
       <Testables>
          <TestableReference
@@ -50,6 +53,17 @@
                BlueprintIdentifier = "45ECEF7A27E910E300C65030"
                BuildableName = "PocketCastsTests.xctest"
                BlueprintName = "PocketCastsTests"
+               ReferencedContainer = "container:podcasts.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F5D46F752B4CBA52006B1D8B"
+               BuildableName = "PocketCastsUITests.xctest"
+               BlueprintName = "PocketCastsUITests"
                ReferencedContainer = "container:podcasts.xcodeproj">
             </BuildableReference>
          </TestableReference>

--- a/podcasts/FolderViewController+CollectionView.swift
+++ b/podcasts/FolderViewController+CollectionView.swift
@@ -38,6 +38,7 @@ extension FolderViewController: UICollectionViewDelegate, UICollectionViewDataSo
             castCell.populateFrom(podcast, badgeType: badgeType)
         } else {
             let castCell = cell as! PodcastGridCell
+            castCell.accessibilityIdentifier = "GridCell-\(podcast.uuid)"
             castCell.populateFrom(podcast: podcast, badgeType: badgeType, libraryType: libraryType)
         }
     }

--- a/podcasts/PCSearchBarController.swift
+++ b/podcasts/PCSearchBarController.swift
@@ -12,6 +12,8 @@ class PCSearchBarController: UIViewController {
     @IBOutlet var roundedBackgroundView: UIView!
     @IBOutlet var searchTextField: UITextField! {
         didSet {
+            searchTextField.adjustsFontForContentSizeCategory = true
+            searchTextField.font = UIFont.font(ofSize: 15, scalingWith: .body)
             searchTextField.addTarget(self, action: #selector(textFieldDidChange), for: .editingChanged)
         }
     }

--- a/podcasts/PodcastListCell.xib
+++ b/podcasts/PodcastListCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22155" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22131"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -34,15 +34,15 @@
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4bI-Ag-WNC">
                                 <rect key="frame" x="0.0" y="0.0" width="180" height="65"/>
                                 <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="500" text="Really really long name for a podcast isn't it, I know it's kinda weird" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yeO-fD-Pus" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="13" width="180" height="19.5"/>
-                                        <fontDescription key="fontDescription" type="system" weight="medium" pointSize="16"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="500" text="Really really long name for a podcast isn't it, I know it's kinda weird" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yeO-fD-Pus" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="12.5" width="180" height="20.5"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                         <color key="textColor" red="0.30196078430000001" green="0.33725490200000002" blue="0.36078431370000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="500" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="21 Episodes" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="14" translatesAutoresizingMaskIntoConstraints="NO" id="yxZ-29-LTD" userLabel="Podcast Info" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="37.5" width="180" height="17"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                    <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="500" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="21 Episodes" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="14" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="yxZ-29-LTD" userLabel="Podcast Info" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="38" width="180" height="18"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                         <color key="textColor" red="0.72156862749999995" green="0.76470588240000004" blue="0.78823529410000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>


### PR DESCRIPTION
**THIS IS AN INITIAL CONCEPT**

Begins #1316 

Adds `UITest` target + initial tests to perform accessibility audits on major tabs.

## To test

#### Manual
* Go to the Podcasts tab
* Open the accessibility inspector
* Verify that changing the preferred text size changes text appropriately

#### UI Test
* Run the UI tests
* Check for errors from the accessibility audit


## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
