### PR TITLE
Player transition: fix UI freeze when Open Player Automatically is enabled

### DIFF
--- a/podcasts/MiniPlayerViewController+Positioning.swift
+++ b/podcasts/MiniPlayerViewController+Positioning.swift
@@ -61,6 +61,8 @@ extension MiniPlayerViewController {
                 AnalyticsHelper.nowPlayingOpened()
                 Analytics.track(.playerShown)
                 completion?()
+            } failure: {
+                self.playerOpenState = .closed
             }
 
             return

--- a/podcasts/SceneHelper.swift
+++ b/podcasts/SceneHelper.swift
@@ -25,7 +25,8 @@ class SceneHelper {
 
     class func rootViewController() -> UIViewController? {
         guard !FeatureFlag.newPlayerTransition.enabled else {
-            return connectedScene()?.windows.mapFirst { $0.rootViewController?.topMostPresentedViewController }
+            let appScene = connectedScene()?.windows.first(where: { $0.rootViewController is MainTabBarController })
+            return appScene?.rootViewController?.topMostPresentedViewController
         }
 
         if let scene = connectedScene() {

--- a/podcasts/UIViewController+Presenting.swift
+++ b/podcasts/UIViewController+Presenting.swift
@@ -18,9 +18,9 @@ extension UIViewController {
     }
 
     /// Presents the given view controller from the root view controller, or the currently presented view controller if there is one.
-    func presentFromRootController(_ controller: UIViewController, animated: Bool = true, completion: (() -> Void)? = nil) {
+    func presentFromRootController(_ controller: UIViewController, animated: Bool = true, completion: (() -> Void)? = nil, failure: (() -> Void)? = nil) {
         guard let presentingController = presentedViewController ?? SceneHelper.rootViewController() else {
-            completion?()
+            failure?()
             return
         }
 


### PR DESCRIPTION
The latest #1350 attempt to fix this issue was not fruitful, so I'm back! But this time I reproduced the issue and know where it is. 😁

This PR fixes:

1. The player being displayed on the wrong `window`, causing the whole UI to freeze
2. The tap on miniplayer to open the player to fail due to player state being set to `open` while is not

The issue was happening because we were using `mapFirst` which sometimes returned a `UIInputWindowController` instead of the app main window.

You can see the freeze happening in this video:

https://github.com/Automattic/pocket-casts-ios/assets/7040243/f6782ab1-d32c-46f0-b8cb-16c19bd6d7fe

## To test

1. Run the app
2. Go to Settings > General > enable Open Player Automatically
3. Add two items on your Up Next
4. Swipe up to display the full player and then swipe down to dismiss it
5. Tap the Up Next icon on the miniplayer
6. Tap the episode that is not playing, then tap play
7. ✅ Nothing should happen and you should still be able to interact with the UI
8. Do this a few more times (swipe up to show full player, swipe down to dismiss, up next icon > play the episode that is not playing) — if you do that on `release/7.55` eventually the app will freeze)
9. Tap the Up Next icon
10. Play the other episode
11. This time, tap the miniplayer (instead of swiping)
12. ✅ The full player should display

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
