### PR TITLE
Fix episode artwork showing behind the video player

### DIFF
--- a/podcasts/MiniPlayerToFullPlayerAnimator.swift
+++ b/podcasts/MiniPlayerToFullPlayerAnimator.swift
@@ -221,7 +221,7 @@ class MiniPlayerToFullPlayerAnimator: NSObject, UIViewControllerAnimatedTransiti
             // Miniplayer
             miniPlayerSnapshotView?.layer.opacity = self.isPresenting ? 0 : 1
         } completion: { completed in
-            self.fullPlayerArtwork.layer.opacity = 1
+            self.fullPlayerArtwork.layer.opacity = !self.isVideoPodcast ? 1 : 0
             self.miniPlayerArtwork.layer.opacity = 1
 
             artwork?.removeFromSuperview()


### PR DESCRIPTION
Fixes #1352

## To test

1. Run the app
2. Play any video podcast (eg.: Twit)
3. ✅ Notice that the artwork is not displayed behind the video

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
