### PR TITLE
SwiftLint setup update and code fixes

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -21,7 +21,7 @@ steps:
   - group: "Linters"
     steps:
       - label: ":swift: SwiftLint"
-        command: .buildkite/commands/run-swiftlint.sh
+        command: .buildkite/commands/run-swiftlint.sh --strict
         plugins:
           - docker#v5.8.0:
               image: "ghcr.io/realm/swiftlint:0.54.0"

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,9 +1,3 @@
 parent_config: https://raw.githubusercontent.com/Automattic/swiftlint-config/0f8ab6388bd8d15a04391825ab125f80cfb90704/.swiftlint.yml
 remote_timeout: 10.0
 
-disabled_rules:
-  # FIXME: The following three rules have been disabled so that CI doesn't fail
-  # the build because of them. They ought to be addressed ASAP.
-  - inverse_text_alignment
-  - natural_content_alignment
-  - natural_text_alignment

--- a/Podfile
+++ b/Podfile
@@ -27,7 +27,7 @@ abstract_target 'CI' do
   platform :ios, app_ios_deployment_target.version
 
   pod 'SwiftGen', '~> 6.0'
-  pod 'SwiftLint', '~> 0.49'
+  pod 'SwiftLint', '~> 0.54'
 end
 
 post_install do |pi|

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -30,13 +30,13 @@ PODS:
     - MaterialComponents/private/Math
     - MaterialComponents/ShadowLayer
   - SwiftGen (6.5.1)
-  - SwiftLint (0.49.1)
+  - SwiftLint (0.54.0)
 
 DEPENDENCIES:
   - google-cast-sdk-no-bluetooth (from `https://github.com/shiftyjelly/google-cast.git`)
   - MaterialComponents/BottomSheet
   - SwiftGen (~> 6.0)
-  - SwiftLint (~> 0.49)
+  - SwiftLint (~> 0.54)
 
 SPEC REPOS:
   trunk:
@@ -57,8 +57,8 @@ SPEC CHECKSUMS:
   google-cast-sdk-no-bluetooth: fd144bf43bb76000a8e92b0410ae605937aa83bf
   MaterialComponents: 1a9b2d9d45b1601ae544de85089adc4c464306d4
   SwiftGen: a6d22010845f08fe18fbdf3a07a8e380fd22e0ea
-  SwiftLint: 32ee33ded0636d0905ef6911b2b67bbaeeedafa5
+  SwiftLint: c1de071d9d08c8aba837545f6254315bc900e211
 
-PODFILE CHECKSUM: 447e34c7b0e913fcf63c0caf29bc68092851ecea
+PODFILE CHECKSUM: d8c7a4679aeeca6d66129939e0d110dc1ea89e37
 
 COCOAPODS: 1.14.2

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -7418,6 +7418,7 @@
 			buildPhases = (
 				DF03311AC9ED8455DC9169CD /* [CP] Check Pods Manifest.lock */,
 				BDBD53E817019B2A0048C8C5 /* Sources */,
+				3C5194112B716756006632DE /* ShellScript */,
 				BDBD53E917019B2A0048C8C5 /* Frameworks */,
 				BDBD53EA17019B2A0048C8C5 /* Resources */,
 				BD5231EA1E3EDA6A000F0D38 /* Embed App Extensions */,
@@ -8265,6 +8266,23 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		3C5194112B716756006632DE /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "[ $CI ] && exit 0\n./Pods/SwiftLint/swiftlint --lenient\n";
+		};
 		3F407FBC28EC30B800818E41 /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;

--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -7,7 +7,7 @@ import PocketCastsServer
 import PocketCastsUtils
 import StoreKit
 
-class AppDelegate: UIResponder, UIApplicationDelegate {
+class AppDelegate: UIResponder, UIApplicationDelegate { 
     private static let initialRefreshDelay = 2.seconds
     private static let minTimeBetweenRefreshes = 5.minutes
 

--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -7,7 +7,7 @@ import PocketCastsServer
 import PocketCastsUtils
 import StoreKit
 
-class AppDelegate: UIResponder, UIApplicationDelegate { 
+class AppDelegate: UIResponder, UIApplicationDelegate {
     private static let initialRefreshDelay = 2.seconds
     private static let minTimeBetweenRefreshes = 5.minutes
 

--- a/podcasts/DateHeadingView.swift
+++ b/podcasts/DateHeadingView.swift
@@ -25,7 +25,7 @@ class DateHeadingView: UIView {
 
         titleLabel = ThemeableLabel(frame: CGRect(x: 20, y: 10, width: bounds.width - 20, height: 30))
         titleLabel?.font = UIFont.systemFont(ofSize: 22, weight: UIFont.Weight.bold)
-        titleLabel?.textAlignment = .left
+        titleLabel?.textAlignment = .natural
         titleLabel?.text = title
         titleLabel?.translatesAutoresizingMaskIntoConstraints = false
         addSubview(titleLabel!)

--- a/podcasts/SimpleActionView.swift
+++ b/podcasts/SimpleActionView.swift
@@ -63,6 +63,7 @@ class SimpleActionView: UIView {
             secondaryLabel.font = UIFont.systemFont(ofSize: 16, weight: .semibold)
             secondaryLabel.numberOfLines = 2
             secondaryLabel.text = secondaryText
+            // swiftlint:disable:next inverse_text_alignment
             secondaryLabel.textAlignment = .right
             secondaryLabel.textColor = ThemeColor.primaryText02(for: themeOverride)
             secondaryLabel.translatesAutoresizingMaskIntoConstraints = false

--- a/podcasts/WhatsNewPageView.swift
+++ b/podcasts/WhatsNewPageView.swift
@@ -91,11 +91,11 @@ class WhatsNewPageView: ThemeableView {
                     let button = WhatsNewLinkButton(url: url)
                     button.setTitle(Bundle.main.localizedString(forKey: text, value: text, table: nil), for: .normal)
                     button.titleLabel?.font = UIFont(name: "SFProText-Medium", size: 18)
-                    button.titleLabel?.textAlignment = .left
+                    button.titleLabel?.textAlignment = .natural
                     button.buttonStyle = .primaryUi01
                     button.textStyle = .primaryInteractive01
                     button.contentMode = .center
-                    button.contentHorizontalAlignment = .left
+                    button.contentHorizontalAlignment = .leading
                     button.titleLabel?.adjustsFontSizeToFitWidth = true
                     button.translatesAutoresizingMaskIntoConstraints = false
                     stackView.addArrangedSubview(button)
@@ -108,10 +108,10 @@ class WhatsNewPageView: ThemeableView {
                     button.delegate = whatsNewLinkDelegate
                     button.setTitle(Bundle.main.localizedString(forKey: text, value: text, table: nil), for: .normal)
                     button.titleLabel?.font = UIFont(name: "SFProText-Medium", size: 18)
-                    button.titleLabel?.textAlignment = .left
+                    button.titleLabel?.textAlignment = .natural
                     button.buttonStyle = .primaryUi01
                     button.textStyle = .primaryInteractive01
-                    button.contentHorizontalAlignment = .left
+                    button.contentHorizontalAlignment = .leading
                     button.titleLabel?.adjustsFontSizeToFitWidth = true
                     button.translatesAutoresizingMaskIntoConstraints = false
                     stackView.addArrangedSubview(button)


### PR DESCRIPTION
This PR builds on https://github.com/Automattic/pocket-casts-ios/pull/1326 and implements the following SwiftLint setup changes:

- Makes any SwiftLint violation to fail the build (`--strict` SwiftLint option)
- Upgraded SwiftLint Pod to align with the one used on CI -- I assume developers use it locally, otherwise we can get rid of it
- Removes all `disabled_rules` so that we don't have additional exceptions
- Fixes all SwiftLint code violations found at this point
- **UPDATE**: added a Build Phase to run SwiftLint locally, reporting warnings to Xcode

## To test

Any SwiftLint violation will now fail the build. I've committed d1c664597d7e14d49206d5d75f2c9fa2fe0250bb (and reverted it) so that a failure would be reported:
<img width="400" alt="Screenshot 2024-01-18 at 15 35 52" src="https://github.com/Automattic/pocket-casts-ios/assets/2152244/f0735f79-dc46-4c51-8f01-08ef4975e7d0">


The code fixes were simple enough and there shouldn't be any problem, but it would be nice to check the UI of some of the affected views using the test build.