### PR TITLE
Mocked URLConnection

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Private/API Tasks/ApiBaseTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Private/API Tasks/ApiBaseTask.swift
@@ -12,7 +12,7 @@ class ApiBaseTask: Operation {
     private let urlConnection: URLConnection
     private let tokenHelper: TokenHelper
 
-    init(dataManager: DataManager = .sharedManager, urlConnection: URLConnection = URLConnection(session: URLSession.shared)) {
+    init(dataManager: DataManager = .sharedManager, urlConnection: URLConnection = URLConnection(handler: URLSession.shared)) {
         self.dataManager = dataManager
         self.urlConnection = urlConnection
         self.tokenHelper = TokenHelper(urlConnection: urlConnection)

--- a/Modules/Server/Sources/PocketCastsServer/Private/TokenHelper.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Private/TokenHelper.swift
@@ -3,7 +3,7 @@ import PocketCastsUtils
 
 class TokenHelper {
 
-    static let shared = TokenHelper(urlConnection: URLConnection(session: URLSession.shared))
+    static let shared = TokenHelper(urlConnection: URLConnection(handler: URLSession.shared))
 
     private let urlConnection: URLConnection
 

--- a/Modules/Server/Sources/PocketCastsServer/Private/TokenHelper.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Private/TokenHelper.swift
@@ -2,13 +2,22 @@ import Foundation
 import PocketCastsUtils
 
 class TokenHelper {
-    class func callSecureUrl(request: URLRequest, completion: @escaping ((HTTPURLResponse?, Data?, Error?) -> Void)) {
-        DispatchQueue.global().async {
-            performCallSecureUrl(request: request, retryOnUnauthorized: true, completion: completion)
+
+    static let shared = TokenHelper(urlConnection: URLConnection(session: URLSession.shared))
+
+    private let urlConnection: URLConnection
+
+    init(urlConnection: URLConnection) {
+        self.urlConnection = urlConnection
+    }
+
+    func callSecureUrl(request: URLRequest, completion: @escaping ((HTTPURLResponse?, Data?, Error?) -> Void)) {
+        DispatchQueue.global().async { [weak self] in
+            self?.performCallSecureUrl(request: request, retryOnUnauthorized: true, completion: completion)
         }
     }
 
-    private class func performCallSecureUrl(request: URLRequest, retryOnUnauthorized: Bool = true, completion: @escaping ((HTTPURLResponse?, Data?, Error?) -> Void)) {
+    private func performCallSecureUrl(request: URLRequest, retryOnUnauthorized: Bool = true, completion: @escaping ((HTTPURLResponse?, Data?, Error?) -> Void)) {
         var mutableRequest = request
 
         if let privateUserAgent = ServerConfig.shared.syncDelegate?.privateUserAgent() {
@@ -19,7 +28,7 @@ class TokenHelper {
             let token: String
             if let storedToken = KeychainHelper.string(for: ServerConstants.Values.syncingV2TokenKey) {
                 token = storedToken
-            } else if let newToken = TokenHelper.acquireToken() {
+            } else if let newToken = acquireToken() {
                 token = newToken
             } else {
                 completion(nil, nil, nil)
@@ -29,7 +38,7 @@ class TokenHelper {
             mutableRequest.setValue("Bearer \(token)", forHTTPHeaderField: ServerConstants.HttpHeaders.authorization)
         }
 
-        URLSession.shared.dataTask(with: mutableRequest) { data, response, error in
+        URLSession.shared.dataTask(with: mutableRequest) { [weak self] data, response, error in
             guard let httpResponse = response as? HTTPURLResponse else {
                 completion(nil, nil, error)
                 return
@@ -38,7 +47,7 @@ class TokenHelper {
             if httpResponse.statusCode == ServerConstants.HttpConstants.unauthorized {
                 if SyncManager.isUserLoggedIn(), retryOnUnauthorized {
                     KeychainHelper.removeKey(ServerConstants.Values.syncingV2TokenKey)
-                    performCallSecureUrl(request: request, retryOnUnauthorized: false, completion: completion)
+                    self?.performCallSecureUrl(request: request, retryOnUnauthorized: false, completion: completion)
                 } else {
                     completion(httpResponse, nil, error)
                 }
@@ -50,7 +59,7 @@ class TokenHelper {
         }.resume()
     }
 
-    class func acquireToken() -> String? {
+    func acquireToken() -> String? {
         let semaphore = DispatchSemaphore(value: 0)
         var refreshedToken: String? = nil
         var refreshedRefreshToken: String? = nil
@@ -95,7 +104,7 @@ class TokenHelper {
 
     // MARK: - Email / Password Token
 
-    private class func acquirePasswordToken() throws -> AuthenticationResponse? {
+    private func acquirePasswordToken() throws -> AuthenticationResponse? {
         guard let email = ServerSettings.syncingEmail(), let password = ServerSettings.syncingPassword() else {
             // if the user doesn't have an email and password, then we'll check if they're using SSO
             return nil
@@ -118,7 +127,7 @@ class TokenHelper {
             let data = try loginRequest.serializedData()
             request.httpBody = data
 
-            let (responseData, response) = try URLConnection.sendSynchronousRequest(with: request)
+            let (responseData, response) = try urlConnection.sendSynchronousRequest(with: request)
             guard let validData = responseData, let httpResponse = response as? HTTPURLResponse else {
                 FileLog.shared.addMessage("TokenHelper: Unable to acquire token")
                 return nil
@@ -151,7 +160,7 @@ class TokenHelper {
 
     // MARK: - Email / Password Token
 
-    private class func asyncAcquireToken(completion: @escaping (Result<AuthenticationResponse?, Error>) -> Void) {
+    func asyncAcquireToken(completion: @escaping (Result<AuthenticationResponse?, Error>) -> Void) {
         do {
             if let authenticationResponse = try acquirePasswordToken() {
                 completion(.success(authenticationResponse))
@@ -176,13 +185,13 @@ class TokenHelper {
 
     // MARK: - SSO Identity Token
 
-    private class func acquireIdentityToken() async throws -> AuthenticationResponse {
+    private func acquireIdentityToken() async throws -> AuthenticationResponse {
         return try await ApiServerHandler.shared.refreshIdentityToken()
     }
 
     // MARK: Cleanup
 
-    private class func tokenCleanUp() {
+    private func tokenCleanUp() {
         var logMessages = [String]()
         if ServerSettings.syncingEmail() == nil {
             logMessages.append("no email address")

--- a/Modules/Server/Sources/PocketCastsServer/Private/TokenHelper.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Private/TokenHelper.swift
@@ -104,7 +104,7 @@ class TokenHelper {
 
     // MARK: - Email / Password Token
 
-    private func acquirePasswordToken() throws -> AuthenticationResponse? {
+    func acquirePasswordToken() throws -> AuthenticationResponse? {
         guard let email = ServerSettings.syncingEmail(), let password = ServerSettings.syncingPassword() else {
             // if the user doesn't have an email and password, then we'll check if they're using SSO
             return nil

--- a/Modules/Server/Sources/PocketCastsServer/Public/Cache/CacheServerHandler.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Cache/CacheServerHandler.swift
@@ -17,6 +17,8 @@ public class CacheServerHandler {
 
     public static var episodeFeedArtwork: Bool = false
 
+    private let tokenHelper = TokenHelper.shared
+
     public init() {
         showNotesUrlCache = URLCache(memoryCapacity: 1.megabytes, diskCapacity: 10.megabytes, diskPath: "show_notes")
         colorsUrlsCache = URLCache(memoryCapacity: 400.kilobytes, diskCapacity: 5.megabytes, diskPath: "colors")
@@ -41,7 +43,7 @@ public class CacheServerHandler {
             didSendCachedNotes = true
         }
 
-        TokenHelper.callSecureUrl(request: request) { [weak self] response, data, _ in
+        tokenHelper.callSecureUrl(request: request) { [weak self] response, data, _ in
             guard let strongSelf = self else { return }
 
             if let data = data, let response = response, let showNotes = strongSelf.topLevelValue(data: data, name: "show_notes", ofType: String.self) {
@@ -118,7 +120,7 @@ public class CacheServerHandler {
         let url = urlForPodcast(uuid: podcastUuid)
         let request = URLRequest(url: url, cachePolicy: .useProtocolCachePolicy, timeoutInterval: CacheServerHandler.defaultTimeout)
 
-        TokenHelper.callSecureUrl(request: request) { [weak self] response, data, _ in
+        tokenHelper.callSecureUrl(request: request) { [weak self] response, data, _ in
             guard let strongSelf = self else { return }
 
             if response?.statusCode == ServerConstants.HttpConstants.ok, let data = data, let podcastInfo = strongSelf.asJson(data: data) {
@@ -139,7 +141,7 @@ public class CacheServerHandler {
         let url = ServerHelper.asUrl(ServerConstants.Urls.cache() + "mobile/episode/url/\(podcastUuid)/\(episodeUuid)")
         let request = URLRequest(url: url, cachePolicy: .useProtocolCachePolicy, timeoutInterval: CacheServerHandler.defaultTimeout)
 
-        TokenHelper.callSecureUrl(request: request) { response, data, _ in
+        tokenHelper.callSecureUrl(request: request) { response, data, _ in
             if response?.statusCode == ServerConstants.HttpConstants.ok, let data = data, let url = String(data: data, encoding: .utf8) {
                 completion(url)
 
@@ -157,7 +159,7 @@ public class CacheServerHandler {
             request.setValue(lastUpdated, forHTTPHeaderField: ServerConstants.HttpHeaders.ifModifiedSince)
         }
 
-        TokenHelper.callSecureUrl(request: request) { [weak self] response, data, _ in
+        tokenHelper.callSecureUrl(request: request) { [weak self] response, data, _ in
             // podcast hasn't changed
             if response?.statusCode == ServerConstants.HttpConstants.notModified {
                 completion(nil, nil)
@@ -206,7 +208,7 @@ public class CacheServerHandler {
             return
         }
 
-        TokenHelper.callSecureUrl(request: request) { response, data, _ in
+        tokenHelper.callSecureUrl(request: request) { response, data, _ in
             guard response?.statusCode == ServerConstants.HttpConstants.ok, let data = data else {
                 completion?(nil)
                 return

--- a/Modules/Server/Sources/PocketCastsServer/Public/Refresh/MainServerHandler.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Refresh/MainServerHandler.swift
@@ -40,6 +40,8 @@ public class MainServerHandler {
         return queue
     }()
 
+    private let tokenHelper = TokenHelper.shared
+
     struct PodcastSearchQuery: BaseRequest {
         var q: String?
         var dt: String?
@@ -205,7 +207,7 @@ public class MainServerHandler {
             return
         }
 
-        TokenHelper.callSecureUrl(request: request) { response, data, error in
+        tokenHelper.callSecureUrl(request: request) { response, data, error in
             let statusCode = response?.statusCode ?? 0
 
             guard statusCode == ServerConstants.HttpConstants.ok, let data = data else {

--- a/Modules/Server/Sources/PocketCastsServer/Public/ServerPodcastManager.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/ServerPodcastManager.swift
@@ -25,7 +25,7 @@ public class ServerPodcastManager: NSObject {
         return queue
     }()
 
-    private let urlConnection = URLConnection(session: URLSession.shared)
+    private let urlConnection = URLConnection(handler: URLSession.shared)
 
     // MARK: - Podcast add fucntions
 

--- a/Modules/Server/Sources/PocketCastsServer/Public/ServerPodcastManager.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/ServerPodcastManager.swift
@@ -25,6 +25,8 @@ public class ServerPodcastManager: NSObject {
         return queue
     }()
 
+    private let urlConnection = URLConnection(session: URLSession.shared)
+
     // MARK: - Podcast add fucntions
 
     public func addFromUuid(podcastUuid: String, subscribe: Bool, completion: ((Bool) -> Void)?) {
@@ -323,7 +325,7 @@ public class ServerPodcastManager: NSObject {
         request.addValue("application/json", forHTTPHeaderField: ServerConstants.HttpHeaders.accept)
         request.setValue("application/json; charset=UTF8", forHTTPHeaderField: ServerConstants.HttpHeaders.contentType)
         do {
-            let (responseData, response) = try URLConnection.sendSynchronousRequest(with: request)
+            let (responseData, response) = try urlConnection.sendSynchronousRequest(with: request)
             guard let data = responseData else { return nil }
 
             if let response = response as? HTTPURLResponse, response.statusCode == ServerConstants.HttpConstants.notModified {

--- a/Modules/Server/Sources/PocketCastsServer/Public/URLConnection.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/URLConnection.swift
@@ -1,14 +1,21 @@
 import Foundation
 
 public class URLConnection {
-    public class func sendSynchronousRequest(with request: URLRequest) throws -> (Data?, URLResponse?) {
+
+    private let session: URLSession
+
+    init(session: URLSession) {
+        self.session = session
+    }
+
+    public func sendSynchronousRequest(with request: URLRequest) throws -> (Data?, URLResponse?) {
         var data: Data?
         var response: URLResponse?
         var error: Error?
 
         let semaphore = DispatchSemaphore(value: 0)
 
-        let dataTask = URLSession.shared.dataTask(with: request) {
+        let dataTask = session.dataTask(with: request) {
             data = $0
             response = $1
             error = $2

--- a/PocketCastsTests/Mocks/MockURLHandler.swift
+++ b/PocketCastsTests/Mocks/MockURLHandler.swift
@@ -2,11 +2,11 @@ import Foundation
 import PocketCastsServer
 
 struct MockRequestHandler {
-    typealias Handler = ((URLRequest) throws -> (Data, URLResponse?))
+    typealias Handler = ((URLRequest) throws -> (Data?, URLResponse?))
 
     let handler: Handler
 
-    init(handler: @escaping ((URLRequest) throws -> (Data, URLResponse?))) {
+    init(handler: @escaping ((URLRequest) throws -> (Data?, URLResponse?))) {
         self.handler = handler
     }
 }
@@ -23,6 +23,8 @@ extension MockRequestHandler: RequestHandler {
 }
 
 extension URLConnection {
+    /// A convenient initializer to pass a block which returns data, response, and error for a given URLRequest.
+    /// - Parameter mockHandler: The handler block (URLRequest) throws -> (Data, URLResponse?)
     convenience init(mockHandler: @escaping MockRequestHandler.Handler) {
         self.init(handler: MockRequestHandler(handler: mockHandler))
     }

--- a/PocketCastsTests/Mocks/MockURLHandler.swift
+++ b/PocketCastsTests/Mocks/MockURLHandler.swift
@@ -1,0 +1,29 @@
+import Foundation
+import PocketCastsServer
+
+struct MockRequestHandler {
+    typealias Handler = ((URLRequest) throws -> (Data, URLResponse?))
+
+    let handler: Handler
+
+    init(handler: @escaping ((URLRequest) throws -> (Data, URLResponse?))) {
+        self.handler = handler
+    }
+}
+
+extension MockRequestHandler: RequestHandler {
+    func send(request: URLRequest, completion: @escaping (Data?, URLResponse?, Error?) -> Void) {
+        do {
+            let (data, response) = try handler(request)
+            completion(data, response, nil)
+        } catch let error {
+            completion(nil, nil, error)
+        }
+    }
+}
+
+extension URLConnection {
+    convenience init(mockHandler: @escaping MockRequestHandler.Handler) {
+        self.init(handler: MockRequestHandler(handler: mockHandler))
+    }
+}

--- a/PocketCastsTests/Tests/Utilities/TokenHelperTests.swift
+++ b/PocketCastsTests/Tests/Utilities/TokenHelperTests.swift
@@ -1,0 +1,117 @@
+import Foundation
+import XCTest
+@testable import PocketCastsServer
+
+fileprivate extension URL {
+    static var userLogin: URL {
+        return ServerHelper.asUrl(ServerConstants.Urls.api() + "user/login")
+    }
+    static var userUpdate: URL {
+        return ServerHelper.asUrl(ServerConstants.Urls.main() + "user/update")
+    }
+}
+
+class TokenHelperTests: XCTestCase {
+
+    /// Tests the acquirePasswordToken function
+    func testAcquirePasswordToken() {
+        ServerSettings.setSyncingEmail(email: "test@test.com")
+        ServerSettings.saveSyncingPassword("1234")
+
+        let tokenHelper = TokenHelper(urlConnection: URLConnection { request in
+            let url = ServerHelper.asUrl(ServerConstants.Urls.api() + "user/login")
+            if request.url == url {
+                let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)
+                var object = Api_UserLoginResponse()
+                object.token = "1234"
+                object.uuid = UUID().uuidString
+                object.email = "test@test.com"
+                let data = try object.serializedData()
+                return (data, response)
+            } else {
+                throw NSError()
+            }
+        })
+        do {
+            let response = try tokenHelper.acquirePasswordToken()
+            XCTAssertEqual(response?.token, "1234")
+            XCTAssertEqual(response?.email, "test@test.com")
+            XCTAssertNotNil(response?.uuid, "Should receive UUID")
+        } catch let error {
+            XCTFail("Acquire Password Token shouldn't fail: \(error)")
+        }
+    }
+
+    /// Tests the acquireAsyncToken function with
+    func testAcquireAsyncToken() {
+        ServerSettings.setSyncingEmail(email: "test@test.com")
+        ServerSettings.saveSyncingPassword("1234")
+
+        let tokenHelper = TokenHelper(urlConnection: URLConnection { request in
+            let url = ServerHelper.asUrl(ServerConstants.Urls.api() + "user/login")
+            if request.url == url {
+                let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)
+                var object = Api_UserLoginResponse()
+                object.token = "1234"
+                object.uuid = UUID().uuidString
+                object.email = "test@test.com"
+                let data = try object.serializedData()
+                return (data, response)
+            } else {
+                throw NSError()
+            }
+        })
+
+        let expectation = XCTestExpectation(description: "Waiting on asyncAcquireToken to complete")
+        tokenHelper.asyncAcquireToken { result in
+            switch result {
+            case .success(let response):
+                XCTAssertEqual(response?.token, "1234")
+                XCTAssertEqual(response?.email, "test@test.com")
+                XCTAssertNotNil(response?.uuid, "Should receive UUID")
+            case .failure(let error):
+                XCTFail("Failed async acquire with error: \(error)")
+            }
+            expectation.fulfill()
+        }
+        wait(for: [expectation])
+    }
+
+    func testCallSecureURL() {
+
+        ServerSettings.setSyncingEmail(email: "test@test.com")
+        ServerSettings.saveSyncingPassword("1234")
+
+        let tokenHelper = TokenHelper(urlConnection: URLConnection { request in
+            switch request.url {
+            case URL.userLogin:
+                let response = HTTPURLResponse(url: .userLogin, statusCode: 200, httpVersion: nil, headerFields: nil)
+                var object = Api_UserLoginResponse()
+                object.token = "1234"
+                object.uuid = UUID().uuidString
+                object.email = "test@test.com"
+                let data = try object.serializedData()
+                return (data, response)
+            case URL.userUpdate:
+                let response = HTTPURLResponse(url: .userUpdate, statusCode: 200, httpVersion: nil, headerFields: nil)
+                // Any data will do here, just to see if it makes it through
+                let data = "Test".data(using: .utf8)
+                return (data!, response)
+            default:
+                throw NSError()
+            }
+        })
+
+        let expectation = XCTestExpectation(description: "Waiting on asyncAcquireToken to complete")
+        tokenHelper.callSecureUrl(request: URLRequest(url: .userUpdate)) { response, data, error in
+            if let error {
+                XCTFail("Failed async acquire with error: \(error)")
+            } else {
+                XCTAssertNotNil(response, "Should have received response")
+                XCTAssertNotNil(data, "Should have received data")
+            }
+            expectation.fulfill()
+        }
+        wait(for: [expectation])
+    }
+}

--- a/PocketCastsTests/Tests/Utilities/TokenHelperTests.swift
+++ b/PocketCastsTests/Tests/Utilities/TokenHelperTests.swift
@@ -96,7 +96,7 @@ class TokenHelperTests: XCTestCase {
                 let response = HTTPURLResponse(url: .userUpdate, statusCode: 200, httpVersion: nil, headerFields: nil)
                 // Any data will do here, just to see if it makes it through
                 let data = "Test".data(using: .utf8)
-                return (data!, response)
+                return (data, response)
             default:
                 throw NSError()
             }

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1590,7 +1590,9 @@
 		E3665F542936CD13001C8372 /* ChaptersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3665F532936CD13001C8372 /* ChaptersTests.swift */; };
 		E3F37446291F0DD1005916ED /* Chapters.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3F37445291F0DD1005916ED /* Chapters.swift */; };
 		E3F37447291F0DD1005916ED /* Chapters.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3F37445291F0DD1005916ED /* Chapters.swift */; };
+		F5BAACCB2B6446D900450E86 /* MockURLHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BAACCA2B6446D900450E86 /* MockURLHandler.swift */; };
 		F5E431D62B50888500A71DB3 /* PlusLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5E431D52B50888500A71DB3 /* PlusLabel.swift */; };
+		F5E949DA2B61762E002DAFC3 /* TokenHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5E949D92B61762E002DAFC3 /* TokenHelperTests.swift */; };
 		FF8970762B5FFC5E004ADB23 /* SubscriptionPriceAndOfferView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF8970752B5FFC5E004ADB23 /* SubscriptionPriceAndOfferView.swift */; };
 /* End PBXBuildFile section */
 
@@ -3351,7 +3353,9 @@
 		ED026EC07A62C137A4959391 /* Pods-PocketCasts-PocketCastsTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PocketCasts-PocketCastsTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-PocketCasts-PocketCastsTests/Pods-PocketCasts-PocketCastsTests.release.xcconfig"; sourceTree = "<group>"; };
 		EF3DD428DC2C444C2D8CEC5A /* Pods-PocketCastsTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PocketCastsTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-PocketCastsTests/Pods-PocketCastsTests.debug.xcconfig"; sourceTree = "<group>"; };
 		EFBF99F57846D0E1AF8DE08D /* Pods-PocketCasts-PocketCastsTests.staging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PocketCasts-PocketCastsTests.staging.xcconfig"; path = "Pods/Target Support Files/Pods-PocketCasts-PocketCastsTests/Pods-PocketCasts-PocketCastsTests.staging.xcconfig"; sourceTree = "<group>"; };
+		F5BAACCA2B6446D900450E86 /* MockURLHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLHandler.swift; sourceTree = "<group>"; };
 		F5E431D52B50888500A71DB3 /* PlusLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlusLabel.swift; sourceTree = "<group>"; };
+		F5E949D92B61762E002DAFC3 /* TokenHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenHelperTests.swift; sourceTree = "<group>"; };
 		FF57373B2B4EB5B100F511C7 /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
 		FF57373C2B4EB5B100F511C7 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		FF8970752B5FFC5E004ADB23 /* SubscriptionPriceAndOfferView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionPriceAndOfferView.swift; sourceTree = "<group>"; };
@@ -4450,6 +4454,7 @@
 				8B484EFE28D257E2001AFA97 /* DataManagerMock.swift */,
 				8B2319422902CF170001C3DE /* EndOfYearManagerMock.swift */,
 				8B484EFC28D2574D001AFA97 /* EpisodeBuilder.swift */,
+				F5BAACCA2B6446D900450E86 /* MockURLHandler.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -7143,6 +7148,7 @@
 			isa = PBXGroup;
 			children = (
 				C7F4C6672A8EAB2800483C37 /* PaidFeatureTests.swift */,
+				F5E949D92B61762E002DAFC3 /* TokenHelperTests.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -8494,6 +8500,7 @@
 				8B317BA528906CAB00A26A13 /* TestingSceneDelegate.swift in Sources */,
 				8B2319432902CF170001C3DE /* EndOfYearManagerMock.swift in Sources */,
 				8B68C1D829421E3400CF25C5 /* FeatureFlagTests.swift in Sources */,
+				F5E949DA2B61762E002DAFC3 /* TokenHelperTests.swift in Sources */,
 				8B317BA328906C8100A26A13 /* TestingAppDelegate.swift in Sources */,
 				C7D8AE5F2A6056DA00C9EBAF /* MutliSelectListViewModel.swift in Sources */,
 				8B484EFD28D2574D001AFA97 /* EpisodeBuilder.swift in Sources */,
@@ -8511,6 +8518,7 @@
 				8B2319412902C8FE0001C3DE /* EndOfYearStoriesBuilderTests.swift in Sources */,
 				C7C0959A2ADE1AF9001E6E3B /* BookmarkAnnouncementViewModelTests.swift in Sources */,
 				8B14E3B329BA43A00069B6F2 /* SearchHistoryModelTests.swift in Sources */,
+				F5BAACCB2B6446D900450E86 /* MockURLHandler.swift in Sources */,
 				8BF0BBD92891AFB5006BBECF /* PodcastBuilder.swift in Sources */,
 				8B1877E52A45DC570025D245 /* AutoplayHelperTests.swift in Sources */,
 				8B2E055028F8579700C2DBDE /* StoriesModelTests.swift in Sources */,


### PR DESCRIPTION
Adds mocking to the `URLConnection` type used by `TokenHelper`, `APIBaseTask`, `MainServerHandler`, `ServerPodcastManager`, and `CacheServerHandler`.

* `TokenHelper` class methods were changed to instance methods
* Uses of the shared `TokenHelper` and `URLConnection` are now properties in various classes and can be overridden in many initializers.
* `TokenHelperTests` tests a variety of the critical paths through `TokenHelper`
* `MockRequestHandler` can be used for mocking tests and a convenience initializer on `URLConnection` makes that simple with a block. These mocks are isolated to that one test so should work in parallel. Create a new `URLConnection` in any test using the following:

```swift
URLConnection { request in
    let url = ServerHelper.asUrl(ServerConstants.Urls.api() + "user/login")
    if request.url == url {
        let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)
        var object = Api_UserLoginResponse()
        object.token = "1234"
        object.uuid = UUID().uuidString
        object.email = "test@test.com"
        let data = try object.serializedData()
        return (data, response)
    } else {
        throw NSError()
    }
}
```

## To test

### App
* Log in to the app with a Plus account
* Ensure refresh and sync work properly
* Ensure Podcast loading works correctly

### Unit Tests
* Run Unit Tests and ensure they pass

### Unit Test known failure
* Remove the early return in  `TokenHelper:167`, returning on a successful `acquirePasswordToken` attempt (this reproduces the issue in https://github.com/Automattic/pocket-casts-ios/pull/1351/commits/c4fe5bba21797931be21fec92d283689a2d1198f)
* Run the app to ensure state is fresh
* Run `TokenHelperTests.testCallSecureURL` and verify that the test fails

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
