### PR TITLE
[Tracks] Track content type on playback events

### DIFF
--- a/podcasts/Analytics/Helpers/AnalyticsCoordinator.swift
+++ b/podcasts/Analytics/Helpers/AnalyticsCoordinator.swift
@@ -54,6 +54,10 @@ class AnalyticsCoordinator {
     /// Sometimes the playback source can't be inferred, just inform it here
     var currentSource: AnalyticsSource?
 
+    private var currentEpisodeIsVideo: Bool {
+        PlaybackManager.shared.currentEpisode()?.videoPodcast() ?? false
+    }
+
     #if !os(watchOS)
         var currentAnalyticsSource: AnalyticsSource {
             if let currentSource = currentSource {
@@ -73,7 +77,7 @@ class AnalyticsCoordinator {
                 return
             }
 
-            let defaultProperties: [String: Any] = ["source": currentAnalyticsSource]
+            let defaultProperties: [String: Any] = ["source": currentAnalyticsSource, "content_type": currentEpisodeIsVideo ? "video" : "audio"]
             let mergedProperties = defaultProperties.merging(properties ?? [:]) { current, _ in current }
             Analytics.track(event, properties: mergedProperties)
         }

--- a/podcasts/Analytics/Helpers/AnalyticsPlaybackHelper.swift
+++ b/podcasts/Analytics/Helpers/AnalyticsPlaybackHelper.swift
@@ -7,12 +7,16 @@ class AnalyticsPlaybackHelper: AnalyticsCoordinator {
     /// Whether to ignore the next seek event
     private var ignoreNextSeek = false
 
+    private var isVideoPodcast: Bool {
+        PlaybackManager.shared.currentEpisode()?.videoPodcast() ?? false
+    }
+
     func play() {
-        track(.playbackPlay)
+        track(.playbackPlay, properties: ["content_type": isVideoPodcast ? "video" : "audio"])
     }
 
     func pause() {
-        track(.playbackPause)
+        track(.playbackPause, properties: ["content_type": isVideoPodcast ? "video" : "audio"])
     }
 
     func skipBack() {

--- a/podcasts/Analytics/Helpers/AnalyticsPlaybackHelper.swift
+++ b/podcasts/Analytics/Helpers/AnalyticsPlaybackHelper.swift
@@ -7,16 +7,12 @@ class AnalyticsPlaybackHelper: AnalyticsCoordinator {
     /// Whether to ignore the next seek event
     private var ignoreNextSeek = false
 
-    private var isVideoPodcast: Bool {
-        PlaybackManager.shared.currentEpisode()?.videoPodcast() ?? false
-    }
-
     func play() {
-        track(.playbackPlay, properties: ["content_type": isVideoPodcast ? "video" : "audio"])
+        track(.playbackPlay)
     }
 
     func pause() {
-        track(.playbackPause, properties: ["content_type": isVideoPodcast ? "video" : "audio"])
+        track(.playbackPause)
     }
 
     func skipBack() {


### PR DESCRIPTION
When tracking play/pause events, add a property to inform whether it's video or audio.

## To test

1. Play any audio podcast
2. ✅ `🔵 Tracked: playback_pause ["content_type": "audio", "source": "?"]` should be tracked (`source` will vary depending from whether did you played)
3. Play a video podcast (eg.: Twit News (Video))
4. ✅ `🔵 Tracked: playback_pause ["content_type": "video", "source": "?"]` should be tracked (`source` will vary depending from whether did you played)
5. Repeat the tests with all the other playback interactions (skip forward, back, etc) `content_type` should be in all of them

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
