### PR TITLE
[Library Update] Move JLRoutes to SPM

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -19,7 +19,6 @@ def kingfisher
 end
 
 def common_pods
-  pod 'JLRoutes'
   pod 'google-cast-sdk-no-bluetooth', git: 'https://github.com/shiftyjelly/google-cast.git'
   pod 'MaterialComponents/BottomSheet'
   kingfisher

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,6 +1,5 @@
 PODS:
   - google-cast-sdk-no-bluetooth (1.0.0)
-  - JLRoutes (2.1)
   - Kingfisher (7.6.2)
   - MaterialComponents/Availability (124.2.0)
   - MaterialComponents/BottomSheet (124.2.0):
@@ -36,7 +35,6 @@ PODS:
 
 DEPENDENCIES:
   - google-cast-sdk-no-bluetooth (from `https://github.com/shiftyjelly/google-cast.git`)
-  - JLRoutes
   - Kingfisher (>= 7.6.2, ~> 7.6)
   - MaterialComponents/BottomSheet
   - SwiftGen (~> 6.0)
@@ -44,7 +42,6 @@ DEPENDENCIES:
 
 SPEC REPOS:
   trunk:
-    - JLRoutes
     - Kingfisher
     - MaterialComponents
     - SwiftGen
@@ -61,12 +58,11 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   google-cast-sdk-no-bluetooth: fd144bf43bb76000a8e92b0410ae605937aa83bf
-  JLRoutes: d755245322b94227662ea3e43492fdca94e05c5b
   Kingfisher: 6c5449c6450c5239166510ba04afe374a98afc4f
   MaterialComponents: 1a9b2d9d45b1601ae544de85089adc4c464306d4
   SwiftGen: a6d22010845f08fe18fbdf3a07a8e380fd22e0ea
   SwiftLint: 32ee33ded0636d0905ef6911b2b67bbaeeedafa5
 
-PODFILE CHECKSUM: 5ab2fbfd041c4568cdfad58ed2204516901808c5
+PODFILE CHECKSUM: 683dd20da0075ce6e4529973fe3486c4ab5c02a8
 
 COCOAPODS: 1.14.2

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -448,6 +448,7 @@
 		8B14E3B029B9159B0069B6F2 /* SearchHistoryModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B14E3AF29B9159B0069B6F2 /* SearchHistoryModel.swift */; };
 		8B14E3B329BA43A00069B6F2 /* SearchHistoryModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B14E3B229BA43A00069B6F2 /* SearchHistoryModelTests.swift */; };
 		8B15E7222AD050EF0077F45A /* DMSans.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 8B15E7212AD050EE0077F45A /* DMSans.ttf */; };
+		8B1762772B6808F700F44450 /* JLRoutes in Frameworks */ = {isa = PBXBuildFile; productRef = 8B1762762B6808F700F44450 /* JLRoutes */; };
 		8B1877E52A45DC570025D245 /* AutoplayHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B1877E42A45DC570025D245 /* AutoplayHelperTests.swift */; };
 		8B1C974628FE1C7E00BD5EB9 /* ImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B1C974528FE1C7E00BD5EB9 /* ImageView.swift */; };
 		8B1C974828FE234B00BD5EB9 /* View+Snapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B1C974728FE234B00BD5EB9 /* View+Snapshot.swift */; };
@@ -3456,6 +3457,7 @@
 				8B365E502B62E82000143DAC /* Agrume in Frameworks */,
 				8BE36E002873552500E35313 /* PocketCastsServer in Frameworks */,
 				BDD239BD267C869B0047750C /* SwipeCellKit in Frameworks */,
+				8B1762772B6808F700F44450 /* JLRoutes in Frameworks */,
 				1C312783007F5948E428F709 /* libPods-podcasts.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -7444,6 +7446,7 @@
 				C72CED33289DA28B0017883A /* AutomatticTracks */,
 				8BAD6E5D2975ADB800DB7259 /* GoogleSignIn */,
 				8B365E4F2B62E82000143DAC /* Agrume */,
+				8B1762762B6808F700F44450 /* JLRoutes */,
 			);
 			productName = podcasts;
 			productReference = BDBD53EC17019B2A0048C8C5 /* podcasts.app */;
@@ -7631,6 +7634,7 @@
 				3FB8642E28896539003A86BE /* XCRemoteSwiftPackageReference "test-collector-swift" */,
 				C7F01AF82911882500EE15D5 /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */,
 				8B365E4E2B62E82000143DAC /* XCRemoteSwiftPackageReference "Agrume" */,
+				8B1762752B6808F700F44450 /* XCRemoteSwiftPackageReference "JLRoutes" */,
 			);
 			productRefGroup = BDBD53ED17019B2A0048C8C5 /* Products */;
 			projectDirPath = "";
@@ -11367,6 +11371,14 @@
 				minimumVersion = 10.20.0;
 			};
 		};
+		8B1762752B6808F700F44450 /* XCRemoteSwiftPackageReference "JLRoutes" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/joeldev/JLRoutes";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.1.1;
+			};
+		};
 		8B365E4E2B62E82000143DAC /* XCRemoteSwiftPackageReference "Agrume" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Automattic/Agrume";
@@ -11442,6 +11454,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 468F00CD27CD575C00FFAAAA /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
 			productName = FirebaseRemoteConfig;
+		};
+		8B1762762B6808F700F44450 /* JLRoutes */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 8B1762752B6808F700F44450 /* XCRemoteSwiftPackageReference "JLRoutes" */;
+			productName = JLRoutes;
 		};
 		8B365E4F2B62E82000143DAC /* Agrume */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/podcasts.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/podcasts.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -155,6 +155,15 @@
         }
       },
       {
+        "package": "JLRoutes",
+        "repositoryURL": "https://github.com/joeldev/JLRoutes",
+        "state": {
+          "branch": null,
+          "revision": "d9f74895e37e0a33a40d39637ede75de3a2d6b66",
+          "version": "2.1.1"
+        }
+      },
+      {
         "package": "leveldb",
         "repositoryURL": "https://github.com/firebase/leveldb.git",
         "state": {


### PR DESCRIPTION
Part of #1366

This PR moves `JLRoutes` from Cocoapods to SPM.

## To test

1. 🟢 build

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
