### PR TITLE
Increase IAP helper tests timeouts

### DIFF
--- a/PocketCastsTests/Tests/IAP/IAPHelperTests.swift
+++ b/PocketCastsTests/Tests/IAP/IAPHelperTests.swift
@@ -20,7 +20,7 @@ final class IAPHelperTests: XCTestCase {
     }
 
     let configurationFile = "Pocket Casts Configuration"
-    let iapTestTimeout: TimeInterval = 1
+    let iapTestTimeout: TimeInterval = 5
 
     func testRequestInfo() throws {
         let session = try SKTestSession(configurationFileNamed: configurationFile)


### PR DESCRIPTION
Fixes #

Increases IAP helper tests timeouts in order to be able to complete them on CI

## To test

Just check that CI tests pass

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
