### PR TITLE
Refactor the IAPHandler to not make requests to the production API during testing

### DIFF
--- a/PocketCastsTests/Extensions/XCTestCase+WaitForNotification.swift
+++ b/PocketCastsTests/Extensions/XCTestCase+WaitForNotification.swift
@@ -1,0 +1,12 @@
+import XCTest
+
+extension XCTestCase {
+    /// Reduces the boilerplate of waiting for a notification expectation to fire into 1 line
+    /// wait(for: .helloWorld, decription: "Hello, of worlds")
+    func wait(for notification: Notification.Name, object: Any? = nil, notificationCenter: NotificationCenter = .default, timeout: TimeInterval = 1, description: String) {
+        let expectation = XCTNSNotificationExpectation(name: notification, object: object, notificationCenter: .default)
+        expectation.expectationDescription = description
+
+        wait(for: [expectation], timeout: timeout)
+    }
+}

--- a/PocketCastsTests/Tests/IAP/IAPHelperTests.swift
+++ b/PocketCastsTests/Tests/IAP/IAPHelperTests.swift
@@ -27,12 +27,6 @@ final class IAPHelperTests: XCTestCase {
     }
 
     func testRequestInfo() throws {
-        let session = try SKTestSession(configurationFileNamed: configurationFile)
-        session.clearTransactions()
-        session.resetToDefaultState()
-        session.disableDialogs = true
-
-        let helper = IAPHelper()
         let expectation = XCTestExpectation(description: "Fetch Products")
         NotificationCenter.default.addObserver(forName: ServerNotifications.iapProductsUpdated, object: nil, queue: nil) { notification in
             expectation.fulfill()
@@ -52,21 +46,9 @@ final class IAPHelperTests: XCTestCase {
 
         let paymentFrequency = helper.getPaymentFrequency(for: .monthly)
         XCTAssertEqual(paymentFrequency, "month")
-
-        session.clearTransactions()
     }
 
     func testPurchase() throws {
-        let session = try SKTestSession(configurationFileNamed: configurationFile)
-        session.clearTransactions()
-        session.resetToDefaultState()
-        session.disableDialogs = true
-
-        let helper = IAPHelper()
-        SKPaymentQueue.default().add(helper)
-        defer {
-            SKPaymentQueue.default().remove(helper)
-        }
         let expectation = XCTestExpectation(description: "Fetch Products")
         NotificationCenter.default.addObserver(forName: ServerNotifications.iapProductsUpdated, object: nil, queue: nil) { notification in
             expectation.fulfill()
@@ -85,7 +67,6 @@ final class IAPHelperTests: XCTestCase {
 
         wait(for: [buyExpectation], timeout: iapTestTimeout)
 
-        session.clearTransactions()
     }
 }
 

--- a/PocketCastsTests/Tests/IAP/IAPHelperTests.swift
+++ b/PocketCastsTests/Tests/IAP/IAPHelperTests.swift
@@ -6,17 +6,11 @@ import PocketCastsServer
 
 final class IAPHelperTests: XCTestCase {
 
-    var email: String?
 
     override func setUpWithError() throws {
-        // Pretend we're logged in
-        email = ServerSettings.syncingEmail()
-        ServerSettings.setSyncingEmail(email: "test@test.com")
     }
 
     override func tearDownWithError() throws {
-        // Restore previous login
-        ServerSettings.setSyncingEmail(email: email)
     }
 
     let configurationFile = "Pocket Casts Configuration"

--- a/PocketCastsTests/Tests/IAP/IAPHelperTests.swift
+++ b/PocketCastsTests/Tests/IAP/IAPHelperTests.swift
@@ -60,7 +60,7 @@ final class IAPHelperTests: XCTestCase {
 
 // MARK: - MockIAPHandler
 
-private class MockIAPHandler: IAPHelper.Settings, IAPHelper.Networking {
+private class MockIAPHandler: IAPHelperSettings, IAPHelperNetworking {
     var isLoggedInValue = true
     var iapUnverifiedPurchaseReceiptDateValue: Date?
     var sendPurchaseReceiptSuccess = true

--- a/PocketCastsTests/Tests/IAP/IAPHelperTests.swift
+++ b/PocketCastsTests/Tests/IAP/IAPHelperTests.swift
@@ -5,16 +5,26 @@ import StoreKitTest
 import PocketCastsServer
 
 final class IAPHelperTests: XCTestCase {
+    let configurationFile = "Pocket Casts Configuration"
+    let iapTestTimeout: TimeInterval = 5
 
+    var session: SKTestSession!
+    var helper: IAPHelper!
 
     override func setUpWithError() throws {
+        session = try SKTestSession(configurationFileNamed: configurationFile)
+        session.clearTransactions()
+        session.resetToDefaultState()
+        session.disableDialogs = true
+
+        helper = IAPHelper(serverHandler: MockIAPHandler())
+        SKPaymentQueue.default().add(helper)
     }
 
     override func tearDownWithError() throws {
+        session.clearTransactions()
+        SKPaymentQueue.default().remove(helper)
     }
-
-    let configurationFile = "Pocket Casts Configuration"
-    let iapTestTimeout: TimeInterval = 5
 
     func testRequestInfo() throws {
         let session = try SKTestSession(configurationFileNamed: configurationFile)

--- a/PocketCastsTests/Tests/IAP/IAPHelperTests.swift
+++ b/PocketCastsTests/Tests/IAP/IAPHelperTests.swift
@@ -83,5 +83,35 @@ final class IAPHelperTests: XCTestCase {
 
         session.clearTransactions()
     }
+}
 
+// MARK: - MockIAPHandler
+
+class MockIAPHandler: IAPHelper.ServerHandler {
+    var isLoggedInValue = true
+    var iapUnverifiedPurchaseReceiptDateValue: Date?
+    var sendPurchaseReceiptSuccess = true
+    var isEligible = true
+
+    override var isLoggedIn: Bool {
+        isLoggedInValue
+    }
+
+    override var iapUnverifiedPurchaseReceiptDate: Date? {
+        set {
+            iapUnverifiedPurchaseReceiptDateValue = newValue
+        }
+
+        get {
+            iapUnverifiedPurchaseReceiptDateValue
+        }
+    }
+
+    override func sendPurchaseReceipt(completion: @escaping (Bool) -> Void) {
+        completion(sendPurchaseReceiptSuccess)
+    }
+
+    override func checkTrialEligibility(_ base64EncodedReceipt: String, completion: @escaping (_ isEligible: Bool?) -> Void) {
+        completion(isEligible)
+    }
 }

--- a/PocketCastsTests/Tests/IAP/IAPHelperTests.swift
+++ b/PocketCastsTests/Tests/IAP/IAPHelperTests.swift
@@ -27,16 +27,8 @@ final class IAPHelperTests: XCTestCase {
     }
 
     func testRequestInfo() throws {
-        let expectation = XCTestExpectation(description: "Fetch Products")
-        NotificationCenter.default.addObserver(forName: ServerNotifications.iapProductsUpdated, object: nil, queue: nil) { notification in
-            expectation.fulfill()
-        }
         helper.requestProductInfo()
-
-        wait(for: [expectation], timeout: iapTestTimeout)
-        XCTAssert(helper.hasLoadedProducts)
-
-        let _ = helper.getProduct(for: .monthly)
+        wait(for: ServerNotifications.iapProductsUpdated, timeout: iapTestTimeout, description: "Fetch Products")
 
         let price = helper.getPrice(for: .monthly)
         XCTAssertEqual(price, "$3.99")
@@ -49,23 +41,15 @@ final class IAPHelperTests: XCTestCase {
     }
 
     func testPurchase() throws {
-        let expectation = XCTestExpectation(description: "Fetch Products")
-        NotificationCenter.default.addObserver(forName: ServerNotifications.iapProductsUpdated, object: nil, queue: nil) { notification in
-            expectation.fulfill()
-        }
         helper.requestProductInfo()
+        wait(for: ServerNotifications.iapProductsUpdated, timeout: iapTestTimeout, description: "Fetch Products")
 
-        wait(for: [expectation], timeout: iapTestTimeout)
         XCTAssert(helper.hasLoadedProducts)
 
-        let buyExpectation = XCTestExpectation(description: "Buy Product")
-        NotificationCenter.default.addObserver(forName: ServerNotifications.iapPurchaseCompleted, object: nil, queue: nil) { notification in
-            buyExpectation.fulfill()
-        }
         let buyResult = helper.buyProduct(identifier: .monthly)
         XCTAssert(buyResult)
 
-        wait(for: [buyExpectation], timeout: iapTestTimeout)
+        wait(for: ServerNotifications.iapPurchaseCompleted, timeout: iapTestTimeout, description: "Buy Products")
 
     }
 }

--- a/PocketCastsTests/Tests/IAP/IAPHelperTests.swift
+++ b/PocketCastsTests/Tests/IAP/IAPHelperTests.swift
@@ -51,6 +51,7 @@ final class IAPHelperTests: XCTestCase {
 
         wait(for: ServerNotifications.iapPurchaseCompleted, timeout: iapTestTimeout, description: "Buy Products")
 
+        XCTAssertEqual(session.allTransactions().first?.productIdentifier, IAPProductID.monthly.rawValue)
     }
 }
 

--- a/PocketCastsTests/Tests/IAP/IAPHelperTests.swift
+++ b/PocketCastsTests/Tests/IAP/IAPHelperTests.swift
@@ -8,16 +8,19 @@ final class IAPHelperTests: XCTestCase {
     let configurationFile = "Pocket Casts Configuration"
     let iapTestTimeout: TimeInterval = 5
 
-    var session: SKTestSession!
-    var helper: IAPHelper!
+    private var session: SKTestSession!
+    private var helper: IAPHelper!
+    private var handler: MockIAPHandler!
 
     override func setUpWithError() throws {
         session = try SKTestSession(configurationFileNamed: configurationFile)
         session.clearTransactions()
         session.resetToDefaultState()
         session.disableDialogs = true
+        
+        handler = MockIAPHandler()
+        helper = IAPHelper(settings: handler, networking: handler)
 
-        helper = IAPHelper(serverHandler: MockIAPHandler())
         SKPaymentQueue.default().add(helper)
     }
 
@@ -57,17 +60,17 @@ final class IAPHelperTests: XCTestCase {
 
 // MARK: - MockIAPHandler
 
-class MockIAPHandler: IAPHelper.ServerHandler {
+private class MockIAPHandler: IAPHelper.Settings, IAPHelper.Networking {
     var isLoggedInValue = true
     var iapUnverifiedPurchaseReceiptDateValue: Date?
     var sendPurchaseReceiptSuccess = true
     var isEligible = true
 
-    override var isLoggedIn: Bool {
+    var isLoggedIn: Bool {
         isLoggedInValue
     }
 
-    override var iapUnverifiedPurchaseReceiptDate: Date? {
+    var iapUnverifiedPurchaseReceiptDate: Date? {
         set {
             iapUnverifiedPurchaseReceiptDateValue = newValue
         }
@@ -77,11 +80,11 @@ class MockIAPHandler: IAPHelper.ServerHandler {
         }
     }
 
-    override func sendPurchaseReceipt(completion: @escaping (Bool) -> Void) {
+    func sendPurchaseReceipt(completion: @escaping (Bool) -> Void) {
         completion(sendPurchaseReceiptSuccess)
     }
 
-    override func checkTrialEligibility(_ base64EncodedReceipt: String, completion: @escaping (_ isEligible: Bool?) -> Void) {
+    func checkTrialEligibility(_ base64EncodedReceipt: String, completion: @escaping (_ isEligible: Bool?) -> Void) {
         completion(isEligible)
     }
 }

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		2F90990E2A4F88B10044FC55 /* ShareViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F90990D2A4F88B10044FC55 /* ShareViewController.swift */; };
 		2F9099112A4F88B10044FC55 /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 2F90990F2A4F88B10044FC55 /* MainInterface.storyboard */; };
 		32163E602B1EBDB6009BB16B /* DatabaseExport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32163E5F2B1EBDB6009BB16B /* DatabaseExport.swift */; };
+		321AC02A2B6AFC45008D6FF2 /* XCTestCase+WaitForNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 321AC0292B6AFC45008D6FF2 /* XCTestCase+WaitForNotification.swift */; };
 		3AAC732D703CDCF4C0F06E10 /* libPods-PocketCastsTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C746C9FCD5A79F9BA9776E01 /* libPods-PocketCastsTests.a */; };
 		3FB8643028896539003A86BE /* BuildkiteTestCollector in Frameworks */ = {isa = PBXBuildFile; productRef = 3FB8642F28896539003A86BE /* BuildkiteTestCollector */; };
 		4000A2A025463C6A00356FCE /* LeftAlignedFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4000A29F25463C6900356FCE /* LeftAlignedFlowLayout.swift */; };
@@ -1812,6 +1813,7 @@
 		2F90991A2A4F89330044FC55 /* Share Extension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Share Extension.entitlements"; sourceTree = "<group>"; };
 		30571BE0029B9924A139FBEE /* Pods-podcasts.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-podcasts.release.xcconfig"; path = "Pods/Target Support Files/Pods-podcasts/Pods-podcasts.release.xcconfig"; sourceTree = "<group>"; };
 		32163E5F2B1EBDB6009BB16B /* DatabaseExport.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseExport.swift; sourceTree = "<group>"; };
+		321AC0292B6AFC45008D6FF2 /* XCTestCase+WaitForNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+WaitForNotification.swift"; sourceTree = "<group>"; };
 		3A427DC232F89CC0DB362F96 /* Pods-PocketCasts-PocketCastsTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PocketCasts-PocketCastsTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-PocketCasts-PocketCastsTests/Pods-PocketCasts-PocketCastsTests.debug.xcconfig"; sourceTree = "<group>"; };
 		3F299D892872BF3600F2ED7F /* PocketCasts.staging.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = PocketCasts.staging.xcconfig; sourceTree = "<group>"; };
 		3F299D8B2872BF3600F2ED7F /* PocketCasts.release.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = PocketCasts.release.xcconfig; sourceTree = "<group>"; };
@@ -4322,6 +4324,7 @@
 				8B484EF828D256F5001AFA97 /* Date+Ext.swift */,
 				8B484EFA28D25719001AFA97 /* Double+Ext.swift */,
 				8BA55A1228CA7425002BECC5 /* XCTestCase+eventually.swift */,
+				321AC0292B6AFC45008D6FF2 /* XCTestCase+WaitForNotification.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -8541,6 +8544,7 @@
 				2F63CE9528809E5B00A34B51 /* ThemeTests.swift in Sources */,
 				8B317BA728906CC200A26A13 /* TestingViewController.swift in Sources */,
 				8BA55A1028CA6843002BECC5 /* AnalyticsPlaybackHelperTests.swift in Sources */,
+				321AC02A2B6AFC45008D6FF2 /* XCTestCase+WaitForNotification.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/podcasts/IAPHelper.swift
+++ b/podcasts/IAPHelper.swift
@@ -26,7 +26,11 @@ class IAPHelper: NSObject {
     /// Whether purchasing is allowed in the current environment or not
     var canMakePurchases = BuildEnvironment.current != .testFlight
 
-    override init() {
+    let serverHandler: ServerHandler
+
+    init(serverHandler: ServerHandler = .init()) {
+        self.serverHandler = serverHandler
+
         super.init()
 
         addSubscriptionNotifications()

--- a/podcasts/IAPHelper.swift
+++ b/podcasts/IAPHelper.swift
@@ -86,7 +86,7 @@ class IAPHelper: NSObject {
     }
 
     public func buyProduct(identifier: IAPProductID) -> Bool {
-        guard let product = getProduct(for: identifier), let _ = ServerSettings.syncingEmail() else {
+        guard serverHandler.isLoggedIn, let product = getProduct(for: identifier) else {
             FileLog.shared.addMessage("IAPHelper Failed to initiate purchase of \(identifier)")
             return false
         }

--- a/podcasts/IAPHelper.swift
+++ b/podcasts/IAPHelper.swift
@@ -26,10 +26,10 @@ class IAPHelper: NSObject {
     /// Whether purchasing is allowed in the current environment or not
     private (set) var canMakePurchases = BuildEnvironment.current != .testFlight
 
-    private var settings: Settings
-    private var networking: Networking
+    private var settings: IAPHelperSettings
+    private var networking: IAPHelperNetworking
 
-    init(settings: Settings, networking: Networking) {
+    init(settings: IAPHelperSettings, networking: IAPHelperNetworking) {
         self.settings = settings
         self.networking = networking
 
@@ -426,28 +426,25 @@ private extension IAPHelper {
 }
 
 // MARK: - Dependencies: Settings / Networking
-
-extension IAPHelper {
-    // Defines the settings the IAPHelper needs to read / write
-    protocol Settings {
-        var isLoggedIn: Bool { get }
-        var iapUnverifiedPurchaseReceiptDate: Date? { get set }
-    }
-
-    /// Defines the non-storekit network methods the IAPHelper uses
-    protocol Networking {
-        func sendPurchaseReceipt(completion: @escaping (Bool) -> Void)
-        func checkTrialEligibility(_ base64EncodedReceipt: String, completion: @escaping (_ isEligible: Bool?) -> Void)
-    }
+// Defines the settings the IAPHelper needs to read / write
+protocol IAPHelperSettings {
+    var isLoggedIn: Bool { get }
+    var iapUnverifiedPurchaseReceiptDate: Date? { get set }
 }
 
-extension ApiServerHandler: IAPHelper.Networking { 
+/// Defines the non-storekit network methods the IAPHelper uses
+protocol IAPHelperNetworking {
+    func sendPurchaseReceipt(completion: @escaping (Bool) -> Void)
+    func checkTrialEligibility(_ base64EncodedReceipt: String, completion: @escaping (_ isEligible: Bool?) -> Void)
+}
+
+extension ApiServerHandler: IAPHelperNetworking {
     /* Already implements the methods 😎 */
 }
 
 private extension IAPHelper {
     /// Acts as a proxy to the `ServerSettings` static methods the IAPHelper uses
-    class SettingsProxy: Settings {
+    class SettingsProxy: IAPHelperSettings {
         var isLoggedIn: Bool {
             SyncManager.isUserLoggedIn()
         }

--- a/podcasts/IAPHelper.swift
+++ b/podcasts/IAPHelper.swift
@@ -290,7 +290,7 @@ private extension IAPHelper {
         }
 
         isCheckingEligibility = true
-        ApiServerHandler.shared.checkTrialEligibility(receiptString) { [weak self] isEligible in
+        serverHandler.checkTrialEligibility(receiptString) { [weak self] isEligible in
             let eligible = isEligible ?? Constants.Values.offerEligibilityDefaultValue
 
             FileLog.shared.addMessage("Refreshed Trial Eligibility: \(eligible ? "Yes" : "No")")
@@ -360,10 +360,11 @@ extension IAPHelper: SKPaymentTransactionObserver {
         }
 
         if hasNewPurchasedReceipt {
-            if ServerSettings.iapUnverifiedPurchaseReceiptDate() == nil {
-                ServerSettings.setIapUnverifiedPurchaseReceiptDate(Date())
+            if serverHandler.iapUnverifiedPurchaseReceiptDate == nil {
+                serverHandler.iapUnverifiedPurchaseReceiptDate = Date()
             }
-            ApiServerHandler.shared.sendPurchaseReceipt(completion: { success in
+
+            serverHandler.sendPurchaseReceipt(completion: { success in
                 if success {
                     FileLog.shared.addMessage("IAPHelper successfully validated receipt")
                 } else {
@@ -421,6 +422,7 @@ private extension IAPHelper {
         Analytics.track(event, properties: properties)
     }
 }
+
 // MARK: - ServerHandler
 
 extension IAPHelper {

--- a/podcasts/IAPHelper.swift
+++ b/podcasts/IAPHelper.swift
@@ -417,3 +417,27 @@ private extension IAPHelper {
         Analytics.track(event, properties: properties)
     }
 }
+// MARK: - ServerHandler
+
+extension IAPHelper {
+    /// Acts as a proxy to the `ServerSettings` static methods the IAPHelper uses, and the `ApiServerHandler` calls
+    /// This allows for these to be injected and test, but keep the functionality the same.
+    class ServerHandler {
+        var isLoggedIn: Bool {
+            SyncManager.isUserLoggedIn()
+        }
+
+        var iapUnverifiedPurchaseReceiptDate: Date? {
+            set { ServerSettings.setIapUnverifiedPurchaseReceiptDate(newValue) }
+            get { ServerSettings.iapUnverifiedPurchaseReceiptDate() }
+        }
+
+        func sendPurchaseReceipt(completion: @escaping (Bool) -> Void) {
+            ApiServerHandler.shared.sendPurchaseReceipt(completion: completion)
+        }
+
+        func checkTrialEligibility(_ base64EncodedReceipt: String, completion: @escaping (_ isEligible: Bool?) -> Void) {
+            ApiServerHandler.shared.checkTrialEligibility(base64EncodedReceipt, completion: completion)
+        }
+    }
+}


### PR DESCRIPTION
While looking into an issue I noticed during unit testing the IAPHelper is sending requests to the production server. 
- After the products request comes in the IAPHelper checks for the [trial eligibility](https://github.com/Automattic/pocket-casts-ios/blob/7c34f752cceb04ffe716fd437ec0dd8611b6c075/podcasts/IAPHelper.swift#L130)
- After making a purchase the IAPHelper [sends the receipt](https://github.com/Automattic/pocket-casts-ios/blob/4dd2fd2966ec8387395e46bb9ad38a2501d7c472/podcasts/IAPHelper.swift#L362-L368) to the server for validation

To fix this, I initially set out to inject the `ApiServerHandler` but in order to subclass those methods I would have had to refactor a lot more since they are contained in a different module and would need to be set as `open`, but since they are defined in an Extension we can't do that without reorganizing that code. 

Instead, I created a simple proxy class ServerHandler (name could be better) that interfaces with the "non-injectable" classes: `ApiServerHandler` and `ServerSettings`. We can then inject this class into IAPHelper and be able to subclass it for unit testing. 

While updating the `IAPHelperTests`, I also did a refactor of the common code for setting up/tearing down the `SKTestSession` and `IAPHelper`. Also, since I'm sure this will come up more as we add more unit tests, I made a small extension to be able to wait for notifications to be fired in the test using a single line. 

## To test

1. 🟢 CI
2. Open `APIServerHandler+TrialEligibility.swift` and put a breakpoint on line 6
3. Open `ApiServerHandler+Account.swift` and put a breakpoint on line 236
4. Open `ServerSettings.swift` and put a breakpoint on lines 152, and 156
5. Open the Scheme Editor, and set the StoreKit Configuration file to Pocket Casts Configuration
6. Launch the app while sign into a non-plus account
7. ✅ Verify the `checkTrialEligibility` breakpoint is hit
8. Tap the Podcasts tab
9. Tap the locked folders icon
10. Continue following the steps to purchase any subscription
11. After finalizing the purchase
12. ✅ Verify the `ServerSettings` line 156 breakpoint is hit
13. Continue
14. ✅ Verify the `ServerSettings` line 152 breakpoint is hit
15. Continue
16. ✅ Verify the `ApiServerHandler+Account` line 236 breakpoint is hit

### Verify no API calls are made during testing
1. Following the steps from above
2. Open Proxyman or Charles
3. Run the tests in IAPHelperTests 
4. ✅ Verify no breakpoints are hit
5. ✅ Verify no API calls are made

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
