### PR TITLE
Replace shared URLSession usage with URLConnection

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Private/TokenHelper.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Private/TokenHelper.swift
@@ -38,7 +38,7 @@ class TokenHelper {
             mutableRequest.setValue("Bearer \(token)", forHTTPHeaderField: ServerConstants.HttpHeaders.authorization)
         }
 
-        URLSession.shared.dataTask(with: mutableRequest) { [weak self] data, response, error in
+        urlConnection.send(request: mutableRequest) { [weak self] data, response, error in
             guard let httpResponse = response as? HTTPURLResponse else {
                 completion(nil, nil, error)
                 return
@@ -56,7 +56,7 @@ class TokenHelper {
             }
 
             completion(httpResponse, data, error)
-        }.resume()
+        }
     }
 
     func acquireToken() -> String? {

--- a/Modules/Server/Sources/PocketCastsServer/Public/URLConnection.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/URLConnection.swift
@@ -41,4 +41,8 @@ public class URLConnection {
         }
         return (data, response)
     }
+
+    public func send(request: URLRequest, completion: @escaping (Data?, URLResponse?, Error?) -> Void) {
+        handler.send(request: request, completion: completion)
+    }
 }


### PR DESCRIPTION
Replaces the `URLSession.shared` usage in `TokenHelper` with `URLConnection` + a new method which just creates a data task and sends a request without the locking from the `sendSynchronousRequest` method.

This avoid actually sending requests in Unit Tests, like `TokenHelperTests.testCallSecureURL`.

## To test

#### Unit Tests
* Run unit tests & ensure they pass
* Connect proxy and Run `TokenHelperTests.testCallSecureURL` – ensure no requests are sent to Pocket Casts APIs. Note that I did see BuildKite and Firebase requests at times, which are unrelated to this change.

#### App Functionality
* Run the app
* Ensure podcasts load
* Ensure Discover loads
* Test logging in and out of an account

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
