### PR TITLE
Settings sync storage

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/AppSettings.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/AppSettings.swift
@@ -1,0 +1,16 @@
+import PocketCastsUtils
+
+/// Model type for synced & stored App Settings
+public struct AppSettings: JSONCodable {
+    @ModifiedDate public var openLinks: Bool
+
+    @ModifiedDate public var rowAction: PrimaryRowAction
+
+    static var defaults: AppSettings {
+        return AppSettings(openLinks: true, rowAction: .download)
+    }
+}
+
+extension SettingsStore<AppSettings> {
+    public static let appSettings = SettingsStore(key: "app_settings", value: AppSettings.defaults)
+}

--- a/Modules/Server/Sources/PocketCastsServer/Public/CodableStore.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/CodableStore.swift
@@ -1,0 +1,38 @@
+import Foundation
+import PocketCastsUtils
+
+@propertyWrapper
+/// Stores a Codable value in UserDefaults,. The `Settings` type provides the User Defaults for writing to so it can be overridden globally.
+struct CodableStore<Value: JSONCodable, Settings: SettingsStore<Value>> {
+    let key: String
+    let defaultValue: Value
+
+    var wrappedValue: Value {
+        get { fatalError("Wrapped value should not be used.") }
+        set { fatalError("Wrapped value should not be used.") }
+    }
+
+    init(wrappedValue: Value, _ key: String) {
+
+        self.defaultValue = wrappedValue
+        self.key = key
+    }
+
+    static subscript(
+        _enclosingInstance instance: Settings,
+        wrapped wrappedKeyPath: ReferenceWritableKeyPath<Settings, Value>,
+        storage storageKeyPath: ReferenceWritableKeyPath<Settings, Self>
+    ) -> Value {
+        get {
+            let container = instance.userDefaults
+            let key = instance[keyPath: storageKeyPath].key
+            let defaultValue = instance[keyPath: storageKeyPath].defaultValue
+            return container.jsonObject(Value.self, forKey: key) ?? defaultValue
+        }
+        set {
+            let container = instance.userDefaults
+            let key = instance[keyPath: storageKeyPath].key
+            container.setJSONObject(newValue, forKey: key)
+        }
+    }
+}

--- a/Modules/Server/Sources/PocketCastsServer/Public/ServerEnums.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/ServerEnums.swift
@@ -58,3 +58,7 @@ extension SubscriptionTier: Comparable {
         return lhsIndex < rhsIndex
     }
 }
+
+public enum PrimaryRowAction: Int32, Codable {
+    case stream = 0, download = 1
+}

--- a/Modules/Server/Sources/PocketCastsServer/Public/SettingsStore.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/SettingsStore.swift
@@ -1,0 +1,27 @@
+import Foundation
+import PocketCastsUtils
+
+/// A storage type for a `Codable` settings value.
+/// This handles storage to `UserDefaults` (optionally overridable)
+@dynamicMemberLookup
+public final class SettingsStore<Value: JSONCodable> {
+    public let userDefaults: UserDefaults
+
+    public init(userDefaults: UserDefaults = .standard, key: String, value: Value) {
+        self.userDefaults = userDefaults
+        _settings = CodableStore(wrappedValue: value, key)
+    }
+
+    @CodableStore var settings: Value
+
+    /// Access any property from `settings` without direct access to settings.
+    /// Avoids having to type `appSettings.settings` and allows for future ObservableObject / publisher adoption in this method
+    public subscript<T>(dynamicMember keyPath: WritableKeyPath<Value, T>) -> T {
+        get {
+            settings[keyPath: keyPath]
+        }
+        set {
+            settings[keyPath: keyPath] = newValue
+        }
+    }
+}

--- a/Modules/Server/Tests/PocketCastsServerTests/SettingsStoreTests.swift
+++ b/Modules/Server/Tests/PocketCastsServerTests/SettingsStoreTests.swift
@@ -4,35 +4,58 @@ import PocketCastsUtils
 
 class SettingsStoreTests: XCTestCase {
 
-    struct TestType: JSONCodable {
+    private struct TestType: JSONCodable {
         var name: String
     }
 
     private let userDefaultsSuiteName = "PocketCastsServer-SettingsStoreTests"
+    private let defaultsKey = "app_settings"
+    private let initialName = "Initial"
+    private let changedName = "Changed"
 
     override func setUp() {
         super.setUp()
         UserDefaults.standard.removePersistentDomain(forName: userDefaultsSuiteName)
     }
 
-    func testStore() throws {
+    /// Tests the initial Empty state of the UserDefaults suite
+    func testEmptyStore() throws {
         let defaults = try XCTUnwrap(UserDefaults(suiteName: userDefaultsSuiteName), "User Defaults suite should load")
-        let defaultsKey = "app_settings"
 
         XCTAssertNil(defaults.data(forKey: defaultsKey), "User Defaults data should not exist yet for \(defaultsKey)")
+    }
 
-        let initialName = "Hello"
+    /// Tests the initial value taken from the SettingsStore.value
+    func testInitialValue() throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: userDefaultsSuiteName), "User Defaults suite should load")
 
         let store = SettingsStore(userDefaults: defaults, key: defaultsKey, value: TestType(name: initialName))
 
-        let changedName = "Changed"
-
         XCTAssertEqual(store.settings.name, initialName, "Accessed initial value should match")
+    }
+
+    /// Tests updating values to a single SettingsStore instance
+    func testValueUpdate() throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: userDefaultsSuiteName), "User Defaults suite should load")
+        let store = SettingsStore(userDefaults: defaults, key: defaultsKey, value: TestType(name: initialName))
+
         store.settings.name = changedName
+
         XCTAssertEqual(store.settings.name, changedName, "Accessed value should match changed value")
+    }
+
+    /// Tests loading values set to SettingsStore with a second instance
+    func testFromUserDefaults() throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: userDefaultsSuiteName), "User Defaults suite should load")
+        let store = SettingsStore(userDefaults: defaults, key: defaultsKey, value: TestType(name: initialName))
+
+        store.settings.name = changedName
 
         let secondStore = SettingsStore(userDefaults: defaults, key: defaultsKey, value: TestType(name: initialName))
+
         XCTAssertNotEqual(secondStore.settings.name, initialName, "Access value should fetch UserDefaults and not initial value of instance")
         XCTAssertEqual(secondStore.settings.name, changedName, "Accessed value on second reference should match changed value")
     }
+
+
 }

--- a/Modules/Server/Tests/PocketCastsServerTests/SettingsStoreTests.swift
+++ b/Modules/Server/Tests/PocketCastsServerTests/SettingsStoreTests.swift
@@ -1,0 +1,38 @@
+import XCTest
+@testable import PocketCastsServer
+import PocketCastsUtils
+
+class SettingsStoreTests: XCTestCase {
+
+    struct TestType: JSONCodable {
+        var name: String
+    }
+
+    private let userDefaultsSuiteName = "PocketCastsServer-SettingsStoreTests"
+
+    override func setUp() {
+        super.setUp()
+        UserDefaults.standard.removePersistentDomain(forName: userDefaultsSuiteName)
+    }
+
+    func testStore() throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: userDefaultsSuiteName), "User Defaults suite should load")
+        let defaultsKey = "app_settings"
+
+        XCTAssertNil(defaults.data(forKey: defaultsKey), "User Defaults data should not exist yet for \(defaultsKey)")
+
+        let initialName = "Hello"
+
+        let store = SettingsStore(userDefaults: defaults, key: defaultsKey, value: TestType(name: initialName))
+
+        let changedName = "Changed"
+
+        XCTAssertEqual(store.settings.name, initialName, "Accessed initial value should match")
+        store.settings.name = changedName
+        XCTAssertEqual(store.settings.name, changedName, "Accessed value should match changed value")
+
+        let secondStore = SettingsStore(userDefaults: defaults, key: defaultsKey, value: TestType(name: initialName))
+        XCTAssertNotEqual(secondStore.settings.name, initialName, "Access value should fetch UserDefaults and not initial value of instance")
+        XCTAssertEqual(secondStore.settings.name, changedName, "Accessed value on second reference should match changed value")
+    }
+}

--- a/Modules/Utils/Sources/PocketCastsUtils/General/ModifiedDate.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/General/ModifiedDate.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+@propertyWrapper
+/// Adds a `modifiedAt` date to any property and adds encode/decode logic.
+public struct ModifiedDate<Value: Codable & Equatable>: Equatable, Codable {
+    var value: Value
+    public private(set) var modifiedAt: Date?
+
+    public init(wrappedValue: Value) {
+        self.value = wrappedValue
+        self.modifiedAt = nil
+    }
+
+    public var wrappedValue: Value {
+        get { value }
+        set {
+            if value != newValue {
+                modifiedAt = Date()
+            }
+            value = newValue
+        }
+    }
+
+    public var projectedValue: Self {
+        get { self }
+        set { self = newValue }
+    }
+}

--- a/Modules/Utils/Tests/PocketCastsUtilsTests/ModifiedDateTests.swift
+++ b/Modules/Utils/Tests/PocketCastsUtilsTests/ModifiedDateTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+@testable import PocketCastsUtils
+
+class ModifiedDateTests: XCTestCase {
+    struct TestType {
+        @ModifiedDate var name: String
+    }
+
+    func testModifiedDate() throws {
+        let initialName = "Hello"
+        let changedName = "Changed"
+
+        var test = TestType(name: initialName)
+        XCTAssertNil(test.$name.modifiedAt, "Initial Modified Date should be nil")
+        test.name = changedName
+        let date = Date()
+        let modifiedDate = try XCTUnwrap(test.$name.modifiedAt, "Modified Data should be set after changing value")
+        XCTAssertEqual(date.timeIntervalSinceReferenceDate, modifiedDate.timeIntervalSinceReferenceDate, accuracy: 0.01, "Modified Data should be roughly equal to the current date")
+    }
+}

--- a/Modules/Utils/Tests/PocketCastsUtilsTests/ModifiedDateTests.swift
+++ b/Modules/Utils/Tests/PocketCastsUtilsTests/ModifiedDateTests.swift
@@ -2,18 +2,31 @@ import XCTest
 @testable import PocketCastsUtils
 
 class ModifiedDateTests: XCTestCase {
-    struct TestType {
+    private struct TestType {
         @ModifiedDate var name: String
     }
 
-    func testModifiedDate() throws {
-        let initialName = "Hello"
-        let changedName = "Changed"
+    private let initialName = "Initial"
+    private let changedName = "Changed"
 
-        var test = TestType(name: initialName)
+    /// Tests the initial value & unset `modifiedAt` date
+    func testInitialValues() throws {
+        let test = TestType(name: initialName)
         XCTAssertNil(test.$name.modifiedAt, "Initial Modified Date should be nil")
+        XCTAssertEqual(test.name, initialName, "Initial Value should be \(initialName)")
+    }
+    
+    /// Tests the `modifiedAt` update when changing value
+    func testModifiedDate() throws {
+        var test = TestType(name: initialName)
+
         test.name = changedName
         let date = Date()
+
+        // Check value
+        XCTAssertEqual(test.name, changedName, "Updated value should be \(changedName)")
+
+        // Check modifiedAt
         let modifiedDate = try XCTUnwrap(test.$name.modifiedAt, "Modified Data should be set after changing value")
         XCTAssertEqual(date.timeIntervalSinceReferenceDate, modifiedDate.timeIntervalSinceReferenceDate, accuracy: 0.01, "Modified Data should be roughly equal to the current date")
     }

--- a/podcasts/Enumerations.swift
+++ b/podcasts/Enumerations.swift
@@ -1,5 +1,7 @@
 import Foundation
 import PocketCastsDataModel
+import PocketCastsServer
+
 enum LibraryType: Int, AnalyticsDescribable {
     case fourByFour = 1, threeByThree = 2, list = 3
 
@@ -131,9 +133,7 @@ enum AppBadge: Int, AnalyticsDescribable {
     }
 }
 
-enum PrimaryRowAction: Int32, AnalyticsDescribable {
-    case stream = 0, download = 1
-
+extension PrimaryRowAction: AnalyticsDescribable {
     var analyticsDescription: String {
         switch self {
         case .stream:

--- a/podcasts/GeneralSettingsViewController.swift
+++ b/podcasts/GeneralSettingsViewController.swift
@@ -1,5 +1,6 @@
 import PocketCastsDataModel
 import PocketCastsServer
+import PocketCastsUtils
 import UIKit
 
 class GeneralSettingsViewController: UIViewController, UITableViewDelegate, UITableViewDataSource {
@@ -124,7 +125,12 @@ class GeneralSettingsViewController: UIViewController, UITableViewDelegate, UITa
             let cell = tableView.dequeueReusableCell(withIdentifier: switchCellId, for: indexPath) as! SwitchCell
 
             cell.cellLabel.text = L10n.settingsGeneralOpenInBrowser
-            cell.cellSwitch.isOn = UserDefaults.standard.bool(forKey: Constants.UserDefaults.openLinksInExternalBrowser)
+
+            if FeatureFlag.settingsSync.enabled {
+                cell.cellSwitch.isOn = SettingsStore.appSettings.openLinks
+            } else {
+                cell.cellSwitch.isOn = UserDefaults.standard.bool(forKey: Constants.UserDefaults.openLinksInExternalBrowser)
+            }
 
             cell.cellSwitch.removeTarget(self, action: nil, for: .valueChanged)
             cell.cellSwitch.addTarget(self, action: #selector(openLinksInBrowserToggled(_:)), for: .valueChanged)
@@ -431,7 +437,11 @@ class GeneralSettingsViewController: UIViewController, UITableViewDelegate, UITa
     }
 
     @objc private func openLinksInBrowserToggled(_ sender: UISwitch) {
-        UserDefaults.standard.set(sender.isOn, forKey: Constants.UserDefaults.openLinksInExternalBrowser)
+        if FeatureFlag.settingsSync.enabled {
+            SettingsStore.appSettings.openLinks = sender.isOn
+        } else {
+            UserDefaults.standard.set(sender.isOn, forKey: Constants.UserDefaults.openLinksInExternalBrowser)
+        }
         Settings.trackValueToggled(.settingsGeneralOpenLinksInBrowserToggled, enabled: sender.isOn)
     }
 

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -131,17 +131,24 @@ class Settings: NSObject {
     private static let primaryRowActionKey = "SJRowAction"
     private static var cachedPrimaryRowAction: PrimaryRowAction? // we cache this because it's used in lists
     class func primaryRowAction() -> PrimaryRowAction {
-        if let action = cachedPrimaryRowAction { return action }
-
-        let storedValue = UserDefaults.standard.integer(forKey: primaryRowActionKey)
-        let primaryAction = PrimaryRowAction(rawValue: Int32(storedValue)) ?? .stream
-        cachedPrimaryRowAction = primaryAction
-
-        return primaryAction
+        if FeatureFlag.settingsSync.enabled {
+            return SettingsStore.appSettings.rowAction
+        } else {
+            if let action = cachedPrimaryRowAction { return action }
+            let storedValue = UserDefaults.standard.integer(forKey: primaryRowActionKey)
+            return PrimaryRowAction(rawValue: Int32(storedValue)) ?? .stream
+        }
     }
 
     class func setPrimaryRowAction(_ action: PrimaryRowAction) {
-        UserDefaults.standard.set(action.rawValue, forKey: primaryRowActionKey)
+        if FeatureFlag.settingsSync.enabled {
+            SettingsStore.appSettings.rowAction = action
+        } else {
+            UserDefaults.standard.set(
+                action.rawValue,
+                forKey: primaryRowActionKey
+            )
+        }
         cachedPrimaryRowAction = action
 
         trackValueChanged(.settingsGeneralRowActionChanged, value: action)


### PR DESCRIPTION
| 📘 Part of: #1400 | Depends on #1405|
|:---:|:---:|

* Adds storage for app settings (to be synced with server) with a modified date attached to each property.
* Converts `openLinks` and `rowAction` General settings to use this new storage mechanism

## Changes

#### Overview
* `CodableStore` is a simple property wrapper for `UserDefaults` that handles encode/decode of a `JSONCodable`.
* `ModifiedDate` is a simple property wrapper to add a `modifiedAt` property which is updated when the value is set.

* `AppSettings` provides a model to represent our synced settings with appropriate primitive types and `JSONCodable` conformance
* `SettingsStore` wraps both the `AppSettings` model and `UserDefaults` to coordinate encoding.

I've added more details below about design thinking and one change to note.

#### Storage

`AppSettings` is a model specific to synced settings and is `JSONCodable` for persistence to `UserDefaults`. This seemed much cleaner than juggling individual `UserDefaults` keys and the data is unlikely to ever get large enough to cause a problem with `UserDefaults`. 

`SettingsStore` wraps `AppSettings` (or any other `JSONCodable` instance) and handles encoding the object and saving to a `UserDefaults` (with `CodableStore`). This indirection is needed so that different stores can be configured with different keys (like for individual podcasts). Simply using a key for the property wrapper in `CodableStore` or `AppStorage` wouldn't work because it can't be dynamic at runtime. `SettingsStore` also provides a centralized location which can be made an `ObservableObject` at a later time. The `dynamicMember` subscript lookup function allows the `AppSettings` properties to be accessed directly, like `store.openLinks` rather than `store.settings.openLinks` but also provides a single point of access where a future Observable/Publisher construct can be added.

#### Notable change

With the feature flag enabled, the cached version of `rowAction` is not used because we don't need to be caching `UserDefaults`.

https://github.com/Automattic/pocket-casts-ios/blob/4a7501b5bd1e1ce239aa3f2eedfaae132333d9f4/podcasts/Settings.swift#L132-L141

[The docs](https://developer.apple.com/documentation/foundation/userdefaults) indicate this is already done by `UserDefaults` automatically:

> At runtime, you use `UserDefaults` objects to read the defaults that your app uses from a user's defaults database. `UserDefaults` caches the information to avoid having to open the user's defaults database each time you need a default value. When you set a default value, it's changed synchronously within your process, and asynchronously to persistent storage and other processes.

## To test

* Run the app
* Enable the `settingsSync` feature flag
* Restart the app
* In General settings, change "Open Links in Browser" (`openLinks`) and "Row Action" (`rowAction`)
* Restart the app
* Make sure the settings persist

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.