### PR TITLE
Settings Sync

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/ApiSetting+ModifiedDate.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/ApiSetting+ModifiedDate.swift
@@ -26,10 +26,12 @@ extension ApiSetting {
 
 extension ModifiedDate {
     /// Updates the ApiSetting ModifiedDate instance with values from an ApiSetting
-    /// - Parameter setting: An `ApiSetting` instance which contains a value and (optional) modified date to set on this `ModifiedDate`
+    /// - Parameter setting: An `ApiSetting` instance which contains a value and (optional) modified date to used to determine whether the value should be overridden
     mutating func update<S: ApiSetting>(setting: S) where Value == S.ReturnValue.T {
-        let referenceDate = Date(timeIntervalSinceReferenceDate: 0)
+        let referenceDate = Date(timeIntervalSince1970: 0)
         if setting.modifiedAt.date > modifiedAt ?? referenceDate {
+            // The `modifiedAt` date is not set here so that we can tell when settings are _actually_ changed on device
+            // Then we include only those values in sending to the server.
             self = ModifiedDate(wrappedValue: setting.value.value)
         }
     }

--- a/Modules/Server/Sources/PocketCastsServer/Public/ApiSetting+ModifiedDate.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/ApiSetting+ModifiedDate.swift
@@ -1,0 +1,69 @@
+import Foundation
+import PocketCastsUtils
+import SwiftProtobuf
+
+// A series of methods to update between ApiSetting (server settings) and ModifiedDate (local) types
+
+extension ApiSetting {
+    /// Updates the `ApiSetting` instance with values from a `ModifiedDate`.
+    /// - Parameter modified: A `ModifiedDate` instance which contains a value and (optional) modified date to set on this `ApiSetting`
+    mutating func update(_ modified: ModifiedDate<ReturnValue.T>) {
+        if let modifiedAt = modified.modifiedAt {
+            self.modifiedAt = Google_Protobuf_Timestamp(date: modifiedAt)
+            value.value = modified.wrappedValue
+        }
+    }
+
+    /// Updates the `ApiSetting` instance with values from a `ModifiedDate`.
+    /// - Parameter modified: A `ModifiedDate` instance which contains a value and (optional) modified date to set on this `ApiSetting`
+    mutating func update<T: RawRepresentable<ReturnValue.T>>(_ modified: ModifiedDate<T>) {
+        if let modifiedAt = modified.modifiedAt {
+            self.modifiedAt = Google_Protobuf_Timestamp(date: modifiedAt)
+            value.value = modified.wrappedValue.rawValue
+        }
+    }
+}
+
+extension ModifiedDate {
+    /// Updates the ApiSetting ModifiedDate instance with values from an ApiSetting
+    /// - Parameter setting: An `ApiSetting` instance which contains a value and (optional) modified date to set on this `ModifiedDate`
+    mutating func update<S: ApiSetting>(setting: S) where Value == S.ReturnValue.T {
+        let referenceDate = Date(timeIntervalSinceReferenceDate: 0)
+        if setting.modifiedAt.date > modifiedAt ?? referenceDate {
+            self = ModifiedDate(wrappedValue: setting.value.value)
+        }
+    }
+}
+
+extension ModifiedDate where Value: RawRepresentable {
+    enum ApiUpdateError: Error {
+        case representableNotFound(value: Any, representable: Value.Type)
+    }
+    
+    /// Updates the ModifiedDate instance with values from an ApiSetting
+    /// - Parameter setting: An `ApiSetting` instance which contains a value and (optional) modified date to set on this `ModifiedDate`
+    mutating private func uncaughtUpdate<S: ApiSetting>(setting: S) throws where Value.RawValue == S.ReturnValue.T {
+        let referenceDate = Date(timeIntervalSinceReferenceDate: 0)
+        if setting.modifiedAt.date > modifiedAt ?? referenceDate {
+            guard let value = Value(rawValue: setting.value.value) else {
+                throw ApiUpdateError.representableNotFound(value: setting.value.value, representable: Value.self)
+            }
+            self = ModifiedDate(wrappedValue: value)
+        }
+    }
+
+    /// Updates the ApiSetting ModifiedDate instance with values from an ApiSetting
+    /// - Parameter setting: An `ApiSetting` instance which contains a value and (optional) modified date to set on this `ModifiedDate`
+    mutating func update<S: ApiSetting>(setting: S) where Value.RawValue == S.ReturnValue.T {
+        do {
+            try uncaughtUpdate(setting: setting)
+        } catch let error {
+            switch error {
+            case ApiUpdateError.representableNotFound(value: let value, representable: let representable):
+                FileLog.shared.addMessage("Failed to represent value: \(value) representing: \(representable)")
+            default:
+                ()
+            }
+        }
+    }
+}

--- a/Modules/Server/Sources/PocketCastsServer/Public/ApiSetting.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/ApiSetting.swift
@@ -1,0 +1,21 @@
+import SwiftProtobuf
+
+/// A server setting which contains a modified date and value
+protocol ApiSetting {
+    associatedtype ReturnValue: ApiReturnValue
+    var modifiedAt: Google_Protobuf_Timestamp { get set }
+    var value: ReturnValue { get set }
+}
+
+/// A generic type representing all Protobuf types with an initializer and value (like Bool, String, Int32)
+protocol ApiReturnValue {
+    associatedtype T: Codable, Equatable
+    init(_: T)
+    var value: T { get set }
+}
+
+extension Api_BoolSetting: ApiSetting {}
+extension Api_Int32Setting: ApiSetting {}
+
+extension Google_Protobuf_BoolValue: ApiReturnValue { }
+extension Google_Protobuf_Int32Value: ApiReturnValue { }

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncSettingsTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncSettingsTask.swift
@@ -3,6 +3,20 @@ import PocketCastsDataModel
 import PocketCastsUtils
 import SwiftProtobuf
 
+extension Api_ChangeableSettings {
+    mutating func update(with settings: AppSettings) {
+        openLinks.update(settings.$openLinks)
+        rowAction.update(settings.$rowAction)
+    }
+}
+
+extension AppSettings {
+    mutating func update(with settings: Api_NamedSettingsResponse) {
+        $openLinks.update(setting: settings.openLinks)
+        $rowAction.update(setting: settings.rowAction)
+    }
+}
+
 class SyncSettingsTask: ApiBaseTask {
 
     let shouldUseNewSync: Bool
@@ -18,7 +32,7 @@ class SyncSettingsTask: ApiBaseTask {
             settingsRequest.m = "iPhone"
 
             if shouldUseNewSync {
-                //New sync logic will go here in future PRs
+                settingsRequest.changedSettings.update(with: SettingsStore.appSettings.settings)
             } else {
                 if ServerSettings.skipBackNeedsSyncing() {
                     settingsRequest.settings.skipBack.value = Int32(ServerSettings.skipBackTime())
@@ -55,7 +69,7 @@ class SyncSettingsTask: ApiBaseTask {
             let settings = try Api_NamedSettingsResponse(serializedData: serverData)
 
             if shouldUseNewSync {
-                // New sync logic will got here in future PRs
+                SettingsStore.appSettings.settings.update(with: settings)
             } else {
                 if settings.skipForward.changed.value {
                     let skipForwardTime = Int(settings.skipForward.value.value)

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncSettingsTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncSettingsTask.swift
@@ -19,10 +19,13 @@ extension AppSettings {
 
 class SyncSettingsTask: ApiBaseTask {
 
-    let shouldUseNewSync: Bool
+    private let shouldUseNewSync: Bool
+    private let appSettings: SettingsStore<AppSettings>
 
-    init(shouldUseNewSync: Bool) {
+    init(shouldUseNewSync: Bool, appSettings: SettingsStore<AppSettings> = SettingsStore.appSettings, dataManager: DataManager = .sharedManager, urlConnection: URLConnection = URLConnection(handler: URLSession.shared)) {
         self.shouldUseNewSync = shouldUseNewSync
+        self.appSettings = appSettings
+        super.init(dataManager: dataManager, urlConnection: urlConnection)
     }
 
     override func apiTokenAcquired(token: String) {
@@ -32,7 +35,7 @@ class SyncSettingsTask: ApiBaseTask {
             settingsRequest.m = "iPhone"
 
             if shouldUseNewSync {
-                settingsRequest.changedSettings.update(with: SettingsStore.appSettings.settings)
+                settingsRequest.changedSettings.update(with: appSettings.settings)
             } else {
                 if ServerSettings.skipBackNeedsSyncing() {
                     settingsRequest.settings.skipBack.value = Int32(ServerSettings.skipBackTime())
@@ -69,7 +72,7 @@ class SyncSettingsTask: ApiBaseTask {
             let settings = try Api_NamedSettingsResponse(serializedData: serverData)
 
             if shouldUseNewSync {
-                SettingsStore.appSettings.settings.update(with: settings)
+                appSettings.settings.update(with: settings)
             } else {
                 if settings.skipForward.changed.value {
                     let skipForwardTime = Int(settings.skipForward.value.value)

--- a/Modules/Server/Tests/MockURLHandler.swift
+++ b/Modules/Server/Tests/MockURLHandler.swift
@@ -1,0 +1,31 @@
+import Foundation
+import PocketCastsServer
+
+struct MockRequestHandler {
+    typealias Handler = ((URLRequest) throws -> (Data?, URLResponse?))
+
+    let handler: Handler
+
+    init(handler: @escaping ((URLRequest) throws -> (Data?, URLResponse?))) {
+        self.handler = handler
+    }
+}
+
+extension MockRequestHandler: RequestHandler {
+    func send(request: URLRequest, completion: @escaping (Data?, URLResponse?, Error?) -> Void) {
+        do {
+            let (data, response) = try handler(request)
+            completion(data, response, nil)
+        } catch let error {
+            completion(nil, nil, error)
+        }
+    }
+}
+
+extension URLConnection {
+    /// A convenient initializer to pass a block which returns data, response, and error for a given URLRequest.
+    /// - Parameter mockHandler: The handler block (URLRequest) throws -> (Data, URLResponse?)
+    convenience init(mockHandler: @escaping MockRequestHandler.Handler) {
+        self.init(handler: MockRequestHandler(handler: mockHandler))
+    }
+}

--- a/Modules/Server/Tests/PocketCastsServerTests/ApiSettingsTests+ModifiedDate.swift
+++ b/Modules/Server/Tests/PocketCastsServerTests/ApiSettingsTests+ModifiedDate.swift
@@ -1,0 +1,29 @@
+import XCTest
+@testable import PocketCastsServer
+import PocketCastsUtils
+
+class APISettingsTests: XCTestCase {
+    func testUpdate() {
+        var settings = Api_BoolSetting()
+
+        let initialValue = true
+        settings.value.value = initialValue
+        XCTAssertEqual(settings.value.value, initialValue, "Initial value should be correct")
+        XCTAssertEqual(settings.modifiedAt.timeIntervalSince1970, Date(timeIntervalSince1970: 0).timeIntervalSince1970, "Initial Timestamp should be epoch")
+
+        let changedValue = false
+
+        var modifiedDate = ModifiedDate(wrappedValue: changedValue)
+        settings.update(modifiedDate)
+        XCTAssertNotEqual(settings.value.value, changedValue, "Settings value should not be changed by the initial value, since it wasn't modified")
+        XCTAssertEqual(settings.modifiedAt.timeIntervalSince1970, Date(timeIntervalSince1970: 0).timeIntervalSince1970, "Initial Timestamp should be epoch")
+
+        let secondChangedValue = true
+
+        let date = Date()
+        modifiedDate.wrappedValue = secondChangedValue
+        settings.update(modifiedDate)
+        XCTAssertEqual(settings.value.value, secondChangedValue, "Changed value should be correct")
+        XCTAssertEqual(settings.modifiedAt.timeIntervalSinceReferenceDate, date.timeIntervalSinceReferenceDate, accuracy: 0.01, "Initial Timestamp should be nil?")
+    }
+}

--- a/Modules/Server/Tests/PocketCastsServerTests/ApiSettingsTests+ModifiedDate.swift
+++ b/Modules/Server/Tests/PocketCastsServerTests/ApiSettingsTests+ModifiedDate.swift
@@ -3,27 +3,47 @@ import XCTest
 import PocketCastsUtils
 
 class APISettingsTests: XCTestCase {
-    func testUpdate() {
+    /// Tests that the initial value is correct
+    func testInitialValue() {
         var settings = Api_BoolSetting()
-
         let initialValue = true
+
         settings.value.value = initialValue
+
         XCTAssertEqual(settings.value.value, initialValue, "Initial value should be correct")
         XCTAssertEqual(settings.modifiedAt.timeIntervalSince1970, Date(timeIntervalSince1970: 0).timeIntervalSince1970, "Initial Timestamp should be epoch")
-
+    }
+    
+    /// Tests that the value changes when a setting is updated
+    func testChangedValue() {
+        var settings = Api_BoolSetting()
+        let initialValue = true
         let changedValue = false
+
+        settings.value.value = initialValue
 
         var modifiedDate = ModifiedDate(wrappedValue: changedValue)
         settings.update(modifiedDate)
+
         XCTAssertNotEqual(settings.value.value, changedValue, "Settings value should not be changed by the initial value, since it wasn't modified")
         XCTAssertEqual(settings.modifiedAt.timeIntervalSince1970, Date(timeIntervalSince1970: 0).timeIntervalSince1970, "Initial Timestamp should be epoch")
-
+    }
+    
+    /// Tests that the value changes when a setting is updated twice
+    func testDoubleChangeValue() {
+        var settings = Api_BoolSetting()
+        let changedValue = false
         let secondChangedValue = true
+
+        var modifiedDate = ModifiedDate(wrappedValue: changedValue)
+        settings.update(modifiedDate)
 
         let date = Date()
         modifiedDate.wrappedValue = secondChangedValue
         settings.update(modifiedDate)
+
         XCTAssertEqual(settings.value.value, secondChangedValue, "Changed value should be correct")
         XCTAssertEqual(settings.modifiedAt.timeIntervalSinceReferenceDate, date.timeIntervalSinceReferenceDate, accuracy: 0.01, "Initial Timestamp should be nil?")
+
     }
 }

--- a/Modules/Server/Tests/PocketCastsServerTests/SyncSettingsTaskTests.swift
+++ b/Modules/Server/Tests/PocketCastsServerTests/SyncSettingsTaskTests.swift
@@ -5,15 +5,17 @@ import SwiftProtobuf
 class SyncSettingsTaskTests: XCTestCase {
 
     private let userDefaultsSuiteName = "PocketCastsTests-SyncSettingsTaskTests"
+    private let defaultsKey = "app_settings"
+    private let token = "1234"
 
     override func setUp() {
         super.setUp()
         UserDefaults.standard.removePersistentDomain(forName: userDefaultsSuiteName)
     }
-
+    
+    /// Tests sending a request with updates from `SettingsStore`
     func testRequest() throws {
         let defaults = try XCTUnwrap(UserDefaults(suiteName: userDefaultsSuiteName), "User Defaults suite should load")
-        let defaultsKey = "app_settings"
 
         XCTAssertNil(defaults.data(forKey: defaultsKey), "User Defaults data should not exist yet for \(defaultsKey)")
 
@@ -40,14 +42,14 @@ class SyncSettingsTaskTests: XCTestCase {
             return (Data(), response)
         })
 
-        task.apiTokenAcquired(token: "1234")
+        task.apiTokenAcquired(token: token)
 
         wait(for: [expectation])
     }
-
+    
+    /// Tests sending a response with updates from `SettingsStore`
     func testResponse() throws {
         let defaults = try XCTUnwrap(UserDefaults(suiteName: userDefaultsSuiteName), "User Defaults suite should load")
-        let defaultsKey = "app_settings"
 
         XCTAssertNil(defaults.data(forKey: defaultsKey), "User Defaults data should not exist yet for \(defaultsKey)")
 
@@ -72,11 +74,11 @@ class SyncSettingsTaskTests: XCTestCase {
             return (data, response)
         })
 
-        task.apiTokenAcquired(token: "1234")
+        task.apiTokenAcquired(token: token)
 
         wait(for: [expectation])
 
         XCTAssertEqual(store.openLinks, changedValue, "Value should be changed")
-
+        XCTAssertNil(store.$openLinks.modifiedAt, "Modified date should be nil")
     }
 }

--- a/Modules/Server/Tests/PocketCastsServerTests/SyncSettingsTaskTests.swift
+++ b/Modules/Server/Tests/PocketCastsServerTests/SyncSettingsTaskTests.swift
@@ -1,0 +1,82 @@
+import XCTest
+@testable import PocketCastsServer
+import SwiftProtobuf
+
+class SyncSettingsTaskTests: XCTestCase {
+
+    private let userDefaultsSuiteName = "PocketCastsTests-SyncSettingsTaskTests"
+
+    override func setUp() {
+        super.setUp()
+        UserDefaults.standard.removePersistentDomain(forName: userDefaultsSuiteName)
+    }
+
+    func testRequest() throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: userDefaultsSuiteName), "User Defaults suite should load")
+        let defaultsKey = "app_settings"
+
+        XCTAssertNil(defaults.data(forKey: defaultsKey), "User Defaults data should not exist yet for \(defaultsKey)")
+
+        let store = SettingsStore(userDefaults: defaults, key: defaultsKey, value: AppSettings(openLinks: false, rowAction: .stream))
+        let changedValue = true
+        let changedDate = Date()
+        store.openLinks = changedValue
+
+        let expectation = XCTestExpectation(description: "Request method should be called")
+        let task = SyncSettingsTask(shouldUseNewSync: true, appSettings: store, urlConnection: URLConnection { urlRequest in
+
+            let data = try XCTUnwrap(urlRequest.httpBody, "Request body should exist")
+            let request = try Api_NamedSettingsRequest(serializedData: data)
+
+            XCTAssertTrue(request.changedSettings.openLinks.hasValue, "Change value should be included")
+            XCTAssertEqual(request.changedSettings.openLinks.modifiedAt.timeIntervalSinceReferenceDate, changedDate.timeIntervalSinceReferenceDate, accuracy: 0.01, "Modified at should be around the time the value was updated")
+            XCTAssertEqual(request.changedSettings.openLinks.value.value, changedValue, "Value should be changed")
+            XCTAssertFalse(request.changedSettings.rowAction.hasChanged, "Unchanged value should not be included")
+            XCTAssertFalse(request.changedSettings.rowAction.hasValue, "Unchanged value should not be included")
+
+            let response = HTTPURLResponse(url: urlRequest.url!, statusCode: 200, httpVersion: nil, headerFields: nil)
+
+            expectation.fulfill()
+            return (Data(), response)
+        })
+
+        task.apiTokenAcquired(token: "1234")
+
+        wait(for: [expectation])
+    }
+
+    func testResponse() throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: userDefaultsSuiteName), "User Defaults suite should load")
+        let defaultsKey = "app_settings"
+
+        XCTAssertNil(defaults.data(forKey: defaultsKey), "User Defaults data should not exist yet for \(defaultsKey)")
+
+        let store = SettingsStore(userDefaults: defaults, key: defaultsKey, value: AppSettings(openLinks: false, rowAction: .stream))
+        let changedValue = true
+        let changedDate = Date()
+
+        XCTAssertFalse(store.openLinks, "Initial value should be false")
+
+        let expectation = XCTestExpectation(description: "Request method should be called")
+        let task = SyncSettingsTask(shouldUseNewSync: true, appSettings: store, urlConnection: URLConnection { urlRequest in
+
+            var serverResponse = Api_NamedSettingsResponse()
+            serverResponse.openLinks.value.value = changedValue
+            serverResponse.openLinks.modifiedAt = Google_Protobuf_Timestamp(date: changedDate)
+            let response = HTTPURLResponse(url: urlRequest.url!, statusCode: 200, httpVersion: nil, headerFields: nil)
+
+            let data = try! XCTUnwrap(serverResponse.serializedData(), "Response should serialize to Data")
+
+            expectation.fulfill()
+
+            return (data, response)
+        })
+
+        task.apiTokenAcquired(token: "1234")
+
+        wait(for: [expectation])
+
+        XCTAssertEqual(store.openLinks, changedValue, "Value should be changed")
+
+    }
+}

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1595,7 +1595,7 @@
 		E3665F542936CD13001C8372 /* ChaptersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3665F532936CD13001C8372 /* ChaptersTests.swift */; };
 		E3F37446291F0DD1005916ED /* Chapters.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3F37445291F0DD1005916ED /* Chapters.swift */; };
 		E3F37447291F0DD1005916ED /* Chapters.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3F37445291F0DD1005916ED /* Chapters.swift */; };
-		F5BAACCB2B6446D900450E86 /* MockURLHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BAACCA2B6446D900450E86 /* MockURLHandler.swift */; };
+		F5D3A0D92B70950100EED067 /* MockURLHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5D3A0D82B70950100EED067 /* MockURLHandler.swift */; };
 		F5E431D62B50888500A71DB3 /* PlusLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5E431D52B50888500A71DB3 /* PlusLabel.swift */; };
 		F5E949DA2B61762E002DAFC3 /* TokenHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5E949D92B61762E002DAFC3 /* TokenHelperTests.swift */; };
 		FF8970762B5FFC5E004ADB23 /* SubscriptionPriceAndOfferView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF8970752B5FFC5E004ADB23 /* SubscriptionPriceAndOfferView.swift */; };
@@ -3360,7 +3360,7 @@
 		ED026EC07A62C137A4959391 /* Pods-PocketCasts-PocketCastsTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PocketCasts-PocketCastsTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-PocketCasts-PocketCastsTests/Pods-PocketCasts-PocketCastsTests.release.xcconfig"; sourceTree = "<group>"; };
 		EF3DD428DC2C444C2D8CEC5A /* Pods-PocketCastsTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PocketCastsTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-PocketCastsTests/Pods-PocketCastsTests.debug.xcconfig"; sourceTree = "<group>"; };
 		EFBF99F57846D0E1AF8DE08D /* Pods-PocketCasts-PocketCastsTests.staging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PocketCasts-PocketCastsTests.staging.xcconfig"; path = "Pods/Target Support Files/Pods-PocketCasts-PocketCastsTests/Pods-PocketCasts-PocketCastsTests.staging.xcconfig"; sourceTree = "<group>"; };
-		F5BAACCA2B6446D900450E86 /* MockURLHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLHandler.swift; sourceTree = "<group>"; };
+		F5D3A0D82B70950100EED067 /* MockURLHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockURLHandler.swift; sourceTree = "<group>"; };
 		F5E431D52B50888500A71DB3 /* PlusLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlusLabel.swift; sourceTree = "<group>"; };
 		F5E949D92B61762E002DAFC3 /* TokenHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenHelperTests.swift; sourceTree = "<group>"; };
 		FF57373B2B4EB5B100F511C7 /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
@@ -4459,12 +4459,12 @@
 		8BF0BBD72891AFA8006BBECF /* Mocks */ = {
 			isa = PBXGroup;
 			children = (
+				F5D3A0D82B70950100EED067 /* MockURLHandler.swift */,
 				8BF0BBDA2891B038006BBECF /* FolderBuilder.swift */,
 				8BF0BBD82891AFB5006BBECF /* PodcastBuilder.swift */,
 				8B484EFE28D257E2001AFA97 /* DataManagerMock.swift */,
 				8B2319422902CF170001C3DE /* EndOfYearManagerMock.swift */,
 				8B484EFC28D2574D001AFA97 /* EpisodeBuilder.swift */,
-				F5BAACCA2B6446D900450E86 /* MockURLHandler.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -8529,13 +8529,13 @@
 				8B2319412902C8FE0001C3DE /* EndOfYearStoriesBuilderTests.swift in Sources */,
 				C7C0959A2ADE1AF9001E6E3B /* BookmarkAnnouncementViewModelTests.swift in Sources */,
 				8B14E3B329BA43A00069B6F2 /* SearchHistoryModelTests.swift in Sources */,
-				F5BAACCB2B6446D900450E86 /* MockURLHandler.swift in Sources */,
 				8BF0BBD92891AFB5006BBECF /* PodcastBuilder.swift in Sources */,
 				8B1877E52A45DC570025D245 /* AutoplayHelperTests.swift in Sources */,
 				8B2E055028F8579700C2DBDE /* StoriesModelTests.swift in Sources */,
 				C7F4BAB728DA8666001C9785 /* BackgroundSignOutListenerTests.swift in Sources */,
 				8B484EFF28D257E2001AFA97 /* DataManagerMock.swift in Sources */,
 				8B484EF928D256F5001AFA97 /* Date+Ext.swift in Sources */,
+				F5D3A0D92B70950100EED067 /* MockURLHandler.swift in Sources */,
 				FFF024CE2B62AC9400457373 /* IAPHelperTests.swift in Sources */,
 				8B3295432A5336DA00BDFA11 /* WhatsNewTests.swift in Sources */,
 				C781EA412A6B72AE001DBFCC /* SearchableListViewModelTests.swift in Sources */,


### PR DESCRIPTION
| 📘 Part of: #1400 | Depends on #1406 |
|:---:|:---:|

Adds syncing for `AppSettings` values.

Only `openLinks` and `rowAction` are synced for now. Future PRs will address the other settings.

## Changes

#### Syncing

`SyncSettingsTask` updates the properties for the request and response types. I wanted a simple way to define these so ended up defining generic methods to do most of the heavy lifting. This way, the "boilerplate" is kept to a minimum. This could be further simplified with a Macro but that seems a little overkill right now.

https://github.com/Automattic/pocket-casts-ios/blob/48a0dd216bd1cd46ff0c3868c83b1f891d623659/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncSettingsTask.swift#L6-L18

#### Transforming between values

The updated methods used above on `ApiSetting` (server) and `ModifiedDate` (local) provide simple interchange with type safety, matching each wrapping type (`ApiSetting` and `ModifiedDate`) with its primitive type (`Bool`, `Int32`, `String`, etc.):

https://github.com/Automattic/pocket-casts-ios/blob/48a0dd216bd1cd46ff0c3868c83b1f891d623659/Modules/Server/Sources/PocketCastsServer/Public/ApiSetting%2BModifiedDate.swift#L7-L69

The types used to represent the more specific types from the Protobuf API are `ApiSetting` and `ApiReturnValue`

`ApiSetting` is a protocol to describe the server-side versions of `ModifiedDate` types – a generic version of the specific `Api_BoolSetting`, `Api_Int32Setting`, etc. with a `value` and `modifiedAt` property.

`ApiReturnValue` is used by `ApiSetting` to describe the generic types of its' value such as, `Google_Protobuf_BoolValue`, the Protobuf equivalents of primitive types like `Bool`, `Int32`, `String`, etc.

https://github.com/Automattic/pocket-casts-ios/blob/48a0dd216bd1cd46ff0c3868c83b1f891d623659/Modules/Server/Sources/PocketCastsServer/Public/ApiSetting.swift#L4-L21

## To test

### Normal Sync
* Log in to the same account on two different devices or simulators
* Enable the `settingsSync` feature flag
* In General, change the "Open Links in Browser" (`openLinks`) and/or "Row Action" (`rowAction`) settings
* Go back to Profile
* Pull to refresh
* Refresh on the other device
* Verify that settings sync *You may need to give the server a few seconds to catch up. I didn't always see the latest result returned immediately.*

### Conflicting Sync
* Enable the `settingsSync` feature flag
* Change the "Open Links in Browser" on one device.
* Before syncing/refreshing, change "Row Action" on the other device
* Pull to refresh on the "Open Links in Browser" device
* Pull to refresh on the "Row Action" device
* The "Row Action" device should reflect _both_ changes. The "Open Links in Browser" device shouldn't until you re-sync again.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
