### PR TITLE
[Slumber] Add Feature Flag

### DIFF
--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -281,7 +281,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             Constants.RemoteParams.patronCloudStorageGB: NSNumber(value: Constants.RemoteParams.patronCloudStorageGBDefault),
             Constants.RemoteParams.addMissingEpisodes: NSNumber(value: Constants.RemoteParams.addMissingEpisodesDefault),
             Constants.RemoteParams.newPlayerTransition: NSNumber(value: Constants.RemoteParams.newPlayerTransitionDefault),
-            Constants.RemoteParams.errorLogoutHandling: NSNumber(value: Constants.RemoteParams.errorLogoutHandlingDefault)
+            Constants.RemoteParams.errorLogoutHandling: NSNumber(value: Constants.RemoteParams.errorLogoutHandlingDefault),
+            Constants.RemoteParams.slumberStudiosPromoCode: NSString(string: Constants.RemoteParams.slumberStudiosPromoCodeDefault)
         ])
 
         remoteConfig.fetch(withExpirationDuration: 2.hour) { [weak self] status, _ in
@@ -311,6 +312,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             }
 
             SyncManager.shouldUseNewSync = FeatureFlag.settingsSync.enabled
+
+            try FeatureFlagOverrideStore().override(FeatureFlag.slumber, withValue: Settings.slumberPromoCode?.isEmpty == false)
 
             // If the flag is off and we're turning it on we won't have the product info yet so we'll ask for them again
             IAPHelper.shared.requestProductInfoIfNeeded()

--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -282,6 +282,9 @@ struct Constants {
 
         static let errorLogoutHandling = "error_logout_handling"
         static let errorLogoutHandlingDefault: Bool = false
+
+        static let slumberStudiosPromoCode = "slumber_studios_promo_code"
+        static let slumberStudiosPromoCodeDefault = ""
     }
 
     static let defaultDebounceTime: TimeInterval = 0.5

--- a/podcasts/FeatureFlag.swift
+++ b/podcasts/FeatureFlag.swift
@@ -60,7 +60,7 @@ enum FeatureFlag: String, CaseIterable {
         case .settingsSync:
             false
         case .slumber:
-            true
+            false
         }
     }
 }

--- a/podcasts/FeatureFlag.swift
+++ b/podcasts/FeatureFlag.swift
@@ -28,6 +28,9 @@ enum FeatureFlag: String, CaseIterable {
     /// Syncing all app and podcast settings
     case settingsSync
 
+    /// Show the modal about the partnership with Slumber Studios
+    case slumber
+
     var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -56,6 +59,8 @@ enum FeatureFlag: String, CaseIterable {
             false
         case .settingsSync:
             false
+        case .slumber:
+            true
         }
     }
 }

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -903,7 +903,7 @@ class Settings: NSObject {
         }
 
     static var slumberPromoCode: String? {
-        return RemoteConfig.remoteConfig().configValue(forKey: Constants.RemoteParams.slumberStudiosPromoCode).stringValue
+        RemoteConfig.remoteConfig().configValue(forKey: Constants.RemoteParams.slumberStudiosPromoCode).stringValue
     }
 
         private class func remoteMsToTime(key: String) -> TimeInterval {

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -902,6 +902,10 @@ class Settings: NSObject {
             return RemoteConfig.remoteConfig().configValue(forKey: Constants.RemoteParams.errorLogoutHandling).boolValue
         }
 
+    static var slumberPromoCode: String? {
+        return RemoteConfig.remoteConfig().configValue(forKey: Constants.RemoteParams.slumberStudiosPromoCode).stringValue
+    }
+
         private class func remoteMsToTime(key: String) -> TimeInterval {
             let remoteMs = RemoteConfig.remoteConfig().configValue(forKey: key)
 


### PR DESCRIPTION
Add Feature Flag (local and remote) for Slumber.

## To test

1. Go to `AppDelegate.swift` and change `2.hour` to `30.seconds`
2. Comment the line `314` (it's from another PR and it's failing the build)
3. Remove the `#if` macro inside `updateRemoteFeatureFlags`
4. Run the app
5. Go to Profile > Settings > Beta Features
6. ✅ `slumber` should be **enabled**
7. Go to Firebase Console
8. Change `slumber_studios_promo_code` to be empty and publish changes
9. Re-run the app
10. Go to Profile > Settings > Beta Features
6. ✅ `slumber` should be **disabled**
7. On Firebase, restore the previous value of `slumber_studios_promo_code` and publish it

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
