### PR TITLE
Fix `SyncManager` variable name in non-debug builds

### DIFF
--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -310,7 +310,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 try FeatureFlagOverrideStore().override(FeatureFlag.errorLogoutHandling, withValue: Settings.errorLogoutHandling)
             }
 
-            SyncManager.shouldUseNewSync = FeatureFlag.settingsSync.enabled
+            SyncManager.shouldUseNewSettingsSync = FeatureFlag.settingsSync.enabled
 
             // If the flag is off and we're turning it on we won't have the product info yet so we'll ask for them again
             IAPHelper.shared.requestProductInfoIfNeeded()


### PR DESCRIPTION
Fixes `SyncManager.shouldUseNewSettingsSync` variable name issue in `AppDelegate`

## To test

* Build & Run Release scheme
* Ensure that project compiles

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
