### PR TITLE
Additional pipeline job for running release builds

### DIFF
--- a/.buildkite/commands/build.sh
+++ b/.buildkite/commands/build.sh
@@ -32,5 +32,15 @@ install_gems # see bash-cache Automattic's Buildkite plugin
 echo "--- Install Pods"
 install_cocoapods # see bash-cache Automattic's Buildkite plugin
 
-echo "--- Build & Test"
-bundle exec fastlane test
+# If a build configuration is provided, we'll add build that config without testing
+if [ $# -eq 1 ]; then
+  echo "--- :closed_lock_with_key: Installing Secrets"
+  bundle exec fastlane run configure_apply
+
+  echo "--- Build $1 without test"
+  bundle exec fastlane build configuration:$1
+else
+  echo "--- Build & Test"
+  bundle exec fastlane test
+fi
+

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -18,6 +18,12 @@ steps:
     env: *common_env
     plugins: *common_plugins
 
+  - label: Build Release
+    command: .buildkite/commands/build.sh "Release"
+    agents: *common_agents
+    env: *common_env
+    plugins: *common_plugins
+
   - group: "Linters"
     steps:
       - label: ":swift: SwiftLint"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -129,7 +129,7 @@ platform :ios do
   ENV['FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT'] = '120'
 
   desc 'Run the unit tests'
-  lane :test do |options|
+  lane :test do
     run_tests(
       scheme: SCHEME
     )
@@ -139,11 +139,11 @@ platform :ios do
   lane :build do |options|
     configure_code_signing
 
-    CONFIGURATION = options[:configuration]
-    if CONFIGURATION
+    configuration = options[:configuration]
+    if configuration
       build_app(
         scheme: SCHEME,
-        configuration: CONFIGURATION,
+        configuration: configuration,
         include_bitcode: false,
         export_method: 'app-store'
       )

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -129,10 +129,30 @@ platform :ios do
   ENV['FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT'] = '120'
 
   desc 'Run the unit tests'
-  lane :test do
+  lane :test do |options|
     run_tests(
       scheme: SCHEME
     )
+  end
+
+  desc 'Build a given (or default) configuration'
+  lane :build do |options|
+    configure_code_signing
+
+    CONFIGURATION = options[:configuration]
+    if CONFIGURATION
+      build_app(
+        scheme: SCHEME,
+        configuration: CONFIGURATION,
+        include_bitcode: false,
+        export_method: 'app-store'
+      )
+    else
+      build_app(
+        scheme: SCHEME,
+        include_bitcode: false
+      )
+    end
   end
 
   desc 'This lane downloads and configures the code signing certificates and profiles.'


### PR DESCRIPTION
This compiles the Release configuration and produces an (unused) IPA file as a result.

## Background

Last week I added a variable which was used inside of an ifdef expression dependent on the DEBUG flag being false and required a follow-up fix (https://github.com/Automattic/pocket-casts-ios/pull/1413).

https://github.com/Automattic/pocket-casts-ios/blob/c795e4025756319d80991fca1cbc06f4dfb94286/podcasts/AppDelegate.swift#L312

The CI jobs all passed successfully and I failed to test the Release configuration locally. Since we have about 6 places where the DEBUG flag is checked, I thought it would be useful to update CI to compile this configuration.

## Q&A

**Should this produce an IPA or is that unnecessary?**
I'm not sure it adds much to the build process so I just left it with default behavior.

**Should the Fastlane lanes for building this job and building the release build (`build_and_upload_app_store_connect`) be combined?**
I didn't think so because the lane includes symbols and other things which probably aren't necessary.

**Should the produced IPA be made available in Buildkite's Artifacts?**
I don't know that it's particularly useful since it isn't signed for ad-hoc installation.

## To test

🟢 CI should be green
* CI Build should include new job for building Release configuration

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.