### PR TITLE
Build Environment runtime DEBUG check

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/General/BuildEnvironment.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/General/BuildEnvironment.swift
@@ -15,6 +15,14 @@ public enum BuildEnvironment {
     /// Returns the `BuildEnvironment` for the current build
     public static var current: BuildEnvironment = .determineCurrentEnvironment
 
+    public var hasDebugFlag: Bool {
+        #if DEBUG
+        return true
+        #else
+        return false
+        #endif
+    }
+
     /// Determines the current environment by:
     /// - If the DEBUG or STAGING preprocessor macros are set, return `.debug`
     /// - If the `appStoreReceiptURL` is `sandboxReceipt` return `.beta`

--- a/Modules/Utils/Sources/PocketCastsUtils/General/BuildEnvironment.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/General/BuildEnvironment.swift
@@ -15,14 +15,6 @@ public enum BuildEnvironment {
     /// Returns the `BuildEnvironment` for the current build
     public static var current: BuildEnvironment = .determineCurrentEnvironment
 
-    public var hasDebugFlag: Bool {
-        #if DEBUG
-        return true
-        #else
-        return false
-        #endif
-    }
-
     /// Determines the current environment by:
     /// - If the DEBUG or STAGING preprocessor macros are set, return `.debug`
     /// - If the `appStoreReceiptURL` is `sandboxReceipt` return `.beta`

--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -296,7 +296,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     private func updateRemoteFeatureFlags() {
-        #if !DEBUG
+        guard !BuildEnvironment.current.hasDebugFlag else { return }
         do {
             if FeatureFlag.newPlayerTransition.enabled != Settings.newPlayerTransition {
                 // If the player transition changes we dismiss the full screen player
@@ -317,7 +317,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         } catch {
             FileLog.shared.addMessage("Failed to set remote feature flag: \(error)")
         }
-        #endif
     }
 
     private func updateEndOfYearRemoteValue() {

--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -296,7 +296,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     private func updateRemoteFeatureFlags() {
-        guard !BuildEnvironment.current.hasDebugFlag else { return }
+        guard BuildEnvironment.current != .debug else { return }
         do {
             if FeatureFlag.newPlayerTransition.enabled != Settings.newPlayerTransition {
                 // If the player transition changes we dismiss the full screen player


### PR DESCRIPTION
* Adds a `hasDebugFlag` check for specifically checking for `DEBUG` builds
* Replaces `#if !DEBUG` compile-time check in `AppDelegate` with this runtime check

## To test

🟢 CI passes
* Build and run the app in Debug and Release configurations

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
