### PR TITLE
Fix SwiftLint strict error

### DIFF
--- a/Modules/Utils/Tests/PocketCastsUtilsTests/ModifiedDateTests.swift
+++ b/Modules/Utils/Tests/PocketCastsUtilsTests/ModifiedDateTests.swift
@@ -15,7 +15,7 @@ class ModifiedDateTests: XCTestCase {
         XCTAssertNil(test.$name.modifiedAt, "Initial Modified Date should be nil")
         XCTAssertEqual(test.name, initialName, "Initial Value should be \(initialName)")
     }
-    
+
     /// Tests the `modifiedAt` update when changing value
     func testModifiedDate() throws {
         var test = TestType(name: initialName)


### PR DESCRIPTION
* Fixes a strict SwiftLint error with `ModifiedDateTests`. 

## To test

🟢 CI should be green

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
