### PR TITLE
Improves large text size support and animations on the upgrade views

### DIFF
--- a/podcasts/Onboarding/Plus/FeaturesCarousel.swift
+++ b/podcasts/Onboarding/Plus/FeaturesCarousel.swift
@@ -36,6 +36,7 @@ struct FeaturesCarousel: View {
                         }
                     }
                 )
+                .frame(height: calculatedCardHeight, alignment: .top)
         }
         .carouselPeekAmount(.constant(tiers.count > 1 ? ViewConstants.peekAmount : 0))
         .carouselItemSpacing(ViewConstants.spacing)

--- a/podcasts/Onboarding/Plus/FeaturesCarousel.swift
+++ b/podcasts/Onboarding/Plus/FeaturesCarousel.swift
@@ -40,7 +40,8 @@ struct FeaturesCarousel: View {
         .carouselPeekAmount(.constant(tiers.count > 1 ? ViewConstants.peekAmount : 0))
         .carouselItemSpacing(ViewConstants.spacing)
         .carouselScrollEnabled(tiers.count > 1)
-        .frame(height: calculatedCardHeight)
+        // Prevent the view from snapping on smaller screens if the height changes
+        .frame(height: UIScreen.isSmallScreen ? nil : calculatedCardHeight, alignment: .top)
         .padding(.leading, 30)
     }
 

--- a/podcasts/Onboarding/Plus/FeaturesCarousel.swift
+++ b/podcasts/Onboarding/Plus/FeaturesCarousel.swift
@@ -12,6 +12,7 @@ struct FeaturesCarousel: View {
     let showInlinePurchaseButton: Bool
 
     @State var calculatedCardHeight: CGFloat?
+    @State var calculatedCardMaxHeight: CGFloat?
 
     var body: some View {
         // Store the calculated card heights
@@ -30,19 +31,23 @@ struct FeaturesCarousel: View {
                             if cardHeights.count == tiers.count {
                                 calculatedCardHeight = cardHeights.max()
 
+                                if (calculatedCardHeight ?? 0) > (calculatedCardMaxHeight ?? 0) {
+                                    calculatedCardMaxHeight = calculatedCardHeight
+                                }
+
                                 // Reset the card heights so any view changes won't use old data
                                 cardHeights = []
                             }
                         }
                     }
                 )
-                .frame(height: calculatedCardHeight, alignment: .top)
+                .frame(maxHeight: calculatedCardHeight, alignment: .top)
         }
         .carouselPeekAmount(.constant(tiers.count > 1 ? ViewConstants.peekAmount : 0))
         .carouselItemSpacing(ViewConstants.spacing)
         .carouselScrollEnabled(tiers.count > 1)
-        // Prevent the view from snapping on smaller screens if the height changes
-        .frame(height: UIScreen.isSmallScreen ? nil : calculatedCardHeight, alignment: .top)
+        // Maintain the largest height
+        .frame(height: calculatedCardMaxHeight, alignment: .top)
         .padding(.leading, 30)
     }
 

--- a/podcasts/Onboarding/Plus/SubscriptionPriceAndOfferView.swift
+++ b/podcasts/Onboarding/Plus/SubscriptionPriceAndOfferView.swift
@@ -19,6 +19,9 @@ struct SubscriptionPriceAndOfferView: View {
         VStack(alignment: .leading, spacing: 10) {
             OfferStack {
                 SubscriptionBadge(tier: product.identifier.subscriptionTier)
+                    // Prevent the badge from changing position after swiping
+                    .transition(.identity.animation(.none))
+                    .id("sub_badge_" + product.identifier.rawValue)
 
                 if let offerDescription = offerDescription(for: product) {
                     Text(offerDescription)

--- a/podcasts/Onboarding/Plus/SubscriptionPriceAndOfferView.swift
+++ b/podcasts/Onboarding/Plus/SubscriptionPriceAndOfferView.swift
@@ -19,7 +19,6 @@ struct SubscriptionPriceAndOfferView: View {
         VStack(alignment: .leading, spacing: 10) {
             OfferStack {
                 SubscriptionBadge(tier: product.identifier.subscriptionTier)
-                    // Prevent the badge from changing position after swiping
                     .transition(.identity.animation(.none))
                     .id("sub_badge_" + product.identifier.rawValue)
 

--- a/podcasts/Onboarding/Plus/SubscriptionPriceAndOfferView.swift
+++ b/podcasts/Onboarding/Plus/SubscriptionPriceAndOfferView.swift
@@ -34,7 +34,6 @@ struct SubscriptionPriceAndOfferView: View {
             }
 
             Text(price(for: product))
-                .minimumScaleFactor(0.8)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.bottom, 12)
@@ -43,8 +42,8 @@ struct SubscriptionPriceAndOfferView: View {
     private func price(for subscriptionInfo: ProductInfo) -> AttributedString {
         let subscriptionPeriod = subscriptionInfo.identifier.productInfo.frequency.description
 
-        let priceFont = UIFont.font(with: .headline, maxSizeCategory: .accessibilityLarge)
-        let periodFont = UIFont.font(with: .footnote, maxSizeCategory: .accessibilityLarge)
+        let priceFont = UIFont.font(with: .headline, maxSizeCategory: .extraExtraExtraLarge)
+        let periodFont = UIFont.font(with: .footnote, maxSizeCategory: .extraExtraExtraLarge)
 
         // Only show the offer price for the intro discount
         guard let offer = subscriptionInfo.offer, offer.type == .discount else {

--- a/podcasts/Onboarding/Plus/SubscriptionPriceAndOfferView.swift
+++ b/podcasts/Onboarding/Plus/SubscriptionPriceAndOfferView.swift
@@ -32,6 +32,7 @@ struct SubscriptionPriceAndOfferView: View {
             }
 
             Text(price(for: product))
+                .minimumScaleFactor(0.8)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.bottom, 12)
@@ -40,8 +41,8 @@ struct SubscriptionPriceAndOfferView: View {
     private func price(for subscriptionInfo: ProductInfo) -> AttributedString {
         let subscriptionPeriod = subscriptionInfo.identifier.productInfo.frequency.description
 
-        let priceFont = UIFont.font(with: .headline, maxSizeCategory: .accessibilityExtraLarge)
-        let periodFont = UIFont.font(with: .footnote, maxSizeCategory: .accessibilityExtraLarge)
+        let priceFont = UIFont.font(with: .headline, maxSizeCategory: .accessibilityLarge)
+        let periodFont = UIFont.font(with: .footnote, maxSizeCategory: .accessibilityLarge)
 
         // Only show the offer price for the intro discount
         guard let offer = subscriptionInfo.offer, offer.type == .discount else {

--- a/podcasts/Onboarding/Plus/SubscriptionPriceAndOfferView.swift
+++ b/podcasts/Onboarding/Plus/SubscriptionPriceAndOfferView.swift
@@ -17,21 +17,21 @@ struct SubscriptionPriceAndOfferView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
-            SubscriptionBadge(tier: product.identifier.subscriptionTier)
-            if let offerDescription = offerDescription(for: product) {
-                Text(offerDescription)
-                    .lineLimit(1)
-                    .fixedSize(horizontal: true, vertical: false)
-                    .foregroundColor(product.identifier.plan == .plus ? Color.black : Color.white)
-                    .padding(EdgeInsets(top: 5, leading: 8, bottom: 5, trailing: 8))
-                    .background(product.identifier.plan == .plus ? Color.plusBackgroundColor2 : Color.patronBackgroundColor)
-                    .textCase(.uppercase)
-                    .font(style: .caption2, weight: .semibold)
-                    .clipShape(.capsule)
-                    .transition(.scale)
-            }
-            Text(price(for: product))
+            OfferStack {
+                SubscriptionBadge(tier: product.identifier.subscriptionTier)
 
+                if let offerDescription = offerDescription(for: product) {
+                    Text(offerDescription)
+                        .foregroundColor(product.identifier.plan == .plus ? Color.black : Color.white)
+                        .padding(EdgeInsets(top: 5, leading: 8, bottom: 5, trailing: 8))
+                        .background(product.identifier.plan == .plus ? Color.plusBackgroundColor2 : Color.patronBackgroundColor)
+                        .textCase(.uppercase)
+                        .font(style: .caption2, weight: .semibold)
+                        .clipShape(.capsule)
+                }
+            }
+
+            Text(price(for: product))
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.bottom, 12)

--- a/podcasts/Onboarding/Plus/SubscriptionPriceAndOfferView.swift
+++ b/podcasts/Onboarding/Plus/SubscriptionPriceAndOfferView.swift
@@ -89,6 +89,29 @@ struct SubscriptionPriceAndOfferView: View {
     }
 }
 
+/// Switches between an HStack and VStack on iOS 16, and defaults to a VStack below
+private struct OfferStack<Content: View>: View {
+    @ViewBuilder let content: () -> Content
+
+    var body: some View {
+        if #available(iOS 16.0, *) {
+            ViewThatFits(in: .horizontal) {
+                HStack(spacing: 10) {
+                    content()
+                }
+
+                VStack(alignment: .leading, spacing: 10) {
+                    content()
+                }
+            }
+        } else {
+            VStack(alignment: .leading, spacing: 10) {
+                content()
+            }
+        }
+    }
+}
+
 #Preview {
     SubscriptionPriceAndOfferView(product: PlusPricingInfoModel.PlusProductPricingInfo(identifier: .monthly, price: "9.99", rawPrice: "9.99", offer: nil), mainTextColor: .black, secondaryTextColor: .gray)
 }

--- a/podcasts/Onboarding/Plus/SubscriptionPriceAndOfferView.swift
+++ b/podcasts/Onboarding/Plus/SubscriptionPriceAndOfferView.swift
@@ -40,42 +40,33 @@ struct SubscriptionPriceAndOfferView: View {
     private func price(for subscriptionInfo: ProductInfo) -> AttributedString {
         let subscriptionPeriod = subscriptionInfo.identifier.productInfo.frequency.description
 
-        guard let offer = subscriptionInfo.offer else {
+        let priceFont = UIFont.font(with: .headline, maxSizeCategory: .accessibilityExtraLarge)
+        let periodFont = UIFont.font(with: .footnote, maxSizeCategory: .accessibilityExtraLarge)
+
+        // Only show the offer price for the intro discount
+        guard let offer = subscriptionInfo.offer, offer.type == .discount else {
             var basePrice =  AttributedString(subscriptionInfo.rawPrice)
-            basePrice.font = .headline
+            basePrice.font = priceFont
             basePrice.foregroundColor = mainTextColor
 
             var basePeriod = AttributedString("/ \(subscriptionPeriod)")
             basePeriod.foregroundColor = secondaryTextColor
-            basePeriod.font = .footnote
-
-            return basePrice + basePeriod
-        }
-
-
-        if offer.type == .freeTrial {
-            var basePrice =  AttributedString(subscriptionInfo.rawPrice)
-            basePrice.font = .headline
-            basePrice.foregroundColor = mainTextColor
-
-            var basePeriod = AttributedString("/ \(subscriptionPeriod)")
-            basePeriod.foregroundColor = secondaryTextColor
-            basePeriod.font = .footnote
+            basePeriod.font = periodFont
 
             return basePrice + basePeriod
         }
 
         var offerPrice = AttributedString(offer.price)
         offerPrice.foregroundColor = mainTextColor
-        offerPrice.font = .headline
+        offerPrice.font = priceFont
 
         var offerPeriod = AttributedString(" /\(subscriptionPeriod)  ")
         offerPeriod.foregroundColor = secondaryTextColor
-        offerPeriod.font = .footnote
+        offerPeriod.font = periodFont
 
         var basePrice = AttributedString("\(offer.rawPrice)/ \(subscriptionPeriod)")
         basePrice.foregroundColor = secondaryTextColor
-        basePrice.font = .footnote
+        basePrice.font = periodFont
         basePrice.strikethroughStyle = .single
 
         return offerPrice + offerPeriod + basePrice

--- a/podcasts/Onboarding/Plus/SubscriptionPriceAndOfferView.swift
+++ b/podcasts/Onboarding/Plus/SubscriptionPriceAndOfferView.swift
@@ -33,6 +33,7 @@ struct SubscriptionPriceAndOfferView: View {
             Text(price(for: product))
 
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.bottom, 12)
     }
 

--- a/podcasts/Onboarding/Plus/UpgradeCard.swift
+++ b/podcasts/Onboarding/Plus/UpgradeCard.swift
@@ -66,8 +66,6 @@ struct UpgradeCard: View {
 
     let showPurchaseButton: Bool
 
-    @State var calculatedCardHeight: CGFloat?
-
     var body: some View {
         VStack {
             VStack(alignment: .leading, spacing: 0) {


### PR DESCRIPTION
| Depends on: https://github.com/Automattic/pocket-casts-ios/pull/1410 |
|:---|

This adds a view that on iOS 16 will layout the Badge + Offer in an HStack or VStack depending on which will fit, and falls back to a VStack on iOS 15, and fixes the following issues:

### 1. The price labels would truncate at larger font sizes

<details>
  <summary><strong>📸 Screenshots</strong></summary>

| Upgrade View Before | After |
|:---:|:---:|
|<img src="https://github.com/Automattic/pocket-casts-ios/assets/793774/8f07f8b6-4786-46b4-823d-c4c0fe9d1855" height="300" />|<img src="https://github.com/Automattic/pocket-casts-ios/assets/793774/80b37bea-c2b6-4753-b8de-f459474ab848" height="300" />|

| Account View Before | After |
|:---:|:---:|
|<img src="https://github.com/Automattic/pocket-casts-ios/assets/793774/bd98d8c8-9b97-4bca-bf34-e4460fa3a18c" height="300" />|<img src="https://github.com/Automattic/pocket-casts-ios/assets/793774/f0270572-7e10-43fa-95bd-5af448a8d468" height="300" />|

</details>

### 2. If the offer label is too long on smaller screens the upgrade UI would break

<details>
  <summary><strong>📸 Screenshots</strong></summary>

This truncates on purpose to avoid breaking the ui further. 

| Before | After |
|:---:|:---:|
|<img src="https://github.com/Automattic/pocket-casts-ios/assets/793774/ceb1a952-b027-4b81-a53c-130798c72e03" height="300" />|<img src="https://github.com/Automattic/pocket-casts-ios/assets/793774/fedca9c2-d29c-4d52-9011-1666eb94ff99" height="300" />|

</details>

### 3. When switching between yearly with an offer and monthly without an offer the views would jump.

<details>
  <summary><strong>🎥 Before</strong></summary>
  
https://github.com/Automattic/pocket-casts-ios/assets/793774/be8bb68e-8181-4f9c-8d5c-9ddd34be837d
  
</details>

<details>
  <summary><strong>🎥 After</strong></summary>

https://github.com/Automattic/pocket-casts-ios/assets/793774/914f1f56-5d68-47ef-b59e-69de49506197

</details>


## To test

### The price labels would truncate at larger font sizes
1. Open Settings > Accessibility > Display and Font Sizes > Enable Larger Font Sizes > Increase to the Max
2. Launch the app
3. Sign into an account without a subscription
4. Go to Profile Tab > Locked Folders Icon
5. ✅ Verify the price label is visible and not clipped
6. Repeat the test on the iPhone SE

### If the offer label is too long on smaller screens the upgrade UI would break
1. Open `SubscriptionPriceAndOfferView.swift` and change line 87 to `return  "50 % de réduction sur votre première année"` (this is a rough translation of the english string is french using Google Translate)
2. Launch the app on the iPhone SE
3. Sign into an account without a subscription
4. Go to Profile Tab > Locked Folders Icon
5. ✅ Verify the offer label is truncated, but the cards are correct

### When switching between yearly with an offer and monthly without an offer the views would jump.
1. Enable the StoreKit Configuration option in the Scheme Editor
2. Update it so only Plus yearly has an offer
3. Launch the app on the iPhone 15 Pro
4. Sign into an account without a subscription
5. Go to Profile Tab > Locked Folders Icon
6. Switch to Monthly
7. ✅ Verify offer disappears and only the plus card changes size and no other UI elements move
8. Swipe to the Patron card
9. Toggle the Monthly / Yearly
10. ✅ Verify it does move
11. Repeat the steps on the iPhone SE running iOS 15


## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
