### PR TITLE
File Size Sometimes Showing As "0 Bytes" #1044

### DIFF
--- a/podcasts/EpisodeDetailViewController+Actions.swift
+++ b/podcasts/EpisodeDetailViewController+Actions.swift
@@ -96,7 +96,7 @@ extension EpisodeDetailViewController {
             downloadBtn.accessibilityLabel = L10n.cancelDownload
         } else {
             downloadBtn.setImage(UIImage(named: "episode-download"), for: .normal)
-            let sizeAsStr = SizeFormatter.shared.noDecimalFormat(bytes: episode.sizeInBytes)
+            let sizeAsStr = episode.sizeInBytes == 0 ? "" : SizeFormatter.shared.noDecimalFormat(bytes: episode.sizeInBytes)
             downloadBtn.setTitle(sizeAsStr == "" ? L10n.download : sizeAsStr, for: .normal)
             downloadBtn.accessibilityLabel = L10n.download
         }


### PR DESCRIPTION
## Fixes

Fixes "0 bytes" label appearing on episodes where the length (from the podcast feed) is "0 bytes"

Example feed:
`<enclosure url="https://pdst.fm/e/chtbl.com/track/18BF3D/traffic.megaphone.fm/IWTYB5494925374.mp3?updated=1692064471" length="0" type="audio/mpeg"/>`
## Changes

Added a condition to display "Download" instead of "0 bytes" when the size is unknown before downloading.

## To test

Search for this podcast: https://pca.st/exftsotu

Tap on an episode's details
The file size will now display "Download" instead of "0 bytes":

<img width="356" alt="301597857-48ed7475-c714-46b5-945d-5f9fcce547c8" src="https://github.com/Automattic/pocket-casts-ios/assets/881441/20e084ca-dee3-486c-b2d7-569fff04eb58">

## Checklist

- [X ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [X ] I have considered adding unit tests for my changes.
- [X] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
