### PR TITLE
Fix for issue #1044: Show "Download" as button label when episode file size is unknown (aka, "0 bytes")

### DIFF
--- a/podcasts/EpisodeDetailViewController+Actions.swift
+++ b/podcasts/EpisodeDetailViewController+Actions.swift
@@ -96,9 +96,9 @@ extension EpisodeDetailViewController {
             downloadBtn.accessibilityLabel = L10n.cancelDownload
         } else {
             downloadBtn.setImage(UIImage(named: "episode-download"), for: .normal)
-            let sizeAsStr = SizeFormatter.shared.noDecimalFormat(bytes: episode.sizeInBytes)
-            downloadBtn.setTitle(sizeAsStr == "" ? L10n.download : sizeAsStr, for: .normal)
-            downloadBtn.accessibilityLabel = L10n.download
+            let buttonTitle = episode.sizeInBytes == 0 ? L10n.download : SizeFormatter.shared.noDecimalFormat(bytes: episode.sizeInBytes)
+            downloadBtn.setTitle(buttonTitle, for: .normal)
+            downloadBtn.accessibilityLabel = (episode.sizeInBytes != 0) ? L10n.download : nil
         }
 
         upNextBtn.setTitle(L10n.upNext, for: .normal)

--- a/podcasts/EpisodeDetailViewController+Actions.swift
+++ b/podcasts/EpisodeDetailViewController+Actions.swift
@@ -98,7 +98,7 @@ extension EpisodeDetailViewController {
             downloadBtn.setImage(UIImage(named: "episode-download"), for: .normal)
             let buttonTitle = episode.sizeInBytes == 0 ? L10n.download : SizeFormatter.shared.noDecimalFormat(bytes: episode.sizeInBytes)
             downloadBtn.setTitle(buttonTitle, for: .normal)
-            downloadBtn.accessibilityLabel = (episode.sizeInBytes != 0) ? L10n.download : nil
+            downloadBtn.accessibilityLabel = L10n.download
         }
 
         upNextBtn.setTitle(L10n.upNext, for: .normal)


### PR DESCRIPTION
Fixes issue #1044 where the download button label would read "0 Bytes" on the episode details screen. This fix changes the label to "Download" when the episode file size is unknown. If file size is known, it'll show the file size (e.g., "86.6 MB"), same behavior as before.

![1044-zero-bytes-download-btn](https://github.com/Automattic/pocket-casts-ios/assets/2607653/5ba60f40-ee12-46c2-b943-2249f3d9b17e)

## To test with podcast: I Will Teach You To Be Rich

1. Open this podcast: https://pca.st/podcast/02821bb0-cdfb-0139-9b2a-0acc26574db2 
2. Tap **Subscribe** on the podcast page
3. Tap the first episode
4. ✅ Confirm the leading button label reads "86.6 MB" (or other file size) 
![Screenshot 2024-02-11 at 15 55 39@2x](https://github.com/Automattic/pocket-casts-ios/assets/2607653/c273abc0-debb-45e3-9225-1c5ac481b196)
6. Dismiss the episode details screen
7. Tap the _second_ episode in the list
8. ✅ Confirm the leading button label reads "Download"
![Screenshot 2024-02-11 at 15 55 56@2x](https://github.com/Automattic/pocket-casts-ios/assets/2607653/70150e19-33b1-4863-93f6-e1f34a35da78)
10. Tap the **Download** button
11. ✅ Confirm download progress spinner and completed download button states display correctly.
![Screenshot 2024-02-11 at 15 56 18@2x](https://github.com/Automattic/pocket-casts-ios/assets/2607653/41a416c3-1c31-493d-bfb6-ffcfe1ba21fe)
![Screenshot 2024-02-11 at 15 56 31@2x](https://github.com/Automattic/pocket-casts-ios/assets/2607653/c067e5af-e6df-4510-a284-e08b46b3c61f)

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
