### PR TITLE
Settings sync: Podcast Custom Effects Settings

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/PodcastDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/PodcastDataManager.swift
@@ -58,7 +58,8 @@ class PodcastDataManager {
         "fullSyncLastSyncAt",
         "showArchived",
         "refreshAvailable",
-        "folderUuid"
+        "folderUuid",
+        "settings"
     ]
 
     func setup(dbQueue: FMDatabaseQueue) {
@@ -583,6 +584,12 @@ class PodcastDataManager {
         values.append(podcast.showArchived)
         values.append(podcast.refreshAvailable)
         values.append(DBUtils.nullIfNil(value: podcast.folderUuid))
+
+        if let settingsData = podcast.settings.jsonData {
+            values.append(String(data: settingsData, encoding: .utf8) as Any)
+        } else {
+            FileLog.shared.addMessage("PodcastDataManager.createValuesFromPodcast: Failed to decode Podcast settings")
+        }
 
         if includeIdForWhere {
             values.append(podcast.id)

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseHelper.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseHelper.swift
@@ -656,6 +656,16 @@ class DatabaseHelper {
             }
         }
 
+        if schemaVersion < 43 {
+            do {
+                try db.executeUpdate("ALTER TABLE SJPodcast ADD COLUMN settings TEXT NOT NULL DEFAULT '';", values: nil)
+                schemaVersion = 43
+            } catch {
+                failedAt(43)
+                return
+            }
+        }
+
         db.commit()
     }
 }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/BaseEpisode.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/BaseEpisode.swift
@@ -49,7 +49,6 @@ import Foundation
     func played() -> Bool
     func unplayed() -> Bool
     func playbackError() -> Bool
-    func jumpToOnStart() -> TimeInterval
 
     // MARK: - Meta Data
 

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Episode.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Episode.swift
@@ -130,10 +130,6 @@ public class Episode: NSObject, BaseEpisode {
         podcastUuid
     }
 
-    public func jumpToOnStart() -> TimeInterval {
-        TimeInterval(parentPodcast()?.startFrom ?? 0)
-    }
-
     // MARK: - Meta
 
     @objc public func videoPodcast() -> Bool {

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Podcast+fromDatabase.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Podcast+fromDatabase.swift
@@ -1,4 +1,5 @@
 import Foundation
+import PocketCastsUtils
 import FMDB
 
 extension Podcast {
@@ -54,6 +55,24 @@ extension Podcast {
         podcast.refreshAvailable = rs.bool(forColumn: "refreshAvailable")
         podcast.folderUuid = rs.string(forColumn: "folderUuid")
 
+        if let settingsString = rs.string(forColumn: "settings") {
+            podcast.settings = DBUtils.convertData(value: settingsString.data(using: .utf8)) ?? podcast.settings
+        } else {
+            FileLog.shared.addMessage("Podcast fromResultSet: Nil settings column")
+        }
+
         return podcast
     }
 }
+
+extension DBUtils {
+    static func convertData<T: JSONCodable>(value: Data?) -> T? {
+        if let value {
+            return T.encodedObject(T.self, from: value)
+        } else {
+            return nil
+        }
+    }
+}
+
+extension ModifiedDate: JSONCodable {}

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Podcast.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Podcast.swift
@@ -1,4 +1,5 @@
 import Foundation
+import PocketCastsUtils
 
 public class Podcast: NSObject, Identifiable {
     @objc public var id = 0 as Int64
@@ -51,6 +52,8 @@ public class Podcast: NSObject, Identifiable {
     @objc public var refreshAvailable = false
     @objc public var folderUuid: String?
 
+    public var settings: PodcastSettings = PodcastSettings.defaults
+
     // transient not saved to database
     public var cachedUnreadCount = 0
 
@@ -93,3 +96,8 @@ public class Podcast: NSObject, Identifiable {
         return podcast
     }
 }
+
+public enum TrimSilenceAmount: Int32, Codable {
+    case off = 0, low = 3, medium = 5, high = 10
+}
+

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Podcast.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Podcast.swift
@@ -101,3 +101,8 @@ public enum TrimSilenceAmount: Int32, Codable {
     case off = 0, low = 3, medium = 5, high = 10
 }
 
+extension Podcast {
+    public override var debugDescription: String {
+        "Podcast: \(uuid) - \(title ?? "missing title")"
+    }
+}

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/PodcastSettings.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/PodcastSettings.swift
@@ -1,4 +1,14 @@
 import PocketCastsUtils
 
 public struct PodcastSettings: JSONCodable, Equatable {
+    @ModifiedDate public var customEffects: Bool = false
+
+    // Playback Effects
+    @ModifiedDate public var trimSilence: TrimSilenceAmount
+    @ModifiedDate public var boostVolume: Bool
+    @ModifiedDate public var playbackSpeed: Double
+
+    public static var defaults: Self {
+        return PodcastSettings(trimSilence: .off, boostVolume: false, playbackSpeed: 1)
+    }
 }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/PodcastSettings.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/PodcastSettings.swift
@@ -1,0 +1,4 @@
+import PocketCastsUtils
+
+public struct PodcastSettings: JSONCodable, Equatable {
+}

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/PodcastSettings.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/PodcastSettings.swift
@@ -3,6 +3,9 @@ import PocketCastsUtils
 public struct PodcastSettings: JSONCodable, Equatable {
     @ModifiedDate public var customEffects: Bool = false
 
+    @ModifiedDate public var autoStartFrom: Int32 = 0
+    @ModifiedDate public var autoSkipLast: Int32 = 0
+
     // Playback Effects
     @ModifiedDate public var trimSilence: TrimSilenceAmount
     @ModifiedDate public var boostVolume: Bool

--- a/Modules/Server/Sources/PocketCastsServer/Public/ApiSetting.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/ApiSetting.swift
@@ -16,6 +16,8 @@ protocol ApiReturnValue {
 
 extension Api_BoolSetting: ApiSetting {}
 extension Api_Int32Setting: ApiSetting {}
+extension Api_DoubleSetting: ApiSetting {}
 
 extension Google_Protobuf_BoolValue: ApiReturnValue { }
 extension Google_Protobuf_Int32Value: ApiReturnValue { }
+extension Google_Protobuf_DoubleValue: ApiReturnValue { }

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
@@ -1,4 +1,5 @@
 import Foundation
+import PocketCastsDataModel
 
 public struct ImportOpmlResponse: Decodable {
     public var status: String? = nil
@@ -220,6 +221,7 @@ public struct PodcastSyncInfo {
     var dateAdded: Date?
     var sortPosition: Int32?
     var folderUuid: String?
+    var settings: PodcastSettings?
 }
 
 public struct FolderSyncInfo {

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+FullSync.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+FullSync.swift
@@ -99,6 +99,10 @@ extension SyncTask {
                 localPodcast.sortOrder = sortOrder
             }
 
+            if let settings = podcast.settings {
+                self.processSettings(settings, to: localPodcast)
+            }
+
             // now grab the sync info for the episodes
             let retrieveEpisodesTask = RetrieveEpisodesTask(podcastUuid: uuid)
             retrieveEpisodesTask.completion = { episodes in
@@ -164,5 +168,12 @@ private extension BookmarkDataManager {
         }
 
         return await permanentlyDelete(bookmarks: [bookmark])
+    }
+}
+
+// MARK: - Settings
+
+private extension SyncTask {
+    func processSettings(_ settings: PodcastSettings, to podcast: Podcast) {
     }
 }

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+FullSync.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+FullSync.swift
@@ -176,6 +176,8 @@ private extension BookmarkDataManager {
 private extension SyncTask {
     func processSettings(_ settings: PodcastSettings, to podcast: Podcast) {
         podcast.settings.$customEffects = settings.$customEffects
+        podcast.settings.$autoStartFrom = settings.$autoStartFrom
+        podcast.settings.$autoSkipLast = settings.$autoSkipLast
         podcast.settings.$trimSilence = settings.$trimSilence
         podcast.settings.$playbackSpeed = settings.$playbackSpeed
         podcast.settings.$boostVolume = settings.$boostVolume

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+FullSync.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+FullSync.swift
@@ -175,5 +175,9 @@ private extension BookmarkDataManager {
 
 private extension SyncTask {
     func processSettings(_ settings: PodcastSettings, to podcast: Podcast) {
+        podcast.settings.$customEffects = settings.$customEffects
+        podcast.settings.$trimSilence = settings.$trimSilence
+        podcast.settings.$playbackSpeed = settings.$playbackSpeed
+        podcast.settings.$boostVolume = settings.$boostVolume
     }
 }

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+LocalChanges.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+LocalChanges.swift
@@ -17,6 +17,7 @@ extension SyncTask {
             podcastRecord.isDeleted.value = !podcast.isSubscribed()
             podcastRecord.subscribed.value = podcast.isSubscribed()
             podcastRecord.sortPosition.value = podcast.sortOrder
+            podcastRecord.settings = podcast.apiSettings
 
             // There's a bug on the watch app that resets all users folders
             // Since the watch don't use folders at all, it shouldn't sync
@@ -206,6 +207,15 @@ private extension Api_SyncUserBookmark {
 
         self.title.value = bookmark.title
         self.titleModified = .init(date: bookmark.titleModified ?? bookmark.created)
+    }
+}
+
+// MARK: Settings Sync
+
+private extension Podcast {
+    var apiSettings: Api_PodcastSettings {
+        var settings = Api_PodcastSettings()
+        return settings
     }
 }
 

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+LocalChanges.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+LocalChanges.swift
@@ -215,6 +215,10 @@ private extension Api_SyncUserBookmark {
 private extension Podcast {
     var apiSettings: Api_PodcastSettings {
         var settings = Api_PodcastSettings()
+        settings.playbackEffects.update(self.settings.$customEffects)
+        settings.playbackSpeed.update(self.settings.$playbackSpeed)
+        settings.trimSilence.update(self.settings.$trimSilence)
+        settings.volumeBoost.update(self.settings.$boostVolume)
         return settings
     }
 }

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+LocalChanges.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+LocalChanges.swift
@@ -216,6 +216,8 @@ private extension Podcast {
     var apiSettings: Api_PodcastSettings {
         var settings = Api_PodcastSettings()
         settings.playbackEffects.update(self.settings.$customEffects)
+        settings.autoStartFrom.update(self.settings.$autoStartFrom)
+        settings.autoSkipLast.update(self.settings.$autoSkipLast)
         settings.playbackSpeed.update(self.settings.$playbackSpeed)
         settings.trimSilence.update(self.settings.$trimSilence)
         settings.volumeBoost.update(self.settings.$boostVolume)

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
@@ -96,6 +96,7 @@ extension SyncTask {
                 podcast.autoArchiveEpisodeLimit = 0
                 podcast.subscribed = 0
                 podcast.autoAddToUpNext = AutoAddToUpNextSetting.off.rawValue
+                podcast.processSettings(podcastItem.settings)
 
                 DataManager.sharedManager.save(podcast: podcast)
             }
@@ -148,6 +149,8 @@ extension SyncTask {
         if checkIsDeleted, podcastItem.hasIsDeleted {
             podcast.subscribed = podcastItem.isDeleted.value ? 0 : 1
         }
+
+        podcast.processSettings(podcastItem.settings)
     }
 
     private func importEpisode(_ episodeItem: Api_SyncUserEpisode) {
@@ -407,5 +410,10 @@ private extension Api_SyncUserBookmark {
 
     var logDescription: String {
         (try? jsonString()) ?? "invalid api bookmark"
+    }
+}
+
+extension Podcast {
+    func processSettings(_ settings: Api_PodcastSettings) {
     }
 }

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
@@ -416,6 +416,8 @@ private extension Api_SyncUserBookmark {
 extension Podcast {
     func processSettings(_ settings: Api_PodcastSettings) {
         self.settings.$customEffects.update(setting: settings.playbackEffects)
+        self.settings.$autoStartFrom.update(setting: settings.autoStartFrom)
+        self.settings.$autoSkipLast.update(setting: settings.autoSkipLast)
         self.settings.$trimSilence.update(setting: settings.trimSilence)
         self.settings.$playbackSpeed.update(setting: settings.playbackSpeed)
         self.settings.$boostVolume.update(setting: settings.volumeBoost)

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
@@ -415,5 +415,9 @@ private extension Api_SyncUserBookmark {
 
 extension Podcast {
     func processSettings(_ settings: Api_PodcastSettings) {
+        self.settings.$customEffects.update(setting: settings.playbackEffects)
+        self.settings.$trimSilence.update(setting: settings.trimSilence)
+        self.settings.$playbackSpeed.update(setting: settings.playbackSpeed)
+        self.settings.$boostVolume.update(setting: settings.volumeBoost)
     }
 }

--- a/PocketCastsTests/Mocks/DataManagerMock.swift
+++ b/PocketCastsTests/Mocks/DataManagerMock.swift
@@ -3,9 +3,14 @@ import Foundation
 @testable import PocketCastsDataModel
 
 class DataManagerMock: DataManager {
+    var podcastsToReturn: [Podcast] = []
     var episodesToReturn: [Episode] = []
 
     override func findEpisodesWhere(customWhere: String, arguments: [Any]?) -> [Episode] {
         return episodesToReturn
+    }
+
+    override func allPodcasts(includeUnsubscribed: Bool, reloadFromDatabase: Bool = false) -> [Podcast] {
+        return podcastsToReturn
     }
 }

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1595,13 +1595,11 @@
 		E3665F542936CD13001C8372 /* ChaptersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3665F532936CD13001C8372 /* ChaptersTests.swift */; };
 		E3F37446291F0DD1005916ED /* Chapters.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3F37445291F0DD1005916ED /* Chapters.swift */; };
 		E3F37447291F0DD1005916ED /* Chapters.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3F37445291F0DD1005916ED /* Chapters.swift */; };
-		F53DC8A62B72D1AB00B197A6 /* AppSettings+ImportUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = F53DC8A52B72D1AB00B197A6 /* AppSettings+ImportUserDefaults.swift */; };
-		F5D3A0D92B70950100EED067 /* MockURLHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5D3A0D82B70950100EED067 /* MockURLHandler.swift */; };
-		F5BAACCB2B6446D900450E86 /* MockURLHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BAACCA2B6446D900450E86 /* MockURLHandler.swift */; };
-		F53DC8A62B72D1AB00B197A6 /* AppSettings+SyncUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = F53DC8A52B72D1AB00B197A6 /* AppSettings+SyncUserDefaults.swift */; };
-		F55449452B75935F00F68AE9 /* AppSettings+ImportUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = F55449442B75935F00F68AE9 /* AppSettings+ImportUserDefaults.swift */; };
 		F55449422B758E8300F68AE9 /* PocketCastsUtils in Frameworks */ = {isa = PBXBuildFile; productRef = F55449412B758E8300F68AE9 /* PocketCastsUtils */; };
 		F55449432B758E8300F68AE9 /* PocketCastsUtils in Embed Frameworks */ = {isa = PBXBuildFile; productRef = F55449412B758E8300F68AE9 /* PocketCastsUtils */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		F55449452B75935F00F68AE9 /* AppSettings+ImportUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = F55449442B75935F00F68AE9 /* AppSettings+ImportUserDefaults.swift */; };
+		F58AFA132B797CF200FC1724 /* Podcast+Settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = F58AFA122B797CF200FC1724 /* Podcast+Settings.swift */; };
+		F58AFA142B797CF200FC1724 /* Podcast+Settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = F58AFA122B797CF200FC1724 /* Podcast+Settings.swift */; };
 		F5D3A0D92B70950100EED067 /* MockURLHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5D3A0D82B70950100EED067 /* MockURLHandler.swift */; };
 		F5DBA58A2B756A8700AED77F /* AppSettings+ImportUserDefaultsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5DBA5892B756A8700AED77F /* AppSettings+ImportUserDefaultsTests.swift */; };
 		F5E431D62B50888500A71DB3 /* PlusLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5E431D52B50888500A71DB3 /* PlusLabel.swift */; };
@@ -3374,11 +3372,8 @@
 		ED026EC07A62C137A4959391 /* Pods-PocketCasts-PocketCastsTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PocketCasts-PocketCastsTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-PocketCasts-PocketCastsTests/Pods-PocketCasts-PocketCastsTests.release.xcconfig"; sourceTree = "<group>"; };
 		EF3DD428DC2C444C2D8CEC5A /* Pods-PocketCastsTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PocketCastsTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-PocketCastsTests/Pods-PocketCastsTests.debug.xcconfig"; sourceTree = "<group>"; };
 		EFBF99F57846D0E1AF8DE08D /* Pods-PocketCasts-PocketCastsTests.staging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PocketCasts-PocketCastsTests.staging.xcconfig"; path = "Pods/Target Support Files/Pods-PocketCasts-PocketCastsTests/Pods-PocketCasts-PocketCastsTests.staging.xcconfig"; sourceTree = "<group>"; };
-		F53DC8A52B72D1AB00B197A6 /* AppSettings+ImportUserDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppSettings+ImportUserDefaults.swift"; sourceTree = "<group>"; };
-		F5D3A0D82B70950100EED067 /* MockURLHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockURLHandler.swift; sourceTree = "<group>"; };
-		F5BAACCA2B6446D900450E86 /* MockURLHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLHandler.swift; sourceTree = "<group>"; };
-		F53DC8A52B72D1AB00B197A6 /* AppSettings+SyncUserDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppSettings+SyncUserDefaults.swift"; sourceTree = "<group>"; };
 		F55449442B75935F00F68AE9 /* AppSettings+ImportUserDefaults.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AppSettings+ImportUserDefaults.swift"; sourceTree = "<group>"; };
+		F58AFA122B797CF200FC1724 /* Podcast+Settings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Podcast+Settings.swift"; sourceTree = "<group>"; };
 		F5D3A0D82B70950100EED067 /* MockURLHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockURLHandler.swift; sourceTree = "<group>"; };
 		F5DBA5892B756A8700AED77F /* AppSettings+ImportUserDefaultsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppSettings+ImportUserDefaultsTests.swift"; sourceTree = "<group>"; };
 		F5E431D52B50888500A71DB3 /* PlusLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlusLabel.swift; sourceTree = "<group>"; };
@@ -5158,6 +5153,7 @@
 			isa = PBXGroup;
 			children = (
 				BD56102C200DA4BC002F2D53 /* Podcast+Formatting.swift */,
+				F58AFA122B797CF200FC1724 /* Podcast+Settings.swift */,
 				BD561030200DADA0002F2D53 /* Episode+Formatting.swift */,
 				40FE395E229CF424004526CD /* UserEpisode+Formatting.swift */,
 				BDA681AC220D185A0053BEEE /* BaseEpisode+Formatting.swift */,
@@ -8838,6 +8834,7 @@
 				BD47E7FA1DD57F7B00C18EE7 /* ShowNotesFormatter.swift in Sources */,
 				8B67A26329A7D6B60076886D /* SearchHistoryCell.swift in Sources */,
 				BD9A2B521C851577003BA898 /* NavigationManager.swift in Sources */,
+				F58AFA132B797CF200FC1724 /* Podcast+Settings.swift in Sources */,
 				BDEC9AB32051118900088D76 /* PCViewController.swift in Sources */,
 				BD3C19301C27B4EC00B7847D /* PodcastListCell.swift in Sources */,
 				BD5AE6831FE0E9A20009B8A1 /* PodcastViewController+TableData.swift in Sources */,
@@ -9496,6 +9493,7 @@
 				C7AF578C289C60C80089E435 /* FeatureFlag.swift in Sources */,
 				C7CE415A28CBCFC200AD063E /* Analytics.swift in Sources */,
 				C7CE415C28CBD01F00AD063E /* String+Analytics.swift in Sources */,
+				F58AFA142B797CF200FC1724 /* Podcast+Settings.swift in Sources */,
 				46C7BB8827DA60E000CD6AE3 /* DownloadListView.swift in Sources */,
 				8B3C7CA52A4DE36000939DED /* AutoplayHelper.swift in Sources */,
 				BDD301951EFB9A4F004A9972 /* WatchDataManager.swift in Sources */,

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1598,6 +1598,7 @@
 		F55449422B758E8300F68AE9 /* PocketCastsUtils in Frameworks */ = {isa = PBXBuildFile; productRef = F55449412B758E8300F68AE9 /* PocketCastsUtils */; };
 		F55449432B758E8300F68AE9 /* PocketCastsUtils in Embed Frameworks */ = {isa = PBXBuildFile; productRef = F55449412B758E8300F68AE9 /* PocketCastsUtils */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		F55449452B75935F00F68AE9 /* AppSettings+ImportUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = F55449442B75935F00F68AE9 /* AppSettings+ImportUserDefaults.swift */; };
+		F565602F2B7ACD9B003E76D5 /* DataManager+Import.swift in Sources */ = {isa = PBXBuildFile; fileRef = F565602E2B7ACD9B003E76D5 /* DataManager+Import.swift */; };
 		F58AFA132B797CF200FC1724 /* Podcast+Settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = F58AFA122B797CF200FC1724 /* Podcast+Settings.swift */; };
 		F58AFA142B797CF200FC1724 /* Podcast+Settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = F58AFA122B797CF200FC1724 /* Podcast+Settings.swift */; };
 		F5D3A0D92B70950100EED067 /* MockURLHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5D3A0D82B70950100EED067 /* MockURLHandler.swift */; };
@@ -3373,6 +3374,7 @@
 		EF3DD428DC2C444C2D8CEC5A /* Pods-PocketCastsTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PocketCastsTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-PocketCastsTests/Pods-PocketCastsTests.debug.xcconfig"; sourceTree = "<group>"; };
 		EFBF99F57846D0E1AF8DE08D /* Pods-PocketCasts-PocketCastsTests.staging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PocketCasts-PocketCastsTests.staging.xcconfig"; path = "Pods/Target Support Files/Pods-PocketCasts-PocketCastsTests/Pods-PocketCasts-PocketCastsTests.staging.xcconfig"; sourceTree = "<group>"; };
 		F55449442B75935F00F68AE9 /* AppSettings+ImportUserDefaults.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AppSettings+ImportUserDefaults.swift"; sourceTree = "<group>"; };
+		F565602E2B7ACD9B003E76D5 /* DataManager+Import.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DataManager+Import.swift"; sourceTree = "<group>"; };
 		F58AFA122B797CF200FC1724 /* Podcast+Settings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Podcast+Settings.swift"; sourceTree = "<group>"; };
 		F5D3A0D82B70950100EED067 /* MockURLHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockURLHandler.swift; sourceTree = "<group>"; };
 		F5DBA5892B756A8700AED77F /* AppSettings+ImportUserDefaultsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppSettings+ImportUserDefaultsTests.swift"; sourceTree = "<group>"; };
@@ -5230,6 +5232,7 @@
 				BD5E8D3C2061E0FB00C84B43 /* PodcastManager+Cleanup.swift */,
 				402772D621B6105D00769811 /* PodcastManager+Delete.swift */,
 				F55449442B75935F00F68AE9 /* AppSettings+ImportUserDefaults.swift */,
+				F565602E2B7ACD9B003E76D5 /* DataManager+Import.swift */,
 				BDE740992060CE1B00FB22C7 /* EpisodeManager.swift */,
 				BD001B882174260B00504DD3 /* FilterManager.swift */,
 				BD5E8D40206211E300C84B43 /* OpmlImporter.swift */,
@@ -9170,6 +9173,7 @@
 				BDA7A0A624C6BBA600ADA8AA /* SecondaryLabel.swift in Sources */,
 				BDDA72D61C9BA7E2003A3BEB /* Theme.swift in Sources */,
 				BDA75074213684FC00AD859C /* NowPlayingAnimationView.swift in Sources */,
+				F565602F2B7ACD9B003E76D5 /* DataManager+Import.swift in Sources */,
 				8B3654172926C13000FD7216 /* CircularProgressView.swift in Sources */,
 				BD74F15327F28F6F00222785 /* HomeGridItem.swift in Sources */,
 				8BE85CAB28762C4900AEB5FF /* LegalAndMoreView.swift in Sources */,

--- a/podcasts/Analytics/Helpers/AnalyticsPlaybackHelper.swift
+++ b/podcasts/Analytics/Helpers/AnalyticsPlaybackHelper.swift
@@ -1,4 +1,5 @@
 import PocketCastsUtils
+import PocketCastsDataModel
 
 /// Helper used to track playback
 class AnalyticsPlaybackHelper: AnalyticsCoordinator {

--- a/podcasts/AppDelegate+Defaults.swift
+++ b/podcasts/AppDelegate+Defaults.swift
@@ -129,25 +129,11 @@ extension AppDelegate {
         if FeatureFlag.settingsSync.enabled {
             performUpdateIfRequired(updateKey: "MigrateToSyncedSettings") {
                 SettingsStore.appSettings.importUserDefaults()
-                updatePodcastSettings()
+                DataManager.sharedManager.importPodcastSettings()
             }
         }
 
         defaults.synchronize()
-    }
-
-    private func updatePodcastSettings() {
-        let podcasts = DataManager.sharedManager.allPodcasts(includeUnsubscribed: true)
-
-        podcasts.forEach { podcast in
-            podcast.settings.$autoStartFrom = ModifiedDate<Int32>(wrappedValue: podcast.startFrom)
-            podcast.settings.$autoSkipLast = ModifiedDate<Int32>(wrappedValue: podcast.skipLast)
-            podcast.settings.$playbackSpeed = ModifiedDate<Double>(wrappedValue: podcast.playbackSpeed)
-            podcast.settings.$trimSilence = ModifiedDate<TrimSilenceAmount>(wrappedValue: TrimSilenceAmount(rawValue: podcast.trimSilenceAmount)!)
-            podcast.settings.$boostVolume = ModifiedDate<Bool>(wrappedValue: podcast.boostVolume)
-
-            DataManager.sharedManager.save(podcast: podcast)
-        }
     }
 
     private func performUpdateIfRequired(updateKey: String, update: () -> Void) {

--- a/podcasts/AppDelegate+Defaults.swift
+++ b/podcasts/AppDelegate+Defaults.swift
@@ -129,10 +129,25 @@ extension AppDelegate {
         if FeatureFlag.settingsSync.enabled {
             performUpdateIfRequired(updateKey: "MigrateToSyncedSettings") {
                 SettingsStore.appSettings.importUserDefaults()
+                updatePodcastSettings()
             }
         }
 
         defaults.synchronize()
+    }
+
+    private func updatePodcastSettings() {
+        let podcasts = DataManager.sharedManager.allPodcasts(includeUnsubscribed: true)
+
+        podcasts.forEach { podcast in
+            podcast.settings.$autoStartFrom = ModifiedDate<Int32>(wrappedValue: podcast.startFrom)
+            podcast.settings.$autoSkipLast = ModifiedDate<Int32>(wrappedValue: podcast.skipLast)
+            podcast.settings.$playbackSpeed = ModifiedDate<Double>(wrappedValue: podcast.playbackSpeed)
+            podcast.settings.$trimSilence = ModifiedDate<TrimSilenceAmount>(wrappedValue: TrimSilenceAmount(rawValue: podcast.trimSilenceAmount)!)
+            podcast.settings.$boostVolume = ModifiedDate<Bool>(wrappedValue: podcast.boostVolume)
+
+            DataManager.sharedManager.save(podcast: podcast)
+        }
     }
 
     private func performUpdateIfRequired(updateKey: String, update: () -> Void) {

--- a/podcasts/DataManager+Import.swift
+++ b/podcasts/DataManager+Import.swift
@@ -1,0 +1,18 @@
+import PocketCastsDataModel
+import PocketCastsUtils
+
+extension DataManager {
+    func importPodcastSettings() {
+        let podcasts = allPodcasts(includeUnsubscribed: true)
+
+        podcasts.forEach { podcast in
+            podcast.settings.$autoStartFrom = ModifiedDate<Int32>(wrappedValue: podcast.startFrom)
+            podcast.settings.$autoSkipLast = ModifiedDate<Int32>(wrappedValue: podcast.skipLast)
+            podcast.settings.$playbackSpeed = ModifiedDate<Double>(wrappedValue: podcast.playbackSpeed)
+            podcast.settings.$trimSilence = ModifiedDate<TrimSilenceAmount>(wrappedValue: TrimSilenceAmount(rawValue: podcast.trimSilenceAmount)!)
+            podcast.settings.$boostVolume = ModifiedDate<Bool>(wrappedValue: podcast.boostVolume)
+
+            save(podcast: podcast)
+        }
+    }
+}

--- a/podcasts/EffectsViewController.swift
+++ b/podcasts/EffectsViewController.swift
@@ -259,7 +259,7 @@ class EffectsViewController: SimpleNotificationsViewController {
     @IBAction func clearForPodcastTapped(_ sender: Any) {
         guard let episode = PlaybackManager.shared.currentEpisode() as? Episode, let podcast = episode.parentPodcast() else { return }
 
-        podcast.overrideGlobalEffects = false
+        podcast.isEffectsOverridden = false
         DataManager.sharedManager.save(podcast: podcast)
         PlaybackManager.shared.effectsChangedExternally()
         updateClearView()
@@ -284,8 +284,8 @@ class EffectsViewController: SimpleNotificationsViewController {
             return
         }
 
-        customEffectsToVolumeBoostConstraint.isActive = podcast.overrideGlobalEffects
-        clearForPodcastView.isHidden = !podcast.overrideGlobalEffects
+        customEffectsToVolumeBoostConstraint.isActive = podcast.isEffectsOverridden
+        clearForPodcastView.isHidden = !podcast.isEffectsOverridden
     }
 
     private func updateRemoveSilenceViews() {

--- a/podcasts/HomeGridListItem.swift
+++ b/podcasts/HomeGridListItem.swift
@@ -49,7 +49,8 @@ class HomeGridListItem: ListItem {
                 podcast.episodeGrouping == otherPodcast.episodeGrouping &&
                 podcast.playbackSpeed == otherPodcast.playbackSpeed &&
                 podcast.boostVolume == otherPodcast.boostVolume &&
-                podcast.trimSilenceAmount == otherPodcast.trimSilenceAmount
+                podcast.trimSilenceAmount == otherPodcast.trimSilenceAmount &&
+                podcast.settings == otherPodcast.settings
         } else if let otherFolder = rhs.folder, let folder = folder {
             return differenceIdentifier == rhs.differenceIdentifier &&
                 frozenBadgeCount == rhs.frozenBadgeCount &&

--- a/podcasts/ListPodcast.swift
+++ b/podcasts/ListPodcast.swift
@@ -33,6 +33,7 @@ class ListPodcast: ListItem {
             podcast.autoArchiveInactiveAfter == rhs.podcast.autoArchiveInactiveAfter &&
             podcast.autoArchivePlayedAfter == rhs.podcast.autoArchivePlayedAfter &&
             podcast.subscribed == rhs.podcast.subscribed &&
-            podcast.episodeGrouping == rhs.podcast.episodeGrouping
+            podcast.episodeGrouping == rhs.podcast.episodeGrouping &&
+            podcast.settings == rhs.podcast.settings
     }
 }

--- a/podcasts/PlaybackEffects.swift
+++ b/podcasts/PlaybackEffects.swift
@@ -1,9 +1,8 @@
 import PocketCastsDataModel
+import PocketCastsServer
 import UIKit
 
-enum TrimSilenceAmount: Int, AnalyticsDescribable {
-    case off = 0, low = 3, medium = 5, high = 10
-
+extension TrimSilenceAmount: AnalyticsDescribable {
     var description: String {
         switch self {
         case .off:
@@ -49,9 +48,16 @@ class PlaybackEffects {
         let effects = PlaybackEffects()
 
         effects.isGlobal = false
-        effects.trimSilence = convertToTrimSilenceAmount(Int(podcast.trimSilenceAmount))
-        effects.volumeBoost = podcast.boostVolume
-        effects.playbackSpeed = podcast.playbackSpeed
+
+        if FeatureFlag.settingsSync.enabled {
+            effects.trimSilence = podcast.settings.trimSilence
+            effects.volumeBoost = podcast.settings.boostVolume
+            effects.playbackSpeed = podcast.settings.playbackSpeed
+        } else {
+            effects.trimSilence = convertToTrimSilenceAmount(podcast.trimSilenceAmount)
+            effects.volumeBoost = podcast.boostVolume
+            effects.playbackSpeed = podcast.playbackSpeed
+        }
 
         return effects
     }
@@ -60,7 +66,7 @@ class PlaybackEffects {
         let effects = PlaybackEffects()
         effects.isGlobal = true
         let removeSilenceAmount = UserDefaults.standard.integer(forKey: Constants.UserDefaults.globalRemoveSilence)
-        effects.trimSilence = convertToTrimSilenceAmount(removeSilenceAmount)
+        effects.trimSilence = convertToTrimSilenceAmount(Int32(removeSilenceAmount))
         effects.volumeBoost = UserDefaults.standard.bool(forKey: Constants.UserDefaults.globalVolumeBoost)
 
         let savedSpeed = UserDefaults.standard.double(forKey: Constants.UserDefaults.globalPlaybackSpeed)
@@ -98,7 +104,7 @@ class PlaybackEffects {
         playbackSpeed = currentSpeed
     }
 
-    private class func convertToTrimSilenceAmount(_ value: Int) -> TrimSilenceAmount {
+    private class func convertToTrimSilenceAmount(_ value: Int32) -> TrimSilenceAmount {
         if let amount = TrimSilenceAmount(rawValue: value) {
             return amount
         }

--- a/podcasts/PlaybackEffects.swift
+++ b/podcasts/PlaybackEffects.swift
@@ -43,7 +43,11 @@ class PlaybackEffects {
     var isGlobal: Bool = true
 
     class func effectsFor(podcast: Podcast) -> PlaybackEffects {
-        if !podcast.overrideGlobalEffects { return globalEffects() }
+        if FeatureFlag.settingsSync.enabled {
+            if !podcast.settings.customEffects { return globalEffects() }
+        } else {
+            if !podcast.overrideGlobalEffects { return globalEffects() }
+        }
 
         let effects = PlaybackEffects()
 

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -1869,13 +1869,13 @@ class PlaybackManager: ServerPlaybackDelegate {
     private func startFromTimeForCurrentEpisode() -> TimeInterval {
         guard let episode = currentEpisode() as? Episode, let parentPodcast = episode.parentPodcast() else { return 0 }
 
-        return TimeInterval(parentPodcast.startFrom)
+        return TimeInterval(parentPodcast.autoStartFrom)
     }
 
     private func skipLastTimeForCurrentEpisode() -> TimeInterval {
         guard let episode = currentEpisode() as? Episode, let parentPodcast = episode.parentPodcast() else { return 0 }
 
-        return TimeInterval(parentPodcast.skipLast)
+        return TimeInterval(parentPodcast.autoSkipLast)
     }
 
     // MARK: - Keep Screen on

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -701,6 +701,12 @@ class PlaybackManager: ServerPlaybackDelegate {
             UserDefaults.standard.set(effects.volumeBoost, forKey: Constants.UserDefaults.globalVolumeBoost)
             UserDefaults.standard.set(effects.playbackSpeed, forKey: Constants.UserDefaults.globalPlaybackSpeed)
         } else if let episode = episode as? Episode, let podcast = episode.parentPodcast() {
+            if FeatureFlag.settingsSync.enabled {
+                podcast.settings.trimSilence = effects.trimSilence
+                podcast.settings.playbackSpeed = effects.playbackSpeed
+                podcast.settings.boostVolume = effects.volumeBoost
+                podcast.syncStatus = SyncStatus.notSynced.rawValue
+            }
             podcast.trimSilenceAmount = Int32(effects.trimSilence.rawValue)
             podcast.playbackSpeed = effects.playbackSpeed
             podcast.boostVolume = effects.volumeBoost

--- a/podcasts/Podcast+Settings.swift
+++ b/podcasts/Podcast+Settings.swift
@@ -1,0 +1,20 @@
+import PocketCastsDataModel
+
+extension Podcast {
+    var isEffectsOverridden: Bool {
+        get {
+            if FeatureFlag.settingsSync.enabled {
+                return settings.customEffects
+            } else {
+                return overrideGlobalEffects
+            }
+        }
+        set {
+            if FeatureFlag.settingsSync.enabled {
+                settings.customEffects = newValue
+            } else {
+                overrideGlobalEffects = newValue
+            }
+        }
+    }
+}

--- a/podcasts/Podcast+Settings.swift
+++ b/podcasts/Podcast+Settings.swift
@@ -17,4 +17,36 @@ extension Podcast {
             }
         }
     }
+
+    var autoStartFrom: Int32 {
+        get {
+            if FeatureFlag.settingsSync.enabled {
+                return settings.autoStartFrom
+            } else {
+                return startFrom
+            }
+        }
+        set {
+            if FeatureFlag.settingsSync.enabled {
+                settings.autoStartFrom = newValue
+            }
+            startFrom = newValue
+        }
+    }
+
+    var autoSkipLast: Int32 {
+        get {
+            if FeatureFlag.settingsSync.enabled {
+                return settings.autoSkipLast
+            } else {
+                return skipLast
+            }
+        }
+        set {
+            if FeatureFlag.settingsSync.enabled {
+                settings.autoSkipLast = newValue
+            }
+            skipLast = newValue
+        }
+    }
 }

--- a/podcasts/PodcastSettingsViewController+Table.swift
+++ b/podcasts/PodcastSettingsViewController+Table.swift
@@ -113,10 +113,10 @@ extension PodcastSettingsViewController: UITableViewDataSource, UITableViewDeleg
             cell.onValueChanged = { [weak self] value in
                 guard let podcast = self?.podcast else { return }
 
-                podcast.startFrom = Int32(value)
+                podcast.autoStartFrom = Int32(value)
                 podcast.syncStatus = SyncStatus.notSynced.rawValue
                 DataManager.sharedManager.save(podcast: podcast)
-                cell.cellSecondaryLabel.text = L10n.timeShorthand(Int(podcast.startFrom))
+                cell.cellSecondaryLabel.text = L10n.timeShorthand(Int(podcast.autoStartFrom))
 
                 self?.debounce.call {
                     Analytics.track(.podcastSettingsSkipFirstChanged, properties: ["value": value])
@@ -133,16 +133,16 @@ extension PodcastSettingsViewController: UITableViewDataSource, UITableViewDeleg
             cell.timeStepper.maximumValue = 40.minutes
             cell.timeStepper.bigIncrements = 5.seconds
             cell.timeStepper.smallIncrements = 5.seconds
-            cell.timeStepper.currentValue = TimeInterval(podcast.skipLast)
+            cell.timeStepper.currentValue = TimeInterval(podcast.autoSkipLast)
             cell.configureWithImage(imageName: "settings-skipoutros", tintColor: podcast.iconTintColor())
 
             cell.onValueChanged = { [weak self] value in
                 guard let podcast = self?.podcast else { return }
 
-                podcast.skipLast = Int32(value)
+                podcast.autoSkipLast = Int32(value)
                 podcast.syncStatus = SyncStatus.notSynced.rawValue
                 DataManager.sharedManager.save(podcast: podcast)
-                cell.cellSecondaryLabel.text = L10n.timeShorthand(Int(podcast.skipLast))
+                cell.cellSecondaryLabel.text = L10n.timeShorthand(Int(podcast.autoSkipLast))
 
                 self?.debounce.call {
                     Analytics.track(.podcastSettingsSkipLastChanged, properties: ["value": value])

--- a/podcasts/PodcastSettingsViewController+Table.swift
+++ b/podcasts/PodcastSettingsViewController+Table.swift
@@ -93,7 +93,7 @@ extension PodcastSettingsViewController: UITableViewDataSource, UITableViewDeleg
         case .playbackEffects:
             let cell = tableView.dequeueReusableCell(withIdentifier: PodcastSettingsViewController.disclosureCellId, for: indexPath) as! DisclosureCell
             cell.cellLabel.text = PlayerAction.effects.title()
-            let imageName = podcast.overrideGlobalEffects ? "podcast-effects-on" : "podcast-effects-off"
+            let imageName = podcast.isEffectsOverridden ? "podcast-effects-on" : "podcast-effects-off"
             cell.setImage(imageName: imageName, tintColor: podcast.iconTintColor())
             cell.cellSecondaryLabel.text = nil
 

--- a/podcasts/ServerSyncManager.swift
+++ b/podcasts/ServerSyncManager.swift
@@ -70,6 +70,9 @@ class ServerSyncManager: ServerSyncDelegate {
         PodcastManager.shared.checkForPendingAndAutoDownloads()
         UserEpisodeManager.checkForPendingUploads()
         UserEpisodeManager.checkForPendingCloudDeletes()
+        DispatchQueue.main.async {
+            PlaybackManager.shared.effectsChangedExternally()
+        }
     }
 
     func cleanupCloudOnlyFiles() {


### PR DESCRIPTION
| 📘 Part of: #1400 |
|:---:|

Adds syncing of Custom Playback Effects Podcast Settings.

<img width=300 src="https://github.com/Automattic/pocket-casts-ios/assets/3250/ccb9a0fd-7ced-49f8-8af9-45d86072129b"/>

## Changes

* Adds a new `PodcastSettings` struct for storing synced settings values with modified dates
* Stores `PodcastSettings` as a `TEXT` column on `SJPodcast`
    I looked throughout the app and didn't see any place where we directly query settings properties. In the event that we do want to query, on iOS 16+ SQLite has [JSON functions](https://www.sqlite.org/json1.html) (`JSON_EXTRACT`, `JSON_QUERY`, and `JSON_MODIFY`) to speed up operations working directly with JSON strings.
* Replaces old setter/getters with new property setters/getters
* Imports existing settings as part of the same one-time job as the `AppSettings` import.
* Adds a small `debugDescription` on `Podcast`. I kept finding it annoying to print out a Podcast and only see the address. This includes the UUID & title.

https://github.com/Automattic/pocket-casts-ios/blob/fc6233dc33fe448b564db56b1224b301d3fa4a6a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Podcast.swift#L104-L108

## To test

> [!IMPORTANT]
> Must be logged into an account before testing this

#### Settings import
* Install a fresh build
* Change a few settings in a podcast's settings under the "Playback Effects" screen or Skip First / Skip Last
* Enable the `settingSync` feature flag
* Kill the app
* Ensure that settings show up as they did before

#### Syncing
* Install on two devices
* D1: Change a few settings in a podcast's settings under the "Playback Effects" screen or Skip First / Skip Last
* D1: Go back to the Podcasts list
* D1: Swipe down to refresh
* D2: Swipe town to refresh on Podcasts list
* D2: Navigate to the same Podcasts' settings and ensure they are synced

#### Player
* D1: Open the player
* D1: Change settings in the "Playback Effects" tray using this button <img width=30 src="https://github.com/Automattic/pocket-casts-ios/assets/3250/94b64f44-fcce-4f8c-b4f2-6689361111f0">
* D1: Go back to the Podcasts list
* D1: Swipe down to refresh
* D2: Swipe town to refresh on Podcasts list
* D2: Navigate to the same Podcasts' settings and ensure they are synced

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes. **I plan to add further unit tests in a future PR. For now, I'm just testing the settings migration.**
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
