### PR TITLE
Settings sync: Podcast Episodes Layout Menu

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Enums.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Enums.swift
@@ -54,3 +54,7 @@ public struct EpisodeBasicData {
     public var isArchived: Bool?
     public var starred: Bool?
 }
+
+public enum PodcastEpisodeSortOrder: Int32, Codable, CaseIterable {
+    case newestToOldest = 1, oldestToNewest, shortestToLongest, longestToShortest
+}

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/PodcastSettings.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/PodcastSettings.swift
@@ -11,6 +11,8 @@ public struct PodcastSettings: JSONCodable, Equatable {
     @ModifiedDate public var boostVolume: Bool
     @ModifiedDate public var playbackSpeed: Double
 
+    @ModifiedDate public var episodesSortOrder: PodcastEpisodeSortOrder = .shortestToLongest
+
     public static var defaults: Self {
         return PodcastSettings(trimSilence: .off, boostVolume: false, playbackSpeed: 1)
     }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/PodcastSettings.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/PodcastSettings.swift
@@ -12,6 +12,7 @@ public struct PodcastSettings: JSONCodable, Equatable {
     @ModifiedDate public var playbackSpeed: Double
 
     @ModifiedDate public var episodesSortOrder: PodcastEpisodeSortOrder = .shortestToLongest
+    @ModifiedDate public var episodeGrouping: PodcastGrouping = .none
 
     public static var defaults: Self {
         return PodcastSettings(trimSilence: .off, boostVolume: false, playbackSpeed: 1)

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+LocalChanges.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+LocalChanges.swift
@@ -222,6 +222,7 @@ private extension Podcast {
         settings.trimSilence.update(self.settings.$trimSilence)
         settings.volumeBoost.update(self.settings.$boostVolume)
         settings.episodesSortOrder.update(self.settings.$episodesSortOrder)
+        settings.episodeGrouping.update(self.settings.$episodeGrouping)
         return settings
     }
 }

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+LocalChanges.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+LocalChanges.swift
@@ -221,6 +221,7 @@ private extension Podcast {
         settings.playbackSpeed.update(self.settings.$playbackSpeed)
         settings.trimSilence.update(self.settings.$trimSilence)
         settings.volumeBoost.update(self.settings.$boostVolume)
+        settings.episodesSortOrder.update(self.settings.$episodesSortOrder)
         return settings
     }
 }

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
@@ -422,5 +422,6 @@ extension Podcast {
         self.settings.$playbackSpeed.update(setting: settings.playbackSpeed)
         self.settings.$boostVolume.update(setting: settings.volumeBoost)
         self.settings.$episodesSortOrder.update(setting: settings.episodesSortOrder)
+        self.settings.$episodeGrouping.update(setting: settings.episodeGrouping)
     }
 }

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
@@ -421,5 +421,6 @@ extension Podcast {
         self.settings.$trimSilence.update(setting: settings.trimSilence)
         self.settings.$playbackSpeed.update(setting: settings.playbackSpeed)
         self.settings.$boostVolume.update(setting: settings.volumeBoost)
+        self.settings.$episodesSortOrder.update(setting: settings.episodesSortOrder)
     }
 }

--- a/Pocket Casts Watch App Extension/OrderPicker.swift
+++ b/Pocket Casts Watch App Extension/OrderPicker.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import PocketCastsDataModel
 
 struct OrderPickerView<T>: View where T: SortOption {
     @Environment(\.presentationMode) var presentationMode

--- a/Pocket Casts Watch App Extension/PodcastEpisodeListViewModel.swift
+++ b/Pocket Casts Watch App Extension/PodcastEpisodeListViewModel.swift
@@ -6,8 +6,10 @@ class PodcastEpisodeListViewModel: ObservableObject {
     static func createEpisodesQuery(forPodcast podcast: Podcast?) -> String {
         guard let podcast = podcast else { return "" }
 
+        let episodeSortOrder = podcast.podcastSortOrder
+
         let sortStr: String
-        let sortOrder = PodcastEpisodeSortOrder(rawValue: podcast.episodeSortOrder) ?? PodcastEpisodeSortOrder.newestToOldest
+        let sortOrder = episodeSortOrder ?? PodcastEpisodeSortOrder.newestToOldest
         switch sortOrder {
         case .newestToOldest:
             sortStr = "ORDER BY publishedDate DESC, addedDate DESC"
@@ -26,7 +28,9 @@ class PodcastEpisodeListViewModel: ObservableObject {
     @Published var episodes: [EpisodeRowViewModel] = []
 
     var sortOption: PodcastEpisodeSortOrder {
-        PodcastEpisodeSortOrder(rawValue: podcast.episodeSortOrder) ?? .newestToOldest
+        let episodeSortOrder = podcast.podcastSortOrder
+
+        return episodeSortOrder ?? .newestToOldest
     }
 
     private var updatePodcast: AnyPublisher<Notification, Never> {
@@ -60,6 +64,10 @@ class PodcastEpisodeListViewModel: ObservableObject {
     }
 
     func didChangeSortOrder(option: PodcastEpisodeSortOrder) {
+        if FeatureFlag.settingsSync.enabled {
+            podcast.settings.episodesSortOrder = option
+            podcast.syncStatus = SyncStatus.notSynced.rawValue
+        }
         podcast.episodeSortOrder = option.rawValue
         DataManager.sharedManager.save(podcast: podcast)
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.podcastUpdated, object: podcast.uuid)

--- a/Pocket Casts Watch App Extension/SortOption.swift
+++ b/Pocket Casts Watch App Extension/SortOption.swift
@@ -9,7 +9,7 @@ protocol SortOption: Identifiable, CaseIterable, Equatable {
 extension PodcastEpisodeSortOrder: SortOption {
     static var pickerTitle: String = L10n.sortEpisodes
 
-    var id: Int32 { rawValue }
+    public var id: Int32 { rawValue }
 }
 
 extension LibrarySort: SortOption {

--- a/podcasts/DataManager+Import.swift
+++ b/podcasts/DataManager+Import.swift
@@ -11,6 +11,9 @@ extension DataManager {
             podcast.settings.$playbackSpeed = ModifiedDate<Double>(wrappedValue: podcast.playbackSpeed)
             podcast.settings.$trimSilence = ModifiedDate<TrimSilenceAmount>(wrappedValue: TrimSilenceAmount(rawValue: podcast.trimSilenceAmount)!)
             podcast.settings.$boostVolume = ModifiedDate<Bool>(wrappedValue: podcast.boostVolume)
+            if let episodeSortOrder = PodcastEpisodeSortOrder(rawValue: podcast.episodeSortOrder) {
+                podcast.settings.$episodesSortOrder = ModifiedDate<PodcastEpisodeSortOrder>(wrappedValue: episodeSortOrder)
+            }
 
             save(podcast: podcast)
         }

--- a/podcasts/DataManager+Import.swift
+++ b/podcasts/DataManager+Import.swift
@@ -13,6 +13,9 @@ extension DataManager {
             podcast.settings.$boostVolume = ModifiedDate<Bool>(wrappedValue: podcast.boostVolume)
             if let episodeSortOrder = PodcastEpisodeSortOrder(rawValue: podcast.episodeSortOrder) {
                 podcast.settings.$episodesSortOrder = ModifiedDate<PodcastEpisodeSortOrder>(wrappedValue: episodeSortOrder)
+			}
+            if let grouping = PodcastGrouping(rawValue: podcast.episodeGrouping) {
+                podcast.settings.$episodeGrouping = ModifiedDate<PodcastGrouping>(wrappedValue: grouping)
             }
 
             save(podcast: podcast)

--- a/podcasts/Enumerations.swift
+++ b/podcasts/Enumerations.swift
@@ -55,9 +55,7 @@ enum PodcastLicensing: Int32 {
     case keepEpisodesAfterExpiry = 0, deleteEpisodesAfterExpiry = 1
 }
 
-enum PodcastEpisodeSortOrder: Int32, CaseIterable, AnalyticsDescribable {
-    case newestToOldest = 1, oldestToNewest, shortestToLongest, longestToShortest
-
+extension PodcastEpisodeSortOrder: AnalyticsDescribable {
     var description: String {
         switch self {
         case .newestToOldest:

--- a/podcasts/EpisodeListSearchController.swift
+++ b/podcasts/EpisodeListSearchController.swift
@@ -138,7 +138,9 @@ class EpisodeListSearchController: SimpleNotificationsViewController, UISearchBa
         }
         optionPicker.addAction(action: MultiSelectAction)
 
-        let currentSort = PodcastEpisodeSortOrder(rawValue: podcast.episodeSortOrder)?.description ?? ""
+        let episodeSortOrder = podcast.podcastSortOrder
+
+        let currentSort = episodeSortOrder?.description ?? ""
         let sortAction = OptionAction(label: L10n.sortEpisodes, secondaryLabel: currentSort, icon: "podcastlist_sort") { [weak self] in
             guard let strongSelf = self else { return }
 
@@ -245,27 +247,29 @@ class EpisodeListSearchController: SimpleNotificationsViewController, UISearchBa
 
         let optionPicker = OptionsPicker(title: L10n.podcastSortOrderTitle)
 
-        let newestToOldestAction = OptionAction(label: PodcastEpisodeSortOrder.newestToOldest.description, selected: podcast.episodeSortOrder == PodcastEpisodeSortOrder.newestToOldest.rawValue) { [weak self] in
+        let sortOrder = podcast.podcastSortOrder
+
+        let newestToOldestAction = OptionAction(label: PodcastEpisodeSortOrder.newestToOldest.description, selected: sortOrder == PodcastEpisodeSortOrder.newestToOldest) { [weak self] in
             self?.setSortSetting(.newestToOldest)
             Analytics.track(.podcastsScreenSortOrderChanged, properties: ["sort_by": PodcastEpisodeSortOrder.newestToOldest])
         }
 
         optionPicker.addAction(action: newestToOldestAction)
 
-        let oldestToNewestAction = OptionAction(label: PodcastEpisodeSortOrder.oldestToNewest.description, selected: podcast.episodeSortOrder == PodcastEpisodeSortOrder.oldestToNewest.rawValue) { [weak self] in
+        let oldestToNewestAction = OptionAction(label: PodcastEpisodeSortOrder.oldestToNewest.description, selected: sortOrder == PodcastEpisodeSortOrder.oldestToNewest) { [weak self] in
             self?.setSortSetting(.oldestToNewest)
             Analytics.track(.podcastsScreenSortOrderChanged, properties: ["sort_by": PodcastEpisodeSortOrder.oldestToNewest])
         }
         optionPicker.addAction(action: oldestToNewestAction)
 
-        let shortestToLongestAction = OptionAction(label: PodcastEpisodeSortOrder.shortestToLongest.description, selected: podcast.episodeSortOrder == PodcastEpisodeSortOrder.shortestToLongest.rawValue) { [weak self] in
+        let shortestToLongestAction = OptionAction(label: PodcastEpisodeSortOrder.shortestToLongest.description, selected: sortOrder == PodcastEpisodeSortOrder.shortestToLongest) { [weak self] in
             self?.setSortSetting(.shortestToLongest)
             Analytics.track(.podcastsScreenSortOrderChanged, properties: ["sort_by": PodcastEpisodeSortOrder.shortestToLongest])
 
         }
         optionPicker.addAction(action: shortestToLongestAction)
 
-        let longestToShortestAction = OptionAction(label: PodcastEpisodeSortOrder.longestToShortest.description, selected: podcast.episodeSortOrder == PodcastEpisodeSortOrder.longestToShortest.rawValue) { [weak self] in
+        let longestToShortestAction = OptionAction(label: PodcastEpisodeSortOrder.longestToShortest.description, selected: sortOrder == PodcastEpisodeSortOrder.longestToShortest) { [weak self] in
             self?.setSortSetting(.longestToShortest)
             Analytics.track(.podcastsScreenSortOrderChanged, properties: ["sort_by": PodcastEpisodeSortOrder.longestToShortest])
 
@@ -338,6 +342,10 @@ class EpisodeListSearchController: SimpleNotificationsViewController, UISearchBa
 
     private func setSortSetting(_ setting: PodcastEpisodeSortOrder) {
         guard let podcast = podcastDelegate?.displayedPodcast() else { return }
+        if FeatureFlag.settingsSync.enabled {
+            podcast.settings.episodesSortOrder = setting
+            podcast.syncStatus = SyncStatus.notSynced.rawValue
+        }
         podcast.episodeSortOrder = setting.rawValue
         DataManager.sharedManager.save(podcast: podcast)
 

--- a/podcasts/EpisodeListSearchController.swift
+++ b/podcasts/EpisodeListSearchController.swift
@@ -148,7 +148,7 @@ class EpisodeListSearchController: SimpleNotificationsViewController, UISearchBa
         }
         optionPicker.addAction(action: sortAction)
 
-        let currentGroup = PodcastGrouping(rawValue: podcast.episodeGrouping)?.description ?? ""
+        let currentGroup = podcast.podcastGrouping().description
         let groupAction = OptionAction(label: L10n.groupEpisodes, secondaryLabel: currentGroup, icon: "option-group") { [weak self] in
             guard let strongSelf = self else { return }
 
@@ -284,35 +284,37 @@ class EpisodeListSearchController: SimpleNotificationsViewController, UISearchBa
 
         let optionPicker = OptionsPicker(title: L10n.podcastGroupOptionsTitle)
 
-        let noneAction = OptionAction(label: L10n.none, selected: podcast.episodeGrouping == PodcastGrouping.none.rawValue) { [weak self] in
+        let episodeGrouping = podcast.podcastGrouping()
+
+        let noneAction = OptionAction(label: L10n.none, selected: episodeGrouping == PodcastGrouping.none) { [weak self] in
             self?.setGroupingSetting(.none)
             Analytics.track(.podcastsScreenEpisodeGroupingChanged, properties: ["value": PodcastGrouping.none])
 
         }
         optionPicker.addAction(action: noneAction)
 
-        let downloadedAction = OptionAction(label: L10n.statusDownloaded, selected: podcast.episodeGrouping == PodcastGrouping.downloaded.rawValue) { [weak self] in
+        let downloadedAction = OptionAction(label: L10n.statusDownloaded, selected: episodeGrouping == PodcastGrouping.downloaded) { [weak self] in
             self?.setGroupingSetting(.downloaded)
             Analytics.track(.podcastsScreenEpisodeGroupingChanged, properties: ["value": PodcastGrouping.downloaded])
 
         }
         optionPicker.addAction(action: downloadedAction)
 
-        let unplayedAction = OptionAction(label: L10n.statusUnplayed, selected: podcast.episodeGrouping == PodcastGrouping.unplayed.rawValue) { [weak self] in
+        let unplayedAction = OptionAction(label: L10n.statusUnplayed, selected: episodeGrouping == PodcastGrouping.unplayed) { [weak self] in
             self?.setGroupingSetting(.unplayed)
             Analytics.track(.podcastsScreenEpisodeGroupingChanged, properties: ["value": PodcastGrouping.unplayed])
 
         }
         optionPicker.addAction(action: unplayedAction)
 
-        let seasonAction = OptionAction(label: L10n.season, selected: podcast.episodeGrouping == PodcastGrouping.season.rawValue) { [weak self] in
+        let seasonAction = OptionAction(label: L10n.season, selected: episodeGrouping == PodcastGrouping.season) { [weak self] in
             self?.setGroupingSetting(.season)
             Analytics.track(.podcastsScreenEpisodeGroupingChanged, properties: ["value": PodcastGrouping.season])
 
         }
         optionPicker.addAction(action: seasonAction)
 
-        let starAction = OptionAction(label: L10n.statusStarred, selected: podcast.episodeGrouping == PodcastGrouping.starred.rawValue) { [weak self] in
+        let starAction = OptionAction(label: L10n.statusStarred, selected: episodeGrouping == PodcastGrouping.starred) { [weak self] in
             self?.setGroupingSetting(.starred)
             Analytics.track(.podcastsScreenEpisodeGroupingChanged, properties: ["value": PodcastGrouping.starred])
 
@@ -354,6 +356,10 @@ class EpisodeListSearchController: SimpleNotificationsViewController, UISearchBa
 
     private func setGroupingSetting(_ setting: PodcastGrouping) {
         guard let podcast = podcastDelegate?.displayedPodcast() else { return }
+        if FeatureFlag.settingsSync.enabled {
+            podcast.settings.episodeGrouping = setting
+            podcast.syncStatus = SyncStatus.notSynced.rawValue
+        }
         podcast.episodeGrouping = setting.rawValue
         DataManager.sharedManager.save(podcast: podcast)
 

--- a/podcasts/EpisodesDataManager.swift
+++ b/podcasts/EpisodesDataManager.swift
@@ -36,7 +36,9 @@ class EpisodesDataManager {
         let searchHeader = ListHeader(headerTitle: L10n.search, isSectionHeader: true)
         var newData = [ArraySection<String, ListItem>(model: searchHeader.headerTitle, elements: [searchHeader])]
 
-        let sortOrder = PodcastEpisodeSortOrder(rawValue: podcast.episodeSortOrder) ?? .newestToOldest
+        let episodeSortOrder = podcast.podcastSortOrder
+
+        let sortOrder = episodeSortOrder ?? .newestToOldest
         switch podcast.podcastGrouping() {
         case .none:
             let episodes = EpisodeTableHelper.loadEpisodes(query: createEpisodesQuery(podcast, uuidsToFilter: uuidsToFilter), arguments: nil)
@@ -76,7 +78,10 @@ class EpisodesDataManager {
 
     func createEpisodesQuery(_ podcast: Podcast, uuidsToFilter: [String]? = nil) -> String {
         let sortStr: String
-        let sortOrder = PodcastEpisodeSortOrder(rawValue: podcast.episodeSortOrder) ?? PodcastEpisodeSortOrder.newestToOldest
+
+        let episodeSortOrder = podcast.podcastSortOrder
+
+        let sortOrder = episodeSortOrder ?? PodcastEpisodeSortOrder.newestToOldest
         switch sortOrder {
         case .newestToOldest:
             sortStr = "ORDER BY publishedDate DESC, addedDate DESC"

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -592,7 +592,9 @@ class PlaybackManager: ServerPlaybackDelegate {
     }
 
     func play(podcast: Podcast, startingAtEpisode: Episode) {
-        let orderDirection = (Int(podcast.episodeSortOrder) == PodcastEpisodeSortOrder.newestToOldest.rawValue) ? "DESC" : "ASC"
+        let episodeSortOrder = podcast.podcastSortOrder
+
+        let orderDirection = (episodeSortOrder == PodcastEpisodeSortOrder.newestToOldest) ? "DESC" : "ASC"
         let episodes = DataManager.sharedManager.findEpisodesWhere(customWhere: "podcastUuid == ? AND archived = 0 AND (playingStatus == \(PlayingStatus.notPlayed.rawValue) OR playingStatus == \(PlayingStatus.inProgress.rawValue)) ORDER BY publishedDate \(orderDirection), addedDate \(orderDirection)", arguments: [podcast.uuid])
 
         if episodes.count > 0 {

--- a/podcasts/Podcast+Formatting.swift
+++ b/podcasts/Podcast+Formatting.swift
@@ -93,6 +93,10 @@ extension Podcast {
     #endif
 
     func podcastGrouping() -> PodcastGrouping {
-        PodcastGrouping(rawValue: episodeGrouping) ?? .none
+        if FeatureFlag.settingsSync.enabled {
+            return settings.episodeGrouping
+        } else {
+            return PodcastGrouping(rawValue: episodeGrouping) ?? .none
+        }
     }
 }

--- a/podcasts/Podcast+Settings.swift
+++ b/podcasts/Podcast+Settings.swift
@@ -49,4 +49,14 @@ extension Podcast {
             skipLast = newValue
         }
     }
+
+    var podcastSortOrder: PodcastEpisodeSortOrder? {
+        get {
+            if FeatureFlag.settingsSync.enabled {
+                return settings.episodesSortOrder
+            } else {
+                return PodcastEpisodeSortOrder(rawValue: episodeSortOrder)
+            }
+        }
+    }
 }

--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -475,10 +475,16 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
                 let episodeCount = episodes?.count ?? 0
                 if episodeCount > 0, episodeLimit > 0, podcast.overrideGlobalArchive {
                     var indexToInsertAt = -1
-                    if PodcastEpisodeSortOrder.newestToOldest.rawValue == Int(podcast.episodeSortOrder) {
+
+                    let episodeSortOrder = podcast.podcastSortOrder
+
+                    switch episodeSortOrder {
+                    case .newestToOldest:
                         indexToInsertAt = episodeLimit <= episodeCount ? episodeLimit : episodeCount
-                    } else if PodcastEpisodeSortOrder.oldestToNewest.rawValue == Int(podcast.episodeSortOrder) {
+                    case .oldestToNewest:
                         indexToInsertAt = episodeCount > episodeLimit ? episodeCount - episodeLimit : episodeCount - 1
+                    default:
+                        ()
                     }
 
                     if indexToInsertAt >= 0 {

--- a/podcasts/SiriShortcutsManager.swift
+++ b/podcasts/SiriShortcutsManager.swift
@@ -444,7 +444,9 @@ class SiriShortcutsManager: CustomObserver {
             return INPlayMediaIntentResponseCode.failureUnknownMediaType
         }
 
-        let sortStr = PodcastEpisodeSortOrder.newestToOldest.rawValue == podcast.episodeSortOrder ? "DESC" : "ASC"
+        let episodeSortOrder = podcast.podcastSortOrder
+
+        let sortStr = PodcastEpisodeSortOrder.newestToOldest == episodeSortOrder ? "DESC" : "ASC"
         let query = "podcast_id = \(podcast.id) AND playingStatus <> \(PlayingStatus.completed.rawValue) AND archived = 0 ORDER BY publishedDate \(sortStr), addedDate \(sortStr) LIMIT 1"
         if let topEpisode = DataManager.sharedManager.findEpisodesWhere(customWhere: query, arguments: nil).first {
             AnalyticsPlaybackHelper.shared.currentSource = analyticsSource


### PR DESCRIPTION
| 📘 Part of: #1400 | Depends on #1432 |
|:---:|:---:|

Adds synced settings for Podcast Episodes Layout Menu (sorting and grouping).

## To test

> [!IMPORTANT]
> Use the Staging build config. Some of these settings are new and only available in Staging.

1. Install the app on two devices & log in with the same account
2. D1: Open the Layout menu in a Podcast using the ⋯ icon
3. D1: Change a Layout setting like "Sort Episodes" or "Group Episodes"
4. D1: Navigate back to the Podcast grid
5. D1: Pull to refresh
6. D2: Pull to Refresh
7. D2: Navigate to the same Podcast from D1
8. D2: Navigate to the Layout menu via the ⋯ icon
9. D2: Ensure the the same layout setting is changed

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
