### PR TITLE
[What's New] Change how the announcements are return to allow remotely enabling them

### DIFF
--- a/PocketCastsTests/Tests/Whats New/WhatsNewTests.swift
+++ b/PocketCastsTests/Tests/Whats New/WhatsNewTests.swift
@@ -69,7 +69,8 @@ class WhatsNewtests: XCTestCase {
         let whatsNew = WhatsNew(
             announcements: [announcement(version: "7.41")],
             previousOpenedVersion: "7.41",
-            currentVersion: "7.41"
+            currentVersion: "7.41",
+            lastWhatsNewShown: "7.41"
         )
 
         XCTAssertNil(whatsNew.viewControllerToShow())
@@ -94,7 +95,8 @@ class WhatsNewtests: XCTestCase {
         let whatsNew = WhatsNew(
             announcements: [announcement(version: "7.42")],
             previousOpenedVersion: "7.42",
-            currentVersion: "7.42.1"
+            currentVersion: "7.42.1",
+            lastWhatsNewShown: "7.42"
         )
 
         XCTAssertNil(whatsNew.viewControllerToShow())
@@ -145,13 +147,11 @@ class WhatsNewtests: XCTestCase {
 
     // Do not show an announcement that has been shown before
     func testDontShowAnAnnouncementTwice() {
-        let lastAnnouncement = announcement(version: "7.12")
-
         let whatsNew = WhatsNew(
             announcements: [
                 announcement(version: "7.10"),
                 announcement(version: "7.40"),
-                lastAnnouncement
+                announcement(version: "7.12")
             ],
             previousOpenedVersion: "7.00",
             currentVersion: "7.40",
@@ -159,6 +159,35 @@ class WhatsNewtests: XCTestCase {
         )
 
         XCTAssertNil(whatsNew.visibleAnnouncement)
+    }
+
+    // Do not show an announcement that has been shown before
+    func testShowAnnouncementAfterItWasEnabled() {
+        let whatsNew = WhatsNew(
+            announcements: [
+                announcement(version: "7.10"),
+                announcement(version: "7.40", isEnabled: false),
+                announcement(version: "7.12")
+            ],
+            previousOpenedVersion: "7.40",
+            currentVersion: "7.40",
+            lastWhatsNewShown: "7.12"
+        )
+
+        XCTAssertNil(whatsNew.visibleAnnouncement)
+
+        let whatsNewWithAnnouncementEnabled = WhatsNew(
+            announcements: [
+                announcement(version: "7.10"),
+                announcement(version: "7.40", isEnabled: true),
+                announcement(version: "7.12")
+            ],
+            previousOpenedVersion: "7.40",
+            currentVersion: "7.40",
+            lastWhatsNewShown: "7.12"
+        )
+
+        XCTAssertEqual(whatsNewWithAnnouncementEnabled.visibleAnnouncement?.version, "7.40")
     }
 
     private func announcement(version: String, isEnabled: Bool = true) -> WhatsNew.Announcement {

--- a/PocketCastsTests/Tests/Whats New/WhatsNewTests.swift
+++ b/PocketCastsTests/Tests/Whats New/WhatsNewTests.swift
@@ -161,7 +161,7 @@ class WhatsNewtests: XCTestCase {
         XCTAssertNil(whatsNew.visibleAnnouncement)
     }
 
-    // Do not show an announcement that has been shown before
+    // Shown an announcement if it was later enabled
     func testShowAnnouncementAfterItWasEnabled() {
         let whatsNew = WhatsNew(
             announcements: [

--- a/PocketCastsTests/Tests/Whats New/WhatsNewTests.swift
+++ b/PocketCastsTests/Tests/Whats New/WhatsNewTests.swift
@@ -10,7 +10,8 @@ class WhatsNewtests: XCTestCase {
         let whatsNew = WhatsNew(
             announcements: [announcement(version: "7.40")],
             previousOpenedVersion: "7.39",
-            currentVersion: "7.40"
+            currentVersion: "7.40",
+            lastWhatsNewShown: nil
         )
 
         XCTAssertNotNil(whatsNew.viewControllerToShow())
@@ -33,7 +34,8 @@ class WhatsNewtests: XCTestCase {
         let whatsNew = WhatsNew(
             announcements: [announcement(version: "7.41")],
             previousOpenedVersion: "7.37",
-            currentVersion: "7.42"
+            currentVersion: "7.42",
+            lastWhatsNewShown: nil
         )
 
         XCTAssertNotNil(whatsNew.viewControllerToShow())
@@ -79,7 +81,8 @@ class WhatsNewtests: XCTestCase {
         let whatsNew = WhatsNew(
             announcements: [announcement(version: "7.42")],
             previousOpenedVersion: "7.41",
-            currentVersion: "7.42.1"
+            currentVersion: "7.42.1",
+            lastWhatsNewShown: "7.40"
         )
 
         XCTAssertNotNil(whatsNew.viewControllerToShow())
@@ -133,10 +136,29 @@ class WhatsNewtests: XCTestCase {
                 lastAnnouncement
             ],
             previousOpenedVersion: "7.00",
-            currentVersion: "7.40"
+            currentVersion: "7.40",
+            lastWhatsNewShown: nil
         )
 
         XCTAssertEqual(whatsNew.visibleAnnouncement?.version, lastAnnouncement.version)
+    }
+
+    // Do not show an announcement that has been shown before
+    func testDontShowAnAnnouncementTwice() {
+        let lastAnnouncement = announcement(version: "7.12")
+
+        let whatsNew = WhatsNew(
+            announcements: [
+                announcement(version: "7.10"),
+                announcement(version: "7.40"),
+                lastAnnouncement
+            ],
+            previousOpenedVersion: "7.00",
+            currentVersion: "7.40",
+            lastWhatsNewShown: "7.40"
+        )
+
+        XCTAssertNil(whatsNew.visibleAnnouncement)
     }
 
     private func announcement(version: String, isEnabled: Bool = true) -> WhatsNew.Announcement {

--- a/podcasts/Whats New/WhatsNew.swift
+++ b/podcasts/Whats New/WhatsNew.swift
@@ -76,6 +76,8 @@ class WhatsNew {
         // Don't show any announcements if this is the first run of the app,
         // or if we've already checked the what's new for this version
         guard let previousOpenedVersion else {
+            // Set the lastWhatsNewShown so it doesn't run after the app is reopened
+            Settings.lastWhatsNewShown = currentVersion
             return nil
         }
 

--- a/podcasts/Whats New/WhatsNew.swift
+++ b/podcasts/Whats New/WhatsNew.swift
@@ -75,7 +75,7 @@ class WhatsNew {
     var visibleAnnouncement: Announcement? {
         // Don't show any announcements if this is the first run of the app,
         // or if we've already checked the what's new for this version
-        guard let previousOpenedVersion, previousOpenedVersion != currentVersion else {
+        guard let previousOpenedVersion, lastWhatsNewShown != currentVersion else {
             return nil
         }
 
@@ -87,7 +87,7 @@ class WhatsNew {
             .last(where: {
                 $0.isEnabled() &&
                 $0.version != lastWhatsNewShown &&
-                $0.version.inRange(of: previousOpenedVersion, upper: currentVersion)
+                $0.version.inRange(of: lastWhatsNewShown ?? "0", upper: currentVersion)
             })
     }
 }

--- a/podcasts/Whats New/WhatsNew.swift
+++ b/podcasts/Whats New/WhatsNew.swift
@@ -75,7 +75,13 @@ class WhatsNew {
     var visibleAnnouncement: Announcement? {
         // Don't show any announcements if this is the first run of the app,
         // or if we've already checked the what's new for this version
-        guard let previousOpenedVersion, lastWhatsNewShown != currentVersion else {
+        guard let previousOpenedVersion else {
+            return nil
+        }
+
+        // Don't show the announcement for the current version if it was
+        // already displayed
+        guard lastWhatsNewShown != currentVersion else {
             return nil
         }
 
@@ -87,7 +93,7 @@ class WhatsNew {
             .last(where: {
                 $0.isEnabled() &&
                 $0.version != lastWhatsNewShown &&
-                $0.version.inRange(of: lastWhatsNewShown ?? "0", upper: currentVersion)
+                $0.version.inRange(of: previousOpenedVersion, upper: currentVersion)
             })
     }
 }
@@ -130,6 +136,6 @@ private extension String {
 
     /// Returns whether the version is above the `lower` and equal to or below the `upper` bounds
     func inRange(of lower: String, upper: String) -> Bool {
-        self > lower && self <= upper
+        self >= lower && self <= upper
     }
 }


### PR DESCRIPTION
The previous What's New code relied on checking the previous opened version, which meant that an announcement that was enabled after the app was updated would never show.

This PR updates this behavior.

## To test

1. Do a clean install of `trunk` and run it
2. Check this branch and run it
3. ✅ No announcement should show
4. Go to Profile > Settings > Beta Features and enable `slumber`
6. Re-run the app
7. ✅ The What's New should show
8. Re-run the app
9. ✅ No announcement should show

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
