### PR TITLE
Settings Sync: Playback effects

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/AppSettings.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/AppSettings.swift
@@ -27,6 +27,12 @@ public struct AppSettings: JSONCodable {
     @ModifiedDate public var chapterTitles: Bool
     @ModifiedDate public var autoPlayEnabled: Bool
 
+    // MARK: Playback Effects
+
+    @ModifiedDate public var volumeBoost: Bool
+    @ModifiedDate public var trimSilence: TrimSilenceAmount
+    @ModifiedDate public var playbackSpeed: Double
+
     static var defaults: AppSettings {
         return AppSettings(openLinks: false,
                            rowAction: .stream,
@@ -43,7 +49,10 @@ public struct AppSettings: JSONCodable {
                            legacyBluetooth: false,
                            multiSelectGesture: true,
                            chapterTitles: true,
-                           autoPlayEnabled: true
+                           autoPlayEnabled: true,
+                           volumeBoost: false,
+                           trimSilence: .off,
+                           playbackSpeed: 0
         )
     }
 }

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncSettingsTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncSettingsTask.swift
@@ -21,6 +21,9 @@ extension Api_ChangeableSettings {
         multiSelectGesture.update(settings.$multiSelectGesture)
         chapterTitles.update(settings.$chapterTitles)
         autoPlayEnabled.update(settings.$autoPlayEnabled)
+        volumeBoost.update(settings.$volumeBoost)
+        trimSilence.update(settings.$trimSilence)
+        playbackSpeed.update(settings.$playbackSpeed)
     }
 }
 
@@ -42,6 +45,9 @@ extension AppSettings {
         $multiSelectGesture.update(setting: settings.multiSelectGesture)
         $chapterTitles.update(setting: settings.chapterTitles)
         $autoPlayEnabled.update(setting: settings.autoPlayEnabled)
+        $volumeBoost.update(setting: settings.volumeBoost)
+        $trimSilence.update(setting: settings.trimSilence)
+        $playbackSpeed.update(setting: settings.playbackSpeed)
     }
 }
 

--- a/podcasts/AppSettings+ImportUserDefaults.swift
+++ b/podcasts/AppSettings+ImportUserDefaults.swift
@@ -21,5 +21,8 @@ extension SettingsStore<AppSettings> {
         self.update(\.$multiSelectGesture, value: UserDefaults.standard.bool(forKey: Settings.multiSelectGestureKey))
         self.update(\.$chapterTitles, value: UserDefaults.standard.bool(forKey: Settings.publishChapterTitlesKey))
         self.update(\.$autoPlayEnabled, value: UserDefaults.standard.bool(forKey: Constants.UserDefaults.autoplay))
+        self.update(\.$volumeBoost, value: UserDefaults.standard.bool(forKey: Constants.UserDefaults.globalVolumeBoost))
+        self.update(\.$trimSilence, value: Int32(UserDefaults.standard.integer(forKey: Constants.UserDefaults.globalRemoveSilence)))
+        self.update(\.$playbackSpeed, value: UserDefaults.standard.double(forKey: Constants.UserDefaults.globalPlaybackSpeed))
     }
 }

--- a/podcasts/PlaybackEffects.swift
+++ b/podcasts/PlaybackEffects.swift
@@ -69,11 +69,19 @@ class PlaybackEffects {
     class func globalEffects() -> PlaybackEffects {
         let effects = PlaybackEffects()
         effects.isGlobal = true
-        let removeSilenceAmount = UserDefaults.standard.integer(forKey: Constants.UserDefaults.globalRemoveSilence)
-        effects.trimSilence = convertToTrimSilenceAmount(Int32(removeSilenceAmount))
-        effects.volumeBoost = UserDefaults.standard.bool(forKey: Constants.UserDefaults.globalVolumeBoost)
+        let savedSpeed: Double
+        if FeatureFlag.settingsSync.enabled {
+            effects.trimSilence = SettingsStore.appSettings.trimSilence
+            effects.volumeBoost = SettingsStore.appSettings.volumeBoost
+            savedSpeed = SettingsStore.appSettings.playbackSpeed
+        } else {
+            let removeSilenceAmount = UserDefaults.standard.integer(forKey: Constants.UserDefaults.globalRemoveSilence)
+            effects.trimSilence = convertToTrimSilenceAmount(Int32(removeSilenceAmount))
+            effects.volumeBoost = UserDefaults.standard.bool(forKey: Constants.UserDefaults.globalVolumeBoost)
 
-        let savedSpeed = UserDefaults.standard.double(forKey: Constants.UserDefaults.globalPlaybackSpeed)
+            savedSpeed = UserDefaults.standard.double(forKey: Constants.UserDefaults.globalPlaybackSpeed)
+        }
+
         var roundedSpeed = round(savedSpeed * 10.0) / 10.0
         if roundedSpeed < 0.5 {
             roundedSpeed = 1.0

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -716,9 +716,15 @@ class PlaybackManager: ServerPlaybackDelegate {
 
         // persist changes
         if effects.isGlobal {
-            UserDefaults.standard.set(effects.trimSilence.rawValue, forKey: Constants.UserDefaults.globalRemoveSilence)
-            UserDefaults.standard.set(effects.volumeBoost, forKey: Constants.UserDefaults.globalVolumeBoost)
-            UserDefaults.standard.set(effects.playbackSpeed, forKey: Constants.UserDefaults.globalPlaybackSpeed)
+            if FeatureFlag.settingsSync.enabled {
+                SettingsStore.appSettings.trimSilence = effects.trimSilence
+                SettingsStore.appSettings.volumeBoost = effects.volumeBoost
+                SettingsStore.appSettings.playbackSpeed = effects.playbackSpeed
+            } else {
+                UserDefaults.standard.set(effects.trimSilence.rawValue, forKey: Constants.UserDefaults.globalRemoveSilence)
+                UserDefaults.standard.set(effects.volumeBoost, forKey: Constants.UserDefaults.globalVolumeBoost)
+                UserDefaults.standard.set(effects.playbackSpeed, forKey: Constants.UserDefaults.globalPlaybackSpeed)
+            }
         } else if let episode = episode as? Episode, let podcast = episode.parentPodcast() {
             if FeatureFlag.settingsSync.enabled {
                 podcast.settings.trimSilence = effects.trimSilence


### PR DESCRIPTION
| 📘 Part of: #1400 |
|:---:|

Syncs global playback effect settings.

## To test

1. D1: Open the player
2. D1: Change playback effects
3. D1: Return to Podcasts list
4. D1: Pull to Refresh
5. D2: Pull to Refresh Podcasts list
6. D2: Open player
7. D2: Verify Playback Effects

Continue these steps back and forth and ensure settings are synced.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
