### PR TITLE
Settings Sync: Warn data usage

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/AppSettings.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/AppSettings.swift
@@ -27,6 +27,8 @@ public struct AppSettings: JSONCodable {
     @ModifiedDate public var chapterTitles: Bool
     @ModifiedDate public var autoPlayEnabled: Bool
 
+    @ModifiedDate public var warnDataUsage: Bool = false
+
     static var defaults: AppSettings {
         return AppSettings(openLinks: false,
                            rowAction: .stream,

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncSettingsTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncSettingsTask.swift
@@ -21,6 +21,7 @@ extension Api_ChangeableSettings {
         multiSelectGesture.update(settings.$multiSelectGesture)
         chapterTitles.update(settings.$chapterTitles)
         autoPlayEnabled.update(settings.$autoPlayEnabled)
+        warnDataUsage.update(settings.$warnDataUsage)
     }
 }
 
@@ -42,6 +43,7 @@ extension AppSettings {
         $multiSelectGesture.update(setting: settings.multiSelectGesture)
         $chapterTitles.update(setting: settings.chapterTitles)
         $autoPlayEnabled.update(setting: settings.autoPlayEnabled)
+        $warnDataUsage.update(setting: settings.warnDataUsage)
     }
 }
 

--- a/podcasts/AppSettings+ImportUserDefaults.swift
+++ b/podcasts/AppSettings+ImportUserDefaults.swift
@@ -21,5 +21,6 @@ extension SettingsStore<AppSettings> {
         self.update(\.$multiSelectGesture, value: UserDefaults.standard.bool(forKey: Settings.multiSelectGestureKey))
         self.update(\.$chapterTitles, value: UserDefaults.standard.bool(forKey: Settings.publishChapterTitlesKey))
         self.update(\.$autoPlayEnabled, value: UserDefaults.standard.bool(forKey: Constants.UserDefaults.autoplay))
+        self.update(\.$warnDataUsage, value: !UserDefaults.standard.bool(forKey: Settings.allowCellularDownloadKey))
     }
 }

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -61,12 +61,19 @@ class Settings: NSObject {
 
     // MARK: - Mobile Data
 
-    private static let allowCellularDownloadKey = "SJUserCellular"
+    static let allowCellularDownloadKey = "SJUserCellular"
     class func mobileDataAllowed() -> Bool {
-        UserDefaults.standard.bool(forKey: Settings.allowCellularDownloadKey)
+        if FeatureFlag.settingsSync.enabled {
+            return !SettingsStore.appSettings.warnDataUsage
+        } else {
+            return UserDefaults.standard.bool(forKey: Settings.allowCellularDownloadKey)
+        }
     }
 
     class func setMobileDataAllowed(_ allow: Bool, userInitiated: Bool = false) {
+        if FeatureFlag.settingsSync.enabled {
+            SettingsStore.appSettings.warnDataUsage = !allow
+        }
         UserDefaults.standard.set(allow, forKey: Settings.allowCellularDownloadKey)
 
         guard userInitiated else { return }


### PR DESCRIPTION
| 📘 Part of: #1400 |
|:---:|

Adds syncing for the `warnDataUsage` flag.

## To test

### Storage & Data Usage

1. D1: Navigate to Settings > Storage & Data Usage
2. D1: Change the "Warn before using Data" switch
3. D1: Navigate back to the Profile & Pull to Refresh
4. D2: Pull to Refresh
5. D2: Navigate to Settings > Storage & Data Usage
6. D2: Verify the "Warn before using Data" state

### Alert

1. After enabling "Warn before using Data"
2. Disconnect from wifi on a device
3. Try downloading a podcast
4. Ensure that the warning alert is shown

<img width=300 src="https://github.com/Automattic/pocket-casts-ios/assets/3250/2a8dc0bf-cf04-46e1-93bb-df01f3157471">

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
