### PR TITLE
Settings Sync: Add bookmarks sort synced settings value

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Enums.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Enums.swift
@@ -58,3 +58,9 @@ public struct EpisodeBasicData {
 public enum PodcastEpisodeSortOrder: Int32, Codable, CaseIterable {
     case newestToOldest = 1, oldestToNewest, shortestToLongest, longestToShortest
 }
+
+public enum BookmarksSort: Int32, Codable {
+    case newestToOldest = 0
+    case oldestToNewest = 1
+    case timestamp = 2
+}

--- a/Modules/Server/Sources/PocketCastsServer/Public/AppSettings.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/AppSettings.swift
@@ -33,6 +33,10 @@ public struct AppSettings: JSONCodable {
     @ModifiedDate public var trimSilence: TrimSilenceAmount
     @ModifiedDate public var playbackSpeed: Double
 
+    @ModifiedDate public var playerBookmarksSortType: BookmarksSort = .newestToOldest
+    @ModifiedDate public var episodeBookmarksSortType: BookmarksSort = .newestToOldest
+    @ModifiedDate public var podcastBookmarksSortType: BookmarksSort = .newestToOldest
+
     @ModifiedDate public var warnDataUsage: Bool = false
 
     static var defaults: AppSettings {

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncSettingsTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncSettingsTask.swift
@@ -25,6 +25,9 @@ extension Api_ChangeableSettings {
         trimSilence.update(settings.$trimSilence)
         playbackSpeed.update(settings.$playbackSpeed)
         warnDataUsage.update(settings.$warnDataUsage)
+        playerBookmarksSortType.update(settings.$playerBookmarksSortType)
+        episodeBookmarksSortType.update(settings.$episodeBookmarksSortType)
+        podcastBookmarksSortType.update(settings.$podcastBookmarksSortType)
     }
 }
 
@@ -50,6 +53,9 @@ extension AppSettings {
         $trimSilence.update(setting: settings.trimSilence)
         $playbackSpeed.update(setting: settings.playbackSpeed)
         $warnDataUsage.update(setting: settings.warnDataUsage)
+        $playerBookmarksSortType.update(setting: settings.playerBookmarksSortType)
+        $episodeBookmarksSortType.update(setting: settings.episodeBookmarksSortType)
+        $podcastBookmarksSortType.update(setting: settings.podcastBookmarksSortType)
     }
 }
 

--- a/podcasts/AppSettings+ImportUserDefaults.swift
+++ b/podcasts/AppSettings+ImportUserDefaults.swift
@@ -1,5 +1,6 @@
 import PocketCastsServer
 import PocketCastsUtils
+import PocketCastsDataModel
 
 extension SettingsStore<AppSettings> {
     /// Updates the values in AppSettings with
@@ -25,5 +26,8 @@ extension SettingsStore<AppSettings> {
         self.update(\.$trimSilence, value: Int32(UserDefaults.standard.integer(forKey: Constants.UserDefaults.globalRemoveSilence)))
         self.update(\.$playbackSpeed, value: UserDefaults.standard.double(forKey: Constants.UserDefaults.globalPlaybackSpeed))
         self.update(\.$warnDataUsage, value: !UserDefaults.standard.bool(forKey: Settings.allowCellularDownloadKey))
+        self.update(\.$playerBookmarksSortType, value: BookmarksSort(option: Constants.UserDefaults.bookmarks.playerSort.value))
+        self.update(\.$podcastBookmarksSortType, value: BookmarksSort(option: Constants.UserDefaults.bookmarks.podcastSort.value))
+        self.update(\.$episodeBookmarksSortType, value: BookmarksSort(option: Constants.UserDefaults.bookmarks.episodeSort.value))
     }
 }

--- a/podcasts/Bookmarks/Episode/BookmarkEpisodeListController.swift
+++ b/podcasts/Bookmarks/Episode/BookmarkEpisodeListController.swift
@@ -18,7 +18,7 @@ class BookmarkEpisodeListController: ThemedHostingController<BookmarkEpisodeList
 
         let viewModel = BookmarkEpisodeListViewModel(episode: episode,
                                                       bookmarkManager: bookmarkManager,
-                                                      sortOption: Constants.UserDefaults.bookmarks.episodeSort)
+                                                      sortOption: Settings.episodeBookmarksSort)
         viewModel.analyticsSource = (episode is Episode) ? .episodes : .files
 
         self.viewModel = viewModel

--- a/podcasts/Bookmarks/List/BookmarkEpisodeListViewModel.swift
+++ b/podcasts/Bookmarks/List/BookmarkEpisodeListViewModel.swift
@@ -1,5 +1,6 @@
 import Combine
 import PocketCastsDataModel
+import SwiftUI
 
 class BookmarkEpisodeListViewModel: BookmarkListViewModel {
     var episode: BaseEpisode? = nil {
@@ -8,7 +9,7 @@ class BookmarkEpisodeListViewModel: BookmarkListViewModel {
         }
     }
 
-    convenience init(episode: BaseEpisode, bookmarkManager: BookmarkManager, sortOption: SortSetting) {
+    convenience init(episode: BaseEpisode, bookmarkManager: BookmarkManager, sortOption: Binding<BookmarkSortOption>) {
         self.init(bookmarkManager: bookmarkManager, sortOption: sortOption)
 
         self.episode = episode

--- a/podcasts/Bookmarks/List/BookmarkListViewModel.swift
+++ b/podcasts/Bookmarks/List/BookmarkListViewModel.swift
@@ -1,9 +1,10 @@
 import Combine
 import PocketCastsDataModel
 import PocketCastsServer
+import SwiftUI
 
 class BookmarkListViewModel: SearchableListViewModel<Bookmark> {
-    typealias SortSetting = Constants.SettingValue<BookmarkSortOption>
+    typealias SortSetting = Binding<BookmarkSortOption>
 
     weak var router: BookmarkListRouter?
 
@@ -14,7 +15,7 @@ class BookmarkListViewModel: SearchableListViewModel<Bookmark> {
             Analytics.track(.bookmarksSortByChanged, source: analyticsSource, properties: [
                 "sort_order": sortOption
             ])
-            sortSettingValue.save(sortOption)
+            sortSettingValue = sortOption
         }
     }
 
@@ -31,15 +32,15 @@ class BookmarkListViewModel: SearchableListViewModel<Bookmark> {
     }
 
     var cancellables = Set<AnyCancellable>()
-    private let sortSettingValue: SortSetting
+    @Binding private var sortSettingValue: BookmarkSortOption
 
     let feature: PaidFeature = .bookmarks
     var analyticsSource: BookmarkAnalyticsSource = .unknown
 
     init(bookmarkManager: BookmarkManager, sortOption: SortSetting) {
         self.bookmarkManager = bookmarkManager
-        self.sortSettingValue = sortOption
-        self.sortOption = sortOption.value
+        self._sortSettingValue = sortOption
+        self.sortOption = sortOption.wrappedValue
 
         super.init()
 

--- a/podcasts/Bookmarks/List/BookmarksListView.swift
+++ b/podcasts/Bookmarks/List/BookmarksListView.swift
@@ -205,7 +205,7 @@ enum BookmarkListConstants {
 
 struct BookmarksListView_Previews: PreviewProvider {
     static var previews: some View {
-        BookmarksListView(viewModel: .init(bookmarkManager: .init(), sortOption: .init("", defaultValue: .newestToOldest)), style: BookmarksPlayerTabStyle())
+        BookmarksListView(viewModel: .init(bookmarkManager: .init(), sortOption: Binding.constant(BookmarkSortOption.newestToOldest)), style: BookmarksPlayerTabStyle())
             .setupDefaultEnvironment()
     }
 }

--- a/podcasts/Bookmarks/Player/BookmarksPlayerTab.swift
+++ b/podcasts/Bookmarks/Player/BookmarksPlayerTab.swift
@@ -14,7 +14,7 @@ struct BookmarksPlayerTab: View {
 
 struct BookmarksPlayerTab_Previews: PreviewProvider {
     static var previews: some View {
-        BookmarksPlayerTab(viewModel: .init(bookmarkManager: .init(), sortOption: .init("", defaultValue: .newestToOldest)))
+        BookmarksPlayerTab(viewModel: .init(bookmarkManager: .init(), sortOption: Binding.constant(BookmarkSortOption.newestToOldest)))
             .setupDefaultEnvironment()
     }
 }

--- a/podcasts/Bookmarks/Player/BookmarksPlayerTabController.swift
+++ b/podcasts/Bookmarks/Player/BookmarksPlayerTabController.swift
@@ -12,7 +12,7 @@ class BookmarksPlayerTabController: PlayerItemViewController {
     private var cancellables = Set<AnyCancellable>()
 
     init(bookmarkManager: BookmarkManager, playbackManager: PlaybackManager) {
-        let viewModel = BookmarkEpisodeListViewModel(bookmarkManager: bookmarkManager, sortOption: Constants.UserDefaults.bookmarks.playerSort)
+        let viewModel = BookmarkEpisodeListViewModel(bookmarkManager: bookmarkManager, sortOption: Settings.playerBookmarksSort)
         viewModel.analyticsSource = .player
 
         self.playbackManager = playbackManager

--- a/podcasts/Bookmarks/Podcast/BookmarksPodcastListController.swift
+++ b/podcasts/Bookmarks/Podcast/BookmarksPodcastListController.swift
@@ -14,7 +14,7 @@ class BookmarksPodcastListController: ThemedHostingController<BookmarksPodcastLi
         self.bookmarkManager = bookmarkManager
         self.playbackManager = playbackManager
 
-        let sortOption = Constants.UserDefaults.bookmarks.podcastSort
+        let sortOption = Settings.podcastBookmarksSort
         let viewModel = BookmarkPodcastListViewModel(podcast: podcast,
                                                       bookmarkManager: bookmarkManager,
                                                       sortOption: sortOption)

--- a/podcasts/Enumerations.swift
+++ b/podcasts/Enumerations.swift
@@ -440,3 +440,27 @@ enum MultiSelectAction: Int32, CaseIterable, AnalyticsDescribable {
         }
     }
 }
+
+extension BookmarksSort {
+    var option: BookmarkSortOption {
+        switch self {
+        case .newestToOldest:
+            return .newestToOldest
+        case .oldestToNewest:
+            return .oldestToNewest
+        case .timestamp:
+            return .timestamp
+        }
+    }
+
+    init(option: BookmarkSortOption) {
+        switch option {
+        case .newestToOldest:
+            self = .newestToOldest
+        case .oldestToNewest:
+            self = .oldestToNewest
+        case .timestamp, .episode:
+            self = .timestamp
+        }
+    }
+}

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -4,6 +4,7 @@ import PocketCastsDataModel
 #endif
 import PocketCastsServer
 import UIKit
+import SwiftUI
 
 class Settings: NSObject {
     // MARK: - Library Type
@@ -960,6 +961,51 @@ class Settings: NSObject {
                 SettingsStore.appSettings.skipForward = Int32(newValue)
             }
             ServerSettings.setSkipForwardTime(newValue)
+        }
+    }
+
+    static var playerBookmarksSort: Binding<BookmarkSortOption> {
+        Binding {
+            if FeatureFlag.settingsSync.enabled {
+                return SettingsStore.appSettings.playerBookmarksSortType.option
+            } else {
+                return Constants.UserDefaults.bookmarks.playerSort.value
+            }
+        } set: { newValue in
+            if FeatureFlag.settingsSync.enabled {
+                SettingsStore.appSettings.playerBookmarksSortType = BookmarksSort(option: newValue)
+            }
+            Constants.UserDefaults.bookmarks.playerSort.save(newValue)
+        }
+    }
+
+    static var episodeBookmarksSort: Binding<BookmarkSortOption> {
+        Binding {
+            if FeatureFlag.settingsSync.enabled {
+                return SettingsStore.appSettings.episodeBookmarksSortType.option
+            } else {
+                return Constants.UserDefaults.bookmarks.playerSort.value
+            }
+        } set: { newValue in
+            if FeatureFlag.settingsSync.enabled {
+                SettingsStore.appSettings.episodeBookmarksSortType = BookmarksSort(option: newValue)
+            }
+            Constants.UserDefaults.bookmarks.playerSort.save(newValue)
+        }
+    }
+
+    static var podcastBookmarksSort: Binding<BookmarkSortOption> {
+        Binding {
+            if FeatureFlag.settingsSync.enabled {
+                return SettingsStore.appSettings.podcastBookmarksSortType.option
+            } else {
+                return Constants.UserDefaults.bookmarks.playerSort.value
+            }
+        } set: { newValue in
+            if FeatureFlag.settingsSync.enabled {
+                SettingsStore.appSettings.podcastBookmarksSortType = BookmarksSort(option: newValue)
+            }
+            Constants.UserDefaults.bookmarks.playerSort.save(newValue)
         }
     }
 


### PR DESCRIPTION
| 📘 Part of: #1400 |
|:---:|

Adds a synced setting for bookmarks sorting in player, episode, and podcasts.

https://github.com/Automattic/pocket-casts-ios/assets/3250/a34bf3f0-b1aa-478f-b29a-a045a771eb6d

## To test

> [!IMPORTANT]
> Must be tested in Staging configuration. None of these values are available in production yet.

### Player Sorting

* Log in with a Plus account on two devices/simulators (or enable plus in settings, although this will need to be done each time before you view bookmarks - doesn't affect syncing).
* D1: Add bookmarks or find an episode which already has them
* D1: Open the Bookmarks section in the Player
* D1: Change the sort setting using the ⋯ button
* D1: Navigate back to either the Podcasts list or the Profile
* D1: Pull to Refresh
* D2: Pull to Refresh on Podcasts list or Profile
* D2: Open the same episode with bookmarks (or any episode, of that matter – this setting is global)
* D2: Verify that settings are sorted properly and selected sort type is correct

### Episode Sorting

* Log in with a Plus account on two devices/simulators (or enable plus in settings, although this will need to be done each time before you view bookmarks - doesn't affect syncing).
* D1: Add bookmarks or find a subscribed episode which already has them
* D1: Open the "Bookmarks" section of the Episode page
* D1: Change the sort setting using the ⋯ button
* D1: Navigate back to either the Podcasts list or the Profile
* D1: Pull to Refresh
* D2: Pull to Refresh on Podcasts list or Profile
* D2: Open the same episode with bookmarks (or any episode, of that matter – this setting is global)
* D2: Verify that settings are sorted properly and selected sort type is correct

### Podcast Sorting

* Log in with a Plus account on two devices/simulators (or enable plus in settings, although this will need to be done each time before you view bookmarks - doesn't affect syncing).
* D1: Add bookmarks or find a subscribed podcast which already has them
* D1: Open the "Bookmarks" section of the subscribed Podcast's page
* D1: Change the sort setting using the ⋯ button
* D1: Navigate back to either the Podcasts list or the Profile
* D1: Pull to Refresh
* D2: Pull to Refresh on Podcasts list or Profile
* D2: Open the same podcast with bookmarks (or any podcast, of that matter – this setting is global)
* D2: Verify that settings are sorted properly and selected sort type is correct

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
