### PR TITLE
 Update search for podcast code to handle polling results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 7.58
 -----
-
+- Fixes an issue where adding a new podcast could fail at the first try. [#1457]
 
 7.57
 -----

--- a/Modules/Server/Sources/PocketCastsServer/Public/Refresh/PodcastSearchOperation.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Refresh/PodcastSearchOperation.swift
@@ -57,7 +57,7 @@ class PodcastSearchOperation: Operation {
         dispatchGroup.enter()
         URLSession.shared.dataTask(with: request) { data, _, error in
             guard let data = data, error == nil else {
-                shouldRetry = false
+                shouldRetry = true
                 self.completion(PodcastSearchResponse.failedResponse())
                 self.dispatchGroup.leave()
 

--- a/Modules/Server/Sources/PocketCastsServer/Public/Refresh/PodcastSearchOperation.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Refresh/PodcastSearchOperation.swift
@@ -58,9 +58,7 @@ class PodcastSearchOperation: Operation {
         URLSession.shared.dataTask(with: request) { data, _, error in
             guard let data = data, error == nil else {
                 shouldRetry = true
-                self.completion(PodcastSearchResponse.failedResponse())
                 self.dispatchGroup.leave()
-
                 return
             }
 

--- a/Modules/Server/Sources/PocketCastsServer/Public/Search/PodcastSearchTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Search/PodcastSearchTask.swift
@@ -14,7 +14,7 @@ struct PodcastsSearchEnvelope: Decodable {
 struct PodcastsSearchEnvelopeResult: Decodable {
     /// Podcast returned when the user searches directly for a URL
     let podcast: PodcastFolderSearchResult?
-    
+
     /// Regular search results based on a search term
     let searchResults: [PodcastFolderSearchResult]?
 

--- a/Modules/Server/Sources/PocketCastsServer/Public/ServerPodcastManager.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/ServerPodcastManager.swift
@@ -29,9 +29,9 @@ public class ServerPodcastManager: NSObject {
 
     // MARK: - Podcast add functions
 
-    /// This tries to add the podcast with UUID up to 3 times.
-    /// If The poll mechanism is to be used in cases when the podcast was just added to server and the first call might fail because the server didn't have time to update
-    /// The call will try a maximum of three time with each call having an exponetial backoff period of base 2 seconds for each try
+    /// This tries to add the podcast with UUID up to 3 times if the call fails first time.
+    /// The retry mechanism is to be used in cases when the podcast was just added to server and the first call might fail because the server didn't have time to update.
+    /// The call will be done a maximum of three times, with each call having an exponetial backoff period of base 2 seconds for each try.
     /// - Parameters:
     ///   - podcastUuid: the uuid of the podcast to caache
     ///   - subscribe: if we should subscribe to the podcast after adding
@@ -39,7 +39,7 @@ public class ServerPodcastManager: NSObject {
     ///   - completion: the code to execute on completion
     public func addFromUuidWithRetries(podcastUuid: String, subscribe: Bool, tries: UInt = 0, completion: ((Bool) -> Void)?) {
         var pollbackCounter = tries
-        addFromUuid(podcastUuid: podcastUuid, subscribe: subscribe) { [weak self]success in
+        addFromUuid(podcastUuid: podcastUuid, subscribe: subscribe) { [weak self] success in
             if success {
                 completion?(success)
                 return
@@ -50,7 +50,7 @@ public class ServerPodcastManager: NSObject {
                 self?.addFromUuidWithRetries(podcastUuid: podcastUuid, subscribe: subscribe, tries: pollbackCounter, completion: completion)
                 return
             }
-            completion?(success)
+            completion?(false)
         }
     }
 

--- a/Modules/Server/Sources/PocketCastsServer/Public/ServerPodcastManager.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/ServerPodcastManager.swift
@@ -27,7 +27,32 @@ public class ServerPodcastManager: NSObject {
 
     private let urlConnection = URLConnection(handler: URLSession.shared)
 
-    // MARK: - Podcast add fucntions
+    // MARK: - Podcast add functions
+    
+    /// This tries to add the podcast with UUID up to 3 times.
+    /// If The poll mechanism is to be used in cases when the podcast was just added to server and the first call might fail because the server didn't have time to update
+    /// The call will try a maximum of three time with each call having an exponetial backoff period of base 2 seconds for each try
+    /// - Parameters:
+    ///   - podcastUuid: the uuid of the podcast to caache
+    ///   - subscribe: if we should subscribe to the podcast after adding
+    ///   - tries: the number of tries already done
+    ///   - completion: the code to execute on completion
+    public func addFromUuidWithRetries(podcastUuid: String, subscribe: Bool, tries: UInt = 0, completion: ((Bool) -> Void)?) {
+        var pollbackCounter = tries
+        addFromUuid(podcastUuid: podcastUuid, subscribe: subscribe) { [weak self]success in
+            if success {
+                completion?(success)
+                return
+            }
+            pollbackCounter += 1
+            if pollbackCounter < 3 {
+                Thread.sleep(forTimeInterval: pow(2, Double(pollbackCounter)))
+                self?.addFromUuidWithRetries(podcastUuid: podcastUuid, subscribe: subscribe, tries: pollbackCounter, completion: completion)
+                return
+            }
+            completion?(success)
+        }
+    }
 
     public func addFromUuid(podcastUuid: String, subscribe: Bool, completion: ((Bool) -> Void)?) {
         CacheServerHandler.shared.loadPodcastInfo(podcastUuid: podcastUuid) { [weak self] podcastInfo, lastModified in

--- a/Modules/Server/Sources/PocketCastsServer/Public/ServerPodcastManager.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/ServerPodcastManager.swift
@@ -28,7 +28,7 @@ public class ServerPodcastManager: NSObject {
     private let urlConnection = URLConnection(handler: URLSession.shared)
 
     // MARK: - Podcast add functions
-    
+
     /// This tries to add the podcast with UUID up to 3 times.
     /// If The poll mechanism is to be used in cases when the podcast was just added to server and the first call might fail because the server didn't have time to update
     /// The call will try a maximum of three time with each call having an exponetial backoff period of base 2 seconds for each try

--- a/podcasts/AppDelegate+UrlHandling.swift
+++ b/podcasts/AppDelegate+UrlHandling.swift
@@ -166,7 +166,7 @@ extension AppDelegate {
 
                         return
                     }
-                    ServerPodcastManager.shared.addFromUuid(podcastUuid: uuid, subscribe: false) { success in
+                    ServerPodcastManager.shared.addFromUuidWithRetries(podcastUuid: uuid, subscribe: false) { success in
                         DispatchQueue.main.async {
                             self?.hideProgressDialog()
 


### PR DESCRIPTION
Fixes #1457 

Update search for podcast code to handle polling results
The poll can happen when a rss feed is so large that our servers takes a while to process it.

## To test

- Start the app
- Open the Podcasts tab
- Insert the url of a new podcast to be added to the server. The best way of doing this is to get a large RSS feed file from a know podcast ( the Daily for example) and store in a service like [Pastebin](https://pastebin.com) or a Gist (you can copy [this one](https://gist.github.com/SergioEstevao/e1ab9e690c3de504c34f6c43620d276a)). Then copy/past the URL for the raw of the file in the search box and tap Enter
- Wait for the search to conclude, if all goes well the podcast should be added to our server and show as a result
- If you want to see if the poll process happens put a break point on `PodcastSearchTask` line 97.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
