### PR TITLE
[Deselect Chapters] Tracks

### DIFF
--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -224,6 +224,8 @@ enum AnalyticsEvent: String {
     case playbackEffectTrimSilenceAmountChanged
     case playbackEffectVolumeBoostToggled
 
+    case playbackChapterSkipped
+
     // MARK: - Autoplay
     case playbackEpisodeAutoplayed
     case autoplayStarted
@@ -661,4 +663,11 @@ enum AnalyticsEvent: String {
     case settingsHeadphoneControlsNextChanged
     case settingsHeadphoneControlsPreviousChanged
     case settingsHeadphoneControlsBookmarkSoundToggled
+
+    // MARK: - Skipping Chapters
+    case deselectChaptersToggledOn
+    case deselectChaptersToggledOff
+    case deselectChaptersChapterSelected
+    case deselectChaptersChapterDeselected
+
 }

--- a/podcasts/Analytics/Helpers/AnalyticsPlaybackHelper.swift
+++ b/podcasts/Analytics/Helpers/AnalyticsPlaybackHelper.swift
@@ -62,4 +62,8 @@ class AnalyticsPlaybackHelper: AnalyticsCoordinator {
     func volumeBoostToggled(enabled: Bool) {
         track(.playbackEffectVolumeBoostToggled, properties: ["enabled": enabled])
     }
+
+    func chapterSkipped() {
+        track(.playbackChapterSkipped)
+    }
 }

--- a/podcasts/ChapterManager.swift
+++ b/podcasts/ChapterManager.swift
@@ -12,6 +12,8 @@ class ChapterManager {
 
     private var lastEpisodeUuid = ""
 
+    var numberOfChaptersSkipped = 0
+
     var currentChapters = Chapters()
 
     init(chapterParser: PodcastChapterParser = PodcastChapterParser()) {
@@ -77,7 +79,10 @@ class ChapterManager {
         let chapters = chaptersForTime(time)
         let hasChanged = currentChapters != chapters
 
-        if hasChanged { currentChapters = chapters }
+        if hasChanged {
+            numberOfChaptersSkipped = abs(chapters.index - currentChapters.index)
+            currentChapters = chapters
+        }
 
         return hasChanged
     }

--- a/podcasts/ChapterManager.swift
+++ b/podcasts/ChapterManager.swift
@@ -80,7 +80,6 @@ class ChapterManager {
         let hasChanged = currentChapters != chapters
 
         if hasChanged {
-            numberOfChaptersSkipped = abs(chapters.index - currentChapters.index)
             currentChapters = chapters
         }
 

--- a/podcasts/ChaptersViewController+Table.swift
+++ b/podcasts/ChaptersViewController+Table.swift
@@ -92,5 +92,13 @@ extension ChaptersViewController: ChaptersHeaderDelegate {
         header.isTogglingChapters = isTogglingChapters
         header.update()
         playbackManager.playableChaptersUpdated()
+
+        if isTogglingChapters {
+            numberOfDeselectedChapters = playbackManager.chapterCount(onlyPlayable: true)
+            Analytics.track(.deselectChaptersToggledOn)
+        } else {
+            numberOfDeselectedChapters -= playbackManager.chapterCount(onlyPlayable: true)
+            Analytics.track(.deselectChaptersToggledOff, properties: ["number_of_deselected_chapters": numberOfDeselectedChapters])
+        }
     }
 }

--- a/podcasts/ChaptersViewController.swift
+++ b/podcasts/ChaptersViewController.swift
@@ -4,6 +4,8 @@ import PocketCastsServer
 class ChaptersViewController: PlayerItemViewController {
     var isTogglingChapters = false
 
+    var numberOfDeselectedChapters = 0
+
     @IBOutlet var chaptersTable: UITableView! {
         didSet {
             registerCells()

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -367,6 +367,7 @@ class PlaybackManager: ServerPlaybackDelegate {
             } else {
                 fireChapterChangeNotification()
                 updateNowPlayingInfo()
+                trackChapterSkippedIfNeeded()
             }
         }
     }
@@ -2067,5 +2068,13 @@ extension PlaybackManager {
         // Start the play process
         PlaybackActionHelper.play(episode: episode, podcastUuid: bookmark.podcastUuid)
         #endif
+    }
+
+    // MARK: - Analytics
+
+    private func trackChapterSkippedIfNeeded() {
+        if chapterManager.numberOfChaptersSkipped > 1 {
+            analyticsPlaybackHelper.chapterSkipped()
+        }
     }
 }

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -305,6 +305,10 @@ class PlaybackManager: ServerPlaybackDelegate {
     func skipToPreviousChapter(startPlaybackAfterSkip: Bool = false) {
         guard let previousChapter = chapterManager.previousVisibleChapter() else { return }
 
+        if abs(currentChapters().index - previousChapter.index) > 1 {
+            trackChapterSkipped()
+        }
+
         seekTo(time: ceil(previousChapter.startTime.seconds), startPlaybackAfterSeek: startPlaybackAfterSkip)
     }
 
@@ -316,6 +320,10 @@ class PlaybackManager: ServerPlaybackDelegate {
             // whatever the producer set.
             skipToEndOfLastChapter()
             return
+        }
+
+        if abs(currentChapters().index - nextChapter.index) > 1 {
+            trackChapterSkipped()
         }
 
         seekTo(time: ceil(nextChapter.startTime.seconds), startPlaybackAfterSeek: startPlaybackAfterSkip)
@@ -364,10 +372,10 @@ class PlaybackManager: ServerPlaybackDelegate {
         if chapterManager.haveTriedToParseChaptersFor(episodeUuid: episodeUuid), chapterManager.updateCurrentChapter(time: currentTime()) {
             if currentChapters().visibleChapter?.isPlayable() == false {
                 skipToNextChapter()
+                trackChapterSkipped()
             } else {
                 fireChapterChangeNotification()
                 updateNowPlayingInfo()
-                trackChapterSkippedIfNeeded()
             }
         }
     }
@@ -2072,9 +2080,7 @@ extension PlaybackManager {
 
     // MARK: - Analytics
 
-    private func trackChapterSkippedIfNeeded() {
-        if chapterManager.numberOfChaptersSkipped > 1 {
-            analyticsPlaybackHelper.chapterSkipped()
-        }
+    private func trackChapterSkipped() {
+        analyticsPlaybackHelper.chapterSkipped()
     }
 }

--- a/podcasts/PlayerChapterCell.swift
+++ b/podcasts/PlayerChapterCell.swift
@@ -123,8 +123,10 @@ class PlayerChapterCell: UITableViewCell {
         if let currentEpisode = PlaybackManager.shared.currentEpisode(), let index = chapter?.index {
             if chapter?.shouldPlay == true {
                 currentEpisode.select(chapterIndex: index)
+                track(.deselectChaptersChapterSelected)
             } else {
                 currentEpisode.deselect(chapterIndex: index)
+                track(.deselectChaptersChapterDeselected)
             }
 
             DataManager.sharedManager.save(episode: currentEpisode)
@@ -157,5 +159,9 @@ class PlayerChapterCell: UITableViewCell {
         chapterName.textColor = shouldDim ? ThemeColor.playerContrast02() : ThemeColor.playerContrast01()
         chapterNumber.textColor = chapterName.textColor
         chapterLength.textColor = chapterName.textColor
+    }
+
+    private func track(_ event: AnalyticsEvent) {
+        Analytics.track(event, properties: ["podcast_uuid": PlaybackManager.shared.currentPodcast?.uuid ?? "unknown", "episode_uuid": PlaybackManager.shared.currentEpisode()?.uuid ?? "unknown"])
     }
 }

--- a/podcasts/PlayerContainerViewController.swift
+++ b/podcasts/PlayerContainerViewController.swift
@@ -281,3 +281,9 @@ private extension PlayerContainerViewController {
         }
     }
 }
+
+extension PlayerContainerViewController: AnalyticsSourceProvider {
+    var analyticsSource: AnalyticsSource {
+        .player
+    }
+}


### PR DESCRIPTION
| 📘 Part of: #1396 | Depends #1460 |
|:---:|:---:|

Add tracks.

These are podcasts with chapters you can use to test:

* Clublife: https://pca.st/rLzZCv
* ATP: https://pca.st/accidentaltech

## To test

1. Go to Profile > Settings > Beta Features > `deselectChapters` and `tracksLogging` should be enabled
2. Go to Profile > Settings > Developer > Set to Paid Patron
3. Play any episode with chapters
4. Open the player and go to Chapters
5. Toggle the chapter selection on
6. ✅ `Tracked: deselect_chapters_toggled_on` should be tracked
7. Deselect 3 chapters
8. ✅ `deselect_chapters_chapter_deselected` should be tracked with `podcast_uuid` and `episode_uuid`
9. Tap Done
8. ✅ `Tracked: deselect_chapters_toggled_off ["number_of_deselected_chapters": 3]` should be tracked
10. Toggle chapter selection again
11. Select a chapter that was deselected
12. ✅ `deselect_chapters_chapter_selected` should be tracked with `podcast_uuid` and `episode_uuid`
13. Tap Done
14. ✅ `Tracked: deselect_chapters_toggled_off ["number_of_deselected_chapters": -1]` should be tracked
15. Play the episode
16. ✅  Whenever a chapter is skipped `Tracked: playback_chapter_skipped ["content_type": "audio", "source": "player"]` should be tracked

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
