### PR TITLE
Settings Sync: Podcast List Layout

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Enums.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Enums.swift
@@ -59,6 +59,10 @@ public enum LibrarySort: Int32, CaseIterable, Codable {
     case dateAddedNewestToOldest = 0, titleAtoZ = 1, episodeDateNewestToOldest = 2, custom = 3
 }
 
+public enum LibraryType: Int32, Codable {
+    case fourByFour = 0, threeByThree = 1, list = 2
+}
+
 public enum PodcastEpisodeSortOrder: Int32, Codable, CaseIterable {
     case newestToOldest = 1, oldestToNewest, shortestToLongest, longestToShortest
 }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Enums.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Enums.swift
@@ -63,6 +63,10 @@ public enum LibraryType: Int32, Codable {
     case fourByFour = 0, threeByThree = 1, list = 2
 }
 
+public enum BadgeType: Int32, Codable {
+    case off = 0, latestEpisode, allUnplayed
+}
+
 public enum PodcastEpisodeSortOrder: Int32, Codable, CaseIterable {
     case newestToOldest = 1, oldestToNewest, shortestToLongest, longestToShortest
 }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Enums.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Enums.swift
@@ -55,6 +55,10 @@ public struct EpisodeBasicData {
     public var starred: Bool?
 }
 
+public enum LibrarySort: Int32, CaseIterable, Codable {
+    case dateAddedNewestToOldest = 0, titleAtoZ = 1, episodeDateNewestToOldest = 2, custom = 3
+}
+
 public enum PodcastEpisodeSortOrder: Int32, Codable, CaseIterable {
     case newestToOldest = 1, oldestToNewest, shortestToLongest, longestToShortest
 }

--- a/Modules/Server/Sources/PocketCastsServer/Public/AppSettings.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/AppSettings.swift
@@ -52,6 +52,7 @@ public struct AppSettings: JSONCodable {
 
     @ModifiedDate public var gridOrder: LibrarySort = .dateAddedNewestToOldest
     @ModifiedDate public var gridLayout: LibraryType = .fourByFour
+    @ModifiedDate public var badges: BadgeType = .off
 
     static var defaults: AppSettings {
         return AppSettings(openLinks: false,

--- a/Modules/Server/Sources/PocketCastsServer/Public/AppSettings.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/AppSettings.swift
@@ -50,6 +50,8 @@ public struct AppSettings: JSONCodable {
     @ModifiedDate public var marketingOptIn: Bool = false
     @ModifiedDate public var freeGiftAcknowledgement: Bool = false
 
+    @ModifiedDate public var gridOrder: LibrarySort = .dateAddedNewestToOldest
+
     static var defaults: AppSettings {
         return AppSettings(openLinks: false,
                            rowAction: .stream,

--- a/Modules/Server/Sources/PocketCastsServer/Public/AppSettings.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/AppSettings.swift
@@ -51,6 +51,7 @@ public struct AppSettings: JSONCodable {
     @ModifiedDate public var freeGiftAcknowledgement: Bool = false
 
     @ModifiedDate public var gridOrder: LibrarySort = .dateAddedNewestToOldest
+    @ModifiedDate public var gridLayout: LibraryType = .fourByFour
 
     static var defaults: AppSettings {
         return AppSettings(openLinks: false,

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncSettingsTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncSettingsTask.swift
@@ -38,6 +38,7 @@ extension Api_ChangeableSettings {
         autoArchiveIncludesStarred.update(settings.$autoArchiveIncludesStarred)
         gridOrder.update(settings.$gridOrder)
         gridLayout.update(settings.$gridLayout)
+        badges.update(settings.$badges)
     }
 }
 
@@ -76,6 +77,7 @@ extension AppSettings {
         $autoArchiveIncludesStarred.update(setting: settings.autoArchiveIncludesStarred)
         $gridOrder.update(setting: settings.gridOrder)
         $gridLayout.update(setting: settings.gridLayout)
+        $badges.update(setting: settings.badges)
     }
 }
 

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncSettingsTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncSettingsTask.swift
@@ -36,6 +36,7 @@ extension Api_ChangeableSettings {
         autoArchivePlayed.update(settings.$autoArchivePlayed)
         autoArchiveInactive.update(settings.$autoArchiveInactive)
         autoArchiveIncludesStarred.update(settings.$autoArchiveIncludesStarred)
+        gridOrder.update(settings.$gridOrder)
     }
 }
 
@@ -72,6 +73,7 @@ extension AppSettings {
         $autoArchivePlayed.update(setting: settings.autoArchivePlayed)
         $autoArchiveInactive.update(setting: settings.autoArchiveInactive)
         $autoArchiveIncludesStarred.update(setting: settings.autoArchiveIncludesStarred)
+        $gridOrder.update(setting: settings.gridOrder)
     }
 }
 

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncSettingsTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncSettingsTask.swift
@@ -37,6 +37,7 @@ extension Api_ChangeableSettings {
         autoArchiveInactive.update(settings.$autoArchiveInactive)
         autoArchiveIncludesStarred.update(settings.$autoArchiveIncludesStarred)
         gridOrder.update(settings.$gridOrder)
+        gridLayout.update(settings.$gridLayout)
     }
 }
 
@@ -74,6 +75,7 @@ extension AppSettings {
         $autoArchiveInactive.update(setting: settings.autoArchiveInactive)
         $autoArchiveIncludesStarred.update(setting: settings.autoArchiveIncludesStarred)
         $gridOrder.update(setting: settings.gridOrder)
+        $gridLayout.update(setting: settings.gridLayout)
     }
 }
 

--- a/Pocket Casts Watch App Extension/SortOption.swift
+++ b/Pocket Casts Watch App Extension/SortOption.swift
@@ -14,7 +14,7 @@ extension PodcastEpisodeSortOrder: SortOption {
 
 extension LibrarySort: SortOption {
     static var pickerTitle: String = L10n.podcastsSort
-    var id: Int { rawValue }
+    public var id: Int { Int(rawValue) }
 
     static var allCases: [LibrarySort] {
         [.dateAddedNewestToOldest, .titleAtoZ, .episodeDateNewestToOldest] // custom not available on watch

--- a/podcasts/AppSettings+ImportUserDefaults.swift
+++ b/podcasts/AppSettings+ImportUserDefaults.swift
@@ -43,5 +43,6 @@ extension SettingsStore<AppSettings> {
         self.update(\.$autoArchiveIncludesStarred, value: UserDefaults.standard.bool(forKey: Settings.archiveStarredEpisodesKey))
         self.update(\.$gridOrder, value: Int32(ServerSettings.homeGridSortOrder()))
         self.update(\.$gridLayout, value: Int32(UserDefaults.standard.integer(forKey: Settings.podcastLibraryGridTypeKey)))
+        self.update(\.$badges, value: Int32(UserDefaults.standard.integer(forKey: Settings.badgeKey)))
     }
 }

--- a/podcasts/AppSettings+ImportUserDefaults.swift
+++ b/podcasts/AppSettings+ImportUserDefaults.swift
@@ -42,5 +42,6 @@ extension SettingsStore<AppSettings> {
         }
         self.update(\.$autoArchiveIncludesStarred, value: UserDefaults.standard.bool(forKey: Settings.archiveStarredEpisodesKey))
         self.update(\.$gridOrder, value: Int32(ServerSettings.homeGridSortOrder()))
+        self.update(\.$gridLayout, value: Int32(UserDefaults.standard.integer(forKey: Settings.podcastLibraryGridTypeKey)))
     }
 }

--- a/podcasts/AppSettings+ImportUserDefaults.swift
+++ b/podcasts/AppSettings+ImportUserDefaults.swift
@@ -41,5 +41,6 @@ extension SettingsStore<AppSettings> {
             self.update(\.$autoArchiveInactive, value: inactive.rawValue)
         }
         self.update(\.$autoArchiveIncludesStarred, value: UserDefaults.standard.bool(forKey: Settings.archiveStarredEpisodesKey))
+        self.update(\.$gridOrder, value: Int32(ServerSettings.homeGridSortOrder()))
     }
 }

--- a/podcasts/Enumerations.swift
+++ b/podcasts/Enumerations.swift
@@ -84,8 +84,43 @@ extension PodcastEpisodeSortOrder: AnalyticsDescribable {
     }
 }
 
-enum LibrarySort: Int, CaseIterable, AnalyticsDescribable {
-    case dateAddedNewestToOldest = 1, titleAtoZ = 2, episodeDateNewestToOldest = 5, custom = 6
+extension LibrarySort: AnalyticsDescribable {
+    enum Old: Int {
+        case dateAddedNewestToOldest = 1, titleAtoZ = 2, episodeDateNewestToOldest = 5, custom = 6
+    }
+
+    init?(oldValue: Int) {
+        guard let old = Old(rawValue: oldValue) else {
+            return nil
+        }
+        self.init(old: old)
+    }
+
+    init(old: Old) {
+        switch old {
+        case .dateAddedNewestToOldest:
+            self = .dateAddedNewestToOldest
+        case .titleAtoZ:
+            self = .titleAtoZ
+        case .episodeDateNewestToOldest:
+            self = .episodeDateNewestToOldest
+        case .custom:
+            self = .custom
+        }
+    }
+
+    var old: Old {
+        switch self {
+        case .dateAddedNewestToOldest:
+            return .dateAddedNewestToOldest
+        case .titleAtoZ:
+            return .titleAtoZ
+        case .episodeDateNewestToOldest:
+            return .episodeDateNewestToOldest
+        case .custom:
+            return .custom
+        }
+    }
 
     var description: String {
         switch self {

--- a/podcasts/Enumerations.swift
+++ b/podcasts/Enumerations.swift
@@ -2,8 +2,39 @@ import Foundation
 import PocketCastsDataModel
 import PocketCastsServer
 
-enum LibraryType: Int, AnalyticsDescribable {
-    case fourByFour = 1, threeByThree = 2, list = 3
+extension LibraryType: AnalyticsDescribable {
+    enum Old: Int {
+        case fourByFour = 1, threeByThree = 2, list = 3
+    }
+
+    init?(oldValue: Int) {
+        guard let old = Old(rawValue: oldValue) else {
+            return nil
+        }
+        self.init(old: old)
+    }
+
+    init(old: Old) {
+        switch old {
+        case .fourByFour:
+            self = .fourByFour
+        case .threeByThree:
+            self = .threeByThree
+        case .list:
+            self = .list
+        }
+    }
+
+    var old: Old {
+        switch self {
+        case .fourByFour:
+            return .fourByFour
+        case .threeByThree:
+            return .threeByThree
+        case .list:
+            return .list
+        }
+    }
 
     var analyticsDescription: String {
         switch self {

--- a/podcasts/Enumerations.swift
+++ b/podcasts/Enumerations.swift
@@ -48,9 +48,7 @@ extension LibraryType: AnalyticsDescribable {
     }
 }
 
-enum BadgeType: Int, AnalyticsDescribable {
-    case off = 0, latestEpisode, allUnplayed
-
+extension BadgeType: AnalyticsDescribable {
     var description: String {
         switch self {
         case .off:

--- a/podcasts/Folder+Formatting.swift
+++ b/podcasts/Folder+Formatting.swift
@@ -3,6 +3,6 @@ import PocketCastsDataModel
 
 extension Folder {
     func librarySort() -> LibrarySort {
-        LibrarySort(rawValue: Int32(sortType)) ?? .dateAddedNewestToOldest
+        LibrarySort(oldValue: Int(sortType)) ?? .dateAddedNewestToOldest
     }
 }

--- a/podcasts/Folder+Formatting.swift
+++ b/podcasts/Folder+Formatting.swift
@@ -3,6 +3,6 @@ import PocketCastsDataModel
 
 extension Folder {
     func librarySort() -> LibrarySort {
-        LibrarySort(rawValue: Int(sortType)) ?? .dateAddedNewestToOldest
+        LibrarySort(rawValue: Int32(sortType)) ?? .dateAddedNewestToOldest
     }
 }

--- a/podcasts/PodcastListViewController+Search.swift
+++ b/podcasts/PodcastListViewController+Search.swift
@@ -1,4 +1,5 @@
 import UIKit
+import PocketCastsDataModel
 
 extension PodcastListViewController: UIScrollViewDelegate, PCSearchBarDelegate {
     var searchControllerView: UIView? {

--- a/podcasts/PodcastListViewController.swift
+++ b/podcasts/PodcastListViewController.swift
@@ -48,6 +48,7 @@ class PodcastListViewController: PCViewController, UIGestureRecognizerDelegate, 
     }
 
     var gridItems = [HomeGridListItem]()
+    var gridLayout: LibraryType = Settings.libraryType()
 
     private var lastWillLayoutWidth: CGFloat = 0
 
@@ -202,10 +203,15 @@ class PodcastListViewController: PCViewController, UIGestureRecognizerDelegate, 
             let newData = HomeGridDataHelper.gridListItems(orderedBy: Settings.homeFolderSortOrder(), badgeType: Settings.podcastBadgeType())
 
             DispatchQueue.main.sync {
-                let stagedSet = StagedChangeset(source: oldData, target: newData)
-                strongSelf.podcastsCollectionView.reload(using: stagedSet, setData: { data in
-                    strongSelf.gridItems = data
-                })
+                if strongSelf.gridLayout != Settings.libraryType() {
+                    strongSelf.podcastsCollectionView.reloadData()
+                    strongSelf.gridLayout = Settings.libraryType()
+                } else {
+                    let stagedSet = StagedChangeset(source: oldData, target: newData)
+                    strongSelf.podcastsCollectionView.reload(using: stagedSet, setData: { data in
+                        strongSelf.gridItems = data
+                    })
+                }
                 strongSelf.noPodcastsView.isHidden = newData.count != 0 || SyncManager.isFirstSyncInProgress()
             }
         }

--- a/podcasts/PodcastPickerModel.swift
+++ b/podcasts/PodcastPickerModel.swift
@@ -15,7 +15,7 @@ class PodcastPickerModel: ObservableObject {
 
     @Published var sortType: LibrarySort = .titleAtoZ {
         didSet {
-            UserDefaults.standard.set(sortType.rawValue, forKey: Constants.UserDefaults.lastPickerSort)
+            UserDefaults.standard.set(sortType.old.rawValue, forKey: Constants.UserDefaults.lastPickerSort)
             loadPodcasts()
         }
     }
@@ -37,7 +37,7 @@ class PodcastPickerModel: ObservableObject {
     func setup() {
         let savedSortTypeInt = UserDefaults.standard.integer(forKey: Constants.UserDefaults.lastPickerSort)
         if savedSortTypeInt != 0 {
-            sortType = LibrarySort(rawValue: savedSortTypeInt) ?? .titleAtoZ
+            sortType = LibrarySort(oldValue: savedSortTypeInt) ?? .titleAtoZ
         }
 
         loadPodcasts()

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -42,11 +42,15 @@ class Settings: NSObject {
 
     // MARK: - Podcast Badge
 
-    private static let badgeKey = "SJBadgeType"
+    static let badgeKey = "SJBadgeType"
     class func podcastBadgeType() -> BadgeType {
+        if FeatureFlag.settingsSync.enabled {
+            return SettingsStore.appSettings.badges
+        }
+
         let storedBadgeType = UserDefaults.standard.integer(forKey: Settings.badgeKey)
 
-        if let type = BadgeType(rawValue: storedBadgeType) {
+        if let type = BadgeType(rawValue: Int32(storedBadgeType)) {
             return type
         }
 
@@ -54,6 +58,9 @@ class Settings: NSObject {
     }
 
     class func setPodcastBadgeType(_ badgeType: BadgeType) {
+        if FeatureFlag.settingsSync.enabled {
+            SettingsStore.appSettings.badges = badgeType
+        }
         UserDefaults.standard.set(badgeType.rawValue, forKey: Settings.badgeKey)
     }
 

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -173,8 +173,12 @@ class Settings: NSObject {
     // MARK: - Podcast Sort Order
 
     class func homeFolderSortOrder() -> LibrarySort {
+        if FeatureFlag.settingsSync.enabled {
+            return SettingsStore.appSettings.gridOrder
+        }
+
         let sortInt = ServerSettings.homeGridSortOrder()
-        if let librarySort = LibrarySort(rawValue: sortInt) {
+        if let librarySort = LibrarySort(oldValue: sortInt) {
             return librarySort
         }
 
@@ -182,7 +186,10 @@ class Settings: NSObject {
     }
 
     class func setHomeFolderSortOrder(order: LibrarySort) {
-        ServerSettings.setHomeGridSortOrder(order.rawValue, syncChange: true)
+        if FeatureFlag.settingsSync.enabled {
+            SettingsStore.appSettings.gridOrder = order
+        }
+        ServerSettings.setHomeGridSortOrder(order.old.rawValue, syncChange: true)
     }
 
     // MARK: - Podcast Grouping Default

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -10,20 +10,28 @@ import PocketCastsUtils
 class Settings: NSObject {
     // MARK: - Library Type
 
-    private static let podcastLibraryGridTypeKey = "SJPodcastLibraryGridType"
+    static let podcastLibraryGridTypeKey = "SJPodcastLibraryGridType"
     private static var cachedlibrarySortType: LibraryType?
     class func setLibraryType(_ type: LibraryType) {
-        UserDefaults.standard.set(type.rawValue, forKey: Settings.podcastLibraryGridTypeKey)
+        if FeatureFlag.settingsSync.enabled {
+            SettingsStore.appSettings.gridLayout = type
+        }
+        UserDefaults.standard.set(type.old.rawValue, forKey: Settings.podcastLibraryGridTypeKey)
         cachedlibrarySortType = type
     }
 
     class func libraryType() -> LibraryType {
+
+        if FeatureFlag.settingsSync.enabled {
+            return SettingsStore.appSettings.gridLayout
+        }
+
         if let type = cachedlibrarySortType {
             return type
         }
 
         let storedValue = UserDefaults.standard.integer(forKey: Settings.podcastLibraryGridTypeKey)
-        if let type = LibraryType(rawValue: storedValue) {
+        if let type = LibraryType(oldValue: storedValue) {
             cachedlibrarySortType = type
 
             return type


### PR DESCRIPTION
| 📘 Part of: #1400 |
|:---:|

Adds syncing of `gridOrder`, `gridLayout`, and `badges` settings.

https://github.com/Automattic/pocket-casts-ios/assets/3250/7178d806-6af5-4d27-9011-33c338df2ae0

## To test

### Order

1. D1: Open the Podcast List layout menu by tapping the ⋯ in the upper right.
2. D1: Change the "Sort By" property
3. D1: Pull to refresh the list
4. D2: Pull to refresh the list
5. D2: Verify that the sort changes

### Layout

1. D1: Open the Podcast List layout menu by tapping the ⋯ in the upper right.
2. D1: Change the "Layout" property
3. D1: Pull to refresh the list
4. D2: Pull to refresh the list
5. D2: Verify that the layout changes

### Badges

1. D1: Open the Podcast List layout menu by tapping the ⋯ in the upper right.
2. D1: Change the "Badges" property
3. D1: Pull to refresh the list
4. D2: Pull to refresh the list
5. D2: Verify that the badges appear/disappear

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
