### PR TITLE
Fix Slumber link on upgrade

### DIFF
--- a/podcasts/Onboarding/Plus/UpgradeCard.swift
+++ b/podcasts/Onboarding/Plus/UpgradeCard.swift
@@ -91,7 +91,7 @@ struct UpgradeCard: View {
                             UnderlineLinkTextView(feature.title)
                                 .font(size: 14, style: .subheadline, weight: .medium)
                                 .foregroundColor(theme.primaryText01)
-                                .tint(.black)
+                                .tint(theme.primaryText01)
                                 .fixedSize(horizontal: false, vertical: true)
                         }
                     }

--- a/podcasts/Onboarding/Plus/UpgradeCard.swift
+++ b/podcasts/Onboarding/Plus/UpgradeCard.swift
@@ -88,9 +88,10 @@ struct UpgradeCard: View {
                                 .aspectRatio(contentMode: .fit)
                                 .foregroundColor(theme.primaryText01)
                                 .frame(width: 16, height: 16)
-                            Text(feature.title)
+                            UnderlineLinkTextView(feature.title)
                                 .font(size: 14, style: .subheadline, weight: .medium)
                                 .foregroundColor(theme.primaryText01)
+                                .tint(.black)
                                 .fixedSize(horizontal: false, vertical: true)
                         }
                     }

--- a/podcasts/Onboarding/Plus/UpgradeCard.swift
+++ b/podcasts/Onboarding/Plus/UpgradeCard.swift
@@ -44,7 +44,7 @@ extension UpgradeTier {
             TierFeature(iconName: "plus-feature-cloud", title: L10n.patronCloudStorageLimit),
             TierFeature(iconName: "patron-badge", title: L10n.patronFeatureProfileBadge),
             TierFeature(iconName: "patron-icons", title: L10n.patronFeatureProfileIcons),
-            slumberOrUndyingGratitude
+            TierFeature(iconName: "plus-feature-love", title: L10n.plusFeatureGratitude)
 
         ],
         background: RadialGradient(colors: [Color(hex: "503ACC").opacity(0.8), Color(hex: "121212")], center: .leading, startRadius: 0, endRadius: 500))


### PR DESCRIPTION
There was a merge conflict when merging 7.57 back to `trunk`. I just realized that it broke the Slumber link. This PR fixes it.

<img src="https://github.com/Automattic/pocket-casts-ios/assets/7040243/0b86152b-1a70-467c-8557-f14590369781" width="300">

## To test

1. Run the app
2. Login to an account with no Plus/Patron
3. Go to Profile > Settings > Beta Features > enable `slumber`
4. Go to Podcats, tap the folder icon
5. ✅ The Slumber Studios should have a link and tapping it should open in the app
6. Go to Profile > Account
7. ✅ The Slumber Studios should have a link and tapping it should open in the app

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
