### PR TITLE
Remove unnecessary IAP sync on syncing remote flags

### DIFF
--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -324,10 +324,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                     let remoteValue = RemoteConfig.remoteConfig().configValue(forKey: remoteKey).boolValue
                     try FeatureFlagOverrideStore().override(flag, withValue: remoteValue)
                 }
-            }
-
-            // If the flag is off and we're turning it on we won't have the product info yet so we'll ask for them again
-            IAPHelper.shared.requestProductInfoIfNeeded()
+            }            
         } catch {
             FileLog.shared.addMessage("Failed to set remote feature flag: \(error)")
         }

--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -324,7 +324,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                     let remoteValue = RemoteConfig.remoteConfig().configValue(forKey: remoteKey).boolValue
                     try FeatureFlagOverrideStore().override(flag, withValue: remoteValue)
                 }
-            }            
+            }
         } catch {
             FileLog.shared.addMessage("Failed to set remote feature flag: \(error)")
         }


### PR DESCRIPTION
Fixes #1113 

This call should have been removed when the patron feature flag was removed. It was used because when activated the FF we added the patron products to the list of available products and we need to fetch IAP info.

## To test

- Start the app
- Go to Profile -> Account
- Disable any active subscription ( Settings -> Developer -> set to No Plus)
- Go back to Profile -> Account 
- Check if subscription prices and info show correctly

Steps to test your PR.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
