### PR TITLE
Encapsulate the StoreKit calls inside the IAPHelper class.

### DIFF
--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -5,7 +5,6 @@ import Foundation
 import PocketCastsDataModel
 import PocketCastsServer
 import PocketCastsUtils
-import StoreKit
 
 class AppDelegate: UIResponder, UIApplicationDelegate {
     private static let initialRefreshDelay = 2.seconds
@@ -79,12 +78,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         setupBackgroundRefresh()
 
-        SKPaymentQueue.default().add(IAPHelper.shared)
-
-        // Request the IAP products on launch
-        if SubscriptionHelper.hasActiveSubscription() == false {
-            IAPHelper.shared.requestProductInfo()
-        }
+        IAPHelper.shared.setup(hasSubscription: SubscriptionHelper.hasActiveSubscription())
 
         NotificationCenter.default.addObserver(self, selector: #selector(handleThemeChanged), name: Constants.Notifications.themeChanged, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(hideOverlays), name: Constants.Notifications.openingNonOverlayableWindow, object: nil)
@@ -163,7 +157,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         badgeHelper.teardown()
         shortcutManager.stopListeningForShortcutChanges()
 
-        SKPaymentQueue.default().remove(IAPHelper.shared)
+        IAPHelper.shared.tearDown()
         UIApplication.shared.endReceivingRemoteControlEvents()
     }
 

--- a/podcasts/IAPHelper.swift
+++ b/podcasts/IAPHelper.swift
@@ -38,6 +38,17 @@ class IAPHelper: NSObject {
         addSubscriptionNotifications()
     }
 
+    func setup(hasSubscription: Bool) {
+        SKPaymentQueue.default().add(self)
+        if !hasSubscription {
+            IAPHelper.shared.requestProductInfo()
+        }
+    }
+
+    func tearDown() {
+        SKPaymentQueue.default().remove(self)
+    }
+
     /// Requests the product info if we're not checking already, and the products we have already are different
     func requestProductInfoIfNeeded() {
         let isMissingProducts = productsArray.isEmpty || productsArray.map { $0.productIdentifier } == productIdentifiers.map { $0.rawValue }


### PR DESCRIPTION
Fixes #1370 

This change encapsulates calls for StoreKit inside the IAPHelper.

## To test
 - Start the app with an account with no subscription on a real device
 - Go to profile -> account
 - Check if the prices for Plus and Patron show correctly
 - Try to purchase one of the plans
 - Check if the purchase process works correctly

Steps to test your PR.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
