### PR TITLE
Fix setting the new upgrade account flow feature flag

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -80,6 +80,8 @@ public enum FeatureFlag: String, CaseIterable {
         switch self {
         case .deselectChapters:
             "deselect_chapters"
+        case .newAccountUpgradePromptFlow:
+            "new_account_upgrade_prompt_flow"
         default:
             nil
         }


### PR DESCRIPTION
Fixes #

Fix setting the new upgrade account flow feature flag.
Value was not been read from the RemoteConfig..

## To test

 - Comment the guard line on `updateRemoteFeatureFlags` code on line 304 of `AppDelegate.swift`
 -  Put a break point on line 324 of the same method
 - Start the app  and check that the `newAccountUpgradePromptFlow` feature flag is overridden with the value on the Remote server. ( it should be false)

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
