### PR TITLE
Main dispatch `Analytics.refreshRegistered` on sync

### DIFF
--- a/podcasts/ServerSyncManager.swift
+++ b/podcasts/ServerSyncManager.swift
@@ -70,8 +70,8 @@ class ServerSyncManager: ServerSyncDelegate {
         PodcastManager.shared.checkForPendingAndAutoDownloads()
         UserEpisodeManager.checkForPendingUploads()
         UserEpisodeManager.checkForPendingCloudDeletes()
-        Analytics.shared.refreshRegistered()
         DispatchQueue.main.async {
+            Analytics.shared.refreshRegistered()
             PlaybackManager.shared.effectsChangedExternally()
             Theme.sharedTheme.toggleTheme()
         }


### PR DESCRIPTION
`Analytics.refreshRegistered` calls out to `UIApplication` for several checks and must be done on the main thread.

![CleanShot 2024-02-27 at 10 15 23@2x](https://github.com/Automattic/pocket-casts-ios/assets/3250/2fb37588-356b-4895-adf2-f74f1e96ef28)

## To test

* Build and run
* Pull to refresh
* Ensure no Main Thread checker warnings are shown

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
