### PR TITLE
[What's New] Ensure announcement is displayed after enabled

### DIFF
--- a/PocketCastsTests/Tests/Whats New/WhatsNewTests.swift
+++ b/PocketCastsTests/Tests/Whats New/WhatsNewTests.swift
@@ -190,6 +190,36 @@ class WhatsNewtests: XCTestCase {
         XCTAssertEqual(whatsNewWithAnnouncementEnabled.visibleAnnouncement?.version, "7.40")
     }
 
+    // Shown an announcement if it was later enabled, even if the user migrated
+    // to a upper version. Ensuring the What's New is always displayed if needs.
+    func testShowAnnouncementAfterItWasEnabledInAUpperVersion() {
+        let whatsNew = WhatsNew(
+            announcements: [
+                announcement(version: "7.10"),
+                announcement(version: "7.40", isEnabled: false),
+                announcement(version: "7.12")
+            ],
+            previousOpenedVersion: "7.40",
+            currentVersion: "7.40",
+            lastWhatsNewShown: "7.12"
+        )
+
+        XCTAssertNil(whatsNew.visibleAnnouncement)
+
+        let whatsNewWithAnnouncementEnabled = WhatsNew(
+            announcements: [
+                announcement(version: "7.10"),
+                announcement(version: "7.40", isEnabled: true),
+                announcement(version: "7.12")
+            ],
+            previousOpenedVersion: "7.41",
+            currentVersion: "7.41",
+            lastWhatsNewShown: "7.12"
+        )
+
+        XCTAssertEqual(whatsNewWithAnnouncementEnabled.visibleAnnouncement?.version, "7.40")
+    }
+
     private func announcement(version: String, isEnabled: Bool = true) -> WhatsNew.Announcement {
         return .init(version: version, header: AnyView(EmptyView()), title: "", message: "", buttonTitle: "", action: {}, isEnabled: isEnabled)
     }

--- a/podcasts/Whats New/WhatsNew.swift
+++ b/podcasts/Whats New/WhatsNew.swift
@@ -95,7 +95,7 @@ class WhatsNew {
             .last(where: {
                 $0.isEnabled() &&
                 $0.version != lastWhatsNewShown &&
-                $0.version.inRange(of: previousOpenedVersion, upper: currentVersion)
+                $0.version.inRange(of: lastWhatsNewShown ?? previousOpenedVersion, upper: currentVersion)
             })
     }
 }


### PR DESCRIPTION
After enabling the Slumber Studios announcement I noticed that in the current TestFlight it was not displayed.

This is because the logic was checking for announcements for the current version (7.58), completely ignoring previous ones not displayed (in this case, 7.57).

This fixed this logic and adds a unit test.

## To test

1. Run `release/7.56`
2. Checkout this branch and run it
3. ✅ No What's New is shown
4. Go to Go to Profile > Settings > Beta Features > enable `slumber`
5. Re-run the app
6. ✅ The What's New should show
7. Close and reopen the app
8. ✅ The What's New should not show

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
