### PR TITLE
[Slumber] Make it available only for lifetime and yearly subscriptions

### DIFF
--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -283,7 +283,7 @@ struct Constants {
         static let errorLogoutHandling = "error_logout_handling"
         static let errorLogoutHandlingDefault: Bool = false
 
-        static let slumberStudiosPromoCode = "slumber_studios_promo_code"
+        static let slumberStudiosPromoCode = "slumber_studios_yearly_promo_code"
         static let slumberStudiosPromoCodeDefault = ""
     }
 

--- a/podcasts/Onboarding/Plus/UpgradeLandingView.swift
+++ b/podcasts/Onboarding/Plus/UpgradeLandingView.swift
@@ -238,7 +238,8 @@ struct UpgradeTier: Identifiable {
     let description: String
     let buttonLabel: String
     let buttonForegroundColor: Color
-    let features: [TierFeature]
+    let monthlyFeatures: [TierFeature]
+    let yearlyFeatures: [TierFeature]
     let background: RadialGradient
 
     var id: String {
@@ -253,7 +254,15 @@ struct UpgradeTier: Identifiable {
 
 extension UpgradeTier {
     static var plus: UpgradeTier {
-        UpgradeTier(tier: .plus, iconName: "plusGold", title: "Plus", plan: .plus, header: L10n.plusMarketingTitle, description: L10n.accountDetailsPlusTitle, buttonLabel: L10n.plusSubscribeTo, buttonForegroundColor: Color.plusButtonFilledTextColor, features: [
+        UpgradeTier(tier: .plus, iconName: "plusGold", title: "Plus", plan: .plus, header: L10n.plusMarketingTitle, description: L10n.accountDetailsPlusTitle, buttonLabel: L10n.plusSubscribeTo, buttonForegroundColor: Color.plusButtonFilledTextColor, monthlyFeatures: [
+            TierFeature(iconName: "plus-feature-desktop", title: L10n.plusMarketingDesktopAppsTitle),
+            TierFeature(iconName: "plus-feature-folders", title: L10n.plusMarketingFoldersAndBookmarksTitle),
+            TierFeature(iconName: "plus-feature-cloud", title: L10n.plusCloudStorageLimit),
+            TierFeature(iconName: "plus-feature-watch", title: L10n.plusMarketingWatchPlaybackTitle),
+            TierFeature(iconName: "plus-feature-extra", title: L10n.plusFeatureThemesIcons),
+            TierFeature(iconName: "plus-feature-love", title: L10n.plusFeatureGratitude)
+        ],
+        yearlyFeatures: [
             TierFeature(iconName: "plus-feature-desktop", title: L10n.plusMarketingDesktopAppsTitle),
             TierFeature(iconName: "plus-feature-folders", title: L10n.plusMarketingFoldersAndBookmarksTitle),
             TierFeature(iconName: "plus-feature-cloud", title: L10n.plusCloudStorageLimit),
@@ -265,7 +274,15 @@ extension UpgradeTier {
     }
 
     static var patron: UpgradeTier {
-        UpgradeTier(tier: .patron, iconName: "patron-heart", title: "Patron", plan: .patron, header: L10n.patronCallout, description: L10n.patronDescription, buttonLabel: L10n.patronSubscribeTo, buttonForegroundColor: .white, features: [
+        UpgradeTier(tier: .patron, iconName: "patron-heart", title: "Patron", plan: .patron, header: L10n.patronCallout, description: L10n.patronDescription, buttonLabel: L10n.patronSubscribeTo, buttonForegroundColor: .white, monthlyFeatures: [
+            TierFeature(iconName: "patron-everything", title: L10n.patronFeatureEverythingInPlus),
+            TierFeature(iconName: "patron-early-access", title: L10n.patronFeatureEarlyAccess),
+            TierFeature(iconName: "plus-feature-cloud", title: L10n.patronCloudStorageLimit),
+            TierFeature(iconName: "patron-badge", title: L10n.patronFeatureProfileBadge),
+            TierFeature(iconName: "patron-icons", title: L10n.patronFeatureProfileIcons),
+            TierFeature(iconName: "plus-feature-love", title: L10n.plusFeatureGratitude)
+        ],
+        yearlyFeatures: [
             TierFeature(iconName: "patron-everything", title: L10n.patronFeatureEverythingInPlus),
             TierFeature(iconName: "patron-early-access", title: L10n.patronFeatureEarlyAccess),
             TierFeature(iconName: "plus-feature-cloud", title: L10n.patronCloudStorageLimit),
@@ -357,7 +374,7 @@ struct UpgradeCard: View {
                     SubscriptionPriceAndOfferView(product: subscriptionInfo, mainTextColor: .black, secondaryTextColor: .black.opacity(0.64))
                 }
                 VStack(alignment: .leading, spacing: 12) {
-                    ForEach(tier.features, id: \.self) { feature in
+                    ForEach(currentPrice.wrappedValue == .monthly ? tier.monthlyFeatures : tier.yearlyFeatures, id: \.self) { feature in
                         HStack(spacing: 16) {
                             Image(feature.iconName)
                                 .renderingMode(.template)

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -172,9 +172,9 @@ internal enum L10n {
   internal static var announcementBookmarksTitleBeta: String { return L10n.tr("Localizable", "announcement_bookmarks_title_beta") }
   /// Code copied to clipboard
   internal static var announcementSlumberCodeCopied: String { return L10n.tr("Localizable", "announcement_slumber_code_copied") }
-  /// Subscribe to Plus and enjoy a 1-year subscription to Slumber Studios content, podcasts designed for the sweetest dreams. Learn more.
+  /// Subscribe to Plus Yearly and enjoy a 1-year subscription to Slumber Studios content, podcasts designed for the sweetest dreams. Learn more.
   internal static var announcementSlumberNonPlusDescription: String { return L10n.tr("Localizable", "announcement_slumber_non_plus_description") }
-  /// As part of your Plus subscription, enjoy a 1-year subscription to Slumber Studios content using code %1$@. Learn more.
+  /// As part of your Yearly Plus subscription, enjoy a 1-year subscription to Slumber Studios content using code %1$@. Learn more.
   internal static func announcementSlumberPlusDescription(_ p1: Any) -> String {
     return L10n.tr("Localizable", "announcement_slumber_plus_description", String(describing: p1))
   }

--- a/podcasts/Whats New/SlumberViews.swift
+++ b/podcasts/Whats New/SlumberViews.swift
@@ -51,7 +51,7 @@ struct SlumberCustomBody: View {
             .padding(.bottom)
             .fixedSize(horizontal: false, vertical: true)
             .onTapGesture {
-                guard SubscriptionHelper.hasActiveSubscription() else {
+                guard viewModel.isEligible() else {
                     return
                 }
 
@@ -85,9 +85,9 @@ class SlumberAnnouncementViewModel: ObservableObject {
     }
 
     private func setUpCopies() {
-        buttonTitle = SubscriptionHelper.hasActiveSubscription() ? L10n.announcementSlumberRedeem : L10n.plusSubscribeTo
+        buttonTitle = isEligible() ? L10n.announcementSlumberRedeem : L10n.plusSubscribeTo
 
-        message = (SubscriptionHelper.hasActiveSubscription() ? L10n.announcementSlumberPlusDescription("**\(Settings.slumberPromoCode ?? "")**") : L10n.announcementSlumberNonPlusDescription).replacingOccurrences(of: L10n.announcementSlumberPlusDescriptionLearnMore, with: "[\(L10n.announcementSlumberPlusDescriptionLearnMore)](https://slumberstudios.com)")
+        message = (isEligible() ? L10n.announcementSlumberPlusDescription("**\(Settings.slumberPromoCode ?? "")**") : L10n.announcementSlumberNonPlusDescription).replacingOccurrences(of: L10n.announcementSlumberPlusDescriptionLearnMore, with: "[\(L10n.announcementSlumberPlusDescriptionLearnMore)](https://slumberstudios.com)")
     }
 
     func update() {
@@ -96,6 +96,10 @@ class SlumberAnnouncementViewModel: ObservableObject {
 
     func showRedeemOrUpgrade() {
         upgradeOrRedeemViewModel.showRedeemOrUpgrade()
+    }
+
+    func isEligible() -> Bool {
+        SubscriptionHelper.subscriptionFrequencyValue() == .yearly || SubscriptionHelper.hasLifetimeGift()
     }
 }
 
@@ -108,7 +112,11 @@ class SlumberUpgradeRedeemViewModel: PlusAccountPromptViewModel {
     }
 
     func showRedeemOrUpgrade() {
-        SubscriptionHelper.hasActiveSubscription() ? showRedeem() : upgradeTapped()
+        isEligible() ? showRedeem() : upgradeTapped()
+    }
+
+    func isEligible() -> Bool {
+        SubscriptionHelper.subscriptionFrequencyValue() == .yearly || SubscriptionHelper.hasLifetimeGift()
     }
 
     private func showRedeem() {

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -3981,13 +3981,13 @@
 "announcement_slumber_title" = "Dream big";
 
 /* Slumber Studios partnership announcement description for subscribed users */
-"announcement_slumber_plus_description" = "As part of your Plus subscription, enjoy a 1-year subscription to Slumber Studios content using code %1$@. Learn more.";
+"announcement_slumber_plus_description" = "As part of your Yearly Plus subscription, enjoy a 1-year subscription to Slumber Studios content using code %1$@. Learn more.";
 
 /* Should match the "Learn more" translation on announcement_slumber_plus_description and announcement_slumber_non_plus_description */
 "announcement_slumber_plus_description_learn_more" = "Learn more";
 
 /* Slumber Studios partnership announcement description for non-subscribed users */
-"announcement_slumber_non_plus_description" = "Subscribe to Plus and enjoy a 1-year subscription to Slumber Studios content, podcasts designed for the sweetest dreams. Learn more.";
+"announcement_slumber_non_plus_description" = "Subscribe to Plus Yearly and enjoy a 1-year subscription to Slumber Studios content, podcasts designed for the sweetest dreams. Learn more.";
 
 /* Button label for a feature the user can redeem using a code */
 "announcement_slumber_redeem" = "Redeem your code";


### PR DESCRIPTION
The Slumber benefit is available only for:

1. Lifetime subscriptions
2. Yearly subscriptions

This PR changes this behavior in:

1. The Upgrade modal
2. The What's new

## To test

Change `WhatsNew.swift` `init` to:

```swift
    init(announcements: [Announcement] = Announcements().announcements, previousOpenedVersion: String? = UserDefaults.standard.string(forKey: Constants.UserDefaults.lastRunVersion), currentVersion: String = Settings.appVersion(), lastWhatsNewShown: String? = Settings.lastWhatsNewShown) {
        self.announcements = announcements
        self.previousOpenedVersion = "7.57"
        self.currentVersion = "7.57"
        self.lastWhatsNewShown = "7.56"
    }
```
 
1. Go to Profile > Settings > Beta Features > enable `slumber`
1. Hit <kbd>Command</kbd>+<kbd>Shift</kbd>+<kbd>,</kbd> to open the Scheme editor
2. Click the options tab
3. Select the `Pocket Casts Configuration.storekit` file in the StoreKit configuration dropdown
4. Run the app and login to an account
5. You should see the What's New
6. Tap the upgrade button
7. Toggle between Yearly/Monthly plus
8. ✅ Slumber is only show for Yearly
9. Subscribe to monthly
10. ✅ You should not see the promocode
11. Subscribe to Yearly
12. ✅ You should now see the promocode
13. Re-run the app
14. ✅ You should see the promocode
15. Delete and reinstall the app
16. Login to an account with lifetime (it can be your A8C one)
17. ✅ You should see the promocode

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
