### PR TITLE
Settings Sync: General Auto Download settings

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Private/Protobuffer/api.pb.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Private/Protobuffer/api.pb.swift
@@ -959,6 +959,69 @@ struct Api_ChangeableSettings {
   /// Clears the value of `filesSortOrder`. Subsequent reads from it will return its default value.
   mutating func clearFilesSortOrder() {_uniqueStorage()._filesSortOrder = nil}
 
+  var backgroundRefresh: Api_BoolSetting {
+    get {return _storage._backgroundRefresh ?? Api_BoolSetting()}
+    set {_uniqueStorage()._backgroundRefresh = newValue}
+  }
+  /// Returns true if `backgroundRefresh` has been explicitly set.
+  var hasBackgroundRefresh: Bool {return _storage._backgroundRefresh != nil}
+  /// Clears the value of `backgroundRefresh`. Subsequent reads from it will return its default value.
+  mutating func clearBackgroundRefresh() {_uniqueStorage()._backgroundRefresh = nil}
+
+  var autoDownloadUnmeteredOnly: Api_BoolSetting {
+    get {return _storage._autoDownloadUnmeteredOnly ?? Api_BoolSetting()}
+    set {_uniqueStorage()._autoDownloadUnmeteredOnly = newValue}
+  }
+  /// Returns true if `autoDownloadUnmeteredOnly` has been explicitly set.
+  var hasAutoDownloadUnmeteredOnly: Bool {return _storage._autoDownloadUnmeteredOnly != nil}
+  /// Clears the value of `autoDownloadUnmeteredOnly`. Subsequent reads from it will return its default value.
+  mutating func clearAutoDownloadUnmeteredOnly() {_uniqueStorage()._autoDownloadUnmeteredOnly = nil}
+
+  var autoDownloadOnlyWhenCharging: Api_BoolSetting {
+    get {return _storage._autoDownloadOnlyWhenCharging ?? Api_BoolSetting()}
+    set {_uniqueStorage()._autoDownloadOnlyWhenCharging = newValue}
+  }
+  /// Returns true if `autoDownloadOnlyWhenCharging` has been explicitly set.
+  var hasAutoDownloadOnlyWhenCharging: Bool {return _storage._autoDownloadOnlyWhenCharging != nil}
+  /// Clears the value of `autoDownloadOnlyWhenCharging`. Subsequent reads from it will return its default value.
+  mutating func clearAutoDownloadOnlyWhenCharging() {_uniqueStorage()._autoDownloadOnlyWhenCharging = nil}
+
+  var autoDownloadUpNext: Api_BoolSetting {
+    get {return _storage._autoDownloadUpNext ?? Api_BoolSetting()}
+    set {_uniqueStorage()._autoDownloadUpNext = newValue}
+  }
+  /// Returns true if `autoDownloadUpNext` has been explicitly set.
+  var hasAutoDownloadUpNext: Bool {return _storage._autoDownloadUpNext != nil}
+  /// Clears the value of `autoDownloadUpNext`. Subsequent reads from it will return its default value.
+  mutating func clearAutoDownloadUpNext() {_uniqueStorage()._autoDownloadUpNext = nil}
+
+  var cloudAutoUpload: Api_BoolSetting {
+    get {return _storage._cloudAutoUpload ?? Api_BoolSetting()}
+    set {_uniqueStorage()._cloudAutoUpload = newValue}
+  }
+  /// Returns true if `cloudAutoUpload` has been explicitly set.
+  var hasCloudAutoUpload: Bool {return _storage._cloudAutoUpload != nil}
+  /// Clears the value of `cloudAutoUpload`. Subsequent reads from it will return its default value.
+  mutating func clearCloudAutoUpload() {_uniqueStorage()._cloudAutoUpload = nil}
+
+  var cloudAutoDownload: Api_BoolSetting {
+    get {return _storage._cloudAutoDownload ?? Api_BoolSetting()}
+    set {_uniqueStorage()._cloudAutoDownload = newValue}
+  }
+  /// Returns true if `cloudAutoDownload` has been explicitly set.
+  var hasCloudAutoDownload: Bool {return _storage._cloudAutoDownload != nil}
+  /// Clears the value of `cloudAutoDownload`. Subsequent reads from it will return its default value.
+  mutating func clearCloudAutoDownload() {_uniqueStorage()._cloudAutoDownload = nil}
+
+  var cloudDownloadUnmeteredOnly: Api_BoolSetting {
+    get {return _storage._cloudDownloadUnmeteredOnly ?? Api_BoolSetting()}
+    set {_uniqueStorage()._cloudDownloadUnmeteredOnly = newValue}
+  }
+  /// Returns true if `cloudDownloadUnmeteredOnly` has been explicitly set.
+  var hasCloudDownloadUnmeteredOnly: Bool {return _storage._cloudDownloadUnmeteredOnly != nil}
+  /// Clears the value of `cloudDownloadUnmeteredOnly`. Subsequent reads from it will return its default value.
+  mutating func clearCloudDownloadUnmeteredOnly() {_uniqueStorage()._cloudDownloadUnmeteredOnly = nil}
+
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
@@ -1603,6 +1666,69 @@ struct Api_NamedSettings {
   /// Clears the value of `filesSortOrder`. Subsequent reads from it will return its default value.
   mutating func clearFilesSortOrder() {_uniqueStorage()._filesSortOrder = nil}
 
+  var backgroundRefresh: SwiftProtobuf.Google_Protobuf_BoolValue {
+    get {return _storage._backgroundRefresh ?? SwiftProtobuf.Google_Protobuf_BoolValue()}
+    set {_uniqueStorage()._backgroundRefresh = newValue}
+  }
+  /// Returns true if `backgroundRefresh` has been explicitly set.
+  var hasBackgroundRefresh: Bool {return _storage._backgroundRefresh != nil}
+  /// Clears the value of `backgroundRefresh`. Subsequent reads from it will return its default value.
+  mutating func clearBackgroundRefresh() {_uniqueStorage()._backgroundRefresh = nil}
+
+  var autoDownloadUnmeteredOnly: SwiftProtobuf.Google_Protobuf_BoolValue {
+    get {return _storage._autoDownloadUnmeteredOnly ?? SwiftProtobuf.Google_Protobuf_BoolValue()}
+    set {_uniqueStorage()._autoDownloadUnmeteredOnly = newValue}
+  }
+  /// Returns true if `autoDownloadUnmeteredOnly` has been explicitly set.
+  var hasAutoDownloadUnmeteredOnly: Bool {return _storage._autoDownloadUnmeteredOnly != nil}
+  /// Clears the value of `autoDownloadUnmeteredOnly`. Subsequent reads from it will return its default value.
+  mutating func clearAutoDownloadUnmeteredOnly() {_uniqueStorage()._autoDownloadUnmeteredOnly = nil}
+
+  var autoDownloadOnlyWhenCharging: SwiftProtobuf.Google_Protobuf_BoolValue {
+    get {return _storage._autoDownloadOnlyWhenCharging ?? SwiftProtobuf.Google_Protobuf_BoolValue()}
+    set {_uniqueStorage()._autoDownloadOnlyWhenCharging = newValue}
+  }
+  /// Returns true if `autoDownloadOnlyWhenCharging` has been explicitly set.
+  var hasAutoDownloadOnlyWhenCharging: Bool {return _storage._autoDownloadOnlyWhenCharging != nil}
+  /// Clears the value of `autoDownloadOnlyWhenCharging`. Subsequent reads from it will return its default value.
+  mutating func clearAutoDownloadOnlyWhenCharging() {_uniqueStorage()._autoDownloadOnlyWhenCharging = nil}
+
+  var autoDownloadUpNext: SwiftProtobuf.Google_Protobuf_BoolValue {
+    get {return _storage._autoDownloadUpNext ?? SwiftProtobuf.Google_Protobuf_BoolValue()}
+    set {_uniqueStorage()._autoDownloadUpNext = newValue}
+  }
+  /// Returns true if `autoDownloadUpNext` has been explicitly set.
+  var hasAutoDownloadUpNext: Bool {return _storage._autoDownloadUpNext != nil}
+  /// Clears the value of `autoDownloadUpNext`. Subsequent reads from it will return its default value.
+  mutating func clearAutoDownloadUpNext() {_uniqueStorage()._autoDownloadUpNext = nil}
+
+  var cloudAutoUpload: SwiftProtobuf.Google_Protobuf_BoolValue {
+    get {return _storage._cloudAutoUpload ?? SwiftProtobuf.Google_Protobuf_BoolValue()}
+    set {_uniqueStorage()._cloudAutoUpload = newValue}
+  }
+  /// Returns true if `cloudAutoUpload` has been explicitly set.
+  var hasCloudAutoUpload: Bool {return _storage._cloudAutoUpload != nil}
+  /// Clears the value of `cloudAutoUpload`. Subsequent reads from it will return its default value.
+  mutating func clearCloudAutoUpload() {_uniqueStorage()._cloudAutoUpload = nil}
+
+  var cloudAutoDownload: SwiftProtobuf.Google_Protobuf_BoolValue {
+    get {return _storage._cloudAutoDownload ?? SwiftProtobuf.Google_Protobuf_BoolValue()}
+    set {_uniqueStorage()._cloudAutoDownload = newValue}
+  }
+  /// Returns true if `cloudAutoDownload` has been explicitly set.
+  var hasCloudAutoDownload: Bool {return _storage._cloudAutoDownload != nil}
+  /// Clears the value of `cloudAutoDownload`. Subsequent reads from it will return its default value.
+  mutating func clearCloudAutoDownload() {_uniqueStorage()._cloudAutoDownload = nil}
+
+  var cloudDownloadUnmeteredOnly: SwiftProtobuf.Google_Protobuf_BoolValue {
+    get {return _storage._cloudDownloadUnmeteredOnly ?? SwiftProtobuf.Google_Protobuf_BoolValue()}
+    set {_uniqueStorage()._cloudDownloadUnmeteredOnly = newValue}
+  }
+  /// Returns true if `cloudDownloadUnmeteredOnly` has been explicitly set.
+  var hasCloudDownloadUnmeteredOnly: Bool {return _storage._cloudDownloadUnmeteredOnly != nil}
+  /// Clears the value of `cloudDownloadUnmeteredOnly`. Subsequent reads from it will return its default value.
+  mutating func clearCloudDownloadUnmeteredOnly() {_uniqueStorage()._cloudDownloadUnmeteredOnly = nil}
+
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
@@ -2246,6 +2372,69 @@ struct Api_NamedSettingsResponse {
   var hasFilesSortOrder: Bool {return _storage._filesSortOrder != nil}
   /// Clears the value of `filesSortOrder`. Subsequent reads from it will return its default value.
   mutating func clearFilesSortOrder() {_uniqueStorage()._filesSortOrder = nil}
+
+  var backgroundRefresh: Api_BoolSetting {
+    get {return _storage._backgroundRefresh ?? Api_BoolSetting()}
+    set {_uniqueStorage()._backgroundRefresh = newValue}
+  }
+  /// Returns true if `backgroundRefresh` has been explicitly set.
+  var hasBackgroundRefresh: Bool {return _storage._backgroundRefresh != nil}
+  /// Clears the value of `backgroundRefresh`. Subsequent reads from it will return its default value.
+  mutating func clearBackgroundRefresh() {_uniqueStorage()._backgroundRefresh = nil}
+
+  var autoDownloadUnmeteredOnly: Api_BoolSetting {
+    get {return _storage._autoDownloadUnmeteredOnly ?? Api_BoolSetting()}
+    set {_uniqueStorage()._autoDownloadUnmeteredOnly = newValue}
+  }
+  /// Returns true if `autoDownloadUnmeteredOnly` has been explicitly set.
+  var hasAutoDownloadUnmeteredOnly: Bool {return _storage._autoDownloadUnmeteredOnly != nil}
+  /// Clears the value of `autoDownloadUnmeteredOnly`. Subsequent reads from it will return its default value.
+  mutating func clearAutoDownloadUnmeteredOnly() {_uniqueStorage()._autoDownloadUnmeteredOnly = nil}
+
+  var autoDownloadOnlyWhenCharging: Api_BoolSetting {
+    get {return _storage._autoDownloadOnlyWhenCharging ?? Api_BoolSetting()}
+    set {_uniqueStorage()._autoDownloadOnlyWhenCharging = newValue}
+  }
+  /// Returns true if `autoDownloadOnlyWhenCharging` has been explicitly set.
+  var hasAutoDownloadOnlyWhenCharging: Bool {return _storage._autoDownloadOnlyWhenCharging != nil}
+  /// Clears the value of `autoDownloadOnlyWhenCharging`. Subsequent reads from it will return its default value.
+  mutating func clearAutoDownloadOnlyWhenCharging() {_uniqueStorage()._autoDownloadOnlyWhenCharging = nil}
+
+  var autoDownloadUpNext: Api_BoolSetting {
+    get {return _storage._autoDownloadUpNext ?? Api_BoolSetting()}
+    set {_uniqueStorage()._autoDownloadUpNext = newValue}
+  }
+  /// Returns true if `autoDownloadUpNext` has been explicitly set.
+  var hasAutoDownloadUpNext: Bool {return _storage._autoDownloadUpNext != nil}
+  /// Clears the value of `autoDownloadUpNext`. Subsequent reads from it will return its default value.
+  mutating func clearAutoDownloadUpNext() {_uniqueStorage()._autoDownloadUpNext = nil}
+
+  var cloudAutoUpload: Api_BoolSetting {
+    get {return _storage._cloudAutoUpload ?? Api_BoolSetting()}
+    set {_uniqueStorage()._cloudAutoUpload = newValue}
+  }
+  /// Returns true if `cloudAutoUpload` has been explicitly set.
+  var hasCloudAutoUpload: Bool {return _storage._cloudAutoUpload != nil}
+  /// Clears the value of `cloudAutoUpload`. Subsequent reads from it will return its default value.
+  mutating func clearCloudAutoUpload() {_uniqueStorage()._cloudAutoUpload = nil}
+
+  var cloudAutoDownload: Api_BoolSetting {
+    get {return _storage._cloudAutoDownload ?? Api_BoolSetting()}
+    set {_uniqueStorage()._cloudAutoDownload = newValue}
+  }
+  /// Returns true if `cloudAutoDownload` has been explicitly set.
+  var hasCloudAutoDownload: Bool {return _storage._cloudAutoDownload != nil}
+  /// Clears the value of `cloudAutoDownload`. Subsequent reads from it will return its default value.
+  mutating func clearCloudAutoDownload() {_uniqueStorage()._cloudAutoDownload = nil}
+
+  var cloudDownloadUnmeteredOnly: Api_BoolSetting {
+    get {return _storage._cloudDownloadUnmeteredOnly ?? Api_BoolSetting()}
+    set {_uniqueStorage()._cloudDownloadUnmeteredOnly = newValue}
+  }
+  /// Returns true if `cloudDownloadUnmeteredOnly` has been explicitly set.
+  var hasCloudDownloadUnmeteredOnly: Bool {return _storage._cloudDownloadUnmeteredOnly != nil}
+  /// Clears the value of `cloudDownloadUnmeteredOnly`. Subsequent reads from it will return its default value.
+  mutating func clearCloudDownloadUnmeteredOnly() {_uniqueStorage()._cloudDownloadUnmeteredOnly = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -7614,6 +7803,13 @@ extension Api_ChangeableSettings: SwiftProtobuf.Message, SwiftProtobuf._MessageI
     70: .standard(proto: "use_dark_up_next_theme"),
     71: .standard(proto: "use_dynamic_colors_for_widget"),
     72: .standard(proto: "files_sort_order"),
+    73: .standard(proto: "background_refresh"),
+    74: .standard(proto: "auto_download_unmetered_only"),
+    75: .standard(proto: "auto_download_only_when_charging"),
+    76: .standard(proto: "auto_download_up_next"),
+    77: .standard(proto: "cloud_auto_upload"),
+    78: .standard(proto: "cloud_auto_download"),
+    79: .standard(proto: "cloud_download_unmetered_only"),
   ]
 
   fileprivate class _StorageClass {
@@ -7687,6 +7883,13 @@ extension Api_ChangeableSettings: SwiftProtobuf.Message, SwiftProtobuf._MessageI
     var _useDarkUpNextTheme: Api_BoolSetting? = nil
     var _useDynamicColorsForWidget: Api_BoolSetting? = nil
     var _filesSortOrder: Api_Int32Setting? = nil
+    var _backgroundRefresh: Api_BoolSetting? = nil
+    var _autoDownloadUnmeteredOnly: Api_BoolSetting? = nil
+    var _autoDownloadOnlyWhenCharging: Api_BoolSetting? = nil
+    var _autoDownloadUpNext: Api_BoolSetting? = nil
+    var _cloudAutoUpload: Api_BoolSetting? = nil
+    var _cloudAutoDownload: Api_BoolSetting? = nil
+    var _cloudDownloadUnmeteredOnly: Api_BoolSetting? = nil
 
     static let defaultInstance = _StorageClass()
 
@@ -7763,6 +7966,13 @@ extension Api_ChangeableSettings: SwiftProtobuf.Message, SwiftProtobuf._MessageI
       _useDarkUpNextTheme = source._useDarkUpNextTheme
       _useDynamicColorsForWidget = source._useDynamicColorsForWidget
       _filesSortOrder = source._filesSortOrder
+      _backgroundRefresh = source._backgroundRefresh
+      _autoDownloadUnmeteredOnly = source._autoDownloadUnmeteredOnly
+      _autoDownloadOnlyWhenCharging = source._autoDownloadOnlyWhenCharging
+      _autoDownloadUpNext = source._autoDownloadUpNext
+      _cloudAutoUpload = source._cloudAutoUpload
+      _cloudAutoDownload = source._cloudAutoDownload
+      _cloudDownloadUnmeteredOnly = source._cloudDownloadUnmeteredOnly
     }
   }
 
@@ -7851,6 +8061,13 @@ extension Api_ChangeableSettings: SwiftProtobuf.Message, SwiftProtobuf._MessageI
         case 70: try { try decoder.decodeSingularMessageField(value: &_storage._useDarkUpNextTheme) }()
         case 71: try { try decoder.decodeSingularMessageField(value: &_storage._useDynamicColorsForWidget) }()
         case 72: try { try decoder.decodeSingularMessageField(value: &_storage._filesSortOrder) }()
+        case 73: try { try decoder.decodeSingularMessageField(value: &_storage._backgroundRefresh) }()
+        case 74: try { try decoder.decodeSingularMessageField(value: &_storage._autoDownloadUnmeteredOnly) }()
+        case 75: try { try decoder.decodeSingularMessageField(value: &_storage._autoDownloadOnlyWhenCharging) }()
+        case 76: try { try decoder.decodeSingularMessageField(value: &_storage._autoDownloadUpNext) }()
+        case 77: try { try decoder.decodeSingularMessageField(value: &_storage._cloudAutoUpload) }()
+        case 78: try { try decoder.decodeSingularMessageField(value: &_storage._cloudAutoDownload) }()
+        case 79: try { try decoder.decodeSingularMessageField(value: &_storage._cloudDownloadUnmeteredOnly) }()
         default: break
         }
       }
@@ -8073,6 +8290,27 @@ extension Api_ChangeableSettings: SwiftProtobuf.Message, SwiftProtobuf._MessageI
       try { if let v = _storage._filesSortOrder {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 72)
       } }()
+      try { if let v = _storage._backgroundRefresh {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 73)
+      } }()
+      try { if let v = _storage._autoDownloadUnmeteredOnly {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 74)
+      } }()
+      try { if let v = _storage._autoDownloadOnlyWhenCharging {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 75)
+      } }()
+      try { if let v = _storage._autoDownloadUpNext {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 76)
+      } }()
+      try { if let v = _storage._cloudAutoUpload {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 77)
+      } }()
+      try { if let v = _storage._cloudAutoDownload {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 78)
+      } }()
+      try { if let v = _storage._cloudDownloadUnmeteredOnly {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 79)
+      } }()
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -8152,6 +8390,13 @@ extension Api_ChangeableSettings: SwiftProtobuf.Message, SwiftProtobuf._MessageI
         if _storage._useDarkUpNextTheme != rhs_storage._useDarkUpNextTheme {return false}
         if _storage._useDynamicColorsForWidget != rhs_storage._useDynamicColorsForWidget {return false}
         if _storage._filesSortOrder != rhs_storage._filesSortOrder {return false}
+        if _storage._backgroundRefresh != rhs_storage._backgroundRefresh {return false}
+        if _storage._autoDownloadUnmeteredOnly != rhs_storage._autoDownloadUnmeteredOnly {return false}
+        if _storage._autoDownloadOnlyWhenCharging != rhs_storage._autoDownloadOnlyWhenCharging {return false}
+        if _storage._autoDownloadUpNext != rhs_storage._autoDownloadUpNext {return false}
+        if _storage._cloudAutoUpload != rhs_storage._cloudAutoUpload {return false}
+        if _storage._cloudAutoDownload != rhs_storage._cloudAutoDownload {return false}
+        if _storage._cloudDownloadUnmeteredOnly != rhs_storage._cloudDownloadUnmeteredOnly {return false}
         return true
       }
       if !storagesAreEqual {return false}
@@ -8234,6 +8479,13 @@ extension Api_NamedSettings: SwiftProtobuf.Message, SwiftProtobuf._MessageImplem
     70: .standard(proto: "use_dark_up_next_theme"),
     71: .standard(proto: "use_dynamic_colors_for_widget"),
     72: .standard(proto: "files_sort_order"),
+    73: .standard(proto: "background_refresh"),
+    74: .standard(proto: "auto_download_unmetered_only"),
+    75: .standard(proto: "auto_download_only_when_charging"),
+    76: .standard(proto: "auto_download_up_next"),
+    77: .standard(proto: "cloud_auto_upload"),
+    78: .standard(proto: "cloud_auto_download"),
+    79: .standard(proto: "cloud_download_unmetered_only"),
   ]
 
   fileprivate class _StorageClass {
@@ -8307,6 +8559,13 @@ extension Api_NamedSettings: SwiftProtobuf.Message, SwiftProtobuf._MessageImplem
     var _useDarkUpNextTheme: SwiftProtobuf.Google_Protobuf_BoolValue? = nil
     var _useDynamicColorsForWidget: SwiftProtobuf.Google_Protobuf_BoolValue? = nil
     var _filesSortOrder: SwiftProtobuf.Google_Protobuf_Int32Value? = nil
+    var _backgroundRefresh: SwiftProtobuf.Google_Protobuf_BoolValue? = nil
+    var _autoDownloadUnmeteredOnly: SwiftProtobuf.Google_Protobuf_BoolValue? = nil
+    var _autoDownloadOnlyWhenCharging: SwiftProtobuf.Google_Protobuf_BoolValue? = nil
+    var _autoDownloadUpNext: SwiftProtobuf.Google_Protobuf_BoolValue? = nil
+    var _cloudAutoUpload: SwiftProtobuf.Google_Protobuf_BoolValue? = nil
+    var _cloudAutoDownload: SwiftProtobuf.Google_Protobuf_BoolValue? = nil
+    var _cloudDownloadUnmeteredOnly: SwiftProtobuf.Google_Protobuf_BoolValue? = nil
 
     static let defaultInstance = _StorageClass()
 
@@ -8383,6 +8642,13 @@ extension Api_NamedSettings: SwiftProtobuf.Message, SwiftProtobuf._MessageImplem
       _useDarkUpNextTheme = source._useDarkUpNextTheme
       _useDynamicColorsForWidget = source._useDynamicColorsForWidget
       _filesSortOrder = source._filesSortOrder
+      _backgroundRefresh = source._backgroundRefresh
+      _autoDownloadUnmeteredOnly = source._autoDownloadUnmeteredOnly
+      _autoDownloadOnlyWhenCharging = source._autoDownloadOnlyWhenCharging
+      _autoDownloadUpNext = source._autoDownloadUpNext
+      _cloudAutoUpload = source._cloudAutoUpload
+      _cloudAutoDownload = source._cloudAutoDownload
+      _cloudDownloadUnmeteredOnly = source._cloudDownloadUnmeteredOnly
     }
   }
 
@@ -8471,6 +8737,13 @@ extension Api_NamedSettings: SwiftProtobuf.Message, SwiftProtobuf._MessageImplem
         case 70: try { try decoder.decodeSingularMessageField(value: &_storage._useDarkUpNextTheme) }()
         case 71: try { try decoder.decodeSingularMessageField(value: &_storage._useDynamicColorsForWidget) }()
         case 72: try { try decoder.decodeSingularMessageField(value: &_storage._filesSortOrder) }()
+        case 73: try { try decoder.decodeSingularMessageField(value: &_storage._backgroundRefresh) }()
+        case 74: try { try decoder.decodeSingularMessageField(value: &_storage._autoDownloadUnmeteredOnly) }()
+        case 75: try { try decoder.decodeSingularMessageField(value: &_storage._autoDownloadOnlyWhenCharging) }()
+        case 76: try { try decoder.decodeSingularMessageField(value: &_storage._autoDownloadUpNext) }()
+        case 77: try { try decoder.decodeSingularMessageField(value: &_storage._cloudAutoUpload) }()
+        case 78: try { try decoder.decodeSingularMessageField(value: &_storage._cloudAutoDownload) }()
+        case 79: try { try decoder.decodeSingularMessageField(value: &_storage._cloudDownloadUnmeteredOnly) }()
         default: break
         }
       }
@@ -8693,6 +8966,27 @@ extension Api_NamedSettings: SwiftProtobuf.Message, SwiftProtobuf._MessageImplem
       try { if let v = _storage._filesSortOrder {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 72)
       } }()
+      try { if let v = _storage._backgroundRefresh {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 73)
+      } }()
+      try { if let v = _storage._autoDownloadUnmeteredOnly {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 74)
+      } }()
+      try { if let v = _storage._autoDownloadOnlyWhenCharging {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 75)
+      } }()
+      try { if let v = _storage._autoDownloadUpNext {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 76)
+      } }()
+      try { if let v = _storage._cloudAutoUpload {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 77)
+      } }()
+      try { if let v = _storage._cloudAutoDownload {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 78)
+      } }()
+      try { if let v = _storage._cloudDownloadUnmeteredOnly {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 79)
+      } }()
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -8772,6 +9066,13 @@ extension Api_NamedSettings: SwiftProtobuf.Message, SwiftProtobuf._MessageImplem
         if _storage._useDarkUpNextTheme != rhs_storage._useDarkUpNextTheme {return false}
         if _storage._useDynamicColorsForWidget != rhs_storage._useDynamicColorsForWidget {return false}
         if _storage._filesSortOrder != rhs_storage._filesSortOrder {return false}
+        if _storage._backgroundRefresh != rhs_storage._backgroundRefresh {return false}
+        if _storage._autoDownloadUnmeteredOnly != rhs_storage._autoDownloadUnmeteredOnly {return false}
+        if _storage._autoDownloadOnlyWhenCharging != rhs_storage._autoDownloadOnlyWhenCharging {return false}
+        if _storage._autoDownloadUpNext != rhs_storage._autoDownloadUpNext {return false}
+        if _storage._cloudAutoUpload != rhs_storage._cloudAutoUpload {return false}
+        if _storage._cloudAutoDownload != rhs_storage._cloudAutoDownload {return false}
+        if _storage._cloudDownloadUnmeteredOnly != rhs_storage._cloudDownloadUnmeteredOnly {return false}
         return true
       }
       if !storagesAreEqual {return false}
@@ -8854,6 +9155,13 @@ extension Api_NamedSettingsResponse: SwiftProtobuf.Message, SwiftProtobuf._Messa
     70: .standard(proto: "use_dark_up_next_theme"),
     71: .standard(proto: "use_dynamic_colors_for_widget"),
     72: .standard(proto: "files_sort_order"),
+    73: .standard(proto: "background_refresh"),
+    74: .standard(proto: "auto_download_unmetered_only"),
+    75: .standard(proto: "auto_download_only_when_charging"),
+    76: .standard(proto: "auto_download_up_next"),
+    77: .standard(proto: "cloud_auto_upload"),
+    78: .standard(proto: "cloud_auto_download"),
+    79: .standard(proto: "cloud_download_unmetered_only"),
   ]
 
   fileprivate class _StorageClass {
@@ -8927,6 +9235,13 @@ extension Api_NamedSettingsResponse: SwiftProtobuf.Message, SwiftProtobuf._Messa
     var _useDarkUpNextTheme: Api_BoolSetting? = nil
     var _useDynamicColorsForWidget: Api_BoolSetting? = nil
     var _filesSortOrder: Api_Int32Setting? = nil
+    var _backgroundRefresh: Api_BoolSetting? = nil
+    var _autoDownloadUnmeteredOnly: Api_BoolSetting? = nil
+    var _autoDownloadOnlyWhenCharging: Api_BoolSetting? = nil
+    var _autoDownloadUpNext: Api_BoolSetting? = nil
+    var _cloudAutoUpload: Api_BoolSetting? = nil
+    var _cloudAutoDownload: Api_BoolSetting? = nil
+    var _cloudDownloadUnmeteredOnly: Api_BoolSetting? = nil
 
     static let defaultInstance = _StorageClass()
 
@@ -9003,6 +9318,13 @@ extension Api_NamedSettingsResponse: SwiftProtobuf.Message, SwiftProtobuf._Messa
       _useDarkUpNextTheme = source._useDarkUpNextTheme
       _useDynamicColorsForWidget = source._useDynamicColorsForWidget
       _filesSortOrder = source._filesSortOrder
+      _backgroundRefresh = source._backgroundRefresh
+      _autoDownloadUnmeteredOnly = source._autoDownloadUnmeteredOnly
+      _autoDownloadOnlyWhenCharging = source._autoDownloadOnlyWhenCharging
+      _autoDownloadUpNext = source._autoDownloadUpNext
+      _cloudAutoUpload = source._cloudAutoUpload
+      _cloudAutoDownload = source._cloudAutoDownload
+      _cloudDownloadUnmeteredOnly = source._cloudDownloadUnmeteredOnly
     }
   }
 
@@ -9091,6 +9413,13 @@ extension Api_NamedSettingsResponse: SwiftProtobuf.Message, SwiftProtobuf._Messa
         case 70: try { try decoder.decodeSingularMessageField(value: &_storage._useDarkUpNextTheme) }()
         case 71: try { try decoder.decodeSingularMessageField(value: &_storage._useDynamicColorsForWidget) }()
         case 72: try { try decoder.decodeSingularMessageField(value: &_storage._filesSortOrder) }()
+        case 73: try { try decoder.decodeSingularMessageField(value: &_storage._backgroundRefresh) }()
+        case 74: try { try decoder.decodeSingularMessageField(value: &_storage._autoDownloadUnmeteredOnly) }()
+        case 75: try { try decoder.decodeSingularMessageField(value: &_storage._autoDownloadOnlyWhenCharging) }()
+        case 76: try { try decoder.decodeSingularMessageField(value: &_storage._autoDownloadUpNext) }()
+        case 77: try { try decoder.decodeSingularMessageField(value: &_storage._cloudAutoUpload) }()
+        case 78: try { try decoder.decodeSingularMessageField(value: &_storage._cloudAutoDownload) }()
+        case 79: try { try decoder.decodeSingularMessageField(value: &_storage._cloudDownloadUnmeteredOnly) }()
         default: break
         }
       }
@@ -9313,6 +9642,27 @@ extension Api_NamedSettingsResponse: SwiftProtobuf.Message, SwiftProtobuf._Messa
       try { if let v = _storage._filesSortOrder {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 72)
       } }()
+      try { if let v = _storage._backgroundRefresh {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 73)
+      } }()
+      try { if let v = _storage._autoDownloadUnmeteredOnly {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 74)
+      } }()
+      try { if let v = _storage._autoDownloadOnlyWhenCharging {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 75)
+      } }()
+      try { if let v = _storage._autoDownloadUpNext {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 76)
+      } }()
+      try { if let v = _storage._cloudAutoUpload {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 77)
+      } }()
+      try { if let v = _storage._cloudAutoDownload {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 78)
+      } }()
+      try { if let v = _storage._cloudDownloadUnmeteredOnly {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 79)
+      } }()
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -9392,6 +9742,13 @@ extension Api_NamedSettingsResponse: SwiftProtobuf.Message, SwiftProtobuf._Messa
         if _storage._useDarkUpNextTheme != rhs_storage._useDarkUpNextTheme {return false}
         if _storage._useDynamicColorsForWidget != rhs_storage._useDynamicColorsForWidget {return false}
         if _storage._filesSortOrder != rhs_storage._filesSortOrder {return false}
+        if _storage._backgroundRefresh != rhs_storage._backgroundRefresh {return false}
+        if _storage._autoDownloadUnmeteredOnly != rhs_storage._autoDownloadUnmeteredOnly {return false}
+        if _storage._autoDownloadOnlyWhenCharging != rhs_storage._autoDownloadOnlyWhenCharging {return false}
+        if _storage._autoDownloadUpNext != rhs_storage._autoDownloadUpNext {return false}
+        if _storage._cloudAutoUpload != rhs_storage._cloudAutoUpload {return false}
+        if _storage._cloudAutoDownload != rhs_storage._cloudAutoDownload {return false}
+        if _storage._cloudDownloadUnmeteredOnly != rhs_storage._cloudDownloadUnmeteredOnly {return false}
         return true
       }
       if !storagesAreEqual {return false}

--- a/Modules/Server/Sources/PocketCastsServer/Public/AppSettings.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/AppSettings.swift
@@ -74,6 +74,12 @@ public struct AppSettings: JSONCodable {
 
     @ModifiedDate public var useDarkUpNextTheme: Bool = true
 
+    @ModifiedDate public var autoDownloadUpNext: Bool = false
+    @ModifiedDate public var autoDownloadUnmeteredOnly: Bool = true
+    @ModifiedDate public var cloudAutoUpload: Bool = false
+    @ModifiedDate public var cloudAutoDownload: Bool = false
+    @ModifiedDate public var cloudDownloadUnmeteredOnly: Bool = true
+
     static var defaults: AppSettings {
         return AppSettings(openLinks: false,
                            rowAction: .stream,

--- a/Modules/Server/Sources/PocketCastsServer/Public/ServerSettings.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/ServerSettings.swift
@@ -218,22 +218,36 @@ public class ServerSettings {
     }
 
     // User files autodownload
-    private static let userEpisodeAutoDownloadKey = "UserEpisodeAutoDownload"
+    public static let userEpisodeAutoDownloadKey = "UserEpisodeAutoDownload"
     public class func userEpisodeAutoDownload() -> Bool {
-        UserDefaults.standard.bool(forKey: userEpisodeAutoDownloadKey)
+        if FeatureFlag.settingsSync.enabled {
+            SettingsStore.appSettings.cloudAutoDownload
+        } else {
+            UserDefaults.standard.bool(forKey: userEpisodeAutoDownloadKey)
+        }
     }
 
     public class func setUserEpisodeAutoDownload(_ value: Bool) {
+        if FeatureFlag.settingsSync.enabled {
+            SettingsStore.appSettings.cloudAutoDownload = value
+        }
         UserDefaults.standard.set(value, forKey: userEpisodeAutoDownloadKey)
     }
 
-    // User files autodownload on wifi
-    private static let userEpisodeOnlyOnWifiKey = "UserEpisodeOnlyOnWifi"
     public class func userEpisodeOnlyOnWifi() -> Bool {
-        UserDefaults.standard.bool(forKey: userEpisodeOnlyOnWifiKey)
+        if FeatureFlag.settingsSync.enabled {
+            SettingsStore.appSettings.cloudDownloadUnmeteredOnly
+        } else {
+            UserDefaults.standard.bool(forKey: userEpisodeOnlyOnWifiKey)
+        }
     }
 
+    // User files autodownload on wifi
+    public static let userEpisodeOnlyOnWifiKey = "UserEpisodeOnlyOnWifi"
     public class func setUserEpisodeOnlyOnWifi(_ value: Bool) {
+        if FeatureFlag.settingsSync.enabled {
+            SettingsStore.appSettings.cloudDownloadUnmeteredOnly = value
+        }
         UserDefaults.standard.set(value, forKey: userEpisodeOnlyOnWifiKey)
     }
 

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncSettingsTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncSettingsTask.swift
@@ -51,6 +51,11 @@ extension Api_ChangeableSettings {
         useDarkUpNextTheme.update(settings.$useDarkUpNextTheme)
         autoUpNextLimit.update(settings.$autoUpNextLimit)
         autoUpNextLimitReached.update(settings.$autoUpNextLimitReached)
+        autoDownloadUpNext.update(settings.$autoDownloadUpNext)
+        autoDownloadUnmeteredOnly.update(settings.$autoDownloadUnmeteredOnly)
+        cloudAutoUpload.update(settings.$cloudAutoUpload)
+        cloudAutoDownload.update(settings.$cloudAutoDownload)
+        cloudDownloadUnmeteredOnly.update(settings.$cloudDownloadUnmeteredOnly)
     }
 }
 
@@ -102,6 +107,11 @@ extension AppSettings {
         $useDarkUpNextTheme.update(setting: settings.useDarkUpNextTheme)
         $autoUpNextLimit.update(setting: settings.autoUpNextLimit)
         $autoUpNextLimitReached.update(setting: settings.autoUpNextLimitReached)
+        $autoDownloadUpNext.update(setting: settings.autoDownloadUpNext)
+        $autoDownloadUnmeteredOnly.update(setting: settings.autoDownloadUnmeteredOnly)
+        $cloudAutoUpload.update(setting: settings.cloudAutoUpload)
+        $cloudAutoDownload.update(setting: settings.cloudAutoDownload)
+        $cloudDownloadUnmeteredOnly.update(setting: settings.cloudDownloadUnmeteredOnly)
     }
 }
 

--- a/podcasts/AppSettings+ImportUserDefaults.swift
+++ b/podcasts/AppSettings+ImportUserDefaults.swift
@@ -64,8 +64,13 @@ extension SettingsStore<AppSettings> {
         self.update(\.$useDarkUpNextTheme, value: Constants.UserDefaults.appearance.darkUpNextTheme.value)
         self.update(\.$autoUpNextLimit, value: Int32(ServerSettings.autoAddToUpNextLimit()))
         self.update(\.$autoUpNextLimitReached, value: ServerSettings.onAutoAddLimitReached())
+        importValue(\.$autoDownloadUpNext, forKey: Settings.autoDownloadUpNext, from: userDefaults)
+        importValue(\.$autoDownloadUnmeteredOnly, forKey: Settings.allowCellularAutoDownloadKey, from: userDefaults)
+        importValue(\.$cloudAutoDownload, forKey: ServerSettings.userEpisodeAutoDownloadKey, from: userDefaults)
+        importValue(\.$cloudDownloadUnmeteredOnly, forKey: ServerSettings.userEpisodeOnlyOnWifiKey, from: userDefaults)
+        importValue(\.$cloudAutoUpload, forKey: Settings.userEpisodeAutoUploadKey, from: userDefaults)
     }
-    
+
     /// Imports a value of a given key from UserDefaults, only if that value exists
     /// - Parameters:
     ///   - modifiedKeyPath: The SettingsStore keyPath to update

--- a/podcasts/AppSettings+ImportUserDefaults.swift
+++ b/podcasts/AppSettings+ImportUserDefaults.swift
@@ -65,4 +65,15 @@ extension SettingsStore<AppSettings> {
         self.update(\.$autoUpNextLimit, value: Int32(ServerSettings.autoAddToUpNextLimit()))
         self.update(\.$autoUpNextLimitReached, value: ServerSettings.onAutoAddLimitReached())
     }
+    
+    /// Imports a value of a given key from UserDefaults, only if that value exists
+    /// - Parameters:
+    ///   - modifiedKeyPath: The SettingsStore keyPath to update
+    ///   - key: The key to check UserDefaults for
+    ///   - from: The UserDefaults instance to check
+    func importValue<T: Equatable & Codable>(_ modifiedKeyPath: WritableKeyPath<Value, ModifiedDate<T>>, forKey key: String, from: UserDefaults) {
+        if let value = UserDefaults.standard.value(forKey: key) as? T {
+            self.update(modifiedKeyPath, value: value)
+        }
+    }
 }

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -66,12 +66,19 @@ class Settings: NSObject {
 
     // MARK: - Up Next Auto Download
 
-    private static let autoDownloadUpNext = "SJAutoDownloadUpNext"
+    static let autoDownloadUpNext = "SJAutoDownloadUpNext"
     class func downloadUpNextEpisodes() -> Bool {
-        UserDefaults.standard.bool(forKey: Settings.autoDownloadUpNext)
+        if FeatureFlag.settingsSync.enabled {
+            SettingsStore.appSettings.autoDownloadUpNext
+        } else {
+            UserDefaults.standard.bool(forKey: Settings.autoDownloadUpNext)
+        }
     }
 
     class func setDownloadUpNextEpisodes(_ download: Bool) {
+        if FeatureFlag.settingsSync.enabled {
+            SettingsStore.appSettings.autoDownloadUpNext = download
+        }
         UserDefaults.standard.set(download, forKey: Settings.autoDownloadUpNext)
         trackValueToggled(.settingsAutoDownloadUpNextToggled, enabled: download)
     }
@@ -99,12 +106,19 @@ class Settings: NSObject {
 
     // MARK: - Auto Download Mobile Data
 
-    private static let allowCellularAutoDownloadKey = "SJUserCellularAutoDownload"
+    static let allowCellularAutoDownloadKey = "SJUserCellularAutoDownload"
     class func autoDownloadMobileDataAllowed() -> Bool {
-        UserDefaults.standard.bool(forKey: Settings.allowCellularAutoDownloadKey)
+        if FeatureFlag.settingsSync.enabled {
+            !SettingsStore.appSettings.autoDownloadUnmeteredOnly
+        } else {
+            UserDefaults.standard.bool(forKey: Settings.allowCellularAutoDownloadKey)
+        }
     }
 
     class func setAutoDownloadMobileDataAllowed(_ allow: Bool, userInitiated: Bool = false) {
+        if FeatureFlag.settingsSync.enabled {
+            SettingsStore.appSettings.autoDownloadUnmeteredOnly = !allow
+        }
         UserDefaults.standard.set(allow, forKey: Settings.allowCellularAutoDownloadKey)
 
         guard userInitiated else { return }
@@ -489,12 +503,19 @@ class Settings: NSObject {
         UserDefaults.standard.set(value, forKey: userEpisodeSortByKey)
     }
 
-    private static let userEpisodeAutoUploadKey = "UserEpisodeAutoUpload"
+    static let userEpisodeAutoUploadKey = "UserEpisodeAutoUpload"
     class func userFilesAutoUpload() -> Bool {
-        UserDefaults.standard.bool(forKey: userEpisodeAutoUploadKey)
+        if FeatureFlag.settingsSync.enabled {
+            SettingsStore.appSettings.cloudAutoUpload
+        } else {
+            UserDefaults.standard.bool(forKey: userEpisodeAutoUploadKey)
+        }
     }
 
     class func setUserEpisodeAutoUpload(_ value: Bool) {
+        if FeatureFlag.settingsSync.enabled {
+            SettingsStore.appSettings.cloudAutoUpload = value
+        }
         UserDefaults.standard.set(value, forKey: userEpisodeAutoUploadKey)
         trackValueToggled(.settingsFilesAutoUploadToCloudToggled, enabled: value)
     }
@@ -1250,7 +1271,7 @@ extension HeadphoneControl {
         case .skipForward:
             return .skipForward
         }
-	}
+    }
 }
 
 extension UserDefaults {


### PR DESCRIPTION
| 📘 Part of: #1400 |
|:---:|

Adds settings for various auto download settings.

## To test

> [!IMPORTANT]
> Use Staging to test. None of these properties are available in Production.

### Auto Download

* D1: Sign in to an account in staging
* D1: Navigate to Profile > Settings > Auto Download
* D1: Change "Up Next" setting
* D1: Pull to Refresh in Profile
* D2: Sign in to same account in staging
* D2: Pull to refresh Profile
* D2: Navigate to Profile > Settings > Auto Download
* D2: Verify that the setting matches

I won't repeat the test steps but "Up Next", "Only on WiFi" should both work

### Files

* D1: Sign in to an account in staging
* D1: Navigate to Profile > Settings > Files
* D1: Change "Auto Upload to Cloud" setting
* D1: Pull to Refresh in Profile
* D2: Sign in to same account in staging
* D2: Pull to refresh Profile
* D2: Navigate to Profile > Settings > Files
* D2: Verify that the setting matches

I won't repeat the test steps but "Auto Upload to Cloud", "Auto Download from Cloud", and "Only on WiFi" should work.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
