### PR TITLE
Flag off `Api_SyncUserPodcast` settings update with settingsSync flag

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+LocalChanges.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+LocalChanges.swift
@@ -1,5 +1,6 @@
 import Foundation
 import PocketCastsDataModel
+import PocketCastsUtils
 import SwiftProtobuf
 
 extension SyncTask {
@@ -17,7 +18,10 @@ extension SyncTask {
             podcastRecord.isDeleted.value = !podcast.isSubscribed()
             podcastRecord.subscribed.value = podcast.isSubscribed()
             podcastRecord.sortPosition.value = podcast.sortOrder
-            podcastRecord.settings = podcast.apiSettings
+
+            if FeatureFlag.settingsSync.enabled {
+                podcastRecord.settings = podcast.apiSettings
+            }
 
             // There's a bug on the watch app that resets all users folders
             // Since the watch don't use folders at all, it shouldn't sync

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum FeatureFlag: String, CaseIterable {
+public enum FeatureFlag: String, CaseIterable {
     /// Whether logging of Tracks events in console are enabled
     case tracksLogging
 
@@ -37,7 +37,7 @@ enum FeatureFlag: String, CaseIterable {
     /// Enable the new flow for Account upgrade prompt where it start IAP flow directly from account cell
     case newAccountUpgradePromptFlow
 
-    var enabled: Bool {
+    public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
         }
@@ -45,7 +45,7 @@ enum FeatureFlag: String, CaseIterable {
         return `default`
     }
 
-    var `default`: Bool {
+    public var `default`: Bool {
         switch self {
         case .tracksLogging:
             false
@@ -76,7 +76,7 @@ enum FeatureFlag: String, CaseIterable {
 
     /// Remote Feature Flag
     /// This should match a Firebase Remote Config Parameter name (key)
-    var remoteKey: String? {
+    public var remoteKey: String? {
         switch self {
         case .deselectChapters:
             "deselect_chapters"
@@ -87,11 +87,11 @@ enum FeatureFlag: String, CaseIterable {
 }
 
 extension FeatureFlag: OverrideableFlag {
-    var description: String {
+    public var description: String {
         rawValue
     }
 
-    var canOverride: Bool {
+    public var canOverride: Bool {
         true
     }
 

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlagOverrideStore.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlagOverrideStore.swift
@@ -3,17 +3,17 @@ import Foundation
 // Protocol allows easier unit testing, so we can implement mock
 // feature flags to use in test cases.
 //
-protocol OverrideableFlag: CustomStringConvertible {
+public protocol OverrideableFlag: CustomStringConvertible {
     var enabled: Bool { get }
     var canOverride: Bool { get }
 }
 
 /// Used to override values for feature flags at runtime in debug builds
 ///
-struct FeatureFlagOverrideStore {
+public struct FeatureFlagOverrideStore {
     private let store: UserDefaults
 
-    init(store: UserDefaults = UserDefaults.standard) {
+    public init(store: UserDefaults = UserDefaults.standard) {
         self.store = store
     }
 
@@ -29,7 +29,7 @@ struct FeatureFlagOverrideStore {
 
     /// Removes any existing overridden value and stores the new value
     ///
-    func override(_ featureFlag: OverrideableFlag, withValue value: Bool) throws {
+    public func override(_ featureFlag: OverrideableFlag, withValue value: Bool) throws {
         guard featureFlag.canOverride == true else {
             throw FeatureFlagError.cannotBeOverridden
         }

--- a/Pocket Casts Watch App Extension/PodcastEpisodeListViewModel.swift
+++ b/Pocket Casts Watch App Extension/PodcastEpisodeListViewModel.swift
@@ -1,6 +1,7 @@
 import Combine
 import Foundation
 import PocketCastsDataModel
+import PocketCastsUtils
 
 class PodcastEpisodeListViewModel: ObservableObject {
     static func createEpisodesQuery(forPodcast podcast: Podcast?) -> String {

--- a/PocketCastsTests/Mocks/FeatureFlagMock.swift
+++ b/PocketCastsTests/Mocks/FeatureFlagMock.swift
@@ -1,4 +1,5 @@
 @testable import podcasts
+import PocketCastsUtils
 
 class FeatureFlagMock {
     private var previousValues: [FeatureFlag: Bool] = [:]

--- a/PocketCastsTests/Tests/FeatureFlagTests.swift
+++ b/PocketCastsTests/Tests/FeatureFlagTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-
+@testable import PocketCastsUtils
 @testable import podcasts
 
 class FeatureFlagTests: XCTestCase {

--- a/PocketCastsTests/Tests/Playback/Chapters/ChapterManagerTests.swift
+++ b/PocketCastsTests/Tests/Playback/Chapters/ChapterManagerTests.swift
@@ -3,6 +3,7 @@ import XCTest
 @testable import podcasts
 @testable import PocketCastsDataModel
 @testable import PocketCastsServer
+import PocketCastsUtils
 
 class ChapterManagerTests: XCTestCase {
     let featureFlagMock = FeatureFlagMock()

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -503,12 +503,6 @@
 		8B67A26929A7D8690076886D /* PodcastCarouselView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B67A26829A7D8690076886D /* PodcastCarouselView.swift */; };
 		8B67A26B29A7D8820076886D /* ThemeableListHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B67A26A29A7D8820076886D /* ThemeableListHeader.swift */; };
 		8B68C1CF2942134300CF25C5 /* BetaMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B68C1CE2942134300CF25C5 /* BetaMenu.swift */; };
-		8B68C1D1294219EB00CF25C5 /* FeatureFlagOverrideStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B68C1D0294219EB00CF25C5 /* FeatureFlagOverrideStore.swift */; };
-		8B68C1D229421B4200CF25C5 /* FeatureFlagOverrideStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B68C1D0294219EB00CF25C5 /* FeatureFlagOverrideStore.swift */; };
-		8B68C1D329421B4300CF25C5 /* FeatureFlagOverrideStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B68C1D0294219EB00CF25C5 /* FeatureFlagOverrideStore.swift */; };
-		8B68C1D429421B4700CF25C5 /* FeatureFlagOverrideStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B68C1D0294219EB00CF25C5 /* FeatureFlagOverrideStore.swift */; };
-		8B68C1D529421B4800CF25C5 /* FeatureFlagOverrideStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B68C1D0294219EB00CF25C5 /* FeatureFlagOverrideStore.swift */; };
-		8B68C1D629421B4800CF25C5 /* FeatureFlagOverrideStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B68C1D0294219EB00CF25C5 /* FeatureFlagOverrideStore.swift */; };
 		8B68C1D829421E3400CF25C5 /* FeatureFlagTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B68C1D729421E3400CF25C5 /* FeatureFlagTests.swift */; };
 		8B6A2C8D29CA4F78002601F5 /* SearchListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6A2C8C29CA4F78002601F5 /* SearchListView.swift */; };
 		8B6B68E528F744520032BFFF /* StoriesDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6B68E428F744520032BFFF /* StoriesDataSource.swift */; };
@@ -1499,12 +1493,6 @@
 		C7A654052992971100BB84C1 /* CPInterfaceController+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A654042992971100BB84C1 /* CPInterfaceController+Helpers.swift */; };
 		C7ACD7F62878B07300AF3AB8 /* AnalyticsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD6B1F001CE05159003CE958 /* AnalyticsHelper.swift */; };
 		C7ADDD202AD73DD000471853 /* BookmarksAnnouncement.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7ADDD1F2AD73DD000471853 /* BookmarksAnnouncement.swift */; };
-		C7AF5789289C60B70089E435 /* FeatureFlag.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7AF5788289C60B70089E435 /* FeatureFlag.swift */; };
-		C7AF578A289C60C50089E435 /* FeatureFlag.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7AF5788289C60B70089E435 /* FeatureFlag.swift */; };
-		C7AF578B289C60C60089E435 /* FeatureFlag.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7AF5788289C60B70089E435 /* FeatureFlag.swift */; };
-		C7AF578C289C60C80089E435 /* FeatureFlag.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7AF5788289C60B70089E435 /* FeatureFlag.swift */; };
-		C7AF578D289C60CA0089E435 /* FeatureFlag.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7AF5788289C60B70089E435 /* FeatureFlag.swift */; };
-		C7AF578E289C60CD0089E435 /* FeatureFlag.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7AF5788289C60B70089E435 /* FeatureFlag.swift */; };
 		C7AF5791289D87CF0089E435 /* Analytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7AF5790289D87CF0089E435 /* Analytics.swift */; };
 		C7AF7B912925E5CD002F0025 /* PlusHostingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7AF7B902925E5CD002F0025 /* PlusHostingViewController.swift */; };
 		C7AF7B992926B307002F0025 /* OnboardingHostingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7AF7B982926B307002F0025 /* OnboardingHostingViewController.swift */; };
@@ -2321,7 +2309,6 @@
 		8B67A26829A7D8690076886D /* PodcastCarouselView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PodcastCarouselView.swift; sourceTree = "<group>"; };
 		8B67A26A29A7D8820076886D /* ThemeableListHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeableListHeader.swift; sourceTree = "<group>"; };
 		8B68C1CE2942134300CF25C5 /* BetaMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BetaMenu.swift; sourceTree = "<group>"; };
-		8B68C1D0294219EB00CF25C5 /* FeatureFlagOverrideStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagOverrideStore.swift; sourceTree = "<group>"; };
 		8B68C1D729421E3400CF25C5 /* FeatureFlagTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagTests.swift; sourceTree = "<group>"; };
 		8B6A2C8C29CA4F78002601F5 /* SearchListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchListView.swift; sourceTree = "<group>"; };
 		8B6B68E428F744520032BFFF /* StoriesDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoriesDataSource.swift; sourceTree = "<group>"; };
@@ -3288,7 +3275,6 @@
 		C7A654022991A7C900BB84C1 /* CarPlayListData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlayListData.swift; sourceTree = "<group>"; };
 		C7A654042992971100BB84C1 /* CPInterfaceController+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CPInterfaceController+Helpers.swift"; sourceTree = "<group>"; };
 		C7ADDD1F2AD73DD000471853 /* BookmarksAnnouncement.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BookmarksAnnouncement.swift; sourceTree = "<group>"; };
-		C7AF5788289C60B70089E435 /* FeatureFlag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlag.swift; sourceTree = "<group>"; };
 		C7AF5790289D87CF0089E435 /* Analytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Analytics.swift; sourceTree = "<group>"; };
 		C7AF7B902925E5CD002F0025 /* PlusHostingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlusHostingViewController.swift; sourceTree = "<group>"; };
 		C7AF7B982926B307002F0025 /* OnboardingHostingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingHostingViewController.swift; sourceTree = "<group>"; };
@@ -4706,8 +4692,6 @@
 				4004F56424EB51F900FBEBE1 /* SceneHelper.swift */,
 				46305CEC272AFA5F003AC87B /* UserDefaults+Helpers.swift */,
 				BD6275BE27D1C5370020A28C /* TraceHelper.swift */,
-				C7AF5788289C60B70089E435 /* FeatureFlag.swift */,
-				8B68C1D0294219EB00CF25C5 /* FeatureFlagOverrideStore.swift */,
 				C7C4CAF228ABFD0900CFC8CF /* Notifications.swift */,
 				C7D6551328E5153200AD7174 /* Debounce.swift */,
 				C791418C294CE32D00F1852B /* StorageManager.swift */,
@@ -8509,14 +8493,12 @@
 				40E8037423FE9E9200B4E1F8 /* IntentHandler.swift in Sources */,
 				40043F0D23FDFD91004A9B57 /* SiriPodcastItem.swift in Sources */,
 				40E8037323FE9E9200B4E1F8 /* SleepTimerIntentHandler.swift in Sources */,
-				8B68C1D529421B4800CF25C5 /* FeatureFlagOverrideStore.swift in Sources */,
 				40E8037123FE9E9200B4E1F8 /* ChapterIntentHandler.swift in Sources */,
 				40E8037623FE9EDB00B4E1F8 /* SiriPodcastSearchManager.swift in Sources */,
 				40E8037223FE9E9200B4E1F8 /* PlayMediaIntentHandler.swift in Sources */,
 				40E8037023FE9E9200B4E1F8 /* OpenFilterIntentHandler.swift in Sources */,
 				46FBD8B6276A874F00867746 /* Intents.intentdefinition in Sources */,
 				40334805240C83D200EE338E /* CommonUpNextItem.swift in Sources */,
-				C7AF578D289C60CA0089E435 /* FeatureFlag.swift in Sources */,
 				40043F0F23FE08B8004A9B57 /* SharedConstants.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -8525,11 +8507,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8B68C1D629421B4800CF25C5 /* FeatureFlagOverrideStore.swift in Sources */,
 				40043F1123FE0A05004A9B57 /* SiriPodcastItem.swift in Sources */,
 				40043F1323FE0D9E004A9B57 /* SharedConstants.swift in Sources */,
 				46FBD8B7276A874F00867746 /* Intents.intentdefinition in Sources */,
-				C7AF578E289C60CD0089E435 /* FeatureFlag.swift in Sources */,
 				403B5B1E21813FFA00821A54 /* IntentViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -8647,8 +8627,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8B68C1D229421B4200CF25C5 /* FeatureFlagOverrideStore.swift in Sources */,
-				C7AF578A289C60C50089E435 /* FeatureFlag.swift in Sources */,
 				BD3A21101E6CFC2400F42241 /* NotificationService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -8913,7 +8891,6 @@
 				C72CED2F289DA1650017883A /* String+Analytics.swift in Sources */,
 				BD0B68742203EFCC002CCE3F /* EpisodeLimitCell.swift in Sources */,
 				8B23193F2902C84A0001C3DE /* EndOfYearStoriesBuilder.swift in Sources */,
-				C7AF5789289C60B70089E435 /* FeatureFlag.swift in Sources */,
 				BD36F3CE21882B87005E0BB2 /* ThemeSecondaryIcon.swift in Sources */,
 				BDC692831BA7B0B70023B9F2 /* TinyPageControl.swift in Sources */,
 				4053CE022150AC4B001C92B1 /* CheckboxCell.swift in Sources */,
@@ -8957,7 +8934,6 @@
 				BD674B0B1F68F2BD00AC1B2B /* PlaylistManager.swift in Sources */,
 				BD955FC2219513240094DF1C /* NothingUpNextCell.swift in Sources */,
 				BD6C3F062379236A00C01403 /* ShelfCell.swift in Sources */,
-				8B68C1D1294219EB00CF25C5 /* FeatureFlagOverrideStore.swift in Sources */,
 				BDFFC9B12148E87E0026D875 /* VideoViewController+Seek.swift in Sources */,
 				BD8032D52123F0AF00BFBB03 /* SleepTimerButton.swift in Sources */,
 				8B208A5329C933D300AEF951 /* MiniPlayerPaddingModifier.swift in Sources */,
@@ -9507,7 +9483,6 @@
 				4633FEC127D7E6B700996077 /* EpisodeRow.swift in Sources */,
 				468A0FBE27D68B1A00F800C8 /* EpisodeActionView.swift in Sources */,
 				C7811D8A2A90334200FC68B4 /* Unlockable+Bookmarks.swift in Sources */,
-				8B68C1D429421B4700CF25C5 /* FeatureFlagOverrideStore.swift in Sources */,
 				46C843B927E373B100D1DBF3 /* NowPlayingImage.swift in Sources */,
 				BD74F15827F2955D00222785 /* FolderView.swift in Sources */,
 				BD4910CD2457DC86005202CF /* SessionManager+Send.swift in Sources */,
@@ -9519,7 +9494,6 @@
 				C761300028E3BC090044C6C2 /* AnalyticsEpisodeHelper.swift in Sources */,
 				BDD3017C1EFB9356004A9972 /* NotificationController.swift in Sources */,
 				BDE48A262410D27300ECA6CA /* Podcast+Formatting.swift in Sources */,
-				C7AF578C289C60C80089E435 /* FeatureFlag.swift in Sources */,
 				C7CE415A28CBCFC200AD063E /* Analytics.swift in Sources */,
 				C7CE415C28CBD01F00AD063E /* String+Analytics.swift in Sources */,
 				F58AFA142B797CF200FC1724 /* Podcast+Settings.swift in Sources */,
@@ -9598,8 +9572,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8B68C1D329421B4300CF25C5 /* FeatureFlagOverrideStore.swift in Sources */,
-				C7AF578B289C60C60089E435 /* FeatureFlag.swift in Sources */,
 				BDEFBA1A1E6D3C2300B9024B /* NotificationViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/podcasts/AnalyticsHelper.swift
+++ b/podcasts/AnalyticsHelper.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import os
+import PocketCastsUtils
 
 class AnalyticsHelper {
     /// Whether the user has opted out of analytics or not

--- a/podcasts/Beta/BetaMenu.swift
+++ b/podcasts/Beta/BetaMenu.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import PocketCastsUtils
 
 struct BetaMenu: View {
     var body: some View {

--- a/podcasts/ChapterInfo.swift
+++ b/podcasts/ChapterInfo.swift
@@ -1,5 +1,6 @@
 import AVFoundation
 import Foundation
+import PocketCastsUtils
 
 class ChapterInfo: Equatable {
     var title = ""

--- a/podcasts/ChaptersViewController+Table.swift
+++ b/podcasts/ChaptersViewController+Table.swift
@@ -1,5 +1,6 @@
 import Foundation
 import SafariServices
+import PocketCastsUtils
 
 extension ChaptersViewController: UITableViewDataSource, UITableViewDelegate, UIScrollViewDelegate {
     private static let chapterCell = "ChapterCell"

--- a/podcasts/End of Year/EndOfYear.swift
+++ b/podcasts/End of Year/EndOfYear.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import PocketCastsServer
 import MaterialComponents.MaterialBottomSheet
 import PocketCastsDataModel
+import PocketCastsUtils
 
 enum EndOfYearPresentationSource: String {
     case modal = "modal"

--- a/podcasts/End of Year/Stories/Views/PaidStoryWallView.swift
+++ b/podcasts/End of Year/Stories/Views/PaidStoryWallView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import PocketCastsServer
+import PocketCastsUtils
 
 struct PaidStoryWallView: View {
     @StateObject private var model = PlusPricingInfoModel()

--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -3,6 +3,7 @@ import PocketCastsServer
 import SafariServices
 import UIKit
 import Combine
+import PocketCastsUtils
 
 class MainTabBarController: UITabBarController, NavigationProtocol {
     enum Tab { case podcasts, filter, discover, profile }

--- a/podcasts/MiniPlayerViewController+Positioning.swift
+++ b/podcasts/MiniPlayerViewController+Positioning.swift
@@ -1,4 +1,5 @@
 import Foundation
+import PocketCastsUtils
 
 extension MiniPlayerViewController {
     func hideMiniPlayer(_ animated: Bool) {

--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -1,6 +1,7 @@
 import Foundation
 import PocketCastsDataModel
 import PocketCastsServer
+import PocketCastsUtils
 
 class MiniPlayerViewController: SimpleNotificationsViewController {
     enum PlayerOpenState {

--- a/podcasts/Onboarding/Plus/Account Prompt/PlusAccountPromptTableCell.swift
+++ b/podcasts/Onboarding/Plus/Account Prompt/PlusAccountPromptTableCell.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import UIKit
+import PocketCastsUtils
 
 class PlusAccountPromptTableCell: ThemeableCell {
 //    static let reuseIdentifier: String = "PlusAccountPromptTableCell"

--- a/podcasts/Onboarding/Plus/Account Prompt/PlusAccountUpgradePrompt.swift
+++ b/podcasts/Onboarding/Plus/Account Prompt/PlusAccountUpgradePrompt.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import PocketCastsServer
+import PocketCastsUtils
 
 struct PlusAccountUpgradePrompt: View {
     typealias ProductInfo = PlusPricingInfoModel.PlusProductPricingInfo

--- a/podcasts/Onboarding/Plus/UpgradeCard.swift
+++ b/podcasts/Onboarding/Plus/UpgradeCard.swift
@@ -1,6 +1,7 @@
 import Foundation
 import SwiftUI
 import PocketCastsServer
+import PocketCastsUtils
 
 struct UpgradeTier: Identifiable {
     let tier: SubscriptionTier

--- a/podcasts/PlaybackEffects.swift
+++ b/podcasts/PlaybackEffects.swift
@@ -1,6 +1,7 @@
 import PocketCastsDataModel
 import PocketCastsServer
 import UIKit
+import PocketCastsUtils
 
 extension TrimSilenceAmount: AnalyticsDescribable {
     var description: String {

--- a/podcasts/Podcast+Settings.swift
+++ b/podcasts/Podcast+Settings.swift
@@ -1,4 +1,5 @@
 import PocketCastsDataModel
+import PocketCastsUtils
 
 extension Podcast {
     var isEffectsOverridden: Bool {

--- a/podcasts/PodcastEffectsViewController+Table.swift
+++ b/podcasts/PodcastEffectsViewController+Table.swift
@@ -1,5 +1,6 @@
 import PocketCastsDataModel
 import PocketCastsServer
+import PocketCastsUtils
 
 extension PodcastEffectsViewController: UITableViewDataSource, UITableViewDelegate {
     private static let disclosureCellId = "DisclosureCell"

--- a/podcasts/Ratings/PodcastRatingViewModel.swift
+++ b/podcasts/Ratings/PodcastRatingViewModel.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import PocketCastsServer
 import PocketCastsDataModel
+import PocketCastsUtils
 
 class PodcastRatingViewModel: ObservableObject {
     @Published var rating: PodcastRating? = nil

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -5,6 +5,7 @@ import PocketCastsDataModel
 import PocketCastsServer
 import UIKit
 import SwiftUI
+import PocketCastsUtils
 
 class Settings: NSObject {
     // MARK: - Library Type


### PR DESCRIPTION
Even though the `settingsSync` flag was disabled, the `Podcast.settings` property was still being added to the `Api_SyncUserPodcast` request. This appears to change the value of `autoStartFrom`.

#### Request
```json
      "podcast": {
        "autoSkipLast": 0,
        "autoStartFrom": 30,
        "dateAdded": "2024-02-18T16:13:11.184999943Z",
        "folderUuid": "973df93c-e4dc-41fb-879e-0c7b532ebb70",
        "isDeleted": 0,
        "settings": {
          "addToUpNext": {},
          "addToUpNextPosition": {},
          "autoArchive": {},
          "autoSkipLast": {},
          "autoStartFrom": {},
          "episodesSortOrder": {},
          "playbackEffects": {},
          "playbackSpeed": {},
          "trimSilence": {},
          "volumeBoost": {}
        },
```

#### Response
```json
      "podcast": {
        "autoSkipLast": 0,
        "autoStartFrom": 20,
        "dateAdded": "2024-02-18T16:13:11Z",
        "folderUuid": "973df93c-e4dc-41fb-879e-0c7b532ebb70",
        "isDeleted": 0,
        "settings": {
          "addToUpNext": {
            "changed": 1,
            "modifiedAt": "2024-02-21T06:22:57.486Z",
            "value": 0
          },
          "addToUpNextPosition": {
            "changed": 1,
            "modifiedAt": "1970-01-01T00:00:00Z",
            "value": 0
          },
          "autoArchive": {
            "changed": 1,
            "modifiedAt": "2024-02-21T05:46:47.567Z",
            "value": 1
          },
          "autoSkipLast": {
            "changed": 1,
            "modifiedAt": "2024-02-28T15:25:52.607Z",
            "value": 0
          },
          "autoStartFrom": {
            "changed": 1,
            "modifiedAt": "2024-02-28T15:25:52.607Z",
            "value": 20
          },
```

To avoid this, I've flagged off setting the `Api_SyncUserPodcast` settings property, which is the same thing we do for the full sync as well.

## To test

* D1: Navigate to a Podcast's settings
* D1: Change the "Skip First" value
* D1: Refresh the Podcasts list
* D2: Refresh the Podcasts list
* D2: Navigate to the same Podcast settings
* D2: Verify the value of "Skip First"

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
