### PR TITLE
Download Issues: URLSession Task Metrics logging

### DIFF
--- a/podcasts/DownloadManager+URLSessionDelegate.swift
+++ b/podcasts/DownloadManager+URLSessionDelegate.swift
@@ -56,6 +56,8 @@ extension DownloadManager: URLSessionDelegate, URLSessionDownloadDelegate {
             return
         }
 
+        FileLog.shared.addMessage("Download failed \(error.domain) \(error.code): \(error.localizedDescription)")
+
         // check for ones we cancelled
         guard let episode = episodeForTask(task, forceReload: true) else { return } // we no longer have this episode
         removeEpisodeFromCache(episode)
@@ -130,6 +132,15 @@ extension DownloadManager: URLSessionDelegate, URLSessionDownloadDelegate {
         }
     }
 
+    func urlSession(_ session: URLSession, task: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics) {
+        let message = log(metrics: metrics)
+
+        if let error = task.error {
+            let url = task.currentRequest?.url?.absoluteString ?? "unknown"
+            FileLog.shared.addMessage("Failed Download for URL: \(url) \(message)")
+        }
+    }
+
     private func episodeForTask(_ task: URLSessionDownloadTask, forceReload: Bool) -> BaseEpisode? {
         guard let downloadId = task.taskDescription else { return nil }
 
@@ -152,5 +163,15 @@ extension DownloadManager: URLSessionDelegate, URLSessionDownloadDelegate {
 
         DataManager.sharedManager.saveEpisode(downloadStatus: .downloadFailed, downloadError: message, downloadTaskId: nil, episode: episode)
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.episodeDownloadStatusChanged, object: episode.uuid)
+    }
+
+    private func log(metrics: URLSessionTaskMetrics) -> String {
+        let duration = metrics.taskInterval.duration
+        let redirectCount = metrics.redirectCount
+        let isProxy = metrics.transactionMetrics.last?.isProxyConnection
+        let isCellular = metrics.transactionMetrics.last?.isCellular
+        let isMultipath = metrics.transactionMetrics.last?.isMultipath
+        let tlsCipherSuite = metrics.transactionMetrics.last?.negotiatedTLSCipherSuite
+        return "Duration: \(duration) Redirects: \(redirectCount) isProxy: \(String(describing: isProxy)) isCellular: \(String(describing: isCellular)) isMultipath: \(String(describing: isMultipath)) tlsCipherSuite: \(String(describing: tlsCipherSuite))"
     }
 }


### PR DESCRIPTION
We need insight into URLSession download errors. This adds logging for URLSession task metrics.

## To test

* 

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
