### PR TITLE
Add `episode_download_failed` Tracks log

### DIFF
--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -368,6 +368,7 @@ enum AnalyticsEvent: String {
     case episodeDownloadFinished
     case episodeBulkDownloadQueued
     case episodeDownloadCancelled
+    case episodeDownloadFailed
 
     case episodeUploadQueued
     case episodeUploadFinished

--- a/podcasts/Analytics/Helpers/AnalyticsEpisodeHelper.swift
+++ b/podcasts/Analytics/Helpers/AnalyticsEpisodeHelper.swift
@@ -47,6 +47,10 @@ class AnalyticsEpisodeHelper: AnalyticsCoordinator {
         episodeEvent(.episodeDownloadFinished, uuid: episodeUUID)
     }
 
+    func downloadFailed(episodeUUID: String, reason: String) {
+        track(.episodeDownloadFailed, properties: ["episode_uuid": episodeUUID, "reason": reason])
+    }
+
     func bulkDownloadEpisodes(episodes: [BaseEpisode]) {
         let uuids = episodes.map { $0.uuid }
         episodeDownloadQueue.formUnion(uuids)


### PR DESCRIPTION
While investigating download issues, I noticed a discrepancy in our Tracks events. Android logs a `episode_download_failed` event when episodes fail to download. On iOS, we don't seem to have an equivalent event.

This adds the `episode_download_failed` event and some additional details in a `reason` property. The values exist here:

https://github.com/Automattic/pocket-casts-ios/blob/a0995a7e9456f2a14814040a904825ed7ab63d9a/podcasts/DownloadManager%2BURLSessionDelegate.swift#L151-L154

And strings with additional info are logged as the `reason` value:

https://github.com/Automattic/pocket-casts-ios/blob/a0995a7e9456f2a14814040a904825ed7ab63d9a/podcasts/DownloadManager%2BURLSessionDelegate.swift#L156-L166

## To test

* Enable `tracksLogging` flag & "Collect Information" under Privacy
* Proxy connection and set a scripting rule as follows. **Make sure "Mock API" is checked**, this avoids the connection staying open too long:

![CleanShot 2024-03-04 at 20 51 44@2x](https://github.com/Automattic/pocket-casts-ios/assets/3250/718e3154-0e5f-455f-81f3-b4f77191683e)

```javascript
async function onResponse(context, url, request, response) {
  response.statusCode = 500;
  response.body = "";
  return response;
}
```


* Subscribe to the NPR "Life Kit" podcast
* Download an episode
* Episode should fail
* Tracks log should show up:
```
🔵 Tracked: episode_download_failed ["source": "podcast_screen", "content_type": "audio", "episode_uuid": "7826249b-ad75-44ac-a76d-7740f89b28ef", "reason": "Status Code: 500"]
```

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
