### PR TITLE
Register for Push Notifications on each app launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 7.59
 -----
-
+- Fixes Push Notification registration after restoring the app from a backup. [#1198]
 
 7.58
 -----

--- a/podcasts/NotificationsHelper.swift
+++ b/podcasts/NotificationsHelper.swift
@@ -53,6 +53,9 @@ class NotificationsHelper: NSObject, UNUserNotificationCenterDelegate {
 
         notificationCenter.getNotificationSettings { settings in
             guard settings.authorizationStatus == .notDetermined else {
+                DispatchQueue.main.async {
+                    UIApplication.shared.registerForRemoteNotifications()
+                }
                 return
             }
 


### PR DESCRIPTION
Fixes #1198 

This changes the `NotificationHelper` logic to register for remote notifications on each app launch. Apple states this is what we should be doing in [Registering your app with APNs](https://developer.apple.com/documentation/usernotifications/registering-your-app-with-apns).

> At launch time, your app communicates with APNs and receives its device token, which you then forward to your provider server.

> You register your app and receive your device token each time your app launches using Apple-provided APIs.

> APNs issues a new token when the user restores a device from a backup, when the user installs your app on a new device, and when the user reinstalls the operating system. You get an up-to-date token each time you ask the system to provide the token.

## To test

* Ensure Notifications are enabled in Settings > Notifications > New Episodes
* Set a breakpoint in [`AppDelegate.application(_:didRegisterForRemoteNotificationsWithDeviceToken:)`](https://github.com/Automattic/pocket-casts-ios/blob/e6a638318a086d36ee6abfbaa3ddbb871a754895/podcasts/AppDelegate.swift#L139)
* Run the app
* Ensure the breakpoint is hit and token is present

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
