### PR TITLE
[Deselect Chapters] Disable for user files

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/BaseEpisode.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/BaseEpisode.swift
@@ -61,4 +61,7 @@ import Foundation
 
     // This property is true if the only filled property is the episode's UUID. If true, this object should only be used as a thin wrapper over the UUID.
     var hasOnlyUuid: Bool { get set }
+
+    /// Whether this is a regular episode, or an user episode (File)
+    var isUserEpisode: Bool { get }
 }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Episode.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Episode.swift
@@ -49,6 +49,10 @@ public class Episode: NSObject, BaseEpisode {
         DataManager.sharedManager.bookmarks.bookmarkCount(forEpisode: uuid) > 0
     }
 
+    public var isUserEpisode: Bool {
+        false
+    }
+
     override public init() {}
 
     public func displayableTitle() -> String {

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/UserEpisode.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/UserEpisode.swift
@@ -41,6 +41,10 @@ public class UserEpisode: NSObject, BaseEpisode {
         DataManager.sharedManager.bookmarks.bookmarkCount(forEpisode: uuid) > 0
     }
 
+    public var isUserEpisode: Bool {
+        true
+    }
+
     override public init() {}
 
     public func displayableTitle() -> String {

--- a/podcasts/ChaptersViewController+Table.swift
+++ b/podcasts/ChaptersViewController+Table.swift
@@ -69,15 +69,19 @@ extension ChaptersViewController: UITableViewDataSource, UITableViewDelegate, UI
     }
 
     func tableView(_ tableView: UITableView, estimatedHeightForHeaderInSection section: Int) -> CGFloat {
-        FeatureFlag.deselectChapters.enabled ? 44 : CGFloat.leastNonzeroMagnitude
+        shouldShowDeselectChaptersHeader ? 44 : CGFloat.leastNonzeroMagnitude
     }
 
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        FeatureFlag.deselectChapters.enabled ? UITableView.automaticDimension : CGFloat.leastNonzeroMagnitude
+        shouldShowDeselectChaptersHeader ? UITableView.automaticDimension : CGFloat.leastNonzeroMagnitude
     }
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         return header
+    }
+
+    var shouldShowDeselectChaptersHeader: Bool {
+        FeatureFlag.deselectChapters.enabled && (PlaybackManager.shared.currentEpisode()?.isUserEpisode == false)
     }
 }
 


### PR DESCRIPTION
| 📘 Part of: #1396 |
|:---:|

Due to syncing not being available for user files on v1, we won't enable deselecting chapters on user files.

These are podcasts with chapters you can use to test:

* Clublife: https://pca.st/rLzZCv
* ATP: https://pca.st/accidentaltech

## To test

Download an episode with chapters ([like this one](https://traffic.libsyn.com/atpfm/atp576.mp3)) and save it on your computer.

1. Go to Profile > Settings > Beta Features > `deselectChapters` and turn it on
2. Drag and drop the file to your simulator
3. Play it
4. Go to the Chapters tab
5. ✅ You should not see the "Skip Chapters" header
6. Play an episode that has chapters (not being the one you just added)
7. Go to Chapters tab
8. ✅ You should see the "Skip Chapters" header

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.