### PR TITLE
Download Issues: Log failure metrics

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1588,6 +1588,8 @@
 		E3665F542936CD13001C8372 /* ChaptersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3665F532936CD13001C8372 /* ChaptersTests.swift */; };
 		E3F37446291F0DD1005916ED /* Chapters.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3F37445291F0DD1005916ED /* Chapters.swift */; };
 		E3F37447291F0DD1005916ED /* Chapters.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3F37445291F0DD1005916ED /* Chapters.swift */; };
+		F5197A402B995A1E007C8D0A /* DownloadManager+Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5197A3F2B995A1E007C8D0A /* DownloadManager+Logging.swift */; };
+		F5197A412B995A1E007C8D0A /* DownloadManager+Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5197A3F2B995A1E007C8D0A /* DownloadManager+Logging.swift */; };
 		F55449422B758E8300F68AE9 /* PocketCastsUtils in Frameworks */ = {isa = PBXBuildFile; productRef = F55449412B758E8300F68AE9 /* PocketCastsUtils */; };
 		F55449432B758E8300F68AE9 /* PocketCastsUtils in Embed Frameworks */ = {isa = PBXBuildFile; productRef = F55449412B758E8300F68AE9 /* PocketCastsUtils */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		F55449452B75935F00F68AE9 /* AppSettings+ImportUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = F55449442B75935F00F68AE9 /* AppSettings+ImportUserDefaults.swift */; };
@@ -3368,6 +3370,7 @@
 		ED026EC07A62C137A4959391 /* Pods-PocketCasts-PocketCastsTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PocketCasts-PocketCastsTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-PocketCasts-PocketCastsTests/Pods-PocketCasts-PocketCastsTests.release.xcconfig"; sourceTree = "<group>"; };
 		EF3DD428DC2C444C2D8CEC5A /* Pods-PocketCastsTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PocketCastsTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-PocketCastsTests/Pods-PocketCastsTests.debug.xcconfig"; sourceTree = "<group>"; };
 		EFBF99F57846D0E1AF8DE08D /* Pods-PocketCasts-PocketCastsTests.staging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PocketCasts-PocketCastsTests.staging.xcconfig"; path = "Pods/Target Support Files/Pods-PocketCasts-PocketCastsTests/Pods-PocketCasts-PocketCastsTests.staging.xcconfig"; sourceTree = "<group>"; };
+		F5197A3F2B995A1E007C8D0A /* DownloadManager+Logging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DownloadManager+Logging.swift"; sourceTree = "<group>"; };
 		F55449442B75935F00F68AE9 /* AppSettings+ImportUserDefaults.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AppSettings+ImportUserDefaults.swift"; sourceTree = "<group>"; };
 		F565602E2B7ACD9B003E76D5 /* DataManager+Import.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DataManager+Import.swift"; sourceTree = "<group>"; };
 		F5AD75442B7FDC2800D65C55 /* SettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsTests.swift; sourceTree = "<group>"; };
@@ -4936,6 +4939,7 @@
 			children = (
 				BDB165DD20806F86007B57CD /* DownloadManager.swift */,
 				BDB165DF208078D5007B57CD /* DownloadManager+URLSessionDelegate.swift */,
+				F5197A3F2B995A1E007C8D0A /* DownloadManager+Logging.swift */,
 				BDC063D0246A626E00208446 /* DownloadManager+SessionManagement.swift */,
 				BDE5B8D71E6401F80039B409 /* EpisodeFileSizeUpdater.swift */,
 				BD2DE2311E65224900BE21A4 /* ShowNotesUpdater.swift */,
@@ -9179,6 +9183,7 @@
 				404A080A24E4C78000308722 /* SceneDelegate.swift in Sources */,
 				BDAE54CF230C063500330680 /* NoSearchResultsCell.swift in Sources */,
 				BDEC9AB52051197900088D76 /* BadgeSettingsViewController.swift in Sources */,
+				F5197A402B995A1E007C8D0A /* DownloadManager+Logging.swift in Sources */,
 				408529A3247C9A53007FE8AA /* PodcastSupporterCell.swift in Sources */,
 				8BD256D22A5C7090006648BE /* SharingHelper+swipeButton.swift in Sources */,
 				BDCD1E82244D636D00B83602 /* LenticularFilter.swift in Sources */,
@@ -9509,6 +9514,7 @@
 				4614556327C6A32700B65F0F /* OrderPicker.swift in Sources */,
 				BDDC199D1F009EA700BAC535 /* ComplicationController.swift in Sources */,
 				46DE81E327E1244B00B696B9 /* OrderPickerToolbar.swift in Sources */,
+				F5197A412B995A1E007C8D0A /* DownloadManager+Logging.swift in Sources */,
 				4649404327D94757007F29C8 /* EpisodeViewModel.swift in Sources */,
 				46D88AB927DF97ED00F3BC43 /* PodcastsListViewModel.swift in Sources */,
 				C7CE415B28CBD00A00AD063E /* AnalyticsEvent.swift in Sources */,

--- a/podcasts/Analytics/Helpers/AnalyticsEpisodeHelper.swift
+++ b/podcasts/Analytics/Helpers/AnalyticsEpisodeHelper.swift
@@ -47,8 +47,12 @@ class AnalyticsEpisodeHelper: AnalyticsCoordinator {
         episodeEvent(.episodeDownloadFinished, uuid: episodeUUID)
     }
 
-    func downloadFailed(episodeUUID: String, reason: String) {
-        track(.episodeDownloadFailed, properties: ["episode_uuid": episodeUUID, "reason": reason])
+    func downloadFailed(episodeUUID: String,
+                        podcastUUID: String,
+                        extraProperties: [String: Any]) {
+        track(.episodeDownloadFailed, properties: ["episode_uuid": episodeUUID,
+                                                   "podcast_uuid": podcastUUID,
+                                                  ].merging(extraProperties, uniquingKeysWith: { (current, _) in return current }))
     }
 
     func bulkDownloadEpisodes(episodes: [BaseEpisode]) {

--- a/podcasts/DownloadManager+Logging.swift
+++ b/podcasts/DownloadManager+Logging.swift
@@ -1,0 +1,127 @@
+import PocketCastsDataModel
+
+extension DownloadManager {
+    func logDownload(_ episode: BaseEpisode, failure: FailureReason, extraProperties: [String: Any?] = [:]) {
+        let properties = ["reason": failure.localizedDescription].merging(extraProperties) { (current, _) in return current }
+        AnalyticsEpisodeHelper.shared.downloadFailed(episodeUUID: episode.uuid,
+                                                     podcastUUID: episode.parentIdentifier(),
+                                                     extraProperties: properties.compactMapValues({ $0 }))
+    }
+
+    func logDownload(_ episode: BaseEpisode, failure: FailureReason, metrics: URLSessionTaskMetrics, session: URLSession) {
+        let errorCode: Int?
+        let errorDomain: String?
+        if case let DownloadManager.FailureReason.unknown(error) = failure {
+            errorCode = error.code
+            errorDomain = error.domain
+        } else {
+            errorCode = nil
+            errorDomain = nil
+        }
+
+        let statusCode: Int?
+        if case let DownloadManager.FailureReason.statusCode(code) = failure {
+            statusCode = code
+        } else {
+            statusCode = metrics.transactionMetrics.last?.response?.extractStatusCode()
+        }
+
+        let fileSize: Int64?
+        if case let DownloadManager.FailureReason.suspiciousContent(size) = failure {
+            fileSize = size
+        } else {
+            fileSize = nil
+        }
+
+        let contentType = metrics.transactionMetrics.last?.response?.mimeType
+        let redirectCount = metrics.redirectCount
+        let duration = Int(metrics.taskInterval.duration * 1000.0) // Convert to milliseconds Int for logging
+        let isProxy = metrics.transactionMetrics.last?.isProxyConnection == true
+        let isCellular = metrics.transactionMetrics.last?.isCellular == true
+        let isMultipath = metrics.transactionMetrics.last?.isMultipath == true
+        let tlsCipherSuite = metrics.transactionMetrics.last?.negotiatedTLSCipherSuite?.debugDescription
+        let expectedContentLength = metrics.transactionMetrics.last?.response?.expectedContentLength
+        let responseBodyBytesReceived = metrics.transactionMetrics.last?.countOfResponseBodyBytesReceived
+        let inBackground = session == cellularBackgroundSession || session == wifiOnlyBackgroundSession
+
+        logDownload(episode,
+                    failure: failure,
+                    extraProperties: [
+            "http_status_code": statusCode,
+            "http_content_type": contentType,
+            "error_code": errorCode,
+            "error_domain": errorDomain,
+            "file_size": fileSize,
+            "redirects": redirectCount,
+            "is_proxy": isProxy,
+            "is_cellular": isCellular,
+            "is_multipath": isMultipath,
+            "tls_cipher_suite": tlsCipherSuite,
+            "duration": duration,
+            "expected_content_length": expectedContentLength,
+            "response_body_bytes_received": responseBodyBytesReceived,
+            "in_background": inBackground
+        ])
+    }
+}
+
+extension tls_ciphersuite_t: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        switch self {
+        case .RSA_WITH_3DES_EDE_CBC_SHA:
+            return "RSA_WITH_3DES_EDE_CBC_SHA"
+        case .RSA_WITH_AES_128_CBC_SHA:
+            return "RSA_WITH_AES_128_CBC_SHA"
+        case .RSA_WITH_AES_256_CBC_SHA:
+            return "RSA_WITH_AES_256_CBC_SHA"
+        case .RSA_WITH_AES_128_GCM_SHA256:
+            return "RSA_WITH_AES_128_GCM_SHA256"
+        case .RSA_WITH_AES_256_GCM_SHA384:
+            return "RSA_WITH_AES_256_GCM_SHA384"
+        case .RSA_WITH_AES_128_CBC_SHA256:
+            return "RSA_WITH_AES_128_CBC_SHA256"
+        case .RSA_WITH_AES_256_CBC_SHA256:
+            return "RSA_WITH_AES_256_CBC_SHA256"
+        case .ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA:
+            return "ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA"
+        case .ECDHE_ECDSA_WITH_AES_128_CBC_SHA:
+            return "ECDHE_ECDSA_WITH_AES_128_CBC_SHA"
+        case .ECDHE_ECDSA_WITH_AES_256_CBC_SHA:
+            return "ECDHE_ECDSA_WITH_AES_256_CBC_SHA"
+        case .ECDHE_RSA_WITH_3DES_EDE_CBC_SHA:
+            return "ECDHE_RSA_WITH_3DES_EDE_CBC_SHA"
+        case .ECDHE_RSA_WITH_AES_128_CBC_SHA:
+            return "ECDHE_RSA_WITH_AES_128_CBC_SHA"
+        case .ECDHE_RSA_WITH_AES_256_CBC_SHA:
+            return "ECDHE_RSA_WITH_AES_256_CBC_SHA"
+        case .ECDHE_ECDSA_WITH_AES_128_CBC_SHA256:
+            return "ECDHE_ECDSA_WITH_AES_128_CBC_SHA256"
+        case .ECDHE_ECDSA_WITH_AES_256_CBC_SHA384:
+            return "ECDHE_ECDSA_WITH_AES_256_CBC_SHA384"
+        case .ECDHE_RSA_WITH_AES_128_CBC_SHA256:
+            return "ECDHE_RSA_WITH_AES_128_CBC_SHA256"
+        case .ECDHE_RSA_WITH_AES_256_CBC_SHA384:
+            return "ECDHE_RSA_WITH_AES_256_CBC_SHA384"
+        case .ECDHE_ECDSA_WITH_AES_128_GCM_SHA256:
+            return "ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"
+        case .ECDHE_ECDSA_WITH_AES_256_GCM_SHA384:
+            return "ECDHE_ECDSA_WITH_AES_256_GCM_SHA384"
+        case .ECDHE_RSA_WITH_AES_128_GCM_SHA256:
+            return "ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+        case .ECDHE_RSA_WITH_AES_256_GCM_SHA384:
+            return "ECDHE_RSA_WITH_AES_256_GCM_SHA384"
+        case .ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256:
+            return "ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256"
+        case .ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256:
+            return "ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256"
+        case .AES_128_GCM_SHA256:
+            return "AES_128_GCM_SHA256"
+        case .AES_256_GCM_SHA384:
+            return "AES_256_GCM_SHA384"
+        case .CHACHA20_POLY1305_SHA256:
+            return "CHACHA20_POLY1305_SHA256"
+        @unknown default:
+            return "UNKNOWN_SUITE"
+        }
+    }
+}

--- a/podcasts/DownloadManager+URLSessionDelegate.swift
+++ b/podcasts/DownloadManager+URLSessionDelegate.swift
@@ -12,20 +12,20 @@ extension DownloadManager: URLSessionDelegate, URLSessionDownloadDelegate {
 
     // make sure to call the completion handler on the main queue, otherwise it will crash
     func urlSessionDidFinishEvents(forBackgroundURLSession session: URLSession) {
-        #if os(watchOS)
-            DispatchQueue.main.async { [weak self] in
-                guard let self = self, let task = self.pendingWatchBackgroundTask else { return }
+#if os(watchOS)
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self, let task = self.pendingWatchBackgroundTask else { return }
 
-                task.setTaskCompletedWithSnapshot(true)
-            }
-        #else
-            DispatchQueue.main.async { [weak self] in
-                guard let strongSelf = self, let appDelegate = strongSelf.appDelegate(), let backgroundHandler = strongSelf.appDelegate()?.backgroundSessionCompletionHandler else { return }
+            task.setTaskCompletedWithSnapshot(true)
+        }
+#else
+        DispatchQueue.main.async { [weak self] in
+            guard let strongSelf = self, let appDelegate = strongSelf.appDelegate(), let backgroundHandler = strongSelf.appDelegate()?.backgroundSessionCompletionHandler else { return }
 
-                appDelegate.backgroundSessionCompletionHandler = nil
-                backgroundHandler()
-            }
-        #endif
+            appDelegate.backgroundSessionCompletionHandler = nil
+            backgroundHandler()
+        }
+#endif
     }
 
     func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didWriteData bytesWritten: Int64, totalBytesWritten: Int64, totalBytesExpectedToWrite: Int64) {
@@ -60,7 +60,8 @@ extension DownloadManager: URLSessionDelegate, URLSessionDownloadDelegate {
         guard let episode = episodeForTask(task, forceReload: true) else { return } // we no longer have this episode
         removeEpisodeFromCache(episode)
 
-        if error.code == NSURLErrorCancelled {
+        switch error.code {
+        case NSURLErrorCancelled:
             if !episode.downloadFailed() {
                 // already handled this error, since we failed the download ourselves
             } else {
@@ -68,6 +69,12 @@ extension DownloadManager: URLSessionDelegate, URLSessionDownloadDelegate {
             }
 
             return
+        case NSURLErrorTimedOut:
+            taskFailure[episode.uuid] = .connectionTimeout
+        case NSURLErrorCannotConnectToHost:
+            taskFailure[episode.uuid] = .unknownHost
+        default:
+            ()
         }
 
         DataManager.sharedManager.saveEpisode(downloadStatus: .downloadFailed, downloadError: error.localizedDescription, downloadTaskId: nil, episode: episode)
@@ -108,7 +115,7 @@ extension DownloadManager: URLSessionDelegate, URLSessionDownloadDelegate {
             let contentType = response.allHeaderFields[ServerConstants.HttpHeaders.contentType] as? String
             // basic sanity checks to make sure the file looks big enough and it's content type isn't text
             if fileSize < DownloadManager.badEpisodeSize || (fileSize < DownloadManager.suspectEpisodeSize && contentType?.contains("text") ?? false) {
-                markEpisode(episode, asFailedWithMessage: L10n.downloadErrorContactAuthorVersion2, reason: .episodeSize(fileSize))
+                markEpisode(episode, asFailedWithMessage: L10n.downloadErrorContactAuthorVersion2, reason: .suspiciousContent(fileSize))
 
                 return
             }
@@ -128,6 +135,21 @@ extension DownloadManager: URLSessionDelegate, URLSessionDownloadDelegate {
         } catch {
             markEpisode(episode, asFailedWithMessage: L10n.downloadErrorNotEnoughSpace, reason: .badResponse)
         }
+    }
+
+    func urlSession(_ session: URLSession, task: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics) {
+        guard let downloadTask = task as? URLSessionDownloadTask,
+              let episode = episodeForTask(downloadTask, forceReload: false) else {
+            return
+        }
+
+        if let failure = taskFailure[episode.uuid] {
+            logDownload(episode, failure: failure, metrics: metrics, session: session)
+            taskFailure.removeValue(forKey: episode.uuid)
+        }
+
+        let taskId = episode.downloadTaskId ?? episode.uuid
+        downloadingEpisodesCache.removeValue(forKey: taskId)
     }
 
     private func episodeForTask(_ task: URLSessionDownloadTask, forceReload: Bool) -> BaseEpisode? {
@@ -150,19 +172,31 @@ extension DownloadManager: URLSessionDelegate, URLSessionDownloadDelegate {
     enum FailureReason: Error {
         case badResponse
         case statusCode(Int)
-        case episodeSize(Int64)
+        case suspiciousContent(Int64)
         case notEnoughSpace
+        case connectionTimeout
+        case unknownHost
+        case malformedHost
+        case unknown(NSError)
 
         var localizedDescription: String {
             switch self {
             case .badResponse:
-                return "Bad Response"
-            case .statusCode(let statusCode):
-                return "Status Code: \(statusCode)"
-            case .episodeSize(let size):
-                return "Episode Size: \(size)"
+                return "bad_response"
+            case .statusCode:
+                return "status_code"
+            case .suspiciousContent:
+                return "suspicious_content"
             case .notEnoughSpace:
-                return "Not Enough Space"
+                return "not_enough_storage"
+            case .connectionTimeout:
+                return "connection_timeout"
+            case .unknownHost:
+                return "unknown_host"
+            case .malformedHost:
+                return "malformed_host"
+            case .unknown:
+                return "unknown"
             }
         }
     }
@@ -173,6 +207,6 @@ extension DownloadManager: URLSessionDelegate, URLSessionDownloadDelegate {
         DataManager.sharedManager.saveEpisode(downloadStatus: .downloadFailed, downloadError: message, downloadTaskId: nil, episode: episode)
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.episodeDownloadStatusChanged, object: episode.uuid)
 
-        AnalyticsEpisodeHelper.shared.downloadFailed(episodeUUID: episode.uuid, reason: reason.localizedDescription)
+        taskFailure[episode.uuid] = reason
     }
 }

--- a/podcasts/DownloadManager+URLSessionDelegate.swift
+++ b/podcasts/DownloadManager+URLSessionDelegate.swift
@@ -14,13 +14,13 @@ extension DownloadManager: URLSessionDelegate, URLSessionDownloadDelegate {
     func urlSessionDidFinishEvents(forBackgroundURLSession session: URLSession) {
 #if os(watchOS)
         DispatchQueue.main.async { [weak self] in
-            guard let self = self, let task = self.pendingWatchBackgroundTask else { return }
+            guard let self, let task = pendingWatchBackgroundTask else { return }
 
             task.setTaskCompletedWithSnapshot(true)
         }
 #else
         DispatchQueue.main.async { [weak self] in
-            guard let strongSelf = self, let appDelegate = strongSelf.appDelegate(), let backgroundHandler = strongSelf.appDelegate()?.backgroundSessionCompletionHandler else { return }
+            guard let self, let appDelegate = appDelegate(), let backgroundHandler = appDelegate.backgroundSessionCompletionHandler else { return }
 
             appDelegate.backgroundSessionCompletionHandler = nil
             backgroundHandler()

--- a/podcasts/DownloadManager.swift
+++ b/podcasts/DownloadManager.swift
@@ -14,6 +14,8 @@ class DownloadManager: NSObject, FilePathProtocol {
 
     var downloadingEpisodesCache = [String: BaseEpisode]()
 
+    var taskFailure: [String: FailureReason] = [:]
+
     #if os(watchOS)
         var pendingWatchBackgroundTask: WKURLSessionRefreshBackgroundTask?
     #endif
@@ -269,6 +271,8 @@ class DownloadManager: NSObject, FilePathProtocol {
         guard let url = downloadUrl, let scheme = url.scheme, scheme.count > 0, scheme.caseInsensitiveCompare("http") == .orderedSame || scheme.caseInsensitiveCompare("https") == .orderedSame else {
             DataManager.sharedManager.saveEpisode(downloadStatus: .downloadFailed, downloadError: L10n.downloadErrorContactAuthor, downloadTaskId: nil, episode: episode)
 
+            logDownload(episode, failure: .malformedHost)
+
             if fireNotification { NotificationCenter.postOnMainThread(notification: Constants.Notifications.episodeDownloadStatusChanged, object: episode.uuid) }
 
             return
@@ -419,9 +423,6 @@ class DownloadManager: NSObject, FilePathProtocol {
     func removeEpisodeFromCache(_ episode: BaseEpisode) {
         progressManager.removeProgressForEpisode(episode.uuid)
 
-        if let taskId = episode.downloadTaskId {
-            downloadingEpisodesCache.removeValue(forKey: taskId)
-        }
     }
 
     private func resumeDownload(tempFilePath: String, session: URLSession, request: URLRequest, previousDownloadFailed: Bool, taskId: String, estimatedBytes: Int64) {


### PR DESCRIPTION
Adds logging with failure reasons and task metrics for debugging download issues.

## Changes

A new `taskFailures` dictionary is used to track the `FailureReason` from `didCompleteWithError` and `markEpisode(_ episode: BaseEpisode, asFailedWithMessage...`

https://github.com/Automattic/pocket-casts-ios/blob/228e556eab8dead540b69a968e5274ced3b87514/podcasts/DownloadManager.swift#L17

These are then used when `didFinishCollection metrics:` returns. As far as I can tell, this method should always be called on `URLSessionDelegate`:

https://github.com/Automattic/pocket-casts-ios/blob/228e556eab8dead540b69a968e5274ced3b87514/podcasts/DownloadManager%2BURLSessionDelegate.swift#L140-L153

The `URLSessionTaskMetrics` is used to fill out details about the request in [`DownloadManager+Logging`](https://github.com/Automattic/pocket-casts-ios/blob/228e556eab8dead540b69a968e5274ced3b87514/podcasts/DownloadManager%2BLogging.swift).

Failure Reason is also updated with a few new reasons which better match Android.

https://github.com/Automattic/pocket-casts-ios/blob/228e556eab8dead540b69a968e5274ced3b87514/podcasts/DownloadManager%2BURLSessionDelegate.swift#L172-L202

## To test

* Enable `tracksLogging` flag & "Collect Information" under Privacy
* Proxy connection and set a scripting rule as follows. **Make sure "Mock API" is checked**, this avoids the connection staying open too long:

![CleanShot 2024-03-04 at 20 51 44@2x](https://github.com/Automattic/pocket-casts-ios/assets/3250/718e3154-0e5f-455f-81f3-b4f77191683e)

```javascript
async function onResponse(context, url, request, response) {
  response.statusCode = 500;
  response.body = "";
  return response;
}
```

* Subscribe to the NPR "Life Kit" podcast
* Download an episode
* Episode should fail
* Tracks log should show up:
```
🔵 Tracked: episode_download_failed ["response_body_bytes_received": 3, "source": "podcast_screen", "redirects": 4, "expected_content_length": -1, "episode_uuid": "7826249b-ad75-44ac-a76d-7740f89b28ef", "reason": "status_code", "http_content_type": "application/json", "is_cellular": false, "duration": 561, "is_proxy": true, "is_multipath": false, "content_type": "audio", "podcast_uuid": "7160b1f0-4a71-0137-f266-1d245fc5f9cf", "tls_cipher_suite": "AES_128_GCM_SHA256", "in_background": true, "http_status_code": 500]
```

You can also verify this in the Tracks Live View (ping me for URL if needed) by searching for Event Name `pcios_episode_download_failed` and check the eventprops.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
