### PR TITLE
Download Issues: Log stale downloads

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -406,6 +406,18 @@ public class DataManager {
         episodeManager.episodesWithListenHistory(limit: limit, dbQueue: dbQueue)
     }
 
+    public func failedDownloadedEpisodesCount() -> Int {
+        episodeManager.failedDownloadEpisodeCount(dbQueue: dbQueue)
+    }
+
+    public func oldestFailedEpisodeDownload() -> Date? {
+        episodeManager.failedDownloadFirstDate(dbQueue: dbQueue, sortOrder: .reverse)
+    }
+
+    public func newestFailedEpisodeDownload() -> Date? {
+        episodeManager.failedDownloadFirstDate(dbQueue: dbQueue, sortOrder: .forward)
+    }
+
     public func findDownloadedEpisodes() -> [BaseEpisode] {
         let query = "episodeStatus = \(DownloadStatus.downloaded.rawValue)"
         let downloadedEpisodes = DataManager.sharedManager.findEpisodesWhere(customWhere: query, arguments: nil)

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -369,6 +369,7 @@ enum AnalyticsEvent: String {
     case episodeBulkDownloadQueued
     case episodeDownloadCancelled
     case episodeDownloadFailed
+    case episodeDownloadsStale
 
     case episodeUploadQueued
     case episodeUploadFinished

--- a/podcasts/AppDelegate+Analytics.swift
+++ b/podcasts/AppDelegate+Analytics.swift
@@ -1,5 +1,6 @@
 import PocketCastsServer
 import PocketCastsUtils
+import PocketCastsDataModel
 
 extension AppDelegate {
     private var shouldRegisterAdapters: Bool {
@@ -13,6 +14,23 @@ extension AppDelegate {
         }
 
         Analytics.register(adapters: [AnalyticsLoggingAdapter(), TracksAdapter(), CrashLoggingAdapter()])
+    }
+
+    func logStaleDownloads() {
+        let failedDownloadCount = DataManager.sharedManager.failedDownloadedEpisodesCount()
+
+        guard failedDownloadCount > 0 else {
+            return
+        }
+
+        let oldestFailedDownload = DataManager.sharedManager.oldestFailedEpisodeDownload()
+        let newestFailedDownload = DataManager.sharedManager.newestFailedEpisodeDownload()
+
+        let properties: [String: Any?] =  ["failed_download_count": failedDownloadCount,
+                                           "oldest_failed_download": oldestFailedDownload?.formatted(.iso8601),
+                                           "newest_failed_download": newestFailedDownload?.formatted(.iso8601)]
+
+        Analytics.track(.episodeDownloadsStale, properties: properties.compactMapValues({ $0 }))
     }
 
     func addAnalyticsObservers() {

--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -86,6 +86,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         setupSignOutListener()
 
+        logStaleDownloads()
+
         return true
     }
 


### PR DESCRIPTION
Adds `episode_downloads_stale` event on app launch with the number of failed downloads a user has along with the oldest and newest failed download attempt dates.

## To test

* Enable `tracksLogging` flag & "Collect Information" under Privacy
* Proxy connection and set a scripting rule as follows. **Make sure "Mock API" is checked**, this avoids the connection staying open too long:

![CleanShot 2024-03-04 at 20 51 44@2x](https://github.com/Automattic/pocket-casts-ios/assets/3250/718e3154-0e5f-455f-81f3-b4f77191683e)

```javascript
async function onResponse(context, url, request, response) {
  response.statusCode = 500;
  response.body = "";
  return response;
}
```

* Subscribe to the NPR "Life Kit" podcast
* Download an episode
* Episode should fail
* Restart the app
* Look for the logged `episode_downloads_stale` event on launch

```
🔵 Tracked: episode_downloads_stale ["newest_failed_download": "2024-03-08T02:23:39Z", "failed_download_count": 2, "oldest_failed_download": "2024-03-08T02:23:33Z"]
```

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
