### PR TITLE
Settings Sync: Remove unused shouldUseNewSettingsSync param

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler.swift
@@ -85,7 +85,7 @@ public class ApiServerHandler {
     }
 
     public func syncSettings() {
-        let syncSettingsTask = SyncSettingsTask(shouldUseNewSync: SyncManager.shouldUseNewSettingsSync)
+        let syncSettingsTask = SyncSettingsTask()
         apiQueue.addOperation(syncSettingsTask)
     }
 

--- a/Modules/Server/Sources/PocketCastsServer/Public/Refresh/RefreshOperation.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Refresh/RefreshOperation.swift
@@ -62,7 +62,7 @@ class RefreshOperation: Operation {
 
                 apiQueue.addOperation(SyncHistoryTask())
 
-                apiQueue.addOperation(SyncSettingsTask(shouldUseNewSync: SyncManager.shouldUseNewSettingsSync))
+                apiQueue.addOperation(SyncSettingsTask())
 
                 #if !os(watchOS)
                     ServerSettings.iapUnverifiedPurchaseReceiptDate() == nil ? apiQueue.addOperation(SubscriptionStatusTask()) : apiQueue.addOperation(PurchaseReceiptTask())

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncManager.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncManager.swift
@@ -28,8 +28,6 @@ public class SyncManager {
         return lastRefreshStartDate.compare(lastRefreshEndDate) == .orderedDescending
     }
 
-    public static var shouldUseNewSettingsSync = false
-
     /// Signs the user out
     /// - Parameter userInitiated: Whether the user initiated the sign out or not
     public class func signout(userInitiated: Bool = false) {

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncSettingsTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncSettingsTask.swift
@@ -120,11 +120,9 @@ extension AppSettings {
 
 class SyncSettingsTask: ApiBaseTask {
 
-    private let shouldUseNewSync: Bool
     private let appSettings: SettingsStore<AppSettings>
 
-    init(shouldUseNewSync: Bool, appSettings: SettingsStore<AppSettings> = SettingsStore.appSettings, dataManager: DataManager = .sharedManager, urlConnection: URLConnection = URLConnection(handler: URLSession.shared)) {
-        self.shouldUseNewSync = shouldUseNewSync
+    init(appSettings: SettingsStore<AppSettings> = SettingsStore.appSettings, dataManager: DataManager = .sharedManager, urlConnection: URLConnection = URLConnection(handler: URLSession.shared)) {
         self.appSettings = appSettings
         super.init(dataManager: dataManager, urlConnection: urlConnection)
     }
@@ -135,7 +133,7 @@ class SyncSettingsTask: ApiBaseTask {
             var settingsRequest = Api_NamedSettingsRequest()
             settingsRequest.m = "iPhone"
 
-            if shouldUseNewSync {
+            if FeatureFlag.settingsSync.enabled {
                 settingsRequest.changedSettings.update(with: appSettings.settings)
                 FileLog.shared.addMessage("Syncing new settings: \(try! settingsRequest.changedSettings.jsonString())")
             } else {
@@ -173,7 +171,7 @@ class SyncSettingsTask: ApiBaseTask {
         do {
             let settings = try Api_NamedSettingsResponse(serializedData: serverData)
 
-            if shouldUseNewSync {
+            if FeatureFlag.settingsSync.enabled {
                 appSettings.settings.update(with: settings)
             } else {
                 if settings.skipForward.changed.value {

--- a/Modules/Server/Tests/PocketCastsServerTests/SyncSettingsTaskTests.swift
+++ b/Modules/Server/Tests/PocketCastsServerTests/SyncSettingsTaskTests.swift
@@ -25,7 +25,7 @@ class SyncSettingsTaskTests: XCTestCase {
         store.openLinks = changedValue
 
         let expectation = XCTestExpectation(description: "Request method should be called")
-        let task = SyncSettingsTask(shouldUseNewSync: true, appSettings: store, urlConnection: URLConnection { urlRequest in
+        let task = SyncSettingsTask(appSettings: store, urlConnection: URLConnection { urlRequest in
 
             let data = try XCTUnwrap(urlRequest.httpBody, "Request body should exist")
             let request = try Api_NamedSettingsRequest(serializedData: data)
@@ -60,7 +60,7 @@ class SyncSettingsTaskTests: XCTestCase {
         XCTAssertFalse(store.openLinks, "Initial value should be false")
 
         let expectation = XCTestExpectation(description: "Request method should be called")
-        let task = SyncSettingsTask(shouldUseNewSync: true, appSettings: store, urlConnection: URLConnection { urlRequest in
+        let task = SyncSettingsTask(appSettings: store, urlConnection: URLConnection { urlRequest in
 
             var serverResponse = Api_NamedSettingsResponse()
             serverResponse.openLinks.value.value = changedValue

--- a/Modules/Server/Tests/PocketCastsServerTests/SyncSettingsTaskTests.swift
+++ b/Modules/Server/Tests/PocketCastsServerTests/SyncSettingsTaskTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @testable import PocketCastsServer
 import SwiftProtobuf
+@testable import PocketCastsUtils
 
 class SyncSettingsTaskTests: XCTestCase {
 
@@ -11,6 +12,11 @@ class SyncSettingsTaskTests: XCTestCase {
     override func setUp() {
         super.setUp()
         UserDefaults.standard.removePersistentDomain(forName: userDefaultsSuiteName)
+        FeatureFlagMock().set(.settingsSync, value: true)
+    }
+
+    override func tearDown() {
+        FeatureFlagMock().reset()
     }
 
     /// Tests sending a request with updates from `SettingsStore`

--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -52,7 +52,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         GoogleCastManager.sharedManager.setup()
 
-        SyncManager.shouldUseNewSettingsSync = FeatureFlag.settingsSync.enabled
         CacheServerHandler.newShowNotesEndpoint = FeatureFlag.newShowNotesEndpoint.enabled
         CacheServerHandler.episodeFeedArtwork = FeatureFlag.episodeFeedArtwork.enabled
 
@@ -308,8 +307,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 ServerConfig.avoidLogoutOnError = FeatureFlag.errorLogoutHandling.enabled
                 try FeatureFlagOverrideStore().override(FeatureFlag.errorLogoutHandling, withValue: Settings.errorLogoutHandling)
             }
-
-            SyncManager.shouldUseNewSettingsSync = FeatureFlag.settingsSync.enabled
 
             try FeatureFlagOverrideStore().override(FeatureFlag.slumber, withValue: Settings.slumberPromoCode?.isEmpty == false)
 


### PR DESCRIPTION
Now that FeatureFlags are available in the Server component, we no longer need the indirection of `shouldUseNewSettingsSync`. This cleans up an unused `shouldUseNewSettingsSync` on `SyncManager` and `SyncSettingsTask`. It also immediately applies the Feature Flag change instead of requiring a restart.

## To test

* Make sure CI compiles 🟢 
* Test that settings syncing works:
    * Install on two devices/simulators
    * Enable the `settingsSync` feature flag
    * Make sure that changing settings on one and refreshing shows the same setting on the other
    * You can verify that the `Syncing new settings: ` message is logged to the console as an easy method to check that syncing is happening.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
