### PR TITLE
Settings Sync: `new_settings_storage` Feature Flag

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/AutoAddQueueDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/AutoAddQueueDataManager.swift
@@ -53,7 +53,7 @@ public struct AutoAddCandidatesDataManager {
 
                 let query: String
 
-                if FeatureFlag.settingsSync.enabled {
+                if FeatureFlag.newSettingsStorage.enabled {
                     query = """
                     SELECT
                         -- Get the Podcast Auto Add Setting
@@ -117,7 +117,7 @@ public struct AutoAddCandidatesDataManager {
         init?(from resultSet: FMResultSet) {
 
             let setting: Int32
-            if FeatureFlag.settingsSync.enabled {
+            if FeatureFlag.newSettingsStorage.enabled {
                 let value = resultSet.int(forColumn: Constants.autoAddSettingColumnName)
                 let position = UpNextPosition(rawValue: value)
                 switch position {

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/PodcastDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/PodcastDataManager.swift
@@ -373,7 +373,7 @@ class PodcastDataManager {
     }
 
     func saveAutoAddToUpNext(podcastUuid: String, autoAddToUpNext: Int32, dbQueue: FMDatabaseQueue) {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             if let podcast = DataManager.sharedManager.findPodcast(uuid: podcastUuid) {
                 if let setting = AutoAddToUpNextSetting(rawValue: autoAddToUpNext) {
                     podcast.setAutoAddToUpNext(setting: setting)
@@ -429,7 +429,7 @@ class PodcastDataManager {
     }
 
     func saveAutoAddToUpNextForAllPodcasts(autoAddToUpNext: Int32, dbQueue: FMDatabaseQueue) {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             setOnAllPodcasts(value: autoAddToUpNext, settingName: "addToUpNext", subscribedOnly: true, dbQueue: dbQueue)
         }
         setOnAllPodcasts(value: autoAddToUpNext, propertyName: "autoAddToUpNext", subscribedOnly: true, dbQueue: dbQueue)
@@ -440,7 +440,7 @@ class PodcastDataManager {
             do {
                 let uuids = podcasts.map { $0.uuid }
 
-                if FeatureFlag.settingsSync.enabled {
+                if FeatureFlag.newSettingsStorage.enabled {
                     let query = """
                     SELECT json_patch('setting', '{\"addToUpNext\": {\"value\": \(value)}}')
                     WHERE uuid IN (\(DataHelper.convertArrayToInString(uuids)))

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Podcast+Settings.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Podcast+Settings.swift
@@ -4,14 +4,14 @@ import Foundation
 extension Podcast {
     public var isEffectsOverridden: Bool {
         get {
-            if FeatureFlag.settingsSync.enabled {
+            if FeatureFlag.newSettingsStorage.enabled {
                 return settings.customEffects
             } else {
                 return overrideGlobalEffects
             }
         }
         set {
-            if FeatureFlag.settingsSync.enabled {
+            if FeatureFlag.newSettingsStorage.enabled {
                 settings.customEffects = newValue
             } else {
                 overrideGlobalEffects = newValue
@@ -21,14 +21,14 @@ extension Podcast {
 
     public var autoStartFrom: Int32 {
         get {
-            if FeatureFlag.settingsSync.enabled {
+            if FeatureFlag.newSettingsStorage.enabled {
                 return settings.autoStartFrom
             } else {
                 return startFrom
             }
         }
         set {
-            if FeatureFlag.settingsSync.enabled {
+            if FeatureFlag.newSettingsStorage.enabled {
                 settings.autoStartFrom = newValue
             }
             startFrom = newValue
@@ -37,14 +37,14 @@ extension Podcast {
 
     public var autoSkipLast: Int32 {
         get {
-            if FeatureFlag.settingsSync.enabled {
+            if FeatureFlag.newSettingsStorage.enabled {
                 return settings.autoSkipLast
             } else {
                 return skipLast
             }
         }
         set {
-            if FeatureFlag.settingsSync.enabled {
+            if FeatureFlag.newSettingsStorage.enabled {
                 settings.autoSkipLast = newValue
             }
             skipLast = newValue
@@ -53,7 +53,7 @@ extension Podcast {
 
     public var podcastSortOrder: PodcastEpisodeSortOrder? {
         get {
-            if FeatureFlag.settingsSync.enabled {
+            if FeatureFlag.newSettingsStorage.enabled {
                 return settings.episodesSortOrder
             } else {
                 return PodcastEpisodeSortOrder(rawValue: episodeSortOrder)
@@ -63,15 +63,15 @@ extension Podcast {
 
     public var autoArchivePlayedAfterTime: TimeInterval {
         get {
-            if FeatureFlag.settingsSync.enabled {
+            if FeatureFlag.newSettingsStorage.enabled {
                 return settings.autoArchivePlayed.time.rawValue
             } else {
                 return autoArchivePlayedAfter
             }
         }
         set {
-            if FeatureFlag.settingsSync.enabled {
-                if FeatureFlag.settingsSync.enabled {
+            if FeatureFlag.newSettingsStorage.enabled {
+                if FeatureFlag.newSettingsStorage.enabled {
                     if let time = AutoArchiveAfterTime(rawValue: newValue), let played = AutoArchiveAfterPlayed(time: time) {
                         settings.autoArchivePlayed = played
                         syncStatus = SyncStatus.notSynced.rawValue
@@ -84,14 +84,14 @@ extension Podcast {
 
     public var autoArchiveInactiveAfterTime: TimeInterval {
         get {
-            if FeatureFlag.settingsSync.enabled {
+            if FeatureFlag.newSettingsStorage.enabled {
                 return settings.autoArchiveInactive.time.rawValue
             } else {
                 return autoArchiveInactiveAfter
             }
         }
         set {
-            if FeatureFlag.settingsSync.enabled {
+            if FeatureFlag.newSettingsStorage.enabled {
                 if let time = AutoArchiveAfterTime(rawValue: newValue), let inactive = AutoArchiveAfterInactive(time: time) {
                     settings.autoArchiveInactive = inactive
                     syncStatus = SyncStatus.notSynced.rawValue
@@ -103,14 +103,14 @@ extension Podcast {
 
     public var autoArchiveEpisodeLimitCount: Int32 {
         get {
-            if FeatureFlag.settingsSync.enabled {
+            if FeatureFlag.newSettingsStorage.enabled {
                 return settings.autoArchiveEpisodeLimit
             } else {
                 return autoArchiveEpisodeLimit
             }
         }
         set {
-            if FeatureFlag.settingsSync.enabled {
+            if FeatureFlag.newSettingsStorage.enabled {
                 settings.autoArchiveEpisodeLimit = newValue
                 syncStatus = SyncStatus.notSynced.rawValue
             }
@@ -120,14 +120,14 @@ extension Podcast {
 
     public var isAutoArchiveOverridden: Bool {
         get {
-            if FeatureFlag.settingsSync.enabled {
+            if FeatureFlag.newSettingsStorage.enabled {
                 return settings.autoArchive
             } else {
                 return overrideGlobalArchive
             }
         }
         set {
-            if FeatureFlag.settingsSync.enabled {
+            if FeatureFlag.newSettingsStorage.enabled {
                 settings.autoArchive = newValue
                 syncStatus = SyncStatus.notSynced.rawValue
             }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Podcast.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Podcast.swift
@@ -66,7 +66,7 @@ public class Podcast: NSObject, Identifiable {
     }
 
     public func autoAddToUpNextOn() -> Bool {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             return settings.addToUpNext
         } else {
             return autoAddToUpNext == AutoAddToUpNextSetting.addLast.rawValue || autoAddToUpNext == AutoAddToUpNextSetting.addFirst.rawValue
@@ -74,7 +74,7 @@ public class Podcast: NSObject, Identifiable {
     }
 
     public func autoAddToUpNextSetting() -> AutoAddToUpNextSetting? {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             if settings.addToUpNext {
                 switch settings.addToUpNextPosition {
                 case .top:
@@ -91,7 +91,7 @@ public class Podcast: NSObject, Identifiable {
     }
 
     public func setAutoAddToUpNext(setting: AutoAddToUpNextSetting) {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             settings.addToUpNext = setting != .off
             settings.addToUpNextPosition = setting == .addFirst ? .top : .bottom
         }

--- a/Modules/DataModel/Tests/PocketCastsDataModelTests/AutoAddCandidatesDataManagerTests.swift
+++ b/Modules/DataModel/Tests/PocketCastsDataModelTests/AutoAddCandidatesDataManagerTests.swift
@@ -33,7 +33,7 @@ final class AutoAddCandidatesDataManagerTests: XCTestCase {
 
     /// Tests new query and autoAddToUpNext property for UpNext candidates
     func testSyncableUpNextSetting() throws {
-        featureFlagMock.set(.settingsSync, value: true)
+        featureFlagMock.set(.newSettingsStorage, value: true)
 
         let dataManager = try setupDatabase()
         let newUpNextSetting = AutoAddToUpNextSetting.addFirst
@@ -63,7 +63,7 @@ final class AutoAddCandidatesDataManagerTests: XCTestCase {
 
     /// Tests old query and autoAddToUpNext property for UpNext candidates
     func testOldUpNextSetting() throws {
-        featureFlagMock.set(.settingsSync, value: false)
+        featureFlagMock.set(.newSettingsStorage, value: false)
 
         let dataManager = try setupDatabase()
         let newUpNextSetting = AutoAddToUpNextSetting.addFirst
@@ -92,7 +92,7 @@ final class AutoAddCandidatesDataManagerTests: XCTestCase {
     }
 
     func testOldQueryPerformance() throws {
-        featureFlagMock.set(.settingsSync, value: false)
+        featureFlagMock.set(.newSettingsStorage, value: false)
 
         let dataManager = try setupDatabase()
         let newUpNextSetting = AutoAddToUpNextSetting.addFirst
@@ -125,7 +125,7 @@ final class AutoAddCandidatesDataManagerTests: XCTestCase {
     }
 
     func testNewQueryPerformance() throws {
-        featureFlagMock.set(.settingsSync, value: true)
+        featureFlagMock.set(.newSettingsStorage, value: true)
 
         let dataManager = try setupDatabase()
         let newUpNextSetting = AutoAddToUpNextSetting.addFirst

--- a/Modules/Server/Sources/PocketCastsServer/Public/ServerSettings.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/ServerSettings.swift
@@ -129,7 +129,7 @@ public class ServerSettings {
     // MARK: Marketing Opt In
 
     public class func setMarketingOptIn(_ value: Bool) {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             SettingsStore.appSettings.marketingOptIn = value
         }
         UserDefaults.standard.set(value, forKey: ServerConstants.UserDefaults.marketingOptInKey)
@@ -137,7 +137,7 @@ public class ServerSettings {
     }
 
     public class func marketingOptIn() -> Bool {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             return SettingsStore.appSettings.marketingOptIn
         } else {
             return UserDefaults.standard.bool(forKey: ServerConstants.UserDefaults.marketingOptInKey)
@@ -220,7 +220,7 @@ public class ServerSettings {
     // User files autodownload
     public static let userEpisodeAutoDownloadKey = "UserEpisodeAutoDownload"
     public class func userEpisodeAutoDownload() -> Bool {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             SettingsStore.appSettings.cloudAutoDownload
         } else {
             UserDefaults.standard.bool(forKey: userEpisodeAutoDownloadKey)
@@ -228,14 +228,14 @@ public class ServerSettings {
     }
 
     public class func setUserEpisodeAutoDownload(_ value: Bool) {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             SettingsStore.appSettings.cloudAutoDownload = value
         }
         UserDefaults.standard.set(value, forKey: userEpisodeAutoDownloadKey)
     }
 
     public class func userEpisodeOnlyOnWifi() -> Bool {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             SettingsStore.appSettings.cloudDownloadUnmeteredOnly
         } else {
             UserDefaults.standard.bool(forKey: userEpisodeOnlyOnWifiKey)
@@ -245,7 +245,7 @@ public class ServerSettings {
     // User files autodownload on wifi
     public static let userEpisodeOnlyOnWifiKey = "UserEpisodeOnlyOnWifi"
     public class func setUserEpisodeOnlyOnWifi(_ value: Bool) {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             SettingsStore.appSettings.cloudDownloadUnmeteredOnly = value
         }
         UserDefaults.standard.set(value, forKey: userEpisodeOnlyOnWifiKey)
@@ -309,7 +309,7 @@ public class ServerSettings {
 
     private static let autoAddLimitKey = "AutoAddToUpNextLimit"
     public class func autoAddToUpNextLimit() -> Int {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             Int(SettingsStore.appSettings.autoUpNextLimit)
         } else {
             UserDefaults.standard.integer(forKey: autoAddLimitKey)
@@ -317,7 +317,7 @@ public class ServerSettings {
     }
 
     public class func setAutoAddToUpNextLimit(_ limit: Int) {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             SettingsStore.appSettings.autoUpNextLimit = Int32(limit)
         }
         UserDefaults.standard.setValue(limit, forKey: autoAddLimitKey)
@@ -325,7 +325,7 @@ public class ServerSettings {
 
     private static let onAutoAddLimitReachedKey = "AutoAddLimitReachedKey"
     public class func onAutoAddLimitReached() -> AutoAddLimitReachedAction {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             return SettingsStore.appSettings.autoUpNextLimitReached
         } else {
             let storedValue = UserDefaults.standard.integer(forKey: onAutoAddLimitReachedKey)
@@ -335,7 +335,7 @@ public class ServerSettings {
     }
 
     public class func setOnAutoAddLimitReached(action: AutoAddLimitReachedAction) {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             SettingsStore.appSettings.autoUpNextLimitReached = action
         }
         UserDefaults.standard.setValue(action.rawValue, forKey: onAutoAddLimitReachedKey)

--- a/Modules/Server/Sources/PocketCastsServer/Public/SubscriptionHelper.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/SubscriptionHelper.swift
@@ -128,7 +128,7 @@ open class SubscriptionHelper: NSObject {
     }
 
     public class func setSubscriptionGiftAcknowledgement(_ value: Bool) {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             SettingsStore.appSettings.freeGiftAcknowledgement = value
         }
         UserDefaults.standard.set(value, forKey: ServerConstants.UserDefaults.subscriptionGiftAcknowledgement)
@@ -136,7 +136,7 @@ open class SubscriptionHelper: NSObject {
     }
 
     public class func subscriptionGiftAcknowledgement() -> Bool {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             return SettingsStore.appSettings.freeGiftAcknowledgement
         } else {
             return UserDefaults.standard.bool(forKey: ServerConstants.UserDefaults.subscriptionGiftAcknowledgement)

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -28,6 +28,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// Enable selecting/deselecting episode chapters
     case deselectChapters
 
+    /// Store settings as JSON in User Defaults (global) or SQLite (podcast)
+    case newSettingsStorage
+
     /// Syncing all app and podcast settings
     case settingsSync
 
@@ -75,6 +78,8 @@ public enum FeatureFlag: String, CaseIterable {
             false
         case .cachePlayingEpisode:
             true
+        case .newSettingsStorage:
+            false
         }
     }
 
@@ -88,6 +93,8 @@ public enum FeatureFlag: String, CaseIterable {
             "new_account_upgrade_prompt_flow"
         case .cachePlayingEpisode:
             "cache_playing_episode"
+        case .newSettingsStorage:
+            "new_settings_storage"
         default:
             nil
         }

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -71,7 +71,7 @@ public enum FeatureFlag: String, CaseIterable {
         case .deselectChapters:
             false
         case .settingsSync:
-            false
+            false // `newSettingsStorage` also needs to be `true` for syncing to function
         case .slumber:
             false
         case .newAccountUpgradePromptFlow:

--- a/Pocket Casts Watch App Extension/PodcastEpisodeListViewModel.swift
+++ b/Pocket Casts Watch App Extension/PodcastEpisodeListViewModel.swift
@@ -65,7 +65,7 @@ class PodcastEpisodeListViewModel: ObservableObject {
     }
 
     func didChangeSortOrder(option: PodcastEpisodeSortOrder) {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             podcast.settings.episodesSortOrder = option
             podcast.syncStatus = SyncStatus.notSynced.rawValue
         }

--- a/PocketCastsTests/Tests/ThemeTests.swift
+++ b/PocketCastsTests/Tests/ThemeTests.swift
@@ -1,11 +1,19 @@
 import Foundation
 @testable import podcasts
 import XCTest
+@testable import PocketCastsUtils
 
 class ThemeTests: XCTestCase {
+    let flagMock = FeatureFlagMock()
+
     override func setUp() {
         UserDefaults.standard.removeObject(forKey: Constants.UserDefaults.shouldFollowSystemThemeKey)
         UserDefaults.standard.removeObject(forKey: Constants.UserDefaults.themeKey)
+        flagMock.set(.newSettingsStorage, value: false)
+    }
+
+    override func tearDown() {
+        flagMock.reset()
     }
 
     // If the user never changed the theme neither toggled light/dark option

--- a/PocketCastsTests/Tests/Utilities/SettingsTests.swift
+++ b/PocketCastsTests/Tests/Utilities/SettingsTests.swift
@@ -32,7 +32,7 @@ final class SettingsTests: XCTestCase {
     }
 
     func testImportOldHeadphoneControls() throws {
-        try override(flag: .settingsSync, value: false)
+        try override(flag: .newSettingsStorage, value: false)
         try setupSettingsStore()
 
         let newNextAction = HeadphoneControlAction.nextChapter
@@ -41,18 +41,18 @@ final class SettingsTests: XCTestCase {
         Settings.headphonesNextAction = newNextAction
         Settings.headphonesPreviousAction = newPreviousAction
 
-        try FeatureFlagOverrideStore().override(FeatureFlag.settingsSync, withValue: true)
+        try FeatureFlagOverrideStore().override(FeatureFlag.newSettingsStorage, withValue: true)
 
         SettingsStore.appSettings.importUserDefaults()
 
         XCTAssertEqual(newNextAction, Settings.headphonesNextAction, "Next action should be imported from old defaults")
         XCTAssertEqual(newPreviousAction, Settings.headphonesPreviousAction, "Previous action should be imported from old defaults")
-        try reset(flag: .settingsSync)
+        try reset(flag: .newSettingsStorage)
     }
 
     func testPlayerActions() throws {
         let unknownString = "test"
-        try override(flag: .settingsSync, value: true)
+        try override(flag: .newSettingsStorage, value: true)
         try setupSettingsStore()
         Settings.updatePlayerActions(PlayerAction.defaultActions.filter { $0.isAvailable }) // Set defaults
 
@@ -71,11 +71,11 @@ final class SettingsTests: XCTestCase {
                         .archive], Settings.playerActions(), "Player actions should exclude unknown actions and include defaults")
         XCTAssertEqual([.known(.addBookmark), .known(.markPlayed), .unknown(unknownString)], SettingsStore.appSettings.playerShelf, "Player shelf should include unknowns at end")
 
-        try reset(flag: .settingsSync)
+        try reset(flag: .newSettingsStorage)
     }
 
     func testOldPlayerActions() throws {
-        try override(flag: .settingsSync, value: false)
+        try override(flag: .newSettingsStorage, value: false)
 
         Settings.updatePlayerActions(PlayerAction.defaultActions.filter { $0.isAvailable }) // Set defaults
         Settings.updatePlayerActions([.addBookmark, .markPlayed])
@@ -91,18 +91,18 @@ final class SettingsTests: XCTestCase {
                         .chromecast,
                         .archive], Settings.playerActions(), "Player actions should include changes from update")
 
-        try reset(flag: .settingsSync)
+        try reset(flag: .newSettingsStorage)
     }
 
     func testImportOldPlayerActions() throws {
         // Start with disabled settingsSync
-        try override(flag: .settingsSync, value: false)
+        try override(flag: .newSettingsStorage, value: false)
 
         Settings.updatePlayerActions(PlayerAction.defaultActions.filter { $0.isAvailable })
         Settings.updatePlayerActions([.addBookmark, .markPlayed]) // This update is tested in testOldPlayerActions
 
         // Enable settingsSync to flip `Settings` to use the new value
-        try FeatureFlagOverrideStore().override(FeatureFlag.settingsSync, withValue: true)
+        try FeatureFlagOverrideStore().override(FeatureFlag.newSettingsStorage, withValue: true)
 
         try setupSettingsStore()
         SettingsStore.appSettings.importUserDefaults()
@@ -118,6 +118,6 @@ final class SettingsTests: XCTestCase {
                         .chromecast,
                         .archive], Settings.playerActions(), "Player actions should include changes from update")
 
-        try reset(flag: .settingsSync)
+        try reset(flag: .newSettingsStorage)
     }
 }

--- a/podcasts/AppDelegate+Defaults.swift
+++ b/podcasts/AppDelegate+Defaults.swift
@@ -126,7 +126,7 @@ extension AppDelegate {
             }
         }
 
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             performUpdateIfRequired(updateKey: "MigrateToSyncedSettings") {
                 SettingsStore.appSettings.importUserDefaults()
                 DataManager.sharedManager.importPodcastSettings()

--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -310,6 +310,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             }
 
             SyncManager.shouldUseNewSettingsSync = FeatureFlag.settingsSync.enabled
+            if FeatureFlag.newSettingsStorage.enabled != Settings.newSettingsStorage {
+                if FeatureFlag.newSettingsStorage.enabled {
+                    SettingsStore.appSettings.importUserDefaults()
+                    DataManager.sharedManager.importPodcastSettings()
+                }
+            }
 
             try FeatureFlagOverrideStore().override(FeatureFlag.slumber, withValue: Settings.slumberPromoCode?.isEmpty == false)
 

--- a/podcasts/EpisodeListSearchController.swift
+++ b/podcasts/EpisodeListSearchController.swift
@@ -344,7 +344,7 @@ class EpisodeListSearchController: SimpleNotificationsViewController, UISearchBa
 
     private func setSortSetting(_ setting: PodcastEpisodeSortOrder) {
         guard let podcast = podcastDelegate?.displayedPodcast() else { return }
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             podcast.settings.episodesSortOrder = setting
             podcast.syncStatus = SyncStatus.notSynced.rawValue
         }
@@ -356,7 +356,7 @@ class EpisodeListSearchController: SimpleNotificationsViewController, UISearchBa
 
     private func setGroupingSetting(_ setting: PodcastGrouping) {
         guard let podcast = podcastDelegate?.displayedPodcast() else { return }
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             podcast.settings.episodeGrouping = setting
             podcast.syncStatus = SyncStatus.notSynced.rawValue
         }

--- a/podcasts/GeneralSettingsViewController.swift
+++ b/podcasts/GeneralSettingsViewController.swift
@@ -116,7 +116,7 @@ class GeneralSettingsViewController: UIViewController, UITableViewDelegate, UITa
 
             cell.cellLabel.text = L10n.settingsGeneralKeepScreenAwake
 
-            if FeatureFlag.settingsSync.enabled {
+            if FeatureFlag.newSettingsStorage.enabled {
                 cell.cellSwitch.isOn = SettingsStore.appSettings.keepScreenAwake
             } else {
                 cell.cellSwitch.isOn = UserDefaults.standard.bool(forKey: Constants.UserDefaults.keepScreenOnWhilePlaying)
@@ -131,7 +131,7 @@ class GeneralSettingsViewController: UIViewController, UITableViewDelegate, UITa
 
             cell.cellLabel.text = L10n.settingsGeneralOpenInBrowser
 
-            if FeatureFlag.settingsSync.enabled {
+            if FeatureFlag.newSettingsStorage.enabled {
                 cell.cellSwitch.isOn = SettingsStore.appSettings.openLinks
             } else {
                 cell.cellSwitch.isOn = UserDefaults.standard.bool(forKey: Constants.UserDefaults.openLinksInExternalBrowser)
@@ -146,7 +146,7 @@ class GeneralSettingsViewController: UIViewController, UITableViewDelegate, UITa
 
             cell.cellLabel.text = L10n.settingsGeneralAutoOpenPlayer
 
-            if FeatureFlag.settingsSync.enabled {
+            if FeatureFlag.newSettingsStorage.enabled {
                 cell.cellSwitch.isOn = SettingsStore.appSettings.openPlayer
             } else {
                 cell.cellSwitch.isOn = UserDefaults.standard.bool(forKey: Constants.UserDefaults.openPlayerAutomatically)
@@ -161,7 +161,7 @@ class GeneralSettingsViewController: UIViewController, UITableViewDelegate, UITa
 
             cell.cellLabel.text = L10n.settingsGeneralSmartPlayback
 
-            if FeatureFlag.settingsSync.enabled {
+            if FeatureFlag.newSettingsStorage.enabled {
                 cell.cellSwitch.isOn = SettingsStore.appSettings.intelligentResumption
             } else {
                 cell.cellSwitch.isOn = UserDefaults.standard.bool(forKey: Constants.UserDefaults.intelligentPlaybackResumption)
@@ -446,7 +446,7 @@ class GeneralSettingsViewController: UIViewController, UITableViewDelegate, UITa
     }
 
     @objc private func screenLockToggled(_ sender: UISwitch) {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             SettingsStore.appSettings.keepScreenAwake = sender.isOn
         }
         UserDefaults.standard.set(sender.isOn, forKey: Constants.UserDefaults.keepScreenOnWhilePlaying)
@@ -455,7 +455,7 @@ class GeneralSettingsViewController: UIViewController, UITableViewDelegate, UITa
     }
 
     @objc private func openLinksInBrowserToggled(_ sender: UISwitch) {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             SettingsStore.appSettings.openLinks = sender.isOn
         } else {
             UserDefaults.standard.set(sender.isOn, forKey: Constants.UserDefaults.openLinksInExternalBrowser)
@@ -476,7 +476,7 @@ class GeneralSettingsViewController: UIViewController, UITableViewDelegate, UITa
     }
 
     @objc private func openPlayerToggled(_ sender: UISwitch) {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             SettingsStore.appSettings.openPlayer = sender.isOn
         }
         UserDefaults.standard.set(sender.isOn, forKey: Constants.UserDefaults.openPlayerAutomatically)
@@ -484,7 +484,7 @@ class GeneralSettingsViewController: UIViewController, UITableViewDelegate, UITa
     }
 
     @objc private func intelligentPlaybackResumptionToggled(_ sender: UISwitch) {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             SettingsStore.appSettings.intelligentResumption = sender.isOn
         }
         UserDefaults.standard.set(sender.isOn, forKey: Constants.UserDefaults.intelligentPlaybackResumption)

--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -208,7 +208,7 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
             setupForEpisode(episode)
             showMiniPlayer()
             let shouldOpenAutomatically: Bool
-            if FeatureFlag.settingsSync.enabled {
+            if FeatureFlag.newSettingsStorage.enabled {
                 shouldOpenAutomatically = SettingsStore.appSettings.openPlayer
             } else {
                 shouldOpenAutomatically = UserDefaults.standard.bool(forKey: Constants.UserDefaults.openPlayerAutomatically)

--- a/podcasts/PlaybackCatchUpHelper.swift
+++ b/podcasts/PlaybackCatchUpHelper.swift
@@ -11,7 +11,7 @@ struct PlaybackCatchUpHelper {
         #else
             // if it's a different episode, or not still at the time it was at when it was last paused, just play from where it's up to
             let intelligentPlaybackResumption: Bool
-            if FeatureFlag.settingsSync.enabled {
+            if FeatureFlag.newSettingsStorage.enabled {
                 intelligentPlaybackResumption = SettingsStore.appSettings.intelligentResumption
             } else {
                 intelligentPlaybackResumption = UserDefaults.standard.bool(forKey: Constants.UserDefaults.intelligentPlaybackResumption)

--- a/podcasts/PlaybackEffects.swift
+++ b/podcasts/PlaybackEffects.swift
@@ -44,7 +44,7 @@ class PlaybackEffects {
     var isGlobal: Bool = true
 
     class func effectsFor(podcast: Podcast) -> PlaybackEffects {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             if !podcast.settings.customEffects { return globalEffects() }
         } else {
             if !podcast.overrideGlobalEffects { return globalEffects() }
@@ -54,7 +54,7 @@ class PlaybackEffects {
 
         effects.isGlobal = false
 
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             effects.trimSilence = podcast.settings.trimSilence.amount
             effects.volumeBoost = podcast.settings.boostVolume
             effects.playbackSpeed = podcast.settings.playbackSpeed
@@ -71,7 +71,7 @@ class PlaybackEffects {
         let effects = PlaybackEffects()
         effects.isGlobal = true
         let savedSpeed: Double
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             effects.trimSilence = SettingsStore.appSettings.trimSilence
             effects.volumeBoost = SettingsStore.appSettings.volumeBoost
             savedSpeed = SettingsStore.appSettings.playbackSpeed

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -736,7 +736,7 @@ class PlaybackManager: ServerPlaybackDelegate {
 
         // persist changes
         if effects.isGlobal {
-            if FeatureFlag.settingsSync.enabled {
+            if FeatureFlag.newSettingsStorage.enabled {
                 SettingsStore.appSettings.trimSilence = effects.trimSilence
                 SettingsStore.appSettings.volumeBoost = effects.volumeBoost
                 SettingsStore.appSettings.playbackSpeed = effects.playbackSpeed
@@ -746,7 +746,7 @@ class PlaybackManager: ServerPlaybackDelegate {
                 UserDefaults.standard.set(effects.playbackSpeed, forKey: Constants.UserDefaults.globalPlaybackSpeed)
             }
         } else if let episode = episode as? Episode, let podcast = episode.parentPodcast() {
-            if FeatureFlag.settingsSync.enabled {
+            if FeatureFlag.newSettingsStorage.enabled {
                 podcast.settings.trimSilence = TrimSilence(amount: effects.trimSilence)
                 podcast.settings.playbackSpeed = effects.playbackSpeed
                 podcast.settings.boostVolume = effects.volumeBoost
@@ -1931,7 +1931,7 @@ class PlaybackManager: ServerPlaybackDelegate {
             DispatchQueue.main.async {
                 if self.playing() {
                     let keepScreenOn: Bool
-                    if FeatureFlag.settingsSync.enabled {
+                    if FeatureFlag.newSettingsStorage.enabled {
                         keepScreenOn = SettingsStore.appSettings.keepScreenAwake
                     } else {
                         keepScreenOn = UserDefaults.standard.bool(forKey: Constants.UserDefaults.keepScreenOnWhilePlaying)

--- a/podcasts/Podcast+Formatting.swift
+++ b/podcasts/Podcast+Formatting.swift
@@ -93,7 +93,7 @@ extension Podcast {
     #endif
 
     func podcastGrouping() -> PodcastGrouping {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             return settings.episodeGrouping
         } else {
             return PodcastGrouping(rawValue: episodeGrouping) ?? .none

--- a/podcasts/PodcastEffectsViewController+Table.swift
+++ b/podcasts/PodcastEffectsViewController+Table.swift
@@ -31,7 +31,7 @@ extension PodcastEffectsViewController: UITableViewDataSource, UITableViewDelega
             let cell = tableView.dequeueReusableCell(withIdentifier: PodcastEffectsViewController.switchCellId, for: indexPath) as! SwitchCell
             cell.cellLabel?.text = L10n.settingsCustom
             cell.cellSwitch.onTintColor = podcast.switchTintColor()
-            if FeatureFlag.settingsSync.enabled {
+            if FeatureFlag.newSettingsStorage.enabled {
                 cell.cellSwitch.isOn = podcast.settings.customEffects
             } else {
                 cell.cellSwitch.isOn = podcast.overrideGlobalEffects
@@ -45,7 +45,7 @@ extension PodcastEffectsViewController: UITableViewDataSource, UITableViewDelega
         case .playbackSpeed:
             let cell = tableView.dequeueReusableCell(withIdentifier: PodcastEffectsViewController.timeStepperCellId, for: indexPath) as! TimeStepperCell
             cell.cellLabel?.text = L10n.settingsPlaySpeed
-            if FeatureFlag.settingsSync.enabled {
+            if FeatureFlag.newSettingsStorage.enabled {
                 cell.cellSecondaryLabel.text = L10n.playbackSpeed(podcast.settings.playbackSpeed.localized())
             } else {
                 cell.cellSecondaryLabel.text = L10n.playbackSpeed(podcast.playbackSpeed.localized())
@@ -57,7 +57,7 @@ extension PodcastEffectsViewController: UITableViewDataSource, UITableViewDelega
             cell.timeStepper.maximumValue = 3
             cell.timeStepper.smallIncrements = 0.1
             cell.timeStepper.smallIncrementThreshold = TimeInterval.greatestFiniteMagnitude
-            if FeatureFlag.settingsSync.enabled {
+            if FeatureFlag.newSettingsStorage.enabled {
                 cell.timeStepper.currentValue = podcast.settings.playbackSpeed
             } else {
                 cell.timeStepper.currentValue = podcast.playbackSpeed
@@ -73,7 +73,7 @@ extension PodcastEffectsViewController: UITableViewDataSource, UITableViewDelega
             cell.cellLabel?.text = L10n.settingsTrimSilence
             cell.cellSwitch.onTintColor = podcast.switchTintColor()
             cell.setImage(imageName: "player_trim")
-            if FeatureFlag.settingsSync.enabled {
+            if FeatureFlag.newSettingsStorage.enabled {
                 cell.cellSwitch.isOn = podcast.settings.trimSilence != .off
             } else {
                 cell.cellSwitch.isOn = podcast.trimSilenceAmount > 0
@@ -90,7 +90,7 @@ extension PodcastEffectsViewController: UITableViewDataSource, UITableViewDelega
 
             let trimAmount: TrimSilenceAmount
 
-            if FeatureFlag.settingsSync.enabled {
+            if FeatureFlag.newSettingsStorage.enabled {
                 trimAmount = podcast.settings.trimSilence.amount
             } else {
                 trimAmount = TrimSilenceAmount(rawValue: Int32(podcast.trimSilenceAmount)) ?? .low
@@ -103,7 +103,7 @@ extension PodcastEffectsViewController: UITableViewDataSource, UITableViewDelega
             cell.cellLabel?.text = L10n.settingsVolumeBoost
             cell.cellSwitch.onTintColor = podcast.switchTintColor()
             cell.setImage(imageName: "player_volumeboost")
-            if FeatureFlag.settingsSync.enabled {
+            if FeatureFlag.newSettingsStorage.enabled {
                 cell.cellSwitch.isOn = podcast.settings.boostVolume
             } else {
                 cell.cellSwitch.isOn = podcast.boostVolume
@@ -136,7 +136,7 @@ extension PodcastEffectsViewController: UITableViewDataSource, UITableViewDelega
         let action = OptionAction(label: level.description, selected: selectedAmount == level) { [weak self] in
             guard let self = self else { return }
 
-            if FeatureFlag.settingsSync.enabled {
+            if FeatureFlag.newSettingsStorage.enabled {
                 self.podcast.settings.trimSilence = TrimSilence(amount: level)
                 self.podcast.syncStatus = SyncStatus.notSynced.rawValue
             }
@@ -171,7 +171,7 @@ extension PodcastEffectsViewController: UITableViewDataSource, UITableViewDelega
     private func playbackSpeedChanged(_ speed: TimeInterval) {
         // round it to the nearest 0.1, so we end up with 1.5 not 1.53667346262
         let roundedSpeed = round(speed * 10.0) / 10.0
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             podcast.settings.playbackSpeed = roundedSpeed
             podcast.syncStatus = SyncStatus.notSynced.rawValue
         }
@@ -185,7 +185,7 @@ extension PodcastEffectsViewController: UITableViewDataSource, UITableViewDelega
     }
 
     @objc private func trimSilenceToggled(_ sender: UISwitch) {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             let defaultAmount = TrimSilenceAmount(rawValue: Int32(PlaybackEffects.defaultRemoveSilenceAmount))
             podcast.settings.trimSilence = TrimSilence(amount: sender.isOn ? (defaultAmount ?? .off) : .off)
             podcast.syncStatus = SyncStatus.notSynced.rawValue
@@ -196,7 +196,7 @@ extension PodcastEffectsViewController: UITableViewDataSource, UITableViewDelega
     }
 
     @objc private func boostVolumeToggled(_ sender: UISwitch) {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             podcast.settings.boostVolume = sender.isOn
             podcast.syncStatus = SyncStatus.notSynced.rawValue
         }
@@ -215,7 +215,7 @@ extension PodcastEffectsViewController: UITableViewDataSource, UITableViewDelega
     }
 
     private func tableData() -> [[TableRow]] {
-        let hasTrimSilence = FeatureFlag.settingsSync.enabled ? podcast.settings.trimSilence != .off : podcast.trimSilenceAmount > 0
+        let hasTrimSilence = FeatureFlag.newSettingsStorage.enabled ? podcast.settings.trimSilence != .off : podcast.trimSilenceAmount > 0
         if podcast.isEffectsOverridden && hasTrimSilence {
             return [[.customForPodcast], [.playbackSpeed, .trimSilence, .trimSilenceAmount, .volumeBoost]]
         }

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -13,7 +13,7 @@ class Settings: NSObject {
     static let podcastLibraryGridTypeKey = "SJPodcastLibraryGridType"
     private static var cachedlibrarySortType: LibraryType?
     class func setLibraryType(_ type: LibraryType) {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             SettingsStore.appSettings.gridLayout = type
         }
         UserDefaults.standard.set(type.old.rawValue, forKey: Settings.podcastLibraryGridTypeKey)
@@ -22,7 +22,7 @@ class Settings: NSObject {
 
     class func libraryType() -> LibraryType {
 
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             return SettingsStore.appSettings.gridLayout
         }
 
@@ -44,7 +44,7 @@ class Settings: NSObject {
 
     static let badgeKey = "SJBadgeType"
     class func podcastBadgeType() -> BadgeType {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             return SettingsStore.appSettings.badges
         }
 
@@ -58,7 +58,7 @@ class Settings: NSObject {
     }
 
     class func setPodcastBadgeType(_ badgeType: BadgeType) {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             SettingsStore.appSettings.badges = badgeType
         }
         UserDefaults.standard.set(badgeType.rawValue, forKey: Settings.badgeKey)
@@ -68,7 +68,7 @@ class Settings: NSObject {
 
     static let autoDownloadUpNext = "SJAutoDownloadUpNext"
     class func downloadUpNextEpisodes() -> Bool {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             SettingsStore.appSettings.autoDownloadUpNext
         } else {
             UserDefaults.standard.bool(forKey: Settings.autoDownloadUpNext)
@@ -76,7 +76,7 @@ class Settings: NSObject {
     }
 
     class func setDownloadUpNextEpisodes(_ download: Bool) {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             SettingsStore.appSettings.autoDownloadUpNext = download
         }
         UserDefaults.standard.set(download, forKey: Settings.autoDownloadUpNext)
@@ -87,7 +87,7 @@ class Settings: NSObject {
 
     static let allowCellularDownloadKey = "SJUserCellular"
     class func mobileDataAllowed() -> Bool {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             return !SettingsStore.appSettings.warnDataUsage
         } else {
             return UserDefaults.standard.bool(forKey: Settings.allowCellularDownloadKey)
@@ -95,7 +95,7 @@ class Settings: NSObject {
     }
 
     class func setMobileDataAllowed(_ allow: Bool, userInitiated: Bool = false) {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             SettingsStore.appSettings.warnDataUsage = !allow
         }
         UserDefaults.standard.set(allow, forKey: Settings.allowCellularDownloadKey)
@@ -108,7 +108,7 @@ class Settings: NSObject {
 
     static let allowCellularAutoDownloadKey = "SJUserCellularAutoDownload"
     class func autoDownloadMobileDataAllowed() -> Bool {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             !SettingsStore.appSettings.autoDownloadUnmeteredOnly
         } else {
             UserDefaults.standard.bool(forKey: Settings.allowCellularAutoDownloadKey)
@@ -116,7 +116,7 @@ class Settings: NSObject {
     }
 
     class func setAutoDownloadMobileDataAllowed(_ allow: Bool, userInitiated: Bool = false) {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             SettingsStore.appSettings.autoDownloadUnmeteredOnly = !allow
         }
         UserDefaults.standard.set(allow, forKey: Settings.allowCellularAutoDownloadKey)
@@ -155,7 +155,7 @@ class Settings: NSObject {
 
     static let defaultArchiveBehaviour = "SJDefaultArchive"
     class func showArchivedDefault() -> Bool {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             return SettingsStore.appSettings.showArchived
         } else {
             return UserDefaults.standard.bool(forKey: defaultArchiveBehaviour)
@@ -163,7 +163,7 @@ class Settings: NSObject {
     }
 
     class func setShowArchivedDefault(_ showArchived: Bool) {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             SettingsStore.appSettings.showArchived = showArchived
         }
         UserDefaults.standard.set(showArchived, forKey: defaultArchiveBehaviour)
@@ -176,7 +176,7 @@ class Settings: NSObject {
     static let primaryRowActionKey = "SJRowAction"
     private static var cachedPrimaryRowAction: PrimaryRowAction? // we cache this because it's used in lists
     class func primaryRowAction() -> PrimaryRowAction {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             return SettingsStore.appSettings.rowAction
         } else {
             if let action = cachedPrimaryRowAction { return action }
@@ -186,7 +186,7 @@ class Settings: NSObject {
     }
 
     class func setPrimaryRowAction(_ action: PrimaryRowAction) {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             SettingsStore.appSettings.rowAction = action
         } else {
             UserDefaults.standard.set(
@@ -202,7 +202,7 @@ class Settings: NSObject {
     // MARK: - Podcast Sort Order
 
     class func homeFolderSortOrder() -> LibrarySort {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             return SettingsStore.appSettings.gridOrder
         }
 
@@ -215,7 +215,7 @@ class Settings: NSObject {
     }
 
     class func setHomeFolderSortOrder(order: LibrarySort) {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             SettingsStore.appSettings.gridOrder = order
         }
         ServerSettings.setHomeGridSortOrder(order.old.rawValue, syncChange: true)
@@ -226,7 +226,7 @@ class Settings: NSObject {
     static let podcastGroupingDefaultKey = "SJDefaultPodcastGrouping"
     private static var cachedPodcastGrouping: PodcastGrouping?
     class func defaultPodcastGrouping() -> PodcastGrouping {
-        guard FeatureFlag.settingsSync.enabled == false else {
+        guard FeatureFlag.newSettingsStorage.enabled == false else {
             return SettingsStore.appSettings.episodeGrouping
         }
 
@@ -240,7 +240,7 @@ class Settings: NSObject {
     }
 
     class func setDefaultPodcastGrouping(_ grouping: PodcastGrouping) {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             SettingsStore.appSettings.episodeGrouping = grouping
         }
         UserDefaults.standard.set(grouping.rawValue, forKey: podcastGroupingDefaultKey)
@@ -254,7 +254,7 @@ class Settings: NSObject {
     static let primaryUpNextSwipeActionKey = "SJUpNextSwipe"
     private static var cachedPrimaryUpNextSwipeAction: PrimaryUpNextSwipeAction? // we cache this because it's used in lists
     class func primaryUpNextSwipeAction() -> PrimaryUpNextSwipeAction {
-        guard FeatureFlag.settingsSync.enabled == false else {
+        guard FeatureFlag.newSettingsStorage.enabled == false else {
             return SettingsStore.appSettings.upNextSwipe
         }
 
@@ -268,7 +268,7 @@ class Settings: NSObject {
     }
 
     class func setPrimaryUpNextSwipeAction(_ action: PrimaryUpNextSwipeAction) {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             SettingsStore.appSettings.upNextSwipe = action
         }
         UserDefaults.standard.set(action.rawValue, forKey: primaryUpNextSwipeActionKey)
@@ -281,14 +281,14 @@ class Settings: NSObject {
 
     static let playUpNextOnTapKey = "SJPlayUpNextOnTap"
     class func playUpNextOnTap() -> Bool {
-        guard FeatureFlag.settingsSync.enabled == false else {
+        guard FeatureFlag.newSettingsStorage.enabled == false else {
             return SettingsStore.appSettings.playUpNextOnTap
         }
         return UserDefaults.standard.bool(forKey: Settings.playUpNextOnTapKey)
     }
 
     class func setPlayUpNextOnTap(_ isOn: Bool) {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             SettingsStore.appSettings.playUpNextOnTap = isOn
         }
         UserDefaults.standard.set(isOn, forKey: Settings.playUpNextOnTapKey)
@@ -329,7 +329,7 @@ class Settings: NSObject {
 
     static let autoArchivePlayedAfterKey = "AutoArchivePlayedAfer"
     class func autoArchivePlayedAfter() -> TimeInterval {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             return SettingsStore.appSettings.autoArchivePlayed.time.rawValue
         } else {
             return UserDefaults.standard.double(forKey: Settings.autoArchivePlayedAfterKey)
@@ -337,7 +337,7 @@ class Settings: NSObject {
     }
 
     class func setAutoArchivePlayedAfter(_ after: TimeInterval, userInitiated: Bool = false) {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             SettingsStore.appSettings.autoArchivePlayed = AutoArchiveAfterPlayed(time: AutoArchiveAfterTime(rawValue: after)!)!
         }
         UserDefaults.standard.set(after, forKey: Settings.autoArchivePlayedAfterKey)
@@ -350,7 +350,7 @@ class Settings: NSObject {
 
     static let autoArchiveInactiveAfterKey = "AutoArchiveInactiveAfer"
     class func autoArchiveInactiveAfter() -> TimeInterval {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             return SettingsStore.appSettings.autoArchiveInactive.time.rawValue
         } else {
             return UserDefaults.standard.double(forKey: Settings.autoArchiveInactiveAfterKey)
@@ -358,7 +358,7 @@ class Settings: NSObject {
     }
 
     class func setAutoArchiveInactiveAfter(_ after: TimeInterval, userInitiated: Bool = false) {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             SettingsStore.appSettings.autoArchiveInactive = AutoArchiveAfterInactive(time: AutoArchiveAfterTime(rawValue: after)!)!
         }
         UserDefaults.standard.set(after, forKey: Settings.autoArchiveInactiveAfterKey)
@@ -371,7 +371,7 @@ class Settings: NSObject {
 
     static let archiveStarredEpisodesKey = "ArchiveStarredEpisodes"
     class func archiveStarredEpisodes() -> Bool {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             return SettingsStore.appSettings.autoArchiveIncludesStarred
         } else {
             return UserDefaults.standard.bool(forKey: Settings.archiveStarredEpisodesKey)
@@ -379,7 +379,7 @@ class Settings: NSObject {
     }
 
     class func setArchiveStarredEpisodes(_ archive: Bool, userInitiated: Bool = false) {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             SettingsStore.appSettings.autoArchiveIncludesStarred = archive
         }
         UserDefaults.standard.set(archive, forKey: Settings.archiveStarredEpisodesKey)
@@ -433,7 +433,7 @@ class Settings: NSObject {
 
     static let mediaSessionActionsKey = "MediaSessionActions"
     class func extraMediaSessionActionsEnabled() -> Bool {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             return SettingsStore.appSettings.playbackActions
         } else {
             return UserDefaults.standard.bool(forKey: Settings.mediaSessionActionsKey)
@@ -441,7 +441,7 @@ class Settings: NSObject {
     }
 
     class func setExtraMediaSessionActionsEnabled(_ enabled: Bool) {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             SettingsStore.appSettings.playbackActions = enabled
         }
         UserDefaults.standard.set(enabled, forKey: Settings.mediaSessionActionsKey)
@@ -455,7 +455,7 @@ class Settings: NSObject {
 
     static let legacyBtSupportKey = "LegacyBtSupport"
     class func legacyBluetoothModeEnabled() -> Bool {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             return SettingsStore.appSettings.legacyBluetooth
         } else {
             return UserDefaults.standard.bool(forKey: Settings.legacyBtSupportKey)
@@ -463,7 +463,7 @@ class Settings: NSObject {
     }
 
     class func setLegacyBluetoothModeEnabled(_ enabled: Bool) {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             SettingsStore.appSettings.legacyBluetooth = enabled
         }
         UserDefaults.standard.set(enabled, forKey: Settings.legacyBtSupportKey)
@@ -474,7 +474,7 @@ class Settings: NSObject {
 
     static let publishChapterTitlesKey = "PublishChapterTitles"
     class func publishChapterTitlesEnabled() -> Bool {
-        guard FeatureFlag.settingsSync.enabled == false else {
+        guard FeatureFlag.newSettingsStorage.enabled == false else {
             return SettingsStore.appSettings.chapterTitles
         }
 
@@ -486,7 +486,7 @@ class Settings: NSObject {
     }
 
     class func setPublishChapterTitlesEnabled(_ enabled: Bool) {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             SettingsStore.appSettings.chapterTitles = enabled
         }
         UserDefaults.standard.set(enabled, forKey: Settings.publishChapterTitlesKey)
@@ -505,7 +505,7 @@ class Settings: NSObject {
 
     static let userEpisodeAutoUploadKey = "UserEpisodeAutoUpload"
     class func userFilesAutoUpload() -> Bool {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             SettingsStore.appSettings.cloudAutoUpload
         } else {
             UserDefaults.standard.bool(forKey: userEpisodeAutoUploadKey)
@@ -513,7 +513,7 @@ class Settings: NSObject {
     }
 
     class func setUserEpisodeAutoUpload(_ value: Bool) {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             SettingsStore.appSettings.cloudAutoUpload = value
         }
         UserDefaults.standard.set(value, forKey: userEpisodeAutoUploadKey)
@@ -522,7 +522,7 @@ class Settings: NSObject {
 
     static let userEpisodeAutoAddToUpNextKey = "UserEpisodeAutoAddToUpNext"
     class func userEpisodeAutoAddToUpNext() -> Bool {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             return SettingsStore.appSettings.filesAutoUpNext
         } else {
             return UserDefaults.standard.bool(forKey: userEpisodeAutoAddToUpNextKey)
@@ -530,7 +530,7 @@ class Settings: NSObject {
     }
 
     class func setUserEpisodeAutoAddToUpNext(_ value: Bool) {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             return SettingsStore.appSettings.filesAutoUpNext = value
         }
         UserDefaults.standard.set(value, forKey: userEpisodeAutoAddToUpNextKey)
@@ -539,7 +539,7 @@ class Settings: NSObject {
 
     static let userEpisodeRemoveFileAfterPlayingKey = "UserEpisodeRemoveFileAfterPlaying"
     class func userEpisodeRemoveFileAfterPlaying() -> Bool {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             return SettingsStore.appSettings.filesAfterPlayingDeleteLocal
         } else {
             return UserDefaults.standard.bool(forKey: userEpisodeRemoveFileAfterPlayingKey)
@@ -547,7 +547,7 @@ class Settings: NSObject {
     }
 
     class func setUserEpisodeRemoveFileAfterPlaying(_ value: Bool) {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             SettingsStore.appSettings.filesAfterPlayingDeleteLocal = value
         }
         UserDefaults.standard.set(value, forKey: userEpisodeRemoveFileAfterPlayingKey)
@@ -556,7 +556,7 @@ class Settings: NSObject {
 
     static let userEpisodeRemoveFromCloudAfterPlayingKey = "UserEpisodeRemoveFromCloudAfterPlaying"
     class func userEpisodeRemoveFromCloudAfterPlaying() -> Bool {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             return SettingsStore.appSettings.filesAfterPlayingDeleteCloud
         } else {
             return UserDefaults.standard.bool(forKey: userEpisodeRemoveFromCloudAfterPlayingKey)
@@ -564,7 +564,7 @@ class Settings: NSObject {
     }
 
     class func setUserEpisodeRemoveFromCloudAfterPlayingKey(_ value: Bool) {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             SettingsStore.appSettings.filesAfterPlayingDeleteCloud = value
         }
         UserDefaults.standard.set(value, forKey: userEpisodeRemoveFromCloudAfterPlayingKey)
@@ -688,14 +688,14 @@ class Settings: NSObject {
     }
 
     class func setShouldFollowSystemTheme(_ value: Bool) {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             SettingsStore.appSettings.useSystemTheme = value
         }
         UserDefaults.standard.set(value, forKey: Constants.UserDefaults.shouldFollowSystemThemeKey)
     }
 
     class func shouldFollowSystemTheme() -> Bool {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             SettingsStore.appSettings.useSystemTheme
         } else {
             UserDefaults.standard.bool(forKey: Constants.UserDefaults.shouldFollowSystemThemeKey)
@@ -710,7 +710,7 @@ class Settings: NSObject {
 
         let playerActions: [PlayerAction]
 
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             playerActions = SettingsStore.appSettings.playerShelf
                 .compactMap { action in
                     switch action {
@@ -728,7 +728,7 @@ class Settings: NSObject {
     }
 
     class func updatePlayerActions(_ actions: [PlayerAction]) {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             let unknowns = SettingsStore.appSettings.playerShelf.compactMap { action -> ActionOption? in
                 switch action {
                 case .known:
@@ -750,7 +750,7 @@ class Settings: NSObject {
 
     static let multiSelectGestureKey = "MultiSelectGestureEnabled"
     class func multiSelectGestureEnabled() -> Bool {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             return SettingsStore.appSettings.multiSelectGesture
         } else {
             return UserDefaults.standard.bool(forKey: multiSelectGestureKey)
@@ -758,7 +758,7 @@ class Settings: NSObject {
     }
 
     class func setMultiSelectGestureEnabled(_ enabled: Bool, userInitiated: Bool = false) {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             SettingsStore.appSettings.multiSelectGesture = enabled
         }
         UserDefaults.standard.set(enabled, forKey: multiSelectGestureKey)
@@ -890,14 +890,14 @@ class Settings: NSObject {
     // MARK: - Tracks
 
     class func setAnalytics(optOut: Bool) {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             SettingsStore.appSettings.privacyAnalytics = !optOut
         }
         UserDefaults.standard.set(optOut, forKey: Constants.UserDefaults.analyticsOptOut)
     }
 
     class func analyticsOptOut() -> Bool {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             return !SettingsStore.appSettings.privacyAnalytics
         } else {
             return UserDefaults.standard.bool(forKey: Constants.UserDefaults.analyticsOptOut)
@@ -976,14 +976,14 @@ class Settings: NSObject {
 
     static var loadEmbeddedImages: Bool {
         get {
-            if FeatureFlag.settingsSync.enabled {
+            if FeatureFlag.newSettingsStorage.enabled {
                 SettingsStore.appSettings.useEmbeddedArtwork
             } else {
                 UserDefaults.standard.bool(forKey: Constants.UserDefaults.loadEmbeddedImages)
             }
         }
         set {
-            if FeatureFlag.settingsSync.enabled {
+            if FeatureFlag.newSettingsStorage.enabled {
                 SettingsStore.appSettings.useEmbeddedArtwork = newValue
             }
             UserDefaults.standard.set(newValue, forKey: Constants.UserDefaults.loadEmbeddedImages)
@@ -995,13 +995,13 @@ class Settings: NSObject {
 
     static var autoplay: Bool {
         set {
-            if FeatureFlag.settingsSync.enabled {
+            if FeatureFlag.newSettingsStorage.enabled {
                 SettingsStore.appSettings.autoPlayEnabled = newValue
             }
             UserDefaults.standard.set(newValue, forKey: Constants.UserDefaults.autoplay)
         }
         get {
-            if FeatureFlag.settingsSync.enabled {
+            if FeatureFlag.newSettingsStorage.enabled {
                 return SettingsStore.appSettings.autoPlayEnabled
             } else {
                 return UserDefaults.standard.bool(forKey: Constants.UserDefaults.autoplay)
@@ -1014,7 +1014,7 @@ class Settings: NSObject {
 
     static var headphonesPreviousAction: HeadphoneControlAction {
         get {
-            if FeatureFlag.settingsSync.enabled {
+            if FeatureFlag.newSettingsStorage.enabled {
                 return SettingsStore.appSettings.headphoneControlsPreviousAction.action
             } else {
                 return Constants.UserDefaults.headphones.previousAction.unlockedValue
@@ -1022,7 +1022,7 @@ class Settings: NSObject {
         }
 
         set {
-            if FeatureFlag.settingsSync.enabled {
+            if FeatureFlag.newSettingsStorage.enabled {
                 SettingsStore.appSettings.headphoneControlsPreviousAction = HeadphoneControl(action: newValue)
             }
             Constants.UserDefaults.headphones.previousAction.save(newValue)
@@ -1031,7 +1031,7 @@ class Settings: NSObject {
 
     static var headphonesNextAction: HeadphoneControlAction {
         get {
-            if FeatureFlag.settingsSync.enabled {
+            if FeatureFlag.newSettingsStorage.enabled {
                 return SettingsStore.appSettings.headphoneControlsNextAction.action
             } else {
                 return Constants.UserDefaults.headphones.nextAction.unlockedValue
@@ -1039,7 +1039,7 @@ class Settings: NSObject {
         }
 
         set {
-            if FeatureFlag.settingsSync.enabled {
+            if FeatureFlag.newSettingsStorage.enabled {
                 SettingsStore.appSettings.headphoneControlsNextAction = HeadphoneControl(action: newValue)
             }
             Constants.UserDefaults.headphones.nextAction.save(newValue)
@@ -1069,7 +1069,7 @@ class Settings: NSObject {
 
     static var darkUpNextTheme: Bool {
         get {
-            if FeatureFlag.settingsSync.enabled {
+            if FeatureFlag.newSettingsStorage.enabled {
                 SettingsStore.appSettings.useDarkUpNextTheme
             } else {
                 Constants.UserDefaults.appearance.darkUpNextTheme.value
@@ -1077,7 +1077,7 @@ class Settings: NSObject {
         }
 
         set {
-            if FeatureFlag.settingsSync.enabled {
+            if FeatureFlag.newSettingsStorage.enabled {
                 SettingsStore.appSettings.useDarkUpNextTheme = newValue
             }
             Constants.UserDefaults.appearance.darkUpNextTheme.save(newValue)
@@ -1086,14 +1086,14 @@ class Settings: NSObject {
 
     static var skipBackTime: Int {
         get {
-            if FeatureFlag.settingsSync.enabled {
+            if FeatureFlag.newSettingsStorage.enabled {
                 return Int(SettingsStore.appSettings.skipBack)
             } else {
                 return ServerSettings.skipBackTime()
             }
         }
         set {
-            if FeatureFlag.settingsSync.enabled {
+            if FeatureFlag.newSettingsStorage.enabled {
                 SettingsStore.appSettings.skipBack = Int32(newValue)
             }
             ServerSettings.setSkipBackTime(newValue)
@@ -1102,14 +1102,14 @@ class Settings: NSObject {
 
     static var skipForwardTime: Int {
         get {
-            if FeatureFlag.settingsSync.enabled {
+            if FeatureFlag.newSettingsStorage.enabled {
                 return Int(SettingsStore.appSettings.skipForward)
             } else {
                 return ServerSettings.skipForwardTime()
             }
         }
         set {
-            if FeatureFlag.settingsSync.enabled {
+            if FeatureFlag.newSettingsStorage.enabled {
                 SettingsStore.appSettings.skipForward = Int32(newValue)
             }
             ServerSettings.setSkipForwardTime(newValue)
@@ -1118,13 +1118,13 @@ class Settings: NSObject {
 
     static var playerBookmarksSort: Binding<BookmarkSortOption> {
         Binding {
-            if FeatureFlag.settingsSync.enabled {
+            if FeatureFlag.newSettingsStorage.enabled {
                 return SettingsStore.appSettings.playerBookmarksSortType.option
             } else {
                 return Constants.UserDefaults.bookmarks.playerSort.value
             }
         } set: { newValue in
-            if FeatureFlag.settingsSync.enabled {
+            if FeatureFlag.newSettingsStorage.enabled {
                 SettingsStore.appSettings.playerBookmarksSortType = BookmarksSort(option: newValue)
             }
             Constants.UserDefaults.bookmarks.playerSort.save(newValue)
@@ -1133,13 +1133,13 @@ class Settings: NSObject {
 
     static var episodeBookmarksSort: Binding<BookmarkSortOption> {
         Binding {
-            if FeatureFlag.settingsSync.enabled {
+            if FeatureFlag.newSettingsStorage.enabled {
                 return SettingsStore.appSettings.episodeBookmarksSortType.option
             } else {
                 return Constants.UserDefaults.bookmarks.playerSort.value
             }
         } set: { newValue in
-            if FeatureFlag.settingsSync.enabled {
+            if FeatureFlag.newSettingsStorage.enabled {
                 SettingsStore.appSettings.episodeBookmarksSortType = BookmarksSort(option: newValue)
             }
             Constants.UserDefaults.bookmarks.playerSort.save(newValue)
@@ -1148,13 +1148,13 @@ class Settings: NSObject {
 
     static var podcastBookmarksSort: Binding<BookmarkSortOption> {
         Binding {
-            if FeatureFlag.settingsSync.enabled {
+            if FeatureFlag.newSettingsStorage.enabled {
                 return SettingsStore.appSettings.podcastBookmarksSortType.option
             } else {
                 return Constants.UserDefaults.bookmarks.playerSort.value
             }
         } set: { newValue in
-            if FeatureFlag.settingsSync.enabled {
+            if FeatureFlag.newSettingsStorage.enabled {
                 SettingsStore.appSettings.podcastBookmarksSortType = BookmarksSort(option: newValue)
             }
             Constants.UserDefaults.bookmarks.playerSort.save(newValue)
@@ -1224,6 +1224,10 @@ class Settings: NSObject {
             let remoteMs = RemoteConfig.remoteConfig().configValue(forKey: key)
 
             return TimeInterval(remoteMs.numberValue.doubleValue / 1000)
+        }
+
+        static var newSettingsStorage: Bool {
+            RemoteConfig.remoteConfig().configValue(forKey: FeatureFlag.newSettingsStorage.remoteKey).boolValue
         }
     #endif
 }

--- a/podcasts/Theme.swift
+++ b/podcasts/Theme.swift
@@ -122,7 +122,7 @@ class Theme: ObservableObject {
             }
         }
         didSet {
-            if FeatureFlag.settingsSync.enabled {
+            if FeatureFlag.newSettingsStorage.enabled {
                 SettingsStore.appSettings.theme = activeTheme
             }
             UserDefaults.standard.set(activeTheme.rawValue, forKey: Theme.themeKey)
@@ -137,7 +137,7 @@ class Theme: ObservableObject {
     }
 
     init() {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             activeTheme = SettingsStore.appSettings.theme
         } else {
             let savedTheme = UserDefaults.standard.integer(forKey: Theme.themeKey)
@@ -169,7 +169,7 @@ class Theme: ObservableObject {
     }
 
     class func preferredDarkTheme() -> ThemeType {
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             return SettingsStore.appSettings.darkThemePreference
         }
 
@@ -184,7 +184,7 @@ class Theme: ObservableObject {
 
     class func setPreferredDarkTheme(_ preferredType: ThemeType, systemIsDark: Bool, userInitiated: Bool = false) {
 
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             SettingsStore.appSettings.darkThemePreference = preferredType
         }
         UserDefaults.standard.setValue(preferredType.old.rawValue, forKey: preferredDarkThemeKey)
@@ -200,7 +200,7 @@ class Theme: ObservableObject {
 
     class func preferredLightTheme() -> ThemeType {
 
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             return SettingsStore.appSettings.lightThemePreference
         }
 
@@ -215,7 +215,7 @@ class Theme: ObservableObject {
 
     class func setPreferredLightTheme(_ preferredType: ThemeType, systemIsDark: Bool) {
 
-        if FeatureFlag.settingsSync.enabled {
+        if FeatureFlag.newSettingsStorage.enabled {
             SettingsStore.appSettings.lightThemePreference = preferredType
         }
         UserDefaults.standard.setValue(preferredType.old.rawValue, forKey: preferredLightThemeKey)


### PR DESCRIPTION
Adds a `new_settings_storage` feature flag for migrating settings to new JSON based format.

The original `settings_sync` flag was trying to accomplish two things:
1. Ensure we can fall back to the same old settings logic in case something breaks
2. Ensure we can enable/disable syncing between devices.

This separates the settings storage changes from the syncing changes. This way, we can disable syncing without disabling storage changes, retaining any modified dates as long as the `new_settings_storage` flag is enabled.

This fixes issues with settings being dropped by simply disabling the syncing logic instead of reverting to the old user defaults. The behavior now matches Android.

I feel that the new flag is still useful to have in case something gets messed up with settings conversion, we have a way to back out ALL of the storage related changes _just in case_.

## To test

* Install this branch on two devices/simulators
* Enable the `new_settings_storage` AND `settings_sync` feature flags & restart the app (this restart won't be needed after https://github.com/Automattic/pocket-casts-ios/pull/1506)
* D1: Change a setting and refresh
* D2: Refresh and ensure setting is synced
* D1: Disable `settings_sync` flag + restart
* D1: Change a setting and refresh
* D2: Refresh and note that the setting remains unchanged
* D2: Change a setting and refresh
* D1: Enable `settings_sync` flag + restart
* D1: Refresh to be sure settings are synced
* D2: Refresh and notice that changes made while `settings_sync` was disabled are reflected now 

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.