### PR TITLE
Settings Sync: Add remote feature flag for `settings_sync`

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
@@ -97,7 +97,9 @@ extension SyncTask {
                 podcast.subscribed = 0
                 podcast.autoAddToUpNext = AutoAddToUpNextSetting.off.rawValue
                 podcast.settings = PodcastSettings.defaults
-                podcast.processSettings(podcastItem.settings)
+                if FeatureFlag.settingsSync.enabled {
+                    podcast.processSettings(podcastItem.settings)
+                }
 
                 DataManager.sharedManager.save(podcast: podcast)
             }
@@ -151,7 +153,9 @@ extension SyncTask {
             podcast.subscribed = podcastItem.isDeleted.value ? 0 : 1
         }
 
-        podcast.processSettings(podcastItem.settings)
+        if FeatureFlag.settingsSync.enabled {
+            podcast.processSettings(podcastItem.settings)
+        }
     }
 
     private func importEpisode(_ episodeItem: Api_SyncUserEpisode) {

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -70,16 +70,16 @@ public enum FeatureFlag: String, CaseIterable {
             false
         case .deselectChapters:
             false
+        case .newSettingsStorage:
+            true
         case .settingsSync:
-            false // `newSettingsStorage` also needs to be `true` for syncing to function
+            BuildEnvironment.current != .appStore
         case .slumber:
             false
         case .newAccountUpgradePromptFlow:
             false
         case .cachePlayingEpisode:
             true
-        case .newSettingsStorage:
-            false
         }
     }
 

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -95,6 +95,8 @@ public enum FeatureFlag: String, CaseIterable {
             "cache_playing_episode"
         case .newSettingsStorage:
             "new_settings_storage"
+        case .settingsSync:
+            "settings_sync"
         default:
             nil
         }

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -71,9 +71,9 @@ public enum FeatureFlag: String, CaseIterable {
         case .deselectChapters:
             false
         case .newSettingsStorage:
-            BuildEnvironment.current != .appStore
+            shouldEnableSyncedSettings
         case .settingsSync:
-            BuildEnvironment.current != .appStore
+            shouldEnableSyncedSettings
         case .slumber:
             false
         case .newAccountUpgradePromptFlow:
@@ -81,6 +81,10 @@ public enum FeatureFlag: String, CaseIterable {
         case .cachePlayingEpisode:
             true
         }
+    }
+
+    private var shouldEnableSyncedSettings: Bool {
+        BuildEnvironment.current != .appStore
     }
 
     /// Remote Feature Flag
@@ -94,9 +98,9 @@ public enum FeatureFlag: String, CaseIterable {
         case .cachePlayingEpisode:
             "cache_playing_episode"
         case .newSettingsStorage:
-            "new_settings_storage"
+            shouldEnableSyncedSettings ? "new_settings_storage" : nil
         case .settingsSync:
-            "settings_sync"
+            shouldEnableSyncedSettings ? "settings_sync" : nil
         default:
             nil
         }

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -71,7 +71,7 @@ public enum FeatureFlag: String, CaseIterable {
         case .deselectChapters:
             false
         case .newSettingsStorage:
-            true
+            BuildEnvironment.current != .appStore
         case .settingsSync:
             BuildEnvironment.current != .appStore
         case .slumber:


### PR DESCRIPTION
| 📘 Part of: #1400 | Depends on #1545 |
|:---:|:---:|

* Adds a `settings_sync` remote feature flag key.
* Sets the default value of `new_settings_storage` to `true` **when not running from the App Store**
* Sets the default value of `settings_sync` to `true` **when not running from the App Store**
* Only syncs the Podcast settings when `settings_sync` is enabled

![CleanShot 2024-03-19 at 15 35 35@2x](https://github.com/Automattic/pocket-casts-ios/assets/3250/521d1c36-0114-4581-a84b-aba98d11c4ef)

## To test

### Enabled
* Delete previous install and install a new build
* Ensure that `newSettingsStorage` and `settingsSync` are enabled under Beta Features
* Test syncing some settings between two devices with the flags enabled

### Disabled
* Set a breakpoint in AppDelegate.checkDefaults:129
* Install with build configuration "Release"
* Ensure the `FeatureFlag.newSettingsStorage.enabled` flagged off portion is skipped

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
