### PR TITLE
Remove bookmark if it's a new bookmark and user pressed dismiss

### DIFF
--- a/podcasts/Bookmarks/Editing/BookmarkEditTitleViewController.swift
+++ b/podcasts/Bookmarks/Editing/BookmarkEditTitleViewController.swift
@@ -3,7 +3,7 @@ import PocketCastsDataModel
 
 class BookmarkEditTitleViewController: ThemedHostingController<BookmarkEditTitleView> {
     private let viewModel: BookmarkEditViewModel
-    let onDismiss: ((String) -> Void)?
+    let onDismiss: ((String, Bool) -> Void)?
 
     var source: BookmarkAnalyticsSource = .unknown {
         didSet {
@@ -14,7 +14,7 @@ class BookmarkEditTitleViewController: ThemedHostingController<BookmarkEditTitle
     init(manager: BookmarkManager,
          bookmark: Bookmark,
          state: BookmarkEditViewModel.EditState,
-         onDismiss: ((String) -> Void)? = nil) {
+         onDismiss: ((String, Bool) -> Void)? = nil) {
         let viewModel = BookmarkEditViewModel(manager: manager, bookmark: bookmark, state: state)
         self.viewModel = viewModel
         self.onDismiss = onDismiss
@@ -39,11 +39,11 @@ class BookmarkEditTitleViewController: ThemedHostingController<BookmarkEditTitle
 extension BookmarkEditTitleViewController: BookmarkEditRouter {
     func dismiss() {
         dismiss(animated: true)
-        onDismiss?(viewModel.originalTitle)
+        onDismiss?(viewModel.originalTitle, true)
     }
 
     func titleUpdated(title: String) {
         dismiss(animated: true)
-        onDismiss?(title)
+        onDismiss?(title, false)
     }
 }

--- a/podcasts/Bookmarks/Player/BookmarksPlayerTabController.swift
+++ b/podcasts/Bookmarks/Player/BookmarksPlayerTabController.swift
@@ -87,8 +87,8 @@ class BookmarksPlayerTabController: PlayerItemViewController {
     }
 
     private func showBookmarkEdit(isNew: Bool, bookmark: Bookmark) {
-        let controller = BookmarkEditTitleViewController(manager: bookmarkManager, bookmark: bookmark, state: isNew ? .adding : .updating, onDismiss: { [weak self] title, cancel in
-            self?.handleEditDismissed(bookmark: bookmark, isNew: isNew, title: title, cancel: cancel)
+        let controller = BookmarkEditTitleViewController(manager: bookmarkManager, bookmark: bookmark, state: isNew ? .adding : .updating, onDismiss: { [weak self] title, canceled in
+            self?.handleEditDismissed(bookmark: bookmark, isNew: isNew, title: title, canceled: canceled)
         })
 
         controller.source = viewModel.analyticsSource
@@ -96,10 +96,10 @@ class BookmarksPlayerTabController: PlayerItemViewController {
         present(controller, animated: true)
     }
 
-    func handleEditDismissed(bookmark: Bookmark, isNew: Bool, title: String, cancel: Bool) {
+    func handleEditDismissed(bookmark: Bookmark, isNew: Bool, title: String, canceled: Bool) {
         guard isNew else { return }
 
-        if cancel {
+        if canceled {
             Task.init {
                 let _ = await bookmarkManager.remove([bookmark])
                 viewModel.reload()

--- a/podcasts/Bookmarks/Player/BookmarksPlayerTabController.swift
+++ b/podcasts/Bookmarks/Player/BookmarksPlayerTabController.swift
@@ -87,8 +87,8 @@ class BookmarksPlayerTabController: PlayerItemViewController {
     }
 
     private func showBookmarkEdit(isNew: Bool, bookmark: Bookmark) {
-        let controller = BookmarkEditTitleViewController(manager: bookmarkManager, bookmark: bookmark, state: isNew ? .adding : .updating, onDismiss: { [weak self] title in
-            self?.handleEditDismissed(isNew: isNew, title: title)
+        let controller = BookmarkEditTitleViewController(manager: bookmarkManager, bookmark: bookmark, state: isNew ? .adding : .updating, onDismiss: { [weak self] title, cancel in
+            self?.handleEditDismissed(bookmark: bookmark, isNew: isNew, title: title, cancel: cancel)
         })
 
         controller.source = viewModel.analyticsSource
@@ -96,9 +96,16 @@ class BookmarksPlayerTabController: PlayerItemViewController {
         present(controller, animated: true)
     }
 
-    func handleEditDismissed(isNew: Bool, title: String) {
+    func handleEditDismissed(bookmark: Bookmark, isNew: Bool, title: String, cancel: Bool) {
         guard isNew else { return }
 
+        if cancel {
+            Task.init {
+                let _ = await bookmarkManager.remove([bookmark])
+                viewModel.reload()
+            }
+            return
+        }
         // If the title is still the default, we'll just show a 'Bookmark Added' message instead of displaying 'Bookmark "Bookmark" Added'.
         let message = title == L10n.bookmarkDefaultTitle ? L10n.bookmarkAdded : L10n.bookmarkAddedNotification(title)
 

--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -641,7 +641,7 @@ private extension MainTabBarController {
         let message = title == L10n.bookmarkDefaultTitle ? L10n.bookmarkAdded : L10n.bookmarkAddedNotification(title)
 
         let action = Toast.Action(title: L10n.changeBookmarkTitle) { [weak self] in
-            let controller = BookmarkEditTitleViewController(manager: bookmarkManager, bookmark: bookmark, state: .updating, onDismiss: { [weak self] updatedTitle in
+            let controller = BookmarkEditTitleViewController(manager: bookmarkManager, bookmark: bookmark, state: .updating, onDismiss: { [weak self] updatedTitle, cancel in
                 guard title != updatedTitle else { return }
 
                 self?.handleBookmarkTitleUpdated(updatedTitle: updatedTitle)


### PR DESCRIPTION
Fixes #1510 

Doesn't create a bookmark if you press dismiss (X) on a new bookmark


https://github.com/Automattic/pocket-casts-ios/assets/651601/836314b8-a6dd-4f3a-9f2a-3b86e6160835



## To test

- Start the app
- Play a podcast
- Open the player full screen
- Create a bookmark
- Tap on the X button on the top right on the new bookmark editor screen
- Check that no toast is shown and if you go to the player bookmarks screen no bookmark was created.


## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
