### PR TITLE
Settings Sync: Revert "Add General Auto-Download settings"

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/AppSettings.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/AppSettings.swift
@@ -75,12 +75,6 @@ public struct AppSettings: JSONCodable {
 
     @ModifiedDate public var useDarkUpNextTheme: Bool = true
 
-    @ModifiedDate public var autoDownloadUpNext: Bool = false
-    @ModifiedDate public var autoDownloadUnmeteredOnly: Bool = true
-    @ModifiedDate public var cloudAutoUpload: Bool = false
-    @ModifiedDate public var cloudAutoDownload: Bool = false
-    @ModifiedDate public var cloudDownloadUnmeteredOnly: Bool = true
-
     static var defaults: AppSettings {
         return AppSettings(openLinks: false,
                            rowAction: .stream,

--- a/Modules/Server/Sources/PocketCastsServer/Public/ServerSettings.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/ServerSettings.swift
@@ -218,36 +218,22 @@ public class ServerSettings {
     }
 
     // User files autodownload
-    public static let userEpisodeAutoDownloadKey = "UserEpisodeAutoDownload"
+    private static let userEpisodeAutoDownloadKey = "UserEpisodeAutoDownload"
     public class func userEpisodeAutoDownload() -> Bool {
-        if FeatureFlag.newSettingsStorage.enabled {
-            SettingsStore.appSettings.cloudAutoDownload
-        } else {
-            UserDefaults.standard.bool(forKey: userEpisodeAutoDownloadKey)
-        }
+        UserDefaults.standard.bool(forKey: userEpisodeAutoDownloadKey)
     }
 
     public class func setUserEpisodeAutoDownload(_ value: Bool) {
-        if FeatureFlag.newSettingsStorage.enabled {
-            SettingsStore.appSettings.cloudAutoDownload = value
-        }
         UserDefaults.standard.set(value, forKey: userEpisodeAutoDownloadKey)
     }
 
+    // User files autodownload on wifi
+    private static let userEpisodeOnlyOnWifiKey = "UserEpisodeOnlyOnWifi"
     public class func userEpisodeOnlyOnWifi() -> Bool {
-        if FeatureFlag.newSettingsStorage.enabled {
-            SettingsStore.appSettings.cloudDownloadUnmeteredOnly
-        } else {
-            UserDefaults.standard.bool(forKey: userEpisodeOnlyOnWifiKey)
-        }
+        UserDefaults.standard.bool(forKey: userEpisodeOnlyOnWifiKey)
     }
 
-    // User files autodownload on wifi
-    public static let userEpisodeOnlyOnWifiKey = "UserEpisodeOnlyOnWifi"
     public class func setUserEpisodeOnlyOnWifi(_ value: Bool) {
-        if FeatureFlag.newSettingsStorage.enabled {
-            SettingsStore.appSettings.cloudDownloadUnmeteredOnly = value
-        }
         UserDefaults.standard.set(value, forKey: userEpisodeOnlyOnWifiKey)
     }
 

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncSettingsTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncSettingsTask.swift
@@ -53,11 +53,6 @@ extension Api_ChangeableSettings {
         useDarkUpNextTheme.update(settings.$useDarkUpNextTheme)
         autoUpNextLimit.update(settings.$autoUpNextLimit)
         autoUpNextLimitReached.update(settings.$autoUpNextLimitReached)
-        autoDownloadUpNext.update(settings.$autoDownloadUpNext)
-        autoDownloadUnmeteredOnly.update(settings.$autoDownloadUnmeteredOnly)
-        cloudAutoUpload.update(settings.$cloudAutoUpload)
-        cloudAutoDownload.update(settings.$cloudAutoDownload)
-        cloudDownloadUnmeteredOnly.update(settings.$cloudDownloadUnmeteredOnly)
     }
 }
 
@@ -111,11 +106,6 @@ extension AppSettings {
         $useDarkUpNextTheme.update(setting: settings.useDarkUpNextTheme)
         $autoUpNextLimit.update(setting: settings.autoUpNextLimit)
         $autoUpNextLimitReached.update(setting: settings.autoUpNextLimitReached)
-        $autoDownloadUpNext.update(setting: settings.autoDownloadUpNext)
-        $autoDownloadUnmeteredOnly.update(setting: settings.autoDownloadUnmeteredOnly)
-        $cloudAutoUpload.update(setting: settings.cloudAutoUpload)
-        $cloudAutoDownload.update(setting: settings.cloudAutoDownload)
-        $cloudDownloadUnmeteredOnly.update(setting: settings.cloudDownloadUnmeteredOnly)
         oldSettings.printDiff(from: self)
     }
 }

--- a/podcasts/AppSettings+ImportUserDefaults.swift
+++ b/podcasts/AppSettings+ImportUserDefaults.swift
@@ -65,11 +65,6 @@ extension SettingsStore<AppSettings> {
         self.update(\.$useDarkUpNextTheme, value: Constants.UserDefaults.appearance.darkUpNextTheme.value)
         self.update(\.$autoUpNextLimit, value: Int32(ServerSettings.autoAddToUpNextLimit()))
         self.update(\.$autoUpNextLimitReached, value: ServerSettings.onAutoAddLimitReached())
-        importValue(\.$autoDownloadUpNext, forKey: Settings.autoDownloadUpNext, from: userDefaults)
-        importValue(\.$autoDownloadUnmeteredOnly, forKey: Settings.allowCellularAutoDownloadKey, from: userDefaults)
-        importValue(\.$cloudAutoDownload, forKey: ServerSettings.userEpisodeAutoDownloadKey, from: userDefaults)
-        importValue(\.$cloudDownloadUnmeteredOnly, forKey: ServerSettings.userEpisodeOnlyOnWifiKey, from: userDefaults)
-        importValue(\.$cloudAutoUpload, forKey: Settings.userEpisodeAutoUploadKey, from: userDefaults)
     }
 
     /// Imports a value of a given key from UserDefaults, only if that value exists

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -66,19 +66,12 @@ class Settings: NSObject {
 
     // MARK: - Up Next Auto Download
 
-    static let autoDownloadUpNext = "SJAutoDownloadUpNext"
+    private static let autoDownloadUpNext = "SJAutoDownloadUpNext"
     class func downloadUpNextEpisodes() -> Bool {
-        if FeatureFlag.newSettingsStorage.enabled {
-            SettingsStore.appSettings.autoDownloadUpNext
-        } else {
-            UserDefaults.standard.bool(forKey: Settings.autoDownloadUpNext)
-        }
+        UserDefaults.standard.bool(forKey: Settings.autoDownloadUpNext)
     }
 
     class func setDownloadUpNextEpisodes(_ download: Bool) {
-        if FeatureFlag.newSettingsStorage.enabled {
-            SettingsStore.appSettings.autoDownloadUpNext = download
-        }
         UserDefaults.standard.set(download, forKey: Settings.autoDownloadUpNext)
         trackValueToggled(.settingsAutoDownloadUpNextToggled, enabled: download)
     }
@@ -106,19 +99,12 @@ class Settings: NSObject {
 
     // MARK: - Auto Download Mobile Data
 
-    static let allowCellularAutoDownloadKey = "SJUserCellularAutoDownload"
+    private static let allowCellularAutoDownloadKey = "SJUserCellularAutoDownload"
     class func autoDownloadMobileDataAllowed() -> Bool {
-        if FeatureFlag.newSettingsStorage.enabled {
-            !SettingsStore.appSettings.autoDownloadUnmeteredOnly
-        } else {
-            UserDefaults.standard.bool(forKey: Settings.allowCellularAutoDownloadKey)
-        }
+        UserDefaults.standard.bool(forKey: Settings.allowCellularAutoDownloadKey)
     }
 
     class func setAutoDownloadMobileDataAllowed(_ allow: Bool, userInitiated: Bool = false) {
-        if FeatureFlag.newSettingsStorage.enabled {
-            SettingsStore.appSettings.autoDownloadUnmeteredOnly = !allow
-        }
         UserDefaults.standard.set(allow, forKey: Settings.allowCellularAutoDownloadKey)
 
         guard userInitiated else { return }
@@ -503,19 +489,12 @@ class Settings: NSObject {
         UserDefaults.standard.set(value, forKey: userEpisodeSortByKey)
     }
 
-    static let userEpisodeAutoUploadKey = "UserEpisodeAutoUpload"
+    private static let userEpisodeAutoUploadKey = "UserEpisodeAutoUpload"
     class func userFilesAutoUpload() -> Bool {
-        if FeatureFlag.newSettingsStorage.enabled {
-            SettingsStore.appSettings.cloudAutoUpload
-        } else {
-            UserDefaults.standard.bool(forKey: userEpisodeAutoUploadKey)
-        }
+        UserDefaults.standard.bool(forKey: userEpisodeAutoUploadKey)
     }
 
     class func setUserEpisodeAutoUpload(_ value: Bool) {
-        if FeatureFlag.newSettingsStorage.enabled {
-            SettingsStore.appSettings.cloudAutoUpload = value
-        }
         UserDefaults.standard.set(value, forKey: userEpisodeAutoUploadKey)
         trackValueToggled(.settingsFilesAutoUploadToCloudToggled, enabled: value)
     }
@@ -1290,7 +1269,7 @@ extension HeadphoneControl {
         case .skipForward:
             return .skipForward
         }
-    }
+	}
 }
 
 extension UserDefaults {


### PR DESCRIPTION
| 📘 Part of: #1400 |
|:---:|

This reverts commit f508cff4e1ef8968871fb9e23adf018bc0a13e54 to remove Auto-Download settings from syncing.

## To test

* Install on two devices/simulators
* D1 & D2: Ensure `settingsSync` AND `newSettingsStorage` Feature Flags are enabled & restart app
* D1: Change any setting in the Auto Download section of Settings
* D1: Refresh Profile
* D2: Refresh Profile
* D2: Auto Download settings should remain unchanged

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
