### PR TITLE
[Deselect Chapters] Enable announcements and change remote feature flag key

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -88,7 +88,7 @@ public enum FeatureFlag: String, CaseIterable {
     public var remoteKey: String? {
         switch self {
         case .deselectChapters:
-            "deselect_chapters"
+            "deselect_chapters_enabled"
         case .newAccountUpgradePromptFlow:
             "new_account_upgrade_prompt_flow"
         case .cachePlayingEpisode:

--- a/podcasts/PaidFeature.swift
+++ b/podcasts/PaidFeature.swift
@@ -7,7 +7,7 @@ import SwiftUI
 
 extension PaidFeature {
     static var bookmarks: PaidFeature = .plusFeature
-    static var deselectChapters: PaidFeature = .patronFeature
+    static var deselectChapters: PaidFeature = .inEarlyAccess
     static var slumber: PaidFeature = .plusFeature
 }
 

--- a/podcasts/Whats New/Announcements.swift
+++ b/podcasts/Whats New/Announcements.swift
@@ -54,22 +54,37 @@ struct Announcements {
             customBody: AnyView(SlumberCustomBody())
         ),
 
-        // Deselect Chapters
+        // Deselect Chapters (Patron announcement)
+        .init(
+            version: "7.60",
+            header: AnyView(Image("deselect_chapters")),
+            title: L10n.skipChapters,
+            message: L10n.announcementDeselectChaptersPatron,
+            buttonTitle: L10n.gotIt,
+            action: {
+                SceneHelper.rootViewController()?.dismiss(animated: true)
+            },
+            isEnabled: chaptersViewModel.isPatronAnnouncementEnabled,
+            fullModal: true
+        ),
+
+        // Deselect Chapters (Plus on TestFlight announcement)
+        .init(
+            version: "7.60",
+            header: AnyView(Image("deselect_chapters")),
+            title: L10n.skipChapters,
+            message: chaptersViewModel.plusFreeMessage,
+            buttonTitle: chaptersViewModel.plusFreeButtonTitle,
+            action: {
+                chaptersViewModel.buttonAction()
+            },
+            isEnabled: chaptersViewModel.isPlusAnnouncementEnabled,
+            fullModal: true
+        ),
+
+        // Deselect Chapters (Non-Patron general public announcement)
 //        .init(
-//            version: "7.59",
-//            header: AnyView(Image("deselect_chapters")),
-//            title: L10n.skipChapters,
-//            message: L10n.announcementDeselectChaptersPatron,
-//            buttonTitle: L10n.gotIt,
-//            action: {
-//                SceneHelper.rootViewController()?.dismiss(animated: true)
-//            },
-//            isEnabled: chaptersViewModel.isPatronAnnouncementEnabled,
-//            fullModal: true
-//        ),
-//
-//        .init(
-//            version: "7.59",
+//            version: "7.61",
 //            header: AnyView(Image("deselect_chapters")),
 //            title: L10n.skipChapters,
 //            message: chaptersViewModel.plusFreeMessage,

--- a/podcasts/Whats New/DeselectChaptersAnnouncementViewModel.swift
+++ b/podcasts/Whats New/DeselectChaptersAnnouncementViewModel.swift
@@ -5,8 +5,7 @@ import PocketCastsUtils
 class DeselectChaptersAnnouncementViewModel {
     var isPatronAnnouncementEnabled: Bool {
         FeatureFlag.deselectChapters.enabled
-            && PaidFeature.deselectChapters.tier == .patron
-            && SubscriptionHelper.activeTier == .patron
+            && PaidFeature.deselectChapters.isUnlocked
     }
 
     // Only for TestFlight early access

--- a/podcasts/Whats New/DeselectChaptersAnnouncementViewModel.swift
+++ b/podcasts/Whats New/DeselectChaptersAnnouncementViewModel.swift
@@ -9,6 +9,13 @@ class DeselectChaptersAnnouncementViewModel {
             && SubscriptionHelper.activeTier == .patron
     }
 
+    // Only for TestFlight early access
+    var isPlusAnnouncementEnabled: Bool {
+        FeatureFlag.deselectChapters.enabled
+            && PaidFeature.deselectChapters.tier == .plus
+            && SubscriptionHelper.activeTier == .plus
+    }
+
     var isPlusFreeAnnouncementEnabled: Bool {
         FeatureFlag.deselectChapters.enabled
             && PaidFeature.deselectChapters.tier == .plus


### PR DESCRIPTION
| 📘 Part of: #1396 | Depends on #1480 |
|:---:|:---:|

* Change Deselect Chapters to be in early access (Only Patron on prod, Plus on beta)
* Enable announcements
* Change the remote feature flag key

These are podcasts with chapters you can use to test:

* Clublife: https://pca.st/rLzZCv
* ATP: https://pca.st/accidentaltech

## To test

Go to `AppDelegate.updateRemoteFeatureFlags` and add a `return` right in the beginning so nothing is changed. Then go to `FeatureFlag` and change `deselectChapters` to `true`.

Finally, go to `WhatsNew.swift` and change the constructor content to:

```swift
        self.announcements = announcements
        self.previousOpenedVersion = "7.57"
        self.currentVersion = "7.60"
        self.lastWhatsNewShown = "7.57"
```

This will allow you to test the announcement.

### Early Access (Patron)

First, let's ensure for prod only Patron users will see the announcement:

1. Run the app
2. Go to Profile > Settings > Developer > Set to No Plus
3. Re-run the app
4. ✅ You should **not** see an announcement
5. Go to Profile > Settings > Developer > Set to Paid Plus
6. Re-run the app
7. ✅ You should **not** see an announcement
8. Go to Profile > Settings > Developer > Set to Paid Patron
9. Re-run the app
10. ✅ You **should see** the announcement

### Early Access (TestFlight)

Now, let's ensure that on TestFlight both Patron and Plus see the announcement. To simulate the TestFlight build, go to `BuildEnvironment.swift` and change `return .debug` to `return .testFlight`

1. Run the app
2. Go to Profile > Settings > Developer > Set to No Plus
3. Re-run the app
4. ✅ You should **not** see an announcement
5. Go to Profile > Settings > Developer > Set to Paid Plus
6. Re-run the app
7. ✅ You **should see** an announcement
8. Go to Profile > Settings > Developer > Set to Paid Patron
9. Re-run the app
10. ✅ You **should see** the announcement

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.