### PR TITLE
[1527] Convert EpisodeInfoHandler into an Actor

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/Cache/CacheServerHandler.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Cache/CacheServerHandler.swift
@@ -28,7 +28,10 @@ public class CacheServerHandler {
 
     public func loadShowNotes(podcastUuid: String, episodeUuid: String, cached: ((String) -> Void)? = nil, completion: ((String?) -> Void)?) {
         guard !Self.newShowNotesEndpoint else {
-            episodeInfoHandler.loadShowNotes(podcastUuid: podcastUuid, episodeUuid: episodeUuid, cached: cached, completion: completion)
+            Task { [weak self] in
+                let result = await self?.episodeInfoHandler.loadShowNotes(podcastUuid: podcastUuid, episodeUuid: episodeUuid)
+                completion?(result)
+            }
             return
         }
 
@@ -69,7 +72,10 @@ public class CacheServerHandler {
             return
         }
 
-        episodeInfoHandler.loadEpisodeArtworkUrl(podcastUuid: podcastUuid, episodeUuid: episodeUuid, completion: completion)
+        Task { [weak self] in
+            let result = await self?.episodeInfoHandler.loadEpisodeArtworkUrl(podcastUuid: podcastUuid, episodeUuid: episodeUuid)
+            completion?(result)
+        }
     }
 
     public func loadPodcastColors(podcastUuid: String, allowCachedVersion: Bool, completion: @escaping ((String?, String?, String?) -> Void)) {

--- a/Modules/Server/Sources/PocketCastsServer/Public/Cache/EpisodeInfoHandler.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Cache/EpisodeInfoHandler.swift
@@ -1,15 +1,16 @@
 import Foundation
 
 /// Request information about an episode using the show notes endpoint
-public class EpisodeInfoHandler {
+public actor EpisodeInfoHandler {
     private let showNotesUrlCache: URLCache
 
-    private var requestingNotes: [String: Bool] = [:]
+    private var requestingNotes: [String: Task<Data, Error>] = [:]
 
-    private var showNotesCompletionBlocks: [String: [(ShowNotesPodcast?) -> Void]] = [:]
-    private var showNotesCachedCompletionBlocks: [String: [(ShowNotesPodcast?) -> Void]] = [:]
-
-    let lock = NSLock()
+    private lazy var decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return decoder
+    }()
 
     init() {
         showNotesUrlCache = URLCache(memoryCapacity: 1.megabytes, diskCapacity: 10.megabytes, diskPath: "show_notes")
@@ -33,107 +34,51 @@ public class EpisodeInfoHandler {
         let image: String?
     }
 
-    public func loadShowNotes(podcastUuid: String, episodeUuid: String, cached: ((String) -> Void)? = nil, completion: ((String?) -> Void)?) {
-        var cachedNotes = ""
-        var didSendCachedNotes = false
-
-        requestShowNotes(for: podcastUuid, cached: { showNotes in
-            if let notes = showNotes?.episode(with: episodeUuid)?.showNotes {
-                cached?(notes)
-                cachedNotes = notes
-                didSendCachedNotes = true
-            }
-        }, completion: { showNotes in
-            if let episodeNotes = showNotes?.episodes.first(where: { $0.uuid == episodeUuid })?.showNotes {
-                if didSendCachedNotes, episodeNotes == cachedNotes {
-                    return
-                }
-
-                completion?(episodeNotes)
-            } else if !didSendCachedNotes {
-                completion?(CacheServerHandler.noShowNotesMessage)
-            }
-        })
+    public func loadShowNotes(podcastUuid: String, episodeUuid: String) async -> String {
+        let showNotes = await loadShowNotes(for: podcastUuid)
+        return showNotes?.podcast.episode(with: episodeUuid)?.showNotes ?? CacheServerHandler.noShowNotesMessage
     }
 
-    /// Multiple calls can be made to this method and we'll ensure that only
-    /// one request per time is made to the show notes endpoint — avoiding
-    /// multiple calls.
-    /// - Parameters:
-    ///   - for: a podcast UUID
-    ///   - cached: a closure that receive a cached notes information
-    ///   - completion: a closure that *might* receive a cached or update notes information
-    private func requestShowNotes(for podcastUuid: String, cached: @escaping (ShowNotesPodcast?) -> Void, completion: @escaping (ShowNotesPodcast?) -> Void) {
-        lock.lock()
-        if showNotesCachedCompletionBlocks[podcastUuid] == nil {
-            showNotesCachedCompletionBlocks[podcastUuid] = []
+    public func loadEpisodeArtworkUrl(podcastUuid: String, episodeUuid: String) async -> String? {
+        let showNotes = await loadShowNotes(for: podcastUuid)
+        return showNotes?.podcast.episode(with: episodeUuid)?.image
+    }
+}
+
+extension EpisodeInfoHandler {
+    private func loadShowNotes(for podcastUuid: String) async -> ShowNotes? {
+        do {
+            let data = try await loadShowNotesData(for: podcastUuid)
+            let showNotes = try decoder.decode(ShowNotes.self, from: data)
+            requestingNotes[podcastUuid] = nil
+            return showNotes
+        } catch {
+            requestingNotes[podcastUuid] = nil
+            return nil
         }
+    }
 
-        if showNotesCompletionBlocks[podcastUuid] == nil {
-            showNotesCompletionBlocks[podcastUuid] = []
+    private func loadShowNotesData(for podcastUuid: String) async throws -> Data {
+        if let task = requestingNotes[podcastUuid] {
+            return try await task.value
         }
-
-        showNotesCachedCompletionBlocks[podcastUuid]?.append(cached)
-        showNotesCompletionBlocks[podcastUuid]?.append(completion)
-
-        guard requestingNotes[podcastUuid] == nil || requestingNotes[podcastUuid] == false else {
-            lock.unlock()
-            return
-        }
-
-        requestingNotes[podcastUuid] = true
-
-        let decoder = JSONDecoder()
-        decoder.keyDecodingStrategy = .convertFromSnakeCase
 
         let url = ServerHelper.asUrl(ServerConstants.Urls.cache() + "mobile/show_notes/full/\(podcastUuid)")
         let request = URLRequest(url: url, cachePolicy: .reloadRevalidatingCacheData)
 
-        // Check for any cached version and if there's any call the cached completion blocks
-        if let cachedResponse = showNotesUrlCache.cachedResponse(for: request),
-           let showNotes = try? decoder.decode(ShowNotes.self, from: cachedResponse.data) {
-
-            showNotesCachedCompletionBlocks[podcastUuid]?.forEach { $0(showNotes.podcast) }
-            showNotesCachedCompletionBlocks[podcastUuid] = []
-            requestingNotes[podcastUuid] = false
-        }
-        lock.unlock()
-
-        // Call the endpoint to request for a more up-to-date notes information
-        URLSession.shared.dataTask(with: request) { [weak self] data, response, _ in
-            if let data = data,
-               let response = response,
-               let showNotes = try? decoder.decode(ShowNotes.self, from: data) {
-                let responseToCache = CachedURLResponse(response: response, data: data)
-                self?.showNotesUrlCache.storeCachedResponse(responseToCache, for: request)
-
-                self?.lock.lock()
-                self?.showNotesCompletionBlocks[podcastUuid]?.forEach { $0(showNotes.podcast) }
-                self?.showNotesCompletionBlocks[podcastUuid] = []
-                self?.lock.unlock()
-            } else {
-                self?.lock.lock()
-                self?.showNotesCompletionBlocks[podcastUuid]?.forEach { $0(nil) }
-                self?.showNotesCompletionBlocks[podcastUuid] = []
-                self?.lock.unlock()
-            }
-
-            self?.requestingNotes[podcastUuid] = false
-        }.resume()
-    }
-
-    public func loadEpisodeArtworkUrl(podcastUuid: String, episodeUuid: String, completion: ((String?) -> Void)?) {
-        var retrievedImage = ""
-        let completionBlock: (ShowNotesPodcast?) -> Void = { episodeNotes in
-            guard let image = episodeNotes?.episodes.first(where: { $0.uuid == episodeUuid })?.image,
-                  image != retrievedImage else {
-                return
-            }
-
-            retrievedImage = image
-            completion?(image)
+        if let cachedResponse = showNotesUrlCache.cachedResponse(for: request) {
+            return cachedResponse.data
         }
 
-        requestShowNotes(for: podcastUuid, cached: completionBlock, completion: completionBlock)
+        let task = Task<Data, Error> {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            let responseToCache = CachedURLResponse(response: response, data: data)
+            showNotesUrlCache.storeCachedResponse(responseToCache, for: request)
+            return data
+        }
+
+        requestingNotes[podcastUuid] = task
+
+        return try await task.value
     }
 }


### PR DESCRIPTION
| 📘 Part of: #1526  |
|:---:|

Ref: #1033

Convert EpisodeInfoHandler into an Actor. The functionality won't change respect the one introduced with #1033.

## To test

### With the flag disabled

1. Change `newShowNotesEndpoint` to `false`
2. Re-run the app
3. Go to Discover > tap on any podcast > tap on an episode
4. ✅ You should see the show notes appear
5. Play the episode
6. Open the full player (by tapping the miniplayer) > tap "Notes"
7. You should see the show notes

### Notes

Before testing it, open Charles or any other proxy debug application so we can test that the cache is working just fine. Also, change `newShowNotesEndpoint` to `true` and re-run the app.

2. Go to Discover > tap on any podcast > tap on an episode
4. ✅ You should see the show notes appear
5. Go to Charles
6. Check requests made to the `shownotes.pocketcasts.com` subdomain
8. ✅ A request should have been made that returned all show notes
9. On the app, dismiss the episode screen
10. Open it again
11. ✅ You should see the notes again
12. On Charles, inspect the last request made to `shownotes.pocketcasts.com`
13. ✅ The server should have responded with a 304 and the headers must contain the `if-none-match` and `if-modified-since` parameters
14. Play the episode
15. Open the player and tap "Notes"
16. ✅ You should see the notes
17. Again, check the last request made to `shownotes.pocketcasts.com` on Charles
18. ✅ The server should have responded with a 304 and the headers must contain the `if-none-match` and `if-modified-since` parameters
19. Stop the app, turn off your Wi-fi (or go airplane mode)
20. Open the app and then tap on the miniplayer
21. ✅ The notes should shown

### Embedded artwork images

1. Go to Profile > Settings (cog icon) > Appearance > enable "Use Embedded Artwork"
2. Search for "The Bulwark Podcast" or "Clublife" (both have embedded XML artwork)
3. Play any episode
4. ✅ After a while the image should change to the embedded episode artwork
5. Download any episode from "The Bulwark Podcast" or "Clublife"
6. Close the app
7. Go offline
8. Reopen the app and play any of those episodes
9. ✅ You should see the episode artwork
10. ✅ Also check that you see the episode artwork on CarPlay and Now Playing screen

### Downloading

1. Open a podcast with many episodes (such as "The Bulwark Podcast")
2. Tap "..." > "Download All"
3. ✅ 100 episodes should be added to the queue
4. Wait for a few of them to download
5. Go offline
6. Play any episode
7. ✅ The episode artwork should show

## Where to show episode artwork?

We show the episode artwork on the player, Now Playing screen on iPhone and CarPlay. In the listing inside the app the podcast image is still being shown. We can discuss whether this is a behavior we would like to keep or change, but I'd wait for users' feedback on it.

Also, once we test this feature, we can consider having "Use Embedded Artwork" enabled by default.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
