### PR TITLE
Settings Sync: Add autoplaylastlistuuid setting

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/AppSettings.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/AppSettings.swift
@@ -74,6 +74,7 @@ public struct AppSettings: JSONCodable {
     @ModifiedDate public var useEmbeddedArtwork: Bool = false
 
     @ModifiedDate public var useDarkUpNextTheme: Bool = true
+    @ModifiedDate public var autoPlayLastListUuid: AutoPlaySource = .uuid("")
 
     static var defaults: AppSettings {
         return AppSettings(openLinks: false,

--- a/Modules/Server/Sources/PocketCastsServer/Public/ServerEnums.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/ServerEnums.swift
@@ -143,3 +143,38 @@ public enum ThemeType: Int32, CaseIterable, Codable {
         case light = 0, dark, extraDark, electric, classic, indigo, radioactive, rosé, contrastLight, contrastDark
     }
 }
+
+public enum AutoPlaySource: Codable, RawRepresentable, Equatable {
+    public typealias RawValue = String
+
+    public init?(rawValue: String) {
+        switch rawValue {
+        case "downloads":
+            self = .downloads
+        case "files":
+            self = .files
+        case "starred":
+            self = .starred
+        default:
+            self = .uuid(rawValue)
+        }
+    }
+
+    public var rawValue: String {
+        switch self {
+        case .uuid(let uuid):
+            return uuid
+        case .downloads:
+            return "downloads"
+        case .files:
+            return "files"
+        case .starred:
+            return "starred"
+        }
+    }
+
+    case uuid(String)
+    case downloads
+    case files
+    case starred
+}

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncSettingsTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncSettingsTask.swift
@@ -53,6 +53,7 @@ extension Api_ChangeableSettings {
         useDarkUpNextTheme.update(settings.$useDarkUpNextTheme)
         autoUpNextLimit.update(settings.$autoUpNextLimit)
         autoUpNextLimitReached.update(settings.$autoUpNextLimitReached)
+        autoPlayLastListUuid.update(settings.$autoPlayLastListUuid)
     }
 }
 
@@ -107,6 +108,7 @@ extension AppSettings {
         $autoUpNextLimit.update(setting: settings.autoUpNextLimit)
         $autoUpNextLimitReached.update(setting: settings.autoUpNextLimitReached)
         oldSettings.printDiff(from: self)
+        $autoPlayLastListUuid.update(setting: settings.autoPlayLastListUuid)
     }
 }
 

--- a/podcasts/AppSettings+ImportUserDefaults.swift
+++ b/podcasts/AppSettings+ImportUserDefaults.swift
@@ -44,6 +44,9 @@ extension SettingsStore<AppSettings> {
             self.update(\.$autoArchiveInactive, value: inactive.rawValue)
         }
         self.update(\.$autoArchiveIncludesStarred, value: UserDefaults.standard.bool(forKey: Settings.archiveStarredEpisodesKey))
+        if let lastPlaylist = AutoplayHelper().userDefaultsPlaylist {
+            self.update(\.$autoPlayLastListUuid, value: AutoPlaySource(playlist: lastPlaylist))
+		}
         self.update(\.$gridOrder, value: Int32(ServerSettings.homeGridSortOrder()))
         self.update(\.$gridLayout, value: Int32(UserDefaults.standard.integer(forKey: Settings.podcastLibraryGridTypeKey)))
         self.update(\.$badges, value: Int32(UserDefaults.standard.integer(forKey: Settings.badgeKey)))

--- a/podcasts/AutoplayHelper.swift
+++ b/podcasts/AutoplayHelper.swift
@@ -1,6 +1,7 @@
 import Foundation
 import PocketCastsDataModel
 import PocketCastsUtils
+import PocketCastsServer
 
 /// Reponsible for handling the Autoplay of episodes
 class AutoplayHelper {
@@ -37,6 +38,27 @@ class AutoplayHelper {
 
     /// Returns the latest playlist that the user played an episode from
     var lastPlaylist: Playlist? {
+        if FeatureFlag.newSettingsStorage.enabled {
+            switch SettingsStore.appSettings.autoPlayLastListUuid {
+            case .downloads:
+                return .downloads
+            case .files:
+                return .files
+            case .starred:
+                return .starred
+            case .uuid(let uuid):
+                if let filter = DataManager.sharedManager.findFilter(uuid: uuid) {
+                    return .filter(uuid: uuid)
+                } else {
+                    return .podcast(uuid: uuid)
+                }
+            }
+        } else {
+            return userDefaultsPlaylist
+        }
+    }
+
+    var userDefaultsPlaylist: Playlist? {
         let lastPlaylist = userDefaults.data(forKey: userDefaultsKey).flatMap {
             try? JSONDecoder().decode(Playlist.self, from: $0)
         }
@@ -83,6 +105,15 @@ class AutoplayHelper {
     }
 
     private func save(selectedPlaylist playlist: Playlist?) {
+
+        if FeatureFlag.newSettingsStorage.enabled {
+            if let playlist {
+                SettingsStore.appSettings.autoPlayLastListUuid = AutoPlaySource(playlist: playlist)
+            } else {
+                SettingsStore.appSettings.autoPlayLastListUuid = .uuid("")
+            }
+        }
+
         guard let playlist else {
             userDefaults.removeObject(forKey: userDefaultsKey)
             FileLog.shared.addMessage("Autoplay: reset the last playlist")
@@ -97,4 +128,21 @@ class AutoplayHelper {
         FileLog.shared.addMessage("Autoplay: saving the latest playlist: \(playlist)")
     }
     #endif
+}
+
+extension AutoPlaySource {
+    init(playlist: AutoplayHelper.Playlist) {
+        switch playlist {
+        case .podcast(uuid: let uuid):
+            self = .uuid(uuid)
+        case .filter(uuid: let uuid):
+            self = .uuid(uuid)
+        case .downloads:
+            self = .downloads
+        case .files:
+            self = .files
+        case .starred:
+            self = .starred
+        }
+    }
 }


### PR DESCRIPTION
| 📘 Part of: #1400 |
|:---:|


## To test

Enable the `newSettingsStore` and `settingsSync` feature flags. Restart the app.

- D1: Navigate into Filter, tap ⋯ button in top right, tap "Play All"
- D1: Pull down to refresh podcasts
- D2: Pull down to refresh podcasts
- D2: Note that the playback artwork and Up Next queue have changed
- D2: Tap to play a podcast episode
- D2: Pull to refresh podcasts
- D1: Pull to refresh podcasts
- D1: Ensure that Now Playing changes to podcast

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
