### PR TITLE
Settings Sync: Show Archived setting

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Podcast+Settings.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Podcast+Settings.swift
@@ -134,4 +134,21 @@ extension Podcast {
             overrideGlobalArchive = newValue
         }
     }
+
+    public var shouldShowArchived: Bool {
+        get {
+            if FeatureFlag.newSettingsStorage.enabled {
+                return settings.showArchived
+            } else {
+                return showArchived
+            }
+        }
+        set {
+            if FeatureFlag.newSettingsStorage.enabled {
+                settings.showArchived = newValue
+                syncStatus = SyncStatus.notSynced.rawValue
+            }
+            showArchived = newValue
+        }
+    }
 }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/PodcastSettings.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/PodcastSettings.swift
@@ -22,6 +22,7 @@ public struct PodcastSettings: JSONCodable, Equatable {
 
     @ModifiedDate public var episodesSortOrder: PodcastEpisodeSortOrder = .shortestToLongest
     @ModifiedDate public var episodeGrouping: PodcastGrouping = .none
+    @ModifiedDate public var showArchived: Bool = false
 
     public static var defaults: Self {
         return PodcastSettings(trimSilence: .off, boostVolume: false, playbackSpeed: 1)

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+FullSync.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+FullSync.swift
@@ -186,6 +186,11 @@ private extension SyncTask {
         podcast.settings.$autoArchivePlayed = settings.$autoArchivePlayed
         podcast.settings.$autoArchiveInactive = settings.$autoArchiveInactive
         podcast.settings.$autoArchiveEpisodeLimit = settings.$autoArchiveEpisodeLimit
+        podcast.settings.$addToUpNext = settings.$addToUpNext
+        podcast.settings.$addToUpNextPosition = settings.$addToUpNextPosition
+        podcast.settings.$episodesSortOrder = settings.$episodesSortOrder
+        podcast.settings.$episodeGrouping = settings.$episodeGrouping
+        podcast.settings.$showArchived = settings.$showArchived
         oldSettings.printDiff(from: podcast.settings, withIdentifier: podcast.uuid)
     }
 }

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+LocalChanges.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+LocalChanges.swift
@@ -235,6 +235,7 @@ private extension Podcast {
         settings.addToUpNextPosition.update(self.settings.$addToUpNextPosition)
         settings.episodesSortOrder.update(self.settings.$episodesSortOrder)
         settings.episodeGrouping.update(self.settings.$episodeGrouping)
+        settings.showArchived.update(self.settings.$showArchived)
         settings.autoArchive.update(self.settings.$autoArchive)
         settings.autoArchivePlayed.update(self.settings.$autoArchivePlayed)
         settings.autoArchiveInactive.update(self.settings.$autoArchiveInactive)

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
@@ -432,6 +432,7 @@ extension Podcast {
         self.settings.$addToUpNextPosition.update(setting: settings.addToUpNextPosition)
         self.settings.$episodesSortOrder.update(setting: settings.episodesSortOrder)
         self.settings.$episodeGrouping.update(setting: settings.episodeGrouping)
+        self.settings.$showArchived.update(setting: settings.showArchived)
         self.settings.$autoArchive.update(setting: settings.autoArchive)
         self.settings.$autoArchivePlayed.update(setting: settings.autoArchivePlayed)
         self.settings.$autoArchiveInactive.update(setting: settings.autoArchiveInactive)

--- a/podcasts/DataManager+Import.swift
+++ b/podcasts/DataManager+Import.swift
@@ -9,6 +9,7 @@ extension DataManager {
             podcast.settings.$autoStartFrom = ModifiedDate<Int32>(wrappedValue: podcast.startFrom)
             podcast.settings.$autoSkipLast = ModifiedDate<Int32>(wrappedValue: podcast.skipLast)
             podcast.settings.$playbackSpeed = ModifiedDate<Double>(wrappedValue: podcast.playbackSpeed)
+            podcast.settings.$showArchived = ModifiedDate<Bool>(wrappedValue: podcast.showArchived)
             if let trimSilence = TrimSilenceAmount(rawValue: podcast.trimSilenceAmount) {
                 podcast.settings.$trimSilence = ModifiedDate<TrimSilence>(wrappedValue: TrimSilence(amount: trimSilence))
             }

--- a/podcasts/EpisodesDataManager.swift
+++ b/podcasts/EpisodesDataManager.swift
@@ -96,7 +96,7 @@ class EpisodesDataManager {
             let inClause = "(\(uuids.map { "'\($0)'" }.joined(separator: ",")))"
             return "podcast_id = \(podcast.id) AND uuid IN \(inClause) \(sortStr)"
         }
-        if !podcast.showArchived {
+        if !podcast.shouldShowArchived {
             return "podcast_id = \(podcast.id) AND archived = 0 \(sortStr)"
         }
 

--- a/podcasts/PodcastViewController+Swipe.swift
+++ b/podcasts/PodcastViewController+Swipe.swift
@@ -38,7 +38,7 @@ extension PodcastViewController: SwipeTableViewCellDelegate, SwipeHandler {
     }
 
     func archivingRemovesFromList() -> Bool {
-        !(podcast?.showArchived ?? false)
+        !(podcast?.shouldShowArchived ?? false)
     }
 
     func actionPerformed(willBeRemoved: Bool) {

--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -727,15 +727,15 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
     func toggleShowArchived() {
         guard let podcast = podcast else { return }
 
-        podcast.showArchived = !podcast.showArchived
+        podcast.shouldShowArchived = !podcast.shouldShowArchived
         DataManager.sharedManager.save(podcast: podcast)
         loadLocalEpisodes(podcast: podcast, animated: true)
 
-        Analytics.track(.podcastScreenToggleArchived, properties: ["show_archived": podcast.showArchived])
+        Analytics.track(.podcastScreenToggleArchived, properties: ["show_archived": podcast.shouldShowArchived])
     }
 
     func showingArchived() -> Bool {
-        podcast?.showArchived ?? false
+        podcast?.shouldShowArchived ?? false
     }
 
     func archiveAllTapped(playedOnly: Bool) {


### PR DESCRIPTION
| 📘 Part of: #1400 |
|:---:|

![CleanShot 2024-03-18 at 23 33 44@2x](https://github.com/Automattic/pocket-casts-ios/assets/3250/740970eb-1f9c-4075-8f44-e97cce66b2db)

## To test

Enable the `newSettingsStore` and `settingsSync` feature flags. Restart the app.

1. D1: Enter a Podcast with recently played episodes
2. D1: Tap "Show Archived"
3. D1: Refresh podcasts list
4. D2: Refresh podcasts list
5. D2: Enter same podcast
6. D2: Ensure Archived podcasts are shown

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
