### PR TITLE
Settings Sync: Bug fixes for Settings Enums

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/AppSettings.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/AppSettings.swift
@@ -39,7 +39,7 @@ public struct AppSettings: JSONCodable {
     // MARK: Playback Effects
 
     @ModifiedDate public var volumeBoost: Bool
-    @ModifiedDate public var trimSilence: TrimSilenceAmount
+    @ModifiedDate public var trimSilence: TrimSilence
     @ModifiedDate public var playbackSpeed: Double
 
     @ModifiedDate public var playerBookmarksSortType: BookmarksSort = .newestToOldest

--- a/Modules/Server/Sources/PocketCastsServer/Public/ServerSettings.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/ServerSettings.swift
@@ -293,7 +293,7 @@ public class ServerSettings {
 
     // MARK: - Auto add to Up Next Limit
 
-    private static let autoAddLimitKey = "AutoAddToUpNextLimit"
+    public static let autoAddLimitKey = "AutoAddToUpNextLimit"
     public class func autoAddToUpNextLimit() -> Int {
         if FeatureFlag.newSettingsStorage.enabled {
             Int(SettingsStore.appSettings.autoUpNextLimit)
@@ -309,7 +309,7 @@ public class ServerSettings {
         UserDefaults.standard.setValue(limit, forKey: autoAddLimitKey)
     }
 
-    private static let onAutoAddLimitReachedKey = "AutoAddLimitReachedKey"
+    public static let onAutoAddLimitReachedKey = "AutoAddLimitReachedKey"
     public class func onAutoAddLimitReached() -> AutoAddLimitReachedAction {
         if FeatureFlag.newSettingsStorage.enabled {
             return SettingsStore.appSettings.autoUpNextLimitReached

--- a/PocketCastsTests/Tests/Playback/AutoplayHelperTests.swift
+++ b/PocketCastsTests/Tests/Playback/AutoplayHelperTests.swift
@@ -1,14 +1,17 @@
 import XCTest
 
+@testable import PocketCastsServer
 @testable import podcasts
 
 class AutoplayHelperTests: XCTestCase {
     var autoplayHelper: AutoplayHelper!
 
     override func setUp() {
+        let userDefaults = UserDefaults(suiteName: "\(Int.random(in: 0..<1000))")!
         autoplayHelper = AutoplayHelper(
-            userDefaults: UserDefaults(suiteName: "\(Int.random(in: 0..<1000))")!
+            userDefaults: userDefaults
         )
+        SettingsStore.appSettings = SettingsStore(userDefaults: userDefaults, key: "app_settings", value: AppSettings.defaults)
     }
 
     func testInitialValueIsNil() {

--- a/podcasts/AppSettings+ImportUserDefaults.swift
+++ b/podcasts/AppSettings+ImportUserDefaults.swift
@@ -75,8 +75,8 @@ extension SettingsStore<AppSettings> {
             self.update(\.$darkThemePreference, value: ThemeType(old: oldTheme))
         }
         self.update(\.$useDarkUpNextTheme, value: Constants.UserDefaults.appearance.darkUpNextTheme.value)
-        self.update(\.$autoUpNextLimit, value: Int32(ServerSettings.autoAddToUpNextLimit()))
-        self.update(\.$autoUpNextLimitReached, value: ServerSettings.onAutoAddLimitReached())
+        self.update(\.$autoUpNextLimit, value: Int32(UserDefaults.standard.integer(forKey: ServerSettings.autoAddLimitKey)))
+        self.update(\.$autoUpNextLimitReached, value: Int32(UserDefaults.standard.integer(forKey: ServerSettings.onAutoAddLimitReachedKey)))
         if let old = UploadedSort.Old(rawValue: UserDefaults.standard.integer(forKey: Settings.userEpisodeSortByKey)) {
             self.update(\.$filesSortOrder, value: UploadedSort(old: old))
          }

--- a/podcasts/AutoplayHelper.swift
+++ b/podcasts/AutoplayHelper.swift
@@ -47,7 +47,10 @@ class AutoplayHelper {
             case .starred:
                 return .starred
             case .uuid(let uuid):
-                if let filter = DataManager.sharedManager.findFilter(uuid: uuid) {
+                guard uuid.isEmpty == false else {
+                    return nil
+                }
+                if DataManager.sharedManager.findFilter(uuid: uuid) != nil {
                     return .filter(uuid: uuid)
                 } else {
                     return .podcast(uuid: uuid)

--- a/podcasts/ChaptersViewController+Table.swift
+++ b/podcasts/ChaptersViewController+Table.swift
@@ -31,7 +31,7 @@ extension ChaptersViewController: UITableViewDataSource, UITableViewDelegate, UI
             }
 
             chapterCell.populateFrom(chapter: chapter, playState: state, isChapterToggleEnabled: isTogglingChapters) { [weak self] url in
-                if UserDefaults.standard.bool(forKey: Constants.UserDefaults.openLinksInExternalBrowser) {
+                if Settings.openLinks {
                     UIApplication.shared.open(url, options: [:], completionHandler: nil)
                 } else {
                     self?.present(SFSafariViewController(with: url), animated: true)

--- a/podcasts/DataManager+Import.swift
+++ b/podcasts/DataManager+Import.swift
@@ -10,6 +10,7 @@ extension DataManager {
             podcast.settings.$autoSkipLast = ModifiedDate<Int32>(wrappedValue: podcast.skipLast)
             podcast.settings.$playbackSpeed = ModifiedDate<Double>(wrappedValue: podcast.playbackSpeed)
             podcast.settings.$showArchived = ModifiedDate<Bool>(wrappedValue: podcast.showArchived)
+            podcast.settings.$customEffects = ModifiedDate<Bool>(wrappedValue: podcast.overrideGlobalEffects)
             if let trimSilence = TrimSilenceAmount(rawValue: podcast.trimSilenceAmount) {
                 podcast.settings.$trimSilence = ModifiedDate<TrimSilence>(wrappedValue: TrimSilence(amount: trimSilence))
             }

--- a/podcasts/DataManager+Import.swift
+++ b/podcasts/DataManager+Import.swift
@@ -27,8 +27,9 @@ extension DataManager {
             if let archiveTime = AutoArchiveAfterTime(rawValue: podcast.autoArchivePlayedAfter), let archivePlayed = AutoArchiveAfterPlayed(time: archiveTime) {
                 podcast.settings.$autoArchivePlayed = ModifiedDate<AutoArchiveAfterPlayed>(wrappedValue: archivePlayed)
             }
+            podcast.settings.autoArchiveEpisodeLimit = podcast.autoArchiveEpisodeLimit
             if let archiveTime = AutoArchiveAfterTime(rawValue: podcast.autoArchiveInactiveAfter), let archiveInactive = AutoArchiveAfterInactive(time: archiveTime) {
-                podcast.settings.$autoArchiveInactive = ModifiedDate<AutoArchiveAfterInactive>(wrappedValue: archiveInactive)
+                podcast.settings.$autoArchiveInactive =  ModifiedDate<AutoArchiveAfterInactive>(wrappedValue: archiveInactive)
             }
 
             if let setting = AutoAddToUpNextSetting(rawValue: podcast.autoAddToUpNext) {

--- a/podcasts/EpisodeDetailViewController+ShowNotes.swift
+++ b/podcasts/EpisodeDetailViewController+ShowNotes.swift
@@ -60,7 +60,7 @@ extension EpisodeDetailViewController: WKNavigationDelegate, SFSafariViewControl
 
     func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
         if navigationAction.navigationType == .linkActivated {
-            if UserDefaults.standard.bool(forKey: Constants.UserDefaults.openLinksInExternalBrowser), let url = navigationAction.request.url {
+            if Settings.openLinks, let url = navigationAction.request.url {
                 UIApplication.shared.open(url, options: [:], completionHandler: nil)
             } else if URLHelper.isValidScheme(navigationAction.request.url?.scheme) {
                 safariViewController = navigationAction.request.url.flatMap {

--- a/podcasts/ExpandedCollectionViewController.swift
+++ b/podcasts/ExpandedCollectionViewController.swift
@@ -100,7 +100,7 @@ class ExpandedCollectionViewController: PCViewController, CollectionHeaderLinkDe
 
         Analytics.track(.discoverCollectionLinkTapped, properties: ["list_id": item.inferredListId])
 
-        if UserDefaults.standard.bool(forKey: Constants.UserDefaults.openLinksInExternalBrowser) {
+        if Settings.openLinks {
             UIApplication.shared.open(url, options: [:], completionHandler: nil)
         } else {
             present(SFSafariViewController(with: url), animated: true, completion: nil)

--- a/podcasts/ExpandedEpisodeListViewController.swift
+++ b/podcasts/ExpandedEpisodeListViewController.swift
@@ -108,7 +108,7 @@ class ExpandedEpisodeListViewController: PCViewController, UITableViewDelegate, 
     func linkTapped() {
         guard let link = podcastCollection.webUrl, let url = URL(string: link) else { return }
 
-        if UserDefaults.standard.bool(forKey: Constants.UserDefaults.openLinksInExternalBrowser) {
+        if Settings.openLinks {
             UIApplication.shared.open(url, options: [:], completionHandler: nil)
         } else {
             present(SFSafariViewController(with: url), animated: true, completion: nil)

--- a/podcasts/GeneralSettingsViewController.swift
+++ b/podcasts/GeneralSettingsViewController.swift
@@ -131,11 +131,7 @@ class GeneralSettingsViewController: UIViewController, UITableViewDelegate, UITa
 
             cell.cellLabel.text = L10n.settingsGeneralOpenInBrowser
 
-            if FeatureFlag.newSettingsStorage.enabled {
-                cell.cellSwitch.isOn = SettingsStore.appSettings.openLinks
-            } else {
-                cell.cellSwitch.isOn = UserDefaults.standard.bool(forKey: Constants.UserDefaults.openLinksInExternalBrowser)
-            }
+            cell.cellSwitch.isOn = Settings.openLinks
 
             cell.cellSwitch.removeTarget(self, action: nil, for: .valueChanged)
             cell.cellSwitch.addTarget(self, action: #selector(openLinksInBrowserToggled(_:)), for: .valueChanged)
@@ -455,11 +451,7 @@ class GeneralSettingsViewController: UIViewController, UITableViewDelegate, UITa
     }
 
     @objc private func openLinksInBrowserToggled(_ sender: UISwitch) {
-        if FeatureFlag.newSettingsStorage.enabled {
-            SettingsStore.appSettings.openLinks = sender.isOn
-        } else {
-            UserDefaults.standard.set(sender.isOn, forKey: Constants.UserDefaults.openLinksInExternalBrowser)
-        }
+        Settings.openLinks = sender.isOn
         Settings.trackValueToggled(.settingsGeneralOpenLinksInBrowserToggled, enabled: sender.isOn)
     }
 

--- a/podcasts/NowPlayingPlayerItemViewController.swift
+++ b/podcasts/NowPlayingPlayerItemViewController.swift
@@ -256,7 +256,7 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
         let chapters = PlaybackManager.shared.currentChapters()
         guard let urlString = chapters.url, let url = URL(string: urlString) else { return }
 
-        if UserDefaults.standard.bool(forKey: Constants.UserDefaults.openLinksInExternalBrowser) {
+        if Settings.openLinks {
             UIApplication.shared.open(url, options: [:], completionHandler: nil)
         } else {
             present(SFSafariViewController(with: url), animated: true)

--- a/podcasts/PlaybackEffects.swift
+++ b/podcasts/PlaybackEffects.swift
@@ -72,7 +72,7 @@ class PlaybackEffects {
         effects.isGlobal = true
         let savedSpeed: Double
         if FeatureFlag.newSettingsStorage.enabled {
-            effects.trimSilence = SettingsStore.appSettings.trimSilence
+            effects.trimSilence = SettingsStore.appSettings.trimSilence.amount
             effects.volumeBoost = SettingsStore.appSettings.volumeBoost
             savedSpeed = SettingsStore.appSettings.playbackSpeed
         } else {

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -737,7 +737,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         // persist changes
         if effects.isGlobal {
             if FeatureFlag.newSettingsStorage.enabled {
-                SettingsStore.appSettings.trimSilence = effects.trimSilence
+                SettingsStore.appSettings.trimSilence = TrimSilence(amount: effects.trimSilence)
                 SettingsStore.appSettings.volumeBoost = effects.volumeBoost
                 SettingsStore.appSettings.playbackSpeed = effects.playbackSpeed
             } else {

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -8,6 +8,23 @@ import SwiftUI
 import PocketCastsUtils
 
 class Settings: NSObject {
+
+    static var openLinks: Bool {
+        set {
+            if FeatureFlag.newSettingsStorage.enabled {
+                SettingsStore.appSettings.openLinks = newValue
+            }
+            UserDefaults.standard.set(newValue, forKey: Constants.UserDefaults.openLinksInExternalBrowser)
+        }
+        get {
+            if FeatureFlag.newSettingsStorage.enabled {
+                return SettingsStore.appSettings.openLinks
+            } else {
+                return UserDefaults.standard.bool(forKey: Constants.UserDefaults.openLinksInExternalBrowser)
+            }
+        }
+    }
+
     // MARK: - Library Type
 
     static let podcastLibraryGridTypeKey = "SJPodcastLibraryGridType"

--- a/podcasts/ShowNotesPlayerItemViewController.swift
+++ b/podcasts/ShowNotesPlayerItemViewController.swift
@@ -196,7 +196,7 @@ class ShowNotesPlayerItemViewController: PlayerItemViewController, SFSafariViewC
                     PlaybackManager.shared.seekTo(time: timeToSkipTo)
                 })
             }
-        } else if UserDefaults.standard.bool(forKey: Constants.UserDefaults.openLinksInExternalBrowser) {
+        } else if Settings.openLinks {
             UIApplication.shared.open(url, options: [:], completionHandler: nil)
         } else {
             if URLHelper.isValidScheme(url.scheme) {


### PR DESCRIPTION
| 📘 Part of: #1400 |
|:---:|

Fixes several enum mismatches, missing setting imports, and settings which weren't reading from the synced location.

* `customEffects`, and `autoArchiveEpisodeLimit` settings were not being imported from user defaults
* `openLinks` was reading from UserDefaults only and not the synced setting
* `TrimSilence` was using the wrong value for synced settings, leading to potential mismatch with Android
* `AutoAddLimit` was not reading from the original user defaults but from the new synced property when importing

These changes are required before we can enable SettingsSync for beta testing since they all directly affect settings imports.

## To test

The `UserDefaults` imports are also tested by unit tests in #1547 and since that PR is based on this one, you can use the CI status to help verify that [these imports are working](https://buildkite.com/automattic/pocket-casts-ios/builds/6252#018e5a65-acaf-4a93-bcc4-7fceaadddebf).

#### User Defaults Imports

* Delete the app and reinstall
* Subscribe to a podcast
* Change the Custom Effects from the player
* Change Podcast Settings > Auto Archive > enable Custom For This Podcast > Episode Limit
* Change the value in Settings > Auto Add to Up Next > Auto Add Limit
* Enable the `newSettingsStorage` feature flag
* Restart the app
* Verify that Custom Effects, Podcast Auto Archive Episode Limit, and Auto Add Up Next Limit are maintained

#### Open Links

* D1: Navigate to Settings > General > Open Links In Browser
* D1: Navigate to a Podcast, like "WikiHole" find and episode with a link in the description and tap on it
* D1: Ensure the browser opens and not an in-app web view
* D1: Pull to Refresh Podcasts
* D2: Pull to Refresh Podcasts
* D2: Navigate to the same Podcast episode and tap the link
* D2: Ensure the browser opens and not an in-app web view

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
