### PR TITLE
Settings Sync: Unit Test additions for Podcast and App Settings imports

### DIFF
--- a/PocketCastsTests/Tests/Utilities/PodcastSettings+ImportUserDefaultsTests.swift
+++ b/PocketCastsTests/Tests/Utilities/PodcastSettings+ImportUserDefaultsTests.swift
@@ -5,26 +5,42 @@ import PocketCastsUtils
 import PocketCastsDataModel
 
 class PodcastSettingsImportUserDefaultsTests: XCTestCase {
+    private let newOverrideGlobalEffects = true
+    private let newAutoStartFrom: Int32 = 20
+    private let newAutoSkipLast: Int32 = 30
     private let newBoostVolume = true
+    private let newPlaybackSpeed = 2.0
+    private let newPushEnabled = true
     private let newTrimSilence = TrimSilenceAmount.medium
+    private let newOverrideGlobalArchive = true
     private let newArchivePlayedAfter = AutoArchiveAfterTime.after1Week
     private let newArchiveInactiveAfter = AutoArchiveAfterTime.after90Days
+    private let newArchiveEpisodeLimit: Int32 = 3
     private let newUpNextPosition = AutoAddToUpNextSetting.addLast
     private let newEpisodeSortOrder = PodcastEpisodeSortOrder.Old.oldestToNewest
     private let newEpisodeGrouping = PodcastGrouping.starred
+    private let newShowArchive = true
 
     let dataManager = DataManagerMock()
 
     override func setUp() {
         super.setUp()
         let podcast = Podcast()
+        podcast.overrideGlobalEffects = newOverrideGlobalEffects
+        podcast.autoStartFrom = newAutoStartFrom
+        podcast.autoSkipLast = newAutoSkipLast
         podcast.trimSilenceAmount = newTrimSilence.rawValue
         podcast.boostVolume = newBoostVolume
+        podcast.playbackSpeed = newPlaybackSpeed
+        podcast.pushEnabled = newPushEnabled
+        podcast.overrideGlobalArchive = newOverrideGlobalArchive
         podcast.autoArchivePlayedAfter = newArchivePlayedAfter.rawValue
         podcast.autoArchiveInactiveAfter = newArchiveInactiveAfter.rawValue
+        podcast.autoArchiveEpisodeLimitCount = newArchiveEpisodeLimit
         podcast.autoAddToUpNext = newUpNextPosition.rawValue
         podcast.episodeSortOrder = newEpisodeSortOrder.rawValue
         podcast.episodeGrouping = newEpisodeGrouping.rawValue
+        podcast.showArchived = newShowArchive
         dataManager.podcastsToReturn = [podcast]
     }
 
@@ -35,12 +51,22 @@ class PodcastSettingsImportUserDefaultsTests: XCTestCase {
         let podcasts = dataManager.allPodcasts(includeUnsubscribed: true)
         let podcast = try XCTUnwrap(podcasts.first)
 
+        XCTAssertEqual(newOverrideGlobalEffects, podcast.settings.customEffects, "Value of customEffects should change after import")
+        XCTAssertEqual(newAutoStartFrom, podcast.settings.autoStartFrom, "Value of autoStartFrom should change after import")
+        XCTAssertEqual(newAutoSkipLast, podcast.settings.autoSkipLast, "Value of autoSkipLast should change after import")
         XCTAssertEqual(TrimSilence(amount: newTrimSilence).rawValue, podcast.settings.trimSilence.rawValue, "Value of trimSilence should change after import")
         XCTAssertEqual(newBoostVolume, podcast.settings.boostVolume, "Value of boostVolume should change after import")
+        XCTAssertEqual(newPlaybackSpeed, podcast.settings.playbackSpeed, "Value of playbackSpeed should change after import")
+        XCTAssertEqual(newPushEnabled, podcast.settings.notification, "Value of notification should change after import")
+        XCTAssertEqual(newOverrideGlobalArchive, podcast.settings.autoArchive, "Value of autoArchive should change after import")
         XCTAssertEqual(AutoArchiveAfterPlayed(time: newArchivePlayedAfter), podcast.settings.autoArchivePlayed, "Value of autoArchivePlayed should change after import")
         XCTAssertEqual(AutoArchiveAfterInactive(time: newArchiveInactiveAfter), podcast.settings.autoArchiveInactive, "Value of autoArchiveInactive should change after import")
+        XCTAssertEqual(newArchiveEpisodeLimit, podcast.settings.autoArchiveEpisodeLimit, "Value of autoArchiveEpisodeLimit should change after import")
+        XCTAssertEqual(newUpNextPosition, podcast.settings.autoUpNextSetting, "Value of addToUpNextPosition should change after import")
+        XCTAssertEqual(newUpNextPosition != .off, podcast.settings.addToUpNext, "Value of addToUpNext should change after import")
         XCTAssertEqual(newUpNextPosition, podcast.settings.autoUpNextSetting, "Value of addToUpNextPosition should change after import")
         XCTAssertEqual(PodcastEpisodeSortOrder(old: newEpisodeSortOrder), podcast.settings.episodesSortOrder, "Value of episodesSortOrder should change after import")
         XCTAssertEqual(newEpisodeGrouping, podcast.settings.episodeGrouping, "Value of autoArchiveInactive should change after import")
+        XCTAssertEqual(newShowArchive, podcast.settings.showArchived, "Value of showArchived should change after import")
     }
 }

--- a/PocketCastsTests/Tests/Utilities/SettingsTests.swift
+++ b/PocketCastsTests/Tests/Utilities/SettingsTests.swift
@@ -143,6 +143,42 @@ final class SettingsTests: XCTestCase {
         let newPreferredLightTheme = ThemeType.contrastLight
         let newPreferredDarkTheme = ThemeType.contrastDark
 
+        let newOpenLinks = true
+        let newShowArchived = true
+        let newSkipForward = 20
+        let newSkipBack = 30
+        let newKeepScreenAwake = true
+        let newOpenPlayer = true
+        let newIntelligentResumption = true
+        let newPlayupNextOnTap = true
+        let newPlaybackActions = true
+        let newLegacyBluetooth = true
+        let newMultiselectGesture = true
+        let newChapterTitles = true
+        let newAutoplayEnabled = true
+        let newNotifications = true
+        let newAppBadgeFilter = "1234"
+        let newAutoarchiveIncludesStarred = true
+        let newVolumeBoost = true
+        let newTrimSilence = TrimSilence.medium
+        let newPlaybackSpeed = 2.0
+        let newFilesAutoUpNext = true
+        let newFilesAfterPlayingDeleteLocal = true
+        let newFilesAfterPlayingDeleteCloud = true
+        let newWarnDataUsage = true
+        let newAutoUpNextLimit = 3
+        let newAutoUpNextLimitReached = AutoAddLimitReachedAction.addToTopOnly
+        let newPrivacyAnalytics = true
+        let newMarketingOptIn = true
+        let newFreeGiftAcknowledgement = true
+        let newGridOrder = LibrarySort.titleAtoZ
+        let newGridLayout = LibraryType.fourByFour
+        let newFilesSortOrder = UploadedSort.titleZtoA
+        let newPlayerShelf: [PlayerAction] = [.effects, .markPlayed]
+        let newUseSystemTheme = true
+        let newUseEmbeddedArtwork = true
+        let newUseDarkUpNextTheme = true
+
         Settings.setPrimaryRowAction(newRowAction)
         Settings.setPrimaryUpNextSwipeAction(newSwipeAction)
         Settings.appBadge = newAppBadge
@@ -156,6 +192,41 @@ final class SettingsTests: XCTestCase {
         Settings.headphonesPreviousAction = newHeadphonesPreviousAction
         Settings.setHomeFolderSortOrder(order: newHomeFolderSortOrder)
         Settings.setPodcastBadgeType(newPodcastBadgeType)
+        Settings.openLinks = newOpenLinks
+        Settings.setShowArchivedDefault(newShowArchived)
+        Settings.skipForwardTime = newSkipForward
+        Settings.skipBackTime = newSkipBack
+        Settings.keepScreenAwake = newKeepScreenAwake
+        Settings.openPlayerAutomatically = newOpenPlayer
+        Settings.intelligentResumption = newIntelligentResumption
+        Settings.setPlayUpNextOnTap(newPlayupNextOnTap)
+        Settings.setExtraMediaSessionActionsEnabled(newPlaybackActions)
+        Settings.setLegacyBluetoothModeEnabled(newLegacyBluetooth)
+        Settings.setMultiSelectGestureEnabled(newMultiselectGesture)
+        Settings.setPublishChapterTitlesEnabled(newChapterTitles)
+        Settings.autoplay = newAutoplayEnabled
+        UserDefaults.standard.set(newNotifications, forKey: Constants.UserDefaults.pushEnabled)
+        Settings.appBadgeFilterUuid = newAppBadgeFilter
+        Settings.setArchiveStarredEpisodes(newAutoarchiveIncludesStarred)
+        UserDefaults.standard.set(newVolumeBoost, forKey: Constants.UserDefaults.globalVolumeBoost)
+        UserDefaults.standard.set(newTrimSilence.amount.rawValue, forKey: Constants.UserDefaults.globalRemoveSilence)
+        UserDefaults.standard.set(newPlaybackSpeed, forKey: Constants.UserDefaults.globalPlaybackSpeed)
+        Settings.setUserEpisodeAutoAddToUpNext(newFilesAutoUpNext)
+        Settings.setUserEpisodeRemoveFileAfterPlaying(newFilesAfterPlayingDeleteLocal)
+        Settings.setUserEpisodeRemoveFileAfterPlaying(newFilesAfterPlayingDeleteCloud)
+        Settings.setMobileDataAllowed(!newWarnDataUsage)
+        ServerSettings.setAutoAddToUpNextLimit(newAutoUpNextLimit)
+        ServerSettings.setOnAutoAddLimitReached(action: newAutoUpNextLimitReached)
+        Settings.setAnalytics(optOut: newPrivacyAnalytics)
+        ServerSettings.setMarketingOptIn(newMarketingOptIn)
+        Settings.setSubscriptionCancelledAcknowledged(newFreeGiftAcknowledgement)
+        Settings.setHomeFolderSortOrder(order: newGridOrder)
+        Settings.setLibraryType(newGridLayout)
+        Settings.setUserEpisodeSortBy(newEpisodeSortBy.rawValue)
+        Settings.updatePlayerActions(newPlayerShelf)
+        Settings.setShouldFollowSystemTheme(newUseSystemTheme)
+        Settings.loadEmbeddedImages = newUseEmbeddedArtwork
+        Settings.darkUpNextTheme = newUseDarkUpNextTheme
 
         Theme.sharedTheme.activeTheme = newTheme
         Theme.setPreferredLightTheme(newPreferredLightTheme, systemIsDark: false)
@@ -185,5 +256,41 @@ final class SettingsTests: XCTestCase {
         XCTAssertEqual(newTheme, Theme.sharedTheme.activeTheme)
         XCTAssertEqual(newPreferredLightTheme, Theme.preferredLightTheme())
         XCTAssertEqual(newPreferredDarkTheme, Theme.preferredDarkTheme())
+
+        XCTAssertEqual(newOpenLinks, Settings.openLinks)
+        XCTAssertEqual(newShowArchived, Settings.showArchivedDefault())
+        XCTAssertEqual(newSkipForward, Settings.skipForwardTime)
+        XCTAssertEqual(newSkipBack, Settings.skipBackTime)
+        XCTAssertEqual(newKeepScreenAwake, Settings.keepScreenAwake)
+        XCTAssertEqual(newOpenPlayer, Settings.openPlayerAutomatically)
+        XCTAssertEqual(newIntelligentResumption, Settings.intelligentResumption)
+        XCTAssertEqual(newPlayupNextOnTap, Settings.playUpNextOnTap())
+        XCTAssertEqual(newPlaybackActions, Settings.extraMediaSessionActionsEnabled())
+        XCTAssertEqual(newLegacyBluetooth, Settings.legacyBluetoothModeEnabled())
+        XCTAssertEqual(newMultiselectGesture, Settings.multiSelectGestureEnabled())
+        XCTAssertEqual(newChapterTitles, Settings.publishChapterTitlesEnabled())
+        XCTAssertEqual(newAutoplayEnabled, Settings.autoplay)
+        XCTAssertEqual(newAutoplayEnabled, Settings.autoplay)
+        XCTAssertEqual(newNotifications, UserDefaults.standard.bool(forKey: Constants.UserDefaults.pushEnabled))
+        XCTAssertEqual(newAppBadgeFilter, Settings.appBadgeFilterUuid)
+        XCTAssertEqual(newAutoarchiveIncludesStarred, Settings.archiveStarredEpisodes())
+        XCTAssertEqual(newVolumeBoost, SettingsStore.appSettings.volumeBoost)
+        XCTAssertEqual(newTrimSilence, SettingsStore.appSettings.trimSilence)
+        XCTAssertEqual(newPlaybackSpeed, SettingsStore.appSettings.playbackSpeed)
+        XCTAssertEqual(newFilesAutoUpNext, Settings.userEpisodeAutoAddToUpNext())
+        XCTAssertEqual(newFilesAfterPlayingDeleteLocal, Settings.userEpisodeRemoveFileAfterPlaying())
+        XCTAssertEqual(newFilesAfterPlayingDeleteCloud, Settings.userEpisodeRemoveFileAfterPlaying())
+        XCTAssertEqual(newWarnDataUsage, !Settings.mobileDataAllowed())
+        XCTAssertEqual(newAutoUpNextLimit, ServerSettings.autoAddToUpNextLimit())
+        XCTAssertEqual(newAutoUpNextLimitReached, ServerSettings.onAutoAddLimitReached())
+        XCTAssertEqual(newPrivacyAnalytics, Settings.analyticsOptOut())
+        XCTAssertEqual(newMarketingOptIn, ServerSettings.marketingOptIn())
+        XCTAssertEqual(newFreeGiftAcknowledgement, Settings.subscriptionCancelledAcknowledged())
+        XCTAssertEqual(newGridOrder, Settings.homeFolderSortOrder())
+        XCTAssertEqual(newGridLayout, Settings.libraryType())
+        XCTAssertEqual(newPlayerShelf, Array(Settings.playerActions().prefix(upTo: newPlayerShelf.count))) // Default actions are appended so only look at set items
+        XCTAssertEqual(newUseSystemTheme, Settings.shouldFollowSystemTheme())
+        XCTAssertEqual(newUseEmbeddedArtwork, Settings.loadEmbeddedImages)
+        XCTAssertEqual(newUseEmbeddedArtwork, Settings.darkUpNextTheme)
     }
 }


### PR DESCRIPTION
| 📘 Part of: #1400 |
|:---:|

Adds unit tests for importing every property currently in Podcast and App settings.

## To test

🟢 CI is green

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
