### PR TITLE
Deselect Chapters: prevent enabling it accidentally

### DIFF
--- a/podcasts/ChaptersViewController.swift
+++ b/podcasts/ChaptersViewController.swift
@@ -6,8 +6,6 @@ class ChaptersViewController: PlayerItemViewController {
 
     var numberOfDeselectedChapters = 0
 
-    private var hasActiveSubscription = SubscriptionHelper.hasActiveSubscription()
-
     @IBOutlet var chaptersTable: UITableView! {
         didSet {
             registerCells()
@@ -56,7 +54,7 @@ class ChaptersViewController: PlayerItemViewController {
         addCustomObserver(Constants.Notifications.podcastChaptersDidUpdate, selector: #selector(update))
         addCustomObserver(Constants.Notifications.podcastChapterChanged, selector: #selector(update))
         addCustomObserver(UIApplication.willEnterForegroundNotification, selector: #selector(update))
-        addCustomObserver(ServerNotifications.subscriptionStatusChanged, selector: #selector(enableOrDisableChapterSelectionIfUserJustPurchased))
+        addCustomObserver(ServerNotifications.iapPurchaseCompleted, selector: #selector(enableOrDisableChapterSelectionIfUserJustPurchased))
     }
 
     @objc private func update() {
@@ -65,11 +63,6 @@ class ChaptersViewController: PlayerItemViewController {
     }
 
     @objc private func enableOrDisableChapterSelectionIfUserJustPurchased() {
-        guard !hasActiveSubscription, SubscriptionHelper.hasActiveSubscription() else {
-            return
-        }
-
-        hasActiveSubscription = SubscriptionHelper.hasActiveSubscription()
         DispatchQueue.main.async { [weak self] in
             self?.isTogglingChapters = PaidFeature.deselectChapters.isUnlocked ? true : false
             self?.header.isTogglingChapters = self?.isTogglingChapters ?? false

--- a/podcasts/ChaptersViewController.swift
+++ b/podcasts/ChaptersViewController.swift
@@ -6,6 +6,8 @@ class ChaptersViewController: PlayerItemViewController {
 
     var numberOfDeselectedChapters = 0
 
+    private var hasActiveSubscription = SubscriptionHelper.hasActiveSubscription()
+
     @IBOutlet var chaptersTable: UITableView! {
         didSet {
             registerCells()
@@ -54,7 +56,7 @@ class ChaptersViewController: PlayerItemViewController {
         addCustomObserver(Constants.Notifications.podcastChaptersDidUpdate, selector: #selector(update))
         addCustomObserver(Constants.Notifications.podcastChapterChanged, selector: #selector(update))
         addCustomObserver(UIApplication.willEnterForegroundNotification, selector: #selector(update))
-        addCustomObserver(ServerNotifications.subscriptionStatusChanged, selector: #selector(enableOrDisableChapterSelection))
+        addCustomObserver(ServerNotifications.subscriptionStatusChanged, selector: #selector(enableOrDisableChapterSelectionIfUserJustPurchased))
     }
 
     @objc private func update() {
@@ -62,7 +64,12 @@ class ChaptersViewController: PlayerItemViewController {
         updateColors()
     }
 
-    @objc private func enableOrDisableChapterSelection() {
+    @objc private func enableOrDisableChapterSelectionIfUserJustPurchased() {
+        guard !hasActiveSubscription, SubscriptionHelper.hasActiveSubscription() else {
+            return
+        }
+
+        hasActiveSubscription = SubscriptionHelper.hasActiveSubscription()
         DispatchQueue.main.async { [weak self] in
             self?.isTogglingChapters = PaidFeature.deselectChapters.isUnlocked ? true : false
             self?.header.isTogglingChapters = self?.isTogglingChapters ?? false


### PR DESCRIPTION
Fixes #1544

We have a small bug in which the chapter selection is enabled without the user's action. This happens because `subscriptionStatusChanged` doesn't necessarily mean the subscription changed.

What was happening is that a function that was supposed to be called only when a purchase happened was being called whenever a refresh happened.

## To test

3. Hit <kbd>Command</kbd>+<kbd>Shift</kbd>+<kbd>,</kbd> to open the Scheme editor
4. Click the options tab
5. Select the `Pocket Casts Configuration.storekit` file in the StoreKit configuration dropdown
2. Run the app 
3. Go to Profile > Settings > Beta Features > `deselectChapters` and turn it on
4. Login into an account without Plus/Patron
5. Play an episode with Chapters
6. Open the player, go to Chapters
7. Tap "Skip chapters"
10. Purchase Patron it and dismiss the screen
11. ✅ The chapter selection should be displayed, the button is now "Done" and there's no icon

## Additional info

If you want to test the bug you can checkout `trunk` and add this to `AppDelegate`:

```swift
        DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
            NotificationCenter.default.post(name: ServerNotifications.subscriptionStatusChanged, object: nil)
        }
```

Then just open the chapters tab on the full player and wait.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
