### PR TITLE
Settings Sync: Active Theme + Layout bug fixes

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/AppSettings.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/AppSettings.swift
@@ -64,7 +64,7 @@ public struct AppSettings: JSONCodable {
     @ModifiedDate public var freeGiftAcknowledgement: Bool = false
 
     @ModifiedDate public var gridOrder: LibrarySort = .dateAddedNewestToOldest
-    @ModifiedDate public var gridLayout: LibraryType = .fourByFour
+    @ModifiedDate public var gridLayout: LibraryType = .threeByThree
     @ModifiedDate public var badges: BadgeType = .off
 
     @ModifiedDate public var filesSortOrder: UploadedSort = .newestToOldest

--- a/podcasts/Theme.swift
+++ b/podcasts/Theme.swift
@@ -125,7 +125,7 @@ class Theme: ObservableObject {
             if FeatureFlag.newSettingsStorage.enabled {
                 SettingsStore.appSettings.theme = activeTheme
             }
-            UserDefaults.standard.set(activeTheme.rawValue, forKey: Theme.themeKey)
+            UserDefaults.standard.set(activeTheme.old.rawValue, forKey: Theme.themeKey)
 
             // if the user is changing from or to the radioactive theme, we need to clear our memory cache because processing is applied to these images
             if oldValue == .radioactive || activeTheme == .radioactive {
@@ -144,7 +144,7 @@ class Theme: ObservableObject {
             if savedTheme == 0 && UserDefaults.standard.object(forKey: Constants.UserDefaults.shouldFollowSystemThemeKey) == nil {
                 Settings.setShouldFollowSystemTheme(true)
             }
-            activeTheme = ThemeType(rawValue: Int32(savedTheme)) ?? .light
+            activeTheme = ThemeType(old: ThemeType.Old(rawValue: savedTheme) ?? .light)
         }
 
         NotificationCenter.default.addObserver(self, selector: #selector(systemThemeDidChange(_:)), name: Constants.Notifications.systemThemeMayHaveChanged, object: nil)


### PR DESCRIPTION
| 📘 Part of: #1400 |
|:---:|

- Sets the default Grid Layout value to Large Grid (3x3). This fixes a bug where the Grid Layout would change if the setting had never been altered.
- Fixes a `ThemeType` conversion when reading & writing to `UserDefaults` which caused the wrong theme to be briefly applied when upgrading from 7.58 → 7.59.

## To test

#### Grid Layout

* Delete and install a fresh build of 7.59
* Install the latest 7.60 on top
* Verify that the Grid Layout is 3x3 and not 4x4

#### Theme

* Install 7.58
* Log in with a Plus/Patron account
* Change Theme to "Dark Contrast"
* Checkout latest 7.60
* Disable synced settings by returning `false` from [`shouldEnableSyncedSettings`](https://github.com/Automattic/pocket-casts-ios/blob/3c6ee17c74e701eee580dec9320f9c865fae49af/Modules/Utils/Sources/PocketCastsUtils/Feature%20Flags/FeatureFlag.swift#L86)
* Run the app
* Verify that theme remains Dark Contrast

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
