### PR TITLE
Disable the Synced Setting flag

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -84,7 +84,7 @@ public enum FeatureFlag: String, CaseIterable {
     }
 
     private var shouldEnableSyncedSettings: Bool {
-        BuildEnvironment.current != .appStore
+        false
     }
 
     /// Remote Feature Flag


### PR DESCRIPTION
Disables the Synced Setting flag

## To test

* Build and run
* Verify that `settingsSync` and `newSettingsStorage` are disabled

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
