### PR TITLE
Update project and CI for xcode15.3

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,7 +6,7 @@ common_params:
   # Common environment values to use with the `env` key.
   - &common_env
     # If you update the image to a newer Xcode version, don't forget to also update the badge in the README.md file accordingly for consistency
-    IMAGE_ID: xcode-15.2
+    IMAGE_ID: xcode-15.3
   # Common agents values to use with the `agents` key.
   - &common_agents
     queue: mac

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -7,7 +7,7 @@ common_params:
     - automattic/a8c-ci-toolkit#2.15.1
   # Common environment values to use with the `env` key.
   - &common_env
-    IMAGE_ID: xcode-15.2
+    IMAGE_ID: xcode-15.3
 
 steps:
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
     <a href="https://buildkite.com/automattic/pocket-casts-ios"><img src="https://badge.buildkite.com/6c995de3d1584006341cc4dfda1312619f375385f5c0319dfe.svg?branch=trunk" /></a>
     <a href="https://github.com/Automattic/pocket-casts-ios/blob/trunk/LICENSE.md"><img src="https://img.shields.io/badge/license-MPL-black" /></a>
     <img src="https://img.shields.io/badge/platform-ios%20%7C%20watchos-lightgrey" />
-    <img src="https://img.shields.io/badge/Xcode-v15.2%2B-informational" />
+    <img src="https://img.shields.io/badge/Xcode-v15.3%2B-informational" />
 </p>
 
 <p align="center">

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -11260,7 +11260,7 @@
 			repositoryURL = "https://github.com/firebase/firebase-ios-sdk.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 10.20.0;
+				minimumVersion = 10.22.0;
 			};
 		};
 		8B1762752B6808F700F44450 /* XCRemoteSwiftPackageReference "JLRoutes" */ = {

--- a/podcasts.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/podcasts.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/google/abseil-cpp-binary.git",
         "state": {
           "branch": null,
-          "revision": "df308b8b46607675f2b9ec8e569109008f9155ce",
-          "version": "1.2022062300.1"
+          "revision": "7ce7be095bc3ed3c98b009532fe2d7698c132614",
+          "version": "1.2024011601.0"
         }
       },
       {
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/firebase/firebase-ios-sdk.git",
         "state": {
           "branch": null,
-          "revision": "f91c8167141d0279726c6f6d9d4a47c026785cbc",
-          "version": "10.21.0"
+          "revision": "fcf5ced6dae2d43fced2581e673cc3b59bdb8ffa",
+          "version": "10.23.0"
         }
       },
       {
@@ -87,8 +87,8 @@
         "repositoryURL": "https://github.com/google/GoogleAppMeasurement.git",
         "state": {
           "branch": null,
-          "revision": "cb8617fab75d181270a1d8f763f26b15c73e2e1e",
-          "version": "10.21.0"
+          "revision": "6ec4ca62b00a665fa09b594fab897753a8c635fa",
+          "version": "10.23.0"
         }
       },
       {
@@ -123,8 +123,8 @@
         "repositoryURL": "https://github.com/google/grpc-binary.git",
         "state": {
           "branch": null,
-          "revision": "a673bc2937fbe886dd1f99c401b01b6d977a9c98",
-          "version": "1.49.1"
+          "revision": "67043f6389d0e28b38fa02d1c6952afeb04d807f",
+          "version": "1.62.1"
         }
       },
       {


### PR DESCRIPTION
Fixes #

Updates the project in order to build on Xcode 15.3 and use the matching CI

## To test

- CI should be green
- Build it locally on your machine and run in a simulator
- Just smoke test the app to see if nothing is broken because of the update

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
