### PR TITLE
Settings: fix podcast sort order being incorrect

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Enums.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Enums.swift
@@ -107,6 +107,23 @@ public enum PodcastEpisodeSortOrder: Int32, Codable, CaseIterable {
             self = .longestToShortest
         }
     }
+
+    public var old: Old {
+        switch self {
+        case .newestToOldest:
+            .newestToOldest
+        case .oldestToNewest:
+            .oldestToNewest
+        case .shortestToLongest:
+            .shortestToLongest
+        case .longestToShortest:
+            .longestToShortest
+        case .titleAtoZ:
+            .newestToOldest
+        case .titleZtoA:
+            .newestToOldest
+        }
+    }
 }
 
 public enum BookmarksSort: Int32, Codable {

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Podcast+Settings.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Podcast+Settings.swift
@@ -56,7 +56,7 @@ extension Podcast {
             if FeatureFlag.newSettingsStorage.enabled {
                 return settings.episodesSortOrder
             } else {
-                return PodcastEpisodeSortOrder(rawValue: episodeSortOrder)
+                return PodcastEpisodeSortOrder(old: PodcastEpisodeSortOrder.Old(rawValue: episodeSortOrder) ?? .newestToOldest)
             }
         }
     }

--- a/podcasts/EpisodeListSearchController.swift
+++ b/podcasts/EpisodeListSearchController.swift
@@ -359,7 +359,7 @@ class EpisodeListSearchController: SimpleNotificationsViewController, UISearchBa
             podcast.settings.episodesSortOrder = setting
             podcast.syncStatus = SyncStatus.notSynced.rawValue
         }
-        podcast.episodeSortOrder = setting.rawValue
+        podcast.episodeSortOrder = setting.old.rawValue
         DataManager.sharedManager.save(podcast: podcast)
 
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.podcastUpdated, object: podcast.uuid)


### PR DESCRIPTION
Fixes #1555

With the new enum changes the default podcast sort order is incorrect (Z-A) instead of newest to oldest, this PR fixes it.

## To test

1. Do a clean install
2. ✅  Check that podcasts on Discover display the sort order from newest to oldest
3. Subscribe to podcasts
4. ✅ Check that your subscribed podcasts display the sort order from newest to oldest
5. Change the sort order
6. ✅ Confirm your sort order is applied

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
