### PR TITLE
Deselect Chapters: fix header background and crash when tapping a chapter

### DIFF
--- a/podcasts/ChapterManager.swift
+++ b/podcasts/ChapterManager.swift
@@ -15,6 +15,10 @@ class ChapterManager {
     var numberOfChaptersSkipped = 0
 
     var currentChapters = Chapters()
+    
+    private var playableChapters: [ChapterInfo] {
+        visibleChapters.filter { $0.isPlayable() }
+    }
 
     init(chapterParser: PodcastChapterParser = PodcastChapterParser()) {
         self.chapterParser = chapterParser
@@ -25,7 +29,7 @@ class ChapterManager {
     }
 
     func playableChapterCount() -> Int {
-        visibleChapters.filter { $0.isPlayable() }.count
+        playableChapters.count
     }
 
     func haveTriedToParseChaptersFor(episodeUuid: String?) -> Bool {
@@ -70,6 +74,14 @@ class ChapterManager {
 
     func playableChapterAt(index: Int) -> ChapterInfo? {
         visibleChapters.filter({ $0.isPlayable() })[safe: index]
+    }
+
+    func index(for chapter: Chapters) -> Int? {
+        guard let visibleChapter = chapter.visibleChapter else {
+            return nil
+        }
+
+        return playableChapters.firstIndex(of: visibleChapter)
     }
 
     @discardableResult

--- a/podcasts/ChaptersHeader.swift
+++ b/podcasts/ChaptersHeader.swift
@@ -11,7 +11,6 @@ class ChaptersHeader: UIView {
         container.layoutMargins = .init(top: 0, left: 12, bottom: 0, right: 12)
         container.isLayoutMarginsRelativeArrangement = true
         container.axis = .horizontal
-        container.backgroundColor = .black
         return container
     }()
 

--- a/podcasts/ChaptersViewController.swift
+++ b/podcasts/ChaptersViewController.swift
@@ -74,5 +74,6 @@ class ChaptersViewController: PlayerItemViewController {
     private func updateColors() {
         view.backgroundColor = PlayerColorHelper.playerBackgroundColor01()
         chaptersTable.backgroundColor = PlayerColorHelper.playerBackgroundColor01()
+        header.backgroundColor = PlayerColorHelper.playerBackgroundColor01()
     }
 }

--- a/podcasts/ChaptersViewController.swift
+++ b/podcasts/ChaptersViewController.swift
@@ -42,8 +42,12 @@ class ChaptersViewController: PlayerItemViewController {
     func scrollToCurrentlyPlayingChapter(animated: Bool) {
         let currentChapter = PlaybackManager.shared.currentChapters()
 
+        guard let index = playbackManager.index(for: currentChapter) else {
+            return
+        }
+
         // scroll far enough to at least see the current chapter + a few more
-        chaptersTable.scrollToRow(at: IndexPath(item: currentChapter.index, section: 0), at: .middle, animated: animated)
+        chaptersTable.scrollToRow(at: IndexPath(item: index, section: 0), at: .middle, animated: animated)
     }
 
     private func addObservers() {

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -343,6 +343,10 @@ class PlaybackManager: ServerPlaybackDelegate {
         onlyPlayable ? chapterManager.playableChapterCount() : chapterManager.visibleChapterCount()
     }
 
+    func index(for chapter: Chapters) -> Int? {
+        chapterManager.index(for: chapter)
+    }
+
     func chapterAt(index: Int) -> ChapterInfo? {
         chapterManager.chapterAt(index: index)
     }


### PR DESCRIPTION
Fixes #1565 and #1564 

Fixes the chapter selection background header

<img src="https://github.com/Automattic/pocket-casts-ios/assets/7040243/5e33db59-d6ae-4b7e-949b-97004dc50293" width="300">

Fixes tapping on a chapter that sometimes causes a crash.

## To test

`deselectChapters` needs to be enabled.

1. Play an episode from any podcast in which the player's background is not black and it has chapters (eg.: https://pca.st/chaosradio
2. Go to Chapters tab
3. ✅ Check that the chapter header background is not black and it matches the rest of the screen
4. Deselect all chapters except the last one
5. Play the last chapter
6. On the player main screen, tap on the chapter's name
7. ✅ You should go to "Chapters" and the app should not crash

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
