### PR TITLE
Settings Sync: Fixes #1566 issue with Folder sort

### DIFF
--- a/podcasts/Enumerations.swift
+++ b/podcasts/Enumerations.swift
@@ -120,6 +120,12 @@ extension PodcastEpisodeSortOrder: AnalyticsDescribable {
     }
 }
 
+extension LibrarySort.Old: AnalyticsDescribable {
+    var analyticsDescription: String {
+        return LibrarySort(old: self).analyticsDescription
+    }
+}
+
 extension LibrarySort: AnalyticsDescribable {
     enum Old: Int {
         case dateAddedNewestToOldest = 1, titleAtoZ = 2, episodeDateNewestToOldest = 5, custom = 6

--- a/podcasts/FolderModel.swift
+++ b/podcasts/FolderModel.swift
@@ -72,7 +72,7 @@ class FolderModel: ObservableObject {
         folder.sortOrder = ServerPodcastManager.shared.lowestSortOrderForHomeGrid() - 1
 
         // the sort type for newly created folders defaults to the same thing the home grid is set to
-        folder.sortType = Int32(Settings.homeFolderSortOrder().rawValue)
+        folder.sortType = Int32(Settings.homeFolderSortOrder().old.rawValue)
         DataManager.sharedManager.save(folder: folder)
 
         // if needed update other folders we might have moved podcasts out of

--- a/podcasts/FolderViewController+CollectionView.swift
+++ b/podcasts/FolderViewController+CollectionView.swift
@@ -75,7 +75,7 @@ extension FolderViewController: UICollectionViewDelegate, UICollectionViewDataSo
         DataManager.sharedManager.saveSortOrders(podcasts: podcasts)
 
         folder.syncModified = TimeFormatter.currentUTCTimeInMillis()
-        folder.sortType = Int32(LibrarySort.custom.rawValue)
+        folder.sortType = Int32(LibrarySort.Old.custom.rawValue)
         DataManager.sharedManager.save(folder: folder)
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.folderChanged, object: folder.uuid)
     }

--- a/podcasts/FolderViewController.swift
+++ b/podcasts/FolderViewController.swift
@@ -205,7 +205,7 @@ class FolderViewController: PCViewController, UIGestureRecognizerDelegate {
         options.show(statusBarStyle: preferredStatusBarStyle)
     }
 
-    private func changeSortOrder(_ order: LibrarySort) {
+    private func changeSortOrder(_ order: LibrarySort.Old) {
         folder.sortType = Int32(order.rawValue)
         folder.syncModified = TimeFormatter.currentUTCTimeInMillis()
         DataManager.sharedManager.save(folder: folder)


### PR DESCRIPTION
Fixes #1566

We need to use the old `LibrarySort` type whenever syncing the Folder sort type. This is converted by `ServerConverter`.

I tested this against Android and sort order seems to be properly syncing.

## To test

### Without settings storage / sync
* Create a folder with several podcasts
* Change the sort order to "Drag and Drop"
* Reorder podcasts
* Refresh the Podcasts list

### Change to other sort type
* Change the sort order of a folder to "Date Added", "Name", or any sort option
* Ensure sort order matches and sort order is maintained when opening the "Sort By" menu

### With settings storage / sync
* D1: Create a folder with several podcasts
* D1: Change the sort order in "Sort By" to "Drag and Drop"
* D1: Reorder podcasts
* D1: Refresh the Podcasts list
* D2: Refresh the Podcasts list
* D2: Check the folder sort and ensure it matches

### Change to other sort type
* D1: Change the sort order in "Sort By" of a folder to "Date Added", "Name", or any sort option
* D1: Reorder podcasts
* D1: Refresh the Podcasts list
* D2: Refresh the Podcasts list
* D2: Ensure folder sort matches

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
