### PR TITLE
[Categories Redesign] Add categories redesign feature flag

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -42,6 +42,8 @@ public enum FeatureFlag: String, CaseIterable {
 
     case cachePlayingEpisode
 
+    case categoriesRedesign
+
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -80,6 +82,8 @@ public enum FeatureFlag: String, CaseIterable {
             false
         case .cachePlayingEpisode:
             true
+        case .categoriesRedesign:
+            false
         }
     }
 


### PR DESCRIPTION
Adds the `categories_redesign` feature flag for future work on this project.

## To test

* Open `Beta Features` section in settings
* Check that `categoriesRedesign` shows up as a feature flag:
![CleanShot 2024-03-26 at 19 25 02@2x](https://github.com/Automattic/pocket-casts-ios/assets/3250/29951cf4-8e37-43a0-9b3e-9bfe24e37dba)

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
