### PR TITLE
Standard Tags: enable new show notes, episode artwork and RSS chapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 -----
 - Opening a shared podcast episode link with the current position, now opens on the right position. [#5]
 - Allow sharing of bookmarks directly on the bookmarks list. [#1558]
+- Adds support to displaying chapters from RSS [#1574]
+- Adds support to displaying episode artwork [#1574]
 
 7.60
 -----

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -64,11 +64,11 @@ public enum FeatureFlag: String, CaseIterable {
         case .endOfYear:
             false
         case .newShowNotesEndpoint:
-            false
+            true
         case .episodeFeedArtwork:
-            false // To be enabled, newShowNotesEndpoint needs to be too
+            true // To be enabled, newShowNotesEndpoint needs to be too
         case .rssChapters:
-            false // To be enabled, newShowNotesEndpoint needs to be too
+            true // To be enabled, newShowNotesEndpoint needs to be too
         case .newPlayerTransition:
             true
         case .errorLogoutHandling:

--- a/podcasts/ShowInfoCoordinating.swift
+++ b/podcasts/ShowInfoCoordinating.swift
@@ -3,12 +3,6 @@ import PocketCastsDataModel
 import PocketCastsServer
 
 protocol ShowInfoCoordinating {
-    init(
-        dataRetriever: ShowInfoDataRetriever,
-        podcastIndexChapterRetriever: PodcastIndexChapterDataRetriever,
-        dataManager: DataManager
-    )
-
     func loadShowNotes(
         podcastUuid: String,
         episodeUuid: String
@@ -18,4 +12,9 @@ protocol ShowInfoCoordinating {
         podcastUuid: String,
         episodeUuid: String
     ) async throws -> String?
+
+    func loadChapters(
+        podcastUuid: String,
+        episodeUuid: String
+    ) async throws -> ([Episode.Metadata.EpisodeChapter]?, [PodcastIndexChapter]?)
 }


### PR DESCRIPTION
Enable those features for 7.61.

## To test

1. 🟢 CI
2. Code-review
3. Play any episode from https://pca.st/chaosradio or https://pca.st/changelog and make sure chapters are shown

The features were tested on their PRs.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
