### PR TITLE
Settings Sync: Settings Property Cleanup

### DIFF
--- a/podcasts/GeneralSettingsViewController.swift
+++ b/podcasts/GeneralSettingsViewController.swift
@@ -137,11 +137,7 @@ class GeneralSettingsViewController: UIViewController, UITableViewDelegate, UITa
 
             cell.cellLabel.text = L10n.settingsGeneralAutoOpenPlayer
 
-            if FeatureFlag.newSettingsStorage.enabled {
-                cell.cellSwitch.isOn = SettingsStore.appSettings.openPlayer
-            } else {
-                cell.cellSwitch.isOn = UserDefaults.standard.bool(forKey: Constants.UserDefaults.openPlayerAutomatically)
-            }
+            cell.cellSwitch.isOn = Settings.openPlayerAutomatically
 
             cell.cellSwitch.removeTarget(self, action: nil, for: .valueChanged)
             cell.cellSwitch.addTarget(self, action: #selector(openPlayerToggled(_:)), for: .valueChanged)
@@ -460,10 +456,7 @@ class GeneralSettingsViewController: UIViewController, UITableViewDelegate, UITa
     }
 
     @objc private func openPlayerToggled(_ sender: UISwitch) {
-        if FeatureFlag.newSettingsStorage.enabled {
-            SettingsStore.appSettings.openPlayer = sender.isOn
-        }
-        UserDefaults.standard.set(sender.isOn, forKey: Constants.UserDefaults.openPlayerAutomatically)
+        Settings.openPlayerAutomatically = sender.isOn
         Settings.trackValueToggled(.settingsGeneralOpenPlayerAutomaticallyToggled, enabled: sender.isOn)
     }
 

--- a/podcasts/GeneralSettingsViewController.swift
+++ b/podcasts/GeneralSettingsViewController.swift
@@ -148,11 +148,7 @@ class GeneralSettingsViewController: UIViewController, UITableViewDelegate, UITa
 
             cell.cellLabel.text = L10n.settingsGeneralSmartPlayback
 
-            if FeatureFlag.newSettingsStorage.enabled {
-                cell.cellSwitch.isOn = SettingsStore.appSettings.intelligentResumption
-            } else {
-                cell.cellSwitch.isOn = UserDefaults.standard.bool(forKey: Constants.UserDefaults.intelligentPlaybackResumption)
-            }
+            cell.cellSwitch.isOn = Settings.intelligentResumption
 
             cell.cellSwitch.removeTarget(self, action: nil, for: .valueChanged)
             cell.cellSwitch.addTarget(self, action: #selector(intelligentPlaybackResumptionToggled(_:)), for: .valueChanged)
@@ -461,10 +457,7 @@ class GeneralSettingsViewController: UIViewController, UITableViewDelegate, UITa
     }
 
     @objc private func intelligentPlaybackResumptionToggled(_ sender: UISwitch) {
-        if FeatureFlag.newSettingsStorage.enabled {
-            SettingsStore.appSettings.intelligentResumption = sender.isOn
-        }
-        UserDefaults.standard.set(sender.isOn, forKey: Constants.UserDefaults.intelligentPlaybackResumption)
+        Settings.intelligentResumption = sender.isOn
         Settings.trackValueToggled(.settingsGeneralIntelligentPlaybackToggled, enabled: sender.isOn)
     }
 

--- a/podcasts/GeneralSettingsViewController.swift
+++ b/podcasts/GeneralSettingsViewController.swift
@@ -116,12 +116,7 @@ class GeneralSettingsViewController: UIViewController, UITableViewDelegate, UITa
 
             cell.cellLabel.text = L10n.settingsGeneralKeepScreenAwake
 
-            if FeatureFlag.newSettingsStorage.enabled {
-                cell.cellSwitch.isOn = SettingsStore.appSettings.keepScreenAwake
-            } else {
-                cell.cellSwitch.isOn = UserDefaults.standard.bool(forKey: Constants.UserDefaults.keepScreenOnWhilePlaying)
-            }
-
+            cell.cellSwitch.isOn = Settings.keepScreenAwake
             cell.cellSwitch.removeTarget(self, action: nil, for: .valueChanged)
             cell.cellSwitch.addTarget(self, action: #selector(screenLockToggled(_:)), for: .valueChanged)
 
@@ -442,10 +437,7 @@ class GeneralSettingsViewController: UIViewController, UITableViewDelegate, UITa
     }
 
     @objc private func screenLockToggled(_ sender: UISwitch) {
-        if FeatureFlag.newSettingsStorage.enabled {
-            SettingsStore.appSettings.keepScreenAwake = sender.isOn
-        }
-        UserDefaults.standard.set(sender.isOn, forKey: Constants.UserDefaults.keepScreenOnWhilePlaying)
+        Settings.keepScreenAwake = sender.isOn
         PlaybackManager.shared.updateIdleTimer()
         Settings.trackValueToggled(.settingsGeneralKeepScreenAwakeToggled, enabled: sender.isOn)
     }

--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -208,11 +208,7 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
             setupForEpisode(episode)
             showMiniPlayer()
             let shouldOpenAutomatically: Bool
-            if FeatureFlag.newSettingsStorage.enabled {
-                shouldOpenAutomatically = SettingsStore.appSettings.openPlayer
-            } else {
-                shouldOpenAutomatically = UserDefaults.standard.bool(forKey: Constants.UserDefaults.openPlayerAutomatically)
-            }
+            shouldOpenAutomatically = Settings.openPlayerAutomatically
             if shouldOpenAutomatically || episode.videoPodcast(), lastEpisodeUuidAutoOpened != episode.uuid {
                 lastEpisodeUuidAutoOpened = episode.uuid
 

--- a/podcasts/PlaybackCatchUpHelper.swift
+++ b/podcasts/PlaybackCatchUpHelper.swift
@@ -11,11 +11,7 @@ struct PlaybackCatchUpHelper {
         #else
             // if it's a different episode, or not still at the time it was at when it was last paused, just play from where it's up to
             let intelligentPlaybackResumption: Bool
-            if FeatureFlag.newSettingsStorage.enabled {
-                intelligentPlaybackResumption = SettingsStore.appSettings.intelligentResumption
-            } else {
-                intelligentPlaybackResumption = UserDefaults.standard.bool(forKey: Constants.UserDefaults.intelligentPlaybackResumption)
-            }
+            intelligentPlaybackResumption = Settings.intelligentResumption
             if !intelligentPlaybackResumption || episode.uuid != lastPausedEpisodeUuid() || episode.playedUpTo != lastPausedAt() { return episode.playedUpTo }
 
             guard let lastPauseTime = lastPauseTime() else { return episode.playedUpTo }

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -1939,11 +1939,7 @@ class PlaybackManager: ServerPlaybackDelegate {
             DispatchQueue.main.async {
                 if self.playing() {
                     let keepScreenOn: Bool
-                    if FeatureFlag.newSettingsStorage.enabled {
-                        keepScreenOn = SettingsStore.appSettings.keepScreenAwake
-                    } else {
-                        keepScreenOn = UserDefaults.standard.bool(forKey: Constants.UserDefaults.keepScreenOnWhilePlaying)
-                    }
+                    keepScreenOn = Settings.keepScreenAwake
                     UIApplication.shared.isIdleTimerDisabled = keepScreenOn
                 } else {
                     UIApplication.shared.isIdleTimerDisabled = false

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -21,6 +21,22 @@ class Settings: NSObject {
                 return SettingsStore.appSettings.openLinks
             } else {
                 return UserDefaults.standard.bool(forKey: Constants.UserDefaults.openLinksInExternalBrowser)
+			}
+		}
+	}
+
+    static var keepScreenAwake: Bool {
+        set {
+            if FeatureFlag.newSettingsStorage.enabled {
+                SettingsStore.appSettings.keepScreenAwake = newValue
+            }
+            UserDefaults.standard.set(newValue, forKey: Constants.UserDefaults.keepScreenOnWhilePlaying)
+        }
+        get {
+            if FeatureFlag.newSettingsStorage.enabled {
+                SettingsStore.appSettings.keepScreenAwake
+            } else {
+                UserDefaults.standard.bool(forKey: Constants.UserDefaults.keepScreenOnWhilePlaying)
             }
         }
     }

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -41,6 +41,22 @@ class Settings: NSObject {
         }
     }
 
+    static var openPlayerAutomatically: Bool {
+        set {
+            if FeatureFlag.newSettingsStorage.enabled {
+                SettingsStore.appSettings.openPlayer = newValue
+            }
+            UserDefaults.standard.set(newValue, forKey: Constants.UserDefaults.openPlayerAutomatically)
+        }
+        get {
+            if FeatureFlag.newSettingsStorage.enabled {
+                SettingsStore.appSettings.openPlayer
+            } else {
+                UserDefaults.standard.bool(forKey: Constants.UserDefaults.openPlayerAutomatically)
+            }
+        }
+    }
+
     // MARK: - Library Type
 
     static let podcastLibraryGridTypeKey = "SJPodcastLibraryGridType"

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -57,6 +57,23 @@ class Settings: NSObject {
         }
     }
 
+    static var intelligentResumption: Bool {
+        set {
+            if FeatureFlag.newSettingsStorage.enabled {
+                SettingsStore.appSettings.intelligentResumption = newValue
+            }
+            UserDefaults.standard.set(newValue, forKey: Constants.UserDefaults.intelligentPlaybackResumption)
+        }
+        get {
+            if FeatureFlag.newSettingsStorage.enabled {
+                SettingsStore.appSettings.intelligentResumption
+            } else {
+                UserDefaults.standard.bool(forKey: Constants.UserDefaults.intelligentPlaybackResumption)
+            }
+        }
+    }
+
+
     // MARK: - Library Type
 
     static let podcastLibraryGridTypeKey = "SJPodcastLibraryGridType"


### PR DESCRIPTION
| 📘 Part of: #1400 |
|:---:|

Moves several app-wide settings to `Settings.swift` to be more concise when used in-app and easier to unit test (https://github.com/Automattic/pocket-casts-ios/pull/1547).

## To test

### Keep Screen Awake

* Toggle the Keep Screen Awake setting in General
* Kill the app
* Ensure the setting is still enabled
* Test that the screen remains awake

### Open Player Automatically

* Toggle the Open Player Automatically setting in General
* Kill the app
* Ensure the setting is still enabled
* Test that playing a podcast from a list opens the player

### Intelligent Resumption

* Toggle the Intelligent Resumption setting in General
* Kill the app
* Ensure the setting is still enabled

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
