### PR TITLE
Fallback to default player when length is not available

### DIFF
--- a/podcasts/EffectsPlayer.swift
+++ b/podcasts/EffectsPlayer.swift
@@ -109,11 +109,15 @@ class EffectsPlayer: PlaybackProtocol, Hashable {
                 if strongSelf.cachedFrameCount == 0 {
                     // we haven't cached a frame count for this episode, do that now
                     strongSelf.cachedFrameCount = strongSelf.audioFile!.length
+                    if strongSelf.cachedFrameCount == 0 {
+                        // If don't have a frameCount we cannot use the effect player
+                        throw AVError(_nsError: NSError(domain: AVFoundationErrorDomain, code: AVError.fileFailedToParse.rawValue))
+                    }
                     DataManager.sharedManager.saveFrameCount(episode: episode, frameCount: strongSelf.cachedFrameCount)
                 }
             } catch {
                 strongSelf.playerLock.unlock()
-                PlaybackManager.shared.playbackDidFail(logMessage: error.localizedDescription, userMessage: nil)
+                PlaybackManager.shared.playbackDidFail(logMessage: error.localizedDescription, userMessage: nil, fallbackToDefaultPlayer: true)
                 return
             }
 


### PR DESCRIPTION
Refs #900

This PR detects goes around one of the issue that can affect the EffectPlayer: the failure to read the frame count on file, that resulted in a exception being throw and the file being skipped. 
With this change if the Effects Player fails to load it will default to the DefaultPlayer and try to play it.

There are still files that even using the default player, they will fail with some foundation error and are unable to play if the file is downloaded locally.

From my tests I saw this error: `AVErrorFourCharCode='optm'` and from my investigation on the documentation it looks related [to this error](https://developer.apple.com/documentation/audiotoolbox/kaudiofilestreamerror_notoptimized).

## To test

- Start the app
- Open the following episode: [https://pca.st/22iph0yt](https://pca.st/22iph0yt)
- Tap play
- Check that it plays correctly to the end

Steps to test your PR.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
