### PR TITLE
Settings Sync: Use wrapped startFrom & skipLast values

### DIFF
--- a/podcasts/PodcastSettingsViewController+Table.swift
+++ b/podcasts/PodcastSettingsViewController+Table.swift
@@ -117,7 +117,7 @@ extension PodcastSettingsViewController: UITableViewDataSource, UITableViewDeleg
                 podcast.autoStartFrom = Int32(value)
                 podcast.syncStatus = SyncStatus.notSynced.rawValue
                 DataManager.sharedManager.save(podcast: podcast)
-                cell.cellSecondaryLabel.text = L10n.timeShorthand(Int(startFrom))
+                cell.cellSecondaryLabel.text = L10n.timeShorthand(Int(podcast.autoStartFrom))
 
                 self?.debounce.call {
                     Analytics.track(.podcastSettingsSkipFirstChanged, properties: ["value": value])
@@ -144,7 +144,7 @@ extension PodcastSettingsViewController: UITableViewDataSource, UITableViewDeleg
                 podcast.autoSkipLast = Int32(value)
                 podcast.syncStatus = SyncStatus.notSynced.rawValue
                 DataManager.sharedManager.save(podcast: podcast)
-                cell.cellSecondaryLabel.text = L10n.timeShorthand(Int(skipLast))
+                cell.cellSecondaryLabel.text = L10n.timeShorthand(Int(podcast.autoSkipLast))
 
                 self?.debounce.call {
                     Analytics.track(.podcastSettingsSkipLastChanged, properties: ["value": value])

--- a/podcasts/PodcastSettingsViewController+Table.swift
+++ b/podcasts/PodcastSettingsViewController+Table.swift
@@ -99,15 +99,16 @@ extension PodcastSettingsViewController: UITableViewDataSource, UITableViewDeleg
 
             return cell
         case .skipFirst:
+            let startFrom = podcast.autoStartFrom
             let cell = tableView.dequeueReusableCell(withIdentifier: PodcastSettingsViewController.timeStepperCellId, for: indexPath) as! TimeStepperCell
             cell.cellLabel.text = L10n.settingsSkipFirst
-            cell.cellSecondaryLabel.text = L10n.timeShorthand(Int(podcast.startFrom))
+            cell.cellSecondaryLabel.text = L10n.timeShorthand(Int(startFrom))
             cell.timeStepper.tintColor = podcast.iconTintColor()
             cell.timeStepper.minimumValue = 0
             cell.timeStepper.maximumValue = 40.minutes
             cell.timeStepper.bigIncrements = 5.seconds
             cell.timeStepper.smallIncrements = 5.seconds
-            cell.timeStepper.currentValue = TimeInterval(podcast.startFrom)
+            cell.timeStepper.currentValue = TimeInterval(startFrom)
             cell.configureWithImage(imageName: "settings-skipintros", tintColor: podcast.iconTintColor())
 
             cell.onValueChanged = { [weak self] value in
@@ -116,7 +117,7 @@ extension PodcastSettingsViewController: UITableViewDataSource, UITableViewDeleg
                 podcast.autoStartFrom = Int32(value)
                 podcast.syncStatus = SyncStatus.notSynced.rawValue
                 DataManager.sharedManager.save(podcast: podcast)
-                cell.cellSecondaryLabel.text = L10n.timeShorthand(Int(podcast.autoStartFrom))
+                cell.cellSecondaryLabel.text = L10n.timeShorthand(Int(startFrom))
 
                 self?.debounce.call {
                     Analytics.track(.podcastSettingsSkipFirstChanged, properties: ["value": value])
@@ -125,15 +126,16 @@ extension PodcastSettingsViewController: UITableViewDataSource, UITableViewDeleg
 
             return cell
         case .skipLast:
+            let skipLast = podcast.autoSkipLast
             let cell = tableView.dequeueReusableCell(withIdentifier: PodcastSettingsViewController.timeStepperCellId, for: indexPath) as! TimeStepperCell
             cell.cellLabel.text = L10n.settingsSkipLast
-            cell.cellSecondaryLabel.text = L10n.timeShorthand(Int(podcast.skipLast))
+            cell.cellSecondaryLabel.text = L10n.timeShorthand(Int(skipLast))
             cell.timeStepper.tintColor = podcast.iconTintColor()
             cell.timeStepper.minimumValue = 0
             cell.timeStepper.maximumValue = 40.minutes
             cell.timeStepper.bigIncrements = 5.seconds
             cell.timeStepper.smallIncrements = 5.seconds
-            cell.timeStepper.currentValue = TimeInterval(podcast.autoSkipLast)
+            cell.timeStepper.currentValue = TimeInterval(skipLast)
             cell.configureWithImage(imageName: "settings-skipoutros", tintColor: podcast.iconTintColor())
 
             cell.onValueChanged = { [weak self] value in
@@ -142,7 +144,7 @@ extension PodcastSettingsViewController: UITableViewDataSource, UITableViewDeleg
                 podcast.autoSkipLast = Int32(value)
                 podcast.syncStatus = SyncStatus.notSynced.rawValue
                 DataManager.sharedManager.save(podcast: podcast)
-                cell.cellSecondaryLabel.text = L10n.timeShorthand(Int(podcast.autoSkipLast))
+                cell.cellSecondaryLabel.text = L10n.timeShorthand(Int(skipLast))
 
                 self?.debounce.call {
                     Analytics.track(.podcastSettingsSkipLastChanged, properties: ["value": value])


### PR DESCRIPTION
The old `startFrom` and `skipLast` properties were still being used in the Podcast settings page.

In practice this should only affect the new conflict resolution with `ModifiedDate` since this setting was [already synced](https://github.com/Automattic/pocket-casts-ios/blob/25a7dd9b44f66d1fe80c6a67f1083a689b08967b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask%2BServerChanges.swift#L136-L140), so sync might have still appeared to work but ended up with an old value when changed out of order.

## To test

### Without synced settings
1. Navigate to a Podcast's settings page
2. Change "Skip First" and "Skip Last" values
3. Restart the app
4. Ensure the settings remain

### Synced Settings
1. Enable the `newSettingsStorage` & `settingsSync` flags on two devices/simulators
2. D1: Restart the app
3. D1: Navigate to a Podcast's settings page
5. D1: Change "Skip First" and "Skip Last" values
6. D1: Pull to refresh the Podcasts list
7. D2: Pull to refresh the Podcasts list
8. D2: Check the "Skip First" and "Skip Last" values 

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
