### PR TITLE
Standard Tags: fixes issues with episode artwork

### DIFF
--- a/podcasts/ImageManager.swift
+++ b/podcasts/ImageManager.swift
@@ -126,6 +126,10 @@ class ImageManager {
         imageView.kf.setImage(with: url, placeholder: placeholderImage, options: [.processor(processor), .targetCache(subscribedPodcastsCache), .transition(.fade(Constants.Animation.defaultAnimationTime))])
     }
 
+    func setPlaceholder(imageView: UIImageView, size: PodcastThumbnailSize) {
+        imageView.image = placeHolderImage(size)
+    }
+
     func loadImage(episode: BaseEpisode, imageView: UIImageView, size: PodcastThumbnailSize) {
         if loadEmbeddedImageIfRequired(in: episode, into: imageView) {
             return

--- a/podcasts/ImageManager.swift
+++ b/podcasts/ImageManager.swift
@@ -123,7 +123,7 @@ class ImageManager {
         let url = URL(string: urlString)!
         let placeholderImage = showPlaceHolder ? placeHolderImage(size) : nil
         let processor = (Theme.sharedTheme.activeTheme == .radioactive ? radioactiveProcessor() : DefaultImageProcessor.default) |> DownsamplingImageProcessor(size: CGSize(width: ImageManager.sizeFor(imageSize: size), height: ImageManager.sizeFor(imageSize: size)))
-        imageView.kf.setImage(with: url, placeholder: placeholderImage, options: [.processor(processor), .targetCache(subscribedPodcastsCache), .transition(.fade(Constants.Animation.defaultAnimationTime))])
+        imageView.kf.setImage(with: url, placeholder: placeholderImage, options: [.processor(processor), .targetCache(subscribedPodcastsCache), .cacheOriginalImage, .transition(.fade(Constants.Animation.defaultAnimationTime))])
     }
 
     func setPlaceholder(imageView: UIImageView, size: PodcastThumbnailSize) {

--- a/podcasts/PodcastImageView.swift
+++ b/podcasts/PodcastImageView.swift
@@ -40,6 +40,7 @@ class PodcastImageView: UIView {
 
                 // The app might run into the case where the episode changed but there's still
                 // a pending task to display the image of another episode
+                // This can happen when dequeing a cell, for example.
                 // This check prevent this from happening.
                 guard episode.uuid == currentEpisode?.uuid else {
                     return

--- a/podcasts/UpNextViewController.swift
+++ b/podcasts/UpNextViewController.swift
@@ -145,8 +145,6 @@ class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        // fix issues with the now playing cell not animating by reloading it on appear
-        reloadTable()
 
         AnalyticsHelper.upNextOpened()
     }


### PR DESCRIPTION
Fixes #1579

This fixes a few things for episode artwork:

* Fix an issue where the Up Next was "blinking" with a different image when showing episode artwork;
* Correctly set up cache so the original image is cached and we don't need to request it more than once;
* Ensure only the correct image is loaded

## To test

It's better to run this on a real device and also ensure on Profile > Settings > Appearance > enable "Use Episode Artwork"

1. Ensure your Up Next queue has many items with episode artwork;
2. Open it
3. ✅ Images should load correctly, you should not see any "blink"
4. Go to a filter with many podcasts
5. Scroll down as fast as you can, then go up
6. ✅ Ensure each episode has loaded its correct image

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
