### PR TITLE
Add developer option to clear caches

### DIFF
--- a/podcasts/DeveloperMenu.swift
+++ b/podcasts/DeveloperMenu.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import PocketCastsServer
 import PocketCastsDataModel
+import Kingfisher
 
 struct DeveloperMenu: View {
     var body: some View {
@@ -26,6 +27,12 @@ struct DeveloperMenu: View {
 
                 Button("Force Reload Discover") {
                     NotificationCenter.postOnMainThread(notification: Constants.Notifications.chartRegionChanged)
+                }
+
+                Button("Clear URL + Image Caches") {
+                    URLCache.shared.removeAllCachedResponses()
+                    ImageManager.sharedManager.clearCaches()
+                    KingfisherManager.shared.cache.clearCache()
                 }
 
                 Button("Unsubscribe from all Podcasts") {

--- a/podcasts/ImageManager.swift
+++ b/podcasts/ImageManager.swift
@@ -520,4 +520,14 @@ class ImageManager {
             return Int(320.0 * UIScreen.main.scale)
         }
     }
+
+    /// Clears all of the caches (disk + memory) managed by this instance.
+    func clearCaches() {
+        subscribedPodcastsCache.clearCache()
+        userEpisodeCache.clearCache()
+        userEpisodeCache.clearCache()
+        discoverCache.clearCache()
+        networkImageCache.clearCache()
+        searchImageCache.clearCache()
+    }
 }


### PR DESCRIPTION
Adds a new "Clear URL + Image Caches" option to the Developer menu.

![CleanShot 2024-04-01 at 13 27 57@2x](https://github.com/Automattic/pocket-casts-ios/assets/3250/0803a209-3454-4908-8c2a-d84bedb43853)

Just clears URLCache, Kingfisher, and ImageManager caches for now

## To test

* Go to Developer menu in settings
* Tap the "Clear URL + Image Caches" cell
* Scroll through Up Next and verify that images reload

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
