### PR TITLE
Settings Sync: Default Settings handling

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/PodcastSettings.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/PodcastSettings.swift
@@ -1,15 +1,18 @@
 import PocketCastsUtils
 
 public struct PodcastSettings: JSONCodable, Equatable {
+
+    public static let defaults = PodcastSettings()
+
     @ModifiedDate public var customEffects: Bool = false
 
     @ModifiedDate public var autoStartFrom: Int32 = 0
     @ModifiedDate public var autoSkipLast: Int32 = 0
 
     // Playback Effects
-    @ModifiedDate public var trimSilence: TrimSilence
-    @ModifiedDate public var boostVolume: Bool
-    @ModifiedDate public var playbackSpeed: Double
+    @ModifiedDate public var trimSilence: TrimSilence = .off
+    @ModifiedDate public var boostVolume: Bool = false
+    @ModifiedDate public var playbackSpeed: Double = 1
 
     @ModifiedDate public var notification: Bool = false
 
@@ -25,8 +28,4 @@ public struct PodcastSettings: JSONCodable, Equatable {
     @ModifiedDate public var episodesSortOrder: PodcastEpisodeSortOrder = .newestToOldest
     @ModifiedDate public var episodeGrouping: PodcastGrouping = .none
     @ModifiedDate public var showArchived: Bool = false
-
-    public static var defaults: Self {
-        return PodcastSettings(trimSilence: .off, boostVolume: false, playbackSpeed: 1)
-    }
 }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/PodcastSettings.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/PodcastSettings.swift
@@ -1,5 +1,11 @@
 import PocketCastsUtils
 
+/// Model type for synced & stored Podcast Settings
+/// **NOTE:** Adding a setting requires additions to several other locations to succesfully decode and sync:
+/// - `init(from: Decoder)` below in this file
+/// - `SyncTask+FullSync`'s `SyncTask.processSettings(PodcastSettings, to: Podcast)`
+/// - `SyncTask+LocalChanges`'s `SyncTask.apiSettings`
+/// - `SyncTask+ServerChanges`'s `Podcast.processSettings(Api_PodcastSettings)`
 public struct PodcastSettings: JSONCodable, Equatable {
 
     public static let defaults = PodcastSettings()

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/PodcastSettings.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/PodcastSettings.swift
@@ -29,3 +29,37 @@ public struct PodcastSettings: JSONCodable, Equatable {
     @ModifiedDate public var episodeGrouping: PodcastGrouping = .none
     @ModifiedDate public var showArchived: Bool = false
 }
+
+extension PodcastSettings {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        let defaults = PodcastSettings()
+
+        try decode(\.$customEffects, forKey: .customEffects, fromContainer: container, withDefaults: defaults)
+        try decode(\.$autoStartFrom, forKey: .autoStartFrom, fromContainer: container, withDefaults: defaults)
+        try decode(\.$autoSkipLast, forKey: .autoSkipLast, fromContainer: container, withDefaults: defaults)
+        try decode(\.$trimSilence, forKey: .trimSilence, fromContainer: container, withDefaults: defaults)
+        try decode(\.$boostVolume, forKey: .boostVolume, fromContainer: container, withDefaults: defaults)
+        try decode(\.$playbackSpeed, forKey: .playbackSpeed, fromContainer: container, withDefaults: defaults)
+        try decode(\.$notification, forKey: .notification, fromContainer: container, withDefaults: defaults)
+        try decode(\.$autoArchive, forKey: .autoArchive, fromContainer: container, withDefaults: defaults)
+        try decode(\.$autoArchivePlayed, forKey: .autoArchivePlayed, fromContainer: container, withDefaults: defaults)
+        try decode(\.$autoArchiveInactive, forKey: .autoArchiveInactive, fromContainer: container, withDefaults: defaults)
+        try decode(\.$autoArchiveEpisodeLimit, forKey: .autoArchiveEpisodeLimit, fromContainer: container, withDefaults: defaults)
+        try decode(\.$addToUpNext, forKey: .addToUpNext, fromContainer: container, withDefaults: defaults)
+        try decode(\.$addToUpNextPosition, forKey: .addToUpNextPosition, fromContainer: container, withDefaults: defaults)
+        try decode(\.$episodesSortOrder, forKey: .episodesSortOrder, fromContainer: container, withDefaults: defaults)
+        try decode(\.$episodeGrouping, forKey: .episodeGrouping, fromContainer: container, withDefaults: defaults)
+        try decode(\.$showArchived, forKey: .showArchived, fromContainer: container, withDefaults: defaults)
+    }
+
+    private mutating func decode<Value: Codable & Equatable>(
+        _ keyPath: WritableKeyPath<Self, ModifiedDate<Value>>,
+        forKey key: CodingKeys,
+        fromContainer container: KeyedDecodingContainer<CodingKeys>,
+        withDefaults defaults: Self
+    ) throws {
+        self[keyPath: keyPath] = try container.decodeIfPresent(ModifiedDate<Value>.self, forKey: key) ?? defaults[keyPath: keyPath]
+    }
+}

--- a/Modules/Server/Sources/PocketCastsServer/Public/AppSettings.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/AppSettings.swift
@@ -86,6 +86,76 @@ public struct AppSettings: JSONCodable {
     @ModifiedDate public var autoPlayLastListUuid: AutoPlaySource = .uuid("")
 }
 
+extension AppSettings {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        let defaults = AppSettings()
+
+        try decode(\.$openLinks, forKey: .openLinks, fromContainer: container, withDefaults: defaults)
+        try decode(\.$rowAction, forKey: .rowAction, fromContainer: container, withDefaults: defaults)
+        try decode(\.$episodeGrouping, forKey: .episodeGrouping, fromContainer: container, withDefaults: defaults)
+        try decode(\.$showArchived, forKey: .showArchived, fromContainer: container, withDefaults: defaults)
+        try decode(\.$upNextSwipe, forKey: .upNextSwipe, fromContainer: container, withDefaults: defaults)
+        try decode(\.$skipForward, forKey: .skipForward, fromContainer: container, withDefaults: defaults)
+        try decode(\.$skipBack, forKey: .skipBack, fromContainer: container, withDefaults: defaults)
+        try decode(\.$keepScreenAwake, forKey: .keepScreenAwake, fromContainer: container, withDefaults: defaults)
+        try decode(\.$openPlayer, forKey: .openPlayer, fromContainer: container, withDefaults: defaults)
+        try decode(\.$intelligentResumption, forKey: .intelligentResumption, fromContainer: container, withDefaults: defaults)
+        try decode(\.$playUpNextOnTap, forKey: .playUpNextOnTap, fromContainer: container, withDefaults: defaults)
+        try decode(\.$playbackActions, forKey: .playbackActions, fromContainer: container, withDefaults: defaults)
+        try decode(\.$legacyBluetooth, forKey: .legacyBluetooth, fromContainer: container, withDefaults: defaults)
+        try decode(\.$multiSelectGesture, forKey: .multiSelectGesture, fromContainer: container, withDefaults: defaults)
+        try decode(\.$chapterTitles, forKey: .chapterTitles, fromContainer: container, withDefaults: defaults)
+        try decode(\.$autoPlayEnabled, forKey: .autoPlayEnabled, fromContainer: container, withDefaults: defaults)
+        try decode(\.$notifications, forKey: .notifications, fromContainer: container, withDefaults: defaults)
+        try decode(\.$appBadge, forKey: .appBadge, fromContainer: container, withDefaults: defaults)
+        try decode(\.$appBadgeFilter, forKey: .appBadgeFilter, fromContainer: container, withDefaults: defaults)
+        try decode(\.$autoArchivePlayed, forKey: .autoArchivePlayed, fromContainer: container, withDefaults: defaults)
+        try decode(\.$autoArchiveInactive, forKey: .autoArchiveInactive, fromContainer: container, withDefaults: defaults)
+        try decode(\.$autoArchiveIncludesStarred, forKey: .autoArchiveIncludesStarred, fromContainer: container, withDefaults: defaults)
+        try decode(\.$volumeBoost, forKey: .volumeBoost, fromContainer: container, withDefaults: defaults)
+        try decode(\.$trimSilence, forKey: .trimSilence, fromContainer: container, withDefaults: defaults)
+        try decode(\.$playbackSpeed, forKey: .playbackSpeed, fromContainer: container, withDefaults: defaults)
+        try decode(\.$playerBookmarksSortType, forKey: .playerBookmarksSortType, fromContainer: container, withDefaults: defaults)
+        try decode(\.$episodeBookmarksSortType, forKey: .episodeBookmarksSortType, fromContainer: container, withDefaults: defaults)
+        try decode(\.$podcastBookmarksSortType, forKey: .podcastBookmarksSortType, fromContainer: container, withDefaults: defaults)
+        try decode(\.$profileBookmarksSortType, forKey: .profileBookmarksSortType, fromContainer: container, withDefaults: defaults)
+        try decode(\.$filesAutoUpNext, forKey: .filesAutoUpNext, fromContainer: container, withDefaults: defaults)
+        try decode(\.$filesAfterPlayingDeleteLocal, forKey: .filesAfterPlayingDeleteLocal, fromContainer: container, withDefaults: defaults)
+        try decode(\.$filesAfterPlayingDeleteCloud, forKey: .filesAfterPlayingDeleteCloud, fromContainer: container, withDefaults: defaults)
+        try decode(\.$warnDataUsage, forKey: .warnDataUsage, fromContainer: container, withDefaults: defaults)
+        try decode(\.$autoUpNextLimit, forKey: .autoUpNextLimit, fromContainer: container, withDefaults: defaults)
+        try decode(\.$autoUpNextLimitReached, forKey: .autoUpNextLimitReached, fromContainer: container, withDefaults: defaults)
+        try decode(\.$headphoneControlsNextAction, forKey: .headphoneControlsNextAction, fromContainer: container, withDefaults: defaults)
+        try decode(\.$headphoneControlsPreviousAction, forKey: .headphoneControlsPreviousAction, fromContainer: container, withDefaults: defaults)
+        try decode(\.$privacyAnalytics, forKey: .privacyAnalytics, fromContainer: container, withDefaults: defaults)
+        try decode(\.$marketingOptIn, forKey: .marketingOptIn, fromContainer: container, withDefaults: defaults)
+        try decode(\.$freeGiftAcknowledgement, forKey: .freeGiftAcknowledgement, fromContainer: container, withDefaults: defaults)
+        try decode(\.$gridOrder, forKey: .gridOrder, fromContainer: container, withDefaults: defaults)
+        try decode(\.$gridLayout, forKey: .gridLayout, fromContainer: container, withDefaults: defaults)
+        try decode(\.$badges, forKey: .badges, fromContainer: container, withDefaults: defaults)
+        try decode(\.$filesSortOrder, forKey: .filesSortOrder, fromContainer: container, withDefaults: defaults)
+        try decode(\.$playerShelf, forKey: .playerShelf, fromContainer: container, withDefaults: defaults)
+        try decode(\.$useSystemTheme, forKey: .useSystemTheme, fromContainer: container, withDefaults: defaults)
+        try decode(\.$theme, forKey: .theme, fromContainer: container, withDefaults: defaults)
+        try decode(\.$lightThemePreference, forKey: .lightThemePreference, fromContainer: container, withDefaults: defaults)
+        try decode(\.$darkThemePreference, forKey: .darkThemePreference, fromContainer: container, withDefaults: defaults)
+        try decode(\.$useEmbeddedArtwork, forKey: .useEmbeddedArtwork, fromContainer: container, withDefaults: defaults)
+        try decode(\.$useDarkUpNextTheme, forKey: .useDarkUpNextTheme, fromContainer: container, withDefaults: defaults)
+        try decode(\.$autoPlayLastListUuid, forKey: .autoPlayLastListUuid, fromContainer: container, withDefaults: defaults)
+    }
+
+    private mutating func decode<Value: Codable & Equatable>(
+        _ keyPath: WritableKeyPath<Self, ModifiedDate<Value>>,
+        forKey key: CodingKeys,
+        fromContainer container: KeyedDecodingContainer<CodingKeys>,
+        withDefaults defaults: Self
+    ) throws {
+        self[keyPath: keyPath] = try container.decodeIfPresent(ModifiedDate<Value>.self, forKey: key) ?? defaults[keyPath: keyPath]
+    }
+}
+
 extension SettingsStore<AppSettings> {
     public static internal(set) var appSettings = SettingsStore(key: "app_settings", value: AppSettings())
 }

--- a/Modules/Server/Sources/PocketCastsServer/Public/AppSettings.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/AppSettings.swift
@@ -4,28 +4,30 @@ import PocketCastsDataModel
 /// Model type for synced & stored App Settings
 public struct AppSettings: JSONCodable {
 
+    public static let defaults = AppSettings()
+
     // MARK: - General
-    @ModifiedDate public var openLinks: Bool
+    @ModifiedDate public var openLinks: Bool = false
 
-    @ModifiedDate public var rowAction: PrimaryRowAction
+    @ModifiedDate public var rowAction: PrimaryRowAction = .stream
 
-    @ModifiedDate public var episodeGrouping: PodcastGrouping
-    @ModifiedDate public var showArchived: Bool
-    @ModifiedDate public var upNextSwipe: PrimaryUpNextSwipeAction
+    @ModifiedDate public var episodeGrouping: PodcastGrouping = .none
+    @ModifiedDate public var showArchived: Bool = false
+    @ModifiedDate public var upNextSwipe: PrimaryUpNextSwipeAction = .playNext
 
-    @ModifiedDate public var skipForward: Int32
-    @ModifiedDate public var skipBack: Int32
+    @ModifiedDate public var skipForward: Int32 = 45
+    @ModifiedDate public var skipBack: Int32 = 10
 
-    @ModifiedDate public var keepScreenAwake: Bool
-    @ModifiedDate public var openPlayer: Bool
-    @ModifiedDate public var intelligentResumption: Bool
+    @ModifiedDate public var keepScreenAwake: Bool = false
+    @ModifiedDate public var openPlayer: Bool = false
+    @ModifiedDate public var intelligentResumption: Bool = true
 
-    @ModifiedDate public var playUpNextOnTap: Bool
-    @ModifiedDate public var playbackActions: Bool
-    @ModifiedDate public var legacyBluetooth: Bool
-    @ModifiedDate public var multiSelectGesture: Bool
-    @ModifiedDate public var chapterTitles: Bool
-    @ModifiedDate public var autoPlayEnabled: Bool
+    @ModifiedDate public var playUpNextOnTap: Bool = false
+    @ModifiedDate public var playbackActions: Bool = false
+    @ModifiedDate public var legacyBluetooth: Bool = false
+    @ModifiedDate public var multiSelectGesture: Bool = true
+    @ModifiedDate public var chapterTitles: Bool = true
+    @ModifiedDate public var autoPlayEnabled: Bool = true
 
     @ModifiedDate public var notifications: Bool = false
 
@@ -38,9 +40,9 @@ public struct AppSettings: JSONCodable {
 
     // MARK: Playback Effects
 
-    @ModifiedDate public var volumeBoost: Bool
-    @ModifiedDate public var trimSilence: TrimSilence
-    @ModifiedDate public var playbackSpeed: Double
+    @ModifiedDate public var volumeBoost: Bool = false
+    @ModifiedDate public var trimSilence: TrimSilence = .off
+    @ModifiedDate public var playbackSpeed: Double = 1
 
     @ModifiedDate public var playerBookmarksSortType: BookmarksSort = .newestToOldest
     @ModifiedDate public var episodeBookmarksSortType: BookmarksSort = .newestToOldest
@@ -82,31 +84,8 @@ public struct AppSettings: JSONCodable {
 
     @ModifiedDate public var useDarkUpNextTheme: Bool = true
     @ModifiedDate public var autoPlayLastListUuid: AutoPlaySource = .uuid("")
-
-    static var defaults: AppSettings {
-        return AppSettings(openLinks: false,
-                           rowAction: .stream,
-                           episodeGrouping: .none,
-                           showArchived: false,
-                           upNextSwipe: .playNext,
-                           skipForward: 45,
-                           skipBack: 10,
-                           keepScreenAwake: false,
-                           openPlayer: false,
-                           intelligentResumption: true,
-                           playUpNextOnTap: false,
-                           playbackActions: false,
-                           legacyBluetooth: false,
-                           multiSelectGesture: true,
-                           chapterTitles: true,
-                           autoPlayEnabled: true,
-                           volumeBoost: false,
-                           trimSilence: .off,
-                           playbackSpeed: 0
-        )
-    }
 }
 
 extension SettingsStore<AppSettings> {
-    public static internal(set) var appSettings = SettingsStore(key: "app_settings", value: AppSettings.defaults)
+    public static internal(set) var appSettings = SettingsStore(key: "app_settings", value: AppSettings())
 }

--- a/Modules/Server/Sources/PocketCastsServer/Public/AppSettings.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/AppSettings.swift
@@ -2,6 +2,10 @@ import PocketCastsUtils
 import PocketCastsDataModel
 
 /// Model type for synced & stored App Settings
+/// **NOTE:** Adding a setting requires additions to several other locations to succesfully decode and sync:
+/// - `init(from: Decoder)` below in this file
+/// - `SyncSettingsTask`'s `Api_ChangeableSettings.update(with: AppSettings)` and `AppSettings.update(with: Api_NamedSettingsResponse`
+/// - `SettingsTests.testImportOldDefaults()` if importing old values
 public struct AppSettings: JSONCodable {
 
     public static let defaults = AppSettings()

--- a/PocketCastsTests/Tests/Utilities/PodcastSettings+ImportUserDefaultsTests.swift
+++ b/PocketCastsTests/Tests/Utilities/PodcastSettings+ImportUserDefaultsTests.swift
@@ -69,4 +69,14 @@ class PodcastSettingsImportUserDefaultsTests: XCTestCase {
         XCTAssertEqual(newEpisodeGrouping, podcast.settings.episodeGrouping, "Value of autoArchiveInactive should change after import")
         XCTAssertEqual(newShowArchive, podcast.settings.showArchived, "Value of showArchived should change after import")
     }
+
+    /// Tests that the default values are used when a value is missing from the JSON (such as when a key was added after writing the JSON object)
+    func testDefaultValuesWhenMissing() throws {
+        let json = "{ \"autoArchive\": { \"value\": true, \"modifiedDate\": \"2024-03-28T13:49:51.141Z\"} }"
+        let settings = try JSONDecoder().decode(PodcastSettings.self, from: json.data(using: .utf8)!)
+
+        XCTAssertTrue(settings.autoArchive, "Should contain new value from JSON")
+        XCTAssertEqual(settings.autoArchivePlayed, .afterPlaying, "Should contain default value")
+        XCTAssertEqual(settings.playbackSpeed, 1, "Should contain default value")
+    }
 }

--- a/PocketCastsTests/Tests/Utilities/SettingsTests.swift
+++ b/PocketCastsTests/Tests/Utilities/SettingsTests.swift
@@ -293,4 +293,15 @@ final class SettingsTests: XCTestCase {
         XCTAssertEqual(newUseEmbeddedArtwork, Settings.loadEmbeddedImages)
         XCTAssertEqual(newUseEmbeddedArtwork, Settings.darkUpNextTheme)
     }
+
+    /// Tests that the default values are used when a value is missing from the JSON (such as when a key was added after writing the JSON object)
+    func testDefaultValuesWhenMissing() throws {
+        let json = "{ \"openLinks\": { \"value\": true, \"modifiedDate\": \"2024-03-28T13:49:51.141Z\"} }"
+        let settings = try JSONDecoder().decode(AppSettings.self, from: json.data(using: .utf8)!)
+
+        XCTAssertTrue(settings.openLinks, "Should contain new value from JSON")
+        XCTAssertEqual(settings.autoArchivePlayed, .afterPlaying, "Should contain default value")
+        XCTAssertTrue(settings.multiSelectGesture, "Should contain default value")
+        XCTAssertEqual(settings.skipForward, 45, "Should contain default value")
+    }
 }


### PR DESCRIPTION
This fixes issues with setting default values while decoding `AppSettings` and `PodcastSettings` from JSON.

It's a bit verbose since I'm implementing `init(from decoder: Decoder)` manually. I investigated using something like [`DefaultCodable`](https://github.com/gonzalezreal/DefaultCodable) or using a Macro solution like [`MetaCodable`](https://github.com/SwiftyLab/MetaCodable) (could [impact our build times](https://forums.swift.org/t/compilation-extremely-slow-since-macros-adoption/67921/68)) but both are tricky with the `ModifiedDate` property wrapper. I want to go ahead and get this in to fix the issue where new settings will overwrite existing settings. I've added comments to cover all of the locations code must be added. In the future, we can simplify this with Macros or some other solution.

### Changes
* Moves all defaults for `PodcastSettings` (https://github.com/Automattic/pocket-casts-ios/pull/1587/commits/c4a467ef78750437fcad639209a651bfabdb0b0a) and `AppSettings` (https://github.com/Automattic/pocket-casts-ios/pull/1587/commits/33aa9b449607601b565e2bbdaf7f4b45ef0b5c39) to property declaration instead of initializer.
* `init(from decoder: Decoder)` implementation for `PodcastSettings` (https://github.com/Automattic/pocket-casts-ios/pull/1587/commits/c34bdcea53e9b94ac3713bd27efb7402913c766a) and `AppSettings` (https://github.com/Automattic/pocket-casts-ios/pull/1587/commits/eae789369f4a206c88bece584753e7e84e7165bc)
* Unit tests (https://github.com/Automattic/pocket-casts-ios/pull/1587/commits/234039cee1def5fe2d130b9f08d9b0f8595eb293) to cover decoding behavior with an incomplete JSON object.

## To test

* Fresh install
* Enable the `newSettingsStorage` flag and restart
* Add a property to `AppSettings` or `PodcastSettings`. Make sure to add to the `init(from decoder: Decoder)` as well.
* Set a breakpoint in `Theme.preferredLightTheme()`
* Check that `SettingsStore.appSettings.<yourSetting>` is set to its default value.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
