### PR TITLE
[Deselect Chapters] Remove it from Patron and update copies

### DIFF
--- a/podcasts/Onboarding/Plus/UpgradeCard.swift
+++ b/podcasts/Onboarding/Plus/UpgradeCard.swift
@@ -53,7 +53,6 @@ extension UpgradeTier {
         UpgradeTier(tier: .patron, iconName: "patron-heart", title: "Patron", plan: .patron, header: L10n.patronCallout, description: L10n.patronDescription, buttonLabel: L10n.patronSubscribeTo, buttonForegroundColor: .white, monthlyFeatures: [
             TierFeature(iconName: "patron-everything", title: L10n.patronFeatureEverythingInPlus),
             TierFeature(iconName: "patron-early-access", title: L10n.patronFeatureEarlyAccess),
-            PaidFeature.deselectChapters.tier == .patron ? TierFeature(iconName: "rounded-selected", title: L10n.skipChapters) : nil,
             TierFeature(iconName: "plus-feature-cloud", title: L10n.patronCloudStorageLimit),
             TierFeature(iconName: "patron-badge", title: L10n.patronFeatureProfileBadge),
             TierFeature(iconName: "patron-icons", title: L10n.patronFeatureProfileIcons),
@@ -63,7 +62,6 @@ extension UpgradeTier {
         yearlyFeatures: [
             TierFeature(iconName: "patron-everything", title: L10n.patronFeatureEverythingInPlus),
             TierFeature(iconName: "patron-early-access", title: L10n.patronFeatureEarlyAccess),
-            PaidFeature.deselectChapters.tier == .patron ? TierFeature(iconName: "rounded-selected", title: L10n.skipChapters) : nil,
             TierFeature(iconName: "plus-feature-cloud", title: L10n.patronCloudStorageLimit),
             TierFeature(iconName: "patron-badge", title: L10n.patronFeatureProfileBadge),
             TierFeature(iconName: "patron-icons", title: L10n.patronFeatureProfileIcons),

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -170,11 +170,11 @@ internal enum L10n {
   internal static var announcementBookmarksTitle: String { return L10n.tr("Localizable", "announcement_bookmarks_title") }
   /// Join us in the beta testing for bookmarks!
   internal static var announcementBookmarksTitleBeta: String { return L10n.tr("Localizable", "announcement_bookmarks_title_beta") }
-  /// Subscribe to Plus now so you can select and skip chapters in any episode that supports them.
+  /// Subscribe to Plus now so you can preselect and skip chapters automatically in any episode that supports them.
   internal static var announcementDeselectChaptersFree: String { return L10n.tr("Localizable", "announcement_deselect_chapters_free") }
-  /// As part of your Patron subscription, you can now select and skip chapters in any episode that supports them.
+  /// As part of your Patron subscription, you can now preselect and skip chapters automatically in any episode that supports them.
   internal static var announcementDeselectChaptersPatron: String { return L10n.tr("Localizable", "announcement_deselect_chapters_patron") }
-  /// As part of your Plus subscription, you can now select and skip chapters in any episode that supports them.
+  /// As part of your Plus subscription, you can now preselect and skip chapters automatically in any episode that supports them.
   internal static var announcementDeselectChaptersPlus: String { return L10n.tr("Localizable", "announcement_deselect_chapters_plus") }
   /// Code copied to clipboard
   internal static var announcementSlumberCodeCopied: String { return L10n.tr("Localizable", "announcement_slumber_code_copied") }
@@ -2790,11 +2790,11 @@ internal enum L10n {
   internal static var siriShortcutToPodcast: String { return L10n.tr("Localizable", "siri_shortcut_to_podcast") }
   /// Skip Back
   internal static var skipBack: String { return L10n.tr("Localizable", "skip_back") }
-  /// Skip chapters
+  /// Preselect chapters
   internal static var skipChapters: String { return L10n.tr("Localizable", "skip_chapters") }
-  /// Skip chapters and more with Pocket Casts Patron
+  /// Preselect chapters and more with Pocket Casts Patron
   internal static var skipChaptersPatronPrompt: String { return L10n.tr("Localizable", "skip_chapters_patron_prompt") }
-  /// Skip chapters and more with Pocket Casts Plus
+  /// Preselect chapters and more with Pocket Casts Plus
   internal static var skipChaptersPlusPrompt: String { return L10n.tr("Localizable", "skip_chapters_plus_prompt") }
   /// Skip Forward
   internal static var skipForward: String { return L10n.tr("Localizable", "skip_forward") }

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4002,7 +4002,7 @@
 "accessibility_hint_player_navigate_to_podcast_label" = "Tap to navigate to main podcast information page";
 
 /* Label that toggles the option for the user to choose which chapters of the podcast they want to skip (to not be played) */
-"skip_chapters" = "Skip chapters";
+"skip_chapters" = "Deselect chapters";
 
 /* Indicates the number of chapters in a podcast episode. %1$@ is the number of chapters. */
 "number_of_chapters" = "%1$@ chapters";
@@ -4017,10 +4017,10 @@
 "number_of_hidden_chapters" = "%1$@ hidden";
 
 /* Prompt for Plus mentioning Skip Chapters, don't translate Pocket Casts Plus */
-"skip_chapters_plus_prompt" = "Skip chapters and more with Pocket Casts Plus";
+"skip_chapters_plus_prompt" = "Deselect chapters and more with Pocket Casts Plus";
 
 /* Prompt for Plus mentioning Skip Chapters, don't translate Pocket Casts Patron */
-"skip_chapters_patron_prompt" = "Skip chapters and more with Pocket Casts Patron";
+"skip_chapters_patron_prompt" = "Deselect chapters and more with Pocket Casts Patron";
 
 /* Slumber Studios partnership feature announcement title */
 "announcement_slumber_title" = "Dream big";
@@ -4041,13 +4041,13 @@
 "announcement_slumber_code_copied" = "Code copied to clipboard";
 
 /* Announcement of Skip Chapters for Patron users */
-"announcement_deselect_chapters_patron" = "As part of your Patron subscription, you can now select and skip chapters in any episode that supports them.";
+"announcement_deselect_chapters_patron" = "As part of your Patron subscription, you can now deselect and skip chapters automatically in any episode that supports them.";
 
 /* Announcement of Skip Chapters for Plus users */
-"announcement_deselect_chapters_plus" = "As part of your Plus subscription, you can now select and skip chapters in any episode that supports them.";
+"announcement_deselect_chapters_plus" = "As part of your Plus subscription, you can now deselect and skip chapters automatically in any episode that supports them.";
 
 /* Announcement of Skip Chapters for free users */
-"announcement_deselect_chapters_free" = "Subscribe to Plus now so you can select and skip chapters in any episode that supports them.";
+"announcement_deselect_chapters_free" = "Subscribe to Plus now so you can deselect and skip chapters automatically in any episode that supports them.";
 
 /* Used in a button meaning that the user undestood the message. */
 "got_it" = "Got it";

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4017,10 +4017,10 @@
 "number_of_hidden_chapters" = "%1$@ hidden";
 
 /* Prompt for Plus mentioning Skip Chapters, don't translate Pocket Casts Plus */
-"skip_chapters_plus_prompt" = "Deselect chapters and more with Pocket Casts Plus";
+"skip_chapters_plus_prompt" = "Preselect chapters and more with Pocket Casts Plus";
 
 /* Prompt for Plus mentioning Skip Chapters, don't translate Pocket Casts Patron */
-"skip_chapters_patron_prompt" = "Deselect chapters and more with Pocket Casts Patron";
+"skip_chapters_patron_prompt" = "Preselect chapters and more with Pocket Casts Patron";
 
 /* Slumber Studios partnership feature announcement title */
 "announcement_slumber_title" = "Dream big";
@@ -4041,13 +4041,13 @@
 "announcement_slumber_code_copied" = "Code copied to clipboard";
 
 /* Announcement of Skip Chapters for Patron users */
-"announcement_deselect_chapters_patron" = "As part of your Patron subscription, you can now deselect and skip chapters automatically in any episode that supports them.";
+"announcement_deselect_chapters_patron" = "As part of your Patron subscription, you can now preselect and skip chapters automatically in any episode that supports them.";
 
 /* Announcement of Skip Chapters for Plus users */
-"announcement_deselect_chapters_plus" = "As part of your Plus subscription, you can now deselect and skip chapters automatically in any episode that supports them.";
+"announcement_deselect_chapters_plus" = "As part of your Plus subscription, you can now preselect and skip chapters automatically in any episode that supports them.";
 
 /* Announcement of Skip Chapters for free users */
-"announcement_deselect_chapters_free" = "Subscribe to Plus now so you can deselect and skip chapters automatically in any episode that supports them.";
+"announcement_deselect_chapters_free" = "Subscribe to Plus now so you can preselect and skip chapters automatically in any episode that supports them.";
 
 /* Used in a button meaning that the user undestood the message. */
 "got_it" = "Got it";

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4002,7 +4002,7 @@
 "accessibility_hint_player_navigate_to_podcast_label" = "Tap to navigate to main podcast information page";
 
 /* Label that toggles the option for the user to choose which chapters of the podcast they want to skip (to not be played) */
-"skip_chapters" = "Deselect chapters";
+"skip_chapters" = "Preselect chapters";
 
 /* Indicates the number of chapters in a podcast episode. %1$@ is the number of chapters. */
 "number_of_chapters" = "%1$@ chapters";
@@ -4016,10 +4016,10 @@
 /* Indicates the number of hidden chapters in a podcast episode. %1$@ is the number of hidden chapters. */
 "number_of_hidden_chapters" = "%1$@ hidden";
 
-/* Prompt for Plus mentioning Skip Chapters, don't translate Pocket Casts Plus */
+/* Prompt for Plus mentioning Pre selecting Chapters, don't translate Pocket Casts Plus */
 "skip_chapters_plus_prompt" = "Preselect chapters and more with Pocket Casts Plus";
 
-/* Prompt for Plus mentioning Skip Chapters, don't translate Pocket Casts Patron */
+/* Prompt for Plus mentioning Pre selecting Chapters, don't translate Pocket Casts Patron */
 "skip_chapters_patron_prompt" = "Preselect chapters and more with Pocket Casts Patron";
 
 /* Slumber Studios partnership feature announcement title */
@@ -4040,13 +4040,13 @@
 /* Message shown when the code is copied to clipboard */
 "announcement_slumber_code_copied" = "Code copied to clipboard";
 
-/* Announcement of Skip Chapters for Patron users */
+/* Announcement of Preselect Chapters for Patron users */
 "announcement_deselect_chapters_patron" = "As part of your Patron subscription, you can now preselect and skip chapters automatically in any episode that supports them.";
 
-/* Announcement of Skip Chapters for Plus users */
+/* Announcement of Preselect Chapters for Plus users */
 "announcement_deselect_chapters_plus" = "As part of your Plus subscription, you can now preselect and skip chapters automatically in any episode that supports them.";
 
-/* Announcement of Skip Chapters for free users */
+/* Announcement of Preselect Chapters for free users */
 "announcement_deselect_chapters_free" = "Subscribe to Plus now so you can preselect and skip chapters automatically in any episode that supports them.";
 
 /* Used in a button meaning that the user undestood the message. */


### PR DESCRIPTION
Do not display "Skip Chapters" under Patron and change copies to "Preselect chapters".

## To test

1. Run the app
2. Login to an account
3. Go to Profile > Developer > Set to No Plus
4. Go to Profile > Account
5. ✅ "Preselect Chapters" should not be displayed under Patron
6. Go to Podcasts > tap the folder icon
7. ✅ "Preselect Chapters" should not be displayed under Patron
8. In `PaidFeature.swift` change `deselectChapters` to `plusFeature`
9. Re-run the app
11. Go to Profile > Account
5. ✅ "Preselect Chapters" should be displayed under Plus only
6. Go to Podcasts > tap the folder icon
7. ✅ "Preselect Chapters" should be displayed under Plus only

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
