### PR TITLE
Fix warnings in unit tests

### DIFF
--- a/Modules/DataModel/Tests/PocketCastsDataModelTests/AutoAddCandidatesDataManagerTests.swift
+++ b/Modules/DataModel/Tests/PocketCastsDataModelTests/AutoAddCandidatesDataManagerTests.swift
@@ -118,7 +118,7 @@ final class AutoAddCandidatesDataManagerTests: XCTestCase {
         }
 
         self.measure {
-            let candidates = dataManager.autoAddCandidates.candidates()
+            _ = dataManager.autoAddCandidates.candidates()
         }
 
         featureFlagMock.reset()
@@ -151,7 +151,7 @@ final class AutoAddCandidatesDataManagerTests: XCTestCase {
         }
 
         self.measure {
-            let candidates = dataManager.autoAddCandidates.candidates()
+            _ = dataManager.autoAddCandidates.candidates()
         }
 
         featureFlagMock.reset()

--- a/Modules/Server/Tests/PocketCastsServerTests/ApiSettingsTests+ModifiedDate.swift
+++ b/Modules/Server/Tests/PocketCastsServerTests/ApiSettingsTests+ModifiedDate.swift
@@ -22,7 +22,7 @@ class APISettingsTests: XCTestCase {
 
         settings.value.value = initialValue
 
-        var modifiedDate = ModifiedDate(wrappedValue: changedValue)
+        let modifiedDate = ModifiedDate(wrappedValue: changedValue)
         settings.update(modifiedDate)
 
         XCTAssertNotEqual(settings.value.value, changedValue, "Settings value should not be changed by the initial value, since it wasn't modified")

--- a/PocketCastsTests/Tests/Utilities/SettingsTests.swift
+++ b/PocketCastsTests/Tests/Utilities/SettingsTests.swift
@@ -173,7 +173,6 @@ final class SettingsTests: XCTestCase {
         let newFreeGiftAcknowledgement = true
         let newGridOrder = LibrarySort.titleAtoZ
         let newGridLayout = LibraryType.fourByFour
-        let newFilesSortOrder = UploadedSort.titleZtoA
         let newPlayerShelf: [PlayerAction] = [.effects, .markPlayed]
         let newUseSystemTheme = true
         let newUseEmbeddedArtwork = true


### PR DESCRIPTION
Fixes up a few (mostly unused variable) warnings in the unit test target.

## To test

Green CI 🟢 

* Build and run unit tests
* Only remaining warnings should be Actors

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
