### PR TITLE
Enable `settingsSync` and `newSettingsStorage` flags

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -93,7 +93,8 @@ public enum FeatureFlag: String, CaseIterable {
     }
 
     private var shouldEnableSyncedSettings: Bool {
-        true
+        // Enabled only out of appstore until we verify that this feature is ready for production.
+        BuildEnvironment.current != .appStore
     }
 
     /// Remote Feature Flag

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -93,7 +93,7 @@ public enum FeatureFlag: String, CaseIterable {
     }
 
     private var shouldEnableSyncedSettings: Bool {
-        false
+        true
     }
 
     /// Remote Feature Flag


### PR DESCRIPTION
Please include a summary of the changes and the related issue.

## To test

* Build and run from new install
* Visit the Beta Features screen
* Ensure `settingsSync` and `newSettingsStorage` flags are enabled

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
