### PR TITLE
Standard Tags: change the solution so it uses less resources

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EpisodeDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EpisodeDataManager.swift
@@ -1063,6 +1063,26 @@ extension EpisodeDataManager {
             }
         }
     }
+
+    func findRawEpisodeMetadata(uuid: String, dbQueue: FMDatabaseQueue) async throws -> String? {
+        return try await withCheckedThrowingContinuation { continuation in
+            dbQueue.inDatabase { db in
+                do {
+                    let resultSet = try db.executeQuery("SELECT metadata from \(DataManager.episodeTableName) WHERE uuid = ?", values: [uuid])
+                    defer { resultSet.close() }
+
+                    if resultSet.next() {
+                        continuation.resume(returning: resultSet.string(forColumn: "metadata"))
+                    } else {
+                        continuation.resume(returning: nil)
+                    }
+                } catch {
+                    FileLog.shared.addMessage("EpisodeDataManager.findRawEpisodeMetadata Episode metadata error: \(error)")
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
 }
 
 // MARK: - New Show Info

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseHelper.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseHelper.swift
@@ -694,10 +694,8 @@ class DatabaseHelper {
 
         if schemaVersion < 46 {
             do {
-                try db.executeUpdate("""
-                    DROP TABLE EpisodeMetadata;
-                    ALTER TABLE SJEpisode ADD COLUMN metadata TEXT;
-                """, values: nil)
+                try db.executeUpdate("DROP TABLE EpisodeMetadata;", values: nil)
+                try db.executeUpdate("ALTER TABLE SJEpisode ADD COLUMN metadata TEXT;", values: nil)
                 schemaVersion = 46
             } catch {
                 failedAt(46)

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseHelper.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseHelper.swift
@@ -692,6 +692,19 @@ class DatabaseHelper {
             }
         }
 
+        if schemaVersion < 46 {
+            do {
+                try db.executeUpdate("""
+                    DROP TABLE EpisodeMetadata;
+                    ALTER TABLE SJEpisode ADD COLUMN metadata TEXT;
+                """, values: nil)
+                schemaVersion = 46
+            } catch {
+                failedAt(46)
+                return
+            }
+        }
+
         db.commit()
     }
 }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -1021,6 +1021,10 @@ extension DataManager {
     public func findEpisodeMetadata(uuid: String) async throws -> Episode.Metadata? {
         try await episodeManager.findEpisodeMetadata(uuid: uuid, dbQueue: dbQueue)
     }
+
+    public func findRawEpisodeMetadata(uuid: String) async throws -> String? {
+        try await episodeManager.findRawEpisodeMetadata(uuid: uuid, dbQueue: dbQueue)
+    }
 }
 
 // MARK: - Show Notes

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -10,6 +10,7 @@ public class DataManager {
     public static let playlistEpisodeTableName = "SJPlaylistEpisode"
     public static let upNextChangesTableName = "UpNextChanges"
     public static let folderTableName = "Folder"
+    public static let metadataTableName = "EpisodeMetadata"
 
     private let podcastManager = PodcastDataManager()
     private let upNextManager = UpNextDataManager()

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/BaseEpisode.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/BaseEpisode.swift
@@ -31,6 +31,8 @@ import Foundation
     var deselectedChapters: String? { get set }
     var deselectedChaptersModified: Int64 { get set }
 
+    var rawMetadata: String? { get set }
+
     func displayableTitle() -> String
     func parentIdentifier() -> String
 

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Episode+fromDatabase.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Episode+fromDatabase.swift
@@ -43,6 +43,7 @@ extension Episode {
         episode.starredModified = rs.longLongInt(forColumn: "starredModified")
         episode.deselectedChapters = rs.string(forColumn: "deselectedChapters")
         episode.deselectedChaptersModified = rs.longLongInt(forColumn: "deselectedChaptersModified")
+        episode.rawMetadata = rs.string(forColumn: "metadata")
         return episode
     }
 }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Episode.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Episode.swift
@@ -177,6 +177,23 @@ public class Episode: NSObject, BaseEpisode {
         taggableId()
     }
 
+    private var parsedMetadata: Episode.Metadata? = nil
+
+    public var metadata: Episode.Metadata? {
+        if let parsedMetadata {
+            return parsedMetadata
+        } else if let data = rawMetadata?.data(using: .utf8) {
+            // Decode and cache metadata
+            let decoder = JSONDecoder()
+            decoder.keyDecodingStrategy = .convertFromSnakeCase
+            let metadata = try? decoder.decode(Episode.Metadata.self, from: data)
+            parsedMetadata = metadata
+            return metadata
+        }
+
+        return nil
+    }
+
     public struct Metadata: Decodable {
         public let showNotes: String?
         public let image: String?

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Episode.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Episode.swift
@@ -45,6 +45,7 @@ public class Episode: NSObject, BaseEpisode {
     @objc public var hasOnlyUuid = false
     @objc public var deselectedChapters: String?
     @objc public var deselectedChaptersModified = 0 as Int64
+    @objc public var rawMetadata: String?
 
     public var hasBookmarks: Bool {
         DataManager.sharedManager.bookmarks.bookmarkCount(forEpisode: uuid) > 0

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/UserEpisode.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/UserEpisode.swift
@@ -35,6 +35,7 @@ public class UserEpisode: NSObject, BaseEpisode {
     @objc public var deselectedChaptersModified = 0 as Int64
     @objc public var image: String?
     @objc public var showNotes: String?
+    @objc public var rawMetadata: String?
 
     // UserEpisode's are never archived or starred
     public var archived = false

--- a/podcasts/DeveloperMenu.swift
+++ b/podcasts/DeveloperMenu.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import PocketCastsServer
 import PocketCastsDataModel
+import Kingfisher
 
 struct DeveloperMenu: View {
     var body: some View {
@@ -26,6 +27,12 @@ struct DeveloperMenu: View {
 
                 Button("Force Reload Discover") {
                     NotificationCenter.postOnMainThread(notification: Constants.Notifications.chartRegionChanged)
+                }
+
+                Button("Clear URL + Image Caches") {
+                    URLCache.shared.removeAllCachedResponses()
+                    ImageManager.sharedManager.clearCaches()
+                    KingfisherManager.shared.cache.clearCache()
                 }
 
                 Button("Unsubscribe from all Podcasts") {

--- a/podcasts/EpisodeDetailViewController+ShowNotes.swift
+++ b/podcasts/EpisodeDetailViewController+ShowNotes.swift
@@ -38,7 +38,7 @@ extension EpisodeDetailViewController: WKNavigationDelegate, SFSafariViewControl
             let podcastUUID = episode.parentIdentifier()
             let episodeUUID = episode.uuid
             Task { [weak self] in
-                if let showNotes = try? await ShowInfoCoordinator.shared.loadShowNotes(podcastUuid: podcastUUID, episodeUuid: episodeUUID) {
+                if let showNotes = await self?.episode.loadMetadata()?.showNotes {
                     self?.downloadingShowNotes = false
                     self?.showNotesDidLoad(showNotes: showNotes)
                 }

--- a/podcasts/ImageManager.swift
+++ b/podcasts/ImageManager.swift
@@ -524,4 +524,14 @@ class ImageManager {
             return Int(320.0 * UIScreen.main.scale)
         }
     }
+
+    /// Clears all of the caches (disk + memory) managed by this instance.
+    func clearCaches() {
+        subscribedPodcastsCache.clearCache()
+        userEpisodeCache.clearCache()
+        userEpisodeCache.clearCache()
+        discoverCache.clearCache()
+        networkImageCache.clearCache()
+        searchImageCache.clearCache()
+    }
 }

--- a/podcasts/PodcastImageView.swift
+++ b/podcasts/PodcastImageView.swift
@@ -33,10 +33,10 @@ class PodcastImageView: UIView {
         currentEpisode = episode
 
         Task {
+            imageView.kf.cancelDownloadTask()
             if FeatureFlag.episodeFeedArtwork.enabled, Settings.loadEmbeddedImages, let episodeArtworkUrl = try? await ShowInfoCoordinator.shared.loadEpisodeArtworkUrl(podcastUuid: episode.parentIdentifier(), episodeUuid: episode.uuid) {
 
                 ImageManager.sharedManager.setPlaceholder(imageView: imageView, size: size)
-                imageView.kf.cancelDownloadTask()
 
                 // The app might run into the case where the episode changed but there's still
                 // a pending task to display the image of another episode

--- a/podcasts/ShowInfoCoordinator.swift
+++ b/podcasts/ShowInfoCoordinator.swift
@@ -10,6 +10,7 @@ actor ShowInfoCoordinator: ShowInfoCoordinating {
     private let dataManager: DataManager
 
     private var requestingShowInfo: [String: Task<Episode.Metadata?, Error>] = [:]
+    private var requestingRawMetadata: [String: Task<String?, Error>] = [:]
 
     init(
         dataRetriever: ShowInfoDataRetriever = ShowInfoDataRetriever(),
@@ -61,6 +62,39 @@ actor ShowInfoCoordinator: ShowInfoCoordinating {
         }
 
         return try await requestShowInfo(podcastUuid: podcastUuid, episodeUuid: episodeUuid)
+    }
+
+    func loadRawMetadata(
+        podcastUuid: String,
+        episodeUuid: String
+    ) async throws -> String? {
+        if let metadata = try? await dataManager.findRawEpisodeMetadata(uuid: episodeUuid) {
+            return metadata
+        }
+
+        return try await requestRawMetadata(podcastUuid: podcastUuid, episodeUuid: episodeUuid)
+    }
+
+    @discardableResult
+    func requestRawMetadata(
+        podcastUuid: String,
+        episodeUuid: String
+    ) async throws -> String? {
+        if let task = requestingRawMetadata[podcastUuid] {
+            return try await task.value
+        }
+
+        let task = Task<String?, Error> { [unowned self] in
+            let data = try await dataRetriever.loadShowInfoData(for: podcastUuid)
+            try await dataManager.storeShowInfo(data: data)
+            let episode = try await dataManager.findRawEpisodeMetadata(uuid: episodeUuid)
+            requestingRawMetadata[podcastUuid] = nil
+            return episode
+        }
+
+        requestingRawMetadata[podcastUuid] = task
+
+        return try await task.value
     }
 
     @discardableResult

--- a/podcasts/ShowInfoCoordinator.swift
+++ b/podcasts/ShowInfoCoordinator.swift
@@ -119,3 +119,14 @@ actor ShowInfoCoordinator: ShowInfoCoordinating {
         return try await task.value
     }
 }
+
+extension Episode {
+    func loadMetadata() async -> Metadata? {
+        if let metadata {
+            return metadata
+        }
+
+        rawMetadata = try? await ShowInfoCoordinator.shared.loadRawMetadata(podcastUuid: parentIdentifier(), episodeUuid: uuid)
+        return metadata
+    }
+}

--- a/podcasts/ShowNotesPlayerItemViewController.swift
+++ b/podcasts/ShowNotesPlayerItemViewController.swift
@@ -133,7 +133,7 @@ class ShowNotesPlayerItemViewController: PlayerItemViewController, SFSafariViewC
             let podcastUUID = episode.parentIdentifier()
             let episodeUUID = episode.uuid
             Task { [weak self] in
-                if let showNotes = try? await ShowInfoCoordinator.shared.loadShowNotes(podcastUuid: podcastUUID, episodeUuid: episodeUUID) {
+                if let showNotes = await episode.loadMetadata()?.showNotes {
                     self?.downloadingShowNotes = false
                     self?.displayShowNotes(showNotes)
 


### PR DESCRIPTION
This refactor the metadata retrieval/saving/parsing to use less resources.

Before, for retrieving any metada we would:

1. Read the database to see if the value was there
2. If it was, we would return the string in which would be converted to the entity (using `JSONDecoder`)
3. If it wasn't, we would request the metadata
4. After saving the metadata we would call the database to return the data and convert it

Now it is:

1. The metadata is coupled to the episode, if it's already there, it will be returned and no additional calls will be made. The only thing will happen is a one-time conversion to the entity (using `JSONDecoder`)
2. If it's not, it will request, save to the database and return it. However, it will save this data to the current `Episode` so there won't be the need to call this again

## To test

1. Run this on top of `trunk` (to ensure migrations are correct)
2. ✅ Test the episode artwork displays fine in different places
3. ✅  Open episodes and ensure the "Details" are shown correct

(No changes were made to chapters as this happens just once per playing episode).

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
