### PR TITLE
Disable performance tests for AutoAddCandidatesDataManager

### DIFF
--- a/PocketCastsTests/UnitTests.xctestplan
+++ b/PocketCastsTests/UnitTests.xctestplan
@@ -63,6 +63,10 @@
       }
     },
     {
+      "skippedTests" : [
+        "AutoAddCandidatesDataManagerTests\/testNewQueryPerformance()",
+        "AutoAddCandidatesDataManagerTests\/testOldQueryPerformance()"
+      ],
       "target" : {
         "containerPath" : "container:Modules\/DataModel",
         "identifier" : "PocketCastsDataModelTests",


### PR DESCRIPTION
These tests are failing in CI and keeping track of baselines between local machines and CI may prove difficult. Skipping them for now.

## To test

* 🟢 CI is green
* Run Unit Tests locally and make sure they pass

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
