### PR TITLE
[Standard Tags] Cancel loading previous images to avoid unnecessary CPU/Network usage

### DIFF
--- a/podcasts/ImageManager.swift
+++ b/podcasts/ImageManager.swift
@@ -113,6 +113,7 @@ class ImageManager {
     // MARK: - Subscribed Podcast Images
 
     func loadImage(podcastUuid: String, imageView: UIImageView, size: PodcastThumbnailSize, showPlaceHolder: Bool) {
+        imageView.kf.cancelDownloadTask()
         let url = podcastUrl(imageSize: size, uuid: podcastUuid)
         let placeholderImage = showPlaceHolder ? placeHolderImage(size) : nil
         let processor = Theme.sharedTheme.activeTheme == .radioactive ? radioactiveProcessor() : DefaultImageProcessor.default
@@ -120,6 +121,7 @@ class ImageManager {
     }
 
     func loadImage(url urlString: String, imageView: UIImageView, size: PodcastThumbnailSize, showPlaceHolder: Bool) {
+        imageView.kf.cancelDownloadTask()
         let url = URL(string: urlString)!
         let placeholderImage = showPlaceHolder ? placeHolderImage(size) : nil
         let processor = (Theme.sharedTheme.activeTheme == .radioactive ? radioactiveProcessor() : DefaultImageProcessor.default) |> DownsamplingImageProcessor(size: CGSize(width: ImageManager.sizeFor(imageSize: size), height: ImageManager.sizeFor(imageSize: size)))

--- a/podcasts/PodcastImageView.swift
+++ b/podcasts/PodcastImageView.swift
@@ -37,8 +37,6 @@ class PodcastImageView: UIView {
         Task {
             if FeatureFlag.episodeFeedArtwork.enabled, Settings.loadEmbeddedImages, let episodeArtworkUrl = await episode.loadMetadata()?.image {
 
-                imageView.kf.cancelDownloadTask()
-
                 // The app might run into the case where the episode changed but there's still
                 // a pending task to display the image of another episode
                 // This can happen when dequeing a cell, for example.


### PR DESCRIPTION
This fixes an issue in which in a long list of episodes and with episode artwork enabled if you scroll too fast, many images will be queued to download and process (downsampling).

This results in images taking too long to appear and spending a lot of CPU/network usage.

[For more information please check this link](https://github.com/onevcat/Kingfisher/wiki/Cheat-Sheet#cancelling-unnecessary-downloading-tasks).

## To test

Before testing, change `loadImage(url urlString: String, imageView: UIImageView, size: PodcastThumbnailSize, showPlaceHolder: Bool)` in `ImageManager.swift` to:

```
    func loadImage(url urlString: String, imageView: UIImageView, size: PodcastThumbnailSize, showPlaceHolder: Bool) {
        imageView.kf.cancelDownloadTask()
        print("🐸 Loading \(urlString)")
        let url = URL(string: urlString)!
        let placeholderImage = showPlaceHolder ? placeHolderImage(size) : nil
        let processor = (Theme.sharedTheme.activeTheme == .radioactive ? radioactiveProcessor() : DefaultImageProcessor.default) |> DownsamplingImageProcessor(size: CGSize(width: ImageManager.sizeFor(imageSize: size), height: ImageManager.sizeFor(imageSize: size)))
        imageView.kf.setImage(with: url, placeholder: placeholderImage, options: [.processor(processor), .targetCache(subscribedPodcastsCache), .cacheOriginalImage, .transition(.fade(Constants.Animation.defaultAnimationTime))]) { result in
            switch result {
            case .success(_):
                print("🐸 Done loading \(urlString)")
            case .failure(let error):
                print("🐸 Failed loading \(urlString): \(error.localizedDescription)")
            }
        }
    }
```

This way you can check logs to understand what's going on.

1. Run the app
2. Go to Profile > Settings > Clear URL + Image Caches
3. Go to Filters
4. Open a filter with many many episodes
5. Scroll down to the end of the list as fast as you can
6. ✅ The images shouldn't take absurdly long to appear (in a good connection)
7. Check the app logs
8. ✅ You should see many "The session task was cancelled. Task: Kingfisher.SessionDataTask, cancel token: 0."

You'll still see a few "Retrieving resource succeeded, but this source is not the one currently expected." I believe this happens because some images can load before another one is set. As long as this is not displayed a lot we should be fine.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
