### PR TITLE
Settings Sync: Only execute podcast cache at end of import

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/PodcastDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/PodcastDataManager.swift
@@ -316,7 +316,7 @@ class PodcastDataManager {
 
     // MARK: - Updates
 
-    func save(podcast: Podcast, dbQueue: FMDatabaseQueue) {
+    func save(podcast: Podcast, dbQueue: FMDatabaseQueue, cache: Bool = true) {
         // Get the existing podcast to compare if folder is being changed
         let existingPodcast = DataManager.sharedManager.findPodcast(uuid: podcast.uuid)
 
@@ -338,7 +338,9 @@ class PodcastDataManager {
                 FileLog.shared.addMessage("PodcastDataManager.save error: \(error)")
             }
         }
-        cachePodcasts(dbQueue: dbQueue)
+        if cache {
+            cachePodcasts(dbQueue: dbQueue)
+        }
     }
 
     func bulkSetFolderUuid(folderUuid: String, podcastUuids: [String], dbQueue: FMDatabaseQueue) {

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -290,8 +290,8 @@ public class DataManager {
         podcastManager.delete(podcast: podcast, dbQueue: dbQueue)
     }
 
-    public func save(podcast: Podcast) {
-        podcastManager.save(podcast: podcast, dbQueue: dbQueue)
+    public func save(podcast: Podcast, cache: Bool = true) {
+        podcastManager.save(podcast: podcast, dbQueue: dbQueue, cache: cache)
     }
 
     public func savePushSetting(podcast: Podcast, pushEnabled: Bool) {

--- a/PocketCastsTests/UnitTests.xctestplan
+++ b/PocketCastsTests/UnitTests.xctestplan
@@ -54,7 +54,8 @@
     {
       "skippedTests" : [
         "IAPHelperTests",
-        "IAPHelperTests\/testPurchase()"
+        "IAPHelperTests\/testPurchase()",
+        "PodcastSettingsImportUserDefaultsTests\/testImportPerformance()"
       ],
       "target" : {
         "containerPath" : "container:podcasts.xcodeproj",

--- a/podcasts/DataManager+Import.swift
+++ b/podcasts/DataManager+Import.swift
@@ -5,7 +5,7 @@ extension DataManager {
     func importPodcastSettings() {
         let podcasts = allPodcasts(includeUnsubscribed: true)
 
-        podcasts.forEach { podcast in
+        podcasts.enumerated().forEach { (idx, podcast) in
             podcast.settings.$autoStartFrom = ModifiedDate<Int32>(wrappedValue: podcast.startFrom)
             podcast.settings.$autoSkipLast = ModifiedDate<Int32>(wrappedValue: podcast.skipLast)
             podcast.settings.$playbackSpeed = ModifiedDate<Double>(wrappedValue: podcast.playbackSpeed)
@@ -36,7 +36,7 @@ extension DataManager {
                 podcast.settings.autoUpNextSetting = setting
             }
 
-            save(podcast: podcast)
+            save(podcast: podcast, cache: idx == podcasts.endIndex)
         }
     }
 }


### PR DESCRIPTION
Fixes #1600

In executing settings import, we import and `save` each podcast inside of a loop. `save` triggers `cachePodcasts`, which queries and decodes each and every podcast in the app on every iteration. This causes very high execution time for long lists of Podcasts.

We shouldn't use `save` in this manner and, instead, should wait to update the cache until all updates are complete.

I added a unit test to cover this:

#### Before

![CleanShot 2024-04-04 at 16 15 18@2x](https://github.com/Automattic/pocket-casts-ios/assets/3250/c65a8b4e-e78e-4aea-aec3-90bd7d89a9fd)

#### After

![CleanShot 2024-04-04 at 16 12 09@2x](https://github.com/Automattic/pocket-casts-ios/assets/3250/b74b90e2-b267-4b3e-ab97-dc1cac4f8f06)

### Alternatives

We could call `update` on a list of podcast IDs with each individual setting. I'm not sure how practical it is to `UPDATE` hundreds of records with different values. It seems like the issue here is calling `cachePodcasts` each time we `save`.

## To test

* Install version prior to 7.61
* Subscribe to several hundred podcasts
* Install 7.61
* Verify that app launches

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
