### PR TITLE
Categories Redesign: Pills

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/Discover/DiscoverServerHandler.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Discover/DiscoverServerHandler.swift
@@ -51,6 +51,20 @@ public class DiscoverServerHandler {
         }
     }
 
+    public func discoverCategories(source: String) async -> [DiscoverCategory] {
+        return await withCheckedContinuation { continuation in
+            DiscoverServerHandler.shared.discoverCategories(source: source, completion: { discoverCategories in
+                DispatchQueue.main.async {
+                    guard let discoverCategories = discoverCategories else {
+                        continuation.resume(returning: [])
+                        return
+                    }
+                    continuation.resume(returning: discoverCategories)
+                }
+            })
+        }
+    }
+
     public func discoverCategoryDetails(source: String, completion: @escaping (DiscoverCategoryDetails?) -> Void) {
         discoverRequest(path: source, type: DiscoverCategoryDetails.self) { categoryDetails, _ in
             completion(categoryDetails)

--- a/Modules/Server/Sources/PocketCastsServer/Public/Discover/DiscoverServerHandler.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Discover/DiscoverServerHandler.swift
@@ -1,5 +1,6 @@
 import Combine
 import Foundation
+import PocketCastsUtils
 
 public class DiscoverServerHandler {
     enum DiscoverServerError: Error {
@@ -28,7 +29,14 @@ public class DiscoverServerHandler {
     }
 
     public func discoverPage(completion: @escaping (DiscoverLayout?, Bool) -> Void) {
-        discoverRequest(path: ServerConstants.Urls.discover() + "ios/content.json", type: DiscoverLayout.self) { discoverItems, cachedResponse in
+        let contentPath: String
+        if FeatureFlag.categoriesRedesign.enabled {
+            contentPath = "ios/content_v2.json"
+        } else {
+            contentPath = "ios/content.json"
+        }
+
+        discoverRequest(path: ServerConstants.Urls.discover() + contentPath, type: DiscoverLayout.self) { discoverItems, cachedResponse in
             completion(discoverItems, cachedResponse)
         }
     }

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
@@ -268,6 +268,7 @@ public struct DiscoverItem: Decodable {
     public var curated: Bool?
     public var regions: [String]
     public var isSponsored: Bool?
+    public var popular: [Int]?
 
     public enum CodingKeys: String, CodingKey {
         case summaryStyle = "summary_style"
@@ -275,7 +276,7 @@ public struct DiscoverItem: Decodable {
         case isSponsored = "sponsored"
         case sponsoredPodcasts = "sponsored_podcasts"
         case expandedTopItemLabel = "expanded_top_item_label"
-        case type, title, source, regions, curated, uuid
+        case type, title, source, regions, curated, uuid, popular
     }
 }
 

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1593,6 +1593,8 @@
 		E3F37447291F0DD1005916ED /* Chapters.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3F37445291F0DD1005916ED /* Chapters.swift */; };
 		F5197A402B995A1E007C8D0A /* DownloadManager+Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5197A3F2B995A1E007C8D0A /* DownloadManager+Logging.swift */; };
 		F5197A412B995A1E007C8D0A /* DownloadManager+Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5197A3F2B995A1E007C8D0A /* DownloadManager+Logging.swift */; };
+		F52B4F8C2BB4A9CA00E87BE4 /* CategoriesSelectorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F52B4F8B2BB4A9CA00E87BE4 /* CategoriesSelectorViewController.swift */; };
+		F52B4F8E2BB4A9ED00E87BE4 /* CategoriesSelectorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F52B4F8D2BB4A9ED00E87BE4 /* CategoriesSelectorView.swift */; };
 		F55449422B758E8300F68AE9 /* PocketCastsUtils in Frameworks */ = {isa = PBXBuildFile; productRef = F55449412B758E8300F68AE9 /* PocketCastsUtils */; };
 		F55449432B758E8300F68AE9 /* PocketCastsUtils in Embed Frameworks */ = {isa = PBXBuildFile; productRef = F55449412B758E8300F68AE9 /* PocketCastsUtils */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		F55449452B75935F00F68AE9 /* AppSettings+ImportUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = F55449442B75935F00F68AE9 /* AppSettings+ImportUserDefaults.swift */; };
@@ -1602,6 +1604,7 @@
 		F5DBA58A2B756A8700AED77F /* PodcastSettings+ImportUserDefaultsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5DBA5892B756A8700AED77F /* PodcastSettings+ImportUserDefaultsTests.swift */; };
 		F5E431D62B50888500A71DB3 /* PlusLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5E431D52B50888500A71DB3 /* PlusLabel.swift */; };
 		F5E949DA2B61762E002DAFC3 /* TokenHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5E949D92B61762E002DAFC3 /* TokenHelperTests.swift */; };
+		F5F6DA702BBE1109009B1934 /* CategoryButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5F6DA6F2BBE1109009B1934 /* CategoryButtonStyle.swift */; };
 		FF2CD57C2B9F4B2D009B58B5 /* PocketCastsDataModel in Frameworks */ = {isa = PBXBuildFile; productRef = FF2CD57B2B9F4B2D009B58B5 /* PocketCastsDataModel */; };
 		FF2CD57E2B9F4B2D009B58B5 /* PocketCastsServer in Frameworks */ = {isa = PBXBuildFile; productRef = FF2CD57D2B9F4B2D009B58B5 /* PocketCastsServer */; };
 		FF2CD5802B9F4B2D009B58B5 /* PocketCastsUtils in Frameworks */ = {isa = PBXBuildFile; productRef = FF2CD57F2B9F4B2D009B58B5 /* PocketCastsUtils */; };
@@ -3367,6 +3370,8 @@
 		EF3DD428DC2C444C2D8CEC5A /* Pods-PocketCastsTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PocketCastsTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-PocketCastsTests/Pods-PocketCastsTests.debug.xcconfig"; sourceTree = "<group>"; };
 		EFBF99F57846D0E1AF8DE08D /* Pods-PocketCasts-PocketCastsTests.staging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PocketCasts-PocketCastsTests.staging.xcconfig"; path = "Pods/Target Support Files/Pods-PocketCasts-PocketCastsTests/Pods-PocketCasts-PocketCastsTests.staging.xcconfig"; sourceTree = "<group>"; };
 		F5197A3F2B995A1E007C8D0A /* DownloadManager+Logging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DownloadManager+Logging.swift"; sourceTree = "<group>"; };
+		F52B4F8B2BB4A9CA00E87BE4 /* CategoriesSelectorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoriesSelectorViewController.swift; sourceTree = "<group>"; };
+		F52B4F8D2BB4A9ED00E87BE4 /* CategoriesSelectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoriesSelectorView.swift; sourceTree = "<group>"; };
 		F55449442B75935F00F68AE9 /* AppSettings+ImportUserDefaults.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AppSettings+ImportUserDefaults.swift"; sourceTree = "<group>"; };
 		F565602E2B7ACD9B003E76D5 /* DataManager+Import.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DataManager+Import.swift"; sourceTree = "<group>"; };
 		F5AD75442B7FDC2800D65C55 /* SettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsTests.swift; sourceTree = "<group>"; };
@@ -3374,6 +3379,7 @@
 		F5DBA5892B756A8700AED77F /* PodcastSettings+ImportUserDefaultsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PodcastSettings+ImportUserDefaultsTests.swift"; sourceTree = "<group>"; };
 		F5E431D52B50888500A71DB3 /* PlusLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlusLabel.swift; sourceTree = "<group>"; };
 		F5E949D92B61762E002DAFC3 /* TokenHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenHelperTests.swift; sourceTree = "<group>"; };
+		F5F6DA6F2BBE1109009B1934 /* CategoryButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryButtonStyle.swift; sourceTree = "<group>"; };
 		FF47245A2BA4749F00EA916B /* MenuRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuRow.swift; sourceTree = "<group>"; };
 		FF4724602BA48CA900EA916B /* FiltersListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FiltersListView.swift; sourceTree = "<group>"; };
 		FF4724622BA48E8D00EA916B /* FiltersListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FiltersListViewModel.swift; sourceTree = "<group>"; };
@@ -7227,6 +7233,7 @@
 		D4DA5CAA1739ED4C003FE24B /* Discovery */ = {
 			isa = PBXGroup;
 			children = (
+				F5F6DA6E2BBE10E2009B1934 /* Categories */,
 				BD4CA19821096D920052F93E /* Summary Items */,
 				4006E30E23A8662100174DEB /* Expanded Items */,
 				BD98C5511BA808CF00E85D3B /* Cells */,
@@ -7260,6 +7267,16 @@
 				8B413D152B76B3A500FAB502 /* ChapterManagerTests.swift */,
 			);
 			path = Chapters;
+			sourceTree = "<group>";
+		};
+		F5F6DA6E2BBE10E2009B1934 /* Categories */ = {
+			isa = PBXGroup;
+			children = (
+				F52B4F8B2BB4A9CA00E87BE4 /* CategoriesSelectorViewController.swift */,
+				F52B4F8D2BB4A9ED00E87BE4 /* CategoriesSelectorView.swift */,
+				F5F6DA6F2BBE1109009B1934 /* CategoryButtonStyle.swift */,
+			);
+			path = Categories;
 			sourceTree = "<group>";
 		};
 		FFC293972B6172E90059F3BB /* InAppPurchases */ = {
@@ -8903,6 +8920,7 @@
 				40FFAD8A2147831400024FCF /* PlaylistViewController+CollectionView.swift in Sources */,
 				BDA1E8161EDD28700098FB9D /* SonosLinkController.swift in Sources */,
 				BD79EACD20D3805900E96572 /* ThemeSecondaryButton.swift in Sources */,
+				F52B4F8E2BB4A9ED00E87BE4 /* CategoriesSelectorView.swift in Sources */,
 				400A3F032277CB3A007361C7 /* NewEmailViewController.swift in Sources */,
 				BDF9DDDB1B8AD29C00E77B35 /* TimeSliderLayer.swift in Sources */,
 				BDB1E4ED1B8C5BCF009AD30F /* FeaturedSummaryViewController.swift in Sources */,
@@ -8988,6 +9006,7 @@
 				C7AF7B912925E5CD002F0025 /* PlusHostingViewController.swift in Sources */,
 				4007B060230E3A81008DDCF5 /* WhatsNewStructs.swift in Sources */,
 				4041FE8D218A7DA60089D4A1 /* SiriShortcutEnabledCell.swift in Sources */,
+				F52B4F8C2BB4A9CA00E87BE4 /* CategoriesSelectorViewController.swift in Sources */,
 				BD5C39541B5E0A2A00C3A499 /* ShiftyLoadingAlert.swift in Sources */,
 				BD2D0AD3243C4138000B313A /* MainEpisodeActionView+Pointer.swift in Sources */,
 				C7E99F092A5E105600E7CBAF /* MultiSelectRow.swift in Sources */,
@@ -9388,6 +9407,7 @@
 				BD92323523629F7B00C1E118 /* PlayerItemViewController.swift in Sources */,
 				103F7DF12BAB158600C44487 /* ShowInfoCoordinator.swift in Sources */,
 				BDB1E4F61B8C5BF9009AD30F /* NetworkSummaryViewController.swift in Sources */,
+				F5F6DA702BBE1109009B1934 /* CategoryButtonStyle.swift in Sources */,
 				404A080724E215A200308722 /* CheckboxSubtitleCell.swift in Sources */,
 				C7A110F0291EFF7A00887A90 /* PlusPurchaseModel.swift in Sources */,
 				409C7929222369C800386495 /* UserEpisodeDetailViewController.swift in Sources */,

--- a/podcasts/Categories/CategoriesSelectorView.swift
+++ b/podcasts/Categories/CategoriesSelectorView.swift
@@ -1,0 +1,112 @@
+import SwiftUI
+import PocketCastsServer
+
+struct Category {
+    let title: String
+    let image: String
+}
+
+struct CategoriesSelectorView: View {
+    @ObservedObject var observable: CategoriesSelectorViewController.Observable
+
+    @State private var categories: [DiscoverCategory]?
+
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack {
+                if let categories {
+                    CategoriesPillsView(categories: categories)
+                        .environmentObject(Theme.sharedTheme)
+                } else {
+                    PlaceholderPillsView()
+                }
+            }
+            .padding(16)
+        }
+        .task(id: observable.item?.source) {
+            guard let source = observable.item?.source else { return }
+            categories = await DiscoverServerHandler.shared.discoverCategories(source: source)
+        }
+    }
+}
+
+struct PlaceholderPillsView: View {
+    var body: some View {
+        ForEach(0..<10) { _ in
+            Button(action: {}, label: {
+                Text("Placeholder")
+            })
+            .buttonStyle(CategoryButtonStyle())
+            .environmentObject(Theme.sharedTheme)
+            .redacted(reason: .placeholder)
+        }
+    }
+}
+
+struct CategoriesPillsView: View {
+    @State private var showingCategories = false
+
+    @State private var selectedCategory: DiscoverCategory?
+
+    @Namespace private var animation
+
+    let categories: [DiscoverCategory]
+
+    var body: some View {
+        if let selectedCategory {
+            CloseButton(selectedCategory: $selectedCategory)
+            CategoryButton(category: selectedCategory, selectedCategory: $selectedCategory)
+                .matchedGeometryEffect(id: selectedCategory.id, in: animation)
+        } else {
+            Button(action: {
+                showingCategories.toggle()
+            }, label: {
+                HStack {
+                    Text("All Categories")
+                    Image(systemName: "chevron.down")
+                }
+            })
+            .buttonStyle(CategoryButtonStyle())
+            ForEach(categories, id: \.id) { category in
+                CategoryButton(category: category, selectedCategory: $selectedCategory)
+                .matchedGeometryEffect(id: category.id, in: animation)
+            }
+        }
+    }
+}
+
+struct CloseButton: View {
+    @Binding var selectedCategory: DiscoverCategory?
+
+    var body: some View {
+        Button(action: {
+            withAnimation {
+                self.selectedCategory = nil
+            }
+        }, label: {
+            Image(systemName: "xmark")
+        })
+        .buttonStyle(CategoryButtonStyle())
+    }
+}
+
+struct CategoryButton: View {
+    let category: DiscoverCategory
+
+    @Binding var selectedCategory: DiscoverCategory?
+
+    var isSelected: Bool {
+        category.id == selectedCategory?.id
+    }
+
+    var body: some View {
+        Button(action: {
+            withAnimation {
+                selectedCategory = category
+            }
+        }, label: {
+            Text(category.name ?? "")
+        })
+        .buttonStyle(CategoryButtonStyle(isSelected: isSelected))
+    }
+}

--- a/podcasts/Categories/CategoriesSelectorView.swift
+++ b/podcasts/Categories/CategoriesSelectorView.swift
@@ -7,7 +7,7 @@ struct Category {
 }
 
 struct CategoriesSelectorView: View {
-    @ObservedObject var observable: CategoriesSelectorViewController.Observable
+    @ObservedObject var discoverItemObservable: CategoriesSelectorViewController.DiscoverItemObservable
 
     @State private var categories: [DiscoverCategory]?
     @State private var popular: [DiscoverCategory]?
@@ -24,13 +24,13 @@ struct CategoriesSelectorView: View {
             }
             .padding(16)
         }
-        .task(id: observable.item?.source) {
-            guard let source = observable.item?.source else { return }
+        .task(id: discoverItemObservable.item?.source) {
+            guard let source = discoverItemObservable.item?.source else { return }
             let categories = await DiscoverServerHandler.shared.discoverCategories(source: source)
             self.categories = categories
             popular = categories.filter {
                 guard let id = $0.id else { return false }
-                return observable.item?.popular?.contains(id) == true
+                return discoverItemObservable.item?.popular?.contains(id) == true
             }
         }
     }

--- a/podcasts/Categories/CategoriesSelectorView.swift
+++ b/podcasts/Categories/CategoriesSelectorView.swift
@@ -10,12 +10,13 @@ struct CategoriesSelectorView: View {
     @ObservedObject var observable: CategoriesSelectorViewController.Observable
 
     @State private var categories: [DiscoverCategory]?
+    @State private var popular: [DiscoverCategory]?
 
     var body: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack {
-                if let categories {
-                    CategoriesPillsView(categories: categories)
+                if let popular {
+                    CategoriesPillsView(categories: popular)
                         .environmentObject(Theme.sharedTheme)
                 } else {
                     PlaceholderPillsView()
@@ -25,7 +26,12 @@ struct CategoriesSelectorView: View {
         }
         .task(id: observable.item?.source) {
             guard let source = observable.item?.source else { return }
-            categories = await DiscoverServerHandler.shared.discoverCategories(source: source)
+            let categories = await DiscoverServerHandler.shared.discoverCategories(source: source)
+            self.categories = categories
+            popular = categories.filter {
+                guard let id = $0.id else { return false }
+                return observable.item?.popular?.contains(id) == true
+            }
         }
     }
 }

--- a/podcasts/Categories/CategoriesSelectorViewController.swift
+++ b/podcasts/Categories/CategoriesSelectorViewController.swift
@@ -3,11 +3,11 @@ import PocketCastsServer
 
 class CategoriesSelectorViewController: UIHostingController<CategoriesSelectorView>, DiscoverSummaryProtocol {
 
-    class Observable: ObservableObject {
+    class DiscoverItemObservable: ObservableObject {
         @Published public var item: DiscoverItem?
     }
 
-    @ObservedObject fileprivate var observable: Observable
+    @ObservedObject fileprivate var observable: DiscoverItemObservable
 
     func registerDiscoverDelegate(_ delegate: any DiscoverDelegate) {}
 
@@ -17,10 +17,10 @@ class CategoriesSelectorViewController: UIHostingController<CategoriesSelectorVi
     }
 
     init() {
-        let observable = Observable()
+        let observable = DiscoverItemObservable()
         self.observable = observable
 
-        super.init(rootView: CategoriesSelectorView(observable: observable))
+        super.init(rootView: CategoriesSelectorView(discoverItemObservable: observable))
         if #available(iOS 16.0, *) {
             sizingOptions =  [.intrinsicContentSize]
         }

--- a/podcasts/Categories/CategoriesSelectorViewController.swift
+++ b/podcasts/Categories/CategoriesSelectorViewController.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+import PocketCastsServer
+
+class CategoriesSelectorViewController: UIHostingController<CategoriesSelectorView> {
+    init(item: DiscoverItem) {
+        super.init(rootView: CategoriesSelectorView(item: item))
+        if #available(iOS 16.0, *) {
+            sizingOptions =  [.intrinsicContentSize]
+        }
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        if #available(iOS 16.0, *) {
+        } else {
+            self.view.invalidateIntrinsicContentSize()
+        }
+    }
+}

--- a/podcasts/Categories/CategoriesSelectorViewController.swift
+++ b/podcasts/Categories/CategoriesSelectorViewController.swift
@@ -1,12 +1,30 @@
 import SwiftUI
 import PocketCastsServer
 
-class CategoriesSelectorViewController: UIHostingController<CategoriesSelectorView> {
-    init(item: DiscoverItem) {
-        super.init(rootView: CategoriesSelectorView(item: item))
+class CategoriesSelectorViewController: UIHostingController<CategoriesSelectorView>, DiscoverSummaryProtocol {
+
+    class Observable: ObservableObject {
+        @Published public var item: DiscoverItem?
+    }
+
+    @ObservedObject fileprivate var observable: Observable
+
+    func registerDiscoverDelegate(_ delegate: any DiscoverDelegate) {}
+
+    func populateFrom(item: PocketCastsServer.DiscoverItem) {
+        observable.item = item
+        view.setNeedsLayout()
+    }
+
+    init() {
+        let observable = Observable()
+        self.observable = observable
+
+        super.init(rootView: CategoriesSelectorView(observable: observable))
         if #available(iOS 16.0, *) {
             sizingOptions =  [.intrinsicContentSize]
         }
+        view.backgroundColor = nil
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/podcasts/Categories/CategoryButtonStyle.swift
+++ b/podcasts/Categories/CategoryButtonStyle.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+
+struct CategoryButtonStyle: ButtonStyle {
+
+    @EnvironmentObject var theme: Theme
+
+    private enum Constants {
+        enum Padding {
+            static let horizontal: CGFloat = 20
+            static let vertical: CGFloat = 8
+        }
+
+        static let cornerRadius: CGFloat = 24
+    }
+
+    // MARK: Colors
+    private var border: Color {
+        theme.primaryField03
+    }
+    private var background: Color {
+        theme.primaryUi02Active
+    }
+    private var foreground: Color {
+        theme.primaryText01
+    }
+    private var selectedBackground: Color {
+        theme.primaryField03Active
+    }
+    private var selectedForeground: Color {
+        theme.primaryUi01
+    }
+
+    // MARK: View
+
+    let isSelected: Bool
+
+    init(isSelected: Bool = false) {
+        self.isSelected = isSelected
+    }
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.callout.weight(.medium))
+            .fixedSize(horizontal: true, vertical: false)
+            .padding(.horizontal, Constants.Padding.horizontal)
+            .padding(.vertical, Constants.Padding.vertical)
+            .cornerRadius(Constants.cornerRadius)
+            .background(isSelected ? selectedBackground : (configuration.isPressed ? background : Color.clear))
+            .foregroundColor(isSelected ? selectedForeground : foreground)
+            .overlay(
+                RoundedRectangle(cornerRadius: Constants.cornerRadius)
+                    .stroke(isSelected ? selectedBackground : border, lineWidth: 1)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: Constants.cornerRadius))
+    }
+}

--- a/podcasts/DiscoverViewController.swift
+++ b/podcasts/DiscoverViewController.swift
@@ -233,8 +233,8 @@ class DiscoverViewController: PCViewController {
                 viewController.view.topAnchor.constraint(equalTo: previousView.bottomAnchor).isActive = true
             }
             viewController.view.bottomAnchor.constraint(equalTo: mainScrollView.bottomAnchor, constant: -65).isActive = true
-        } else if let previousView = summaryViewControllers.last?.view {
-            if summaryViewControllers.count == 1 {
+        } else if let previousVC = summaryViewControllers.last, let previousView = previousVC.view {
+            if previousVC is FeaturedSummaryViewController {
                 viewController.view.topAnchor.constraint(equalTo: previousView.bottomAnchor, constant: -10).isActive = true
                 mainScrollView.sendSubviewToBack(viewController.view)
             } else {

--- a/podcasts/DiscoverViewController.swift
+++ b/podcasts/DiscoverViewController.swift
@@ -171,17 +171,6 @@ class DiscoverViewController: PCViewController {
         self.discoverLayout = layout
         loadingIndicator.stopAnimating()
 
-        if FeatureFlag.categoriesRedesign.enabled {
-            let categoriesItem = items.first { item in
-                return item.type == "categories"
-            }
-
-            if let categoriesItem {
-                let categories = CategoriesSelectorViewController(item: categoriesItem)
-                addToScrollView(viewController: categories, isLast: false)
-            }
-        }
-
         let currentRegion = Settings.discoverRegion(discoverLayout: layout)
         for discoverItem in items {
             guard let type = discoverItem.type, let summaryStyle = discoverItem.summaryStyle, discoverItem.regions.contains(currentRegion) else { continue }
@@ -190,6 +179,8 @@ class DiscoverViewController: PCViewController {
             guard coordinator.shouldDisplay(discoverItem) else { continue }
 
             switch (type, summaryStyle, expandedStyle) {
+            case ("categories", "pills", _):
+                addSummaryController(CategoriesSelectorViewController(), discoverItem: discoverItem)
             case ("podcast_list", "carousel", _):
                 addSummaryController(FeaturedSummaryViewController(), discoverItem: discoverItem)
             case ("podcast_list", "small_list", _):
@@ -202,7 +193,7 @@ class DiscoverViewController: PCViewController {
                 addSummaryController(CollectionSummaryViewController(), discoverItem: discoverItem)
             case ("network_list", _, _):
                 addSummaryController(NetworkSummaryViewController(), discoverItem: discoverItem)
-            case ("categories", _, _):
+            case ("categories", "category", _):
                 addSummaryController(CategorySummaryViewController(regionCode: currentRegion), discoverItem: discoverItem)
             case ("episode_list", "single_episode", _):
                 addSummaryController(SingleEpisodeViewController(), discoverItem: discoverItem)

--- a/podcasts/DiscoverViewController.swift
+++ b/podcasts/DiscoverViewController.swift
@@ -1,5 +1,6 @@
 import PocketCastsServer
 import UIKit
+import PocketCastsUtils
 
 class DiscoverViewController: PCViewController {
     @IBOutlet var mainScrollView: UIScrollView!
@@ -169,6 +170,17 @@ class DiscoverViewController: PCViewController {
 
         self.discoverLayout = layout
         loadingIndicator.stopAnimating()
+
+        if FeatureFlag.categoriesRedesign.enabled {
+            let categoriesItem = items.first { item in
+                return item.type == "categories"
+            }
+
+            if let categoriesItem {
+                let categories = CategoriesSelectorViewController(item: categoriesItem)
+                addToScrollView(viewController: categories, isLast: false)
+            }
+        }
 
         let currentRegion = Settings.discoverRegion(discoverLayout: layout)
         for discoverItem in items {


### PR DESCRIPTION
### Changes

Adds a scrolling set of pills/chips to the top of Discover to navigate categories.

<img width=300 src="https://github.com/Automattic/pocket-casts-ios/assets/3250/88e1a503-cc45-4ae6-9760-91ea2a1c3de5">

<br/>

<img width=300 src="https://github.com/Automattic/pocket-casts-ios/assets/3250/69b65d29-75f1-4ba9-b243-da80987b6b8d">

<img width=300 src="https://github.com/Automattic/pocket-casts-ios/assets/3250/f7e42c2c-efb3-4c74-a27a-66b4a717a5b1">

<img width=300 src="https://github.com/Automattic/pocket-casts-ios/assets/3250/23f22d02-9959-478e-a643-988e2e107923">

<img width=300 src="https://github.com/Automattic/pocket-casts-ios/assets/3250/de23bb5f-4ae9-41e5-9cfb-a42206161f1f">

### Code Changes

* `CategoriesSelectorView` loads the categories from the Discover source and displays loading state
* `CategoriesPillsView` contains the pill layout and specific buttons
* `CategoryButtonStyle` encapsulates the style of these buttons with border, pressed and selected states
* `CategoriesSelectorViewController` is a `UIHostingController` which handles sizing, storing the observable for updating the Discover Item, and implementing `DiscoverSummaryProtocol`
* A new `DiscoverServerHandler.discoverCategories` async method is added to better interface with SwiftUI
* The `content_v2.json` file is used when the `categoriesRedesign` is enabled
* The new `pills` summaryStyle is used to differentiate this style from the old `category` style, which could still be returned if needed.

## To test

* Build using Staging configuration
* Enable the `categoriesRedesign` feature flag in Beta Features
* Navigate to Discover - If Discover doesn't reload for some reason, go to Developer menu and `Force Reload Discover`
* Verify that Category pills appear and they are not shown at the bottom of Discover
* Verify that tapping a pill changes state and hides other pills

### Known Issues

* Close button needs to be rounded and some other small styling tweaks will probably need to be made.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
