### PR TITLE
Categories Redesign: Discover loading changes

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
@@ -256,7 +256,7 @@ public struct DiscoverRegion: Decodable {
     public var flag: String
 }
 
-public struct DiscoverItem: Decodable {
+public struct DiscoverItem: Decodable, Equatable {
     public var id: String?
     public var uuid: String?
     public var title: String?
@@ -281,7 +281,7 @@ public struct DiscoverItem: Decodable {
     }
 }
 
-public struct CarouselSponsoredPodcast: Decodable {
+public struct CarouselSponsoredPodcast: Decodable, Equatable {
     public var position: Int?
     public var source: String?
 }

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
@@ -257,6 +257,7 @@ public struct DiscoverRegion: Decodable {
 }
 
 public struct DiscoverItem: Decodable {
+    public var id: String?
     public var uuid: String?
     public var title: String?
     public var type: String?
@@ -276,7 +277,7 @@ public struct DiscoverItem: Decodable {
         case isSponsored = "sponsored"
         case sponsoredPodcasts = "sponsored_podcasts"
         case expandedTopItemLabel = "expanded_top_item_label"
-        case type, title, source, regions, curated, uuid, popular
+        case type, title, source, regions, curated, uuid, popular, id
     }
 }
 

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
@@ -279,6 +279,22 @@ public struct DiscoverItem: Decodable, Equatable {
         case expandedTopItemLabel = "expanded_top_item_label"
         case type, title, source, regions, curated, uuid, popular, id
     }
+
+    public init(id: String? = nil, uuid: String? = nil, title: String? = nil, type: String? = nil, summaryStyle: String? = nil, expandedStyle: String? = nil, source: String? = nil, sponsoredPodcasts: [CarouselSponsoredPodcast]? = nil, expandedTopItemLabel: String? = nil, curated: Bool? = nil, regions: [String], isSponsored: Bool? = nil, popular: [Int]? = nil) {
+        self.id = id
+        self.uuid = uuid
+        self.title = title
+        self.type = type
+        self.summaryStyle = summaryStyle
+        self.expandedStyle = expandedStyle
+        self.source = source
+        self.sponsoredPodcasts = sponsoredPodcasts
+        self.expandedTopItemLabel = expandedTopItemLabel
+        self.curated = curated
+        self.regions = regions
+        self.isSponsored = isSponsored
+        self.popular = popular
+    }
 }
 
 public struct CarouselSponsoredPodcast: Decodable, Equatable {

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
@@ -280,20 +280,11 @@ public struct DiscoverItem: Decodable, Equatable {
         case type, title, source, regions, curated, uuid, popular, id
     }
 
-    public init(id: String? = nil, uuid: String? = nil, title: String? = nil, type: String? = nil, summaryStyle: String? = nil, expandedStyle: String? = nil, source: String? = nil, sponsoredPodcasts: [CarouselSponsoredPodcast]? = nil, expandedTopItemLabel: String? = nil, curated: Bool? = nil, regions: [String], isSponsored: Bool? = nil, popular: [Int]? = nil) {
+    public init(id: String? = nil, title: String? = nil, source: String? = nil, regions: [String]) {
         self.id = id
-        self.uuid = uuid
         self.title = title
-        self.type = type
-        self.summaryStyle = summaryStyle
-        self.expandedStyle = expandedStyle
         self.source = source
-        self.sponsoredPodcasts = sponsoredPodcasts
-        self.expandedTopItemLabel = expandedTopItemLabel
-        self.curated = curated
         self.regions = regions
-        self.isSponsored = isSponsored
-        self.popular = popular
     }
 }
 

--- a/podcasts/Categories/CategoriesSelectorView.swift
+++ b/podcasts/Categories/CategoriesSelectorView.swift
@@ -16,7 +16,7 @@ struct CategoriesSelectorView: View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack {
                 if let popular {
-                    CategoriesPillsView(categories: popular)
+                    CategoriesPillsView(categories: popular, selectedCategory: $observable.selectedCategory)
                         .environmentObject(Theme.sharedTheme)
                 } else {
                     PlaceholderPillsView()
@@ -50,13 +50,12 @@ struct PlaceholderPillsView: View {
 }
 
 struct CategoriesPillsView: View {
+    let categories: [DiscoverCategory]
+    @Binding var selectedCategory: DiscoverCategory?
+
     @State private var showingCategories = false
 
-    @State private var selectedCategory: DiscoverCategory?
-
     @Namespace private var animation
-
-    let categories: [DiscoverCategory]
 
     var body: some View {
         if let selectedCategory {

--- a/podcasts/Categories/CategoriesSelectorView.swift
+++ b/podcasts/Categories/CategoriesSelectorView.swift
@@ -16,7 +16,7 @@ struct CategoriesSelectorView: View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack {
                 if let popular {
-                    CategoriesPillsView(categories: popular, selectedCategory: $observable.selectedCategory)
+                    CategoriesPillsView(categories: popular, selectedCategory: $observable.selectedCategory.animation(.easeOut(duration: 0.25)))
                         .environmentObject(Theme.sharedTheme)
                 } else {
                     PlaceholderPillsView()
@@ -85,9 +85,7 @@ struct CloseButton: View {
 
     var body: some View {
         Button(action: {
-            withAnimation {
-                self.selectedCategory = nil
-            }
+            self.selectedCategory = nil
         }, label: {
             Image(systemName: "xmark")
         })
@@ -106,9 +104,7 @@ struct CategoryButton: View {
 
     var body: some View {
         Button(action: {
-            withAnimation {
-                selectedCategory = category
-            }
+            selectedCategory = category
         }, label: {
             Text(category.name ?? "")
         })

--- a/podcasts/Categories/CategoriesSelectorViewController.swift
+++ b/podcasts/Categories/CategoriesSelectorViewController.swift
@@ -1,15 +1,23 @@
 import SwiftUI
 import PocketCastsServer
+import Combine
 
 class CategoriesSelectorViewController: UIHostingController<CategoriesSelectorView>, DiscoverSummaryProtocol {
 
     class Observable: ObservableObject {
         @Published public var item: DiscoverItem?
+        @Published public var selectedCategory: DiscoverCategory?
     }
 
     @ObservedObject fileprivate var observable: Observable
 
-    func registerDiscoverDelegate(_ delegate: any DiscoverDelegate) {}
+    private weak var delegate: DiscoverDelegate?
+
+    private var cancellables: Set<AnyCancellable> = []
+
+    func registerDiscoverDelegate(_ delegate: any DiscoverDelegate) {
+        self.delegate = delegate
+    }
 
     func populateFrom(item: PocketCastsServer.DiscoverItem) {
         observable.item = item
@@ -25,6 +33,11 @@ class CategoriesSelectorViewController: UIHostingController<CategoriesSelectorVi
             sizingOptions =  [.intrinsicContentSize]
         }
         view.backgroundColor = nil
+
+        observable.$selectedCategory.sink { [weak self] category in
+            guard let item = observable.item else { return }
+            self?.delegate?.showExpanded(item: item, category: category)
+        }.store(in: &cancellables)
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/podcasts/CategoryPodcastsViewController.swift
+++ b/podcasts/CategoryPodcastsViewController.swift
@@ -18,7 +18,7 @@ class CategoryPodcastsViewController: PCViewController, UITableViewDelegate, UIT
     @IBOutlet var noNetworkView: UIView!
     @IBOutlet var loadingIndicator: UIActivityIndicatorView!
 
-    private weak var delegate: DiscoverDelegate?
+    weak var delegate: DiscoverDelegate?
 
     private var category: DiscoverCategory
     private var podcasts = [DiscoverPodcast]()

--- a/podcasts/DiscoverSummaryProtocol.swift
+++ b/podcasts/DiscoverSummaryProtocol.swift
@@ -10,6 +10,7 @@ protocol DiscoverDelegate: AnyObject {
     func show(podcastInfo: PodcastInfo, placeholderImage: UIImage?, isFeatured: Bool, listUuid: String?)
     func show(discoverPodcast: DiscoverPodcast, placeholderImage: UIImage?, isFeatured: Bool, listUuid: String?)
     func show(podcast: Podcast)
+    func showExpanded(item: DiscoverItem, category: DiscoverCategory?)
     func showExpanded(item: DiscoverItem, podcasts: [DiscoverPodcast], podcastCollection: PodcastCollection?)
     func showExpanded(item: DiscoverItem, episodes: [DiscoverEpisode], podcastCollection: PodcastCollection?)
     func replaceRegionCode(string: String?) -> String?

--- a/podcasts/DiscoverViewController+DiscoverDelegate.swift
+++ b/podcasts/DiscoverViewController+DiscoverDelegate.swift
@@ -3,6 +3,14 @@ import PocketCastsDataModel
 import PocketCastsServer
 
 extension DiscoverViewController: DiscoverDelegate {
+    func showExpanded(item: PocketCastsServer.DiscoverItem, category: PocketCastsServer.DiscoverCategory?) {
+        if let category {
+            reload(except: [item], category: category)
+        } else {
+            reloadDiscoverTapped(NSObject())
+        }
+    }
+
     func show(podcastInfo: PodcastInfo, placeholderImage: UIImage?, isFeatured: Bool, listUuid: String?) {
         let podcastController = PodcastViewController(podcastInfo: podcastInfo, existingImage: placeholderImage)
         podcastController.featuredPodcast = isFeatured

--- a/podcasts/DiscoverViewController.swift
+++ b/podcasts/DiscoverViewController.swift
@@ -145,6 +145,29 @@ class DiscoverViewController: PCViewController {
         }
     }
 
+    /// Reloads discover, keeping the items listed in `exclude`
+    /// - Parameters:
+    ///   - items: Items to exclude from the reload process. These items will REMAIN in Discover
+    ///   - category: The `DiscoverCategory` to add to the layout. This is sort of an artifical `DiscoverLayout`.
+    func reload(except items: [DiscoverItem], category: DiscoverCategory) {
+
+        let categoryVC = CategoryPodcastsViewController(category: category)
+        categoryVC.registerDiscoverDelegate(self)
+
+        //TODO: Allow this to accept a Discover Layout?
+        //TODO: Add fade animation
+        let item = DiscoverItem(id: "category-\(category.id ?? 0)", title: category.name, source: category.source, regions: items.first?.regions ?? [])
+
+        let itemsToRemove = Set(currentSnapshot?.itemIdentifiers ?? []).subtracting(items)
+        if var newSnapshot = currentSnapshot {
+            newSnapshot.deleteItems(Array(itemsToRemove))
+            newSnapshot.appendItems([item])
+            apply(snapshot: newSnapshot, currentRegion: Settings.discoverRegion(discoverLayout: discoverLayout!))
+            addToScrollView(viewController: categoryVC, for: item, isLast: true)
+        }
+        categoryVC.podcastsTable.isScrollEnabled = false
+    }
+
     private func showPageLoading() {
         loadingContent = true
 

--- a/podcasts/DiscoverViewController.swift
+++ b/podcasts/DiscoverViewController.swift
@@ -151,7 +151,7 @@ class DiscoverViewController: PCViewController {
     ///   - category: The `DiscoverCategory` to add to the layout. This is sort of an artifical `DiscoverLayout`.
     func reload(except items: [DiscoverItem], category: DiscoverCategory) {
         let categoryVC = CategoryPodcastsViewController(category: category)
-        categoryVC.registerDiscoverDelegate(self)
+        categoryVC.delegate = self
         categoryVC.view.alpha = 0
 
         let item = DiscoverItem(id: "category-\(category.id ?? 0)", title: category.name, source: category.source, regions: items.first?.regions ?? [])

--- a/podcasts/ThemeableTable.swift
+++ b/podcasts/ThemeableTable.swift
@@ -54,4 +54,17 @@ class ThemeableTable: UITableView {
         separatorColor = AppTheme.tableDividerColor(for: themeOverride)
         indicatorStyle = AppTheme.indicatorStyle()
     }
+
+    override var intrinsicContentSize: CGSize {
+        self.layoutIfNeeded()
+        return self.contentSize
+    }
+
+    override var contentSize: CGSize {
+        didSet {
+            UIView.performWithoutAnimation {
+                self.invalidateIntrinsicContentSize()
+            }
+        }
+    }
 }


### PR DESCRIPTION
Includes the changes necessary to reload Discover when selecting a category.

https://github.com/Automattic/pocket-casts-ios/assets/3250/91e80a75-d75e-40ff-b192-4c31cd0cd9e1

### Code Changes

* Adds an `NSDiffableDataSourceSnapshot` based `apply` method to `DiscoverViewController` - eventually, I think this screen should switch to using a `UICollectionView`, so this is a stepping stone in that direction.
* Adds a `showExpanded(item: DiscoverItem, category: DiscoverCategory?)` method to `DiscoverDelegate` for the `CategoriesSelectionViewController` to call.
* Adds a `reload(except: [DiscoverItem], category: DiscoverCategory)` method to `DiscoverViewController` which creates the `CategoryPodcastsViewController` and a new snapshot to reload Discover.
* Adds some animations by setting `alphas` of the added views to 0 and then animating them during the reload process.

## To test

* Build using the `Staging` build configuration
* Ensure the `categoriesRedesign` flag is on
* Navigate to the Discover tab
* Tap a Category Pill
* Notice that the Discover screen changes to a Category list but the Category Pills remain at the top and properly animate

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
