### PR TITLE
Standard Tags: ensure metadata is updated when it needs to do so

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/Cache/ShowInfoDataRetriever.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Cache/ShowInfoDataRetriever.swift
@@ -2,13 +2,9 @@ import Foundation
 
 /// Request information about an episode using the show notes endpoint
 public actor ShowInfoDataRetriever {
-    private let showNotesUrlCache: URLCache
-
     private var dataRequestMap: [String: Task<Data, Error>] = [:]
 
-    public init() {
-        showNotesUrlCache = URLCache(memoryCapacity: 1.megabytes, diskCapacity: 10.megabytes, diskPath: "show_notes")
-    }
+    public init() { }
 
     public func loadShowInfoData(
         for podcastUuid: String
@@ -20,14 +16,8 @@ public actor ShowInfoDataRetriever {
         let url = ServerHelper.asUrl(ServerConstants.Urls.cache() + "mobile/show_notes/full/\(podcastUuid)")
         let request = URLRequest(url: url, cachePolicy: .reloadRevalidatingCacheData)
 
-        if let cachedResponse = showNotesUrlCache.cachedResponse(for: request) {
-            return cachedResponse.data
-        }
-
         let task = Task<Data, Error> {
-            let (data, response) = try await URLSession.shared.data(for: request)
-            let responseToCache = CachedURLResponse(response: response, data: data)
-            showNotesUrlCache.storeCachedResponse(responseToCache, for: request)
+            let (data, _) = try await URLSession.shared.data(for: request)
             dataRequestMap[podcastUuid] = nil
             return data
         }


### PR DESCRIPTION
I discovered an issue with the cache system we're using to show metadata, it prevents new episodes from ever updating until the `URLCache` expires.

For the user, what it causes is that episode metadata (such as artwork, show notes) never updates. It works like this:

1. The app fetches the metadata and store in the `URLCache`
2. When a new episode is released the app requests `ShowInfoDataRetriever` for the metadata
3. It looks into the `URLCache` and returns the cached data there
4. The cached data don't contain the new episode

All I did was to remove the `URLCache`, given we do not need it anymore, as we're persisting episode metadata into the database.

## To test

To see the bug in action use the app installed on your phone, go to Podcasts > Sort By Episode Release Date > open any podcast new episode and see that the show notes never displays (you need to have loaded the show notes before, otherwise it will just work).

Anyway, the PR can still be tested by:

1. Run the app
2. Open any episode
3. ✅ Ensure the show notes (Details) appear correctly

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
