### PR TITLE
Deselect Chapters: enable for Plus users and general public announcement

### DIFF
--- a/podcasts/PaidFeature.swift
+++ b/podcasts/PaidFeature.swift
@@ -7,7 +7,7 @@ import SwiftUI
 
 extension PaidFeature {
     static var bookmarks: PaidFeature = .plusFeature
-    static var deselectChapters: PaidFeature = .inEarlyAccess
+    static var deselectChapters: PaidFeature = .plusFeature
     static var slumber: PaidFeature = .plusFeature
 }
 

--- a/podcasts/Whats New/Announcements.swift
+++ b/podcasts/Whats New/Announcements.swift
@@ -83,18 +83,18 @@ struct Announcements {
         ),
 
         // Deselect Chapters (Non-Patron general public announcement)
-//        .init(
-//            version: "7.61",
-//            header: AnyView(Image("deselect_chapters")),
-//            title: L10n.skipChapters,
-//            message: chaptersViewModel.plusFreeMessage,
-//            buttonTitle: chaptersViewModel.plusFreeButtonTitle,
-//            action: {
-//                chaptersViewModel.buttonAction()
-//            },
-//            isEnabled: chaptersViewModel.isPlusFreeAnnouncementEnabled,
-//            fullModal: true
-//        )
+        .init(
+            version: "7.61",
+            header: AnyView(Image("deselect_chapters")),
+            title: L10n.skipChapters,
+            message: chaptersViewModel.plusFreeMessage,
+            buttonTitle: chaptersViewModel.plusFreeButtonTitle,
+            action: {
+                chaptersViewModel.buttonAction()
+            },
+            isEnabled: chaptersViewModel.isPlusFreeAnnouncementEnabled,
+            fullModal: true
+        )
     ]
 }
 

--- a/podcasts/Whats New/DeselectChaptersAnnouncementViewModel.swift
+++ b/podcasts/Whats New/DeselectChaptersAnnouncementViewModel.swift
@@ -19,6 +19,7 @@ class DeselectChaptersAnnouncementViewModel {
         FeatureFlag.deselectChapters.enabled
             && PaidFeature.deselectChapters.tier == .plus
             && SubscriptionHelper.activeTier < .patron
+            && BuildEnvironment.current == .appStore
     }
 
     var plusFreeMessage: String {


### PR DESCRIPTION
Enable Preselect Chapters for Plus users and the general public announcement.

## To test

Change `WhatsNew.swift` constructor to:

```swift
    init(announcements: [Announcement] = Announcements().announcements, previousOpenedVersion: String? = UserDefaults.standard.string(forKey: Constants.UserDefaults.lastRunVersion), currentVersion: String = Settings.appVersion(), lastWhatsNewShown: String? = Settings.lastWhatsNewShown) {
        self.announcements = announcements
        self.previousOpenedVersion = "7.60"
        self.currentVersion = currentVersion.majorMinor
        self.lastWhatsNewShown = "7.60"
    }
```

1. Change `BuildEnvironment.swift` line `24` to `return .appStore`
2. Run the app
3. ✅ You should see an announcement
4. Play any episode with chapters
5. ✅ Preselect Chapters should be available for Plus

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
