### PR TITLE
Standard Tags: fix artwork pulsing/blinking

### DIFF
--- a/podcasts/EpisodeDetailViewController+ShowNotes.swift
+++ b/podcasts/EpisodeDetailViewController+ShowNotes.swift
@@ -35,13 +35,10 @@ extension EpisodeDetailViewController: WKNavigationDelegate, SFSafariViewControl
         hideErrorMessage(hide: true)
 
         if FeatureFlag.newShowNotesEndpoint.enabled {
-            let podcastUUID = episode.parentIdentifier()
-            let episodeUUID = episode.uuid
             Task { [weak self] in
-                if let showNotes = await self?.episode.loadMetadata()?.showNotes {
-                    self?.downloadingShowNotes = false
-                    self?.showNotesDidLoad(showNotes: showNotes)
-                }
+                let showNotes = await self?.episode.loadMetadata()?.showNotes
+                self?.downloadingShowNotes = false
+                self?.showNotesDidLoad(showNotes: showNotes ?? CacheServerHandler.noShowNotesMessage)
             }
             return
         }

--- a/podcasts/PodcastImageView.swift
+++ b/podcasts/PodcastImageView.swift
@@ -30,6 +30,11 @@ class PodcastImageView: UIView {
     func setEpisode(_ episode: Episode, size: PodcastThumbnailSize) {
         guard let imageView = imageView else { return }
 
+        guard episode != currentEpisode else {
+            // Don't start the whole process again if the episode is the same
+            return
+        }
+
         currentEpisode = episode
 
         ImageManager.sharedManager.setPlaceholder(imageView: imageView, size: size)


### PR DESCRIPTION
This fixes an issue in which the episode/podcast artwork briefly blinks.

## To test

Run on a real device.

1. Open any episode detail
2. Lock screen
3. Unlock screen
4. ✅ The episode/podcast artwork should not pulse/blink

If you test the same on `release/7.61` you'll see that the placeholder briefly appears and it's replaced by the correct artwork.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
