### PR TITLE
Categories: Pills styling

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
@@ -365,6 +365,11 @@ public struct DiscoverCategory: Decodable, Equatable {
     public var name: String?
     public var source: String?
     public var icon: String?
+
+    public init(id: Int?, name: String?) {
+        self.id = id
+        self.name = name
+    }
 }
 
 public struct DiscoverCategoryDetails: Decodable {

--- a/podcasts/Categories/CategoriesSelectorView.swift
+++ b/podcasts/Categories/CategoriesSelectorView.swift
@@ -12,6 +12,8 @@ struct CategoriesSelectorView: View {
     @State private var categories: [DiscoverCategory]?
     @State private var popular: [DiscoverCategory]?
 
+    @EnvironmentObject var theme: Theme
+
     var body: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack {
@@ -22,8 +24,11 @@ struct CategoriesSelectorView: View {
                     PlaceholderPillsView()
                 }
             }
-            .padding(16)
+            .padding(.top, 2)
+            .padding(.bottom, 16)
+            .padding(.horizontal, 16)
         }
+        .background(theme.secondaryUi01)
         .task(id: discoverItemObservable.item?.source) {
             guard let source = discoverItemObservable.item?.source else { return }
             let categories = await DiscoverServerHandler.shared.discoverCategories(source: source)
@@ -43,7 +48,6 @@ struct PlaceholderPillsView: View {
                 Text("Placeholder")
             })
             .buttonStyle(CategoryButtonStyle())
-            .environmentObject(Theme.sharedTheme)
             .redacted(reason: .placeholder)
         }
     }

--- a/podcasts/Categories/CategoriesSelectorView.swift
+++ b/podcasts/Categories/CategoriesSelectorView.swift
@@ -12,14 +12,13 @@ struct CategoriesSelectorView: View {
     @State private var categories: [DiscoverCategory]?
     @State private var popular: [DiscoverCategory]?
 
-    @EnvironmentObject var theme: Theme
+    @EnvironmentObject private var theme: Theme
 
     var body: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack {
                 if let categories, let popular {
                     CategoriesPillsView(pillCategories: popular, overflowCategories: categories, selectedCategory: $discoverItemObservable.selectedCategory.animation(.easeOut(duration: 0.25)))
-                        .environmentObject(Theme.sharedTheme)
                 } else {
                     PlaceholderPillsView()
                 }
@@ -30,13 +29,9 @@ struct CategoriesSelectorView: View {
         }
         .background(theme.secondaryUi01)
         .task(id: discoverItemObservable.item?.source) {
-            guard let source = discoverItemObservable.item?.source else { return }
-            let categories = await DiscoverServerHandler.shared.discoverCategories(source: source)
-            self.categories = categories
-            popular = categories.filter {
-                guard let id = $0.id else { return false }
-                return discoverItemObservable.item?.popular?.contains(id) == true
-            }
+            let result = await discoverItemObservable.load()
+            self.categories = result?.categories
+            self.popular = result?.popular
         }
     }
 }
@@ -134,5 +129,34 @@ struct CategoryButton: View {
             Text(category.name ?? "")
         })
         .buttonStyle(CategoryButtonStyle(isSelected: isSelected))
+    }
+}
+
+// MARK: Previews
+
+#Preview("unselected") {
+    let category = DiscoverCategory(id: 0, name: "Test")
+    let observable = CategoriesSelectorViewController.DiscoverItemObservable {
+        return ([category], [category])
+    }
+    return ScrollView(.vertical) {
+        CategoriesSelectorView(discoverItemObservable: observable)
+            .frame(width: 400)
+            .previewWithAllThemes()
+    }
+}
+
+#Preview("selected") {
+    let category = DiscoverCategory(id: 0, name: "Test")
+    let observable = CategoriesSelectorViewController.DiscoverItemObservable {
+        return ([category], [category])
+    }
+    return ScrollView(.vertical) {
+        CategoriesSelectorView(discoverItemObservable: observable)
+            .frame(width: 400)
+            .previewWithAllThemes()
+            .onAppear {
+                observable.selectedCategory = category
+            }
     }
 }

--- a/podcasts/Categories/CategoriesSelectorViewController.swift
+++ b/podcasts/Categories/CategoriesSelectorViewController.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import PocketCastsServer
 import Combine
 
-class CategoriesSelectorViewController: UIHostingController<CategoriesSelectorView>, DiscoverSummaryProtocol {
+class CategoriesSelectorViewController: ThemedHostingController<CategoriesSelectorView>, DiscoverSummaryProtocol {
 
     class DiscoverItemObservable: ObservableObject {
         @Published public var item: DiscoverItem?

--- a/podcasts/Categories/CategoriesSelectorViewController.swift
+++ b/podcasts/Categories/CategoriesSelectorViewController.swift
@@ -7,6 +7,23 @@ class CategoriesSelectorViewController: ThemedHostingController<CategoriesSelect
     class DiscoverItemObservable: ObservableObject {
         @Published public var item: DiscoverItem?
         @Published public var selectedCategory: DiscoverCategory?
+
+        lazy var load: (() async -> (categories: [DiscoverCategory], popular: [DiscoverCategory])?) = { [weak self] in
+            guard let source = self?.item?.source else { return nil }
+            let categories = await DiscoverServerHandler.shared.discoverCategories(source: source)
+            let popular = categories.filter {
+                guard let id = $0.id else { return false }
+                return self?.item?.popular?.contains(id) == true
+            }
+
+            return (categories, popular)
+        }
+
+        init(load: (() async -> (categories: [DiscoverCategory], popular: [DiscoverCategory])?)? = nil) {
+            if let load {
+                self.load = load
+            }
+        }
     }
 
     @ObservedObject fileprivate var observable: DiscoverItemObservable

--- a/podcasts/Categories/CategoryButtonStyle.swift
+++ b/podcasts/Categories/CategoryButtonStyle.swift
@@ -39,7 +39,7 @@ struct CategoryButtonStyle: ButtonStyle {
     // MARK: View
 
     let isSelected: Bool
- 
+
     /// Used for generating previews with isPressed button state
     fileprivate var forcePressed = false
 

--- a/podcasts/Categories/CategoryButtonStyle.swift
+++ b/podcasts/Categories/CategoryButtonStyle.swift
@@ -39,6 +39,9 @@ struct CategoryButtonStyle: ButtonStyle {
     // MARK: View
 
     let isSelected: Bool
+ 
+    /// Used for generating previews with isPressed button state
+    fileprivate var forcePressed = false
 
     init(isSelected: Bool = false) {
         self.isSelected = isSelected
@@ -51,7 +54,7 @@ struct CategoryButtonStyle: ButtonStyle {
             .padding(.horizontal, Constants.Padding.horizontal)
             .padding(.vertical, Constants.Padding.vertical)
             .cornerRadius(Constants.cornerRadius)
-            .background(isSelected ? selectedBackground : (configuration.isPressed ? pressedBackground : background))
+            .background(isSelected ? selectedBackground : ((configuration.isPressed || forcePressed) ? pressedBackground : background))
             .foregroundColor(isSelected ? selectedForeground : foreground)
             .overlay(
                 RoundedRectangle(cornerRadius: Constants.cornerRadius)
@@ -61,9 +64,28 @@ struct CategoryButtonStyle: ButtonStyle {
     }
 }
 
-#Preview {
+// MARK: Previews
+
+#Preview("normal") {
+    Button("Hello", action: {
+
+    }).buttonStyle(CategoryButtonStyle(isSelected: false))
+    .previewWithAllThemes()
+}
+
+#Preview("selected") {
     Button("Hello", action: {
 
     }).buttonStyle(CategoryButtonStyle(isSelected: true))
+    .previewWithAllThemes()
+}
+
+#Preview("pressed") {
+    var buttonStyle = CategoryButtonStyle(isSelected: false)
+    buttonStyle.forcePressed = true
+    return Button("Hello", action: {
+
+    }).buttonStyle(buttonStyle)
+    .applyButtonEffect(isPressed: true)
     .previewWithAllThemes()
 }

--- a/podcasts/Categories/CategoryButtonStyle.swift
+++ b/podcasts/Categories/CategoryButtonStyle.swift
@@ -15,7 +15,7 @@ struct CategoryButtonStyle: ButtonStyle {
 
     // MARK: Colors
     private var border: Color {
-        theme.primaryIcon02
+        theme.primaryField03
     }
 
     private var background: Color {

--- a/podcasts/Categories/CategoryButtonStyle.swift
+++ b/podcasts/Categories/CategoryButtonStyle.swift
@@ -60,3 +60,10 @@ struct CategoryButtonStyle: ButtonStyle {
             .clipShape(RoundedRectangle(cornerRadius: Constants.cornerRadius))
     }
 }
+
+#Preview {
+    Button("Hello", action: {
+
+    }).buttonStyle(CategoryButtonStyle(isSelected: true))
+    .previewWithAllThemes()
+}

--- a/podcasts/Categories/CategoryButtonStyle.swift
+++ b/podcasts/Categories/CategoryButtonStyle.swift
@@ -15,19 +15,25 @@ struct CategoryButtonStyle: ButtonStyle {
 
     // MARK: Colors
     private var border: Color {
-        theme.primaryField03
+        theme.primaryIcon02
     }
+
     private var background: Color {
-        theme.primaryUi02Active
+        theme.primaryUi01
     }
+
+    private var pressedBackground: Color {
+        theme.primaryUi02Selected
+    }
+
     private var foreground: Color {
         theme.primaryText01
     }
     private var selectedBackground: Color {
-        theme.primaryField03Active
+        theme.primaryIcon01
     }
     private var selectedForeground: Color {
-        theme.primaryUi01
+        theme.primaryUi02Selected
     }
 
     // MARK: View
@@ -45,7 +51,7 @@ struct CategoryButtonStyle: ButtonStyle {
             .padding(.horizontal, Constants.Padding.horizontal)
             .padding(.vertical, Constants.Padding.vertical)
             .cornerRadius(Constants.cornerRadius)
-            .background(isSelected ? selectedBackground : (configuration.isPressed ? background : Color.clear))
+            .background(isSelected ? selectedBackground : (configuration.isPressed ? pressedBackground : background))
             .foregroundColor(isSelected ? selectedForeground : foreground)
             .overlay(
                 RoundedRectangle(cornerRadius: Constants.cornerRadius)

--- a/podcasts/Categories/CategoryButtonStyle.swift
+++ b/podcasts/Categories/CategoryButtonStyle.swift
@@ -30,10 +30,10 @@ struct CategoryButtonStyle: ButtonStyle {
         theme.primaryText01
     }
     private var selectedBackground: Color {
-        theme.primaryIcon01
+        theme.secondaryIcon01
     }
     private var selectedForeground: Color {
-        theme.primaryUi02Selected
+        theme.secondaryUi01
     }
 
     // MARK: View


### PR DESCRIPTION
Tweaks a few colors and padding for Category Pills

* The background of the Category pills matches the search bar background
* Various color changes to the pill backgrounds, selected, and pressed colors

|  |  |  |
|---|---|---|
| ![Simulator Screenshot - iPhone 15 Pro Max - 2024-04-09 at 21 44 33](https://github.com/Automattic/pocket-casts-ios/assets/3250/6805120a-c3ac-4b1d-a023-cebafe5b7fb1) | ![Simulator Screenshot - iPhone 15 Pro Max - 2024-04-09 at 21 44 38](https://github.com/Automattic/pocket-casts-ios/assets/3250/4a4f9d56-b2fc-4d5c-b2fb-14e49fec83c1) | ![Simulator Screenshot - iPhone 15 Pro Max - 2024-04-09 at 21 44 42](https://github.com/Automattic/pocket-casts-ios/assets/3250/1e71ed81-97f3-49d3-a26e-c747525c51a8) |
| ![Simulator Screenshot - iPhone 15 Pro Max - 2024-04-09 at 21 44 29](https://github.com/Automattic/pocket-casts-ios/assets/3250/2af874aa-1255-42f3-9057-be07e17f1b05) | ![Simulator Screenshot - iPhone 15 Pro Max - 2024-04-09 at 21 44 48](https://github.com/Automattic/pocket-casts-ios/assets/3250/8a27d8e1-103e-456a-a113-5b9324321be4) | ![Simulator Screenshot - iPhone 15 Pro Max - 2024-04-09 at 21 44 54](https://github.com/Automattic/pocket-casts-ios/assets/3250/0c091617-484e-492d-a2c3-bf719acba342) |
| ![Simulator Screenshot - iPhone 15 Pro Max - 2024-04-09 at 21 45 00](https://github.com/Automattic/pocket-casts-ios/assets/3250/34a51ae5-9c31-4dd5-9a1c-f19c6d1804e2) | ![Simulator Screenshot - iPhone 15 Pro Max - 2024-04-09 at 21 44 23](https://github.com/Automattic/pocket-casts-ios/assets/3250/c433b269-218a-4a1b-af90-c715a10a5b27) | ![Simulator Screenshot - iPhone 15 Pro Max - 2024-04-09 at 21 44 16](https://github.com/Automattic/pocket-casts-ios/assets/3250/d875a2ee-89b8-4cd8-99fb-02525100a2f6) |
| ![Simulator Screenshot - iPhone 15 Pro Max - 2024-04-09 at 21 44 11](https://github.com/Automattic/pocket-casts-ios/assets/3250/8c77bcd1-0db9-44cc-b7a3-668fb1f0f142) |  |

## To test

* Build for Staging
* Enable the `categoriesRedesign` feature flag
* Navigate to Discover
* Ensure that the Category pills appear and are interactive
* Change themes
* Ensure that the Category pills reflect the current theme and appear to have the correct styling

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
