### PR TITLE
Sleep Timer: automatically restart if playback is resumed within 5 minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 7.62
 -----
-
+- Sleep Timer restarts automatically if you play again within 5 minutes [#1612]
 
 7.61
 -----

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -457,6 +457,8 @@
 		8B17627A2B684E7100F44450 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 8B1762792B684E7100F44450 /* Kingfisher */; };
 		8B17627C2B684ED300F44450 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 8B17627B2B684ED300F44450 /* Kingfisher */; };
 		8B1877E52A45DC570025D245 /* AutoplayHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B1877E42A45DC570025D245 /* AutoplayHelperTests.swift */; };
+		8B1B782B2BC7104000DC3373 /* SleepTimerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B1B782A2BC7104000DC3373 /* SleepTimerManager.swift */; };
+		8B1B782C2BC7104000DC3373 /* SleepTimerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B1B782A2BC7104000DC3373 /* SleepTimerManager.swift */; };
 		8B1C974628FE1C7E00BD5EB9 /* ImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B1C974528FE1C7E00BD5EB9 /* ImageView.swift */; };
 		8B1C974828FE234B00BD5EB9 /* View+Snapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B1C974728FE234B00BD5EB9 /* View+Snapshot.swift */; };
 		8B1F09BA29BB5A3D00842854 /* SearchResultsListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B1F09B929BB5A3D00842854 /* SearchResultsListView.swift */; };
@@ -2264,6 +2266,7 @@
 		8B17365C298D47B10057E893 /* ca */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ca; path = ca.lproj/Localizable.strings; sourceTree = "<group>"; };
 		8B17365D298D47B20057E893 /* ca */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ca; path = ca.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		8B1877E42A45DC570025D245 /* AutoplayHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoplayHelperTests.swift; sourceTree = "<group>"; };
+		8B1B782A2BC7104000DC3373 /* SleepTimerManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SleepTimerManager.swift; sourceTree = "<group>"; };
 		8B1C974528FE1C7E00BD5EB9 /* ImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageView.swift; sourceTree = "<group>"; };
 		8B1C974728FE234B00BD5EB9 /* View+Snapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Snapshot.swift"; sourceTree = "<group>"; };
 		8B1F09B929BB5A3D00842854 /* SearchResultsListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultsListView.swift; sourceTree = "<group>"; };
@@ -4927,6 +4930,7 @@
 				BDF15A3D1B54E053000EC323 /* PlaybackManager.swift */,
 				BDF15A3F1B54E064000EC323 /* PlaybackQueue.swift */,
 				BDF15A451B54E21B000EC323 /* PlaybackEffects.swift */,
+				8B1B782A2BC7104000DC3373 /* SleepTimerManager.swift */,
 				BD44A4442302DAC6004F55B2 /* CommonUpNextItem.swift */,
 				BD2219F0253EAEAF000025BE /* PlaybackCatchUpHelper.swift */,
 				C725285E299B315000A582C3 /* BookmarkManager.swift */,
@@ -9422,6 +9426,7 @@
 				8B6A2C8D29CA4F78002601F5 /* SearchListView.swift in Sources */,
 				BD57646A17E140BE0039CF8B /* NSNull+Length.m in Sources */,
 				BD7BCF151F6A5C510006E008 /* VideoPlayerView.swift in Sources */,
+				8B1B782B2BC7104000DC3373 /* SleepTimerManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -9431,6 +9436,7 @@
 			files = (
 				BD455D8827F17C330041AE3D /* NowPlayingControls.swift in Sources */,
 				BDE48A202410D0A000ECA6CA /* DownloadProgressManager.swift in Sources */,
+				8B1B782C2BC7104000DC3373 /* SleepTimerManager.swift in Sources */,
 				FF47245B2BA4749F00EA916B /* MenuRow.swift in Sources */,
 				463FCE7F27BEAE6400E5AF89 /* WatchHostingController.swift in Sources */,
 				BD74F15A27F2956800222785 /* FolderViewModel.swift in Sources */,

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -348,6 +348,7 @@ enum AnalyticsEvent: String {
     case playerSleepTimerEnabled
     case playerSleepTimerExtended
     case playerSleepTimerCancelled
+    case playerSleepTimerRestarted
 
     // MARK: - Player: Shelf
 

--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -159,6 +159,9 @@ struct Constants {
 
         static let searchHistoryEntries = "SearchHistoryEntries"
 
+        static let sleepTimerFinishedDate = "sleepTimerFinishedDate"
+        static let sleepTimerSetting = "sleepTimerSetting"
+
         enum headphones {
             static let previousAction = SettingValue("headphones.previousAction",
                                                       defaultValue: HeadphoneControlAction.skipBack)

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -23,6 +23,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         didSet {
             if sleepOnEpisodeEnd {
                 sleepTimeRemaining = -1
+                sleepTimerManager.recordSleepTimerDuration(duration: nil, onEpisodeEnd: true)
             }
             NotificationCenter.postOnMainThread(notification: Constants.Notifications.sleepTimerChanged)
         }
@@ -59,6 +60,8 @@ class PlaybackManager: ServerPlaybackDelegate {
     lazy var bookmarkManager: BookmarkManager = {
         BookmarkManager(playbackManager: self)
     }()
+
+    private lazy var sleepTimerManager = SleepTimerManager()
 
     /// The player we should fallback to
     private var fallbackToPlayer: PlaybackProtocol.Type? = nil
@@ -236,6 +239,8 @@ class PlaybackManager: ServerPlaybackDelegate {
             }
 
             self.updateIdleTimer()
+
+            self.sleepTimerManager.restartSleepTimerIfNeeded()
         })
     }
 
@@ -945,7 +950,7 @@ class PlaybackManager: ServerPlaybackDelegate {
 
     func playerDidFinishPlayingEpisode() {
         if sleepOnEpisodeEnd {
-            pause()
+            pauseAndRecordSleepTimerFinished()
             cancelSleepTimer()
             return
         }
@@ -1366,13 +1371,18 @@ class PlaybackManager: ServerPlaybackDelegate {
             sleepTimeRemaining = sleepTimeRemaining - updateTimerInterval
 
             if sleepTimeRemaining < 0 {
-                pause()
+                pauseAndRecordSleepTimerFinished()
             }
         }
 
         if player.buffering() == false {
             updateChapterInfo()
         }
+    }
+
+    private func pauseAndRecordSleepTimerFinished() {
+        sleepTimerManager.recordSleepTimerFinished()
+        pause()
     }
 
     private func fireProgressNotification() {
@@ -1473,6 +1483,7 @@ class PlaybackManager: ServerPlaybackDelegate {
     }
 
     func setSleepTimerInterval(_ stopIn: TimeInterval) {
+        sleepTimerManager.recordSleepTimerDuration(duration: stopIn, onEpisodeEnd: nil)
         sleepTimeRemaining = stopIn
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.sleepTimerChanged)
         Analytics.track(.playerSleepTimerEnabled, properties: ["time": Int(stopIn)])

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -1473,6 +1473,7 @@ class PlaybackManager: ServerPlaybackDelegate {
     // MARK: - Sleep Timer
 
     func cancelSleepTimer() {
+        sleepTimerManager.cancelSleepTimer()
         sleepTimeRemaining = -1
         sleepOnEpisodeEnd = false
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.sleepTimerChanged)

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -1472,8 +1472,8 @@ class PlaybackManager: ServerPlaybackDelegate {
 
     // MARK: - Sleep Timer
 
-    func cancelSleepTimer() {
-        sleepTimerManager.cancelSleepTimer()
+    func cancelSleepTimer(userInitiated: Bool = false) {
+        sleepTimerManager.cancelSleepTimer(userInitiated: userInitiated)
         sleepTimeRemaining = -1
         sleepOnEpisodeEnd = false
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.sleepTimerChanged)

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -956,6 +956,28 @@ class Settings: NSObject {
         }
     }
 
+    // MARK: - Sleep Timer (internal)
+
+    class var sleepTimerFinishedDate: Date? {
+        set {
+            UserDefaults.standard.set(newValue, forKey: Constants.UserDefaults.sleepTimerFinishedDate)
+        }
+
+        get {
+            UserDefaults.standard.object(forKey: Constants.UserDefaults.sleepTimerFinishedDate) as? Date
+        }
+    }
+
+    class var sleepTimerLastSetting: SleepTimerManager.SleepTimerSetting? {
+        set {
+            UserDefaults.standard.setJSONObject(newValue, forKey: Constants.UserDefaults.sleepTimerSetting)
+        }
+
+        get {
+            try? UserDefaults.standard.jsonObject(SleepTimerManager.SleepTimerSetting.self, forKey: Constants.UserDefaults.sleepTimerSetting)
+        }
+    }
+
     // MARK: - End of Year 2022
 
     class var showBadgeForEndOfYear: Bool {

--- a/podcasts/SleepTimerManager.swift
+++ b/podcasts/SleepTimerManager.swift
@@ -31,7 +31,7 @@ class SleepTimerManager {
            let setting = Settings.sleepTimerLastSetting {
             if let duration = setting.duration {
                 PlaybackManager.shared.setSleepTimerInterval(duration)
-                Analytics.shared.track(.playerSleepTimerRestarted, properties: ["duration": duration])
+                Analytics.shared.track(.playerSleepTimerRestarted, properties: ["time": duration])
                 FileLog.shared.addMessage("Sleep Timer: restarting it automatically")
             } else if setting.sleepOnEpisodeEnd == true {
                 observePlaybackEndAndReactivateTime()
@@ -45,7 +45,7 @@ class SleepTimerManager {
 
     @objc private func playbackTrackChanged() {
         FileLog.shared.addMessage("Sleep Timer: restarting it automatically to the end of the episode")
-        Analytics.shared.track(.playerSleepTimerRestarted, properties: ["duration": "end_of_episode"])
+        Analytics.shared.track(.playerSleepTimerRestarted, properties: ["time": "end_of_episode"])
         PlaybackManager.shared.sleepOnEpisodeEnd = true
         NotificationCenter.default.removeObserver(self)
     }

--- a/podcasts/SleepTimerManager.swift
+++ b/podcasts/SleepTimerManager.swift
@@ -19,6 +19,7 @@ class SleepTimerManager {
            let setting = Settings.sleepTimerLastSetting {
             if let duration = setting.duration {
                 PlaybackManager.shared.setSleepTimerInterval(duration)
+                FileLog.shared.addMessage("Sleep Timer: restarting it automatically")
             } else if setting.sleepOnEpisodeEnd == true {
                 observePlaybackEndAndReactivateTime()
             }
@@ -30,6 +31,7 @@ class SleepTimerManager {
     }
 
     @objc private func playbackTrackChanged() {
+        FileLog.shared.addMessage("Sleep Timer: restarting it automatically to the end of the episode")
         PlaybackManager.shared.sleepOnEpisodeEnd = true
         NotificationCenter.default.removeObserver(self)
     }

--- a/podcasts/SleepTimerManager.swift
+++ b/podcasts/SleepTimerManager.swift
@@ -13,7 +13,11 @@ class SleepTimerManager {
         Settings.sleepTimerLastSetting = setting
     }
 
-    func cancelSleepTimer() {
+    func cancelSleepTimer(userInitiated: Bool) {
+        guard userInitiated else {
+            return
+        }
+
         Settings.sleepTimerFinishedDate = .distantPast
     }
 

--- a/podcasts/SleepTimerManager.swift
+++ b/podcasts/SleepTimerManager.swift
@@ -14,6 +14,10 @@ class SleepTimerManager {
     }
 
     func restartSleepTimerIfNeeded() {
+        guard !PlaybackManager.shared.sleepTimerActive() else {
+            return
+        }
+
         if let sleepTimerFinishedDate = Settings.sleepTimerFinishedDate,
            Date.now.timeIntervalSince(sleepTimerFinishedDate) <= restartSleepTimerIfPlayingAgainWithin,
            let setting = Settings.sleepTimerLastSetting {

--- a/podcasts/SleepTimerManager.swift
+++ b/podcasts/SleepTimerManager.swift
@@ -14,7 +14,7 @@ class SleepTimerManager {
     }
 
     func cancelSleepTimer() {
-        Settings.sleepTimerLastSetting = nil
+        Settings.sleepTimerFinishedDate = .distantPast
     }
 
     func restartSleepTimerIfNeeded() {

--- a/podcasts/SleepTimerManager.swift
+++ b/podcasts/SleepTimerManager.swift
@@ -19,6 +19,7 @@ class SleepTimerManager {
            let setting = Settings.sleepTimerLastSetting {
             if let duration = setting.duration {
                 PlaybackManager.shared.setSleepTimerInterval(duration)
+                Analytics.shared.track(.playerSleepTimerRestarted, properties: ["duration": duration])
                 FileLog.shared.addMessage("Sleep Timer: restarting it automatically")
             } else if setting.sleepOnEpisodeEnd == true {
                 observePlaybackEndAndReactivateTime()
@@ -32,6 +33,7 @@ class SleepTimerManager {
 
     @objc private func playbackTrackChanged() {
         FileLog.shared.addMessage("Sleep Timer: restarting it automatically to the end of the episode")
+        Analytics.shared.track(.playerSleepTimerRestarted, properties: ["duration": "end_of_episode"])
         PlaybackManager.shared.sleepOnEpisodeEnd = true
         NotificationCenter.default.removeObserver(self)
     }

--- a/podcasts/SleepTimerManager.swift
+++ b/podcasts/SleepTimerManager.swift
@@ -1,0 +1,41 @@
+import Foundation
+import PocketCastsUtils
+
+class SleepTimerManager {
+    private var restartSleepTimerIfPlayingAgainWithin: TimeInterval = 5.minutes
+
+    func recordSleepTimerFinished() {
+        Settings.sleepTimerFinishedDate = .now
+    }
+
+    func recordSleepTimerDuration(duration: TimeInterval?, onEpisodeEnd: Bool?) {
+        let setting = SleepTimerSetting(duration: duration, sleepOnEpisodeEnd: onEpisodeEnd)
+        Settings.sleepTimerLastSetting = setting
+    }
+
+    func restartSleepTimerIfNeeded() {
+        if let sleepTimerFinishedDate = Settings.sleepTimerFinishedDate,
+           Date.now.timeIntervalSince(sleepTimerFinishedDate) <= restartSleepTimerIfPlayingAgainWithin,
+           let setting = Settings.sleepTimerLastSetting {
+            if let duration = setting.duration {
+                PlaybackManager.shared.setSleepTimerInterval(duration)
+            } else if setting.sleepOnEpisodeEnd == true {
+                observePlaybackEndAndReactivateTime()
+            }
+        }
+    }
+
+    private func observePlaybackEndAndReactivateTime() {
+        NotificationCenter.default.addObserver(self, selector: #selector(playbackTrackChanged), name: Constants.Notifications.playbackTrackChanged, object: nil)
+    }
+
+    @objc private func playbackTrackChanged() {
+        PlaybackManager.shared.sleepOnEpisodeEnd = true
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    struct SleepTimerSetting: JSONEncodable, JSONDecodable {
+        let duration: TimeInterval?
+        let sleepOnEpisodeEnd: Bool?
+    }
+}

--- a/podcasts/SleepTimerManager.swift
+++ b/podcasts/SleepTimerManager.swift
@@ -13,6 +13,10 @@ class SleepTimerManager {
         Settings.sleepTimerLastSetting = setting
     }
 
+    func cancelSleepTimer() {
+        Settings.sleepTimerLastSetting = nil
+    }
+
     func restartSleepTimerIfNeeded() {
         guard !PlaybackManager.shared.sleepTimerActive() else {
             return

--- a/podcasts/SleepTimerViewController.swift
+++ b/podcasts/SleepTimerViewController.swift
@@ -274,7 +274,7 @@ class SleepTimerViewController: SimpleNotificationsViewController {
 
     @IBAction func cancelTapped(_ sender: Any) {
         Analytics.track(.playerSleepTimerCancelled)
-        PlaybackManager.shared.cancelSleepTimer()
+        PlaybackManager.shared.cancelSleepTimer(userInitiated: true)
         dismiss(animated: true, completion: nil)
     }
 


### PR DESCRIPTION
This PR implements a mechanism to restart the sleep timer whenever the user restarts playback within **5 minutes**.

* The sleep timer will restart with the same configuration as before (same time or end of episode)
* If playing after more than 5 minutes, the sleep timer should not restart

I haven't added any confirmation sound because if I'm sleeping I don't feel like hearing a voice or a confirmation sound for the sleep timer, but we can adjust accordingly in the future based on feedback.

## To test

To make testing faster, go to `SleepTimerViewController.swift` and change the `fiveMinutesTapped` function to `5.seconds` (instead of `5.minutes`), also go to Profile > Beta Features > and enable `tracksLogging`.

### Restarting timer for a given amount of time

1. Run the app
2. Add 5 to 10 podcasts to your Up Next
3. Play something
4. Open the full player, tap the sleep timer icon (zZz), select 5 minutes (in our case it will be 5 seconds)
5. After 5 seconds the playback should stop
6. Tap play again
7. ✅ The sleep timer should restart with 5 seconds
8. ✅ Ensure `🔵 Tracked: player_sleep_timer_restarted ["duration": 5.0]` is tracked

### Not restarting timer

Go to `SleepTimerManager.swift` and change `restartSleepTimerIfPlayingAgainWithin` to `5.seconds`.

1. Play something
4. Open the full player, tap the sleep timer icon (zZz), select 5 minutes (in our case it will be 5 seconds)
5. After 5 seconds the playback should stop
6. Wait for 10 seconds
7. Tap play again
9. ✅ The sleep timer should not restart

### Restarting timer for end of episode

Go to `SleepTimerManager.swift` and revert `restartSleepTimerIfPlayingAgainWithin` to `5.minutes`.

1. Play something
4. Open the full player, tap the sleep timer icon (zZz), select end of episode
5. Drag the scrubber close to the end of the episode and wait till it's finished
7. Tap play again
8. ✅ The next episode should play and sleep timer should restart for end of episode
9. ✅ Ensure `🔵 Tracked: player_sleep_timer_restarted ["duration": "end_of_episode"]` is tracked

### Pausing

1. Play something
4. Open the full player, tap the sleep timer icon (zZz), select any timer
5. Pause the playback
7. Check how many time is left in the timer
8. Unpause
9. ✅ The timer should restart from where it was, it should not reset

### Canceling

1. Play something
4. Open the full player, tap the sleep timer icon (zZz), select any timer
5. Open the timer sheet again and cancel the timer
7. Pause and play again
9. ✅ The timer should not restart

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
