### PR TITLE
Categories: Sponsored Posts

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
@@ -270,6 +270,7 @@ public struct DiscoverItem: Decodable, Equatable {
     public var regions: [String]
     public var isSponsored: Bool?
     public var popular: [Int]?
+    public var categoryID: Int?
 
     public enum CodingKeys: String, CodingKey {
         case summaryStyle = "summary_style"
@@ -277,6 +278,7 @@ public struct DiscoverItem: Decodable, Equatable {
         case isSponsored = "sponsored"
         case sponsoredPodcasts = "sponsored_podcasts"
         case expandedTopItemLabel = "expanded_top_item_label"
+        case categoryID = "category_id"
         case type, title, source, regions, curated, uuid, popular, id
     }
 

--- a/podcasts/DiscoverViewController.swift
+++ b/podcasts/DiscoverViewController.swift
@@ -241,7 +241,7 @@ class DiscoverViewController: PCViewController {
         }
         currentSnapshot = snapshot
     }
-    
+
     /// Populate the scroll view using a DiscoverLayout with optional shouldInclude and shouldReset filters.
     /// - Parameters:
     ///   - discoverLayout: A `DiscoverLayout`

--- a/podcasts/DiscoverViewController.swift
+++ b/podcasts/DiscoverViewController.swift
@@ -155,14 +155,12 @@ class DiscoverViewController: PCViewController {
         categoryVC.view.alpha = 0
 
         let item = DiscoverItem(id: "category-\(category.id ?? 0)", title: category.name, source: category.source, regions: items.first?.regions ?? [])
-
-        let itemsToRemove = Set(currentSnapshot?.itemIdentifiers ?? []).subtracting(items)
-        if var newSnapshot = currentSnapshot {
-            newSnapshot.deleteItems(Array(itemsToRemove))
-            newSnapshot.appendItems([item])
-            apply(snapshot: newSnapshot, currentRegion: Settings.discoverRegion(discoverLayout: discoverLayout!))
-            addToScrollView(viewController: categoryVC, for: item, isLast: true)
-        }
+        populateFrom(discoverLayout: discoverLayout, shouldInclude: {
+            ($0.categoryID == category.id) || items.contains($0)
+        }, shouldReset: {
+            !items.contains($0)
+        })
+        addToScrollView(viewController: categoryVC, for: item, isLast: true)
         categoryVC.podcastsTable.isScrollEnabled = false
     }
 
@@ -178,9 +176,9 @@ class DiscoverViewController: PCViewController {
 
     private var currentSnapshot: NSDiffableDataSourceSnapshot<Int, DiscoverItem>?
 
-    private func apply(snapshot: NSDiffableDataSourceSnapshot<Int, DiscoverItem>, currentRegion: String) {
+    private func resetSummaryViewControllers(filter: ((DiscoverItem) -> Bool)?) {
         let viewsToRemove = summaryViewControllers.filter { sumItem in
-            !snapshot.itemIdentifiers.contains { $0 == sumItem.item }
+            filter?(sumItem.item) ?? true
         }
 
         UIView.animate(withDuration: 0.1) {
@@ -202,16 +200,18 @@ class DiscoverViewController: PCViewController {
         }
 
         summaryViewControllers.removeAll { sumItem in
-            !snapshot.itemIdentifiers.contains { $0 == sumItem.item }
+            filter?(sumItem.item) ?? true
         }
+    }
 
+    private func apply(snapshot: NSDiffableDataSourceSnapshot<Int, DiscoverItem>, currentRegion: String) {
         for discoverItem in snapshot.itemIdentifiers {
             guard let type = discoverItem.type, let summaryStyle = discoverItem.summaryStyle else { continue }
             let expandedStyle = discoverItem.expandedStyle ?? ""
 
             guard coordinator.shouldDisplay(discoverItem) else { continue }
 
-            guard snapshot.indexOfItem(discoverItem) != currentSnapshot?.indexOfItem(discoverItem) else { continue }
+            guard summaryViewControllers.contains(where: { $0.item == discoverItem }) == false else { continue }
 
             switch (type, summaryStyle, expandedStyle) {
             case ("categories", "pills", _):
@@ -241,8 +241,13 @@ class DiscoverViewController: PCViewController {
         }
         currentSnapshot = snapshot
     }
-
-    private func populateFrom(discoverLayout: DiscoverLayout?) {
+    
+    /// Populate the scroll view using a DiscoverLayout with optional shouldInclude and shouldReset filters.
+    /// - Parameters:
+    ///   - discoverLayout: A `DiscoverLayout`
+    ///   - shouldInclude: Whether a `DiscoverItem` from the layout should be included in the scroll view. This is used to filter items meant only for certain categories, for instance.
+    ///   - shouldReset: Whether a view controller from `summaryViewControllers` should be reset during this operation. This is used by the Categories pills to avoid triggering a view reload, allowing animations to continue.
+    private func populateFrom(discoverLayout: DiscoverLayout?, shouldInclude: ((DiscoverItem) -> Bool)? = nil, shouldReset: ((DiscoverItem) -> Bool)? = nil) {
         loadingContent = false
 
         guard let layout = discoverLayout, let items = layout.layout, let _ = layout.regions, items.count > 0 else {
@@ -260,20 +265,26 @@ class DiscoverViewController: PCViewController {
 
             let section = 0
             snapshot.appendSections([section])
-            snapshot.appendItems(items)
+            snapshot.appendItems(items.filter({ shouldInclude?($0) ?? true }))
 
             return snapshot
         }
 
         let snapshot = makeDataSourceSnapshot(from: items)
+        resetSummaryViewControllers {
+            shouldReset?($0) ?? true
+        }
         apply(snapshot: snapshot, currentRegion: currentRegion)
 
-        let countrySummary = CountrySummaryViewController()
-        countrySummary.discoverLayout = layout
-        countrySummary.registerDiscoverDelegate(self)
         let regions = layout.regions?.keys as? [String]
         let item = DiscoverItem(id: "country-summary", regions: regions ?? [])
-        addToScrollView(viewController: countrySummary, for: item, isLast: true)
+
+        if shouldInclude?(item) ?? true {
+            let countrySummary = CountrySummaryViewController()
+            countrySummary.discoverLayout = layout
+            countrySummary.registerDiscoverDelegate(self)
+            addToScrollView(viewController: countrySummary, for: item, isLast: true)
+        }
 
         mainScrollView.isHidden = false
         noNetworkView.isHidden = true


### PR DESCRIPTION
Adds display of Sponsored Posts in the Discover Category screen.

<img width=300 src="https://github.com/Automattic/pocket-casts-ios/assets/3250/2eefa2b5-779c-4c24-b715-84f9baff1171"/>

## To test

* Build for Staging
* Enable `categoriesRedesign` feature flag
* Visit Discover
* Verify that Categories pills show up along the top
* Scroll through and verify that no sponsored items are shown
* Tap on "All Categories" and then "Arts"
* Verify that screen changes to show category specific podcasts, "Arts" pill is selected, and sponsored ad appears along the top

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
