### PR TITLE
Settings Sync: Fix Up Next settings

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/AutoAddQueueDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/AutoAddQueueDataManager.swift
@@ -58,6 +58,7 @@ public struct AutoAddCandidatesDataManager {
                     SELECT
                         -- Get the Podcast Auto Add Setting
                         json_extract(podcast.settings, '$.addToUpNextPosition.value') AS \(Constants.autoAddSettingColumnName),
+                        json_extract(podcast.settings, '$.addToUpNext.value') AS \(Constants.autoAddEnabledColumnName),
 
                         -- Get the episode UUID
                         queue.id AS \(Constants.idColumnName),
@@ -118,12 +119,13 @@ public struct AutoAddCandidatesDataManager {
 
             let setting: Int32
             if FeatureFlag.newSettingsStorage.enabled {
-                let value = resultSet.int(forColumn: Constants.autoAddSettingColumnName)
-                let position = UpNextPosition(rawValue: value)
-                switch position {
-                case .top:
+                let enabledValue = resultSet.bool(forColumn: Constants.autoAddSettingColumnName)
+                let positionValue = resultSet.int(forColumn: Constants.autoAddSettingColumnName)
+                let position = UpNextPosition(rawValue: positionValue)
+                switch (enabledValue, position) {
+                case (true, .top):
                     setting = AutoAddToUpNextSetting.addFirst.rawValue
-                case .bottom:
+                case (true, .bottom):
                     setting = AutoAddToUpNextSetting.addLast.rawValue
                 default:
                     setting = AutoAddToUpNextSetting.off.rawValue
@@ -151,6 +153,7 @@ public struct AutoAddCandidatesDataManager {
     private enum Constants {
         static let tableName = "AutoAddCandidates"
         static let autoAddSettingColumnName = "auto_add_setting"
+        static let autoAddEnabledColumnName = "auto_add_enabled"
         static let settingsColumnName = "settings"
         static let episodeColumnName = "episode_uuid"
         static let idColumnName = "id"

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/PodcastSettings+OldSettings.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/PodcastSettings+OldSettings.swift
@@ -23,9 +23,7 @@ extension PodcastSettings {
 
 public extension AutoAddToUpNextSetting {
     var enabled: Bool {
-        get {
-            return self != .off
-        }
+        return self != .off
     }
 
     var position: UpNextPosition? {

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/PodcastSettings+OldSettings.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/PodcastSettings+OldSettings.swift
@@ -13,16 +13,29 @@ extension PodcastSettings {
             }
         }
         set {
-            switch newValue {
-            case .addFirst:
-                addToUpNext = true
-                addToUpNextPosition = .top
-            case .addLast:
-                addToUpNext = true
-                addToUpNextPosition = .bottom
-            case .off:
-                addToUpNext = false
+            addToUpNext = newValue.enabled
+            if let position = newValue.position {
+                addToUpNextPosition = position
             }
+        }
+    }
+}
+
+public extension AutoAddToUpNextSetting {
+    var enabled: Bool {
+        get {
+            return self != .off
+        }
+    }
+
+    var position: UpNextPosition? {
+        switch self {
+        case .addFirst:
+            return .top
+        case .addLast:
+            return .bottom
+        case .off:
+            return nil
         }
     }
 }

--- a/Modules/DataModel/Tests/PocketCastsDataModelTests/AutoAddCandidatesDataManagerTests.swift
+++ b/Modules/DataModel/Tests/PocketCastsDataModelTests/AutoAddCandidatesDataManagerTests.swift
@@ -37,6 +37,7 @@ final class AutoAddCandidatesDataManagerTests: XCTestCase {
 
         let dataManager = try setupDatabase()
         let newUpNextSetting = AutoAddToUpNextSetting.addFirst
+        let secondUpNextSetting = AutoAddToUpNextSetting.off
 
         let podcast = Podcast()
         podcast.uuid = "1234"
@@ -57,6 +58,16 @@ final class AutoAddCandidatesDataManagerTests: XCTestCase {
         let matchingCandidate = candidates.first(where: { $0.episodeUuid == episode.uuid })
         XCTAssertNotNil(matchingCandidate, "Episode should appear in Up Next candidates")
         XCTAssertEqual(matchingCandidate?.autoAddToUpNextSetting, newUpNextSetting)
+
+        // Disable the setting and ensure it is removed from candidates
+
+        podcast.setAutoAddToUpNext(setting: secondUpNextSetting)
+        dataManager.save(podcast: podcast)
+
+        let offCandidates = dataManager.autoAddCandidates.candidates()
+
+        let matchingOffCandidate = offCandidates.first(where: { $0.episodeUuid == episode.uuid })
+        XCTAssertEqual(matchingOffCandidate?.autoAddToUpNextSetting, secondUpNextSetting)
 
         featureFlagMock.reset()
     }

--- a/podcasts/DataManager+Import.swift
+++ b/podcasts/DataManager+Import.swift
@@ -33,7 +33,10 @@ extension DataManager {
             }
 
             if let setting = AutoAddToUpNextSetting(rawValue: podcast.autoAddToUpNext) {
-                podcast.settings.autoUpNextSetting = setting
+                podcast.settings.addToUpNext = setting.enabled
+                if let position = setting.position {
+                    podcast.settings.addToUpNextPosition = position
+                }
             }
 
             save(podcast: podcast, cache: idx == podcasts.endIndex)


### PR DESCRIPTION
Fixes a minor issue when importing the Up Next setting. Previously this passed through the new update mechanism which would set the `ModifiedDate` to the current date, so this setting would be overwritten by the last device to import, which was not the original guidelines. We want any imported values to be assigned an epoch date (done in https://github.com/Automattic/pocket-casts-ios/pull/1616), not the current date, so they are clearly delineated from changed settings.

## To test

* Change the return value of `shouldEnableSyncedSettings` in `FeatureFlag.swift` to false
* Subscribe to a podcast
* Enable "Add to Up Next" in the Podcast settings
* Enable the `newSettingsStorage` and `settingsSync` feature flags
* Restart the app
* Ensure your "Add to Up Next" setting remains the same

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
