### PR TITLE
Settings Sync: Set Modified Date on settings import

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Private/API Tasks/RetrievePodcastsTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Private/API Tasks/RetrievePodcastsTask.swift
@@ -57,6 +57,9 @@ class RetrievePodcastsTask: ApiBaseTask {
         podcast.folderUuid = (protoPodcast.hasFolderUuid && protoPodcast.folderUuid.value != DataConstants.homeGridFolderUuid) ? protoPodcast.folderUuid.value : nil
         podcast.sortPosition = protoPodcast.hasSortPosition ? protoPodcast.sortPosition.value : nil
         podcast.dateAdded = protoPodcast.hasDateAdded ? protoPodcast.dateAdded.date : nil
+        var settings = PodcastSettings.defaults
+        settings.processSettings(protoPodcast.settings)
+        podcast.settings = settings
 
         return podcast
     }

--- a/Modules/Server/Sources/PocketCastsServer/Public/ApiSetting+ModifiedDate.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/ApiSetting+ModifiedDate.swift
@@ -24,12 +24,13 @@ extension ApiSetting {
     }
 }
 
+let serverDefaultDate = Date(timeIntervalSince1970: 0)
+
 extension ModifiedDate {
     /// Updates the ApiSetting ModifiedDate instance with values from an ApiSetting
     /// - Parameter setting: An `ApiSetting` instance which contains a value and (optional) modified date to used to determine whether the value should be overridden
     mutating func update<S: ApiSetting>(setting: S) where Value == S.ReturnValue.T {
-        let referenceDate = Date(timeIntervalSince1970: 0)
-        if setting.modifiedAt.date > modifiedAt ?? referenceDate {
+        if setting.modifiedAt.date > modifiedAt ?? serverDefaultDate {
             // The `modifiedAt` date is not set here so that we can tell when settings are _actually_ changed on device
             // Then we include only those values in sending to the server.
             self = ModifiedDate(wrappedValue: setting.value.value)
@@ -45,8 +46,7 @@ extension ModifiedDate where Value: RawRepresentable {
     /// Updates the ModifiedDate instance with values from an ApiSetting
     /// - Parameter setting: An `ApiSetting` instance which contains a value and (optional) modified date to set on this `ModifiedDate`
     mutating private func uncaughtUpdate<S: ApiSetting>(setting: S) throws where Value.RawValue == S.ReturnValue.T {
-        let referenceDate = Date(timeIntervalSinceReferenceDate: 0)
-        if setting.modifiedAt.date > modifiedAt ?? referenceDate {
+        if setting.modifiedAt.date > modifiedAt ?? serverDefaultDate {
             guard let value = Value(rawValue: setting.value.value) else {
                 throw ApiUpdateError.representableNotFound(value: setting.value.value, representable: Value.self)
             }

--- a/Modules/Server/Sources/PocketCastsServer/Public/SettingsStore.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/SettingsStore.swift
@@ -38,16 +38,16 @@ extension SettingsStore {
         }
     }
 
-    public func update<T: RawRepresentable>(_ keyPath: WritableKeyPath<Value, ModifiedDate<T>>, value: T.RawValue) {
+    public func update<T: RawRepresentable>(_ keyPath: WritableKeyPath<Value, ModifiedDate<T>>, value: T.RawValue, modifiedAt: Date? = nil) {
         if let representable = T(rawValue: value) {
-            self.update(keyPath, value: representable)
+            self.update(keyPath, value: representable, modifiedAt: modifiedAt)
         }
     }
 
-    public func update<T: Equatable & Codable>(_ modifiedKeyPath: WritableKeyPath<Value, ModifiedDate<T>>, value: T) {
+    public func update<T: Equatable & Codable>(_ modifiedKeyPath: WritableKeyPath<Value, ModifiedDate<T>>, value: T, modifiedAt: Date? = nil) {
         let openLinksValue = value
         if openLinksValue != self[dynamicMember: modifiedKeyPath].wrappedValue {
-            self[modifiedDate: modifiedKeyPath].projectedValue = ModifiedDate(wrappedValue: openLinksValue)
+            self[modifiedDate: modifiedKeyPath].projectedValue = ModifiedDate(wrappedValue: openLinksValue, modifiedAt: modifiedAt)
         }
     }
 }

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
@@ -98,7 +98,9 @@ extension SyncTask {
                 podcast.autoAddToUpNext = AutoAddToUpNextSetting.off.rawValue
                 podcast.settings = PodcastSettings.defaults
                 if FeatureFlag.settingsSync.enabled {
-                    podcast.processSettings(podcastItem.settings)
+                    let oldSettings = podcast.settings
+                    podcast.settings.processSettings(podcastItem.settings)
+                    oldSettings.printDiff(from: podcast.settings, withIdentifier: podcast.uuid)
                 }
 
                 DataManager.sharedManager.save(podcast: podcast)
@@ -154,7 +156,9 @@ extension SyncTask {
         }
 
         if FeatureFlag.settingsSync.enabled {
-            podcast.processSettings(podcastItem.settings)
+            let oldSettings = podcast.settings
+            podcast.settings.processSettings(podcastItem.settings)
+            oldSettings.printDiff(from: podcast.settings, withIdentifier: podcast.uuid)
         }
     }
 
@@ -423,25 +427,23 @@ private extension Api_SyncUserBookmark {
     }
 }
 
-extension Podcast {
-    func processSettings(_ settings: Api_PodcastSettings) {
-        let oldSettings = self.settings
-        self.settings.$customEffects.update(setting: settings.playbackEffects)
-        self.settings.$autoStartFrom.update(setting: settings.autoStartFrom)
-        self.settings.$autoSkipLast.update(setting: settings.autoSkipLast)
-        self.settings.$trimSilence.update(setting: settings.trimSilence)
-        self.settings.$playbackSpeed.update(setting: settings.playbackSpeed)
-        self.settings.$boostVolume.update(setting: settings.volumeBoost)
-        self.settings.$notification.update(setting: settings.notification)
-        self.settings.$addToUpNext.update(setting: settings.addToUpNext)
-        self.settings.$addToUpNextPosition.update(setting: settings.addToUpNextPosition)
-        self.settings.$episodesSortOrder.update(setting: settings.episodesSortOrder)
-        self.settings.$episodeGrouping.update(setting: settings.episodeGrouping)
-        self.settings.$showArchived.update(setting: settings.showArchived)
-        self.settings.$autoArchive.update(setting: settings.autoArchive)
-        self.settings.$autoArchivePlayed.update(setting: settings.autoArchivePlayed)
-        self.settings.$autoArchiveInactive.update(setting: settings.autoArchiveInactive)
-        self.settings.$autoArchiveEpisodeLimit.update(setting: settings.autoArchiveEpisodeLimit)
-        oldSettings.printDiff(from: self.settings, withIdentifier: self.uuid)
+extension PodcastSettings {
+    mutating func processSettings(_ settings: Api_PodcastSettings) {
+        self.$customEffects.update(setting: settings.playbackEffects)
+        self.$autoStartFrom.update(setting: settings.autoStartFrom)
+        self.$autoSkipLast.update(setting: settings.autoSkipLast)
+        self.$trimSilence.update(setting: settings.trimSilence)
+        self.$playbackSpeed.update(setting: settings.playbackSpeed)
+        self.$boostVolume.update(setting: settings.volumeBoost)
+        self.$notification.update(setting: settings.notification)
+        self.$addToUpNext.update(setting: settings.addToUpNext)
+        self.$addToUpNextPosition.update(setting: settings.addToUpNextPosition)
+        self.$episodesSortOrder.update(setting: settings.episodesSortOrder)
+        self.$episodeGrouping.update(setting: settings.episodeGrouping)
+        self.$showArchived.update(setting: settings.showArchived)
+        self.$autoArchive.update(setting: settings.autoArchive)
+        self.$autoArchivePlayed.update(setting: settings.autoArchivePlayed)
+        self.$autoArchiveInactive.update(setting: settings.autoArchiveInactive)
+        self.$autoArchiveEpisodeLimit.update(setting: settings.autoArchiveEpisodeLimit)
     }
 }

--- a/PocketCastsTests/Tests/Utilities/Date+SyncDateJSON.swift
+++ b/PocketCastsTests/Tests/Utilities/Date+SyncDateJSON.swift
@@ -1,0 +1,11 @@
+import XCTest
+@testable import podcasts
+import SwiftProtobuf
+
+final class DateSyncDateJSONTest: XCTestCase {
+    func testJSON() throws {
+        let timestamp = SwiftProtobuf.Google_Protobuf_Timestamp(date: Date.syncDefaultDate)
+        let json = try timestamp.jsonString()
+        XCTAssertEqual(json, "\"1970-01-01T00:00:01Z\"", "JSON Output should match expected string")
+    }
+}

--- a/PocketCastsTests/Tests/Utilities/PodcastSettings+ImportUserDefaultsTests.swift
+++ b/PocketCastsTests/Tests/Utilities/PodcastSettings+ImportUserDefaultsTests.swift
@@ -95,6 +95,7 @@ class PodcastSettingsImportUserDefaultsTests: XCTestCase {
         XCTAssertEqual(PodcastEpisodeSortOrder(old: newEpisodeSortOrder), podcast.settings.episodesSortOrder, "Value of episodesSortOrder should change after import")
         XCTAssertEqual(newEpisodeGrouping, podcast.settings.episodeGrouping, "Value of autoArchiveInactive should change after import")
         XCTAssertEqual(newShowArchive, podcast.settings.showArchived, "Value of showArchived should change after import")
+        XCTAssertNotNil(podcast.settings.$showArchived.modifiedAt)
     }
 
     /// Tests that the default values are used when a value is missing from the JSON (such as when a key was added after writing the JSON object)

--- a/PocketCastsTests/Tests/Utilities/PodcastSettings+ImportUserDefaultsTests.swift
+++ b/PocketCastsTests/Tests/Utilities/PodcastSettings+ImportUserDefaultsTests.swift
@@ -95,7 +95,7 @@ class PodcastSettingsImportUserDefaultsTests: XCTestCase {
         XCTAssertEqual(PodcastEpisodeSortOrder(old: newEpisodeSortOrder), podcast.settings.episodesSortOrder, "Value of episodesSortOrder should change after import")
         XCTAssertEqual(newEpisodeGrouping, podcast.settings.episodeGrouping, "Value of autoArchiveInactive should change after import")
         XCTAssertEqual(newShowArchive, podcast.settings.showArchived, "Value of showArchived should change after import")
-        XCTAssertNotNil(podcast.settings.$showArchived.modifiedAt)
+        XCTAssertEqual(podcast.settings.$showArchived.modifiedAt, Date.syncDefaultDate, "Modified Date should equal the default sync date")
     }
 
     /// Tests that the default values are used when a value is missing from the JSON (such as when a key was added after writing the JSON object)

--- a/PocketCastsTests/Tests/Utilities/SettingsTests.swift
+++ b/PocketCastsTests/Tests/Utilities/SettingsTests.swift
@@ -291,6 +291,8 @@ final class SettingsTests: XCTestCase {
         XCTAssertEqual(newUseSystemTheme, Settings.shouldFollowSystemTheme())
         XCTAssertEqual(newUseEmbeddedArtwork, Settings.loadEmbeddedImages)
         XCTAssertEqual(newUseEmbeddedArtwork, Settings.darkUpNextTheme)
+
+        XCTAssertNotNil(SettingsStore.appSettings.$appBadge.modifiedAt)
     }
 
     /// Tests that the default values are used when a value is missing from the JSON (such as when a key was added after writing the JSON object)

--- a/PocketCastsTests/Tests/Utilities/SettingsTests.swift
+++ b/PocketCastsTests/Tests/Utilities/SettingsTests.swift
@@ -292,7 +292,7 @@ final class SettingsTests: XCTestCase {
         XCTAssertEqual(newUseEmbeddedArtwork, Settings.loadEmbeddedImages)
         XCTAssertEqual(newUseEmbeddedArtwork, Settings.darkUpNextTheme)
 
-        XCTAssertNotNil(SettingsStore.appSettings.$appBadge.modifiedAt)
+        XCTAssertEqual(SettingsStore.appSettings.$appBadge.modifiedAt, Date.syncDefaultDate, "Modified Date should equal the default sync date")
     }
 
     /// Tests that the default values are used when a value is missing from the JSON (such as when a key was added after writing the JSON object)

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1600,6 +1600,7 @@
 		F55449452B75935F00F68AE9 /* AppSettings+ImportUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = F55449442B75935F00F68AE9 /* AppSettings+ImportUserDefaults.swift */; };
 		F565602F2B7ACD9B003E76D5 /* DataManager+Import.swift in Sources */ = {isa = PBXBuildFile; fileRef = F565602E2B7ACD9B003E76D5 /* DataManager+Import.swift */; };
 		F56ADE562B7FE37500ADFE31 /* SettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5AD75442B7FDC2800D65C55 /* SettingsTests.swift */; };
+		F5A383742BCD81D700E3DC99 /* Date+SyncDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5A383732BCD81D700E3DC99 /* Date+SyncDate.swift */; };
 		F5D3A0D92B70950100EED067 /* MockURLHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5D3A0D82B70950100EED067 /* MockURLHandler.swift */; };
 		F5DBA58A2B756A8700AED77F /* PodcastSettings+ImportUserDefaultsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5DBA5892B756A8700AED77F /* PodcastSettings+ImportUserDefaultsTests.swift */; };
 		F5E431D62B50888500A71DB3 /* PlusLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5E431D52B50888500A71DB3 /* PlusLabel.swift */; };
@@ -3374,6 +3375,7 @@
 		F52B4F8D2BB4A9ED00E87BE4 /* CategoriesSelectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoriesSelectorView.swift; sourceTree = "<group>"; };
 		F55449442B75935F00F68AE9 /* AppSettings+ImportUserDefaults.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AppSettings+ImportUserDefaults.swift"; sourceTree = "<group>"; };
 		F565602E2B7ACD9B003E76D5 /* DataManager+Import.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DataManager+Import.swift"; sourceTree = "<group>"; };
+		F5A383732BCD81D700E3DC99 /* Date+SyncDate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+SyncDate.swift"; sourceTree = "<group>"; };
 		F5AD75442B7FDC2800D65C55 /* SettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsTests.swift; sourceTree = "<group>"; };
 		F5D3A0D82B70950100EED067 /* MockURLHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockURLHandler.swift; sourceTree = "<group>"; };
 		F5DBA5892B756A8700AED77F /* PodcastSettings+ImportUserDefaultsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PodcastSettings+ImportUserDefaultsTests.swift"; sourceTree = "<group>"; };
@@ -6362,6 +6364,7 @@
 				C7F87F0F2913242B00C15980 /* UIFont+FontStyle.swift */,
 				C7B7123929DC98BD00965BF7 /* SFSafariViewController+Creation.swift */,
 				C7D5E7F02A8BF3150039F4A1 /* UIViewController+Presenting.swift */,
+				F5A383732BCD81D700E3DC99 /* Date+SyncDate.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -9254,6 +9257,7 @@
 				8BFB434E2A1FFB4B00F3D409 /* StatusPageViewModel.swift in Sources */,
 				4006E31123A88AE600174DEB /* ExpandedCollectionViewController.swift in Sources */,
 				C72223D6292CAE92006B3B55 /* OnboardingFlow.swift in Sources */,
+				F5A383742BCD81D700E3DC99 /* Date+SyncDate.swift in Sources */,
 				BD240C45231F471B00FB2CDD /* PCSearchBarController+Animation.swift in Sources */,
 				4029E3ED229CD67B0003BEEB /* ProgressPieView.swift in Sources */,
 				BDF050801FBA677900194D68 /* EpisodeCell.swift in Sources */,

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1601,6 +1601,7 @@
 		F565602F2B7ACD9B003E76D5 /* DataManager+Import.swift in Sources */ = {isa = PBXBuildFile; fileRef = F565602E2B7ACD9B003E76D5 /* DataManager+Import.swift */; };
 		F56ADE562B7FE37500ADFE31 /* SettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5AD75442B7FDC2800D65C55 /* SettingsTests.swift */; };
 		F5A383742BCD81D700E3DC99 /* Date+SyncDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5A383732BCD81D700E3DC99 /* Date+SyncDate.swift */; };
+		F5A383762BCD9BFC00E3DC99 /* Date+SyncDateJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5A383752BCD9BFC00E3DC99 /* Date+SyncDateJSON.swift */; };
 		F5D3A0D92B70950100EED067 /* MockURLHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5D3A0D82B70950100EED067 /* MockURLHandler.swift */; };
 		F5DBA58A2B756A8700AED77F /* PodcastSettings+ImportUserDefaultsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5DBA5892B756A8700AED77F /* PodcastSettings+ImportUserDefaultsTests.swift */; };
 		F5E431D62B50888500A71DB3 /* PlusLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5E431D52B50888500A71DB3 /* PlusLabel.swift */; };
@@ -3376,6 +3377,7 @@
 		F55449442B75935F00F68AE9 /* AppSettings+ImportUserDefaults.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AppSettings+ImportUserDefaults.swift"; sourceTree = "<group>"; };
 		F565602E2B7ACD9B003E76D5 /* DataManager+Import.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DataManager+Import.swift"; sourceTree = "<group>"; };
 		F5A383732BCD81D700E3DC99 /* Date+SyncDate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+SyncDate.swift"; sourceTree = "<group>"; };
+		F5A383752BCD9BFC00E3DC99 /* Date+SyncDateJSON.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+SyncDateJSON.swift"; sourceTree = "<group>"; };
 		F5AD75442B7FDC2800D65C55 /* SettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsTests.swift; sourceTree = "<group>"; };
 		F5D3A0D82B70950100EED067 /* MockURLHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockURLHandler.swift; sourceTree = "<group>"; };
 		F5DBA5892B756A8700AED77F /* PodcastSettings+ImportUserDefaultsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PodcastSettings+ImportUserDefaultsTests.swift"; sourceTree = "<group>"; };
@@ -7199,6 +7201,7 @@
 				F5E949D92B61762E002DAFC3 /* TokenHelperTests.swift */,
 				F5DBA5892B756A8700AED77F /* PodcastSettings+ImportUserDefaultsTests.swift */,
 				F5AD75442B7FDC2800D65C55 /* SettingsTests.swift */,
+				F5A383752BCD9BFC00E3DC99 /* Date+SyncDateJSON.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -8587,6 +8590,7 @@
 				F5D3A0D92B70950100EED067 /* MockURLHandler.swift in Sources */,
 				FFF024CE2B62AC9400457373 /* IAPHelperTests.swift in Sources */,
 				8B3295432A5336DA00BDFA11 /* WhatsNewTests.swift in Sources */,
+				F5A383762BCD9BFC00E3DC99 /* Date+SyncDateJSON.swift in Sources */,
 				C781EA412A6B72AE001DBFCC /* SearchableListViewModelTests.swift in Sources */,
 				8B484EF728D23F06001AFA97 /* PlaybackTimeHelperTests.swift in Sources */,
 				45ECEF8627E910FB00C65030 /* ShowNotesFormatterUtilsTests.swift in Sources */,

--- a/podcasts/AppSettings+ImportUserDefaults.swift
+++ b/podcasts/AppSettings+ImportUserDefaults.swift
@@ -6,7 +6,7 @@ extension SettingsStore<AppSettings> {
     /// Updates the values in AppSettings with
     /// - Parameter userDefaults: The UserDefaults to read values from
     func importUserDefaults(_ userDefaults: UserDefaults = UserDefaults.standard) {
-        let date = Date(timeIntervalSince1970: 1)
+        let date = Date.syncDefaultDate
         self.update(\.$openLinks, value: userDefaults.bool(forKey: Constants.UserDefaults.openLinksInExternalBrowser), modifiedAt: date)
         self.update(\.$rowAction, value: Int32(userDefaults.integer(forKey: Settings.primaryRowActionKey)), modifiedAt: date)
         self.update(\.$skipForward, value: Int32(ServerSettings.skipForwardTime()), modifiedAt: date)

--- a/podcasts/AppSettings+ImportUserDefaults.swift
+++ b/podcasts/AppSettings+ImportUserDefaults.swift
@@ -6,79 +6,80 @@ extension SettingsStore<AppSettings> {
     /// Updates the values in AppSettings with
     /// - Parameter userDefaults: The UserDefaults to read values from
     func importUserDefaults(_ userDefaults: UserDefaults = UserDefaults.standard) {
-        self.update(\.$openLinks, value: userDefaults.bool(forKey: Constants.UserDefaults.openLinksInExternalBrowser))
-        self.update(\.$rowAction, value: Int32(userDefaults.integer(forKey: Settings.primaryRowActionKey)))
-        self.update(\.$skipForward, value: Int32(ServerSettings.skipForwardTime()))
-        self.update(\.$skipBack, value: Int32(ServerSettings.skipBackTime()))
-        self.update(\.$keepScreenAwake, value: UserDefaults.standard.bool(forKey: Constants.UserDefaults.keepScreenOnWhilePlaying))
-        self.update(\.$openPlayer, value: UserDefaults.standard.bool(forKey: Constants.UserDefaults.openPlayerAutomatically))
-        self.update(\.$intelligentResumption, value: UserDefaults.standard.bool(forKey: Constants.UserDefaults.intelligentPlaybackResumption))
-        self.update(\.$episodeGrouping, value: Int32(UserDefaults.standard.integer(forKey: Settings.podcastGroupingDefaultKey)))
-        self.update(\.$showArchived, value: UserDefaults.standard.bool(forKey: Settings.defaultArchiveBehaviour))
-        self.update(\.$upNextSwipe, value: Int32(UserDefaults.standard.integer(forKey: Settings.primaryUpNextSwipeActionKey)))
-        self.update(\.$playUpNextOnTap, value: UserDefaults.standard.bool(forKey: Settings.playUpNextOnTapKey))
-        self.update(\.$playbackActions, value: UserDefaults.standard.bool(forKey: Settings.mediaSessionActionsKey))
-        self.update(\.$legacyBluetooth, value: UserDefaults.standard.bool(forKey: Settings.legacyBtSupportKey))
-        self.update(\.$multiSelectGesture, value: UserDefaults.standard.bool(forKey: Settings.multiSelectGestureKey))
-        self.update(\.$chapterTitles, value: UserDefaults.standard.bool(forKey: Settings.publishChapterTitlesKey))
-        self.update(\.$autoPlayEnabled, value: UserDefaults.standard.bool(forKey: Constants.UserDefaults.autoplay))
-        self.update(\.$notifications, value: UserDefaults.standard.bool(forKey: Constants.UserDefaults.pushEnabled))
-        self.update(\.$appBadge, value: Int32(UserDefaults.standard.integer(forKey: Constants.UserDefaults.appBadge)))
+        let date = Date(timeIntervalSince1970: 0)
+        self.update(\.$openLinks, value: userDefaults.bool(forKey: Constants.UserDefaults.openLinksInExternalBrowser), modifiedAt: date)
+        self.update(\.$rowAction, value: Int32(userDefaults.integer(forKey: Settings.primaryRowActionKey)), modifiedAt: date)
+        self.update(\.$skipForward, value: Int32(ServerSettings.skipForwardTime()), modifiedAt: date)
+        self.update(\.$skipBack, value: Int32(ServerSettings.skipBackTime()), modifiedAt: date)
+        self.update(\.$keepScreenAwake, value: UserDefaults.standard.bool(forKey: Constants.UserDefaults.keepScreenOnWhilePlaying), modifiedAt: date)
+        self.update(\.$openPlayer, value: UserDefaults.standard.bool(forKey: Constants.UserDefaults.openPlayerAutomatically), modifiedAt: date)
+        self.update(\.$intelligentResumption, value: UserDefaults.standard.bool(forKey: Constants.UserDefaults.intelligentPlaybackResumption), modifiedAt: date)
+        self.update(\.$episodeGrouping, value: Int32(UserDefaults.standard.integer(forKey: Settings.podcastGroupingDefaultKey)), modifiedAt: date)
+        self.update(\.$showArchived, value: UserDefaults.standard.bool(forKey: Settings.defaultArchiveBehaviour), modifiedAt: date)
+        self.update(\.$upNextSwipe, value: Int32(UserDefaults.standard.integer(forKey: Settings.primaryUpNextSwipeActionKey)), modifiedAt: date)
+        self.update(\.$playUpNextOnTap, value: UserDefaults.standard.bool(forKey: Settings.playUpNextOnTapKey), modifiedAt: date)
+        self.update(\.$playbackActions, value: UserDefaults.standard.bool(forKey: Settings.mediaSessionActionsKey), modifiedAt: date)
+        self.update(\.$legacyBluetooth, value: UserDefaults.standard.bool(forKey: Settings.legacyBtSupportKey), modifiedAt: date)
+        self.update(\.$multiSelectGesture, value: UserDefaults.standard.bool(forKey: Settings.multiSelectGestureKey), modifiedAt: date)
+        self.update(\.$chapterTitles, value: UserDefaults.standard.bool(forKey: Settings.publishChapterTitlesKey), modifiedAt: date)
+        self.update(\.$autoPlayEnabled, value: UserDefaults.standard.bool(forKey: Constants.UserDefaults.autoplay), modifiedAt: date)
+        self.update(\.$notifications, value: UserDefaults.standard.bool(forKey: Constants.UserDefaults.pushEnabled), modifiedAt: date)
+        self.update(\.$appBadge, value: Int32(UserDefaults.standard.integer(forKey: Constants.UserDefaults.appBadge)), modifiedAt: date)
         if let filter = UserDefaults.standard.string(forKey: Constants.UserDefaults.appBadgeFilterUuid) {
-            self.update(\.$appBadgeFilter, value: filter)
+            self.update(\.$appBadgeFilter, value: filter, modifiedAt: date)
         }
         self.update(\.$volumeBoost, value: UserDefaults.standard.bool(forKey: Constants.UserDefaults.globalVolumeBoost))
         if let trimSilenceAmount = TrimSilenceAmount(rawValue: Int32(UserDefaults.standard.integer(forKey: Constants.UserDefaults.globalRemoveSilence))) {
-            self.update(\.$trimSilence, value: TrimSilence(amount: trimSilenceAmount).rawValue)
+            self.update(\.$trimSilence, value: TrimSilence(amount: trimSilenceAmount).rawValue, modifiedAt: date)
         }
-        self.update(\.$playbackSpeed, value: UserDefaults.standard.double(forKey: Constants.UserDefaults.globalPlaybackSpeed))
-        self.update(\.$warnDataUsage, value: !UserDefaults.standard.bool(forKey: Settings.allowCellularDownloadKey))
-        self.update(\.$playerBookmarksSortType, value: BookmarksSort(option: Constants.UserDefaults.bookmarks.playerSort.value))
-        self.update(\.$podcastBookmarksSortType, value: BookmarksSort(option: Constants.UserDefaults.bookmarks.podcastSort.value))
-        self.update(\.$episodeBookmarksSortType, value: BookmarksSort(option: Constants.UserDefaults.bookmarks.episodeSort.value))
-        self.update(\.$profileBookmarksSortType, value: BookmarksSort(option: Constants.UserDefaults.bookmarks.profileSort.value))
-        self.update(\.$headphoneControlsNextAction, value: HeadphoneControl(action: Constants.UserDefaults.headphones.nextAction.unlockedValue))
-        self.update(\.$headphoneControlsPreviousAction, value: HeadphoneControl(action: Constants.UserDefaults.headphones.previousAction.unlockedValue))
-        self.update(\.$privacyAnalytics, value: !UserDefaults.standard.bool(forKey: Constants.UserDefaults.analyticsOptOut))
-        self.update(\.$marketingOptIn, value: UserDefaults.standard.bool(forKey: ServerConstants.UserDefaults.marketingOptInKey))
-        self.update(\.$freeGiftAcknowledgement, value: UserDefaults.standard.bool(forKey: ServerConstants.UserDefaults.subscriptionGiftAcknowledgement))
+        self.update(\.$playbackSpeed, value: UserDefaults.standard.double(forKey: Constants.UserDefaults.globalPlaybackSpeed), modifiedAt: date)
+        self.update(\.$warnDataUsage, value: !UserDefaults.standard.bool(forKey: Settings.allowCellularDownloadKey), modifiedAt: date)
+        self.update(\.$playerBookmarksSortType, value: BookmarksSort(option: Constants.UserDefaults.bookmarks.playerSort.value), modifiedAt: date)
+        self.update(\.$podcastBookmarksSortType, value: BookmarksSort(option: Constants.UserDefaults.bookmarks.podcastSort.value), modifiedAt: date)
+        self.update(\.$episodeBookmarksSortType, value: BookmarksSort(option: Constants.UserDefaults.bookmarks.episodeSort.value), modifiedAt: date)
+        self.update(\.$profileBookmarksSortType, value: BookmarksSort(option: Constants.UserDefaults.bookmarks.profileSort.value), modifiedAt: date)
+        self.update(\.$headphoneControlsNextAction, value: HeadphoneControl(action: Constants.UserDefaults.headphones.nextAction.unlockedValue), modifiedAt: date)
+        self.update(\.$headphoneControlsPreviousAction, value: HeadphoneControl(action: Constants.UserDefaults.headphones.previousAction.unlockedValue), modifiedAt: date)
+        self.update(\.$privacyAnalytics, value: !UserDefaults.standard.bool(forKey: Constants.UserDefaults.analyticsOptOut), modifiedAt: date)
+        self.update(\.$marketingOptIn, value: UserDefaults.standard.bool(forKey: ServerConstants.UserDefaults.marketingOptInKey), modifiedAt: date)
+        self.update(\.$freeGiftAcknowledgement, value: UserDefaults.standard.bool(forKey: ServerConstants.UserDefaults.subscriptionGiftAcknowledgement), modifiedAt: date)
         if let time = AutoArchiveAfterTime(rawValue: UserDefaults.standard.double(forKey: Settings.autoArchivePlayedAfterKey)), let played = AutoArchiveAfterPlayed(time: time) {
-            self.update(\.$autoArchivePlayed, value: played.rawValue)
+            self.update(\.$autoArchivePlayed, value: played.rawValue, modifiedAt: date)
         }
         if let time = AutoArchiveAfterTime(rawValue: UserDefaults.standard.double(forKey: Settings.autoArchiveInactiveAfterKey)), let inactive = AutoArchiveAfterInactive(time: time) {
-            self.update(\.$autoArchiveInactive, value: inactive.rawValue)
+            self.update(\.$autoArchiveInactive, value: inactive.rawValue, modifiedAt: date)
         }
         self.update(\.$autoArchiveIncludesStarred, value: UserDefaults.standard.bool(forKey: Settings.archiveStarredEpisodesKey))
         if let lastPlaylist = AutoplayHelper().userDefaultsPlaylist {
-            self.update(\.$autoPlayLastListUuid, value: AutoPlaySource(playlist: lastPlaylist))
+            self.update(\.$autoPlayLastListUuid, value: AutoPlaySource(playlist: lastPlaylist), modifiedAt: date)
 		}
         if let old = LibrarySort.Old(rawValue: ServerSettings.homeGridSortOrder()) {
-            self.update(\.$gridOrder, value: LibrarySort(old: old))
+            self.update(\.$gridOrder, value: LibrarySort(old: old), modifiedAt: date)
         }
         if let old = LibraryType.Old(rawValue: UserDefaults.standard.integer(forKey: Settings.podcastLibraryGridTypeKey)) {
-            self.update(\.$gridLayout, value: LibraryType(old: old))
+            self.update(\.$gridLayout, value: LibraryType(old: old), modifiedAt: date)
         }
-        self.update(\.$badges, value: Int32(UserDefaults.standard.integer(forKey: Settings.badgeKey)))
-        self.update(\.$filesAutoUpNext, value: UserDefaults.standard.bool(forKey: Settings.userEpisodeAutoAddToUpNextKey))
-        self.update(\.$filesAfterPlayingDeleteLocal, value: UserDefaults.standard.bool(forKey: Settings.userEpisodeRemoveFileAfterPlayingKey))
-        self.update(\.$filesAfterPlayingDeleteCloud, value: UserDefaults.standard.bool(forKey: Settings.userEpisodeRemoveFromCloudAfterPlayingKey))
-        self.update(\.$playerShelf, value: (UserDefaults.standard.playerActions ?? PlayerAction.defaultActions).map { ActionOption.known($0) })
-        self.update(\.$useEmbeddedArtwork, value: UserDefaults.standard.bool(forKey: Constants.UserDefaults.loadEmbeddedImages))
+        self.update(\.$badges, value: Int32(UserDefaults.standard.integer(forKey: Settings.badgeKey)), modifiedAt: date)
+        self.update(\.$filesAutoUpNext, value: UserDefaults.standard.bool(forKey: Settings.userEpisodeAutoAddToUpNextKey), modifiedAt: date)
+        self.update(\.$filesAfterPlayingDeleteLocal, value: UserDefaults.standard.bool(forKey: Settings.userEpisodeRemoveFileAfterPlayingKey), modifiedAt: date)
+        self.update(\.$filesAfterPlayingDeleteCloud, value: UserDefaults.standard.bool(forKey: Settings.userEpisodeRemoveFromCloudAfterPlayingKey), modifiedAt: date)
+        self.update(\.$playerShelf, value: (UserDefaults.standard.playerActions ?? PlayerAction.defaultActions).map { ActionOption.known($0) }, modifiedAt: date)
+        self.update(\.$useEmbeddedArtwork, value: UserDefaults.standard.bool(forKey: Constants.UserDefaults.loadEmbeddedImages), modifiedAt: date)
         if let oldTheme = ThemeType.Old(rawValue: UserDefaults.standard.integer(forKey: Theme.themeKey)) {
-            self.update(\.$theme, value: ThemeType(old: oldTheme))
+            self.update(\.$theme, value: ThemeType(old: oldTheme), modifiedAt: date)
         }
-        self.update(\.$useSystemTheme, value: UserDefaults.standard.bool(forKey: Constants.UserDefaults.shouldFollowSystemThemeKey))
+        self.update(\.$useSystemTheme, value: UserDefaults.standard.bool(forKey: Constants.UserDefaults.shouldFollowSystemThemeKey), modifiedAt: date)
         if let oldTheme = ThemeType.Old(rawValue: UserDefaults.standard.integer(forKey: Theme.preferredLightThemeKey)) {
-            self.update(\.$lightThemePreference, value: ThemeType(old: oldTheme))
+            self.update(\.$lightThemePreference, value: ThemeType(old: oldTheme), modifiedAt: date)
         }
         if let oldTheme = ThemeType.Old(rawValue: UserDefaults.standard.integer(forKey: Theme.preferredDarkThemeKey)) {
-            self.update(\.$darkThemePreference, value: ThemeType(old: oldTheme))
+            self.update(\.$darkThemePreference, value: ThemeType(old: oldTheme), modifiedAt: date)
         }
-        self.update(\.$useDarkUpNextTheme, value: Constants.UserDefaults.appearance.darkUpNextTheme.value)
-        self.update(\.$autoUpNextLimit, value: Int32(UserDefaults.standard.integer(forKey: ServerSettings.autoAddLimitKey)))
-        self.update(\.$autoUpNextLimitReached, value: Int32(UserDefaults.standard.integer(forKey: ServerSettings.onAutoAddLimitReachedKey)))
+        self.update(\.$useDarkUpNextTheme, value: Constants.UserDefaults.appearance.darkUpNextTheme.value, modifiedAt: date)
+        self.update(\.$autoUpNextLimit, value: Int32(UserDefaults.standard.integer(forKey: ServerSettings.autoAddLimitKey)), modifiedAt: date)
+        self.update(\.$autoUpNextLimitReached, value: Int32(UserDefaults.standard.integer(forKey: ServerSettings.onAutoAddLimitReachedKey)), modifiedAt: date)
         if let old = UploadedSort.Old(rawValue: UserDefaults.standard.integer(forKey: Settings.userEpisodeSortByKey)) {
-            self.update(\.$filesSortOrder, value: UploadedSort(old: old))
+            self.update(\.$filesSortOrder, value: UploadedSort(old: old), modifiedAt: date)
          }
     }
 

--- a/podcasts/AppSettings+ImportUserDefaults.swift
+++ b/podcasts/AppSettings+ImportUserDefaults.swift
@@ -6,7 +6,7 @@ extension SettingsStore<AppSettings> {
     /// Updates the values in AppSettings with
     /// - Parameter userDefaults: The UserDefaults to read values from
     func importUserDefaults(_ userDefaults: UserDefaults = UserDefaults.standard) {
-        let date = Date(timeIntervalSince1970: 0)
+        let date = Date(timeIntervalSince1970: 1)
         self.update(\.$openLinks, value: userDefaults.bool(forKey: Constants.UserDefaults.openLinksInExternalBrowser), modifiedAt: date)
         self.update(\.$rowAction, value: Int32(userDefaults.integer(forKey: Settings.primaryRowActionKey)), modifiedAt: date)
         self.update(\.$skipForward, value: Int32(ServerSettings.skipForwardTime()), modifiedAt: date)

--- a/podcasts/DataManager+Import.swift
+++ b/podcasts/DataManager+Import.swift
@@ -5,37 +5,38 @@ extension DataManager {
     func importPodcastSettings() {
         let podcasts = allPodcasts(includeUnsubscribed: true)
 
+        let date = Date(timeIntervalSince1970: 0)
         podcasts.enumerated().forEach { (idx, podcast) in
-            podcast.settings.$autoStartFrom = ModifiedDate<Int32>(wrappedValue: podcast.startFrom)
-            podcast.settings.$autoSkipLast = ModifiedDate<Int32>(wrappedValue: podcast.skipLast)
-            podcast.settings.$playbackSpeed = ModifiedDate<Double>(wrappedValue: podcast.playbackSpeed)
-            podcast.settings.$showArchived = ModifiedDate<Bool>(wrappedValue: podcast.showArchived)
-            podcast.settings.$customEffects = ModifiedDate<Bool>(wrappedValue: podcast.overrideGlobalEffects)
+            podcast.settings.$autoStartFrom = ModifiedDate<Int32>(wrappedValue: podcast.startFrom, modifiedAt: date)
+            podcast.settings.$autoSkipLast = ModifiedDate<Int32>(wrappedValue: podcast.skipLast, modifiedAt: date)
+            podcast.settings.$playbackSpeed = ModifiedDate<Double>(wrappedValue: podcast.playbackSpeed, modifiedAt: date)
+            podcast.settings.$showArchived = ModifiedDate<Bool>(wrappedValue: podcast.showArchived, modifiedAt: date)
+            podcast.settings.$customEffects = ModifiedDate<Bool>(wrappedValue: podcast.overrideGlobalEffects, modifiedAt: date)
             if let trimSilence = TrimSilenceAmount(rawValue: podcast.trimSilenceAmount) {
-                podcast.settings.$trimSilence = ModifiedDate<TrimSilence>(wrappedValue: TrimSilence(amount: trimSilence))
+                podcast.settings.$trimSilence = ModifiedDate<TrimSilence>(wrappedValue: TrimSilence(amount: trimSilence), modifiedAt: date)
             }
-            podcast.settings.$boostVolume = ModifiedDate<Bool>(wrappedValue: podcast.boostVolume)
-            podcast.settings.$notification = ModifiedDate<Bool>(wrappedValue: podcast.pushEnabled)
+            podcast.settings.$boostVolume = ModifiedDate<Bool>(wrappedValue: podcast.boostVolume, modifiedAt: date)
+            podcast.settings.$notification = ModifiedDate<Bool>(wrappedValue: podcast.pushEnabled, modifiedAt: date)
             if let oldValue = PodcastEpisodeSortOrder.Old(rawValue: podcast.episodeSortOrder) {
                 let episodeSortOrder = PodcastEpisodeSortOrder(old: oldValue)
-                podcast.settings.$episodesSortOrder = ModifiedDate<PodcastEpisodeSortOrder>(wrappedValue: episodeSortOrder)
+                podcast.settings.$episodesSortOrder = ModifiedDate<PodcastEpisodeSortOrder>(wrappedValue: episodeSortOrder, modifiedAt: date)
 			}
             if let grouping = PodcastGrouping(rawValue: podcast.episodeGrouping) {
-                podcast.settings.$episodeGrouping = ModifiedDate<PodcastGrouping>(wrappedValue: grouping)
+                podcast.settings.$episodeGrouping = ModifiedDate<PodcastGrouping>(wrappedValue: grouping, modifiedAt: date)
             }
-            podcast.settings.$autoArchive = ModifiedDate<Bool>(wrappedValue: podcast.overrideGlobalArchive)
+            podcast.settings.$autoArchive = ModifiedDate<Bool>(wrappedValue: podcast.overrideGlobalArchive, modifiedAt: date)
             if let archiveTime = AutoArchiveAfterTime(rawValue: podcast.autoArchivePlayedAfter), let archivePlayed = AutoArchiveAfterPlayed(time: archiveTime) {
-                podcast.settings.$autoArchivePlayed = ModifiedDate<AutoArchiveAfterPlayed>(wrappedValue: archivePlayed)
+                podcast.settings.$autoArchivePlayed = ModifiedDate<AutoArchiveAfterPlayed>(wrappedValue: archivePlayed, modifiedAt: date)
             }
             podcast.settings.autoArchiveEpisodeLimit = podcast.autoArchiveEpisodeLimit
             if let archiveTime = AutoArchiveAfterTime(rawValue: podcast.autoArchiveInactiveAfter), let archiveInactive = AutoArchiveAfterInactive(time: archiveTime) {
-                podcast.settings.$autoArchiveInactive =  ModifiedDate<AutoArchiveAfterInactive>(wrappedValue: archiveInactive)
+                podcast.settings.$autoArchiveInactive =  ModifiedDate<AutoArchiveAfterInactive>(wrappedValue: archiveInactive, modifiedAt: date)
             }
 
             if let setting = AutoAddToUpNextSetting(rawValue: podcast.autoAddToUpNext) {
-                podcast.settings.addToUpNext = setting.enabled
+                podcast.settings.$addToUpNext = ModifiedDate<Bool>(wrappedValue: setting.enabled, modifiedAt: date)
                 if let position = setting.position {
-                    podcast.settings.addToUpNextPosition = position
+                    podcast.settings.$addToUpNextPosition = ModifiedDate<UpNextPosition>(wrappedValue: position, modifiedAt: date)
                 }
             }
 

--- a/podcasts/DataManager+Import.swift
+++ b/podcasts/DataManager+Import.swift
@@ -5,7 +5,7 @@ extension DataManager {
     func importPodcastSettings() {
         let podcasts = allPodcasts(includeUnsubscribed: true)
 
-        let date = Date(timeIntervalSince1970: 1)
+        let date = Date.syncDefaultDate
         podcasts.enumerated().forEach { (idx, podcast) in
             podcast.settings.$autoStartFrom = ModifiedDate<Int32>(wrappedValue: podcast.startFrom, modifiedAt: date)
             podcast.settings.$autoSkipLast = ModifiedDate<Int32>(wrappedValue: podcast.skipLast, modifiedAt: date)

--- a/podcasts/DataManager+Import.swift
+++ b/podcasts/DataManager+Import.swift
@@ -40,6 +40,7 @@ extension DataManager {
                 }
             }
 
+            podcast.syncStatus = SyncStatus.notSynced.rawValue
             save(podcast: podcast, cache: idx == podcasts.endIndex)
         }
     }

--- a/podcasts/DataManager+Import.swift
+++ b/podcasts/DataManager+Import.swift
@@ -5,7 +5,7 @@ extension DataManager {
     func importPodcastSettings() {
         let podcasts = allPodcasts(includeUnsubscribed: true)
 
-        let date = Date(timeIntervalSince1970: 0)
+        let date = Date(timeIntervalSince1970: 1)
         podcasts.enumerated().forEach { (idx, podcast) in
             podcast.settings.$autoStartFrom = ModifiedDate<Int32>(wrappedValue: podcast.startFrom, modifiedAt: date)
             podcast.settings.$autoSkipLast = ModifiedDate<Int32>(wrappedValue: podcast.skipLast, modifiedAt: date)

--- a/podcasts/Date+SyncDate.swift
+++ b/podcasts/Date+SyncDate.swift
@@ -2,6 +2,6 @@ extension Date {
     /// A default date to use when syncing with the server.
     /// The server defaults to the epoch date and if we don't set to a date _slightly_ after that, it will not store the new setting.
     static var syncDefaultDate: Date {
-        Date(timeIntervalSince1970: 1 / 1000)
+        Date(timeIntervalSince1970: 1)
     }
 }

--- a/podcasts/Date+SyncDate.swift
+++ b/podcasts/Date+SyncDate.swift
@@ -1,0 +1,7 @@
+extension Date {
+    /// A default date to use when syncing with the server.
+    /// The server defaults to the epoch date and if we don't set to a date _slightly_ after that, it will not store the new setting.
+    static var syncDefaultDate: Date {
+        Date(timeIntervalSince1970: 1 / 1000)
+    }
+}


### PR DESCRIPTION
| **Depends On** | https://github.com/Automattic/pocket-casts-ios/pull/1615 |
|-|-|

Set the Modified Date on all imported settings to 1 second after the epoch date.

* This ensures that imported settings are sent to the server (any settings without a date are not).
* By defaulting to 1 second after, the setting is stored by the server. A default epoch date is effectively a "null" value and will not replace the default value.

## To test

* Change the return value of `shouldEnableSyncedSettings` in `FeatureFlag.swift` to `false`
* Build and run
* Log in to an account which hasn't used synced settings
* Change a few settings
* Enable the `newSettingsStorage` and `settingsSync` feature flags
* Restart the app
* Pull to refresh or tap "Refresh Now" in profile
* Ensure changed settings remain
* Delete the app
* Change `shouldEnableSyncedSettings` in `FeatureFlag.swift` back to its original implementation or set to `true`
* Build and run
* Log in to the same account from above
* Verify that the changed settings are the same as when changed above

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
