### PR TITLE
Convert bookmark sort options from server to local sort option

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Enums.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Enums.swift
@@ -130,8 +130,6 @@ public enum BookmarksSort: Int32, Codable {
     case newestToOldest = 0
     case oldestToNewest = 1
     case timestamp = 2
-    case episode = 3
-    case podcastAndEspisode = 4
 }
 
 public enum AutoArchiveAfterPlayed: Int32, Codable {

--- a/PocketCastsTests/Tests/Utilities/SettingsTests.swift
+++ b/PocketCastsTests/Tests/Utilities/SettingsTests.swift
@@ -131,9 +131,9 @@ final class SettingsTests: XCTestCase {
         let newPlayedAfter = AutoArchiveAfterTime.after1Week
         let newInactiveAfter = AutoArchiveAfterTime.after90Days
         let newEpisodeSortBy = UploadedSort.titleAtoZ
-        let newPlayerBookmarksSort = BookmarkSortOption.podcastAndEpisode
-        let newEpisodeBookmarksSort = BookmarkSortOption.episode
-        let newProfileBookmarksSort = BookmarkSortOption.newestToOldest
+        let newPlayerBookmarksSort = BookmarkSortOption.newestToOldest
+        let newEpisodeBookmarksSort = BookmarkSortOption.oldestToNewest
+        let newProfileBookmarksSort = BookmarkSortOption.podcastAndEpisode
         let newHeadphonesNextAction = HeadphoneControlAction.previousChapter
         let newHeadphonesPreviousAction = HeadphoneControlAction.skipForward
         let newHomeFolderSortOrder = LibrarySort.titleAtoZ

--- a/podcasts/Enumerations.swift
+++ b/podcasts/Enumerations.swift
@@ -568,18 +568,14 @@ enum MultiSelectAction: Int32, CaseIterable, AnalyticsDescribable {
 }
 
 extension BookmarksSort {
-    var option: BookmarkSortOption {
+    func option(lastOption: BookmarkSortOption) -> BookmarkSortOption {
         switch self {
         case .newestToOldest:
             return .newestToOldest
         case .oldestToNewest:
             return .oldestToNewest
         case .timestamp:
-            return .timestamp
-        case .episode:
-            return .episode
-        case .podcastAndEspisode:
-            return .podcastAndEpisode
+            return lastOption
         }
     }
 
@@ -589,12 +585,8 @@ extension BookmarksSort {
             self = .newestToOldest
         case .oldestToNewest:
             self = .oldestToNewest
-        case .timestamp:
+        case .timestamp, .episode, .podcastAndEpisode:
             self = .timestamp
-        case .episode:
-            self = .episode
-        case .podcastAndEpisode:
-            self = .podcastAndEspisode
         }
     }
 }

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -1171,7 +1171,7 @@ class Settings: NSObject {
     static var playerBookmarksSort: Binding<BookmarkSortOption> {
         Binding {
             if FeatureFlag.newSettingsStorage.enabled {
-                return SettingsStore.appSettings.playerBookmarksSortType.option
+                return SettingsStore.appSettings.playerBookmarksSortType.option(lastOption: .timestamp)
             } else {
                 return Constants.UserDefaults.bookmarks.playerSort.value
             }
@@ -1186,7 +1186,7 @@ class Settings: NSObject {
     static var episodeBookmarksSort: Binding<BookmarkSortOption> {
         Binding {
             if FeatureFlag.newSettingsStorage.enabled {
-                return SettingsStore.appSettings.episodeBookmarksSortType.option
+                return SettingsStore.appSettings.episodeBookmarksSortType.option(lastOption: .timestamp)
             } else {
                 return Constants.UserDefaults.bookmarks.episodeSort.value
             }
@@ -1201,7 +1201,7 @@ class Settings: NSObject {
     static var podcastBookmarksSort: Binding<BookmarkSortOption> {
         Binding {
             if FeatureFlag.newSettingsStorage.enabled {
-                return SettingsStore.appSettings.podcastBookmarksSortType.option
+                return SettingsStore.appSettings.podcastBookmarksSortType.option(lastOption: .episode)
             } else {
                 return Constants.UserDefaults.bookmarks.podcastSort.value
             }
@@ -1216,7 +1216,7 @@ class Settings: NSObject {
     static var profileBookmarksSort: Binding<BookmarkSortOption> {
         Binding {
             if FeatureFlag.newSettingsStorage.enabled {
-                return SettingsStore.appSettings.profileBookmarksSortType.option
+                return SettingsStore.appSettings.profileBookmarksSortType.option(lastOption: .podcastAndEpisode)
             } else {
                 return Constants.UserDefaults.bookmarks.profileSort.value
             }


### PR DESCRIPTION
Fixes #

The server always use 2 for the last sort order and depending of the screen where the sort is used that translates to a different sort option

## To test
- Start the app logged in using a plus account
- Go to Profile-> Bookmarks
- If you don't have any bookmarks please add some on multiple podcasts and episodes
- Tap on Sort Options
- Set the option Podcast & Episode
- Exit the screen
- Check on another device with the same account if the sort option is synced
- Open a podcasts where you saved a bookmark
- Tap on Bookmarks
- Tap on Sort Options and chose Episode
- Exit the screen
- Sync on the other device ( pull to refresh on the Podcasts screen)
- Open the same podcast and bookmarks tab
- Check if the sort option shows correctly

Steps to test your PR.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
