### PR TITLE
Add Most Popular section to Discover Categories page

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
@@ -263,6 +263,7 @@ public struct DiscoverItem: Decodable, Equatable {
     public var type: String?
     public var summaryStyle: String?
     public var expandedStyle: String?
+    public var summaryItemCount: Int?
     public var source: String?
     public var sponsoredPodcasts: [CarouselSponsoredPodcast]?
     public var expandedTopItemLabel: String?
@@ -282,11 +283,38 @@ public struct DiscoverItem: Decodable, Equatable {
         case type, title, source, regions, curated, uuid, popular, id
     }
 
-    public init(id: String? = nil, title: String? = nil, source: String? = nil, regions: [String]) {
+    public init(
+        id: String? = nil,
+        uuid: String? = nil,
+        title: String? = nil,
+        type: String? = nil,
+        summaryStyle: String? = nil,
+        summaryItemCount: Int? = nil,
+        expandedStyle: String? = nil,
+        source: String? = nil,
+        sponsoredPodcasts: [CarouselSponsoredPodcast]? = nil,
+        expandedTopItemLabel: String? = nil,
+        curated: Bool? = nil,
+        regions: [String],
+        isSponsored: Bool? = nil,
+        popular: [Int]? = nil,
+        categoryID: Int? = nil
+    ) {
         self.id = id
+        self.uuid = uuid
         self.title = title
+        self.type = type
+        self.summaryStyle = summaryStyle
+        self.summaryItemCount = summaryItemCount
+        self.expandedStyle = expandedStyle
         self.source = source
+        self.sponsoredPodcasts = sponsoredPodcasts
+        self.expandedTopItemLabel = expandedTopItemLabel
+        self.curated = curated
         self.regions = regions
+        self.isSponsored = isSponsored
+        self.popular = popular
+        self.categoryID = categoryID
     }
 }
 

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1600,6 +1600,7 @@
 		F55449422B758E8300F68AE9 /* PocketCastsUtils in Frameworks */ = {isa = PBXBuildFile; productRef = F55449412B758E8300F68AE9 /* PocketCastsUtils */; };
 		F55449432B758E8300F68AE9 /* PocketCastsUtils in Embed Frameworks */ = {isa = PBXBuildFile; productRef = F55449412B758E8300F68AE9 /* PocketCastsUtils */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		F55449452B75935F00F68AE9 /* AppSettings+ImportUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = F55449442B75935F00F68AE9 /* AppSettings+ImportUserDefaults.swift */; };
+		F55C4C762BCF064500A10352 /* DiscoverViewController+CategoryRedesign.swift in Sources */ = {isa = PBXBuildFile; fileRef = F55C4C752BCF064500A10352 /* DiscoverViewController+CategoryRedesign.swift */; };
 		F565602F2B7ACD9B003E76D5 /* DataManager+Import.swift in Sources */ = {isa = PBXBuildFile; fileRef = F565602E2B7ACD9B003E76D5 /* DataManager+Import.swift */; };
 		F56ADE562B7FE37500ADFE31 /* SettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5AD75442B7FDC2800D65C55 /* SettingsTests.swift */; };
 		F5D3A0D92B70950100EED067 /* MockURLHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5D3A0D82B70950100EED067 /* MockURLHandler.swift */; };
@@ -3377,6 +3378,7 @@
 		F52B4F8B2BB4A9CA00E87BE4 /* CategoriesSelectorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoriesSelectorViewController.swift; sourceTree = "<group>"; };
 		F52B4F8D2BB4A9ED00E87BE4 /* CategoriesSelectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoriesSelectorView.swift; sourceTree = "<group>"; };
 		F55449442B75935F00F68AE9 /* AppSettings+ImportUserDefaults.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AppSettings+ImportUserDefaults.swift"; sourceTree = "<group>"; };
+		F55C4C752BCF064500A10352 /* DiscoverViewController+CategoryRedesign.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DiscoverViewController+CategoryRedesign.swift"; sourceTree = "<group>"; };
 		F565602E2B7ACD9B003E76D5 /* DataManager+Import.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DataManager+Import.swift"; sourceTree = "<group>"; };
 		F5AD75442B7FDC2800D65C55 /* SettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsTests.swift; sourceTree = "<group>"; };
 		F5D3A0D82B70950100EED067 /* MockURLHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockURLHandler.swift; sourceTree = "<group>"; };
@@ -7247,6 +7249,7 @@
 				BD18FB1C219ACC770012C41D /* Search */,
 				8BAB8B2D299ABC5E00B8404C /* New Search */,
 				BDB1E4DB1B8C5998009AD30F /* DiscoverViewController.swift */,
+				F55C4C752BCF064500A10352 /* DiscoverViewController+CategoryRedesign.swift */,
 				BDE60ACD2108597D00A7281B /* DiscoverViewController+DiscoverDelegate.swift */,
 				BDDA14D4219AF8D50066441E /* DiscoverViewController+Search.swift */,
 				BDB1E4DC1B8C5998009AD30F /* DiscoverViewController.xib */,
@@ -8811,6 +8814,7 @@
 				BD1EBD6E1CB7770B004F83D6 /* AppearanceViewController.swift in Sources */,
 				BD13574E27BF24B500A5D7C6 /* EditFolderPodcastsView.swift in Sources */,
 				C713D4FA2A04C90500A78468 /* AccountHeaderViewModel.swift in Sources */,
+				F55C4C762BCF064500A10352 /* DiscoverViewController+CategoryRedesign.swift in Sources */,
 				BDF09F041E669E16009E9845 /* BasePlayPauseButton.swift in Sources */,
 				407B21E72231F6A300B4E492 /* UploadedSettingsViewController.swift in Sources */,
 				BD339C5C2149E35600E655F9 /* VideoViewController+Controls.swift in Sources */,

--- a/podcasts/Categories/CategoryButtonStyle.swift
+++ b/podcasts/Categories/CategoryButtonStyle.swift
@@ -80,13 +80,13 @@ struct CategoryButtonStyle: ButtonStyle {
             .fixedSize(horizontal: true, vertical: false)
             .padding(.horizontal, cornerStyle.horizontalPadding)
             .padding(.vertical, Constants.Padding.vertical)
+            .padding(cornerStyle == .circle ? 3 : 0)
             .cornerRadius(Constants.cornerRadius)
             .background(isSelected ? selectedBackground : ((configuration.isPressed || forcePressed) ? pressedBackground : background))
             .foregroundColor(isSelected ? selectedForeground : foreground)
             .modify {
                 if #available(iOS 16.0, *) {
                     $0
-                        .padding(cornerStyle == .circle ? 3 : 0)
                         .overlay(
                         cornerStyle.shape
                             .stroke(isSelected ? selectedBackground : border, lineWidth: 1)
@@ -124,6 +124,19 @@ struct CategoryButtonStyle: ButtonStyle {
     buttonStyle.forcePressed = true
     return Button("Hello", action: {
 
+    }).buttonStyle(buttonStyle)
+    .applyButtonEffect(isPressed: true)
+    .previewWithAllThemes()
+}
+
+#Preview("closed") {
+    var buttonStyle = CategoryButtonStyle(isSelected: false, cornerStyle: .circle)
+    buttonStyle.forcePressed = true
+    return Button(action: {
+
+    }, label: {
+        Image(systemName: "xmark")
+            .imageScale(.small)
     }).buttonStyle(buttonStyle)
     .applyButtonEffect(isPressed: true)
     .previewWithAllThemes()

--- a/podcasts/CategoryPodcastsViewController.swift
+++ b/podcasts/CategoryPodcastsViewController.swift
@@ -21,10 +21,12 @@ class CategoryPodcastsViewController: PCViewController, UITableViewDelegate, UIT
     weak var delegate: DiscoverDelegate?
 
     private var category: DiscoverCategory
+    private var skipCount: Int
     private var podcasts = [DiscoverPodcast]()
     private var promotion: DiscoverCategoryPromotion?
-    init(category: DiscoverCategory) {
+    init(category: DiscoverCategory, skipCount: Int = 0) {
         self.category = category
+        self.skipCount = skipCount
         super.init(nibName: "CategoryPodcastsViewController", bundle: nil)
 
         title = category.name?.localized
@@ -121,7 +123,7 @@ class CategoryPodcastsViewController: PCViewController, UITableViewDelegate, UIT
                 }
 
                 strongSelf.loadingIndicator.stopAnimating()
-                strongSelf.podcasts = podcasts
+                strongSelf.podcasts = Array(podcasts.dropFirst(strongSelf.skipCount))
                 strongSelf.promotion = categoryDetails?.promotion
                 strongSelf.podcastsTable.reloadData()
 

--- a/podcasts/DiscoverViewController+CategoryRedesign.swift
+++ b/podcasts/DiscoverViewController+CategoryRedesign.swift
@@ -1,8 +1,10 @@
 import PocketCastsServer
 
-private let popularItemsCount = 5
-
 extension DiscoverViewController {
+    private enum Constants {
+        static let popularItemsCount = 5
+    }
+
     /// Reloads discover, keeping the items listed in `exclude`
     /// - Parameters:
     ///   - items: Items to exclude from the reload process. These items will REMAIN in Discover
@@ -47,7 +49,7 @@ extension DiscoverViewController {
             title: title,
             type: "podcast_list",
             summaryStyle: "large_list",
-            summaryItemCount: popularItemsCount,
+            summaryItemCount: Constants.popularItemsCount,
             source: source,
             regions: items.first?.regions ?? [],
             categoryID: category.id
@@ -60,7 +62,7 @@ extension DiscoverViewController {
 
     private func addCategoryVC(for category: DiscoverCategory, regions: [String]) {
         let region = discoverLayout.map { Settings.discoverRegion(discoverLayout: $0) }
-        let categoryVC = CategoryPodcastsViewController(category: category, region: region, skipCount: popularItemsCount)
+        let categoryVC = CategoryPodcastsViewController(category: category, region: region, skipCount: Constants.popularItemsCount)
         categoryVC.delegate = self
         categoryVC.view.alpha = 0
         categoryVC.podcastsTable.isScrollEnabled = false

--- a/podcasts/DiscoverViewController+CategoryRedesign.swift
+++ b/podcasts/DiscoverViewController+CategoryRedesign.swift
@@ -1,0 +1,70 @@
+import PocketCastsServer
+
+private let popularItemsCount = 5
+
+extension DiscoverViewController {
+    /// Reloads discover, keeping the items listed in `exclude`
+    /// - Parameters:
+    ///   - items: Items to exclude from the reload process. These items will REMAIN in Discover
+    ///   - category: The `DiscoverCategory` to add to the layout. This is sort of an artifical `DiscoverLayout`.
+    func reload(except items: [DiscoverItem], category: DiscoverCategory?) {
+        let newLayout: DiscoverLayout?
+
+        if let category {
+            newLayout = modified(layout: discoverLayout, for: category, with: items)
+        } else {
+            newLayout = discoverLayout
+        }
+
+        populateFrom(discoverLayout: newLayout, shouldInclude: {
+            ($0.categoryID == category?.id) || items.contains($0)
+        }, shouldReset: {
+            !items.contains($0)
+        })
+
+        guard let category else { return }
+        addCategoryVC(for: category, regions: items.first?.regions ?? [])
+    }
+
+    private func modified(layout: DiscoverLayout?, for category: DiscoverCategory, with items: [DiscoverItem]) -> DiscoverLayout? {
+
+        let popularID = "category-popular-\(category.id ?? 0)"
+
+        // Only add if we haven't already added
+        guard layout?.layout?.contains(where: { $0.id == popularID }) == false else { return layout }
+
+        let source = replaceRegionCode(string: category.source)
+
+        let title: String
+        if let name = category.name {
+            title = "Most Popular in \(name)"
+        } else {
+            title = "Most Popular"
+        }
+
+        let item = DiscoverItem(
+            id: popularID,
+            title: title,
+            type: "podcast_list",
+            summaryStyle: "large_list",
+            summaryItemCount: popularItemsCount,
+            source: source,
+            regions: items.first?.regions ?? [],
+            categoryID: category.id
+        )
+
+        var newLayout = layout
+        newLayout?.layout?.insert(item, at: layout?.layout?.startIndex ?? 0)
+        return newLayout
+    }
+
+    private func addCategoryVC(for category: DiscoverCategory, regions: [String]) {
+        let categoryVC = CategoryPodcastsViewController(category: category, skipCount: popularItemsCount)
+        categoryVC.delegate = self
+        categoryVC.view.alpha = 0
+        categoryVC.podcastsTable.isScrollEnabled = false
+
+        let item = DiscoverItem(id: "category-\(category.id ?? 0)", title: category.name, source: category.source, regions: regions)
+        addToScrollView(viewController: categoryVC, for: item, isLast: true)
+    }
+}

--- a/podcasts/DiscoverViewController+CategoryRedesign.swift
+++ b/podcasts/DiscoverViewController+CategoryRedesign.swift
@@ -37,9 +37,9 @@ extension DiscoverViewController {
 
         let title: String
         if let name = category.name {
-            title = "Most Popular in \(name)"
+            title = L10n.mostPopularWithName(name)
         } else {
-            title = "Most Popular"
+            title = L10n.mostPopular
         }
 
         let item = DiscoverItem(

--- a/podcasts/DiscoverViewController.swift
+++ b/podcasts/DiscoverViewController.swift
@@ -305,6 +305,10 @@ class DiscoverViewController: PCViewController {
                 } else {
                     viewController.view.topAnchor.constraint(equalTo: previousView.bottomAnchor).isActive = true
                 }
+
+                if previousVC is CategoriesSelectorViewController {
+                    (viewController as? LargeListSummaryViewController)?.padding = 25
+                }
             }
         } else {
             viewController.view.topAnchor.constraint(equalTo: mainScrollView.topAnchor).isActive = true

--- a/podcasts/DiscoverViewController.swift
+++ b/podcasts/DiscoverViewController.swift
@@ -145,31 +145,6 @@ class DiscoverViewController: PCViewController {
         }
     }
 
-    /// Reloads discover, keeping the items listed in `exclude`
-    /// - Parameters:
-    ///   - items: Items to exclude from the reload process. These items will REMAIN in Discover
-    ///   - category: The `DiscoverCategory` to add to the layout. This is sort of an artifical `DiscoverLayout`.
-    func reload(except items: [DiscoverItem], category: DiscoverCategory?) {
-        populateFrom(discoverLayout: discoverLayout, shouldInclude: {
-            ($0.categoryID == category?.id) || items.contains($0)
-        }, shouldReset: {
-            !items.contains($0)
-        })
-
-        guard let category else { return }
-        addCategoryVC(for: category, regions: items.first?.regions ?? [])
-    }
-
-    private func addCategoryVC(for category: DiscoverCategory, regions: [String]) {
-        let categoryVC = CategoryPodcastsViewController(category: category)
-        categoryVC.delegate = self
-        categoryVC.view.alpha = 0
-        categoryVC.podcastsTable.isScrollEnabled = false
-
-        let item = DiscoverItem(id: "category-\(category.id ?? 0)", title: category.name, source: category.source, regions: regions)
-        addToScrollView(viewController: categoryVC, for: item, isLast: true)
-    }
-
     private func showPageLoading() {
         loadingContent = true
 
@@ -253,7 +228,7 @@ class DiscoverViewController: PCViewController {
     ///   - discoverLayout: A `DiscoverLayout`
     ///   - shouldInclude: Whether a `DiscoverItem` from the layout should be included in the scroll view. This is used to filter items meant only for certain categories, for instance.
     ///   - shouldReset: Whether a view controller from `summaryViewControllers` should be reset during this operation. This is used by the Categories pills to avoid triggering a view reload, allowing animations to continue.
-    private func populateFrom(discoverLayout: DiscoverLayout?, shouldInclude: ((DiscoverItem) -> Bool)? = nil, shouldReset: ((DiscoverItem) -> Bool)? = nil) {
+    func populateFrom(discoverLayout: DiscoverLayout?, shouldInclude: ((DiscoverItem) -> Bool)? = nil, shouldReset: ((DiscoverItem) -> Bool)? = nil) {
         loadingContent = false
 
         guard let layout = discoverLayout, let items = layout.layout, let _ = layout.regions, items.count > 0 else {
@@ -306,7 +281,7 @@ class DiscoverViewController: PCViewController {
         controller.populateFrom(item: discoverItem)
     }
 
-    private func addToScrollView(viewController: UIViewController, for item: DiscoverItem, isLast: Bool) {
+    func addToScrollView(viewController: UIViewController, for item: DiscoverItem, isLast: Bool) {
         mainScrollView.addSubview(viewController.view)
         addCommonConstraintsFor(viewController)
 

--- a/podcasts/LargeListSummaryViewController.swift
+++ b/podcasts/LargeListSummaryViewController.swift
@@ -135,13 +135,22 @@ class LargeListSummaryViewController: DiscoverPeekViewController, DiscoverSummar
         guard let source = item.source else { return }
         guard let title = item.title?.localized else { return }
 
+        showAllBtn.isHidden = item.expandedStyle == nil
+
         self.item = item
         titleLabel.text = delegate?.replaceRegionName(string: title)
         titleLabel.sizeToFit()
         DiscoverServerHandler.shared.discoverPodcastList(source: source, completion: { [weak self] podcastList in
             guard let strongSelf = self, let discoverPodcast = podcastList?.podcasts else { return }
 
-            for podcast in discoverPodcast {
+            let podcasts: [DiscoverPodcast]
+            if let itemCount = item.summaryItemCount {
+                podcasts = Array(discoverPodcast[0..<itemCount])
+            } else {
+                podcasts = discoverPodcast
+            }
+
+            for podcast in podcasts {
                 strongSelf.podcasts.append(podcast)
             }
 

--- a/podcasts/LargeListSummaryViewController.swift
+++ b/podcasts/LargeListSummaryViewController.swift
@@ -2,6 +2,8 @@ import PocketCastsServer
 import UIKit
 
 class LargeListSummaryViewController: DiscoverPeekViewController, DiscoverSummaryProtocol, UICollectionViewDataSource, GridLayoutDelegate, UICollectionViewDelegateFlowLayout {
+
+    @IBOutlet weak var titleTopConstraint: NSLayoutConstraint!
     @IBOutlet var titleLabel: ThemeableLabel!
     @IBOutlet var showAllBtn: UIButton! {
         didSet {
@@ -18,6 +20,13 @@ class LargeListSummaryViewController: DiscoverPeekViewController, DiscoverSummar
     private var item: DiscoverItem?
 
     @IBOutlet var largeListCollectionViewHeight: NSLayoutConstraint!
+
+    var padding: CGFloat? {
+        didSet {
+            view.setNeedsLayout()
+        }
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -44,9 +53,13 @@ class LargeListSummaryViewController: DiscoverPeekViewController, DiscoverSummar
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
 
+        if padding != nil {
+            titleTopConstraint.constant = 0
+        }
+
         if lastLayedOutWidth != view.bounds.width {
             lastLayedOutWidth = view.bounds.width
-            largeListCollectionViewHeight.constant = cellWidth + 50
+            largeListCollectionViewHeight.constant = cellWidth + (padding ?? 50)
             collectionView.layoutIfNeeded()
         }
     }

--- a/podcasts/LargeListSummaryViewController.swift
+++ b/podcasts/LargeListSummaryViewController.swift
@@ -53,8 +53,8 @@ class LargeListSummaryViewController: DiscoverPeekViewController, DiscoverSummar
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
 
-        if padding != nil {
-            titleTopConstraint.constant = 0
+        if let padding {
+            titleTopConstraint.constant = padding / 2
         }
 
         if lastLayedOutWidth != view.bounds.width {

--- a/podcasts/LargeListSummaryViewController.xib
+++ b/podcasts/LargeListSummaryViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22684"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -14,6 +14,7 @@
                 <outlet property="largeListCollectionViewHeight" destination="O9B-Ec-Krr" id="8nl-ey-dbz"/>
                 <outlet property="showAllBtn" destination="sF0-fo-tPV" id="NQp-Ou-W2d"/>
                 <outlet property="titleLabel" destination="0VX-rs-RFl" id="gRb-Ti-AKA"/>
+                <outlet property="titleTopConstraint" destination="bMc-9I-2X9" id="oAi-dY-rrx"/>
                 <outlet property="view" destination="Fw0-IT-oEE" id="dU6-pd-YkH"/>
             </connections>
         </placeholder>

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -1388,6 +1388,12 @@ internal enum L10n {
   internal static var month: String { return L10n.tr("Localizable", "month") }
   /// Monthly
   internal static var monthly: String { return L10n.tr("Localizable", "monthly") }
+  /// Most Popular
+  internal static var mostPopular: String { return L10n.tr("Localizable", "most_popular") }
+  /// Most Popular in %1$@
+  internal static func mostPopularWithName(_ p1: Any) -> String {
+    return L10n.tr("Localizable", "most_popular_with_name", String(describing: p1))
+  }
   /// Move to Bottom
   internal static var moveToBottom: String { return L10n.tr("Localizable", "move_to_bottom") }
   /// Move to Top

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4054,3 +4054,9 @@
 
 /* Prompting the user to upgrade to Plus. Don't translate "Plus" */
 "upgrade_to_plus" = "Upgrade to Plus";
+
+/* A title used to a show a list of the most popular podcasts in a category with the provided name of that category. */
+"most_popular_with_name" = "Most Popular in %1$@";
+
+/* A title used to a show a list of the most popular podcasts in a category. */
+"most_popular" = "Most Popular";


### PR DESCRIPTION
Adds the Most Popular section to the new Categories page in Discover.

| | |
|-|-|
| ![Simulator Screenshot - iPhone 15 Pro Max - 2024-04-16 at 14 34 20](https://github.com/Automattic/pocket-casts-ios/assets/3250/734983e5-8480-469a-9ffd-c7a672d54d42) | ![Simulator Screenshot - iPhone 15 Pro Max - 2024-04-16 at 14 34 16](https://github.com/Automattic/pocket-casts-ios/assets/3250/b3d0f539-ed25-476d-8736-c5153521c3cd) |

## To test

* Build using the "Staging" configuration
* Enable the `categoriesRedesign` feature flag
* Switch to Discover tab
* Select the Category pills
* Make sure the "Most Popular" section shows at the top
* Tap the "Sports" section in "All Categories"
* Ensure that the sponsored podcast is shown _below_ the Most Popular

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
