### PR TITLE
Categories: Regions Fix

### DIFF
--- a/podcasts/DiscoverViewController.swift
+++ b/podcasts/DiscoverViewController.swift
@@ -246,7 +246,7 @@ class DiscoverViewController: PCViewController {
 
             let section = 0
             snapshot.appendSections([section])
-            snapshot.appendItems(items.filter({ shouldInclude?($0) ?? true }))
+            snapshot.appendItems(items.filter({ (shouldInclude?($0) ?? true) && $0.regions.contains(currentRegion) }))
 
             return snapshot
         }


### PR DESCRIPTION
I missed the check that an item was included in the selected region [in this pr](https://github.com/Automattic/pocket-casts-ios/pull/1604/files#diff-7ace00507c7ae070e7e49bb9884e38981c21f38977964a3ba9ace1adb32b26adL176):
```
discoverItem.regions.contains(currentRegion)
```


| Before | After |
|--|--|
| <img src="https://github.com/Automattic/pocket-casts-ios/assets/3250/aa9e3184-582c-4000-8449-46a7434d8835" width=300> | <img src="https://github.com/Automattic/pocket-casts-ios/assets/3250/1d9a0190-c010-4b4e-8ef7-869019cf5114" width=300> |


| Before | After |
|--|--|
| <img src="https://github.com/Automattic/pocket-casts-ios/assets/3250/c44f93db-dd23-48eb-9c46-bbfb54611924" width=300> | <img src="https://github.com/Automattic/pocket-casts-ios/assets/3250/5c1120a7-4743-485e-af9a-9a3aff2cca54" width=300> |


## To test

* Load Discover and make sure only one "Popular" section is shown at the bottom and no "Popular in Worldwide" section
* Select a different region than "Worldwide"
* Ensure Discover reloads and "Popular" section is replaced with "Popular in <Region>"

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.