### PR TITLE
Standard Tags: fix an issue when an episode fails to load

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/Cache/ShowInfoDataRetriever.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Cache/ShowInfoDataRetriever.swift
@@ -17,11 +17,15 @@ public actor ShowInfoDataRetriever {
         let request = URLRequest(url: url, cachePolicy: .reloadRevalidatingCacheData)
 
         let task = Task<Data, Error> {
-            let (data, _) = try await URLSession.shared.data(for: request)
-            dataRequestMap[podcastUuid] = nil
-            return data
+            do {
+                let (data, _) = try await URLSession.shared.data(for: request)
+                dataRequestMap[podcastUuid] = nil
+                return data
+            } catch {
+                dataRequestMap[podcastUuid] = nil
+                throw error
+            }
         }
-
         dataRequestMap[podcastUuid] = task
 
         return try await task.value

--- a/podcasts/ShowInfoCoordinator.swift
+++ b/podcasts/ShowInfoCoordinator.swift
@@ -85,11 +85,16 @@ actor ShowInfoCoordinator: ShowInfoCoordinating {
         }
 
         let task = Task<String?, Error> { [unowned self] in
-            let data = try await dataRetriever.loadShowInfoData(for: podcastUuid)
-            try await dataManager.storeShowInfo(data: data)
-            let episode = try await dataManager.findRawEpisodeMetadata(uuid: episodeUuid)
-            requestingRawMetadata[podcastUuid] = nil
-            return episode
+            do {
+                let data = try await dataRetriever.loadShowInfoData(for: podcastUuid)
+                try await dataManager.storeShowInfo(data: data)
+                let episode = try await dataManager.findRawEpisodeMetadata(uuid: episodeUuid)
+                requestingRawMetadata[podcastUuid] = nil
+                return episode
+            } catch {
+                requestingRawMetadata[podcastUuid] = nil
+                throw error
+            }
         }
 
         requestingRawMetadata[podcastUuid] = task
@@ -107,11 +112,16 @@ actor ShowInfoCoordinator: ShowInfoCoordinating {
         }
 
         let task = Task<Episode.Metadata?, Error> { [unowned self] in
-            let data = try await dataRetriever.loadShowInfoData(for: podcastUuid)
-            try await dataManager.storeShowInfo(data: data)
-            let episode = try await dataManager.findEpisodeMetadata(uuid: episodeUuid)
-            requestingShowInfo[podcastUuid] = nil
-            return episode
+            do {
+                let data = try await dataRetriever.loadShowInfoData(for: podcastUuid)
+                try await dataManager.storeShowInfo(data: data)
+                let episode = try await dataManager.findEpisodeMetadata(uuid: episodeUuid)
+                requestingShowInfo[podcastUuid] = nil
+                return episode
+            } catch {
+                requestingShowInfo[podcastUuid] = nil
+                throw error
+            }
         }
 
         requestingShowInfo[podcastUuid] = task


### PR DESCRIPTION
We received an App Store review and feedback [on the Beta Slack](https://pocketcastsbeta.slack.com/archives/C0GKZ8J4A/p1713791842656129) that sometimes shows notes don't load and only closing/reopening the app fixes it.

I did some investigation and discovered that when anything fails (either a network request or decoding process) the task gets "stuck" and unless you close/reopen the app, the notes will never load. This PR fixes it.

## To test

1. Using any proxy app (such as Charles or any other tool) block any request to `https://cache.pocketcasts.com/mobile/show_notes/full/*`
2. Run the app
3. Open an episode you haven't interacted with before
4. ✅ You should see the "Unable to find..." message
5. Unblock the requests to `https://cache.pocketcasts.com/mobile/show_notes/full/*`
6. Tap "Try Again"
7. ✅ It should work

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
