### PR TITLE
Standard Tags: prioritize embedded chapters

### DIFF
--- a/podcasts/ChapterManager.swift
+++ b/podcasts/ChapterManager.swift
@@ -140,14 +140,22 @@ class ChapterManager {
         async let (podloveChaptersAsync, podcastIndexChaptersAsync) = await
         showInfoCoordinator.loadChapters(podcastUuid: episode.parentIdentifier(), episodeUuid: episode.uuid)
 
-        let (fileChapters, podloveChapters, podcastIndexChapters) = try await (fileChaptersAsync, podloveChaptersAsync, podcastIndexChaptersAsync)
-
-        // Once both arrives, check the one with more chapters to display
         var chapters: [ChapterInfo]
-        if let externalChapters = parseExternalChapters(podlove: podloveChapters, podcastIndex: podcastIndexChapters, duration: duration) {
-            chapters = externalChapters.count >= fileChapters.count ? externalChapters : fileChapters
-        } else {
-            chapters = fileChapters
+
+        do {
+            let (fileChapters, podloveChapters, podcastIndexChapters) = try await (fileChaptersAsync, podloveChaptersAsync, podcastIndexChaptersAsync)
+
+            // Prioritize embedded chapters, given for some shows it will take
+            // into account dynamic ads
+            if !fileChapters.isEmpty {
+                chapters = fileChapters
+            } else if let externalChapters = parseExternalChapters(podlove: podloveChapters, podcastIndex: podcastIndexChapters, duration: duration) {
+                chapters = externalChapters
+            } else {
+                chapters = []
+            }
+        } catch {
+            chapters = await fileChaptersAsync
         }
 
         if lastEpisodeUuid == episode.uuid {


### PR DESCRIPTION
Initially, we agreed that we would prioritize the source of chapters (embedded, Podlove, or Podcast Index) with the biggest number of chapters.

However, embedded chapters have a few advantages over the rest as explained here: https://github.com/Automattic/pocket-casts-android/issues/2093

This changes the behavior to favor embedded artworks whenever there are chapters.

I also fixed a small issue that could potentially lead to chapters not showing.

## To test

1. Subscribe to https://pca.st/chaosradio
2. Subscribe to https://pca.st/changelog
3. Subscribe to https://pca.st/rLzZCv
4. Play episodes for all these podcasts
5. ✅ You should be able to see chapters

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
