### PR TITLE
Fix: Ensure tab bar icons respect increase contrast setting for all combinations of PC themes and iOS appearance

### DIFF
--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -556,7 +556,6 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
         tabBar.scrollEdgeAppearance = appearance
         tabBar.unselectedItemTintColor = AppTheme.unselectedTabBarItemColor()
         tabBar.tintColor = AppTheme.tabBarItemTintColor()
-        
         // Link userInterfaceStyle to Theme type so iOS's Increase Contrast setting does the right thing
         let isDarkTheme = Theme.isDarkTheme()
         tabBar.overrideUserInterfaceStyle = isDarkTheme ? .dark : .light

--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -556,6 +556,10 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
         tabBar.scrollEdgeAppearance = appearance
         tabBar.unselectedItemTintColor = AppTheme.unselectedTabBarItemColor()
         tabBar.tintColor = AppTheme.tabBarItemTintColor()
+        
+        // Link userInterfaceStyle to Theme type so iOS's Increase Contrast setting does the right thing
+        let isDarkTheme = Theme.isDarkTheme()
+        tabBar.overrideUserInterfaceStyle = isDarkTheme ? .dark : .light
     }
 
     private func displayEndOfYearBadgeIfNeeded() {

--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -557,8 +557,7 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
         tabBar.unselectedItemTintColor = AppTheme.unselectedTabBarItemColor()
         tabBar.tintColor = AppTheme.tabBarItemTintColor()
         // Link userInterfaceStyle to Theme type so iOS's Increase Contrast setting does the right thing
-        let isDarkTheme = Theme.isDarkTheme()
-        tabBar.overrideUserInterfaceStyle = isDarkTheme ? .dark : .light
+        tabBar.overrideUserInterfaceStyle = Theme.isDarkTheme() ? .dark : .light
     }
 
     private func displayEndOfYearBadgeIfNeeded() {


### PR DESCRIPTION
Set the `tabBar`'s `userInterfaceStyle` to match Pocket Casts' Theme type so iOS's **Increase Contrast** setting always increases icon contrast.

## Problem
When a _single_ Pocket Cast theme is selected and doesn't change based on iOS light/dark mode, iOS's **Accessibility › Display & Text Size › Increase Contrast** setting doesn't always increase the contrast of the tabBar icons. If the PC theme is light and the iOS theme is dark, the icons will actually get lighter instead of darker. The same is true when light/dark are reversed.

Here's a summary of the different combinations. Notice the **increase contrast** cells aren't correct (❌) when the Pocket Casts theme is _opposite_ the iOS appearance.

| iOS Appearance/Contrast| Pocket Cast "Default Light" | "Default Dark" |
|--------|--------|--------|
| Light/Standard | ![Screenshot 2024-04-22 at 11 24 24@2x](https://github.com/Automattic/pocket-casts-ios/assets/2607653/ab2c87b6-207d-4cdf-8e30-ad50b0dc28ae) | ![Screenshot 2024-04-22 at 11 25 23@2x](https://github.com/Automattic/pocket-casts-ios/assets/2607653/28a33ea3-477a-4f65-916d-2dd907b97714) |
| Light/Increased | ✅ ![Screenshot 2024-04-22 at 11 24 37@2x](https://github.com/Automattic/pocket-casts-ios/assets/2607653/91058898-1eef-4305-b5f6-7a528746a76a) | ❌ ![Screenshot 2024-04-22 at 11 25 35@2x](https://github.com/Automattic/pocket-casts-ios/assets/2607653/858b5158-870d-4e92-b6fd-4cd71a4851c4) |
| Dark/Standard | ![Screenshot 2024-04-22 at 11 24 10@2x](https://github.com/Automattic/pocket-casts-ios/assets/2607653/95855cfb-eed5-46fc-93b0-7cb5a9b07331) | ![Screenshot 2024-04-22 at 11 25 49@2x](https://github.com/Automattic/pocket-casts-ios/assets/2607653/bf9c8f0b-1093-4708-a27b-babf9d0f8ae5) |
| Dark/Increased | ❌ ![Screenshot 2024-04-22 at 11 23 07@2x](https://github.com/Automattic/pocket-casts-ios/assets/2607653/7b5ab71d-216a-4cb1-a65f-459e6553a721) | ✅ ![Screenshot 2024-04-22 at 11 26 45@2x](https://github.com/Automattic/pocket-casts-ios/assets/2607653/7d901e29-5480-4870-974f-d9dba0b832a6) |

**Video of Issue**

https://github.com/Automattic/pocket-casts-ios/assets/2607653/1e23403a-a77e-45c2-a62c-99d7c0ec8926

## Fix
This fix sets the overrideUserInterfaceStyle so it matches the PC theme. When **Increase Contrast** is enabled, it always makes it darker with a light theme and lighter with a dark theme, regardless of whether iOS is dark or light (since the background color isn't changing with iOS).

**Video of Fix**

https://github.com/Automattic/pocket-casts-ios/assets/2607653/1fd9f4f7-7a99-4e77-9e59-d45631162184

## To test

### Single Pocket Casts Theme

1. **Pocket Casts › Settings › Appearance**, turn off **Use iOS Light/Dark Mode**
2. Select **Default Light** theme
3. Set iOS **Appearance** to **Light**
4. Toggle on/off iOS **Settings › Accessibility › Display & Text Size › Increase Contrast** (simulator menu **Features › Toggle Increased Contrast**)
5. ✅ Confirm the tab bar icons get _darker_ when **Increase Contrast** is on.
6. Set iOS **Appearance** to **Dark**
7. Toggle on/off iOS **Settings › Accessibility › Display & Text Size › Increase Contrast** (simulator menu **Features › Toggle Increased Contrast**)
8. ✅ Confirm the tab bar icons get _darker_ when **Increase Contrast** is on.

### Separate Pocket Casts Themes for iOS Light/Dark mode
1. **Pocket Casts › Settings › Appearance**, turn on **Use iOS Light/Dark Mode**
2. For **Light Theme**, select **Default Light**
3. For **Dark Theme**, select **Default Dark**
4. Set iOS **Appearance** to **Light**
5. Toggle on/off iOS **Settings › Accessibility › Display & Text Size › Increase Contrast** (simulator menu **Features › Toggle Increased Contrast**)
6. ✅ Confirm the tab bar icons get _darker_ when **Increase Contrast** is on.
7. Set iOS **Appearance** to **Dark**
8. Toggle on/off iOS **Settings › Accessibility › Display & Text Size › Increase Contrast** (simulator menu **Features › Toggle Increased Contrast**)
9. ✅ Confirm the tab bar icons get _lighter_ when **Increase Contrast** is on.
## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
