### PR TITLE
Fix: Ensure nav bar icons respect 'increase contrast' for all combos of PC theme and iOS appearance 

### DIFF
--- a/podcasts/PCNavigationController.swift
+++ b/podcasts/PCNavigationController.swift
@@ -57,6 +57,9 @@ class PCNavigationController: UINavigationController, UIGestureRecognizerDelegat
         labelAppearance.adjustsFontSizeToFitWidth = true
         labelAppearance.minimumScaleFactor = 0.75
         labelAppearance.baselineAdjustment = .none
+
+        // Link UserInterfaceStyle to Theme type so iOS's Increase Contrast does the right thing
+        navigationBar.overrideUserInterfaceStyle = Theme.isDarkTheme() ? .dark : .light
     }
 
     override var preferredStatusBarStyle: UIStatusBarStyle {


### PR DESCRIPTION
Set the `navigationBar`'s `userInterfaceStyle` to match Pocket Casts' Theme type so iOS's **Increase Contrast** setting always increases icon contrast.

## Problem
When a _single_ Pocket Cast theme is selected and doesn't change based on iOS light/dark mode, iOS's **Increase Contrast** accessibility setting doesn't always increase the contrast of the navigationBar icons. If the PC theme is light and the iOS theme is dark, the icons will actually get _lighter_ instead of darker. And it's also a problem when light/dark are reversed.

Here's a summary of the different combinations. Notice the **increase contrast** cells aren't correct (❌) when the Pocket Casts theme is _opposite_ the iOS appearance.

| iOS Appearance / Contrast| Pocket Cast "Default Light" | "Default Dark" |
|--------|--------|--------|
| Light / Standard | ![DefaultLight01](https://github.com/Automattic/pocket-casts-ios/assets/2607653/fe30991a-90f0-47a7-a859-30c54a054bd3) | ![DefaultDark01](https://github.com/Automattic/pocket-casts-ios/assets/2607653/0a1a115e-dfe4-4f15-a02a-b0b48ea79127) | 
| Light / Increased | ✅ ![DefaultLight02](https://github.com/Automattic/pocket-casts-ios/assets/2607653/a25d4932-bcfc-4ec5-b01f-d568dff706dd) | ❌ ![DefaultDark04](https://github.com/Automattic/pocket-casts-ios/assets/2607653/c3dde671-ef66-40ed-a503-a1fadd19f792) |
| Dark / Standard | ![DefaultLight01](https://github.com/Automattic/pocket-casts-ios/assets/2607653/fe30991a-90f0-47a7-a859-30c54a054bd3) | ![DefaultDark03](https://github.com/Automattic/pocket-casts-ios/assets/2607653/8d018228-64dd-4f9a-a8cf-eeb69854bf3e) |
| Dark / Increased | ❌ ![DefaultLight04](https://github.com/Automattic/pocket-casts-ios/assets/2607653/dffac171-e06b-44b5-abdb-6466cd270693)  | ✅  ![DefaultDark02](https://github.com/Automattic/pocket-casts-ios/assets/2607653/06015907-3459-4d96-b822-76a628eb9df3) |

**Video of Issue**

https://github.com/Automattic/pocket-casts-ios/assets/2607653/ece04c52-b621-417a-91b7-d894d67d6e8e

## Fix
This fix sets the `overrideUserInterfaceStyle` on the `navigationBar` so it matches the Pocket Casts' theme. When **Increase Contrast** is enabled, it always makes it darker with a light theme and lighter with a dark theme, regardless of whether _iOS_ is dark or light (since the background color doesn't change with iOS appearance).

**Video of Fix**

https://github.com/Automattic/pocket-casts-ios/assets/2607653/b3a6fbb1-6209-4669-b113-67b2a59bdbcc

## To test

### Single Pocket Casts Theme

1. In Pocket Casts, click **Profile menu › Settings › Appearance**, turn OFF **Use iOS Light/Dark Mode** and select **Default Light** theme
2. Go back to **Profile** screen
3. Confirm iOS **Appearance** is set to **Light** (**Cmd+Shift+A** in simulator)
4. Toggle on/off iOS **Settings › Accessibility › Display & Text Size › Increase Contrast** (simulator menu **Features › Toggle Increased Contrast**)
5. ✅ In the top navigation bar, confirm the **left chevron** and **gear** icons get _darker_ when **Increase Contrast** is on
6. Set iOS **Appearance** to **Dark**
7. Toggle on/off iOS **Settings › Accessibility › Display & Text Size › Increase Contrast** (simulator menu **Features › Toggle Increased Contrast**)
8. ✅ Confirm the **left chevron** and **gear** icons get _darker_ when **Increase Contrast** is on

### Separate Pocket Casts Themes for iOS Light/Dark mode
**Note**: Issue doesn't affect this use case, but need to test to make sure it still works properly
1. In Pocket Casts, click **Profile menu › Settings › Appearance**, turn ON **Use iOS Light/Dark Mode**
2. For **Light Theme**, select **Default Light**
3. For **Dark Theme**, select **Default Dark**
4. Go back to **Profile** screen
5. Set iOS **Appearance** to **Light**
6. Toggle on/off iOS **Settings › Accessibility › Display & Text Size › Increase Contrast** (simulator menu **Features › Toggle Increased Contrast**)
7. ✅ Confirm the tab bar icons get _darker_ when **Increase Contrast** is on
8. Set iOS **Appearance** to **Dark**
9. Toggle on/off iOS **Settings › Accessibility › Display & Text Size › Increase Contrast** (simulator menu **Features › Toggle Increased Contrast**)
10. ✅ Confirm the tab bar icons get _lighter_ when **Increase Contrast** is on

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
