### PR TITLE
Disable the Settings Sync feature flag for the 7.63 beta releases

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -98,8 +98,7 @@ public enum FeatureFlag: String, CaseIterable {
     }
 
     private var shouldEnableSyncedSettings: Bool {
-        // Enabled only out of appstore until we verify that this feature is ready for production.
-        BuildEnvironment.current != .appStore
+        false
     }
 
     /// Remote Feature Flag


### PR DESCRIPTION
Disables the `settingsSync` and `newSettingsStorage` flags.

## To test

* Install a non-prod version prior to this one
* Change some basic app and podcast settings
* Build and run this version to upgrade the non-prod one
* Ensure that flags `settingsSync` and `newSettingsStorage` are disabled in Beta Features under Settings
* Ensure your settings remain

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
