### PR TITLE
Order the popular discover categories

### DIFF
--- a/podcasts/Categories/CategoriesSelectorView.swift
+++ b/podcasts/Categories/CategoriesSelectorView.swift
@@ -31,7 +31,9 @@ struct CategoriesSelectorView: View {
         .task(id: discoverItemObservable.item?.source) {
             let result = await discoverItemObservable.load()
             self.categories = result?.categories
-            self.popular = result?.popular
+            self.popular = discoverItemObservable.item?.popular?.compactMap({ orderedItem in
+                result?.popular.first(where: { $0.id == orderedItem }) ?? result?.categories.first(where: { $0.id == orderedItem })
+            }) ?? result?.popular
         }
     }
 }


### PR DESCRIPTION
Fixes #1646

Reorders the discover items by the popularity ordering from the original discover item in the `contents` response.

## To test

* Load Discover
* Ensure that the ordering of the category pills is: True Crime, Comedy, Culture, History, Fiction, Technology
* Tap category pills and ensure everything functions as expected

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
