### PR TITLE
Standard Tags: do not force unwrap custom episode artwork URLs

### DIFF
--- a/podcasts/ImageManager.swift
+++ b/podcasts/ImageManager.swift
@@ -122,7 +122,11 @@ class ImageManager {
 
     func loadImage(url urlString: String, imageView: UIImageView, size: PodcastThumbnailSize, showPlaceHolder: Bool) {
         imageView.kf.cancelDownloadTask()
-        let url = URL(string: urlString)!
+        guard let url = URL(string: urlString) else {
+            setPlaceholder(imageView: imageView, size: size)
+            return
+        }
+
         let placeholderImage = showPlaceHolder ? placeHolderImage(size) : nil
         let processor = (Theme.sharedTheme.activeTheme == .radioactive ? radioactiveProcessor() : DefaultImageProcessor.default) |> DownsamplingImageProcessor(size: CGSize(width: ImageManager.sizeFor(imageSize: size), height: ImageManager.sizeFor(imageSize: size)))
         imageView.kf.setImage(with: url, placeholder: placeholderImage, options: [.processor(processor), .targetCache(subscribedPodcastsCache), .cacheOriginalImage, .transition(.fade(Constants.Animation.defaultAnimationTime))])


### PR DESCRIPTION
There's a crash happening for very few users when forcing unwrapping the episode artwork URL, this PR removes this.

## To test

1. Open any episode list
2. ✅ Swipe and make sure episode/podcast artwork appears

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
