### PR TITLE
Performance: Podcast Cache

### DIFF
--- a/Modules/DataModel/Tests/PocketCastsDataModelTests/AutoAddCandidatesDataManagerTests.swift
+++ b/Modules/DataModel/Tests/PocketCastsDataModelTests/AutoAddCandidatesDataManagerTests.swift
@@ -13,21 +13,7 @@ final class AutoAddCandidatesDataManagerTests: XCTestCase {
     }
 
     private func setupDatabase() throws -> DataManager {
-        let documentsPath = NSSearchPathForDirectoriesInDomains(.applicationSupportDirectory, .userDomainMask, true).last as NSString?
-        guard let dbFolderPath = documentsPath?.appendingPathComponent("Pocket Casts") as? NSString else {
-            throw TestError.dbFolderPathFailure
-        }
-
-        if !FileManager.default.fileExists(atPath: dbFolderPath as String) {
-            try FileManager.default.createDirectory(atPath: dbFolderPath as String, withIntermediateDirectories: true)
-        }
-
-        let dbPath = dbFolderPath.appendingPathComponent("podcast_testDB.sqlite3")
-        if FileManager.default.fileExists(atPath: dbPath) {
-            try FileManager.default.removeItem(atPath: dbPath)
-        }
-        let flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FILEPROTECTION_NONE
-        let dbQueue = try XCTUnwrap(FMDatabaseQueue(path: dbPath, flags: flags))
+        let dbQueue = try XCTUnwrap(FMDatabaseQueue.newTestDatabase())
         return DataManager(dbQueue: dbQueue)
     }
 

--- a/Modules/DataModel/Tests/PocketCastsDataModelTests/DataManager+TestDatabase.swift
+++ b/Modules/DataModel/Tests/PocketCastsDataModelTests/DataManager+TestDatabase.swift
@@ -25,4 +25,3 @@ extension FMDatabaseQueue {
         return FMDatabaseQueue(path: dbPath, flags: flags)
     }
 }
-

--- a/Modules/DataModel/Tests/PocketCastsDataModelTests/DataManager+TestDatabase.swift
+++ b/Modules/DataModel/Tests/PocketCastsDataModelTests/DataManager+TestDatabase.swift
@@ -1,0 +1,28 @@
+import SQLite3
+import FMDB
+import Foundation
+
+extension FMDatabaseQueue {
+    enum TestError: Error {
+        case dbFolderPathFailure
+    }
+
+    static func newTestDatabase() throws -> FMDatabaseQueue? {
+        let documentsPath = NSSearchPathForDirectoriesInDomains(.applicationSupportDirectory, .userDomainMask, true).last as NSString?
+        guard let dbFolderPath = documentsPath?.appendingPathComponent("Pocket Casts") as? NSString else {
+            throw TestError.dbFolderPathFailure
+        }
+
+        if !FileManager.default.fileExists(atPath: dbFolderPath as String) {
+            try FileManager.default.createDirectory(atPath: dbFolderPath as String, withIntermediateDirectories: true)
+        }
+
+        let dbPath = dbFolderPath.appendingPathComponent("podcast_testDB.sqlite3")
+        if FileManager.default.fileExists(atPath: dbPath) {
+            try FileManager.default.removeItem(atPath: dbPath)
+        }
+        let flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FILEPROTECTION_NONE
+        return FMDatabaseQueue(path: dbPath, flags: flags)
+    }
+}
+

--- a/Modules/DataModel/Tests/PocketCastsDataModelTests/PodcastDataManagerTests.swift
+++ b/Modules/DataModel/Tests/PocketCastsDataModelTests/PodcastDataManagerTests.swift
@@ -1,0 +1,47 @@
+import XCTest
+import SQLite3
+import FMDB
+@testable import PocketCastsDataModel
+
+final class PodcastDataManagerTests: XCTestCase {
+    private func setupDatabase() throws -> DataManager {
+        let dbQueue = try XCTUnwrap(FMDatabaseQueue.newTestDatabase())
+        return DataManager(dbQueue: dbQueue)
+    }
+
+    private func setupDataManager() throws -> DataManager {
+        let dataManager = try setupDatabase()
+        let podcastCount = 1000
+        let episodeCount = 50
+
+        (0...podcastCount).forEach { idx in
+            let podcast = Podcast()
+            podcast.uuid = "\(idx)"
+            podcast.addedDate = Date()
+
+            dataManager.save(podcast: podcast)
+
+            (0...episodeCount).forEach { _ in
+                let episode = Episode()
+                episode.uuid = UUID().uuidString
+                episode.addedDate = Date()
+                episode.podcastUuid = podcast.uuid
+
+                dataManager.save(episode: episode)
+            }
+        }
+
+        return dataManager
+    }
+
+    func testFindPodcastPerformance() throws {
+        let dataManager = try setupDataManager()
+
+        self.measure {
+            (0...10000).forEach { _ in
+                let random = Int.random(in: 0...1000)
+                _ = dataManager.findPodcast(uuid: "\(random)")
+            }
+        }
+    }
+}


### PR DESCRIPTION
`PodcastDataManager.find(uuid:)` is called frequently on the main thread. For instance, `EpisodeCell` calls `Episode.subTitle()` → `Episode.parentPodcast` each time the cell is prepared for reuse:

![CleanShot 2024-04-27 at 09 23 57@2x](https://github.com/Automattic/pocket-casts-ios/assets/3250/a663232d-e899-46fd-a464-8a99e28cbf13)

* Old loop through `cachedPodcasts` was O(n)
* New dictionary is O(1)

Added a new unit test to prove this: 
| Before | After |
| -- | -- |
| ![CleanShot 2024-04-26 at 16 00 45@2x](https://github.com/Automattic/pocket-casts-ios/assets/3250/07714e63-5776-454f-bf01-4f3ebe5edb5a) | ![CleanShot 2024-04-26 at 16 01 43@2x](https://github.com/Automattic/pocket-casts-ios/assets/3250/f66d29cc-feb1-4f5c-ba89-821e8a4412a8) |

if you want, apply the unit test commit to `trunk` and crank up the iteration to 100000 or more and you'll quickly see the exponential growth.

This may not have a huge impact on performance, especially if the `showTick` change (https://github.com/Automattic/pocket-casts-ios/pull/1663) is merged, but it seems like an obvious performance improvement with little downside.

## To test

* Build and run
* Scroll through podcasts
* Test Podcast playback

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.