### PR TITLE
Performance: Only re-run showTick when value changes

### DIFF
--- a/podcasts/EpisodeCell.swift
+++ b/podcasts/EpisodeCell.swift
@@ -515,6 +515,7 @@ class EpisodeCell: ThemeableSwipeCell, MainEpisodeActionViewDelegate {
 
     var showTick = false {
         didSet {
+            guard showTick != oldValue else { return }
             selectTickImageView.isHidden = !showTick
             selectCircleView.layer.borderWidth = showTick ? 0 : 2
             selectView.accessibilityLabel = showTick ? L10n.accessibilityDeselectEpisode : L10n.accessibilitySelectEpisode


### PR DESCRIPTION
`EpisodeCell.showTick` is called each time the cell is prepared for reuse. However, the code in this `didSet` is expensive, triggering a `PodcastManager.find` call (see https://github.com/Automattic/pocket-casts-ios/pull/1662) for accessibility label, image generation from tinting via `updateColor`, etc — all on the main thread. The  `showTick` value shouldn't really change between cells since it's only enabled when multi-select is active. This change only runs the internal code if the value has changed.

![CleanShot 2024-04-27 at 09 34 17@2x](https://github.com/Automattic/pocket-casts-ios/assets/3250/01a11be4-59d8-49aa-ba06-eb78729a7ece)

While scrolling through a Filter/Playlist this reduces the `prepareForReuse` time by ~80%:
| Before | After |
| -- | -- |
| ![CleanShot 2024-04-27 at 10 27 06@2x](https://github.com/Automattic/pocket-casts-ios/assets/3250/91c1745d-5f83-48c6-8319-1be97336e8b2) | ![CleanShot 2024-04-27 at 10 25 05@2x](https://github.com/Automattic/pocket-casts-ios/assets/3250/1a0b87b0-e6ac-4031-b8cb-613a061dcbc3) |

## To test

* Visit a Podcast page
* Scroll through Episodes
* Ensure cells look correct
* Enable Multi-select by tapping and holding
* Ensure tick shows up along the left
* Scroll around and make sure cells look correct

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
