### PR TITLE
Only propagate episode changes if the file size actually changed

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Private/API Tasks/MetadataTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Private/API Tasks/MetadataTask.swift
@@ -56,7 +56,7 @@ class MetadataTask: Operation {
             }
         }
 
-        if let contentLength = responseHeaders["Content-Length"] as? String, let intLength = Int64(contentLength), intLength > MetadataTask.minBytesInFile {
+        if let contentLength = responseHeaders["Content-Length"] as? String, let intLength = Int64(contentLength), intLength > MetadataTask.minBytesInFile, episode.sizeInBytes != intLength {
             DataManager.sharedManager.saveEpisode(fileSize: intLength, episode: episode)
             performedUpdate = true
         }

--- a/podcasts/EpisodeCell.swift
+++ b/podcasts/EpisodeCell.swift
@@ -358,13 +358,14 @@ class EpisodeCell: ThemeableSwipeCell, MainEpisodeActionViewDelegate {
         updateCell(episodeUuid: episode.uuid)
     }
 
-    @objc private func updateCellFromSpecificEvent(_ notification: Notification) {        
+    @objc private func updateCellFromSpecificEvent(_ notification: Notification) {
         DispatchQueue.main.async { [weak self] in
             guard let episodeUuid = notification.object as? String, episodeUuid == self?.episode?.uuid else {
                 return
             }
-
-            self?.updateCell(episodeUuid: episodeUuid)
+            DispatchQueue.global(qos: .userInteractive).async {
+                self?.updateCell(episodeUuid: episodeUuid)
+            }
         }
     }
 

--- a/podcasts/EpisodeCell.swift
+++ b/podcasts/EpisodeCell.swift
@@ -358,12 +358,14 @@ class EpisodeCell: ThemeableSwipeCell, MainEpisodeActionViewDelegate {
         updateCell(episodeUuid: episode.uuid)
     }
 
-    @objc private func updateCellFromSpecificEvent(_ notification: Notification) {
-        guard let episodeUuid = notification.object as? String, episodeUuid == episode?.uuid else {
-            return
-        }
+    @objc private func updateCellFromSpecificEvent(_ notification: Notification) {        
+        DispatchQueue.main.async { [weak self] in
+            guard let episodeUuid = notification.object as? String, episodeUuid == self?.episode?.uuid else {
+                return
+            }
 
-        updateCell(episodeUuid: episodeUuid)
+            self?.updateCell(episodeUuid: episodeUuid)
+        }
     }
 
     private func updateCell(episodeUuid: String) {


### PR DESCRIPTION
Fixes #

This PR changes the way we detect if changes are made on the content length in order to propagate notification, and changes.
It also changes code in EpisodeCell in a way that operations are done correctly between main thread and background threads to avoid racing conditions.

## To test

- Start the app
- Open a podcast 
- Ensure that you have trim silence on the player
- Start a playing of a episode
- Check that only once the `episodeTypeOrLengthChanged` notification is sent on the `MetadataTask` class method `updateEpisodeFrom`. A breakpoint here can help to test this
- Open another episode
- Tap on the option to download the episode
- While the episode is downloading scroll the episode list up and down
- Check that no crashes happen and episode information is show correctly

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
