### PR TITLE
Move logStaleDownloads to background dispatch

### DIFF
--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -61,6 +61,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         NotificationsHelper.shared.register(checkToken: false)
 
         DispatchQueue.global().async { [weak self] in
+            self?.logStaleDownloads()
             self?.postLaunchSetup()
             self?.checkIfRestoreCleanupRequired()
             ImageManager.sharedManager.updatePodcastImagesIfRequired()
@@ -81,8 +82,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         NotificationCenter.default.addObserver(self, selector: #selector(showOverlays), name: Constants.Notifications.closedNonOverlayableWindow, object: nil)
 
         setupSignOutListener()
-
-        logStaleDownloads()
 
         return true
     }


### PR DESCRIPTION
The `logStaleDownloads` call isn't critical to launch and could, conceivably, be leading to hangs or watchdog terminations. This moves the call on to a background thread but puts it before `postLaunchSetup` to ensure no "stuck" downloads are removed before it has a chance to run.

## To test

* Enable `tracksLogging` flag & "Collect Information" under Privacy
* Proxy connection and set a scripting rule as follows. **Make sure "Mock API" is checked**, this avoids the connection staying open too long:

![CleanShot 2024-03-04 at 20 51 44@2x](https://github.com/Automattic/pocket-casts-ios/assets/3250/718e3154-0e5f-455f-81f3-b4f77191683e)

```javascript
async function onResponse(context, url, request, response) {
  response.statusCode = 500;
  response.body = "";
  return response;
}
```

* Subscribe to the NPR "Life Kit" podcast
* Download an episode
* Episode should fail
* Restart the app
* Look for the logged `episode_downloads_stale` event on launch

```
🔵 Tracked: episode_downloads_stale ["newest_failed_download": "2024-03-08T02:23:39Z", "failed_download_count": 2, "oldest_failed_download": "2024-03-08T02:23:33Z"]
```

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
