### PR TITLE
Only update podcasts cache on last save

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/Refresh/RefreshOperation.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Refresh/RefreshOperation.swift
@@ -113,7 +113,7 @@ class RefreshOperation: Operation {
         let podcasts = DataManager.sharedManager.allPodcasts(includeUnsubscribed: false)
         let updatedPodcasts = refreshResult.podcastUpdates
         var metadataRequestsQueued = 0
-        for podcast in podcasts {
+        for (idx, podcast) in podcasts.enumerated() {
             guard let podcastEpisodes = updatedPodcasts?[podcast.uuid], podcastEpisodes.count > 0 else { continue }
 
             for episode in podcastEpisodes.reversed() {
@@ -153,7 +153,7 @@ class RefreshOperation: Operation {
             }
 
             // there's at least one new episode, so update the latestEpisodeUuid
-            ServerPodcastManager.shared.updateLatestEpisodeInfo(podcast: podcast, setDefaults: false)
+            ServerPodcastManager.shared.updateLatestEpisodeInfo(podcast: podcast, setDefaults: false, cache: idx == podcasts.endIndex)
         }
 
         ServerConfig.shared.syncDelegate?.checkForUnusedPodcasts()


### PR DESCRIPTION
When updating podcasts via the `RefreshOperation`, this save method is called for each subscription and triggers a new `SELECT` query to update the cache on every save. Instead of running this cache on each save.

`RefreshOperation` -> `updateLatestEpisodeInfo` -> 

I had to do a similar thing in [`DataManager+Import`](https://github.com/Automattic/pocket-casts-ios/blob/06fc3b54a1d678a45d7a7e8b465f66b351dd6287/podcasts/DataManager%2BImport.swift#L39) for synced settings.

## To test

* Test subscribing to podcasts, killing the app, and refreshing

### Large Database

* Test with a very large database with many subscriptions (reach out to me if you need one)
* Delete the app
* Build and run with the 

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
