### PR TITLE
Disable UpNext on the tab bar

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -93,7 +93,7 @@ public enum FeatureFlag: String, CaseIterable {
         case .categoriesRedesign:
             true
         case .upNextOnTabBar:
-            true
+            false
         }
     }
 


### PR DESCRIPTION
Fixes #

Reverts the default value for the FF of UpNext on the tab bar

## To test

- Start the app from a brad new install
- Check if the UpNext does not show on the tab bar
- Check if the Profile Icon is back on the tab bar on the right
- Tap on profile and see if it opens correctly

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
