### PR TITLE
Ensure that real mini player is hidden at the start of the transitions.

### DIFF
--- a/podcasts/MiniPlayerToFullPlayerAnimator.swift
+++ b/podcasts/MiniPlayerToFullPlayerAnimator.swift
@@ -219,6 +219,7 @@ class MiniPlayerToFullPlayerAnimator: NSObject, UIViewControllerAnimatedTransiti
         }
         containerView.insertSubview(gradientView, belowSubview: backgroundTransitionView)
 
+        self.fromViewController.view.layer.opacity = 0
         animate(withDuration: duration) { [self] in
             // Artwork
             artwork?.frame = self.isPresenting ? fullPlayerArtworkFrame : miniPlayerArtworkFrame


### PR DESCRIPTION
Fixes #

Ensure that real mini player is hidden at the start of the transitions. The snapshot of it will take it's place until the end of the animation


https://github.com/Automattic/pocket-casts-ios/assets/651601/33ac3f8c-ece1-4836-b215-e5bb2472c751



## To test

 - Start the application 
 - Ensure the mini-player is visible by playing a podcast
 - Enable Slow animations on the simulator
 - Tap on the mini player to go full screen
 - Check that when the animation to full screen the original mini-player is hidden
 - Close the mini-player
 - Ensure that the animation goes smoothly and in the end the mini-player is shown correctly.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
