### PR TITLE
Performance: add `downloadTaskId` partial INDEX

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseHelper.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseHelper.swift
@@ -717,6 +717,7 @@ class DatabaseHelper {
         if schemaVersion < 48 {
             do {
                 try db.executeUpdate("CREATE INDEX \"episodeArchived\" ON \"SJEpisode\" (\"archived\");", values: nil)
+                try db.executeUpdate("CREATE INDEX non_null_download_task_id ON SJEpisode(downloadTaskId) WHERE downloadTaskId IS NOT NULL;", values: nil)
                 schemaVersion = 48
             } catch {
                 failedAt(48)

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseHelper.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseHelper.swift
@@ -718,6 +718,7 @@ class DatabaseHelper {
             do {
                 try db.executeUpdate("CREATE INDEX \"episodeArchived\" ON \"SJEpisode\" (\"archived\");", values: nil)
                 try db.executeUpdate("CREATE INDEX non_null_download_task_id ON SJEpisode(downloadTaskId) WHERE downloadTaskId IS NOT NULL;", values: nil)
+                try db.executeUpdate("CREATE INDEX IF NOT EXISTS episode_added_date ON SJEpisode (addedDate);", values: nil)
                 schemaVersion = 48
             } catch {
                 failedAt(48)

--- a/podcasts/AppDelegate+Defaults.swift
+++ b/podcasts/AppDelegate+Defaults.swift
@@ -5,8 +5,8 @@ import PocketCastsUtils
 
 extension AppDelegate {
     func checkDefaults() {
-        let defaults = UserDefaults.standard
-        let dataManager = DataManager.sharedManager
+        lazy var defaults = UserDefaults.standard
+        lazy var dataManager = DataManager.sharedManager
 
         performUpdateIfRequired(updateKey: "v5Run") {
             // these are considered defaults for a new app install

--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -33,8 +33,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         configureFirebase()
         TraceManager.shared.setup(handler: traceHandler)
 
-        setupWhatsNew()
-
         setupSecrets()
         addAnalyticsObservers()
         setupAnalytics()
@@ -60,6 +58,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             guard let self else {
                 return
             }
+
+            setupWhatsNew()
 
             logStaleDownloads()
             postLaunchSetup()

--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -25,7 +25,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     private var backgroundSignOutListener: BackgroundSignOutListener?
 
-    var whatsNew: WhatsNew?
+    lazy var whatsNew = WhatsNew()
 
     // MARK: - App Lifecycle
 
@@ -58,8 +58,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             guard let self else {
                 return
             }
-
-            setupWhatsNew()
 
             logStaleDownloads()
             postLaunchSetup()
@@ -410,11 +408,5 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
 
         backgroundSignOutListener = BackgroundSignOutListener(presentingViewController: SceneHelper.rootViewController())
-    }
-
-    // MARK: What's New
-
-    private func setupWhatsNew() {
-        whatsNew = WhatsNew()
     }
 }

--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -54,17 +54,22 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         setupRoutes()
 
-        ServerConfig.shared.syncDelegate = ServerSyncManager.shared
-        ServerConfig.shared.playbackDelegate = PlaybackManager.shared
-        checkDefaults()
-
         NotificationsHelper.shared.register(checkToken: false)
 
         DispatchQueue.global().async { [weak self] in
-            self?.postLaunchSetup()
-            self?.checkIfRestoreCleanupRequired()
+            guard let self else {
+                return
+            }
+
+            logStaleDownloads()
+            postLaunchSetup()
+            checkIfRestoreCleanupRequired()
             ImageManager.sharedManager.updatePodcastImagesIfRequired()
             WidgetHelper.shared.cleanupAppGroupImages()
+
+            ServerConfig.shared.syncDelegate = ServerSyncManager.shared
+            ServerConfig.shared.playbackDelegate = PlaybackManager.shared
+            checkDefaults()
         }
 
         badgeHelper.setup()
@@ -81,8 +86,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         NotificationCenter.default.addObserver(self, selector: #selector(showOverlays), name: Constants.Notifications.closedNonOverlayableWindow, object: nil)
 
         setupSignOutListener()
-
-        logStaleDownloads()
 
         return true
     }

--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -59,15 +59,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 return
             }
 
+            ServerConfig.shared.syncDelegate = ServerSyncManager.shared
+            ServerConfig.shared.playbackDelegate = PlaybackManager.shared
+            checkDefaults()
+
             logStaleDownloads()
             postLaunchSetup()
             checkIfRestoreCleanupRequired()
             ImageManager.sharedManager.updatePodcastImagesIfRequired()
             WidgetHelper.shared.cleanupAppGroupImages()
-
-            ServerConfig.shared.syncDelegate = ServerSyncManager.shared
-            ServerConfig.shared.playbackDelegate = PlaybackManager.shared
-            checkDefaults()
         }
 
         badgeHelper.setup()

--- a/podcasts/ChapterManager.swift
+++ b/podcasts/ChapterManager.swift
@@ -104,8 +104,8 @@ class ChapterManager {
     }
 
     func parseChapters(episode: BaseEpisode, duration: TimeInterval) {
-        Task {
-            await parseChapters(episode: episode, duration: duration)
+        Task.detached { [weak self] in
+            await self?.parseChapters(episode: episode, duration: duration)
         }
     }
 

--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -749,7 +749,7 @@ private extension MainTabBarController {
     func showWhatsNewIfNeeded() {
         guard let controller = view.window?.rootViewController else { return }
 
-        if let whatsNewViewController = appDelegate()?.whatsNew?.viewControllerToShow() {
+        if let whatsNewViewController = appDelegate()?.whatsNew.viewControllerToShow() {
             controller.present(whatsNewViewController, animated: true)
             isShowingWhatsNew = true
         }

--- a/podcasts/Whats New/Announcements.swift
+++ b/podcasts/Whats New/Announcements.swift
@@ -26,21 +26,6 @@ struct Announcements {
             isEnabled: true
         ),
 
-        // Bookmarks: Full Release
-        // Show for everyone, except those who saw the `Early Access: Release` announcement
-        .init(
-            version: "7.53",
-            header: AnyView(BookmarksWhatsNewHeader()),
-            title: L10n.announcementBookmarksTitle,
-            message: L10n.announcementBookmarksDescription,
-            buttonTitle: bookmarksViewModel.upgradeOrEnableButtonTitle,
-            action: {
-                bookmarksViewModel.enableAction()
-            },
-            displayTier: bookmarksViewModel.displayTier,
-            isEnabled: bookmarksViewModel.isReleaseAnnouncementEnabled
-        ),
-
         // Slumber Studios partnership
         .init(
             version: "7.57",


### PR DESCRIPTION
In my tests, `postLaunchSetup` takes a long time just by querying episodes with `NON NULL downloadId`. This PR [adds a partial index](https://www.sqlite.org/partialindex.html) so this query is as fast as it can.

## To test

1. Run the app with a huge database
2. ✅ Startup should be slightly faster the second time ¶

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
