### PR TITLE
Performance: add `addedDate` INDEX

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseHelper.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseHelper.swift
@@ -718,6 +718,7 @@ class DatabaseHelper {
             do {
                 try db.executeUpdate("CREATE INDEX \"episodeArchived\" ON \"SJEpisode\" (\"archived\");", values: nil)
                 try db.executeUpdate("CREATE INDEX non_null_download_task_id ON SJEpisode(downloadTaskId) WHERE downloadTaskId IS NOT NULL;", values: nil)
+                try db.executeUpdate("CREATE INDEX IF NOT EXISTS episode_added_date ON SJEpisode (addedDate);", values: nil)
                 schemaVersion = 48
             } catch {
                 failedAt(48)


### PR DESCRIPTION
While checking for slow queries I saw one for filters took +5s. Adding the `addedDate` INDEX takes the number close to a 1s.

## To test

1. Run the app with a huge database
2. ✅ Check that filters are faster

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
