### PR TITLE
Performance: Download task index

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseHelper.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseHelper.swift
@@ -716,6 +716,7 @@ class DatabaseHelper {
 
         if schemaVersion < 48 {
             do {
+                try db.executeUpdate("CREATE INDEX IF NOT EXISTS episode_download_task_id ON SJEpisode (downloadTaskId);", values: nil)
                 try db.executeUpdate("CREATE INDEX \"episodeArchived\" ON \"SJEpisode\" (\"archived\");", values: nil)
                 schemaVersion = 48
             } catch {


### PR DESCRIPTION
Adds an index for the `downloadTaskId` property on episodes.

The `DownloadManager.didWriteData` method checks for a matching episode frequently. Although there is a cache, this cache can miss, especially in the beginning when other queries may be blocking, and hit the database repeatedly in short succession. Any speed up to these queries drastically reduces the time downloads take in the background.

| Before | After |
| -- | -- |
| ![CleanShot 2024-04-30 at 15 19 43@2x](https://github.com/Automattic/pocket-casts-ios/assets/3250/1604e536-7a66-4ee0-b365-008c3fe76b69) | ![CleanShot 2024-04-30 at 15 22 01@2x](https://github.com/Automattic/pocket-casts-ios/assets/3250/79954ef4-bbf1-4df4-8628-c0e016645958) |


## To test

* Try downloading episodes from the podcast or filters lists
* Ensure they download and that progress is shown in the episode cell

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
