### PR TITLE
Performance: Bulk save improvements

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/Refresh/MainServerHandler.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Refresh/MainServerHandler.swift
@@ -229,8 +229,8 @@ public class MainServerHandler {
             return nil
         }
 
-        for podcast in podcasts { // ensure podcasts have up to date latest episode uuids
-            ServerPodcastManager.shared.updateLatestEpisodeInfo(podcast: podcast, setDefaults: false)
+        for (idx, podcast) in podcasts.enumerated() { // ensure podcasts have up to date latest episode uuids
+            ServerPodcastManager.shared.updateLatestEpisodeInfo(podcast: podcast, setDefaults: false, cache: idx == podcasts.endIndex)
         }
 
         let pushEnabled = ServerConfig.shared.syncDelegate?.isPushEnabled() ?? false

--- a/Modules/Server/Sources/PocketCastsServer/Public/Refresh/RefreshOperation.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Refresh/RefreshOperation.swift
@@ -113,7 +113,7 @@ class RefreshOperation: Operation {
         let podcasts = DataManager.sharedManager.allPodcasts(includeUnsubscribed: false)
         let updatedPodcasts = refreshResult.podcastUpdates
         var metadataRequestsQueued = 0
-        for podcast in podcasts {
+        for (idx, podcast) in podcasts.enumerated() {
             guard let podcastEpisodes = updatedPodcasts?[podcast.uuid], podcastEpisodes.count > 0 else { continue }
 
             for episode in podcastEpisodes.reversed() {
@@ -153,7 +153,7 @@ class RefreshOperation: Operation {
             }
 
             // there's at least one new episode, so update the latestEpisodeUuid
-            ServerPodcastManager.shared.updateLatestEpisodeInfo(podcast: podcast, setDefaults: false)
+            ServerPodcastManager.shared.updateLatestEpisodeInfo(podcast: podcast, setDefaults: false, cache: idx == podcasts.endIndex)
         }
 
         ServerConfig.shared.syncDelegate?.checkForUnusedPodcasts()

--- a/Modules/Server/Sources/PocketCastsServer/Public/Refresh/RefreshOperation.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Refresh/RefreshOperation.swift
@@ -116,15 +116,9 @@ class RefreshOperation: Operation {
         for (idx, podcast) in podcasts.enumerated() {
             guard let podcastEpisodes = updatedPodcasts?[podcast.uuid], podcastEpisodes.count > 0 else { continue }
 
-            for episode in podcastEpisodes.reversed() {
-                if isCancelled {
-                    cleanupAfterCancel()
-
-                    return .cancelled
-                }
-
-                guard let episodeUuid = episode.uuid else { continue }
-                if let _ = DataManager.sharedManager.findEpisode(uuid: episodeUuid) { continue }
+            let episodes: [Episode] = podcastEpisodes.reversed().compactMap({ episode in
+                guard let episodeUuid = episode.uuid else { return nil }
+                if let _ = DataManager.sharedManager.findEpisode(uuid: episodeUuid) { return nil }
 
                 let newEpisode = Episode()
                 newEpisode.podcast_id = podcast.id
@@ -133,24 +127,34 @@ class RefreshOperation: Operation {
                 newEpisode.episodeStatus = DownloadStatus.notDownloaded.rawValue
                 newEpisode.addedDate = Date()
                 newEpisode.populate(fromEpisode: episode)
-                DataManager.sharedManager.save(episode: newEpisode)
+                return newEpisode
+            })
 
-                newEpisodesAdded += 1
+            DataManager.sharedManager.bulkSave(episodes: episodes)
+
+            for episode in episodes {
+                if isCancelled {
+                    cleanupAfterCancel()
+
+                    return .cancelled
+                }
 
                 // store episodes that we might possibly add to Up Next for processing after a sync
                 if podcast.autoAddToUpNextOn() {
-                    DataManager.sharedManager.autoAddCandidates.add(podcastUUID: podcast.uuid, episodeUUID: newEpisode.uuid)
+                    DataManager.sharedManager.autoAddCandidates.add(podcastUUID: podcast.uuid, episodeUUID: episode.uuid)
                 }
 
                 #if !os(watchOS)
                     // so we don't flood the users phone, set a limit on the amount of meta data requests made. So if they open it after
                     // 4 weeks of not using it doesn't sit there for years
                     if metadataRequestsQueued < 10 {
-                        MetadataUpdater.shared.updatedMetadata(episodeUuid: newEpisode.uuid)
+                        MetadataUpdater.shared.updatedMetadata(episodeUuid: episode.uuid)
                         metadataRequestsQueued += 1
                     }
                 #endif
             }
+
+            newEpisodesAdded += episodes.count
 
             // there's at least one new episode, so update the latestEpisodeUuid
             ServerPodcastManager.shared.updateLatestEpisodeInfo(podcast: podcast, setDefaults: false, cache: idx == podcasts.endIndex)

--- a/Modules/Server/Sources/PocketCastsServer/Public/ServerPodcastManager+Update.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/ServerPodcastManager+Update.swift
@@ -191,7 +191,7 @@ extension ServerPodcastManager {
         }
     }
 
-    public func updateLatestEpisodeInfo(podcast: Podcast, setDefaults: Bool) {
+    public func updateLatestEpisodeInfo(podcast: Podcast, setDefaults: Bool, cache: Bool = true) {
         guard let latestEpisode = podcast.latestEpisode() else { return }
 
         // no need to re-save one we already have
@@ -199,7 +199,7 @@ extension ServerPodcastManager {
 
         podcast.latestEpisodeDate = latestEpisode.publishedDate
         podcast.latestEpisodeUuid = latestEpisode.uuid
-        DataManager.sharedManager.save(podcast: podcast)
+        DataManager.sharedManager.save(podcast: podcast, cache: cache)
 
         if setDefaults {
             setDefaultsAndLoadMetadataForNewlyAddedPodcast(podcast, latestEpisode: latestEpisode)


### PR DESCRIPTION
This addresses issues around bulk saving podcasts and episodes.

* Only update the cache on the _last_ podcast updated in a loop. I made a similar in [DataManager+Import](https://github.com/Automattic/pocket-casts-ios/blob/06fc3b54a1d678a45d7a7e8b465f66b351dd6287/podcasts/DataManager%2BImport.swift#L39) for synced settings. We could probably add a bulk save for podcasts as well but I'll leave that for a future PR if we need it.
* Use episode bulk save instead of saving each episode

## To test

* Subscribe to a podcast
* Refresh the podcasts list

* Subscribe to a podcast from the web player on an account
* Refresh the podcasts list from the same account on iOS

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
