### PR TITLE
Performance: change podcasts ordered by newest episodes query

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/PodcastDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/PodcastDataManager.swift
@@ -129,7 +129,7 @@ class PodcastDataManager {
                     whereClause += " AND p.folderUuid = ?"
                     values = [inFolderUuid]
                 }
-                let query = "SELECT DISTINCT p.id, p.* FROM \(DataManager.podcastTableName) p LEFT JOIN \(DataManager.episodeTableName) e ON p.id = e.podcast_id AND e.id = (SELECT e.id FROM \(DataManager.episodeTableName) e WHERE e.podcast_id = p.id AND e.playingStatus != 3 AND e.archived = 0 ORDER BY e.publishedDate DESC LIMIT 1) \(whereClause) ORDER BY CASE WHEN e.publishedDate IS NULL THEN 1 ELSE 0 END, e.publishedDate DESC, p.latestEpisodeDate DESC"
+                let query = "SELECT DISTINCT p.id, p.* FROM \(DataManager.podcastTableName) p LEFT JOIN \(DataManager.episodeTableName) e ON p.id = e.podcast_id AND e.id = (SELECT e.id FROM \(DataManager.episodeTableName) e WHERE e.playingStatus != 3 AND e.archived = 0 ORDER BY e.publishedDate DESC LIMIT 1) \(whereClause) ORDER BY CASE WHEN e.publishedDate IS NULL THEN 1 ELSE 0 END, e.publishedDate DESC, p.latestEpisodeDate DESC"
                 let resultSet = try db.executeQuery(query, values: values)
                 defer { resultSet.close() }
 


### PR DESCRIPTION
After the inclusion of the `archived` index the performance of `allPodcastsOrderedByNewestEpisodes` dropped down a lot due to using it. This PR changes it so it gets back to what it used to be.

## To test

### In app

1. Run the app with a huge database
2. ✅  Test ordering the main grid by newest episodes

### In databases

1. Pick different databases
2. Run the query as it was before: `SELECT DISTINCT p.id, p.* FROM SJPodcast p LEFT JOIN SJEpisode e ON p.id = e.podcast_id AND e.id = (SELECT e.id FROM SJEpisode e WHERE e.podcast_id = p.id AND e.playingStatus != 3 AND e.archived = 0 ORDER BY e.publishedDate DESC LIMIT 1) WHERE p.subscribed = 1 ORDER BY CASE WHEN e.publishedDate IS NULL THEN 1 ELSE 0 END, e.publishedDate DESC, p.latestEpisodeDate DESC`
3. Run the query as it is now: `SELECT DISTINCT p.id, p.* FROM SJPodcast p LEFT JOIN SJEpisode e ON p.id = e.podcast_id AND e.id = (SELECT e.id FROM SJEpisode e WHERE e.playingStatus != 3 AND e.archived = 0 ORDER BY e.publishedDate DESC LIMIT 1) WHERE p.subscribed = 1 ORDER BY CASE WHEN e.publishedDate IS NULL THEN 1 ELSE 0 END, e.publishedDate DESC, p.latestEpisodeDate DESC`
4. ✅ Ensure results are the same

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
