### PR TITLE
Performance: add back improvements on top of 7.63

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/PodcastDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/PodcastDataManager.swift
@@ -129,7 +129,7 @@ class PodcastDataManager {
                     whereClause += " AND p.folderUuid = ?"
                     values = [inFolderUuid]
                 }
-                let query = "SELECT DISTINCT p.id, p.* FROM \(DataManager.podcastTableName) p LEFT JOIN \(DataManager.episodeTableName) e ON p.id = e.podcast_id AND e.id = (SELECT e.id FROM \(DataManager.episodeTableName) e WHERE e.podcast_id = p.id AND e.playingStatus != 3 AND e.archived = 0 ORDER BY e.publishedDate DESC LIMIT 1) \(whereClause) ORDER BY CASE WHEN e.publishedDate IS NULL THEN 1 ELSE 0 END, e.publishedDate DESC, p.latestEpisodeDate DESC"
+                let query = "SELECT DISTINCT p.id, p.* FROM \(DataManager.podcastTableName) p LEFT JOIN \(DataManager.episodeTableName) e ON p.id = e.podcast_id AND e.id = (SELECT e.id FROM \(DataManager.episodeTableName) e WHERE e.playingStatus != 3 AND e.archived = 0 ORDER BY e.publishedDate DESC LIMIT 1) \(whereClause) ORDER BY CASE WHEN e.publishedDate IS NULL THEN 1 ELSE 0 END, e.publishedDate DESC, p.latestEpisodeDate DESC"
                 let resultSet = try db.executeQuery(query, values: values)
                 defer { resultSet.close() }
 

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseHelper.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseHelper.swift
@@ -727,10 +727,6 @@ class DatabaseHelper {
         // Revert all the changes from 7.61 to 7.63
         if schemaVersion < 49 {
             do {
-                try db.executeUpdate("DROP INDEX IF EXISTS episode_download_task_id;", values: nil)
-                try db.executeUpdate("DROP INDEX IF EXISTS episode_archived;", values: nil)
-                try db.executeUpdate("DROP INDEX IF EXISTS episode_non_null_download_task_id;", values: nil)
-                try db.executeUpdate("DROP INDEX IF EXISTS episode_added_date;", values: nil)
                 try db.executeUpdate("ALTER TABLE SJEpisode DROP COLUMN contentType", values: nil)
                 try db.executeUpdate("ALTER TABLE SJUserEpisode DROP COLUMN contentType", values: nil)
                 schemaVersion = 49

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseIndexHelper.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseIndexHelper.swift
@@ -20,9 +20,9 @@ public class DatabaseIndexHelper {
                 } catch {
                     rollback.pointee = true
                 }
-
-                self?.queue.close()
             }
+
+            self?.queue.close()
         }
     }
 }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseIndexHelper.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseIndexHelper.swift
@@ -1,0 +1,28 @@
+import FMDB
+import SQLite3
+
+public class DatabaseIndexHelper {
+    let queue: FMDatabaseQueue
+
+    public init() {
+        let flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FILEPROTECTION_NONE
+        queue = FMDatabaseQueue(path: DataManager.pathToDb(), flags: flags)!
+    }
+
+    public func run() {
+        DispatchQueue.global().async { [weak self] in
+            self?.queue.inTransaction { db, rollback in
+                do {
+                    try db.executeUpdate("CREATE INDEX IF NOT EXISTS episode_download_task_id ON SJEpisode (downloadTaskId);", values: nil)
+                    try db.executeUpdate("CREATE INDEX IF NOT EXISTS episode_archived ON SJEpisode (archived);", values: nil)
+                    try db.executeUpdate("CREATE INDEX IF NOT EXISTS episode_non_null_download_task_id ON SJEpisode(downloadTaskId) WHERE downloadTaskId IS NOT NULL;", values: nil)
+                    try db.executeUpdate("CREATE INDEX IF NOT EXISTS episode_added_date ON SJEpisode (addedDate);", values: nil)
+                } catch {
+                    rollback.pointee = true
+                }
+
+                self?.queue.close()
+            }
+        }
+    }
+}

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseIndexHelper.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseIndexHelper.swift
@@ -10,7 +10,7 @@ public class DatabaseIndexHelper {
     }
 
     public func run() {
-        DispatchQueue.global().async { [weak self] in
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             self?.queue.inTransaction { db, rollback in
                 do {
                     try db.executeUpdate("CREATE INDEX IF NOT EXISTS episode_download_task_id ON SJEpisode (downloadTaskId);", values: nil)

--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -122,6 +122,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             UserEpisodeManager.checkForPendingUploads()
         }
         PlaybackManager.shared.updateIdleTimer()
+
+        updateDatabaseIndexes()
     }
 
     func application(_ application: UIApplication, handleEventsForBackgroundURLSession identifier: String, completionHandler: @escaping () -> Void) {
@@ -407,9 +409,18 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         backgroundSignOutListener = BackgroundSignOutListener(presentingViewController: SceneHelper.rootViewController())
     }
 
-    // MARK: What's New
+    // MARK: - Database
 
-    private func setupWhatsNew() {
-        whatsNew = WhatsNew()
+    lazy var indexHelper = DatabaseIndexHelper()
+
+    private func updateDatabaseIndexes() {
+        guard !Settings.upgradedIndexes else {
+            return
+        }
+
+        Toast.show("Indexes being created")
+        indexHelper.run()
+        Settings.upgradedIndexes = true
+        Toast.show("Indexes created")
     }
 }

--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -418,9 +418,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             return
         }
 
-        Toast.show("Indexes being created")
         indexHelper.run()
         Settings.upgradedIndexes = true
-        Toast.show("Indexes created")
     }
 }

--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -25,15 +25,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     private var backgroundSignOutListener: BackgroundSignOutListener?
 
-    var whatsNew: WhatsNew?
+    lazy var whatsNew: WhatsNew = WhatsNew()
 
     // MARK: - App Lifecycle
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
         configureFirebase()
         TraceManager.shared.setup(handler: traceHandler)
-
-        setupWhatsNew()
 
         setupSecrets()
         addAnalyticsObservers()
@@ -52,20 +50,23 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         GoogleCastManager.sharedManager.setup()
 
-        CacheServerHandler.newShowNotesEndpoint = FeatureFlag.newShowNotesEndpoint.enabled
-        CacheServerHandler.episodeFeedArtwork = FeatureFlag.episodeFeedArtwork.enabled
-
         setupRoutes()
-
-        ServerConfig.shared.syncDelegate = ServerSyncManager.shared
-        ServerConfig.shared.playbackDelegate = PlaybackManager.shared
-        checkDefaults()
 
         NotificationsHelper.shared.register(checkToken: false)
 
         DispatchQueue.global().async { [weak self] in
-            self?.postLaunchSetup()
-            self?.checkIfRestoreCleanupRequired()
+            guard let self else {
+                return
+            }
+
+            ServerConfig.shared.syncDelegate = ServerSyncManager.shared
+            ServerConfig.shared.playbackDelegate = PlaybackManager.shared
+            checkDefaults()
+
+            logStaleDownloads()
+            postLaunchSetup()
+            checkIfRestoreCleanupRequired()
+
             ImageManager.sharedManager.updatePodcastImagesIfRequired()
             WidgetHelper.shared.cleanupAppGroupImages()
         }
@@ -84,8 +85,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         NotificationCenter.default.addObserver(self, selector: #selector(showOverlays), name: Constants.Notifications.closedNonOverlayableWindow, object: nil)
 
         setupSignOutListener()
-
-        logStaleDownloads()
 
         return true
     }

--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -709,7 +709,7 @@ private extension MainTabBarController {
     func showWhatsNewIfNeeded() {
         guard let controller = view.window?.rootViewController else { return }
 
-        if let whatsNewViewController = appDelegate()?.whatsNew?.viewControllerToShow() {
+        if let whatsNewViewController = appDelegate()?.whatsNew.viewControllerToShow() {
             controller.present(whatsNewViewController, animated: true)
             isShowingWhatsNew = true
         }

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -1211,6 +1211,18 @@ class Settings: NSObject {
         }
     }
 
+    // MARK: - Database (internal)
+
+    class var upgradedIndexes: Bool {
+        set {
+            UserDefaults.standard.setValue(newValue, forKey: "upgraded_indexes")
+        }
+
+        get {
+            UserDefaults.standard.bool(forKey: "upgraded_indexes")
+        }
+    }
+
     // MARK: - Variables that are loaded/changed through Firebase
 
     #if !os(watchOS)


### PR DESCRIPTION
Now that we've reverted 7.63 to 7.60.1 we can add back the performance improvements.

The big change here is that the index creation now happens after the app is active, so we avoid watchdog terminations. 

## To test

1. Install a previous version of the app with a huge database
2. Run this branch
3. ✅ A toast saying "indexes being created" and then finished should appear
4. ✅ App performance should be faster, especially on filters
5. Also, make sure to order podcasts by Episode Release Date
6. ✅ The app should not freeze
7. Run the app again
8. ✅ You should see no toast

Ps.: the toast message is just for testing purposes. I'm going to remove it before merging it.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
