### PR TITLE
Performance: Settings Query

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/PodcastDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/PodcastDataManager.swift
@@ -59,7 +59,6 @@ class PodcastDataManager {
         "showArchived",
         "refreshAvailable",
         "folderUuid",
-        "settings"
     ]
 
     func setup(dbQueue: FMDatabaseQueue) {
@@ -680,12 +679,6 @@ class PodcastDataManager {
         values.append(podcast.showArchived)
         values.append(podcast.refreshAvailable)
         values.append(DBUtils.nullIfNil(value: podcast.folderUuid))
-
-        if let settingsData = podcast.settings.jsonData {
-            values.append(String(data: settingsData, encoding: .utf8) as Any)
-        } else {
-            FileLog.shared.addMessage("PodcastDataManager.createValuesFromPodcast: Failed to decode Podcast settings")
-        }
 
         if includeIdForWhere {
             values.append(podcast.id)

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseHelper.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseHelper.swift
@@ -740,6 +740,15 @@ class DatabaseHelper {
             }
         }
 
+        if schemaVersion < 50 {
+            do {
+                try db.executeUpdate("ALTER TABLE SJPodcast DROP COLUMN settings;", values: nil)
+            } catch {
+                failedAt(50)
+                return
+            }
+        }
+
         db.commit()
     }
 }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Podcast+fromDatabase.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Podcast+fromDatabase.swift
@@ -55,16 +55,6 @@ extension Podcast {
         podcast.refreshAvailable = rs.bool(forColumn: "refreshAvailable")
         podcast.folderUuid = rs.string(forColumn: "folderUuid")
 
-        if let settingsString = rs.string(forColumn: "settings"), let data = settingsString.data(using: .utf8) {
-            do {
-                podcast.settings = try DBUtils.convertData(value: data) ?? podcast.settings
-            } catch let error {
-                FileLog.shared.addMessage("Podcast fromResultSet: Failed to decode: \(error)")
-            }
-        } else {
-            FileLog.shared.addMessage("Podcast fromResultSet: Nil settings column")
-        }
-
         return podcast
     }
 }

--- a/PocketCastsTests/UnitTests.xctestplan
+++ b/PocketCastsTests/UnitTests.xctestplan
@@ -63,6 +63,10 @@
       }
     },
     {
+      "skippedTests" : [
+        "AutoAddCandidatesDataManagerTests\/testNewQueryPerformance()",
+        "AutoAddCandidatesDataManagerTests\/testSyncableUpNextSetting()"
+      ],
       "target" : {
         "containerPath" : "container:Modules\/DataModel",
         "identifier" : "PocketCastsDataModelTests",


### PR DESCRIPTION
Removes the synced settings column so we aren't deserializing missing data.

This isn't really a performance thing and more cleanup to avoid additional logging and things.

## To test

* Load podcasts and refresh them
* Navigate to podcasts in Discover and make sure they load
* Subscribe to a podcast and make sure it is properly subscribed
* Change some podcast settings, restart the app, make sure podcast settings remain

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
