### PR TITLE
Performance: Podcast cache

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/PodcastDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/PodcastDataManager.swift
@@ -2,7 +2,7 @@ import FMDB
 import PocketCastsUtils
 
 class PodcastDataManager {
-    private var cachedPodcasts = [Podcast]()
+    private var cachedPodcasts = [String: Podcast]()
     private lazy var cachedPodcastsQueue: DispatchQueue = {
         let queue = DispatchQueue(label: "au.com.pocketcasts.PodcastDataQueue")
 
@@ -72,7 +72,7 @@ class PodcastDataManager {
 
         var allPodcasts = [Podcast]()
         cachedPodcastsQueue.sync {
-            for podcast in cachedPodcasts {
+            for podcast in cachedPodcasts.values {
                 if !podcast.isSubscribed(), !includeUnsubscribed { continue }
 
                 allPodcasts.append(podcast)
@@ -87,7 +87,7 @@ class PodcastDataManager {
 
         var allPodcasts = [Podcast]()
         cachedPodcastsQueue.sync {
-            for podcast in cachedPodcasts {
+            for podcast in cachedPodcasts.values {
                 if !podcast.isSubscribed() { continue }
 
                 allPodcasts.append(podcast)
@@ -104,7 +104,7 @@ class PodcastDataManager {
 
         var allPodcasts = [Podcast]()
         cachedPodcastsQueue.sync {
-            for podcast in cachedPodcasts {
+            for podcast in cachedPodcasts.values {
                 if !podcast.isSubscribed() { continue }
 
                 allPodcasts.append(podcast)
@@ -169,7 +169,7 @@ class PodcastDataManager {
     func allUnsubscribedPodcastUuids(dbQueue: FMDatabaseQueue) -> [String] {
         var allUnsubscribed = [String]()
         cachedPodcastsQueue.sync {
-            for podcast in cachedPodcasts {
+            for podcast in cachedPodcasts.values {
                 if podcast.isSubscribed() { continue }
 
                 allUnsubscribed.append(podcast.uuid)
@@ -182,7 +182,7 @@ class PodcastDataManager {
     func allUnsubscribedPodcasts(dbQueue: FMDatabaseQueue) -> [Podcast] {
         var allUnsubscribed = [Podcast]()
         cachedPodcastsQueue.sync {
-            for podcast in cachedPodcasts {
+            for podcast in cachedPodcasts.values {
                 if podcast.isSubscribed() { continue }
 
                 allUnsubscribed.append(podcast)
@@ -203,7 +203,7 @@ class PodcastDataManager {
         // the other 3 cases we do in memory
         var allPodcastsInFolder: [Podcast] = []
         cachedPodcastsQueue.sync {
-            allPodcastsInFolder = cachedPodcasts.filter { $0.isSubscribed() && $0.folderUuid == folder.uuid }
+            allPodcastsInFolder = cachedPodcasts.values.filter { $0.isSubscribed() && $0.folderUuid == folder.uuid }
         }
 
         allPodcastsInFolder.sort { podcast1, podcast2 in
@@ -221,14 +221,14 @@ class PodcastDataManager {
 
     func countOfPodcastsInFolder(folder: Folder?, dbQueue: FMDatabaseQueue) -> Int {
         cachedPodcastsQueue.sync {
-            cachedPodcasts.filter { $0.isSubscribed() && $0.folderUuid == folder?.uuid }.count
+            cachedPodcasts.values.filter { $0.isSubscribed() && $0.folderUuid == folder?.uuid }.count
         }
     }
 
     func allPaidPodcasts(dbQueue: FMDatabaseQueue) -> [Podcast] {
         var allPaid = [Podcast]()
         cachedPodcastsQueue.sync {
-            for podcast in cachedPodcasts {
+            for podcast in cachedPodcasts.values {
                 if !podcast.isPaid { continue }
 
                 allPaid.append(podcast)
@@ -241,7 +241,7 @@ class PodcastDataManager {
     func allUnsynced(dbQueue: FMDatabaseQueue) -> [Podcast] {
         var unsyncedPodcasts = [Podcast]()
         cachedPodcastsQueue.sync {
-            for podcast in cachedPodcasts {
+            for podcast in cachedPodcasts.values {
                 if podcast.syncStatus == SyncStatus.notSynced.rawValue {
                     unsyncedPodcasts.append(podcast)
                 }
@@ -254,7 +254,7 @@ class PodcastDataManager {
     func allOverrideGlobalArchivePodcasts(dbQueue: FMDatabaseQueue) -> [Podcast] {
         var podcastsOverrideArchive = [Podcast]()
         cachedPodcastsQueue.sync {
-            for podcast in cachedPodcasts {
+            for podcast in cachedPodcasts.values {
                 if podcast.isSubscribed(), podcast.isAutoArchiveOverridden {
                     podcastsOverrideArchive.append(podcast)
                 }
@@ -266,22 +266,18 @@ class PodcastDataManager {
 
     func find(uuid: String, includeUnsubscribed: Bool, dbQueue: FMDatabaseQueue) -> Podcast? {
         cachedPodcastsQueue.sync {
-            for podcast in cachedPodcasts {
-                if podcast.uuid == uuid {
-                    if !includeUnsubscribed, !podcast.isSubscribed() { return nil }
+            guard let podcast = cachedPodcasts[uuid] else { return nil }
 
-                    return podcast
-                }
-            }
+            if !includeUnsubscribed, !podcast.isSubscribed() { return nil }
 
-            return nil
+            return podcast
         }
     }
 
     func count(dbQueue: FMDatabaseQueue) -> Int {
         var count = 0
         cachedPodcastsQueue.sync {
-            for podcast in cachedPodcasts {
+            for podcast in cachedPodcasts.values {
                 if !podcast.isSubscribed() { continue }
 
                 count += 1
@@ -608,10 +604,10 @@ class PodcastDataManager {
                 let resultSet = try db.executeQuery("SELECT * from \(DataManager.podcastTableName) ORDER BY sortOrder ASC", values: nil)
                 defer { resultSet.close() }
 
-                var newPodcasts = [Podcast]()
+                var newPodcasts = [String: Podcast]()
                 while resultSet.next() {
                     let podcast = self.createPodcastFrom(resultSet: resultSet)
-                    newPodcasts.append(podcast)
+                    newPodcasts[podcast.uuid] = podcast
                 }
                 cachedPodcastsQueue.sync {
                     cachedPodcasts = newPodcasts

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseIndexHelper.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseIndexHelper.swift
@@ -13,8 +13,8 @@ public class DatabaseIndexHelper {
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             self?.queue.inTransaction { db, rollback in
                 do {
+                    try db.executeUpdate("DROP INDEX IF EXISTS episode_archived;", values: nil)
                     try db.executeUpdate("CREATE INDEX IF NOT EXISTS episode_download_task_id ON SJEpisode (downloadTaskId);", values: nil)
-                    try db.executeUpdate("CREATE INDEX IF NOT EXISTS episode_archived ON SJEpisode (archived);", values: nil)
                     try db.executeUpdate("CREATE INDEX IF NOT EXISTS episode_non_null_download_task_id ON SJEpisode(downloadTaskId) WHERE downloadTaskId IS NOT NULL;", values: nil)
                     try db.executeUpdate("CREATE INDEX IF NOT EXISTS episode_added_date ON SJEpisode (addedDate);", values: nil)
                 } catch {

--- a/Modules/DataModel/Tests/PocketCastsDataModelTests/AutoAddCandidatesDataManagerTests.swift
+++ b/Modules/DataModel/Tests/PocketCastsDataModelTests/AutoAddCandidatesDataManagerTests.swift
@@ -13,21 +13,7 @@ final class AutoAddCandidatesDataManagerTests: XCTestCase {
     }
 
     private func setupDatabase() throws -> DataManager {
-        let documentsPath = NSSearchPathForDirectoriesInDomains(.applicationSupportDirectory, .userDomainMask, true).last as NSString?
-        guard let dbFolderPath = documentsPath?.appendingPathComponent("Pocket Casts") as? NSString else {
-            throw TestError.dbFolderPathFailure
-        }
-
-        if !FileManager.default.fileExists(atPath: dbFolderPath as String) {
-            try FileManager.default.createDirectory(atPath: dbFolderPath as String, withIntermediateDirectories: true)
-        }
-
-        let dbPath = dbFolderPath.appendingPathComponent("podcast_testDB.sqlite3")
-        if FileManager.default.fileExists(atPath: dbPath) {
-            try FileManager.default.removeItem(atPath: dbPath)
-        }
-        let flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FILEPROTECTION_NONE
-        let dbQueue = try XCTUnwrap(FMDatabaseQueue(path: dbPath, flags: flags))
+        let dbQueue = try XCTUnwrap(FMDatabaseQueue.newTestDatabase())
         return DataManager(dbQueue: dbQueue)
     }
 

--- a/Modules/DataModel/Tests/PocketCastsDataModelTests/DataManager+TestDatabase.swift
+++ b/Modules/DataModel/Tests/PocketCastsDataModelTests/DataManager+TestDatabase.swift
@@ -25,4 +25,3 @@ extension FMDatabaseQueue {
         return FMDatabaseQueue(path: dbPath, flags: flags)
     }
 }
-

--- a/Modules/DataModel/Tests/PocketCastsDataModelTests/DataManager+TestDatabase.swift
+++ b/Modules/DataModel/Tests/PocketCastsDataModelTests/DataManager+TestDatabase.swift
@@ -1,0 +1,28 @@
+import SQLite3
+import FMDB
+import Foundation
+
+extension FMDatabaseQueue {
+    enum TestError: Error {
+        case dbFolderPathFailure
+    }
+
+    static func newTestDatabase() throws -> FMDatabaseQueue? {
+        let documentsPath = NSSearchPathForDirectoriesInDomains(.applicationSupportDirectory, .userDomainMask, true).last as NSString?
+        guard let dbFolderPath = documentsPath?.appendingPathComponent("Pocket Casts") as? NSString else {
+            throw TestError.dbFolderPathFailure
+        }
+
+        if !FileManager.default.fileExists(atPath: dbFolderPath as String) {
+            try FileManager.default.createDirectory(atPath: dbFolderPath as String, withIntermediateDirectories: true)
+        }
+
+        let dbPath = dbFolderPath.appendingPathComponent("podcast_testDB.sqlite3")
+        if FileManager.default.fileExists(atPath: dbPath) {
+            try FileManager.default.removeItem(atPath: dbPath)
+        }
+        let flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FILEPROTECTION_NONE
+        return FMDatabaseQueue(path: dbPath, flags: flags)
+    }
+}
+

--- a/Modules/DataModel/Tests/PocketCastsDataModelTests/PodcastDataManagerTests.swift
+++ b/Modules/DataModel/Tests/PocketCastsDataModelTests/PodcastDataManagerTests.swift
@@ -1,0 +1,47 @@
+import XCTest
+import SQLite3
+import FMDB
+@testable import PocketCastsDataModel
+
+final class PodcastDataManagerTests: XCTestCase {
+    private func setupDatabase() throws -> DataManager {
+        let dbQueue = try XCTUnwrap(FMDatabaseQueue.newTestDatabase())
+        return DataManager(dbQueue: dbQueue)
+    }
+
+    private func setupDataManager() throws -> DataManager {
+        let dataManager = try setupDatabase()
+        let podcastCount = 1000
+        let episodeCount = 50
+
+        (0...podcastCount).forEach { idx in
+            let podcast = Podcast()
+            podcast.uuid = "\(idx)"
+            podcast.addedDate = Date()
+
+            dataManager.save(podcast: podcast)
+
+            (0...episodeCount).forEach { _ in
+                let episode = Episode()
+                episode.uuid = UUID().uuidString
+                episode.addedDate = Date()
+                episode.podcastUuid = podcast.uuid
+
+                dataManager.save(episode: episode)
+            }
+        }
+
+        return dataManager
+    }
+
+    func testFindPodcastPerformance() throws {
+        let dataManager = try setupDataManager()
+
+        self.measure {
+            (0...10000).forEach { _ in
+                let random = Int.random(in: 0...1000)
+                _ = dataManager.findPodcast(uuid: "\(random)")
+            }
+        }
+    }
+}

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -1215,11 +1215,11 @@ class Settings: NSObject {
 
     class var upgradedIndexes: Bool {
         set {
-            UserDefaults.standard.setValue(newValue, forKey: "upgraded_indexes")
+            UserDefaults.standard.setValue(newValue, forKey: "upgraded_indexes_v2")
         }
 
         get {
-            UserDefaults.standard.bool(forKey: "upgraded_indexes")
+            UserDefaults.standard.bool(forKey: "upgraded_indexes_v2")
         }
     }
 


### PR DESCRIPTION
`PodcastDataManager.find(uuid:)` is called frequently on the main thread. For instance, `EpisodeCell` calls `Episode.subTitle()` → `Episode.parentPodcast` each time the cell is prepared for reuse:

![CleanShot 2024-04-27 at 09 23 57@2x](https://github.com/Automattic/pocket-casts-ios/assets/3250/a663232d-e899-46fd-a464-8a99e28cbf13)

* Old loop through `cachedPodcasts` was O(n)
* New dictionary is O(1)

Added a new unit test to prove this: 
| Before | After |
| -- | -- |
| ![CleanShot 2024-04-26 at 16 00 45@2x](https://github.com/Automattic/pocket-casts-ios/assets/3250/07714e63-5776-454f-bf01-4f3ebe5edb5a) | ![CleanShot 2024-04-26 at 16 01 43@2x](https://github.com/Automattic/pocket-casts-ios/assets/3250/f66d29cc-feb1-4f5c-ba89-821e8a4412a8) |

if you want, apply the unit test commit to `trunk` and crank up the iteration to 100000 or more and you'll quickly see the exponential growth.

This may not have a huge impact on performance, especially if the `showTick` change (https://github.com/Automattic/pocket-casts-ios/pull/1663) is merged, but it seems like an obvious performance improvement with little downside.

## To test

* Build and run
* Scroll through podcasts
* Test Podcast playback

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.