### PR TITLE
Performance: move filter queries to background

### DIFF
--- a/podcasts/PlaylistViewController.swift
+++ b/podcasts/PlaylistViewController.swift
@@ -133,6 +133,15 @@ class PlaylistViewController: PCViewController, TitleButtonDelegate {
 
     var cellHeights: [IndexPath: CGFloat] = [:]
 
+    private var loadingIndicator: ThemeLoadingIndicator! {
+        didSet {
+            view.addSubview(loadingIndicator)
+            loadingIndicator.center = view.center
+        }
+    }
+
+    private var firstTimeLoading = true
+
     // MARK: - View Methods
 
     override func viewDidLoad() {
@@ -166,6 +175,8 @@ class PlaylistViewController: PCViewController, TitleButtonDelegate {
         filterCollectionView.filter = filter
 
         isChipHidden = !isNewFilter
+
+        loadingIndicator = ThemeLoadingIndicator()
 
         Analytics.track(.filterShown)
     }
@@ -253,11 +264,21 @@ class PlaylistViewController: PCViewController, TitleButtonDelegate {
     }
 
     private func reloadFilterAndRefresh(animated: Bool = false) {
-        if let reloadedFilter = DataManager.sharedManager.findFilter(uuid: filter.uuid) {
-            filter = reloadedFilter
-            filterCollectionView.filter = reloadedFilter
+        if firstTimeLoading {
+            loadingIndicator.startAnimating()
         }
-        refreshEpisodes(animated: animated)
+
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            guard let self else { return }
+            if let reloadedFilter = DataManager.sharedManager.findFilter(uuid: filter.uuid) {
+                filter = reloadedFilter
+                DispatchQueue.main.async {
+                    self.filterCollectionView.filter = reloadedFilter
+                }
+            }
+
+            refreshEpisodes(animated: animated)
+        }
     }
 
     // MARK: - UIScrollView
@@ -478,6 +499,9 @@ class PlaylistViewController: PCViewController, TitleButtonDelegate {
     func refreshEpisodes(animated: Bool) {
         let refreshOperation = PlaylistRefreshOperation(tableView: tableView, filter: filter) { [weak self] newData in
             guard let strongSelf = self else { return }
+
+            strongSelf.firstTimeLoading = false
+            strongSelf.loadingIndicator.stopAnimating()
 
             strongSelf.tableView.isHidden = (newData.count == 0)
             if animated {


### PR DESCRIPTION
Currently, the queries to:

1. Retrieve the filters
2. Retrieve a specific filter

Are done in the main thread. If there's any blocker database operation (and a lot of times for big databases it has) the UI will freeze until those are made. And for (1) it doesn't even matter if Filters are being displayed or not.

This moves these calls to background threads and displays a spinner while data is loading.

## To test

1. Run the app with a huge database (1k+ podcasts preferably) that has filters
2. Open Filters
3. ✅ You should see a spinner
4. ✅ Once the filters load, all filters are displayed and the spinner is gone
5. Tap on any filter
6. ✅ You should see a spinner
7. ✅ Once episodes load, the spinner disappears
8. While still in filters, close and re-run the app
9. ✅ The latest open filter should display

You should see a "Warning once only: UITableView was told to layout its visible cells and other contents without being in the view hierarchy (the table view or one of its superviews has not been added to a window)." because sometimes the filters will be rendered while the main screen is not the main screen anymore.

As far as I'm concerned this shouldn't cause big issues and I can tackle in another PR.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
