### PR TITLE
Performance: check for pending downloads in the background

### DIFF
--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -118,8 +118,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 RefreshManager.shared.refreshPodcasts()
             })
         } else {
-            PodcastManager.shared.checkForPendingAndAutoDownloads()
-            UserEpisodeManager.checkForPendingUploads()
+            DispatchQueue.global(qos: .userInitiated).async {
+                PodcastManager.shared.checkForPendingAndAutoDownloads()
+                UserEpisodeManager.checkForPendingUploads()
+            }
         }
         PlaybackManager.shared.updateIdleTimer()
 


### PR DESCRIPTION
When running the app we check for pending downloads/uploads from the main thread.

This PR moves those checks to the background.

## To test

1. Add any episode to download
2. Kill the app
3. Reopen it
4. ✅ Check that this episode should resume downloading

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
