### PR TITLE
Performance: remove bookmark check

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Episode.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Episode.swift
@@ -47,7 +47,12 @@ public class Episode: NSObject, BaseEpisode {
     @objc public var deselectedChaptersModified = 0 as Int64
 
     public var hasBookmarks: Bool {
-        DataManager.sharedManager.bookmarks.bookmarkCount(forEpisode: uuid) > 0
+        // This wil cause a regression in which the bookmarks won't be displayed
+        // for episodes with bookmarks.
+        // However, this call is happening on the main thread and can block the whole app.
+        // We will re-add this again in a way that's not a blocker
+        //DataManager.sharedManager.bookmarks.bookmarkCount(forEpisode: uuid) > 0
+        false
     }
 
     public var isUserEpisode: Bool {


### PR DESCRIPTION
Every episode that is shown is checked to whether they have a bookmark or not. This query is not expensive, however, if there's any other more expensive query in the queue, this will block the whole app.

I temporarily disabled this call here and this causes a regression: the bookmark icon is not shown anymore. Of course, we will re-add this back in a non-blocking way soon.

## To test

1. Run the app with a huge database
2. Go to a long list of episodes
3. Scroll down
4. ✅ Scroll should be as smooth as possible

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
