### PR TITLE
Performance: Background SiriShortcutsManager

### DIFF
--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -69,11 +69,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
             ImageManager.sharedManager.updatePodcastImagesIfRequired()
             WidgetHelper.shared.cleanupAppGroupImages()
+            SiriShortcutsManager.shared.setup()
         }
 
         badgeHelper.setup()
         WatchManager.shared.setup()
-        SiriShortcutsManager.shared.setup()
         shortcutManager.listenForShortcutChanges()
 
         setupBackgroundRefresh()


### PR DESCRIPTION
Moves the `SiriShortcutsManager` setup to the background on launch. This setup process ends up calling `allPodcastsOrderedByTitle` for one of its labels, which takes a while on large databases.

I'm not really sure why the results need to be ordered by title since the only user of them (`matchUtteranceToPodcast`) re-sorts them based on a [fuzzy search score](https://github.com/krisk/fuse-swift) but in order to avoid regression this late in the cycle, I stuck with moving it to the background.

The results aren't needed immediately at launch, so this is safe to delay.

## To test

* Launch the app with a large database
* Trigger siri
* Say "Play <podcast name> in Pocket Casts"
* Ensure that playback begins after a short delay

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
