### PR TITLE
Improve folders performance

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -338,10 +338,12 @@ public class DataManager {
     }
 
     public func bulkSetFolderUuid(folderUuid: String, podcastUuids: [String]) {
+        folderPodcastUuuidCache.removeAll()
         podcastManager.bulkSetFolderUuid(folderUuid: folderUuid, podcastUuids: podcastUuids, dbQueue: dbQueue)
     }
 
     public func updatePodcastFolder(podcastUuid: String, to folderUuid: String?, sortOrder: Int32) {
+        folderPodcastUuuidCache.removeAll()
         podcastManager.updatePodcastFolder(podcastUuid: podcastUuid, sortOrder: sortOrder, folderUuid: folderUuid, dbQueue: dbQueue)
     }
 
@@ -821,6 +823,7 @@ public class DataManager {
     // MARK: - Folders
 
     public func save(folder: Folder) {
+        folderPodcastUuuidCache[folder.uuid] = nil
         folderManager.save(folder: folder, dbQueue: dbQueue)
     }
 
@@ -830,6 +833,17 @@ public class DataManager {
 
     public func findFolder(uuid: String) -> Folder? {
         folderManager.findFolder(uuid: uuid, dbQueue: dbQueue)
+    }
+
+    private var folderPodcastUuuidCache: [String: [String]] = [:]
+
+    public func topPodcastsUuidInFolder(folder: Folder) -> [String] {
+        if let topPodcasts = folderPodcastUuuidCache[folder.uuid] {
+            return topPodcasts
+        }
+        let topPodcasts = podcastManager.allPodcastsInFolder(folder: folder, dbQueue: dbQueue).map({$0.uuid})
+        folderPodcastUuuidCache[folder.uuid] = topPodcasts
+        return topPodcasts
     }
 
     public func allPodcastsInFolder(folder: Folder) -> [Podcast] {

--- a/podcasts/FolderPreviewView.swift
+++ b/podcasts/FolderPreviewView.swift
@@ -38,16 +38,18 @@ class FolderPreviewView: UIView {
         if folderName.isEmpty { showFolderName = false }
 
         for i in 0 ... (previewCount - 1) {
-            let imageView = PodcastImageView()
+            let imageView: PodcastImageView
+            if i < images.count {
+                imageView = images[i]
+            } else {
+                imageView = PodcastImageView()
+                addSubview(imageView)
+                images.append(imageView)
+            }
 
             if let uuid = topPodcastUuids[safe: i] {
                 setImage(in: imageView, for: uuid)
-            } else {
-                imageView.setTransparentNoArtwork(size: .list)
             }
-
-            addSubview(imageView)
-            images.append(imageView)
         }
 
         layoutTiles()
@@ -95,9 +97,8 @@ class FolderPreviewView: UIView {
 
     private func cleanupImages() {
         images.forEach { imageView in
-            imageView.removeFromSuperview()
+            imageView.setTransparentNoArtwork(size: .list)
         }
-        images.removeAll()
     }
 
     private func configureGradient() {

--- a/podcasts/FolderPreviewView.swift
+++ b/podcasts/FolderPreviewView.swift
@@ -18,7 +18,7 @@ class FolderPreviewView: UIView {
     private var nameLabelBottomConstraint: NSLayoutConstraint?
 
     func populateFrom(folder: Folder) {
-        let podcastUuids = DataManager.sharedManager.allPodcastsInFolder(folder: folder).map(\.uuid)
+        let podcastUuids = DataManager.sharedManager.topPodcastsUuidInFolder(folder: folder)
         setup(folderName: folder.name, folderColor: folder.color, topPodcastUuids: podcastUuids)
     }
 

--- a/podcasts/PodcastImageView.swift
+++ b/podcasts/PodcastImageView.swift
@@ -44,9 +44,9 @@ class PodcastImageView: UIView {
     }
 
     func setTransparentNoArtwork(size: PodcastThumbnailSize) {
+        imageView?.kf.cancelDownloadTask()
         imageView?.image = nil
         imageView?.backgroundColor = UIColor.black.withAlphaComponent(0.1)
-
         adjustForSize(size)
     }
 


### PR DESCRIPTION
Fixes #

This PR implements a folder cache of it's top podcasts uuids

## To test

- Start app using a large database with folders with lot of podcasts episodes
- Open podcasts view
- Scroll down ( still some slow down can happen while the cache is being fulfilled)
- Scroll back up and scroll performance should be optimal.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
