### PR TITLE
Only propagate episode changes notifications if the file size actually changed

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Private/API Tasks/MetadataTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Private/API Tasks/MetadataTask.swift
@@ -56,7 +56,7 @@ class MetadataTask: Operation {
             }
         }
 
-        if let contentLength = responseHeaders["Content-Length"] as? String, let intLength = Int64(contentLength), intLength > MetadataTask.minBytesInFile {
+        if let contentLength = responseHeaders["Content-Length"] as? String, let intLength = Int64(contentLength), intLength > MetadataTask.minBytesInFile, episode.sizeInBytes != intLength {
             DataManager.sharedManager.saveEpisode(fileSize: intLength, episode: episode)
             performedUpdate = true
         }


### PR DESCRIPTION
Fixes #

This PR changes the metadata task code to only propagate episode changes notifications if the file size actually changed.
When downloading files for streaming download the application was sending notifications for every delegate callback for bytes received.

## To test

- Start the app
- Start playing an episode with Trim Silence active, check if episode notification is only send by the MetadataTask when the download starts

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
