### PR TITLE
Performance: `VACUUM` the database

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -82,6 +82,10 @@ public class DataManager {
 
             }
         }
+
+        dbQueue.inDatabase { db in
+            try? db.executeUpdate("VACUUM;", values: nil)
+        }
     }
 
     // MARK: - Up Next

--- a/podcasts/MainTabBarController+Alert.swift
+++ b/podcasts/MainTabBarController+Alert.swift
@@ -1,16 +1,17 @@
 extension MainTabBarController {
     func presentLoader() {
         DispatchQueue.main.async { [weak self] in
-            let alert = UIAlertController(title: L10n.hangOn, message: L10n.databaseMigration, preferredStyle: .alert)
+            guard let self else { return }
+            let alert = ShiftyLoadingAlert(title: L10n.databaseMigration)
 
-            self?.present(alert, animated: true)
-            self?.alert = alert
+            alert.showAlert(self, hasProgress: false, completion: nil)
+            self.alert = alert
         }
     }
 
     func dismissLoader() {
         DispatchQueue.main.async { [weak self] in
-            self?.alert?.dismiss(animated: true)
+            self?.alert?.hideAlert(true)
         }
     }
 }

--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -24,7 +24,7 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
     var isShowingWhatsNew: Bool = false
 
     /// Displayed during database migrations
-    var alert: UIAlertController?
+    var alert: ShiftyLoadingAlert?
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -1215,11 +1215,11 @@ class Settings: NSObject {
 
     class var upgradedIndexes: Bool {
         set {
-            UserDefaults.standard.setValue(newValue, forKey: "upgraded_indexes_v3")
+            UserDefaults.standard.setValue(newValue, forKey: "upgraded_indexes_v4")
         }
 
         get {
-            UserDefaults.standard.bool(forKey: "upgraded_indexes_v3")
+            UserDefaults.standard.bool(forKey: "upgraded_indexes_v4")
         }
     }
 


### PR DESCRIPTION
For old, big databases, `VACUUM` can reduce the database's size and increase performance absurdly.

This is an initial attempt to add it. In theory, we should be smart when running it:

1. Check disk space
2. Run in moments when the user is not actively using the app

However, I think the ideal for now would be to test that ASAP as it's probably the biggest change we can make in terms of performance.

<img src="https://github.com/Automattic/pocket-casts-ios/assets/7040243/19f6f980-015b-44b3-bf56-4f810cc715a4" width="300">

## To test

1. Run another branch with a huge database with complex filters (the one we have with 500mb+ is ideal)
2. Run this branch
3. ✅ You should see a message when opening the app with a spinner
4. It will take a while to disappear (it depends on your hardware)
5. ✅ Once it's gone, interact with the app, filters, playback and everything should be snappier

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
