### PR TITLE
Categories: Remove truncation for sponsored podcasts description

### DIFF
--- a/podcasts/SinglePodcastViewController.swift
+++ b/podcasts/SinglePodcastViewController.swift
@@ -102,7 +102,6 @@ class SinglePodcastViewController: UIViewController, DiscoverSummaryProtocol {
         if let isSponsored = item?.isSponsored, isSponsored {
             typeBadgeLabel.text = L10n.discoverSponsored
             typeBadgeLabel.style = .primaryText02
-            podcastDescription.numberOfLines = 3
         } else {
             typeBadgeLabel.text = L10n.discoverFreshPick
             typeBadgeLabel.style = .support02


### PR DESCRIPTION
Removes the truncation of sponsored podcast cells in Discover

| Before | After |
| -- | -- |
| ![Simulator Screenshot - iPhone 15 - 2024-05-06 at 12 25 34](https://github.com/Automattic/pocket-casts-ios/assets/3250/e59932bf-26f6-4463-9c80-6d2d09b0a659) | ![Simulator Screenshot - iPhone 15 - 2024-05-06 at 12 24 56](https://github.com/Automattic/pocket-casts-ios/assets/3250/a8e42340-68f7-4be4-b12a-c3cdb148265c) |

## To test

* Open Discover
* Tap on a Category
* Ensure that the sponsored podcast shows its full description

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
