### PR TITLE
Categories: Re-merge pull requests for Categories Redesign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+7.62
+-----
+- Sleep Timer restarts automatically if you play again within 5 minutes [#1612]
+- Add redesigned Categories picker to the top of Discover. [#1621]
+
 7.61
 -----
 

--- a/Modules/Server/Sources/PocketCastsServer/Public/Discover/DiscoverServerHandler.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Discover/DiscoverServerHandler.swift
@@ -51,6 +51,20 @@ public class DiscoverServerHandler {
         }
     }
 
+    public func discoverCategories(source: String) async -> [DiscoverCategory] {
+        return await withCheckedContinuation { continuation in
+            DiscoverServerHandler.shared.discoverCategories(source: source, completion: { discoverCategories in
+                DispatchQueue.main.async {
+                    guard let discoverCategories = discoverCategories else {
+                        continuation.resume(returning: [])
+                        return
+                    }
+                    continuation.resume(returning: discoverCategories)
+                }
+            })
+        }
+    }
+
     public func discoverCategoryDetails(source: String, completion: @escaping (DiscoverCategoryDetails?) -> Void) {
         discoverRequest(path: source, type: DiscoverCategoryDetails.self) { categoryDetails, _ in
             completion(categoryDetails)

--- a/Modules/Server/Sources/PocketCastsServer/Public/Discover/DiscoverServerHandler.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Discover/DiscoverServerHandler.swift
@@ -1,5 +1,6 @@
 import Combine
 import Foundation
+import PocketCastsUtils
 
 public class DiscoverServerHandler {
     enum DiscoverServerError: Error {
@@ -28,7 +29,14 @@ public class DiscoverServerHandler {
     }
 
     public func discoverPage(completion: @escaping (DiscoverLayout?, Bool) -> Void) {
-        discoverRequest(path: ServerConstants.Urls.discover() + "ios/content.json", type: DiscoverLayout.self) { discoverItems, cachedResponse in
+        let contentPath: String
+        if FeatureFlag.categoriesRedesign.enabled {
+            contentPath = "ios/content_v2.json"
+        } else {
+            contentPath = "ios/content.json"
+        }
+
+        discoverRequest(path: ServerConstants.Urls.discover() + contentPath, type: DiscoverLayout.self) { discoverItems, cachedResponse in
             completion(discoverItems, cachedResponse)
         }
     }

--- a/Modules/Server/Sources/PocketCastsServer/Public/Discover/DiscoverServerHandler.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Discover/DiscoverServerHandler.swift
@@ -10,7 +10,7 @@ public class DiscoverServerHandler {
 
     public static let shared = DiscoverServerHandler()
 
-    private lazy var discoveryCache: URLCache = {
+    public private(set) lazy var discoveryCache: URLCache = {
         let cache = URLCache(memoryCapacity: 1024 * 1024, diskCapacity: 5 * 1024 * 1024, diskPath: "discovery")
         return cache
     }()

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
@@ -256,7 +256,7 @@ public struct DiscoverRegion: Decodable {
     public var flag: String
 }
 
-public struct DiscoverItem: Decodable {
+public struct DiscoverItem: Decodable, Equatable {
     public var id: String?
     public var uuid: String?
     public var title: String?
@@ -281,7 +281,7 @@ public struct DiscoverItem: Decodable {
     }
 }
 
-public struct CarouselSponsoredPodcast: Decodable {
+public struct CarouselSponsoredPodcast: Decodable, Equatable {
     public var position: Int?
     public var source: String?
 }

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
@@ -360,7 +360,7 @@ public struct DiscoverPodcast: Codable, Equatable {
     }
 }
 
-public struct DiscoverCategory: Decodable {
+public struct DiscoverCategory: Decodable, Equatable {
     public var id: Int?
     public var name: String?
     public var source: String?

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
@@ -263,6 +263,7 @@ public struct DiscoverItem: Decodable, Equatable {
     public var type: String?
     public var summaryStyle: String?
     public var expandedStyle: String?
+    public var summaryItemCount: Int?
     public var source: String?
     public var sponsoredPodcasts: [CarouselSponsoredPodcast]?
     public var expandedTopItemLabel: String?
@@ -282,11 +283,38 @@ public struct DiscoverItem: Decodable, Equatable {
         case type, title, source, regions, curated, uuid, popular, id
     }
 
-    public init(id: String? = nil, title: String? = nil, source: String? = nil, regions: [String]) {
+    public init(
+        id: String? = nil,
+        uuid: String? = nil,
+        title: String? = nil,
+        type: String? = nil,
+        summaryStyle: String? = nil,
+        summaryItemCount: Int? = nil,
+        expandedStyle: String? = nil,
+        source: String? = nil,
+        sponsoredPodcasts: [CarouselSponsoredPodcast]? = nil,
+        expandedTopItemLabel: String? = nil,
+        curated: Bool? = nil,
+        regions: [String],
+        isSponsored: Bool? = nil,
+        popular: [Int]? = nil,
+        categoryID: Int? = nil
+    ) {
         self.id = id
+        self.uuid = uuid
         self.title = title
+        self.type = type
+        self.summaryStyle = summaryStyle
+        self.summaryItemCount = summaryItemCount
+        self.expandedStyle = expandedStyle
         self.source = source
+        self.sponsoredPodcasts = sponsoredPodcasts
+        self.expandedTopItemLabel = expandedTopItemLabel
+        self.curated = curated
         self.regions = regions
+        self.isSponsored = isSponsored
+        self.popular = popular
+        self.categoryID = categoryID
     }
 }
 

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
@@ -257,6 +257,7 @@ public struct DiscoverRegion: Decodable {
 }
 
 public struct DiscoverItem: Decodable {
+    public var id: String?
     public var uuid: String?
     public var title: String?
     public var type: String?
@@ -276,7 +277,7 @@ public struct DiscoverItem: Decodable {
         case isSponsored = "sponsored"
         case sponsoredPodcasts = "sponsored_podcasts"
         case expandedTopItemLabel = "expanded_top_item_label"
-        case type, title, source, regions, curated, uuid, popular
+        case type, title, source, regions, curated, uuid, popular, id
     }
 }
 

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
@@ -279,6 +279,22 @@ public struct DiscoverItem: Decodable, Equatable {
         case expandedTopItemLabel = "expanded_top_item_label"
         case type, title, source, regions, curated, uuid, popular, id
     }
+
+    public init(id: String? = nil, uuid: String? = nil, title: String? = nil, type: String? = nil, summaryStyle: String? = nil, expandedStyle: String? = nil, source: String? = nil, sponsoredPodcasts: [CarouselSponsoredPodcast]? = nil, expandedTopItemLabel: String? = nil, curated: Bool? = nil, regions: [String], isSponsored: Bool? = nil, popular: [Int]? = nil) {
+        self.id = id
+        self.uuid = uuid
+        self.title = title
+        self.type = type
+        self.summaryStyle = summaryStyle
+        self.expandedStyle = expandedStyle
+        self.source = source
+        self.sponsoredPodcasts = sponsoredPodcasts
+        self.expandedTopItemLabel = expandedTopItemLabel
+        self.curated = curated
+        self.regions = regions
+        self.isSponsored = isSponsored
+        self.popular = popular
+    }
 }
 
 public struct CarouselSponsoredPodcast: Decodable, Equatable {

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
@@ -365,6 +365,11 @@ public struct DiscoverCategory: Decodable, Equatable {
     public var name: String?
     public var source: String?
     public var icon: String?
+
+    public init(id: Int?, name: String?) {
+        self.id = id
+        self.name = name
+    }
 }
 
 public struct DiscoverCategoryDetails: Decodable {

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
@@ -270,6 +270,7 @@ public struct DiscoverItem: Decodable, Equatable {
     public var regions: [String]
     public var isSponsored: Bool?
     public var popular: [Int]?
+    public var categoryID: Int?
 
     public enum CodingKeys: String, CodingKey {
         case summaryStyle = "summary_style"
@@ -277,6 +278,7 @@ public struct DiscoverItem: Decodable, Equatable {
         case isSponsored = "sponsored"
         case sponsoredPodcasts = "sponsored_podcasts"
         case expandedTopItemLabel = "expanded_top_item_label"
+        case categoryID = "category_id"
         case type, title, source, regions, curated, uuid, popular, id
     }
 

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
@@ -280,20 +280,11 @@ public struct DiscoverItem: Decodable, Equatable {
         case type, title, source, regions, curated, uuid, popular, id
     }
 
-    public init(id: String? = nil, uuid: String? = nil, title: String? = nil, type: String? = nil, summaryStyle: String? = nil, expandedStyle: String? = nil, source: String? = nil, sponsoredPodcasts: [CarouselSponsoredPodcast]? = nil, expandedTopItemLabel: String? = nil, curated: Bool? = nil, regions: [String], isSponsored: Bool? = nil, popular: [Int]? = nil) {
+    public init(id: String? = nil, title: String? = nil, source: String? = nil, regions: [String]) {
         self.id = id
-        self.uuid = uuid
         self.title = title
-        self.type = type
-        self.summaryStyle = summaryStyle
-        self.expandedStyle = expandedStyle
         self.source = source
-        self.sponsoredPodcasts = sponsoredPodcasts
-        self.expandedTopItemLabel = expandedTopItemLabel
-        self.curated = curated
         self.regions = regions
-        self.isSponsored = isSponsored
-        self.popular = popular
     }
 }
 

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
@@ -268,6 +268,7 @@ public struct DiscoverItem: Decodable {
     public var curated: Bool?
     public var regions: [String]
     public var isSponsored: Bool?
+    public var popular: [Int]?
 
     public enum CodingKeys: String, CodingKey {
         case summaryStyle = "summary_style"
@@ -275,7 +276,7 @@ public struct DiscoverItem: Decodable {
         case isSponsored = "sponsored"
         case sponsoredPodcasts = "sponsored_podcasts"
         case expandedTopItemLabel = "expanded_top_item_label"
-        case type, title, source, regions, curated, uuid
+        case type, title, source, regions, curated, uuid, popular
     }
 }
 

--- a/Modules/Utils/Sources/PocketCastsUtils/Extensions/UI/View+Modify.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Extensions/UI/View+Modify.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+extension View {
+    @ViewBuilder
+    public func modify(@ViewBuilder _ transform: (Self) -> (some View)?) -> some View {
+        if let view = transform(self), !(view is EmptyView) {
+            view
+        } else {
+            self
+        }
+    }
+}

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -42,6 +42,8 @@ public enum FeatureFlag: String, CaseIterable {
 
     case cachePlayingEpisode
 
+    case categoriesRedesign
+
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -80,6 +82,8 @@ public enum FeatureFlag: String, CaseIterable {
             false
         case .cachePlayingEpisode:
             true
+        case .categoriesRedesign:
+            false
         }
     }
 

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -105,6 +105,8 @@ public enum FeatureFlag: String, CaseIterable {
             shouldEnableSyncedSettings ? "new_settings_storage" : nil
         case .settingsSync:
             shouldEnableSyncedSettings ? "settings_sync" : nil
+        case .categoriesRedesign:
+            "categories_redesign"
         default:
             nil
         }

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -83,7 +83,7 @@ public enum FeatureFlag: String, CaseIterable {
         case .cachePlayingEpisode:
             true
         case .categoriesRedesign:
-            false
+            true
         }
     }
 

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1604,6 +1604,7 @@
 		F5E431D62B50888500A71DB3 /* PlusLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5E431D52B50888500A71DB3 /* PlusLabel.swift */; };
 		F5E949DA2B61762E002DAFC3 /* TokenHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5E949D92B61762E002DAFC3 /* TokenHelperTests.swift */; };
 		F5F6DA702BBE1109009B1934 /* CategoryButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5F6DA6F2BBE1109009B1934 /* CategoryButtonStyle.swift */; };
+		F5F6DA822BC0B512009B1934 /* CategoriesModalPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5F6DA812BC0B512009B1934 /* CategoriesModalPicker.swift */; };
 		FF2CD57C2B9F4B2D009B58B5 /* PocketCastsDataModel in Frameworks */ = {isa = PBXBuildFile; productRef = FF2CD57B2B9F4B2D009B58B5 /* PocketCastsDataModel */; };
 		FF2CD57E2B9F4B2D009B58B5 /* PocketCastsServer in Frameworks */ = {isa = PBXBuildFile; productRef = FF2CD57D2B9F4B2D009B58B5 /* PocketCastsServer */; };
 		FF2CD5802B9F4B2D009B58B5 /* PocketCastsUtils in Frameworks */ = {isa = PBXBuildFile; productRef = FF2CD57F2B9F4B2D009B58B5 /* PocketCastsUtils */; };
@@ -3378,6 +3379,7 @@
 		F5E431D52B50888500A71DB3 /* PlusLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlusLabel.swift; sourceTree = "<group>"; };
 		F5E949D92B61762E002DAFC3 /* TokenHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenHelperTests.swift; sourceTree = "<group>"; };
 		F5F6DA6F2BBE1109009B1934 /* CategoryButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryButtonStyle.swift; sourceTree = "<group>"; };
+		F5F6DA812BC0B512009B1934 /* CategoriesModalPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoriesModalPicker.swift; sourceTree = "<group>"; };
 		FF47245A2BA4749F00EA916B /* MenuRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuRow.swift; sourceTree = "<group>"; };
 		FF4724602BA48CA900EA916B /* FiltersListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FiltersListView.swift; sourceTree = "<group>"; };
 		FF4724622BA48E8D00EA916B /* FiltersListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FiltersListViewModel.swift; sourceTree = "<group>"; };
@@ -7270,6 +7272,7 @@
 			children = (
 				F52B4F8B2BB4A9CA00E87BE4 /* CategoriesSelectorViewController.swift */,
 				F52B4F8D2BB4A9ED00E87BE4 /* CategoriesSelectorView.swift */,
+				F5F6DA812BC0B512009B1934 /* CategoriesModalPicker.swift */,
 				F5F6DA6F2BBE1109009B1934 /* CategoryButtonStyle.swift */,
 			);
 			path = Categories;
@@ -8682,6 +8685,7 @@
 				BD0B68712203DC58002CCE3F /* EpisodeLimitPlaceholder.swift in Sources */,
 				4041FE99218A872B0089D4A1 /* SiriShortcutDisclosureCell.swift in Sources */,
 				4009F3F3253D12CA0050AFCB /* FilterChipCollectionView.swift in Sources */,
+				F5F6DA822BC0B512009B1934 /* CategoriesModalPicker.swift in Sources */,
 				BD1F07F91BAAA6F0007A768D /* CategoryPodcastsViewController.swift in Sources */,
 				BD998ACA27B2408500B38857 /* CreateFolderView.swift in Sources */,
 				4067563124D7B163003684FC /* CategorySponsoredCell.swift in Sources */,

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1597,6 +1597,7 @@
 		F55449422B758E8300F68AE9 /* PocketCastsUtils in Frameworks */ = {isa = PBXBuildFile; productRef = F55449412B758E8300F68AE9 /* PocketCastsUtils */; };
 		F55449432B758E8300F68AE9 /* PocketCastsUtils in Embed Frameworks */ = {isa = PBXBuildFile; productRef = F55449412B758E8300F68AE9 /* PocketCastsUtils */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		F55449452B75935F00F68AE9 /* AppSettings+ImportUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = F55449442B75935F00F68AE9 /* AppSettings+ImportUserDefaults.swift */; };
+		F55C4C762BCF064500A10352 /* DiscoverViewController+CategoryRedesign.swift in Sources */ = {isa = PBXBuildFile; fileRef = F55C4C752BCF064500A10352 /* DiscoverViewController+CategoryRedesign.swift */; };
 		F565602F2B7ACD9B003E76D5 /* DataManager+Import.swift in Sources */ = {isa = PBXBuildFile; fileRef = F565602E2B7ACD9B003E76D5 /* DataManager+Import.swift */; };
 		F56ADE562B7FE37500ADFE31 /* SettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5AD75442B7FDC2800D65C55 /* SettingsTests.swift */; };
 		F5D3A0D92B70950100EED067 /* MockURLHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5D3A0D82B70950100EED067 /* MockURLHandler.swift */; };
@@ -3372,6 +3373,7 @@
 		F52B4F8B2BB4A9CA00E87BE4 /* CategoriesSelectorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoriesSelectorViewController.swift; sourceTree = "<group>"; };
 		F52B4F8D2BB4A9ED00E87BE4 /* CategoriesSelectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoriesSelectorView.swift; sourceTree = "<group>"; };
 		F55449442B75935F00F68AE9 /* AppSettings+ImportUserDefaults.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AppSettings+ImportUserDefaults.swift"; sourceTree = "<group>"; };
+		F55C4C752BCF064500A10352 /* DiscoverViewController+CategoryRedesign.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DiscoverViewController+CategoryRedesign.swift"; sourceTree = "<group>"; };
 		F565602E2B7ACD9B003E76D5 /* DataManager+Import.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DataManager+Import.swift"; sourceTree = "<group>"; };
 		F5AD75442B7FDC2800D65C55 /* SettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsTests.swift; sourceTree = "<group>"; };
 		F5D3A0D82B70950100EED067 /* MockURLHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockURLHandler.swift; sourceTree = "<group>"; };
@@ -7239,6 +7241,7 @@
 				BD18FB1C219ACC770012C41D /* Search */,
 				8BAB8B2D299ABC5E00B8404C /* New Search */,
 				BDB1E4DB1B8C5998009AD30F /* DiscoverViewController.swift */,
+				F55C4C752BCF064500A10352 /* DiscoverViewController+CategoryRedesign.swift */,
 				BDE60ACD2108597D00A7281B /* DiscoverViewController+DiscoverDelegate.swift */,
 				BDDA14D4219AF8D50066441E /* DiscoverViewController+Search.swift */,
 				BDB1E4DC1B8C5998009AD30F /* DiscoverViewController.xib */,
@@ -8803,6 +8806,7 @@
 				BD1EBD6E1CB7770B004F83D6 /* AppearanceViewController.swift in Sources */,
 				BD13574E27BF24B500A5D7C6 /* EditFolderPodcastsView.swift in Sources */,
 				C713D4FA2A04C90500A78468 /* AccountHeaderViewModel.swift in Sources */,
+				F55C4C762BCF064500A10352 /* DiscoverViewController+CategoryRedesign.swift in Sources */,
 				BDF09F041E669E16009E9845 /* BasePlayPauseButton.swift in Sources */,
 				407B21E72231F6A300B4E492 /* UploadedSettingsViewController.swift in Sources */,
 				BD339C5C2149E35600E655F9 /* VideoViewController+Controls.swift in Sources */,

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1592,6 +1592,8 @@
 		E3F37447291F0DD1005916ED /* Chapters.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3F37445291F0DD1005916ED /* Chapters.swift */; };
 		F5197A402B995A1E007C8D0A /* DownloadManager+Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5197A3F2B995A1E007C8D0A /* DownloadManager+Logging.swift */; };
 		F5197A412B995A1E007C8D0A /* DownloadManager+Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5197A3F2B995A1E007C8D0A /* DownloadManager+Logging.swift */; };
+		F52B4F8C2BB4A9CA00E87BE4 /* CategoriesSelectorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F52B4F8B2BB4A9CA00E87BE4 /* CategoriesSelectorViewController.swift */; };
+		F52B4F8E2BB4A9ED00E87BE4 /* CategoriesSelectorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F52B4F8D2BB4A9ED00E87BE4 /* CategoriesSelectorView.swift */; };
 		F55449422B758E8300F68AE9 /* PocketCastsUtils in Frameworks */ = {isa = PBXBuildFile; productRef = F55449412B758E8300F68AE9 /* PocketCastsUtils */; };
 		F55449432B758E8300F68AE9 /* PocketCastsUtils in Embed Frameworks */ = {isa = PBXBuildFile; productRef = F55449412B758E8300F68AE9 /* PocketCastsUtils */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		F55449452B75935F00F68AE9 /* AppSettings+ImportUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = F55449442B75935F00F68AE9 /* AppSettings+ImportUserDefaults.swift */; };
@@ -1601,6 +1603,7 @@
 		F5DBA58A2B756A8700AED77F /* PodcastSettings+ImportUserDefaultsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5DBA5892B756A8700AED77F /* PodcastSettings+ImportUserDefaultsTests.swift */; };
 		F5E431D62B50888500A71DB3 /* PlusLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5E431D52B50888500A71DB3 /* PlusLabel.swift */; };
 		F5E949DA2B61762E002DAFC3 /* TokenHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5E949D92B61762E002DAFC3 /* TokenHelperTests.swift */; };
+		F5F6DA702BBE1109009B1934 /* CategoryButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5F6DA6F2BBE1109009B1934 /* CategoryButtonStyle.swift */; };
 		FF2CD57C2B9F4B2D009B58B5 /* PocketCastsDataModel in Frameworks */ = {isa = PBXBuildFile; productRef = FF2CD57B2B9F4B2D009B58B5 /* PocketCastsDataModel */; };
 		FF2CD57E2B9F4B2D009B58B5 /* PocketCastsServer in Frameworks */ = {isa = PBXBuildFile; productRef = FF2CD57D2B9F4B2D009B58B5 /* PocketCastsServer */; };
 		FF2CD5802B9F4B2D009B58B5 /* PocketCastsUtils in Frameworks */ = {isa = PBXBuildFile; productRef = FF2CD57F2B9F4B2D009B58B5 /* PocketCastsUtils */; };
@@ -3365,6 +3368,8 @@
 		EF3DD428DC2C444C2D8CEC5A /* Pods-PocketCastsTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PocketCastsTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-PocketCastsTests/Pods-PocketCastsTests.debug.xcconfig"; sourceTree = "<group>"; };
 		EFBF99F57846D0E1AF8DE08D /* Pods-PocketCasts-PocketCastsTests.staging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PocketCasts-PocketCastsTests.staging.xcconfig"; path = "Pods/Target Support Files/Pods-PocketCasts-PocketCastsTests/Pods-PocketCasts-PocketCastsTests.staging.xcconfig"; sourceTree = "<group>"; };
 		F5197A3F2B995A1E007C8D0A /* DownloadManager+Logging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DownloadManager+Logging.swift"; sourceTree = "<group>"; };
+		F52B4F8B2BB4A9CA00E87BE4 /* CategoriesSelectorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoriesSelectorViewController.swift; sourceTree = "<group>"; };
+		F52B4F8D2BB4A9ED00E87BE4 /* CategoriesSelectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoriesSelectorView.swift; sourceTree = "<group>"; };
 		F55449442B75935F00F68AE9 /* AppSettings+ImportUserDefaults.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AppSettings+ImportUserDefaults.swift"; sourceTree = "<group>"; };
 		F565602E2B7ACD9B003E76D5 /* DataManager+Import.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DataManager+Import.swift"; sourceTree = "<group>"; };
 		F5AD75442B7FDC2800D65C55 /* SettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsTests.swift; sourceTree = "<group>"; };
@@ -3372,6 +3377,7 @@
 		F5DBA5892B756A8700AED77F /* PodcastSettings+ImportUserDefaultsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PodcastSettings+ImportUserDefaultsTests.swift"; sourceTree = "<group>"; };
 		F5E431D52B50888500A71DB3 /* PlusLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlusLabel.swift; sourceTree = "<group>"; };
 		F5E949D92B61762E002DAFC3 /* TokenHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenHelperTests.swift; sourceTree = "<group>"; };
+		F5F6DA6F2BBE1109009B1934 /* CategoryButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryButtonStyle.swift; sourceTree = "<group>"; };
 		FF47245A2BA4749F00EA916B /* MenuRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuRow.swift; sourceTree = "<group>"; };
 		FF4724602BA48CA900EA916B /* FiltersListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FiltersListView.swift; sourceTree = "<group>"; };
 		FF4724622BA48E8D00EA916B /* FiltersListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FiltersListViewModel.swift; sourceTree = "<group>"; };
@@ -7223,6 +7229,7 @@
 		D4DA5CAA1739ED4C003FE24B /* Discovery */ = {
 			isa = PBXGroup;
 			children = (
+				F5F6DA6E2BBE10E2009B1934 /* Categories */,
 				BD4CA19821096D920052F93E /* Summary Items */,
 				4006E30E23A8662100174DEB /* Expanded Items */,
 				BD98C5511BA808CF00E85D3B /* Cells */,
@@ -7256,6 +7263,16 @@
 				8B413D152B76B3A500FAB502 /* ChapterManagerTests.swift */,
 			);
 			path = Chapters;
+			sourceTree = "<group>";
+		};
+		F5F6DA6E2BBE10E2009B1934 /* Categories */ = {
+			isa = PBXGroup;
+			children = (
+				F52B4F8B2BB4A9CA00E87BE4 /* CategoriesSelectorViewController.swift */,
+				F52B4F8D2BB4A9ED00E87BE4 /* CategoriesSelectorView.swift */,
+				F5F6DA6F2BBE1109009B1934 /* CategoryButtonStyle.swift */,
+			);
+			path = Categories;
 			sourceTree = "<group>";
 		};
 		FFC293972B6172E90059F3BB /* InAppPurchases */ = {
@@ -8898,6 +8915,7 @@
 				40FFAD8A2147831400024FCF /* PlaylistViewController+CollectionView.swift in Sources */,
 				BDA1E8161EDD28700098FB9D /* SonosLinkController.swift in Sources */,
 				BD79EACD20D3805900E96572 /* ThemeSecondaryButton.swift in Sources */,
+				F52B4F8E2BB4A9ED00E87BE4 /* CategoriesSelectorView.swift in Sources */,
 				400A3F032277CB3A007361C7 /* NewEmailViewController.swift in Sources */,
 				BDF9DDDB1B8AD29C00E77B35 /* TimeSliderLayer.swift in Sources */,
 				BDB1E4ED1B8C5BCF009AD30F /* FeaturedSummaryViewController.swift in Sources */,
@@ -8983,6 +9001,7 @@
 				C7AF7B912925E5CD002F0025 /* PlusHostingViewController.swift in Sources */,
 				4007B060230E3A81008DDCF5 /* WhatsNewStructs.swift in Sources */,
 				4041FE8D218A7DA60089D4A1 /* SiriShortcutEnabledCell.swift in Sources */,
+				F52B4F8C2BB4A9CA00E87BE4 /* CategoriesSelectorViewController.swift in Sources */,
 				BD5C39541B5E0A2A00C3A499 /* ShiftyLoadingAlert.swift in Sources */,
 				BD2D0AD3243C4138000B313A /* MainEpisodeActionView+Pointer.swift in Sources */,
 				C7E99F092A5E105600E7CBAF /* MultiSelectRow.swift in Sources */,
@@ -9382,6 +9401,7 @@
 				BDDF8AA4240CE598009BA263 /* ThemeableSwipeCell.swift in Sources */,
 				BD92323523629F7B00C1E118 /* PlayerItemViewController.swift in Sources */,
 				BDB1E4F61B8C5BF9009AD30F /* NetworkSummaryViewController.swift in Sources */,
+				F5F6DA702BBE1109009B1934 /* CategoryButtonStyle.swift in Sources */,
 				404A080724E215A200308722 /* CheckboxSubtitleCell.swift in Sources */,
 				C7A110F0291EFF7A00887A90 /* PlusPurchaseModel.swift in Sources */,
 				409C7929222369C800386495 /* UserEpisodeDetailViewController.swift in Sources */,

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -305,6 +305,8 @@ enum AnalyticsEvent: String {
     case discoverRegionChanged
     case discoverCollectionLinkTapped
 
+    case discoverAdCategoryTapped
+
     // MARK: - Mini Player
 
     case miniPlayerLongPressMenuShown

--- a/podcasts/AnalyticsHelper.swift
+++ b/podcasts/AnalyticsHelper.swift
@@ -114,7 +114,7 @@ class AnalyticsHelper {
     }
 
     class func adTapped(promotionUUID: String, podcastUUID: String, categoryID: Int) {
-        let properties = ["promotion_uuid": promotionUUID, "podcast_uuid": podcastUUID, "category_id": category]
+        let properties: [String: Any] = ["promotion_uuid": promotionUUID, "podcast_uuid": podcastUUID, "category_id": categoryID]
         Analytics.track(.discoverAdCategoryTapped, properties: properties)
     }
 

--- a/podcasts/AnalyticsHelper.swift
+++ b/podcasts/AnalyticsHelper.swift
@@ -113,8 +113,8 @@ class AnalyticsHelper {
         bumpStat("discover_list_podcast_tap", parameters: properties)
     }
 
-    class func adTapped(promotionUUID: String, podcastUUID: String, category: String) {
-        let properties = ["promotion_uuid": promotionUUID, "podcast_uuid": podcastUUID, "category": category]
+    class func adTapped(promotionUUID: String, podcastUUID: String, categoryID: Int) {
+        let properties = ["promotion_uuid": promotionUUID, "podcast_uuid": podcastUUID, "category_id": category]
         Analytics.track(.discoverAdCategoryTapped, properties: properties)
     }
 

--- a/podcasts/AnalyticsHelper.swift
+++ b/podcasts/AnalyticsHelper.swift
@@ -113,6 +113,11 @@ class AnalyticsHelper {
         bumpStat("discover_list_podcast_tap", parameters: properties)
     }
 
+    class func adTapped(promotionUUID: String, podcastUUID: String, category: String) {
+        let properties = ["promotion_uuid": promotionUUID, "podcast_uuid": podcastUUID, "category": category]
+        Analytics.track(.discoverAdCategoryTapped, properties: properties)
+    }
+
     class func podcastEpisodeTapped(fromList listId: String, podcastUuid: String, episodeUuid: String) {
         let properties = ["list_id": listId, "podcast_uuid": podcastUuid, "episode_uuid": episodeUuid]
 

--- a/podcasts/Categories/CategoriesModalPicker.swift
+++ b/podcasts/Categories/CategoriesModalPicker.swift
@@ -11,8 +11,8 @@ struct CategoriesModalPicker: View {
 
     private enum Constants {
         enum Padding {
-            static let title: CGFloat = 20
-            static let cell: CGFloat = 12
+            static let title = EdgeInsets(top: 26, leading: 20, bottom: 4, trailing: 20)
+            static let cell = EdgeInsets(top: 25, leading: 20, bottom: 25, trailing: 20)
         }
         static let imageSize: CGFloat = 24
         static let cellSpacing: CGFloat = 20

--- a/podcasts/Categories/CategoriesModalPicker.swift
+++ b/podcasts/Categories/CategoriesModalPicker.swift
@@ -32,45 +32,63 @@ struct CategoriesModalPicker: View {
         theme.primaryText01
     }
 
+    private var selectedBackground: Color {
+        theme.primaryUi01Active
+    }
+
     var body: some View {
         VStack(alignment: .leading) {
-            Text("Select a Category".uppercased())
-                .font(.subheadline)
-                .fontWeight(.semibold)
-                .foregroundStyle(titleForeground)
-                .padding(.top, Constants.Padding.title)
-                .padding(.leading, Constants.Padding.title)
-            List(selection: $selectedCategory, content: {
+            title
+                .padding(Constants.Padding.title)
+            List {
                 ForEach(categories, id: \.self) { category in
-                    HStack(spacing: Constants.cellSpacing) {
-                        if let icon = category.icon, let url = URL(string: icon) {
-                            KFImage(url)
-                                .renderingMode(.template)
-                                .resizable()
-                                .frame(width: Constants.imageSize, height: Constants.imageSize)
-                        }
-                        Text(category.name ?? "")
-                            .font(.headline)
-                    }
-                    .foregroundStyle(cellForeground)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.vertical, Constants.Padding.cell)
-                    .listRowSeparatorTint(separator)
-                    .modify {
-                        if #available(iOS 16.0, *) {
-                            $0.alignmentGuide(.listRowSeparatorLeading) { d in
-                                    d[.leading]
+                    cell(category)
+                        .listRowInsets(EdgeInsets())
+                        .listRowBackground(background)
+                        .listRowSeparatorTint(separator)
+                        .modify {
+                            if #available(iOS 16.0, *) {
+                                $0.alignmentGuide(.listRowSeparatorLeading) { d in
+                                    d[.leading] + Constants.Padding.cell.leading
                                 }
                                 .alignmentGuide(.listRowSeparatorTrailing) { d in
-                                    d[.trailing]
+                                    d[.trailing] - Constants.Padding.cell.trailing
                                 }
+                            }
                         }
-                    }
-                    .listRowBackground(background)
                 }
-            })
+            }
             .listStyle(.plain)
         }
         .background(background)
+    }
+
+    @ViewBuilder var title: some View {
+        Text("Select a Category".uppercased())
+            .font(.subheadline)
+            .fontWeight(.bold)
+            .foregroundStyle(titleForeground)
+    }
+
+    @ViewBuilder func cell(_ category: DiscoverCategory) -> some View {
+        HStack(spacing: Constants.cellSpacing) {
+            if let icon = category.icon, let url = URL(string: icon) {
+                KFImage(url)
+                    .renderingMode(.template)
+                    .resizable()
+                    .frame(width: Constants.imageSize, height: Constants.imageSize)
+            }
+            Text(category.name ?? "")
+                .font(.headline)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(Constants.Padding.cell)
+        .buttonize {
+            selectedCategory = category
+        } customize: { config in
+            config.label
+                .foregroundStyle(cellForeground)
+                .background(config.isPressed ? selectedBackground : background)
+        }
     }
 }

--- a/podcasts/Categories/CategoriesModalPicker.swift
+++ b/podcasts/Categories/CategoriesModalPicker.swift
@@ -1,0 +1,73 @@
+import SwiftUI
+import PocketCastsServer
+import Kingfisher
+
+@available(iOS 16.0, *) //
+struct CategoriesModalPicker: View {
+    let categories: [DiscoverCategory]
+
+    @Binding var selectedCategory: DiscoverCategory?
+
+    @EnvironmentObject var theme: Theme
+
+    private enum Constants {
+        enum Padding {
+            static let title: CGFloat = 20
+            static let cell: CGFloat = 12
+        }
+        static let imageSize: CGFloat = 24
+        static let cellSpacing: CGFloat = 20
+    }
+
+    // MARK: Colors
+    private var separator: Color {
+        theme.primaryField03
+    }
+    private var background: Color {
+        theme.primaryUi01
+    }
+    private var titleForeground: Color {
+        theme.secondaryIcon01
+    }
+    private var cellForeground: Color {
+        theme.primaryText01
+    }
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            Text("Select a Category".uppercased())
+                .font(.subheadline)
+                .fontWeight(.semibold)
+                .foregroundStyle(titleForeground)
+                .padding(.top, Constants.Padding.title)
+                .padding(.leading, Constants.Padding.title)
+            List(selection: $selectedCategory, content: {
+                ForEach(categories, id: \.self) { category in
+                    HStack(spacing: Constants.cellSpacing) {
+                        if let icon = category.icon, let url = URL(string: icon) {
+                            KFImage(url)
+                                .renderingMode(.template)
+                                .resizable()
+                                .frame(width: Constants.imageSize, height: Constants.imageSize)
+                        }
+                        Text(category.name ?? "")
+                            .font(.headline)
+                    }
+                    .foregroundStyle(cellForeground)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.vertical, Constants.Padding.cell)
+                    .listRowSeparatorTint(separator)
+                    .alignmentGuide(.listRowSeparatorLeading) { d in
+                        d[.leading]
+                    }
+                    .alignmentGuide(.listRowSeparatorTrailing) { d in
+                        d[.trailing]
+                    }
+                    .listRowBackground(background)
+                }
+            })
+            .listStyle(.plain)
+        }
+        .background(background)
+    }
+}

--- a/podcasts/Categories/CategoriesModalPicker.swift
+++ b/podcasts/Categories/CategoriesModalPicker.swift
@@ -26,7 +26,7 @@ struct CategoriesModalPicker: View {
         theme.primaryUi01
     }
     private var titleForeground: Color {
-        theme.secondaryIcon01
+        theme.support01
     }
     private var cellForeground: Color {
         theme.primaryText01

--- a/podcasts/Categories/CategoriesModalPicker.swift
+++ b/podcasts/Categories/CategoriesModalPicker.swift
@@ -2,7 +2,6 @@ import SwiftUI
 import PocketCastsServer
 import Kingfisher
 
-@available(iOS 16.0, *) //
 struct CategoriesModalPicker: View {
     let categories: [DiscoverCategory]
 
@@ -57,11 +56,15 @@ struct CategoriesModalPicker: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.vertical, Constants.Padding.cell)
                     .listRowSeparatorTint(separator)
-                    .alignmentGuide(.listRowSeparatorLeading) { d in
-                        d[.leading]
-                    }
-                    .alignmentGuide(.listRowSeparatorTrailing) { d in
-                        d[.trailing]
+                    .modify {
+                        if #available(iOS 16.0, *) {
+                            $0.alignmentGuide(.listRowSeparatorLeading) { d in
+                                    d[.leading]
+                                }
+                                .alignmentGuide(.listRowSeparatorTrailing) { d in
+                                    d[.trailing]
+                                }
+                        }
                     }
                     .listRowBackground(background)
                 }

--- a/podcasts/Categories/CategoriesSelectorView.swift
+++ b/podcasts/Categories/CategoriesSelectorView.swift
@@ -12,6 +12,8 @@ struct CategoriesSelectorView: View {
     @State private var categories: [DiscoverCategory]?
     @State private var popular: [DiscoverCategory]?
 
+    @EnvironmentObject var theme: Theme
+
     var body: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack {
@@ -22,8 +24,11 @@ struct CategoriesSelectorView: View {
                     PlaceholderPillsView()
                 }
             }
-            .padding(16)
+            .padding(.top, 2)
+            .padding(.bottom, 16)
+            .padding(.horizontal, 16)
         }
+        .background(theme.secondaryUi01)
         .task(id: discoverItemObservable.item?.source) {
             guard let source = discoverItemObservable.item?.source else { return }
             let categories = await DiscoverServerHandler.shared.discoverCategories(source: source)
@@ -43,7 +48,6 @@ struct PlaceholderPillsView: View {
                 Text("Placeholder")
             })
             .buttonStyle(CategoryButtonStyle())
-            .environmentObject(Theme.sharedTheme)
             .redacted(reason: .placeholder)
         }
     }

--- a/podcasts/Categories/CategoriesSelectorView.swift
+++ b/podcasts/Categories/CategoriesSelectorView.swift
@@ -1,0 +1,112 @@
+import SwiftUI
+import PocketCastsServer
+
+struct Category {
+    let title: String
+    let image: String
+}
+
+struct CategoriesSelectorView: View {
+    @ObservedObject var observable: CategoriesSelectorViewController.Observable
+
+    @State private var categories: [DiscoverCategory]?
+
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack {
+                if let categories {
+                    CategoriesPillsView(categories: categories)
+                        .environmentObject(Theme.sharedTheme)
+                } else {
+                    PlaceholderPillsView()
+                }
+            }
+            .padding(16)
+        }
+        .task(id: observable.item?.source) {
+            guard let source = observable.item?.source else { return }
+            categories = await DiscoverServerHandler.shared.discoverCategories(source: source)
+        }
+    }
+}
+
+struct PlaceholderPillsView: View {
+    var body: some View {
+        ForEach(0..<10) { _ in
+            Button(action: {}, label: {
+                Text("Placeholder")
+            })
+            .buttonStyle(CategoryButtonStyle())
+            .environmentObject(Theme.sharedTheme)
+            .redacted(reason: .placeholder)
+        }
+    }
+}
+
+struct CategoriesPillsView: View {
+    @State private var showingCategories = false
+
+    @State private var selectedCategory: DiscoverCategory?
+
+    @Namespace private var animation
+
+    let categories: [DiscoverCategory]
+
+    var body: some View {
+        if let selectedCategory {
+            CloseButton(selectedCategory: $selectedCategory)
+            CategoryButton(category: selectedCategory, selectedCategory: $selectedCategory)
+                .matchedGeometryEffect(id: selectedCategory.id, in: animation)
+        } else {
+            Button(action: {
+                showingCategories.toggle()
+            }, label: {
+                HStack {
+                    Text("All Categories")
+                    Image(systemName: "chevron.down")
+                }
+            })
+            .buttonStyle(CategoryButtonStyle())
+            ForEach(categories, id: \.id) { category in
+                CategoryButton(category: category, selectedCategory: $selectedCategory)
+                .matchedGeometryEffect(id: category.id, in: animation)
+            }
+        }
+    }
+}
+
+struct CloseButton: View {
+    @Binding var selectedCategory: DiscoverCategory?
+
+    var body: some View {
+        Button(action: {
+            withAnimation {
+                self.selectedCategory = nil
+            }
+        }, label: {
+            Image(systemName: "xmark")
+        })
+        .buttonStyle(CategoryButtonStyle())
+    }
+}
+
+struct CategoryButton: View {
+    let category: DiscoverCategory
+
+    @Binding var selectedCategory: DiscoverCategory?
+
+    var isSelected: Bool {
+        category.id == selectedCategory?.id
+    }
+
+    var body: some View {
+        Button(action: {
+            withAnimation {
+                selectedCategory = category
+            }
+        }, label: {
+            Text(category.name ?? "")
+        })
+        .buttonStyle(CategoryButtonStyle(isSelected: isSelected))
+    }
+}

--- a/podcasts/Categories/CategoriesSelectorView.swift
+++ b/podcasts/Categories/CategoriesSelectorView.swift
@@ -81,7 +81,8 @@ struct CategoriesPillsView: View {
                 CategoriesModalPicker(categories: overflowCategories, selectedCategory: $selectedCategory)
                     .modify {
                         if #available(iOS 16.0, *) {
-                            $0.presentationDetents([.medium])
+                            $0.presentationDetents([.medium, .large])
+                                .presentationDragIndicator(.hidden)
                         } else {
                             $0
                         }

--- a/podcasts/Categories/CategoriesSelectorView.swift
+++ b/podcasts/Categories/CategoriesSelectorView.swift
@@ -108,8 +108,9 @@ struct CloseButton: View {
             self.selectedCategory = nil
         }, label: {
             Image(systemName: "xmark")
+                .imageScale(.small)
         })
-        .buttonStyle(CategoryButtonStyle())
+        .buttonStyle(CategoryButtonStyle(cornerStyle: .circle))
     }
 }
 

--- a/podcasts/Categories/CategoriesSelectorView.swift
+++ b/podcasts/Categories/CategoriesSelectorView.swift
@@ -16,7 +16,7 @@ struct CategoriesSelectorView: View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack {
                 if let popular {
-                    CategoriesPillsView(categories: popular)
+                    CategoriesPillsView(categories: popular, selectedCategory: $observable.selectedCategory)
                         .environmentObject(Theme.sharedTheme)
                 } else {
                     PlaceholderPillsView()
@@ -50,13 +50,12 @@ struct PlaceholderPillsView: View {
 }
 
 struct CategoriesPillsView: View {
+    let categories: [DiscoverCategory]
+    @Binding var selectedCategory: DiscoverCategory?
+
     @State private var showingCategories = false
 
-    @State private var selectedCategory: DiscoverCategory?
-
     @Namespace private var animation
-
-    let categories: [DiscoverCategory]
 
     var body: some View {
         if let selectedCategory {

--- a/podcasts/Categories/CategoriesSelectorView.swift
+++ b/podcasts/Categories/CategoriesSelectorView.swift
@@ -31,7 +31,9 @@ struct CategoriesSelectorView: View {
         .task(id: discoverItemObservable.item?.source) {
             let result = await discoverItemObservable.load()
             self.categories = result?.categories
-            self.popular = result?.popular
+            self.popular = discoverItemObservable.item?.popular?.compactMap({ orderedItem in
+                result?.popular.first(where: { $0.id == orderedItem }) ?? result?.categories.first(where: { $0.id == orderedItem })
+            }) ?? result?.popular
         }
     }
 }

--- a/podcasts/Categories/CategoriesSelectorView.swift
+++ b/podcasts/Categories/CategoriesSelectorView.swift
@@ -7,7 +7,7 @@ struct Category {
 }
 
 struct CategoriesSelectorView: View {
-    @ObservedObject var observable: CategoriesSelectorViewController.Observable
+    @ObservedObject var discoverItemObservable: CategoriesSelectorViewController.DiscoverItemObservable
 
     @State private var categories: [DiscoverCategory]?
     @State private var popular: [DiscoverCategory]?
@@ -24,13 +24,13 @@ struct CategoriesSelectorView: View {
             }
             .padding(16)
         }
-        .task(id: observable.item?.source) {
-            guard let source = observable.item?.source else { return }
+        .task(id: discoverItemObservable.item?.source) {
+            guard let source = discoverItemObservable.item?.source else { return }
             let categories = await DiscoverServerHandler.shared.discoverCategories(source: source)
             self.categories = categories
             popular = categories.filter {
                 guard let id = $0.id else { return false }
-                return observable.item?.popular?.contains(id) == true
+                return discoverItemObservable.item?.popular?.contains(id) == true
             }
         }
     }

--- a/podcasts/Categories/CategoriesSelectorView.swift
+++ b/podcasts/Categories/CategoriesSelectorView.swift
@@ -12,14 +12,13 @@ struct CategoriesSelectorView: View {
     @State private var categories: [DiscoverCategory]?
     @State private var popular: [DiscoverCategory]?
 
-    @EnvironmentObject var theme: Theme
+    @EnvironmentObject private var theme: Theme
 
     var body: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack {
                 if let categories, let popular {
-                    CategoriesPillsView(pillCategories: popular, overflowCategories: categories, selectedCategory: $observable.selectedCategory.animation(.easeOut(duration: 0.25)))
-                        .environmentObject(Theme.sharedTheme)
+                    CategoriesPillsView(pillCategories: popular, overflowCategories: categories, selectedCategory: $discoverItemObservable.selectedCategory.animation(.easeOut(duration: 0.25)))
                 } else {
                     PlaceholderPillsView()
                 }
@@ -30,13 +29,9 @@ struct CategoriesSelectorView: View {
         }
         .background(theme.secondaryUi01)
         .task(id: discoverItemObservable.item?.source) {
-            guard let source = discoverItemObservable.item?.source else { return }
-            let categories = await DiscoverServerHandler.shared.discoverCategories(source: source)
-            self.categories = categories
-            popular = categories.filter {
-                guard let id = $0.id else { return false }
-                return discoverItemObservable.item?.popular?.contains(id) == true
-            }
+            let result = await discoverItemObservable.load()
+            self.categories = result?.categories
+            self.popular = result?.popular
         }
     }
 }
@@ -134,5 +129,34 @@ struct CategoryButton: View {
             Text(category.name ?? "")
         })
         .buttonStyle(CategoryButtonStyle(isSelected: isSelected))
+    }
+}
+
+// MARK: Previews
+
+#Preview("unselected") {
+    let category = DiscoverCategory(id: 0, name: "Test")
+    let observable = CategoriesSelectorViewController.DiscoverItemObservable {
+        return ([category], [category])
+    }
+    return ScrollView(.vertical) {
+        CategoriesSelectorView(discoverItemObservable: observable)
+            .frame(width: 400)
+            .previewWithAllThemes()
+    }
+}
+
+#Preview("selected") {
+    let category = DiscoverCategory(id: 0, name: "Test")
+    let observable = CategoriesSelectorViewController.DiscoverItemObservable {
+        return ([category], [category])
+    }
+    return ScrollView(.vertical) {
+        CategoriesSelectorView(discoverItemObservable: observable)
+            .frame(width: 400)
+            .previewWithAllThemes()
+            .onAppear {
+                observable.selectedCategory = category
+            }
     }
 }

--- a/podcasts/Categories/CategoriesSelectorView.swift
+++ b/podcasts/Categories/CategoriesSelectorView.swift
@@ -10,12 +10,13 @@ struct CategoriesSelectorView: View {
     @ObservedObject var observable: CategoriesSelectorViewController.Observable
 
     @State private var categories: [DiscoverCategory]?
+    @State private var popular: [DiscoverCategory]?
 
     var body: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack {
-                if let categories {
-                    CategoriesPillsView(categories: categories)
+                if let popular {
+                    CategoriesPillsView(categories: popular)
                         .environmentObject(Theme.sharedTheme)
                 } else {
                     PlaceholderPillsView()
@@ -25,7 +26,12 @@ struct CategoriesSelectorView: View {
         }
         .task(id: observable.item?.source) {
             guard let source = observable.item?.source else { return }
-            categories = await DiscoverServerHandler.shared.discoverCategories(source: source)
+            let categories = await DiscoverServerHandler.shared.discoverCategories(source: source)
+            self.categories = categories
+            popular = categories.filter {
+                guard let id = $0.id else { return false }
+                return observable.item?.popular?.contains(id) == true
+            }
         }
     }
 }

--- a/podcasts/Categories/CategoriesSelectorView.swift
+++ b/podcasts/Categories/CategoriesSelectorView.swift
@@ -15,8 +15,8 @@ struct CategoriesSelectorView: View {
     var body: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack {
-                if let popular {
-                    CategoriesPillsView(categories: popular, selectedCategory: $observable.selectedCategory.animation(.easeOut(duration: 0.25)))
+                if let categories, let popular {
+                    CategoriesPillsView(pillCategories: popular, overflowCategories: categories, selectedCategory: $observable.selectedCategory.animation(.easeOut(duration: 0.25)))
                         .environmentObject(Theme.sharedTheme)
                 } else {
                     PlaceholderPillsView()
@@ -50,7 +50,8 @@ struct PlaceholderPillsView: View {
 }
 
 struct CategoriesPillsView: View {
-    let categories: [DiscoverCategory]
+    let pillCategories: [DiscoverCategory]
+    let overflowCategories: [DiscoverCategory]
     @Binding var selectedCategory: DiscoverCategory?
 
     @State private var showingCategories = false
@@ -72,11 +73,28 @@ struct CategoriesPillsView: View {
                 }
             })
             .buttonStyle(CategoryButtonStyle())
-            ForEach(categories, id: \.id) { category in
+            ForEach(pillCategories, id: \.id) { category in
                 CategoryButton(category: category, selectedCategory: $selectedCategory)
                 .matchedGeometryEffect(id: category.id, in: animation)
             }
+            .sheet(isPresented: $showingCategories) {
+                if #available(iOS 16.0, *) {
+                    CategoriesModalPicker(categories: overflowCategories, selectedCategory: $selectedCategory)
+                    .presentationDetents([.medium])
+                } else {
+                    // Fallback on earlier versions
+                }
+            }
+            .onChange(of: selectedCategory) { _ in
+                showingCategories = false
+            }
         }
+    }
+}
+
+extension DiscoverCategory: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
     }
 }
 

--- a/podcasts/Categories/CategoriesSelectorView.swift
+++ b/podcasts/Categories/CategoriesSelectorView.swift
@@ -78,12 +78,14 @@ struct CategoriesPillsView: View {
                 .matchedGeometryEffect(id: category.id, in: animation)
             }
             .sheet(isPresented: $showingCategories) {
-                if #available(iOS 16.0, *) {
-                    CategoriesModalPicker(categories: overflowCategories, selectedCategory: $selectedCategory)
-                    .presentationDetents([.medium])
-                } else {
-                    // Fallback on earlier versions
-                }
+                CategoriesModalPicker(categories: overflowCategories, selectedCategory: $selectedCategory)
+                    .modify {
+                        if #available(iOS 16.0, *) {
+                            $0.presentationDetents([.medium])
+                        } else {
+                            $0
+                        }
+                    }
             }
             .onChange(of: selectedCategory) { _ in
                 showingCategories = false

--- a/podcasts/Categories/CategoriesSelectorView.swift
+++ b/podcasts/Categories/CategoriesSelectorView.swift
@@ -16,7 +16,7 @@ struct CategoriesSelectorView: View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack {
                 if let popular {
-                    CategoriesPillsView(categories: popular, selectedCategory: $observable.selectedCategory)
+                    CategoriesPillsView(categories: popular, selectedCategory: $observable.selectedCategory.animation(.easeOut(duration: 0.25)))
                         .environmentObject(Theme.sharedTheme)
                 } else {
                     PlaceholderPillsView()
@@ -85,9 +85,7 @@ struct CloseButton: View {
 
     var body: some View {
         Button(action: {
-            withAnimation {
-                self.selectedCategory = nil
-            }
+            self.selectedCategory = nil
         }, label: {
             Image(systemName: "xmark")
         })
@@ -106,9 +104,7 @@ struct CategoryButton: View {
 
     var body: some View {
         Button(action: {
-            withAnimation {
-                selectedCategory = category
-            }
+            selectedCategory = category
         }, label: {
             Text(category.name ?? "")
         })

--- a/podcasts/Categories/CategoriesSelectorViewController.swift
+++ b/podcasts/Categories/CategoriesSelectorViewController.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import PocketCastsServer
 import Combine
 
-class CategoriesSelectorViewController: UIHostingController<CategoriesSelectorView>, DiscoverSummaryProtocol {
+class CategoriesSelectorViewController: ThemedHostingController<CategoriesSelectorView>, DiscoverSummaryProtocol {
 
     class DiscoverItemObservable: ObservableObject {
         @Published public var item: DiscoverItem?

--- a/podcasts/Categories/CategoriesSelectorViewController.swift
+++ b/podcasts/Categories/CategoriesSelectorViewController.swift
@@ -3,11 +3,11 @@ import PocketCastsServer
 
 class CategoriesSelectorViewController: UIHostingController<CategoriesSelectorView>, DiscoverSummaryProtocol {
 
-    class Observable: ObservableObject {
+    class DiscoverItemObservable: ObservableObject {
         @Published public var item: DiscoverItem?
     }
 
-    @ObservedObject fileprivate var observable: Observable
+    @ObservedObject fileprivate var observable: DiscoverItemObservable
 
     func registerDiscoverDelegate(_ delegate: any DiscoverDelegate) {}
 
@@ -17,10 +17,10 @@ class CategoriesSelectorViewController: UIHostingController<CategoriesSelectorVi
     }
 
     init() {
-        let observable = Observable()
+        let observable = DiscoverItemObservable()
         self.observable = observable
 
-        super.init(rootView: CategoriesSelectorView(observable: observable))
+        super.init(rootView: CategoriesSelectorView(discoverItemObservable: observable))
         if #available(iOS 16.0, *) {
             sizingOptions =  [.intrinsicContentSize]
         }

--- a/podcasts/Categories/CategoriesSelectorViewController.swift
+++ b/podcasts/Categories/CategoriesSelectorViewController.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+import PocketCastsServer
+
+class CategoriesSelectorViewController: UIHostingController<CategoriesSelectorView> {
+    init(item: DiscoverItem) {
+        super.init(rootView: CategoriesSelectorView(item: item))
+        if #available(iOS 16.0, *) {
+            sizingOptions =  [.intrinsicContentSize]
+        }
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        if #available(iOS 16.0, *) {
+        } else {
+            self.view.invalidateIntrinsicContentSize()
+        }
+    }
+}

--- a/podcasts/Categories/CategoriesSelectorViewController.swift
+++ b/podcasts/Categories/CategoriesSelectorViewController.swift
@@ -7,6 +7,23 @@ class CategoriesSelectorViewController: ThemedHostingController<CategoriesSelect
     class DiscoverItemObservable: ObservableObject {
         @Published public var item: DiscoverItem?
         @Published public var selectedCategory: DiscoverCategory?
+
+        lazy var load: (() async -> (categories: [DiscoverCategory], popular: [DiscoverCategory])?) = { [weak self] in
+            guard let source = self?.item?.source else { return nil }
+            let categories = await DiscoverServerHandler.shared.discoverCategories(source: source)
+            let popular = categories.filter {
+                guard let id = $0.id else { return false }
+                return self?.item?.popular?.contains(id) == true
+            }
+
+            return (categories, popular)
+        }
+
+        init(load: (() async -> (categories: [DiscoverCategory], popular: [DiscoverCategory])?)? = nil) {
+            if let load {
+                self.load = load
+            }
+        }
     }
 
     @ObservedObject fileprivate var observable: DiscoverItemObservable

--- a/podcasts/Categories/CategoriesSelectorViewController.swift
+++ b/podcasts/Categories/CategoriesSelectorViewController.swift
@@ -1,12 +1,30 @@
 import SwiftUI
 import PocketCastsServer
 
-class CategoriesSelectorViewController: UIHostingController<CategoriesSelectorView> {
-    init(item: DiscoverItem) {
-        super.init(rootView: CategoriesSelectorView(item: item))
+class CategoriesSelectorViewController: UIHostingController<CategoriesSelectorView>, DiscoverSummaryProtocol {
+
+    class Observable: ObservableObject {
+        @Published public var item: DiscoverItem?
+    }
+
+    @ObservedObject fileprivate var observable: Observable
+
+    func registerDiscoverDelegate(_ delegate: any DiscoverDelegate) {}
+
+    func populateFrom(item: PocketCastsServer.DiscoverItem) {
+        observable.item = item
+        view.setNeedsLayout()
+    }
+
+    init() {
+        let observable = Observable()
+        self.observable = observable
+
+        super.init(rootView: CategoriesSelectorView(observable: observable))
         if #available(iOS 16.0, *) {
             sizingOptions =  [.intrinsicContentSize]
         }
+        view.backgroundColor = nil
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/podcasts/Categories/CategoriesSelectorViewController.swift
+++ b/podcasts/Categories/CategoriesSelectorViewController.swift
@@ -1,15 +1,23 @@
 import SwiftUI
 import PocketCastsServer
+import Combine
 
 class CategoriesSelectorViewController: UIHostingController<CategoriesSelectorView>, DiscoverSummaryProtocol {
 
     class DiscoverItemObservable: ObservableObject {
         @Published public var item: DiscoverItem?
+        @Published public var selectedCategory: DiscoverCategory?
     }
 
     @ObservedObject fileprivate var observable: DiscoverItemObservable
 
-    func registerDiscoverDelegate(_ delegate: any DiscoverDelegate) {}
+    private weak var delegate: DiscoverDelegate?
+
+    private var cancellables: Set<AnyCancellable> = []
+
+    func registerDiscoverDelegate(_ delegate: any DiscoverDelegate) {
+        self.delegate = delegate
+    }
 
     func populateFrom(item: PocketCastsServer.DiscoverItem) {
         observable.item = item
@@ -25,6 +33,11 @@ class CategoriesSelectorViewController: UIHostingController<CategoriesSelectorVi
             sizingOptions =  [.intrinsicContentSize]
         }
         view.backgroundColor = nil
+
+        observable.$selectedCategory.sink { [weak self] category in
+            guard let item = observable.item else { return }
+            self?.delegate?.showExpanded(item: item, category: category)
+        }.store(in: &cancellables)
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/podcasts/Categories/CategoryButtonStyle.swift
+++ b/podcasts/Categories/CategoryButtonStyle.swift
@@ -39,7 +39,7 @@ struct CategoryButtonStyle: ButtonStyle {
     // MARK: View
 
     let isSelected: Bool
- 
+
     /// Used for generating previews with isPressed button state
     fileprivate var forcePressed = false
 

--- a/podcasts/Categories/CategoryButtonStyle.swift
+++ b/podcasts/Categories/CategoryButtonStyle.swift
@@ -39,6 +39,9 @@ struct CategoryButtonStyle: ButtonStyle {
     // MARK: View
 
     let isSelected: Bool
+ 
+    /// Used for generating previews with isPressed button state
+    fileprivate var forcePressed = false
 
     init(isSelected: Bool = false) {
         self.isSelected = isSelected
@@ -51,7 +54,7 @@ struct CategoryButtonStyle: ButtonStyle {
             .padding(.horizontal, Constants.Padding.horizontal)
             .padding(.vertical, Constants.Padding.vertical)
             .cornerRadius(Constants.cornerRadius)
-            .background(isSelected ? selectedBackground : (configuration.isPressed ? pressedBackground : background))
+            .background(isSelected ? selectedBackground : ((configuration.isPressed || forcePressed) ? pressedBackground : background))
             .foregroundColor(isSelected ? selectedForeground : foreground)
             .overlay(
                 RoundedRectangle(cornerRadius: Constants.cornerRadius)
@@ -61,9 +64,28 @@ struct CategoryButtonStyle: ButtonStyle {
     }
 }
 
-#Preview {
+// MARK: Previews
+
+#Preview("normal") {
+    Button("Hello", action: {
+
+    }).buttonStyle(CategoryButtonStyle(isSelected: false))
+    .previewWithAllThemes()
+}
+
+#Preview("selected") {
     Button("Hello", action: {
 
     }).buttonStyle(CategoryButtonStyle(isSelected: true))
+    .previewWithAllThemes()
+}
+
+#Preview("pressed") {
+    var buttonStyle = CategoryButtonStyle(isSelected: false)
+    buttonStyle.forcePressed = true
+    return Button("Hello", action: {
+
+    }).buttonStyle(buttonStyle)
+    .applyButtonEffect(isPressed: true)
     .previewWithAllThemes()
 }

--- a/podcasts/Categories/CategoryButtonStyle.swift
+++ b/podcasts/Categories/CategoryButtonStyle.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+
+struct CategoryButtonStyle: ButtonStyle {
+
+    @EnvironmentObject var theme: Theme
+
+    private enum Constants {
+        enum Padding {
+            static let horizontal: CGFloat = 20
+            static let vertical: CGFloat = 8
+        }
+
+        static let cornerRadius: CGFloat = 24
+    }
+
+    // MARK: Colors
+    private var border: Color {
+        theme.primaryField03
+    }
+    private var background: Color {
+        theme.primaryUi02Active
+    }
+    private var foreground: Color {
+        theme.primaryText01
+    }
+    private var selectedBackground: Color {
+        theme.primaryField03Active
+    }
+    private var selectedForeground: Color {
+        theme.primaryUi01
+    }
+
+    // MARK: View
+
+    let isSelected: Bool
+
+    init(isSelected: Bool = false) {
+        self.isSelected = isSelected
+    }
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.callout.weight(.medium))
+            .fixedSize(horizontal: true, vertical: false)
+            .padding(.horizontal, Constants.Padding.horizontal)
+            .padding(.vertical, Constants.Padding.vertical)
+            .cornerRadius(Constants.cornerRadius)
+            .background(isSelected ? selectedBackground : (configuration.isPressed ? background : Color.clear))
+            .foregroundColor(isSelected ? selectedForeground : foreground)
+            .overlay(
+                RoundedRectangle(cornerRadius: Constants.cornerRadius)
+                    .stroke(isSelected ? selectedBackground : border, lineWidth: 1)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: Constants.cornerRadius))
+    }
+}

--- a/podcasts/Categories/CategoryButtonStyle.swift
+++ b/podcasts/Categories/CategoryButtonStyle.swift
@@ -6,7 +6,8 @@ struct CategoryButtonStyle: ButtonStyle {
 
     private enum Constants {
         enum Padding {
-            static let horizontal: CGFloat = 20
+            static let roundedHorizontal: CGFloat = 20
+            static let circleHorizontal: CGFloat = 8
             static let vertical: CGFloat = 8
         }
 
@@ -39,28 +40,66 @@ struct CategoryButtonStyle: ButtonStyle {
     // MARK: View
 
     let isSelected: Bool
+    let cornerStyle: CornerStyle
+
+    enum CornerStyle {
+        case rounded
+        case circle
+
+        @available(iOS 16.0, *)
+        var shape: some Shape {
+            switch self {
+            case .rounded:
+                AnyShape(RoundedRectangle(cornerRadius: Constants.cornerRadius))
+            case .circle:
+               AnyShape(Circle())
+            }
+        }
+
+        var horizontalPadding: CGFloat {
+            switch self {
+            case .rounded:
+                Constants.Padding.roundedHorizontal
+            case .circle:
+                Constants.Padding.circleHorizontal
+            }
+        }
+    }
 
     /// Used for generating previews with isPressed button state
     fileprivate var forcePressed = false
 
-    init(isSelected: Bool = false) {
+    init(isSelected: Bool = false, cornerStyle: CornerStyle = .rounded) {
         self.isSelected = isSelected
+        self.cornerStyle = cornerStyle
     }
 
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
             .font(.callout.weight(.medium))
             .fixedSize(horizontal: true, vertical: false)
-            .padding(.horizontal, Constants.Padding.horizontal)
+            .padding(.horizontal, cornerStyle.horizontalPadding)
             .padding(.vertical, Constants.Padding.vertical)
             .cornerRadius(Constants.cornerRadius)
             .background(isSelected ? selectedBackground : ((configuration.isPressed || forcePressed) ? pressedBackground : background))
             .foregroundColor(isSelected ? selectedForeground : foreground)
-            .overlay(
-                RoundedRectangle(cornerRadius: Constants.cornerRadius)
-                    .stroke(isSelected ? selectedBackground : border, lineWidth: 1)
-            )
-            .clipShape(RoundedRectangle(cornerRadius: Constants.cornerRadius))
+            .modify {
+                if #available(iOS 16.0, *) {
+                    $0
+                        .padding(cornerStyle == .circle ? 3 : 0)
+                        .overlay(
+                        cornerStyle.shape
+                            .stroke(isSelected ? selectedBackground : border, lineWidth: 1)
+                    )
+                    .clipShape(cornerStyle.shape)
+                } else {
+                    $0.overlay(
+                        RoundedRectangle(cornerRadius: Constants.cornerRadius)
+                            .stroke(isSelected ? selectedBackground : border, lineWidth: 1)
+                    )
+                    .clipShape(RoundedRectangle(cornerRadius: Constants.cornerRadius))
+                }
+            }
     }
 }
 

--- a/podcasts/Categories/CategoryButtonStyle.swift
+++ b/podcasts/Categories/CategoryButtonStyle.swift
@@ -15,7 +15,7 @@ struct CategoryButtonStyle: ButtonStyle {
 
     // MARK: Colors
     private var border: Color {
-        theme.primaryIcon02
+        theme.primaryField03
     }
 
     private var background: Color {

--- a/podcasts/Categories/CategoryButtonStyle.swift
+++ b/podcasts/Categories/CategoryButtonStyle.swift
@@ -60,3 +60,10 @@ struct CategoryButtonStyle: ButtonStyle {
             .clipShape(RoundedRectangle(cornerRadius: Constants.cornerRadius))
     }
 }
+
+#Preview {
+    Button("Hello", action: {
+
+    }).buttonStyle(CategoryButtonStyle(isSelected: true))
+    .previewWithAllThemes()
+}

--- a/podcasts/Categories/CategoryButtonStyle.swift
+++ b/podcasts/Categories/CategoryButtonStyle.swift
@@ -15,19 +15,25 @@ struct CategoryButtonStyle: ButtonStyle {
 
     // MARK: Colors
     private var border: Color {
-        theme.primaryField03
+        theme.primaryIcon02
     }
+
     private var background: Color {
-        theme.primaryUi02Active
+        theme.primaryUi01
     }
+
+    private var pressedBackground: Color {
+        theme.primaryUi02Selected
+    }
+
     private var foreground: Color {
         theme.primaryText01
     }
     private var selectedBackground: Color {
-        theme.primaryField03Active
+        theme.primaryIcon01
     }
     private var selectedForeground: Color {
-        theme.primaryUi01
+        theme.primaryUi02Selected
     }
 
     // MARK: View
@@ -45,7 +51,7 @@ struct CategoryButtonStyle: ButtonStyle {
             .padding(.horizontal, Constants.Padding.horizontal)
             .padding(.vertical, Constants.Padding.vertical)
             .cornerRadius(Constants.cornerRadius)
-            .background(isSelected ? selectedBackground : (configuration.isPressed ? background : Color.clear))
+            .background(isSelected ? selectedBackground : (configuration.isPressed ? pressedBackground : background))
             .foregroundColor(isSelected ? selectedForeground : foreground)
             .overlay(
                 RoundedRectangle(cornerRadius: Constants.cornerRadius)

--- a/podcasts/Categories/CategoryButtonStyle.swift
+++ b/podcasts/Categories/CategoryButtonStyle.swift
@@ -80,13 +80,13 @@ struct CategoryButtonStyle: ButtonStyle {
             .fixedSize(horizontal: true, vertical: false)
             .padding(.horizontal, cornerStyle.horizontalPadding)
             .padding(.vertical, Constants.Padding.vertical)
+            .padding(cornerStyle == .circle ? 3 : 0)
             .cornerRadius(Constants.cornerRadius)
             .background(isSelected ? selectedBackground : ((configuration.isPressed || forcePressed) ? pressedBackground : background))
             .foregroundColor(isSelected ? selectedForeground : foreground)
             .modify {
                 if #available(iOS 16.0, *) {
                     $0
-                        .padding(cornerStyle == .circle ? 3 : 0)
                         .overlay(
                         cornerStyle.shape
                             .stroke(isSelected ? selectedBackground : border, lineWidth: 1)
@@ -124,6 +124,19 @@ struct CategoryButtonStyle: ButtonStyle {
     buttonStyle.forcePressed = true
     return Button("Hello", action: {
 
+    }).buttonStyle(buttonStyle)
+    .applyButtonEffect(isPressed: true)
+    .previewWithAllThemes()
+}
+
+#Preview("closed") {
+    var buttonStyle = CategoryButtonStyle(isSelected: false, cornerStyle: .circle)
+    buttonStyle.forcePressed = true
+    return Button(action: {
+
+    }, label: {
+        Image(systemName: "xmark")
+            .imageScale(.small)
     }).buttonStyle(buttonStyle)
     .applyButtonEffect(isPressed: true)
     .previewWithAllThemes()

--- a/podcasts/Categories/CategoryButtonStyle.swift
+++ b/podcasts/Categories/CategoryButtonStyle.swift
@@ -30,10 +30,10 @@ struct CategoryButtonStyle: ButtonStyle {
         theme.primaryText01
     }
     private var selectedBackground: Color {
-        theme.primaryIcon01
+        theme.secondaryIcon01
     }
     private var selectedForeground: Color {
-        theme.primaryUi02Selected
+        theme.secondaryUi01
     }
 
     // MARK: View

--- a/podcasts/CategoryPodcastsViewController.swift
+++ b/podcasts/CategoryPodcastsViewController.swift
@@ -21,12 +21,14 @@ class CategoryPodcastsViewController: PCViewController, UITableViewDelegate, UIT
     weak var delegate: DiscoverDelegate?
 
     private var category: DiscoverCategory
+    private var skipCount: Int
     private var podcasts = [DiscoverPodcast]()
     private var promotion: DiscoverCategoryPromotion?
     private let region: String?
-    init(category: DiscoverCategory, region: String?) {
+    init(category: DiscoverCategory, region: String?, skipCount: Int = 0) {
         self.category = category
         self.region = region
+        self.skipCount = skipCount
         super.init(nibName: "CategoryPodcastsViewController", bundle: nil)
 
         title = category.name?.localized
@@ -126,7 +128,7 @@ class CategoryPodcastsViewController: PCViewController, UITableViewDelegate, UIT
                 }
 
                 strongSelf.loadingIndicator.stopAnimating()
-                strongSelf.podcasts = podcasts
+                strongSelf.podcasts = Array(podcasts.dropFirst(strongSelf.skipCount))
                 strongSelf.promotion = categoryDetails?.promotion
                 strongSelf.podcastsTable.reloadData()
 

--- a/podcasts/CategoryPodcastsViewController.swift
+++ b/podcasts/CategoryPodcastsViewController.swift
@@ -18,7 +18,7 @@ class CategoryPodcastsViewController: PCViewController, UITableViewDelegate, UIT
     @IBOutlet var noNetworkView: UIView!
     @IBOutlet var loadingIndicator: UIActivityIndicatorView!
 
-    private weak var delegate: DiscoverDelegate?
+    weak var delegate: DiscoverDelegate?
 
     private var category: DiscoverCategory
     private var podcasts = [DiscoverPodcast]()

--- a/podcasts/CategoryPodcastsViewController.swift
+++ b/podcasts/CategoryPodcastsViewController.swift
@@ -23,8 +23,10 @@ class CategoryPodcastsViewController: PCViewController, UITableViewDelegate, UIT
     private var category: DiscoverCategory
     private var podcasts = [DiscoverPodcast]()
     private var promotion: DiscoverCategoryPromotion?
-    init(category: DiscoverCategory) {
+    private let region: String?
+    init(category: DiscoverCategory, region: String?) {
         self.category = category
+        self.region = region
         super.init(nibName: "CategoryPodcastsViewController", bundle: nil)
 
         title = category.name?.localized
@@ -84,7 +86,10 @@ class CategoryPodcastsViewController: PCViewController, UITableViewDelegate, UIT
         if let cell = tableView.cellForRow(at: indexPath) as? DiscoverPodcastTableCell {
             let podcast = podcasts[indexPath.row]
 
-            delegate.show(discoverPodcast: podcast, placeholderImage: cell.podcastImage.image, isFeatured: false, listUuid: nil)
+            let categoryName = category.name ?? "unknown"
+            let listUuid = "category-\(categoryName.lowercased())-\(region ?? "unknown")"
+
+            delegate.show(discoverPodcast: podcast, placeholderImage: cell.podcastImage.image, isFeatured: false, listUuid: listUuid)
         } else if let cell = tableView.cellForRow(at: indexPath) as? CategorySponsoredCell, let promotion = promotion {
             var podcastInfo = PodcastInfo()
             podcastInfo.title = promotion.title

--- a/podcasts/CategorySummaryViewController.swift
+++ b/podcasts/CategorySummaryViewController.swift
@@ -72,7 +72,7 @@ class CategorySummaryViewController: UIViewController, UITableViewDataSource, UI
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let category = categories[indexPath.row]
 
-        let categoryPodcastsController = CategoryPodcastsViewController(category: category)
+        let categoryPodcastsController = CategoryPodcastsViewController(category: category, region: regionCode)
         if let delegate = delegate {
             categoryPodcastsController.registerDiscoverDelegate(delegate)
             delegate.navController()?.pushViewController(categoryPodcastsController, animated: true)

--- a/podcasts/DeveloperMenu.swift
+++ b/podcasts/DeveloperMenu.swift
@@ -25,6 +25,7 @@ struct DeveloperMenu: View {
                 }
 
                 Button("Force Reload Discover") {
+                    DiscoverServerHandler.shared.discoveryCache.removeAllCachedResponses()
                     NotificationCenter.postOnMainThread(notification: Constants.Notifications.chartRegionChanged)
                 }
 

--- a/podcasts/DiscoverSummaryProtocol.swift
+++ b/podcasts/DiscoverSummaryProtocol.swift
@@ -10,6 +10,7 @@ protocol DiscoverDelegate: AnyObject {
     func show(podcastInfo: PodcastInfo, placeholderImage: UIImage?, isFeatured: Bool, listUuid: String?)
     func show(discoverPodcast: DiscoverPodcast, placeholderImage: UIImage?, isFeatured: Bool, listUuid: String?)
     func show(podcast: Podcast)
+    func showExpanded(item: DiscoverItem, category: DiscoverCategory?)
     func showExpanded(item: DiscoverItem, podcasts: [DiscoverPodcast], podcastCollection: PodcastCollection?)
     func showExpanded(item: DiscoverItem, episodes: [DiscoverEpisode], podcastCollection: PodcastCollection?)
     func replaceRegionCode(string: String?) -> String?

--- a/podcasts/DiscoverViewController+CategoryRedesign.swift
+++ b/podcasts/DiscoverViewController+CategoryRedesign.swift
@@ -1,0 +1,71 @@
+import PocketCastsServer
+
+private let popularItemsCount = 5
+
+extension DiscoverViewController {
+    /// Reloads discover, keeping the items listed in `exclude`
+    /// - Parameters:
+    ///   - items: Items to exclude from the reload process. These items will REMAIN in Discover
+    ///   - category: The `DiscoverCategory` to add to the layout. This is sort of an artifical `DiscoverLayout`.
+    func reload(except items: [DiscoverItem], category: DiscoverCategory?) {
+        let newLayout: DiscoverLayout?
+
+        if let category {
+            newLayout = modified(layout: discoverLayout, for: category, with: items)
+        } else {
+            newLayout = discoverLayout
+        }
+
+        populateFrom(discoverLayout: newLayout, shouldInclude: {
+            ($0.categoryID == category?.id) || items.contains($0)
+        }, shouldReset: {
+            !items.contains($0)
+        })
+
+        guard let category else { return }
+        addCategoryVC(for: category, regions: items.first?.regions ?? [])
+    }
+
+    private func modified(layout: DiscoverLayout?, for category: DiscoverCategory, with items: [DiscoverItem]) -> DiscoverLayout? {
+
+        let popularID = "category-popular-\(category.id ?? 0)"
+
+        // Only add if we haven't already added
+        guard layout?.layout?.contains(where: { $0.id == popularID }) == false else { return layout }
+
+        let source = replaceRegionCode(string: category.source)
+
+        let title: String
+        if let name = category.name {
+            title = "Most Popular in \(name)"
+        } else {
+            title = "Most Popular"
+        }
+
+        let item = DiscoverItem(
+            id: popularID,
+            title: title,
+            type: "podcast_list",
+            summaryStyle: "large_list",
+            summaryItemCount: popularItemsCount,
+            source: source,
+            regions: items.first?.regions ?? [],
+            categoryID: category.id
+        )
+
+        var newLayout = layout
+        newLayout?.layout?.insert(item, at: layout?.layout?.startIndex ?? 0)
+        return newLayout
+    }
+
+    private func addCategoryVC(for category: DiscoverCategory, regions: [String]) {
+        let region = discoverLayout.map { Settings.discoverRegion(discoverLayout: $0) }
+        let categoryVC = CategoryPodcastsViewController(category: category, region: region, skipCount: Constants.popularItemsCount)
+        categoryVC.delegate = self
+        categoryVC.view.alpha = 0
+        categoryVC.podcastsTable.isScrollEnabled = false
+
+        let item = DiscoverItem(id: "category-\(category.id ?? 0)", title: category.name, source: category.source, regions: regions)
+        addToScrollView(viewController: categoryVC, for: item, isLast: true)
+    }
+}

--- a/podcasts/DiscoverViewController+CategoryRedesign.swift
+++ b/podcasts/DiscoverViewController+CategoryRedesign.swift
@@ -1,8 +1,10 @@
 import PocketCastsServer
 
-private let popularItemsCount = 5
-
 extension DiscoverViewController {
+    private enum Constants {
+        static let popularItemsCount = 5
+    }
+
     /// Reloads discover, keeping the items listed in `exclude`
     /// - Parameters:
     ///   - items: Items to exclude from the reload process. These items will REMAIN in Discover
@@ -47,7 +49,7 @@ extension DiscoverViewController {
             title: title,
             type: "podcast_list",
             summaryStyle: "large_list",
-            summaryItemCount: popularItemsCount,
+            summaryItemCount: Constants.popularItemsCount,
             source: source,
             regions: items.first?.regions ?? [],
             categoryID: category.id

--- a/podcasts/DiscoverViewController+CategoryRedesign.swift
+++ b/podcasts/DiscoverViewController+CategoryRedesign.swift
@@ -37,9 +37,9 @@ extension DiscoverViewController {
 
         let title: String
         if let name = category.name {
-            title = "Most Popular in \(name)"
+            title = L10n.mostPopularWithName(name)
         } else {
-            title = "Most Popular"
+            title = L10n.mostPopular
         }
 
         let item = DiscoverItem(

--- a/podcasts/DiscoverViewController+DiscoverDelegate.swift
+++ b/podcasts/DiscoverViewController+DiscoverDelegate.swift
@@ -5,6 +5,10 @@ import PocketCastsServer
 extension DiscoverViewController: DiscoverDelegate {
     func showExpanded(item: PocketCastsServer.DiscoverItem, category: PocketCastsServer.DiscoverCategory?) {
         if let category {
+            if let categoryId = category.id, let categoryName = category.name, let discoverLayout {
+                let currentRegion = Settings.discoverRegion(discoverLayout: discoverLayout)
+                Analytics.track(.discoverCategoryShown, properties: ["name": categoryName, "region": currentRegion, "id": categoryId])
+            }
             reload(except: [item], category: category)
         } else {
             reload(except: [item], category: nil)

--- a/podcasts/DiscoverViewController+DiscoverDelegate.swift
+++ b/podcasts/DiscoverViewController+DiscoverDelegate.swift
@@ -7,7 +7,7 @@ extension DiscoverViewController: DiscoverDelegate {
         if let category {
             reload(except: [item], category: category)
         } else {
-            reloadDiscoverTapped(NSObject())
+            reload(except: [item], category: nil)
         }
     }
 

--- a/podcasts/DiscoverViewController+DiscoverDelegate.swift
+++ b/podcasts/DiscoverViewController+DiscoverDelegate.swift
@@ -3,6 +3,14 @@ import PocketCastsDataModel
 import PocketCastsServer
 
 extension DiscoverViewController: DiscoverDelegate {
+    func showExpanded(item: PocketCastsServer.DiscoverItem, category: PocketCastsServer.DiscoverCategory?) {
+        if let category {
+            reload(except: [item], category: category)
+        } else {
+            reloadDiscoverTapped(NSObject())
+        }
+    }
+
     func show(podcastInfo: PodcastInfo, placeholderImage: UIImage?, isFeatured: Bool, listUuid: String?) {
         let podcastController = PodcastViewController(podcastInfo: podcastInfo, existingImage: placeholderImage)
         podcastController.featuredPodcast = isFeatured

--- a/podcasts/DiscoverViewController.swift
+++ b/podcasts/DiscoverViewController.swift
@@ -149,7 +149,13 @@ class DiscoverViewController: PCViewController {
     /// - Parameters:
     ///   - items: Items to exclude from the reload process. These items will REMAIN in Discover
     ///   - category: The `DiscoverCategory` to add to the layout. This is sort of an artifical `DiscoverLayout`.
-    func reload(except items: [DiscoverItem], category: DiscoverCategory?) {
+    func reload(except items: [DiscoverItem], category: DiscoverCategory) {
+        let region = discoverLayout.map { Settings.discoverRegion(discoverLayout: $0) }
+        let categoryVC = CategoryPodcastsViewController(category: category, region: region)
+        categoryVC.delegate = self
+        categoryVC.view.alpha = 0
+
+        let item = DiscoverItem(id: "category-\(category.id ?? 0)", title: category.name, source: category.source, regions: items.first?.regions ?? [])
         populateFrom(discoverLayout: discoverLayout, shouldInclude: {
             ($0.categoryID == category?.id) || items.contains($0)
         }, shouldReset: {

--- a/podcasts/DiscoverViewController.swift
+++ b/podcasts/DiscoverViewController.swift
@@ -312,8 +312,12 @@ class DiscoverViewController: PCViewController {
 
         // anchor the bottom view to the bottom, the middle ones to each other, and the last one to the bottom and the one above it
         if isLast {
-            if let previousView = summaryViewControllers.last?.viewController.view {
-                viewController.view.topAnchor.constraint(equalTo: previousView.bottomAnchor).isActive = true
+            if let previousVC = summaryViewControllers.last?.viewController, let previousView = previousVC.view {
+                if viewController is CategoryPodcastsViewController && (previousVC is CategoriesSelectorViewController) == false {
+                    viewController.view.topAnchor.constraint(equalTo: previousView.bottomAnchor, constant: 10).isActive = true
+                } else {
+                    viewController.view.topAnchor.constraint(equalTo: previousView.bottomAnchor).isActive = true
+                }
             }
             viewController.view.bottomAnchor.constraint(equalTo: mainScrollView.bottomAnchor, constant: -65).isActive = true
         } else if let previousVC = summaryViewControllers.last?.viewController, let previousView = previousVC.view {
@@ -321,7 +325,11 @@ class DiscoverViewController: PCViewController {
                 viewController.view.topAnchor.constraint(equalTo: previousView.bottomAnchor, constant: -10).isActive = true
                 mainScrollView.sendSubviewToBack(viewController.view)
             } else {
-                viewController.view.topAnchor.constraint(equalTo: previousView.bottomAnchor).isActive = true
+                if viewController is CategoryPodcastsViewController && (previousVC is CategoriesSelectorViewController) == false {
+                    viewController.view.topAnchor.constraint(equalTo: previousView.bottomAnchor, constant: 10).isActive = true
+                } else {
+                    viewController.view.topAnchor.constraint(equalTo: previousView.bottomAnchor).isActive = true
+                }
             }
         } else {
             viewController.view.topAnchor.constraint(equalTo: mainScrollView.topAnchor).isActive = true

--- a/podcasts/DiscoverViewController.swift
+++ b/podcasts/DiscoverViewController.swift
@@ -145,37 +145,6 @@ class DiscoverViewController: PCViewController {
         }
     }
 
-    /// Reloads discover, keeping the items listed in `exclude`
-    /// - Parameters:
-    ///   - items: Items to exclude from the reload process. These items will REMAIN in Discover
-    ///   - category: The `DiscoverCategory` to add to the layout. This is sort of an artifical `DiscoverLayout`.
-    func reload(except items: [DiscoverItem], category: DiscoverCategory) {
-        let region = discoverLayout.map { Settings.discoverRegion(discoverLayout: $0) }
-        let categoryVC = CategoryPodcastsViewController(category: category, region: region)
-        categoryVC.delegate = self
-        categoryVC.view.alpha = 0
-
-        let item = DiscoverItem(id: "category-\(category.id ?? 0)", title: category.name, source: category.source, regions: items.first?.regions ?? [])
-        populateFrom(discoverLayout: discoverLayout, shouldInclude: {
-            ($0.categoryID == category?.id) || items.contains($0)
-        }, shouldReset: {
-            !items.contains($0)
-        })
-
-        guard let category else { return }
-        addCategoryVC(for: category, regions: items.first?.regions ?? [])
-    }
-
-    private func addCategoryVC(for category: DiscoverCategory, regions: [String]) {
-        let categoryVC = CategoryPodcastsViewController(category: category)
-        categoryVC.delegate = self
-        categoryVC.view.alpha = 0
-        categoryVC.podcastsTable.isScrollEnabled = false
-
-        let item = DiscoverItem(id: "category-\(category.id ?? 0)", title: category.name, source: category.source, regions: regions)
-        addToScrollView(viewController: categoryVC, for: item, isLast: true)
-    }
-
     private func showPageLoading() {
         loadingContent = true
 
@@ -259,7 +228,7 @@ class DiscoverViewController: PCViewController {
     ///   - discoverLayout: A `DiscoverLayout`
     ///   - shouldInclude: Whether a `DiscoverItem` from the layout should be included in the scroll view. This is used to filter items meant only for certain categories, for instance.
     ///   - shouldReset: Whether a view controller from `summaryViewControllers` should be reset during this operation. This is used by the Categories pills to avoid triggering a view reload, allowing animations to continue.
-    private func populateFrom(discoverLayout: DiscoverLayout?, shouldInclude: ((DiscoverItem) -> Bool)? = nil, shouldReset: ((DiscoverItem) -> Bool)? = nil) {
+    func populateFrom(discoverLayout: DiscoverLayout?, shouldInclude: ((DiscoverItem) -> Bool)? = nil, shouldReset: ((DiscoverItem) -> Bool)? = nil) {
         loadingContent = false
 
         guard let layout = discoverLayout, let items = layout.layout, let _ = layout.regions, items.count > 0 else {
@@ -312,7 +281,7 @@ class DiscoverViewController: PCViewController {
         controller.populateFrom(item: discoverItem)
     }
 
-    private func addToScrollView(viewController: UIViewController, for item: DiscoverItem, isLast: Bool) {
+    func addToScrollView(viewController: UIViewController, for item: DiscoverItem, isLast: Bool) {
         mainScrollView.addSubview(viewController.view)
         addCommonConstraintsFor(viewController)
 

--- a/podcasts/DiscoverViewController.swift
+++ b/podcasts/DiscoverViewController.swift
@@ -145,6 +145,29 @@ class DiscoverViewController: PCViewController {
         }
     }
 
+    /// Reloads discover, keeping the items listed in `exclude`
+    /// - Parameters:
+    ///   - items: Items to exclude from the reload process. These items will REMAIN in Discover
+    ///   - category: The `DiscoverCategory` to add to the layout. This is sort of an artifical `DiscoverLayout`.
+    func reload(except items: [DiscoverItem], category: DiscoverCategory) {
+
+        let categoryVC = CategoryPodcastsViewController(category: category)
+        categoryVC.registerDiscoverDelegate(self)
+
+        //TODO: Allow this to accept a Discover Layout?
+        //TODO: Add fade animation
+        let item = DiscoverItem(id: "category-\(category.id ?? 0)", title: category.name, source: category.source, regions: items.first?.regions ?? [])
+
+        let itemsToRemove = Set(currentSnapshot?.itemIdentifiers ?? []).subtracting(items)
+        if var newSnapshot = currentSnapshot {
+            newSnapshot.deleteItems(Array(itemsToRemove))
+            newSnapshot.appendItems([item])
+            apply(snapshot: newSnapshot, currentRegion: Settings.discoverRegion(discoverLayout: discoverLayout!))
+            addToScrollView(viewController: categoryVC, for: item, isLast: true)
+        }
+        categoryVC.podcastsTable.isScrollEnabled = false
+    }
+
     private func showPageLoading() {
         loadingContent = true
 

--- a/podcasts/DiscoverViewController.swift
+++ b/podcasts/DiscoverViewController.swift
@@ -305,6 +305,10 @@ class DiscoverViewController: PCViewController {
                 } else {
                     viewController.view.topAnchor.constraint(equalTo: previousView.bottomAnchor).isActive = true
                 }
+
+                if previousVC is CategoriesSelectorViewController {
+                    (viewController as? LargeListSummaryViewController)?.padding = 25
+                }
             }
         } else {
             viewController.view.topAnchor.constraint(equalTo: mainScrollView.topAnchor).isActive = true

--- a/podcasts/DiscoverViewController.swift
+++ b/podcasts/DiscoverViewController.swift
@@ -233,8 +233,8 @@ class DiscoverViewController: PCViewController {
                 viewController.view.topAnchor.constraint(equalTo: previousView.bottomAnchor).isActive = true
             }
             viewController.view.bottomAnchor.constraint(equalTo: mainScrollView.bottomAnchor, constant: -65).isActive = true
-        } else if let previousView = summaryViewControllers.last?.view {
-            if summaryViewControllers.count == 1 {
+        } else if let previousVC = summaryViewControllers.last, let previousView = previousVC.view {
+            if previousVC is FeaturedSummaryViewController {
                 viewController.view.topAnchor.constraint(equalTo: previousView.bottomAnchor, constant: -10).isActive = true
                 mainScrollView.sendSubviewToBack(viewController.view)
             } else {

--- a/podcasts/DiscoverViewController.swift
+++ b/podcasts/DiscoverViewController.swift
@@ -171,17 +171,6 @@ class DiscoverViewController: PCViewController {
         self.discoverLayout = layout
         loadingIndicator.stopAnimating()
 
-        if FeatureFlag.categoriesRedesign.enabled {
-            let categoriesItem = items.first { item in
-                return item.type == "categories"
-            }
-
-            if let categoriesItem {
-                let categories = CategoriesSelectorViewController(item: categoriesItem)
-                addToScrollView(viewController: categories, isLast: false)
-            }
-        }
-
         let currentRegion = Settings.discoverRegion(discoverLayout: layout)
         for discoverItem in items {
             guard let type = discoverItem.type, let summaryStyle = discoverItem.summaryStyle, discoverItem.regions.contains(currentRegion) else { continue }
@@ -190,6 +179,8 @@ class DiscoverViewController: PCViewController {
             guard coordinator.shouldDisplay(discoverItem) else { continue }
 
             switch (type, summaryStyle, expandedStyle) {
+            case ("categories", "pills", _):
+                addSummaryController(CategoriesSelectorViewController(), discoverItem: discoverItem)
             case ("podcast_list", "carousel", _):
                 addSummaryController(FeaturedSummaryViewController(), discoverItem: discoverItem)
             case ("podcast_list", "small_list", _):
@@ -202,7 +193,7 @@ class DiscoverViewController: PCViewController {
                 addSummaryController(CollectionSummaryViewController(), discoverItem: discoverItem)
             case ("network_list", _, _):
                 addSummaryController(NetworkSummaryViewController(), discoverItem: discoverItem)
-            case ("categories", _, _):
+            case ("categories", "category", _):
                 addSummaryController(CategorySummaryViewController(regionCode: currentRegion), discoverItem: discoverItem)
             case ("episode_list", "single_episode", _):
                 addSummaryController(SingleEpisodeViewController(), discoverItem: discoverItem)

--- a/podcasts/DiscoverViewController.swift
+++ b/podcasts/DiscoverViewController.swift
@@ -226,7 +226,7 @@ class DiscoverViewController: PCViewController {
     /// Populate the scroll view using a DiscoverLayout with optional shouldInclude and shouldReset filters.
     /// - Parameters:
     ///   - discoverLayout: A `DiscoverLayout`
-    ///   - shouldInclude: Whether a `DiscoverItem` from the layout should be included in the scroll view. This is used to filter items meant only for certain categories, for instance.
+    ///   - shouldInclude: Whether a `DiscoverItem` from the layout should be included in the scroll view. This is used to filter items meant only for certain categories, for instance. By default, this filter will exclude items with a category which are to be shown in the Category page.
     ///   - shouldReset: Whether a view controller from `summaryViewControllers` should be reset during this operation. This is used by the Categories pills to avoid triggering a view reload, allowing animations to continue.
     func populateFrom(discoverLayout: DiscoverLayout?, shouldInclude: ((DiscoverItem) -> Bool)? = nil, shouldReset: ((DiscoverItem) -> Bool)? = nil) {
         loadingContent = false
@@ -234,6 +234,10 @@ class DiscoverViewController: PCViewController {
         guard let layout = discoverLayout, let items = layout.layout, let _ = layout.regions, items.count > 0 else {
             handleLoadFailed()
             return
+        }
+
+        let itemFilter = shouldInclude ?? { item in
+            item.categoryID == nil
         }
 
         self.discoverLayout = layout
@@ -246,7 +250,7 @@ class DiscoverViewController: PCViewController {
 
             let section = 0
             snapshot.appendSections([section])
-            snapshot.appendItems(items.filter({ (shouldInclude?($0) ?? true) && $0.regions.contains(currentRegion) }))
+            snapshot.appendItems(items.filter({ (itemFilter($0)) && $0.regions.contains(currentRegion) }))
 
             return snapshot
         }
@@ -260,7 +264,7 @@ class DiscoverViewController: PCViewController {
         let regions = layout.regions?.keys as? [String]
         let item = DiscoverItem(id: "country-summary", regions: regions ?? [])
 
-        if shouldInclude?(item) ?? true {
+        if itemFilter(item) {
             let countrySummary = CountrySummaryViewController()
             countrySummary.discoverLayout = layout
             countrySummary.registerDiscoverDelegate(self)

--- a/podcasts/DiscoverViewController.swift
+++ b/podcasts/DiscoverViewController.swift
@@ -246,7 +246,7 @@ class DiscoverViewController: PCViewController {
 
             let section = 0
             snapshot.appendSections([section])
-            snapshot.appendItems(items.filter({ shouldInclude?($0) ?? true }))
+            snapshot.appendItems(items.filter({ (shouldInclude?($0) ?? true) && $0.regions.contains(currentRegion) }))
 
             return snapshot
         }

--- a/podcasts/DiscoverViewController.swift
+++ b/podcasts/DiscoverViewController.swift
@@ -241,7 +241,7 @@ class DiscoverViewController: PCViewController {
         }
         currentSnapshot = snapshot
     }
-    
+
     /// Populate the scroll view using a DiscoverLayout with optional shouldInclude and shouldReset filters.
     /// - Parameters:
     ///   - discoverLayout: A `DiscoverLayout`

--- a/podcasts/DiscoverViewController.swift
+++ b/podcasts/DiscoverViewController.swift
@@ -151,7 +151,7 @@ class DiscoverViewController: PCViewController {
     ///   - category: The `DiscoverCategory` to add to the layout. This is sort of an artifical `DiscoverLayout`.
     func reload(except items: [DiscoverItem], category: DiscoverCategory) {
         let categoryVC = CategoryPodcastsViewController(category: category)
-        categoryVC.registerDiscoverDelegate(self)
+        categoryVC.delegate = self
         categoryVC.view.alpha = 0
 
         let item = DiscoverItem(id: "category-\(category.id ?? 0)", title: category.name, source: category.source, regions: items.first?.regions ?? [])

--- a/podcasts/DiscoverViewController.swift
+++ b/podcasts/DiscoverViewController.swift
@@ -1,5 +1,6 @@
 import PocketCastsServer
 import UIKit
+import PocketCastsUtils
 
 class DiscoverViewController: PCViewController {
     @IBOutlet var mainScrollView: UIScrollView!
@@ -169,6 +170,17 @@ class DiscoverViewController: PCViewController {
 
         self.discoverLayout = layout
         loadingIndicator.stopAnimating()
+
+        if FeatureFlag.categoriesRedesign.enabled {
+            let categoriesItem = items.first { item in
+                return item.type == "categories"
+            }
+
+            if let categoriesItem {
+                let categories = CategoriesSelectorViewController(item: categoriesItem)
+                addToScrollView(viewController: categories, isLast: false)
+            }
+        }
 
         let currentRegion = Settings.discoverRegion(discoverLayout: layout)
         for discoverItem in items {

--- a/podcasts/DiscoverViewController.swift
+++ b/podcasts/DiscoverViewController.swift
@@ -149,19 +149,25 @@ class DiscoverViewController: PCViewController {
     /// - Parameters:
     ///   - items: Items to exclude from the reload process. These items will REMAIN in Discover
     ///   - category: The `DiscoverCategory` to add to the layout. This is sort of an artifical `DiscoverLayout`.
-    func reload(except items: [DiscoverItem], category: DiscoverCategory) {
-        let categoryVC = CategoryPodcastsViewController(category: category)
-        categoryVC.delegate = self
-        categoryVC.view.alpha = 0
-
-        let item = DiscoverItem(id: "category-\(category.id ?? 0)", title: category.name, source: category.source, regions: items.first?.regions ?? [])
+    func reload(except items: [DiscoverItem], category: DiscoverCategory?) {
         populateFrom(discoverLayout: discoverLayout, shouldInclude: {
-            ($0.categoryID == category.id) || items.contains($0)
+            ($0.categoryID == category?.id) || items.contains($0)
         }, shouldReset: {
             !items.contains($0)
         })
-        addToScrollView(viewController: categoryVC, for: item, isLast: true)
+
+        guard let category else { return }
+        addCategoryVC(for: category, regions: items.first?.regions ?? [])
+    }
+
+    private func addCategoryVC(for category: DiscoverCategory, regions: [String]) {
+        let categoryVC = CategoryPodcastsViewController(category: category)
+        categoryVC.delegate = self
+        categoryVC.view.alpha = 0
         categoryVC.podcastsTable.isScrollEnabled = false
+
+        let item = DiscoverItem(id: "category-\(category.id ?? 0)", title: category.name, source: category.source, regions: regions)
+        addToScrollView(viewController: categoryVC, for: item, isLast: true)
     }
 
     private func showPageLoading() {

--- a/podcasts/DiscoverViewController.swift
+++ b/podcasts/DiscoverViewController.swift
@@ -155,14 +155,12 @@ class DiscoverViewController: PCViewController {
         categoryVC.view.alpha = 0
 
         let item = DiscoverItem(id: "category-\(category.id ?? 0)", title: category.name, source: category.source, regions: items.first?.regions ?? [])
-
-        let itemsToRemove = Set(currentSnapshot?.itemIdentifiers ?? []).subtracting(items)
-        if var newSnapshot = currentSnapshot {
-            newSnapshot.deleteItems(Array(itemsToRemove))
-            newSnapshot.appendItems([item])
-            apply(snapshot: newSnapshot, currentRegion: Settings.discoverRegion(discoverLayout: discoverLayout!))
-            addToScrollView(viewController: categoryVC, for: item, isLast: true)
-        }
+        populateFrom(discoverLayout: discoverLayout, shouldInclude: {
+            ($0.categoryID == category.id) || items.contains($0)
+        }, shouldReset: {
+            !items.contains($0)
+        })
+        addToScrollView(viewController: categoryVC, for: item, isLast: true)
         categoryVC.podcastsTable.isScrollEnabled = false
     }
 
@@ -178,9 +176,9 @@ class DiscoverViewController: PCViewController {
 
     private var currentSnapshot: NSDiffableDataSourceSnapshot<Int, DiscoverItem>?
 
-    private func apply(snapshot: NSDiffableDataSourceSnapshot<Int, DiscoverItem>, currentRegion: String) {
+    private func resetSummaryViewControllers(filter: ((DiscoverItem) -> Bool)?) {
         let viewsToRemove = summaryViewControllers.filter { sumItem in
-            !snapshot.itemIdentifiers.contains { $0 == sumItem.item }
+            filter?(sumItem.item) ?? true
         }
 
         UIView.animate(withDuration: 0.1) {
@@ -202,16 +200,18 @@ class DiscoverViewController: PCViewController {
         }
 
         summaryViewControllers.removeAll { sumItem in
-            !snapshot.itemIdentifiers.contains { $0 == sumItem.item }
+            filter?(sumItem.item) ?? true
         }
+    }
 
+    private func apply(snapshot: NSDiffableDataSourceSnapshot<Int, DiscoverItem>, currentRegion: String) {
         for discoverItem in snapshot.itemIdentifiers {
             guard let type = discoverItem.type, let summaryStyle = discoverItem.summaryStyle else { continue }
             let expandedStyle = discoverItem.expandedStyle ?? ""
 
             guard coordinator.shouldDisplay(discoverItem) else { continue }
 
-            guard snapshot.indexOfItem(discoverItem) != currentSnapshot?.indexOfItem(discoverItem) else { continue }
+            guard summaryViewControllers.contains(where: { $0.item == discoverItem }) == false else { continue }
 
             switch (type, summaryStyle, expandedStyle) {
             case ("categories", "pills", _):
@@ -241,8 +241,13 @@ class DiscoverViewController: PCViewController {
         }
         currentSnapshot = snapshot
     }
-
-    private func populateFrom(discoverLayout: DiscoverLayout?) {
+    
+    /// Populate the scroll view using a DiscoverLayout with optional shouldInclude and shouldReset filters.
+    /// - Parameters:
+    ///   - discoverLayout: A `DiscoverLayout`
+    ///   - shouldInclude: Whether a `DiscoverItem` from the layout should be included in the scroll view. This is used to filter items meant only for certain categories, for instance.
+    ///   - shouldReset: Whether a view controller from `summaryViewControllers` should be reset during this operation. This is used by the Categories pills to avoid triggering a view reload, allowing animations to continue.
+    private func populateFrom(discoverLayout: DiscoverLayout?, shouldInclude: ((DiscoverItem) -> Bool)? = nil, shouldReset: ((DiscoverItem) -> Bool)? = nil) {
         loadingContent = false
 
         guard let layout = discoverLayout, let items = layout.layout, let _ = layout.regions, items.count > 0 else {
@@ -260,20 +265,26 @@ class DiscoverViewController: PCViewController {
 
             let section = 0
             snapshot.appendSections([section])
-            snapshot.appendItems(items)
+            snapshot.appendItems(items.filter({ shouldInclude?($0) ?? true }))
 
             return snapshot
         }
 
         let snapshot = makeDataSourceSnapshot(from: items)
+        resetSummaryViewControllers {
+            shouldReset?($0) ?? true
+        }
         apply(snapshot: snapshot, currentRegion: currentRegion)
 
-        let countrySummary = CountrySummaryViewController()
-        countrySummary.discoverLayout = layout
-        countrySummary.registerDiscoverDelegate(self)
         let regions = layout.regions?.keys as? [String]
         let item = DiscoverItem(id: "country-summary", regions: regions ?? [])
-        addToScrollView(viewController: countrySummary, for: item, isLast: true)
+
+        if shouldInclude?(item) ?? true {
+            let countrySummary = CountrySummaryViewController()
+            countrySummary.discoverLayout = layout
+            countrySummary.registerDiscoverDelegate(self)
+            addToScrollView(viewController: countrySummary, for: item, isLast: true)
+        }
 
         mainScrollView.isHidden = false
         noNetworkView.isHidden = true

--- a/podcasts/LargeListSummaryViewController.swift
+++ b/podcasts/LargeListSummaryViewController.swift
@@ -135,13 +135,22 @@ class LargeListSummaryViewController: DiscoverPeekViewController, DiscoverSummar
         guard let source = item.source else { return }
         guard let title = item.title?.localized else { return }
 
+        showAllBtn.isHidden = item.expandedStyle == nil
+
         self.item = item
         titleLabel.text = delegate?.replaceRegionName(string: title)
         titleLabel.sizeToFit()
         DiscoverServerHandler.shared.discoverPodcastList(source: source, completion: { [weak self] podcastList in
             guard let strongSelf = self, let discoverPodcast = podcastList?.podcasts else { return }
 
-            for podcast in discoverPodcast {
+            let podcasts: [DiscoverPodcast]
+            if let itemCount = item.summaryItemCount {
+                podcasts = Array(discoverPodcast[0..<itemCount])
+            } else {
+                podcasts = discoverPodcast
+            }
+
+            for podcast in podcasts {
                 strongSelf.podcasts.append(podcast)
             }
 

--- a/podcasts/LargeListSummaryViewController.swift
+++ b/podcasts/LargeListSummaryViewController.swift
@@ -3,6 +3,7 @@ import UIKit
 
 class LargeListSummaryViewController: DiscoverPeekViewController, DiscoverSummaryProtocol, UICollectionViewDataSource, GridLayoutDelegate, UICollectionViewDelegateFlowLayout {
 
+    @IBOutlet weak var divider: ThemeDividerView!
     @IBOutlet weak var titleTopConstraint: NSLayoutConstraint!
     @IBOutlet var titleLabel: ThemeableLabel!
     @IBOutlet var showAllBtn: UIButton! {
@@ -153,6 +154,7 @@ class LargeListSummaryViewController: DiscoverPeekViewController, DiscoverSummar
         self.item = item
         titleLabel.text = delegate?.replaceRegionName(string: title)
         titleLabel.sizeToFit()
+        divider.isHidden = true
         DiscoverServerHandler.shared.discoverPodcastList(source: source, completion: { [weak self] podcastList in
             guard let strongSelf = self, let discoverPodcast = podcastList?.podcasts else { return }
 
@@ -168,6 +170,7 @@ class LargeListSummaryViewController: DiscoverPeekViewController, DiscoverSummar
             }
 
             DispatchQueue.main.async {
+                strongSelf.divider.isHidden = false
                 strongSelf.collectionView.reloadData()
             }
         })

--- a/podcasts/LargeListSummaryViewController.swift
+++ b/podcasts/LargeListSummaryViewController.swift
@@ -2,6 +2,8 @@ import PocketCastsServer
 import UIKit
 
 class LargeListSummaryViewController: DiscoverPeekViewController, DiscoverSummaryProtocol, UICollectionViewDataSource, GridLayoutDelegate, UICollectionViewDelegateFlowLayout {
+
+    @IBOutlet weak var titleTopConstraint: NSLayoutConstraint!
     @IBOutlet var titleLabel: ThemeableLabel!
     @IBOutlet var showAllBtn: UIButton! {
         didSet {
@@ -18,6 +20,13 @@ class LargeListSummaryViewController: DiscoverPeekViewController, DiscoverSummar
     private var item: DiscoverItem?
 
     @IBOutlet var largeListCollectionViewHeight: NSLayoutConstraint!
+
+    var padding: CGFloat? {
+        didSet {
+            view.setNeedsLayout()
+        }
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -44,9 +53,13 @@ class LargeListSummaryViewController: DiscoverPeekViewController, DiscoverSummar
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
 
+        if padding != nil {
+            titleTopConstraint.constant = 0
+        }
+
         if lastLayedOutWidth != view.bounds.width {
             lastLayedOutWidth = view.bounds.width
-            largeListCollectionViewHeight.constant = cellWidth + 50
+            largeListCollectionViewHeight.constant = cellWidth + (padding ?? 50)
             collectionView.layoutIfNeeded()
         }
     }

--- a/podcasts/LargeListSummaryViewController.swift
+++ b/podcasts/LargeListSummaryViewController.swift
@@ -53,8 +53,8 @@ class LargeListSummaryViewController: DiscoverPeekViewController, DiscoverSummar
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
 
-        if padding != nil {
-            titleTopConstraint.constant = 0
+        if let padding {
+            titleTopConstraint.constant = padding / 2
         }
 
         if lastLayedOutWidth != view.bounds.width {

--- a/podcasts/LargeListSummaryViewController.xib
+++ b/podcasts/LargeListSummaryViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22684"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -14,6 +14,7 @@
                 <outlet property="largeListCollectionViewHeight" destination="O9B-Ec-Krr" id="8nl-ey-dbz"/>
                 <outlet property="showAllBtn" destination="sF0-fo-tPV" id="NQp-Ou-W2d"/>
                 <outlet property="titleLabel" destination="0VX-rs-RFl" id="gRb-Ti-AKA"/>
+                <outlet property="titleTopConstraint" destination="bMc-9I-2X9" id="oAi-dY-rrx"/>
                 <outlet property="view" destination="Fw0-IT-oEE" id="dU6-pd-YkH"/>
             </connections>
         </placeholder>

--- a/podcasts/LargeListSummaryViewController.xib
+++ b/podcasts/LargeListSummaryViewController.xib
@@ -14,7 +14,7 @@
                 <outlet property="largeListCollectionViewHeight" destination="O9B-Ec-Krr" id="8nl-ey-dbz"/>
                 <outlet property="showAllBtn" destination="sF0-fo-tPV" id="NQp-Ou-W2d"/>
                 <outlet property="titleLabel" destination="0VX-rs-RFl" id="gRb-Ti-AKA"/>
-                <outlet property="titleTopConstraint" destination="bMc-9I-2X9" id="oAi-dY-rrx"/>
+                <outlet property="titleTopConstraint" destination="iGU-3S-axn" id="MLu-4G-TLm"/>
                 <outlet property="view" destination="Fw0-IT-oEE" id="dU6-pd-YkH"/>
             </connections>
         </placeholder>
@@ -23,12 +23,31 @@
             <rect key="frame" x="0.0" y="0.0" width="370" height="275"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Featured" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0VX-rs-RFl" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                    <rect key="frame" x="16" y="30" width="92" height="20"/>
-                    <fontDescription key="fontDescription" type="boldSystem" pointSize="22"/>
-                    <color key="textColor" red="0.30196078430000001" green="0.33725490200000002" blue="0.36078431370000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                    <nil key="highlightedColor"/>
-                </label>
+                <stackView opaque="NO" contentMode="scaleToFill" alignment="lastBaseline" translatesAutoresizingMaskIntoConstraints="NO" id="X56-LC-Q5n">
+                    <rect key="frame" x="16" y="30" width="338" height="20"/>
+                    <subviews>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Featured" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0VX-rs-RFl" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
+                            <rect key="frame" x="0.0" y="0.0" width="92" height="20"/>
+                            <fontDescription key="fontDescription" type="boldSystem" pointSize="22"/>
+                            <color key="textColor" red="0.30196078430000001" green="0.33725490200000002" blue="0.36078431370000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dtr-d4-ivC">
+                            <rect key="frame" x="92" y="0.0" width="176" height="20"/>
+                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        </view>
+                        <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" pointerInteraction="YES" translatesAutoresizingMaskIntoConstraints="NO" id="sF0-fo-tPV" customClass="ThemeableUIButton" customModule="podcasts" customModuleProvider="target">
+                            <rect key="frame" x="268" y="0.0" width="70" height="28"/>
+                            <fontDescription key="fontDescription" type="boldSystem" pointSize="13"/>
+                            <state key="normal" title="SHOW ALL">
+                                <color key="titleColor" red="0.035672488410000001" green="1" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                            </state>
+                            <connections>
+                                <action selector="showAllTapped:" destination="-1" eventType="touchUpInside" id="moq-wQ-lrZ"/>
+                            </connections>
+                        </button>
+                    </subviews>
+                </stackView>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8lf-U1-Pgg" customClass="ThemeDividerView" customModule="podcasts" customModuleProvider="target">
                     <rect key="frame" x="16" y="274" width="338" height="1"/>
                     <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -36,16 +55,6 @@
                         <constraint firstAttribute="height" constant="1" id="1Sj-ah-DW1"/>
                     </constraints>
                 </view>
-                <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" pointerInteraction="YES" translatesAutoresizingMaskIntoConstraints="NO" id="sF0-fo-tPV" customClass="ThemeableUIButton" customModule="podcasts" customModuleProvider="target">
-                    <rect key="frame" x="284" y="32.5" width="70" height="28"/>
-                    <fontDescription key="fontDescription" type="boldSystem" pointSize="13"/>
-                    <state key="normal" title="SHOW ALL">
-                        <color key="titleColor" red="0.035672488410000001" green="1" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                    </state>
-                    <connections>
-                        <action selector="showAllTapped:" destination="-1" eventType="touchUpInside" id="moq-wQ-lrZ"/>
-                    </connections>
-                </button>
                 <collectionView multipleTouchEnabled="YES" contentMode="scaleToFill" pagingEnabled="YES" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="iJi-Yt-ez5" customClass="ThemeableCollectionView" customModule="podcasts" customModuleProvider="target">
                     <rect key="frame" x="16" y="66" width="350" height="169"/>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -62,16 +71,14 @@
             <viewLayoutGuide key="safeArea" id="LyU-Kg-8Dd"/>
             <constraints>
                 <constraint firstAttribute="trailing" secondItem="8lf-U1-Pgg" secondAttribute="trailing" constant="16" id="4UU-zd-txK"/>
-                <constraint firstAttribute="trailing" secondItem="sF0-fo-tPV" secondAttribute="trailing" constant="16" id="JpU-a4-kSM"/>
+                <constraint firstItem="X56-LC-Q5n" firstAttribute="leading" secondItem="LyU-Kg-8Dd" secondAttribute="leading" constant="16" id="IL6-Cs-p4a"/>
+                <constraint firstItem="LyU-Kg-8Dd" firstAttribute="trailing" secondItem="X56-LC-Q5n" secondAttribute="trailing" constant="16" id="IM6-3S-kcq"/>
+                <constraint firstItem="iJi-Yt-ez5" firstAttribute="top" secondItem="X56-LC-Q5n" secondAttribute="bottom" constant="16" id="OQB-xb-uvH"/>
                 <constraint firstAttribute="bottom" secondItem="8lf-U1-Pgg" secondAttribute="bottom" id="a4K-dl-1du"/>
-                <constraint firstItem="0VX-rs-RFl" firstAttribute="top" secondItem="Fw0-IT-oEE" secondAttribute="top" constant="30" id="bMc-9I-2X9"/>
+                <constraint firstItem="X56-LC-Q5n" firstAttribute="top" secondItem="Fw0-IT-oEE" secondAttribute="top" constant="30" id="iGU-3S-axn"/>
                 <constraint firstAttribute="trailing" secondItem="iJi-Yt-ez5" secondAttribute="trailing" constant="4" id="jUE-w2-UeS"/>
                 <constraint firstItem="8lf-U1-Pgg" firstAttribute="leading" secondItem="Fw0-IT-oEE" secondAttribute="leading" constant="16" id="lAW-pH-GZr"/>
-                <constraint firstItem="sF0-fo-tPV" firstAttribute="firstBaseline" secondItem="0VX-rs-RFl" secondAttribute="firstBaseline" id="nq8-FH-y7i"/>
-                <constraint firstItem="iJi-Yt-ez5" firstAttribute="top" secondItem="0VX-rs-RFl" secondAttribute="bottom" constant="16" id="oXK-90-rK5"/>
                 <constraint firstAttribute="bottom" secondItem="iJi-Yt-ez5" secondAttribute="bottom" constant="40" id="p8E-lt-7LD"/>
-                <constraint firstItem="0VX-rs-RFl" firstAttribute="leading" secondItem="Fw0-IT-oEE" secondAttribute="leading" constant="16" id="pjG-Iv-ws5"/>
-                <constraint firstItem="sF0-fo-tPV" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="0VX-rs-RFl" secondAttribute="trailing" constant="4" id="sFw-LV-ZvT"/>
                 <constraint firstItem="iJi-Yt-ez5" firstAttribute="leading" secondItem="Fw0-IT-oEE" secondAttribute="leading" constant="16" id="tSn-G0-qnf"/>
             </constraints>
             <nil key="simulatedStatusBarMetrics"/>

--- a/podcasts/LargeListSummaryViewController.xib
+++ b/podcasts/LargeListSummaryViewController.xib
@@ -11,6 +11,7 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="LargeListSummaryViewController" customModule="podcasts" customModuleProvider="target">
             <connections>
                 <outlet property="collectionView" destination="iJi-Yt-ez5" id="lqV-Pl-Ekp"/>
+                <outlet property="divider" destination="8lf-U1-Pgg" id="5tp-81-JYJ"/>
                 <outlet property="largeListCollectionViewHeight" destination="O9B-Ec-Krr" id="8nl-ey-dbz"/>
                 <outlet property="showAllBtn" destination="sF0-fo-tPV" id="NQp-Ou-W2d"/>
                 <outlet property="titleLabel" destination="0VX-rs-RFl" id="gRb-Ti-AKA"/>

--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -332,7 +332,11 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
 
         hasAppearedAlready = true // we use this so the page doesn't double load from viewDidLoad and viewDidAppear
 
-        Analytics.track(.podcastScreenShown, properties: ["uuid": podcastUUID])
+        var properties = ["uuid": podcastUUID]
+        if let listUuid {
+            properties["list_id"] = listUuid
+        }
+        Analytics.track(.podcastScreenShown, properties: properties)
     }
 
     override func viewDidDisappear(_ animated: Bool) {

--- a/podcasts/SinglePodcastViewController.swift
+++ b/podcasts/SinglePodcastViewController.swift
@@ -146,7 +146,7 @@ class SinglePodcastViewController: UIViewController, DiscoverSummaryProtocol {
             }
 
             if item.isSponsored == true {
-                AnalyticsHelper.adTapped(promotionUUID: item.uuid ?? "", podcastUUID: podcastUuid, category: item.categoryID ?? 0)
+                AnalyticsHelper.adTapped(promotionUUID: item.uuid ?? "", podcastUUID: podcastUuid, categoryID: item.categoryID ?? 0)
             }
         }
     }

--- a/podcasts/SinglePodcastViewController.swift
+++ b/podcasts/SinglePodcastViewController.swift
@@ -102,7 +102,6 @@ class SinglePodcastViewController: UIViewController, DiscoverSummaryProtocol {
         if let isSponsored = item?.isSponsored, isSponsored {
             typeBadgeLabel.text = L10n.discoverSponsored
             typeBadgeLabel.style = .primaryText02
-            podcastDescription.numberOfLines = 3
         } else {
             typeBadgeLabel.text = L10n.discoverFreshPick
             typeBadgeLabel.style = .support02

--- a/podcasts/SinglePodcastViewController.swift
+++ b/podcasts/SinglePodcastViewController.swift
@@ -102,6 +102,7 @@ class SinglePodcastViewController: UIViewController, DiscoverSummaryProtocol {
         if let isSponsored = item?.isSponsored, isSponsored {
             typeBadgeLabel.text = L10n.discoverSponsored
             typeBadgeLabel.style = .primaryText02
+            podcastDescription.numberOfLines = 3
         } else {
             typeBadgeLabel.text = L10n.discoverFreshPick
             typeBadgeLabel.style = .support02

--- a/podcasts/SinglePodcastViewController.swift
+++ b/podcasts/SinglePodcastViewController.swift
@@ -140,8 +140,14 @@ class SinglePodcastViewController: UIViewController, DiscoverSummaryProtocol {
 
         delegate?.show(discoverPodcast: podcast, placeholderImage: nil, isFeatured: true, listUuid: item?.uuid)
 
-        if let listId = item?.uuid, let podcastUuid = podcast.uuid {
-            AnalyticsHelper.podcastTappedFromList(listId: listId, podcastUuid: podcastUuid)
+        if let item, let podcastUuid = podcast.uuid {
+            if let listId = item.uuid {
+                AnalyticsHelper.podcastTappedFromList(listId: listId, podcastUuid: podcastUuid)
+            }
+
+            if item.isSponsored == true {
+                AnalyticsHelper.adTapped(promotionUUID: item.uuid ?? "", podcastUUID: podcastUuid, category: "\(item.categoryID ?? 0)")
+            }
         }
     }
 

--- a/podcasts/SinglePodcastViewController.swift
+++ b/podcasts/SinglePodcastViewController.swift
@@ -146,7 +146,7 @@ class SinglePodcastViewController: UIViewController, DiscoverSummaryProtocol {
             }
 
             if item.isSponsored == true {
-                AnalyticsHelper.adTapped(promotionUUID: item.uuid ?? "", podcastUUID: podcastUuid, category: "\(item.categoryID ?? 0)")
+                AnalyticsHelper.adTapped(promotionUUID: item.uuid ?? "", podcastUUID: podcastUuid, category: item.categoryID ?? 0)
             }
         }
     }

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -1392,6 +1392,12 @@ internal enum L10n {
   internal static var month: String { return L10n.tr("Localizable", "month") }
   /// Monthly
   internal static var monthly: String { return L10n.tr("Localizable", "monthly") }
+  /// Most Popular
+  internal static var mostPopular: String { return L10n.tr("Localizable", "most_popular") }
+  /// Most Popular in %1$@
+  internal static func mostPopularWithName(_ p1: Any) -> String {
+    return L10n.tr("Localizable", "most_popular_with_name", String(describing: p1))
+  }
   /// Move to Bottom
   internal static var moveToBottom: String { return L10n.tr("Localizable", "move_to_bottom") }
   /// Move to Top

--- a/podcasts/ThemeableTable.swift
+++ b/podcasts/ThemeableTable.swift
@@ -54,4 +54,17 @@ class ThemeableTable: UITableView {
         separatorColor = AppTheme.tableDividerColor(for: themeOverride)
         indicatorStyle = AppTheme.indicatorStyle()
     }
+
+    override var intrinsicContentSize: CGSize {
+        self.layoutIfNeeded()
+        return self.contentSize
+    }
+
+    override var contentSize: CGSize {
+        didSet {
+            UIView.performWithoutAnimation {
+                self.invalidateIntrinsicContentSize()
+            }
+        }
+    }
 }

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4060,3 +4060,9 @@
 
 /* Message displayed when doing heavy database operations */
 "database_migration" = "We're moving a few bits and bytes so the app runs faster...";
+
+/* A title used to a show a list of the most popular podcasts in a category with the provided name of that category. */
+"most_popular_with_name" = "Most Popular in %1$@";
+
+/* A title used to a show a list of the most popular podcasts in a category. */
+"most_popular" = "Most Popular";


### PR DESCRIPTION
This re-applies all commits from Pull Requests related to the Categories Redesign for the 7.63 release.

I cherry picked the commits from the following PRs:
#1717
#1712
#1660
#1648
#1631
#1626
#1622
#1621
#1620
#1614
#1611
#1605
#1604
#1602
#1570

https://github.com/Automattic/pocket-casts-ios/assets/3250/167f0c4f-384f-4b7b-8d46-cddd147d462c

## To test

All steps in previous PRs can be followed for thorough testing

* Open Discover tab
* Ensure that new Category tabs are shown
* Ensure no sponsored podcasts are shown on the Discover page (outside of the Featured carousel)
* Tap on a category tab
* Ensure a single Sponsored podcast appears here (for most categories)
* Ensure tapping the Sponsored podcast works

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
