### PR TITLE
Categories: Update tracks events for Categories redesign

### DIFF
--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -286,9 +286,12 @@ enum AnalyticsEvent: String {
 
     case discoverShown
     case discoverCategoryShown
+    case discoverCategoriesPillTapped
     case discoverFeaturedPodcastTapped
     case discoverFeaturedPodcastSubscribed
     case discoverShowAllTapped
+    case discoverCategoryCloseButtonTapped
+    case discoverCategoriesPickerPick
 
     case discoverListImpression
     case discoverListShowAllTapped

--- a/podcasts/Categories/CategoriesModalPicker.swift
+++ b/podcasts/Categories/CategoriesModalPicker.swift
@@ -6,6 +6,8 @@ struct CategoriesModalPicker: View {
     let categories: [DiscoverCategory]
 
     @Binding var selectedCategory: DiscoverCategory?
+    
+    let region: String?
 
     @EnvironmentObject var theme: Theme
 
@@ -85,7 +87,7 @@ struct CategoriesModalPicker: View {
         .padding(Constants.Padding.cell)
         .buttonize {
             selectedCategory = category
-            Analytics.track(.discoverCategoriesPickerPick, properties: ["id": category.id, "name": category.name ?? "all"])
+            Analytics.track(.discoverCategoriesPickerPick, properties: ["id": category.id ?? -1, "name": category.name ?? "all", "region": region ?? "none"])
         } customize: { config in
             config.label
                 .foregroundStyle(cellForeground)

--- a/podcasts/Categories/CategoriesModalPicker.swift
+++ b/podcasts/Categories/CategoriesModalPicker.swift
@@ -85,6 +85,7 @@ struct CategoriesModalPicker: View {
         .padding(Constants.Padding.cell)
         .buttonize {
             selectedCategory = category
+            Analytics.track(.discoverCategoriesPickerPick, properties: ["id": category.id, "name": category.name ?? "all"])
         } customize: { config in
             config.label
                 .foregroundStyle(cellForeground)

--- a/podcasts/Categories/CategoriesModalPicker.swift
+++ b/podcasts/Categories/CategoriesModalPicker.swift
@@ -6,7 +6,7 @@ struct CategoriesModalPicker: View {
     let categories: [DiscoverCategory]
 
     @Binding var selectedCategory: DiscoverCategory?
-    
+
     let region: String?
 
     @EnvironmentObject var theme: Theme

--- a/podcasts/Categories/CategoriesSelectorView.swift
+++ b/podcasts/Categories/CategoriesSelectorView.swift
@@ -18,7 +18,10 @@ struct CategoriesSelectorView: View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack {
                 if let categories, let popular {
-                    CategoriesPillsView(pillCategories: popular, overflowCategories: categories, selectedCategory: $discoverItemObservable.selectedCategory.animation(.easeOut(duration: 0.25)))
+                    CategoriesPillsView(pillCategories: popular,
+                                        overflowCategories: categories,
+                                        selectedCategory: $discoverItemObservable.selectedCategory.animation(.easeOut(duration: 0.25)),
+                                        region: discoverItemObservable.region)
                 } else {
                     PlaceholderPillsView()
                 }
@@ -55,6 +58,8 @@ struct CategoriesPillsView: View {
     let overflowCategories: [DiscoverCategory]
     @Binding var selectedCategory: DiscoverCategory?
 
+    let region: String?
+
     @State private var showingCategories = false
 
     @Namespace private var animation
@@ -62,11 +67,12 @@ struct CategoriesPillsView: View {
     var body: some View {
         if let selectedCategory {
             CloseButton(selectedCategory: $selectedCategory)
-            CategoryButton(category: selectedCategory, selectedCategory: $selectedCategory)
+            CategoryButton(category: selectedCategory, selectedCategory: $selectedCategory, region: region)
                 .matchedGeometryEffect(id: selectedCategory.id, in: animation)
         } else {
             Button(action: {
                 showingCategories.toggle()
+                Analytics.track(.discoverCategoriesPillTapped, properties: ["name": "all", "region": region ?? "none", "id": -1])
             }, label: {
                 HStack {
                     Text("All Categories")
@@ -75,11 +81,11 @@ struct CategoriesPillsView: View {
             })
             .buttonStyle(CategoryButtonStyle())
             ForEach(pillCategories, id: \.id) { category in
-                CategoryButton(category: category, selectedCategory: $selectedCategory)
+                CategoryButton(category: category, selectedCategory: $selectedCategory, region: region)
                 .matchedGeometryEffect(id: category.id, in: animation)
             }
             .sheet(isPresented: $showingCategories) {
-                CategoriesModalPicker(categories: overflowCategories, selectedCategory: $selectedCategory)
+                CategoriesModalPicker(categories: overflowCategories, selectedCategory: $selectedCategory, region: region)
                     .modify {
                         if #available(iOS 16.0, *) {
                             $0.presentationDetents([.medium, .large])
@@ -122,6 +128,8 @@ struct CategoryButton: View {
 
     @Binding var selectedCategory: DiscoverCategory?
 
+    let region: String?
+
     var isSelected: Bool {
         category.id == selectedCategory?.id
     }
@@ -129,7 +137,7 @@ struct CategoryButton: View {
     var body: some View {
         Button(action: {
             selectedCategory = category
-            Analytics.track(.discoverCategoriesPillTapped)
+            Analytics.track(.discoverCategoriesPillTapped, properties: ["name": category.name ?? "none", "region": region ?? "none", "id": category.id ?? -1])
         }, label: {
             Text(category.name ?? "")
         })

--- a/podcasts/Categories/CategoriesSelectorView.swift
+++ b/podcasts/Categories/CategoriesSelectorView.swift
@@ -108,6 +108,7 @@ struct CloseButton: View {
     var body: some View {
         Button(action: {
             self.selectedCategory = nil
+            Analytics.track(.discoverCategoryCloseButtonTapped)
         }, label: {
             Image(systemName: "xmark")
                 .imageScale(.small)
@@ -128,6 +129,7 @@ struct CategoryButton: View {
     var body: some View {
         Button(action: {
             selectedCategory = category
+            Analytics.track(.discoverCategoriesPillTapped)
         }, label: {
             Text(category.name ?? "")
         })

--- a/podcasts/Categories/CategoriesSelectorViewController.swift
+++ b/podcasts/Categories/CategoriesSelectorViewController.swift
@@ -7,6 +7,7 @@ class CategoriesSelectorViewController: ThemedHostingController<CategoriesSelect
     class DiscoverItemObservable: ObservableObject {
         @Published public var item: DiscoverItem?
         @Published public var selectedCategory: DiscoverCategory?
+        @Published public var region: String?
 
         lazy var load: (() async -> (categories: [DiscoverCategory], popular: [DiscoverCategory])?) = { [weak self] in
             guard let source = self?.item?.source else { return nil }
@@ -36,8 +37,9 @@ class CategoriesSelectorViewController: ThemedHostingController<CategoriesSelect
         self.delegate = delegate
     }
 
-    func populateFrom(item: PocketCastsServer.DiscoverItem) {
+    func populateFrom(item: PocketCastsServer.DiscoverItem, region: String?) {
         observable.item = item
+        observable.region = region
         view.setNeedsLayout()
     }
 

--- a/podcasts/CategorySummaryViewController.swift
+++ b/podcasts/CategorySummaryViewController.swift
@@ -40,7 +40,7 @@ class CategorySummaryViewController: UIViewController, UITableViewDataSource, UI
         self.delegate = delegate
     }
 
-    func populateFrom(item: DiscoverItem) {
+    func populateFrom(item: DiscoverItem, region: String?) {
         guard let source = item.source else { return }
 
         DiscoverServerHandler.shared.discoverCategories(source: source, completion: { [weak self] discoverCategories in

--- a/podcasts/CollectionSummaryViewController.swift
+++ b/podcasts/CollectionSummaryViewController.swift
@@ -76,7 +76,7 @@ class CollectionSummaryViewController: UIViewController, DiscoverSummaryProtocol
     // MARK: DiscoverSummaryProtocol
 
     var podcastCollection: PodcastCollection?
-    func populateFrom(item: DiscoverItem) {
+    func populateFrom(item: DiscoverItem, region: String?) {
         guard let source = item.source else { return }
 
         self.item = item

--- a/podcasts/CountrySummaryViewController.swift
+++ b/podcasts/CountrySummaryViewController.swift
@@ -42,7 +42,7 @@ class CountrySummaryViewController: UIViewController, DiscoverSummaryProtocol {
         self.delegate = delegate
     }
 
-    func populateFrom(item: DiscoverItem) {}
+    func populateFrom(item: DiscoverItem, region: String?) {}
 
     @objc private func changeCountryTapped() {
         let countryChooser = CountryChooserViewController()

--- a/podcasts/DiscoverSummaryProtocol.swift
+++ b/podcasts/DiscoverSummaryProtocol.swift
@@ -3,7 +3,7 @@ import PocketCastsServer
 
 protocol DiscoverSummaryProtocol: AnyObject {
     func registerDiscoverDelegate(_ delegate: DiscoverDelegate)
-    func populateFrom(item: DiscoverItem)
+    func populateFrom(item: DiscoverItem, region: String?)
 }
 
 protocol DiscoverDelegate: AnyObject {

--- a/podcasts/DiscoverViewController+CategoryRedesign.swift
+++ b/podcasts/DiscoverViewController+CategoryRedesign.swift
@@ -51,7 +51,7 @@ extension DiscoverViewController {
             summaryStyle: "large_list",
             summaryItemCount: Constants.popularItemsCount,
             source: source,
-            regions: items.first?.regions ?? [],
+            regions: [currentRegion ?? ""],
             categoryID: category.id
         )
 

--- a/podcasts/DiscoverViewController.swift
+++ b/podcasts/DiscoverViewController.swift
@@ -30,6 +30,8 @@ class DiscoverViewController: PCViewController {
 
     var discoverLayout: DiscoverLayout?
 
+    var currentRegion: String?
+
     private let coordinator: DiscoverCoordinator
 
     init(coordinator: DiscoverCoordinator) {
@@ -186,6 +188,9 @@ class DiscoverViewController: PCViewController {
     }
 
     private func apply(snapshot: NSDiffableDataSourceSnapshot<Int, DiscoverItem>, currentRegion: String) {
+
+        self.currentRegion = currentRegion
+
         for discoverItem in snapshot.itemIdentifiers {
             guard let type = discoverItem.type, let summaryStyle = discoverItem.summaryStyle else { continue }
             let expandedStyle = discoverItem.expandedStyle ?? ""
@@ -282,7 +287,7 @@ class DiscoverViewController: PCViewController {
         addToScrollView(viewController: viewController, for: discoverItem, isLast: false)
 
         controller.registerDiscoverDelegate(self)
-        controller.populateFrom(item: discoverItem)
+        controller.populateFrom(item: discoverItem, region: currentRegion)
     }
 
     func addToScrollView(viewController: UIViewController, for item: DiscoverItem, isLast: Bool) {

--- a/podcasts/FeaturedSummaryViewController.swift
+++ b/podcasts/FeaturedSummaryViewController.swift
@@ -164,7 +164,7 @@ class FeaturedSummaryViewController: SimpleNotificationsViewController, GridLayo
 
     // MARK: - DiscoverSummaryProtocol
 
-    func populateFrom(item: DiscoverItem) {
+    func populateFrom(item: DiscoverItem, region: String?) {
         guard let source = item.source, let title = item.title?.localized else { return }
 
         if let delegate = delegate {

--- a/podcasts/LargeListSummaryViewController.swift
+++ b/podcasts/LargeListSummaryViewController.swift
@@ -145,7 +145,7 @@ class LargeListSummaryViewController: DiscoverPeekViewController, DiscoverSummar
 
     // MARK: - Populate From Data
 
-    func populateFrom(item: DiscoverItem) {
+    func populateFrom(item: DiscoverItem, region: String?) {
         guard let source = item.source else { return }
         guard let title = item.title?.localized else { return }
 

--- a/podcasts/NetworkSummaryViewController.swift
+++ b/podcasts/NetworkSummaryViewController.swift
@@ -86,7 +86,7 @@ class NetworkSummaryViewController: DiscoverPeekViewController, DiscoverSummaryP
 
     // MARK: - Populate From Data
 
-    func populateFrom(item: DiscoverItem) {
+    func populateFrom(item: DiscoverItem, region: String?) {
         guard let source = item.source else { return }
 
         DiscoverServerHandler.shared.discoverNetworkList(source: source) { [weak self] podcastNetworks in

--- a/podcasts/SingleEpisodeViewController.swift
+++ b/podcasts/SingleEpisodeViewController.swift
@@ -110,7 +110,7 @@ extension SingleEpisodeViewController: DiscoverSummaryProtocol {
         viewModel.delegate = delegate
     }
 
-    func populateFrom(item: DiscoverItem) {
+    func populateFrom(item: DiscoverItem, region: String?) {
         viewModel.discoverItem = item
 
         typeBadgeLabel.text = (item.title ?? L10n.discoverFeaturedEpisode).uppercased()

--- a/podcasts/SinglePodcastViewController.swift
+++ b/podcasts/SinglePodcastViewController.swift
@@ -66,7 +66,7 @@ class SinglePodcastViewController: UIViewController, DiscoverSummaryProtocol {
 
     // MARK: DiscoverSummaryProtocol
 
-    func populateFrom(item: DiscoverItem) {
+    func populateFrom(item: DiscoverItem, region: String?) {
         guard let source = item.source else { return }
 
         self.item = item

--- a/podcasts/SmallPagedListSummaryViewController.swift
+++ b/podcasts/SmallPagedListSummaryViewController.swift
@@ -158,7 +158,7 @@ class SmallPagedListSummaryViewController: DiscoverPeekViewController, GridLayou
 
     // MARK: - DiscoverSummaryProtocol
 
-    func populateFrom(item: DiscoverItem) {
+    func populateFrom(item: DiscoverItem, region: String?) {
         guard let source = delegate?.replaceRegionCode(string: item.source), let title = item.title?.localized else { return }
 
         self.item = item


### PR DESCRIPTION
See https://github.com/Automattic/pocket-casts-android/pull/2155 on Android

* A `discover_categories_pill_tapped` event was added to only be logged when physically tapping on a pill
* A `discover_category_close_button_tapped` event was added to identify taps on the "Close" pill
* A `discover_categories_picker_pick` event was added to identify taps on categories from the modal view (rather than pills)

## To test

* Enable "Tracks Logging" under "Beta Features" in Profile
* Go to Discover
* Tap on "All Categories" pill at the top
* ✅ Ensure `discover_categories_picker_pick` is logged:
```
🔵 Tracked: discover_categories_pill_tapped ["region": "global", "id": -1, "name": "all"]
```
* Tap on "Business" from modal list
* ✅ Ensure `discover_category_shown` is logged:
```
🔵 Tracked: discover_category_shown ["id": 2, "name": "Business", "region": "global"]
```
* ✅ Ensure `discover_categories_picker_pick` is logged:
```
🔵 Tracked: discover_categories_picker_pick ["name": "Business", "id": 2, "region": "global"]
```
* Tap on Close pill to clear the category selection
* ✅ Ensure `discover_category_close_button_tapped` is logged:
```
🔵 Tracked: discover_category_close_button_tapped
```
* Tap on "True Crime" pill
* ✅ Ensure `discover_category_shown` is logged:
```
🔵 Tracked: discover_category_shown ["region": "global", "name": "True Crime", "id": 19]
```
* ✅ Ensure `discover_categories_pill_tapped` is logged:
```
🔵 Tracked: discover_categories_pill_tapped ["id": 19, "name": "True Crime", "region": "global"]
```

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
