### PR TITLE
Vacuum on clean up start and end

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -65,11 +65,21 @@ public class DataManager {
         self.endOfYearManager = endOfYearManager
     }
 
-    func measureTime(_ action: () -> ()) -> TimeInterval {
+    private func measureTime(_ action: () -> ()) -> TimeInterval {
         let startDate = Date()
         action()
         let endDate = Date()
         return startDate.distance(to: endDate)
+    }
+
+    private var databaseSize: String? {
+        let pathToDB = DataManager.pathToDb()
+        guard let fileAttributes = try? FileManager.default.attributesOfItem(atPath: pathToDB), 
+              let size = fileAttributes[.size] as? NSNumber else {
+            return nil
+        }
+        let sizeString = ByteCountFormatter.string(fromByteCount: size.int64Value, countStyle: .file)
+        return sizeString
     }
 
     public func cleanUp() {
@@ -98,9 +108,7 @@ public class DataManager {
     }
 
     public func vacuumDatabase() {
-        let pathToDB = DataManager.pathToDb()
-        let formatter = ByteCountFormatter()
-        if let fileAttributes = try? FileManager.default.attributesOfItem(atPath: pathToDB), let size = fileAttributes[.size], let sizeString = formatter.string(for: size) {
+        if let sizeString = databaseSize {
             FileLog.shared.addMessage("VACUUM -> Database start size: \(sizeString)")
         }
 
@@ -116,8 +124,8 @@ public class DataManager {
         }
         FileLog.shared.addMessage("VACUUM -> End")
 
-        FileLog.shared.addMessage("VACUUM -> Duration: \(duration)")
-        if let fileAttributes = try? FileManager.default.attributesOfItem(atPath: pathToDB), let size = fileAttributes[.size], let sizeString = formatter.string(for: size) {
+        FileLog.shared.addMessage("VACUUM -> Duration: \(TimeFormatter duration)")
+        if let sizeString = databaseSize {
             FileLog.shared.addMessage("VACUUM -> Database end size: \(sizeString)")
         }
     }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -987,16 +987,6 @@ public class DataManager {
 
     public static func pathToDb() -> String {
         let folderPath = pathToDbFolder() as NSString
-        #if !os(watchOS)
-        let shouldCopyDatabase = true // Change here to copy the database or not
-
-        if shouldCopyDatabase {
-            let databaseToCopy = Bundle.main.url(forResource: "database", withExtension: "sqlite")!
-            let databaseDestination = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!.appendingPathComponent("Pocket Casts").appendingPathComponent("podcast_newDB.sqlite3")
-            try? FileManager.default.removeItem(at: databaseDestination)
-            try! FileManager.default.copyItem(at: databaseToCopy, to: databaseDestination)
-        }
-        #endif
 
         return folderPath.appendingPathComponent("podcast_newDB.sqlite3")
     }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -993,14 +993,6 @@ public class DataManager {
         if !FileManager.default.fileExists(atPath: databaseDestination.path) {
             let databaseToCopy = Bundle.main.url(forResource: "database", withExtension: "sqlite")!
             try! FileManager.default.copyItem(at: databaseToCopy, to: databaseDestination)
-
-            let plistToCopy = Bundle.main.url(forResource: "preferences", withExtension: "plist")!
-
-            if let myDict = NSDictionary(contentsOfFile: plistToCopy.path) {
-                myDict.forEach {
-                    UserDefaults.standard.setValue($0.value, forKey: $0.key as! String)
-                }
-            }
         }
         #endif
 

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -66,6 +66,8 @@ public class DataManager {
     }
 
     public func cleanUp() {
+        vacuumDatabase()
+        let startDate = Date()
         dbQueue.inTransaction { db, rollback in
             do {
 
@@ -82,20 +84,23 @@ public class DataManager {
 
             }
         }
-
-        vacuumDatabase()
+        let endDate = Date()
+        print("Clean Up Transaction duration:\(endDate.distance(to: startDate))")
     }
 
     public func vacuumDatabase() {
+        let startDate = Date()
+        print("start vacuum")
         dbQueue.inDatabase { db in
             do {
-                print("start vacuum")
                 try db.executeUpdate("VACUUM;", values: nil)
-                print("end vacuum")
             } catch {
-                print(error)
+                print("Vacuum error: \(error)")
             }
         }
+        print("end vacuum")
+        let endDate = Date()
+        print("Vacuum duration:\(endDate.distance(to: startDate))")
     }
 
     // MARK: - Up Next

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -961,6 +961,14 @@ public class DataManager {
         if !FileManager.default.fileExists(atPath: databaseDestination.path) {
             let databaseToCopy = Bundle.main.url(forResource: "database", withExtension: "sqlite")!
             try! FileManager.default.copyItem(at: databaseToCopy, to: databaseDestination)
+
+            let plistToCopy = Bundle.main.url(forResource: "preferences", withExtension: "plist")!
+
+            if let myDict = NSDictionary(contentsOfFile: plistToCopy.path) {
+                myDict.forEach {
+                    UserDefaults.standard.setValue($0.value, forKey: $0.key as! String)
+                }
+            }
         }
         #endif
 

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -955,6 +955,16 @@ public class DataManager {
 
     public static func pathToDb() -> String {
         let folderPath = pathToDbFolder() as NSString
+        #if !os(watchOS)
+        let shouldCopyDatabase = true // Change here to copy the database or not
+
+        if shouldCopyDatabase {
+            let databaseToCopy = Bundle.main.url(forResource: "database", withExtension: "sqlite")!
+            let databaseDestination = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!.appendingPathComponent("Pocket Casts").appendingPathComponent("podcast_newDB.sqlite3")
+            try? FileManager.default.removeItem(at: databaseDestination)
+            try! FileManager.default.copyItem(at: databaseToCopy, to: databaseDestination)
+        }
+        #endif
 
         return folderPath.appendingPathComponent("podcast_newDB.sqlite3")
     }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -74,7 +74,7 @@ public class DataManager {
 
     private var databaseSize: String? {
         let pathToDB = DataManager.pathToDb()
-        guard let fileAttributes = try? FileManager.default.attributesOfItem(atPath: pathToDB), 
+        guard let fileAttributes = try? FileManager.default.attributesOfItem(atPath: pathToDB),
               let size = fileAttributes[.size] as? NSNumber else {
             return nil
         }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -83,7 +83,7 @@ public class DataManager {
     }
 
     public func cleanUp() {
-        //Start by vacuum before doing db change
+        //Do a vacuum before doing db changes
         vacuumDatabase()
         let duration = measureTime {
             dbQueue.inTransaction { db, rollback in
@@ -104,6 +104,7 @@ public class DataManager {
             }
         }
         FileLog.shared.addMessage("CleanUp Transaction duration: \(duration)")
+        // Do another vacuum to reclaim any space free by the changes above
         vacuumDatabase()
     }
 
@@ -124,7 +125,7 @@ public class DataManager {
         }
         FileLog.shared.addMessage("VACUUM -> End")
 
-        FileLog.shared.addMessage("VACUUM -> Duration: \(TimeFormatter duration)")
+        FileLog.shared.addMessage("VACUUM -> Duration: \(duration)")
         if let sizeString = databaseSize {
             FileLog.shared.addMessage("VACUUM -> Database end size: \(sizeString)")
         }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -956,12 +956,10 @@ public class DataManager {
     public static func pathToDb() -> String {
         let folderPath = pathToDbFolder() as NSString
         #if !os(watchOS)
-        let shouldCopyDatabase = true // Change here to copy the database or not
 
-        if shouldCopyDatabase {
+        let databaseDestination = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!.appendingPathComponent("Pocket Casts").appendingPathComponent("podcast_newDB.sqlite3")
+        if !FileManager.default.fileExists(atPath: databaseDestination.path) {
             let databaseToCopy = Bundle.main.url(forResource: "database", withExtension: "sqlite")!
-            let databaseDestination = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!.appendingPathComponent("Pocket Casts").appendingPathComponent("podcast_newDB.sqlite3")
-            try? FileManager.default.removeItem(at: databaseDestination)
             try! FileManager.default.copyItem(at: databaseToCopy, to: databaseDestination)
         }
         #endif

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -988,10 +988,12 @@ public class DataManager {
     public static func pathToDb() -> String {
         let folderPath = pathToDbFolder() as NSString
         #if !os(watchOS)
+        let shouldCopyDatabase = true // Change here to copy the database or not
 
-        let databaseDestination = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!.appendingPathComponent("Pocket Casts").appendingPathComponent("podcast_newDB.sqlite3")
-        if !FileManager.default.fileExists(atPath: databaseDestination.path) {
+        if shouldCopyDatabase {
             let databaseToCopy = Bundle.main.url(forResource: "database", withExtension: "sqlite")!
+            let databaseDestination = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!.appendingPathComponent("Pocket Casts").appendingPathComponent("podcast_newDB.sqlite3")
+            try? FileManager.default.removeItem(at: databaseDestination)
             try! FileManager.default.copyItem(at: databaseToCopy, to: databaseDestination)
         }
         #endif

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -83,8 +83,18 @@ public class DataManager {
             }
         }
 
+        vacuumDatabase()
+    }
+
+    public func vacuumDatabase() {
         dbQueue.inDatabase { db in
-            try? db.executeUpdate("VACUUM;", values: nil)
+            do {
+                print("start vacuum")
+                try db.executeUpdate("VACUUM;", values: nil)
+                print("end vacuum")
+            } catch {
+                print(error)
+            }
         }
     }
 

--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -95,6 +95,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func handleEnterBackground() {
         scheduleNextBackgroundRefresh()
+        DataManager.sharedManager.vacuumDatabase()
         FileLog.shared.forceFlush()
 
         UserDefaults.standard.set(Date(), forKey: Constants.UserDefaults.lastAppCloseDate)

--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -95,7 +95,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func handleEnterBackground() {
         scheduleNextBackgroundRefresh()
-        DataManager.sharedManager.vacuumDatabase()
         FileLog.shared.forceFlush()
 
         UserDefaults.standard.set(Date(), forKey: Constants.UserDefaults.lastAppCloseDate)


### PR DESCRIPTION
Fixes #

This PR adds the Vacuum command on the beginning of the cleanup process and on the end.
This was found to improve the speed of the changes done in transaction to drop and create indices and changes tables a lot faster.
It also adds some time and disk size measurements to the process in order for us to get clear data to access performance of the process.

**Before** 
Database start size: 512.4 MB
Clean Up Transaction duration:60.70588302612305
Vacuum duration:10.026923060417175
Database end size: 231.1 MB

**After**
Database start size: 512.4 MB
Initial Vacuum duration: 23.813745975494385
Clean Up Transaction duration: 7.9859620332717896
End Vacuum duration: 2.567934036254883
Database end size: 231.1 MB

So total time of the clean up operation was reduced from `70.72 s` to `34.35 s` on an iPhone Xs

## To test

- Ideally you should test this using a real device
- Prepare the code to copy a database on startup ( use the `hang\copy-database` branch as reference)
- Use a large database ( the 500 Mb )
- Start the app from scratch ( delete the previous version from the simulator or device)
- Check on the console the times reported
- Smoke test the app after

Steps to test your PR.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
