### PR TITLE
Update `CHANGELOG` and copies on `trunk`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,26 @@
+7.64
+-----
+- Show the Up Next bar on the tab bar. [#1613]
+- New design for the Podcasts grid layouts. [#1628]
+- Shake the device to restart Sleep Timer [#1627]
+- Playback fades out when finishing a sleep timer [#1629]
+- New design for the mini-player bar [#1634]
+
+7.63
+-----
+- Performance improvements
+
+7.62
+-----
+- Sleep Timer restarts automatically if you play again within 5 minutes [#1612]
+- Add redesigned Categories picker to the top of Discover. [#1621]
+
 7.61
 -----
-
+- Opening a shared podcast episode link with the current position, now opens on the right position. [#5]
+- Allow sharing of bookmarks directly on the bookmarks list. [#1558]
+- Adds support to displaying chapters from RSS [#1574]
+- Adds support to displaying episode artwork [#1574]
 
 7.60
 -----

--- a/fastlane/Frozen.strings
+++ b/fastlane/Frozen.strings
@@ -221,11 +221,11 @@
 /* Section header for the appearance settings related to artwork. */
 "appearance_artwork_header" = "Podcast Artwork";
 
-/* Prompt to toggle on the use of artwork that's embedded in the episode download files. */
-"appearance_embedded_artwork" = "Use Embedded Artwork";
+/* Prompt to toggle on the use of artwork per episode, as opposed to per podcast. */
+"appearance_embedded_artwork" = "Use Episode Artwork";
 
-/* Subtitle explaining embedded artwork in the episode download files. */
-"appearance_embedded_artwork_subtitle" = "Shows artwork from the downloaded file (if it exists) in the player instead of using the show's artwork.";
+/* Subtitle explaining episode artwork. */
+"appearance_embedded_artwork_subtitle" = "Some shows have custom artwork for certain episodes. Enable this option and Pocket Casts will display them instead of the show’s artwork.";
 
 /* Prompt to toggle whether the theme will match the device theme or not. */
 "appearance_match_device_theme" = "Use iOS Light/Dark Mode";
@@ -4006,7 +4006,7 @@
 "accessibility_hint_player_navigate_to_podcast_label" = "Tap to navigate to main podcast information page";
 
 /* Label that toggles the option for the user to choose which chapters of the podcast they want to skip (to not be played) */
-"skip_chapters" = "Skip chapters";
+"skip_chapters" = "Preselect chapters";
 
 /* Indicates the number of chapters in a podcast episode. %1$@ is the number of chapters. */
 "number_of_chapters" = "%1$@ chapters";
@@ -4020,11 +4020,11 @@
 /* Indicates the number of hidden chapters in a podcast episode. %1$@ is the number of hidden chapters. */
 "number_of_hidden_chapters" = "%1$@ hidden";
 
-/* Prompt for Plus mentioning Skip Chapters, don't translate Pocket Casts Plus */
-"skip_chapters_plus_prompt" = "Skip chapters and more with Pocket Casts Plus";
+/* Prompt for Plus mentioning Pre selecting Chapters, don't translate Pocket Casts Plus */
+"skip_chapters_plus_prompt" = "Preselect chapters and more with Pocket Casts Plus";
 
-/* Prompt for Plus mentioning Skip Chapters, don't translate Pocket Casts Patron */
-"skip_chapters_patron_prompt" = "Skip chapters and more with Pocket Casts Patron";
+/* Prompt for Plus mentioning Pre selecting Chapters, don't translate Pocket Casts Patron */
+"skip_chapters_patron_prompt" = "Preselect chapters and more with Pocket Casts Patron";
 
 /* Slumber Studios partnership feature announcement title */
 "announcement_slumber_title" = "Dream big";
@@ -4044,20 +4044,29 @@
 /* Message shown when the code is copied to clipboard */
 "announcement_slumber_code_copied" = "Code copied to clipboard";
 
-/* Announcement of Skip Chapters for Patron users */
-"announcement_deselect_chapters_patron" = "As part of your Patron subscription, you can now select and skip chapters in any episode that supports them.";
+/* Announcement of Preselect Chapters for Patron users */
+"announcement_deselect_chapters_patron" = "As part of your Patron subscription, you can now preselect and skip chapters automatically in any episode that supports them.";
 
-/* Announcement of Skip Chapters for Plus users */
-"announcement_deselect_chapters_plus" = "As part of your Plus subscription, you can now select and skip chapters in any episode that supports them.";
+/* Announcement of Preselect Chapters for Plus users */
+"announcement_deselect_chapters_plus" = "As part of your Plus subscription, you can now preselect and skip chapters automatically in any episode that supports them.";
 
-/* Announcement of Skip Chapters for free users */
-"announcement_deselect_chapters_free" = "Subscribe to Plus now so you can select and skip chapters in any episode that supports them.";
+/* Announcement of Preselect Chapters for free users */
+"announcement_deselect_chapters_free" = "Subscribe to Plus now so you can preselect and skip chapters automatically in any episode that supports them.";
 
 /* Used in a button meaning that the user undestood the message. */
 "got_it" = "Got it";
 
 /* Prompting the user to upgrade to Plus. Don't translate "Plus" */
 "upgrade_to_plus" = "Upgrade to Plus";
+
+/* A title used to a show a list of the most popular podcasts in a category with the provided name of that category. */
+"most_popular_with_name" = "Most Popular in %1$@";
+
+/* A title used to a show a list of the most popular podcasts in a category. */
+"most_popular" = "Most Popular";
+
+/* Message explaining why the sleep timer was restarted after the user shook the device */
+"device_shake_sleep_timer" = "Sleep timer restarted due to device shake";
 
 /* MARK: - InfoPlist.strings */
 

--- a/podcasts/ca.lproj/Localizable.strings
+++ b/podcasts/ca.lproj/Localizable.strings
@@ -222,7 +222,7 @@
     <key>appearance_embedded_artwork</key>
     <string>Empra les caràtules integrades</string>
     <key>appearance_embedded_artwork_subtitle</key>
-    <string>Al reproductor, mostra les caràtules des de l'arxiu integrat (si existeix), enlloc d'emprar les del programa.</string>
+    <string>Alguns podcasts tenen il·lustracions personalitzades per a certs episodis. Activa aquesta opció i Pocket Casts les mostrarà en lloc de la il·lustració del podcast.</string>
     <key>appearance_light_theme</key>
     <string>Tema clar</string>
     <key>appearance_match_device_theme</key>
@@ -451,6 +451,8 @@
     <string>Esborrar només del dispositiu</string>
     <key>deselect_all</key>
     <string>Anul·lar totes les seleccions</string>
+    <key>device_shake_sleep_timer</key>
+    <string>El temporitzador de son s'ha reiniciat perquè s'ha agitat el dispositiu</string>
     <key>discover</key>
     <string>Descobrir</string>
     <key>discover_all_episodes</key>
@@ -1217,6 +1219,10 @@ Nota: És possible que t'hagis d'enviar el fitxer OPML a tu mateix per correu el
     <string>mes</string>
     <key>monthly</key>
     <string>Mensualment</string>
+    <key>most_popular</key>
+    <string>Més popular</string>
+    <key>most_popular_with_name</key>
+    <string>Més popular a %1$@</string>
     <key>move_to_bottom</key>
     <string>Moure al final</string>
     <key>move_to_top</key>
@@ -2423,7 +2429,7 @@ Si vols noves idees, vés a la pestanya Descobrir.</string>
     <key>skip_back</key>
     <string>Endarrerir</string>
     <key>skip_chapters</key>
-    <string>Saltar capítols</string>
+    <string>Capítols preseleccionats</string>
     <key>skip_chapters_patron_prompt</key>
     <string>Salta capítols i més amb Pocket Casts Patron</string>
     <key>skip_chapters_plus_prompt</key>
@@ -2662,9 +2668,9 @@ Mai es compartirà la teva adreça de correu electrònic, ni la contrasenya ni c
     <key>watch_no_podcasts</key>
     <string>No hi ha podcasts</string>
     <key>watch_nothing_playing_subtitle</key>
-    <string>Gaudeix del silenci o troba alguna cosa nova per reproduir.
+    <string>Gaudeix del silenci o troba alguna cosa nova per a reproduir.
 
-Sincerament, ambdues són bones decisions.</string>
+Sincerament, totes dues són bones decisions. 🙂</string>
     <key>watch_nothing_playing_title</key>
     <string>No sona res</string>
     <key>watch_source_msg</key>

--- a/podcasts/de.lproj/Localizable.strings
+++ b/podcasts/de.lproj/Localizable.strings
@@ -154,11 +154,11 @@ Tippe auf den Button unten, um dich erneut in deinem Pocket Casts-Konto anzumeld
     <key>announcement_bookmarks_title_beta</key>
     <string>Sei beim Testen der Beta-Version der Lesezeichen dabei!</string>
     <key>announcement_deselect_chapters_free</key>
-    <string>Abonniere Plus jetzt, damit du in jeder Folge Kapitel auswählen und überspringen kannst (falls unterstützt).</string>
+    <string>Abonniere Plus jetzt, damit du in jeder Folge Kapitel vorauswählen und automatisch überspringen kannst (falls unterstützt).</string>
     <key>announcement_deselect_chapters_patron</key>
-    <string>Als Teil deines Patron-Abonnements kannst du nun in jeder Folge Kapitel auswählen und überspringen kannst (falls unterstützt).</string>
+    <string>Als Teil deines Patron-Abonnements kannst du nun in jeder Folge Kapitel vorauswählen und automatisch überspringen (falls unterstützt).</string>
     <key>announcement_deselect_chapters_plus</key>
-    <string>Als Teil deines Plus-Abonnements kannst du nun in jeder Folge Kapitel auswählen und überspringen kannst (falls unterstützt).</string>
+    <string>Als Teil deines Plus-Abonnements kannst du nun in jeder Folge Kapitel vorauswählen und automatisch überspringen (falls unterstützt).</string>
     <key>announcement_slumber_code_copied</key>
     <string>Code in Zwischenablage kopiert</string>
     <key>announcement_slumber_non_plus_description</key>
@@ -220,9 +220,9 @@ Tippe auf den Button unten, um dich erneut in deinem Pocket Casts-Konto anzumeld
     <key>appearance_dark_theme</key>
     <string>Dunkles Theme</string>
     <key>appearance_embedded_artwork</key>
-    <string>Eingebettete Covers verwenden</string>
+    <string>Cover der Folge verwenden</string>
     <key>appearance_embedded_artwork_subtitle</key>
-    <string>Dadurch wird im Player anstelle des Podcast-Covers das Cover aus der heruntergeladenen Datei (falls vorhanden) angezeigt.</string>
+    <string>Für manche Shows stehen für bestimmte Folgen individuelle Cover zur Verfügung. Aktiviere diese Option, damit Pocket Casts diese anstelle des Show-Covers anzeigt.</string>
     <key>appearance_light_theme</key>
     <string>Helles Theme</string>
     <key>appearance_match_device_theme</key>
@@ -1221,6 +1221,10 @@ Podcasts mit</string>
     <string>Monat</string>
     <key>monthly</key>
     <string>Monatlich</string>
+    <key>most_popular</key>
+    <string>Am beliebtesten</string>
+    <key>most_popular_with_name</key>
+    <string>Am beliebtesten in %1$@</string>
     <key>move_to_bottom</key>
     <string>Ans Ende verschieben</string>
     <key>move_to_top</key>
@@ -2428,11 +2432,11 @@ Viele Anregungen findest du im Tab „Entdecken“.</string>
     <key>skip_back</key>
     <string>Zurück</string>
     <key>skip_chapters</key>
-    <string>Kapitel überspringen</string>
+    <string>Kapitel vorauswählen</string>
     <key>skip_chapters_patron_prompt</key>
-    <string>Überspringe Kapitel und mehr mit Pocket Casts Patron</string>
+    <string>Kapitel vorauswählen und mehr mit Pocket Casts Patron</string>
     <key>skip_chapters_plus_prompt</key>
-    <string>Überspringe Kapitel und mehr mit Pocket Casts Plus</string>
+    <string>Kapitel vorauswählen und mehr mit Pocket Casts Plus</string>
     <key>skip_forward</key>
     <string>Vor</string>
     <key>sleep_timer</key>

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -217,11 +217,11 @@
 /* Section header for the appearance settings related to artwork. */
 "appearance_artwork_header" = "Podcast Artwork";
 
-/* Prompt to toggle on the use of artwork that's embedded in the episode download files. */
-"appearance_embedded_artwork" = "Use Embedded Artwork";
+/* Prompt to toggle on the use of artwork per episode, as opposed to per podcast. */
+"appearance_embedded_artwork" = "Use Episode Artwork";
 
-/* Subtitle explaining embedded artwork in the episode download files. */
-"appearance_embedded_artwork_subtitle" = "Shows artwork from the downloaded file (if it exists) in the player instead of using the show's artwork.";
+/* Subtitle explaining episode artwork. */
+"appearance_embedded_artwork_subtitle" = "Some shows have custom artwork for certain episodes. Enable this option and Pocket Casts will display them instead of the show’s artwork.";
 
 /* Prompt to toggle whether the theme will match the device theme or not. */
 "appearance_match_device_theme" = "Use iOS Light/Dark Mode";
@@ -4054,3 +4054,12 @@
 
 /* Prompting the user to upgrade to Plus. Don't translate "Plus" */
 "upgrade_to_plus" = "Upgrade to Plus";
+
+/* A title used to a show a list of the most popular podcasts in a category with the provided name of that category. */
+"most_popular_with_name" = "Most Popular in %1$@";
+
+/* A title used to a show a list of the most popular podcasts in a category. */
+"most_popular" = "Most Popular";
+
+/* Message explaining why the sleep timer was restarted after the user shook the device */
+"device_shake_sleep_timer" = "Sleep timer restarted due to device shake";

--- a/podcasts/es-MX.lproj/Localizable.strings
+++ b/podcasts/es-MX.lproj/Localizable.strings
@@ -154,11 +154,11 @@ Toca el botón de abajo para volver a acceder a tu cuenta de Pocket Casts.</stri
     <key>announcement_bookmarks_title_beta</key>
     <string>¡Únete a nosotros en las pruebas beta de marcadores!</string>
     <key>announcement_deselect_chapters_free</key>
-    <string>Suscríbete a Plus y podrás elegir y omitir capítulos en los episodios compatibles.</string>
+    <string>Suscríbete a Plus y podrás preseleccionar y omitir capítulos automáticamente en los episodios compatibles.</string>
     <key>announcement_deselect_chapters_patron</key>
-    <string>Como parte de tu suscripción a Patron, ahora podrás elegir y omitir capítulos en los episodios compatibles.</string>
+    <string>Como parte de tu suscripción a Patron, ahora podrás preseleccionar y omitir capítulos automáticamente en los episodios compatibles.</string>
     <key>announcement_deselect_chapters_plus</key>
-    <string>Como parte de tu suscripción a Plus, ahora podrás elegir y omitir capítulos en los episodios compatibles.</string>
+    <string>Como parte de tu suscripción a Plus, ahora podrás preseleccionar y omitir capítulos automáticamente en los episodios compatibles.</string>
     <key>announcement_slumber_code_copied</key>
     <string>El código se ha copiado en el portapapeles</string>
     <key>announcement_slumber_non_plus_description</key>
@@ -220,9 +220,9 @@ Toca el botón de abajo para volver a acceder a tu cuenta de Pocket Casts.</stri
     <key>appearance_dark_theme</key>
     <string>Tema oscuro</string>
     <key>appearance_embedded_artwork</key>
-    <string>Usar ilustraciones integradas</string>
+    <string>Usar carátula del episodio</string>
     <key>appearance_embedded_artwork_subtitle</key>
-    <string>Muestra las ilustraciones del archivo descargado (si corresponde) en el reproductor en lugar de utilizar el material gráfico del programa.</string>
+    <string>Algunos programas disponen de carátulas personalizadas para determinados episodios. Activa esta opción y Pocket Casts las mostrará en lugar de la carátula del programa.</string>
     <key>appearance_light_theme</key>
     <string>Tema claro</string>
     <key>appearance_match_device_theme</key>
@@ -1221,6 +1221,10 @@ pódcast contigo</string>
     <string>mes</string>
     <key>monthly</key>
     <string>Mensual</string>
+    <key>most_popular</key>
+    <string>Los más populares</string>
+    <key>most_popular_with_name</key>
+    <string>Los más populares en %1$@</string>
     <key>move_to_bottom</key>
     <string>Mover al final</string>
     <key>move_to_top</key>
@@ -2428,11 +2432,11 @@ Si buscas inspiración, prueba la pestaña Descubrir.</string>
     <key>skip_back</key>
     <string>Retroceder</string>
     <key>skip_chapters</key>
-    <string>Omitir capítulos</string>
+    <string>Preselección de capítulos</string>
     <key>skip_chapters_patron_prompt</key>
-    <string>Omite capítulos y haz otros cambios con Pocket Casts Patron</string>
+    <string>Preselecciona capítulos y haz otros ajustes con Pocket Casts Patron</string>
     <key>skip_chapters_plus_prompt</key>
-    <string>Omite capítulos y haz otros cambios con Pocket Casts Plus</string>
+    <string>Preselecciona capítulos y haz otros ajustes con Pocket Casts Plus</string>
     <key>skip_forward</key>
     <string>Adelantar</string>
     <key>sleep_timer</key>

--- a/podcasts/es.lproj/Localizable.strings
+++ b/podcasts/es.lproj/Localizable.strings
@@ -154,11 +154,11 @@ Toca el botón de abajo para volver a acceder a tu cuenta de Pocket Casts.</stri
     <key>announcement_bookmarks_title_beta</key>
     <string>¡Únete a nosotros en las pruebas beta de marcadores!</string>
     <key>announcement_deselect_chapters_free</key>
-    <string>Suscríbete a Plus y podrás elegir y omitir capítulos en los episodios compatibles.</string>
+    <string>Suscríbete a Plus y podrás preseleccionar y omitir capítulos automáticamente en los episodios compatibles.</string>
     <key>announcement_deselect_chapters_patron</key>
-    <string>Como parte de tu suscripción a Patron, ahora podrás elegir y omitir capítulos en los episodios compatibles.</string>
+    <string>Como parte de tu suscripción a Patron, ahora podrás preseleccionar y omitir capítulos automáticamente en los episodios compatibles.</string>
     <key>announcement_deselect_chapters_plus</key>
-    <string>Como parte de tu suscripción a Plus, ahora podrás elegir y omitir capítulos en los episodios compatibles.</string>
+    <string>Como parte de tu suscripción a Plus, ahora podrás preseleccionar y omitir capítulos automáticamente en los episodios compatibles.</string>
     <key>announcement_slumber_code_copied</key>
     <string>El código se ha copiado en el portapapeles</string>
     <key>announcement_slumber_non_plus_description</key>
@@ -220,9 +220,9 @@ Toca el botón de abajo para volver a acceder a tu cuenta de Pocket Casts.</stri
     <key>appearance_dark_theme</key>
     <string>Tema oscuro</string>
     <key>appearance_embedded_artwork</key>
-    <string>Utilizar carátulas integradas</string>
+    <string>Usar carátula del episodio</string>
     <key>appearance_embedded_artwork_subtitle</key>
-    <string>En el reproductor, muestra las carátulas desde el archivo descargado (si existe), en lugar de utilizar las del programa.</string>
+    <string>Algunos programas disponen de carátulas personalizadas para determinados episodios. Activa esta opción y Pocket Casts las mostrará en lugar de la carátula del programa.</string>
     <key>appearance_light_theme</key>
     <string>Tema claro</string>
     <key>appearance_match_device_theme</key>
@@ -1221,6 +1221,10 @@ pódcast contigo</string>
     <string>mes</string>
     <key>monthly</key>
     <string>Mensual</string>
+    <key>most_popular</key>
+    <string>Los más populares</string>
+    <key>most_popular_with_name</key>
+    <string>Los más populares en %1$@</string>
     <key>move_to_bottom</key>
     <string>Mover al final</string>
     <key>move_to_top</key>
@@ -2428,11 +2432,11 @@ Si quieres nuevas ideas, ve a la pestaña Descubrir.</string>
     <key>skip_back</key>
     <string>Saltar atrás</string>
     <key>skip_chapters</key>
-    <string>Omitir capítulos</string>
+    <string>Preselección de capítulos</string>
     <key>skip_chapters_patron_prompt</key>
-    <string>Omite capítulos y haz otros cambios con Pocket Casts Patron</string>
+    <string>Preselecciona capítulos y haz otros ajustes con Pocket Casts Patron</string>
     <key>skip_chapters_plus_prompt</key>
-    <string>Omite capítulos y haz otros cambios con Pocket Casts Plus</string>
+    <string>Preselecciona capítulos y haz otros ajustes con Pocket Casts Plus</string>
     <key>skip_forward</key>
     <string>Saltar adelante</string>
     <key>sleep_timer</key>

--- a/podcasts/fr-CA.lproj/Localizable.strings
+++ b/podcasts/fr-CA.lproj/Localizable.strings
@@ -154,11 +154,11 @@ Tap the button below to sign into your Pocket Casts account again.</string>
     <key>announcement_bookmarks_title_beta</key>
     <string>Rejoignez-nous pour le bêta-test des favoris !</string>
     <key>announcement_deselect_chapters_free</key>
-    <string>Abonnez-vous à Plus dès maintenant pour pouvoir sélectionner et passer des chapitres dans n’importe quel épisode qui en comporte.</string>
+    <string>Abonnez-vous à Plus dès maintenant pour pouvoir présélectionner et passer automatiquement des chapitres dans n’importe quel épisode qui en comporte.</string>
     <key>announcement_deselect_chapters_patron</key>
-    <string>Dans le cadre de votre abonnement Patron, vous pouvez maintenant sélectionner et passer des chapitres dans n’importe quel épisode qui en comporte.</string>
+    <string>Dans le cadre de votre abonnement Patron, vous pouvez maintenant présélectionner et passer automatiquement des chapitres dans n’importe quel épisode qui en comporte.</string>
     <key>announcement_deselect_chapters_plus</key>
-    <string>Dans le cadre de votre abonnement Plus, vous pouvez maintenant sélectionner et passer des chapitres dans n’importe quel épisode qui en comporte.</string>
+    <string>Dans le cadre de votre abonnement Plus, vous pouvez maintenant présélectionner et passer automatiquement des chapitres dans n’importe quel épisode qui en comporte.</string>
     <key>announcement_slumber_code_copied</key>
     <string>Code copié dans le presse-papiers</string>
     <key>announcement_slumber_non_plus_description</key>
@@ -220,9 +220,9 @@ Tap the button below to sign into your Pocket Casts account again.</string>
     <key>appearance_dark_theme</key>
     <string>Thème sombre</string>
     <key>appearance_embedded_artwork</key>
-    <string>Utiliser l’illustration intégrée</string>
+    <string>Utiliser l’illustration de l’épisode</string>
     <key>appearance_embedded_artwork_subtitle</key>
-    <string>Affiche l’illustration des émissions du fichier téléchargé (s’il existe) dans le lecteur plutôt que d’utiliser l’illustration de l’émission.</string>
+    <string>Certaines émissions ont des illustrations personnalisées pour certains épisodes. Activez cette option et Pocket Casts les affichera à la place de l’illustration de l’émission.</string>
     <key>appearance_light_theme</key>
     <string>Thème clair</string>
     <key>appearance_match_device_theme</key>
@@ -1221,6 +1221,10 @@ podcasts partout avec</string>
     <string>mois</string>
     <key>monthly</key>
     <string>Mensuel</string>
+    <key>most_popular</key>
+    <string>Les plus populaires</string>
+    <key>most_popular_with_name</key>
+    <string>Les plus populaires dans %1$@</string>
     <key>move_to_bottom</key>
     <string>Déplacer au bas</string>
     <key>move_to_top</key>
@@ -2428,11 +2432,11 @@ Si vous voulez obtenir des suggestions, essayez l’onglet Découvertes.</string
     <key>skip_back</key>
     <string>Saut vers l’arrière</string>
     <key>skip_chapters</key>
-    <string>Sauter les chapitres</string>
+    <string>Présélectionner des chapitres</string>
     <key>skip_chapters_patron_prompt</key>
-    <string>Passer des chapitres et plus encore avec Pocket Casts Patron</string>
+    <string>Présélectionner des chapitres et plus encore avec Pocket Casts Patron</string>
     <key>skip_chapters_plus_prompt</key>
-    <string>Passer des chapitres et plus encore avec Pocket Casts Plus</string>
+    <string>Présélectionner des chapitres et plus encore avec Pocket Casts Plus</string>
     <key>skip_forward</key>
     <string>Saut vers l’avant</string>
     <key>sleep_timer</key>

--- a/podcasts/fr.lproj/Localizable.strings
+++ b/podcasts/fr.lproj/Localizable.strings
@@ -154,11 +154,11 @@ Tap the button below to sign into your Pocket Casts account again.</string>
     <key>announcement_bookmarks_title_beta</key>
     <string>Rejoignez-nous pour le bêta-test des favoris !</string>
     <key>announcement_deselect_chapters_free</key>
-    <string>Abonnez-vous à Plus dès maintenant pour pouvoir sélectionner et passer des chapitres dans n’importe quel épisode qui en comporte.</string>
+    <string>Abonnez-vous à Plus dès maintenant pour pouvoir présélectionner et passer automatiquement des chapitres dans n’importe quel épisode qui en comporte.</string>
     <key>announcement_deselect_chapters_patron</key>
-    <string>Dans le cadre de votre abonnement Patron, vous pouvez maintenant sélectionner et passer des chapitres dans n’importe quel épisode qui en comporte.</string>
+    <string>Dans le cadre de votre abonnement Patron, vous pouvez maintenant présélectionner et passer automatiquement des chapitres dans n’importe quel épisode qui en comporte.</string>
     <key>announcement_deselect_chapters_plus</key>
-    <string>Dans le cadre de votre abonnement Plus, vous pouvez maintenant sélectionner et passer des chapitres dans n’importe quel épisode qui en comporte.</string>
+    <string>Dans le cadre de votre abonnement Plus, vous pouvez maintenant présélectionner et passer automatiquement des chapitres dans n’importe quel épisode qui en comporte.</string>
     <key>announcement_slumber_code_copied</key>
     <string>Code copié dans le presse-papiers</string>
     <key>announcement_slumber_non_plus_description</key>
@@ -220,9 +220,9 @@ Tap the button below to sign into your Pocket Casts account again.</string>
     <key>appearance_dark_theme</key>
     <string>Thème sombre</string>
     <key>appearance_embedded_artwork</key>
-    <string>Utiliser les illustrations intégrées</string>
+    <string>Utiliser l’illustration de l’épisode</string>
     <key>appearance_embedded_artwork_subtitle</key>
-    <string>Affiche l’illustration du fichier téléchargé (si elle existe) dans le lecteur au lieu d’utiliser l’illustration de l’émission.</string>
+    <string>Certaines émissions ont des illustrations personnalisées pour certains épisodes. Activez cette option et Pocket Casts les affichera à la place de l’illustration de l’émission.</string>
     <key>appearance_light_theme</key>
     <string>Thème clair</string>
     <key>appearance_match_device_theme</key>
@@ -1221,6 +1221,10 @@ podcasts partout avec</string>
     <string>mois</string>
     <key>monthly</key>
     <string>Mensuellement</string>
+    <key>most_popular</key>
+    <string>Les plus populaires</string>
+    <key>most_popular_with_name</key>
+    <string>Les plus populaires dans %1$@</string>
     <key>move_to_bottom</key>
     <string>Déplacer vers le bas</string>
     <key>move_to_top</key>
@@ -2428,11 +2432,11 @@ Si vous cherchez de l’inspiration, consultez l’onglet Découvrir.</string>
     <key>skip_back</key>
     <string>Retour rapide</string>
     <key>skip_chapters</key>
-    <string>Sauter les chapitres</string>
+    <string>Présélectionner des chapitres</string>
     <key>skip_chapters_patron_prompt</key>
-    <string>Passer des chapitres et plus encore avec Pocket Casts Patron</string>
+    <string>Présélectionner des chapitres et plus encore avec Pocket Casts Patron</string>
     <key>skip_chapters_plus_prompt</key>
-    <string>Passer des chapitres et plus encore avec Pocket Casts Plus</string>
+    <string>Présélectionner des chapitres et plus encore avec Pocket Casts Plus</string>
     <key>skip_forward</key>
     <string>Avance rapide</string>
     <key>sleep_timer</key>

--- a/podcasts/it.lproj/Localizable.strings
+++ b/podcasts/it.lproj/Localizable.strings
@@ -154,11 +154,11 @@ Tocca il pulsante in basso per accedere nuovamente al tuo account Pocket Casts.<
     <key>announcement_bookmarks_title_beta</key>
     <string>Unisciti a noi per il beta test della funzionalità dei segnalibri.</string>
     <key>announcement_deselect_chapters_free</key>
-    <string>Iscriviti a Plus ora per selezionare e saltare i capitoli in qualsiasi episodio che li supporta.</string>
+    <string>Iscriviti a Plus ora per preselezionare e saltare i capitoli automaticamente in qualsiasi episodio che li supporta.</string>
     <key>announcement_deselect_chapters_patron</key>
-    <string>Grazie al tuo abbonamento a Patron, ora puoi selezionare e saltare i capitoli in qualsiasi episodio che li supporta.</string>
+    <string>Grazie al tuo abbonamento a Patron, ora puoi preselezionare e saltare i capitoli automaticamente in qualsiasi episodio che li supporta.</string>
     <key>announcement_deselect_chapters_plus</key>
-    <string>Grazie al tuo abbonamento a Plus, ora puoi selezionare e saltare i capitoli in qualsiasi episodio che li supporta.</string>
+    <string>Grazie al tuo abbonamento a Plus, ora puoi preselezionare e saltare i capitoli automaticamente in qualsiasi episodio che li supporta.</string>
     <key>announcement_slumber_code_copied</key>
     <string>Codice copiato negli appunti</string>
     <key>announcement_slumber_non_plus_description</key>
@@ -220,9 +220,9 @@ Tocca il pulsante in basso per accedere nuovamente al tuo account Pocket Casts.<
     <key>appearance_dark_theme</key>
     <string>Tema scuro</string>
     <key>appearance_embedded_artwork</key>
-    <string>Usa grafica incorporata</string>
+    <string>Usa la grafica dell'episodio</string>
     <key>appearance_embedded_artwork_subtitle</key>
-    <string>Mostra la grafica del file scaricato (se esiste) nel lettore invece di usare la grafica dello show.</string>
+    <string>Alcuni programmi hanno grafiche personalizzate per certi episodi. Abilita questa opzione e Pocket Casts le mostrerà al posto della grafica del programma.</string>
     <key>appearance_light_theme</key>
     <string>Tema chiaro</string>
     <key>appearance_match_device_theme</key>
@@ -1221,6 +1221,10 @@ pocast con te</string>
     <string>mese</string>
     <key>monthly</key>
     <string>Mensile</string>
+    <key>most_popular</key>
+    <string>Più popolari</string>
+    <key>most_popular_with_name</key>
+    <string>Più popolari in %1$@</string>
     <key>move_to_bottom</key>
     <string>Sposta in fondo</string>
     <key>move_to_top</key>
@@ -2428,11 +2432,11 @@ Se stai cercando ispirazione, prova la scheda Scopri.</string>
     <key>skip_back</key>
     <string>Salta indietro</string>
     <key>skip_chapters</key>
-    <string>Salta capitoli</string>
+    <string>Preseleziona i capitoli</string>
     <key>skip_chapters_patron_prompt</key>
-    <string>Salta capitoli e altro ancora con Pocket Casts Patron</string>
+    <string>Preseleziona capitoli e altro ancora con Pocket Casts Patron</string>
     <key>skip_chapters_plus_prompt</key>
-    <string>Salta capitoli e altro ancora con Pocket Casts Plus</string>
+    <string>Preseleziona capitoli e altro ancora con Pocket Casts Plus</string>
     <key>skip_forward</key>
     <string>Salta in avanti</string>
     <key>sleep_timer</key>

--- a/podcasts/ja.lproj/Localizable.strings
+++ b/podcasts/ja.lproj/Localizable.strings
@@ -154,11 +154,11 @@
     <key>announcement_bookmarks_title_beta</key>
     <string>ブックマークのベータテストに参加してください !</string>
     <key>announcement_deselect_chapters_free</key>
-    <string>今すぐ Plus に登録すると、チャプターに対応するどのエピソードでも、選択したチャプターをスキップできます。</string>
+    <string>今すぐ Plus に登録すると、チャプターに対応するどのエピソードでも、事前に選択したチャプターを自動でスキップできます。</string>
     <key>announcement_deselect_chapters_patron</key>
-    <string>Patron サブスクリプションの一環として、チャプターに対応するどのエピソードでも、選択したチャプターをスキップできるようになりました。</string>
+    <string>Patron サブスクリプションの一環として、チャプターに対応するどのエピソードでも、事前に選択したチャプターを自動でスキップできるようになりました。</string>
     <key>announcement_deselect_chapters_plus</key>
-    <string>Plus サブスクリプションの一環として、チャプターに対応するどのエピソードでも、選択したチャプターをスキップできるようになりました。</string>
+    <string>Plus サブスクリプションの一環として、チャプターに対応するどのエピソードでも、事前に選択したチャプターを自動でスキップできるようになりました。</string>
     <key>announcement_slumber_code_copied</key>
     <string>コードをクリップボードにコピーしました</string>
     <key>announcement_slumber_non_plus_description</key>
@@ -220,9 +220,9 @@
     <key>appearance_dark_theme</key>
     <string>ダークテーマ</string>
     <key>appearance_embedded_artwork</key>
-    <string>埋め込みアートワークを使用</string>
+    <string>エピソードのアートワークを使用</string>
     <key>appearance_embedded_artwork_subtitle</key>
-    <string>番組のアートワークを使用する代わりに、プレーヤーのダウンロードファイルからのアートワークを表示します (存在する場合)。</string>
+    <string>一部の番組には特定のエピソードにカスタムのアートワークがあります。 このオプションを有効化すると、Pocket Casts は番組のアートワークではなく、そのカスタムのアートワークを表示します。</string>
     <key>appearance_light_theme</key>
     <string>ライトテーマ</string>
     <key>appearance_match_device_theme</key>
@@ -1221,6 +1221,10 @@ Pocket Casts で共有すればここに表示されるようになります</st
     <string>月</string>
     <key>monthly</key>
     <string>月払い</string>
+    <key>most_popular</key>
+    <string>人気上位</string>
+    <key>most_popular_with_name</key>
+    <string> %1$@ の人気上位</string>
     <key>move_to_bottom</key>
     <string>一番下へ移動</string>
     <key>move_to_top</key>
@@ -2428,11 +2432,11 @@ Pocket Casts で共有すればここに表示されるようになります</st
     <key>skip_back</key>
     <string>巻き戻し</string>
     <key>skip_chapters</key>
-    <string>チャプターをスキップ</string>
+    <string>チャプターを事前に選択</string>
     <key>skip_chapters_patron_prompt</key>
-    <string>Pocket Casts Patron でチャプターのスキップやその他の機能を利用</string>
+    <string>Pocket Casts Patron でチャプターの事前選択やその他の機能を利用</string>
     <key>skip_chapters_plus_prompt</key>
-    <string>Pocket Casts Plus でチャプターのスキップやその他の機能を利用</string>
+    <string>Pocket Casts Plus でチャプターの事前選択やその他の機能を利用</string>
     <key>skip_forward</key>
     <string>早送り</string>
     <key>sleep_timer</key>

--- a/podcasts/nl.lproj/Localizable.strings
+++ b/podcasts/nl.lproj/Localizable.strings
@@ -154,11 +154,11 @@ Tik op de onderstaande knop om opnieuw in te loggen bij je Pocket Casts-account.
     <key>announcement_bookmarks_title_beta</key>
     <string>Doe mee met de bètatests voor bladwijzers!</string>
     <key>announcement_deselect_chapters_free</key>
-    <string>Neem een Plus-abonnement om waar mogelijk hoofdstukken van afleveringen te selecteren en over te slaan.</string>
+    <string>Neem een Plus-abonnement om waar mogelijk hoofdstukken van afleveringen automatisch voor te selecteren en over te slaan.</string>
     <key>announcement_deselect_chapters_patron</key>
-    <string>Met het Patron-abonnement kan je waar mogelijk hoofdstukken van afleveringen selecteren en overslaan.</string>
+    <string>Met het Patron-abonnement kan je waar mogelijk hoofdstukken van afleveringen automatisch voorselecteren en overslaan.</string>
     <key>announcement_deselect_chapters_plus</key>
-    <string>Met het Plus-abonnement kan je waar mogelijk hoofdstukken van afleveringen selecteren en overslaan.</string>
+    <string>Met het Plus-abonnement kan je waar mogelijk hoofdstukken van afleveringen automatisch voorselecteren en overslaan.</string>
     <key>announcement_slumber_code_copied</key>
     <string>Code gekopieerd naar klembord</string>
     <key>announcement_slumber_non_plus_description</key>
@@ -220,9 +220,9 @@ Tik op de onderstaande knop om opnieuw in te loggen bij je Pocket Casts-account.
     <key>appearance_dark_theme</key>
     <string>Donker thema</string>
     <key>appearance_embedded_artwork</key>
-    <string>Artwork-embed gebruiken</string>
+    <string>Artwork van afleveringen gebruiken</string>
     <key>appearance_embedded_artwork_subtitle</key>
-    <string>Geeft de artwork van het gedownloade bestand weer (als het bestaat) in de speler, in plaats van de artwork van de serie te gebruiken.</string>
+    <string>Sommige shows hebben apart artwork voor bepaalde afleveringen Als je deze optie inschakelt, zal dit worden weergegeven in plaats van het artwork van de show.</string>
     <key>appearance_light_theme</key>
     <string>Licht thema</string>
     <key>appearance_match_device_theme</key>
@@ -1221,6 +1221,10 @@ podcasts mee</string>
     <string>maand</string>
     <key>monthly</key>
     <string>Maandelijks</string>
+    <key>most_popular</key>
+    <string>Populairste</string>
+    <key>most_popular_with_name</key>
+    <string>Populairst in %1$@</string>
     <key>move_to_bottom</key>
     <string>Verplaats naar beneden</string>
     <key>move_to_top</key>
@@ -2428,11 +2432,11 @@ Als je op zoek bent naar inspiratie, probeer dan het tabblad Ontdekken.</string>
     <key>skip_back</key>
     <string>Terugspoelen</string>
     <key>skip_chapters</key>
-    <string>Hoofdstukken overslaan</string>
+    <string>Hoofdstukken voorselecteren</string>
     <key>skip_chapters_patron_prompt</key>
-    <string>Sla hoofdstukken over en geniet van extra functies met Pocket Casts Patron</string>
+    <string>Selecteer hoofdstukken voor en geniet van extra functies met Pocket Casts Patron</string>
     <key>skip_chapters_plus_prompt</key>
-    <string>Sla hoofdstukken over en geniet van extra functies met Pocket Casts Plus</string>
+    <string>Selecteer hoofdstukken voor en geniet van extra functies met Pocket Casts Plus</string>
     <key>skip_forward</key>
     <string>Doorspoelen</string>
     <key>sleep_timer</key>

--- a/podcasts/pt-BR.lproj/Localizable.strings
+++ b/podcasts/pt-BR.lproj/Localizable.strings
@@ -154,11 +154,11 @@ Toque no botão abaixo para entrar novamente na sua conta do Pocket Casts.</stri
     <key>announcement_bookmarks_title_beta</key>
     <string>Junte-se a nós na versão beta dos favoritos!</string>
     <key>announcement_deselect_chapters_free</key>
-    <string>Assine o Plus agora para selecionar e pular capítulos em qualquer episódio que seja compatível com esses recursos.</string>
+    <string>Assine o Plus agora para pré-selecionar e pular capítulos automaticamente em qualquer episódio que seja compatível com esses recursos.</string>
     <key>announcement_deselect_chapters_patron</key>
-    <string>Como parte da assinatura do Patron, você pode selecionar e pular capítulos em qualquer episódio que seja compatível com esses recursos.</string>
+    <string>Como parte da assinatura do Patron, agora você pode pré-selecionar e pular capítulos automaticamente em qualquer episódio que seja compatível com esses recursos.</string>
     <key>announcement_deselect_chapters_plus</key>
-    <string>Como parte da assinatura do Plus, você pode selecionar e pular capítulos em qualquer episódio que seja compatível com esses recursos.</string>
+    <string>Como parte da assinatura do Plus, agora você pode pré-selecionar e pular capítulos automaticamente em qualquer episódio que seja compatível com esses recursos.</string>
     <key>announcement_slumber_code_copied</key>
     <string>Código copiado para a área de transferência</string>
     <key>announcement_slumber_non_plus_description</key>
@@ -220,9 +220,9 @@ Toque no botão abaixo para entrar novamente na sua conta do Pocket Casts.</stri
     <key>appearance_dark_theme</key>
     <string>Tema escuro</string>
     <key>appearance_embedded_artwork</key>
-    <string>Usar arte incorporada</string>
+    <string>Usar arte do episódio</string>
     <key>appearance_embedded_artwork_subtitle</key>
-    <string>Mostra a arte dos arquivos baixados (se houver) no reprodutor, em vez da arte do programa.</string>
+    <string>Alguns programas usam arte personalizada para determinados episódios. Se você ativar esta opção, o Pocket Casts exibirá essa arte em vez da arte do programa.</string>
     <key>appearance_light_theme</key>
     <string>Tema claro</string>
     <key>appearance_match_device_theme</key>
@@ -1221,6 +1221,10 @@ podcasts com você</string>
     <string>mês</string>
     <key>monthly</key>
     <string>Mensal</string>
+    <key>most_popular</key>
+    <string>Mais populares</string>
+    <key>most_popular_with_name</key>
+    <string>Mais populares em %1$@</string>
     <key>move_to_bottom</key>
     <string>Mover para o fim</string>
     <key>move_to_top</key>
@@ -2428,11 +2432,11 @@ Se você estiver buscando inspiração, experimente a guia Explorar.</string>
     <key>skip_back</key>
     <string>Voltar</string>
     <key>skip_chapters</key>
-    <string>Pular capítulos</string>
+    <string>Pré-selecionar capítulos</string>
     <key>skip_chapters_patron_prompt</key>
-    <string>Pule capítulos e muito mais com o Pocket Casts Patron</string>
+    <string>Pré-selecione capítulos e muito mais com o Pocket Casts Patron</string>
     <key>skip_chapters_plus_prompt</key>
-    <string>Pule capítulos e muito mais com o Pocket Casts Plus</string>
+    <string>Pré-selecione capítulos e muito mais com o Pocket Casts Plus</string>
     <key>skip_forward</key>
     <string>Avançar</string>
     <key>sleep_timer</key>

--- a/podcasts/ru.lproj/Localizable.strings
+++ b/podcasts/ru.lproj/Localizable.strings
@@ -154,11 +154,11 @@
     <key>announcement_bookmarks_title_beta</key>
     <string>Примите участие в бета-тестировании закладок!</string>
     <key>announcement_deselect_chapters_free</key>
-    <string>Подпишитесь на Plus, и вы сможете выбирать и пропускать главы во всех выпусках, поддерживающих эту функцию.</string>
+    <string>Подпишитесь на Plus, и вы сможете предварительно выбирать и автоматически пропускать главы во всех выпусках, поддерживающих эту функцию.</string>
     <key>announcement_deselect_chapters_patron</key>
-    <string>В рамках подписки на Patron вы теперь можете выбирать и пропускать главы во всех выпусках, поддерживающих эту функцию.</string>
+    <string>В рамках подписки на Patron вы теперь можете предварительно выбирать и автоматически пропускать главы во всех выпусках, поддерживающих эту функцию.</string>
     <key>announcement_deselect_chapters_plus</key>
-    <string>В рамках подписки на Plus вы теперь можете выбирать и пропускать главы во всех выпусках, поддерживающих эту функцию.</string>
+    <string>В рамках подписки на Plus вы теперь можете предварительно выбирать и автоматически пропускать главы во всех выпусках, поддерживающих эту функцию.</string>
     <key>announcement_slumber_code_copied</key>
     <string>Код скопирован в буфер обмена</string>
     <key>announcement_slumber_non_plus_description</key>
@@ -220,9 +220,9 @@
     <key>appearance_dark_theme</key>
     <string>Тёмная тема</string>
     <key>appearance_embedded_artwork</key>
-    <string>Использовать встроенную тему</string>
+    <string>Отображать оформление выпусков</string>
     <key>appearance_embedded_artwork_subtitle</key>
-    <string>Показывает в плеере тему из загруженного файла (при наличии) вместо темы шоу.</string>
+    <string>В некоторых шоу есть специальное оформление отдельных выпусков. Включите эту опцию, и Pocket Casts будет отображать его вместо общего оформления шоу.</string>
     <key>appearance_light_theme</key>
     <string>Светлая тема</string>
     <key>appearance_match_device_theme</key>
@@ -1221,6 +1221,10 @@
     <string>мес.</string>
     <key>monthly</key>
     <string>Ежемесячно</string>
+    <key>most_popular</key>
+    <string>Самое популярное</string>
+    <key>most_popular_with_name</key>
+    <string>Самое популярное в %1$@</string>
     <key>move_to_bottom</key>
     <string>Переместить вниз</string>
     <key>move_to_top</key>
@@ -2428,11 +2432,11 @@
     <key>skip_back</key>
     <string>Перейти назад</string>
     <key>skip_chapters</key>
-    <string>Пропустить главы</string>
+    <string>Предварительный выбор глав</string>
     <key>skip_chapters_patron_prompt</key>
-    <string>Возможность пропускать главы и множество других функций с Pocket Casts Patron</string>
+    <string>Возможность предварительно выбирать главы и множество других функций с Pocket Casts Patron</string>
     <key>skip_chapters_plus_prompt</key>
-    <string>Возможность пропускать главы и множество других функций с Pocket Casts Plus</string>
+    <string>Возможность предварительно выбирать главы и множество других функций с Pocket Casts Plus</string>
     <key>skip_forward</key>
     <string>Перейти дальше</string>
     <key>sleep_timer</key>

--- a/podcasts/sv.lproj/Localizable.strings
+++ b/podcasts/sv.lproj/Localizable.strings
@@ -154,11 +154,11 @@ Tryck på knappen nedan för att logga in på ditt Pocket Casts-konto igen.</str
     <key>announcement_bookmarks_title_beta</key>
     <string>Var med och betatesta bokmärken!</string>
     <key>announcement_deselect_chapters_free</key>
-    <string>Prenumerera på Plus nu så att du kan välja och hoppa över kapitel i avsnitt som stöder detta.</string>
+    <string>Prenumerera på Plus nu så att du kan välja och hoppa över kapitel automatiskt i avsnitt som stöder detta.</string>
     <key>announcement_deselect_chapters_patron</key>
-    <string>Som en del av din Patron-prenumeration kan du nu välja och hoppa över kapitel i avsnitt som stöder detta.</string>
+    <string>Som en del av din Patron-prenumeration kan du nu välja och hoppa över kapitel automatiskt i avsnitt som stöder detta.</string>
     <key>announcement_deselect_chapters_plus</key>
-    <string>Som en del av din Plus-prenumeration kan du nu välja och hoppa över kapitel i avsnitt som stöder detta.</string>
+    <string>Som en del av din Plus-prenumeration kan du nu välja och hoppa över kapitel automatiskt i avsnitt som stöder detta.</string>
     <key>announcement_slumber_code_copied</key>
     <string>Kod kopierad till urklipp</string>
     <key>announcement_slumber_non_plus_description</key>
@@ -220,9 +220,9 @@ Tryck på knappen nedan för att logga in på ditt Pocket Casts-konto igen.</str
     <key>appearance_dark_theme</key>
     <string>Mörkt tema</string>
     <key>appearance_embedded_artwork</key>
-    <string>Använd inbäddat omslag</string>
+    <string>Använd avsnittsomslag</string>
     <key>appearance_embedded_artwork_subtitle</key>
-    <string>Visar omslaget från den nedladdade filen (om det finns någon) istället för omslaget som showen använder.</string>
+    <string>Vissa serier har anpassade omslag för specifika avsnitt. Aktivera det här alternativet så visar Pocket Casts dem istället för seriens omslag.</string>
     <key>appearance_light_theme</key>
     <string>Ljust tema</string>
     <key>appearance_match_device_theme</key>
@@ -1221,6 +1221,10 @@ podcasts med dig</string>
     <string>månad</string>
     <key>monthly</key>
     <string>Månadsvis</string>
+    <key>most_popular</key>
+    <string>Mest populär</string>
+    <key>most_popular_with_name</key>
+    <string>Mest populär under %1$@</string>
     <key>move_to_bottom</key>
     <string>Flytta längst ned</string>
     <key>move_to_top</key>
@@ -2428,11 +2432,11 @@ Om du behöver inspiration så kan du Upptäcka nya podcasts nedan.</string>
     <key>skip_back</key>
     <string>Hoppa tillbaka</string>
     <key>skip_chapters</key>
-    <string>Hoppa över kapitel</string>
+    <string>Förvalda kapitel</string>
     <key>skip_chapters_patron_prompt</key>
-    <string>Hoppa över kapitel och mycket annat med Pocket Casts Patron</string>
+    <string>Välj kapitel och mer i förväg med Pocket Casts Patron</string>
     <key>skip_chapters_plus_prompt</key>
-    <string>Hoppa över kapitel och mycket annat med Pocket Casts Plus</string>
+    <string>Välj kapitel och mer i förväg med Pocket Casts Plus</string>
     <key>skip_forward</key>
     <string>Hoppa framåt</string>
     <key>sleep_timer</key>

--- a/podcasts/zh-Hans.lproj/Localizable.strings
+++ b/podcasts/zh-Hans.lproj/Localizable.strings
@@ -154,11 +154,11 @@
     <key>announcement_bookmarks_title_beta</key>
     <string>加入我们的 Beta 测试，试用书签功能！</string>
     <key>announcement_deselect_chapters_free</key>
-    <string>立即订阅 Plus，然后您就能在任何支持相应功能的剧集中选择和跳过章节。</string>
+    <string>立即订阅 Plus，然后您就能在任何支持相应功能的剧集中自动预选和跳过章节。</string>
     <key>announcement_deselect_chapters_patron</key>
-    <string>订阅 Patron 后，您就能在任何支持相应功能的剧集中选择和跳过章节。</string>
+    <string>订阅 Patron 后，您就能在任何支持相应功能的剧集中自动预选和跳过章节。</string>
     <key>announcement_deselect_chapters_plus</key>
-    <string>订阅 Plus 后，您就能在任何支持相应功能的剧集中选择和跳过章节。</string>
+    <string>订阅 Plus 后，您就能在任何支持相应功能的剧集中自动预选和跳过章节。</string>
     <key>announcement_slumber_code_copied</key>
     <string>代码已复制到剪贴板</string>
     <key>announcement_slumber_non_plus_description</key>
@@ -220,9 +220,9 @@
     <key>appearance_dark_theme</key>
     <string>深色主题</string>
     <key>appearance_embedded_artwork</key>
-    <string>使用嵌入式插图</string>
+    <string>使用剧集插图</string>
     <key>appearance_embedded_artwork_subtitle</key>
-    <string>在播放器中显示下载文件（如果存在）中的插图，而不是使用节目的插图。</string>
+    <string>有些节目会为特定剧集定制插图。 启用此选项后，Pocket Casts 将显示剧集的插图，而非节目的插图。</string>
     <key>appearance_light_theme</key>
     <string>浅色主题</string>
     <key>appearance_match_device_theme</key>
@@ -1221,6 +1221,10 @@
     <string>月</string>
     <key>monthly</key>
     <string>每月</string>
+    <key>most_popular</key>
+    <string>最受欢迎</string>
+    <key>most_popular_with_name</key>
+    <string>在 %1$@ 类中最受欢迎</string>
     <key>move_to_bottom</key>
     <string>移到底部</string>
     <key>move_to_top</key>
@@ -2428,11 +2432,11 @@
     <key>skip_back</key>
     <string>后跳</string>
     <key>skip_chapters</key>
-    <string>跳过章节</string>
+    <string>预选章节</string>
     <key>skip_chapters_patron_prompt</key>
-    <string>使用 Pocket Casts Patron，享受跳过章节等更多功能</string>
+    <string>使用 Pocket Casts Patron，享受预选章节等更多功能</string>
     <key>skip_chapters_plus_prompt</key>
-    <string>使用 Pocket Casts Plus，享受跳过章节等更多功能</string>
+    <string>使用 Pocket Casts Plus，享受预选章节等更多功能</string>
     <key>skip_forward</key>
     <string>前跳</string>
     <key>sleep_timer</key>

--- a/podcasts/zh-Hant.lproj/Localizable.strings
+++ b/podcasts/zh-Hant.lproj/Localizable.strings
@@ -154,11 +154,11 @@ Tap the button below to sign into your Pocket Casts account again.</string>
     <key>announcement_bookmarks_title_beta</key>
     <string>加入我們的書籤 Beta 測試！</string>
     <key>announcement_deselect_chapters_free</key>
-    <string>立即訂閱 Plus，就能在支援章節功能的節目中選取並跳過章節。</string>
+    <string>立即訂閱 Plus，就能在支援章節功能的節目中自動預先選取並跳過章節。</string>
     <key>announcement_deselect_chapters_patron</key>
-    <string>你已訂閱 Patron，現在可以在支援章節功能的節目中選取並跳過章節。</string>
+    <string>你已訂閱 Patron，現在可以在支援章節功能的節目中自動預先選取並跳過章節。</string>
     <key>announcement_deselect_chapters_plus</key>
-    <string>你已訂閱 Plus，現在可以在支援章節功能的節目中選取並跳過章節。</string>
+    <string>你已訂閱 Plus，現在可以在支援章節功能的節目中自動預先選取並跳過章節。</string>
     <key>announcement_slumber_code_copied</key>
     <string>代碼已複製到剪貼簿</string>
     <key>announcement_slumber_non_plus_description</key>
@@ -220,9 +220,9 @@ Tap the button below to sign into your Pocket Casts account again.</string>
     <key>appearance_dark_theme</key>
     <string>深色佈景主題</string>
     <key>appearance_embedded_artwork</key>
-    <string>使用內嵌封面作品</string>
+    <string>使用單集封面圖片</string>
     <key>appearance_embedded_artwork_subtitle</key>
-    <string>在播放器中顯示下載檔案的封面 (如有)，而不使用節目的封面。</string>
+    <string>有些節目會針對特定單集推出自訂封面圖片。 若啟用此選項，Pocket Casts 就會顯示這些封面圖片，而非節目的封面圖片。</string>
     <key>appearance_light_theme</key>
     <string>淺色佈景主題</string>
     <key>appearance_match_device_theme</key>
@@ -1221,6 +1221,10 @@ Tap the button below to sign into your Pocket Casts account again.</string>
     <string>月</string>
     <key>monthly</key>
     <string>每月</string>
+    <key>most_popular</key>
+    <string>最受歡迎</string>
+    <key>most_popular_with_name</key>
+    <string>在「%1$@」最受歡迎</string>
     <key>move_to_bottom</key>
     <string>移至底部</string>
     <key>move_to_top</key>
@@ -2428,11 +2432,11 @@ Tap the button below to sign into your Pocket Casts account again.</string>
     <key>skip_back</key>
     <string>倒轉跳過</string>
     <key>skip_chapters</key>
-    <string>略過章節</string>
+    <string>預先選取的章節</string>
     <key>skip_chapters_patron_prompt</key>
-    <string>訂閱 Pocket Casts Patron，就能跳過章節並享有更多功能</string>
+    <string>訂閱 Pocket Casts Patron，就能預先選取章節並享有更多功能</string>
     <key>skip_chapters_plus_prompt</key>
-    <string>訂閱 Pocket Casts Plus，就能跳過章節並享有更多功能</string>
+    <string>訂閱 Pocket Casts Plus，就能預先選取章節並享有更多功能</string>
     <key>skip_forward</key>
     <string>快轉跳過</string>
     <key>sleep_timer</key>


### PR DESCRIPTION
Given we reverted `trunk` to `7.60.1` we lost the changes in `CHANGELOG` and also the copies.

This adds it back

## To test

1. 🟢 CI

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
