### PR TITLE
Re-add: Fall back to root VC if no topmostPresented is found

### DIFF
--- a/podcasts/SceneHelper.swift
+++ b/podcasts/SceneHelper.swift
@@ -26,7 +26,8 @@ class SceneHelper {
     class func rootViewController() -> UIViewController? {
         guard !FeatureFlag.newPlayerTransition.enabled else {
             let appScene = connectedScene()?.windows.first(where: { $0.rootViewController is MainTabBarController })
-            return appScene?.rootViewController?.topMostPresentedViewController
+            let rootVC = appScene?.rootViewController
+            return rootVC?.topMostPresentedViewController ?? rootVC
         }
 
         if let scene = connectedScene() {


### PR DESCRIPTION
Re-submission of https://github.com/Automattic/pocket-casts-ios/pull/1653

## To test

- Build and run on device
- Kill the app
- Add a link (https://pca.st/podcast/eebcc9f0-cec7-013c-5ce5-0acc26574db2) to reminders
- Tap the link
- Verify that the app displays the loading alert and opens to the podcast
- Tap the link again while the app is backgrounded
- Ensure that the podcast opens

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
