### PR TITLE
Categories: Tracks events

### DIFF
--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -309,6 +309,7 @@ enum AnalyticsEvent: String {
     case discoverCollectionLinkTapped
 
     case discoverAdCategoryTapped
+    case discoverAdCategorySubscribed
 
     // MARK: - Mini Player
 

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -292,6 +292,8 @@ enum AnalyticsEvent: String {
     case discoverShowAllTapped
     case discoverCategoryCloseButtonTapped
     case discoverCategoriesPickerPick
+    case discoverCategoriesPickerClosed
+    case discoverCategoriesPickerShown
 
     case discoverListImpression
     case discoverListShowAllTapped

--- a/podcasts/AnalyticsHelper.swift
+++ b/podcasts/AnalyticsHelper.swift
@@ -118,6 +118,11 @@ class AnalyticsHelper {
         Analytics.track(.discoverAdCategoryTapped, properties: properties)
     }
 
+    class func adSubscribed(promotionUUID: String, podcastUUID: String, categoryID: Int) {
+        let properties: [String: Any] = ["promotion_uuid": promotionUUID, "podcast_uuid": podcastUUID, "category_id": categoryID]
+        Analytics.track(.discoverAdCategorySubscribed, properties: properties)
+    }
+
     class func podcastEpisodeTapped(fromList listId: String, podcastUuid: String, episodeUuid: String) {
         let properties = ["list_id": listId, "podcast_uuid": podcastUuid, "episode_uuid": episodeUuid]
 

--- a/podcasts/Categories/CategoriesSelectorView.swift
+++ b/podcasts/Categories/CategoriesSelectorView.swift
@@ -95,6 +95,13 @@ struct CategoriesPillsView: View {
                         }
                     }
             }
+            .onChange(of: showingCategories) { isShowing in
+                if isShowing {
+                    Analytics.track(.discoverCategoriesPickerShown, properties: ["region": region ?? "none"])
+                } else {
+                    Analytics.track(.discoverCategoriesPickerClosed, properties: ["region": region ?? "none"])
+                }
+            }
             .onChange(of: selectedCategory) { _ in
                 showingCategories = false
             }

--- a/podcasts/SinglePodcastViewController.swift
+++ b/podcasts/SinglePodcastViewController.swift
@@ -130,6 +130,7 @@ class SinglePodcastViewController: UIViewController, DiscoverSummaryProtocol {
         if let listId = item?.uuid, let podcastUuid = podcast.uuid {
             AnalyticsHelper.podcastSubscribedFromList(listId: listId, podcastUuid: podcastUuid)
         }
+        AnalyticsHelper.adSubscribed(promotionUUID: item?.uuid ?? "", podcastUUID: podcast.uuid ?? "", categoryID: item?.categoryID ?? 0)
 
         delegate?.subscribe(podcast: podcast)
     }


### PR DESCRIPTION
Adds new events to track Categories redesign behavior.

See https://github.com/Automattic/pocket-casts-webplayer/pull/2664 for more info on these changes.

## To test

* Navigate to a category
* Tap the "+" button to subscribe to a sponsored podcast
```
🔵 Tracked: discover_list_podcast_subscribed ["podcast_uuid": "5b8d9890-80e6-013b-f2c3-0acc26574db2", "list_id": "e2d26ae1-1793-4465-94a5-c81ca7c8c39c"]
🔵 Tracked: discover_ad_category_subscribed ["category_id": 19, "podcast_uuid": "5b8d9890-80e6-013b-f2c3-0acc26574db2", "promotion_uuid": "e2d26ae1-1793-4465-94a5-c81ca7c8c39c"]
🔵 Tracked: podcast_subscribed ["uuid": "5b8d9890-80e6-013b-f2c3-0acc26574db2", "source": "discover"]
```

* Tap the X pill to close back out to the main Discover page
* Tap "All Categories"
* Verify the following event is logged:
```
🔵 Tracked: discover_categories_picker_shown ["region": "global"]
```
* Close the picker by tapping outside of it _or_ selecting a category
```
🔵 Tracked: discover_categories_picker_closed ["region": "global"]
```

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
