### PR TITLE
Re-add: convert bookmark sort options to server sort options

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Enums.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Enums.swift
@@ -130,8 +130,6 @@ public enum BookmarksSort: Int32, Codable {
     case newestToOldest = 0
     case oldestToNewest = 1
     case timestamp = 2
-    case episode = 3
-    case podcastAndEspisode = 4
 }
 
 public enum AutoArchiveAfterPlayed: Int32, Codable {

--- a/PocketCastsTests/Tests/Utilities/SettingsTests.swift
+++ b/PocketCastsTests/Tests/Utilities/SettingsTests.swift
@@ -131,9 +131,9 @@ final class SettingsTests: XCTestCase {
         let newPlayedAfter = AutoArchiveAfterTime.after1Week
         let newInactiveAfter = AutoArchiveAfterTime.after90Days
         let newEpisodeSortBy = UploadedSort.titleAtoZ
-        let newPlayerBookmarksSort = BookmarkSortOption.podcastAndEpisode
-        let newEpisodeBookmarksSort = BookmarkSortOption.episode
-        let newProfileBookmarksSort = BookmarkSortOption.newestToOldest
+        let newPlayerBookmarksSort = BookmarkSortOption.newestToOldest
+        let newEpisodeBookmarksSort = BookmarkSortOption.oldestToNewest
+        let newProfileBookmarksSort = BookmarkSortOption.podcastAndEpisode
         let newHeadphonesNextAction = HeadphoneControlAction.previousChapter
         let newHeadphonesPreviousAction = HeadphoneControlAction.skipForward
         let newHomeFolderSortOrder = LibrarySort.titleAtoZ

--- a/podcasts/Enumerations.swift
+++ b/podcasts/Enumerations.swift
@@ -568,18 +568,14 @@ enum MultiSelectAction: Int32, CaseIterable, AnalyticsDescribable {
 }
 
 extension BookmarksSort {
-    var option: BookmarkSortOption {
+    func option(lastOption: BookmarkSortOption) -> BookmarkSortOption {
         switch self {
         case .newestToOldest:
             return .newestToOldest
         case .oldestToNewest:
             return .oldestToNewest
         case .timestamp:
-            return .timestamp
-        case .episode:
-            return .episode
-        case .podcastAndEspisode:
-            return .podcastAndEpisode
+            return lastOption
         }
     }
 
@@ -589,12 +585,8 @@ extension BookmarksSort {
             self = .newestToOldest
         case .oldestToNewest:
             self = .oldestToNewest
-        case .timestamp:
+        case .timestamp, .episode, .podcastAndEpisode:
             self = .timestamp
-        case .episode:
-            self = .episode
-        case .podcastAndEpisode:
-            self = .podcastAndEspisode
         }
     }
 }

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -1144,7 +1144,7 @@ class Settings: NSObject {
     static var playerBookmarksSort: Binding<BookmarkSortOption> {
         Binding {
             if FeatureFlag.newSettingsStorage.enabled {
-                return SettingsStore.appSettings.playerBookmarksSortType.option
+                return SettingsStore.appSettings.playerBookmarksSortType.option(lastOption: .timestamp)
             } else {
                 return Constants.UserDefaults.bookmarks.playerSort.value
             }
@@ -1159,7 +1159,7 @@ class Settings: NSObject {
     static var episodeBookmarksSort: Binding<BookmarkSortOption> {
         Binding {
             if FeatureFlag.newSettingsStorage.enabled {
-                return SettingsStore.appSettings.episodeBookmarksSortType.option
+                return SettingsStore.appSettings.episodeBookmarksSortType.option(lastOption: .timestamp)
             } else {
                 return Constants.UserDefaults.bookmarks.episodeSort.value
             }
@@ -1174,7 +1174,7 @@ class Settings: NSObject {
     static var podcastBookmarksSort: Binding<BookmarkSortOption> {
         Binding {
             if FeatureFlag.newSettingsStorage.enabled {
-                return SettingsStore.appSettings.podcastBookmarksSortType.option
+                return SettingsStore.appSettings.podcastBookmarksSortType.option(lastOption: .episode)
             } else {
                 return Constants.UserDefaults.bookmarks.podcastSort.value
             }
@@ -1189,7 +1189,7 @@ class Settings: NSObject {
     static var profileBookmarksSort: Binding<BookmarkSortOption> {
         Binding {
             if FeatureFlag.newSettingsStorage.enabled {
-                return SettingsStore.appSettings.profileBookmarksSortType.option
+                return SettingsStore.appSettings.profileBookmarksSortType.option(lastOption: .podcastAndEpisode)
             } else {
                 return Constants.UserDefaults.bookmarks.profileSort.value
             }


### PR DESCRIPTION
Re-add [convert bookmark sort options to server sort options](https://github.com/Automattic/pocket-casts-ios/pull/1618)

## To test

Please check the original PR above for test steps.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
