### PR TITLE
Remove folders cache

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -404,12 +404,10 @@ public class DataManager {
     }
 
     public func bulkSetFolderUuid(folderUuid: String, podcastUuids: [String]) {
-        folderPodcastUuuidCache.removeAll()
         podcastManager.bulkSetFolderUuid(folderUuid: folderUuid, podcastUuids: podcastUuids, dbQueue: dbQueue)
     }
 
     public func updatePodcastFolder(podcastUuid: String, to folderUuid: String?, sortOrder: Int32) {
-        folderPodcastUuuidCache.removeAll()
         podcastManager.updatePodcastFolder(podcastUuid: podcastUuid, sortOrder: sortOrder, folderUuid: folderUuid, dbQueue: dbQueue)
     }
 
@@ -889,7 +887,6 @@ public class DataManager {
     // MARK: - Folders
 
     public func save(folder: Folder) {
-        folderPodcastUuuidCache[folder.uuid] = nil
         folderManager.save(folder: folder, dbQueue: dbQueue)
     }
 
@@ -901,19 +898,9 @@ public class DataManager {
         folderManager.findFolder(uuid: uuid, dbQueue: dbQueue)
     }
 
-    private var folderPodcastUuuidCache: [String: [String]] = [:]
-
     public func topPodcastsUuidInFolder(folder: Folder) -> [String] {
-        if let topPodcasts = folderPodcastUuuidCache[folder.uuid] {
-            return topPodcasts
-        }
         let topPodcasts = podcastManager.allPodcastsInFolder(folder: folder, dbQueue: dbQueue).map({$0.uuid})
-        folderPodcastUuuidCache[folder.uuid] = topPodcasts
         return topPodcasts
-    }
-
-    public func clearFolderCache(folderUuid: String) {
-        folderPodcastUuuidCache[folderUuid] = nil
     }
 
     public func allPodcastsInFolder(folder: Folder) -> [Podcast] {

--- a/podcasts/PodcastManager+Delete.swift
+++ b/podcasts/PodcastManager+Delete.swift
@@ -38,7 +38,6 @@ extension PodcastManager {
         // additionally if this podcast was in a folder, update the folder
         if let folderUuid = savedFolderUuid {
             DataManager.sharedManager.updateFolderSyncModified(folderUuid: folderUuid, syncModified: TimeFormatter.currentUTCTimeInMillis())
-            DataManager.sharedManager.clearFolderCache(folderUuid: folderUuid)
             NotificationCenter.postOnMainThread(notification: Constants.Notifications.folderChanged, object: folderUuid)
         }
 


### PR DESCRIPTION
This PR removes the folder top podcasts cache that was causing the following issues:

‼️ EXC_BAD_ACCESS: 3ab-c1c01d826b25 > Dictionary._Variant.isUniquelyReferenced [View Issue](https://a8c.sentry.io/issues/5331386349/?referrer=github-pr-bot)
‼️ EXC_BAD_ACCESS: Exception 1, Code 1, Subcode 9223372036854775848 > __RawDictionaryStorage.find<T> [View Issue](https://a8c.sentry.io/issues/5343133351/?referrer=github-pr-bot)
‼️ EXC_BAD_ACCESS: ce: %s > rvice: %s > Dictionary._Variant.isUniquelyReferenced [View Issue](https://a8c.sentry.io/issues/5345610905/?referrer=github-pr-bot)
‼️ EXC_BAD_ACCESS: Exception 1, Code 1, Subcode 18446744073709551600 > Dictionary._Variant.removeValue [View Issue](https://a8c.sentry.io/issues/5345690870/?referrer=github-pr-bot)
‼️ EXC_BAD_ACCESS: Exception 1, Code 1, Subcode 9223372036854775824 > Dictionary.subscript.getter [View Issue](https://a8c.sentry.io/issues/5346165205/?referrer=github-pr-bot)

## To test

- Start the app using a large database
- Check there is no crashes when scrolling around folders
- Check that the performance is good: no hands when folders scrolling in and out.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
