### PR TITLE
Ensure mini-player is visible in the background when full player is displaying

### DIFF
--- a/podcasts/MiniPlayerToFullPlayerAnimator.swift
+++ b/podcasts/MiniPlayerToFullPlayerAnimator.swift
@@ -245,7 +245,7 @@ class MiniPlayerToFullPlayerAnimator: NSObject, UIViewControllerAnimatedTransiti
             playerView.frame = self.isPresenting ? self.containerView.frame : playerView.frame
             playerView.isHidden = false
 
-            self.fromViewController.view.layer.opacity = self.isPresenting ? 0 : 1
+            self.fromViewController.view.layer.opacity = 1
 
             transitionContext.completeTransition(true)
         }


### PR DESCRIPTION
Fixes #

This fix an issue where the mini-player was missing after opening up the full player and exiting to another screen and not closing directly the full player.

## To test

1. Start playing a podcast with a few additional podcasts queued;
2. Pull up to see Up Next queue;
3. Click on a podcast in the queue to see details;
4. Click on the podcast name to go to the list of episodes from that podcast;
5. Add another episode to the Up Next queue and then go back;
6. Check if the mini-player is still visible

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
