### PR TITLE
Fix ThemableTable crash in `intrinsicContentSize` getter

### DIFF
--- a/podcasts/ThemeableTable.swift
+++ b/podcasts/ThemeableTable.swift
@@ -56,7 +56,9 @@ class ThemeableTable: UITableView {
     }
 
     override var intrinsicContentSize: CGSize {
-        self.layoutIfNeeded()
+        if dataSource != nil {
+            self.layoutIfNeeded()
+        }
         return self.contentSize
     }
 


### PR DESCRIPTION
Fixes [crash](https://a8c.sentry.io/issues/5279755686/?project=4503921846583296) in `ThemeableTable` by checking the table view data source before calling `layoutIfNeeded`.

## To test

I was unable to reproduce this issue. These are steps which I *think* may be causing the crash based on the stack traces:

* Tap the Chromecast button from the player
* Ensure that table is shown and app doesn't crash

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
