### PR TITLE
Remove obsolete `register_device` lane

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -918,50 +918,6 @@ inal copy, and try again.")
     )
   end
 
-  desc 'Registers a device to the Apple Developer Portal and adds it to the appropriate provisioning profiles'
-  lane :register_new_device do |options|
-    device_name = UI.input('Device name (leave empty if already added in portal): ') if options[:device_name].nil?
-    unless device_name.empty?
-      device_id = UI.input('Device ID: ') if options[:device_id].nil?
-      UI.message "Adding #{device_name} with ID #{device_id} to the Developer Portal"
-      UI.message 'Also registering it with any provisioning profiles associated with the following bundle identifiers:'
-      BUNDLE_IDENTIFIERS_APP_STORE.each do |identifier|
-        puts "\t#{identifier}"
-      end
-
-      # Register the user's device
-      register_device(
-        name: device_name,
-        udid: device_id,
-        team_id: TEAM_ID_APP_STORE,
-        api_key: app_store_connect_api_key
-      )
-    end
-
-    # We're about to use `add_development_certificates_to_provisioning_profiles` and `add_all_devices_to_provisioning_profiles`.
-    # These actions use Developer Portal APIs that don't yet support authentication via API key (-.-').
-    # Let's preemptively ask for and set the email here to avoid being asked twice for it if not set.
-
-    require 'credentials_manager'
-
-    # If Fastlane cannot instantiate a user, it will ask the caller for the email.
-    # Once we have it, we can set it as `FASTLANE_USER` in the environment (which has lifecycle limited to this call) so that the next commands will already have access to it.
-    # Note that if the user is already available to `AccountManager`, setting it in the environment is redundant, but Fastlane doesn't provide a way to check it so we have to do it anyway.
-    ENV['FASTLANE_USER'] = CredentialsManager::AccountManager.new.user
-
-    # Add all development certificates to the provisioning profiles (just in case – this is an easy step to miss)
-    add_development_certificates_to_provisioning_profiles(
-      team_id: TEAM_ID_APP_STORE,
-      app_identifier: BUNDLE_IDENTIFIERS_APP_STORE
-    )
-
-    # Add all devices to the provisioning profiles
-    add_all_devices_to_provisioning_profiles(
-      team_id: TEAM_ID_APP_STORE,
-      app_identifier: BUNDLE_IDENTIFIERS_APP_STORE
-    )
-  end
-
   # Generates a HTML containing the libraries acknowledgments.
   #
   desc 'Generates a HTML with the list of used libraries and their licenses'


### PR DESCRIPTION
We now have better internal self-service utilities to accomplish this.

See also https://github.com/Automattic/pocket-casts-ios/pull/1749#discussion_r1599901554

## To test

Nothing to test, as this removes a lane.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary. – N.A.
- [x] I have considered adding unit tests for my changes. – N.A.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics. – N.A.
