### PR TITLE
Add lowerSnakeCased default remoteKey

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Extensions/StringExtension.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Extensions/StringExtension.swift
@@ -60,4 +60,12 @@ public extension String {
 
         return attributedSize.width
     }
+
+    /// Returns a lowercased copy of the string with punctuation removed and spaces replaced
+    /// by a single underscore, e.g., "the_quick_brown_fox_jumps_over_the_lazy_dog".
+    func lowerSnakeCased() -> String {
+        return enumerated().map { index, character in
+            character.isUppercase ? "_\(character.lowercased())" : "\(character)"
+        }.joined()
+    }
 }

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -132,7 +132,7 @@ public enum FeatureFlag: String, CaseIterable {
         case .defaultPlayerFilterCallbackFix:
             "default_player_filter_callback_fix"
         default:
-            nil
+            rawValue.lowerSnakeCased()
         }
     }
 }

--- a/Modules/Utils/Tests/PocketCastsUtilsTests/StringExtensionsTest.swift
+++ b/Modules/Utils/Tests/PocketCastsUtilsTests/StringExtensionsTest.swift
@@ -20,4 +20,10 @@ class StringExtensionTests: XCTestCase {
         XCTAssertFalse("email@".isValidEmail)
         XCTAssertFalse("email@example.com email@example.com".isValidEmail)
     }
+
+    func testSnakeCased() {
+        XCTAssertEqual("test", "test".lowerSnakeCased())
+        XCTAssertEqual("test_snake", "testSnake".lowerSnakeCased())
+        XCTAssertEqual("test_snake_case", "testSnakeCase".lowerSnakeCased())
+    }
 }

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -545,10 +545,10 @@
 		8BAD6E5E2975ADB800DB7259 /* GoogleSignIn in Frameworks */ = {isa = PBXBuildFile; productRef = 8BAD6E5D2975ADB800DB7259 /* GoogleSignIn */; };
 		8BAD6E612975AFAA00DB7259 /* GoogleSocialLogin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BAD6E602975AFAA00DB7259 /* GoogleSocialLogin.swift */; };
 		8BB2E58B2A8AA02E00E93088 /* SharedConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD054A791E3EDEB300D9195B /* SharedConstants.swift */; };
-		8BB4AA662BD1A8040091480A /* sleep-timer-restarted-sound.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 8BB4AA652BD1A8040091480A /* sleep-timer-restarted-sound.mp3 */; };
-		8BB4AA672BD1A80E0091480A /* sleep-timer-restarted-sound.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 8BB4AA652BD1A8040091480A /* sleep-timer-restarted-sound.mp3 */; };
 		8BB4AA632BD17EC10091480A /* FadeOutManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB4AA622BD17EC10091480A /* FadeOutManager.swift */; };
 		8BB4AA642BD17EC10091480A /* FadeOutManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB4AA622BD17EC10091480A /* FadeOutManager.swift */; };
+		8BB4AA662BD1A8040091480A /* sleep-timer-restarted-sound.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 8BB4AA652BD1A8040091480A /* sleep-timer-restarted-sound.mp3 */; };
+		8BB4AA672BD1A80E0091480A /* sleep-timer-restarted-sound.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 8BB4AA652BD1A8040091480A /* sleep-timer-restarted-sound.mp3 */; };
 		8BB55E3A28FEEE99001D1766 /* StoryShareableProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB55E3928FEEE99001D1766 /* StoryShareableProvider.swift */; };
 		8BBE19EE2BEA973E009E944B /* ShowInfoCoordinating.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BBE19ED2BEA973E009E944B /* ShowInfoCoordinating.swift */; };
 		8BBE19F02BEA9865009E944B /* PodcastIndexChapterDataRetriever.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BBE19EF2BEA9865009E944B /* PodcastIndexChapterDataRetriever.swift */; };
@@ -1609,6 +1609,7 @@
 		F55C4C762BCF064500A10352 /* DiscoverViewController+CategoryRedesign.swift in Sources */ = {isa = PBXBuildFile; fileRef = F55C4C752BCF064500A10352 /* DiscoverViewController+CategoryRedesign.swift */; };
 		F565602F2B7ACD9B003E76D5 /* DataManager+Import.swift in Sources */ = {isa = PBXBuildFile; fileRef = F565602E2B7ACD9B003E76D5 /* DataManager+Import.swift */; };
 		F56ADE562B7FE37500ADFE31 /* SettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5AD75442B7FDC2800D65C55 /* SettingsTests.swift */; };
+		F5B312B42BF5B6D400290696 /* FirebaseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5B312B32BF5B6D400290696 /* FirebaseManager.swift */; };
 		F5D3A0D92B70950100EED067 /* MockURLHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5D3A0D82B70950100EED067 /* MockURLHandler.swift */; };
 		F5DBA58A2B756A8700AED77F /* PodcastSettings+ImportUserDefaultsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5DBA5892B756A8700AED77F /* PodcastSettings+ImportUserDefaultsTests.swift */; };
 		F5E431D62B50888500A71DB3 /* PlusLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5E431D52B50888500A71DB3 /* PlusLabel.swift */; };
@@ -2359,8 +2360,8 @@
 		8BAB8B2E299ABC8200B8404C /* SearchResultsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultsViewController.swift; sourceTree = "<group>"; };
 		8BAD2EB32AEE9620006264B3 /* PaidStoryWallView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaidStoryWallView.swift; sourceTree = "<group>"; };
 		8BAD6E602975AFAA00DB7259 /* GoogleSocialLogin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleSocialLogin.swift; sourceTree = "<group>"; };
-		8BB4AA652BD1A8040091480A /* sleep-timer-restarted-sound.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = "sleep-timer-restarted-sound.mp3"; sourceTree = "<group>"; };
 		8BB4AA622BD17EC10091480A /* FadeOutManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FadeOutManager.swift; sourceTree = "<group>"; };
+		8BB4AA652BD1A8040091480A /* sleep-timer-restarted-sound.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = "sleep-timer-restarted-sound.mp3"; sourceTree = "<group>"; };
 		8BB55E3928FEEE99001D1766 /* StoryShareableProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoryShareableProvider.swift; sourceTree = "<group>"; };
 		8BBE19ED2BEA973E009E944B /* ShowInfoCoordinating.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShowInfoCoordinating.swift; sourceTree = "<group>"; };
 		8BBE19EF2BEA9865009E944B /* PodcastIndexChapterDataRetriever.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PodcastIndexChapterDataRetriever.swift; sourceTree = "<group>"; };
@@ -3393,6 +3394,7 @@
 		F55C4C752BCF064500A10352 /* DiscoverViewController+CategoryRedesign.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DiscoverViewController+CategoryRedesign.swift"; sourceTree = "<group>"; };
 		F565602E2B7ACD9B003E76D5 /* DataManager+Import.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DataManager+Import.swift"; sourceTree = "<group>"; };
 		F5AD75442B7FDC2800D65C55 /* SettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsTests.swift; sourceTree = "<group>"; };
+		F5B312B32BF5B6D400290696 /* FirebaseManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseManager.swift; sourceTree = "<group>"; };
 		F5D3A0D82B70950100EED067 /* MockURLHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockURLHandler.swift; sourceTree = "<group>"; };
 		F5DBA5892B756A8700AED77F /* PodcastSettings+ImportUserDefaultsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PodcastSettings+ImportUserDefaultsTests.swift"; sourceTree = "<group>"; };
 		F5E431D52B50888500A71DB3 /* PlusLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlusLabel.swift; sourceTree = "<group>"; };
@@ -5295,6 +5297,7 @@
 				8B484EF428D23BEF001AFA97 /* PlaybackTimeHelper.swift */,
 				C7F4BAB428DA6BBB001C9785 /* BackgroundSignOutListener.swift */,
 				4647623028F70CD0006D005A /* AuthenticationHelper.swift */,
+				F5B312B32BF5B6D400290696 /* FirebaseManager.swift */,
 			);
 			name = "Managers and Helpers";
 			sourceTree = "<group>";
@@ -8307,7 +8310,6 @@
 				8B10E78A28D9094A00702C54 /* GoogleService-Info.plist in Resources */,
 				105A6C442BAA0B3E0025B855 /* PrivacyInfo.xcprivacy in Resources */,
 				BDD3016A1EFB9356004A9972 /* Assets.xcassets in Resources */,
-				8B10E78928D9094900702C54 /* GoogleService-Info.plist in Resources */,
 				8BB4AA672BD1A80E0091480A /* sleep-timer-restarted-sound.mp3 in Resources */,
 				463538A426E16A2E00BA9D35 /* Localizable.strings in Resources */,
 				BDD301681EFB9356004A9972 /* Interface.storyboard in Resources */,
@@ -9408,6 +9410,7 @@
 				BD6F1645219AB82700F34D14 /* UISearchBar+TextColor.swift in Sources */,
 				BDA028621C74466500476B28 /* GoogleCastPlayer.swift in Sources */,
 				BDB5F0CD20450FDC00437669 /* Enumerations.swift in Sources */,
+				F5B312B42BF5B6D400290696 /* FirebaseManager.swift in Sources */,
 				BD7166971ECA880D007DD36E /* IndentedTextField.swift in Sources */,
 				C7CA0559293E8918000E41BD /* HolographicEffect.swift in Sources */,
 				BD0F6D7B24BD60FF00EDFB99 /* FilterDurationViewController.swift in Sources */,

--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -269,38 +269,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     private func configureFirebase() {
         FirebaseApp.configure()
 
-        // we user remote config for varies parameters in the app we want to be able to set remotely. Here we set the defaults, then fetch new ones
-        let remoteConfig = RemoteConfig.remoteConfig()
-        var remoteConfigDefaults = [
-            Constants.RemoteParams.periodicSaveTimeMs: NSNumber(value: Constants.RemoteParams.periodicSaveTimeMsDefault),
-            Constants.RemoteParams.episodeSearchDebounceMs: NSNumber(value: Constants.RemoteParams.episodeSearchDebounceMsDefault),
-            Constants.RemoteParams.podcastSearchDebounceMs: NSNumber(value: Constants.RemoteParams.podcastSearchDebounceMsDefault),
-            Constants.RemoteParams.customStorageLimitGB: NSNumber(value: Constants.RemoteParams.customStorageLimitGBDefault),
-            Constants.RemoteParams.endOfYearRequireAccount: NSNumber(value: Constants.RemoteParams.endOfYearRequireAccountDefault),
-            Constants.RemoteParams.effectsPlayerStrategy: NSNumber(value: Constants.RemoteParams.effectsPlayerStrategyDefault),
-            Constants.RemoteParams.patronCloudStorageGB: NSNumber(value: Constants.RemoteParams.patronCloudStorageGBDefault),
-            Constants.RemoteParams.addMissingEpisodes: NSNumber(value: Constants.RemoteParams.addMissingEpisodesDefault),
-            Constants.RemoteParams.newPlayerTransition: NSNumber(value: Constants.RemoteParams.newPlayerTransitionDefault),
-            Constants.RemoteParams.errorLogoutHandling: NSNumber(value: Constants.RemoteParams.errorLogoutHandlingDefault),
-            Constants.RemoteParams.slumberStudiosPromoCode: NSString(string: Constants.RemoteParams.slumberStudiosPromoCodeDefault)
-        ]
-        FeatureFlag.allCases.filter { $0.remoteKey != nil }.forEach { flag in
-            remoteConfigDefaults[flag.remoteKey!] = NSNumber(value: flag.default)
-        }
-        remoteConfig.setDefaults(remoteConfigDefaults)
-
-        remoteConfig.fetch(withExpirationDuration: 2.hour) { [weak self] status, _ in
-            if status == .success {
-                remoteConfig.activate(completion: nil)
-
-                self?.updateEndOfYearRemoteValue()
-                self?.updateRemoteFeatureFlags()
-                ServerConfig.avoidLogoutOnError = FeatureFlag.errorLogoutHandling.enabled
-            }
+        FirebaseManager.refreshRemoteConfig() { [weak self] status in
+            self?.updateEndOfYearRemoteValue()
+            self?.updateRemoteFeatureFlags()
+            ServerConfig.avoidLogoutOnError = FeatureFlag.errorLogoutHandling.enabled
         }
     }
 
-    private func updateRemoteFeatureFlags() {
+    func updateRemoteFeatureFlags() {
         guard BuildEnvironment.current != .debug else { return }
         do {
             if FeatureFlag.newPlayerTransition.enabled != Settings.newPlayerTransition {

--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -302,8 +302,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
             try FeatureFlag.allCases.forEach { flag in
                 if let remoteKey = flag.remoteKey {
-                    let remoteValue = RemoteConfig.remoteConfig().configValue(forKey: remoteKey).boolValue
-                    try FeatureFlagOverrideStore().override(flag, withValue: remoteValue)
+                    let remoteValue = RemoteConfig.remoteConfig().configValue(forKey: remoteKey)
+                    if remoteValue.source == .remote {
+                        try FeatureFlagOverrideStore().override(flag, withValue: remoteValue.boolValue)
+                    }
                 }
             }
         } catch {

--- a/podcasts/DeveloperMenu.swift
+++ b/podcasts/DeveloperMenu.swift
@@ -36,6 +36,12 @@ struct DeveloperMenu: View {
                         PodcastManager.shared.unsubscribe(podcast: podcast)
                     }
                 }
+
+                Button("Force Reload Feature Flags") {
+                    FirebaseManager.refreshRemoteConfig(expirationDuration: 0) { _ in
+                        (UIApplication.shared.delegate as? AppDelegate)?.updateRemoteFeatureFlags()
+                    }
+                }
             }
 
             Section {

--- a/podcasts/FirebaseManager.swift
+++ b/podcasts/FirebaseManager.swift
@@ -1,0 +1,33 @@
+import PocketCastsUtils
+import FirebaseRemoteConfig
+
+struct FirebaseManager {
+    static func refreshRemoteConfig(expirationDuration: TimeInterval = 2.hour, completion: ((RemoteConfigFetchStatus) -> Void)? = nil) {
+        // we user remote config for varies parameters in the app we want to be able to set remotely. Here we set the defaults, then fetch new ones
+        let remoteConfig = RemoteConfig.remoteConfig()
+        var remoteConfigDefaults = [
+            Constants.RemoteParams.periodicSaveTimeMs: NSNumber(value: Constants.RemoteParams.periodicSaveTimeMsDefault),
+            Constants.RemoteParams.episodeSearchDebounceMs: NSNumber(value: Constants.RemoteParams.episodeSearchDebounceMsDefault),
+            Constants.RemoteParams.podcastSearchDebounceMs: NSNumber(value: Constants.RemoteParams.podcastSearchDebounceMsDefault),
+            Constants.RemoteParams.customStorageLimitGB: NSNumber(value: Constants.RemoteParams.customStorageLimitGBDefault),
+            Constants.RemoteParams.endOfYearRequireAccount: NSNumber(value: Constants.RemoteParams.endOfYearRequireAccountDefault),
+            Constants.RemoteParams.effectsPlayerStrategy: NSNumber(value: Constants.RemoteParams.effectsPlayerStrategyDefault),
+            Constants.RemoteParams.patronCloudStorageGB: NSNumber(value: Constants.RemoteParams.patronCloudStorageGBDefault),
+            Constants.RemoteParams.addMissingEpisodes: NSNumber(value: Constants.RemoteParams.addMissingEpisodesDefault),
+            Constants.RemoteParams.newPlayerTransition: NSNumber(value: Constants.RemoteParams.newPlayerTransitionDefault),
+            Constants.RemoteParams.errorLogoutHandling: NSNumber(value: Constants.RemoteParams.errorLogoutHandlingDefault),
+            Constants.RemoteParams.slumberStudiosPromoCode: NSString(string: Constants.RemoteParams.slumberStudiosPromoCodeDefault)
+        ]
+        FeatureFlag.allCases.filter { $0.remoteKey != nil }.forEach { flag in
+            remoteConfigDefaults[flag.remoteKey!] = NSNumber(value: flag.default)
+        }
+        remoteConfig.setDefaults(remoteConfigDefaults)
+
+        remoteConfig.fetch(withExpirationDuration: expirationDuration) { status, _ in
+            if status == .success {
+                remoteConfig.activate(completion: nil)
+            }
+            completion?(status)
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1716

* Adds a "Force Reload Feature Flags" option in the Developer menu - this could also be a refresh button in the Feature Flags screen if that would make more sense.
* Adds default keys for any `FeatureFlag` using snake case

## To test

### Developer Menu

![CleanShot 2024-05-22 at 21 53 20@2x](https://github.com/Automattic/pocket-casts-ios/assets/3250/da5428e7-b04c-4c54-8707-4cf14b86327d)

### Default Flag

* Comment out [the `BuildEnvironment.current != .debug` check](https://github.com/Automattic/pocket-casts-ios/blob/52cf5470c2012b5c1a394ed47d93f7b2e42ece9e/podcasts/AppDelegate.swift#L304) in `AppDelegate.updateRemoteFeatureFlags`
* Add a new flag to `FeatureFlag.swift`, like `newFlag`
* Set the `default` value to `false`
* Add a new flag under the Remote Config section of Firebase
* Ensure that the flag is disabled in `Beta Features`
* Set up the conditions and values like so:
![CleanShot 2024-05-15 at 21 32 10@2x](https://github.com/Automattic/pocket-casts-ios/assets/3250/6e22d584-92bd-4788-ba14-f63e3c877ce5)
* Go to the Developer section and tap "Force Reload Feature Flags"
* Ensure that the flag is enabled in `Beta Features`

### Keep overridden value

* Delete the feature flag from Firebase
* Go to the Developer section and tap "Force Reload Feature Flags"
* Ensure that the flag remains enabled in `Beta Features`

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
