### PR TITLE
Adjusts play button size to 40 points

### DIFF
--- a/podcasts/MiniPlayerViewController.xib
+++ b/podcasts/MiniPlayerViewController.xib
@@ -68,7 +68,7 @@
                             </constraints>
                         </view>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" pointerInteraction="YES" translatesAutoresizingMaskIntoConstraints="NO" id="92g-6h-Yd9" userLabel="Skip Back">
-                            <rect key="frame" x="80.5" y="5.5" width="44" height="44"/>
+                            <rect key="frame" x="76.5" y="5.5" width="44" height="44"/>
                             <accessibility key="accessibilityConfiguration" label="Skip Back"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="44" id="Woi-QS-Vfx"/>
@@ -80,18 +80,18 @@
                             </connections>
                         </button>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="CjL-4C-tuh" userLabel="Play Pause Button" customClass="PlayPauseButton" customModule="podcasts" customModuleProvider="target">
-                            <rect key="frame" x="138.5" y="11.5" width="32" height="32"/>
+                            <rect key="frame" x="134.5" y="7.5" width="40" height="40"/>
                             <accessibility key="accessibilityConfiguration" label="Play/Pause"/>
                             <constraints>
-                                <constraint firstAttribute="width" constant="32" id="Q9t-vc-8fw"/>
-                                <constraint firstAttribute="height" constant="32" id="UGD-jw-hmp"/>
+                                <constraint firstAttribute="width" constant="40" id="Q9t-vc-8fw"/>
+                                <constraint firstAttribute="height" constant="40" id="UGD-jw-hmp"/>
                             </constraints>
                             <connections>
                                 <action selector="playPauseTapped:" destination="-1" eventType="touchUpInside" id="MHK-aa-QTy"/>
                             </connections>
                         </button>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" pointerInteraction="YES" translatesAutoresizingMaskIntoConstraints="NO" id="JHq-wc-GDV" userLabel="Skip Forward">
-                            <rect key="frame" x="184.5" y="5.5" width="44" height="44"/>
+                            <rect key="frame" x="188.5" y="5.5" width="44" height="44"/>
                             <accessibility key="accessibilityConfiguration" label="Skip Forward"/>
                             <constraints>
                                 <constraint firstAttribute="width" constant="44" id="lSC-b9-3WW"/>


### PR DESCRIPTION
Fixes #1763

Adjusts the sizing of the Play/Pause button in the mini player to be 40 points.

| Before | After |
| -- | -- |
| ![CleanShot 2024-05-16 at 11 59 59@2x](https://github.com/Automattic/pocket-casts-ios/assets/3250/823b91d2-be3b-44ad-8d6b-dad3ca78c020) | ![CleanShot 2024-05-16 at 11 59 28@2x](https://github.com/Automattic/pocket-casts-ios/assets/3250/533611ea-c2e8-49be-93b6-2d3efa1530a1) |

## To test

* Play an episode
* Close the player
* Ensure Mini Player play button is larger

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
