### PR TITLE
Standard Tags: fix show notes failing to retry and not persisting

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/Cache/ShowInfoDataRetriever.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Cache/ShowInfoDataRetriever.swift
@@ -10,17 +10,6 @@ public actor ShowInfoDataRetriever {
         cache = URLCache(memoryCapacity: 1.megabytes, diskCapacity: 100.megabytes, diskPath: "show_notes")
     }
 
-    public func loadEpisodeData(
-        for podcastUuid: String,
-        episodeUuid: String
-    ) async throws -> String? {
-        if let data = try? await loadShowInfoData(for: podcastUuid) {
-            return extractMetadata(for: episodeUuid, from: data)
-        }
-
-        return nil
-    }
-
     /// Try to load episode data from cache
     /// If it's not found, request it
     public func loadEpisodeDataFromCache(
@@ -80,6 +69,17 @@ public actor ShowInfoDataRetriever {
         dataRequestMap[podcastUuid] = task
 
         return try await task.value
+    }
+
+    private func loadEpisodeData(
+        for podcastUuid: String,
+        episodeUuid: String
+    ) async throws -> String? {
+        if let data = try? await loadShowInfoData(for: podcastUuid) {
+            return extractMetadata(for: episodeUuid, from: data)
+        }
+
+        return nil
     }
 
     private func extractMetadata(for episodeUuid: String, from data: Data) -> String? {

--- a/podcasts/Episode Info Coordinator/ShowInfoCoordinator.swift
+++ b/podcasts/Episode Info Coordinator/ShowInfoCoordinator.swift
@@ -104,7 +104,7 @@ actor ShowInfoCoordinator: ShowInfoCoordinating {
         let task = Task<Episode.Metadata?, Error> { [unowned self] in
             do {
                 let data = try await dataRetriever.loadEpisodeData(for: podcastUuid, episodeUuid: episodeUuid)
-                requestingRawMetadata[episodeUuid] = nil
+                requestingShowInfo[episodeUuid] = nil
                 return await getShowInfo(for: data?.data(using: .utf8))
             } catch {
                 requestingShowInfo[episodeUuid] = nil

--- a/podcasts/Episode Info Coordinator/ShowInfoCoordinator.swift
+++ b/podcasts/Episode Info Coordinator/ShowInfoCoordinator.swift
@@ -103,7 +103,7 @@ actor ShowInfoCoordinator: ShowInfoCoordinating {
 
         let task = Task<Episode.Metadata?, Error> { [unowned self] in
             do {
-                let data = try await dataRetriever.loadEpisodeData(for: podcastUuid, episodeUuid: episodeUuid)
+                let data = try await dataRetriever.loadEpisodeDataFromCache(for: podcastUuid, episodeUuid: episodeUuid)
                 requestingShowInfo[episodeUuid] = nil
                 return await getShowInfo(for: data?.data(using: .utf8))
             } catch {


### PR DESCRIPTION
When failing to load show notes the "retry" button wasn't working due to the use of a wrong dictionary that holds the task.

https://github.com/Automattic/pocket-casts-ios/assets/7040243/f531ae1d-4ece-4512-a8e3-33764e0c1ada


## To test

1. Run the app while offline
2. Open any episode without show notes
3. ✅ You should see "Unable to find show notes..."
4. Restore your internet connection
5. Tap "Try Again"
6. ✅ Notes should appear
7. Go offline again
8. Close and reopen the app
9. Open the same episode
10. ✅ Notes should appear

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
