### PR TITLE
Fix mini player dissapearing on the iPad

### DIFF
--- a/podcasts/MiniPlayerViewController+Positioning.swift
+++ b/podcasts/MiniPlayerViewController+Positioning.swift
@@ -28,8 +28,7 @@ extension MiniPlayerViewController {
 
         changeHeightTo(desiredHeight())
         moveToHiddenBottomPosition()
-        self.view.isHidden = false
-        if playerOpenState != .open { view.isHidden = true }
+        self.view.isHidden = false        
         view.superview?.layoutIfNeeded()
         UIView.animate(withDuration: 0.2, animations: { () in
             self.moveToShownPosition()

--- a/podcasts/MiniPlayerViewController+Positioning.swift
+++ b/podcasts/MiniPlayerViewController+Positioning.swift
@@ -28,7 +28,8 @@ extension MiniPlayerViewController {
 
         changeHeightTo(desiredHeight())
         moveToHiddenBottomPosition()
-        if playerOpenState != .open { view.isHidden = false }
+        self.view.isHidden = false
+        if playerOpenState != .open { view.isHidden = true }
         view.superview?.layoutIfNeeded()
         UIView.animate(withDuration: 0.2, animations: { () in
             self.moveToShownPosition()

--- a/podcasts/MiniPlayerViewController+Positioning.swift
+++ b/podcasts/MiniPlayerViewController+Positioning.swift
@@ -28,7 +28,7 @@ extension MiniPlayerViewController {
 
         changeHeightTo(desiredHeight())
         moveToHiddenBottomPosition()
-        self.view.isHidden = false        
+        self.view.isHidden = false
         view.superview?.layoutIfNeeded()
         UIView.animate(withDuration: 0.2, animations: { () in
             self.moveToShownPosition()


### PR DESCRIPTION
Fixes #1774 

Ensure that mini-player stays visible after rotating on the iPad

## To test

- Start the app on the iPad
- Start playing an episode so the mini-player is visible
- Open it full screen
- Transition to the Podcast view by tapping on the podcast name bellow the image
- Rotate the device
- Mini-player should stay visible
- Long press on the mini-player and choose the option Close and Clear Up Next
- Rotate device and see if mini-player stays hidden

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
