### PR TITLE
Signing back in: fixes issues with outdated podcast information

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/ServerSettings.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/ServerSettings.swift
@@ -278,6 +278,10 @@ public class ServerSettings {
         UserDefaults.standard.removeObject(forKey: ServerConstants.UserDefaults.lastSyncTime)
     }
 
+    public class var lastSyncTime: Date? {
+        UserDefaults.standard.object(forKey: ServerConstants.UserDefaults.lastSyncTime) as? Date
+    }
+
     // Push Token
     public class func pushToken() -> String? {
         UserDefaults.standard.string(forKey: ServerConstants.UserDefaults.pushToken)

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -54,6 +54,11 @@ public enum FeatureFlag: String, CaseIterable {
     /// This is to fix this: https://a8c.sentry.io/share/issue/39a6d2958b674ec3b7a4d9248b4b5ffa/
     case defaultPlayerFilterCallbackFix
 
+    /// When a user sign in, we always mark ALL podcasts as unsynced
+    /// This recently caused issues, syncing changes that shouldn't have been synced
+    /// When `true`, we only mark podcasts as unsynced if the user never signed in before
+    case onlyMarkPodcastsUnsyncedForNewUsers
+
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -99,6 +104,8 @@ public enum FeatureFlag: String, CaseIterable {
         case .defaultPlayerFilterCallbackFix:
             true
         case .upNextOnTabBar:
+            true
+        case .onlyMarkPodcastsUnsyncedForNewUsers:
             true
         }
     }

--- a/podcasts/AuthenticationHelper.swift
+++ b/podcasts/AuthenticationHelper.swift
@@ -66,7 +66,8 @@ class AuthenticationHelper {
 
         // we've signed in, set all our existing podcasts to
         // be non synced if the user never logged in before
-        if ServerSettings.lastSyncTime == nil {
+        if (FeatureFlag.onlyMarkPodcastsUnsyncedForNewUsers.enabled && ServerSettings.lastSyncTime == nil)
+            || !FeatureFlag.onlyMarkPodcastsUnsyncedForNewUsers.enabled {
             DataManager.sharedManager.markAllPodcastsUnsynced()
         }
 

--- a/podcasts/AuthenticationHelper.swift
+++ b/podcasts/AuthenticationHelper.swift
@@ -65,7 +65,9 @@ class AuthenticationHelper {
         ServerSettings.refreshToken = response.refreshToken
 
         // we've signed in, set all our existing podcasts to be non synced
-        DataManager.sharedManager.markAllPodcastsUnsynced()
+        if ServerSettings.lastSyncTime == nil {
+            DataManager.sharedManager.markAllPodcastsUnsynced()
+        }
 
         SyncManager.syncReason = .login
         ServerSettings.clearLastSyncTime()

--- a/podcasts/AuthenticationHelper.swift
+++ b/podcasts/AuthenticationHelper.swift
@@ -64,7 +64,8 @@ class AuthenticationHelper {
         ServerSettings.syncingV2Token = response.token
         ServerSettings.refreshToken = response.refreshToken
 
-        // we've signed in, set all our existing podcasts to be non synced
+        // we've signed in, set all our existing podcasts to
+        // be non synced if the user never logged in before
         if ServerSettings.lastSyncTime == nil {
             DataManager.sharedManager.markAllPodcastsUnsynced()
         }

--- a/podcasts/DeveloperMenu.swift
+++ b/podcasts/DeveloperMenu.swift
@@ -36,6 +36,10 @@ struct DeveloperMenu: View {
                         PodcastManager.shared.unsubscribe(podcast: podcast)
                     }
                 }
+
+                Button("Clear all folder information") {
+                    DataManager.sharedManager.clearAllFolderInformation()
+                }
             }
 
             Section {

--- a/podcasts/SyncSigninViewController.swift
+++ b/podcasts/SyncSigninViewController.swift
@@ -330,7 +330,8 @@ class SyncSigninViewController: PCViewController, UITextFieldDelegate {
         ServerSettings.userId = userId
         ServerSettings.saveSyncingPassword(password)
 
-        // we've signed in, set all our existing podcasts to be non synced
+        // we've signed in, set all our existing podcasts to
+        // be non synced if the user never logged in before
         if ServerSettings.lastSyncTime == nil {
             DataManager.sharedManager.markAllPodcastsUnsynced()
         }

--- a/podcasts/SyncSigninViewController.swift
+++ b/podcasts/SyncSigninViewController.swift
@@ -331,7 +331,9 @@ class SyncSigninViewController: PCViewController, UITextFieldDelegate {
         ServerSettings.saveSyncingPassword(password)
 
         // we've signed in, set all our existing podcasts to be non synced
-        DataManager.sharedManager.markAllPodcastsUnsynced()
+        if ServerSettings.lastSyncTime == nil {
+            DataManager.sharedManager.markAllPodcastsUnsynced()
+        }
 
         SyncManager.syncReason = .login
         ServerSettings.clearLastSyncTime()

--- a/podcasts/SyncSigninViewController.swift
+++ b/podcasts/SyncSigninViewController.swift
@@ -332,7 +332,8 @@ class SyncSigninViewController: PCViewController, UITextFieldDelegate {
 
         // we've signed in, set all our existing podcasts to
         // be non synced if the user never logged in before
-        if ServerSettings.lastSyncTime == nil {
+        if (FeatureFlag.onlyMarkPodcastsUnsyncedForNewUsers.enabled && ServerSettings.lastSyncTime == nil)
+            || !FeatureFlag.onlyMarkPodcastsUnsyncedForNewUsers.enabled {
             DataManager.sharedManager.markAllPodcastsUnsynced()
         }
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/pocket-casts-ios/issues/791#issuecomment-2125086525

We recently had an issue where a user had all their podcasts removed from folders when signing back in on another device.

This happened because they had outdated information and the app marked it as unsynced.

## To test

### With `onlyMarkPodcastsUnsyncedForNewUsers` enabled

1. Go to Profile > Settings > Beta Features > enable `onlyMarkPodcastsUnsyncedForNewUsers`
1. Sign in to a Plus account
2. Create a folder with some podcasts in it and refresh
3. Log out
4. Go to Settings > Developer > Clear all folder information
5. Subscribe to a few new podcasts
6. Log back into the same account
7. ✅ Under "Podcasts" the folder should be visible and with the same podcasts from before
8. Go to Profile > Refresh Now
9. ✅  Login into the web player, and ensure the newly subscribed podcasts were correctly synced

### With `onlyMarkPodcastsUnsyncedForNewUsers` disabled

1. Go to Profile > Settings > Beta Features > disable `onlyMarkPodcastsUnsyncedForNewUsers`
1. Add a breakpoint in `SyncSigninViewController.swift:337`
1. Sign in to a Plus account
2. Create a folder with some podcasts in it and refresh
3. Log out
4. Go to Settings > Developer > Clear all folder information
6. Log back into the same account
7. ✅ Breakpoint should hit
8. ✅ Under "Podcasts" the podcasts will be out of their folders

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
