### PR TITLE
Fixes bar for episode selection in Podcast screen

### DIFF
--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -165,8 +165,8 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
     @IBOutlet weak var multiSelectHeaderViewConstraint: NSLayoutConstraint!
 
     private func setMultiSelectHeaderViewConstraint() {
-        let heightConstant = 40 + view.safeAreaInsets.top
-        self.multiSelectHeaderViewConstraint.constant = heightConstant
+        let heightConstant: CGFloat = 40
+        self.multiSelectHeaderViewConstraint.constant = heightConstant + view.safeAreaInsets.top
     }
 
     static let headerSection = 0

--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -165,21 +165,8 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
     @IBOutlet weak var multiSelectHeaderViewConstraint: NSLayoutConstraint!
 
     private func setMultiSelectHeaderViewConstraint() {
-        let screenWidth = UIScreen.main.bounds.width
-        var setConstant: Double
-
-        switch screenWidth {
-        /* iPod Touch (320) to iPhone SE 3rd gen (375) and
-         iPad Mini 4 (760) to iPad 6th Gen (1024) */
-        case 320...380, 760...1024:
-            setConstant = 65.0
-        /* Covers most modern devices (380+ width),
-         from iPhone 6 Plus (414) to iPhone 14 Pro Max (430) */
-        default:
-            setConstant = 90.0
-        }
-
-        self.multiSelectHeaderViewConstraint.constant = setConstant
+        let heightConstant = 40 + view.safeAreaInsets.top
+        self.multiSelectHeaderViewConstraint.constant = heightConstant
     }
 
     static let headerSection = 0
@@ -196,6 +183,11 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
         view.backgroundColor = .clear
         return view
     }()
+
+    override func viewSafeAreaInsetsDidChange() {
+        super.viewSafeAreaInsetsDidChange()
+        setMultiSelectHeaderViewConstraint()
+    }
 
     init(podcast: Podcast) {
         self.podcast = podcast


### PR DESCRIPTION
On smaller devices, this navbar was cut off because we had incorrect sizing for various screen sizes. I refactored this to use the `safeAreaInset` and also to refresh the constraint when the safe area inset changes.

This also increases the height just a bit because it doesn't cover the full bar on dynamic island devices.

Fixes #1302

| Before | After |
| -- | -- |
| <img width=300 src="https://github.com/Automattic/pocket-casts-ios/assets/3250/ae981b8f-00d7-469e-a032-d1b303e54ad2"> | <img width=300 src="https://github.com/Automattic/pocket-casts-ios/assets/3250/514083e3-52a0-4d4b-9ffc-b668783d0086"> |

| Before | After |
| -- | -- |
| <img width=300 src="https://github.com/Automattic/pocket-casts-ios/assets/3250/5d94f938-2298-43da-9432-40bdf9c64d75"> | <img width=300 src="https://github.com/Automattic/pocket-casts-ios/assets/3250/905e6f1d-dc32-438c-9a03-110412ffb0e9"> |

## To test

* Build and run for iPhone 13 Mini simulator
* Navigate to Podcast screen
* Tap and hold to begin cell selection
* Ensure that top bar controls are visible and functional

Repeat steps on several different devices including iPhone 15 Pro and Pro Max, iPhone 8, and iPad

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
