### PR TITLE
Download Issues: Log active download tasks on launch

### DIFF
--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -381,6 +381,7 @@ enum AnalyticsEvent: String {
     case episodeDownloadCancelled
     case episodeDownloadFailed
     case episodeDownloadsStale
+    case episodeDownloadTasks
 
     case episodeUploadQueued
     case episodeUploadFinished

--- a/podcasts/AppDelegate+Analytics.swift
+++ b/podcasts/AppDelegate+Analytics.swift
@@ -16,6 +16,16 @@ extension AppDelegate {
         Analytics.register(adapters: [AnalyticsLoggingAdapter(), TracksAdapter(), CrashLoggingAdapter()])
     }
 
+    func logActiveDownloadTasks() {
+        Task {
+            let tasks = await DownloadManager.shared.activeTasks()
+
+            let properties: [String: Any?] =  ["tasks_count": tasks.count]
+
+            Analytics.track(.episodeDownloadTasks, properties: properties.compactMapValues({ $0 }))
+        }
+    }
+
     func logStaleDownloads() {
         let failedDownloadCount = DataManager.sharedManager.failedDownloadedEpisodesCount()
 

--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -63,6 +63,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             ServerConfig.shared.playbackDelegate = PlaybackManager.shared
             checkDefaults()
 
+            logActiveDownloadTasks()
             logStaleDownloads()
             postLaunchSetup()
             checkIfRestoreCleanupRequired()

--- a/podcasts/DownloadManager.swift
+++ b/podcasts/DownloadManager.swift
@@ -496,4 +496,10 @@ class DownloadManager: NSObject, FilePathProtocol {
             }
         }
     }
+
+    func activeTasks() async -> [URLSessionTask] {
+        return [await wifiOnlyBackgroundSession.allTasks,
+         await cellularForegroundSession.allTasks,
+         await cellularBackgroundSession.allTasks].flatMap { $0 }
+    }
 }


### PR DESCRIPTION
Adds event to log the current count of URLSession tasks scheduled by `DownloadManager`.

## To test

* Enable the `tracksLogging` feature flag
* Relaunch the app
* Verify that the `episode_download_tasks` event is logged with the `tasks_count` property

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
