### PR TITLE
Sleep timer: add options to enable/disable shake and auto restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 7.65
 -----
 - Show the Up Next bar on the tab bar. [#1613]
+- Add options to enable/disable Sleep Timer shake and auto restart [#1790]
 
 7.64
 -----

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -486,6 +486,8 @@ enum AnalyticsEvent: String {
     case settingsGeneralMultiSelectGestureToggled
     case settingsGeneralPublishChapterTitlesToggled
     case settingsGeneralAutoplayToggled
+    case settingsGeneralAutoSleepTimerRestartToggled
+    case settingsGeneralShakeToResetSleepTimerToggled
 
     // MARK: - Settings: Notifications
 

--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -157,6 +157,9 @@ struct Constants {
 
         static let autoplay = "autoplay"
 
+        static let autoRestartSleepTimer = "autoRestartSleepTimer"
+        static let shakeToRestartSleepTimer = "shakeToRestartSleepTimer"
+
         static let searchHistoryEntries = "SearchHistoryEntries"
 
         static let sleepTimerFinishedDate = "sleepTimerFinishedDate"

--- a/podcasts/GeneralSettingsViewController.swift
+++ b/podcasts/GeneralSettingsViewController.swift
@@ -261,7 +261,7 @@ class GeneralSettingsViewController: PCViewController, UITableViewDelegate, UITa
         case .autoRestartSleepTimer:
             let cell = tableView.dequeueReusableCell(withIdentifier: switchCellId, for: indexPath) as! SwitchCell
 
-            cell.cellLabel.text = "Auto Restart Sleep Timer"
+            cell.cellLabel.text = L10n.autoRestartSleepTimer
             cell.cellSwitch.isOn = Settings.autoRestartSleepTimer
 
             cell.cellSwitch.removeTarget(self, action: nil, for: .valueChanged)
@@ -271,7 +271,7 @@ class GeneralSettingsViewController: PCViewController, UITableViewDelegate, UITa
         case .shakeToRestartSleepTimer:
             let cell = tableView.dequeueReusableCell(withIdentifier: switchCellId, for: indexPath) as! SwitchCell
 
-            cell.cellLabel.text = "Shake to restart Sleep Timer"
+            cell.cellLabel.text = L10n.shakeToRestartSleepTimer
             cell.cellSwitch.isOn = Settings.shakeToRestartSleepTimer
 
             cell.cellSwitch.removeTarget(self, action: nil, for: .valueChanged)
@@ -422,9 +422,9 @@ class GeneralSettingsViewController: PCViewController, UITableViewDelegate, UITa
         case .autoplay:
             return L10n.settingsGeneralAutoplaySubtitle
         case .autoRestartSleepTimer:
-            return "If on, the sleep timer will restart automatically if you play an episode within 5 minutes after the last pause."
+            return L10n.autoRestartSleepTimerDescription
         case .shakeToRestartSleepTimer:
-            return "If on, the sleep timer will restart when you shake your phone."
+            return L10n.shakeToRestartSleepTimerDescription
         default:
             return nil
         }

--- a/podcasts/GeneralSettingsViewController.swift
+++ b/podcasts/GeneralSettingsViewController.swift
@@ -10,8 +10,8 @@ class GeneralSettingsViewController: PCViewController, UITableViewDelegate, UITa
 
     let debounce = Debounce(delay: Constants.defaultDebounceTime)
 
-    private enum TableRow { case skipForward, skipBack, keepScreenAwake, openPlayer, intelligentPlaybackResumption, defaultRowAction, extraMediaActions, defaultAddToUpNextSwipe, defaultGrouping, defaultArchive, playUpNextOnTap, legacyBluetooth, multiSelectGesture, openLinksInBrowser, publishChapterTitles, autoplay }
-    private var tableData: [[TableRow]] = [[.defaultRowAction, .defaultGrouping, .defaultArchive, .defaultAddToUpNextSwipe, .openLinksInBrowser], [.skipForward, .skipBack, .keepScreenAwake, .openPlayer, .intelligentPlaybackResumption], [.playUpNextOnTap], [.extraMediaActions], [.legacyBluetooth], [.multiSelectGesture], [.publishChapterTitles], [.autoplay]]
+    private enum TableRow { case skipForward, skipBack, keepScreenAwake, openPlayer, intelligentPlaybackResumption, defaultRowAction, extraMediaActions, defaultAddToUpNextSwipe, defaultGrouping, defaultArchive, playUpNextOnTap, legacyBluetooth, multiSelectGesture, openLinksInBrowser, publishChapterTitles, autoplay, autoRestartSleepTimer, shakeToRestartSleepTimer }
+    private var tableData: [[TableRow]] = [[.defaultRowAction, .defaultGrouping, .defaultArchive, .defaultAddToUpNextSwipe, .openLinksInBrowser], [.skipForward, .skipBack, .keepScreenAwake, .openPlayer, .intelligentPlaybackResumption], [.autoRestartSleepTimer], [.shakeToRestartSleepTimer], [.playUpNextOnTap], [.extraMediaActions], [.legacyBluetooth], [.multiSelectGesture], [.publishChapterTitles], [.autoplay]]
 
     @IBOutlet var settingsTable: UITableView! {
         didSet {
@@ -258,6 +258,26 @@ class GeneralSettingsViewController: PCViewController, UITableViewDelegate, UITa
             cell.cellSwitch.addTarget(self, action: #selector(autoplayToggled(_:)), for: .valueChanged)
 
             return cell
+        case .autoRestartSleepTimer:
+            let cell = tableView.dequeueReusableCell(withIdentifier: switchCellId, for: indexPath) as! SwitchCell
+
+            cell.cellLabel.text = "Auto Restart Sleep Timer"
+            cell.cellSwitch.isOn = Settings.autoRestartSleepTimer
+
+            cell.cellSwitch.removeTarget(self, action: nil, for: .valueChanged)
+            cell.cellSwitch.addTarget(self, action: #selector(autoRestartSleepTimerToggled(_:)), for: .valueChanged)
+
+            return cell
+        case .shakeToRestartSleepTimer:
+            let cell = tableView.dequeueReusableCell(withIdentifier: switchCellId, for: indexPath) as! SwitchCell
+
+            cell.cellLabel.text = "Shake to restart Sleep Timer"
+            cell.cellSwitch.isOn = Settings.shakeToRestartSleepTimer
+
+            cell.cellSwitch.removeTarget(self, action: nil, for: .valueChanged)
+            cell.cellSwitch.addTarget(self, action: #selector(shakeToRestartSleepTimerToggled(_:)), for: .valueChanged)
+
+            return cell
         }
     }
 
@@ -372,6 +392,8 @@ class GeneralSettingsViewController: PCViewController, UITableViewDelegate, UITa
             return SettingsTableHeader(frame: headerFrame, title: L10n.settingsGeneralDefaultsHeader)
         } else if section == 1 {
             return SettingsTableHeader(frame: headerFrame, title: L10n.settingsGeneralPlayerHeader)
+        } else if tableData[safe: section]?.contains(.autoRestartSleepTimer) == true {
+            return SettingsTableHeader(frame: headerFrame, title: L10n.sleepTimer)
         }
 
         return nil
@@ -399,6 +421,10 @@ class GeneralSettingsViewController: PCViewController, UITableViewDelegate, UITa
             return L10n.settingsGeneralPublishChapterTitlesSubtitle
         case .autoplay:
             return L10n.settingsGeneralAutoplaySubtitle
+        case .autoRestartSleepTimer:
+            return "If on, the sleep timer will restart automatically if you play an episode within 5 minutes after the last pause."
+        case .shakeToRestartSleepTimer:
+            return "If on, the sleep timer will restart when you shake your phone."
         default:
             return nil
         }
@@ -502,6 +528,14 @@ class GeneralSettingsViewController: PCViewController, UITableViewDelegate, UITa
 
 
         Settings.trackValueToggled(.settingsGeneralAutoplayToggled, enabled: sender.isOn)
+    }
+
+    @objc private func autoRestartSleepTimerToggled(_ sender: UISwitch) {
+        Settings.autoRestartSleepTimer = sender.isOn
+    }
+
+    @objc private func shakeToRestartSleepTimerToggled(_ sender: UISwitch) {
+        Settings.shakeToRestartSleepTimer = sender.isOn
     }
 
     override var preferredStatusBarStyle: UIStatusBarStyle {

--- a/podcasts/GeneralSettingsViewController.swift
+++ b/podcasts/GeneralSettingsViewController.swift
@@ -526,16 +526,19 @@ class GeneralSettingsViewController: PCViewController, UITableViewDelegate, UITa
     @objc private func autoplayToggled(_ sender: UISwitch) {
         Settings.autoplay = sender.isOn
 
-
         Settings.trackValueToggled(.settingsGeneralAutoplayToggled, enabled: sender.isOn)
     }
 
     @objc private func autoRestartSleepTimerToggled(_ sender: UISwitch) {
         Settings.autoRestartSleepTimer = sender.isOn
+
+        Settings.trackValueToggled(.settingsGeneralAutoSleepTimerRestartToggled, enabled: sender.isOn)
     }
 
     @objc private func shakeToRestartSleepTimerToggled(_ sender: UISwitch) {
         Settings.shakeToRestartSleepTimer = sender.isOn
+
+        Settings.trackValueToggled(.settingsGeneralShakeToResetSleepTimerToggled, enabled: sender.isOn)
     }
 
     override var preferredStatusBarStyle: UIStatusBarStyle {

--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -656,7 +656,7 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
 
     override func motionEnded(_ motion: UIEvent.EventSubtype, with event: UIEvent?) {
         super.motionEnded(motion, with: event)
-        if motion == .motionShake {
+        if motion == .motionShake && Settings.shakeToRestartSleepTimer {
             PlaybackManager.shared.restartSleepTimer()
         }
     }

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -1043,6 +1043,25 @@ class Settings: NSObject {
         }
     }
 
+    // MARK: - Sleep Timer
+
+    static var autoRestartSleepTimer: Bool {
+        set {
+            UserDefaults.standard.set(newValue, forKey: Constants.UserDefaults.autoRestartSleepTimer)
+        }
+        get {
+            UserDefaults.standard.object(forKey: Constants.UserDefaults.autoRestartSleepTimer) as? Bool ?? true
+        }
+    }
+
+    static var shakeToRestartSleepTimer: Bool {
+        set {
+            UserDefaults.standard.set(newValue, forKey: Constants.UserDefaults.shakeToRestartSleepTimer)
+        }
+        get {
+            UserDefaults.standard.object(forKey: Constants.UserDefaults.shakeToRestartSleepTimer) as? Bool ?? true
+        }
+    }
 
     // MARK: - Headphone Controls
 

--- a/podcasts/SleepTimerManager.swift
+++ b/podcasts/SleepTimerManager.swift
@@ -124,7 +124,7 @@ class BackgroundShakeObserver {
     }
 
     @objc private func appMovedToBackground() {
-        if PlaybackManager.shared.sleepTimerActive() {
+        if PlaybackManager.shared.sleepTimerActive() && Settings.shakeToRestartSleepTimer {
             startObserving()
         }
     }

--- a/podcasts/SleepTimerManager.swift
+++ b/podcasts/SleepTimerManager.swift
@@ -53,7 +53,7 @@ class SleepTimerManager {
     }
 
     func restartSleepTimerIfNeeded() {
-        guard !PlaybackManager.shared.sleepTimerActive() else {
+        guard !PlaybackManager.shared.sleepTimerActive(), Settings.autoRestartSleepTimer else {
             return
         }
 

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -286,6 +286,10 @@ internal enum L10n {
   }
   /// First
   internal static var autoDownloadPromptFirst: String { return L10n.tr("Localizable", "auto_download_prompt_first") }
+  /// Auto Restart Sleep Timer
+  internal static var autoRestartSleepTimer: String { return L10n.tr("Localizable", "auto_restart_sleep_timer") }
+  /// If on, the sleep timer will restart automatically if you play an episode within 5 minutes after the last pause.
+  internal static var autoRestartSleepTimerDescription: String { return L10n.tr("Localizable", "auto_restart_sleep_timer_description") }
   /// Back
   internal static var back: String { return L10n.tr("Localizable", "back") }
   /// Please download Pocket Casts from the App Store to purchase %1$@.
@@ -2700,6 +2704,10 @@ internal enum L10n {
   }
   /// Set Up Account
   internal static var setupAccount: String { return L10n.tr("Localizable", "setup_account") }
+  /// Shake to restart Sleep Timer
+  internal static var shakeToRestartSleepTimer: String { return L10n.tr("Localizable", "shake_to_restart_sleep_timer") }
+  /// If on, the sleep timer will restart when you shake your phone.
+  internal static var shakeToRestartSleepTimerDescription: String { return L10n.tr("Localizable", "shake_to_restart_sleep_timer_description") }
   /// Share
   internal static var share: String { return L10n.tr("Localizable", "share") }
   /// Current Position

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4078,3 +4078,15 @@
 
 /* Message displayed when doing heavy database operations */
 "database_migration" = "We're moving a few bits and bytes so the app runs faster...";
+
+/* Name of the option to restart sleep timer */
+"auto_restart_sleep_timer" = "Auto Restart Sleep Timer";
+
+/* Name of the option to shake to restart sleep timer */
+"shake_to_restart_sleep_timer" = "Shake to restart Sleep Timer";
+
+/* Description of the option to restart sleep timer */
+"auto_restart_sleep_timer_description" = "If on, the sleep timer will restart automatically if you play an episode within 5 minutes after the last pause.";
+
+/* Description of the option to shake to restart sleep timer */
+"shake_to_restart_sleep_timer_description" = "If on, the sleep timer will restart when you shake your phone.";


### PR DESCRIPTION
We have users reporting that they would like to configure the Auto Restart Sleep Timer and Shake to Restart features. This PR add these options.

By default, they're **enabled**.

## To test

To make testing faster, go to `SleepTimerViewController.swift` and change the `fiveMinutesTapped` function to `5.seconds` (instead of `5.minutes`), also go to Profile > Beta Features > and enable `tracksLogging`.

1. Run the app on a real device
2. Go to Profile > Settings
3. ✅ Auto Restart Sleep Timer and Shake to restart Sleep Timer should be enabled
4. Play an episode and start a 5 minutes Sleep Timer
5. When it stops, tap play again
6. ✅ Sleep timer should restart automatically
7. Go to Profile > Settings > disable Auto Restart Sleep Timer
8. ✅ Ensure `settings_general_auto_sleep_timer_restart_toggled ["enabled": false]` is logged
9. Go back and play the episode again, start the sleep timer
10. When it finishes, play again
11. ✅ Sleep timer should not restart
12. Play again and start a big sleep timer
13. With the app on foreground, shake it
14. ✅ Sleep timer should restart
15. Put the app on background, shake it
16. ✅ Sleep timer should restart and you should listen a sound
17. Open the app, pause the episode
18. Go to Profile > Settings > disable Shake to Restart Sleep Timer
19. ✅ Ensure `settings_general_shake_to_reset_sleep_timer_toggled ["enabled": false]` is logged
20. Play the episode again, ensure a sleep timer is going on
21. Shake the device
22. ✅ Nothing should happen, sleep timer will not be restarted
23. Put the app on background, shake it
24. ✅ Nothing should happen, sleep timer will not be restarted

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
