### PR TITLE
Fix visibility of multi-select on UpNextView controller

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1633,6 +1633,7 @@
 		FF91A0FA2B6BBFD1002A0590 /* UpgradeCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF91A0F92B6BBFD1002A0590 /* UpgradeCard.swift */; };
 		FF91A0FC2B6BC1D2002A0590 /* UpgradePrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF91A0FB2B6BC1D2002A0590 /* UpgradePrompt.swift */; };
 		FF91A0FE2B6BC4BD002A0590 /* FeaturesCarousel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF91A0FD2B6BC4BD002A0590 /* FeaturesCarousel.swift */; };
+		FFAA063E2C086DEA00FBC38F /* InsetAdjuster.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFAA063D2C086DEA00FBC38F /* InsetAdjuster.swift */; };
 		FFC293992B6173400059F3BB /* IAPTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFC293982B6173400059F3BB /* IAPTypes.swift */; };
 		FFD3AB8C2BD15E8F00C562CB /* CircleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFD3AB8B2BD15E8F00C562CB /* CircleView.swift */; };
 		FFF024CE2B62AC9400457373 /* IAPHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFF024CD2B62AC9400457373 /* IAPHelperTests.swift */; };
@@ -3411,6 +3412,7 @@
 		FF91A0F92B6BBFD1002A0590 /* UpgradeCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpgradeCard.swift; sourceTree = "<group>"; };
 		FF91A0FB2B6BC1D2002A0590 /* UpgradePrompt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpgradePrompt.swift; sourceTree = "<group>"; };
 		FF91A0FD2B6BC4BD002A0590 /* FeaturesCarousel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturesCarousel.swift; sourceTree = "<group>"; };
+		FFAA063D2C086DEA00FBC38F /* InsetAdjuster.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsetAdjuster.swift; sourceTree = "<group>"; };
 		FFC293982B6173400059F3BB /* IAPTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IAPTypes.swift; sourceTree = "<group>"; };
 		FFD3AB8B2BD15E8F00C562CB /* CircleView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CircleView.swift; sourceTree = "<group>"; };
 		FFF024CD2B62AC9400457373 /* IAPHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IAPHelperTests.swift; sourceTree = "<group>"; };
@@ -5578,6 +5580,7 @@
 				BDD40A171FA1ABF500A53AE1 /* PCNavigationController.swift */,
 				BD6B432B27561EA8005E4017 /* PCHostingController.swift */,
 				C7C4F9BE2A4CC359002822DD /* PCTableViewController.swift */,
+				FFAA063D2C086DEA00FBC38F /* InsetAdjuster.swift */,
 			);
 			name = "VIew Controllers";
 			sourceTree = "<group>";
@@ -9068,6 +9071,7 @@
 				BDF0507C1FBA65ED00194D68 /* ListeningHistoryViewController.swift in Sources */,
 				BD6C3EFF2378EC5900C01403 /* NowPlayingPlayerItemViewController+Shelf.swift in Sources */,
 				408F0B36227FF41E0019584D /* ProfileProgressCircleView.swift in Sources */,
+				FFAA063E2C086DEA00FBC38F /* InsetAdjuster.swift in Sources */,
 				BDD62981200EEA6700168DF7 /* SimpleNotificationsViewController.swift in Sources */,
 				BD4BBFA41D223AA9001BEE4D /* Settings.swift in Sources */,
 				400AB2FD220BA3050003EE21 /* UploadedViewController.swift in Sources */,

--- a/podcasts/InsetAdjuster.swift
+++ b/podcasts/InsetAdjuster.swift
@@ -1,0 +1,45 @@
+import Foundation
+import UIKit
+
+/// Class to adjust scroll insets and scroll indicator depending of mini-player visibility and multi-select being enabled
+class InsetAdjuster {
+
+    let ignoreMiniPlayer: Bool
+
+    init(ignoreMiniPlayer: Bool = false) {
+        self.ignoreMiniPlayer = ignoreMiniPlayer
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+
+    var isMultiSelectEnabled: Bool = false {
+        didSet {
+            miniPlayerVisibilityDidChange()
+        }
+    }
+
+    private weak var scrollViewAdjustableToMiniPlayer: UIScrollView?
+
+    func setupInsetAdjustmentsForMiniPlayer(scrollView: UIScrollView) {
+        guard scrollViewAdjustableToMiniPlayer == nil else {
+            // This method should only be called once for each ViewController
+            return
+        }
+        scrollViewAdjustableToMiniPlayer = scrollView
+
+        NotificationCenter.default.addObserver(self, selector: #selector(miniPlayerVisibilityDidChange), name: Constants.Notifications.miniPlayerDidDisappear, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(miniPlayerVisibilityDidChange), name: Constants.Notifications.miniPlayerDidAppear, object: nil)
+
+        miniPlayerVisibilityDidChange()
+    }
+
+    @objc func miniPlayerVisibilityDidChange() {
+        guard let scrollView = scrollViewAdjustableToMiniPlayer else {
+            return
+        }
+        scrollView.updateContentInset(multiSelectEnabled: self.isMultiSelectEnabled, ignoreMiniPlayer: ignoreMiniPlayer)
+    }
+}

--- a/podcasts/PCViewController.swift
+++ b/podcasts/PCViewController.swift
@@ -195,47 +195,5 @@ class PCViewController: SimpleNotificationsViewController {
     func handleAppWillBecomeActive() {}
     func handleThemeChanged() {}
 
-    var insetAdjuster = MiniPlayerInsetAdjuster()
-}
-
-class MiniPlayerInsetAdjuster {
-
-    let ignoreMiniPlayer: Bool
-
-    init(ignoreMiniPlayer: Bool = false) {
-        self.ignoreMiniPlayer = ignoreMiniPlayer
-    }
-
-    deinit {
-        NotificationCenter.default.removeObserver(self)
-    }
-
-
-    var isMultiSelectEnabled: Bool = false {
-        didSet {
-            miniPlayerVisibilityDidChange()
-        }
-    }
-
-    private weak var scrollViewAdjustableToMiniPlayer: UIScrollView?
-
-    func setupInsetAdjustmentsForMiniPlayer(scrollView: UIScrollView) {
-        guard scrollViewAdjustableToMiniPlayer == nil else {
-            // This method should only be called once for each ViewController
-            return
-        }
-        scrollViewAdjustableToMiniPlayer = scrollView
-
-        NotificationCenter.default.addObserver(self, selector: #selector(miniPlayerVisibilityDidChange), name: Constants.Notifications.miniPlayerDidDisappear, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(miniPlayerVisibilityDidChange), name: Constants.Notifications.miniPlayerDidAppear, object: nil)
-
-        miniPlayerVisibilityDidChange()
-    }
-
-    @objc func miniPlayerVisibilityDidChange() {
-        guard let scrollView = scrollViewAdjustableToMiniPlayer else {
-            return
-        }
-        scrollView.updateContentInset(multiSelectEnabled: self.isMultiSelectEnabled, ignoreMiniPlayer: ignoreMiniPlayer)
-    }
+    var insetAdjuster = InsetAdjuster()
 }

--- a/podcasts/PCViewController.swift
+++ b/podcasts/PCViewController.swift
@@ -200,8 +200,10 @@ class PCViewController: SimpleNotificationsViewController {
 
 class MiniPlayerInsetAdjuster {
 
-    init() {
+    let ignoreMiniPlayer: Bool
 
+    init(ignoreMiniPlayer: Bool = false) {
+        self.ignoreMiniPlayer = ignoreMiniPlayer
     }
 
     deinit {
@@ -234,6 +236,6 @@ class MiniPlayerInsetAdjuster {
         guard let scrollView = scrollViewAdjustableToMiniPlayer else {
             return
         }
-        scrollView.updateContentInset(multiSelectEnabled: self.isMultiSelectEnabled)
+        scrollView.updateContentInset(multiSelectEnabled: self.isMultiSelectEnabled, ignoreMiniPlayer: ignoreMiniPlayer)
     }
 }

--- a/podcasts/UIScrollView+MiniPlayer.swift
+++ b/podcasts/UIScrollView+MiniPlayer.swift
@@ -9,10 +9,10 @@ extension UIScrollView {
         verticalScrollIndicatorInsets = UIEdgeInsets(top: existingScrollIndicatorInset.top, left: existingScrollIndicatorInset.left, bottom: existingScrollIndicatorInset.bottom + Constants.Values.miniPlayerOffset + additionalBottomInset, right: existingScrollIndicatorInset.right)
     }
 
-    func updateContentInset(multiSelectEnabled: Bool) {
+    func updateContentInset(multiSelectEnabled: Bool, ignoreMiniPlayer: Bool = false) {
         let existingInset = contentInset
         let multiSelectFooterOffset: CGFloat = multiSelectEnabled ? 80 : 0
-        let miniPlayerOffset: CGFloat = PlaybackManager.shared.currentEpisode() == nil ? 0 : Constants.Values.miniPlayerOffset
+        let miniPlayerOffset: CGFloat = (ignoreMiniPlayer || PlaybackManager.shared.currentEpisode() == nil) ? 0 : Constants.Values.miniPlayerOffset
         contentInset = UIEdgeInsets(top: existingInset.top, left: existingInset.left, bottom: miniPlayerOffset + multiSelectFooterOffset, right: existingInset.right)
 
         let existingScrollIndicatorInset = verticalScrollIndicatorInsets

--- a/podcasts/UpNextViewController.swift
+++ b/podcasts/UpNextViewController.swift
@@ -20,7 +20,7 @@ class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
     var themeOverride: Theme.ThemeType? = nil
 
     lazy var contentInseter = {
-        MiniPlayerInsetAdjuster(ignoreMiniPlayer: !self.showingInTab)
+        InsetAdjuster(ignoreMiniPlayer: !self.showingInTab)
     }()
 
     var isMultiSelectEnabled = false {

--- a/podcasts/UpNextViewController.swift
+++ b/podcasts/UpNextViewController.swift
@@ -18,6 +18,10 @@ class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
 
     var themeOverride: Theme.ThemeType? = nil
 
+    lazy var contentInseter = {
+        MiniPlayerInsetAdjuster(ignoreMiniPlayer: !self.showingInTab)
+    }()
+
     var isMultiSelectEnabled = false {
         didSet {
             let didChange = oldValue != isMultiSelectEnabled
@@ -35,7 +39,7 @@ class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
                     self.track(.upNextMultiSelectEntered)
                 }
                 if self.showingInTab {
-                    self.upNextTable.updateContentInset(multiSelectEnabled: isMultiSelectEnabled)
+                    self.multiSelectActionBarBottomConstraint.constant = PlaybackManager.shared.currentEpisode() == nil ? 8 : Constants.Values.miniPlayerOffset + 8
                 }
                 reloadTable()
             }
@@ -50,9 +54,9 @@ class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
         didSet {
             multiSelectActionBar.setSelectedCount(count: selectedPlayListEpisodes.count)
             if selectedPlayListEpisodes.count == 0 {
-                upNextTable.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
+                contentInseter.isMultiSelectEnabled = false
             } else {
-                upNextTable.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: 80, right: 0)
+                contentInseter.isMultiSelectEnabled = true
             }
             updateNavBarButtons()
         }
@@ -142,14 +146,13 @@ class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
         clearQueueButton.titleLabel?.font = UIFont.systemFont(ofSize: 13, weight: .bold)
         clearQueueButton.addTarget(self, action: #selector(clearQueueTapped), for: .touchUpInside)
 
+        contentInseter.setupInsetAdjustmentsForMiniPlayer(scrollView: upNextTable)
+
         refreshSections()
     }
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        if showingInTab {
-            upNextTable.updateContentInset(multiSelectEnabled: isMultiSelectEnabled)
-        }
         // fix issues with the now playing cell not animating by reloading it on appear
         reloadTable()
 

--- a/podcasts/UpNextViewController.swift
+++ b/podcasts/UpNextViewController.swift
@@ -11,6 +11,7 @@ class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
     static let noUpNextRowHeight: CGFloat = 180
     static let nowPlayingRowHeight: CGFloat = 72
     static let rearrangeWidth: CGFloat = 60
+    static let bottomMargin: CGFloat = 8
 
     enum sections: Int { case nowPlayingSection = 0, upNextSection }
 
@@ -39,7 +40,7 @@ class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
                     self.track(.upNextMultiSelectEntered)
                 }
                 if self.showingInTab {
-                    self.multiSelectActionBarBottomConstraint.constant = PlaybackManager.shared.currentEpisode() == nil ? 8 : Constants.Values.miniPlayerOffset + 8
+                    self.multiSelectActionBarBottomConstraint.constant = PlaybackManager.shared.currentEpisode() == nil ? Self.bottomMargin : Constants.Values.miniPlayerOffset + Self.bottomMargin
                 }
                 reloadTable()
             }


### PR DESCRIPTION
Fixes #

Use content inset class to control visibility of mini-player and multi select on `UpNextViewController`

| On the Tab Controller | On the Bottom Sheet |
| - | - |
| ![Simulator Screenshot - iPhone 15 Pro - 2024-05-29 at 16 16 03](https://github.com/Automattic/pocket-casts-ios/assets/651601/00e21c29-6397-49a3-877e-c45ce2e67987) |  ![Simulator Screenshot - iPhone 15 Pro - 2024-05-29 at 16 17 00](https://github.com/Automattic/pocket-casts-ios/assets/651601/abf47af8-6d54-43ad-b246-33b283812492) |

## To test

- Start the app
- Ensure that you have some episode on the UpNext queue by adding some items to listen
- Start playing one item
- Select UpNext on the root tab bar
- Tap Select on the top right
- Select some items
- Check that the Actions bar is visible on the bottom, above the mini-player
- On the mini-player tap on upnext icon the right
- Check that on this view you don't see the mini-player
- Check that the bottom margins when you scroll down are correct
- Tap on Select on the top right
- Check that you can scroll the items on the upnext and make them visible.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
