### PR TITLE
Folders: add history and the option to restore

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/FolderHistoryManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/FolderHistoryManager.swift
@@ -14,8 +14,9 @@ public class FolderHistoryManager {
             do {
                 db.beginTransaction()
 
+                let date = Date()
                 try podcastsAndFolders.forEach {
-                    try db.executeUpdate("INSERT INTO PodcastFoldersHistory VALUES ?, ?, ?", values: [$0.key, $0.value, Date()])
+                    try db.executeUpdate("INSERT INTO PodcastFoldersHistory VALUES (?, ?, ?)", values: [$0.key, $0.value, date])
                 }
                 try db.executeUpdate("DELETE FROM PodcastFoldersHistory WHERE date <= ?", values: [Date().addingTimeInterval(-periodOfSnapshot)])
 
@@ -75,5 +76,22 @@ public class FolderHistoryManager {
 
         public let date: Date
         public let changesCount: Int
+    }
+}
+
+public class FolderHistoryHelper {
+    public static let shared = FolderHistoryHelper()
+
+    private var podcastAndFolderUuids: [String: String] = [:]
+
+    public func add(podcastUuid: String, folderUuid: String) {
+        podcastAndFolderUuids[podcastUuid] = folderUuid
+    }
+
+    public func snapshot() {
+        if !podcastAndFolderUuids.isEmpty {
+            DataManager.sharedManager.snapshot(podcastsAndFolders: podcastAndFolderUuids)
+            podcastAndFolderUuids = [:]
+        }
     }
 }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/FolderHistoryManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/FolderHistoryManager.swift
@@ -1,0 +1,79 @@
+import FMDB
+import PocketCastsUtils
+
+public class FolderHistoryManager {
+    /// The number of days to keep the history
+    private let periodOfSnapshot: TimeInterval = 14.days
+
+    // MARK: - Queries
+
+    /// Saves a list of podcast UUID and folders UUID so it can be
+    /// restored later
+    func snapshot(podcastsAndFolders: [String: String], dbQueue: FMDatabaseQueue) {
+        dbQueue.inDatabase { db in
+            do {
+                db.beginTransaction()
+
+                try podcastsAndFolders.forEach {
+                    try db.executeUpdate("INSERT INTO PodcastFoldersHistory VALUES ?, ?, ?", values: [$0.key, $0.value, Date()])
+                }
+                try db.executeUpdate("DELETE FROM PodcastFoldersHistory WHERE date <= ?", values: [Date().addingTimeInterval(-periodOfSnapshot)])
+
+                db.commit()
+            } catch {
+                FileLog.shared.addMessage("FolderHistoryManager.snapshot error: \(error)")
+            }
+        }
+    }
+
+    /// Return all the available Up Next entries
+    func entries(dbQueue: FMDatabaseQueue) -> [PodcastFoldersHistoryEntry] {
+        var entries: [PodcastFoldersHistoryEntry] = []
+        dbQueue.inDatabase { db in
+            do {
+                let resultSet = try db.executeQuery("SELECT COUNT(*) as count, date FROM PodcastFoldersHistory GROUP BY (date) ORDER BY date DESC", values: nil)
+                defer { resultSet.close() }
+
+                while resultSet.next() {
+                    if let date = resultSet.date(forColumn: "date") {
+                        entries.append(PodcastFoldersHistoryEntry(date: date, changesCount: Int(resultSet.int(forColumn: "count"))))
+                    }
+                }
+            } catch {
+                FileLog.shared.addMessage("FolderHistoryManager.entries error: \(error)")
+            }
+        }
+
+        return entries
+    }
+
+    func podcastsAndFolders(entry: Date, dbQueue: FMDatabaseQueue) -> [String: String] {
+        var podcastsAndFolders: [String: String] = [:]
+        dbQueue.inDatabase { db in
+            do {
+                let resultSet = try db.executeQuery("SELECT podcastUuid, folderUuid FROM PodcastFoldersHistory WHERE date = ?", values: [entry])
+                defer { resultSet.close() }
+
+                while resultSet.next() {
+                    if let podcastUuid = resultSet.string(forColumn: "podcastUuid"),
+                       let folderUuid = resultSet.string(forColumn: "folderUuid") {
+                        podcastsAndFolders[podcastUuid] = folderUuid
+                    }
+                }
+            } catch {
+                FileLog.shared.addMessage("FolderHistoryManager.podcastsAndFolders error: \(error)")
+            }
+        }
+
+        return podcastsAndFolders
+    }
+
+    public struct PodcastFoldersHistoryEntry: Hashable, Identifiable {
+        public var id: Date {
+            date
+        }
+
+        public let date: Date
+        public let changesCount: Int
+    }
+}

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseHelper.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseHelper.swift
@@ -760,7 +760,6 @@ class DatabaseHelper {
             do {
                 try db.executeUpdate("""
                     CREATE TABLE PodcastFoldersHistory (
-                    id INTEGER KEY,
                     podcastUuid TEXT NOT NULL,
                     folderUuid TEXT NOT NULL,
                     date REAL NOT NULL
@@ -769,9 +768,9 @@ class DatabaseHelper {
 
                 try db.executeUpdate("CREATE INDEX IF NOT EXISTS podcast_folders_history_date ON PlaylistEpisodeHistory (date);", values: nil)
 
-                schemaVersion = 51
+                schemaVersion = 52
             } catch {
-                failedAt(51)
+                failedAt(52)
                 return
             }
         }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseHelper.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseHelper.swift
@@ -756,6 +756,26 @@ class DatabaseHelper {
             }
         }
 
+        if schemaVersion < 52 {
+            do {
+                try db.executeUpdate("""
+                    CREATE TABLE PodcastFoldersHistory (
+                    id INTEGER KEY,
+                    podcastUuid TEXT NOT NULL,
+                    folderUuid TEXT NOT NULL,
+                    date REAL NOT NULL
+                    );
+                """, values: nil)
+
+                try db.executeUpdate("CREATE INDEX IF NOT EXISTS podcast_folders_history_date ON PlaylistEpisodeHistory (date);", values: nil)
+
+                schemaVersion = 51
+            } catch {
+                failedAt(51)
+                return
+            }
+        }
+
         db.commit()
     }
 }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -20,6 +20,7 @@ public class DataManager {
     private let folderManager = FolderDataManager()
     private lazy var endOfYearManager = EndOfYearDataManager()
     private lazy var upNextHistoryManager = UpNextHistoryManager()
+    private lazy var folderHistoryManager = FolderHistoryManager()
 
     public let autoAddCandidates: AutoAddCandidatesDataManager
     public let bookmarks: BookmarkDataManager
@@ -1032,6 +1033,16 @@ public class DataManager {
 
     public func upNextHistoryEpisodes(entry: Date) -> [String] {
         upNextHistoryManager.episodes(entry: entry, dbQueue: dbQueue)
+    }
+
+    // MARK: - Folders History
+
+    public func snapshot(podcastsAndFolders: [String: String]) {
+        folderHistoryManager.snapshot(podcastsAndFolders: podcastsAndFolders, dbQueue: dbQueue)
+    }
+
+    public func foldersHistoryEntries() -> [FolderHistoryManager.PodcastFoldersHistoryEntry] {
+        folderHistoryManager.entries(dbQueue: dbQueue)
     }
 }
 

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -1044,6 +1044,10 @@ public class DataManager {
     public func foldersHistoryEntries() -> [FolderHistoryManager.PodcastFoldersHistoryEntry] {
         folderHistoryManager.entries(dbQueue: dbQueue)
     }
+
+    public func folderHistory(entry: Date) -> [String: String] {
+        folderHistoryManager.podcastsAndFolders(entry: entry, dbQueue: dbQueue)
+    }
 }
 
 // MARK: - Ghost Episode Cleanup

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
@@ -85,6 +85,10 @@ extension SyncTask {
         }
 
         importQueue.waitUntilAllOperationsAreFinished()
+
+        // If any podcasts were moved out of their folders, the app saves this info
+        // In case of sync errors the user can restore.
+        FolderHistoryHelper.shared.snapshot()
     }
 
     private func importPodcast(_ podcastItem: Api_SyncUserPodcast) {
@@ -142,6 +146,10 @@ extension SyncTask {
             let folderUuid = podcastItem.folderUuid.value
 
             FileLog.shared.foldersIssue("SyncTask importItem: \(podcast.title ?? "") changing folder from \(podcast.folderUuid ?? "nil") to \(((folderUuid == DataConstants.homeGridFolderUuid) ? nil : folderUuid) ?? "nil")")
+
+            if folderUuid == DataConstants.homeGridFolderUuid, let originalFolderUuid = podcast.folderUuid {
+                FolderHistoryHelper.shared.add(podcastUuid: podcastItem.uuid, folderUuid: originalFolderUuid)
+            }
 
             podcast.folderUuid = (folderUuid == DataConstants.homeGridFolderUuid) ? nil : folderUuid
         }

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -594,6 +594,7 @@
 		8BD7A2432C09130C00CF84E8 /* FolderHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BD7A2422C09130C00CF84E8 /* FolderHistoryView.swift */; };
 		8BD7A2452C09132A00CF84E8 /* FolderHistoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BD7A2442C09132A00CF84E8 /* FolderHistoryViewController.swift */; };
 		8BD7A2472C09134900CF84E8 /* FolderHistoryModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BD7A2462C09134900CF84E8 /* FolderHistoryModel.swift */; };
+		8BD7A2492C09190200CF84E8 /* FolderHistoryEntryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BD7A2482C09190200CF84E8 /* FolderHistoryEntryView.swift */; };
 		8BDDD2AC29770479009E4DD3 /* SyncLoadingAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BDDD2AB29770479009E4DD3 /* SyncLoadingAlert.swift */; };
 		8BDE43062AC33BEE00C2D5C9 /* RatePodcastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BDE43052AC33BEE00C2D5C9 /* RatePodcastView.swift */; };
 		8BDE43082AC34A7600C2D5C9 /* RatePodcastViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BDE43072AC34A7600C2D5C9 /* RatePodcastViewModel.swift */; };
@@ -2410,6 +2411,7 @@
 		8BD7A2422C09130C00CF84E8 /* FolderHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FolderHistoryView.swift; sourceTree = "<group>"; };
 		8BD7A2442C09132A00CF84E8 /* FolderHistoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FolderHistoryViewController.swift; sourceTree = "<group>"; };
 		8BD7A2462C09134900CF84E8 /* FolderHistoryModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FolderHistoryModel.swift; sourceTree = "<group>"; };
+		8BD7A2482C09190200CF84E8 /* FolderHistoryEntryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FolderHistoryEntryView.swift; sourceTree = "<group>"; };
 		8BDDD2AB29770479009E4DD3 /* SyncLoadingAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncLoadingAlert.swift; sourceTree = "<group>"; };
 		8BDE43052AC33BEE00C2D5C9 /* RatePodcastView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RatePodcastView.swift; sourceTree = "<group>"; };
 		8BDE43072AC34A7600C2D5C9 /* RatePodcastViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RatePodcastViewModel.swift; sourceTree = "<group>"; };
@@ -4506,6 +4508,7 @@
 		8BD7A2412C09126300CF84E8 /* Folder History */ = {
 			isa = PBXGroup;
 			children = (
+				8BD7A2482C09190200CF84E8 /* FolderHistoryEntryView.swift */,
 				8BD7A2422C09130C00CF84E8 /* FolderHistoryView.swift */,
 				8BD7A2442C09132A00CF84E8 /* FolderHistoryViewController.swift */,
 				8BD7A2462C09134900CF84E8 /* FolderHistoryModel.swift */,
@@ -8704,6 +8707,7 @@
 				C7E99EFE2A5C918900E7CBAF /* NonBlockingLongPressView.swift in Sources */,
 				BDED92F4251DC3E2000BF622 /* CarPlaySceneDelegate.swift in Sources */,
 				BD24E6F320E3474600A712E3 /* ArchiveHelper.swift in Sources */,
+				8BD7A2492C09190200CF84E8 /* FolderHistoryEntryView.swift in Sources */,
 				BD9CF8C2281FC6970000F29A /* AboutViewModel.swift in Sources */,
 				4000A2A025463C6A00356FCE /* LeftAlignedFlowLayout.swift in Sources */,
 				BD59E6BA24107C110019AF1C /* StarredViewController+Swipe.swift in Sources */,

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -591,6 +591,9 @@
 		8BD7A2382C04F0DD00CF84E8 /* UpNextHistoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BD7A2372C04F0DD00CF84E8 /* UpNextHistoryViewController.swift */; };
 		8BD7A23A2C04F63000CF84E8 /* UpNextHistoryModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BD7A2392C04F63000CF84E8 /* UpNextHistoryModel.swift */; };
 		8BD7A23C2C06254400CF84E8 /* UpNextEntryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BD7A23B2C06254400CF84E8 /* UpNextEntryView.swift */; };
+		8BD7A2432C09130C00CF84E8 /* FolderHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BD7A2422C09130C00CF84E8 /* FolderHistoryView.swift */; };
+		8BD7A2452C09132A00CF84E8 /* FolderHistoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BD7A2442C09132A00CF84E8 /* FolderHistoryViewController.swift */; };
+		8BD7A2472C09134900CF84E8 /* FolderHistoryModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BD7A2462C09134900CF84E8 /* FolderHistoryModel.swift */; };
 		8BDDD2AC29770479009E4DD3 /* SyncLoadingAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BDDD2AB29770479009E4DD3 /* SyncLoadingAlert.swift */; };
 		8BDE43062AC33BEE00C2D5C9 /* RatePodcastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BDE43052AC33BEE00C2D5C9 /* RatePodcastView.swift */; };
 		8BDE43082AC34A7600C2D5C9 /* RatePodcastViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BDE43072AC34A7600C2D5C9 /* RatePodcastViewModel.swift */; };
@@ -1607,7 +1610,6 @@
 		F5197A412B995A1E007C8D0A /* DownloadManager+Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5197A3F2B995A1E007C8D0A /* DownloadManager+Logging.swift */; };
 		F52B4F8C2BB4A9CA00E87BE4 /* CategoriesSelectorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F52B4F8B2BB4A9CA00E87BE4 /* CategoriesSelectorViewController.swift */; };
 		F52B4F8E2BB4A9ED00E87BE4 /* CategoriesSelectorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F52B4F8D2BB4A9ED00E87BE4 /* CategoriesSelectorView.swift */; };
-		F543F6A22C07FC7300FEC8B6 /* DBTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = F543F6A12C07FC7300FEC8B6 /* DBTestCase.swift */; };
 		F543F6A42C0804FA00FEC8B6 /* AnyPublisher+Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = F543F6A32C0804FA00FEC8B6 /* AnyPublisher+Async.swift */; };
 		F55449422B758E8300F68AE9 /* PocketCastsUtils in Frameworks */ = {isa = PBXBuildFile; productRef = F55449412B758E8300F68AE9 /* PocketCastsUtils */; };
 		F55449432B758E8300F68AE9 /* PocketCastsUtils in Embed Frameworks */ = {isa = PBXBuildFile; productRef = F55449412B758E8300F68AE9 /* PocketCastsUtils */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
@@ -2405,6 +2407,9 @@
 		8BD7A2372C04F0DD00CF84E8 /* UpNextHistoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpNextHistoryViewController.swift; sourceTree = "<group>"; };
 		8BD7A2392C04F63000CF84E8 /* UpNextHistoryModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpNextHistoryModel.swift; sourceTree = "<group>"; };
 		8BD7A23B2C06254400CF84E8 /* UpNextEntryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpNextEntryView.swift; sourceTree = "<group>"; };
+		8BD7A2422C09130C00CF84E8 /* FolderHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FolderHistoryView.swift; sourceTree = "<group>"; };
+		8BD7A2442C09132A00CF84E8 /* FolderHistoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FolderHistoryViewController.swift; sourceTree = "<group>"; };
+		8BD7A2462C09134900CF84E8 /* FolderHistoryModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FolderHistoryModel.swift; sourceTree = "<group>"; };
 		8BDDD2AB29770479009E4DD3 /* SyncLoadingAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncLoadingAlert.swift; sourceTree = "<group>"; };
 		8BDE43052AC33BEE00C2D5C9 /* RatePodcastView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RatePodcastView.swift; sourceTree = "<group>"; };
 		8BDE43072AC34A7600C2D5C9 /* RatePodcastViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RatePodcastViewModel.swift; sourceTree = "<group>"; };
@@ -3397,7 +3402,6 @@
 		F5197A3F2B995A1E007C8D0A /* DownloadManager+Logging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DownloadManager+Logging.swift"; sourceTree = "<group>"; };
 		F52B4F8B2BB4A9CA00E87BE4 /* CategoriesSelectorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoriesSelectorViewController.swift; sourceTree = "<group>"; };
 		F52B4F8D2BB4A9ED00E87BE4 /* CategoriesSelectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoriesSelectorView.swift; sourceTree = "<group>"; };
-		F543F6A12C07FC7300FEC8B6 /* DBTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DBTestCase.swift; sourceTree = "<group>"; };
 		F543F6A32C0804FA00FEC8B6 /* AnyPublisher+Async.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AnyPublisher+Async.swift"; sourceTree = "<group>"; };
 		F55449442B75935F00F68AE9 /* AppSettings+ImportUserDefaults.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AppSettings+ImportUserDefaults.swift"; sourceTree = "<group>"; };
 		F55C4C752BCF064500A10352 /* DiscoverViewController+CategoryRedesign.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DiscoverViewController+CategoryRedesign.swift"; sourceTree = "<group>"; };
@@ -4499,6 +4503,16 @@
 			path = "Up Next History";
 			sourceTree = "<group>";
 		};
+		8BD7A2412C09126300CF84E8 /* Folder History */ = {
+			isa = PBXGroup;
+			children = (
+				8BD7A2422C09130C00CF84E8 /* FolderHistoryView.swift */,
+				8BD7A2442C09132A00CF84E8 /* FolderHistoryViewController.swift */,
+				8BD7A2462C09134900CF84E8 /* FolderHistoryModel.swift */,
+			);
+			path = "Folder History";
+			sourceTree = "<group>";
+		};
 		8BE36DC928734F6500E35313 /* Modules */ = {
 			isa = PBXGroup;
 			children = (
@@ -5198,6 +5212,7 @@
 				BD7516E01C0FC8180099F53E /* Downloads */,
 				BDF4D30D2175AA0D0086463E /* Starred */,
 				BDF050791FBA65BE00194D68 /* Listening History */,
+				8BD7A2412C09126300CF84E8 /* Folder History */,
 				400AB2FF220BA3110003EE21 /* Files */,
 				40542E292265600200046330 /* Account Management */,
 				BD8139D01FB95C3900DBF0EC /* ProfileViewController.swift */,
@@ -8810,6 +8825,7 @@
 				BDB5F0C52045036200437669 /* OptionAction.swift in Sources */,
 				40FFAD93214A170200024FCF /* FilterSettingsOverlayController.swift in Sources */,
 				BD998ACC27B2436000B38857 /* NameFolderView.swift in Sources */,
+				8BD7A2432C09130C00CF84E8 /* FolderHistoryView.swift in Sources */,
 				C7FAFF5D2941844C00329B40 /* CancelConfirmationViewModel.swift in Sources */,
 				BD14CCDF1D7D3CB800DB4547 /* SelectedPodcastCell.swift in Sources */,
 				BD93FDA120157B2000F6EF55 /* PodcastImageView.swift in Sources */,
@@ -8864,6 +8880,7 @@
 				F55C4C762BCF064500A10352 /* DiscoverViewController+CategoryRedesign.swift in Sources */,
 				BDF09F041E669E16009E9845 /* BasePlayPauseButton.swift in Sources */,
 				407B21E72231F6A300B4E492 /* UploadedSettingsViewController.swift in Sources */,
+				8BD7A2472C09134900CF84E8 /* FolderHistoryModel.swift in Sources */,
 				BD339C5C2149E35600E655F9 /* VideoViewController+Controls.swift in Sources */,
 				C7B7123C29DF49BC00965BF7 /* HorizontalCarousel.swift in Sources */,
 				4041FE572181751F0089D4A1 /* SiriShortcutsManager.swift in Sources */,
@@ -9205,6 +9222,7 @@
 				BD00CB2B24BD20CD00A10257 /* TimeStepperCell.swift in Sources */,
 				8B9D459F28F9AD3F0034219E /* EndOfYearStoriesDataSource.swift in Sources */,
 				BDC377631C44E6BD001FD219 /* EmptyHeaderView.swift in Sources */,
+				8BD7A2452C09132A00CF84E8 /* FolderHistoryViewController.swift in Sources */,
 				BD9324772398BC9D004F19A1 /* FeatureTour.swift in Sources */,
 				BDFB53C72362A2570001806E /* NowPlayingPlayerItemViewController.swift in Sources */,
 				BD4DB9951CAB8CFF009E512F /* PCRefreshControl.swift in Sources */,

--- a/podcasts/Folder History/FolderHistoryEntryView.swift
+++ b/podcasts/Folder History/FolderHistoryEntryView.swift
@@ -24,14 +24,14 @@ struct FolderHistoryEntryView: View {
                 Button(L10n.restore) {
                     showingAlert = true
                 }
-                .alert(L10n.restoreUpNext, isPresented: $showingAlert, actions: {
+                .alert(L10n.restoreFolders, isPresented: $showingAlert, actions: {
                     Button(L10n.restore) {
-                        //
+                        model.restore()
                         dismiss()
                     }
                     Button(L10n.cancel, role: .cancel) { }
                 }, message: {
-                    Text(L10n.restoreUpNextMessage)
+                    Text(L10n.restoreFoldersMessage)
                 })
                 Spacer()
                 Text("\(entryDate.formatted())").bold()
@@ -41,29 +41,23 @@ struct FolderHistoryEntryView: View {
                 }
             }.padding()
 
-//            List(model.episodes, id: \.uuid) { episode in
-//                HStack {
-//                    EpisodeImage(episode: episode)
-//                        .frame(width: 48, height: 48)
-//                    VStack(alignment: .leading) {
-//                        Text("\(DateFormatHelper.sharedHelper.tinyLocalizedFormat(episode.publishedDate).localizedUppercase)")
-//                            .foregroundStyle(theme.primaryText02)
-//                            .font(style: .footnote)
-//                        Text("\(episode.title ?? "")")
-//                            .lineLimit(1)
-//                            .font(style: .body)
-//                        Text(episode.displayableInfo(includeSize: false))
-//                            .foregroundStyle(theme.primaryText02)
-//                            .font(style: .footnote)
-//                    }
-//                }
-//                .listRowBackground(theme.primaryUi02)
-//                .listRowSeparatorTint(theme.primaryUi05)
-//            }
+            List(model.podcastsAndFolders, id: \.0.uuid) { podcast, folder in
+                HStack {
+                    PodcastCover(podcastUuid: podcast.uuid)
+                        .frame(width: 48, height: 48)
+                    VStack(alignment: .leading) {
+                        Text(L10n.podcastRemovedFromFolder(podcast.title ?? "", folder.name))
+                            .foregroundStyle(theme.primaryText02)
+                            .font(style: .footnote)
+                    }
+                }
+                .listRowBackground(theme.primaryUi02)
+                .listRowSeparatorTint(theme.primaryUi05)
+            }
         }
         .modifier(HiddenScrollContentBackground())
         .background(theme.primaryUi04)
-//        .onAppear { model.loadEpisodes(for: entryDate) }
+        .onAppear { model.loadFoldersHistory(for: entryDate) }
         .navigationTitle("\(entryDate.formatted())")
         .applyDefaultThemeOptions()
     }

--- a/podcasts/Folder History/FolderHistoryEntryView.swift
+++ b/podcasts/Folder History/FolderHistoryEntryView.swift
@@ -1,0 +1,74 @@
+import SwiftUI
+import PocketCastsUtils
+
+struct FolderHistoryEntryView: View {
+    @EnvironmentObject var theme: Theme
+    @ObservedObject var model = FolderHistoryModel()
+    @Environment(\.dismiss) var dismiss
+
+    @State var showingAlert = false
+
+    let entryDate: Date
+
+    init(entryDate: Date) {
+        self.entryDate = entryDate
+
+        if #unavailable(iOS 16.0) {
+            UITableView.appearance().backgroundColor = .clear
+        }
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(alignment: .center) {
+                Button(L10n.restore) {
+                    showingAlert = true
+                }
+                .alert(L10n.restoreUpNext, isPresented: $showingAlert, actions: {
+                    Button(L10n.restore) {
+                        //
+                        dismiss()
+                    }
+                    Button(L10n.cancel, role: .cancel) { }
+                }, message: {
+                    Text(L10n.restoreUpNextMessage)
+                })
+                Spacer()
+                Text("\(entryDate.formatted())").bold()
+                Spacer()
+                Button(L10n.cancel) {
+                    dismiss()
+                }
+            }.padding()
+
+//            List(model.episodes, id: \.uuid) { episode in
+//                HStack {
+//                    EpisodeImage(episode: episode)
+//                        .frame(width: 48, height: 48)
+//                    VStack(alignment: .leading) {
+//                        Text("\(DateFormatHelper.sharedHelper.tinyLocalizedFormat(episode.publishedDate).localizedUppercase)")
+//                            .foregroundStyle(theme.primaryText02)
+//                            .font(style: .footnote)
+//                        Text("\(episode.title ?? "")")
+//                            .lineLimit(1)
+//                            .font(style: .body)
+//                        Text(episode.displayableInfo(includeSize: false))
+//                            .foregroundStyle(theme.primaryText02)
+//                            .font(style: .footnote)
+//                    }
+//                }
+//                .listRowBackground(theme.primaryUi02)
+//                .listRowSeparatorTint(theme.primaryUi05)
+//            }
+        }
+        .modifier(HiddenScrollContentBackground())
+        .background(theme.primaryUi04)
+//        .onAppear { model.loadEpisodes(for: entryDate) }
+        .navigationTitle("\(entryDate.formatted())")
+        .applyDefaultThemeOptions()
+    }
+}
+
+#Preview {
+    UpNextEntryView(entryDate: Date())
+}

--- a/podcasts/Folder History/FolderHistoryModel.swift
+++ b/podcasts/Folder History/FolderHistoryModel.swift
@@ -3,6 +3,7 @@ import PocketCastsServer
 
 class FolderHistoryModel: ObservableObject {
     @Published var historyEntries: [FolderHistoryManager.PodcastFoldersHistoryEntry] = []
+    @Published var podcastsAndFolders: [(Podcast, Folder)] = []
 
     private let dataManager: DataManager
 
@@ -15,5 +16,30 @@ class FolderHistoryModel: ObservableObject {
         Task {
             historyEntries = dataManager.foldersHistoryEntries()
         }
+    }
+
+    @MainActor
+    func loadFoldersHistory(for entry: Date) {
+        Task {
+            podcastsAndFolders = dataManager.folderHistory(entry: entry).compactMap {
+                if let podcast = dataManager.findPodcast(uuid: $0.key),
+                   let folder = dataManager.findFolder(uuid: $0.value) {
+                    return (podcast, folder)
+                }
+
+                return nil
+            }
+        }
+    }
+
+    func restore() {
+        podcastsAndFolders.forEach { podcast, folder in
+            podcast.folderUuid = folder.uuid
+            podcast.syncStatus = SyncStatus.notSynced.rawValue
+            dataManager.save(podcast: podcast)
+            NotificationCenter.postOnMainThread(notification: Constants.Notifications.folderChanged, object: folder.uuid)
+        }
+        RefreshManager.shared.refreshPodcasts(forceEvenIfRefreshedRecently: true)
+        Toast.show(L10n.restoreFoldersSuccess)
     }
 }

--- a/podcasts/Folder History/FolderHistoryModel.swift
+++ b/podcasts/Folder History/FolderHistoryModel.swift
@@ -1,0 +1,19 @@
+import PocketCastsDataModel
+import PocketCastsServer
+
+class FolderHistoryModel: ObservableObject {
+    @Published var historyEntries: [FolderHistoryManager.PodcastFoldersHistoryEntry] = []
+
+    private let dataManager: DataManager
+
+    init(dataManager: DataManager = DataManager.sharedManager) {
+        self.dataManager = dataManager
+    }
+
+    @MainActor
+    func loadEntries() {
+        Task {
+            historyEntries = dataManager.foldersHistoryEntries()
+        }
+    }
+}

--- a/podcasts/Folder History/FolderHistoryView.swift
+++ b/podcasts/Folder History/FolderHistoryView.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+import PocketCastsDataModel
+
+struct FolderHistoryView: View {
+    @EnvironmentObject var theme: Theme
+    @ObservedObject var model = FolderHistoryModel()
+
+    @State var presentingEntry = false
+    @State var selectedEntry: FolderHistoryManager.PodcastFoldersHistoryEntry?
+
+    init() {
+        if #unavailable(iOS 16.0) {
+            UITableView.appearance().backgroundColor = .clear
+        }
+    }
+
+    var body: some View {
+        List {
+            Section {
+
+            } footer: {
+                Text(L10n.upNextHistoryExplanation)
+                    .foregroundStyle(theme.primaryText02)
+            }
+
+            Section {
+                ForEach(model.historyEntries) { entry in
+                    Button(action: {
+                        selectedEntry = entry
+                        presentingEntry = true
+                    }, label: {
+                        Text("\(entry.date.formatted()): \(entry.changesCount) podcasts removed from folders")
+                    })
+                    .listRowBackground(theme.primaryUi02)
+                    .listRowSeparatorTint(theme.primaryUi05)
+                }
+            }
+        }
+        .modifier(HiddenScrollContentBackground())
+        .background(theme.primaryUi04)
+        .sheet(item: $selectedEntry) { entry in
+            UpNextEntryView(entryDate: entry.date)
+        }
+        .onAppear {
+            model.loadEntries()
+        }
+        .navigationTitle(L10n.upNextHistory)
+        .applyDefaultThemeOptions()
+    }
+}
+
+#Preview {
+    UpNextHistoryView()
+}

--- a/podcasts/Folder History/FolderHistoryView.swift
+++ b/podcasts/Folder History/FolderHistoryView.swift
@@ -19,7 +19,7 @@ struct FolderHistoryView: View {
             Section {
 
             } footer: {
-                Text(L10n.upNextHistoryExplanation)
+                Text(L10n.foldersHistoryExplanation)
                     .foregroundStyle(theme.primaryText02)
             }
 

--- a/podcasts/Folder History/FolderHistoryView.swift
+++ b/podcasts/Folder History/FolderHistoryView.swift
@@ -39,7 +39,7 @@ struct FolderHistoryView: View {
         .modifier(HiddenScrollContentBackground())
         .background(theme.primaryUi04)
         .sheet(item: $selectedEntry) { entry in
-            UpNextEntryView(entryDate: entry.date)
+            FolderHistoryEntryView(entryDate: entry.date)
         }
         .onAppear {
             model.loadEntries()

--- a/podcasts/Folder History/FolderHistoryViewController.swift
+++ b/podcasts/Folder History/FolderHistoryViewController.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+class FolderHistoryViewController: ThemedHostingController<FolderHistoryView> {
+    convenience init() {
+        self.init(rootView: FolderHistoryView())
+    }
+}

--- a/podcasts/SettingsViewController.swift
+++ b/podcasts/SettingsViewController.swift
@@ -67,9 +67,9 @@ class SettingsViewController: PCViewController, UITableViewDataSource, UITableVi
             case .headphoneControls:
                 return (L10n.settingsHeadphoneControls, .init(named: "settings_headphone_controls"))
             case .upNextHistory:
-                return (L10n.foldersHistory, .init(named: "upnext"))
+                return (L10n.upNextHistory, .init(named: "upnext"))
             case .foldersHistory:
-                return (L10n.upNextHistory, .init(named: "folder-empty"))
+                return (L10n.foldersHistory, .init(named: "folder-empty"))
             }
         }
     }

--- a/podcasts/SettingsViewController.swift
+++ b/podcasts/SettingsViewController.swift
@@ -10,7 +10,7 @@ class SettingsViewController: PCViewController, UITableViewDataSource, UITableVi
         case autoArchive, autoDownload, autoAddToUpNext, siriShortcuts
         case watch, customFiles, importSteps, opml
         case about, pocketCastsPlus, privacy
-        case upNextHistory
+        case upNextHistory, foldersHistory
         case headphoneControls
         case developer, beta
 
@@ -67,7 +67,9 @@ class SettingsViewController: PCViewController, UITableViewDataSource, UITableVi
             case .headphoneControls:
                 return (L10n.settingsHeadphoneControls, .init(named: "settings_headphone_controls"))
             case .upNextHistory:
-                return (L10n.upNextHistory, .init(named: "upnext"))
+                return (L10n.foldersHistory, .init(named: "upnext"))
+            case .foldersHistory:
+                return (L10n.upNextHistory, .init(named: "folder-empty"))
             }
         }
     }
@@ -89,7 +91,7 @@ class SettingsViewController: PCViewController, UITableViewDataSource, UITableVi
             [.autoArchive, .autoDownload, .autoAddToUpNext],
             [.storageAndDataUse, .siriShortcuts, .headphoneControls, .watch, .customFiles],
             [.importSteps, .opml],
-            [.upNextHistory],
+            [.upNextHistory, .foldersHistory],
             [.privacy, .about]
         ]
     }()
@@ -198,6 +200,9 @@ class SettingsViewController: PCViewController, UITableViewDataSource, UITableVi
         case .upNextHistory:
             let upNextHistory = UpNextHistoryViewController()
             navigationController?.pushViewController(upNextHistory, animated: true)
+        case .foldersHistory:
+            let foldersHistoryViewController = FolderHistoryViewController()
+            navigationController?.pushViewController(foldersHistoryViewController, animated: true)
         }
     }
 

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -1176,6 +1176,8 @@ internal enum L10n {
   internal static var folderUnnamed: String { return L10n.tr("Localizable", "folder_unnamed") }
   /// Folders
   internal static var folders: String { return L10n.tr("Localizable", "folders") }
+  /// Folders History
+  internal static var foldersHistory: String { return L10n.tr("Localizable", "folders_history") }
   /// No Payment Now – Cancel Anytime
   internal static var freeTrialDetailLabel: String { return L10n.tr("Localizable", "free_trial_detail_label") }
   /// %1$@ FREE

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -1178,6 +1178,8 @@ internal enum L10n {
   internal static var folders: String { return L10n.tr("Localizable", "folders") }
   /// Folders History
   internal static var foldersHistory: String { return L10n.tr("Localizable", "folders_history") }
+  /// A list of podcasts that were removed from folders as a result of a sync.
+  internal static var foldersHistoryExplanation: String { return L10n.tr("Localizable", "folders_history_explanation") }
   /// No Payment Now – Cancel Anytime
   internal static var freeTrialDetailLabel: String { return L10n.tr("Localizable", "free_trial_detail_label") }
   /// %1$@ FREE

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -1986,6 +1986,10 @@ internal enum L10n {
   internal static var podcastQueuing: String { return L10n.tr("Localizable", "podcast_queuing") }
   /// Refresh Artwork
   internal static var podcastRefreshArtwork: String { return L10n.tr("Localizable", "podcast_refresh_artwork") }
+  /// %1$@ removed from %2$@
+  internal static func podcastRemovedFromFolder(_ p1: Any, _ p2: Any) -> String {
+    return L10n.tr("Localizable", "podcast_removed_from_folder", String(describing: p1), String(describing: p2))
+  }
   /// Season %1$@
   internal static func podcastSeasonFormat(_ p1: Any) -> String {
     return L10n.tr("Localizable", "podcast_season_format", String(describing: p1))
@@ -2220,6 +2224,12 @@ internal enum L10n {
   internal static var renewSubscription: String { return L10n.tr("Localizable", "renew_subscription") }
   /// Restore
   internal static var restore: String { return L10n.tr("Localizable", "restore") }
+  /// Restore podcasts to folders?
+  internal static var restoreFolders: String { return L10n.tr("Localizable", "restore_folders") }
+  /// These podcasts will be permanently added back to the folders listed here
+  internal static var restoreFoldersMessage: String { return L10n.tr("Localizable", "restore_folders_message") }
+  /// Podcasts restored to their original folders
+  internal static var restoreFoldersSuccess: String { return L10n.tr("Localizable", "restore_folders_success") }
   /// Restore Up Next?
   internal static var restoreUpNext: String { return L10n.tr("Localizable", "restore_up_next") }
   /// These episodes will be added to the bottom of your current Up Next

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4108,3 +4108,6 @@
 
 /* Title of a screen that display Folders history */
 "folders_history" = "Folders History";
+
+/* A message explaining how to use the Folders history */
+"folders_history_explanation" = "A list of podcasts that were removed from folders as a result of a sync.";

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4111,3 +4111,15 @@
 
 /* A message explaining how to use the Folders history */
 "folders_history_explanation" = "A list of podcasts that were removed from folders as a result of a sync.";
+
+/* Title confirming to the user if they want to restore podcasts to original folders */
+"restore_folders" = "Restore podcasts to folders?";
+
+/* Details about what will happen if they restore folders */
+"restore_folders_message" = "These podcasts will be permanently added back to the folders listed here";
+
+/* Entry informing which podcasts was removed from which folder, %1$@ is the podcast's title, %2$@ folder's name */
+"podcast_removed_from_folder" = "%1$@ removed from %2$@";
+
+/* Message confirming podcasts were restored to the folders */
+"restore_folders_success" = "Podcasts restored to their original folders";

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4105,3 +4105,6 @@
 
 /* Description of the option to shake to restart sleep timer */
 "shake_to_restart_sleep_timer_description" = "If on, the sleep timer will restart when you shake your phone.";
+
+/* Title of a screen that display Folders history */
+"folders_history" = "Folders History";


### PR DESCRIPTION
Last year we had a bug — due to Apple Watch sync issues — that was removing podcasts from their original folders. This bug has been fixed for a while, but recently we've seen two reports from people who experienced the same.

While this issue was also fixed, it's always bad when users contact us about this issue and we can't do anything.

Now we can! We'll store when podcasts are removed from folders as part of sync and the user can restore this if they want to.

https://github.com/Automattic/pocket-casts-ios/assets/7040243/37251d90-4676-47a4-bd8d-94f14c7c9fae

## To test

You'll need to login into the same account (a Plus one) on two devices. I recommend using the web player and the iOS simulator.

1. Create a folder and add podcasts to it
2. Go to Profile > Refresh Now
3. On web, remove all podcasts from this folder
4. Go back to the iOS app: Profile > Refresh Now
5. Confirm that all podcasts are out of their folders
6. Go to Profile > Settings > Folders History
7. ✅ You should see the history of this sync there
8. Tap on it
9. ✅ You should see a list with the podcasts removed from the folders
10. Tap restore, confirm
11. ✅ Check that podcasts are now back in their original folders
12. Go to web, refresh
13. ✅ Podcasts should be back in their original folders

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
