### PR TITLE
Playback: only update podcast if episode playback fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 7.66
 -----
 - Re-add Use contentType to set extension for downloaded files. [#1743]
+- Improve responsiveness when playing a podcast [#1801]
 
 7.65
 -----

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -63,6 +63,7 @@ public enum FeatureFlag: String, CaseIterable {
 
     /// Only update an episode if it fails playing
     /// If set to `false`, it will use the previous mechanism that always update
+    /// but can lead to a bigger time between tapping play and actually playing it
     case whenPlayingOnlyUpdateEpisodeIfPlaybackFails
 
     public var enabled: Bool {

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -61,6 +61,10 @@ public enum FeatureFlag: String, CaseIterable {
     /// When `true`, we only mark podcasts as unsynced if the user never signed in before
     case onlyMarkPodcastsUnsyncedForNewUsers
 
+    /// Only update an episode if it fails playing
+    /// If set to `false`, it will use the previous mechanism that always update
+    case whenPlayingOnlyUpdateEpisodeIfPlaybackFails
+
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -110,6 +114,8 @@ public enum FeatureFlag: String, CaseIterable {
         case .downloadFixes:
             true
         case .onlyMarkPodcastsUnsyncedForNewUsers:
+            true
+        case .whenPlayingOnlyUpdateEpisodeIfPlaybackFails:
             true
         }
     }

--- a/podcasts/DefaultPlayer.swift
+++ b/podcasts/DefaultPlayer.swift
@@ -232,6 +232,14 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
 
     private func playerStatusDidChange() {
         if player?.currentItem?.status == .failed {
+
+            if FeatureFlag.whenPlayingOnlyUpdateEpisodeIfPlaybackFails.enabled,
+               (player?.currentItem?.error as? NSError)?.domain == NSURLErrorDomain,
+                let episodeUuid {
+                PlaybackManager.shared.urlFailedToLoad(for: episodeUuid)
+                return
+            }
+
             PlaybackManager.shared.playbackDidFail(logMessage: "AVPlayerItemStatusFailed on currentItem", userMessage: nil)
 
             return

--- a/podcasts/PlaybackActionHelper.swift
+++ b/podcasts/PlaybackActionHelper.swift
@@ -92,7 +92,6 @@ class PlaybackActionHelper {
 
             // if we're streaming an episode, try to make sure the URL is up to date. Authors can change URLs at any time, so this is handy to fix cases where they post the wrong one and update it later
             if !FeatureFlag.whenPlayingOnlyUpdateEpisodeIfPlaybackFails.enabled,
-               !GoogleCastManager.sharedManager.connectedOrConnectingToDevice(),
                let episode = episode as? Episode, let podcast = episode.parentPodcast(), !episode.downloaded(pathFinder: DownloadManager.shared) {
                 ServerPodcastManager.shared.updatePodcastIfRequired(podcast: podcast) { wasUpdated in
                     guard let updatedEpisode = wasUpdated ? DataManager.sharedManager.findEpisode(uuid: episode.uuid) : episode else { return }

--- a/podcasts/PlaybackActionHelper.swift
+++ b/podcasts/PlaybackActionHelper.swift
@@ -92,6 +92,7 @@ class PlaybackActionHelper {
 
             // if we're streaming an episode, try to make sure the URL is up to date. Authors can change URLs at any time, so this is handy to fix cases where they post the wrong one and update it later
             if !FeatureFlag.whenPlayingOnlyUpdateEpisodeIfPlaybackFails.enabled,
+               !GoogleCastManager.sharedManager.connectedOrConnectingToDevice(),
                let episode = episode as? Episode, let podcast = episode.parentPodcast(), !episode.downloaded(pathFinder: DownloadManager.shared) {
                 ServerPodcastManager.shared.updatePodcastIfRequired(podcast: podcast) { wasUpdated in
                     guard let updatedEpisode = wasUpdated ? DataManager.sharedManager.findEpisode(uuid: episode.uuid) : episode else { return }

--- a/podcasts/PlaybackActionHelper.swift
+++ b/podcasts/PlaybackActionHelper.swift
@@ -91,7 +91,8 @@ class PlaybackActionHelper {
             }
 
             // if we're streaming an episode, try to make sure the URL is up to date. Authors can change URLs at any time, so this is handy to fix cases where they post the wrong one and update it later
-            if let episode = episode as? Episode, let podcast = episode.parentPodcast(), !episode.downloaded(pathFinder: DownloadManager.shared) {
+            if !FeatureFlag.whenPlayingOnlyUpdateEpisodeIfPlaybackFails.enabled,
+               let episode = episode as? Episode, let podcast = episode.parentPodcast(), !episode.downloaded(pathFinder: DownloadManager.shared) {
                 ServerPodcastManager.shared.updatePodcastIfRequired(podcast: podcast) { wasUpdated in
                     guard let updatedEpisode = wasUpdated ? DataManager.sharedManager.findEpisode(uuid: episode.uuid) : episode else { return }
 

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -2034,7 +2034,7 @@ class PlaybackManager: ServerPlaybackDelegate {
                 guard let self,
                       let updatedEpisode = wasUpdated ? DataManager.sharedManager.findEpisode(uuid: episodeUuid) : episode else { return }
 
-                FileLog.shared.addMessage("PlaybackManager: Episode \(wasUpdated ? "" : "not") updated, trying to play again.")
+                FileLog.shared.addMessage("PlaybackManager: Episode\(wasUpdated ? " " : " not") updated, trying to play again.")
 
                 load(episode: updatedEpisode, autoPlay: true, overrideUpNext: false)
             }


### PR DESCRIPTION
When playing an episode, we have a mechanism that given some conditions might lead to a bigger time between tapping play and the app playing. Eg.:

1. User taps play on a `The Daily` episode
2. Before playing, we check to see if the podcast needs to be updated
3. If it needs, we update the podcast (small podcasts updates fast, bigger ones slower)
4. Then we start the `AVPlayer` that will then start buffering the episode

We do that no matter whether the URL we have works or not.

This PR changes this to only update in case the playback fails. Which means it will only execute it if needed.

As this is a playback change, it's behind a feature flag that we can remote control.

## To test

1. Run a clean install of the app (we'll mess with the database)
6. Go to Discover, add different episodes from different podcasts to Up Next
7. Stop the app
8. Go to the terminal and execute the following command: `sqlite3 "$(xcrun simctl get_app_container booted au.com.shiftyjelly.podcasts data)/Library/Application Support/Pocket Casts/podcast_newDB.sqlite3" "UPDATE SJPodcast SET lastUpdatedAt = 'Fri, 29 May 2020 08:06:13 GMT'; UPDATE SJEpisode SET downloadUrl = 'https://pocketcasts.com/fail.mp3';"`
9. Re-run the app
10. Play any episode from Up Next
11. ✅ On the console you should see `PlaybackManager: URL failed to load, trying to update episode and playing again` and `PlaybackManager: Episode  updated, trying to play again.`
12. ✅ The episode should play
13. Try the same on a few more episodes, they all should play
14. Go to Profile > Beta Features > disable `whenPlayingOnlyUpdateEpisodeIfPlaybackFails`
15. Play any episode not played yet
16. ✅ It should play and you should not see the aforementioned logs on the console

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
