### PR TITLE
Switching tabs position to center Discover

### DIFF
--- a/.xcode.env
+++ b/.xcode.env
@@ -1,1 +1,0 @@
-export NODE_BINARY=

--- a/.xcode.env
+++ b/.xcode.env
@@ -1,0 +1,1 @@
+export NODE_BINARY=

--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -30,7 +30,7 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
         super.viewDidLoad()
 
         if FeatureFlag.upNextOnTabBar.enabled {
-            tabs = [.podcasts, .upNext, .filter, .discover, .profile]
+            tabs = [.podcasts, .filter, .discover, .upNext, .profile]
         } else {
             tabs = [.podcasts, .filter, .discover, .profile]
         }
@@ -52,7 +52,7 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
         if FeatureFlag.upNextOnTabBar.enabled {
             let upNextViewController = UpNextViewController(source: .tabBar, showingInTab: true)
             upNextViewController.tabBarItem = UITabBarItem(title: L10n.upNext, image: UIImage(named: "upnext_tab"), tag: tabs.firstIndex(of: .upNext)!)
-            vcsInTab = [podcastsController, upNextViewController, filtersViewController, discoverViewController, profileViewController]
+            vcsInTab = [podcastsController, filtersViewController, discoverViewController, upNextViewController, profileViewController]
         } else {
             vcsInTab = [podcastsController, filtersViewController, discoverViewController, profileViewController]
         }


### PR DESCRIPTION
This PR switches the position of the 5 item tab bar to center Discover. The new order is Podcasts, Filters, Discover, Up Next, Profile. This order seems to reflect access levels on Android per data collected in recent release. 

![Simulator Screenshot - iPhone 15 Pro - 2024-06-04 at 19 39 07](https://github.com/Automattic/pocket-casts-ios/assets/1335657/60ac1f02-340e-43ec-ba33-5acf13861078)


- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
