### PR TITLE
Chapter Manager: add logs

### DIFF
--- a/podcasts/ChapterManager.swift
+++ b/podcasts/ChapterManager.swift
@@ -149,13 +149,17 @@ class ChapterManager {
             // into account dynamic ads
             if !fileChapters.isEmpty {
                 chapters = fileChapters
+                FileLog.shared.addMessage("ChapterManager: using file chapters")
             } else if let externalChapters = parseExternalChapters(podlove: podloveChapters, podcastIndex: podcastIndexChapters, duration: duration) {
                 chapters = externalChapters
+                FileLog.shared.addMessage("ChapterManager: using external chapters")
             } else {
                 chapters = []
+                FileLog.shared.addMessage("ChapterManager: failed. Displaying no chapters.")
             }
         } catch {
             chapters = await fileChaptersAsync
+            FileLog.shared.addMessage("ChapterManager: using file chapters because there was an error retrieving external sources")
         }
 
         if lastEpisodeUuid == episode.uuid {


### PR DESCRIPTION
Recently we had two reports from chapters not loading for episodes that, at least, have file chapters.

Given we're still unsure what's happening, these logs might help us find the answer.

Ps.: I think this is a pretty safe change to have in `7.65`.

## To test

1. Play any episode with chapters
2. ✅ Check that some `ChapterManager` entries are printed to the debug console

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
