### PR TITLE
Make prototype build conditional and split build from upload steps

### DIFF
--- a/.buildkite/commands/prototype-build.sh
+++ b/.buildkite/commands/prototype-build.sh
@@ -16,4 +16,4 @@ echo "--- :swift: Setting up Swift Packages"
 install_swiftpm_dependencies
 
 echo "--- :hammer_and_wrench: Building"
-bundle exec fastlane build_and_upload_entreprise
+bundle exec fastlane build_enterprise

--- a/.buildkite/commands/prototype-upload.sh
+++ b/.buildkite/commands/prototype-upload.sh
@@ -17,4 +17,4 @@ echo "--- :closed_lock_with_key: Installing Secrets"
 bundle exec fastlane run configure_apply
 
 echo "--- :hammer_and_wrench: Uploading"
-bundle exec fastlane upload_entreprise
+bundle exec fastlane upload_enterprise

--- a/.buildkite/commands/prototype-upload.sh
+++ b/.buildkite/commands/prototype-upload.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -eu
+
+# Sentry CLI needs to be up-to-date
+brew upgrade sentry-cli
+
+echo "--- :arrow_down: Downloading Prototype Build"
+buildkite-agent artifact download "artifacts/*.ipa" . --step build_prototype
+buildkite-agent artifact download "artifacts/*.app.dSYM.zip" . --step build_prototype
+
+echo "--- :rubygems: Setting up Gems"
+install_gems
+
+echo "--- :cocoapods: Setting up Pods"
+install_cocoapods
+
+echo "--- :closed_lock_with_key: Installing Secrets"
+bundle exec fastlane run configure_apply
+
+echo "--- :hammer_and_wrench: Uploading"
+bundle exec fastlane upload_entreprise

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -18,34 +18,6 @@ steps:
     env: *common_env
     plugins: *common_plugins
 
-  - group: Prototype Build
-    steps:
-      - label: Build
-        key: build_protoype
-        command: .buildkite/commands/prototype-build.sh
-        agents: *common_agents
-        env: *common_env
-        plugins: *common_plugins
-        # The folder and name are configured in Fastlane
-        artifact_paths:
-          - artifacts/*.ipa
-          - artifacts/*.app.dSYM.zip
-        notify:
-          - github_commit_status:
-              context: Prototype Build - Package
-        if: "build.pull_request.id != null || build.pull_request.draft"
-
-      - label: Upload
-        depends_on: build_protoype
-        command: .buildkite/commands/prototype-upload.sh
-        agents: *common_agents
-        env: *common_env
-        plugins: *common_plugins
-        notify:
-          - github_commit_status:
-              context: Prototype Build - Upload
-        if: "build.pull_request.id != null || build.pull_request.draft"
-
   - group: "Linters"
     steps:
       - label: "☢️ Danger - PR Check"
@@ -70,3 +42,39 @@ steps:
         command: lint_localized_strings_format
         plugins: *common_plugins
         env: *common_env
+
+  - block: Deploy Prototype Build
+    prompt: Share a Prototype Build via App Center?
+    key: prototype_triggered
+    # Block steps have implicit dependency on the steps that come before them.
+    # See https://buildkite.com/docs/pipelines/trigger-step
+    #
+    # Make it depend on nothing so we don't have to wait for previous steps to finish before the deployment can start.
+    depends_on: ~
+
+  - group: Prototype Build
+    steps:
+      - label: Prototype Build - Build
+        key: build_prototype
+        depends_on: prototype_triggered
+        command: .buildkite/commands/prototype-build.sh
+        agents: *common_agents
+        env: *common_env
+        plugins: *common_plugins
+        # The folder name is are configured in Fastlane
+        artifact_paths:
+          - artifacts/*.ipa
+          - artifacts/*.app.dSYM.zip
+        notify:
+          - github_commit_status:
+              context: Prototype Build - Build
+
+      - label: Prototype Build - Upload
+        depends_on: build_prototype
+        command: .buildkite/commands/prototype-upload.sh
+        agents: *common_agents
+        env: *common_env
+        plugins: *common_plugins
+        notify:
+          - github_commit_status:
+              context: Prototype Build - Upload

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -18,15 +18,33 @@ steps:
     env: *common_env
     plugins: *common_plugins
 
-  - label: Prototype Build
-    command: .buildkite/commands/prototype-build.sh
-    agents: *common_agents
-    env: *common_env
-    plugins: *common_plugins
-    notify:
-      - github_commit_status:
-          context: Prototype Build
-    if: "build.pull_request.id != null || build.pull_request.draft"
+  - group: Prototype Build
+    steps:
+      - label: Build
+        key: build_protoype
+        command: .buildkite/commands/prototype-build.sh
+        agents: *common_agents
+        env: *common_env
+        plugins: *common_plugins
+        # The folder and name are configured in Fastlane
+        artifact_paths:
+          - artifacts/*.ipa
+          - artifacts/*.app.dSYM.zip
+        notify:
+          - github_commit_status:
+              context: Prototype Build - Package
+        if: "build.pull_request.id != null || build.pull_request.draft"
+
+      - label: Upload
+        depends_on: build_protoype
+        command: .buildkite/commands/prototype-upload.sh
+        agents: *common_agents
+        env: *common_env
+        plugins: *common_plugins
+        notify:
+          - github_commit_status:
+              context: Prototype Build - Upload
+        if: "build.pull_request.id != null || build.pull_request.draft"
 
   - group: "Linters"
     steps:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -10,6 +10,7 @@ default_platform :ios
 PROJECT_ROOT_FOLDER = File.dirname(File.expand_path(__dir__))
 FASTLANE_FOLDER = File.join(PROJECT_ROOT_FOLDER, 'fastlane')
 APP_STORE_METADATA_FOLDER = File.join(FASTLANE_FOLDER, 'metadata')
+ARTIFACTS_FOLDER = File.join(PROJECT_ROOT_FOLDER, 'artifacts')
 SECRETS_FOLDER = File.join(Dir.home, '.configure', 'pocketcasts-ios', 'secrets')
 VERSION_XCCONFIG_PATH = File.join(PROJECT_ROOT_FOLDER, 'config', 'Version.xcconfig')
 # Unfortunately, ios_current_branch_is_hotfix relies on this ENV var under the hood.
@@ -39,6 +40,8 @@ DEFAULT_BRANCH = 'trunk'
 
 SCHEME = 'pocketcasts'
 SCHEME_ENTERPRISE = 'Pocket Casts Prototype Build'
+
+PROTOTYPE_BUILD_NAME = 'pocket-casts-prototype'
 
 # Instanstiate versioning classes
 VERSION_CALCULATOR = Fastlane::Wpmreleasetoolkit::Versioning::SemanticVersionCalculator.new
@@ -607,9 +610,7 @@ platform :ios do
   desc 'Builds and distributes via Enterprise account (Prototype Build)'
   lane :build_and_upload_entreprise do
     build_enterprise
-    upload_pocket_casts_to_appcenter
-    annotate_pr_with_appcenter_link
-    annotate_buildkite_with_appcenter_link
+    upload_enterprise
   end
 
   desc 'Builds for Enterprise distribution (Prototype Build)'
@@ -635,11 +636,23 @@ platform :ios do
       include_bitcode: false,
       include_symbols: true,
       clean: true,
+      output_directory: ARTIFACTS_FOLDER,
+      output_name: PROTOTYPE_BUILD_NAME,
       export_options: {
         method: 'enterprise',
         manageAppVersionAndBuildNumber: false
       }
     )
+  end
+
+  desc 'Distributes a local app via Enterprise account (Prototype Build)'
+  lane :upload_enterprise do
+    upload_pocket_casts_to_appcenter
+
+    next unless is_ci
+
+    annotate_pr_with_appcenter_link
+    annotate_buildkite_with_appcenter_link
   end
 
   # Sets the stage to start working on a hotfix
@@ -1213,8 +1226,8 @@ def upload_pocket_casts_to_appcenter
     owner_name: APPCENTER_OWNER_NAME,
     owner_type: APPCENTER_OWNER_TYPE,
     app_name: APPCENTER_APP_SLUG,
-    file: lane_context[SharedValues::IPA_OUTPUT_PATH],
-    dsym: lane_context[SharedValues::DSYM_OUTPUT_PATH],
+    file: File.join(ARTIFACTS_FOLDER, "#{PROTOTYPE_BUILD_NAME}.ipa"),
+    dsym: File.join(ARTIFACTS_FOLDER, "#{PROTOTYPE_BUILD_NAME}.app.dSYM.zip"),
     release_notes: release_notes,
     destinations: 'Collaborators',
     notify_testers: false

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1255,7 +1255,7 @@ def annotate_buildkite_with_appcenter_link
   metadata = version_data.merge(build_type: 'Prototype', 'appcenter:id': appcenter_id)
   appcenter_install_url = "https://install.appcenter.ms/orgs/#{APPCENTER_OWNER_NAME}/apps/#{APPCENTER_APP_SLUG}/releases/#{appcenter_id}"
   list = metadata.map { |k, v| " - **#{k}**: #{v}" }.join("\n")
-  buildkite_annotate(context: 'appcenter-info-pocket-casts', style: 'info', message: "Pocket Casts iOS [AppCenter Build](#{appcenter_install_url}) Info:\n\n#{list}")
+  buildkite_annotate(context: 'appcenter-info-pocket-casts', style: 'info', message: "Pocket Casts iOS [App Center Build](#{appcenter_install_url}) Info:\n\n#{list}")
 end
 
 # Generates a build number for Prototype Builds, based on the PR number and short commit SHA1

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -608,7 +608,7 @@ platform :ios do
   end
 
   desc 'Builds and distributes via Enterprise account (Prototype Build)'
-  lane :build_and_upload_entreprise do
+  lane :build_and_upload_enterprise do
     build_enterprise
     upload_enterprise
   end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -613,8 +613,12 @@ platform :ios do
   end
 
   desc 'Builds for Enterprise distribution (Prototype Build)'
-  lane :build_enterprise do
-    configure_code_signing_enterprise
+  lane :build_enterprise do |options|
+    if options[:skip_code_sign_setup]
+      UI.message('Skipping fetch certificates and provisioning profiles as requested.')
+    else
+      configure_code_signing_enterprise
+    end
 
     version_settings = Xcodeproj::Config.new(File.new(VERSION_XCCONFIG_PATH)).to_hash
     build_number = generate_prototype_build_number


### PR DESCRIPTION
Follows up on the gated Prototype Builds conversation from https://github.com/Automattic/pocket-casts-ios/pull/1804#issuecomment-2151213221

I went for the simplest (for me, at least) step of having a CI button. Nothing stops us from changing it to a trigger label in the future as @SergioEstevao suggested, but personally, this seems more straightforward. The work in `Fastfile` will be useful regardless of the trigger strategy.c

https://github.com/Automattic/pocket-casts-ios/assets/1218433/c97452c5-d49c-4d07-bde8-59a5204fa0ac

Additionally, it splits the process in two steps: build and upload. This way, if we get and App Center issue like it happened yesterday, https://status.appcenter.ms/, we can retry the upload in isolation without wasting time rebuilding.

## To test

See CI behavior. Notice that the SwiftLint failure in more recent builds is unrelated with this build. Internal ref p1717658270512599-slack-C020Q0Z579V

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary. – N.A.
- [x] I have considered adding unit tests for my changes. – N.A.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics. – N.A.