### PR TITLE
Sleep Timer: ensure sleep timer is restarted due to shake only if sleep timer and the option is active

### DIFF
--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -1059,7 +1059,7 @@ class Settings: NSObject {
             UserDefaults.standard.set(newValue, forKey: Constants.UserDefaults.shakeToRestartSleepTimer)
         }
         get {
-            UserDefaults.standard.object(forKey: Constants.UserDefaults.shakeToRestartSleepTimer) as? Bool ?? true
+            UserDefaults.standard.bool(forKey: Constants.UserDefaults.shakeToRestartSleepTimer)
         }
     }
 

--- a/podcasts/SleepTimerManager.swift
+++ b/podcasts/SleepTimerManager.swift
@@ -30,8 +30,7 @@ class SleepTimerManager {
     init(backgroundShakeObserver: BackgroundShakeObserver = BackgroundShakeObserver()) {
         self.backgroundShakeObserver = backgroundShakeObserver
         backgroundShakeObserver.whenShook = { [weak self] in
-            self?.restartSleepTimer()
-            self?.playTone()
+            self?.restartSleepTimerAndPlayTone()
         }
     }
 
@@ -95,6 +94,16 @@ class SleepTimerManager {
         Analytics.shared.track(.playerSleepTimerRestarted, properties: ["time": "end_of_episode", "number_of_episodes": numberOfEpisodes])
         PlaybackManager.shared.numberOfEpisodesToSleepAfter = numberOfEpisodes
         NotificationCenter.default.removeObserver(self, name: Constants.Notifications.episodeDurationChanged, object: nil)
+    }
+
+    private func restartSleepTimerAndPlayTone() {
+        guard PlaybackManager.shared.sleepTimerActive() && Settings.shakeToRestartSleepTimer else {
+            backgroundShakeObserver.stopObserving()
+            return
+        }
+
+        restartSleepTimer()
+        playTone()
     }
 
     func playTone() {


### PR DESCRIPTION
We have some reports that the shake to restart sleep timer is active even when it shouldn't: https://www.reddit.com/r/pocketcasts/comments/1d4u3nf/ding_sound_on_ios/

This PR adds an additional check so the sleep timer is restarted and the tone played if, and only if, the option is enabled and there is an active timer going on.

I also changed the default for this option to `false` as it is still not easily discoverable, so we don't want people wondering from where this tone is coming.

## To test

To make testing faster, go to `SleepTimerViewController.swift` and change the `fiveMinutesTapped` function to `5.seconds` (instead of `5.minutes`), also go to Profile > Beta Features > and enable `tracksLogging`.

1. Run the app on a real device
1. Go to Profile > Settings > enable Shake to Restart Sleep Timer
12. Play and start a big sleep timer (30 minutes or more)
13. With the app on foreground, shake it
14. ✅ Sleep timer should restart
15. Put the app on background, shake it
16. ✅ Sleep timer should restart and you should listen to a sound
18. Go to Profile > Settings > disable Shake to Restart Sleep Timer
20. Play the episode again, ensure a sleep timer is going on
21. Shake the device
22. ✅ Nothing should happen, sleep timer will not be restarted
23. Put the app on background, shake it
24. ✅ Nothing should happen, sleep timer will not be restarted

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
