### PR TITLE
Developer: Write the pcasts bundle on db export

### DIFF
--- a/podcasts/DatabaseExport.swift
+++ b/podcasts/DatabaseExport.swift
@@ -70,31 +70,15 @@ class DatabaseExport {
             let logsFile = exportDirectory.appendingPathComponent("logs.txt", isDirectory: false)
             try fileManager.copyItem(at: URL(fileURLWithPath: logFile), to: logsFile)
 
-            // Write the preferences to the export folder
-            let preferencesFile = exportDirectory.appendingPathComponent("preferences.plist", isDirectory: false)
-            try writePreferences(to: preferencesFile)
-
-            // Copy the database file into the export folder
-            let databaseFile = exportDirectory.appendingPathComponent("database.sqlite", isDirectory: false)
-            try fileManager.copyItem(at: databaseURL, to: databaseFile)
+            // Write the bundle document
+            let exportFile = exportDirectory.appendingPathComponent("export", conformingTo: .pcasts)
+            let wrapper = try PCBundleDoc().fileWrapper()
+            try wrapper.write(to: exportFile, originalContentsURL: nil)
 
             return exportDirectory
         } catch {
             FileLog.shared.addMessage("[Export] Prepare failed with error: \(error)")
             return nil
         }
-    }
-
-    /// Save the preferences to the url
-    private func writePreferences(to url: URL) throws {
-        guard
-            let library = fileManager.urls(for: .libraryDirectory, in: .userDomainMask).first,
-            let bundle = Bundle.main.bundleIdentifier
-        else {
-            return
-        }
-
-        let preferencesFile = library.appendingPathComponent("Preferences/\(bundle).plist")
-        try fileManager.copyItem(at: preferencesFile, to: url)
     }
 }

--- a/podcasts/PCBundleDoc.swift
+++ b/podcasts/PCBundleDoc.swift
@@ -51,7 +51,10 @@ struct PCBundleDoc: FileDocument {
     }
 
     func fileWrapper(configuration: WriteConfiguration) throws -> FileWrapper {
+        try fileWrapper()
+    }
 
+    func fileWrapper() throws -> FileWrapper {
         let wrapper = FileWrapper(directoryWithFileWrappers: [:])
 
         let databaseFileWrapper = try FileWrapper(url: FileManager.databaseURL)


### PR DESCRIPTION
To unify the importing/exporting from the new `pcasts` file handling, this uses the new bundle format when exporting using the "Export Database" option from Help & Feedback. It should make it easier for us to use the export while still being able to get at the raw data inside.

![CleanShot 2024-06-06 at 13 02 23@2x](https://github.com/Automattic/pocket-casts-ios/assets/3250/533a87c9-2a46-4c62-9237-4756fdc3421c)

## To test

### Exporting
* Navigate to Profile > Help & Feedback > ⋯ > Export Database
* Save the file
* Follow the instructions below to access export:
  * **Device**: Airdrop the file to your computer 
  * **Simulator**: Run this script to access the files from Files.app:
```bash
#!/bin/bash
open "$(xcrun simctl get_app_container booted com.apple.DocumentsApp groups | grep LocalStorage | awk -F'\t' '{print $2 "/File Provider Storage"}')"
``` 
* Unzip the export
* Verify that `export.pcasts` is included
* Right click on `export.pcasts` and "Show Package Contents"
* Verify that `database.sqlite` and `preferences.plist` are inside

### Using the export
* Reinstall the app
* Drag and drop the `export.pcasts` file and import the file
* Make sure podcasts and settings have been changed

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
