### PR TITLE
Move `setup` calls to `didMoveToSuperview`

### DIFF
--- a/podcasts/PCGoogleCastButton.swift
+++ b/podcasts/PCGoogleCastButton.swift
@@ -6,15 +6,12 @@ class PCGoogleCastButton: UIButton {
     private static let connectedIconName = "nav_cast_on"
     private static let animatedIconNames = ["nav_cast_on0", "nav_cast_on1", "nav_cast_on2"]
 
-    override init(frame: CGRect) {
-        super.init(frame: frame)
-
-        setup()
-    }
-
-    required init?(coder decoder: NSCoder) {
-        super.init(coder: decoder)
-
+    override func didMoveToSuperview() {
+        super.didMoveToSuperview()
+        guard superview != nil else {
+            NotificationCenter.default.removeObserver(self, name: Constants.Notifications.googleCastStatusChanged, object: nil)
+            return
+        }
         setup()
     }
 


### PR DESCRIPTION
This is a second attempt to fix a crash in `ThemeableTable.intrinsicContentSize`

I tried reproducing this several different ways (posting a notification right after the `setup`, casting to a TV, changing turning Google Cast devices on and off while entering these screens) and none seemed to reproduce the issue.

I think it's worth making this change anyway as we should only set up the button and be listening for the notifications when the view is part of the view hierarchy and not before.

## To test

* Visit a Podcast page and make sure Google Cast button works properly
* Visit a Filter page and make sure Google Cast button works properly

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
