### PR TITLE
Handle errors from token Keychain access

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Private/API Tasks/ApiBaseTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Private/API Tasks/ApiBaseTask.swift
@@ -26,7 +26,7 @@ class ApiBaseTask: Operation {
     }
 
     func runTaskSynchronously() {
-        if let token = KeychainHelper.string(for: ServerConstants.Values.syncingV2TokenKey) {
+        if let token = try? KeychainHelper.string(for: ServerConstants.Values.syncingV2TokenKey) {
             apiTokenAcquired(token: token)
         } else if let token = tokenHelper.acquireToken() {
             apiTokenAcquired(token: token)

--- a/Modules/Server/Sources/PocketCastsServer/Private/TokenHelper.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Private/TokenHelper.swift
@@ -90,7 +90,8 @@ class TokenHelper {
                 case APIError.TOKEN_DEAUTH?, APIError.PERMISSION_DENIED?:
                     tokenCleanUp()
                 default:
-                    () // Do nothing so the user is not disrupted in the case of non-auth errors
+                    // Do nothing so the user is not disrupted in the case of non-auth errors
+                    FileLog.shared.addMessage("TokenHelper: Unable to acquire token but avoided logout due to error: \(String(describing: error))")
                 }
             } else {
                 tokenCleanUp()

--- a/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+SocialAuth.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+SocialAuth.swift
@@ -60,7 +60,7 @@ public extension ApiServerHandler {
 
     func refreshIdentityToken() async throws -> AuthenticationResponse {
         guard
-            let identityToken = ServerSettings.refreshToken,
+            let identityToken = try ServerSettings.refreshToken(),
             let request = tokenRequest(identityToken: identityToken, cachePolicy: .reloadIgnoringLocalCacheData, timeoutInterval: 30.seconds)
         else {
             FileLog.shared.addMessage("Unable to locate Apple SSO token in Keychain")

--- a/Modules/Server/Sources/PocketCastsServer/Public/ServerSettings.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/ServerSettings.swift
@@ -238,7 +238,7 @@ public class ServerSettings {
     }
 
     public class func syncingEmail() -> String? {
-        KeychainHelper.string(for: ServerConstants.Values.syncingEmailKey)
+        try? KeychainHelper.string(for: ServerConstants.Values.syncingEmailKey)
     }
 
     public class func setSyncingEmail(email: String?) {
@@ -263,7 +263,7 @@ public class ServerSettings {
     }
 
     public class func syncingPassword() -> String? {
-        KeychainHelper.string(for: ServerConstants.Values.syncingPasswordKey)
+        try? KeychainHelper.string(for: ServerConstants.Values.syncingPasswordKey)
     }
 
     public class func lastRefreshStartTime() -> Date? {
@@ -353,7 +353,7 @@ public extension ServerSettings {
 
     class var syncingV2Token: String? {
         get {
-            KeychainHelper.string(for: ServerConstants.Values.syncingV2TokenKey)
+            try? KeychainHelper.string(for: ServerConstants.Values.syncingV2TokenKey)
         }
 
         set {
@@ -361,13 +361,11 @@ public extension ServerSettings {
         }
     }
 
-    class var refreshToken: String? {
-        get {
-            KeychainHelper.string(for: ServerConstants.Values.refreshTokenKey)
-        }
+    class func refreshToken() throws -> String? {
+        try KeychainHelper.string(for: ServerConstants.Values.refreshTokenKey)
+    }
 
-        set {
-            KeychainHelper.save(string: newValue, key: ServerConstants.Values.refreshTokenKey, accessibility: kSecAttrAccessibleAfterFirstUnlock)
-        }
+    class func setRefreshToken(_ newValue: String?) {
+        KeychainHelper.save(string: newValue, key: ServerConstants.Values.refreshTokenKey, accessibility: kSecAttrAccessibleAfterFirstUnlock)
     }
 }

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/BackgroundSyncManager.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/BackgroundSyncManager.swift
@@ -53,7 +53,7 @@ public class BackgroundSyncManager: NSObject {
         // we also need to perform all these on the same URLSession as download tasks, so the app can be put to sleep and woken up when they are done later
 
         let urlSession = createUrlSession(identifier: BackgroundSyncManager.sessionIdPrefix + UUID().uuidString)
-        guard let token = KeychainHelper.string(for: ServerConstants.Values.syncingV2TokenKey), let refreshTask = refreshDownloadTask(subscribedPodcasts: subscribedPodcasts, urlSession: urlSession), let upNextTask = upNextDownloadTask(token: token, urlSession: urlSession), let syncTask = syncDownloadTask(token: token, urlSession: urlSession) else {
+        guard let token = try? KeychainHelper.string(for: ServerConstants.Values.syncingV2TokenKey), let refreshTask = refreshDownloadTask(subscribedPodcasts: subscribedPodcasts, urlSession: urlSession), let upNextTask = upNextDownloadTask(token: token, urlSession: urlSession), let syncTask = syncDownloadTask(token: token, urlSession: urlSession) else {
             FileLog.shared.addMessage("Unable to create tasks required to perform background refresh")
 
             return

--- a/Modules/Utils/Sources/PocketCastsUtils/General/KeychainHelper.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/General/KeychainHelper.swift
@@ -44,6 +44,7 @@ public class KeychainHelper {
         case errSecItemNotFound, errSecSuccess:
             ()
         default:
+            FileLog.shared.addMessage("KeychainHelper: Failed to fetch \(key) osstatus: \(status)")
             throw KeychainError.status(status)
         }
 

--- a/Pocket Casts Watch App/WatchSyncManager.swift
+++ b/Pocket Casts Watch App/WatchSyncManager.swift
@@ -109,7 +109,7 @@ class WatchSyncManager {
 
                 ServerSettings.setSyncingEmail(email: username)
                 ServerSettings.saveSyncingPassword(password)
-                ServerSettings.refreshToken = refreshToken
+                ServerSettings.setRefreshToken(refreshToken)
 
                 if !username.isEmpty {
                     self.login()
@@ -175,7 +175,7 @@ class WatchSyncManager {
 
             ServerSettings.setSyncingEmail(email: username)
             ServerSettings.saveSyncingPassword(password)
-            ServerSettings.refreshToken = refreshToken
+            ServerSettings.setRefreshToken(refreshToken)
 
             if SyncManager.isUserLoggedIn(), username.isEmpty {
                 FileLog.shared.addMessage("Logging out as phone has logged out ")

--- a/podcasts/AuthenticationHelper.swift
+++ b/podcasts/AuthenticationHelper.swift
@@ -13,7 +13,7 @@ class AuthenticationHelper {
         if let username = ServerSettings.syncingEmail(), let password = ServerSettings.syncingPassword(), !password.isEmpty {
             return try await validateLogin(username: username, password: password, scope: scope).token
         }
-        else if let token = ServerSettings.refreshToken {
+        else if let token = try? ServerSettings.refreshToken() {
             return try await validateLogin(identityToken: token, scope: scope).token
         }
 
@@ -43,7 +43,7 @@ class AuthenticationHelper {
         let response = try await ApiServerHandler.shared.validateLogin(identityToken: identityToken, scope: scope)
         handleSuccessfulSignIn(response)
 
-        ServerSettings.refreshToken = response.refreshToken
+        ServerSettings.setRefreshToken(response.refreshToken)
 
         return response
     }
@@ -62,7 +62,7 @@ class AuthenticationHelper {
 
         ServerSettings.userId = response.uuid
         ServerSettings.syncingV2Token = response.token
-        ServerSettings.refreshToken = response.refreshToken
+        ServerSettings.setRefreshToken(response.refreshToken)
 
         // we've signed in, set all our existing podcasts to
         // be non synced if the user never logged in before

--- a/podcasts/WatchManager.swift
+++ b/podcasts/WatchManager.swift
@@ -341,7 +341,7 @@ class WatchManager: NSObject, WCSessionDelegate {
         if let password = ServerSettings.syncingPassword() {
             response[WatchConstants.Messages.LoginDetailsResponse.password] = password
         }
-        else if let refreshToken = ServerSettings.refreshToken {
+        else if let refreshToken = try? ServerSettings.refreshToken() {
             response[WatchConstants.Messages.LoginDetailsResponse.refreshToken] = refreshToken
         }
 


### PR DESCRIPTION
The Apple SSO token may be stored in the keychain but not be accessible after a restart. This is a theoretical fix for a logout bug.

## To test

### Reproducing the issue
* Log in using Apple Sign-In
* Apply the following patch on this branch:
[pocket-casts-ios-3-20-47 PM.patch](https://github.com/user-attachments/files/15779217/pocket-casts-ios-3-20-47.PM.patch)
* Set a breakpoint at the end of the `AppDelegate.scheduleNextBackgroundRefresh` function
* Run the app
* Background the app
* When the breakpoint is hit and execution is stopped, run the following LLDB command:
```
e -l objc -- (void)[[BGTaskScheduler sharedScheduler] _simulateLaunchForTaskWithIdentifier:@"au.com.shiftyjelly.podcasts.Refresh"]
```
* Verify that the user is logged out

### Fixing the issue
* Log in using Apple Sign-In
* Discard the changes to `TokenHelper.swift` from the patch
* Set a breakpoint at the end of the `AppDelegate.scheduleNextBackgroundRefresh` function
* Run the app
* Background the app
* When the breakpoint is hit and execution is stopped, run the following LLDB command:
```
e -l objc -- (void)[[BGTaskScheduler sharedScheduler] _simulateLaunchForTaskWithIdentifier:@"au.com.shiftyjelly.podcasts.Refresh"]
```
* Verify that the user is still logged in

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
