### PR TITLE
Fix Episode detail view on iPad

### DIFF
--- a/podcasts/EpisodeDetailViewController.xib
+++ b/podcasts/EpisodeDetailViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="dark"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21678"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22684"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -49,30 +49,32 @@
             <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" directionalLockEnabled="YES" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" delaysContentTouches="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tmT-f0-kSM" userLabel="Container Scroll View" customClass="PagedUIScrollView" customModule="PocketCastsUtils">
+                <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" directionalLockEnabled="YES" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" delaysContentTouches="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tmT-f0-kSM" userLabel="Container Scroll View" customClass="PagedUIScrollView" customModule="PocketCastsUtils">
                     <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                     <subviews>
-                        <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" directionalLockEnabled="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ffa-0D-OU4" userLabel="Content Scroll View" customClass="DismissableNestedScrollView" customModule="PocketCastsUtils">
-                            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" directionalLockEnabled="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ffa-0D-OU4" userLabel="Content Scroll View" customClass="DismissableNestedScrollView" customModule="PocketCastsUtils">
+                            <rect key="frame" x="0.0" y="0.0" width="420" height="667"/>
                             <subviews>
-                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="SYi-ag-GDK" userLabel="Top Section">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="546"/>
+                                <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="SYi-ag-GDK" userLabel="Top Section">
+                                    <rect key="frame" x="0.0" y="0.0" width="420" height="546"/>
                                     <subviews>
-                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4IP-4N-SIa" customClass="PodcastImageView" customModule="podcasts" customModuleProvider="target">
+                                        <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4IP-4N-SIa" customClass="PodcastImageView" customModule="podcasts" customModuleProvider="target">
                                             <rect key="frame" x="100" y="12" width="175" height="175"/>
                                             <color key="backgroundColor" red="0.0" green="0.65745162960000003" blue="0.95673888920000005" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                             <constraints>
+                                                <constraint firstAttribute="height" relation="lessThanOrEqual" constant="175" id="Ush-Bm-S7A"/>
                                                 <constraint firstAttribute="width" secondItem="4IP-4N-SIa" secondAttribute="height" multiplier="1:1" id="lhn-l4-F67"/>
+                                                <constraint firstAttribute="width" relation="lessThanOrEqual" constant="175" id="mbB-ao-L3L"/>
                                             </constraints>
                                         </view>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Episode Name" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" minimumFontSize="18" translatesAutoresizingMaskIntoConstraints="NO" id="dsg-ff-pnB" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                                            <rect key="frame" x="16" y="231" width="343" height="26.5"/>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Episode Name" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" minimumFontSize="18" translatesAutoresizingMaskIntoConstraints="NO" id="dsg-ff-pnB" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
+                                            <rect key="frame" x="16" y="231" width="388" height="26.5"/>
                                             <fontDescription key="fontDescription" type="boldSystem" pointSize="22"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
-                                        <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="akC-zS-r4u">
-                                            <rect key="frame" x="91.5" y="203" width="192" height="18"/>
+                                        <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="akC-zS-r4u">
+                                            <rect key="frame" x="114" y="203" width="192" height="18"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="3 December 2019" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ytP-Wg-gNG" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
                                                     <rect key="frame" x="0.0" y="0.0" width="122.5" height="18"/>
@@ -94,27 +96,27 @@
                                                 </label>
                                             </subviews>
                                         </stackView>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" verticalHuggingPriority="251" text="Loading..." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mqv-46-8ea">
-                                            <rect key="frame" x="146" y="265.5" width="73.5" height="19.5"/>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" verticalHuggingPriority="251" ambiguous="YES" text="Loading..." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mqv-46-8ea">
+                                            <rect key="frame" x="168.5" y="265.5" width="73.5" height="19.5"/>
                                             <fontDescription key="fontDescription" type="system" weight="medium" pointSize="16"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
-                                        <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="episode-chevron" translatesAutoresizingMaskIntoConstraints="NO" id="sEv-1n-DxV">
-                                            <rect key="frame" x="221.5" y="267.5" width="16" height="16"/>
+                                        <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" image="episode-chevron" translatesAutoresizingMaskIntoConstraints="NO" id="sEv-1n-DxV">
+                                            <rect key="frame" x="244" y="267.5" width="16" height="16"/>
                                         </imageView>
-                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mhS-eS-X3U" userLabel="Buttons View">
-                                            <rect key="frame" x="0.0" y="305" width="375" height="235"/>
+                                        <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mhS-eS-X3U" userLabel="Buttons View">
+                                            <rect key="frame" x="0.0" y="305" width="420" height="235"/>
                                             <subviews>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qhA-bj-I2z" customClass="ThemeDividerView" customModule="podcasts" customModuleProvider="target">
-                                                    <rect key="frame" x="0.0" y="40" width="375" height="1"/>
+                                                    <rect key="frame" x="0.0" y="40" width="420" height="1"/>
                                                     <color key="backgroundColor" red="0.56078431370000004" green="0.59215686270000001" blue="0.64313725489999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="1" id="Yec-wv-a4R"/>
                                                     </constraints>
                                                 </view>
                                                 <stackView opaque="NO" contentMode="scaleToFill" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="pbD-yD-5ea">
-                                                    <rect key="frame" x="0.0" y="55" width="375" height="60"/>
+                                                    <rect key="frame" x="0.0" y="55" width="420" height="60"/>
                                                     <subviews>
                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Gr7-N7-0qa">
                                                             <rect key="frame" x="0.0" y="0.0" width="70" height="55"/>
@@ -160,14 +162,14 @@
                                                             </connections>
                                                         </button>
                                                         <view contentMode="scaleToFill" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="HUn-8V-DZb" userLabel="Spacer View">
-                                                            <rect key="frame" x="165" y="0.0" width="45" height="60"/>
+                                                            <rect key="frame" x="165" y="0.0" width="90" height="60"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="width" relation="lessThanOrEqual" constant="90" id="g9Y-IZ-thm"/>
                                                                 <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="10" id="oDB-AL-siM"/>
                                                             </constraints>
                                                         </view>
                                                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="top" lineBreakMode="wordWrap" pointerInteraction="YES" translatesAutoresizingMaskIntoConstraints="NO" id="6vC-l3-5p9" userLabel="Mark Played Button" customClass="ActionIconButton" customModule="podcasts" customModuleProvider="target">
-                                                            <rect key="frame" x="210" y="0.0" width="95" height="24"/>
+                                                            <rect key="frame" x="255" y="0.0" width="95" height="24"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="width" constant="95" id="u40-Ap-MBz"/>
                                                             </constraints>
@@ -178,7 +180,7 @@
                                                             </connections>
                                                         </button>
                                                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="top" lineBreakMode="wordWrap" pointerInteraction="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1WD-bM-NYS" customClass="ActionIconButton" customModule="podcasts" customModuleProvider="target">
-                                                            <rect key="frame" x="305" y="0.0" width="70" height="24"/>
+                                                            <rect key="frame" x="350" y="0.0" width="70" height="24"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="width" constant="70" id="m4c-gr-c6s"/>
                                                             </constraints>
@@ -193,7 +195,7 @@
                                                     </subviews>
                                                 </stackView>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="21U-r9-JP1" userLabel="Message View" customClass="RoundedBorderView" customModule="podcasts" customModuleProvider="target">
-                                                    <rect key="frame" x="16" y="125" width="343" height="90"/>
+                                                    <rect key="frame" x="16" y="125" width="388" height="90"/>
                                                     <subviews>
                                                         <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="episode-archive" translatesAutoresizingMaskIntoConstraints="NO" id="IaZ-ts-eDq">
                                                             <rect key="frame" x="13" y="13" width="24" height="24"/>
@@ -203,13 +205,13 @@
                                                             </constraints>
                                                         </imageView>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Episode Manually Unarchived" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QSl-m4-wUL" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                                                            <rect key="frame" x="50" y="15.5" width="283" height="19.5"/>
+                                                            <rect key="frame" x="50" y="15.5" width="328" height="19.5"/>
                                                             <fontDescription key="fontDescription" type="system" weight="medium" pointSize="16"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="It won't be auto archived by your new episode limit of 2" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aet-FO-Uny" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                                                            <rect key="frame" x="50" y="40" width="283" height="33.5"/>
+                                                            <rect key="frame" x="50" y="40" width="328" height="33.5"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                             <color key="textColor" red="0.53333333329999999" green="0.53333333329999999" blue="0.53333333329999999" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                                             <nil key="highlightedColor"/>
@@ -234,7 +236,7 @@
                                                     </userDefinedRuntimeAttributes>
                                                 </view>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="x4a-0Q-f1h" customClass="PlayPauseButton" customModule="podcasts" customModuleProvider="target">
-                                                    <rect key="frame" x="147.5" y="0.0" width="80" height="80"/>
+                                                    <rect key="frame" x="170" y="0.0" width="80" height="80"/>
                                                     <accessibility key="accessibilityConfiguration" label="Play/Pause Episode"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" secondItem="x4a-0Q-f1h" secondAttribute="height" multiplier="1:1" id="BiR-C3-bY5"/>
@@ -245,7 +247,7 @@
                                                     </connections>
                                                 </button>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="19d-9v-ihd" customClass="ThemeDividerView" customModule="podcasts" customModuleProvider="target">
-                                                    <rect key="frame" x="0.0" y="234" width="375" height="1"/>
+                                                    <rect key="frame" x="0.0" y="234" width="420" height="1"/>
                                                     <color key="backgroundColor" red="0.56078431370000004" green="0.59215686270000001" blue="0.64313725489999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="1" id="dya-K0-LEK"/>
@@ -290,7 +292,6 @@
                                         <constraint firstItem="sEv-1n-DxV" firstAttribute="centerY" secondItem="mqv-46-8ea" secondAttribute="centerY" id="8FF-D7-oYB"/>
                                         <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="mqv-46-8ea" secondAttribute="trailing" constant="40" id="Cu8-Sf-4MD"/>
                                         <constraint firstItem="dsg-ff-pnB" firstAttribute="top" secondItem="akC-zS-r4u" secondAttribute="bottom" constant="10" id="GLy-9A-UJJ"/>
-                                        <constraint firstItem="4IP-4N-SIa" firstAttribute="leading" secondItem="SYi-ag-GDK" secondAttribute="leading" constant="100" id="NRp-t8-OKj"/>
                                         <constraint firstAttribute="trailing" secondItem="dsg-ff-pnB" secondAttribute="trailing" constant="16" id="UjW-5V-YVv"/>
                                         <constraint firstItem="mhS-eS-X3U" firstAttribute="leading" secondItem="SYi-ag-GDK" secondAttribute="leading" id="V1O-Po-PXt"/>
                                         <constraint firstItem="akC-zS-r4u" firstAttribute="centerX" secondItem="SYi-ag-GDK" secondAttribute="centerX" id="VoY-ug-v6h"/>
@@ -300,27 +301,27 @@
                                         <constraint firstItem="Fv5-YL-ggw" firstAttribute="width" secondItem="SYi-ag-GDK" secondAttribute="width" multiplier="0.01" id="lXv-7B-jbA"/>
                                         <constraint firstItem="mqv-46-8ea" firstAttribute="top" secondItem="dsg-ff-pnB" secondAttribute="bottom" constant="8" id="nLo-3O-J0B"/>
                                         <constraint firstItem="mqv-46-8ea" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="SYi-ag-GDK" secondAttribute="leading" constant="40" id="oVa-1E-U1g"/>
-                                        <constraint firstAttribute="trailing" secondItem="4IP-4N-SIa" secondAttribute="trailing" constant="100" id="sbJ-eu-q46"/>
+                                        <constraint firstItem="4IP-4N-SIa" firstAttribute="centerX" secondItem="SYi-ag-GDK" secondAttribute="centerX" id="sbJ-eu-q46"/>
                                         <constraint firstItem="mqv-46-8ea" firstAttribute="centerX" secondItem="SYi-ag-GDK" secondAttribute="centerX" constant="-5" id="sgC-t1-vtP"/>
                                         <constraint firstAttribute="bottom" secondItem="mhS-eS-X3U" secondAttribute="bottom" constant="6" id="xmi-xu-ARI"/>
                                         <constraint firstItem="4IP-4N-SIa" firstAttribute="top" secondItem="SYi-ag-GDK" secondAttribute="top" constant="12" id="zTA-af-M9q"/>
                                         <constraint firstAttribute="trailing" secondItem="mhS-eS-X3U" secondAttribute="trailing" id="zYZ-o7-5kJ"/>
                                     </constraints>
                                 </view>
-                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XID-El-uKH">
-                                    <rect key="frame" x="0.0" y="546" width="375" height="334"/>
+                                <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="XID-El-uKH">
+                                    <rect key="frame" x="0.0" y="546" width="420" height="334"/>
                                     <subviews>
                                         <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="white" translatesAutoresizingMaskIntoConstraints="NO" id="bTC-FT-bUv">
-                                            <rect key="frame" x="177.5" y="40" width="20" height="20"/>
+                                            <rect key="frame" x="200" y="40" width="20" height="20"/>
                                         </activityIndicatorView>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Unable to find show notes for this episode" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Gye-vZ-4Rq" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                                            <rect key="frame" x="16" y="20" width="343" height="19.5"/>
+                                            <rect key="frame" x="16" y="20" width="388" height="19.5"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" pointerInteraction="YES" translatesAutoresizingMaskIntoConstraints="NO" id="X1H-6J-Cmx" customClass="ThemeableUIButton" customModule="podcasts" customModuleProvider="target">
-                                            <rect key="frame" x="150" y="50" width="75" height="29"/>
+                                            <rect key="frame" x="172.5" y="50" width="75" height="29"/>
                                             <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="14"/>
                                             <state key="normal" title="TRY AGAIN"/>
                                             <connections>
@@ -357,9 +358,7 @@
                     <constraints>
                         <constraint firstItem="Ffa-0D-OU4" firstAttribute="leading" secondItem="hDz-Sd-hOx" secondAttribute="leading" placeholder="YES" id="0w4-DA-dIz"/>
                         <constraint firstItem="Ffa-0D-OU4" firstAttribute="bottom" secondItem="hDz-Sd-hOx" secondAttribute="bottom" placeholder="YES" id="Bly-tW-HUG"/>
-                        <constraint firstItem="Ffa-0D-OU4" firstAttribute="height" secondItem="j2b-On-X9W" secondAttribute="height" priority="250" placeholder="YES" id="P4i-9u-7YD"/>
                         <constraint firstItem="Ffa-0D-OU4" firstAttribute="trailing" secondItem="hDz-Sd-hOx" secondAttribute="trailing" placeholder="YES" id="d6W-jL-sEF"/>
-                        <constraint firstItem="Ffa-0D-OU4" firstAttribute="width" secondItem="j2b-On-X9W" secondAttribute="width" placeholder="YES" id="nhg-hq-qPc"/>
                         <constraint firstItem="Ffa-0D-OU4" firstAttribute="top" secondItem="hDz-Sd-hOx" secondAttribute="top" placeholder="YES" id="xO7-dE-cbz"/>
                     </constraints>
                     <viewLayoutGuide key="contentLayoutGuide" id="hDz-Sd-hOx"/>


### PR DESCRIPTION
Fixes #1810

This PR updates the constraint on the episode image so it does not grow to an huge size that makes action buttons to be cropped.

| Before | After |
| - | - | 
| ![Simulator Screenshot - iPad mini (6th generation) - 2024-06-06 at 16 36 29](https://github.com/Automattic/pocket-casts-ios/assets/651601/2441acfe-4fad-4130-9cad-49aef62a3a02) |  ![Simulator Screenshot - iPad mini (6th generation) - 2024-06-10 at 16 19 08](https://github.com/Automattic/pocket-casts-ios/assets/651601/b5ad763f-31db-4c2b-9da2-17c2cc6045e5) |

## To test

 - Start the application on the iPad
 - Open a Podcast and tap on a episode
 - Check if the episode detail shows correctly and all actions are visible
 - Check the design keeps correct by rotating the device and by entering the multiple iPad multitasks mode.
 - Check on the iPhone to see if the design is still correct.
 
## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.- [ ] 