### PR TITLE
Accelerate Effects

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -66,6 +66,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// but can lead to a bigger time between tapping play and actually playing it
     case whenPlayingOnlyUpdateEpisodeIfPlaybackFails
 
+    /// Use the Accelerate framework to speed up custom effects
+    case accelerateEffects
+
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -117,6 +120,8 @@ public enum FeatureFlag: String, CaseIterable {
         case .onlyMarkPodcastsUnsyncedForNewUsers:
             true
         case .whenPlayingOnlyUpdateEpisodeIfPlaybackFails:
+            true
+        case .accelerateEffects:
             true
         }
     }

--- a/PocketCastsTests/Tests/Playback/Effects/AudioUtilsTests.swift
+++ b/PocketCastsTests/Tests/Playback/Effects/AudioUtilsTests.swift
@@ -35,7 +35,7 @@ final class AudioUtilsTests: XCTestCase {
         let samples: [Float32] = [-8, -4, -0, 2, 4, 8]
 
         var audioBuffer = AudioBuffer()
-        audioBuffer.mNumberChannels = 1 // Mono audio
+        audioBuffer.mNumberChannels = 2 // Stereo
         audioBuffer.mDataByteSize = UInt32(samples.count * MemoryLayout<Float32>.size)
         audioBuffer.mData = UnsafeMutableRawPointer.allocate(byteCount: Int(audioBuffer.mDataByteSize), alignment: MemoryLayout<Float32>.alignment)
 

--- a/PocketCastsTests/Tests/Playback/Effects/AudioUtilsTests.swift
+++ b/PocketCastsTests/Tests/Playback/Effects/AudioUtilsTests.swift
@@ -1,0 +1,172 @@
+import XCTest
+@testable import podcasts
+import AVFoundation
+import Accelerate
+
+final class AudioUtilsTests: XCTestCase {
+
+    var audioBuffer: AudioBuffer!
+
+    override func setUp() async throws {
+        audioBuffer = sampleBuffer()
+    }
+
+    override func tearDown() async throws {
+        cleanUpAudioBuffer(buffer: &audioBuffer)
+    }
+
+    private var bufferFormat: AVAudioFormat = {
+        var asbd = AudioStreamBasicDescription(
+            mSampleRate: 44100.0,
+            mFormatID: kAudioFormatLinearPCM,
+            mFormatFlags: kAudioFormatFlagIsFloat | kAudioFormatFlagIsPacked,
+            mBytesPerPacket: UInt32(MemoryLayout<Float32>.size),
+            mFramesPerPacket: 1,
+            mBytesPerFrame: UInt32(MemoryLayout<Float32>.size),
+            mChannelsPerFrame: 1,
+            mBitsPerChannel: UInt32(8 * MemoryLayout<Float32>.size),
+            mReserved: 0
+        )
+
+        return AVAudioFormat(streamDescription: &asbd)!
+    }()
+
+    private func sampleBuffer() -> AudioBuffer {
+        let samples: [Float32] = [-8, -4, -0, 2, 4, 8]
+
+        var audioBuffer = AudioBuffer()
+        audioBuffer.mNumberChannels = 1 // Mono audio
+        audioBuffer.mDataByteSize = UInt32(samples.count * MemoryLayout<Float32>.size)
+        audioBuffer.mData = UnsafeMutableRawPointer.allocate(byteCount: Int(audioBuffer.mDataByteSize), alignment: MemoryLayout<Float32>.alignment)
+
+        audioBuffer.mData?.initializeMemory(as: Float32.self, repeating: 0, count: samples.count)
+        audioBuffer.mData?.copyMemory(from: samples, byteCount: Int(audioBuffer.mDataByteSize))
+
+        return audioBuffer
+    }
+
+    // Function to deallocate memory and clean up
+    private func cleanUpAudioBuffer(buffer: inout AudioBuffer) {
+        buffer.mData?.deallocate()
+        buffer.mData = nil
+    }
+
+    private func audioBufferToAVAudioPCMBuffer(audioBuffer: AudioBuffer, format: AVAudioFormat) -> AVAudioPCMBuffer? {
+        // Calculate the number of frames in the AudioBuffer
+        let frameLength = audioBuffer.mDataByteSize / format.streamDescription.pointee.mBytesPerFrame
+
+        // Create an AVAudioPCMBuffer with the same format and frame capacity
+        guard let pcmBuffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: AVAudioFrameCount(frameLength)) else {
+            return nil
+        }
+
+        // Copy the data from the AudioBuffer to the AVAudioPCMBuffer
+        pcmBuffer.frameLength = AVAudioFrameCount(frameLength)
+        let audioBufferData = audioBuffer.mData!.assumingMemoryBound(to: Float32.self)
+        let pcmBufferData = pcmBuffer.floatChannelData![0]
+        memcpy(pcmBufferData, audioBufferData, Int(audioBuffer.mDataByteSize))
+
+        return pcmBuffer
+    }
+
+    func testOldRms() throws {
+        let result = AudioUtils.calculateRms(audioBuffer)
+        XCTAssertEqual(result, 5.228129, "Result of Root Mean Square should be 5.228129")
+    }
+
+    func testNewRms() throws {
+        let result = AudioUtils.newCalculateRms(audioBuffer)
+        XCTAssertEqual(result, 5.228129, "Result of Root Mean Square should be 5.228129")
+    }
+
+    func testOldRmsPerformance() throws {
+        self.measure {
+            (0...1000000).forEach { _ in
+                _ = AudioUtils.calculateRms(audioBuffer)
+            }
+        }
+    }
+
+    func testNewRmsPerformance() throws {
+        self.measure {
+            (0...1000000).forEach { _ in
+                _ = AudioUtils.newCalculateRms(audioBuffer)
+            }
+        }
+    }
+
+    func testOldPerformFadeOut() {
+        let length: Float32 = 6
+        var data: [Float32] = [1, 1, 1, 1, 1, 1]
+        let expected: [Float32] = [1.0, 0.8, 0.6, 0.4, 0.2, 0.0]
+
+        data.withUnsafeMutableBufferPointer { bufferPointer in
+            AudioUtils.oldPerformFade(true, length: length, data: bufferPointer.baseAddress)
+        }
+
+        let roundedData = data.map { round($0 * 10) / 10 }
+        XCTAssertEqual(roundedData, expected, "Fade out did not produce the expected result")
+    }
+
+    func testOldPerformFadeIn() {
+        let length: Float32 = 6
+        var data: [Float32] = [1, 1, 1, 1, 1, 1]
+        let expected: [Float32] = [0.0, 0.2, 0.4, 0.6, 0.8, 1.0]
+
+        data.withUnsafeMutableBufferPointer { bufferPointer in
+            AudioUtils.oldPerformFade(false, length: length, data: bufferPointer.baseAddress)
+        }
+
+        let roundedData = data.map { round($0 * 10) / 10 }
+        XCTAssertEqual(roundedData, expected, "Fade in did not produce the expected result")
+    }
+
+    func testNewPerformFadeOut() {
+        let length: vDSP_Length = 6
+        var data: [Float32] = [1, 1, 1, 1, 1, 1]
+        let expected: [Float32] = [1.0, 0.8, 0.6, 0.4, 0.2, 0.0]
+
+        data.withUnsafeMutableBufferPointer { bufferPointer in
+            AudioUtils.newPerformFade(true, length: length, data: bufferPointer.baseAddress)
+        }
+
+        let roundedData = data.map { round($0 * 10) / 10 }
+        XCTAssertEqual(roundedData, expected, "Fade out did not produce the expected result")
+    }
+
+    func testNewPerformFadeIn() {
+        let length: vDSP_Length = 6
+        var data: [Float32] = [1, 1, 1, 1, 1, 1]
+        let expected: [Float32] = [0.0, 0.2, 0.4, 0.6, 0.8, 1.0]
+
+        data.withUnsafeMutableBufferPointer { bufferPointer in
+            AudioUtils.newPerformFade(false, length: length, data: bufferPointer.baseAddress)
+        }
+
+        let roundedData = data.map { round($0 * 10) / 10 }
+        XCTAssertEqual(roundedData, expected, "Fade in did not produce the expected result")
+    }
+
+    func testOldFadePerformance() throws {
+        let audioBuffer = audioBufferToAVAudioPCMBuffer(audioBuffer: audioBuffer, format: bufferFormat)
+        let buffer = BufferedAudio(audioBuffer: audioBuffer!, framePosition: AVAudioFramePosition(), shouldFadeOut: false, shouldFadeIn: true)
+        let channelCount: UInt32 = 1
+        self.measure {
+            (0...1000000).forEach { _ in
+                AudioUtils.oldFadeAudio(buffer, fadeOut: true, channelCount: channelCount)
+            }
+        }
+    }
+
+    func testNewFadePerformance() throws {
+        let audioBuffer = audioBufferToAVAudioPCMBuffer(audioBuffer: audioBuffer, format: bufferFormat)
+        let buffer = BufferedAudio(audioBuffer: audioBuffer!, framePosition: AVAudioFramePosition(), shouldFadeOut: false, shouldFadeIn: true)
+        let channelCount: UInt32 = 1
+        self.measure {
+            (0...1000000).forEach { _ in
+                AudioUtils.newFadeAudio(buffer, fadeOut: true, channelCount: channelCount)
+            }
+        }
+    }
+
+}

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1625,6 +1625,7 @@
 		F5952FCA2C057C6400754BC3 /* FMDatabaseQueue+Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5952FC92C057C6400754BC3 /* FMDatabaseQueue+Test.swift */; };
 		F5952FCC2C05814100754BC3 /* DownloadManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5952FCB2C05814100754BC3 /* DownloadManagerTests.swift */; };
 		F5B312B42BF5B6D400290696 /* FirebaseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5B312B32BF5B6D400290696 /* FirebaseManager.swift */; };
+		F5B6F0DF2C18DF0900AF5150 /* AudioUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5B6F0DD2C18DF0900AF5150 /* AudioUtilsTests.swift */; };
 		F5D3A0D92B70950100EED067 /* MockURLHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5D3A0D82B70950100EED067 /* MockURLHandler.swift */; };
 		F5DBA58A2B756A8700AED77F /* PodcastSettings+ImportUserDefaultsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5DBA5892B756A8700AED77F /* PodcastSettings+ImportUserDefaultsTests.swift */; };
 		F5E3DAA72BDD5567002BD4E4 /* PCBundleDoc.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5E3DAA62BDD5567002BD4E4 /* PCBundleDoc.swift */; };
@@ -3433,6 +3434,7 @@
 		F5952FCB2C05814100754BC3 /* DownloadManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadManagerTests.swift; sourceTree = "<group>"; };
 		F5AD75442B7FDC2800D65C55 /* SettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsTests.swift; sourceTree = "<group>"; };
 		F5B312B32BF5B6D400290696 /* FirebaseManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseManager.swift; sourceTree = "<group>"; };
+		F5B6F0DD2C18DF0900AF5150 /* AudioUtilsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AudioUtilsTests.swift; sourceTree = "<group>"; };
 		F5D3A0D82B70950100EED067 /* MockURLHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockURLHandler.swift; sourceTree = "<group>"; };
 		F5DBA5892B756A8700AED77F /* PodcastSettings+ImportUserDefaultsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PodcastSettings+ImportUserDefaultsTests.swift"; sourceTree = "<group>"; };
 		F5E3DAA62BDD5567002BD4E4 /* PCBundleDoc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PCBundleDoc.swift; sourceTree = "<group>"; };
@@ -7367,6 +7369,7 @@
 		E3665F552936CD33001C8372 /* Playback */ = {
 			isa = PBXGroup;
 			children = (
+				F5B6F0DE2C18DF0900AF5150 /* Effects */,
 				E3665F562936CD6C001C8372 /* Chapters */,
 				8B1877E42A45DC570025D245 /* AutoplayHelperTests.swift */,
 			);
@@ -7380,6 +7383,14 @@
 				8B413D152B76B3A500FAB502 /* ChapterManagerTests.swift */,
 			);
 			path = Chapters;
+			sourceTree = "<group>";
+		};
+		F5B6F0DE2C18DF0900AF5150 /* Effects */ = {
+			isa = PBXGroup;
+			children = (
+				F5B6F0DD2C18DF0900AF5150 /* AudioUtilsTests.swift */,
+			);
+			path = Effects;
 			sourceTree = "<group>";
 		};
 		F5F6DA6E2BBE10E2009B1934 /* Categories */ = {
@@ -8691,6 +8702,7 @@
 				E3665F542936CD13001C8372 /* ChaptersTests.swift in Sources */,
 				C7F4C6682A8EAB2800483C37 /* PaidFeatureTests.swift in Sources */,
 				C79E1E4028887549008524CB /* PlusUpgradeViewSourceTests.swift in Sources */,
+				F5B6F0DF2C18DF0900AF5150 /* AudioUtilsTests.swift in Sources */,
 				C7D8AE5D2A6056C900C9EBAF /* ListViewModelTests.swift in Sources */,
 				8B2319412902C8FE0001C3DE /* EndOfYearStoriesBuilderTests.swift in Sources */,
 				C7C0959A2ADE1AF9001E6E3B /* BookmarkAnnouncementViewModelTests.swift in Sources */,

--- a/podcasts/AudioReadTask.swift
+++ b/podcasts/AudioReadTask.swift
@@ -224,7 +224,7 @@ class AudioReadTask {
                 // don't trim silence from the last 5 seconds
                 rms = 1
             } else {
-                rms = (channelCount == 1) ? calculateRms(bufferListPointer[0]) : calculateStereoRms(bufferListPointer[0], rightBuffer: bufferListPointer[1])
+                rms = (channelCount == 1) ? AudioUtils.calculateRms(bufferListPointer[0]) : AudioUtils.calculateStereoRms(bufferListPointer[0], rightBuffer: bufferListPointer[1])
             }
 
             if rms > minRMS, !foundGap {
@@ -292,42 +292,6 @@ class AudioReadTask {
         if !cancelled.value {
             bufferManager.push(buffer)
         }
-    }
-
-    private func calculateRms(_ audioBuffer: AudioBuffer) -> Float32 {
-        var sum: Float32 = 0.0
-        let bufferSize = Float32(audioBuffer.mDataByteSize) / bufferByteSize
-        guard let buffer = audioBuffer.mData?.bindMemory(to: Float32.self, capacity: Int(bufferSize)) else { return 0 }
-
-        for i in 0 ..< Int(bufferSize) {
-            sum += buffer[i] * buffer[i]
-        }
-
-        return sqrt(sum / bufferSize)
-    }
-
-    private func calculateStereoRms(_ leftBuffer: AudioBuffer, rightBuffer: AudioBuffer) -> Float32 {
-        var sum: Float32 = 0.0
-        let leftSize = Float32(leftBuffer.mDataByteSize) / bufferByteSize
-        if let left = leftBuffer.mData?.bindMemory(to: Float32.self, capacity: Int(leftSize)) {
-            for i in 0 ..< Int(leftSize) {
-                sum += left[i] * left[i]
-            }
-        }
-
-        let leftRms = sqrt(sum / leftSize)
-
-        sum = 0
-        let rightSize = Float32(rightBuffer.mDataByteSize) / bufferByteSize
-        if let right = rightBuffer.mData?.bindMemory(to: Float32.self, capacity: Int(rightSize)) {
-            for i in 0 ..< Int(rightSize) {
-                sum += right[i] * right[i]
-            }
-        }
-
-        let rightRms = sqrt(sum / rightSize)
-
-        return (leftRms + rightRms) / 2
     }
 
     private func gapSizeForSilenceAmount() -> Int {

--- a/podcasts/AudioUtils.swift
+++ b/podcasts/AudioUtils.swift
@@ -1,34 +1,116 @@
 import AVFoundation
 import Foundation
+import Accelerate
+import PocketCastsUtils
 
 class AudioUtils {
     private static let bufferLength = UInt32(Constants.Audio.defaultFrameSize)
     private static let bufferByteSize = Float32(MemoryLayout<Float32>.size)
 
     class func fadeAudio(_ audio: BufferedAudio, fadeOut: Bool, channelCount: UInt32) {
+        if FeatureFlag.accelerateEffects.enabled {
+            newFadeAudio(audio, fadeOut: fadeOut, channelCount: channelCount)
+        } else {
+            oldFadeAudio(audio, fadeOut: fadeOut, channelCount: channelCount)
+        }
+    }
+
+    class func oldFadeAudio(_ audio: BufferedAudio, fadeOut: Bool, channelCount: UInt32) {
         let bufferList = UnsafeMutableAudioBufferListPointer(audio.audioBuffer.mutableAudioBufferList)
         let length = Float32(bufferList[0].mDataByteSize) / bufferByteSize
         let data = bufferList[0].mData?.bindMemory(to: Float32.self, capacity: Int(length))
 
-        AudioUtils.performFade(fadeOut, length: length, data: data)
+        AudioUtils.oldPerformFade(fadeOut, length: length, data: data)
 
         if channelCount > 1 {
             let extraChannelLength = Float32(bufferList[1].mDataByteSize) / bufferByteSize
             let extraChannelData = bufferList[1].mData?.bindMemory(to: Float32.self, capacity: Int(extraChannelLength))
 
-            AudioUtils.performFade(fadeOut, length: extraChannelLength, data: extraChannelData)
+            AudioUtils.oldPerformFade(fadeOut, length: extraChannelLength, data: extraChannelData)
         }
     }
 
-    private class func performFade(_ fadeOut: Bool, length: Float32, data: UnsafeMutablePointer<Float32>?) {
+    class func oldPerformFade(_ fadeOut: Bool, length: Float32, data: UnsafeMutablePointer<Float32>?) {
         guard let data = data else { return }
 
         for i in 0 ..< Int(length) {
             if fadeOut {
-                data[i] = data[i] * (length - Float32(i)) / length
+                data[i] = data[i] * ((length - 1) - Float32(i)) / (length - 1)
             } else {
-                data[i] = data[i] * Float32(i) / length
+                data[i] = data[i] * Float32(i) / (length - 1)
             }
         }
+    }
+
+    class func newFadeAudio(_ audio: BufferedAudio, fadeOut: Bool, channelCount: UInt32) {
+        let bufferList = UnsafeMutableAudioBufferListPointer(audio.audioBuffer.mutableAudioBufferList)
+        let length = vDSP_Length(bufferList[0].mDataByteSize) / vDSP_Length(bufferByteSize)
+        let data = bufferList[0].mData?.bindMemory(to: Float32.self, capacity: Int(length))
+
+        AudioUtils.newPerformFade(fadeOut, length: length, data: data)
+
+        if channelCount > 1 {
+            let extraChannelLength = vDSP_Length(bufferList[1].mDataByteSize) / vDSP_Length(bufferByteSize)
+            let extraChannelData = bufferList[1].mData?.bindMemory(to: Float32.self, capacity: Int(extraChannelLength))
+
+            AudioUtils.newPerformFade(fadeOut, length: extraChannelLength, data: extraChannelData)
+        }
+    }
+
+    class func newPerformFade(_ fadeOut: Bool, length: vDSP_Length, data: UnsafeMutablePointer<Float32>?) {
+        guard let data = data else { return }
+
+        var ramp = [Float32](repeating: 0, count: Int(length))
+
+        if fadeOut {
+            vDSP_vgen([1.0], [0.0], &ramp, 1, length)
+        } else {
+            vDSP_vgen([0.0], [1.0], &ramp, 1, length)
+        }
+
+        vDSP_vmul(data, 1, ramp, 1, data, 1, length)
+    }
+
+
+    class func calculateStereoRms(_ leftBuffer: AudioBuffer, rightBuffer: AudioBuffer) -> Float32 {
+        let leftRms = calculateRms(leftBuffer)
+        let rightRms = calculateRms(rightBuffer)
+
+        return (leftRms + rightRms) / 2
+    }
+
+    class func calculateRms(_ audioBuffer: AudioBuffer) -> Float32 {
+
+        if FeatureFlag.accelerateEffects.enabled {
+            return newCalculateRms(audioBuffer)
+        }
+
+        var sum: Float32 = 0.0
+        let bufferSize = Float32(audioBuffer.mDataByteSize) / bufferByteSize
+        guard let buffer = audioBuffer.mData?.bindMemory(to: Float32.self, capacity: Int(bufferSize)) else { return 0 }
+
+        for i in 0 ..< Int(bufferSize) {
+            sum += buffer[i] * buffer[i]
+        }
+
+        return sqrt(sum / bufferSize)
+    }
+
+    class func newCalculateRms(_ audioBuffer: AudioBuffer) -> Float32 {
+        let bufferSize = Float32(audioBuffer.mDataByteSize) / bufferByteSize
+        guard let buffer = audioBuffer.mData?.bindMemory(to: Float32.self, capacity: Int(bufferSize)) else { return 0 }
+
+        let stride = vDSP_Stride(1)
+
+        let n = vDSP_Length(bufferSize)
+
+        var c = Float32()
+
+        vDSP_rmsqv(buffer,
+                   stride,
+                   &c,
+                   n)
+
+        return c
     }
 }


### PR DESCRIPTION
This updates our APIs to use the [Accelerate framework](https://developer.apple.com/documentation/accelerate) in an effort to reduce battery usage during episode playback when the Trim Silence effect is enabled.

* Adds an `accelerateEffects` feature flag so we can test before/after and disable if needed.
* Adds a new implementation of the `calculateRms` and `calculateStereoRms` functions which use Accelerate's vDSP functions.
* Adds a new implementation of the `fadeAudio` function which use Accelerates `vDSP_vgen` and `vDSP_vmul` to scale the values from the audio buffer.

> [!NOTE]  
> While adding unit tests, I noticed that my simple example of fading from 0-1 showed drifting results in the old fade implementation. I believe there was an off-by-one error when using the length and fixed that here. It may not have been noticeable because the values typically were within 20% of the final 0 or 1 values for the fade.

These RMS and Fade calculations are run frequently while playing with Trim Silence enabled. In our Xcode Energy usage reports, RMS is reported as the second highest cause of high energy usage terminations.

![CleanShot 2024-06-11 at 16 03 52@2x](https://github.com/Automattic/pocket-casts-ios/assets/3250/ccd451c1-3d17-4bfc-8581-71fc5b6d3ac9)

The performance tests show about a 3x speed improvement and Accelerate should be more power efficient as well.

## To test

* Run with Trim Silence enabled and verify that audio sounds correct
* Disable the `accelerateEffects` feature flag and ensure audio still sounds correct with trim silence enabled

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
