### PR TITLE
Exploration: Use Gravatar SDK's profile view in account settings

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -50,6 +50,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// show UpNext tab on the main tab bar
     case upNextOnTabBar
 
+    /// Enhances the profile view to display more fields from the user's Gravatar profile.
+    case displayGravatarProfile
+
     /// When enabled it updates the code on filter callback to use a safer method to convert unmanaged player references
     /// This is to fix this: https://a8c.sentry.io/share/issue/39a6d2958b674ec3b7a4d9248b4b5ffa/
     case defaultPlayerFilterCallbackFix
@@ -112,6 +115,8 @@ public enum FeatureFlag: String, CaseIterable {
             true
         case .upNextOnTabBar:
             true
+        case .displayGravatarProfile:
+            false
         case .downloadFixes:
             true
         case .onlyMarkPodcastsUnsyncedForNewUsers:

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -116,7 +116,7 @@ public enum FeatureFlag: String, CaseIterable {
         case .upNextOnTabBar:
             true
         case .displayGravatarProfile:
-            false
+            true
         case .downloadFixes:
             true
         case .onlyMarkPodcastsUnsyncedForNewUsers:

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -7796,6 +7796,7 @@
 				8B365E4E2B62E82000143DAC /* XCRemoteSwiftPackageReference "Agrume" */,
 				8B1762752B6808F700F44450 /* XCRemoteSwiftPackageReference "JLRoutes" */,
 				8B1762782B684E7100F44450 /* XCRemoteSwiftPackageReference "Kingfisher" */,
+				91319B4A2C1899D1000220A4 /* XCRemoteSwiftPackageReference "Gravatar-SDK-iOS" */,
 			);
 			productRefGroup = BDBD53ED17019B2A0048C8C5 /* Products */;
 			projectDirPath = "";
@@ -11846,6 +11847,14 @@
 			requirement = {
 				kind = upToNextMajorVersion;
 				minimumVersion = 5.6.12;
+			};
+		};
+		91319B4A2C1899D1000220A4 /* XCRemoteSwiftPackageReference "Gravatar-SDK-iOS" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Automattic/Gravatar-SDK-iOS.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.0.0;
 			};
 		};
 		BD44F74E267C850000810148 /* XCRemoteSwiftPackageReference "DifferenceKit" */ = {

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 60;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -624,6 +624,8 @@
 		8BF1C61D2881F05D007E80BF /* FolderModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BF1C61C2881F05D007E80BF /* FolderModelTests.swift */; };
 		8BF9CC0C2ADDA90F004E9B65 /* YearOverYearStory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BF9CC0B2ADDA90F004E9B65 /* YearOverYearStory.swift */; };
 		8BFB434E2A1FFB4B00F3D409 /* StatusPageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BFB434D2A1FFB4B00F3D409 /* StatusPageViewModel.swift */; };
+		91319B512C1984AD000220A4 /* Gravatar in Frameworks */ = {isa = PBXBuildFile; productRef = 91319B502C1984AD000220A4 /* Gravatar */; };
+		91319B532C1984AD000220A4 /* GravatarUI in Frameworks */ = {isa = PBXBuildFile; productRef = 91319B522C1984AD000220A4 /* GravatarUI */; };
 		BD001B892174260B00504DD3 /* FilterManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD001B882174260B00504DD3 /* FilterManager.swift */; };
 		BD00CB2B24BD20CD00A10257 /* TimeStepperCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD00CB2924BD20CD00A10257 /* TimeStepperCell.swift */; };
 		BD00CB2C24BD20CD00A10257 /* TimeStepperCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = BD00CB2A24BD20CD00A10257 /* TimeStepperCell.xib */; };
@@ -3552,11 +3554,13 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				91319B512C1984AD000220A4 /* Gravatar in Frameworks */,
 				46C22EE028F73D9A00F4173B /* AuthenticationServices.framework in Frameworks */,
 				468F00D327CD575C00FFAAAA /* FirebasePerformance in Frameworks */,
 				BD11C41D2524741C00E308E6 /* CarPlay.framework in Frameworks */,
 				BD44F750267C850000810148 /* DifferenceKit in Frameworks */,
 				C72CED34289DA28B0017883A /* AutomatticTracks in Frameworks */,
+				91319B532C1984AD000220A4 /* GravatarUI in Frameworks */,
 				BDD8AABF267C858D0013494D /* Fuse in Frameworks */,
 				46305CF0272B082C003AC87B /* AutomatticEncryptedLogs in Frameworks */,
 				468F00CF27CD575C00FFAAAA /* FirebaseAnalyticsWithoutAdIdSupport in Frameworks */,
@@ -7630,6 +7634,8 @@
 				8B365E4F2B62E82000143DAC /* Agrume */,
 				8B1762762B6808F700F44450 /* JLRoutes */,
 				8B1762792B684E7100F44450 /* Kingfisher */,
+				91319B502C1984AD000220A4 /* Gravatar */,
+				91319B522C1984AD000220A4 /* GravatarUI */,
 			);
 			productName = podcasts;
 			productReference = BDBD53EC17019B2A0048C8C5 /* podcasts.app */;
@@ -7796,7 +7802,7 @@
 				8B365E4E2B62E82000143DAC /* XCRemoteSwiftPackageReference "Agrume" */,
 				8B1762752B6808F700F44450 /* XCRemoteSwiftPackageReference "JLRoutes" */,
 				8B1762782B684E7100F44450 /* XCRemoteSwiftPackageReference "Kingfisher" */,
-				91319B4A2C1899D1000220A4 /* XCRemoteSwiftPackageReference "Gravatar-SDK-iOS" */,
+				91319B4F2C1984AD000220A4 /* XCLocalSwiftPackageReference "../Gravatar-SDK-iOS" */,
 			);
 			productRefGroup = BDBD53ED17019B2A0048C8C5 /* Products */;
 			projectDirPath = "";
@@ -11800,6 +11806,13 @@
 		};
 /* End XCConfigurationList section */
 
+/* Begin XCLocalSwiftPackageReference section */
+		91319B4F2C1984AD000220A4 /* XCLocalSwiftPackageReference "../Gravatar-SDK-iOS" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = "../Gravatar-SDK-iOS";
+		};
+/* End XCLocalSwiftPackageReference section */
+
 /* Begin XCRemoteSwiftPackageReference section */
 		3FB8642E28896539003A86BE /* XCRemoteSwiftPackageReference "test-collector-swift" */ = {
 			isa = XCRemoteSwiftPackageReference;
@@ -11847,14 +11860,6 @@
 			requirement = {
 				kind = upToNextMajorVersion;
 				minimumVersion = 5.6.12;
-			};
-		};
-		91319B4A2C1899D1000220A4 /* XCRemoteSwiftPackageReference "Gravatar-SDK-iOS" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/Automattic/Gravatar-SDK-iOS.git";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 2.0.0;
 			};
 		};
 		BD44F74E267C850000810148 /* XCRemoteSwiftPackageReference "DifferenceKit" */ = {
@@ -11985,6 +11990,14 @@
 		8BF0BBD3289199D2006BBECF /* PocketCastsDataModel */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = PocketCastsDataModel;
+		};
+		91319B502C1984AD000220A4 /* Gravatar */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = Gravatar;
+		};
+		91319B522C1984AD000220A4 /* GravatarUI */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = GravatarUI;
 		};
 		BD44F74F267C850000810148 /* DifferenceKit */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 60;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -626,6 +626,8 @@
 		8BFB434E2A1FFB4B00F3D409 /* StatusPageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BFB434D2A1FFB4B00F3D409 /* StatusPageViewModel.swift */; };
 		91319B512C1984AD000220A4 /* Gravatar in Frameworks */ = {isa = PBXBuildFile; productRef = 91319B502C1984AD000220A4 /* Gravatar */; };
 		91319B532C1984AD000220A4 /* GravatarUI in Frameworks */ = {isa = PBXBuildFile; productRef = 91319B522C1984AD000220A4 /* GravatarUI */; };
+		91319B562C19E838000220A4 /* Gravatar in Frameworks */ = {isa = PBXBuildFile; productRef = 91319B552C19E838000220A4 /* Gravatar */; };
+		91319B582C19E838000220A4 /* GravatarUI in Frameworks */ = {isa = PBXBuildFile; productRef = 91319B572C19E838000220A4 /* GravatarUI */; };
 		BD001B892174260B00504DD3 /* FilterManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD001B882174260B00504DD3 /* FilterManager.swift */; };
 		BD00CB2B24BD20CD00A10257 /* TimeStepperCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD00CB2924BD20CD00A10257 /* TimeStepperCell.swift */; };
 		BD00CB2C24BD20CD00A10257 /* TimeStepperCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = BD00CB2A24BD20CD00A10257 /* TimeStepperCell.xib */; };
@@ -3562,6 +3564,7 @@
 				C72CED34289DA28B0017883A /* AutomatticTracks in Frameworks */,
 				91319B532C1984AD000220A4 /* GravatarUI in Frameworks */,
 				BDD8AABF267C858D0013494D /* Fuse in Frameworks */,
+				91319B562C19E838000220A4 /* Gravatar in Frameworks */,
 				46305CF0272B082C003AC87B /* AutomatticEncryptedLogs in Frameworks */,
 				468F00CF27CD575C00FFAAAA /* FirebaseAnalyticsWithoutAdIdSupport in Frameworks */,
 				8BAD6E5E2975ADB800DB7259 /* GoogleSignIn in Frameworks */,
@@ -3572,6 +3575,7 @@
 				8B365E502B62E82000143DAC /* Agrume in Frameworks */,
 				8BE36E002873552500E35313 /* PocketCastsServer in Frameworks */,
 				BDD239BD267C869B0047750C /* SwipeCellKit in Frameworks */,
+				91319B582C19E838000220A4 /* GravatarUI in Frameworks */,
 				8B1762772B6808F700F44450 /* JLRoutes in Frameworks */,
 				8B17627A2B684E7100F44450 /* Kingfisher in Frameworks */,
 				1C312783007F5948E428F709 /* libPods-podcasts.a in Frameworks */,
@@ -7636,6 +7640,8 @@
 				8B1762792B684E7100F44450 /* Kingfisher */,
 				91319B502C1984AD000220A4 /* Gravatar */,
 				91319B522C1984AD000220A4 /* GravatarUI */,
+				91319B552C19E838000220A4 /* Gravatar */,
+				91319B572C19E838000220A4 /* GravatarUI */,
 			);
 			productName = podcasts;
 			productReference = BDBD53EC17019B2A0048C8C5 /* podcasts.app */;
@@ -7802,7 +7808,7 @@
 				8B365E4E2B62E82000143DAC /* XCRemoteSwiftPackageReference "Agrume" */,
 				8B1762752B6808F700F44450 /* XCRemoteSwiftPackageReference "JLRoutes" */,
 				8B1762782B684E7100F44450 /* XCRemoteSwiftPackageReference "Kingfisher" */,
-				91319B4F2C1984AD000220A4 /* XCLocalSwiftPackageReference "../Gravatar-SDK-iOS" */,
+				91319B542C19E837000220A4 /* XCRemoteSwiftPackageReference "Gravatar-SDK-iOS" */,
 			);
 			productRefGroup = BDBD53ED17019B2A0048C8C5 /* Products */;
 			projectDirPath = "";
@@ -11806,13 +11812,6 @@
 		};
 /* End XCConfigurationList section */
 
-/* Begin XCLocalSwiftPackageReference section */
-		91319B4F2C1984AD000220A4 /* XCLocalSwiftPackageReference "../Gravatar-SDK-iOS" */ = {
-			isa = XCLocalSwiftPackageReference;
-			relativePath = "../Gravatar-SDK-iOS";
-		};
-/* End XCLocalSwiftPackageReference section */
-
 /* Begin XCRemoteSwiftPackageReference section */
 		3FB8642E28896539003A86BE /* XCRemoteSwiftPackageReference "test-collector-swift" */ = {
 			isa = XCRemoteSwiftPackageReference;
@@ -11860,6 +11859,14 @@
 			requirement = {
 				kind = upToNextMajorVersion;
 				minimumVersion = 5.6.12;
+			};
+		};
+		91319B542C19E837000220A4 /* XCRemoteSwiftPackageReference "Gravatar-SDK-iOS" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Automattic/Gravatar-SDK-iOS.git";
+			requirement = {
+				kind = revision;
+				revision = afe715820691a17f286fac9891afc5290d0e2981;
 			};
 		};
 		BD44F74E267C850000810148 /* XCRemoteSwiftPackageReference "DifferenceKit" */ = {
@@ -11997,6 +12004,16 @@
 		};
 		91319B522C1984AD000220A4 /* GravatarUI */ = {
 			isa = XCSwiftPackageProductDependency;
+			productName = GravatarUI;
+		};
+		91319B552C19E838000220A4 /* Gravatar */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 91319B542C19E837000220A4 /* XCRemoteSwiftPackageReference "Gravatar-SDK-iOS" */;
+			productName = Gravatar;
+		};
+		91319B572C19E838000220A4 /* GravatarUI */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 91319B542C19E837000220A4 /* XCRemoteSwiftPackageReference "Gravatar-SDK-iOS" */;
 			productName = GravatarUI;
 		};
 		BD44F74F267C850000810148 /* DifferenceKit */ = {

--- a/podcasts.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/podcasts.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -119,6 +119,15 @@
         }
       },
       {
+        "package": "Gravatar",
+        "repositoryURL": "https://github.com/Automattic/Gravatar-SDK-iOS.git",
+        "state": {
+          "branch": null,
+          "revision": "9855eb4cd835dc6bbf7aadec2dd015dae841fe19",
+          "version": "2.0.0"
+        }
+      },
+      {
         "package": "gRPC",
         "repositoryURL": "https://github.com/google/grpc-binary.git",
         "state": {

--- a/podcasts.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/podcasts.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -119,15 +119,6 @@
         }
       },
       {
-        "package": "Gravatar",
-        "repositoryURL": "https://github.com/Automattic/Gravatar-SDK-iOS.git",
-        "state": {
-          "branch": null,
-          "revision": "9855eb4cd835dc6bbf7aadec2dd015dae841fe19",
-          "version": "2.0.0"
-        }
-      },
-      {
         "package": "gRPC",
         "repositoryURL": "https://github.com/google/grpc-binary.git",
         "state": {

--- a/podcasts.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/podcasts.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -119,6 +119,15 @@
         }
       },
       {
+        "package": "Gravatar",
+        "repositoryURL": "https://github.com/Automattic/Gravatar-SDK-iOS.git",
+        "state": {
+          "branch": null,
+          "revision": "afe715820691a17f286fac9891afc5290d0e2981",
+          "version": null
+        }
+      },
+      {
         "package": "gRPC",
         "repositoryURL": "https://github.com/google/grpc-binary.git",
         "state": {

--- a/podcasts/AccountViewController.swift
+++ b/podcasts/AccountViewController.swift
@@ -346,7 +346,7 @@ extension Palette {
             foreground: ForegroundColors(primary: ThemeColor.primaryText01(),
                                          primarySlightlyDimmed: ThemeColor.secondaryText01(),
                                          secondary: ThemeColor.primaryText02()),
-            background: BackgroundColors(primary: ThemeColor.primaryUi02()),
+            background: BackgroundColors(primary: ThemeColor.primaryUi01()),
             avatar: AvatarColors(border: ThemeColor.primaryUi05(),
                                  background: ThemeColor.primaryUi04()),
             border: ThemeColor.primaryUi05(),

--- a/podcasts/AccountViewController.swift
+++ b/podcasts/AccountViewController.swift
@@ -1,8 +1,9 @@
 import Combine
+import GravatarUI
 import PocketCastsServer
 import PocketCastsUtils
 import UIKit
-import GravatarUI
+import SafariServices
 
 class AccountViewController: UIViewController, ChangeEmailDelegate {
     enum UIConstants {
@@ -266,8 +267,7 @@ extension AccountViewController: ProfileViewDelegate {
                 var claimProfileConfig = ProfileViewConfiguration.claimProfile(profileStyle: gravatarConfiguration.profileStyle)
                 claimProfileConfig.padding = UIConstants.Gravatar.padding
                 claimProfileConfig.delegate = self
-                claimProfileConfig.avatarConfiguration.placeholder = UIImage(named: "profileAvatar")?.withRenderingMode(.alwaysTemplate).tintedImage(ThemeColor.primaryUi05())
-                claimProfileConfig.palette = .custom(claimProfileConfig.pocketCastsPalette)
+                claimProfileConfig.palette = .custom(Palette.pocketCasts)
                 self.gravatarConfiguration = claimProfileConfig
             case .failure:
                 // TODO: handle error
@@ -293,17 +293,20 @@ extension AccountViewController: ProfileViewDelegate {
             await gravatarViewModel.fetchProfile(profileIdentifier: ProfileIdentifier.email(email))
         }
     }
-    func profileView(_ view: GravatarUI.BaseProfileView, didTapOnProfileButtonWithStyle style: GravatarUI.ProfileButtonStyle, profileURL: URL?) {
 
+    func profileView(_ view: GravatarUI.BaseProfileView, didTapOnProfileButtonWithStyle style: GravatarUI.ProfileButtonStyle, profileURL: URL?) {
+        guard let profileURL else { return }
+        let safari = SFSafariViewController(url: profileURL)
+        present(safari, animated: true)
     }
 
     func profileView(_ view: GravatarUI.BaseProfileView, didTapOnAccountButtonWithModel accountModel: any GravatarUI.AccountModel) {
-
+        guard let accountURL = accountModel.accountURL else { return }
+        let safari = SFSafariViewController(url: accountURL)
+        present(safari, animated: true)
     }
 
-    func profileView(_ view: GravatarUI.BaseProfileView, didTapOnAvatarWithID avatarID: Gravatar.AvatarIdentifier?) {
-
-    }
+    func profileView(_ view: GravatarUI.BaseProfileView, didTapOnAvatarWithID avatarID: Gravatar.AvatarIdentifier?) {}
 }
 
 extension AccountViewController: AvatarProviding {
@@ -328,25 +331,31 @@ fileprivate extension ProfileViewConfiguration {
 
     func updatedForPocketCasts(delegate: ProfileViewDelegate) -> ProfileViewConfiguration {
         var config = self
-        config.avatarConfiguration.placeholder = UIImage(named: "profileAvatar")?.withRenderingMode(.alwaysTemplate).tintedImage(ThemeColor.primaryUi05())
         config.padding = AccountViewController.UIConstants.Gravatar.padding
         config.profileButtonStyle = .edit
         config.delegate = delegate
-        config.palette = .custom(pocketCastsPalette)
+        config.palette = .custom(Palette.pocketCasts)
         return config
     }
+}
 
-    func pocketCastsPalette() -> GravatarUI.Palette {
-        GravatarUI.Palette(name: Theme.sharedTheme.activeTheme.description,
-                         foreground: ForegroundColors(primary: ThemeColor.primaryText01(),
-                                                      primarySlightlyDimmed: ThemeColor.secondaryText01(),
-                                                      secondary: ThemeColor.primaryText02()),
-                         background: BackgroundColors(primary: ThemeColor.primaryUi02()),
-                         avatar: AvatarColors(border: ThemeColor.primaryUi05(),
-                                              background: ThemeColor.primaryUi04()),
-                         border: ThemeColor.primaryUi05(),
-                         placeholder: PlaceholderColors(backgroundColor: ThemeColor.primaryUi04(),
-                                                        loadingAnimationColors: [ThemeColor.primaryUi04(), ThemeColor.primaryUi05()]),
-                         preferredUserInterfaceStyle: Theme.sharedTheme.activeTheme.isDark ? .dark: .light)
+extension Palette {
+    static func pocketCasts() -> GravatarUI.Palette {
+        GravatarUI.Palette(
+            name: Theme.sharedTheme.activeTheme.description,
+            foreground: ForegroundColors(primary: ThemeColor.primaryText01(),
+                                         primarySlightlyDimmed: ThemeColor.secondaryText01(),
+                                         secondary: ThemeColor.primaryText02()),
+            background: BackgroundColors(primary: ThemeColor.primaryUi02()),
+            avatar: AvatarColors(border: ThemeColor.primaryUi05(),
+                                 background: ThemeColor.primaryUi04()),
+            border: ThemeColor.primaryUi05(),
+            placeholder: PlaceholderColors(backgroundColor: ThemeColor.primaryText01().withAlphaComponent(0.05),
+                                           loadingAnimationColors: [
+                                            ThemeColor.primaryText01().withAlphaComponent(0.05),
+                                            ThemeColor.primaryText01().withAlphaComponent(0.1)
+                                           ]),
+            preferredUserInterfaceStyle: Theme.sharedTheme.activeTheme.isDark ? .dark: .light
+        )
     }
 }

--- a/podcasts/Profile - SwiftUI/Account/AccountHeaderView.swift
+++ b/podcasts/Profile - SwiftUI/Account/AccountHeaderView.swift
@@ -9,9 +9,11 @@ struct AccountHeaderView: View {
     var body: some View {
         container { proxy in
             VStack(spacing: Constants.padding.vertical) {
-                SubscriptionProfileImage(viewModel: viewModel)
-                    .frame(width: Constants.imageSize, height: Constants.imageSize)
-                ProfileInfoLabels(profile: viewModel.profile, alignment: .center, spacing: Constants.spacing)
+                if !viewModel.shouldDisplayGravatarProfile {
+                    SubscriptionProfileImage(viewModel: viewModel)
+                        .frame(width: Constants.imageSize, height: Constants.imageSize)
+                    ProfileInfoLabels(profile: viewModel.profile, alignment: .center, spacing: Constants.spacing)
+                }
                 // Subscription badge
                 viewModel.subscription.map {
                     SubscriptionBadge(tier: $0.tier)

--- a/podcasts/Profile - SwiftUI/Account/AccountHeaderView.swift
+++ b/podcasts/Profile - SwiftUI/Account/AccountHeaderView.swift
@@ -12,8 +12,8 @@ struct AccountHeaderView: View {
                 if !viewModel.shouldDisplayGravatarProfile {
                     SubscriptionProfileImage(viewModel: viewModel)
                         .frame(width: Constants.imageSize, height: Constants.imageSize)
-                    ProfileInfoLabels(profile: viewModel.profile, alignment: .center, spacing: Constants.spacing)
                 }
+                ProfileInfoLabels(profile: viewModel.profile, alignment: .center, spacing: Constants.spacing)
                 // Subscription badge
                 viewModel.subscription.map {
                     SubscriptionBadge(tier: $0.tier)
@@ -109,7 +109,7 @@ struct AccountHeaderView: View {
                 content(proxy)
                     .frame(maxWidth: .infinity)
             }
-            .padding(.top, Constants.padding.top)
+            .padding(.top, viewModel.shouldDisplayGravatarProfile ? Constants.padding.vertical : Constants.padding.top)
             .padding(.bottom, Constants.padding.bottom)
             .padding(.horizontal, Constants.padding.horizontal)
         } contentSizeUpdated: { size in

--- a/podcasts/Profile - SwiftUI/Profile/ProfileHeaderView.swift
+++ b/podcasts/Profile - SwiftUI/Profile/ProfileHeaderView.swift
@@ -212,7 +212,7 @@ struct ProfileHeaderView: View {
     }
 
     // MARK: - View Constants
-    private enum Constants {
+    enum Constants {
         static let spacing = 16.0
         static let imageSize = 104.0
         static let paddingTop = 30.0

--- a/podcasts/Profile - SwiftUI/View Models/ProfileDataViewModel.swift
+++ b/podcasts/Profile - SwiftUI/View Models/ProfileDataViewModel.swift
@@ -2,6 +2,7 @@ import Foundation
 import Combine
 import PocketCastsServer
 import PocketCastsDataModel
+import PocketCastsUtils
 
 /// Represents a view that will display information about the users profile such as email, subscription status, and stats
 class ProfileDataViewModel: ObservableObject {
@@ -18,6 +19,9 @@ class ProfileDataViewModel: ObservableObject {
 
     /// Listening Stats
     var stats: UserInfo.Stats = .init()
+
+    /// If true we let the Gravatar SDK to display the profile view.
+    var shouldDisplayGravatarProfile: Bool = false
 
     private var notifications = Set<AnyCancellable>()
 
@@ -37,7 +41,7 @@ class ProfileDataViewModel: ObservableObject {
         profile = .init()
         subscription = .init(loggedIn: profile.isLoggedIn)
         stats = .init()
-
+        shouldDisplayGravatarProfile = FeatureFlag.displayGravatarProfile.enabled && profile.isLoggedIn
         objectWillChange.send()
     }
 


### PR DESCRIPTION
Fixes #

Exploring the usage of [Gravatar SDK](https://github.com/Automattic/Gravatar-SDK-iOS) for displaying the user's Gravatar profile.

Feature Flag: `displayGravatarProfile` (local)

Logged in with an email that has a Gravatar account:

<img src="https://github.com/Automattic/pocket-casts-ios/assets/5032900/be409294-0c93-47be-b1bf-435d35f67534" width=300/>

-----

Logged in with an email that does NOT have a Gravatar account:

 
<img src="https://github.com/Automattic/pocket-casts-ios/assets/5032900/86990290-1e02-4fdf-ba8d-07f7ca46878b" width=300/>


## To test

Steps to test your PR.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
