### PR TITLE
Fix background gradient on the mini-player

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Re-add Use contentType to set extension for downloaded files. [#1743]
 - Improve responsiveness when playing a podcast [#1801]
 - Grid layouts tweaks for better readability [#1823]
+- Fix gradient view on mini-player in dark themes [#1832]
 
 7.65
 -----

--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -299,7 +299,7 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
         }
         view.backgroundColor = .clear
 
-        gradientView.colors = [ThemeColor.primaryUi01().withAlphaComponent(0), ThemeColor.primaryUi01()]
+        gradientView.colors = [ThemeColor.primaryUi02().withAlphaComponent(0), ThemeColor.primaryUi02()]
 
         let bgColor = ThemeColor.podcastUi02(podcastColor: actionColor)
         mainView.backgroundColor = bgColor


### PR DESCRIPTION
Fixes #1830

Just updates the color on the gradient view to match the background color being used on the screens.

| Before | After |
| - | - |
| ![electricity_before](https://github.com/Automattic/pocket-casts-ios/assets/651601/964d197d-9999-4a34-bd1f-66ca37b7d36b) | ![electricity_after](https://github.com/Automattic/pocket-casts-ios/assets/651601/b4b241a0-140b-4b73-9dae-e86e80359eab) |
|![extra_dark_contrast_before](https://github.com/Automattic/pocket-casts-ios/assets/651601/0c4c0df2-95c6-48e2-88b4-657b466a7e1d) |  ![extra_dark_contrast_after](https://github.com/Automattic/pocket-casts-ios/assets/651601/0ee79c2b-7af5-4dfe-b4d3-36d020247dd3) |
| ![extra_dark_before](https://github.com/Automattic/pocket-casts-ios/assets/651601/216a0957-d74c-4de6-8d36-61c110fcd23d) | ![extra_dark_after](https://github.com/Automattic/pocket-casts-ios/assets/651601/220f4f41-e8c2-424a-b6c9-811b8caacc82) |
| ![dark_defore](https://github.com/Automattic/pocket-casts-ios/assets/651601/3dd3b4c9-cf52-4825-902c-e77d76721c5e) | ![dark_after](https://github.com/Automattic/pocket-casts-ios/assets/651601/17e4564c-92f4-4ff9-a621-3707d182eafb) |


## To test

- Start the app
- Select a dark theme on Profile->Settings->Appearance ( Dark theme ,  Extra Dark Theme, Electricity and Extra Dark Constrast)
- Go to Podcasts tab
- Start playing an episode to ensure that the mini-player is visible
- Check if the gradient behind the mini-player matches the color of the screen background.
- Smoke test on the lighter themes too.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
