### PR TITLE
EffectsPlayer: remove different setup mechanisms

### DIFF
--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -275,9 +275,6 @@ struct Constants {
         static let endOfYearRequireAccount = "end_of_year_require_account"
         static let endOfYearRequireAccountDefault: Bool = true
 
-        static let effectsPlayerStrategy = "effects_player_strategy"
-        static let effectsPlayerStrategyDefault: Int = 1
-
         static let patronCloudStorageGB = "patron_custom_storage_limit_gb"
         static let patronCloudStorageGBDefault = 100
 

--- a/podcasts/EffectsPlayer.swift
+++ b/podcasts/EffectsPlayer.swift
@@ -7,12 +7,6 @@ import UIKit
 class EffectsPlayer: PlaybackProtocol, Hashable {
     private static let targetVolumeDbGain = 15.0 as Float
 
-    /// The maximum number this player will retry to restard an audio if it fails
-    private static let maxNumberOfRetries = 3
-
-    /// The current attempt number to start the player
-    private static var attemptNumber = 1
-
     private var engine: AVAudioEngine?
     private var player: AVAudioPlayerNode?
 

--- a/podcasts/EffectsPlayer.swift
+++ b/podcasts/EffectsPlayer.swift
@@ -4,12 +4,6 @@ import PocketCastsDataModel
 import PocketCastsUtils
 import UIKit
 
-enum EffectsPlayerStrategy: Int {
-    case normalPlay = 1
-    case playAndCatchExceptionIfNeeded = 2
-    case playAndFallbackIfNeeded = 3
-}
-
 class EffectsPlayer: PlaybackProtocol, Hashable {
     private static let targetVolumeDbGain = 15.0 as Float
 
@@ -169,16 +163,7 @@ class EffectsPlayer: PlaybackProtocol, Hashable {
                 return
             }
 
-            switch Settings.effectsPlayerStrategy {
-            case .normalPlay:
-                strongSelf.normalPlay()
-            case .playAndCatchExceptionIfNeeded:
-                strongSelf.playAndCatchExceptionIfNeeded()
-            case .playAndFallbackIfNeeded:
-                strongSelf.playAndFallbackIfNeeded()
-            default:
-                strongSelf.normalPlay()
-            }
+            strongSelf.playAndCatchExceptionIfNeeded()
 
             strongSelf.playerLock.unlock()
 
@@ -195,13 +180,6 @@ class EffectsPlayer: PlaybackProtocol, Hashable {
     }
 
     // MARK: - Play
-    /// We have three ways to start the player here. This is here to try
-    /// to fix one of our top-crashes which is related to EffectsPlayer initialization
-
-    /// Just play the player and don't deal with any exception
-    func normalPlay() {
-        player?.play()
-    }
 
     /// Try to play. If an exception happens, just pause it.
     func playAndCatchExceptionIfNeeded() {
@@ -213,18 +191,6 @@ class EffectsPlayer: PlaybackProtocol, Hashable {
             FileLog.shared.addMessage("EffectsPlayer: failed to start playback: \(error)")
             self.playerLock.unlock()
             PlaybackManager.shared.pause(userInitiated: false)
-        }
-    }
-
-    /// Try to play. If it fails, fallback to DefaultPlayer
-    func playAndFallbackIfNeeded() {
-        do {
-            try SJCommonUtils.catchException {
-                self.player?.play()
-            }
-        } catch {
-            self.playerLock.unlock()
-            PlaybackManager.shared.playbackDidFail(logMessage: error.localizedDescription, userMessage: nil, fallbackToDefaultPlayer: true)
         }
     }
 

--- a/podcasts/FirebaseManager.swift
+++ b/podcasts/FirebaseManager.swift
@@ -11,7 +11,6 @@ struct FirebaseManager {
             Constants.RemoteParams.podcastSearchDebounceMs: NSNumber(value: Constants.RemoteParams.podcastSearchDebounceMsDefault),
             Constants.RemoteParams.customStorageLimitGB: NSNumber(value: Constants.RemoteParams.customStorageLimitGBDefault),
             Constants.RemoteParams.endOfYearRequireAccount: NSNumber(value: Constants.RemoteParams.endOfYearRequireAccountDefault),
-            Constants.RemoteParams.effectsPlayerStrategy: NSNumber(value: Constants.RemoteParams.effectsPlayerStrategyDefault),
             Constants.RemoteParams.patronCloudStorageGB: NSNumber(value: Constants.RemoteParams.patronCloudStorageGBDefault),
             Constants.RemoteParams.addMissingEpisodes: NSNumber(value: Constants.RemoteParams.addMissingEpisodesDefault),
             Constants.RemoteParams.newPlayerTransition: NSNumber(value: Constants.RemoteParams.newPlayerTransitionDefault),

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -1303,11 +1303,6 @@ class Settings: NSObject {
             return remote.boolValue
         }
 
-        static var effectsPlayerStrategy: EffectsPlayerStrategy? {
-            let remote = RemoteConfig.remoteConfig().configValue(forKey: Constants.RemoteParams.effectsPlayerStrategy)
-            return EffectsPlayerStrategy(rawValue: remote.numberValue.intValue)
-        }
-
         static var plusCloudStorageLimit: Int {
             RemoteConfig.remoteConfig().configValue(forKey: Constants.RemoteParams.customStorageLimitGB).numberValue.intValue
         }


### PR DESCRIPTION
This undo the changes from #1055 keeping the setup number 2 which solved the issue (that was later updated on #1132).

Ps.: I won't remove Firebase flag because it will make the apps revert to the number 1 setup, which we don't want.

## To test

1. Comment (or remove) `EffectsPlayer.swift` lines `144` to `158` (by doing this the engine won't start thus the playback will fail)
1. Download some episodes or add Files and **enable** trim silence

Then:

2. Play a downloaded episode or local file with trim silence enabled
3. ✅ The play shouldn't work
4. Check the logs, you should see three `Loading <episode title>`, and for the first two you should see something like `EffectsPlayer: failed to start playback`

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
