### PR TITLE
Tracks: fix Up Next event

### DIFF
--- a/podcasts/UpNextViewController.swift
+++ b/podcasts/UpNextViewController.swift
@@ -115,7 +115,6 @@ class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        track(.upNextShown, properties: ["source": source])
 
         title = L10n.upNext
 
@@ -159,6 +158,8 @@ class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
         super.viewDidAppear(animated)
         // fix issues with the now playing cell not animating by reloading it on appear
         reloadTable()
+
+        track(.upNextShown, properties: ["source": source])
 
         AnalyticsHelper.upNextOpened()
     }


### PR DESCRIPTION
Makes a small change so `up_next_shown` is always trigerred when tapping the Up Next icon in the tab bar.

## To test

1. Go to Profile > Settings > Beta Features > enable `tracksLogging`
2. Tap Up Next in the tab bar
3. ✅ `up_next_shown ["source": "tab_bar"]` should appear in the console
4. Tap another tab, and Up Next again
5. ✅ `up_next_shown ["source": "tab_bar"]` should appear in the console
6. Open the Up Next from the miniplayer or full player
7.  ✅ `up_next_shown ["source": "?"]` should appear in the console (where `?` depends on where you opened it)

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
