### PR TITLE
Attach Up Next bottom to superview

### DIFF
--- a/podcasts/UpNextViewController.xib
+++ b/podcasts/UpNextViewController.xib
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_0" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22684"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -23,7 +24,7 @@
             <subviews>
                 <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" style="grouped" separatorStyle="none" allowsSelectionDuringEditing="YES" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="1" sectionFooterHeight="1" translatesAutoresizingMaskIntoConstraints="NO" id="lik-kf-6rP" customClass="ThemeableTable" customModule="podcasts" customModuleProvider="target">
                     <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
-                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     <connections>
                         <outlet property="dataSource" destination="-1" id="sUz-Vc-XiD"/>
                         <outlet property="delegate" destination="-1" id="Tem-gi-Iir"/>
@@ -32,12 +33,13 @@
                 </tableView>
                 <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="VqG-ZR-Alm" customClass="MultiSelectFooterView" customModule="podcasts" customModuleProvider="target">
                     <rect key="frame" x="8" y="488" width="304" height="64"/>
-                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="64" id="3dV-GY-T95"/>
                     </constraints>
                 </view>
             </subviews>
+            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <constraints>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="lik-kf-6rP" secondAttribute="trailing" id="BHO-6k-fKT"/>
@@ -45,11 +47,15 @@
                 <constraint firstItem="VqG-ZR-Alm" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="8" id="R3w-t7-lz2"/>
                 <constraint firstItem="lik-kf-6rP" firstAttribute="bottom" secondItem="VqG-ZR-Alm" secondAttribute="bottom" constant="16" id="i5Q-Q3-dx3"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="VqG-ZR-Alm" secondAttribute="trailing" constant="8" id="iJf-Sm-VdB"/>
-                <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="lik-kf-6rP" secondAttribute="bottom" id="u8S-cz-24J"/>
+                <constraint firstAttribute="bottom" secondItem="lik-kf-6rP" secondAttribute="bottom" id="u8S-cz-24J"/>
                 <constraint firstItem="lik-kf-6rP" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="uZj-bH-npT"/>
             </constraints>
-            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <point key="canvasLocation" x="131.8840579710145" y="136.60714285714286"/>
         </view>
     </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>


### PR DESCRIPTION
The Up Next scroll view was cut off on the bottom instead of being extended all the way.

| Before | After |
| -- | -- |
| ![simulator_screenshot_9D809AD3-25AD-4962-80FD-0136619CA5C5](https://github.com/Automattic/pocket-casts-ios/assets/3250/ee300486-5707-456e-8e14-29ff3fc04656) | ![Simulator Screenshot - iPhone 15 Pro - 2024-06-18 at 21 03 59](https://github.com/Automattic/pocket-casts-ios/assets/3250/68453c66-8e13-4bbe-af8c-adc9c888d8b4) |

The scroll inset is already offset by the safe area so we should set to the superview bottom.

## To test

* Queue 10 or so things to play
* Open Up Next
* Make sure the scroll content is beneath the home indicator instead of being cut off
* Make sure scrolling all the way to the bottom isn't covered by the home indicator

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
