### PR TITLE
Reimagine Sharing: Add new sharing UI with shareable image preview

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -11235,10 +11235,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIconPrototype;
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_ENTITLEMENTS = podcasts/podcastsDebug.entitlements;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				DEVELOPMENT_ASSET_PATHS = "";
-				DEVELOPMENT_TEAM = PZYM8XX95Q;
+				CODE_SIGN_ENTITLEMENTS = podcasts/podcasts.prototype.entitlements;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -11526,9 +11523,6 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = podcasts/podcastsDebug.entitlements;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				DEVELOPMENT_ASSET_PATHS = "";
-				DEVELOPMENT_TEAM = PZYM8XX95Q;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -11555,8 +11549,6 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = podcasts/podcasts.entitlements;
-				DEVELOPMENT_ASSET_PATHS = "";
-				DEVELOPMENT_TEAM = PZYM8XX95Q;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1632,7 +1632,12 @@
 		F5F69D802C07C867000B3C87 /* FMDatabaseQueue+Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5F69D7F2C07C867000B3C87 /* FMDatabaseQueue+Test.swift */; };
 		F5F6DA702BBE1109009B1934 /* CategoryButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5F6DA6F2BBE1109009B1934 /* CategoryButtonStyle.swift */; };
 		F5F6DA822BC0B512009B1934 /* CategoriesModalPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5F6DA812BC0B512009B1934 /* CategoriesModalPicker.swift */; };
+		F5FE747B2C223A6100DF2EAA /* ShareImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5FF61222BD07E3A00190711 /* ShareImageView.swift */; };
+		F5FE747D2C223A6E00DF2EAA /* PocketCastsLogoPill.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5FF61242BD0831200190711 /* PocketCastsLogoPill.swift */; };
+		F5FF61232BD07E3A00190711 /* ShareImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5FF61222BD07E3A00190711 /* ShareImageView.swift */; };
+		F5FF61252BD0831200190711 /* PocketCastsLogoPill.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5FF61242BD0831200190711 /* PocketCastsLogoPill.swift */; };
 		F5FF61292BD6D88C00190711 /* SharingModal.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5FF61282BD6D88C00190711 /* SharingModal.swift */; };
+		F5FF612B2BD6EB3B00190711 /* ModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5FF612A2BD6EB3B00190711 /* ModalView.swift */; };
 		FF03F7C42C0E331E00369572 /* SourceInterfaceModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF03F7C32C0E331E00369572 /* SourceInterfaceModel.swift */; };
 		FF05C98F2C0A0BF800E41EB3 /* FileManager+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF05C98E2C0A0BF800E41EB3 /* FileManager+Helper.swift */; };
 		FF05C9902C0A255600E41EB3 /* FileManager+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF05C98E2C0A0BF800E41EB3 /* FileManager+Helper.swift */; };
@@ -3443,7 +3448,10 @@
 		F5F69D7F2C07C867000B3C87 /* FMDatabaseQueue+Test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FMDatabaseQueue+Test.swift"; sourceTree = "<group>"; };
 		F5F6DA6F2BBE1109009B1934 /* CategoryButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryButtonStyle.swift; sourceTree = "<group>"; };
 		F5F6DA812BC0B512009B1934 /* CategoriesModalPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoriesModalPicker.swift; sourceTree = "<group>"; };
+		F5FF61222BD07E3A00190711 /* ShareImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareImageView.swift; sourceTree = "<group>"; };
+		F5FF61242BD0831200190711 /* PocketCastsLogoPill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PocketCastsLogoPill.swift; sourceTree = "<group>"; };
 		F5FF61282BD6D88C00190711 /* SharingModal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharingModal.swift; sourceTree = "<group>"; };
+		F5FF612A2BD6EB3B00190711 /* ModalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalView.swift; sourceTree = "<group>"; };
 		FF03F7C32C0E331E00369572 /* SourceInterfaceModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceInterfaceModel.swift; sourceTree = "<group>"; };
 		FF05C98E2C0A0BF800E41EB3 /* FileManager+Helper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FileManager+Helper.swift"; sourceTree = "<group>"; };
 		FF05C9912C0E044C00E41EB3 /* DBTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DBTestCase.swift; sourceTree = "<group>"; };
@@ -7291,6 +7299,7 @@
 				C7252E132A71950500E7D3C0 /* EpisodeImage.swift */,
 				C7E99F072A5E103A00E7CBAF /* List View */,
 				C7DC401C2A67025D00883D03 /* Toast */,
+				F5FF612A2BD6EB3B00190711 /* ModalView.swift */,
 			);
 			path = "Common SwiftUI";
 			sourceTree = "<group>";
@@ -7414,6 +7423,8 @@
 			children = (
 				F52ADE432BD8B0F300AC647F /* SharingView.swift */,
 				F5FF61282BD6D88C00190711 /* SharingModal.swift */,
+				F5FF61222BD07E3A00190711 /* ShareImageView.swift */,
+				F5FF61242BD0831200190711 /* PocketCastsLogoPill.swift */,
 			);
 			path = Sharing;
 			sourceTree = "<group>";
@@ -8868,6 +8879,7 @@
 				40AB3D23224C4E1000A4DC13 /* ProgressCircleView.swift in Sources */,
 				C7252E122A718AD600E7D3C0 /* BookmarkListRouter.swift in Sources */,
 				4053CDF7214B6B61001C92B1 /* EpisodeFilterOverlayController.swift in Sources */,
+				F5FE747B2C223A6100DF2EAA /* ShareImageView.swift in Sources */,
 				BD998AD327B3430700B38857 /* ColorPreviewFolderView.swift in Sources */,
 				BD7C1FFD237D16C600B3353B /* PCAlwaysVisibleCastBtn.swift in Sources */,
 				BD9324712398BB50004F19A1 /* TourView.swift in Sources */,
@@ -8887,6 +8899,7 @@
 				C7BDECAB2A15310800BECF02 /* SwiftUI+Accessibility.swift in Sources */,
 				403B5AFE2179670F00821A54 /* MediaFilterOverlayController.swift in Sources */,
 				BD001B892174260B00504DD3 /* FilterManager.swift in Sources */,
+				F5FE747D2C223A6E00DF2EAA /* PocketCastsLogoPill.swift in Sources */,
 				BD2A49E61701A6AE00C2F192 /* SJCommonUtils.m in Sources */,
 				406D9F8E253F9BF400B654C6 /* FilterPreviewViewController.swift in Sources */,
 				BD1B32AB204CFA3800F06F67 /* ExpandableLabel.swift in Sources */,
@@ -8922,6 +8935,7 @@
 				409C793722387C0500386495 /* AllArchivedCell.swift in Sources */,
 				405471272163345400341BF6 /* PodcastSelectionHeaderView.swift in Sources */,
 				BD9086A7204E120C00C0C78D /* DescriptiveActionView.swift in Sources */,
+				F5FF612B2BD6EB3B00190711 /* ModalView.swift in Sources */,
 				C7612FFF28E397A00044C6C2 /* AnalyticsEpisodeHelper.swift in Sources */,
 				BDF4D3162175C56F0086463E /* ThemeLoadingIndicator.swift in Sources */,
 				4030D4612496446000BEC7D9 /* MultiSelectActionController.swift in Sources */,
@@ -9175,6 +9189,7 @@
 				C7FF770F291C2CBA0082A464 /* LoginButtonStyles.swift in Sources */,
 				462EE0A826FB9FDA003D67DC /* ActivityDialog.swift in Sources */,
 				404367C323BAD4E200328B1D /* DiscoverCollectionHeader.swift in Sources */,
+				F5FF61232BD07E3A00190711 /* ShareImageView.swift in Sources */,
 				C71C04CD2924403800F2858A /* ImportDetailsView.swift in Sources */,
 				8B7298F829144EEC0059C077 /* PodcastCover.swift in Sources */,
 				BDA756DE1BFAE61A0035EE13 /* PlaylistColorChooserCell.swift in Sources */,
@@ -9492,6 +9507,7 @@
 				40484F0122F1507F007DBD55 /* ThemeableRoundedButton.swift in Sources */,
 				BDEBD3A91BA0108800AD038F /* BufferedAudio.swift in Sources */,
 				402772D721B6105D00769811 /* PodcastManager+Delete.swift in Sources */,
+				F5FF61252BD0831200190711 /* PocketCastsLogoPill.swift in Sources */,
 				403B5B02217D5F1500821A54 /* TitleViewWithCollapseButton.swift in Sources */,
 				F52ADE472BD9698B00AC647F /* ModalView.swift in Sources */,
 				C713D4FD2A05168B00A78468 /* Theme+AppColors.swift in Sources */,
@@ -11219,7 +11235,10 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIconPrototype;
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_ENTITLEMENTS = podcasts/podcasts.prototype.entitlements;
+				CODE_SIGN_ENTITLEMENTS = podcasts/podcastsDebug.entitlements;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				DEVELOPMENT_ASSET_PATHS = "";
+				DEVELOPMENT_TEAM = PZYM8XX95Q;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -11507,6 +11526,9 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = podcasts/podcastsDebug.entitlements;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				DEVELOPMENT_ASSET_PATHS = "";
+				DEVELOPMENT_TEAM = PZYM8XX95Q;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -11533,6 +11555,8 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = podcasts/podcasts.entitlements;
+				DEVELOPMENT_ASSET_PATHS = "";
+				DEVELOPMENT_TEAM = PZYM8XX95Q;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",

--- a/podcasts/NowPlayingPlayerItemViewController+Shelf.swift
+++ b/podcasts/NowPlayingPlayerItemViewController+Shelf.swift
@@ -414,9 +414,9 @@ extension NowPlayingPlayerItemViewController: NowPlayingActionsDelegate {
 
         if FeatureFlag.newSharing.enabled {
             if fromTime == 0 {
-                SharingModal.show(option: .episode, episode: episode, in: self)
+                SharingModal.show(option: .episode(episode), episode: episode, in: self)
             } else {
-                SharingModal.show(option: .currentPosition, episode: episode, in: self)
+                SharingModal.show(option: .currentPosition(episode, fromTime), episode: episode, in: self)
             }
         } else {
             let sourceRect = buttonSuperview.convert(source.frame, to: view)
@@ -429,7 +429,7 @@ extension NowPlayingPlayerItemViewController: NowPlayingActionsDelegate {
 
         Analytics.track(.podcastShared, properties: ["type": "podcast", "source": "player"])
         if FeatureFlag.newSharing.enabled {
-            SharingModal.show(option: .episode, podcast: podcast, episode: nil, in: self)
+            SharingModal.show(option: .podcast(podcast), podcast: podcast, episode: nil, in: self)
         } else {
             let sourceRect = buttonSuperview.convert(source.frame, to: view)
             SharingHelper.shared.shareLinkTo(podcast: podcast, fromController: self, sourceRect: sourceRect, sourceView: view)

--- a/podcasts/NowPlayingPlayerItemViewController+Shelf.swift
+++ b/podcasts/NowPlayingPlayerItemViewController+Shelf.swift
@@ -414,9 +414,9 @@ extension NowPlayingPlayerItemViewController: NowPlayingActionsDelegate {
 
         if FeatureFlag.newSharing.enabled {
             if fromTime == 0 {
-                SharingModal.show(option: .episode(episode), episode: episode, in: self)
+                SharingModal.show(option: .episode(episode), in: self)
             } else {
-                SharingModal.show(option: .currentPosition(episode, fromTime), episode: episode, in: self)
+                SharingModal.show(option: .currentPosition(episode, fromTime), in: self)
             }
         } else {
             let sourceRect = buttonSuperview.convert(source.frame, to: view)
@@ -429,7 +429,7 @@ extension NowPlayingPlayerItemViewController: NowPlayingActionsDelegate {
 
         Analytics.track(.podcastShared, properties: ["type": "podcast", "source": "player"])
         if FeatureFlag.newSharing.enabled {
-            SharingModal.show(option: .podcast(podcast), podcast: podcast, episode: nil, in: self)
+            SharingModal.show(option: .podcast(podcast), in: self)
         } else {
             let sourceRect = buttonSuperview.convert(source.frame, to: view)
             SharingHelper.shared.shareLinkTo(podcast: podcast, fromController: self, sourceRect: sourceRect, sourceView: view)

--- a/podcasts/Sharing/PocketCastsLogoPill.swift
+++ b/podcasts/Sharing/PocketCastsLogoPill.swift
@@ -1,11 +1,3 @@
-//
-//  PocketCastsLogoPill.swift
-//  podcasts
-//
-//  Created by Brandon Titus on 4/17/24.
-//  Copyright © 2024 Shifty Jelly. All rights reserved.
-//
-
 import SwiftUI
 
 struct PocketCastsLogoPill: View {

--- a/podcasts/Sharing/PocketCastsLogoPill.swift
+++ b/podcasts/Sharing/PocketCastsLogoPill.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct PocketCastsLogoPill: View {
     var body: some View {
         HStack {
-            Image("pocketcasts")
+            Image("splashlogo")
                 .resizable()
                 .frame(width: 18, height: 18)
             Text("Pocket Casts")

--- a/podcasts/Sharing/PocketCastsLogoPill.swift
+++ b/podcasts/Sharing/PocketCastsLogoPill.swift
@@ -1,0 +1,30 @@
+//
+//  PocketCastsLogoPill.swift
+//  podcasts
+//
+//  Created by Brandon Titus on 4/17/24.
+//  Copyright © 2024 Shifty Jelly. All rights reserved.
+//
+
+import SwiftUI
+
+struct PocketCastsLogoPill: View {
+    var body: some View {
+        HStack {
+            Image("pocketcasts")
+                .resizable()
+                .frame(width: 18, height: 18)
+            Text("Pocket Casts")
+                .padding(.trailing, 7)
+                .font(Font.system(size: 12, weight: .semibold))
+        }
+        .padding(4)
+        .foregroundStyle(.white)
+        .background(Theme(previewTheme: .classic).primaryIcon01)
+        .clipShape(Capsule())
+    }
+}
+
+#Preview {
+    PocketCastsLogoPill()
+}

--- a/podcasts/Sharing/ShareImageView.swift
+++ b/podcasts/Sharing/ShareImageView.swift
@@ -93,7 +93,7 @@ struct ShareImageView: View {
     }
 }
 
-let previewInfo = ShareImageInfo(name: "This American Life", title: "Dylan Field, Figma Co-founder, Talks Design, Economy, and life after failed Adobe acquisitions", description: Date().formatted(), artwork: URL(string: "")!, gradient: Gradient(colors: [Color.red, Color(hex: "620603")]))
+let previewInfo = ShareImageInfo(name: "This American Life", title: "Dylan Field, Figma Co-founder, Talks Design, Economy, and life after failed Adobe acquisitions", description: Date().formatted(), artwork: URL(string: "https://static.pocketcasts.com/discover/images/280/3782b780-0bc5-012e-fb02-00163e1b201c.jpg")!, gradient: Gradient(colors: [Color.red, Color(hex: "620603")]))
 
 #Preview("large") {
     ShareImageView(info: previewInfo, style: .large)

--- a/podcasts/Sharing/ShareImageView.swift
+++ b/podcasts/Sharing/ShareImageView.swift
@@ -1,0 +1,108 @@
+import SwiftUI
+import Kingfisher
+
+struct ShareImageInfo {
+    let name: String
+    let title: String
+    let description: String
+    let artwork: URL
+    let gradient: Gradient
+}
+
+enum ShareImageStyle: CaseIterable {
+    case large
+    case medium
+    case small
+
+    var tabString: String {
+        switch self {
+        case .large:
+            return "large"
+        case .medium:
+            return "medium"
+        case .small:
+            return "small"
+        }
+    }
+}
+
+struct ShareImageView: View {
+
+    let info: ShareImageInfo
+    let style: ShareImageStyle
+
+    var body: some View {
+        ZStack {
+            LinearGradient(gradient: info.gradient, startPoint: .top, endPoint: .bottom)
+            Color.black.opacity(0.2)
+            switch style {
+            case .large:
+                VStack(spacing: 32) {
+                    image()
+                        .frame(width: 200, height: 200)
+                    text()
+                    PocketCastsLogoPill()
+                }
+                .padding(24)
+                .frame(width: 292, height: 438)
+            case .medium:
+                VStack(spacing: 24) {
+                    image()
+                        .frame(width: 120, height: 120)
+                    text()
+                        .frame(alignment: .leading)
+                }
+                .padding(24)
+                .frame(width: 292, height: 293)
+            case .small:
+                HStack(spacing: 18) {
+                    image()
+                        .frame(width: 120, height: 120)
+                    text(alignment: .leading, textAlignment: .leading, lineLimit: 3)
+                }
+                .padding(24)
+                .frame(width: 324, height: 169)
+            }
+        }
+        .fixedSize()
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+
+    @ViewBuilder func image() -> some View {
+        KFImage(info.artwork)
+            .resizable()
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+
+    @ViewBuilder func text(alignment: HorizontalAlignment = .center, textAlignment: TextAlignment = .center, lineLimit: Int = 2) -> some View {
+        VStack(alignment: alignment, spacing: 6) {
+            Text(info.name)
+                .font(.caption)
+                .fontWeight(.semibold)
+                .foregroundStyle(.white.opacity(0.5))
+            Text(info.title)
+                .font(Font.system(size: 15, weight: .semibold))
+                .foregroundStyle(.white)
+                .lineLimit(lineLimit)
+            Text(info.description)
+                .font(.caption)
+                .fontWeight(.semibold)
+                .foregroundStyle(.white.opacity(0.5))
+        }
+        .multilineTextAlignment(textAlignment)
+    }
+}
+
+let previewInfo = ShareImageInfo(name: "This American Life", title: "Dylan Field, Figma Co-founder, Talks Design, Economy, and life after failed Adobe acquisitions", description: Date().formatted(), artwork: URL(string: "")!, gradient: Gradient(colors: [Color.red, Color(hex: "620603")]))
+
+#Preview("large") {
+    ShareImageView(info: previewInfo, style: .large)
+}
+
+#Preview("medium") {
+    ShareImageView(info: previewInfo, style: .medium)
+}
+
+#Preview("small") {
+    ShareImageView(info: previewInfo, style: .small)
+}

--- a/podcasts/Sharing/SharingModal.swift
+++ b/podcasts/Sharing/SharingModal.swift
@@ -1,15 +1,16 @@
 import PocketCastsDataModel
 import SwiftUI
+import PocketCastsUtils
 
 enum SharingModal {
 
     /// Share options including which type of content will be shared
-    enum Option: CaseIterable {
-        case episode
-        case currentPosition
-        case podcast
+    enum Option {
+        case episode(Episode)
+        case currentPosition(Episode, TimeInterval)
+        case podcast(Podcast)
 
-        var title: String {
+        var buttonTitle: String {
             switch self {
             case .episode:
                 L10n.episode
@@ -17,6 +18,31 @@ enum SharingModal {
                 L10n.shareCurrentPosition
             case .podcast:
                 L10n.podcastSingular
+            }
+        }
+
+        var shareTitle: String {
+            switch self {
+            case .episode:
+                L10n.shareEpisode
+            case .currentPosition(_, let time):
+                L10n.shareEpisodeAt(TimeFormatter.shared.playTimeFormat(time: time))
+            case .podcast:
+                L10n.sharePodcast
+            }
+        }
+
+        static func allCases(episode: Episode?, podcast: Podcast, currentTime: TimeInterval) -> [Option] {
+            if let episode {
+                [
+                    .episode(episode),
+                    .podcast(podcast),
+                    .currentPosition(episode, currentTime)
+                ]
+            } else {
+                [
+                    .podcast(podcast)
+                ]
             }
         }
     }
@@ -34,8 +60,8 @@ enum SharingModal {
 
         let optionPicker = OptionsPicker(title: L10n.share.uppercased(), themeOverride: .dark, colors: colors)
 
-        let actions: [OptionAction] = Option.allCases.map { option in
-                .init(label: option.title, action: {
+        let actions: [OptionAction] = Option.allCases(episode: episode, podcast: podcast, currentTime: PlaybackManager.shared.currentTime()).map { option in
+                .init(label: option.buttonTitle, action: {
                 show(option: option, podcast: podcast, episode: episode, in: viewController)
             })
         }
@@ -53,9 +79,7 @@ enum SharingModal {
     }
 
     static func show(option: Option, podcast: Podcast, episode: Episode?, in viewController: UIViewController) {
-        let shareInfo = ShareInfo(podcast: podcast, episode: episode)
-
-        let sharingView = SharingView(shareInfo: shareInfo)
+        let sharingView = SharingView(selectedOption: option)
         let modalView = ModalView {
             sharingView
         } dismissAction: {
@@ -66,5 +90,89 @@ enum SharingModal {
         let hostingController = ThemedHostingController(rootView: modalView, theme: Theme(previewTheme: .contrastLight))
         viewController.present(hostingController, animated: true)
 
+    }
+}
+
+extension SharingModal.Option {
+    private var description: String {
+        switch self {
+        case .episode(let episode), .currentPosition(let episode, _):
+            if let date = episode.publishedDate {
+                return date.formatted(Date.FormatStyle(date: .abbreviated, time: .omitted))
+            } else {
+                return ""
+            }
+        case .podcast(let podcast):
+            return [podcast.episodeCount, podcast.frequency].compactMap { $0 }.joined(separator: " ⋅ ")
+        }
+    }
+
+    private var title: String? {
+        switch self {
+        case .episode(let episode), .currentPosition(let episode, _):
+            episode.title
+        case .podcast(let podcast):
+            podcast.title
+        }
+    }
+
+    private var name: String? {
+        switch self {
+        case .episode(let episode), .currentPosition(let episode, _):
+            episode.parentPodcast()?.title
+        case .podcast(let podcast):
+            podcast.author
+        }
+    }
+
+    private var podcast: Podcast {
+        switch self {
+        case .episode(let episode), .currentPosition(let episode, _):
+            return episode.parentPodcast()!
+        case .podcast(let podcast):
+            return podcast
+        }
+    }
+
+    var imageInfo: ShareImageInfo {
+        let gradient = Gradient(colors: [
+            Color(uiColor: ColorManager.lightThemeTintForPodcast(podcast)),
+            Color(uiColor: UIColor.calculateColor(orgColor: UIColor.black, overlayColor: ColorManager.lightThemeTintForPodcast(podcast).withAlphaComponent(0.8))),
+        ])
+        let artwork = ImageManager.sharedManager.podcastUrl(imageSize: .page, uuid: podcast.uuid)
+        let imageInfo = ShareImageInfo(name: name ?? "",
+                                       title: title ?? "",
+                                       description: description,
+                                       artwork: artwork,
+                                       gradient: gradient)
+        return imageInfo
+    }
+
+    var shareURL: String {
+        switch self {
+        case .episode(let episode):
+            return episode.shareURL
+        case .podcast(let podcast):
+            return podcast.shareURL
+        case .currentPosition(let episode, let timeInterval):
+            return episode.shareURL + "?t=\(round(timeInterval))"
+        }
+    }
+}
+
+fileprivate extension Podcast {
+    var episodeCount: String? {
+        let count = PodcastManager.episodeCountForPodcast(self, excludeArchive: false)
+        guard count > 0 else {
+            return nil
+        }
+        return L10n.episodeCountPluralFormat(count)
+    }
+
+    var frequency: String? {
+        guard let frequency = episodeFrequency?.lowercased(), frequency != "unknown" else {
+            return nil
+        }
+        return L10n.paidPodcastReleaseFrequencyFormat(frequency)
     }
 }

--- a/podcasts/Sharing/SharingModal.swift
+++ b/podcasts/Sharing/SharingModal.swift
@@ -62,7 +62,7 @@ enum SharingModal {
 
         let actions: [OptionAction] = Option.allCases(episode: episode, podcast: podcast, currentTime: PlaybackManager.shared.currentTime()).map { option in
                 .init(label: option.buttonTitle, action: {
-                show(option: option, podcast: podcast, episode: episode, in: viewController)
+                show(option: option, in: viewController)
             })
         }
         optionPicker.addActions(actions)
@@ -70,15 +70,7 @@ enum SharingModal {
         optionPicker.show(statusBarStyle: AppTheme.defaultStatusBarStyle())
     }
 
-    static func show(option: Option, episode: Episode, in viewController: UIViewController) {
-        guard let podcast = DataManager.sharedManager.findPodcast(uuid: episode.podcastUuid) else {
-            assertionFailure("Podcast should exist for episode")
-            return
-        }
-        show(option: option, podcast: podcast, episode: episode, in: viewController)
-    }
-
-    static func show(option: Option, podcast: Podcast, episode: Episode?, in viewController: UIViewController) {
+    static func show(option: Option, in viewController: UIViewController) {
         let sharingView = SharingView(selectedOption: option)
         let modalView = ModalView {
             sharingView

--- a/podcasts/Sharing/SharingModal.swift
+++ b/podcasts/Sharing/SharingModal.swift
@@ -48,7 +48,7 @@ enum SharingModal {
     }
 
     static func showModal(episode: Episode, in viewController: UIViewController) {
-        guard let podcast = DataManager.sharedManager.findPodcast(uuid: episode.podcastUuid) else {
+        guard let podcast = episode.parentPodcast() else {
             assertionFailure("Podcast should exist for episode")
             return
         }

--- a/podcasts/Sharing/SharingView.swift
+++ b/podcasts/Sharing/SharingView.swift
@@ -1,10 +1,6 @@
 import SwiftUI
 import PocketCastsDataModel
-
-struct ShareInfo {
-    let podcast: Podcast
-    let episode: Episode?
-}
+import PocketCastsUtils
 
 struct SharingView: View {
 
@@ -12,11 +8,14 @@ struct SharingView: View {
         static let descriptionMaxWidth: CGFloat = 200
     }
 
-    let shareInfo: ShareInfo
+    let selectedOption: SharingModal.Option
+
+    @State private var selectedMedia: ShareImageStyle = .large
 
     var body: some View {
         VStack {
             title
+            image
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .foregroundStyle(Color.white)
@@ -24,7 +23,7 @@ struct SharingView: View {
 
     @ViewBuilder var title: some View {
         VStack {
-            Text(shareInfo.episode != nil ? L10n.shareEpisode : L10n.sharePodcast)
+            Text(selectedOption.shareTitle)
                 .font(.headline)
             Text(L10n.shareDescription)
                 .font(.subheadline)
@@ -33,8 +32,18 @@ struct SharingView: View {
                 .frame(maxWidth: Constants.descriptionMaxWidth)
         }
     }
+
+    @ViewBuilder var image: some View {
+        TabView(selection: $selectedMedia) {
+            ForEach(ShareImageStyle.allCases, id: \.self) { style in
+                ShareImageView(info: selectedOption.imageInfo, style: style)
+                    .tabItem { Text(style.tabString) }
+            }
+        }
+        .tabViewStyle(.page)
+    }
 }
 
 #Preview {
-    SharingView(shareInfo: ShareInfo(podcast: Podcast.previewPodcast(), episode: nil))
+    SharingView(selectedOption: .podcast(Podcast.previewPodcast()))
 }

--- a/podcasts/SharingHelper.swift
+++ b/podcasts/SharingHelper.swift
@@ -10,7 +10,7 @@ class SharingHelper: NSObject {
         AnalyticsHelper.sharedPodcast()
 
         if FeatureFlag.newSharing.enabled {
-            SharingModal.show(option: .podcast(podcast), podcast: podcast, episode: nil, in: fromController)
+            SharingModal.show(option: .podcast(podcast), in: fromController)
         } else {
             let sharingUrl = podcast.shareURL
             activityController = UIActivityViewController(activityItems: [URL(string: sharingUrl)!], applicationActivities: nil)
@@ -52,7 +52,7 @@ class SharingHelper: NSObject {
         AnalyticsHelper.sharedPodcast()
 
         if FeatureFlag.newSharing.enabled {
-            SharingModal.show(option: .podcast(podcast), podcast: podcast, episode: nil, in: fromController)
+            SharingModal.show(option: .podcast(podcast), in: fromController)
         } else {
             let sharingUrl = podcast.shareURL
             activityController = UIActivityViewController(activityItems: [URL(string: sharingUrl)!], applicationActivities: nil)
@@ -88,7 +88,7 @@ class SharingHelper: NSObject {
 
     func shareLinkTo(episode: Episode, shareTime: TimeInterval, fromController: UIViewController, barButtonItem: UIBarButtonItem?) {
         guard FeatureFlag.newSharing.enabled == false else {
-            SharingModal.show(option: .episode(episode), episode: episode, in: fromController)
+            SharingModal.show(option: .episode(episode), in: fromController)
             return
         }
 

--- a/podcasts/SharingHelper.swift
+++ b/podcasts/SharingHelper.swift
@@ -10,7 +10,7 @@ class SharingHelper: NSObject {
         AnalyticsHelper.sharedPodcast()
 
         if FeatureFlag.newSharing.enabled {
-            SharingModal.show(option: .podcast, podcast: podcast, episode: nil, in: fromController)
+            SharingModal.show(option: .podcast(podcast), podcast: podcast, episode: nil, in: fromController)
         } else {
             let sharingUrl = podcast.shareURL
             activityController = UIActivityViewController(activityItems: [URL(string: sharingUrl)!], applicationActivities: nil)
@@ -52,7 +52,7 @@ class SharingHelper: NSObject {
         AnalyticsHelper.sharedPodcast()
 
         if FeatureFlag.newSharing.enabled {
-            SharingModal.show(option: .podcast, podcast: podcast, episode: nil, in: fromController)
+            SharingModal.show(option: .podcast(podcast), podcast: podcast, episode: nil, in: fromController)
         } else {
             let sharingUrl = podcast.shareURL
             activityController = UIActivityViewController(activityItems: [URL(string: sharingUrl)!], applicationActivities: nil)
@@ -88,7 +88,7 @@ class SharingHelper: NSObject {
 
     func shareLinkTo(episode: Episode, shareTime: TimeInterval, fromController: UIViewController, barButtonItem: UIBarButtonItem?) {
         guard FeatureFlag.newSharing.enabled == false else {
-            SharingModal.show(option: .podcast, episode: episode, in: fromController)
+            SharingModal.show(option: .episode(episode), episode: episode, in: fromController)
             return
         }
 

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -2732,8 +2732,6 @@ internal enum L10n {
   internal static var share: String { return L10n.tr("Localizable", "share") }
   /// Link copied to clipboard
   internal static var shareCopiedToClipboard: String { return L10n.tr("Localizable", "share_copied_to_clipboard") }
-  /// Copy link
-  internal static var shareCopyLink: String { return L10n.tr("Localizable", "share_copy_link") }
   /// Current Position
   internal static var shareCurrentPosition: String { return L10n.tr("Localizable", "share_current_position") }
   /// Choose a format and a platform to share to
@@ -2748,8 +2746,6 @@ internal enum L10n {
   internal static var shareEpisodeTitle: String { return L10n.tr("Localizable", "share_episode_title") }
   /// Subscribing...
   internal static var shareListSubscribing: String { return L10n.tr("Localizable", "share_list_subscribing") }
-  /// More
-  internal static var shareMoreActions: String { return L10n.tr("Localizable", "share_more_actions") }
   /// Share podcast
   internal static var sharePodcast: String { return L10n.tr("Localizable", "share_podcast") }
   /// Share podcast

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -2730,16 +2730,30 @@ internal enum L10n {
   internal static var shakeToRestartSleepTimerDescription: String { return L10n.tr("Localizable", "shake_to_restart_sleep_timer_description") }
   /// Share
   internal static var share: String { return L10n.tr("Localizable", "share") }
+  /// Link copied to clipboard
+  internal static var shareCopiedToClipboard: String { return L10n.tr("Localizable", "share_copied_to_clipboard") }
+  /// Copy link
+  internal static var shareCopyLink: String { return L10n.tr("Localizable", "share_copy_link") }
   /// Current Position
   internal static var shareCurrentPosition: String { return L10n.tr("Localizable", "share_current_position") }
   /// Choose a format and a platform to share to
   internal static var shareDescription: String { return L10n.tr("Localizable", "share_description") }
   /// Share episode
   internal static var shareEpisode: String { return L10n.tr("Localizable", "share_episode") }
+  /// Share episode at %1$@
+  internal static func shareEpisodeAt(_ p1: Any) -> String {
+    return L10n.tr("Localizable", "share_episode_at", String(describing: p1))
+  }
+  /// Share episode
+  internal static var shareEpisodeTitle: String { return L10n.tr("Localizable", "share_episode_title") }
   /// Subscribing...
   internal static var shareListSubscribing: String { return L10n.tr("Localizable", "share_list_subscribing") }
+  /// More
+  internal static var shareMoreActions: String { return L10n.tr("Localizable", "share_more_actions") }
   /// Share podcast
   internal static var sharePodcast: String { return L10n.tr("Localizable", "share_podcast") }
+  /// Share podcast
+  internal static var sharePodcastTitle: String { return L10n.tr("Localizable", "share_podcast_title") }
   /// ALL SELECTED
   internal static var sharePodcastsAllSelected: String { return L10n.tr("Localizable", "share_podcasts_all_selected") }
   /// Create List

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -2710,6 +2710,12 @@
 /* A common string used throughout the app. Option to share the episode at the current playback position. */
 "share_current_position" = "Current Position";
 
+/* A common string used throughout the app. Option to share the episode at the current playback position. */
+"share_episode_at" = "Share episode at %1$@";
+
+/* A message shown when a share link is copied to the clipboard */
+"share_copied_to_clipboard" = "Link copied to clipboard";
+
 /* Message indicating that the process to subscribe to a podcast list is in progress. */
 "share_list_subscribing" = "Subscribing...";
 
@@ -4135,3 +4141,9 @@
 
 /* A message shown when sharing an image representation of a podcast or episode to social media platforms */
 "share_description" = "Choose a format and a platform to share to";
+
+/* A title used when sharing artwork and link to a podcast episode */
+"share_episode_title" = "Share episode";
+
+/* A title used when sharing artwork and link to a podcast */
+"share_podcast_title" = "Share podcast";


### PR DESCRIPTION
| 📘 Part of: https://github.com/Automattic/pocket-casts-ios/issues/1910 |
|:---:|

This adds the beginning of the new UI for sharing Episodes, Podcasts, and Current Position with an image asset.

| Episode | Podcast | Current Position |
| -- | -- | -- |
| ![Simulator Screenshot - iPhone 15 Pro - 2024-06-20 at 14 22 40](https://github.com/Automattic/pocket-casts-ios/assets/3250/d5e80efa-0147-4f7c-93b2-0417b22a4300) | ![Simulator Screenshot - iPhone 15 Pro - 2024-06-20 at 14 22 46](https://github.com/Automattic/pocket-casts-ios/assets/3250/0311f456-cf66-4a3b-a81d-e85683332876) | ![Simulator Screenshot - iPhone 15 Pro - 2024-06-20 at 14 22 51](https://github.com/Automattic/pocket-casts-ios/assets/3250/917a53ee-91ce-4f8e-adc0-30bf86aa30fa) |

We will likely need to tweak a few small design things, like the gradient used for the shared asset, but this can be done in a follow up PR.

A few things are missing from this first PR:
* Sharing options - to keep the line count low for review
* Sharing from the Episode page - still working on a few edge cases there
* Asset generation + sharing - need sharing actions first

## To test

> [!NOTE]
> Enable the `newSharing` feature flag to test this

### Test Sharing from Podcast page
* Visit a Podcast page
* Tap the Share icon at the top
* Verify the new sharing appears

### Test Sharing from Now Playing
* Play a Podcast episode
* Share from the Now Playing Screen
* Choose Episode, Current Position, or Podcast
* Verify that the image that shows appears correct

## Test different image sizes
* Swiping left and right should display differently sized share images. Make sure these appear properly.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
