### PR TITLE
Deeplink: increase the time when waiting for a recent added podcast

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/Refresh/PodcastSearchOperation.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Refresh/PodcastSearchOperation.swift
@@ -34,7 +34,7 @@ class PodcastSearchOperation: Operation {
                 if !shouldRetry { break }
 
                 pollCount += 1
-                let backOffTime = pollBackoffTime(pollCount: pollCount)
+                let backOffTime = pollCount.pollWaitingTime
                 if backOffTime < 0 {
                     completion(PodcastSearchResponse.failedResponse())
                     break
@@ -80,19 +80,5 @@ class PodcastSearchOperation: Operation {
         _ = dispatchGroup.wait(timeout: .now() + 15.seconds)
 
         return shouldRetry
-    }
-
-    private func pollBackoffTime(pollCount: Int) -> TimeInterval {
-        if pollCount < 3 {
-            return 2
-        }
-        if pollCount < 7 {
-            return 5
-        }
-        if pollCount == 7 {
-            return 10
-        }
-
-        return -1
     }
 }

--- a/Modules/Server/Sources/PocketCastsServer/Public/Search/PodcastSearchTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Search/PodcastSearchTask.swift
@@ -109,15 +109,27 @@ public class PodcastSearchTask {
 
     private func pollBackoffTime(pollCount: Int) -> UInt64 {
         let multiply = pow(10, 9)
-        var seconds = 0
-        if pollCount < 3 {
-            seconds = 2
-        } else if pollCount < 7 {
-            seconds = 5
-        } else if pollCount == 7 {
-            seconds = 10
-        }
 
-        return UInt64(NSDecimalNumber(decimal: Decimal(seconds) * multiply).uint64Value)
+        return UInt64(NSDecimalNumber(decimal: Decimal(pollCount.pollWaitingTime) * multiply).uint64Value)
+    }
+}
+
+extension Int {
+    // Return a correspondent poll waiting time for a given number
+    // From 1 to 2: 2 seconds
+    // From 3 to 6: 5 second
+    // For 7: 10 seconds
+    // Others: -1
+    var pollWaitingTime: TimeInterval {
+        switch self {
+        case 1..<3:
+            2
+        case 3..<7:
+            5
+        case 7:
+            10
+        default:
+            -1
+        }
     }
 }

--- a/Modules/Server/Sources/PocketCastsServer/Public/ServerPodcastManager.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/ServerPodcastManager.swift
@@ -38,7 +38,7 @@ public class ServerPodcastManager: NSObject {
     ///   - subscribe: if we should subscribe to the podcast after adding
     ///   - tries: the number of tries already done
     ///   - completion: the code to execute on completion
-    public func addFromUuidWithRetries(podcastUuid: String, subscribe: Bool, tries: UInt = 0, completion: ((Bool) -> Void)?) {
+    public func addFromUuidWithRetries(podcastUuid: String, subscribe: Bool, tries: Int = 0, completion: ((Bool) -> Void)?) {
         var pollbackCounter = tries
         addFromUuid(podcastUuid: podcastUuid, subscribe: subscribe) { [weak self] success in
             guard let self else {
@@ -52,24 +52,11 @@ public class ServerPodcastManager: NSObject {
 
             pollbackCounter += 1
             if pollbackCounter < 8 {
-                Thread.sleep(forTimeInterval: pollBackoffTime(pollCount: pollbackCounter - 1))
+                Thread.sleep(forTimeInterval: pollbackCounter.pollWaitingTime)
                 addFromUuidWithRetries(podcastUuid: podcastUuid, subscribe: subscribe, tries: pollbackCounter, completion: completion)
                 return
             }
             completion?(false)
-        }
-    }
-
-    private func pollBackoffTime(pollCount: UInt) -> TimeInterval {
-        switch pollCount {
-        case 0..<2:
-            2
-        case 2..<6:
-            5
-        case 6:
-            10
-        default:
-            -1
         }
     }
 


### PR DESCRIPTION
This is a follow-up to #1456

This PR changes the retry times from 3 to 7 and change the time it will wait (matching `PodcastSearchOperation`).

## To test

On `ServerPodcastManager.swift` comment lines `48-51` (to simulate a podcast taking a long time to load). Then add a breakpoint in line `55`.

1. Create a gist containing a feed ([you can copy the contents from here](https://gist.githubusercontent.com/leandroalonso/9ad43b593bbd270d06c98f9a8f4efdbf/raw/1d407be92a8cbad660bdee5c92658b33b0fe7654/gistfile1.txt))
2. Once created, get the URL of the raw file
3. Run the app
4. Go to Safari (on the device or simulator) and go to `pktc://subscribe/your-gist-url`
5. ✅ Breakpoint should hit
6. On the console type `po pollBackoffTime(pollCount: pollbackCounter - 1)`
7. ✅ Output should be 2
8. ✅ Resume execution and hitpoint should be hit again, output should be 2
9. Repeat these same steps
10. ✅ Subsequent outputs should be 5, 5, 5, 5, 10

Go to Nodeweb and disable the podcast you just added.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
