### PR TITLE
Reimagine Sharing: Add new sharing to Episode detail page

### DIFF
--- a/podcasts/Sharing/SharingModal.swift
+++ b/podcasts/Sharing/SharingModal.swift
@@ -60,12 +60,17 @@ enum SharingModal {
 
         let optionPicker = OptionsPicker(title: L10n.share.uppercased(), themeOverride: .dark, colors: colors)
 
-        let actions: [OptionAction] = Option.allCases(episode: episode, podcast: podcast, currentTime: PlaybackManager.shared.currentTime()).map { option in
+        let actions: [OptionAction] = Option.allCases(episode: episode, podcast: podcast, currentTime: episode?.playedUpTo ?? 0).map { option in
                 .init(label: option.buttonTitle, action: {
                 show(option: option, in: viewController)
             })
         }
         optionPicker.addActions(actions)
+
+        if let vc = (viewController as? EpisodeDetailViewController),
+           let fileAction = vc.episodeFileAction(from: .zero) {
+            optionPicker.addAction(action: fileAction)
+        }
 
         optionPicker.show(statusBarStyle: AppTheme.defaultStatusBarStyle())
     }


### PR DESCRIPTION
| 📘 Part of: https://github.com/Automattic/pocket-casts-ios/issues/1910 |
|:---:|

Adds new sharing functionality to Episode Detail page. For now, I left the "Podcast" sharing option in the list because I think it doesn't hurt to have.

| Before | After |
| -- | -- |
| ![Simulator Screenshot - iPhone 15 Pro - 2024-06-21 at 08 57 14](https://github.com/Automattic/pocket-casts-ios/assets/3250/5b9ab661-79ce-4938-a187-a2b97bdac186) | ![Simulator Screenshot - iPhone 15 Pro - 2024-06-21 at 08 58 42](https://github.com/Automattic/pocket-casts-ios/assets/3250/6454baf2-b7fd-4208-92f0-bb3e41bfbdac) |

## To test

> [!NOTE]
> Enable the `newSharing` feature flag to test this

### New Sharing Modal
* Navigate to an Episode within a podcast from Subscriptions
* Tap the Share button in the upper right
* Ensure share options are shown
* Ensure that the new sharing modal opens when selecting one

### Open downloaded file
* Download an episode
* Tap the Share button
* Ensure that the "Open File in..." option is included in the menu
* Tap the "Open File in..." option and make sure the file is being shared

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
