### PR TITLE
Fix crash in Up Next when import file

### DIFF
--- a/podcasts/UpNextViewController.swift
+++ b/podcasts/UpNextViewController.swift
@@ -166,6 +166,8 @@ class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
+
+        guard isViewLoaded else { return } // This method was called as a result of `setSelectedIndex` on UITabBarController. The view is not loaded at this point so we don't need to do anything to reset.
         selectedPlayListEpisodes.removeAll()
         isMultiSelectEnabled = false
     }


### PR DESCRIPTION
Fixes #1843

Adds a check that Up Next view was loaded before resetting views in `viewWillDisappear`

Here's the stack trace from the crash which shows the call coming through `viewWillDisappear`. I considered adding this check to the properties but that seems unnecessary and duplicative.

![CleanShot 2024-06-22 at 13 33 15@2x](https://github.com/Automattic/pocket-casts-ios/assets/3250/d5a3a346-7c88-4fa3-b49b-ed152c052480)

## To test

* Add an mp3 to Files.app
* Visit the Up Next tab in the app
* Kill the app
* Share the mp3 from Files to Pocket Casts
* Add Files screen should appear with no crash

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
