### PR TITLE
Add feature flag for transcripts

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -75,6 +75,9 @@ public enum FeatureFlag: String, CaseIterable {
 
     case newSharing
 
+    /// Enable the transcripts feature on podcasts episodes
+    case transcripts
+
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -132,6 +135,8 @@ public enum FeatureFlag: String, CaseIterable {
         case .accelerateEffects:
             true
         case .newSharing:
+            false
+        case .transcripts:
             false
         }
     }


### PR DESCRIPTION
Refs #1848 

Add feature flag for transcripts. 
At the moment is not controlling anything it's just to have it before starting implementing features.

## To test

 - Start the app
 - Open Profile -> Settings -> Beta Features
 - Check if Transcript FF is present and is disabled by default.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
