### PR TITLE
Transcripts add network parse code

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Episode.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Episode.swift
@@ -199,5 +199,13 @@ public class Episode: NSObject, BaseEpisode {
             public let title: String?
             public let endTime: TimeInterval?
         }
+
+        public let transcripts: [Transcript]
+
+        public struct Transcript: Decodable {
+            public let url: String
+            public let type: String
+            public let language: String
+        }
     }
 }

--- a/PocketCastsTests/Tests/Playback/Chapters/ChapterManagerTests.swift
+++ b/PocketCastsTests/Tests/Playback/Chapters/ChapterManagerTests.swift
@@ -141,6 +141,10 @@ private class ShowInfoCoordinatorMock: ShowInfoCoordinating {
     func loadChapters(podcastUuid: String, episodeUuid: String) async throws -> ([PocketCastsDataModel.Episode.Metadata.EpisodeChapter]?, [podcasts.PodcastIndexChapter]?) {
         (nil, nil)
     }
+
+    func loadTranscripts(podcastUuid: String, episodeUuid: String) async throws -> [Episode.Metadata.Transcript] {
+        return []
+    }
 }
 
 private class EpisodeMock: Episode {

--- a/podcasts/Episode Info Coordinator/ShowInfoCoordinating.swift
+++ b/podcasts/Episode Info Coordinator/ShowInfoCoordinating.swift
@@ -17,4 +17,9 @@ protocol ShowInfoCoordinating {
         podcastUuid: String,
         episodeUuid: String
     ) async throws -> ([Episode.Metadata.EpisodeChapter]?, [PodcastIndexChapter]?)
+
+    func loadTranscripts(
+        podcastUuid: String,
+        episodeUuid: String
+    ) async throws -> [Episode.Metadata.Transcript]
 }

--- a/podcasts/Episode Info Coordinator/ShowInfoCoordinator.swift
+++ b/podcasts/Episode Info Coordinator/ShowInfoCoordinator.swift
@@ -52,6 +52,17 @@ actor ShowInfoCoordinator: ShowInfoCoordinating {
         return (metadata?.chapters, nil)
     }
 
+    public func loadTranscripts(podcastUuid: String, episodeUuid: String
+    ) async throws -> [Episode.Metadata.Transcript] {
+        let metadata = try await loadShowInfo(podcastUuid: podcastUuid, episodeUuid: episodeUuid)
+
+        guard let transcripts = metadata?.transcripts else {
+            return []
+        }
+
+        return transcripts
+    }
+
     @discardableResult
     func loadShowInfo(
         podcastUuid: String,

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -162,6 +162,8 @@ class PlaybackManager: ServerPlaybackDelegate {
             chapterManager.clearChapterInfo()
         }
 
+        loadTranscripts()
+
         if saveCurrentEpisode && currentEpisode() != nil && !switchingToDifferentUpNextEpisode {
             recordPlaybackPosition(sendToServerImmediately: false, fireNotifications: false)
         }
@@ -2079,6 +2081,16 @@ private extension PlaybackManager {
 
         lastSeekTime = Date()
         isBack ? skipBack() : skipForward()
+    }
+
+    // MARK: - Transcripts
+    private func loadTranscripts() {
+        guard FeatureFlag.transcripts.enabled, let episode = currentEpisode(), let podcast = currentPodcast else {
+            return
+        }
+        Task.init {
+            let _ = try? await ShowInfoCoordinator.shared.loadTranscripts(podcastUuid: podcast.uuid, episodeUuid: episode.uuid)
+        }
     }
 }
 

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -2088,6 +2088,7 @@ private extension PlaybackManager {
         guard FeatureFlag.transcripts.enabled, let episode = currentEpisode(), let podcast = currentPodcast else {
             return
         }
+
         Task.init {
             let _ = try? await ShowInfoCoordinator.shared.loadTranscripts(podcastUuid: podcast.uuid, episodeUuid: episode.uuid)
         }

--- a/podcasts/ShowNotesUpdater.swift
+++ b/podcasts/ShowNotesUpdater.swift
@@ -4,10 +4,14 @@ import PocketCastsUtils
 
 class ShowNotesUpdater {
     class func updateShowNotesInBackground(podcastUuid: String, episodeUuid: String) {
-        if FeatureFlag.newShowNotesEndpoint.enabled {
+        if FeatureFlag.newShowNotesEndpoint.enabled || FeatureFlag.transcripts.enabled {
             Task {
                 // Load the show notes and any available chapters
                 _ = try? await ShowInfoCoordinator.shared.loadChapters(podcastUuid: podcastUuid, episodeUuid: episodeUuid)
+
+                if FeatureFlag.transcripts.enabled {
+                 _ = try? await ShowInfoCoordinator.shared.loadTranscripts(podcastUuid: podcastUuid, episodeUuid: episodeUuid)
+                }
             }
             return
         }

--- a/podcasts/ShowNotesUpdater.swift
+++ b/podcasts/ShowNotesUpdater.swift
@@ -4,7 +4,7 @@ import PocketCastsUtils
 
 class ShowNotesUpdater {
     class func updateShowNotesInBackground(podcastUuid: String, episodeUuid: String) {
-        if FeatureFlag.newShowNotesEndpoint.enabled || FeatureFlag.transcripts.enabled {
+        if FeatureFlag.newShowNotesEndpoint.enabled {
             Task {
                 // Load the show notes and any available chapters
                 _ = try? await ShowInfoCoordinator.shared.loadChapters(podcastUuid: podcastUuid, episodeUuid: episodeUuid)


### PR DESCRIPTION
Refs #1848 

Adds the network code to parse transcript information on episode. This only ensures that the transcript metadata is parsed.
This also ensure that the transcript info is load when episodes are load to play and cache/loaded when the other episode notes are loaded.

## To test

- Start the app
- Ensure  that you have the `transcripts` and `useNewShowNotesEndpoint` FF enabled
- Add a breakpoint on ShowInfoCoordinator line 59
- Open an Episode of the Podcast `Cautionary Tales with Tim Hartford` 
- Check if the break point is hit and you can do in console `po metadata.transcripts` and see the transcripts info.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
