### PR TITLE
Rename feature flag for control Stream and Cache solution

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -47,7 +47,7 @@ public enum FeatureFlag: String, CaseIterable {
     /// Enable the new flow for Account upgrade prompt where it start IAP flow directly from account cell
     case newAccountUpgradePromptFlow
 
-    case cachePlayingEpisode
+    case streamAndCachePlayingEpisode
 
     case categoriesRedesign
 
@@ -115,7 +115,7 @@ public enum FeatureFlag: String, CaseIterable {
             false
         case .newAccountUpgradePromptFlow:
             false
-        case .cachePlayingEpisode:
+        case .streamAndCachePlayingEpisode:
             true
         case .categoriesRedesign:
             true
@@ -148,8 +148,6 @@ public enum FeatureFlag: String, CaseIterable {
             "deselect_chapters_enabled"
         case .newAccountUpgradePromptFlow:
             "new_account_upgrade_prompt_flow"
-        case .cachePlayingEpisode:
-            "cache_playing_episode"
         case .newSettingsStorage:
             shouldEnableSyncedSettings ? "new_settings_storage" : nil
         case .settingsSync:

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -47,6 +47,7 @@ public enum FeatureFlag: String, CaseIterable {
     /// Enable the new flow for Account upgrade prompt where it start IAP flow directly from account cell
     case newAccountUpgradePromptFlow
 
+    /// Enable the AVExportSession parallel download of any playing episode
     case streamAndCachePlayingEpisode
 
     case categoriesRedesign

--- a/podcasts/DownloadManager.swift
+++ b/podcasts/DownloadManager.swift
@@ -255,7 +255,7 @@ class DownloadManager: NSObject, FilePathProtocol {
             return nil
         }
 
-        guard FeatureFlag.cachePlayingEpisode.enabled,
+        guard FeatureFlag.streamAndCachePlayingEpisode.enabled,
               !episode.videoPodcast(),
               !episode.isUserEpisode,
               let urlAsset = playbackItem.asset as? AVURLAsset,
@@ -394,7 +394,7 @@ class DownloadManager: NSObject, FilePathProtocol {
             let sessionToUse = useCellularSession ? cellularBackgroundSession : wifiOnlyBackgroundSession
         #endif
 
-        if FeatureFlag.cachePlayingEpisode.enabled, downloadAndStreamEpisodes.contains(episode.uuid) {
+        if FeatureFlag.streamAndCachePlayingEpisode.enabled, downloadAndStreamEpisodes.contains(episode.uuid) {
             return
         }
 
@@ -455,7 +455,7 @@ class DownloadManager: NSObject, FilePathProtocol {
             saveRequired = true
         }
 
-        if FeatureFlag.cachePlayingEpisode.enabled, downloadAndStreamEpisodes.contains(episode.uuid) {
+        if FeatureFlag.streamAndCachePlayingEpisode.enabled, downloadAndStreamEpisodes.contains(episode.uuid) {
             episode.downloadTaskId = episode.uuid
             episode.autoDownloadStatus = AutoDownloadStatus.playerDownloadedForStreaming.rawValue
             saveRequired = true

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -1947,7 +1947,7 @@ class PlaybackManager: ServerPlaybackDelegate {
     // MARK: - Private helpers
 
     private func checkIfStreamBufferRequired(episode: BaseEpisode, effects: PlaybackEffects) {
-        let downloadEpisode = effects.trimSilence.isEnabled() && !FeatureFlag.cachePlayingEpisode.enabled
+        let downloadEpisode = effects.trimSilence.isEnabled() && !FeatureFlag.streamAndCachePlayingEpisode.enabled
         if downloadEpisode, !episode.downloaded(pathFinder: DownloadManager.shared) {
             // the user is streaming and has turned on remove silence, kick off a download so we can fulfill that request
             DownloadManager.shared.addToQueue(episodeUuid: episode.uuid, fireNotification: false, autoDownloadStatus: .playerDownloadedForStreaming)

--- a/podcasts/PlaybackQueue.swift
+++ b/podcasts/PlaybackQueue.swift
@@ -321,7 +321,7 @@ class PlaybackQueue: NSObject {
 
         DispatchQueue.global().async { [weak self] in
             guard let self = self else { return }
-            let episodes = self.allEpisodes(includeNowPlaying: !FeatureFlag.cachePlayingEpisode.enabled)
+            let episodes = self.allEpisodes(includeNowPlaying: !FeatureFlag.streamAndCachePlayingEpisode.enabled)
             for episode in episodes {
                 self.autoDownloadIfRequired(episode: episode)
             }


### PR DESCRIPTION


Fixes #

This is done in order to avoid conflict with the previous use of the cachePlayingEpisode FF in older versions of the app.

## To test

 - Start the app
 - Ensure that the new flag `streamAndCachePlayingEpisode` is enable on Profile -> Settings -> Beta features
 - Start playing an episode
 - Check that in the logs you see `DownloadManager export session: start exporting: [UUID]`

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
