### PR TITLE
Listening Speed: support up to 5x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 -----
 - WatchOS refactor main screen and app entry point to SwiftUI. [#1800]
 - Playback skipping: Sync export session with download states. [#1819]
+- Playback speed: increase to 5x [#1855]
 
 7.66
 -----

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -792,7 +792,7 @@ class PlaybackManager: ServerPlaybackDelegate {
 
     func increasePlaybackSpeed() {
         let playbackEffects = effects()
-        if playbackEffects.playbackSpeed > 2.9 { return }
+        if playbackEffects.playbackSpeed > 4.9 { return }
 
         playbackEffects.playbackSpeed = playbackEffects.playbackSpeed + 0.1
         changeEffects(playbackEffects)

--- a/podcasts/PodcastEffectsViewController+Table.swift
+++ b/podcasts/PodcastEffectsViewController+Table.swift
@@ -54,7 +54,7 @@ extension PodcastEffectsViewController: UITableViewDataSource, UITableViewDelega
 
             cell.timeStepper.tintColor = podcast.iconTintColor()
             cell.timeStepper.minimumValue = 0.5
-            cell.timeStepper.maximumValue = 3
+            cell.timeStepper.maximumValue = 5
             cell.timeStepper.smallIncrements = 0.1
             cell.timeStepper.smallIncrementThreshold = TimeInterval.greatestFiniteMagnitude
             if FeatureFlag.newSettingsStorage.enabled {


### PR DESCRIPTION
Increases the max speed time from 3 to 5x.

## To test

### From the player

1. Download an episode
2. Play it
3. Tap the Playback Effects icon in the player
4. Change the speed to values bigger than 3x
5. ✅ Playback should speed up above 3x and continuously increment
6. Play an episode not downloaded
7. Repeat the steps

### Podcast settings

1. Open a podcast
2. Tap the cog icon
3. Tap "Playback Effects"
4. Enable "Custom for this podcast" if disabled
5. Change play speed to any value above 3x
6. Play any episode from this podcast
7. ✅ The desired speed should be applied

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
