### PR TITLE
Discover Categories: Add category name + region to tapped & subscribe events

### DIFF
--- a/podcasts/AnalyticsHelper.swift
+++ b/podcasts/AnalyticsHelper.swift
@@ -113,13 +113,13 @@ class AnalyticsHelper {
         bumpStat("discover_list_podcast_tap", parameters: properties)
     }
 
-    class func adTapped(promotionUUID: String, podcastUUID: String, categoryID: Int) {
-        let properties: [String: Any] = ["promotion_uuid": promotionUUID, "podcast_uuid": podcastUUID, "category_id": categoryID]
+    class func adTapped(categoryName: String, region: String, podcastUUID: String, categoryID: Int) {
+        let properties: [String: Any] = ["name": categoryName, "region": region, "id": categoryID, "podcast_id": podcastUUID]
         Analytics.track(.discoverAdCategoryTapped, properties: properties)
     }
 
-    class func adSubscribed(promotionUUID: String, podcastUUID: String, categoryID: Int) {
-        let properties: [String: Any] = ["promotion_uuid": promotionUUID, "podcast_uuid": podcastUUID, "category_id": categoryID]
+    class func adSubscribed(categoryName: String, region: String, podcastUUID: String, categoryID: Int) {
+        let properties: [String: Any] = ["name": categoryName, "region": region, "id": categoryID, "podcast_id": podcastUUID]
         Analytics.track(.discoverAdCategorySubscribed, properties: properties)
     }
 

--- a/podcasts/Categories/CategoriesSelectorViewController.swift
+++ b/podcasts/Categories/CategoriesSelectorViewController.swift
@@ -37,7 +37,7 @@ class CategoriesSelectorViewController: ThemedHostingController<CategoriesSelect
         self.delegate = delegate
     }
 
-    func populateFrom(item: PocketCastsServer.DiscoverItem, region: String?) {
+    func populateFrom(item: PocketCastsServer.DiscoverItem, region: String?, category: DiscoverCategory?) {
         observable.item = item
         observable.region = region
         view.setNeedsLayout()

--- a/podcasts/CategorySummaryViewController.swift
+++ b/podcasts/CategorySummaryViewController.swift
@@ -40,7 +40,7 @@ class CategorySummaryViewController: UIViewController, UITableViewDataSource, UI
         self.delegate = delegate
     }
 
-    func populateFrom(item: DiscoverItem, region: String?) {
+    func populateFrom(item: DiscoverItem, region: String?, category: DiscoverCategory?) {
         guard let source = item.source else { return }
 
         DiscoverServerHandler.shared.discoverCategories(source: source, completion: { [weak self] discoverCategories in

--- a/podcasts/CollectionSummaryViewController.swift
+++ b/podcasts/CollectionSummaryViewController.swift
@@ -76,7 +76,7 @@ class CollectionSummaryViewController: UIViewController, DiscoverSummaryProtocol
     // MARK: DiscoverSummaryProtocol
 
     var podcastCollection: PodcastCollection?
-    func populateFrom(item: DiscoverItem, region: String?) {
+    func populateFrom(item: DiscoverItem, region: String?, category: DiscoverCategory?) {
         guard let source = item.source else { return }
 
         self.item = item

--- a/podcasts/CountrySummaryViewController.swift
+++ b/podcasts/CountrySummaryViewController.swift
@@ -42,7 +42,7 @@ class CountrySummaryViewController: UIViewController, DiscoverSummaryProtocol {
         self.delegate = delegate
     }
 
-    func populateFrom(item: DiscoverItem, region: String?) {}
+    func populateFrom(item: DiscoverItem, region: String?, category: DiscoverCategory?) {}
 
     @objc private func changeCountryTapped() {
         let countryChooser = CountryChooserViewController()

--- a/podcasts/DiscoverSummaryProtocol.swift
+++ b/podcasts/DiscoverSummaryProtocol.swift
@@ -3,7 +3,7 @@ import PocketCastsServer
 
 protocol DiscoverSummaryProtocol: AnyObject {
     func registerDiscoverDelegate(_ delegate: DiscoverDelegate)
-    func populateFrom(item: DiscoverItem, region: String?)
+    func populateFrom(item: DiscoverItem, region: String?, category: DiscoverCategory?)
 }
 
 protocol DiscoverDelegate: AnyObject {

--- a/podcasts/DiscoverViewController+CategoryRedesign.swift
+++ b/podcasts/DiscoverViewController+CategoryRedesign.swift
@@ -11,6 +11,7 @@ extension DiscoverViewController {
     ///   - category: The `DiscoverCategory` to add to the layout. This is sort of an artifical `DiscoverLayout`.
     func reload(except items: [DiscoverItem], category: DiscoverCategory?) {
         let newLayout: DiscoverLayout?
+        self.selectedCategory = category
 
         if let category {
             newLayout = modified(layout: discoverLayout, for: category, with: items)

--- a/podcasts/DiscoverViewController.swift
+++ b/podcasts/DiscoverViewController.swift
@@ -31,6 +31,7 @@ class DiscoverViewController: PCViewController {
     var discoverLayout: DiscoverLayout?
 
     var currentRegion: String?
+    var selectedCategory: DiscoverCategory?
 
     private let coordinator: DiscoverCoordinator
 
@@ -292,7 +293,7 @@ class DiscoverViewController: PCViewController {
         addToScrollView(viewController: viewController, for: discoverItem, isLast: false)
 
         controller.registerDiscoverDelegate(self)
-        controller.populateFrom(item: discoverItem, region: currentRegion)
+        controller.populateFrom(item: discoverItem, region: currentRegion, category: selectedCategory)
     }
 
     func addToScrollView(viewController: UIViewController, for item: DiscoverItem, isLast: Bool) {

--- a/podcasts/FeaturedSummaryViewController.swift
+++ b/podcasts/FeaturedSummaryViewController.swift
@@ -164,7 +164,7 @@ class FeaturedSummaryViewController: SimpleNotificationsViewController, GridLayo
 
     // MARK: - DiscoverSummaryProtocol
 
-    func populateFrom(item: DiscoverItem, region: String?) {
+    func populateFrom(item: DiscoverItem, region: String?, category: DiscoverCategory?) {
         guard let source = item.source, let title = item.title?.localized else { return }
 
         if let delegate = delegate {

--- a/podcasts/LargeListSummaryViewController.swift
+++ b/podcasts/LargeListSummaryViewController.swift
@@ -145,7 +145,7 @@ class LargeListSummaryViewController: DiscoverPeekViewController, DiscoverSummar
 
     // MARK: - Populate From Data
 
-    func populateFrom(item: DiscoverItem, region: String?) {
+    func populateFrom(item: DiscoverItem, region: String?, category: DiscoverCategory?) {
         guard let source = item.source else { return }
         guard let title = item.title?.localized else { return }
 

--- a/podcasts/NetworkSummaryViewController.swift
+++ b/podcasts/NetworkSummaryViewController.swift
@@ -86,7 +86,7 @@ class NetworkSummaryViewController: DiscoverPeekViewController, DiscoverSummaryP
 
     // MARK: - Populate From Data
 
-    func populateFrom(item: DiscoverItem, region: String?) {
+    func populateFrom(item: DiscoverItem, region: String?, category: DiscoverCategory?) {
         guard let source = item.source else { return }
 
         DiscoverServerHandler.shared.discoverNetworkList(source: source) { [weak self] podcastNetworks in

--- a/podcasts/SingleEpisodeViewController.swift
+++ b/podcasts/SingleEpisodeViewController.swift
@@ -110,7 +110,7 @@ extension SingleEpisodeViewController: DiscoverSummaryProtocol {
         viewModel.delegate = delegate
     }
 
-    func populateFrom(item: DiscoverItem, region: String?) {
+    func populateFrom(item: DiscoverItem, region: String?, category: DiscoverCategory?) {
         viewModel.discoverItem = item
 
         typeBadgeLabel.text = (item.title ?? L10n.discoverFeaturedEpisode).uppercased()

--- a/podcasts/SinglePodcastViewController.swift
+++ b/podcasts/SinglePodcastViewController.swift
@@ -33,6 +33,8 @@ class SinglePodcastViewController: UIViewController, DiscoverSummaryProtocol {
     private var podcast: DiscoverPodcast?
     private var item: DiscoverItem?
     private var featuredDescription: String?
+    private var region: String?
+    private var category: DiscoverCategory?
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -66,10 +68,12 @@ class SinglePodcastViewController: UIViewController, DiscoverSummaryProtocol {
 
     // MARK: DiscoverSummaryProtocol
 
-    func populateFrom(item: DiscoverItem, region: String?) {
+    func populateFrom(item: DiscoverItem, region: String?, category: DiscoverCategory?) {
         guard let source = item.source else { return }
 
         self.item = item
+        self.region = region
+        self.category = category
         DiscoverServerHandler.shared.discoverPodcastList(source: source, completion: { [weak self] podcastList in
             guard let discoverPodcast = podcastList?.podcasts else { return }
 
@@ -130,7 +134,7 @@ class SinglePodcastViewController: UIViewController, DiscoverSummaryProtocol {
         if let listId = item?.uuid, let podcastUuid = podcast.uuid {
             AnalyticsHelper.podcastSubscribedFromList(listId: listId, podcastUuid: podcastUuid)
         }
-        AnalyticsHelper.adSubscribed(promotionUUID: item?.uuid ?? "", podcastUUID: podcast.uuid ?? "", categoryID: item?.categoryID ?? 0)
+        AnalyticsHelper.adSubscribed(categoryName: self.category?.name ?? "unknown", region: region ?? "unknown", podcastUUID: podcast.uuid ?? "unknown", categoryID: item?.categoryID ?? 0)
 
         delegate?.subscribe(podcast: podcast)
     }
@@ -146,7 +150,7 @@ class SinglePodcastViewController: UIViewController, DiscoverSummaryProtocol {
             }
 
             if item.isSponsored == true {
-                AnalyticsHelper.adTapped(promotionUUID: item.uuid ?? "", podcastUUID: podcastUuid, categoryID: item.categoryID ?? 0)
+                AnalyticsHelper.adTapped(categoryName: self.category?.name ?? "unknown", region: region ?? "unknown", podcastUUID: podcastUuid, categoryID: item.categoryID ?? 0)
             }
         }
     }

--- a/podcasts/SmallPagedListSummaryViewController.swift
+++ b/podcasts/SmallPagedListSummaryViewController.swift
@@ -158,7 +158,7 @@ class SmallPagedListSummaryViewController: DiscoverPeekViewController, GridLayou
 
     // MARK: - DiscoverSummaryProtocol
 
-    func populateFrom(item: DiscoverItem, region: String?) {
+    func populateFrom(item: DiscoverItem, region: String?, category: DiscoverCategory?) {
         guard let source = delegate?.replaceRegionCode(string: item.source), let title = item.title?.localized else { return }
 
         self.item = item


### PR DESCRIPTION
The `discover_ad_category_tapped` and `discover_ad_category_subscribed` events were not logging category name or region. They were logging category ID and podcast ID but under different names which matched other iOS and discover events instead of the newer events from web and Android:
https://github.com/Automattic/pocket-casts-android/pull/2196

## To test

* Enable the "logTracks" feature flag and debug the app or use the Network Debugger to view logs

### Tap Sponsored Category Podcast
* Navigate to Discover
* Select "All Categories" and the "News" category
* Select the Sponsored podcast
* Verify the following event is logged:
```
🔵 Tracked: discover_ad_category_tapped ["id": 10, "name": "News", "podcast_id": "a7b99000-6b03-0137-f267-1d245fc5f9cf", "region": "us"]
```

### Subscribe to Sponsored Category Podcast
* Navigate back to the News category page
* Tap the "+" button on the Sponsored podcast
* Verify the following event is logged:

```
🔵 Tracked: discover_ad_category_subscribed ["region": "us", "name": "News", "podcast_id": "a7b99000-6b03-0137-f267-1d245fc5f9cf", "id": 10]
```

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
