### PR TITLE
Add events for support email & feedback to match Android

### DIFF
--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -564,6 +564,8 @@ enum AnalyticsEvent: String {
     // MARK: - Settings: Help and Feedback
 
     case settingsHelpShown
+    case settingsGetSupport
+    case settingsLeaveFeedback
 
     // MARK: - Settings: Import / Export OPML
 

--- a/podcasts/AnalyticsHelper.swift
+++ b/podcasts/AnalyticsHelper.swift
@@ -32,8 +32,10 @@ class AnalyticsHelper {
     class func userGuideEmail(feedback: Bool) {
         if feedback {
             userGuideEmailFeedback()
+            Analytics.track(.settingsLeaveFeedback)
         } else {
             userGuideEmailSupport()
+            Analytics.track(.settingsGetSupport)
         }
     }
 


### PR DESCRIPTION
This adds the following tracks events in Help & Feedback:
* `settings_leave_feedback`
* `settings_get_support`

## To test

* Enable `tracksLogging` feature flag
* Visit Profile > Help & Feedback
* Scroll to the bottom and tap "Get in touch"
* Tap "Leave Feedback"
* Verify the following event is logged:
```
🔵 Tracked: settings_leave_feedback
```
* Tap "Get Support"
* Verify the following event is logged:
```
🔵 Tracked: settings_get_support
```

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
