### PR TITLE
Release: revert branch protection to the old code

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -382,7 +382,7 @@ platform :ios do
     after_confirming_push(push_merge_branch: true) do
       trigger_beta_build(branch_to_build: release_branch_name)
 
-      copy_branch_protection(repository: GHHELPER_REPO, from_branch: DEFAULT_BRANCH, to_branch: release_branch_name)
+      set_branch_protection(repository: GHHELPER_REPO, branch: release_branch_name)
       set_milestone_frozen_marker(repository: GHHELPER_REPO, milestone: release_version_current)
     end
   end


### PR DESCRIPTION
While @bjtitus was releasing a new beta he faced issues because pushes to `release/7.67` were denied:

```
Exit status of command 'git push origin release/7.67:release/7.67' was 1 instead of 0.
remote: error: GH006: Protected branch update failed for refs/heads/release/7.67.
remote: error: Changes must be made through a pull request. 2 of 2 required status checks are expected.
To https://github.com/Automattic/pocket-casts-ios.git
 ! [remote rejected]   release/7.67 -> release/7.67 (protected branch hook declined)
error: failed to push some refs to 'https://github.com/Automattic/pocket-casts-ios.git'
```

## To test

This will be tested in the next code freeze. 🟢 is enough for now.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
