### PR TITLE
Sleep Timer: add logs to debug issues with auto restart

### DIFF
--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -25,6 +25,7 @@ class PlaybackManager: ServerPlaybackDelegate {
             if numberOfEpisodesToSleepAfter > 0 {
                 sleepTimeRemaining = -1
                 sleepTimerManager.recordSleepTimerDuration(duration: nil, onEpisodeEnd: true)
+                FileLog.shared.addMessage("Sleep Timer: starting with \(numberOfEpisodesToSleepAfter) episodes")
             }
             NotificationCenter.postOnMainThread(notification: Constants.Notifications.sleepTimerChanged)
         }
@@ -1491,6 +1492,7 @@ class PlaybackManager: ServerPlaybackDelegate {
     }
 
     func setSleepTimerInterval(_ stopIn: TimeInterval) {
+        FileLog.shared.addMessage("Sleep Timer: starting with \(stopIn)")
         sleepTimerManager.recordSleepTimerDuration(duration: stopIn, onEpisodeEnd: nil)
         sleepTimeRemaining = stopIn
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.sleepTimerChanged)

--- a/podcasts/SleepTimerManager.swift
+++ b/podcasts/SleepTimerManager.swift
@@ -36,6 +36,7 @@ class SleepTimerManager {
 
     func recordSleepTimerFinished() {
         Settings.sleepTimerFinishedDate = .now
+        FileLog.shared.addMessage("Sleep Timer: finished (\(Settings.sleepTimerFinishedDate?.description ?? ""))")
     }
 
     func recordSleepTimerDuration(duration: TimeInterval?, onEpisodeEnd: Bool?) {
@@ -56,13 +57,14 @@ class SleepTimerManager {
             return
         }
 
+        let now = Date.now
         if let sleepTimerFinishedDate = Settings.sleepTimerFinishedDate,
-           Date.now.timeIntervalSince(sleepTimerFinishedDate) <= restartSleepTimerIfPlayingAgainWithin,
+           now.timeIntervalSince(sleepTimerFinishedDate) <= restartSleepTimerIfPlayingAgainWithin,
            let setting = Settings.sleepTimerLastSetting {
             if let duration = setting.duration {
                 PlaybackManager.shared.setSleepTimerInterval(duration)
                 Analytics.shared.track(.playerSleepTimerRestarted, properties: ["time": duration])
-                FileLog.shared.addMessage("Sleep Timer: restarting it automatically")
+                FileLog.shared.addMessage("Sleep Timer: restarting it automatically (\(now.description) - \(sleepTimerFinishedDate.description) <= 5 minutes")
             } else if setting.sleepOnEpisodeEnd == true {
                 observePlaybackEndAndReactivateTime()
             }


### PR DESCRIPTION
Some users apparently are experiencing the Sleep Timer stoping their playback. This seems related to the auto restart feature but I hasn't been able to reproduce it.

This PR adds additional logs to help me discover the issue.

## To test

1. Change `SleepTimerViewController.swift` line `276` to `5.seconds`
2. Play an episode
3. Start sleep timer
4. ✅ Check the logs and you should see info about the sleep timer start
5. ✅ When it fades out it should log info

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
