### PR TITLE
Update CI to support Xcode 15.4

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,7 +6,7 @@ common_params:
   # Common environment values to use with the `env` key.
   - &common_env
     # If you update the image to a newer Xcode version, don't forget to also update the badge in the README.md file accordingly for consistency
-    IMAGE_ID: xcode-15.3
+    IMAGE_ID: xcode-15.4
   # Common agents values to use with the `agents` key.
   - &common_agents
     queue: mac

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -7,7 +7,7 @@ common_params:
     - automattic/a8c-ci-toolkit#2.15.1
   # Common environment values to use with the `env` key.
   - &common_env
-    IMAGE_ID: xcode-15.3
+    IMAGE_ID: xcode-15.4
 
 steps:
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
     <a href="https://buildkite.com/automattic/pocket-casts-ios"><img src="https://badge.buildkite.com/6c995de3d1584006341cc4dfda1312619f375385f5c0319dfe.svg?branch=trunk" /></a>
     <a href="https://github.com/Automattic/pocket-casts-ios/blob/trunk/LICENSE.md"><img src="https://img.shields.io/badge/license-MPL-black" /></a>
     <img src="https://img.shields.io/badge/platform-ios%20%7C%20watchos-lightgrey" />
-    <img src="https://img.shields.io/badge/Xcode-v15.3%2B-informational" />
+    <img src="https://img.shields.io/badge/Xcode-v15.4%2B-informational" />
 </p>
 
 <p align="center">


### PR DESCRIPTION
Fixes #

Updates the buildkite files to use Xcode 15.4 on CI

## To test

• CI should be green
• Build it locally on your machine and run in a simulator
• Just smoke test the app to see if nothing is broken because of the update

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
