### PR TITLE
Apply Figma color to stars matching Android

### DIFF
--- a/podcasts/Ratings/StarRatingView.swift
+++ b/podcasts/Ratings/StarRatingView.swift
@@ -84,6 +84,8 @@ struct StarRatingView: View {
         let stars = Int(rating)
         // Get the float value
         let half = rating.truncatingRemainder(dividingBy: 1)
+        let themeStyle = FeatureFlag.giveRatings.enabled ? ThemeStyle.primaryUi05Selected : ThemeStyle.filter03
+        let color = AppTheme.color(for: themeStyle, theme: theme)
 
         HStack(spacing: 3) {
             ForEach(0..<Constants.maxStars, id: \.self) { index in
@@ -91,9 +93,9 @@ struct StarRatingView: View {
                     .renderingMode(.template)
                     .resizable()
                     .aspectRatio(contentMode: .fit)
-                    .foregroundStyle(theme.filter03)
+                    .foregroundStyle(color)
             }
-        }.foregroundColor(AppTheme.color(for: .filter03, theme: theme))
+        }.foregroundColor(color)
     }
 
     @ViewBuilder


### PR DESCRIPTION
Fixes #1882

Fix the start color for give rating view to match with figma designs

| Before | After |
| -------- | -------- |
|  ![image (1)](https://github.com/Automattic/pocket-casts-ios/assets/912252/29963247-c1b8-4bfb-b35c-11b6bb9b0192) | ![image (2)](https://github.com/Automattic/pocket-casts-ios/assets/912252/a9222112-e5dc-4986-ba4f-cc72d1b12668) |

## To test

- Make sure the PR builds and CI is 🟢 
- Enable the Feature Flag _giveRatings_
- Open a podcast with some ratings like _The Rest is Politics: US_
- The stars color should match the screenshot and the [Android value](https://github.com/Automattic/pocket-casts-android/pull/2432/files)
- Disable the FF and reload the podcast page. You should see the yellow color applied

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
