### PR TITLE
[Give Ratings] Apply restriction to rate and modify the rate star

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EpisodeDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EpisodeDataManager.swift
@@ -90,7 +90,7 @@ class EpisodeDataManager {
                 do {
                     let resultSet = try db.executeQuery(query, values: [podcastId])
                     defer { resultSet.close() }
-                    
+
                     if resultSet.next() {
                         count = Int(resultSet.int(forColumn: "Count"))
                     }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EpisodeDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EpisodeDataManager.swift
@@ -82,6 +82,27 @@ class EpisodeDataManager {
         return episodes
     }
 
+    func findPlayedEpisodesCount(podcastId: Int64, dbQueue: FMDatabaseQueue) async -> Int {
+        return await withCheckedContinuation { continuation in
+            var count = 0
+            let query = "SELECT COUNT(*) as Count from \(DataManager.episodeTableName) WHERE podcast_id = ? AND playedUpTo > (duration / 2)"
+            dbQueue.inDatabase { db in
+                do {
+                    let resultSet = try db.executeQuery(query, values: [podcastId])
+                    defer { resultSet.close() }
+                    
+                    if resultSet.next() {
+                        count = Int(resultSet.int(forColumn: "Count"))
+                    }
+                    continuation.resume(returning: count)
+                } catch {
+                    FileLog.shared.addMessage("EpisodeDataManager.findPlayedEpisodesCount error: \(error)")
+                    continuation.resume(returning: 0)
+                }
+            }
+        }
+    }
+
     func downloadedEpisodeExists(uuid: String, dbQueue: FMDatabaseQueue) -> Bool {
         var found = false
         dbQueue.inDatabase { db in

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -421,6 +421,10 @@ public class DataManager {
         episodeManager.findPlayedEpisodes(uuids: uuids, dbQueue: dbQueue)
     }
 
+    public func findPlayedEpisodesCount(podcastId: Int64) async -> Int {
+        await episodeManager.findPlayedEpisodesCount(podcastId: podcastId, dbQueue: dbQueue)
+    }
+
     public func markAllEpisodePlaybackHistorySynced() {
         episodeManager.markAllEpisodePlaybackHistorySynced(dbQueue: dbQueue)
     }

--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -211,7 +211,7 @@ struct Constants {
         public static let offerEligibilityDefaultValue = true
 
         static let bookmarkMaxTitleLength = 100
-        
+
         static let numberOfEpisodesListenedRequiredToRate = 2
     }
 

--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -211,6 +211,8 @@ struct Constants {
         public static let offerEligibilityDefaultValue = true
 
         static let bookmarkMaxTitleLength = 100
+        
+        static let numberOfEpisodesListenedRequiredToRate = 2
     }
 
     enum Limits {

--- a/podcasts/Ratings/RatePodcastView.swift
+++ b/podcasts/Ratings/RatePodcastView.swift
@@ -76,11 +76,7 @@ struct RatePodcastView: View {
                     let currentStar = viewModel.stars - Double(index)
 
                     Group {
-                        if currentStar > 0 && currentStar < 1 {
-                            Image("star-half")
-                                .resizable()
-                                .renderingMode(.template)
-                        } else if currentStar > 0 {
+                        if currentStar > 0 {
                             Image("star-full")
                                 .resizable()
                                 .renderingMode(.template)

--- a/podcasts/Ratings/RatePodcastView.swift
+++ b/podcasts/Ratings/RatePodcastView.swift
@@ -99,7 +99,7 @@ struct RatePodcastView: View {
                     .onChanged { gesture in
                         var starValue = (gesture.location.x * 5) / reader.size.width
                         starValue = (starValue * 2).rounded() / 2
-                        viewModel.stars = max(1, min(5, starValue))
+                        viewModel.stars = max(1, min(5, starValue.rounded()))
                     }
             )
         }, contentSizeUpdated: { _ in

--- a/podcasts/Ratings/RatePodcastViewModel.swift
+++ b/podcasts/Ratings/RatePodcastViewModel.swift
@@ -61,6 +61,9 @@ class RatePodcastViewModel: ObservableObject {
             guard let self else { return }
             let count = await self.dataManager.findPlayedEpisodesCount(podcastId: id)
             self.userCanRate = count < Constants.Values.numberOfEpisodesListenedRequiredToRate ? .disallowed : .allowed
+            if self.userCanRate == .allowed {
+                // API to fetch the rate list and check if the user needs to update or submit a rate
+            }
         }
     }
 

--- a/podcasts/Ratings/RatePodcastViewModel.swift
+++ b/podcasts/Ratings/RatePodcastViewModel.swift
@@ -60,10 +60,11 @@ class RatePodcastViewModel: ObservableObject {
         Task { @MainActor [weak self] in
             guard let self else { return }
             let count = await self.dataManager.findPlayedEpisodesCount(podcastId: id)
-            self.userCanRate = count < Constants.Values.numberOfEpisodesListenedRequiredToRate ? .disallowed : .allowed
-            if self.userCanRate == .allowed {
+            let userCanRate: UserCanRate = count < Constants.Values.numberOfEpisodesListenedRequiredToRate ? .disallowed : .allowed
+            if userCanRate == .allowed {
                 // API to fetch the rate list and check if the user needs to update or submit a rate
             }
+            self.userCanRate = userCanRate
         }
     }
 

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -2172,6 +2172,8 @@ internal enum L10n {
   internal static var ratingNoRatings: String { return L10n.tr("Localizable", "rating_no_ratings") }
   /// Your rating was submitted!
   internal static var ratingSubmitted: String { return L10n.tr("Localizable", "rating_submitted") }
+  /// Thank you for rating
+  internal static var ratingThankYou: String { return L10n.tr("Localizable", "rating_thank_you") }
   /// Rate %1$@
   internal static func ratingTitle(_ p1: Any) -> String {
     return L10n.tr("Localizable", "rating_title", String(describing: p1))

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -3998,6 +3998,9 @@
 /* Confirmation message that a user rating for a podcast was submitted */
 "rating_submitted" = "Your rating was submitted!";
 
+/* Thank you message that a user rating for a podcast was submitted */
+"rating_thank_you" = "Thank you for rating";
+
 /* Error message when a user rating for a podcast couldn't be submitted */
 "rating_error" = "Ops! There was an error.";
 


### PR DESCRIPTION
Fixes #1886 
Fixes #1891 

This PR adds:
• Apply this rate restriction: 
```
Episode listened: played_up_to is greater than half the duration
Podcast listened: at least two episodes "listened" (based on above criteria)
```
• The user can only rate in whole stars

## To test

Have `giveRatings` feature flag enabled

1. Open a podcast that you did not listen any episode
2. Tap Rate button
3. ✅ Ensure you can't rate
4. Listen any episode from this podcast. Seek to almost the end of the episode
5. Repeat the same step 4 for another episode
6. Try to rate again this podcast
7. ✅ Ensure you can rate

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
