### PR TITLE
Reimagine Sharing: Add Clip sharing item

### DIFF
--- a/podcasts/PlayerColorHelper.swift
+++ b/podcasts/PlayerColorHelper.swift
@@ -77,7 +77,7 @@ struct PlayerColorHelper {
         return theme.isDark ? ColorManager.darkThemeTintForPodcast(parentPodcast) : ColorManager.lightThemeTintForPodcast(parentPodcast)
     }
 
-    private static func backgroundColor(for episode: BaseEpisode?) -> UIColor? {
+    static func backgroundColor(for episode: BaseEpisode?) -> UIColor? {
         guard let parentPodcast = (episode as? Episode)?.parentPodcast() else {
             return nil
         }

--- a/podcasts/Sharing/SharingView.swift
+++ b/podcasts/Sharing/SharingView.swift
@@ -56,7 +56,7 @@ struct SharingView: View {
                     }
                         .frame(height: 72)
                         .tint(color)
-                    Button("Clip", action: {
+                    Button(L10n.clip, action: {
                         print("Clip: s:\(clipTime.start) e:\(clipTime.end)")
                     }).buttonStyle(RoundedButtonStyle(theme: theme, backgroundColor: color))
                 }

--- a/podcasts/Sharing/SharingView.swift
+++ b/podcasts/Sharing/SharingView.swift
@@ -2,7 +2,19 @@ import SwiftUI
 import PocketCastsDataModel
 import PocketCastsUtils
 
+class ClipTime: ObservableObject {
+    @Published var start: TimeInterval
+    @Published var end: TimeInterval
+
+    init(start: TimeInterval, end: TimeInterval) {
+        self.start = start
+        self.end = end
+    }
+}
+
 struct SharingView: View {
+
+    @EnvironmentObject var theme: Theme
 
     private enum Constants {
         static let descriptionMaxWidth: CGFloat = 200
@@ -11,27 +23,73 @@ struct SharingView: View {
     let destinations: [ShareDestination]
     let selectedOption: SharingModal.Option
 
-    @State private var selectedMedia: ShareImageStyle = .large
+    @State private var selectedMedia: ShareImageStyle
+
+    @ObservedObject var clipTime: ClipTime
+
+    init(destinations: [ShareDestination], selectedOption: SharingModal.Option, selectedMedia: ShareImageStyle = .large) {
+        self.destinations = destinations
+        self.selectedOption = selectedOption
+        self.selectedMedia = selectedMedia
+
+        switch selectedOption {
+        case .clip(_, let time):
+            self.clipTime = ClipTime(start: time, end: time + 60)
+        default:
+            self.clipTime = ClipTime(start: 0, end: 0)
+        }
+    }
 
     var body: some View {
         VStack {
             title
             image
-            buttons
+            switch selectedOption {
+            case .episode, .podcast, .currentPosition:
+                buttons
+            case .clip:
+                VStack(spacing: 16) {
+                    ZStack {
+                        Rectangle()
+                            .foregroundColor(.gray)
+                        Text("Timeline")
+                    }
+                        .frame(height: 72)
+                        .tint(color)
+                    Button("Clip", action: {
+                        print("Clip: s:\(clipTime.start) e:\(clipTime.end)")
+                    }).buttonStyle(RoundedButtonStyle(theme: theme, backgroundColor: color))
+                }
+                .padding(.horizontal, 16)
+            }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .foregroundStyle(Color.white)
+    }
+
+    var color: Color {
+        switch selectedOption {
+        case .clip(let episode, _):
+            PlayerColorHelper.backgroundColor(for: episode)?.color ?? PlayerColorHelper.playerBackgroundColor01(for: theme.activeTheme).color
+        default:
+            PlayerColorHelper.playerBackgroundColor01(for: theme.activeTheme).color
+        }
     }
 
     @ViewBuilder var title: some View {
         VStack {
             Text(selectedOption.shareTitle)
                 .font(.headline)
-            Text(L10n.shareDescription)
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
-                .multilineTextAlignment(.center)
-                .frame(maxWidth: Constants.descriptionMaxWidth)
+            switch selectedOption {
+            case .clip:
+                EmptyView() // Don't show the description to give extra space for trim view
+            default:
+                Text(L10n.shareDescription)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: Constants.descriptionMaxWidth)
+            }
         }
     }
 

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -434,6 +434,8 @@ internal enum L10n {
   internal static var clearUpNextMessage: String { return L10n.tr("Localizable", "clear_up_next_message") }
   /// Token authentication failed.
   internal static var clientErrorTokenDeauth: String { return L10n.tr("Localizable", "client_error_token_deauth") }
+  /// Clip
+  internal static var clip: String { return L10n.tr("Localizable", "clip") }
   /// Close
   internal static var close: String { return L10n.tr("Localizable", "close") }
   /// Color
@@ -462,6 +464,8 @@ internal enum L10n {
   internal static var createAccountFreePrice: String { return L10n.tr("Localizable", "create_account_free_price") }
   /// Everything unlocked
   internal static var createAccountPlusDetails: String { return L10n.tr("Localizable", "create_account_plus_details") }
+  /// Create clip
+  internal static var createClip: String { return L10n.tr("Localizable", "create_clip") }
   /// Create Filter
   internal static var createFilter: String { return L10n.tr("Localizable", "create_filter") }
   /// Current Email

--- a/podcasts/Styles.swift
+++ b/podcasts/Styles.swift
@@ -155,15 +155,17 @@ struct BasicButtonStyle: ButtonStyle {
 struct RoundedButtonStyle: ButtonStyle {
     @ObservedObject var theme: Theme
     let textColor: ThemeStyle
+    let backgroundColor: Color?
 
-    init(theme: Theme, textColor: ThemeStyle = .primaryInteractive02) {
+    init(theme: Theme, textColor: ThemeStyle = .primaryInteractive02, backgroundColor: Color? = nil) {
         self.theme = theme
         self.textColor = textColor
+        self.backgroundColor = backgroundColor
     }
 
     func makeBody(configuration: Self.Configuration) -> some View {
         let text = AppTheme.color(for: textColor, theme: theme)
-        let background = AppTheme.color(for: .primaryInteractive01, theme: theme)
+        let background = backgroundColor ?? AppTheme.color(for: .primaryInteractive01, theme: theme)
                             .opacity(configuration.isPressed ? 0.6 : 1)
 
         BasicButtonStyle(textColor: text, backgroundColor: background)

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4159,3 +4159,9 @@
 
 /* A common string used throughout the app. Often refers to the Transcript tab in the player. */
 "transcript" = "Transcript";
+
+/* A title shown for a share option which creates an audio clip of an episode */
+"create_clip" = "Create clip";
+
+/* Shown in a button when creating a shareable audio clip of an episode */
+"clip" = "Clip";


### PR DESCRIPTION
| 📘 Part of: https://github.com/Automattic/pocket-casts-ios/issues/1910 |
|:---:|

This adds a new sharing option to share a clip of an episode.

The "Timeline" view is a placeholder for the implementation in https://github.com/Automattic/pocket-casts-ios/pull/1896

| Option | Placeholder Screen |
| -- | -- |
| ![Simulator Screenshot - iPhone 13 Pro - 2024-07-09 at 16 52 51](https://github.com/Automattic/pocket-casts-ios/assets/3250/b413c22f-baa0-4b0c-8d5f-0b47724d0612) | ![Simulator Screenshot - iPhone 13 Pro - 2024-07-09 at 16 52 54](https://github.com/Automattic/pocket-casts-ios/assets/3250/4c52aa29-2db3-4abe-9d67-5e477ed21279) |

## To test

> [!NOTE]
> Enable the `newSharing` feature flag to test this

### Now Playing
* Open the Now Playing screen
* Tap the Share option in the actions drawer
* Tap Clip
* Ensure screen above is shown with a placeholder "Timeline"
* Navigate to multiple episodes and ensure the Clip button changes to match the predominant episode color.

### Episode Detail
* Open an Episode detail page
* Tap the Share icon in the upper right
* Tap Clip
* Ensure screen above is shown with a placeholder "Timeline"
* Navigate to multiple episodes and ensure the Clip button changes to match the predominant episode color.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
