### PR TITLE
Reimagine Sharing: Add scrollable timeline view

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Extensions/ComparableExtension.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Extensions/ComparableExtension.swift
@@ -9,3 +9,13 @@ public extension Comparable {
         self > limits.lowerBound && self < limits.upperBound ? self : self.clamped(to: limits)
     }
 }
+
+public extension Comparable {
+    func clamped(to limits: ClosedRange<Self>) -> Self {
+        min(max(self, limits.lowerBound), limits.upperBound)
+    }
+
+    func betweenOrClamped(to limits: ClosedRange<Self>) -> Self {
+        self > limits.lowerBound && self < limits.upperBound ? self : self.clamped(to: limits)
+    }
+}

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1608,6 +1608,10 @@
 		E3F37447291F0DD1005916ED /* Chapters.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3F37445291F0DD1005916ED /* Chapters.swift */; };
 		F5197A402B995A1E007C8D0A /* DownloadManager+Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5197A3F2B995A1E007C8D0A /* DownloadManager+Logging.swift */; };
 		F5197A412B995A1E007C8D0A /* DownloadManager+Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5197A3F2B995A1E007C8D0A /* DownloadManager+Logging.swift */; };
+		F5235EE02C3CCB1D00C98739 /* RoundedCorner.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5235EDF2C3CCB1D00C98739 /* RoundedCorner.swift */; };
+		F5235EE22C3CE5B300C98739 /* MediaTrimBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5235EE12C3CE5B300C98739 /* MediaTrimBar.swift */; };
+		F5235EE82C3DE13100C98739 /* ScrollableScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5235EE72C3DE13100C98739 /* ScrollableScrollView.swift */; };
+		F5235EEE2C3DF95C00C98739 /* PlayButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5235EED2C3DF95C00C98739 /* PlayButton.swift */; };
 		F52ADE442BD8B0F300AC647F /* SharingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F52ADE432BD8B0F300AC647F /* SharingView.swift */; };
 		F52ADE472BD9698B00AC647F /* ModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F52ADE462BD9698B00AC647F /* ModalView.swift */; };
 		F52B4F8C2BB4A9CA00E87BE4 /* CategoriesSelectorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F52B4F8B2BB4A9CA00E87BE4 /* CategoriesSelectorViewController.swift */; };
@@ -1623,9 +1627,11 @@
 		F56ADE562B7FE37500ADFE31 /* SettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5AD75442B7FDC2800D65C55 /* SettingsTests.swift */; };
 		F57BAC672C00CD9C007B24BD /* URLSession+Episode.swift in Sources */ = {isa = PBXBuildFile; fileRef = F57BAC662C00CD9C007B24BD /* URLSession+Episode.swift */; };
 		F57BAC682C00E7E6007B24BD /* URLSession+Episode.swift in Sources */ = {isa = PBXBuildFile; fileRef = F57BAC662C00CD9C007B24BD /* URLSession+Episode.swift */; };
+		F57CD7D92C2624AD0035269A /* MediaTrimView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F57CD7D82C2624AD0035269A /* MediaTrimView.swift */; };
 		F586959A2C04320100E0754A /* PodcastManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F58695992C04320100E0754A /* PodcastManagerTests.swift */; };
 		F5952FCA2C057C6400754BC3 /* FMDatabaseQueue+Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5952FC92C057C6400754BC3 /* FMDatabaseQueue+Test.swift */; };
 		F5952FCC2C05814100754BC3 /* DownloadManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5952FCB2C05814100754BC3 /* DownloadManagerTests.swift */; };
+		F5AD9C4D2C3C705200A01896 /* AudioWaveformView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5AD9C4C2C3C705200A01896 /* AudioWaveformView.swift */; };
 		F5B312B42BF5B6D400290696 /* FirebaseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5B312B32BF5B6D400290696 /* FirebaseManager.swift */; };
 		F5B6F0DF2C18DF0900AF5150 /* AudioUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5B6F0DD2C18DF0900AF5150 /* AudioUtilsTests.swift */; };
 		F5D3A0D92B70950100EED067 /* MockURLHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5D3A0D82B70950100EED067 /* MockURLHandler.swift */; };
@@ -1633,6 +1639,7 @@
 		F5E3DAA72BDD5567002BD4E4 /* PCBundleDoc.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5E3DAA62BDD5567002BD4E4 /* PCBundleDoc.swift */; };
 		F5E431D62B50888500A71DB3 /* PlusLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5E431D52B50888500A71DB3 /* PlusLabel.swift */; };
 		F5E949DA2B61762E002DAFC3 /* TokenHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5E949D92B61762E002DAFC3 /* TokenHelperTests.swift */; };
+		F5F479A62C3EF8AB002B4475 /* PlayheadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5F479A52C3EF8AB002B4475 /* PlayheadView.swift */; };
 		F5F69D802C07C867000B3C87 /* FMDatabaseQueue+Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5F69D7F2C07C867000B3C87 /* FMDatabaseQueue+Test.swift */; };
 		F5F6DA702BBE1109009B1934 /* CategoryButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5F6DA6F2BBE1109009B1934 /* CategoryButtonStyle.swift */; };
 		F5F6DA822BC0B512009B1934 /* CategoriesModalPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5F6DA812BC0B512009B1934 /* CategoriesModalPicker.swift */; };
@@ -3435,6 +3442,10 @@
 		EF3DD428DC2C444C2D8CEC5A /* Pods-PocketCastsTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PocketCastsTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-PocketCastsTests/Pods-PocketCastsTests.debug.xcconfig"; sourceTree = "<group>"; };
 		EFBF99F57846D0E1AF8DE08D /* Pods-PocketCasts-PocketCastsTests.staging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PocketCasts-PocketCastsTests.staging.xcconfig"; path = "Pods/Target Support Files/Pods-PocketCasts-PocketCastsTests/Pods-PocketCasts-PocketCastsTests.staging.xcconfig"; sourceTree = "<group>"; };
 		F5197A3F2B995A1E007C8D0A /* DownloadManager+Logging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DownloadManager+Logging.swift"; sourceTree = "<group>"; };
+		F5235EDF2C3CCB1D00C98739 /* RoundedCorner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundedCorner.swift; sourceTree = "<group>"; };
+		F5235EE12C3CE5B300C98739 /* MediaTrimBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaTrimBar.swift; sourceTree = "<group>"; };
+		F5235EE72C3DE13100C98739 /* ScrollableScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollableScrollView.swift; sourceTree = "<group>"; };
+		F5235EED2C3DF95C00C98739 /* PlayButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlayButton.swift; sourceTree = "<group>"; };
 		F52ADE432BD8B0F300AC647F /* SharingView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SharingView.swift; sourceTree = "<group>"; };
 		F52ADE462BD9698B00AC647F /* ModalView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ModalView.swift; sourceTree = "<group>"; };
 		F52B4F8B2BB4A9CA00E87BE4 /* CategoriesSelectorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoriesSelectorViewController.swift; sourceTree = "<group>"; };
@@ -3446,10 +3457,12 @@
 		F56295282C0FC14900C44E8A /* DBTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DBTestCase.swift; sourceTree = "<group>"; };
 		F565602E2B7ACD9B003E76D5 /* DataManager+Import.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DataManager+Import.swift"; sourceTree = "<group>"; };
 		F57BAC662C00CD9C007B24BD /* URLSession+Episode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLSession+Episode.swift"; sourceTree = "<group>"; };
+		F57CD7D82C2624AD0035269A /* MediaTrimView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaTrimView.swift; sourceTree = "<group>"; };
 		F58695992C04320100E0754A /* PodcastManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PodcastManagerTests.swift; sourceTree = "<group>"; };
 		F5952FC92C057C6400754BC3 /* FMDatabaseQueue+Test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FMDatabaseQueue+Test.swift"; sourceTree = "<group>"; };
 		F5952FCB2C05814100754BC3 /* DownloadManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadManagerTests.swift; sourceTree = "<group>"; };
 		F5AD75442B7FDC2800D65C55 /* SettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsTests.swift; sourceTree = "<group>"; };
+		F5AD9C4C2C3C705200A01896 /* AudioWaveformView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioWaveformView.swift; sourceTree = "<group>"; };
 		F5B312B32BF5B6D400290696 /* FirebaseManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseManager.swift; sourceTree = "<group>"; };
 		F5B6F0DD2C18DF0900AF5150 /* AudioUtilsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AudioUtilsTests.swift; sourceTree = "<group>"; };
 		F5D3A0D82B70950100EED067 /* MockURLHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockURLHandler.swift; sourceTree = "<group>"; };
@@ -3457,6 +3470,7 @@
 		F5E3DAA62BDD5567002BD4E4 /* PCBundleDoc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PCBundleDoc.swift; sourceTree = "<group>"; };
 		F5E431D52B50888500A71DB3 /* PlusLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlusLabel.swift; sourceTree = "<group>"; };
 		F5E949D92B61762E002DAFC3 /* TokenHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenHelperTests.swift; sourceTree = "<group>"; };
+		F5F479A52C3EF8AB002B4475 /* PlayheadView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayheadView.swift; sourceTree = "<group>"; };
 		F5F69D7F2C07C867000B3C87 /* FMDatabaseQueue+Test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FMDatabaseQueue+Test.swift"; sourceTree = "<group>"; };
 		F5F6DA6F2BBE1109009B1934 /* CategoryButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryButtonStyle.swift; sourceTree = "<group>"; };
 		F5F6DA812BC0B512009B1934 /* CategoriesModalPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoriesModalPicker.swift; sourceTree = "<group>"; };
@@ -7321,6 +7335,7 @@
 				C7E99F072A5E103A00E7CBAF /* List View */,
 				C7DC401C2A67025D00883D03 /* Toast */,
 				F5FF612A2BD6EB3B00190711 /* ModalView.swift */,
+				F5235EDF2C3CCB1D00C98739 /* RoundedCorner.swift */,
 			);
 			path = "Common SwiftUI";
 			sourceTree = "<group>";
@@ -7420,6 +7435,18 @@
 			path = Chapters;
 			sourceTree = "<group>";
 		};
+		F5235EDA2C3CCAA100C98739 /* Clip */ = {
+			isa = PBXGroup;
+			children = (
+				F5235EED2C3DF95C00C98739 /* PlayButton.swift */,
+				F57CD7D82C2624AD0035269A /* MediaTrimView.swift */,
+				F5235EE12C3CE5B300C98739 /* MediaTrimBar.swift */,
+				F5235EE72C3DE13100C98739 /* ScrollableScrollView.swift */,
+				F5F479A52C3EF8AB002B4475 /* PlayheadView.swift */,
+			);
+			path = Clip;
+			sourceTree = "<group>";
+		};
 		F5B6F0DE2C18DF0900AF5150 /* Effects */ = {
 			isa = PBXGroup;
 			children = (
@@ -7442,11 +7469,13 @@
 		F5FF611A2BD06EB600190711 /* Sharing */ = {
 			isa = PBXGroup;
 			children = (
+				F5235EDA2C3CCAA100C98739 /* Clip */,
 				F52ADE432BD8B0F300AC647F /* SharingView.swift */,
 				F5FF61282BD6D88C00190711 /* SharingModal.swift */,
 				F5FF61222BD07E3A00190711 /* ShareImageView.swift */,
 				F5FF61242BD0831200190711 /* PocketCastsLogoPill.swift */,
 				F533F19C2C24B8CB00EDE9AA /* ShareDestination.swift */,
+				F5AD9C4C2C3C705200A01896 /* AudioWaveformView.swift */,
 			);
 			path = Sharing;
 			sourceTree = "<group>";
@@ -8864,6 +8893,7 @@
 				8BBE19EE2BEA973E009E944B /* ShowInfoCoordinating.swift in Sources */,
 				E3F37446291F0DD1005916ED /* Chapters.swift in Sources */,
 				BD7EA4DC1E52D4320014EAC5 /* PlayPauseButton.swift in Sources */,
+				F57CD7D92C2624AD0035269A /* MediaTrimView.swift in Sources */,
 				C7BDECB62A15327000BECF02 /* UnlockHaptic.swift in Sources */,
 				BD85E3A61E667475001B17C1 /* SkipButton.swift in Sources */,
 				46FBD8B5276A874F00867746 /* Intents.intentdefinition in Sources */,
@@ -8954,6 +8984,7 @@
 				40FFAD93214A170200024FCF /* FilterSettingsOverlayController.swift in Sources */,
 				BD998ACC27B2436000B38857 /* NameFolderView.swift in Sources */,
 				8BD7A2432C09130C00CF84E8 /* FolderHistoryView.swift in Sources */,
+				F5AD9C4D2C3C705200A01896 /* AudioWaveformView.swift in Sources */,
 				C7FAFF5D2941844C00329B40 /* CancelConfirmationViewModel.swift in Sources */,
 				BD14CCDF1D7D3CB800DB4547 /* SelectedPodcastCell.swift in Sources */,
 				BD93FDA120157B2000F6EF55 /* PodcastImageView.swift in Sources */,
@@ -9063,6 +9094,7 @@
 				40FFCDB022FA817300395CA5 /* ThemeAbstractCell.swift in Sources */,
 				BDE60ACE2108597D00A7281B /* DiscoverViewController+DiscoverDelegate.swift in Sources */,
 				BDB3BDC11FE23F9000FD8D24 /* PodcastChooserCell.swift in Sources */,
+				F5F479A62C3EF8AB002B4475 /* PlayheadView.swift in Sources */,
 				BDFF77301C9929660086282A /* NavigationProtocol.swift in Sources */,
 				BD96575E2469053600873BB5 /* GoogleCastCell.swift in Sources */,
 				C71C04C929243F7D00F2858A /* ImportViewModel.swift in Sources */,
@@ -9072,6 +9104,7 @@
 				C7BF5E47290832FD00733C1E /* DiscoverCoordinator.swift in Sources */,
 				F5E431D62B50888500A71DB3 /* PlusLabel.swift in Sources */,
 				BDD40A181FA1ABF500A53AE1 /* PCNavigationController.swift in Sources */,
+				F5235EEE2C3DF95C00C98739 /* PlayButton.swift in Sources */,
 				40B1613822F3B66900759E41 /* ThemeableTextField.swift in Sources */,
 				407CD7292266DF510033C18E /* CancelInfoViewController.swift in Sources */,
 				C7F2257F29145988001E4547 /* ShareableMetadataProvider.swift in Sources */,
@@ -9093,6 +9126,7 @@
 				8BD7A2362C04EDFD00CF84E8 /* UpNextHistoryView.swift in Sources */,
 				BD36F3CE21882B87005E0BB2 /* ThemeSecondaryIcon.swift in Sources */,
 				BDC692831BA7B0B70023B9F2 /* TinyPageControl.swift in Sources */,
+				F5235EE22C3CE5B300C98739 /* MediaTrimBar.swift in Sources */,
 				4053CE022150AC4B001C92B1 /* CheckboxCell.swift in Sources */,
 				BD96575B2469047600873BB5 /* CastToViewController+Table.swift in Sources */,
 				409C792C22237DD900386495 /* UserEpisodeDetailViewController+Table.swift in Sources */,
@@ -9523,6 +9557,7 @@
 				C7B3C60C2919DCC800054145 /* ActionView.swift in Sources */,
 				BD240C3F231E8BE000FB2CDD /* PCSearchBarController.swift in Sources */,
 				C7DC40242A67054000883D03 /* ToastTheme.swift in Sources */,
+				F5235EE82C3DE13100C98739 /* ScrollableScrollView.swift in Sources */,
 				BD9FF61C1B8EDDBB009F075E /* NetworkCell.swift in Sources */,
 				C7C4CAF328ABFD0900CFC8CF /* Notifications.swift in Sources */,
 				461C46C7274D80990003D3A9 /* LocalizationHelpers.swift in Sources */,
@@ -9568,6 +9603,7 @@
 				BD874EF71C9A428B00F5B2A5 /* GeneralSettingsViewController.swift in Sources */,
 				C7A110F7291F65FB00887A90 /* WelcomeView.swift in Sources */,
 				BD98C54B1BA802AA00E85D3B /* DiscoverDisclosureCell.swift in Sources */,
+				F5235EE02C3CCB1D00C98739 /* RoundedCorner.swift in Sources */,
 				4065143E2485EB8E00B7E789 /* LastSupporterPodcastCell.swift in Sources */,
 				BDD3579327BCD50D0000D155 /* FolderViewController+CollectionView.swift in Sources */,
 				BDE5B8D81E6401F80039B409 /* EpisodeFileSizeUpdater.swift in Sources */,

--- a/podcasts/Common SwiftUI/ModalView.swift
+++ b/podcasts/Common SwiftUI/ModalView.swift
@@ -14,6 +14,6 @@ struct ModalView<Content: View>: View {
             ModalCloseButton(background: Color.gray.opacity(0.2), foreground: Color.white.opacity(0.5), action: dismissAction)
             content()
         }
-        .padding(.top, 20)
+        .padding(UIDevice.current.userInterfaceIdiom == .pad ? .vertical : .top, 20)
     }
 }

--- a/podcasts/Common SwiftUI/RoundedCorner.swift
+++ b/podcasts/Common SwiftUI/RoundedCorner.swift
@@ -1,0 +1,70 @@
+import SwiftUI
+
+/// Used as a fallback for iOS 15 when `UnevenRoundedRectangle` is necessary
+struct PCUnevenRoundedRectangle: Shape {
+    let topLeadingRadius: CGFloat
+    let bottomLeadingRadius: CGFloat
+    let bottomTrailingRadius: CGFloat
+    let topTrailingRadius: CGFloat
+
+    init(topLeadingRadius: CGFloat,
+         bottomLeadingRadius: CGFloat,
+         bottomTrailingRadius: CGFloat,
+         topTrailingRadius: CGFloat) {
+        self.topLeadingRadius = topLeadingRadius
+        self.bottomLeadingRadius = bottomLeadingRadius
+        self.bottomTrailingRadius = bottomTrailingRadius
+        self.topTrailingRadius = topTrailingRadius
+    }
+
+    func path(in rect: CGRect) -> Path {
+        let path = CGMutablePath()
+
+        // Start at top-left corner
+        path.move(to: CGPoint(x: rect.minX + topLeadingRadius, y: rect.minY))
+
+        // Top edge and top-right corner
+        path.addLine(to: CGPoint(x: rect.maxX - topTrailingRadius, y: rect.minY))
+        if topTrailingRadius > 0 {
+            path.addArc(center: CGPoint(x: rect.maxX - topTrailingRadius, y: rect.minY + topTrailingRadius),
+                        radius: topTrailingRadius,
+                        startAngle: .pi * 3 / 2,
+                        endAngle: 0,
+                        clockwise: false)
+        }
+
+        // Right edge and bottom-right corner
+        path.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY - bottomTrailingRadius))
+        if bottomTrailingRadius > 0 {
+            path.addArc(center: CGPoint(x: rect.maxX - bottomTrailingRadius, y: rect.maxY - bottomTrailingRadius),
+                        radius: bottomTrailingRadius,
+                        startAngle: 0,
+                        endAngle: .pi / 2,
+                        clockwise: false)
+        }
+
+        // Bottom edge and bottom-left corner
+        path.addLine(to: CGPoint(x: rect.minX + bottomLeadingRadius, y: rect.maxY))
+        if bottomLeadingRadius > 0 {
+            path.addArc(center: CGPoint(x: rect.minX + bottomLeadingRadius, y: rect.maxY - bottomLeadingRadius),
+                        radius: bottomLeadingRadius,
+                        startAngle: .pi / 2,
+                        endAngle: .pi,
+                        clockwise: false)
+        }
+
+        // Left edge and top-left corner
+        path.addLine(to: CGPoint(x: rect.minX, y: rect.minY + topLeadingRadius))
+        if topLeadingRadius > 0 {
+            path.addArc(center: CGPoint(x: rect.minX + topLeadingRadius, y: rect.minY + topLeadingRadius),
+                        radius: topLeadingRadius,
+                        startAngle: .pi,
+                        endAngle: .pi * 3 / 2,
+                        clockwise: false)
+        }
+
+        path.closeSubpath()
+
+        return Path(path)
+    }
+}

--- a/podcasts/Sharing/AudioWaveformView.swift
+++ b/podcasts/Sharing/AudioWaveformView.swift
@@ -1,10 +1,11 @@
 import SwiftUI
 
 struct AudioWaveformView: View {
-    let baseLineWidth: CGFloat = 2
-    let baseLineSpacing: CGFloat = 2
-    var scale: CGFloat
-    var width: CGFloat
+    let scale: CGFloat
+    let width: CGFloat
+
+    private let baseLineWidth: CGFloat = 2
+    private let baseLineSpacing: CGFloat = 2
 
     enum LineHeight: CaseIterable {
         case shortest

--- a/podcasts/Sharing/AudioWaveformView.swift
+++ b/podcasts/Sharing/AudioWaveformView.swift
@@ -6,11 +6,12 @@ struct AudioWaveformView: View {
     var scale: CGFloat
     var width: CGFloat
 
-    enum LineHeight: Int, CaseIterable {
-        case shortest = 0
-        case medium = 1
-        case tallest = 2
+    enum LineHeight: CaseIterable {
+        case shortest
+        case medium
+        case tallest
 
+        /// The height of the line as a fraction of the full height of the view
         var fraction: CGFloat {
             switch self {
             case .shortest: return 0.1
@@ -19,6 +20,7 @@ struct AudioWaveformView: View {
             }
         }
 
+        /// Determines how when each line type begins fading
         var fadeStartScale: CGFloat {
             switch self {
             case .shortest: return 1.8
@@ -27,8 +29,9 @@ struct AudioWaveformView: View {
             }
         }
 
+        /// Determines how quickly each line type fades out
         var fadeDuration: CGFloat {
-            return 0.5  // This determines how quickly each line type fades out
+            return 0.5
         }
     }
 

--- a/podcasts/Sharing/AudioWaveformView.swift
+++ b/podcasts/Sharing/AudioWaveformView.swift
@@ -1,0 +1,109 @@
+import SwiftUI
+
+struct AudioWaveformView: View {
+    let baseLineWidth: CGFloat = 2
+    let baseLineSpacing: CGFloat = 2
+    var scale: CGFloat
+    var width: CGFloat
+
+    enum LineHeight: Int, CaseIterable {
+        case shortest = 0
+        case medium = 1
+        case tallest = 2
+
+        var fraction: CGFloat {
+            switch self {
+            case .shortest: return 0.1
+            case .medium: return 0.25
+            case .tallest: return 0.5
+            }
+        }
+
+        var fadeStartScale: CGFloat {
+            switch self {
+            case .shortest: return 1.8
+            case .medium: return 0.5
+            case .tallest: return 0.5
+            }
+        }
+
+        var fadeDuration: CGFloat {
+            return 0.5  // This determines how quickly each line type fades out
+        }
+    }
+
+    var body: some View {
+        GeometryReader { geometry in
+            Canvas { context, size in
+                let lineCount = Int(width / (lineWidth + lineSpacing))
+                let midY = size.height / 2
+
+                for index in 0..<lineCount {
+                    let x = CGFloat(index) * (lineWidth + lineSpacing)
+                    let lineHeight = getLineHeight(for: index)
+                    let barHeight = size.height * lineHeight.fraction
+                    let opacity = opacityForLine(at: index)
+
+                    var path = Path()
+                    path.move(to: CGPoint(x: x, y: midY - barHeight / 2))
+                    path.addLine(to: CGPoint(x: x, y: midY + barHeight / 2))
+
+                    context.opacity = opacity
+                    context.stroke(path, with: .color(.gray), lineWidth: lineWidth)
+                }
+            }
+            .frame(width: width)
+        }
+    }
+
+    private var lineWidth: CGFloat {
+        baseLineWidth
+    }
+
+    private var lineSpacing: CGFloat {
+        baseLineSpacing * scale
+    }
+
+    private var lineCount: Int {
+        Int(width / (lineWidth + lineSpacing))
+    }
+
+    private func opacityForLine(at index: Int) -> Double {
+        let lineHeight = getLineHeight(for: index)
+
+        let fadeStartScale = lineHeight.fadeStartScale
+        let fadeEndScale = fadeStartScale + lineHeight.fadeDuration
+
+        if scale >= fadeEndScale {
+            return 1.0
+        } else if scale <= fadeStartScale {
+            return 0.0
+        } else {
+            return Double((scale - fadeStartScale) / lineHeight.fadeDuration)
+        }
+    }
+
+    private func getLineHeight(for index: Int) -> LineHeight {
+        switch index % 16 {
+        case 0:
+            return .tallest
+        case 4, 8, 12:
+            return .medium
+        default:
+            return .shortest
+        }
+    }
+
+    private func lineBar(for index: Int, viewHeight: CGFloat) -> some View {
+        let lineHeight = getLineHeight(for: index)
+        let barHeight = viewHeight * lineHeight.fraction
+
+        return VStack {
+            Spacer()
+            Rectangle()
+                .fill(Color.gray)
+                .frame(width: lineWidth, height: barHeight)
+            Spacer()
+        }
+    }
+}

--- a/podcasts/Sharing/Clip/MediaTrimBar.swift
+++ b/podcasts/Sharing/Clip/MediaTrimBar.swift
@@ -11,7 +11,7 @@ struct MediaTrimBar: View {
 
     var body: some View {
         HStack(spacing: 0) {
-            PlayButton(isPlaying: false)
+            TrimPlayButton(isPlaying: false)
                 .frame(width: Constants.height)
                 .background(Constants.trimBorderColor)
                 .modify { view in

--- a/podcasts/Sharing/Clip/MediaTrimBar.swift
+++ b/podcasts/Sharing/Clip/MediaTrimBar.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+struct MediaTrimBar: View {
+    @ObservedObject var clipTime: ClipTime
+
+    private enum Colors {
+        static var trimBorderColor = Color(hex: "6B6B6B")
+    }
+
+    var body: some View {
+        HStack(spacing: 0) {
+            PlayButton(isPlaying: false)
+                .frame(width: 70)
+                .background(Colors.trimBorderColor.opacity(0.28))
+                .modify { view in
+                    if #available(iOS 16, *) {
+                        view.clipShape(.rect(topLeadingRadius: 12,
+                                             bottomLeadingRadius: 12,
+                                             bottomTrailingRadius: 0,
+                                             topTrailingRadius: 0))
+                    } else {
+                        view.clipShape(PCUnevenRoundedRectangle(topLeadingRadius: 12,
+                                                                bottomLeadingRadius: 12,
+                                                                bottomTrailingRadius: 0,
+                                                                topTrailingRadius: 0))
+                    }
+                }
+            MediaTrimView(duration: PlaybackManager.shared.duration(), startTime: $clipTime.start, endTime: $clipTime.end, playTime: $clipTime.playback)
+        }
+    }
+}

--- a/podcasts/Sharing/Clip/MediaTrimBar.swift
+++ b/podcasts/Sharing/Clip/MediaTrimBar.swift
@@ -3,24 +3,26 @@ import SwiftUI
 struct MediaTrimBar: View {
     @ObservedObject var clipTime: ClipTime
 
-    private enum Colors {
-        static var trimBorderColor = Color(hex: "6B6B6B")
+    private enum Constants {
+        static var trimBorderColor = Color(hex: "6B6B6B").opacity(0.28)
+        static var borderRadius: CGFloat = 12
+        static var height: CGFloat = 70
     }
 
     var body: some View {
         HStack(spacing: 0) {
             PlayButton(isPlaying: false)
-                .frame(width: 70)
-                .background(Colors.trimBorderColor.opacity(0.28))
+                .frame(width: Constants.height)
+                .background(Constants.trimBorderColor)
                 .modify { view in
                     if #available(iOS 16, *) {
-                        view.clipShape(.rect(topLeadingRadius: 12,
-                                             bottomLeadingRadius: 12,
+                        view.clipShape(.rect(topLeadingRadius: Constants.borderRadius,
+                                             bottomLeadingRadius: Constants.borderRadius,
                                              bottomTrailingRadius: 0,
                                              topTrailingRadius: 0))
                     } else {
-                        view.clipShape(PCUnevenRoundedRectangle(topLeadingRadius: 12,
-                                                                bottomLeadingRadius: 12,
+                        view.clipShape(PCUnevenRoundedRectangle(topLeadingRadius: Constants.borderRadius,
+                                                                bottomLeadingRadius: Constants.borderRadius,
                                                                 bottomTrailingRadius: 0,
                                                                 topTrailingRadius: 0))
                     }

--- a/podcasts/Sharing/Clip/MediaTrimView.swift
+++ b/podcasts/Sharing/Clip/MediaTrimView.swift
@@ -1,0 +1,109 @@
+import SwiftUI
+import AVFoundation
+
+struct MediaTrimView: View {
+    let duration: TimeInterval
+
+    @Binding var startTime: TimeInterval
+    @Binding var endTime: TimeInterval
+    @Binding var playTime: TimeInterval
+
+    @State private var scale: CGFloat = .zero
+    @State private var playPosition: CGFloat = 0
+
+    private enum Constants {
+        static let trimLineWidth: CGFloat = 4
+        static let playLineWidth: CGFloat = 3
+    }
+
+    private enum Colors {
+        static var trimBorderColor = Color(hex: "6B6B6B")
+    }
+
+    var body: some View {
+        GeometryReader { geometry in
+            ScrollableScrollView(scale: $scale, duration: duration, geometry: geometry) { scrollable in
+                AudioWaveformView(scale: scale, width: geometry.size.width * scale)
+                borderView(in: geometry)
+                PlayheadView(position: scaledPosition($playPosition), onChanged: {
+                    print("Moved playhead to: \($0)")
+                })
+                    .frame(maxHeight: .infinity)
+                    .frame(width: Constants.playLineWidth)
+                    .onAppear {
+                        initializePositions(in: geometry)
+                        DispatchQueue.main.async {
+                            let currentSecond = Int(playTime)
+                            scrollable.scrollTo("\(currentSecond)", anchor: .center)
+                        }
+                    }
+                    .onChange(of: playTime) { _ in
+                        //TODO: Change this to listen to the play/pause event?
+                        let currentSecond = Int(playTime)
+                        scrollable.scrollTo("\(currentSecond)", anchor: .center)
+                        playPosition = durationRelative(value: playTime, for: geometry.size.width)
+                    }
+                .onAppear {
+                    initializePositions(in: geometry)
+                    DispatchQueue.main.async {
+                        let currentSecond = Int(startTime)
+                        scrollable.scrollTo("\(currentSecond)", anchor: .center)
+                    }
+                }
+            }
+        }
+    }
+
+    private func borderView(in geometry: GeometryProxy) -> some View {
+        RoundedRectangle(cornerRadius: 20)
+            .fill(Color.clear)
+            .border(Colors.trimBorderColor.opacity(0.28), width: Constants.trimLineWidth)
+    }
+
+    private func scaledPosition(_ position: Binding<CGFloat>) -> Binding<CGFloat> {
+        Binding<CGFloat>(
+            get: { position.wrappedValue * scale },
+            set: { newValue in
+                position.wrappedValue = newValue / scale
+            }
+        )
+    }
+
+    private func initializePositions(in geometry: GeometryProxy) {
+        let viewWidth = geometry.size.width
+        updatePositions(for: viewWidth)
+
+        let zoomScale = initialScale / 2
+        scale = zoomScale
+    }
+
+    private func updatePositions(for width: CGFloat) {
+        playPosition = durationRelative(value: playTime, for: width)
+    }
+
+    private var initialScale: CGFloat {
+        let visibleDuration = endTime - startTime
+        let fullDuration = duration
+        let durationRatio = fullDuration / visibleDuration
+
+        // The scale should make the visible duration fit the view width
+        let scale = durationRatio / 2
+
+        return max(scale, 1.0)
+    }
+
+    private func durationRelative(value: CGFloat, for width: CGFloat) -> CGFloat {
+        return (value / duration) * width
+    }
+}
+
+struct MediaTrimView_Previews: PreviewProvider {
+    static var previews: some View {
+        MediaTrimView(
+            duration: 60,
+            startTime: .constant(.zero),
+            endTime: .constant(30),
+            playTime: .constant(15)
+        )
+    }
+}

--- a/podcasts/Sharing/Clip/MediaTrimView.swift
+++ b/podcasts/Sharing/Clip/MediaTrimView.swift
@@ -17,7 +17,7 @@ struct MediaTrimView: View {
     }
 
     private enum Colors {
-        static var trimBorderColor = Color(hex: "6B6B6B")
+        static var trimBorderColor = Color(hex: "6B6B6B").opacity(0.28)
     }
 
     var body: some View {
@@ -37,12 +37,6 @@ struct MediaTrimView: View {
                             scrollable.scrollTo("\(currentSecond)", anchor: .center)
                         }
                     }
-                    .onChange(of: playTime) { _ in
-                        //TODO: Change this to listen to the play/pause event?
-                        let currentSecond = Int(playTime)
-                        scrollable.scrollTo("\(currentSecond)", anchor: .center)
-                        playPosition = durationRelative(value: playTime, for: geometry.size.width)
-                    }
                 .onAppear {
                     initializePositions(in: geometry)
                     DispatchQueue.main.async {
@@ -57,7 +51,7 @@ struct MediaTrimView: View {
     private func borderView(in geometry: GeometryProxy) -> some View {
         RoundedRectangle(cornerRadius: 20)
             .fill(Color.clear)
-            .border(Colors.trimBorderColor.opacity(0.28), width: Constants.trimLineWidth)
+            .border(Colors.trimBorderColor, width: Constants.trimLineWidth)
     }
 
     private func scaledPosition(_ position: Binding<CGFloat>) -> Binding<CGFloat> {

--- a/podcasts/Sharing/Clip/PlayButton.swift
+++ b/podcasts/Sharing/Clip/PlayButton.swift
@@ -17,4 +17,3 @@ struct PlayButton: View {
         }
     }
 }
-

--- a/podcasts/Sharing/Clip/PlayButton.swift
+++ b/podcasts/Sharing/Clip/PlayButton.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-struct PlayButton: View {
+struct TrimPlayButton: View {
     @State var isPlaying: Bool
 
     var body: some View {

--- a/podcasts/Sharing/Clip/PlayButton.swift
+++ b/podcasts/Sharing/Clip/PlayButton.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+struct PlayButton: View {
+    @State var isPlaying: Bool
+
+    var body: some View {
+        Button(action: {
+            isPlaying.toggle()
+        }) {
+            if !isPlaying {
+                Image(systemName: "play.fill")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                Image(systemName: "pause.fill")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        }
+    }
+}
+

--- a/podcasts/Sharing/Clip/PlayheadView.swift
+++ b/podcasts/Sharing/Clip/PlayheadView.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+
+struct PlayheadView: View {
+    @Binding var position: CGFloat
+    var onChanged: (CGFloat) -> Void
+
+    var body: some View {
+        Rectangle()
+            .fill(Color.white)
+            .offset(x: position)
+            .onTapGesture {} // This is needed to ensure parent ScrollView doesn't intercept
+            .highPriorityGesture(
+                DragGesture(minimumDistance: 0)
+                    .onChanged { value in
+                        onChanged(value.location.x)
+                    }
+            )
+    }
+}

--- a/podcasts/Sharing/Clip/ScrollableScrollView.swift
+++ b/podcasts/Sharing/Clip/ScrollableScrollView.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+
+/// A type used by ScrollableScrollView for scrolling to a particular position
+struct Scrollable {
+    let prefix: String
+    let scrollProxy: ScrollViewProxy
+
+    func scrollTo(_ id: String, anchor: UnitPoint? = nil) {
+        scrollProxy.scrollTo("\(prefix)_\(id)", anchor: anchor)
+    }
+}
+
+/// A ScrollView which can be zoomed and scrolled using the Scrollable type provided in the Content block
+struct ScrollableScrollView<Content: View>: View {
+
+    @Binding var scale: CGFloat
+    var duration: TimeInterval
+    let geometry: GeometryProxy
+
+    @State private var lastScale: CGFloat?
+
+    @ViewBuilder let content: (Scrollable) -> Content
+
+    private let scrollIDPrefix = "tick"
+
+    var body: some View {
+        ScrollViewReader { scrollProxy in
+            ScrollView(.horizontal, showsIndicators: false) {
+                ZStack(alignment: .leading) {
+                    invisibleTickMarks(for: geometry)
+                        .frame(width: geometry.size.width * scale)
+                    content(Scrollable(prefix: scrollIDPrefix, scrollProxy: scrollProxy))
+                }
+            }
+            .clipped()
+        }
+    }
+
+    /// A series of invisible "tick marks" used to mark positions in the scrollable view
+    /// - Parameter geometry: Geometry proxy
+    /// - Returns: A view containing a series of invisible tick marks
+    @ViewBuilder private func invisibleTickMarks(for geometry: GeometryProxy) -> some View {
+        let totalSeconds = Int(duration)
+        let width = ((geometry.size.width * scale) / CGFloat(totalSeconds) / 2)
+        HStack(spacing: width) {
+            ForEach(0...totalSeconds, id: \.self) { second in
+                Color.clear
+                    .frame(width: width, height: geometry.size.height)
+                    .id("\(scrollIDPrefix)_\(second)")
+            }
+        }
+    }
+}

--- a/podcasts/Sharing/SharingView.swift
+++ b/podcasts/Sharing/SharingView.swift
@@ -5,10 +5,12 @@ import PocketCastsUtils
 class ClipTime: ObservableObject {
     @Published var start: TimeInterval
     @Published var end: TimeInterval
+    @Published var playback: TimeInterval
 
     init(start: TimeInterval, end: TimeInterval) {
         self.start = start
         self.end = end
+        self.playback = start
     }
 }
 
@@ -49,11 +51,7 @@ struct SharingView: View {
                 buttons
             case .clip:
                 VStack(spacing: 16) {
-                    ZStack {
-                        Rectangle()
-                            .foregroundColor(.gray)
-                        Text("Timeline")
-                    }
+                    MediaTrimBar(clipTime: clipTime)
                         .frame(height: 72)
                         .tint(color)
                     Button("Clip", action: {


### PR DESCRIPTION
| 📘 Part of: https://github.com/Automattic/pocket-casts-ios/issues/1910 |
|:---:|

Adds the timeline view for clip sharing from the Reimagine Sharing project.

https://github.com/Automattic/pocket-casts-ios/assets/3250/d7902514-2999-427b-b0b3-17d48e3b540e

### Code Changes

* `MediaTrimBar` contains the play button and the timeline with associated styled elements
* `MediaTrimView` contains the scrollable timeline portion which will include Trim handles in the future
* `ScrollableScrollView` is a wrapper which handles scrolling operations via the `scrollTo` modifier and set of `invisibleTickMarks`. There are some newer APIs we could use in the future but this approach works for now.
* `AudioWaveformView` renders the lines for our "pseudo waveform". This may be replaced with an actual waveform in the future but is a static stylized version for now.
* `PCUnevenRoundedRectangle` is a fallback for rounding corners in iOS 15 similar to `UnevenRoundedRectangle` in iOS 16+.

## To test

> [!NOTE]
> Enable the `newSharing` feature flag to test this

* Open the Now Playing view in the player
* Tap the share button in the upper right
* Tap the "Clip" option
* Verify that the Clip sharing page appears
* Ensure that timeline is scrolled to the correct position
* Verify that the timeline behaves as expected by scrolling back and forth and changing playback position from the episode and re-entering

A few missing items which I'll submit separately:
* Zoom gesture handling - the building blocks are there in `AudioWaveformView ` for hiding and showing lines
* Playback following
* Play/Pause button functionality

The tick marks may not match the designs exactly as they will be recalculated depending on scale (which may adjust with zooming). I'll be cleaning this up in a future update.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
