### PR TITLE
Transcripts: add player transition to Transcripts

### DIFF
--- a/podcasts/NowPlayingPlayerItemViewController+Update.swift
+++ b/podcasts/NowPlayingPlayerItemViewController+Update.swift
@@ -68,8 +68,8 @@ extension NowPlayingPlayerItemViewController {
     private func updateColors() {
         let backgroundColor = PlayerColorHelper.playerBackgroundColor01()
         view.backgroundColor = backgroundColor
-        transcriptContainerView.backgroundColor = view.backgroundColor
         playPauseBtn.playButtonColor = backgroundColor
+        transcriptContainerView.backgroundColor = backgroundColor
 
         let buttonColor = ThemeColor.playerContrast01()
         playPauseBtn.circleColor = buttonColor

--- a/podcasts/NowPlayingPlayerItemViewController+Update.swift
+++ b/podcasts/NowPlayingPlayerItemViewController+Update.swift
@@ -68,6 +68,7 @@ extension NowPlayingPlayerItemViewController {
     private func updateColors() {
         let backgroundColor = PlayerColorHelper.playerBackgroundColor01()
         view.backgroundColor = backgroundColor
+        transcriptContainerView.backgroundColor = view.backgroundColor
         playPauseBtn.playButtonColor = backgroundColor
 
         let buttonColor = ThemeColor.playerContrast01()

--- a/podcasts/NowPlayingPlayerItemViewController.swift
+++ b/podcasts/NowPlayingPlayerItemViewController.swift
@@ -352,6 +352,10 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
     }
 
     private func showTranscript() {
+        skipBackBtn.prepareForAnimateTransition(withBackground: view.backgroundColor)
+        skipFwdBtn.prepareForAnimateTransition(withBackground: view.backgroundColor)
+        playPauseBtn.prepareForAnimateTransition(withBackground: view.backgroundColor)
+
         transcriptContainerView.layer.opacity = 0
         UIView.animate(withDuration: 0.35, animations: { [weak self] in
             guard let self else { return }
@@ -379,12 +383,20 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
 
             // Ask parent VC to hide tabs
             playerContainer?.hideTabsAndLockScrollView()
-        }, completion: { _ in
+        }, completion: { [weak self] _ in
+            guard let self else { return }
 
+            playPauseBtn.finishedTransition()
+            skipBackBtn.finishedTransition()
+            skipFwdBtn.finishedTransition()
         })
     }
 
     private func hideTranscript() {
+        skipBackBtn.prepareForAnimateTransition(withBackground: view.backgroundColor)
+        skipFwdBtn.prepareForAnimateTransition(withBackground: view.backgroundColor)
+        playPauseBtn.prepareForAnimateTransition(withBackground: view.backgroundColor)
+
         UIView.animate(withDuration: 0.35, animations: { [weak self] in
             guard let self else { return }
 
@@ -414,6 +426,10 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
             guard let self else { return }
 
             transcriptContainerView.isHidden = true
+
+            playPauseBtn.finishedTransition()
+            skipBackBtn.finishedTransition()
+            skipFwdBtn.finishedTransition()
         })
     }
 }

--- a/podcasts/NowPlayingPlayerItemViewController.swift
+++ b/podcasts/NowPlayingPlayerItemViewController.swift
@@ -369,8 +369,8 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
             fillView.isHidden = false
 
             // Change skip back and forward size
-            skipBackBtn.change(width: 32, height: 32, fontSize: 10)
-            skipFwdBtn.change(width: 32, height: 32, fontSize: 10)
+            skipBackBtn.changeSize(to: .small)
+            skipFwdBtn.changeSize(to: .small)
             skipBackBtn.layoutIfNeeded()
             skipFwdBtn.layoutIfNeeded()
 

--- a/podcasts/NowPlayingPlayerItemViewController.swift
+++ b/podcasts/NowPlayingPlayerItemViewController.swift
@@ -150,6 +150,8 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
 
     @IBOutlet weak var fillView: UIView!
 
+    @IBOutlet weak var bottomControlsStackView: UIStackView!
+
     let chromecastBtn = PCAlwaysVisibleCastBtn()
     let routePicker = PCRoutePickerView(frame: CGRect.zero)
 
@@ -189,6 +191,10 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
         }
 
         displayTranscript = true
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+            self.displayTranscript = false
+        }
     }
 
     private var lastBoundsAdjustedFor = CGRect.zero
@@ -366,8 +372,8 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
             episodeImage.layer.opacity = 0
 
             // Change the stack view that contains the player button
-            (timeSliderHolderView.superview as! UIStackView).distribution = .fill
-            (timeSliderHolderView.superview as! UIStackView).spacing = 10
+            bottomControlsStackView.distribution = .fill
+            bottomControlsStackView.spacing = 10
 
             // Display the view that will fill the empty space
             fillView.isHidden = false
@@ -386,6 +392,38 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
     }
 
     private func hideTranscript() {
+        UIView.animate(withDuration: 0.35, animations: { [weak self] in
+            guard let self else { return }
 
+            // Show shelf
+            shelfBg.isHidden = false
+            shelfBg.layer.opacity = 1
+
+            // Show episode info/chapter/etc
+            episodeInfoView.superview?.isHidden = false
+            episodeInfoView.superview?.layer.opacity = 1
+
+            // Show episode artwork
+            episodeImage.isHidden = false
+            episodeImage.layer.opacity = 1
+
+            // Change the stack view that contains the player button
+            bottomControlsStackView.distribution = .equalSpacing
+            bottomControlsStackView.spacing = 30
+
+            // Hide the view that will fill the empty space
+            fillView.isHidden = true
+
+            // Change skip back and forward size
+            skipBackBtn.changeSize(to: .large)
+            skipFwdBtn.changeSize(to: .large)
+            skipBackBtn.layoutIfNeeded()
+            skipFwdBtn.layoutIfNeeded()
+
+            // Ask parent VC to hide tabs
+            playerContainer?.showTabsAndUnlockScrollView()
+        }, completion: { _ in
+
+        })
     }
 }

--- a/podcasts/NowPlayingPlayerItemViewController.swift
+++ b/podcasts/NowPlayingPlayerItemViewController.swift
@@ -247,7 +247,9 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
     }
 
     @IBAction func playPauseTapped(_ sender: Any) {
-        displayTranscript.toggle()
+        analyticsPlaybackHelper.currentSource = analyticsSource
+        HapticsHelper.triggerPlayPauseHaptic()
+        PlaybackManager.shared.playPause()
     }
 
     @IBAction func skipFwdTapped(_ sender: Any) {

--- a/podcasts/NowPlayingPlayerItemViewController.swift
+++ b/podcasts/NowPlayingPlayerItemViewController.swift
@@ -152,6 +152,8 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
 
     @IBOutlet weak var bottomControlsStackView: UIStackView!
 
+    @IBOutlet weak var transcriptContainerView: UIView!
+
     let chromecastBtn = PCAlwaysVisibleCastBtn()
     let routePicker = PCRoutePickerView(frame: CGRect.zero)
 
@@ -188,12 +190,6 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
         // Show the overflow menu
         if AnnouncementFlow.current == .bookmarksPlayer {
             overflowTapped()
-        }
-
-        displayTranscript = true
-
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-            self.displayTranscript = false
         }
     }
 
@@ -356,6 +352,7 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
     }
 
     private func showTranscript() {
+        transcriptContainerView.layer.opacity = 0
         UIView.animate(withDuration: 0.35, animations: { [weak self] in
             guard let self else { return }
 
@@ -363,13 +360,9 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
             shelfBg.isHidden = true
             shelfBg.layer.opacity = 0
 
-            // Hide episode info/chapter/etc
-            episodeInfoView.superview?.isHidden = true
-            episodeInfoView.superview?.layer.opacity = 0
-
-            // Hide episode artwork
-            episodeImage.isHidden = true
-            episodeImage.layer.opacity = 0
+            // Show transcript container view
+            transcriptContainerView.isHidden = false
+            transcriptContainerView.layer.opacity = 1
 
             // Change the stack view that contains the player button
             bottomControlsStackView.distribution = .fill
@@ -399,13 +392,8 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
             shelfBg.isHidden = false
             shelfBg.layer.opacity = 1
 
-            // Show episode info/chapter/etc
-            episodeInfoView.superview?.isHidden = false
-            episodeInfoView.superview?.layer.opacity = 1
-
-            // Show episode artwork
-            episodeImage.isHidden = false
-            episodeImage.layer.opacity = 1
+            // Hide transcript container view
+            transcriptContainerView.layer.opacity = 0
 
             // Change the stack view that contains the player button
             bottomControlsStackView.distribution = .equalSpacing
@@ -422,8 +410,10 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
 
             // Ask parent VC to hide tabs
             playerContainer?.showTabsAndUnlockScrollView()
-        }, completion: { _ in
+        }, completion: { [weak self] _ in
+            guard let self else { return }
 
+            transcriptContainerView.isHidden = true
         })
     }
 }

--- a/podcasts/NowPlayingPlayerItemViewController.swift
+++ b/podcasts/NowPlayingPlayerItemViewController.swift
@@ -376,7 +376,7 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
             skipFwdBtn.layoutIfNeeded()
 
             // Ask parent VC to hide tabs
-            playerContainer?.hideTabsAndLockScrollView()
+            playerContainer?.updateTabsAndScrollView(isEnabled: false)
         }, completion: { [weak self] _ in
             guard let self else { return }
 
@@ -415,7 +415,7 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
             skipFwdBtn.layoutIfNeeded()
 
             // Ask parent VC to hide tabs
-            playerContainer?.showTabsAndUnlockScrollView()
+            playerContainer?.updateTabsAndScrollView(isEnabled: true)
         }, completion: { [weak self] _ in
             guard let self else { return }
 

--- a/podcasts/NowPlayingPlayerItemViewController.swift
+++ b/podcasts/NowPlayingPlayerItemViewController.swift
@@ -148,6 +148,8 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
 
     @IBOutlet var playPauseHeightConstraint: NSLayoutConstraint!
 
+    @IBOutlet weak var fillView: UIView!
+
     let chromecastBtn = PCAlwaysVisibleCastBtn()
     let routePicker = PCRoutePickerView(frame: CGRect.zero)
 
@@ -185,6 +187,31 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
         if AnnouncementFlow.current == .bookmarksPlayer {
             overflowTapped()
         }
+
+        UIView.animate(withDuration: 0.8,
+                           delay: 0.0,
+                           usingSpringWithDamping: 0.9,
+                           initialSpringVelocity: 1,
+                           options: [],
+                           animations: {
+            self.shelfBg.isHidden = true
+            self.shelfBg.layer.opacity = 0
+            self.episodeInfoView.superview?.isHidden = true
+            self.episodeInfoView.superview?.layer.opacity = 0
+            self.episodeImage.isHidden = true
+            self.episodeImage.layer.opacity = 0
+            self.playPauseHeightConstraint.constant = 40
+            (self.playPauseBtn.superview as! UIStackView).distribution = .fill
+            self.fillView.isHidden = false
+            self.view.layoutIfNeeded()
+
+//            (self.parent as? PlayerContainerViewController)?.headerView.isHidden = true
+            (self.parent as? PlayerContainerViewController)?.topSpaceToHeader.priority = .defaultLow
+            (self.parent as? PlayerContainerViewController)?.topSpaceToSafeArea.priority = .defaultHigh
+//
+            (self.parent as? PlayerContainerViewController)?.view.layoutIfNeeded()
+                            },
+                           completion: nil)
     }
 
     private var lastBoundsAdjustedFor = CGRect.zero
@@ -192,6 +219,8 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
     var analyticsSource: AnalyticsSource {
         .player
     }
+
+    var displayTranscripts = false
 
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
@@ -204,8 +233,12 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
         let spacing: CGFloat = screenHeight > 600 ? 30 : 20
         if playerControlsStackView.spacing != spacing { playerControlsStackView.spacing = spacing }
 
-        let height: CGFloat = screenHeight > 710 ? 100 : 80
-        if playPauseHeightConstraint.constant != height { playPauseHeightConstraint.constant = height }
+        if displayTranscripts {
+            playPauseHeightConstraint.constant = 40
+        } else {
+            let height: CGFloat = screenHeight > 710 ? 100 : 80
+            if playPauseHeightConstraint.constant != height { playPauseHeightConstraint.constant = height }
+        }
     }
 
     override func willBeAddedToPlayer() {

--- a/podcasts/NowPlayingPlayerItemViewController.swift
+++ b/podcasts/NowPlayingPlayerItemViewController.swift
@@ -204,12 +204,15 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
             self.episodeInfoView.superview?.layer.opacity = 0
             self.episodeImage.isHidden = true
             self.episodeImage.layer.opacity = 0
-            (self.playPauseBtn.superview as! UIStackView).distribution = .fill
+            (self.timeSliderHolderView.superview as! UIStackView).distribution = .fill
+            (self.timeSliderHolderView.superview as! UIStackView).spacing = 10
             self.fillView.isHidden = false
             self.view.layoutIfNeeded()
 
             self.skipBackBtn.change(width: 32, height: 32, fontSize: 10)
             self.skipFwdBtn.change(width: 32, height: 32, fontSize: 10)
+            self.skipBackBtn.layoutIfNeeded()
+            self.skipFwdBtn.layoutIfNeeded()
 
             (self.parent as? PlayerContainerViewController)?.topSpaceToHeader.priority = .defaultLow
             (self.parent as? PlayerContainerViewController)?.topSpaceToSafeArea.priority = .defaultHigh

--- a/podcasts/NowPlayingPlayerItemViewController.swift
+++ b/podcasts/NowPlayingPlayerItemViewController.swift
@@ -188,37 +188,7 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
             overflowTapped()
         }
 
-        displayTranscripts = true
-
-        (self.parent as? PlayerContainerViewController)?.mainScrollView.isScrollEnabled = false
-
-        UIView.animate(withDuration: 0.8,
-                           delay: 0.0,
-                           usingSpringWithDamping: 0.9,
-                           initialSpringVelocity: 1,
-                           options: [],
-                           animations: {
-            self.shelfBg.isHidden = true
-            self.shelfBg.layer.opacity = 0
-            self.episodeInfoView.superview?.isHidden = true
-            self.episodeInfoView.superview?.layer.opacity = 0
-            self.episodeImage.isHidden = true
-            self.episodeImage.layer.opacity = 0
-            (self.timeSliderHolderView.superview as! UIStackView).distribution = .fill
-            (self.timeSliderHolderView.superview as! UIStackView).spacing = 10
-            self.fillView.isHidden = false
-            self.view.layoutIfNeeded()
-
-            self.skipBackBtn.change(width: 32, height: 32, fontSize: 10)
-            self.skipFwdBtn.change(width: 32, height: 32, fontSize: 10)
-            self.skipBackBtn.layoutIfNeeded()
-            self.skipFwdBtn.layoutIfNeeded()
-
-            (self.parent as? PlayerContainerViewController)?.topSpaceToHeader.priority = .defaultLow
-            (self.parent as? PlayerContainerViewController)?.topSpaceToSafeArea.priority = .defaultHigh
-            (self.parent as? PlayerContainerViewController)?.view.layoutIfNeeded()
-                            },
-                           completion: nil)
+        displayTranscript = true
     }
 
     private var lastBoundsAdjustedFor = CGRect.zero
@@ -227,7 +197,11 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
         .player
     }
 
-    var displayTranscripts = false
+    var displayTranscript = false {
+        didSet {
+            displayTranscript ? showTranscript() : hideTranscript()
+        }
+    }
 
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
@@ -240,7 +214,7 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
         let spacing: CGFloat = screenHeight > 600 ? 30 : 20
         if playerControlsStackView.spacing != spacing { playerControlsStackView.spacing = spacing }
 
-        if displayTranscripts {
+        if displayTranscript {
             playPauseHeightConstraint.constant = 40
         } else {
             let height: CGFloat = screenHeight > 710 ? 100 : 80
@@ -369,5 +343,45 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
         navController.modalPresentationStyle = .fullScreen
 
         present(navController, animated: true, completion: nil)
+    }
+
+    private func showTranscript() {
+        UIView.animate(withDuration: 0.35, animations: { [weak self] in
+            guard let self else { return }
+
+            // Hide shelf
+            shelfBg.isHidden = true
+            shelfBg.layer.opacity = 0
+
+            // Hide episode info/chapter/etc
+            episodeInfoView.superview?.isHidden = true
+            episodeInfoView.superview?.layer.opacity = 0
+
+            // Hide episode artwork
+            episodeImage.isHidden = true
+            episodeImage.layer.opacity = 0
+
+            // Change the stack view that contains the player button
+            (timeSliderHolderView.superview as! UIStackView).distribution = .fill
+            (timeSliderHolderView.superview as! UIStackView).spacing = 10
+
+            // Display the view that will fill the empty space
+            fillView.isHidden = false
+
+            // Change skip back and forward size
+            skipBackBtn.change(width: 32, height: 32, fontSize: 10)
+            skipFwdBtn.change(width: 32, height: 32, fontSize: 10)
+            skipBackBtn.layoutIfNeeded()
+            skipFwdBtn.layoutIfNeeded()
+
+            // Ask parent VC to hide tabs
+            (parent as? PlayerContainerViewController)?.hideTabsAndLockScrollView()
+        }, completion: { _ in
+
+        })
+    }
+
+    private func hideTranscript() {
+
     }
 }

--- a/podcasts/NowPlayingPlayerItemViewController.swift
+++ b/podcasts/NowPlayingPlayerItemViewController.swift
@@ -247,9 +247,7 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
     }
 
     @IBAction func playPauseTapped(_ sender: Any) {
-        analyticsPlaybackHelper.currentSource = analyticsSource
-        HapticsHelper.triggerPlayPauseHaptic()
-        PlaybackManager.shared.playPause()
+        displayTranscript.toggle()
     }
 
     @IBAction func skipFwdTapped(_ sender: Any) {
@@ -350,7 +348,7 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
     private func showTranscript() {
         skipBackBtn.prepareForAnimateTransition(withBackground: view.backgroundColor)
         skipFwdBtn.prepareForAnimateTransition(withBackground: view.backgroundColor)
-        playPauseBtn.prepareForAnimateTransition(withBackground: view.backgroundColor)
+        playPauseBtn.prepareForAnimateTransition()
 
         transcriptContainerView.layer.opacity = 0
         UIView.animate(withDuration: 0.35, animations: { [weak self] in
@@ -391,7 +389,7 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
     private func hideTranscript() {
         skipBackBtn.prepareForAnimateTransition(withBackground: view.backgroundColor)
         skipFwdBtn.prepareForAnimateTransition(withBackground: view.backgroundColor)
-        playPauseBtn.prepareForAnimateTransition(withBackground: view.backgroundColor)
+        playPauseBtn.prepareForAnimateTransition()
 
         UIView.animate(withDuration: 0.35, animations: { [weak self] in
             guard let self else { return }

--- a/podcasts/NowPlayingPlayerItemViewController.swift
+++ b/podcasts/NowPlayingPlayerItemViewController.swift
@@ -201,7 +201,7 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
 
     private var displayTranscript = false {
         didSet {
-            displayTranscript ? showTranscript() : hideTranscript()
+            toggleTranscript()
         }
     }
 
@@ -345,81 +345,46 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
         present(navController, animated: true, completion: nil)
     }
 
-    private func showTranscript() {
+    private func toggleTranscript() {
+        let isShowing = displayTranscript
+
         skipBackBtn.prepareForAnimateTransition(withBackground: view.backgroundColor)
         skipFwdBtn.prepareForAnimateTransition(withBackground: view.backgroundColor)
         playPauseBtn.prepareForAnimateTransition()
 
-        transcriptContainerView.layer.opacity = 0
+        transcriptContainerView.layer.opacity = isShowing ? 0 : 1
+
         UIView.animate(withDuration: 0.35, animations: { [weak self] in
             guard let self else { return }
 
-            // Hide shelf
-            shelfBg.isHidden = true
-            shelfBg.layer.opacity = 0
+            // Hide/show shelf
+            shelfBg.isHidden = isShowing
+            shelfBg.layer.opacity = isShowing ? 0 : 1
 
-            // Show transcript container view
+            // Show/hide transcript container view
             transcriptContainerView.isHidden = false
-            transcriptContainerView.layer.opacity = 1
+            transcriptContainerView.layer.opacity = isShowing ? 1 : 0
 
             // Change the stack view that contains the player button
-            bottomControlsStackView.distribution = .fill
-            bottomControlsStackView.spacing = 10
+            bottomControlsStackView.distribution = isShowing ? .fill : .equalSpacing
+            bottomControlsStackView.spacing = isShowing ? 10 : 30
 
-            // Display the view that will fill the empty space
-            fillView.isHidden = false
+            // Display/hide the view that will fill the empty space
+            fillView.isHidden = !isShowing
 
             // Change skip back and forward size
-            skipBackBtn.changeSize(to: .small)
-            skipFwdBtn.changeSize(to: .small)
+            let skipButtonSize: SkipButton.Size = isShowing ? .small : .large
+            skipBackBtn.changeSize(to: skipButtonSize)
+            skipFwdBtn.changeSize(to: skipButtonSize)
             skipBackBtn.layoutIfNeeded()
             skipFwdBtn.layoutIfNeeded()
 
-            // Ask parent VC to hide tabs
-            playerContainer?.updateTabsAndScrollView(isEnabled: false)
+            // Ask parent VC to hide/show tabs
+            playerContainer?.updateTabsAndScrollView(isEnabled: !isShowing)
         }, completion: { [weak self] _ in
             guard let self else { return }
 
-            playPauseBtn.finishedTransition()
-            skipBackBtn.finishedTransition()
-            skipFwdBtn.finishedTransition()
-        })
-    }
-
-    private func hideTranscript() {
-        skipBackBtn.prepareForAnimateTransition(withBackground: view.backgroundColor)
-        skipFwdBtn.prepareForAnimateTransition(withBackground: view.backgroundColor)
-        playPauseBtn.prepareForAnimateTransition()
-
-        UIView.animate(withDuration: 0.35, animations: { [weak self] in
-            guard let self else { return }
-
-            // Show shelf
-            shelfBg.isHidden = false
-            shelfBg.layer.opacity = 1
-
-            // Hide transcript container view
-            transcriptContainerView.layer.opacity = 0
-
-            // Change the stack view that contains the player button
-            bottomControlsStackView.distribution = .equalSpacing
-            bottomControlsStackView.spacing = 30
-
-            // Hide the view that will fill the empty space
-            fillView.isHidden = true
-
-            // Change skip back and forward size
-            skipBackBtn.changeSize(to: .large)
-            skipFwdBtn.changeSize(to: .large)
-            skipBackBtn.layoutIfNeeded()
-            skipFwdBtn.layoutIfNeeded()
-
-            // Ask parent VC to hide tabs
-            playerContainer?.updateTabsAndScrollView(isEnabled: true)
-        }, completion: { [weak self] _ in
-            guard let self else { return }
-
-            transcriptContainerView.isHidden = true
+            transcriptContainerView.isHidden = isShowing ? false : true
 
             playPauseBtn.finishedTransition()
             skipBackBtn.finishedTransition()

--- a/podcasts/NowPlayingPlayerItemViewController.swift
+++ b/podcasts/NowPlayingPlayerItemViewController.swift
@@ -197,10 +197,14 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
         .player
     }
 
-    var displayTranscript = false {
+    private var displayTranscript = false {
         didSet {
             displayTranscript ? showTranscript() : hideTranscript()
         }
+    }
+
+    private var playerContainer: PlayerContainerViewController? {
+        parent as? PlayerContainerViewController
     }
 
     override func viewDidLayoutSubviews() {
@@ -375,7 +379,7 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
             skipFwdBtn.layoutIfNeeded()
 
             // Ask parent VC to hide tabs
-            (parent as? PlayerContainerViewController)?.hideTabsAndLockScrollView()
+            playerContainer?.hideTabsAndLockScrollView()
         }, completion: { _ in
 
         })

--- a/podcasts/NowPlayingPlayerItemViewController.swift
+++ b/podcasts/NowPlayingPlayerItemViewController.swift
@@ -188,6 +188,10 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
             overflowTapped()
         }
 
+        displayTranscripts = true
+
+        (self.parent as? PlayerContainerViewController)?.mainScrollView.isScrollEnabled = false
+
         UIView.animate(withDuration: 0.8,
                            delay: 0.0,
                            usingSpringWithDamping: 0.9,
@@ -200,15 +204,15 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
             self.episodeInfoView.superview?.layer.opacity = 0
             self.episodeImage.isHidden = true
             self.episodeImage.layer.opacity = 0
-            self.playPauseHeightConstraint.constant = 40
             (self.playPauseBtn.superview as! UIStackView).distribution = .fill
             self.fillView.isHidden = false
             self.view.layoutIfNeeded()
 
-//            (self.parent as? PlayerContainerViewController)?.headerView.isHidden = true
+            self.skipBackBtn.change(width: 32, height: 32, fontSize: 10)
+            self.skipFwdBtn.change(width: 32, height: 32, fontSize: 10)
+
             (self.parent as? PlayerContainerViewController)?.topSpaceToHeader.priority = .defaultLow
             (self.parent as? PlayerContainerViewController)?.topSpaceToSafeArea.priority = .defaultHigh
-//
             (self.parent as? PlayerContainerViewController)?.view.layoutIfNeeded()
                             },
                            completion: nil)

--- a/podcasts/NowPlayingPlayerItemViewController.swift
+++ b/podcasts/NowPlayingPlayerItemViewController.swift
@@ -220,12 +220,8 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
         let spacing: CGFloat = screenHeight > 600 ? 30 : 20
         if playerControlsStackView.spacing != spacing { playerControlsStackView.spacing = spacing }
 
-        if displayTranscript {
-            playPauseHeightConstraint.constant = 40
-        } else {
-            let height: CGFloat = screenHeight > 710 ? 100 : 80
-            if playPauseHeightConstraint.constant != height { playPauseHeightConstraint.constant = height }
-        }
+        let height: CGFloat = displayTranscript ? 40 : screenHeight > 710 ? 100 : 80
+        if playPauseHeightConstraint.constant != height { playPauseHeightConstraint.constant = height }
     }
 
     override func willBeAddedToPlayer() {

--- a/podcasts/NowPlayingPlayerItemViewController.xib
+++ b/podcasts/NowPlayingPlayerItemViewController.xib
@@ -4,6 +4,7 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22684"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -34,6 +35,7 @@
                 <outlet property="timeRemaining" destination="1nY-hc-503" id="kQs-v5-qfg"/>
                 <outlet property="timeSlider" destination="v3N-m7-an0" id="Isd-Kl-TGM"/>
                 <outlet property="timeSliderHolderView" destination="T2E-0H-hwM" id="AP1-uU-3Id"/>
+                <outlet property="transcriptContainerView" destination="Nvx-nQ-jae" id="nEQ-nr-hb7"/>
                 <outlet property="view" destination="Dsl-xJ-ho3" id="gSW-Zh-fo1"/>
             </connections>
         </placeholder>
@@ -44,13 +46,6 @@
                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="WxQ-7h-0WZ">
                     <rect key="frame" x="0.0" y="8" width="414" height="858"/>
                     <subviews>
-                        <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="sbN-fi-Mv7">
-                            <rect key="frame" x="0.0" y="-50" width="414" height="50"/>
-                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                            <constraints>
-                                <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="50" id="l1V-3a-EuZ"/>
-                            </constraints>
-                        </view>
                         <imageView contentMode="scaleAspectFit" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="dXr-Zd-0wP">
                             <rect key="frame" x="30" y="0.0" width="354" height="354"/>
                             <accessibility key="accessibilityConfiguration" label="Podcast Artwork">
@@ -201,6 +196,13 @@
                                 <constraint firstAttribute="trailing" secondItem="t3O-EF-0h2" secondAttribute="trailing" id="teO-fZ-khZ"/>
                                 <constraint firstAttribute="bottom" secondItem="MLe-7y-U6n" secondAttribute="bottom" id="uLj-5x-y5r"/>
                                 <constraint firstItem="MLe-7y-U6n" firstAttribute="leading" secondItem="Sme-fz-BDA" secondAttribute="leading" id="ygZ-bt-S0i"/>
+                            </constraints>
+                        </view>
+                        <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="sbN-fi-Mv7">
+                            <rect key="frame" x="0.0" y="459" width="414" height="50"/>
+                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <constraints>
+                                <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="50" id="l1V-3a-EuZ"/>
                             </constraints>
                         </view>
                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="30" translatesAutoresizingMaskIntoConstraints="NO" id="UmO-Rc-jIG" userLabel="Bottom Controls Stack View">
@@ -378,6 +380,10 @@
                         <constraint firstAttribute="width" secondItem="auM-3f-elA" secondAttribute="height" multiplier="1:1" id="r9y-4s-XLM"/>
                     </constraints>
                 </view>
+                <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Nvx-nQ-jae">
+                    <rect key="frame" x="0.0" y="0.0" width="414" height="467"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                </view>
             </subviews>
             <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <accessibility key="accessibilityConfiguration" label="Full Size Player">
@@ -388,9 +394,13 @@
                 <constraint firstItem="sam-0S-73x" firstAttribute="trailing" secondItem="dXr-Zd-0wP" secondAttribute="trailing" constant="-10" id="2fE-dE-Tel"/>
                 <constraint firstItem="auM-3f-elA" firstAttribute="centerX" secondItem="dXr-Zd-0wP" secondAttribute="centerX" id="3QC-yl-rk2"/>
                 <constraint firstAttribute="trailing" secondItem="WxQ-7h-0WZ" secondAttribute="trailing" id="4fc-om-1OZ"/>
+                <constraint firstItem="Nvx-nQ-jae" firstAttribute="top" secondItem="Dsl-xJ-ho3" secondAttribute="top" id="8pY-ln-4Ky"/>
+                <constraint firstItem="UmO-Rc-jIG" firstAttribute="top" secondItem="Nvx-nQ-jae" secondAttribute="bottom" id="OWX-bb-BTi"/>
                 <constraint firstItem="auM-3f-elA" firstAttribute="centerY" secondItem="dXr-Zd-0wP" secondAttribute="centerY" id="P1f-xu-Ze5"/>
+                <constraint firstItem="Nvx-nQ-jae" firstAttribute="width" secondItem="Dsl-xJ-ho3" secondAttribute="width" id="PrN-n2-F73"/>
                 <constraint firstItem="sam-0S-73x" firstAttribute="top" secondItem="WxQ-7h-0WZ" secondAttribute="top" constant="10" id="fgs-F6-NzZ"/>
                 <constraint firstItem="WxQ-7h-0WZ" firstAttribute="top" secondItem="Dsl-xJ-ho3" secondAttribute="top" constant="8" id="hS4-XE-bck"/>
+                <constraint firstItem="Nvx-nQ-jae" firstAttribute="centerX" secondItem="Dsl-xJ-ho3" secondAttribute="centerX" id="kbl-l4-hvD"/>
                 <constraint firstItem="WxQ-7h-0WZ" firstAttribute="leading" secondItem="Dsl-xJ-ho3" secondAttribute="leading" id="wSN-3z-fOR"/>
                 <constraint firstItem="auM-3f-elA" firstAttribute="height" secondItem="dXr-Zd-0wP" secondAttribute="height" id="ycO-kv-OEO"/>
                 <constraint firstAttribute="bottom" secondItem="WxQ-7h-0WZ" secondAttribute="bottom" constant="30" id="zFk-ce-kom"/>
@@ -404,5 +414,8 @@
         <image name="chapter-link-white" width="24" height="24"/>
         <image name="chapter-skipbackwards" width="30" height="30"/>
         <image name="chapter-skipforward" width="30" height="30"/>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
     </resources>
 </document>

--- a/podcasts/NowPlayingPlayerItemViewController.xib
+++ b/podcasts/NowPlayingPlayerItemViewController.xib
@@ -9,6 +9,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="NowPlayingPlayerItemViewController" customModule="podcasts" customModuleProvider="target">
             <connections>
+                <outlet property="bottomControlsStackView" destination="UmO-Rc-jIG" id="hwW-jm-hhg"/>
                 <outlet property="chapterCounter" destination="98m-xR-mw0" id="tsa-Tf-HrX"/>
                 <outlet property="chapterInfoView" destination="t3O-EF-0h2" id="4vf-Tn-hEJ"/>
                 <outlet property="chapterLink" destination="sam-0S-73x" id="pjd-Tg-E5M"/>

--- a/podcasts/NowPlayingPlayerItemViewController.xib
+++ b/podcasts/NowPlayingPlayerItemViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22155" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22131"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22684"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -20,6 +20,7 @@
                 <outlet property="episodeImage" destination="dXr-Zd-0wP" id="g0t-eE-u5G"/>
                 <outlet property="episodeInfoView" destination="MLe-7y-U6n" id="0K2-Ws-I3X"/>
                 <outlet property="episodeName" destination="ool-HF-az4" id="87D-Nv-oIM"/>
+                <outlet property="fillView" destination="sbN-fi-Mv7" id="AN8-6l-tnT"/>
                 <outlet property="floatingVideoView" destination="auM-3f-elA" id="OGa-U7-JAh"/>
                 <outlet property="playPauseBtn" destination="XXp-BW-AVr" id="Di2-7G-pn5"/>
                 <outlet property="playPauseHeightConstraint" destination="dtu-hS-iiu" id="s0N-0P-nEh"/>
@@ -42,6 +43,13 @@
                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="WxQ-7h-0WZ">
                     <rect key="frame" x="0.0" y="8" width="414" height="858"/>
                     <subviews>
+                        <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="sbN-fi-Mv7">
+                            <rect key="frame" x="0.0" y="-50" width="414" height="50"/>
+                            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <constraints>
+                                <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="50" id="l1V-3a-EuZ"/>
+                            </constraints>
+                        </view>
                         <imageView contentMode="scaleAspectFit" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="dXr-Zd-0wP">
                             <rect key="frame" x="30" y="0.0" width="354" height="354"/>
                             <accessibility key="accessibilityConfiguration" label="Podcast Artwork">
@@ -324,6 +332,7 @@
                         </stackView>
                     </subviews>
                     <constraints>
+                        <constraint firstItem="sbN-fi-Mv7" firstAttribute="width" secondItem="WxQ-7h-0WZ" secondAttribute="width" id="0Qg-hG-Xav"/>
                         <constraint firstAttribute="trailing" secondItem="Sme-fz-BDA" secondAttribute="trailing" constant="20" id="9GS-az-gTh"/>
                         <constraint firstAttribute="trailing" secondItem="UmO-Rc-jIG" secondAttribute="trailing" id="Lgo-ja-KKq"/>
                         <constraint firstItem="Sme-fz-BDA" firstAttribute="leading" secondItem="dXr-Zd-0wP" secondAttribute="leading" priority="750" id="X7s-hz-x0i"/>

--- a/podcasts/NowPlayingPlayerItemViewController.xib
+++ b/podcasts/NowPlayingPlayerItemViewController.xib
@@ -45,7 +45,7 @@
                     <subviews>
                         <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="sbN-fi-Mv7">
                             <rect key="frame" x="0.0" y="-50" width="414" height="50"/>
-                            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <constraints>
                                 <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="50" id="l1V-3a-EuZ"/>
                             </constraints>

--- a/podcasts/PlayPauseButton.swift
+++ b/podcasts/PlayPauseButton.swift
@@ -4,6 +4,9 @@ import UIKit
 class PlayPauseButton: BasePlayPauseButton {
     private let circleView = UIView()
 
+    // Used to animate given LottieAnimationView doesn't animate with UIView.animate
+    private var snapshot: UIView?
+
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
 
@@ -44,5 +47,25 @@ class PlayPauseButton: BasePlayPauseButton {
             animation.widthAnchor.constraint(equalTo: circleView.widthAnchor, multiplier: 0.48),
             animation.heightAnchor.constraint(equalTo: circleView.heightAnchor, multiplier: 0.48)
         ])
+    }
+
+    // When using UIVIew.animate LottieAnimationView doesn't play nice with it
+    // Here we snapshot the view to provide a smooth animation
+    func prepareForAnimateTransition(withBackground: UIColor?) {
+        guard let snapshot = snapshotView(afterScreenUpdates: false) else { return }
+
+        snapshot.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(snapshot)
+        NSLayoutConstraint.activate([
+            snapshot.widthAnchor.constraint(equalTo: widthAnchor),
+            snapshot.heightAnchor.constraint(equalTo: heightAnchor),
+            snapshot.centerXAnchor.constraint(equalTo: centerXAnchor),
+            snapshot.centerYAnchor.constraint(equalTo: centerYAnchor)
+        ])
+        self.snapshot = snapshot
+    }
+
+    func finishedTransition() {
+        snapshot?.removeFromSuperview()
     }
 }

--- a/podcasts/PlayPauseButton.swift
+++ b/podcasts/PlayPauseButton.swift
@@ -51,7 +51,7 @@ class PlayPauseButton: BasePlayPauseButton {
 
     // When using UIVIew.animate LottieAnimationView doesn't play nice with it
     // Here we snapshot the view to provide a smooth animation
-    func prepareForAnimateTransition(withBackground: UIColor?) {
+    func prepareForAnimateTransition() {
         guard let snapshot = snapshotView(afterScreenUpdates: false) else { return }
 
         snapshot.translatesAutoresizingMaskIntoConstraints = false

--- a/podcasts/PlayerContainerViewController.swift
+++ b/podcasts/PlayerContainerViewController.swift
@@ -25,9 +25,9 @@ class PlayerContainerViewController: SimpleNotificationsViewController, PlayerTa
 
     @IBOutlet var headerHeightConstraint: NSLayoutConstraint!
 
-    @IBOutlet weak var topSpaceToHeader: NSLayoutConstraint!
+    @IBOutlet var topSpaceToHeader: NSLayoutConstraint!
 
-    @IBOutlet weak var topSpaceToSafeArea: NSLayoutConstraint!
+    @IBOutlet var topSpaceToSafeArea: NSLayoutConstraint!
 
     lazy var nowPlayingItem: NowPlayingPlayerItemViewController = {
         let item = NowPlayingPlayerItemViewController()
@@ -276,15 +276,15 @@ class PlayerContainerViewController: SimpleNotificationsViewController, PlayerTa
 
     func hideTabsAndLockScrollView() {
         mainScrollView.isScrollEnabled = false
-        topSpaceToHeader.priority = .defaultLow
-        topSpaceToSafeArea.priority = .defaultHigh
+        topSpaceToHeader.isActive = false
+        topSpaceToSafeArea.isActive = true
         view.layoutIfNeeded()
     }
 
     func showTabsAndUnlockScrollView() {
         mainScrollView.isScrollEnabled = true
-        topSpaceToHeader.priority = .defaultHigh
-        topSpaceToSafeArea.priority = .defaultLow
+        topSpaceToHeader.isActive = true
+        topSpaceToSafeArea.isActive = false
         view.layoutIfNeeded()
     }
 }

--- a/podcasts/PlayerContainerViewController.swift
+++ b/podcasts/PlayerContainerViewController.swift
@@ -25,6 +25,10 @@ class PlayerContainerViewController: SimpleNotificationsViewController, PlayerTa
 
     @IBOutlet var headerHeightConstraint: NSLayoutConstraint!
 
+    @IBOutlet weak var topSpaceToHeader: NSLayoutConstraint!
+    
+    @IBOutlet weak var topSpaceToSafeArea: NSLayoutConstraint!
+    
     lazy var nowPlayingItem: NowPlayingPlayerItemViewController = {
         let item = NowPlayingPlayerItemViewController()
         item.containerDelegate = self

--- a/podcasts/PlayerContainerViewController.swift
+++ b/podcasts/PlayerContainerViewController.swift
@@ -274,17 +274,10 @@ class PlayerContainerViewController: SimpleNotificationsViewController, PlayerTa
 
     // MARK: - Hide/Show tabs
 
-    func hideTabsAndLockScrollView() {
-        mainScrollView.isScrollEnabled = false
-        topSpaceToHeader.isActive = false
-        topSpaceToSafeArea.isActive = true
-        view.layoutIfNeeded()
-    }
-
-    func showTabsAndUnlockScrollView() {
-        mainScrollView.isScrollEnabled = true
-        topSpaceToHeader.isActive = true
-        topSpaceToSafeArea.isActive = false
+    func updateTabsAndScrollView(isEnabled: Bool) {
+        mainScrollView.isScrollEnabled = isEnabled
+        topSpaceToHeader.isActive = isEnabled
+        topSpaceToSafeArea.isActive = !isEnabled
         view.layoutIfNeeded()
     }
 }

--- a/podcasts/PlayerContainerViewController.swift
+++ b/podcasts/PlayerContainerViewController.swift
@@ -280,6 +280,13 @@ class PlayerContainerViewController: SimpleNotificationsViewController, PlayerTa
         topSpaceToSafeArea.priority = .defaultHigh
         view.layoutIfNeeded()
     }
+
+    func showTabsAndUnlockScrollView() {
+        mainScrollView.isScrollEnabled = true
+        topSpaceToHeader.priority = .defaultHigh
+        topSpaceToSafeArea.priority = .defaultLow
+        view.layoutIfNeeded()
+    }
 }
 
 private extension PlayerContainerViewController {

--- a/podcasts/PlayerContainerViewController.swift
+++ b/podcasts/PlayerContainerViewController.swift
@@ -26,9 +26,9 @@ class PlayerContainerViewController: SimpleNotificationsViewController, PlayerTa
     @IBOutlet var headerHeightConstraint: NSLayoutConstraint!
 
     @IBOutlet weak var topSpaceToHeader: NSLayoutConstraint!
-    
+
     @IBOutlet weak var topSpaceToSafeArea: NSLayoutConstraint!
-    
+
     lazy var nowPlayingItem: NowPlayingPlayerItemViewController = {
         let item = NowPlayingPlayerItemViewController()
         item.containerDelegate = self
@@ -270,6 +270,15 @@ class PlayerContainerViewController: SimpleNotificationsViewController, PlayerTa
 
     @objc func handleAppWillBecomeActive() {
         didSwitchToTab(index: tabsView.currentTab)
+    }
+
+    // MARK: - Hide/Show tabs
+
+    func hideTabsAndLockScrollView() {
+        mainScrollView.isScrollEnabled = false
+        topSpaceToHeader.priority = .defaultLow
+        topSpaceToSafeArea.priority = .defaultHigh
+        view.layoutIfNeeded()
     }
 }
 

--- a/podcasts/PlayerContainerViewController.xib
+++ b/podcasts/PlayerContainerViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21678"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22684"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -15,6 +15,8 @@
                 <outlet property="headerView" destination="tuk-fS-Mph" id="YKz-RD-dYe"/>
                 <outlet property="mainScrollView" destination="jyM-S1-fQW" id="GsL-TZ-dEm"/>
                 <outlet property="tabsView" destination="DY8-o1-Oqt" id="aZi-9q-1H6"/>
+                <outlet property="topSpaceToHeader" destination="QNv-lA-xUW" id="2r0-oz-j9B"/>
+                <outlet property="topSpaceToSafeArea" destination="gZo-Eg-DzI" id="6Bl-e7-1aw"/>
                 <outlet property="upNextBtn" destination="HBu-bE-aeT" id="BCf-TR-qEj"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
             </connections>
@@ -82,6 +84,7 @@
                 <constraint firstAttribute="top" secondItem="tuk-fS-Mph" secondAttribute="top" id="V0b-Ya-heu"/>
                 <constraint firstItem="jyM-S1-fQW" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="Vu0-o1-JuT"/>
                 <constraint firstItem="tuk-fS-Mph" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="ZVO-ed-MuN"/>
+                <constraint firstItem="jyM-S1-fQW" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" priority="999" id="gZo-Eg-DzI"/>
                 <constraint firstAttribute="bottom" secondItem="jyM-S1-fQW" secondAttribute="bottom" id="iHP-ln-ubZ"/>
                 <constraint firstAttribute="trailing" secondItem="tuk-fS-Mph" secondAttribute="trailing" id="jMd-Bl-UDQ"/>
             </constraints>

--- a/podcasts/SkipButton.swift
+++ b/podcasts/SkipButton.swift
@@ -70,7 +70,8 @@ class SkipButton: UIButton {
 
     private lazy var animationHeightAnchor = animationView.heightAnchor.constraint(equalToConstant: Size.large.sizes.height)
     private lazy var animationWidthAnchor = animationView.widthAnchor.constraint(equalToConstant: Size.large.sizes.width)
-    private lazy var skipLabelTopAnchor = skipLabel.topAnchor.constraint(equalTo: animationView.topAnchor, constant: Size.large.sizes.topPadding)
+    private lazy var skipLabelCenterYAnchor = skipLabel.centerYAnchor.constraint(equalTo: centerYAnchor, constant: Size.large.sizes.topPadding / 2)
+    private lazy var skipLabelXConstraint = skipBack ? trailingAnchor.constraint(equalTo: skipLabel.trailingAnchor, constant: SkipButton.buttonPadding) : skipLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: SkipButton.buttonPadding)
 
     func setupViews() {
         animationView.translatesAutoresizingMaskIntoConstraints = false
@@ -87,10 +88,10 @@ class SkipButton: UIButton {
         addSubview(skipLabel)
         skipLabel.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            skipLabel.leadingAnchor.constraint(equalTo: animationView.leadingAnchor),
-            skipLabel.trailingAnchor.constraint(equalTo: animationView.trailingAnchor),
-            skipLabel.bottomAnchor.constraint(equalTo: animationView.bottomAnchor),
-            skipLabelTopAnchor
+            skipLabel.heightAnchor.constraint(equalToConstant: Size.large.sizes.height),
+            skipLabel.widthAnchor.constraint(equalToConstant: Size.large.sizes.width),
+            skipLabelXConstraint,
+            skipLabelCenterYAnchor
         ])
     }
 
@@ -110,8 +111,13 @@ class SkipButton: UIButton {
         let sizes = currentSize.sizes
         animationHeightAnchor.constant = sizes.height
         animationWidthAnchor.constant = sizes.width
-        skipLabel.font = UIFont.systemFont(ofSize: sizes.fontSize, weight: .medium)
-        skipLabelTopAnchor.constant = sizes.topPadding
+        skipLabelCenterYAnchor.constant = sizes.topPadding / 2
+
+        let labelScale = UIFont.systemFont(ofSize: sizes.fontSize, weight: .medium).pointSize / skipLabel.font.pointSize
+        skipLabel.transform = .init(scaleX: labelScale, y: labelScale)
+
+        let subtract = currentSize == .small ? (Size.large.sizes.width - Size.small.sizes.width) / 2 : 0
+        skipLabelXConstraint.constant = SkipButton.buttonPadding - subtract
     }
 
     enum Size {

--- a/podcasts/SkipButton.swift
+++ b/podcasts/SkipButton.swift
@@ -66,14 +66,18 @@ class SkipButton: UIButton {
         setupViews()
     }
 
+    private lazy var animationHeightAnchor = animationView.heightAnchor.constraint(equalToConstant: 53)
+    private lazy var animationWidthAnchor = animationView.widthAnchor.constraint(equalToConstant: 45)
+    private lazy var skipLabelTopAnchor = skipLabel.topAnchor.constraint(equalTo: animationView.topAnchor, constant: 8)
+
     func setupViews() {
         animationView.translatesAutoresizingMaskIntoConstraints = false
         addSubview(animationView)
 
         let xConstraint = skipBack ? trailingAnchor.constraint(equalTo: animationView.trailingAnchor, constant: SkipButton.buttonPadding) : animationView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: SkipButton.buttonPadding)
         NSLayoutConstraint.activate([
-            animationView.heightAnchor.constraint(equalToConstant: 53),
-            animationView.widthAnchor.constraint(equalToConstant: 45),
+            animationHeightAnchor,
+            animationWidthAnchor,
             xConstraint,
             animationView.centerYAnchor.constraint(equalTo: centerYAnchor)
         ])
@@ -84,7 +88,7 @@ class SkipButton: UIButton {
             skipLabel.leadingAnchor.constraint(equalTo: animationView.leadingAnchor),
             skipLabel.trailingAnchor.constraint(equalTo: animationView.trailingAnchor),
             skipLabel.bottomAnchor.constraint(equalTo: animationView.bottomAnchor),
-            skipLabel.topAnchor.constraint(equalTo: animationView.topAnchor, constant: 8)
+            skipLabelTopAnchor
         ])
     }
 
@@ -97,5 +101,12 @@ class SkipButton: UIButton {
     @objc private func playAnimation() {
         animationView.currentProgress = 0
         animationView.play()
+    }
+
+    func change(width: CGFloat, height: CGFloat, fontSize: CGFloat) {
+        animationHeightAnchor.constant = height
+        animationWidthAnchor.constant = width
+        skipLabel.font = UIFont.systemFont(ofSize: fontSize, weight: .medium)
+        skipLabelTopAnchor.constant = 5
     }
 }

--- a/podcasts/SkipButton.swift
+++ b/podcasts/SkipButton.swift
@@ -144,7 +144,6 @@ class SkipButton: UIButton {
     func finishedTransition() {
         guard let lottieView = subviews.first else { return }
 
-
         animationView.clipsToBounds = false
         lottieView.subviews.first?.removeFromSuperview()
     }

--- a/podcasts/SkipButton.swift
+++ b/podcasts/SkipButton.swift
@@ -47,7 +47,7 @@ class SkipButton: UIButton {
         animationView.clipsToBounds = false
 
         skipLabel.textAlignment = .center
-        skipLabel.font = UIFont.systemFont(ofSize: 14, weight: .medium)
+        skipLabel.font = UIFont.systemFont(ofSize: Size.large.sizes.fontSize, weight: .medium)
         skipLabel.textColor = UIColor.white
 
         addTarget(self, action: #selector(playAnimation), for: .touchUpInside)
@@ -66,9 +66,9 @@ class SkipButton: UIButton {
         setupViews()
     }
 
-    private lazy var animationHeightAnchor = animationView.heightAnchor.constraint(equalToConstant: 53)
-    private lazy var animationWidthAnchor = animationView.widthAnchor.constraint(equalToConstant: 45)
-    private lazy var skipLabelTopAnchor = skipLabel.topAnchor.constraint(equalTo: animationView.topAnchor, constant: 8)
+    private lazy var animationHeightAnchor = animationView.heightAnchor.constraint(equalToConstant: Size.large.sizes.height)
+    private lazy var animationWidthAnchor = animationView.widthAnchor.constraint(equalToConstant: Size.large.sizes.width)
+    private lazy var skipLabelTopAnchor = skipLabel.topAnchor.constraint(equalTo: animationView.topAnchor, constant: Size.large.sizes.topPadding)
 
     func setupViews() {
         animationView.translatesAutoresizingMaskIntoConstraints = false
@@ -103,10 +103,20 @@ class SkipButton: UIButton {
         animationView.play()
     }
 
-    func change(width: CGFloat, height: CGFloat, fontSize: CGFloat) {
-        animationHeightAnchor.constant = height
-        animationWidthAnchor.constant = width
-        skipLabel.font = UIFont.systemFont(ofSize: fontSize, weight: .medium)
-        skipLabelTopAnchor.constant = 5
+    func changeSize(to size: Size) {
+        let sizes = size.sizes
+        animationHeightAnchor.constant = sizes.height
+        animationWidthAnchor.constant = sizes.width
+        skipLabel.font = UIFont.systemFont(ofSize: sizes.fontSize, weight: .medium)
+        skipLabelTopAnchor.constant = sizes.topPadding
+    }
+
+    enum Size {
+        case small
+        case large
+
+        var sizes: (width: CGFloat, height: CGFloat, fontSize: CGFloat, topPadding: CGFloat) {
+            self == .small ? (32, 32, 10, 5) : (45, 53, 14, 8)
+        }
     }
 }

--- a/podcasts/SkipButton.swift
+++ b/podcasts/SkipButton.swift
@@ -36,7 +36,12 @@ class SkipButton: UIButton {
     private var animationView: LottieAnimationView
     private let skipLabel: UILabel
 
-    var currentSize: Size = .large
+    private var currentSize: Size = .large
+
+    private lazy var animationHeightAnchor = animationView.heightAnchor.constraint(equalToConstant: Size.large.sizes.height)
+    private lazy var animationWidthAnchor = animationView.widthAnchor.constraint(equalToConstant: Size.large.sizes.width)
+    private lazy var skipLabelCenterYAnchor = skipLabel.centerYAnchor.constraint(equalTo: centerYAnchor, constant: Size.large.sizes.topPadding / 2)
+    private lazy var skipLabelXConstraint = skipBack ? trailingAnchor.constraint(equalTo: skipLabel.trailingAnchor, constant: SkipButton.buttonPadding) : skipLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: SkipButton.buttonPadding)
 
     required init?(coder aDecoder: NSCoder) {
         animationView = LottieAnimationView(name: "skip_button")
@@ -67,11 +72,6 @@ class SkipButton: UIButton {
 
         setupViews()
     }
-
-    private lazy var animationHeightAnchor = animationView.heightAnchor.constraint(equalToConstant: Size.large.sizes.height)
-    private lazy var animationWidthAnchor = animationView.widthAnchor.constraint(equalToConstant: Size.large.sizes.width)
-    private lazy var skipLabelCenterYAnchor = skipLabel.centerYAnchor.constraint(equalTo: centerYAnchor, constant: Size.large.sizes.topPadding / 2)
-    private lazy var skipLabelXConstraint = skipBack ? trailingAnchor.constraint(equalTo: skipLabel.trailingAnchor, constant: SkipButton.buttonPadding) : skipLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: SkipButton.buttonPadding)
 
     func setupViews() {
         animationView.translatesAutoresizingMaskIntoConstraints = false
@@ -120,15 +120,6 @@ class SkipButton: UIButton {
         skipLabelXConstraint.constant = SkipButton.buttonPadding - subtract
     }
 
-    enum Size {
-        case small
-        case large
-
-        var sizes: (width: CGFloat, height: CGFloat, fontSize: CGFloat, topPadding: CGFloat) {
-            self == .small ? (32, 32, 10, 5) : (45, 53, 14, 8)
-        }
-    }
-
     // When using UIVIew.animate LottieAnimationView doesn't play nice with it
     // Here we snapshot the view to provide a smooth animation
     func prepareForAnimateTransition(withBackground: UIColor?) {
@@ -156,5 +147,14 @@ class SkipButton: UIButton {
 
         animationView.clipsToBounds = false
         lottieView.subviews.first?.removeFromSuperview()
+    }
+
+    enum Size {
+        case small
+        case large
+
+        var sizes: (width: CGFloat, height: CGFloat, fontSize: CGFloat, topPadding: CGFloat) {
+            self == .small ? (32, 32, 10, 5) : (45, 53, 14, 8)
+        }
     }
 }


### PR DESCRIPTION
Part of #1848

This adds a transition in the player, allowing transcripts to be displayed while the play controls are still present.

Notice that we haven't defined yet the point of entry to the feature.

https://github.com/Automattic/pocket-casts-ios/assets/7040243/fe7ea98a-98f3-4978-8207-a661a6f39d53

Important: the transition here is not strictly the same as the [one here](https://pocketcastsp2.wordpress.com/2024/04/29/transcripts-i1/#a-icon-toggle). There are still tweaks to be done, but I've spent quite some time on this task for now. I believe the current state allows the work to proceed and then we can refine transitions once the bulk part of the work is done.

Important pt 2: During scoping, we discussed migration of the player to SwiftUI but that will be a complex task and a project on its own.

## To test

Change `playPauseTapped` in `NowPlayingPlayerItemViewController.swift` to:

```swift
    @IBAction func playPauseTapped(_ sender: Any) {
        displayTranscript.toggle()
    }
```

1. Run the app
2. If the miniplayer is visible, tap it. If not, play any episode
3. Tap the play/pause button on the full player
4. ✅ Notice how the player controls and the progress bar goes to the bottom and the tabs disappear
5. Test on small iPhone, big iPhone and iPad

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
