### PR TITLE
Reimagine Sharing: Add trim handles for clip trimming

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1631,6 +1631,8 @@
 		F586959A2C04320100E0754A /* PodcastManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F58695992C04320100E0754A /* PodcastManagerTests.swift */; };
 		F5952FCA2C057C6400754BC3 /* FMDatabaseQueue+Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5952FC92C057C6400754BC3 /* FMDatabaseQueue+Test.swift */; };
 		F5952FCC2C05814100754BC3 /* DownloadManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5952FCB2C05814100754BC3 /* DownloadManagerTests.swift */; };
+		F5954D5E2C3F284D004A8C04 /* TrimSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5954D5D2C3F284D004A8C04 /* TrimSelectionView.swift */; };
+		F5954D602C3F2864004A8C04 /* TrimHandle.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5954D5F2C3F2864004A8C04 /* TrimHandle.swift */; };
 		F5AD9C4D2C3C705200A01896 /* AudioWaveformView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5AD9C4C2C3C705200A01896 /* AudioWaveformView.swift */; };
 		F5B312B42BF5B6D400290696 /* FirebaseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5B312B32BF5B6D400290696 /* FirebaseManager.swift */; };
 		F5B6F0DF2C18DF0900AF5150 /* AudioUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5B6F0DD2C18DF0900AF5150 /* AudioUtilsTests.swift */; };
@@ -3461,6 +3463,8 @@
 		F58695992C04320100E0754A /* PodcastManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PodcastManagerTests.swift; sourceTree = "<group>"; };
 		F5952FC92C057C6400754BC3 /* FMDatabaseQueue+Test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FMDatabaseQueue+Test.swift"; sourceTree = "<group>"; };
 		F5952FCB2C05814100754BC3 /* DownloadManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadManagerTests.swift; sourceTree = "<group>"; };
+		F5954D5D2C3F284D004A8C04 /* TrimSelectionView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrimSelectionView.swift; sourceTree = "<group>"; };
+		F5954D5F2C3F2864004A8C04 /* TrimHandle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrimHandle.swift; sourceTree = "<group>"; };
 		F5AD75442B7FDC2800D65C55 /* SettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsTests.swift; sourceTree = "<group>"; };
 		F5AD9C4C2C3C705200A01896 /* AudioWaveformView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioWaveformView.swift; sourceTree = "<group>"; };
 		F5B312B32BF5B6D400290696 /* FirebaseManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseManager.swift; sourceTree = "<group>"; };
@@ -7438,6 +7442,8 @@
 		F5235EDA2C3CCAA100C98739 /* Clip */ = {
 			isa = PBXGroup;
 			children = (
+				F5954D5F2C3F2864004A8C04 /* TrimHandle.swift */,
+				F5954D5D2C3F284D004A8C04 /* TrimSelectionView.swift */,
 				F5235EED2C3DF95C00C98739 /* PlayButton.swift */,
 				F57CD7D82C2624AD0035269A /* MediaTrimView.swift */,
 				F5235EE12C3CE5B300C98739 /* MediaTrimBar.swift */,
@@ -9040,6 +9046,7 @@
 				BD13574E27BF24B500A5D7C6 /* EditFolderPodcastsView.swift in Sources */,
 				C713D4FA2A04C90500A78468 /* AccountHeaderViewModel.swift in Sources */,
 				F55C4C762BCF064500A10352 /* DiscoverViewController+CategoryRedesign.swift in Sources */,
+				F5954D602C3F2864004A8C04 /* TrimHandle.swift in Sources */,
 				BDF09F041E669E16009E9845 /* BasePlayPauseButton.swift in Sources */,
 				407B21E72231F6A300B4E492 /* UploadedSettingsViewController.swift in Sources */,
 				8BD7A2472C09134900CF84E8 /* FolderHistoryModel.swift in Sources */,
@@ -9075,6 +9082,7 @@
 				4022A4C0236BA15800900734 /* SleepTimerViewController.swift in Sources */,
 				40F0DE8D22E45236001DAA52 /* PlusLockedInfoCell.swift in Sources */,
 				4086511B23B1CE8400D7585A /* CreateSiriShortcutCell.swift in Sources */,
+				F5954D5E2C3F284D004A8C04 /* TrimSelectionView.swift in Sources */,
 				8B68C1CF2942134300CF25C5 /* BetaMenu.swift in Sources */,
 				4053CE092159E477001C92B1 /* CreateFilterViewController.swift in Sources */,
 				C7D8AE572A5F6D2600C9EBAF /* ActionBarOverlayView.swift in Sources */,

--- a/podcasts/Sharing/Clip/TrimHandle.swift
+++ b/podcasts/Sharing/Clip/TrimHandle.swift
@@ -1,0 +1,74 @@
+import SwiftUI
+
+struct TrimHandle: View {
+    enum Side {
+        case leading
+        case trailing
+    }
+
+    @Binding var position: CGFloat
+    let side: Side
+    let onChanged: (CGFloat) -> Void
+
+    private enum Constants {
+        static let innerLineColor = Color(hex: "281313").opacity(0.2)
+        static let innerLineWidth = 1.5
+        static let width: CGFloat = 17
+        static let cornerRadius: CGFloat = 8
+    }
+
+    var body: some View {
+        ZStack {
+            Rectangle()
+                .fill(.tint)
+                .modify { view in
+                    if #available(iOS 16, *) {
+                        view.clipShape(.rect(topLeadingRadius: edgeRadius.leading,
+                                             bottomLeadingRadius: edgeRadius.leading,
+                                             bottomTrailingRadius: edgeRadius.trailing,
+                                             topTrailingRadius: edgeRadius.trailing))
+                    } else {
+                        view.clipShape(PCUnevenRoundedRectangle(topLeadingRadius: edgeRadius.leading,
+                                                                bottomLeadingRadius: edgeRadius.leading,
+                                                                bottomTrailingRadius: edgeRadius.trailing,
+                                                                topTrailingRadius: edgeRadius.trailing))
+                    }
+                }
+            handleLine
+        }
+        .frame(width: Constants.width)
+        .offset(x: offset)
+        .onTapGesture {}
+        .highPriorityGesture(
+            DragGesture(minimumDistance: 0)
+                .onChanged { value in
+                    onChanged(value.location.x)
+                }
+        )
+    }
+
+    @ViewBuilder private var handleLine: some View {
+        RoundedRectangle(cornerRadius: Constants.cornerRadius)
+            .fill(Constants.innerLineColor)
+            .frame(width: Constants.innerLineWidth)
+            .padding(.vertical, Constants.width)
+    }
+
+    var offset: CGFloat {
+        switch side {
+        case .leading:
+            position - Constants.width
+        case .trailing:
+            position
+        }
+    }
+
+    var edgeRadius: (leading: CGFloat, trailing: CGFloat) {
+        switch side {
+        case .leading:
+            return (Constants.cornerRadius, 0)
+        case .trailing:
+            return (0, Constants.cornerRadius)
+        }
+    }
+}

--- a/podcasts/Sharing/Clip/TrimHandle.swift
+++ b/podcasts/Sharing/Clip/TrimHandle.swift
@@ -66,9 +66,9 @@ struct TrimHandle: View {
     var edgeRadius: (leading: CGFloat, trailing: CGFloat) {
         switch side {
         case .leading:
-            return (Constants.cornerRadius, 0)
+            (Constants.cornerRadius, 0)
         case .trailing:
-            return (0, Constants.cornerRadius)
+            (0, Constants.cornerRadius)
         }
     }
 }

--- a/podcasts/Sharing/Clip/TrimSelectionView.swift
+++ b/podcasts/Sharing/Clip/TrimSelectionView.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+struct TrimSelectionView: View {
+    @Binding var leading: CGFloat
+    @Binding var trailing: CGFloat
+
+    let changed: (CGFloat, TrimHandle.Side) -> Void
+
+    private enum Constants {
+        static let borderWidth: CGFloat = 4
+    }
+
+    var body: some View {
+        ZStack(alignment: .leading) {
+            Rectangle()
+                .foregroundColor(Color.clear)
+                .border(.tint, width: Constants.borderWidth)
+                // Offset and frame are adjusted to hide this rectangle behind the Trim Handles
+                .frame(width: (trailing - leading) + (Constants.borderWidth * 2))
+                .offset(x: leading - Constants.borderWidth)
+            TrimHandle(position: $leading, side: .leading, onChanged: { changed($0, .leading) })
+            TrimHandle(position: $trailing, side: .trailing, onChanged: { changed( $0, .trailing) })
+        }
+    }
+}


### PR DESCRIPTION
| 📘 Part of: https://github.com/Automattic/pocket-casts-ios/issues/1910 |
|:---:|

Adds trim handles for selecting a section to be clipped.

<img src="https://github.com/Automattic/pocket-casts-ios/assets/3250/f7a7e5d1-6a41-48e4-8859-e85f7045da44" width=300>

## To test

> [!NOTE]
> Enable the `newSharing` feature flag to test this

* Open the Now Playing view in the player
* Tap the share button in the upper right
* Tap the "Clip" option
* Verify that the timeline behaves as expected by scrolling back and forth
* Verify that the handles work as expected. **NOTE**: Right now, the positions aren't locked in relation to the playhead.
* Tap the "Clip" button
* Check the console and verify that the clip values appear correct
```
Clip: s:1387.8048706054688 e:1483.1244444444444
```

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
