### PR TITLE
Determine download content type from URL extension

### DIFF
--- a/podcasts/DownloadManager.swift
+++ b/podcasts/DownloadManager.swift
@@ -281,7 +281,7 @@ class DownloadManager: NSObject, FilePathProtocol {
             } else {
                 episode.autoDownloadStatus = Settings.downloadUpNextEpisodes() ? AutoDownloadStatus.autoDownloaded.rawValue :  AutoDownloadStatus.playerDownloadedForStreaming.rawValue
             }
-            episode.contentType = UTType.mpeg4Audio.preferredMIMEType
+            episode.contentType = UTType(episode.fileExtension())?.preferredMIMEType
             let downloadTaskUUID = episode.uuid
             downloadingEpisodesCache[downloadTaskUUID] = episode
             downloadAndStreamEpisodes.insert(downloadTaskUUID)
@@ -301,7 +301,7 @@ class DownloadManager: NSObject, FilePathProtocol {
             downloadAndStreamEpisodes.remove(downloadTaskUUID)
 
             if exportCompleted, let episode = dataManager.findBaseEpisode(uuid: episode.uuid) {
-                if let contentType = UTType.mpeg4Audio.preferredMIMEType {
+                if let contentType = episode.contentType {
                     DataManager.sharedManager.saveEpisode(contentType: contentType, episode: episode)
                 }
                 if episode.autoDownloadStatus == AutoDownloadStatus.notSpecified.rawValue || episode.autoDownloadStatus == AutoDownloadStatus.autoDownloaded.rawValue {


### PR DESCRIPTION
| 📘 Part of: https://github.com/Automattic/pocket-casts-ios/issues/1795 |
|:---:|

Fixes a streaming audio glitch when caching the episode using `AVExportSession`

## To test

* Navigate to an episode like [this one](https://pca.st/xn1iqlip)
* Play the episode
* Verify that no skipping happens within the first 10 seconds (other than the minor jump from stream to download)

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
