### PR TITLE
[Give Rating] Add tracks events

### DIFF
--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -659,6 +659,11 @@ enum AnalyticsEvent: String {
 
     // MARK: - Ratings
     case ratingStarsTapped
+    case ratingScreenShown
+    case ratingScreenDismissed
+    case ratingScreenSubmitTapped
+    case notAllowedToRateScreenShown
+    case notAllowedToRateScreenDismissed
 
     // MARK: - Patron
     case patronWelcomeAppIconChanged

--- a/podcasts/Ratings/RatePodcastView.swift
+++ b/podcasts/Ratings/RatePodcastView.swift
@@ -143,6 +143,6 @@ struct RatePodcastView: View {
 }
 
 #Preview {
-    RatePodcastView(viewModel: RatePodcastViewModel(presented: .constant(true), podcast: Podcast.previewPodcast()))
+    RatePodcastView(viewModel: RatePodcastViewModel(presented: .constant(true), dismissAction: .constant(.default), podcast: Podcast.previewPodcast()))
         .environmentObject(Theme.sharedTheme)
 }

--- a/podcasts/Ratings/RatePodcastViewModel.swift
+++ b/podcasts/Ratings/RatePodcastViewModel.swift
@@ -62,6 +62,9 @@ class RatePodcastViewModel: ObservableObject {
 
     func submit() {
         isSubmitting = true
+        Analytics.shared.track(.ratingScreenSubmitTapped,
+                               properties: ["uuid": podcast.uuid,
+                                            "stars": stars])
         Task { @MainActor [weak self] in
             guard let self else { return }
             let success = await ApiServerHandler.shared.addRating(uuid: self.podcast.uuid, rating: Int(self.stars))
@@ -74,6 +77,8 @@ class RatePodcastViewModel: ObservableObject {
     }
 
     func dismiss() {
+        let event: AnalyticsEvent = userCanRate == .allowed ? .ratingScreenDismissed : .notAllowedToRateScreenDismissed
+        Analytics.shared.track(event)
         presented = false
     }
 
@@ -87,6 +92,8 @@ class RatePodcastViewModel: ObservableObject {
                 self.stars = Double(userPodcastRating.podcastRating)
                 self.userPodcastRating = userPodcastRating
             }
+            let event: AnalyticsEvent = userCanRate == .allowed ? .ratingScreenShown : .notAllowedToRateScreenShown
+            Analytics.shared.track(event, properties: ["uuid": uuid])
             self.userCanRate = userCanRate
         }
     }

--- a/podcasts/Ratings/RatePodcastViewModel.swift
+++ b/podcasts/Ratings/RatePodcastViewModel.swift
@@ -70,15 +70,17 @@ class RatePodcastViewModel: ObservableObject {
             let success = await ApiServerHandler.shared.addRating(uuid: self.podcast.uuid, rating: Int(self.stars))
             self.isSubmitting = false
             if success {
-                self.dismiss()
+                self.dismiss(trackingEvent: false)
                 Toast.show(L10n.ratingThankYou)
             }
         }
     }
 
-    func dismiss() {
-        let event: AnalyticsEvent = userCanRate == .allowed ? .ratingScreenDismissed : .notAllowedToRateScreenDismissed
-        Analytics.shared.track(event)
+    func dismiss(trackingEvent: Bool = true) {
+        if trackingEvent {
+            let event: AnalyticsEvent = userCanRate == .allowed ? .ratingScreenDismissed : .notAllowedToRateScreenDismissed
+            Analytics.shared.track(event)
+        }
         presented = false
     }
 

--- a/podcasts/Ratings/StarRatingView.swift
+++ b/podcasts/Ratings/StarRatingView.swift
@@ -6,6 +6,8 @@ struct StarRatingView: View {
     @EnvironmentObject var theme: Theme
     @ObservedObject var viewModel: PodcastRatingViewModel
 
+    @State private var dismissAction: RatePodcastViewModel.DismissAction = .default
+
     /// Keeps track of when we appear to determine if we should animate
     private var startDate: Date = .now
 
@@ -45,11 +47,19 @@ struct StarRatingView: View {
                         viewModel.didTapRating()
                     }
             }
-            .sheet(isPresented: $viewModel.presentingGiveRatings) {
-                if let podcast = viewModel.podcast {
-                    RatePodcastView(viewModel: RatePodcastViewModel(presented: $viewModel.presentingGiveRatings, podcast: podcast))
+            .sheet(isPresented: $viewModel.presentingGiveRatings, onDismiss: {
+                switch dismissAction {
+                case .dismissAndTracking(let event):
+                    Analytics.shared.track(event)
+                default:
+                    break
                 }
-            }
+                dismissAction = .default
+            }, content: {
+                if let podcast = viewModel.podcast {
+                    RatePodcastView(viewModel: RatePodcastViewModel(presented: $viewModel.presentingGiveRatings, dismissAction: $dismissAction, podcast: podcast))
+                }
+            })
 
             Rectangle()
                 .foregroundStyle(theme.primaryUi05)


### PR DESCRIPTION
| 📘 Part of: #1879 
|:---:|

Fixes #1885 

This PR adds these Tracks event:

<img width="1482" alt="image" src="https://github.com/Automattic/pocket-casts-android/assets/42220351/f5b396ea-893d-4dbc-b942-ae8384ad08fd">

## To test

> [!NOTE]
> Make sure the Tracks logger is enabled

1. Open a podcast that you did not listened any episode before
2. Tap on podcast image to open more details
3. Tap on Rate button
4. Ensure 🔵 Tracked: rating_stars_tapped ["uuid": UUID] is tracked
5. ✅ Ensure 🔵 Tracked: not_allowed_to_rate_screen_shown ["uuid": UUID] is tracked
6. Dismiss this screen
7. ✅ Ensure 🔵 Tracked: not_allowed_to_rate_screen_dismissed is tracked
8. Listen some episodes from this podcast
9. ✅ Ensure 🔵 Tracked: rating_stars_tapped ["uuid": UUID] is tracked
10. ✅ Ensure 🔵 Tracked: rating_screen_shown ["uuid": UUID] is tracked
11. Dismiss this screen
12. ✅ Ensure 🔵 Tracked: rating_screen_dismissed is tracked
13. Back to the rating screen again and submit a rate
14. ✅ Ensure 🔵 Tracked: rating_screen_submit_tapped ["uuid": UUID, "stars": VALUE] is tracked

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
