### PR TITLE
[Give Rating] Minimum played episode rate required

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -417,8 +417,8 @@ public class DataManager {
         return episodeManager.findBy(uuid: uuid, dbQueue: dbQueue)
     }
 
-    public func findEpisodeCount(podcastId: Int64) async -> Int {
-        await count(query: "SELECT COUNT(*) FROM \(DataManager.episodeTableName) WHERE podcast_id == ?", values: [podcastId])
+    public func findEpisodeCount(podcastId: Int64) -> Int {
+        count(query: "SELECT COUNT(*) FROM \(DataManager.episodeTableName) WHERE podcast_id == ?", values: [podcastId])
     }
 
     public func findPlayedEpisodes(uuids: [String]) -> [String] {
@@ -973,29 +973,12 @@ public class DataManager {
                     count = resultSet.long(forColumnIndex: 0)
                 }
                 resultSet.close()
-            } catch {}
+            } catch {
+                FileLog.shared.addMessage("DataManager.count error: \(error)")
+            }
         }
 
         return count
-    }
-
-    public func count(query: String, values: [Any]?) async -> Int {
-        return await withCheckedContinuation { continuation in
-            dbQueue.inDatabase { db in
-                do {
-                    var count = 0
-                    let resultSet = try db.executeQuery(query, values: values)
-                    if resultSet.next() {
-                        count = resultSet.long(forColumnIndex: 0)
-                    }
-                    resultSet.close()
-                    continuation.resume(returning: count)
-                } catch {
-                    FileLog.shared.addMessage("DataManager.count error: \(error)")
-                    continuation.resume(returning: 0)
-                }
-            }
-        }
     }
 
     // MARK: - Path Related

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -417,6 +417,10 @@ public class DataManager {
         return episodeManager.findBy(uuid: uuid, dbQueue: dbQueue)
     }
 
+    public func findEpisodeCount(podcastId: Int64) async -> Int {
+        await count(query: "SELECT COUNT(*) FROM \(DataManager.episodeTableName) WHERE podcast_id == ?", values: [podcastId])
+    }
+
     public func findPlayedEpisodes(uuids: [String]) -> [String] {
         episodeManager.findPlayedEpisodes(uuids: uuids, dbQueue: dbQueue)
     }
@@ -973,6 +977,25 @@ public class DataManager {
         }
 
         return count
+    }
+
+    public func count(query: String, values: [Any]?) async -> Int {
+        return await withCheckedContinuation { continuation in
+            dbQueue.inDatabase { db in
+                do {
+                    var count = 0
+                    let resultSet = try db.executeQuery(query, values: values)
+                    if resultSet.next() {
+                        count = resultSet.long(forColumnIndex: 0)
+                    }
+                    resultSet.close()
+                    continuation.resume(returning: count)
+                } catch {
+                    FileLog.shared.addMessage("DataManager.count error: \(error)")
+                    continuation.resume(returning: 0)
+                }
+            }
+        }
     }
 
     // MARK: - Path Related


### PR DESCRIPTION
| 📘 Part of: #1879
|:---:|

Fixes #1907 

This PR add the logic that set the minimum played episode count required to allow the user to rate a podcast.
The value could be 1 or 2 depending bby the number of episodes a podcast can have.
If the podcast has only 1 episode, than the minimum value will be 1.
If the podcast has more than 1 episode, than the minimum value is 2.

## To test

> [!NOTE]
> Have giveRatings feature flag enabled
> Please use Staging to test

1. Find a podcast with more than 1 episodes you never listen to
2. Open the rating view and confirm you can NOT rate it
3. Play few episodes
4. Re-open it and confirm you can rate it
5. Find a podcast with 1 episode you never listen to. If you don't have one use [https://anchor.fm/s/f68090c0/podcast/rss](https://anchor.fm/s/f68090c0/podcast/rss)
6. Open the rating view and confirm you can NOT rate it
3. Play the episode
4. Re-open it and confirm you can rate it

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
