### PR TITLE
Reimagine Sharing: Clip Links

### DIFF
--- a/podcasts/Sharing/SharingModal.swift
+++ b/podcasts/Sharing/SharingModal.swift
@@ -10,6 +10,7 @@ enum SharingModal {
         case podcast(Podcast)
         case currentPosition(Episode, TimeInterval)
         case clip(Episode, TimeInterval)
+        case clipShare(Episode, ClipTime)
 
         var buttonTitle: String {
             switch self {
@@ -19,7 +20,7 @@ enum SharingModal {
                 L10n.shareCurrentPosition
             case .podcast:
                 L10n.podcastSingular
-            case .clip:
+            case .clip, .clipShare:
                 L10n.clip
             }
         }
@@ -34,6 +35,8 @@ enum SharingModal {
                 L10n.sharePodcast
             case .clip:
                 L10n.createClip
+            case .clipShare:
+                L10n.shareClip
             }
         }
 
@@ -107,7 +110,7 @@ enum SharingModal {
 extension SharingModal.Option {
     private var description: String {
         switch self {
-        case .episode(let episode), .currentPosition(let episode, _), .clip(let episode, _):
+        case .episode(let episode), .currentPosition(let episode, _), .clip(let episode, _), .clipShare(let episode, _):
             if let date = episode.publishedDate {
                 return date.formatted(Date.FormatStyle(date: .abbreviated, time: .omitted))
             } else {
@@ -120,7 +123,7 @@ extension SharingModal.Option {
 
     private var title: String? {
         switch self {
-        case .episode(let episode), .currentPosition(let episode, _), .clip(let episode, _):
+        case .episode(let episode), .currentPosition(let episode, _), .clip(let episode, _), .clipShare(let episode, _):
             episode.title
         case .podcast(let podcast):
             podcast.title
@@ -129,7 +132,7 @@ extension SharingModal.Option {
 
     private var name: String? {
         switch self {
-        case .episode(let episode), .currentPosition(let episode, _), .clip(let episode, _):
+        case .episode(let episode), .currentPosition(let episode, _), .clip(let episode, _), .clipShare(let episode, _):
             episode.parentPodcast()?.title
         case .podcast(let podcast):
             podcast.author
@@ -138,7 +141,7 @@ extension SharingModal.Option {
 
     private var podcast: Podcast {
         switch self {
-        case .episode(let episode), .currentPosition(let episode, _), .clip(let episode, _):
+        case .episode(let episode), .currentPosition(let episode, _), .clip(let episode, _), .clipShare(let episode, _):
             return episode.parentPodcast()!
         case .podcast(let podcast):
             return podcast
@@ -169,6 +172,8 @@ extension SharingModal.Option {
             return episode.shareURL + "?t=\(round(timeInterval))"
         case .clip(let episode, let timeInterval):
             return episode.shareURL + "?t=\(round(timeInterval))"
+        case .clipShare(let episode, let clipTime):
+            return episode.shareURL + "?t=\(clipTime.start),\(clipTime.end)"
         }
     }
 }

--- a/podcasts/Sharing/SharingView.swift
+++ b/podcasts/Sharing/SharingView.swift
@@ -56,7 +56,9 @@ struct SharingView: View {
                         .frame(height: 72)
                         .tint(color)
                     Button(L10n.clip, action: {
-                        selectedOption = .clipShare(episode, clipTime)
+                        withAnimation {
+                            selectedOption = .clipShare(episode, clipTime)
+                        }
                     }).buttonStyle(RoundedButtonStyle(theme: theme, backgroundColor: color))
                 }
                 .padding(.horizontal, 16)
@@ -86,7 +88,9 @@ struct SharingView: View {
                 EmptyView() // Don't show the description to give extra space for trim view
             case .clipShare(let episode, let clipTime):
                 Button(action: {
-                    selectedOption = .clip(episode, clipTime.playback)
+                    withAnimation {
+                        selectedOption = .clip(episode, clipTime.playback)
+                    }
                 }) {
                     Text(L10n.editClip)
                         .padding(.vertical, 4)
@@ -96,6 +100,7 @@ struct SharingView: View {
                                 .fill(.white.opacity(0.2))
                         )
                 }
+                .padding(.top, 14)
             default:
                 Text(L10n.shareDescription)
                     .font(.subheadline)

--- a/podcasts/Sharing/SharingView.swift
+++ b/podcasts/Sharing/SharingView.swift
@@ -23,7 +23,8 @@ struct SharingView: View {
     }
 
     let destinations: [ShareDestination]
-    let selectedOption: SharingModal.Option
+
+    @State var selectedOption: SharingModal.Option
 
     @State private var selectedMedia: ShareImageStyle
 
@@ -49,16 +50,18 @@ struct SharingView: View {
             switch selectedOption {
             case .episode, .podcast, .currentPosition:
                 buttons
-            case .clip:
+            case .clip(let episode, _):
                 VStack(spacing: 16) {
                     MediaTrimBar(clipTime: clipTime)
                         .frame(height: 72)
                         .tint(color)
                     Button(L10n.clip, action: {
-                        print("Clip: s:\(clipTime.start) e:\(clipTime.end)")
+                        selectedOption = .clipShare(episode, clipTime)
                     }).buttonStyle(RoundedButtonStyle(theme: theme, backgroundColor: color))
                 }
                 .padding(.horizontal, 16)
+            case .clipShare:
+                buttons
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -81,6 +84,18 @@ struct SharingView: View {
             switch selectedOption {
             case .clip:
                 EmptyView() // Don't show the description to give extra space for trim view
+            case .clipShare(let episode, let clipTime):
+                Button(action: {
+                    selectedOption = .clip(episode, clipTime.playback)
+                }) {
+                    Text(L10n.editClip)
+                        .padding(.vertical, 4)
+                        .padding(.horizontal, 10)
+                        .background(
+                            Capsule()
+                                .fill(.white.opacity(0.2))
+                        )
+                }
             default:
                 Text(L10n.shareDescription)
                     .font(.subheadline)

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -758,6 +758,8 @@ internal enum L10n {
   internal static var downloadsStopAllDownloads: String { return L10n.tr("Localizable", "downloads_stop_all_downloads") }
   /// Edit
   internal static var edit: String { return L10n.tr("Localizable", "edit") }
+  /// Edit clip
+  internal static var editClip: String { return L10n.tr("Localizable", "edit_clip") }
   /// Enable it now
   internal static var enableItNow: String { return L10n.tr("Localizable", "enable_it_now") }
   /// See your listening stats, top podcasts, and more.
@@ -2738,6 +2740,8 @@ internal enum L10n {
   internal static var shakeToRestartSleepTimerDescription: String { return L10n.tr("Localizable", "shake_to_restart_sleep_timer_description") }
   /// Share
   internal static var share: String { return L10n.tr("Localizable", "share") }
+  /// Share clip
+  internal static var shareClip: String { return L10n.tr("Localizable", "share_clip") }
   /// Link copied to clipboard
   internal static var shareCopiedToClipboard: String { return L10n.tr("Localizable", "share_copied_to_clipboard") }
   /// Copy link

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4168,3 +4168,9 @@
 
 /* Shown in a button when creating a shareable audio clip of an episode */
 "clip" = "Clip";
+
+/* A title shown for a button to return to editing a clip */
+"edit_clip" = "Edit clip";
+
+/* A title shown after editing a clip but before sharing */
+"share_clip" = "Share clip";


### PR DESCRIPTION
| 📘 Part of: https://github.com/Automattic/pocket-casts-ios/issues/1910 |
|:---:|
| 🔧 Implements: https://github.com/Automattic/pocket-casts-ios/issues/1911 |

## To test

> [!NOTE]
> Enable the `newSharing` feature flag to test this

* Open the Now Playing view in the player
* Tap the share button in the upper right
* Tap the "Clip" option
* Tap the "Clip" button
* Verify that the screen changes to show the sharing destinations
* Tap the "Copy Link" button
* Verify that the copied link works in Safari or elsewhere to open a web page with the correct clip of the episode
* Try changing the selection by tapping the "Edit Clip" and verify that those changes are reflected in the final shared clip link

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
