### PR TITLE
[Give Ratings] Present login screen if not logged in

### DIFF
--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -248,6 +248,18 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
         NotificationCenter.default.addObserver(self, selector: #selector(folderChanged(_:)), name: Constants.Notifications.folderChanged, object: nil)
 
         listenForBookmarkChanges()
+        if FeatureFlag.giveRatings.enabled {
+            setupLogin()
+        }
+    }
+
+    private func setupLogin() {
+        podcastRatingViewModel.presentLogin = { [weak self] viewModel in
+            let loginViewController = LoginCoordinator.make()
+            self?.present(loginViewController, animated: true)
+
+            Toast.show(L10n.ratingLoginRequired)
+        }
     }
 
     private func listenForBookmarkChanges() {

--- a/podcasts/Ratings/PodcastRatingViewModel.swift
+++ b/podcasts/Ratings/PodcastRatingViewModel.swift
@@ -7,6 +7,8 @@ class PodcastRatingViewModel: ObservableObject {
     @Published var rating: PodcastRating? = nil
     @Published var presentingGiveRatings = false
 
+    var presentLogin: ((PodcastRatingViewModel) -> Void)? = nil
+
     /// Whether we should display the total ratings or not
     var showTotal: Bool = true
 
@@ -58,6 +60,14 @@ class PodcastRatingViewModel: ObservableObject {
 extension PodcastRatingViewModel {
     func didTapRating() {
         if FeatureFlag.giveRatings.enabled {
+            if SyncManager.isUserLoggedIn() {
+                presentingGiveRatings = true
+            } else {
+                DispatchQueue.main.async {
+                    self.presentLogin?(self)
+                }
+            }
+        } else {
             presentingGiveRatings = true
         }
 

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -2172,6 +2172,8 @@ internal enum L10n {
   internal static var ratingListenToThisPodcastMessage: String { return L10n.tr("Localizable", "rating_listen_to_this_podcast_message") }
   /// Please listen to this podcast first
   internal static var ratingListenToThisPodcastTitle: String { return L10n.tr("Localizable", "rating_listen_to_this_podcast_title") }
+  /// You must log in to leave a rating
+  internal static var ratingLoginRequired: String { return L10n.tr("Localizable", "rating_login_required") }
   /// No ratings
   internal static var ratingNoRatings: String { return L10n.tr("Localizable", "rating_no_ratings") }
   /// Your rating was submitted!

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4010,6 +4010,9 @@
 /* Title of a button that takes the user to a screen to rate a podcast */
 "rate" = "Rate";
 
+/* Toast message to alert a user to log in to leave a rating */
+"rating_login_required" = "You must log in to leave a rating";
+
 /* Title of a message shown when the users data is being exported */
 "exporting_database" = "Exporting Database...";
 


### PR DESCRIPTION
| 📘 Part of: #1879
|:---:|

Fixes #1890 

We want to align the behaviour with Android by presenting the login sceen if the user is not signed in. Also we show the Toast explaining why we presented the screen.

## To test

> [!NOTE]
> Enable `giveRatings` feture flag

https://github.com/user-attachments/assets/3968fbed-c28d-4054-9a05-db97b7edca97

- Make sure your user is signed in
- Open a podcast
- Tapping rate should display the rate view
- Log out
- Open a podcast
- Tapping rate should present the login page and the toast
- Login
- Tap rate again: you should see the rate page

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
