### PR TITLE
Fix video/mp4 content type back for file handling

### DIFF
--- a/podcasts/FileTypeUtil.swift
+++ b/podcasts/FileTypeUtil.swift
@@ -6,6 +6,7 @@ class FileTypeUtil {
 
         if type.contains("video/3gpp") { return ".3gp" }
         else if type.contains("video/3gpp2") { return ".3g2" }
+        else if type.contains("video/mp4") { return ".mp4" }
         else if type.contains("video/x-mp4") { return ".mp4" }
         else if type.contains("video/quicktime") { return ".mov" }
         else if type.contains("video/m4v") { return ".m4v" }
@@ -44,6 +45,7 @@ class FileTypeUtil {
         if fileExtension.contains(".3gp") { return "video/3gpp" }
         else if fileExtension.contains(".3g2") { return "video/3gpp2" }
         else if fileExtension.contains(".mov") { return "video/quicktime" }
+        else if fileExtension.contains(".mp4") { return "video/mp4" }
         else if fileExtension.contains(".m4v") { return "video/m4v" }
         else if fileExtension.contains(".m4a") { return "audio/aac" }
         else if fileExtension.contains(".aiff") { return "audio/aiff" }


### PR DESCRIPTION
Fixes an issue where video mp4s would not play

## To test

* Add a `mp4` file to the Files app
* Go back to Pocket Casts
* Navigate to Profile > Files > Add File
* Pick the mp4 and add it
* Make sure the mp4 plays back

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
