### PR TITLE
Remove private key swap for private repos — No longer needed

### DIFF
--- a/.buildkite/commands/build.sh
+++ b/.buildkite/commands/build.sh
@@ -1,21 +1,5 @@
 #!/bin/bash -u
 
-echo "--- Set up SPM"
-PRIVATE_REPO_FETCH_KEY_NAME=private_repos_key
-add_ssh_key_to_agent "$PRIVATE_REPOS_BOT_KEY" $PRIVATE_REPO_FETCH_KEY_NAME
-PRIVATE_REPO_FETCH_KEY=~/.ssh/$PRIVATE_REPO_FETCH_KEY_NAME
-
-add_host_to_ssh_known_hosts 'github.com'
-
-# Configuring Git to use the custom SSH key for the pocket-casts-ios-utils
-# private repo. This is a different key than the one we use to fetch the Pocket
-# Casts repo itself. If all goes well, the Git instance Xcode will use will
-# adopt this setting, too (see IDEPackageSupportUseBuiltinSCM below).
-#
-# See https://stackoverflow.com/a/38474137/809944
-export GIT_SSH_COMMAND="ssh -i $PRIVATE_REPO_FETCH_KEY -o IdentitiesOnly=yes"
-echo "Git SSH command is $GIT_SSH_COMMAND"
-
 echo "--- :swift: Installing Swift Package Manager Dependencies"
 install_swiftpm_dependencies
 


### PR DESCRIPTION
The discussion about read-only vs read-write and deploy key vs account SSH key in https://github.com/wordpress-mobile/WordPress-iOS/pull/23424 made me wonder whether this repo still needed to access private components after going open source [two years ago](e39c856710047a5443c9ca9f08219f623836b356).

I skimmed the dependencies and couldn't find anything private so I remove the `GIT_SSH_COMMAND` override and, verified CI was green, including the Prototype Build just in case.

## To test

See green CI

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary. – N.A.
- [x] I have considered adding unit tests for my changes. – N.A.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics. – N.A.