### PR TITLE
Adds CHANGELOG entry for mp4 playback fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 -----
 - New designs for Widgets. [#1343](https://github.com/Automattic/pocket-casts-ios/pull/1343)
 - Search: fix an issue with scroll when tapping an episode [#1874](https://github.com/Automattic/pocket-casts-ios/pull/1874)
+- Fixes video playback on mp4 files [#1918](https://github.com/Automattic/pocket-casts-ios/pull/1918)
 
 7.67
 -----


### PR DESCRIPTION
Adds a changelog entry for the https://github.com/Automattic/pocket-casts-ios/pull/1918 PR

This was already added to the App Store release notes see: pfmMyT-28-p2#comment-66

## To test

Nothing

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.