### PR TITLE
Show Notes: force the request to be made if an episode is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 7.69
 -----
-
+- Fix an issue for show notes not loading. [#1928](https://github.com/Automattic/pocket-casts-ios/pull/1928)
 
 7.68
 -----

--- a/Modules/Server/Sources/PocketCastsServer/Public/Cache/ShowInfoDataRetriever.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Cache/ShowInfoDataRetriever.swift
@@ -22,7 +22,7 @@ public actor ShowInfoDataRetriever {
 
         if let cachedResponse = cache.cachedResponse(for: request),
             let metadata = extractMetadata(for: episodeUuid, from: cachedResponse.data) {
-            FileLog.shared.addMessage("Show Info: returning cached data for \(episodeUuid)")
+            FileLog.shared.addMessage("Show Info: returning cached data for episode \(episodeUuid)")
             return metadata
         }
 

--- a/Modules/Server/Sources/PocketCastsServer/Public/Cache/ShowInfoDataRetriever.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Cache/ShowInfoDataRetriever.swift
@@ -49,6 +49,8 @@ public actor ShowInfoDataRetriever {
             }
         }
 
+        FileLog.shared.addMessage("Show Info: requesting info for podcast \(podcastUuid)")
+
         let task = Task<Data, Error> {
             do {
                 let (data, response) = try await URLSession.shared.data(for: request)
@@ -56,14 +58,17 @@ public actor ShowInfoDataRetriever {
                 if response.extractStatusCode() == 200 {
                     let responseToCache = CachedURLResponse(response: response, data: data)
                     cache.storeCachedResponse(responseToCache, for: request)
+                    FileLog.shared.addMessage("Show Info: request succeeded for podcast \(podcastUuid).")
                 } else if let data = cache.cachedResponse(for: request)?.data {
                     dataRequestMap[podcastUuid] = nil
+                    FileLog.shared.addMessage("Show Info: request failed for podcast \(podcastUuid). Returning cached data")
                     return data
                 }
 
                 dataRequestMap[podcastUuid] = nil
                 return data
             } catch {
+                FileLog.shared.addMessage("Show Info: request failed for podcast \(podcastUuid): \(error.localizedDescription). Returning cached data")
                 dataRequestMap[podcastUuid] = nil
                 throw error
             }

--- a/Modules/Server/Sources/PocketCastsServer/Public/Cache/ShowInfoDataRetriever.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Cache/ShowInfoDataRetriever.swift
@@ -1,4 +1,5 @@
 import Foundation
+import PocketCastsUtils
 
 /// Request information about an episode using the show notes endpoint
 public actor ShowInfoDataRetriever {
@@ -21,6 +22,7 @@ public actor ShowInfoDataRetriever {
 
         if let cachedResponse = cache.cachedResponse(for: request),
             let metadata = extractMetadata(for: episodeUuid, from: cachedResponse.data) {
+            FileLog.shared.addMessage("Show Info: returning cached data for \(episodeUuid)")
             return metadata
         }
 

--- a/Modules/Server/Sources/PocketCastsServer/Public/Cache/ShowInfoDataRetriever.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Cache/ShowInfoDataRetriever.swift
@@ -37,7 +37,7 @@ public actor ShowInfoDataRetriever {
         }
 
         let url = ServerHelper.asUrl(ServerConstants.Urls.cache() + "mobile/show_notes/full/\(podcastUuid)")
-        var request = URLRequest(url: url, cachePolicy: .reloadRevalidatingCacheData)
+        var request = URLRequest(url: url, cachePolicy: .reloadIgnoringLocalAndRemoteCacheData)
 
         if let cachedResponse = cache.cachedResponse(for: URLRequest(url: url)) {
             if let etag = cachedResponse.response.etag {

--- a/podcasts/Episode Info Coordinator/ShowInfoCoordinator.swift
+++ b/podcasts/Episode Info Coordinator/ShowInfoCoordinator.swift
@@ -71,38 +71,6 @@ actor ShowInfoCoordinator: ShowInfoCoordinating {
         try await requestShowInfo(podcastUuid: podcastUuid, episodeUuid: episodeUuid)
     }
 
-    func loadRawMetadata(
-        podcastUuid: String,
-        episodeUuid: String
-    ) async throws -> String? {
-        try await requestRawMetadata(podcastUuid: podcastUuid, episodeUuid: episodeUuid)
-    }
-
-    @discardableResult
-    func requestRawMetadata(
-        podcastUuid: String,
-        episodeUuid: String
-    ) async throws -> String? {
-        if let task = requestingRawMetadata[episodeUuid] {
-            return try await task.value
-        }
-
-        let task = Task<String?, Error> { [unowned self] in
-            do {
-                let data = try await dataRetriever.loadEpisodeDataFromCache(for: podcastUuid, episodeUuid: episodeUuid)
-                requestingRawMetadata[episodeUuid] = nil
-                return data
-            } catch {
-                requestingRawMetadata[episodeUuid] = nil
-                throw error
-            }
-        }
-
-        requestingRawMetadata[episodeUuid] = task
-
-        return try await task.value
-    }
-
     @discardableResult
     func requestShowInfo(
         podcastUuid: String,


### PR DESCRIPTION
We have a few complaints about the episode notes not showing for some users. After looking at it, I believe this is what happens:

1. The show notes for a given episode are requested
2. The app can't find it in the cache, so it requests
3. However we were using `reloadRevalidatingCacheData`. If our `etag` or `lastModified` matches the server (which is weird for me but it seems it's happening), the request won't be made and the cached data will be returned again

This creates a scenario where the show notes will never update unless the `etag` or `lastModified` changes server-wise.

In order to fix it, I changed the policy to `reloadIgnoringLocalAndRemoteCacheData`. This shouldn't be a problem given we check the cache ourselves before calling the method that does it.

I also went ahead and added logs so we can have more info.

## To test

1. Run the app
2. Open any episode from a podcast you haven't interacted with before
3. ✅ `Show Info: requesting info for podcast X` should be logged
4. Open any other episode
5. ✅ `Show Info: returning cached data for episode X` should be logged

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
