### PR TITLE
Transcripts: change logic to check transcript availability

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -500,6 +500,7 @@
 		8B5AB48A29018A950018C637 /* EpilogueStory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B5AB48929018A950018C637 /* EpilogueStory.swift */; };
 		8B5AB48C29018EFA0018C637 /* StoriesConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B5AB48B29018EFA0018C637 /* StoriesConfiguration.swift */; };
 		8B5AB48E2901A8BD0018C637 /* StoriesController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B5AB48D2901A8BD0018C637 /* StoriesController.swift */; };
+		8B5BD0B82C50235400C687CB /* Episode+Transcript.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B5BD0B72C50235400C687CB /* Episode+Transcript.swift */; };
 		8B5F9A6728EFBB9800DE1C12 /* AppIcon-Halloween@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 8B5F9A6528EFBB9700DE1C12 /* AppIcon-Halloween@2x.png */; };
 		8B5F9A6828EFBB9800DE1C12 /* AppIcon-Halloween@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = 8B5F9A6628EFBB9800DE1C12 /* AppIcon-Halloween@3x.png */; };
 		8B5FB8212B88FF52007576F0 /* DeselectChaptersAnnouncementViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B5FB8202B88FF52007576F0 /* DeselectChaptersAnnouncementViewModel.swift */; };
@@ -2372,6 +2373,7 @@
 		8B5AB48929018A950018C637 /* EpilogueStory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EpilogueStory.swift; sourceTree = "<group>"; };
 		8B5AB48B29018EFA0018C637 /* StoriesConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoriesConfiguration.swift; sourceTree = "<group>"; };
 		8B5AB48D2901A8BD0018C637 /* StoriesController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoriesController.swift; sourceTree = "<group>"; };
+		8B5BD0B72C50235400C687CB /* Episode+Transcript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Episode+Transcript.swift"; sourceTree = "<group>"; };
 		8B5F9A6528EFBB9700DE1C12 /* AppIcon-Halloween@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "AppIcon-Halloween@2x.png"; sourceTree = "<group>"; };
 		8B5F9A6628EFBB9800DE1C12 /* AppIcon-Halloween@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "AppIcon-Halloween@3x.png"; sourceTree = "<group>"; };
 		8B5FB8202B88FF52007576F0 /* DeselectChaptersAnnouncementViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeselectChaptersAnnouncementViewModel.swift; sourceTree = "<group>"; };
@@ -7500,6 +7502,7 @@
 				FF7F89E92C2979D900FC0ED5 /* TranscriptsViewController.swift */,
 				FF7F89EC2C2AF6DE00FC0ED5 /* TranscriptManager.swift */,
 				FF7F89F02C2C0FD600FC0ED5 /* TranscriptModel.swift */,
+				8B5BD0B72C50235400C687CB /* Episode+Transcript.swift */,
 			);
 			name = Transcripts;
 			sourceTree = "<group>";
@@ -9241,6 +9244,7 @@
 				8B087FC929DC976F0027EAE5 /* PodcastImage.swift in Sources */,
 				BD95ED6A1BAFA532004335B0 /* CountryChooserViewController.swift in Sources */,
 				C722245C2936CA15006B3B55 /* StoryLogoView.swift in Sources */,
+				8B5BD0B82C50235400C687CB /* Episode+Transcript.swift in Sources */,
 				C713D4F52A04C90500A78468 /* ProfileImage.swift in Sources */,
 				466DE3F6278794D50046F722 /* EpisodeListTableViewCell.swift in Sources */,
 				BD056F111F6F8CE800AF8260 /* MainTabBarController.swift in Sources */,

--- a/podcasts/Episode+Transcript.swift
+++ b/podcasts/Episode+Transcript.swift
@@ -1,0 +1,12 @@
+import PocketCastsDataModel
+
+extension Episode {
+    func checkTranscriptAvailability() {
+        Task.init {
+            if let transcripts = try? await ShowInfoCoordinator.shared.loadTranscripts(podcastUuid: parentIdentifier(), episodeUuid: uuid) {
+                let transcriptsAvailable = !transcripts.isEmpty
+                NotificationCenter.postOnMainThread(notification: Constants.Notifications.episodeTranscriptAvailabilityChanged, userInfo: ["episodeUuid": uuid, "isAvailable": transcriptsAvailable])
+            }
+        }
+    }
+}

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -165,8 +165,6 @@ class PlaybackManager: ServerPlaybackDelegate {
             chapterManager.clearChapterInfo()
         }
 
-        loadTranscripts(episode: episode)
-
         if saveCurrentEpisode && currentEpisode() != nil && !switchingToDifferentUpNextEpisode {
             recordPlaybackPosition(sendToServerImmediately: false, fireNotifications: false)
         }
@@ -2085,20 +2083,6 @@ private extension PlaybackManager {
 
         lastSeekTime = Date()
         isBack ? skipBack() : skipForward()
-    }
-
-    // MARK: - Transcripts
-    private func loadTranscripts(episode: BaseEpisode) {
-        guard FeatureFlag.transcripts.enabled, let episode = episode as? Episode, let podcast = episode.parentPodcast() else {
-            return
-        }
-        transcriptsAvailable = false
-        Task.init {
-            if let transcripts = try? await ShowInfoCoordinator.shared.loadTranscripts(podcastUuid: podcast.uuid, episodeUuid: episode.uuid) {
-                transcriptsAvailable = !transcripts.isEmpty
-                NotificationCenter.postOnMainThread(notification: Constants.Notifications.episodeTranscriptAvailabilityChanged)
-            }
-        }
     }
 }
 

--- a/podcasts/PlayerContainerViewController.swift
+++ b/podcasts/PlayerContainerViewController.swift
@@ -194,7 +194,6 @@ class PlayerContainerViewController: SimpleNotificationsViewController, PlayerTa
         addCustomObserver(Constants.Notifications.playbackStarted, selector: #selector(update))
         addCustomObserver(Constants.Notifications.playbackTrackChanged, selector: #selector(update))
         addCustomObserver(Constants.Notifications.podcastChaptersDidUpdate, selector: #selector(update))
-        addCustomObserver(Constants.Notifications.episodeTranscriptAvailabilityChanged, selector: #selector(update))
         addCustomObserver(Constants.Notifications.themeChanged, selector: #selector(themeDidChange))
     }
 

--- a/podcasts/TranscriptShelfButton.swift
+++ b/podcasts/TranscriptShelfButton.swift
@@ -1,10 +1,11 @@
 import UIKit
+import PocketCastsDataModel
 
 class TranscriptShelfButton: UIButton {
     override init(frame: CGRect) {
         super.init(frame: frame)
         addObservers()
-        playingStateDidChange()
+        checkTranscriptAvailability()
     }
 
     required init?(coder: NSCoder) {
@@ -12,10 +13,40 @@ class TranscriptShelfButton: UIButton {
     }
 
     func addObservers() {
-        NotificationCenter.default.addObserver(self, selector: #selector(playingStateDidChange), name: Constants.Notifications.episodeTranscriptAvailabilityChanged, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(episodeTranscriptAvailabilityChanged), name: Constants.Notifications.episodeTranscriptAvailabilityChanged, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(playbackTrackChanged), name: Constants.Notifications.playbackTrackChanged, object: nil)
     }
 
-    @objc func playingStateDidChange() {
-        isEnabled = PlaybackManager.shared.transcriptsAvailable
+    @objc func playbackTrackChanged() {
+        checkTranscriptAvailability()
+    }
+
+    @objc func episodeTranscriptAvailabilityChanged(notification: NSNotification) {
+        guard let episodeUuid = notification.userInfo?["episodeUuid"] as? String,
+              let isAvailable = notification.userInfo?["isAvailable"] as? Bool,
+              episodeUuid == PlaybackManager.shared.currentEpisode()?.uuid else {
+            return
+        }
+
+        isEnabled = isAvailable
+    }
+
+    private func checkTranscriptAvailability() {
+        isEnabled = false
+        let currentEpisode = PlaybackManager.shared.currentEpisode() as? Episode
+        currentEpisode?.checkTranscriptAvailability()
+    }
+}
+
+extension Episode {
+    // MARK: - Transcripts
+
+    func checkTranscriptAvailability() {
+        Task.init {
+            if let transcripts = try? await ShowInfoCoordinator.shared.loadTranscripts(podcastUuid: parentIdentifier(), episodeUuid: uuid) {
+                let transcriptsAvailable = !transcripts.isEmpty
+                NotificationCenter.postOnMainThread(notification: Constants.Notifications.episodeTranscriptAvailabilityChanged, userInfo: ["episodeUuid": uuid, "isAvailable": transcriptsAvailable])
+            }
+        }
     }
 }

--- a/podcasts/TranscriptShelfButton.swift
+++ b/podcasts/TranscriptShelfButton.swift
@@ -37,16 +37,3 @@ class TranscriptShelfButton: UIButton {
         currentEpisode?.checkTranscriptAvailability()
     }
 }
-
-extension Episode {
-    // MARK: - Transcripts
-
-    func checkTranscriptAvailability() {
-        Task.init {
-            if let transcripts = try? await ShowInfoCoordinator.shared.loadTranscripts(podcastUuid: parentIdentifier(), episodeUuid: uuid) {
-                let transcriptsAvailable = !transcripts.isEmpty
-                NotificationCenter.postOnMainThread(notification: Constants.Notifications.episodeTranscriptAvailabilityChanged, userInfo: ["episodeUuid": uuid, "isAvailable": transcriptsAvailable])
-            }
-        }
-    }
-}


### PR DESCRIPTION
| 📘 Part of: #1848 | 
|:---:|

Changes how we check for transcript availability.

1. Removes the code from `PlaybackManager`
2. Ties it with the `Episode` model instead
3. Add the logic only on the `TranscriptShelfButton`

Additionally, it fixed an issue that displayed the button as disabled until play was tapped.

## To test

1. **Enable** the `transcripts` flag
2. Add episodes to your Up Next containing transcript ([podcasts with transcripts](https://lists.pocketcasts.com/b852a088-ccee-4e4b-a3c5-4bb7fd700a02))
3. Add episodes that do not contain transcripts (such as The Daily)
4. Play an episode with transcripts and open the player
5. ✅ The transcript button should be enabled
6. Tap the Up Next icon, play an episode without a transcript
7. ✅ The transcript button should be disabled
8. Play an episode with transcripts again
9. Close the app, reopen it and open the player
10. ✅ The transcript button should be enabled

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
