### PR TITLE
Make "Pocket Casts Champion" tappable and display a message

### DIFF
--- a/podcasts/AccountViewController+TableView.swift
+++ b/podcasts/AccountViewController+TableView.swift
@@ -6,11 +6,7 @@ import UIKit
 extension AccountViewController: UITableViewDataSource, UITableViewDelegate {
 
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        guard section == 0 else {
-            return UITableView.automaticDimension
-        }
-
-        return headerViewModel.contentSize?.height ?? UITableView.automaticDimension
+        UITableView.automaticDimension
     }
 
     func numberOfSections(in tableView: UITableView) -> Int {

--- a/podcasts/AccountViewController.swift
+++ b/podcasts/AccountViewController.swift
@@ -32,6 +32,7 @@ class AccountViewController: UIViewController, ChangeEmailDelegate {
         let viewModel = AccountHeaderViewModel()
 
         viewModel.viewContentSizeChanged = { [weak self] in
+            self?.updatedHeaderContentView.frame = .init(x: 0, y: 0, width: self?.headerViewModel.contentSize?.width ?? 0, height: self?.headerViewModel.contentSize?.height ?? 0)
             self?.tableView.reloadData()
         }
 

--- a/podcasts/Profile - SwiftUI/Account/AccountHeaderView.swift
+++ b/podcasts/Profile - SwiftUI/Account/AccountHeaderView.swift
@@ -28,7 +28,11 @@ struct AccountHeaderView: View {
                         Text(title)
                             .fixedSize(horizontal: false, vertical: true)
                         Spacer()
-                        label
+                        Button(action: {
+                            Toast.show(L10n.plusChampionMessage)
+                        }, label: {
+                            label
+                        })
                             .fixedSize(horizontal: false, vertical: true)
                     }
                     .foregroundColor(theme.primaryText01)
@@ -65,7 +69,7 @@ struct AccountHeaderView: View {
             // Lifetime membership, show a thank you message
             return (
                 L10n.subscriptionsThankYou,
-                Text(L10n.plusLifetimeMembership)
+                Text(L10n.plusChampion)
                     .foregroundColor(theme.green)
             )
         case .paymentCancelled:

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -1749,6 +1749,10 @@ internal enum L10n {
   internal static var plusButtonTitleUnlockAll: String { return L10n.tr("Localizable", "plus_button_title_unlock_all") }
   /// Can be canceled at any time
   internal static var plusCancelTerms: String { return L10n.tr("Localizable", "plus_cancel_terms") }
+  /// Pocket Casts Champion
+  internal static var plusChampion: String { return L10n.tr("Localizable", "plus_champion") }
+  /// Thanks for being with Pocket Casts from the start. You're a real champion!
+  internal static var plusChampionMessage: String { return L10n.tr("Localizable", "plus_champion_message") }
   /// %1$@ GB Cloud Storage
   internal static func plusCloudStorageLimitFormat(_ p1: Any) -> String {
     return L10n.tr("Localizable", "plus_cloud_storage_limit_format", String(describing: p1))
@@ -1775,8 +1779,6 @@ internal enum L10n {
   internal static func plusFreeMembershipFormat(_ p1: Any) -> String {
     return L10n.tr("Localizable", "plus_free_membership_format", String(describing: p1))
   }
-  /// Lifetime Member
-  internal static var plusLifetimeMembership: String { return L10n.tr("Localizable", "plus_lifetime_membership") }
   /// Desktop & web apps
   internal static var plusMarketingDesktopAppsTitle: String { return L10n.tr("Localizable", "plus_marketing_desktop_apps_title") }
   /// Folders & Bookmarks

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -1558,8 +1558,11 @@
 /* Account detail message informing the user that they have been granted a limited free membership. '%1$@' is a placeholder for a localized string for the free time period. */
 "plus_free_membership_format" = "%1$@ Free Trial";
 
-/* Account detail message informing the user that they have been granted a lifetime membership. */
-"plus_lifetime_membership" = "Lifetime Member";
+/* Account detail message informing the user that they have been granted a lifetime membership, don't translate "Pocket Casts Champion" */
+"plus_champion" = "Pocket Casts Champion";
+
+/* Message displayed when teh user tap "Pocket Casts Champion" button */
+"plus_champion_message" = "Thanks for being with Pocket Casts from the start. You're a real champion!";
 
 /* Pocket Casts Plus marketing page, description of the Cloud Storage feature */
 "plus_marketing_updated_cloud_storage_description" = "Upload your files to cloud storage and have it available everywhere";


### PR DESCRIPTION
Make the "Pocket Casts Champion" label tappable with a message to our champions! ✨ 

## To test

1. Login with an account with a very long Plus gift
2. Go to Profile > Account
3. Tap "Pocket Casts Champion"
4. ✅ You should see a toast displaying a message

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
