### PR TITLE
Fix scrolling drift on Podcasts list grid view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 7.69
 -----
 - Fix an issue for show notes not loading. [#1928](https://github.com/Automattic/pocket-casts-ios/pull/1928)
+- Fix scrolling drift on Podcasts list grid view. [#1930](https://github.com/Automattic/pocket-casts-ios/issues/1930)
 
 7.68
 -----

--- a/podcasts/GridHelper.swift
+++ b/podcasts/GridHelper.swift
@@ -32,7 +32,7 @@ class GridHelper {
         let gridType = Settings.libraryType()
         let spacing = gridType == .list ? 0 : self.spacing
         // Blocks horizontal scrolling on the collection view
-        collectionView.contentSize.width = 0
+        collectionView.contentSize.width = collectionView.bounds.width - 1
         flowLayout.minimumLineSpacing = spacing
         flowLayout.minimumInteritemSpacing = spacing
         flowLayout.sectionInset = UIEdgeInsets(top: spacing * 2, left: 0, bottom: 0, right: 0)

--- a/podcasts/PCSearchBarController+Scrolling.swift
+++ b/podcasts/PCSearchBarController+Scrolling.swift
@@ -4,7 +4,7 @@ extension PCSearchBarController {
     func setupScrollView(_ scrollView: UIScrollView, hideSearchInitially: Bool) {
         if !hideSearchInitially {
             scrollView.contentInset = UIEdgeInsets(top: PCSearchBarController.defaultHeight, left: scrollView.contentInset.left, bottom: scrollView.contentInset.bottom, right: scrollView.contentInset.right)
-            scrollView.setContentOffset(CGPoint(x: 0, y: -PCSearchBarController.defaultHeight), animated: false)
+            scrollView.setContentOffset(CGPoint(x: scrollView.contentOffset.x, y: -PCSearchBarController.defaultHeight), animated: false)
         }
     }
 
@@ -40,9 +40,9 @@ extension PCSearchBarController {
         }
 
         if shouldAnimateDown {
-            scrollView.setContentOffset(CGPoint(x: 0, y: -PCSearchBarController.defaultHeight - topOffset), animated: true)
+            scrollView.setContentOffset(CGPoint(x: scrollView.contentOffset.x, y: -PCSearchBarController.defaultHeight - topOffset), animated: true)
         } else if shouldAnimateUp {
-            scrollView.setContentOffset(CGPoint(x: 0, y: -topOffset), animated: true)
+            scrollView.setContentOffset(CGPoint(x: scrollView.contentOffset.x, y: -topOffset), animated: true)
         }
     }
 }


### PR DESCRIPTION
Fixes #1930 

This PR tries to fix the issue of the scrolling drifting to the side on the Podcast grid view.

## To test

- Start the app on a device ( it's been reported that this happens on smaller sized screens but it's also seen on larger sizes)
- Open the podcasts tab and switch to one of the grid mode.
- Scroll the list of podcasts by dragging you finger down and to the side ( left or right)
- Check if no scroll happens horizontally, it should only scroll vertically.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
