### PR TITLE
Check for empty transcripts

### DIFF
--- a/PocketCastsTests/Tests/Player/Transcripts/TranscriptModelFilterTests.swift
+++ b/PocketCastsTests/Tests/Player/Transcripts/TranscriptModelFilterTests.swift
@@ -138,4 +138,24 @@ final class TranscriptModelFilterTests: XCTestCase {
         XCTAssertEqual(filtered.trim(), expected)
     }
 
+    func testVTTEmpty() throws {
+        let transcript = """
+        WEBVTT
+
+        NOTE
+        Podcast: My Favourite Podcast
+        Episode: Some Random Episode
+        Publishing Date: 2024-07-08T13:44:46+02:00
+        Podcast URL: https://random.com
+        Episode URL: https://random.com/some_random_episode
+        """
+
+        guard let model = TranscriptModel.makeModel(from: transcript, format: .vtt) else {
+            XCTFail("Model should be created")
+            return
+        }
+
+        XCTAssertEqual(model.isEmtpy, true)
+    }
+
 }

--- a/podcasts/TranscriptManager.swift
+++ b/podcasts/TranscriptManager.swift
@@ -19,7 +19,7 @@ enum TranscriptError: Error {
         case .failedToParse:
             return "Transcript failed to parse"
         case .empty:
-            return "Transcript is emtpy"
+            return "Transcript is empty"
         }
     }
 }

--- a/podcasts/TranscriptManager.swift
+++ b/podcasts/TranscriptManager.swift
@@ -6,6 +6,7 @@ enum TranscriptError: Error {
     case failedToLoad
     case notSupported(format: String)
     case failedToParse
+    case empty
 
     var localizedDescription: String {
         switch self {
@@ -17,6 +18,8 @@ enum TranscriptError: Error {
             return "Transcript format not supported: \(format)"
         case .failedToParse:
             return "Transcript failed to parse"
+        case .empty:
+            return "Transcript is emtpy"
         }
     }
 }
@@ -61,6 +64,10 @@ class TranscriptManager {
 
         guard let model = TranscriptModel.makeModel(from: transcriptText, format: transcriptFormat) else {
             throw TranscriptError.failedToParse
+        }
+
+        guard !model.isEmtpy else {
+            throw TranscriptError.empty
         }
 
         return model

--- a/podcasts/TranscriptManager.swift
+++ b/podcasts/TranscriptManager.swift
@@ -66,7 +66,7 @@ class TranscriptManager {
             throw TranscriptError.failedToParse
         }
 
-        guard !model.isEmtpy else {
+        if model.isEmtpy {
             throw TranscriptError.empty
         }
 

--- a/podcasts/TranscriptModel.swift
+++ b/podcasts/TranscriptModel.swift
@@ -70,4 +70,8 @@ struct TranscriptModel: Sendable {
     @inlinable public func firstCue(containing secondsValue: Double) -> TranscriptCue? {
         self.cues.first { $0.contains(timeInSeconds: secondsValue) }
     }
+
+    var isEmtpy: Bool {
+        return attributedText.string.trim().isEmpty
+    }
 }


### PR DESCRIPTION
| 📘 Part of: #1848  | 
|:---:|

This PR implements checks for empty transcripts when the feed points to a valid transcript file but the file is empty and no transcript info is available.

## To test

- Start the app
- Ensure that you have the `transcripts` and `newShowNotesEndpoint` FF enabled
- Start playing an episode with transcript support but with empty files. Ex: [ChaosRadio](https://pca.st/r2ct46up)
- Open the full screen player
- Tap on the transcript shelf button 
- Check if the screen shows the Empty Transcript error.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
