### PR TITLE
Reimagine Sharing: Clip playback

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1626,6 +1626,7 @@
 		F55449422B758E8300F68AE9 /* PocketCastsUtils in Frameworks */ = {isa = PBXBuildFile; productRef = F55449412B758E8300F68AE9 /* PocketCastsUtils */; };
 		F55449432B758E8300F68AE9 /* PocketCastsUtils in Embed Frameworks */ = {isa = PBXBuildFile; productRef = F55449412B758E8300F68AE9 /* PocketCastsUtils */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		F55449452B75935F00F68AE9 /* AppSettings+ImportUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = F55449442B75935F00F68AE9 /* AppSettings+ImportUserDefaults.swift */; };
+		F55598112C534D4100C02EEB /* CMTimeScale+Common.swift in Sources */ = {isa = PBXBuildFile; fileRef = F55598102C534D4100C02EEB /* CMTimeScale+Common.swift */; };
 		F55C4C762BCF064500A10352 /* DiscoverViewController+CategoryRedesign.swift in Sources */ = {isa = PBXBuildFile; fileRef = F55C4C752BCF064500A10352 /* DiscoverViewController+CategoryRedesign.swift */; };
 		F56295292C0FC14900C44E8A /* DBTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = F56295282C0FC14900C44E8A /* DBTestCase.swift */; };
 		F565602F2B7ACD9B003E76D5 /* DataManager+Import.swift in Sources */ = {isa = PBXBuildFile; fileRef = F565602E2B7ACD9B003E76D5 /* DataManager+Import.swift */; };
@@ -3468,6 +3469,7 @@
 		F533F19C2C24B8CB00EDE9AA /* ShareDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareDestination.swift; sourceTree = "<group>"; };
 		F543F6A32C0804FA00FEC8B6 /* AnyPublisher+Async.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AnyPublisher+Async.swift"; sourceTree = "<group>"; };
 		F55449442B75935F00F68AE9 /* AppSettings+ImportUserDefaults.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AppSettings+ImportUserDefaults.swift"; sourceTree = "<group>"; };
+		F55598102C534D4100C02EEB /* CMTimeScale+Common.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMTimeScale+Common.swift"; sourceTree = "<group>"; };
 		F55C4C752BCF064500A10352 /* DiscoverViewController+CategoryRedesign.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DiscoverViewController+CategoryRedesign.swift"; sourceTree = "<group>"; };
 		F56295282C0FC14900C44E8A /* DBTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DBTestCase.swift; sourceTree = "<group>"; };
 		F565602E2B7ACD9B003E76D5 /* DataManager+Import.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DataManager+Import.swift"; sourceTree = "<group>"; };
@@ -6561,6 +6563,7 @@
 				F57BAC662C00CD9C007B24BD /* URLSession+Episode.swift */,
 				F543F6A32C0804FA00FEC8B6 /* AnyPublisher+Async.swift */,
 				FF05C98E2C0A0BF800E41EB3 /* FileManager+Helper.swift */,
+				F55598102C534D4100C02EEB /* CMTimeScale+Common.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -9685,6 +9688,7 @@
 				BDA028621C74466500476B28 /* GoogleCastPlayer.swift in Sources */,
 				BDB5F0CD20450FDC00437669 /* Enumerations.swift in Sources */,
 				F5B312B42BF5B6D400290696 /* FirebaseManager.swift in Sources */,
+				F55598112C534D4100C02EEB /* CMTimeScale+Common.swift in Sources */,
 				BD7166971ECA880D007DD36E /* IndentedTextField.swift in Sources */,
 				C7CA0559293E8918000E41BD /* HolographicEffect.swift in Sources */,
 				BD0F6D7B24BD60FF00EDFB99 /* FilterDurationViewController.swift in Sources */,

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1610,6 +1610,7 @@
 		E3665F542936CD13001C8372 /* ChaptersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3665F532936CD13001C8372 /* ChaptersTests.swift */; };
 		E3F37446291F0DD1005916ED /* Chapters.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3F37445291F0DD1005916ED /* Chapters.swift */; };
 		E3F37447291F0DD1005916ED /* Chapters.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3F37445291F0DD1005916ED /* Chapters.swift */; };
+		F508F0FB2C4F1EC000822159 /* ClipPlaybackManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F508F0FA2C4F1EC000822159 /* ClipPlaybackManager.swift */; };
 		F5197A402B995A1E007C8D0A /* DownloadManager+Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5197A3F2B995A1E007C8D0A /* DownloadManager+Logging.swift */; };
 		F5197A412B995A1E007C8D0A /* DownloadManager+Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5197A3F2B995A1E007C8D0A /* DownloadManager+Logging.swift */; };
 		F5235EE02C3CCB1D00C98739 /* RoundedCorner.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5235EDF2C3CCB1D00C98739 /* RoundedCorner.swift */; };
@@ -3454,6 +3455,7 @@
 		ED026EC07A62C137A4959391 /* Pods-PocketCasts-PocketCastsTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PocketCasts-PocketCastsTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-PocketCasts-PocketCastsTests/Pods-PocketCasts-PocketCastsTests.release.xcconfig"; sourceTree = "<group>"; };
 		EF3DD428DC2C444C2D8CEC5A /* Pods-PocketCastsTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PocketCastsTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-PocketCastsTests/Pods-PocketCastsTests.debug.xcconfig"; sourceTree = "<group>"; };
 		EFBF99F57846D0E1AF8DE08D /* Pods-PocketCasts-PocketCastsTests.staging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PocketCasts-PocketCastsTests.staging.xcconfig"; path = "Pods/Target Support Files/Pods-PocketCasts-PocketCastsTests/Pods-PocketCasts-PocketCastsTests.staging.xcconfig"; sourceTree = "<group>"; };
+		F508F0FA2C4F1EC000822159 /* ClipPlaybackManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipPlaybackManager.swift; sourceTree = "<group>"; };
 		F5197A3F2B995A1E007C8D0A /* DownloadManager+Logging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DownloadManager+Logging.swift"; sourceTree = "<group>"; };
 		F5235EDF2C3CCB1D00C98739 /* RoundedCorner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundedCorner.swift; sourceTree = "<group>"; };
 		F5235EE12C3CE5B300C98739 /* MediaTrimBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaTrimBar.swift; sourceTree = "<group>"; };
@@ -7483,6 +7485,7 @@
 				F5235EE12C3CE5B300C98739 /* MediaTrimBar.swift */,
 				F5235EE72C3DE13100C98739 /* ScrollableScrollView.swift */,
 				F5F479A52C3EF8AB002B4475 /* PlayheadView.swift */,
+				F508F0FA2C4F1EC000822159 /* ClipPlaybackManager.swift */,
 			);
 			path = Clip;
 			sourceTree = "<group>";
@@ -9224,6 +9227,7 @@
 				BD8032D52123F0AF00BFBB03 /* SleepTimerButton.swift in Sources */,
 				8B208A5329C933D300AEF951 /* MiniPlayerPaddingModifier.swift in Sources */,
 				BD1F97821FD7C64600F89CCD /* PlaylistViewController+TableData.swift in Sources */,
+				F508F0FB2C4F1EC000822159 /* ClipPlaybackManager.swift in Sources */,
 				C700A8702A78BCD60091F895 /* EpisodeDetailTabView.swift in Sources */,
 				408971AD2512EE1F00783253 /* PodcastBundleCountView.swift in Sources */,
 				8B205C8129E84B6B0069BAF9 /* PageIndicatorView.swift in Sources */,

--- a/podcasts/CMTimeScale+Common.swift
+++ b/podcasts/CMTimeScale+Common.swift
@@ -1,0 +1,7 @@
+extension CMTimeScale {
+    // A common 44.1 kHz sample rate for audio
+    public static var audio: Self = 44100
+    // A common multiple of typical video formats like 24 & 30 fps.
+    // See https://developer.apple.com/library/archive/documentation/AudioVideo/Conceptual/AVFoundationPG/Articles/06_MediaRepresentations.html#//apple_ref/doc/uid/TP40010188-CH2-SW8
+    static var video: Self = 600
+}

--- a/podcasts/Sharing/Clip/ClipPlaybackManager.swift
+++ b/podcasts/Sharing/Clip/ClipPlaybackManager.swift
@@ -11,6 +11,9 @@ class ClipPlaybackManager: ObservableObject {
     @Published var currentTime: TimeInterval?
     @Published var duration: TimeInterval = 0
 
+    private let normalPlaybackManager = PlaybackManager.shared
+    private let downloadManager = DownloadManager.shared
+
     private var avPlayer: AVPlayer?
     private var timeObserverToken: Any?
     private var cancellables = Set<AnyCancellable>()
@@ -23,9 +26,9 @@ class ClipPlaybackManager: ObservableObject {
             avPlayer = nil
         }
 
-        PlaybackManager.shared.pause()
+        normalPlaybackManager.pause()
 
-        guard let playerItem = DownloadManager.shared.downloadParallelToStream(of: episode) else {
+        guard let playerItem = downloadManager.downloadParallelToStream(of: episode) else {
             return
         }
 
@@ -37,7 +40,7 @@ class ClipPlaybackManager: ObservableObject {
 
         let playbackCMTime = CMTime(seconds: playbackTime, preferredTimescale: .audio)
 
-        PlaybackManager.shared.activateAudioSession(completion: { [weak self] activated in
+        normalPlaybackManager.activateAudioSession(completion: { [weak self] activated in
             self?.avPlayer?.seek(to: playbackCMTime)
             self?.avPlayer?.play()
         })

--- a/podcasts/Sharing/Clip/ClipPlaybackManager.swift
+++ b/podcasts/Sharing/Clip/ClipPlaybackManager.swift
@@ -1,0 +1,123 @@
+import AVFoundation
+import PocketCastsDataModel
+import Combine
+import SwiftUI
+
+class ClipPlaybackManager: ObservableObject {
+
+    static var shared = ClipPlaybackManager()
+
+    @Published var isPlaying: Bool = false
+    @Published var currentTime: TimeInterval?
+    @Published var duration: TimeInterval = 0
+
+    private var startTime: TimeInterval = 0
+    private var endTime: TimeInterval = 0
+
+    private var avPlayer: AVPlayer?
+    private var timeObserverToken: Any?
+    private var cancellables = Set<AnyCancellable>()
+
+    @ObservedObject var clipTime: ClipTime = ClipTime(start: 0, end: 0)
+
+    func play(episode: BaseEpisode, clipTime: ObservedObject<ClipTime>) {
+        if avPlayer != nil {
+            stop()
+            avPlayer = nil
+        }
+
+        PlaybackManager.shared.pause()
+
+        //TODO: Check the Player's current episode and reuse the player item
+        guard let playerItem = DownloadManager.shared.downloadParallelToStream(of: episode) else {
+//            handlePlaybackError("Unable to create playback item")
+            return
+        }
+
+        avPlayer = AVPlayer(playerItem: playerItem)
+
+        let startTime = clipTime.projectedValue.start.wrappedValue
+        let endTime = clipTime.projectedValue.end.wrappedValue
+
+        let startCMTime = CMTime(seconds: startTime, preferredTimescale: 600)
+        let endCMTime = CMTime(seconds: endTime, preferredTimescale: 600)
+
+        PlaybackManager.shared.activateAudioSession(completion: { [weak self] activated in
+            self?.avPlayer?.currentItem?.forwardPlaybackEndTime = endCMTime
+
+            self?.avPlayer?.seek(to: startCMTime)
+            self?.avPlayer?.play()
+        })
+
+        isPlaying = true
+        self.startTime = startTime
+        self.endTime = endTime
+        duration = endTime - startTime
+
+        setupTimeObserver()
+        observePlaybackEnd()
+
+        self._clipTime = clipTime
+
+        self.clipTime.$start.sink(receiveValue: { start in
+            self.startTime = start
+        }).store(in: &cancellables)
+
+        self.clipTime.$end.sink(receiveValue: { end in
+            self.endTime = end
+        }).store(in: &cancellables)
+
+        $currentTime.sink(receiveValue: { currentTime in
+//            if let currentTime, currentTime != self?.avPlayer?.currentTime().seconds {
+//                self?.avPlayer?.seek(to: CMTime(seconds: currentTime, preferredTimescale: 600))
+//            }
+            if let currentTime, currentTime > 0 {
+                clipTime.wrappedValue.playback = currentTime
+            }
+        }).store(in: &cancellables)
+    }
+
+    func seek(to time: CMTime) {
+        avPlayer?.seek(to: time)
+    }
+
+    func stop() {
+        avPlayer?.pause()
+        isPlaying = false
+        currentTime = 0
+        duration = 0
+        removeTimeObserver()
+    }
+
+    private func setupTimeObserver() {
+        let interval = CMTime(seconds: 0.5, preferredTimescale: CMTimeScale(NSEC_PER_SEC))
+        timeObserverToken = avPlayer?.addPeriodicTimeObserver(forInterval: interval, queue: .main) { [weak self] time in
+            guard let self else {
+                return
+            }
+            // Loops back to the beginning at end of clip range
+            guard time.seconds < self.endTime else {
+                self.avPlayer?.seek(to: CMTime(seconds: startTime, preferredTimescale: 600))
+                return
+            }
+            self.currentTime = time.seconds
+        }
+    }
+
+    private func removeTimeObserver() {
+        if let token = timeObserverToken {
+            avPlayer?.removeTimeObserver(token)
+            timeObserverToken = nil
+        }
+    }
+
+    private func observePlaybackEnd() {
+        avPlayer?.publisher(for: \.timeControlStatus)
+            .sink { [weak self] status in
+                if status == .paused {
+//                    self?.stop()
+                }
+            }
+            .store(in: &cancellables)
+    }
+}

--- a/podcasts/Sharing/Clip/ClipPlaybackManager.swift
+++ b/podcasts/Sharing/Clip/ClipPlaybackManager.swift
@@ -37,9 +37,7 @@ class ClipPlaybackManager: ObservableObject {
         let endTime = clipTime.projectedValue.end.wrappedValue
         let playbackTime = clipTime.projectedValue.playback.wrappedValue
 
-        let startCMTime = CMTime(seconds: startTime, preferredTimescale: 600)
-        let endCMTime = CMTime(seconds: endTime, preferredTimescale: 600)
-        let playbackCMTime = CMTime(seconds: playbackTime, preferredTimescale: 600)
+        let playbackCMTime = CMTime(seconds: playbackTime, preferredTimescale: .audio)
 
         PlaybackManager.shared.activateAudioSession(completion: { [weak self] activated in
             self?.avPlayer?.seek(to: playbackCMTime)
@@ -82,7 +80,7 @@ class ClipPlaybackManager: ObservableObject {
             }
             // Loops back to the beginning at end of clip range
             guard time.seconds < clipTime.end else {
-                avPlayer?.seek(to: CMTime(seconds: clipTime.start, preferredTimescale: 600)) { [weak self] _ in
+                avPlayer?.seek(to: CMTime(seconds: clipTime.start, preferredTimescale: .audio)) { [weak self] _ in
                     guard let self else {
                         return
                     }

--- a/podcasts/Sharing/Clip/ClipPlaybackManager.swift
+++ b/podcasts/Sharing/Clip/ClipPlaybackManager.swift
@@ -25,9 +25,7 @@ class ClipPlaybackManager: ObservableObject {
 
         PlaybackManager.shared.pause()
 
-        //TODO: Check the Player's current episode and reuse the player item
         guard let playerItem = DownloadManager.shared.downloadParallelToStream(of: episode) else {
-//            handlePlaybackError("Unable to create playback item")
             return
         }
 

--- a/podcasts/Sharing/Clip/MediaTrimBar.swift
+++ b/podcasts/Sharing/Clip/MediaTrimBar.swift
@@ -46,6 +46,9 @@ struct MediaTrimBar: View {
                         playbackManager.stop()
                     }
                 }
+                .onDisappear {
+                    playbackManager.stop()
+                }
             MediaTrimView(duration: episode.duration, startTime: $clipTime.start, endTime: $clipTime.end, playTime: $clipTime.playback)
                 .onChange(of: clipTime.playback) { newValue in
                     if let currentTime = playbackManager.currentTime, abs(currentTime - newValue) > 0.1 {

--- a/podcasts/Sharing/Clip/MediaTrimView.swift
+++ b/podcasts/Sharing/Clip/MediaTrimView.swift
@@ -28,9 +28,13 @@ struct MediaTrimView: View {
             ScrollableScrollView(scale: $scale, duration: duration, geometry: geometry) { scrollable in
                 AudioWaveformView(scale: scale, width: geometry.size.width * scale)
                 borderView(in: geometry)
-                PlayheadView(position: scaledPosition($playPosition), onChanged: {
-                    print("Moved playhead to: \($0)")
-                })
+                PlayheadView(position: scaledPosition($playPosition))
+                    .onChange(of: playTime) { playTime in
+                        playPosition = durationRelative(value: playTime, for: geometry.size.width)
+                    }
+                    .onChange(of: playPosition) { playPosition in
+                        playTime = (playPosition * duration) / geometry.size.width
+                    }
                     .frame(width: Constants.playLineWidth)
                 TrimSelectionView(leading: scaledPosition($startPosition), trailing: scaledPosition($endPosition), changed: { position, side in
                     update(position: position, for: side, in: geometry.size.width)

--- a/podcasts/Sharing/Clip/MediaTrimView.swift
+++ b/podcasts/Sharing/Clip/MediaTrimView.swift
@@ -36,7 +36,7 @@ struct MediaTrimView: View {
                         playTime = (playPosition * duration) / geometry.size.width
                     }
                     .frame(width: Constants.playLineWidth)
-                TrimSelectionView(leading: scaledPosition($startPosition), trailing: scaledPosition($endPosition), changed: { position, side in
+                TrimSelectionView(leading: scaledPosition($startPosition), trailing: scaledPosition($endPosition), indicatorWidth: Constants.playLineWidth, changed: { position, side in
                     update(position: position, for: side, in: geometry.size.width)
                 })
                 .onAppear {

--- a/podcasts/Sharing/Clip/MediaTrimView.swift
+++ b/podcasts/Sharing/Clip/MediaTrimView.swift
@@ -28,7 +28,7 @@ struct MediaTrimView: View {
             ScrollableScrollView(scale: $scale, duration: duration, geometry: geometry) { scrollable in
                 AudioWaveformView(scale: scale, width: geometry.size.width * scale)
                 borderView(in: geometry)
-                PlayheadView(position: scaledPosition($playPosition))
+                PlayheadView(position: scaledPosition($playPosition), validRange: scaledPosition($startPosition).wrappedValue...scaledPosition($endPosition).wrappedValue)
                     .onChange(of: playTime) { playTime in
                         playPosition = durationRelative(value: playTime, for: geometry.size.width)
                     }
@@ -129,6 +129,8 @@ struct MediaTrimView: View {
             endTime = time
             endPosition = newPosition
         }
+
+        playTime = playTime.clamped(to: startTime...endTime)
     }
 }
 

--- a/podcasts/Sharing/Clip/MediaTrimView.swift
+++ b/podcasts/Sharing/Clip/MediaTrimView.swift
@@ -49,7 +49,7 @@ struct MediaTrimView: View {
                 .onAppear {
                     initializePositions(in: geometry)
                     DispatchQueue.main.async {
-                        let currentSecond = Int(startTime)
+                        let currentSecond = Int(startTime + (endTime - startTime) / 2)
                         scrollable.scrollTo("\(currentSecond)", anchor: .center)
                     }
                 }
@@ -92,7 +92,7 @@ struct MediaTrimView: View {
         let durationRatio = fullDuration / visibleDuration
 
         // The scale should make the visible duration fit the view width
-        let scale = durationRatio / 2
+        let scale = durationRatio
 
         return max(scale, 1.0)
     }

--- a/podcasts/Sharing/Clip/PlayButton.swift
+++ b/podcasts/Sharing/Clip/PlayButton.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct TrimPlayButton: View {
-    @State var isPlaying: Bool
+    @Binding var isPlaying: Bool
 
     var body: some View {
         Button(action: {

--- a/podcasts/Sharing/Clip/PlayButton.swift
+++ b/podcasts/Sharing/Clip/PlayButton.swift
@@ -15,5 +15,8 @@ struct TrimPlayButton: View {
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
         }
+        .onReceive(ClipPlaybackManager.shared.$isPlaying) { playerIsPlaying in
+            isPlaying = playerIsPlaying
+        }
     }
 }

--- a/podcasts/Sharing/Clip/PlayheadView.swift
+++ b/podcasts/Sharing/Clip/PlayheadView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct PlayheadView: View {
     @Binding var position: CGFloat
+    let validRange: ClosedRange<CGFloat>
 
     // Represents the true offset position. Any updates to `position` will be ignored will drag is occurring.
     @State private var realPosition: CGFloat = 0
@@ -17,7 +18,7 @@ struct PlayheadView: View {
                     .onChanged { value in
                         let currentTranslation = value.translation.width
                         let delta = currentTranslation - (lastTranslation ?? 0)
-                        realPosition = realPosition + delta
+                        realPosition = (realPosition + delta).clamped(to: validRange)
                         lastTranslation = currentTranslation
                     }
                     .onEnded { _ in

--- a/podcasts/Sharing/Clip/PlayheadView.swift
+++ b/podcasts/Sharing/Clip/PlayheadView.swift
@@ -2,18 +2,34 @@ import SwiftUI
 
 struct PlayheadView: View {
     @Binding var position: CGFloat
-    var onChanged: (CGFloat) -> Void
+
+    // Represents the true offset position. Any updates to `position` will be ignored will drag is occurring.
+    @State private var realPosition: CGFloat = 0
+    @State private var lastTranslation: CGFloat?
 
     var body: some View {
         Rectangle()
             .fill(Color.white)
-            .offset(x: position)
+            .offset(x: realPosition)
             .onTapGesture {} // This is needed to ensure parent ScrollView doesn't intercept
             .highPriorityGesture(
                 DragGesture(minimumDistance: 0)
                     .onChanged { value in
-                        onChanged(value.location.x)
+                        let currentTranslation = value.translation.width
+                        let delta = currentTranslation - (lastTranslation ?? 0)
+                        realPosition = realPosition + delta
+                        lastTranslation = currentTranslation
+                    }
+                    .onEnded { _ in
+                        lastTranslation = nil
+                        position = realPosition
                     }
             )
+            .onChange(of: position) { position in
+                // Only update playhead when not dragging
+                if lastTranslation == nil {
+                    realPosition = position
+                }
+            }
     }
 }

--- a/podcasts/Sharing/Clip/TrimHandle.swift
+++ b/podcasts/Sharing/Clip/TrimHandle.swift
@@ -8,6 +8,7 @@ struct TrimHandle: View {
 
     @Binding var position: CGFloat
     let side: Side
+    let indicatorWidth: CGFloat
     let onChanged: (CGFloat) -> Void
 
     private enum Constants {
@@ -59,7 +60,7 @@ struct TrimHandle: View {
         case .leading:
             position - Constants.width
         case .trailing:
-            position
+            position + indicatorWidth
         }
     }
 

--- a/podcasts/Sharing/Clip/TrimSelectionView.swift
+++ b/podcasts/Sharing/Clip/TrimSelectionView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct TrimSelectionView: View {
     @Binding var leading: CGFloat
     @Binding var trailing: CGFloat
+    let indicatorWidth: CGFloat
 
     let changed: (CGFloat, TrimHandle.Side) -> Void
 
@@ -16,10 +17,10 @@ struct TrimSelectionView: View {
                 .foregroundColor(Color.clear)
                 .border(.tint, width: Constants.borderWidth)
                 // Offset and frame are adjusted to hide this rectangle behind the Trim Handles
-                .frame(width: (trailing - leading) + (Constants.borderWidth * 2))
+                .frame(width: (trailing - leading + indicatorWidth) + (Constants.borderWidth * 2))
                 .offset(x: leading - Constants.borderWidth)
-            TrimHandle(position: $leading, side: .leading, onChanged: { changed($0, .leading) })
-            TrimHandle(position: $trailing, side: .trailing, onChanged: { changed( $0, .trailing) })
+            TrimHandle(position: $leading, side: .leading, indicatorWidth: indicatorWidth, onChanged: { changed($0, .leading) })
+            TrimHandle(position: $trailing, side: .trailing, indicatorWidth: indicatorWidth, onChanged: { changed( $0, .trailing) })
         }
     }
 }

--- a/podcasts/Sharing/SharingView.swift
+++ b/podcasts/Sharing/SharingView.swift
@@ -52,7 +52,7 @@ struct SharingView: View {
                 buttons
             case .clip(let episode, _):
                 VStack(spacing: 16) {
-                    MediaTrimBar(clipTime: clipTime)
+                    MediaTrimBar(clipTime: clipTime, episode: episode)
                         .frame(height: 72)
                         .tint(color)
                     Button(L10n.clip, action: {


### PR DESCRIPTION
| 📘 Part of: #1910 |
|:---:|

Adds clip playback via a new `ClipPlaybackManager` which uses a separate `AVPlayer` instance.

https://github.com/user-attachments/assets/ceabce5f-2162-484e-8944-b214dff11c63

### Known Issues

* The playback head disappears behind the trailing trim handle
* The "Audio waveform" doesn't look right at the zoom level
* The playback position indicator is not as smooth as it might be
* Trim handles are slightly sluggish during playback, especially on older devices

## To test

> [!NOTE]
> Enable the `newSharing` feature flag to test this

### Playback

* Play an episode
* Navigate to the player and then the "Share" button in the action bar
* Tap "Clip"
* Verify that tapping the Play button plays back the audio for the clip
* Tapping Pause should stop audio playback
* Moving the playhead should change the current play time when ending the gesture
* Moving the Trim Handles should change the start/stop point of playback
* Upon reaching the end, the clip should seek back to the beginning and pause

### Sharing 

* Tap the "Clip" button
* Tap "Copy Link"
* Verify that the link which was created mirrors the clip you expected to create. This clip should play in the web page.
* Try testing with changing the range of the clip in the editor

### Dismiss Clip Editor

* Navigate back to the Player
* Ensure that the episode playback position remains where it was when you began sharing the clip

### Episode Detail

* Navigate to an Episode Detail page for an episode which isn't playing but which you have played a bit of
* Tap the share button in the upper right
* Tap "Clip"
* Verify that the clip editor page comes up
* Verify that playback works but doesn't affect the currently playing episode

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
