### PR TITLE
Transcripts: Refactor transcript manager

### DIFF
--- a/PocketCastsTests/Tests/Player/Transcripts/TranscriptManagerTests.swift
+++ b/PocketCastsTests/Tests/Player/Transcripts/TranscriptManagerTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+@testable import PocketCastsDataModel
+@testable import podcasts
+
+final class TranscriptManagerTests: XCTestCase {
+
+    class MockShowCoordinator: ShowInfoCoordinating {
+        func loadShowNotes(podcastUuid: String, episodeUuid: String) async throws -> String {
+            return ""
+        }
+
+        func loadEpisodeArtworkUrl(podcastUuid: String, episodeUuid: String) async throws -> String? {
+            return nil
+        }
+
+        func loadChapters(podcastUuid: String, episodeUuid: String) async throws -> ([Episode.Metadata.EpisodeChapter]?, [podcasts.PodcastIndexChapter]?) {
+            return (nil, nil)
+        }
+
+        func loadTranscripts(podcastUuid: String, episodeUuid: String) async throws -> [Episode.Metadata.Transcript] {
+            guard let transcriptURL = Bundle(for: Self.self).url(forResource: "sample", withExtension: "vtt") else {
+                return []
+            }
+            let transcript = Episode.Metadata.Transcript(url: transcriptURL.absoluteString, type: "text/vtt", language: nil)
+            return [transcript]
+        }
+
+    }
+
+    func testLoadingTranscript() async throws {
+        let mockShowCoordinator = MockShowCoordinator()
+        let manager = TranscriptManager(episodeUUID: UUID().uuidString, podcastUUID: UUID().uuidString, showCoordinator: mockShowCoordinator)
+
+        let model = try await manager.loadTranscript()
+
+        XCTAssertFalse(model.cues.isEmpty)
+        XCTAssertEqual(model.cues.count, 13)
+    }
+
+}

--- a/PocketCastsTests/Tests/Player/Transcripts/sample.vtt
+++ b/PocketCastsTests/Tests/Player/Transcripts/sample.vtt
@@ -1,0 +1,40 @@
+WEBVTT - Lorem ipsum translated to English
+
+0:00:15.410 --> 0:00:25.850
+<v Speaker 1>But I must explain to you how all this mistaken idea
+
+0:00:26.530 --> 0:00:30.650
+<v Speaker 1>of reprobating pleasure and extolling pain arose. To do so, I will give you a complete account of the system,
+
+0:00:30.690 --> 0:00:33.130
+<v Speaker 1>and expound the actual teachings of the great explorer of the truth,
+
+0:00:33.330 --> 0:00:37.690
+<v Speaker 1>the master-builder of human happiness. No one rejects,
+
+0:00:37.770 --> 0:00:41.610
+<v Speaker 1>dislikes or avoids pleasure itself, because it is pleasure, but because
+
+0:00:41.610 --> 0:00:44.490
+<v Speaker 1>those who do not know how to pursue pleasure rationally encounter consequences
+
+0:00:45.050 --> 0:00:49.050
+<v Speaker 1>that are extremely painful. Nor again is there anyone who loves or pursues or desires to obtain pain
+
+0:00:49.050 --> 0:00:52.450
+<v Speaker 1>of itself, because it is pain, but occasionally circumstances occur in which toil and pain can procure
+
+0:00:52.610 --> 0:00:57.850
+<v Speaker 1>him some great pleasure. To take a trivial example, which of us ever undertakes laborious
+
+0:00:57.850 --> 0:01:02.530
+<v Speaker 1>physical exercise, except to obtain some advantage from it? But who has any right
+
+0:01:02.610 --> 0:01:07.610
+<v Speaker 1>to find fault with a man who chooses to enjoy a pleasure that has no annoying consequences,
+
+0:01:07.650 --> 0:01:11.810
+<v Speaker 1>or one who avoids a pain
+
+0:01:11.890 --> 0:01:15.490
+<v Speaker 1>that produces no resultant pleasure?

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1674,6 +1674,8 @@
 		FF4E93122BDBF0D800F370AA /* MiniPlayerGradientView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF4E93112BDBF0D800F370AA /* MiniPlayerGradientView.swift */; };
 		FF5B2A442BB1859B009F3DC2 /* SourceInterfaceNavigationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF5B2A432BB1859B009F3DC2 /* SourceInterfaceNavigationView.swift */; };
 		FF5B2A462BB189C7009F3DC2 /* PocketCastsApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF5B2A452BB189C7009F3DC2 /* PocketCastsApp.swift */; };
+		FF6BBCEE2C53E9D000604A01 /* TranscriptManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF6BBCED2C53E9D000604A01 /* TranscriptManagerTests.swift */; };
+		FF6BBCF02C53EA1F00604A01 /* sample.vtt in Resources */ = {isa = PBXBuildFile; fileRef = FF6BBCEF2C53EA1F00604A01 /* sample.vtt */; };
 		FF7F89EA2C2979D900FC0ED5 /* TranscriptsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF7F89E92C2979D900FC0ED5 /* TranscriptsViewController.swift */; };
 		FF7F89ED2C2AF6DE00FC0ED5 /* TranscriptManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF7F89EC2C2AF6DE00FC0ED5 /* TranscriptManager.swift */; };
 		FF7F89EF2C2AF7B600FC0ED5 /* SwiftSubtitles in Frameworks */ = {isa = PBXBuildFile; productRef = FF7F89EE2C2AF7B600FC0ED5 /* SwiftSubtitles */; };
@@ -3508,6 +3510,8 @@
 		FF57373C2B4EB5B100F511C7 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		FF5B2A432BB1859B009F3DC2 /* SourceInterfaceNavigationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceInterfaceNavigationView.swift; sourceTree = "<group>"; };
 		FF5B2A452BB189C7009F3DC2 /* PocketCastsApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PocketCastsApp.swift; sourceTree = "<group>"; };
+		FF6BBCED2C53E9D000604A01 /* TranscriptManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TranscriptManagerTests.swift; sourceTree = "<group>"; };
+		FF6BBCEF2C53EA1F00604A01 /* sample.vtt */ = {isa = PBXFileReference; lastKnownFileType = text; path = sample.vtt; sourceTree = "<group>"; };
 		FF7F89E92C2979D900FC0ED5 /* TranscriptsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptsViewController.swift; sourceTree = "<group>"; };
 		FF7F89EC2C2AF6DE00FC0ED5 /* TranscriptManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptManager.swift; sourceTree = "<group>"; };
 		FF7F89F02C2C0FD600FC0ED5 /* TranscriptModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptModel.swift; sourceTree = "<group>"; };
@@ -4508,6 +4512,8 @@
 			children = (
 				8BA6CAFD2C404C3600FB4704 /* ComposeFilterTests.swift */,
 				FFD044182C4FE9F400CCB192 /* TranscriptModelFilterTests.swift */,
+				FF6BBCED2C53E9D000604A01 /* TranscriptManagerTests.swift */,
+				FF6BBCEF2C53EA1F00604A01 /* sample.vtt */,
 			);
 			path = Transcripts;
 			sourceTree = "<group>";
@@ -7998,6 +8004,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				FFF024CF2B62B13A00457373 /* Pocket Casts Configuration.storekit in Resources */,
+				FF6BBCF02C53EA1F00604A01 /* sample.vtt in Resources */,
 				8B317BA92890704400A26A13 /* TestingScreen.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -8851,6 +8858,7 @@
 				8B3295432A5336DA00BDFA11 /* WhatsNewTests.swift in Sources */,
 				F586959A2C04320100E0754A /* PodcastManagerTests.swift in Sources */,
 				C781EA412A6B72AE001DBFCC /* SearchableListViewModelTests.swift in Sources */,
+				FF6BBCEE2C53E9D000604A01 /* TranscriptManagerTests.swift in Sources */,
 				F5952FCA2C057C6400754BC3 /* FMDatabaseQueue+Test.swift in Sources */,
 				8B484EF728D23F06001AFA97 /* PlaybackTimeHelperTests.swift in Sources */,
 				45ECEF8627E910FB00C65030 /* ShowNotesFormatterUtilsTests.swift in Sources */,

--- a/podcasts/TranscriptManager.swift
+++ b/podcasts/TranscriptManager.swift
@@ -28,10 +28,16 @@ class TranscriptManager {
 
     typealias Transcript = Episode.Metadata.Transcript
 
-    let playbackManager: PlaybackManager
+    let episode: BaseEpisode
 
-    init(playbackManager: PlaybackManager) {
-        self.playbackManager  = playbackManager
+    let podcast: Podcast
+
+    let showCoordinator: ShowInfoCoordinating
+
+    init(episode: BaseEpisode, podcast: Podcast, showCoordinator: ShowInfoCoordinating = ShowInfoCoordinator.shared) {
+        self.episode = episode
+        self.podcast = podcast
+        self.showCoordinator = showCoordinator
     }
 
     private func bestTranscript(from available: [Transcript]) -> Transcript? {
@@ -45,8 +51,7 @@ class TranscriptManager {
 
     public func loadTranscript() async throws -> TranscriptModel {
         guard
-            let episode = self.playbackManager.currentEpisode(), let podcast = self.playbackManager.currentPodcast,
-            let transcripts = try? await ShowInfoCoordinator.shared.loadTranscripts(podcastUuid: podcast.uuid, episodeUuid: episode.uuid),
+            let transcripts = try? await showCoordinator.loadTranscripts(podcastUuid: podcast.uuid, episodeUuid: episode.uuid),
             let transcript = bestTranscript(from: transcripts) else {
             throw TranscriptError.notAvailable
         }

--- a/podcasts/TranscriptManager.swift
+++ b/podcasts/TranscriptManager.swift
@@ -28,15 +28,15 @@ class TranscriptManager {
 
     typealias Transcript = Episode.Metadata.Transcript
 
-    let episode: BaseEpisode
+    let episodeUUID: String
 
-    let podcast: Podcast
+    let podcastUUID: String
 
     let showCoordinator: ShowInfoCoordinating
 
-    init(episode: BaseEpisode, podcast: Podcast, showCoordinator: ShowInfoCoordinating = ShowInfoCoordinator.shared) {
-        self.episode = episode
-        self.podcast = podcast
+    init(episodeUUID: String, podcastUUID: String, showCoordinator: ShowInfoCoordinating = ShowInfoCoordinator.shared) {
+        self.episodeUUID = episodeUUID
+        self.podcastUUID = podcastUUID
         self.showCoordinator = showCoordinator
     }
 
@@ -51,7 +51,7 @@ class TranscriptManager {
 
     public func loadTranscript() async throws -> TranscriptModel {
         guard
-            let transcripts = try? await showCoordinator.loadTranscripts(podcastUuid: podcast.uuid, episodeUuid: episode.uuid),
+            let transcripts = try? await showCoordinator.loadTranscripts(podcastUuid: podcastUUID, episodeUuid: episodeUUID),
             let transcript = bestTranscript(from: transcripts) else {
             throw TranscriptError.notAvailable
         }

--- a/podcasts/TranscriptsViewController.swift
+++ b/podcasts/TranscriptsViewController.swift
@@ -220,7 +220,8 @@ class TranscriptsViewController: PlayerItemViewController {
 
     private func addObservers() {
         addCustomObserver(Constants.Notifications.playbackTrackChanged, selector: #selector(update))
-        addCustomObserver(Constants.Notifications.playbackProgress, selector: #selector(updateTranscriptPosition))
+        //We disabled the method bellow until we find a way to resync/shift transcript positions
+        //addCustomObserver(Constants.Notifications.playbackProgress, selector: #selector(updateTranscriptPosition))
     }
 
     @objc private func updateTranscriptPosition() {

--- a/podcasts/TranscriptsViewController.swift
+++ b/podcasts/TranscriptsViewController.swift
@@ -150,10 +150,10 @@ class TranscriptsViewController: PlayerItemViewController {
     private func loadTranscript() {
         activityIndicatorView.startAnimating()
         Task.detached { [weak self] in
-            guard let self else {
+            guard let self, let episode = playbackManager.currentEpisode(), let podcast = playbackManager.currentPodcast else {
                 return
             }
-            let transcriptManager = TranscriptManager(playbackManager: self.playbackManager)
+            let transcriptManager = TranscriptManager(episode: episode, podcast: podcast)
             do {
                 let transcript = try await transcriptManager.loadTranscript()
                 await show(transcript: transcript)

--- a/podcasts/TranscriptsViewController.swift
+++ b/podcasts/TranscriptsViewController.swift
@@ -153,7 +153,7 @@ class TranscriptsViewController: PlayerItemViewController {
             guard let self, let episode = playbackManager.currentEpisode(), let podcast = playbackManager.currentPodcast else {
                 return
             }
-            let transcriptManager = TranscriptManager(episode: episode, podcast: podcast)
+            let transcriptManager = TranscriptManager(episodeUUID: episode.uuid, podcastUUID: podcast.uuid)
             do {
                 let transcript = try await transcriptManager.loadTranscript()
                 await show(transcript: transcript)


### PR DESCRIPTION
| 📘 Part of: #1848  | 
|:---:|

This PR refactors the Transcript Manager dependencies the following way:
- Remove direct dependency of PlaybackManager
- Remove direct use of `ShowInfoCoordinator.shared`

Also used this PR to disable the sync between audio and transcript but kept the code so it can be used in the future when we are able to resync transcripts.

## To test

- Start the app
- Ensure that you have the `transcripts` and `newShowNotesEndpoint` FF enabled
- Start playing an episode with transcript. Ex: Cautionary Tales
- Open the full screen player
- Tap on the transcript shelf button 
- Check that the transcript shows correctly and no auto scroll is happening ( the transcript does not scroll while the audio is progressing)

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
