### PR TITLE
Reimagine Sharing: Confine playhead to Trim range

### DIFF
--- a/podcasts/Sharing/Clip/MediaTrimView.swift
+++ b/podcasts/Sharing/Clip/MediaTrimView.swift
@@ -36,7 +36,7 @@ struct MediaTrimView: View {
                         playTime = (playPosition * duration) / geometry.size.width
                     }
                     .frame(width: Constants.playLineWidth)
-                TrimSelectionView(leading: scaledPosition($startPosition), trailing: scaledPosition($endPosition), changed: { position, side in
+                TrimSelectionView(leading: scaledPosition($startPosition), trailing: scaledPosition($endPosition), indicatorWidth: Constants.playLineWidth, changed: { position, side in
                     update(position: position, for: side, in: geometry.size.width)
                 })
                 .onAppear {

--- a/podcasts/Sharing/Clip/MediaTrimView.swift
+++ b/podcasts/Sharing/Clip/MediaTrimView.swift
@@ -28,7 +28,7 @@ struct MediaTrimView: View {
             ScrollableScrollView(scale: $scale, duration: duration, geometry: geometry) { scrollable in
                 AudioWaveformView(scale: scale, width: geometry.size.width * scale)
                 borderView(in: geometry)
-                PlayheadView(position: scaledPosition($playPosition))
+                PlayheadView(position: scaledPosition($playPosition), validRange: scaledPosition($startPosition).wrappedValue...scaledPosition($endPosition).wrappedValue)
                     .onChange(of: playTime) { playTime in
                         playPosition = durationRelative(value: playTime, for: geometry.size.width)
                     }
@@ -129,6 +129,8 @@ struct MediaTrimView: View {
             endTime = time
             endPosition = newPosition
         }
+
+        playTime = playTime.clamped(to: startTime...endTime)
     }
 }
 

--- a/podcasts/Sharing/Clip/PlayheadView.swift
+++ b/podcasts/Sharing/Clip/PlayheadView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct PlayheadView: View {
     @Binding var position: CGFloat
+    let validRange: ClosedRange<CGFloat>
 
     // Represents the true offset position. Any updates to `position` will be ignored will drag is occurring.
     @State private var realPosition: CGFloat = 0
@@ -17,7 +18,7 @@ struct PlayheadView: View {
                     .onChanged { value in
                         let currentTranslation = value.translation.width
                         let delta = currentTranslation - (lastTranslation ?? 0)
-                        realPosition = realPosition + delta
+                        realPosition = (realPosition + delta).clamped(to: validRange)
                         lastTranslation = currentTranslation
                     }
                     .onEnded { _ in

--- a/podcasts/Sharing/Clip/TrimHandle.swift
+++ b/podcasts/Sharing/Clip/TrimHandle.swift
@@ -8,6 +8,7 @@ struct TrimHandle: View {
 
     @Binding var position: CGFloat
     let side: Side
+    let indicatorWidth: CGFloat
     let onChanged: (CGFloat) -> Void
 
     private enum Constants {
@@ -59,7 +60,7 @@ struct TrimHandle: View {
         case .leading:
             position - Constants.width
         case .trailing:
-            position
+            position + indicatorWidth
         }
     }
 

--- a/podcasts/Sharing/Clip/TrimSelectionView.swift
+++ b/podcasts/Sharing/Clip/TrimSelectionView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct TrimSelectionView: View {
     @Binding var leading: CGFloat
     @Binding var trailing: CGFloat
+    let indicatorWidth: CGFloat
 
     let changed: (CGFloat, TrimHandle.Side) -> Void
 
@@ -16,10 +17,10 @@ struct TrimSelectionView: View {
                 .foregroundColor(Color.clear)
                 .border(.tint, width: Constants.borderWidth)
                 // Offset and frame are adjusted to hide this rectangle behind the Trim Handles
-                .frame(width: (trailing - leading) + (Constants.borderWidth * 2))
+                .frame(width: (trailing - leading + indicatorWidth) + (Constants.borderWidth * 2))
                 .offset(x: leading - Constants.borderWidth)
-            TrimHandle(position: $leading, side: .leading, onChanged: { changed($0, .leading) })
-            TrimHandle(position: $trailing, side: .trailing, onChanged: { changed( $0, .trailing) })
+            TrimHandle(position: $leading, side: .leading, indicatorWidth: indicatorWidth, onChanged: { changed($0, .leading) })
+            TrimHandle(position: $trailing, side: .trailing, indicatorWidth: indicatorWidth, onChanged: { changed( $0, .trailing) })
         }
     }
 }


### PR DESCRIPTION
| 📘 Part of: #1910 |
|:---:|

Confines the playhead to only remain inside of the clip area.

## To test

> [!NOTE]
> Enable the `newSharing` feature flag to test this

* Play an episode
* Tap the "Share" button in the action bar
* Tap the "Clip" option
* Try moving the playhead and ensure it doesn't move past the trim handles
* Try moving the trim handles and make sure the playhead remains inside of them

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
