### PR TITLE
Transcripts dynamic font support

### DIFF
--- a/podcasts/TranscriptsViewController.swift
+++ b/podcasts/TranscriptsViewController.swift
@@ -164,8 +164,7 @@ class TranscriptsViewController: PlayerItemViewController {
     }
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        if traitCollection.preferredContentSizeCategory != previousTraitCollection?.preferredContentSizeCategory, 
-            let transcript = transcript {
+        if traitCollection.preferredContentSizeCategory != previousTraitCollection?.preferredContentSizeCategory {
             refreshText()
         }
     }

--- a/podcasts/TranscriptsViewController.swift
+++ b/podcasts/TranscriptsViewController.swift
@@ -163,6 +163,20 @@ class TranscriptsViewController: PlayerItemViewController {
         }
     }
 
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        if traitCollection.preferredContentSizeCategory != previousTraitCollection?.preferredContentSizeCategory, 
+            let transcript = transcript {
+            refreshText()
+        }
+    }
+
+    private func refreshText() {
+        guard let transcript else {
+            return
+        }
+        transcriptView.attributedText = styleText(transcript: transcript)
+    }
+
     private func show(transcript: TranscriptModel) {
             activityIndicatorView.stopAnimating()
             self.previousRange = nil
@@ -178,12 +192,12 @@ class TranscriptsViewController: PlayerItemViewController {
         paragraphStyle.paragraphSpacing = 10
         paragraphStyle.lineBreakMode = .byWordWrapping
 
-        var standardFont = UIFont.systemFont(ofSize: 18)
+        var standardFont = UIFont.preferredFont(forTextStyle: .body)
 
         if let descriptor = UIFontDescriptor.preferredFontDescriptor(
           withTextStyle: .body)
           .withDesign(.serif) {
-            standardFont = UIFont(descriptor: descriptor, size: 16)
+            standardFont =  UIFont(descriptor: descriptor, size: 0)
         }
 
 


### PR DESCRIPTION
| 📘 Part of: #1848  |  <!-- project issue number, if applicable -->
|:---:|

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

This PR ensures that the Transcript text takes in account the accessibility settings for Text size and adapts correctly when those settings are changed.

| Small  | Large |
|- | - |
| ![Simulator Screenshot - iPhone 15 - 2024-07-29 at 18 05 37](https://github.com/user-attachments/assets/42c1d61e-7e27-4a75-8584-1aac6c0dbcaf) |  ![Simulator Screenshot - iPhone 15 - 2024-07-29 at 18 04 16](https://github.com/user-attachments/assets/01351641-feec-4caf-a248-3930eddfa6c9) |

## To test

- Ensure that you have the `transcripts` and `newShowNotesEndpoint` FF enabled
- Start playing an episode with transcript supports. Ex:  One of this list: https://lists.pocketcasts.com/b852a088-ccee-4e4b-a3c5-4bb7fd700a02
- Open the full screen player
- Tap on the transcript shelf button 
- See that the font that is used for the transcript adopts the correct size that you have set on your device
- With the transcript screen left open switch to Settings-> Accessibility -> Larger Text and change the text size
- Go back to PocketCasts transcript screen
- Check if the transcript text change size correctly

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
