### PR TITLE
Adds support for JSON PodcastIndex.org format

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -12115,7 +12115,7 @@
 			repositoryURL = "https://github.com/dagronf/SwiftSubtitles";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.3.0;
+				minimumVersion = 1.5.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/podcasts.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/podcasts.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -249,8 +249,8 @@
         "repositoryURL": "https://github.com/dagronf/SwiftSubtitles",
         "state": {
           "branch": null,
-          "revision": "ed8c19dab44e285b9463000c3bbb31dcea7790e9",
-          "version": "1.3.0"
+          "revision": "751866f632ccf438025472eb1c1dccffbc5176a3",
+          "version": "1.5.2"
         }
       },
       {

--- a/podcasts/TranscriptModel.swift
+++ b/podcasts/TranscriptModel.swift
@@ -5,6 +5,7 @@ enum TranscriptFormat: String {
     case srt = "application/srt"
     case vtt = "text/vtt"
     case textHTML = "text/html"
+    case jsonPodcastIndex = "application/json"
 
     var fileExtension: String {
         switch self {
@@ -14,11 +15,13 @@ enum TranscriptFormat: String {
             return "vtt"
         case .textHTML:
             return "html"
+        case .jsonPodcastIndex:
+            return "json"
         }
     }
 
     // Transcript formats we support in order of priority of use
-    static let supportedFormats: [TranscriptFormat] = [.vtt, .srt]
+    static let supportedFormats: [TranscriptFormat] = [.jsonPodcastIndex, .vtt, .srt]
 }
 
 struct TranscriptCue: Sendable {


### PR DESCRIPTION
| 📘 Part of: #1848  |
|:---:|

This PR adds support for [PodcastIndex.org transcript json format](https://github.com/Podcastindex-org/podcast-namespace/blob/main/transcripts/transcripts.md#json).

## To test

- Start the app
- Ensure that you have the `transcripts` and `newShowNotesEndpoint` FF enabled
- Start playing an episode with transcript with PodcastIndex JSON format. Ex:  [Chaos Radio](https://pca.st/r2ct46up)
- Open the full screen player
- Tap on the transcript shelf button 
- Check if the transcripts shows correctly

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
