### PR TITLE
Fix display of multi-select of UpNext when displaying from the the main tab bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 -----
 - Fix an issue for show notes not loading. [#1928](https://github.com/Automattic/pocket-casts-ios/pull/1928)
 - Fix scrolling drift on Podcasts list grid view. [#1930](https://github.com/Automattic/pocket-casts-ios/issues/1930)
+- Fix UpNext on the tab bar multi-select action bar diplay. [#1913](https://github.com/Automattic/pocket-casts-ios/issues/1913)
 
 7.68
 -----

--- a/podcasts/UpNextViewController.swift
+++ b/podcasts/UpNextViewController.swift
@@ -30,6 +30,7 @@ class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
             DispatchQueue.main.async { [weak self] in
                 guard let self = self else { return }
                 self.updateNavBarButtons()
+                contentInseter.isMultiSelectEnabled = isMultiSelectEnabled
                 if !self.isMultiSelectEnabled {
                     self.multiSelectActionBar.isHidden = true
                     self.selectedPlayListEpisodes.removeAll()

--- a/podcasts/UpNextViewController.xib
+++ b/podcasts/UpNextViewController.xib
@@ -3,7 +3,7 @@
     <device id="retina4_0" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22684"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22685"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -45,7 +45,7 @@
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="lik-kf-6rP" secondAttribute="trailing" id="BHO-6k-fKT"/>
                 <constraint firstItem="lik-kf-6rP" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="Kko-ho-6Tw"/>
                 <constraint firstItem="VqG-ZR-Alm" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="8" id="R3w-t7-lz2"/>
-                <constraint firstItem="lik-kf-6rP" firstAttribute="bottom" secondItem="VqG-ZR-Alm" secondAttribute="bottom" constant="16" id="i5Q-Q3-dx3"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="VqG-ZR-Alm" secondAttribute="bottom" constant="16" id="i5Q-Q3-dx3"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="VqG-ZR-Alm" secondAttribute="trailing" constant="8" id="iJf-Sm-VdB"/>
                 <constraint firstAttribute="bottom" secondItem="lik-kf-6rP" secondAttribute="bottom" id="u8S-cz-24J"/>
                 <constraint firstItem="lik-kf-6rP" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="uZj-bH-npT"/>


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes #1913 
<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR fixes the multi-select action bar display when used on the UpNext screen on the tab bar.

| Tab bar | Mini-Player |
| - | - |
| ![Simulator Screenshot - iPhone 15 - 2024-07-30 at 18 40 55](https://github.com/user-attachments/assets/f559a310-1850-499b-b65a-6bf548d146f6) | ![Simulator Screenshot - iPhone 15 - 2024-07-30 at 18 41 05](https://github.com/user-attachments/assets/cb6b255f-9282-45b1-a518-08edc1d0a861) |

## To test

- Start the app
- Add some episodes on the UpNext queue
- Tap on UpNext on the tab bar
- Tap on Select and then Select All
- Check the Action bar for multi-select is displayed correctly
- Tap on UpNext on the mini-player
- Tap on Select and then Select All 
- Check the Action bar for multi-select is displayed correctly

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
