### PR TITLE
[Kids Profile] Submit Feedback screen

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		105A6C442BAA0B3E0025B855 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 10B558EC2BA472E80061847C /* PrivacyInfo.xcprivacy */; };
 		105A6C452BAA0B410025B855 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 10B558ED2BA476BA0061847C /* PrivacyInfo.xcprivacy */; };
 		10756F832C57D00B0089D34F /* KidsProfileThankYouScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10756F822C57D00B0089D34F /* KidsProfileThankYouScreen.swift */; };
+		10756F8B2C5945C00089D34F /* KidsProfileSubmitScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10756F8A2C5945C00089D34F /* KidsProfileSubmitScreen.swift */; };
 		10A4F7532C515D720084D783 /* KidsProfile.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 10A4F7522C515D720084D783 /* KidsProfile.xcassets */; };
 		10A4F7562C5162C90084D783 /* KidsProfileBannerTableCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10A4F7552C5162C90084D783 /* KidsProfileBannerTableCell.swift */; };
 		10A4F7582C52635F0084D783 /* KidsProfileBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10A4F7572C52635F0084D783 /* KidsProfileBannerView.swift */; };
@@ -1890,6 +1891,7 @@
 		0A1708DEC0501FB8417E31BE /* Pods_NotificationExtension.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_NotificationExtension.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		0C2912CCAD9A1CEDF0484604 /* Pods-PocketCasts-podcasts.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PocketCasts-podcasts.debug.xcconfig"; path = "Pods/Target Support Files/Pods-PocketCasts-podcasts/Pods-PocketCasts-podcasts.debug.xcconfig"; sourceTree = "<group>"; };
 		10756F822C57D00B0089D34F /* KidsProfileThankYouScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = KidsProfileThankYouScreen.swift; path = "Kids Profile/KidsProfileThankYouScreen.swift"; sourceTree = "<group>"; };
+		10756F8A2C5945C00089D34F /* KidsProfileSubmitScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = KidsProfileSubmitScreen.swift; path = "Kids Profile/KidsProfileSubmitScreen.swift"; sourceTree = "<group>"; };
 		10A4F7522C515D720084D783 /* KidsProfile.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = KidsProfile.xcassets; sourceTree = "<group>"; };
 		10A4F7552C5162C90084D783 /* KidsProfileBannerTableCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = KidsProfileBannerTableCell.swift; path = "Kids Profile/KidsProfileBannerTableCell.swift"; sourceTree = "<group>"; };
 		10A4F7572C52635F0084D783 /* KidsProfileBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = KidsProfileBannerView.swift; path = "Kids Profile/KidsProfileBannerView.swift"; sourceTree = "<group>"; };
@@ -3700,6 +3702,7 @@
 			isa = PBXGroup;
 			children = (
 				10756F822C57D00B0089D34F /* KidsProfileThankYouScreen.swift */,
+				10756F8A2C5945C00089D34F /* KidsProfileSubmitScreen.swift */,
 			);
 			name = Screens;
 			sourceTree = "<group>";
@@ -9289,6 +9292,7 @@
 				BD35E91A1D45BBDA00CAE2A7 /* EmailHelper.swift in Sources */,
 				BDDF8AA6240CE85D009BA263 /* PodcastViewController+Swipe.swift in Sources */,
 				463C127A2714B57800178F9E /* Themeable+SwiftUI.swift in Sources */,
+				10756F8B2C5945C00089D34F /* KidsProfileSubmitScreen.swift in Sources */,
 				C7080C5F29233BA000D7A432 /* PlusAccountPromptViewModel.swift in Sources */,
 				40FFAD8A2147831400024FCF /* PlaylistViewController+CollectionView.swift in Sources */,
 				BDA1E8161EDD28700098FB9D /* SonosLinkController.swift in Sources */,

--- a/podcasts/Kids Profile/KidsProfileSheet.swift
+++ b/podcasts/Kids Profile/KidsProfileSheet.swift
@@ -10,7 +10,7 @@ struct KidsProfileSheet: View {
     var body: some View {
         VStack {
             if viewModel.currentScreen == .submit {
-                submitScreen
+                KidsProfileSubmitScreen(viewModel: viewModel, theme: theme)
                     .transition(transition)
             } else {
                 KidsProfileThankYouScreen(viewModel: viewModel, theme: theme)
@@ -20,19 +20,6 @@ struct KidsProfileSheet: View {
         }
         .animation(.easeOut, value: viewModel.currentScreen)
         .background(theme.primaryUi01)
-    }
-
-    private var submitScreen: some View {
-        // this will be replaced by the next screen
-        ZStack {
-            Rectangle().background(.black)
-                .padding(.leading, 20.0)
-                .padding(.top, 20.0)
-                .padding(.trailing, 20.0)
-                .frame(height: 330)
-            Text("Placeholder")
-                .foregroundStyle(.white)
-        }
     }
 }
 

--- a/podcasts/Kids Profile/KidsProfileSheetHost.swift
+++ b/podcasts/Kids Profile/KidsProfileSheetHost.swift
@@ -29,7 +29,13 @@ class KidsProfileSheetHost: ThemedHostingController<KidsProfileSheet> {
 
     private func setupSheetController() {
         if let sheetController = sheetPresentationController {
-            sheetController.detents = [.medium()]
+            if #available(iOS 16.0, *) {
+                sheetController.detents = [.custom { _ in
+                    return 500.0
+                }]
+            } else {
+                sheetController.detents = [.large()]
+            }
             sheetController.prefersGrabberVisible = true
         }
     }

--- a/podcasts/Kids Profile/KidsProfileSheetViewModel.swift
+++ b/podcasts/Kids Profile/KidsProfileSheetViewModel.swift
@@ -4,6 +4,8 @@ import SwiftUI
 class KidsProfileSheetViewModel: ObservableObject {
     @Published private(set) var currentScreen: SheetScreen = .thankYou
 
+    @Published var textToSend = ""
+
     var onDismissScreenTap: (() -> Void)? = nil
     var onSendFeedbackTap: (() -> Void)? = nil
 
@@ -14,6 +16,18 @@ class KidsProfileSheetViewModel: ObservableObject {
     func sendFeedback() {
         onSendFeedbackTap?()
         currentScreen = .submit
+    }
+
+    func submitFeedback() {
+        // Send message
+
+        //If message sent succeded
+        Toast.show(L10n.kidsProfileSubmitSuccess)
+
+        //If message sent fail
+//        Toast.show(L10n.serverErrorUnknown)
+
+        dismissScreen()
     }
 
     enum SheetScreen {

--- a/podcasts/Kids Profile/KidsProfileSubmitScreen.swift
+++ b/podcasts/Kids Profile/KidsProfileSubmitScreen.swift
@@ -1,0 +1,66 @@
+import SwiftUI
+
+struct KidsProfileSubmitScreen: View {
+    @ObservedObject var viewModel: KidsProfileSheetViewModel
+
+    @FocusState private var isFocused: Bool
+
+    var theme: Theme
+
+    var body: some View {
+        VStack {
+            Text(L10n.kidsProfileSubmitFeedbackTitle)
+                .font(size: Constants.titleSize, style: .body, weight: .semibold)
+                .multilineTextAlignment(.center)
+                .foregroundStyle(theme.primaryText01)
+                .padding(.leading, Constants.buttonHPadding)
+                .padding(.trailing, Constants.buttonHPadding)
+                .padding(.bottom, Constants.vPadding)
+
+            TextEditor(text: $viewModel.textToSend)
+                .themedTextField()
+                .foregroundStyle(theme.secondaryText02)
+                .focused($isFocused)
+                .frame(minHeight: Constants.textEditorMinHeight, maxHeight: Constants.textEditorMaxHeight)
+                .padding(.bottom, Constants.vPadding)
+
+            sendButton
+        }
+        .padding(Constants.contentinset)
+        .onAppear {
+            isFocused = true
+        }
+    }
+
+    private var sendButton: some View {
+        Button(action: viewModel.submitFeedback) {
+            Text(L10n.kidsProfileSubmitFeedbackSendButton)
+        }
+        .buttonStyle(BasicButtonStyle(textColor: theme.primaryInteractive02, backgroundColor: theme.primaryInteractive01))
+        .frame(height: Constants.buttonHeight)
+    }
+
+    enum Constants {
+        static let buttonHeight = 56.0
+
+        static let titleSize = 18.0
+        static let textSize = 14.0
+
+        static let vPadding = 16.0
+
+        static let buttonHPadding = 40.0
+
+        static let textEditorMinHeight = 75.0
+        static let textEditorMaxHeight = 200.0
+
+        static let contentinset = EdgeInsets(top: 63.0,
+                                             leading: 20.0,
+                                             bottom: 20.0,
+                                             trailing: 20.0)
+    }
+}
+
+#Preview {
+    KidsProfileSubmitScreen(viewModel: KidsProfileSheetViewModel(),
+                            theme: Theme(previewTheme: .light))
+}

--- a/podcasts/Kids Profile/KidsProfileThankYouScreen.swift
+++ b/podcasts/Kids Profile/KidsProfileThankYouScreen.swift
@@ -8,13 +8,13 @@ struct KidsProfileThankYouScreen: View {
         VStack {
             Image("kids-profile-view-face")
                 .padding(.top, Constants.imageTopPadding)
-                .padding(.bottom, Constants.smallBottomPadding)
+                .padding(.bottom, Constants.vPadding)
 
             Text(L10n.kidsProfileThankyouTitle)
                 .font(size: Constants.titleSize, style: .body, weight: .semibold)
                 .multilineTextAlignment(.center)
                 .foregroundStyle(theme.primaryText01)
-                .padding(.bottom, Constants.smallBottomPadding)
+                .padding(.bottom, Constants.vPadding)
 
             Text(L10n.kidsProfileThankyouText)
                 .font(size: Constants.textSize, style: .body, weight: .medium)
@@ -52,11 +52,9 @@ struct KidsProfileThankYouScreen: View {
         static let buttonHeight = 56.0
 
         static let hPadding = 20.0
-        static let vPadding = 8.0
+        static let vPadding = 12.0
 
-        static let imageTopPadding = 12.0
-
-        static let smallBottomPadding = 4.0
+        static let imageTopPadding = 55.0
 
         static let titleSize = 18.0
         static let textSize = 14.0

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -1388,6 +1388,12 @@ internal enum L10n {
   internal static var kidsProfileBannerText: String { return L10n.tr("Localizable", "kids_profile_banner_text") }
   /// Kids Profile
   internal static var kidsProfileBannerTitle: String { return L10n.tr("Localizable", "kids_profile_banner_title") }
+  /// Send
+  internal static var kidsProfileSubmitFeedbackSendButton: String { return L10n.tr("Localizable", "kids_profile_submit_feedback_send_button") }
+  /// What would you like to see in a Kids profile for Pocket Casts?
+  internal static var kidsProfileSubmitFeedbackTitle: String { return L10n.tr("Localizable", "kids_profile_submit_feedback_title") }
+  /// Thank you for your feedback!
+  internal static var kidsProfileSubmitSuccess: String { return L10n.tr("Localizable", "kids_profile_submit_success") }
   /// No, thank you
   internal static var kidsProfileThankyouButtonClose: String { return L10n.tr("Localizable", "kids_profile_thankyou_button_close") }
   /// Send Feedback

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4216,3 +4216,12 @@
 
 /* Kids Profile Thank You screen close button title */
 "kids_profile_thankyou_button_close" = "No, thank you";
+
+/* Kids Profile Submit screen title */
+"kids_profile_submit_feedback_title" = "What would you like to see in a Kids profile for Pocket Casts?";
+
+/* Kids Profile Submit screen send button title */
+"kids_profile_submit_feedback_send_button" = "Send";
+
+/* Kids Profile Toast message if feedback sent succeeded */
+"kids_profile_submit_success" = "Thank you for your feedback!";


### PR DESCRIPTION
| 📘 Part of: #1935 
|:---:|

Fixes #1938 

This PR introduces the last screen for the Kids Profile. This screens contains the text editor used to send the feedback.

## To test

> [!NOTE]
> You need to enable the `kidsProfile` Feature Flag

- CI must be 🟢
- Run this branch and go to your profile page
- You should see the Kids Profile banner
- Tap on _Request Early Access_
- You should see a sheet being prompted
- Tap on _Send feedback_ to open the next screen
- You should see the text editor view assigend as first responder
- If you tap send the sheet should dismiss triggering the Toast
- You can ålso dismiss it by drop down the sheet

https://github.com/user-attachments/assets/e7957900-d300-47cb-8a04-ce9d9aed187e

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
