### PR TITLE
Transcripts small UI fixes

### DIFF
--- a/podcasts/TranscriptsViewController.swift
+++ b/podcasts/TranscriptsViewController.swift
@@ -34,12 +34,12 @@ class TranscriptsViewController: PlayerItemViewController {
             [
                 transcriptView.topAnchor.constraint(equalTo: view.topAnchor),
                 transcriptView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-                transcriptView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 32),
-                transcriptView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -32)
+                transcriptView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+                transcriptView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
             ]
         )
 
-        transcriptView.textContainerInset = .init(top: 0.75 * Sizes.topGradientHeight, left: 0, bottom: 0.7 * Sizes.bottomGradientHeight, right: 0)
+        transcriptView.textContainerInset = .init(top: 0.75 * Sizes.topGradientHeight, left: 32, bottom: 0.7 * Sizes.bottomGradientHeight, right: 32)
         transcriptView.scrollIndicatorInsets = .init(top: 0.75 * Sizes.topGradientHeight, left: 0, bottom: 0.7 * Sizes.bottomGradientHeight, right: 0)
 
         view.addSubview(activityIndicatorView)

--- a/podcasts/TranscriptsViewController.swift
+++ b/podcasts/TranscriptsViewController.swift
@@ -183,7 +183,7 @@ class TranscriptsViewController: PlayerItemViewController {
             transcriptView.attributedText = styleText(transcript: transcript)
     }
 
-    private func styleText(transcript: TranscriptModel, position: Double = 0) -> NSAttributedString {
+    private func styleText(transcript: TranscriptModel, position: Double = -1) -> NSAttributedString {
         let formattedText = NSMutableAttributedString(attributedString: transcript.attributedText)
 
         let paragraphStyle = NSMutableParagraphStyle()
@@ -214,7 +214,7 @@ class TranscriptsViewController: PlayerItemViewController {
 
         formattedText.addAttributes(normalStyle, range: NSRange(location: 0, length: formattedText.length))
 
-        if let range = transcript.firstCue(containing: position)?.characterRange {
+        if position != -1, let range = transcript.firstCue(containing: position)?.characterRange {
             formattedText.addAttributes(highlightStyle, range: range)
         }
 

--- a/podcasts/TranscriptsViewController.swift
+++ b/podcasts/TranscriptsViewController.swift
@@ -165,8 +165,8 @@ class TranscriptsViewController: PlayerItemViewController {
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         if traitCollection.preferredContentSizeCategory != previousTraitCollection?.preferredContentSizeCategory {
             refreshText()
-            updateTextMargins()
         }
+        updateTextMargins()
     }
 
     public override func viewDidLayoutSubviews() {

--- a/podcasts/TranscriptsViewController.swift
+++ b/podcasts/TranscriptsViewController.swift
@@ -38,8 +38,7 @@ class TranscriptsViewController: PlayerItemViewController {
                 transcriptView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
             ]
         )
-
-        transcriptView.textContainerInset = .init(top: 0.75 * Sizes.topGradientHeight, left: 32, bottom: 0.7 * Sizes.bottomGradientHeight, right: 32)
+        updateTextMargins()
         transcriptView.scrollIndicatorInsets = .init(top: 0.75 * Sizes.topGradientHeight, left: 0, bottom: 0.7 * Sizes.bottomGradientHeight, right: 0)
 
         view.addSubview(activityIndicatorView)
@@ -166,7 +165,18 @@ class TranscriptsViewController: PlayerItemViewController {
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         if traitCollection.preferredContentSizeCategory != previousTraitCollection?.preferredContentSizeCategory {
             refreshText()
+            updateTextMargins()
         }
+    }
+
+    public override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        updateTextMargins()
+    }
+
+    private func updateTextMargins() {
+        let margin = self.view.readableContentGuide.layoutFrame.minX + 8
+        transcriptView.textContainerInset = .init(top: 0.75 * Sizes.topGradientHeight, left: margin, bottom: 0.7 * Sizes.bottomGradientHeight, right: margin)
     }
 
     private func refreshText() {


### PR DESCRIPTION
| 📘 Part of: #1848  |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

This PR fixes two small UI issues on the Transcript screen:

- While we disable the sync between sound and transcript the first cue of the transcript was still being styled if the position started on zero. So I disable that
- The scrolling indicators for text were going next to the text instead of the side of the screen.

<img src="https://github.com/user-attachments/assets/51feb258-381f-4797-8573-9941b47a6a29" width=320>

## To test

- Ensure that you have the `transcripts` and `newShowNotesEndpoint` FF enabled
- Start playing an episode with transcript supports. Ex:  One of this [list](https://lists.pocketcasts.com/b852a088-ccee-4e4b-a3c5-4bb7fd700a02)
- Open the full screen player
- Tap on the transcript shelf button 
- Check if the transcripts shows correctly
  - No paragraph is hightlighted
  - Scroll indicators are on the edge of the screen
  - 
## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
