### PR TITLE
Transcripts: prevent search from appearing when selecting text

### DIFF
--- a/podcasts/TranscriptsViewController.swift
+++ b/podcasts/TranscriptsViewController.swift
@@ -3,11 +3,13 @@ import PocketCastsUtils
 
 class TranscriptsViewController: PlayerItemViewController {
 
-    let playbackManager: PlaybackManager
-    var transcript: TranscriptModel?
-    var previousRange: NSRange?
+    private let playbackManager: PlaybackManager
+    private var transcript: TranscriptModel?
+    private var previousRange: NSRange?
 
-    var canScrollToDismiss = true
+    private var canScrollToDismiss = true
+
+    private var isSearching = false
 
     init(playbackManager: PlaybackManager) {
         self.playbackManager = playbackManager
@@ -103,8 +105,12 @@ class TranscriptsViewController: PlayerItemViewController {
         ])
     }
 
+    // Only return the searchView as the input acessory view
+    // if search has been enabled.
+    // This prevents the input acessory view from appearing
+    // when selecting text
     override var inputAccessoryView: UIView? {
-        searchView
+        isSearching ? searchView : nil
     }
 
     lazy var searchView: TranscriptSearchAccessoryView = {
@@ -115,6 +121,8 @@ class TranscriptsViewController: PlayerItemViewController {
     }()
 
     @objc private func search() {
+        isSearching = true
+
         // Keep the inputAccessoryView dark
         parent?.view.overrideUserInterfaceStyle = .dark
 
@@ -125,6 +133,8 @@ class TranscriptsViewController: PlayerItemViewController {
     }
 
     private func dismissSearch() {
+        isSearching = false
+
         searchView.textField.resignFirstResponder()
 
         resignFirstResponder()
@@ -136,6 +146,7 @@ class TranscriptsViewController: PlayerItemViewController {
         textView.font = .systemFont(ofSize: 16)
         textView.isEditable = false
         textView.showsVerticalScrollIndicator = true
+        textView.inputAccessoryView = nil
         return textView
     }()
 


### PR DESCRIPTION
| 📘 Part of: #1848  <!-- project issue number, if applicable --> |
|:---:|

When selecting text the search was appearing while it shouldn't.

## To test

1. Ensure **transcripts** is enabled
2. Play any episode with transcripts (Cautionary Tales or If Books Could Kill)
3. Select any text
4. ✅ The search should not appear at the bottom
5. Tap "Search"
6. ✅ Keyboard should appear alongside the search input accessory view
7. Tap "search" on the keyboard
8. ✅ The search input accessory view should still be visible
9. Tap "Done"
10. Select text
11. ✅ The input accessory view shouldn't appear

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
