### PR TITLE
[Kids Profile] Add UserDefaults logic to hide banner

### DIFF
--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -189,6 +189,10 @@ struct Constants {
         enum appearance {
             static let darkUpNextTheme = SettingValue("appearance.darkUpNextTheme", defaultValue: true)
         }
+
+        enum kidsProfile {
+            static let shouldHideBanner = "ShouldHideKidsBannerKey"
+        }
     }
 
     enum Values {

--- a/podcasts/Kids Profile/KidsProfileBannerViewModel.swift
+++ b/podcasts/Kids Profile/KidsProfileBannerViewModel.swift
@@ -5,6 +5,7 @@ class KidsProfileBannerViewModel {
     var onRequestEarlyAccessTap: (() -> Void)? = nil
 
     func closeButtonTap() {
+        UserDefaults.standard.setValue(true, forKey: Constants.UserDefaults.kidsProfile.shouldHideBanner)
         onCloseButtonTap?()
     }
 

--- a/podcasts/Kids Profile/KidsProfileBannerViewModel.swift
+++ b/podcasts/Kids Profile/KidsProfileBannerViewModel.swift
@@ -5,7 +5,7 @@ class KidsProfileBannerViewModel {
     var onRequestEarlyAccessTap: (() -> Void)? = nil
 
     func closeButtonTap() {
-        UserDefaults.standard.setValue(true, forKey: Constants.UserDefaults.kidsProfile.shouldHideBanner)
+        Settings.shouldHideBanner = true
         onCloseButtonTap?()
     }
 

--- a/podcasts/ProfileViewController.swift
+++ b/podcasts/ProfileViewController.swift
@@ -35,10 +35,6 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
         }
     }
 
-    private var shouldHideKidsProfileBanner: Bool {
-        UserDefaults.standard.bool(forKey: Constants.UserDefaults.kidsProfile.shouldHideBanner)
-    }
-
     var promoRedeemedMessage: String?
     private let settingsCellId = "SettingsCell"
     private let endOfYearPromptCell = "EndOfYearPromptCell"
@@ -245,7 +241,7 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
             return tableView.dequeueReusableCell(withIdentifier: endOfYearPromptCell, for: indexPath) as! EndOfYearPromptCell
         }
 
-        if FeatureFlag.kidsProfile.enabled, row == .kidsProfile, !shouldHideKidsProfileBanner {
+        if row == .kidsProfile {
             let cell = tableView.dequeueReusableCell(withIdentifier: KidsProfileBannerTableCell.identifier, for: indexPath) as! KidsProfileBannerTableCell
             cell.onCloseButtonTap = { [weak self] cell in
                 if let cell, let indexPath = tableView.indexPath(for: cell) {
@@ -300,17 +296,14 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
 
     func tableView(_ tableView: UITableView, shouldHighlightRowAt indexPath: IndexPath) -> Bool {
         let row = tableData[indexPath.section][indexPath.row]
-        if FeatureFlag.kidsProfile.enabled, row == .kidsProfile, !shouldHideKidsProfileBanner {
-            return false
-        }
-        return true
+        return row != .kidsProfile
     }
 
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         let row = tableData[indexPath.section][indexPath.row]
 
         if EndOfYear.isEligible && row == .endOfYearPrompt ||
-            FeatureFlag.kidsProfile.enabled && row == .kidsProfile && !shouldHideKidsProfileBanner {
+            row == .kidsProfile {
             return UITableView.automaticDimension
         } else {
             return 70
@@ -373,7 +366,7 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
             data[0].insert(.endOfYearPrompt, at: 0)
         }
 
-        if FeatureFlag.kidsProfile.enabled && !shouldHideKidsProfileBanner {
+        if FeatureFlag.kidsProfile.enabled && !Settings.shouldHideBanner {
             data[0].insert(.kidsProfile, at: 0)
         }
 

--- a/podcasts/ProfileViewController.swift
+++ b/podcasts/ProfileViewController.swift
@@ -35,6 +35,10 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
         }
     }
 
+    private var shouldHideKidsProfileBanner: Bool {
+        UserDefaults.standard.bool(forKey: Constants.UserDefaults.kidsProfile.shouldHideBanner)
+    }
+
     var promoRedeemedMessage: String?
     private let settingsCellId = "SettingsCell"
     private let endOfYearPromptCell = "EndOfYearPromptCell"
@@ -241,7 +245,7 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
             return tableView.dequeueReusableCell(withIdentifier: endOfYearPromptCell, for: indexPath) as! EndOfYearPromptCell
         }
 
-        if FeatureFlag.kidsProfile.enabled, row == .kidsProfile {
+        if FeatureFlag.kidsProfile.enabled, row == .kidsProfile, !shouldHideKidsProfileBanner {
             let cell = tableView.dequeueReusableCell(withIdentifier: KidsProfileBannerTableCell.identifier, for: indexPath) as! KidsProfileBannerTableCell
             cell.onCloseButtonTap = { [weak self] cell in
                 if let cell, let indexPath = tableView.indexPath(for: cell) {
@@ -296,7 +300,7 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
 
     func tableView(_ tableView: UITableView, shouldHighlightRowAt indexPath: IndexPath) -> Bool {
         let row = tableData[indexPath.section][indexPath.row]
-        if FeatureFlag.kidsProfile.enabled, row == .kidsProfile {
+        if FeatureFlag.kidsProfile.enabled, row == .kidsProfile, !shouldHideKidsProfileBanner {
             return false
         }
         return true
@@ -306,7 +310,7 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
         let row = tableData[indexPath.section][indexPath.row]
 
         if EndOfYear.isEligible && row == .endOfYearPrompt ||
-            FeatureFlag.kidsProfile.enabled && row == .kidsProfile {
+            FeatureFlag.kidsProfile.enabled && row == .kidsProfile && !shouldHideKidsProfileBanner {
             return UITableView.automaticDimension
         } else {
             return 70
@@ -369,7 +373,7 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
             data[0].insert(.endOfYearPrompt, at: 0)
         }
 
-        if FeatureFlag.kidsProfile.enabled {
+        if FeatureFlag.kidsProfile.enabled && !shouldHideKidsProfileBanner {
             data[0].insert(.kidsProfile, at: 0)
         }
 

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -1261,6 +1261,17 @@ class Settings: NSObject {
         }
     }
 
+    // MARK: - Kids Profile
+
+    static var shouldHideBanner: Bool {
+        get {
+            UserDefaults.standard.bool(forKey: Constants.UserDefaults.kidsProfile.shouldHideBanner)
+        }
+        set {
+            UserDefaults.standard.setValue(newValue, forKey: Constants.UserDefaults.kidsProfile.shouldHideBanner)
+        }
+    }
+
     // MARK: - Database (internal)
 
     class var upgradedIndexes: Bool {


### PR DESCRIPTION
| 📘 Part of: #1935 
|:---:|

Fixes #1956 

If a user taps on the `x` to dismiss the banner, we don't want to show it anymore.

## To test

> [!NOTE]
> Enable the `kidsProfile` feature flag

• Run the app and go to your profile
• Tap on the `x` to dismiss the banner
• Make sure that the banner doesn't reload if you pull down, return to the profile, restart the app


## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
