### PR TITLE
Fix: handling `/get/?args`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix scrolling drift on Podcasts list grid view. [#1930](https://github.com/Automattic/pocket-casts-ios/issues/1930)
 - Fix UpNext on the tab bar multi-select action bar display. [#1913](https://github.com/Automattic/pocket-casts-ios/issues/1913)
 - Fix a crash caused by the Categories redesign. [#1968](https://github.com/Automattic/pocket-casts-ios/pull/1968)
+- Fix handling /get/?args. [#1977](https://github.com/Automattic/pocket-casts-ios/pull/1977)
 
 7.68
 -----

--- a/podcasts/AppDelelgate+SiriShortcuts.swift
+++ b/podcasts/AppDelelgate+SiriShortcuts.swift
@@ -23,7 +23,8 @@ extension AppDelegate {
                 let components = NSURLComponents(url: incomingURL, resolvingAgainstBaseURL: true),
                 let path = components.path,
                 let controller = SceneHelper.rootViewController(),
-                path != "/get"
+                path != "/get",
+                path != "/get/"
             else { return }
 
             // Also pass any query params from the share URL to the server to allow support for episode position handling


### PR DESCRIPTION
In the latest newsletter we add a new type of `/get` link, eg.: `https://pocketcasts.com/get/?utm_source=email`.

The app doesn't handle `/get/` though, which makes it to open the browser.

## To test

1. Run the app on a real device
2. Add `https://pocketcasts.com/get/?utm_source=email` to the Notes app for example
3. Tap on it
4. ✅ The app should open and it should not open Safari
5. Test `https://pocketcasts.com/get`
6. ✅ It should open the app

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
