### PR TITLE
Skip Back: try to fix audio moving forward, not backwards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - A new button is added under Account Settings: "Change Avatar". It opens the in-app Safari with Gravatar's Avatar Quick Editor. [#1770](https://github.com/Automattic/pocket-casts-ios/pull/1770)
 - Adds the ability to rate podcasts [#1879](https://github.com/Automattic/pocket-casts-ios/issues/1879)
 - Improve the sort by name algorithm [#1959](https://github.com/Automattic/pocket-casts-ios/issues/1959)
+- Attempt fixing rapidly tapping skip back results in skipping forward [#1950](https://github.com/Automattic/pocket-casts-ios/issues/1950)
 
 7.69
 -----

--- a/podcasts/EffectsPlayer.swift
+++ b/podcasts/EffectsPlayer.swift
@@ -41,6 +41,8 @@ class EffectsPlayer: PlaybackProtocol, Hashable {
     // this lock is to avoid race conditions where you're destroying the player while in the middle of setting it up (since the play method does its work asynchronously)
     private lazy var playerLock = NSLock()
 
+    private let serialSeekQueue = DispatchQueue(label: "effectsplayer.serial.queue")
+
     private lazy var episodeArtwork = EpisodeArtwork()
 
     // MARK: - PlaybackProtocol Impl
@@ -209,19 +211,23 @@ class EffectsPlayer: PlaybackProtocol, Hashable {
     func seekTo(_ time: TimeInterval, completion: (() -> Void)?) {
         guard let readOperation = audioReadTask else { return }
 
-        lastSeekTime = max(0.1, time)
-        seeking = true
-        readOperation.seekTo(time, completion: { [weak self] seekedToEnd in
-            if !seekedToEnd {
-                completion?()
-            } else if !(self?.playBufferManager?.haveNotifiedPlayer.value ?? false) {
-                self?.playBufferManager?.haveNotifiedPlayer.value = true
-                FileLog.shared.addMessage("EffectsPlayer seeked passed end of episode, calling finished playing")
-                PlaybackManager.shared.playerDidFinishPlayingEpisode()
-            }
+        serialSeekQueue.async { [weak self] in
+            guard let self else { return }
 
-            self?.seeking = false
-        })
+            lastSeekTime = max(0.1, time)
+            seeking = true
+            readOperation.seekTo(time, completion: { [weak self] seekedToEnd in
+                if !seekedToEnd {
+                    completion?()
+                } else if !(self?.playBufferManager?.haveNotifiedPlayer.value ?? false) {
+                    self?.playBufferManager?.haveNotifiedPlayer.value = true
+                    FileLog.shared.addMessage("EffectsPlayer seeked passed end of episode, calling finished playing")
+                    PlaybackManager.shared.playerDidFinishPlayingEpisode()
+                }
+
+                self?.seeking = false
+            })
+        }
     }
 
     func currentTime() -> TimeInterval {


### PR DESCRIPTION
Fixes #1950

This is an attempt to fix #1950. Since our move to Accelerate in #1821, the operation seems so fast that it is causing this side-effect. 🙃

This PR tries to fix it by adding every seek operation into a serial queue.

## To test

I highly recommend testing on a real device. In order to reproduce the issue and test this PR you need:

1. To download an episode
2. To enable trim silence
3. Then, play the episode

Then:

1. Open the full screen player.
4. Tap the play button.
5. Tap the "skip back" button in rapid succession.
6. ✅ The audio should skip back, not forward

## Discussion

Reproducing that is not as straightforward as it seems. Sometimes I experience the problem, sometimes not. But by turning `accelerateEffects` off I never manage to reproduce it. 

A better solution for this problem would be to cancel any ongoing seek if a new one comes in, but I didn't have any success by using `Task`. I fear this would require big changes in the player.

I also haven't added this behind a feature flag because we will have feedback about it on our beta release.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
