### PR TITLE
[Kids Profile] Send Feedback API implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 7.71
 -----
-
+- Kids Profile banner implementation [#1935](https://github.com/Automattic/pocket-casts-ios/issues/1935)
 
 7.70
 -----

--- a/Modules/Server/Sources/PocketCastsServer/Private/API Tasks/ApiBaseTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Private/API Tasks/ApiBaseTask.swift
@@ -9,8 +9,8 @@ class ApiBaseTask: Operation {
 
     let dataManager: DataManager
 
-    let urlConnection: URLConnection
-    let tokenHelper: TokenHelper
+    private let urlConnection: URLConnection
+    private let tokenHelper: TokenHelper
 
     init(dataManager: DataManager = .sharedManager, urlConnection: URLConnection = URLConnection(handler: URLSession.shared)) {
         self.dataManager = dataManager

--- a/Modules/Server/Sources/PocketCastsServer/Private/API Tasks/SupportFeedbackTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Private/API Tasks/SupportFeedbackTask.swift
@@ -1,0 +1,58 @@
+import Foundation
+import PocketCastsUtils
+import SwiftProtobuf
+
+class SupportFeedbackTask: ApiBaseTask {
+    var completion: ((Bool) -> Void)?
+
+    private let message: String
+    private let feedbackType: FeedbackType
+
+    init(message: String, feedbackType: FeedbackType) {
+        self.message = message
+        self.feedbackType = feedbackType
+    }
+
+    override func apiTokenAcquired(token: String) {
+        do {
+            let urlString = "\(ServerConstants.Urls.api())\(feedbackType.endpoint)"
+
+            var request = Api_SupportFeedbackRequest()
+            request.message = message
+            request.subject = "Pocket Casts - Kids Profile Ideas"
+            request.inbox = "research"
+
+            let data = try request.serializedData()
+
+            let (response, httpStatus) = postToServer(url: urlString, token: token, data: data)
+
+            if response == nil {
+                FileLog.shared.addMessage("Failed to send the feedback message because response is empty")
+                completion?(false)
+                return
+            }
+
+            if httpStatus == ServerConstants.HttpConstants.ok {
+                FileLog.shared.addMessage("Feedback message as \(feedbackType.rawValue) sent successfully")
+            } else {
+                FileLog.shared.addMessage("Failed to send the feedback message as \(feedbackType.rawValue), http status \(httpStatus)")
+            }
+            completion?(httpStatus == ServerConstants.HttpConstants.ok)
+        } catch {
+            FileLog.shared.addMessage("Failed to serialize Api_SupportFeedbackRequest \(error.localizedDescription)")
+            completion?(false)
+        }
+    }
+
+    enum FeedbackType: String {
+        case authenticated
+        case anonymous
+
+        var endpoint: String {
+            switch self {
+            case .authenticated: "support/feedback"
+            case .anonymous: "anonymous/feedback"
+            }
+        }
+    }
+}

--- a/Modules/Server/Sources/PocketCastsServer/Private/Protobuffer/api.pb.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Private/Protobuffer/api.pb.swift
@@ -138,6 +138,8 @@ struct Api_SupportFeedbackRequest {
 
   var debug: String = String()
 
+  var inbox: String = String()
+
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
@@ -7824,6 +7826,7 @@ extension Api_SupportFeedbackRequest: SwiftProtobuf.Message, SwiftProtobuf._Mess
     2: .same(proto: "email"),
     3: .same(proto: "subject"),
     4: .same(proto: "debug"),
+    5: .same(proto: "inbox"),
   ]
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -7836,6 +7839,7 @@ extension Api_SupportFeedbackRequest: SwiftProtobuf.Message, SwiftProtobuf._Mess
       case 2: try { try decoder.decodeSingularStringField(value: &self.email) }()
       case 3: try { try decoder.decodeSingularStringField(value: &self.subject) }()
       case 4: try { try decoder.decodeSingularStringField(value: &self.debug) }()
+      case 5: try { try decoder.decodeSingularStringField(value: &self.inbox) }()
       default: break
       }
     }
@@ -7854,6 +7858,9 @@ extension Api_SupportFeedbackRequest: SwiftProtobuf.Message, SwiftProtobuf._Mess
     if !self.debug.isEmpty {
       try visitor.visitSingularStringField(value: self.debug, fieldNumber: 4)
     }
+    if !self.inbox.isEmpty {
+      try visitor.visitSingularStringField(value: self.inbox, fieldNumber: 5)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -7862,6 +7869,7 @@ extension Api_SupportFeedbackRequest: SwiftProtobuf.Message, SwiftProtobuf._Mess
     if lhs.email != rhs.email {return false}
     if lhs.subject != rhs.subject {return false}
     if lhs.debug != rhs.debug {return false}
+    if lhs.inbox != rhs.inbox {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+SupportFeedbackRequest.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+SupportFeedbackRequest.swift
@@ -1,21 +1,8 @@
 import Foundation
 
 public extension ApiServerHandler {
-    func sendFeedback(message: String) async {
-        await sendFeedback(message: message, feedbackType: .authenticated)
-    }
-
-    func sendAnonymousFeedback(message: String) async {
-        await sendFeedback(message: message, feedbackType: .anonymous)
-    }
-
-    private func sendFeedback(message: String, feedbackType: SupportFeedbackTask.FeedbackType) async {
-        await withCheckedContinuation { continuation in
-            let operation = SupportFeedbackTask(message: message, feedbackType: feedbackType)
-            operation.completion = { _ in
-                continuation.resume()
-            }
-            apiQueue.addOperation(operation)
-        }
+    func sendFeedback(message: String) {
+        let operation = SupportFeedbackTask(message: message)
+        apiQueue.addOperation(operation)
     }
 }

--- a/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+SupportFeedbackRequest.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+SupportFeedbackRequest.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+public extension ApiServerHandler {
+    func sendFeedback(message: String) async {
+        await sendFeedback(message: message, feedbackType: .authenticated)
+    }
+
+    func sendAnonymousFeedback(message: String) async {
+        await sendFeedback(message: message, feedbackType: .anonymous)
+    }
+
+    private func sendFeedback(message: String, feedbackType: SupportFeedbackTask.FeedbackType) async {
+        await withCheckedContinuation { continuation in
+            let operation = SupportFeedbackTask(message: message, feedbackType: feedbackType)
+            operation.completion = { _ in
+                continuation.resume()
+            }
+            apiQueue.addOperation(operation)
+        }
+    }
+}

--- a/podcasts/Kids Profile/KidsProfileBannerView.swift
+++ b/podcasts/Kids Profile/KidsProfileBannerView.swift
@@ -22,7 +22,12 @@ struct KidsProfileBannerView: View {
                         Spacer()
 
                         Image("kids-profile-banner-face")
-                            .clipShape(RoundedRectangle(cornerRadius: Constants.cornerRadiusBig))
+                            .clipShape(
+                                PCUnevenRoundedRectangle(topLeadingRadius: 0,
+                                                         bottomLeadingRadius: 0,
+                                                         bottomTrailingRadius: Constants.cornerRadiusBig,
+                                                         topTrailingRadius: 0)
+                            )
                     }
 
                     VStack {
@@ -62,10 +67,11 @@ struct KidsProfileBannerView: View {
 
             Button(action: viewModel.requestEarlyAccessTap) {
                 Text(L10n.kidsProfileBannerRequestButton)
-                    .font(size: Constants.textSize, style: .body, weight: .medium)
+                    .font(size: Constants.buttonTitleSize, style: .body, weight: .medium)
                     .foregroundStyle(theme.primaryInteractive01)
                     .opacity(Constants.opacity)
             }
+            .buttonStyle(.plain)
         }
     }
 
@@ -86,6 +92,7 @@ struct KidsProfileBannerView: View {
         static let opacity = 0.8
         static let titleSize = 15.0
         static let textSize = 11.0
+        static let buttonTitleSize = 13.0
 
         static let minHeight = 105.0
         static let buttonSize = 24.0

--- a/podcasts/Kids Profile/KidsProfileSheetViewModel.swift
+++ b/podcasts/Kids Profile/KidsProfileSheetViewModel.swift
@@ -30,20 +30,13 @@ class KidsProfileSheetViewModel: ObservableObject {
     }
 
     func submitFeedback() {
-        Task { @MainActor [weak self] in
-            guard let self else { return }
+        //Optimistic feedback sent
+        ApiServerHandler.shared.sendFeedback(message: textToSend)
 
-            if SyncManager.isUserLoggedIn() {
-                await ApiServerHandler.shared.sendFeedback(message: textToSend)
-            } else {
-                await ApiServerHandler.shared.sendAnonymousFeedback(message: textToSend)
-            }
+        Analytics.track(.kidsProfileFeedbackSent)
+        Toast.show(L10n.kidsProfileSubmitSuccess)
 
-            Analytics.track(.kidsProfileFeedbackSent)
-            Toast.show(L10n.kidsProfileSubmitSuccess)
-
-            onDismissScreenTap?()
-        }
+        onDismissScreenTap?()
     }
 
     enum SheetScreen {

--- a/podcasts/Kids Profile/KidsProfileSubmitScreen.swift
+++ b/podcasts/Kids Profile/KidsProfileSubmitScreen.swift
@@ -39,6 +39,8 @@ struct KidsProfileSubmitScreen: View {
         }
         .buttonStyle(BasicButtonStyle(textColor: theme.primaryInteractive02, backgroundColor: theme.primaryInteractive01))
         .frame(height: Constants.buttonHeight)
+        .disabled(!viewModel.canSendFeedback)
+        .opacity(viewModel.buttonOpacity)
     }
 
     enum Constants {


### PR DESCRIPTION
| 📘 Part of: #1935
|:---:|

Fixes #1939

This PR implements the Send Feedback API as `Api_SupportFeedbackRequest` protobuf object.
I updated some protobuf object, to allow to use this request even when the user is not signed out. 
The action is optimistially handled.

I also updated the UI. in the banner view:
- The `Request Early Access` button title has increased by 2 pts
- I fixed the mask for the round face

## To test

> [!NOTE]
> Make sure kidsProfile feature is enabled

- CI must be 🟢 

#### Authenticated User scenario
- Navigate to Profile
- You should see the Kids Banner
- Tap on `Request Early Access`
- Then tap on `Send Feedback`
- If the text view is empty you should not be able to send any message
- Write a message and then send
- The sheet should dismiss and you should see the toast message

#### Signed out scenario
- Navigate to Profile and log out
- You should see the Kids Banner
- Tap on `Request Early Access`
- Then tap on `Send Feedback`
- If the text view is empty you should not be able to send any message
- Write a message and then send
- The sheet should dismiss and you should see the toast message


## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
