### PR TITLE
Update Extra Playback Actions copy

### DIFF
--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -2570,7 +2570,7 @@ internal enum L10n {
   internal static var settingsGeneralOpenInBrowser: String { return L10n.tr("Localizable", "settings_general_open_in_browser") }
   /// Extra Playback Actions
   internal static var settingsGeneralPlayBackActions: String { return L10n.tr("Localizable", "settings_general_play_back_actions") }
-  /// Adds a mark played and star option to your phone lock screen and CarPlay. Note: on the lock screen this will replace the skip back button.
+  /// Adds a star option to your phone lock screen.
   internal static var settingsGeneralPlayBackActionsSubtitle: String { return L10n.tr("Localizable", "settings_general_play_back_actions_subtitle") }
   /// PLAYER
   internal static var settingsGeneralPlayerHeader: String { return L10n.tr("Localizable", "settings_general_player_header") }

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -2441,7 +2441,7 @@
 "settings_general_play_back_actions" = "Extra Playback Actions";
 
 /* Subtitle explaining the toggle to modify what controls are available on the lock screen. */
-"settings_general_play_back_actions_subtitle" = "Adds a mark played and star option to your phone lock screen and CarPlay. Note: on the lock screen this will replace the skip back button.";
+"settings_general_play_back_actions_subtitle" = "Adds a star option to your phone lock screen.";
 
 /* Section header for the general settings that are more player related. */
 "settings_general_player_header" = "PLAYER";


### PR DESCRIPTION
| 📘 Part of: #194 
|:---:|

Based on a new discussion [here](https://github.com/Automattic/pocket-casts-ios/issues/194#issuecomment-2271352971), we decided to remove the reference to mark as played and replacing the skip back button.

<img width="392" alt="Screenshot 2024-08-06 at 18 16 56" src="https://github.com/user-attachments/assets/f5e3853a-7c94-4889-ab57-f23d594d65b6">

## To test

- Run the App
- Go to Profile -> Settings -> General
- Scroll down till `Extra Playback Actions` and check the new copy
