### PR TITLE
[Kids Profile] Add generic error for feedback toast

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+SupportFeedbackRequest.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+SupportFeedbackRequest.swift
@@ -1,8 +1,13 @@
 import Foundation
 
 public extension ApiServerHandler {
-    func sendFeedback(message: String) {
-        let operation = SupportFeedbackTask(message: message)
-        apiQueue.addOperation(operation)
+    func sendFeedback(message: String) async -> Bool {
+        return await withCheckedContinuation { continuation in
+            let operation = SupportFeedbackTask(message: message)
+            operation.completion = { success in
+                continuation.resume(returning: success)
+            }
+            apiQueue.addOperation(operation)
+        }
     }
 }

--- a/podcasts/Kids Profile/KidsProfileSheetViewModel.swift
+++ b/podcasts/Kids Profile/KidsProfileSheetViewModel.swift
@@ -31,10 +31,16 @@ class KidsProfileSheetViewModel: ObservableObject {
 
     func submitFeedback() {
         //Optimistic feedback sent
-        ApiServerHandler.shared.sendFeedback(message: textToSend)
+        Task { @MainActor in
+            let success = await ApiServerHandler.shared.sendFeedback(message: textToSend)
+            if success {
+                Toast.show(L10n.kidsProfileSubmitSuccess)
+            } else {
+                Toast.show(L10n.kidsProfileSubmitError)
+            }
+        }
 
         Analytics.track(.kidsProfileFeedbackSent)
-        Toast.show(L10n.kidsProfileSubmitSuccess)
 
         onDismissScreenTap?()
     }

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -1388,6 +1388,8 @@ internal enum L10n {
   internal static var kidsProfileBannerText: String { return L10n.tr("Localizable", "kids_profile_banner_text") }
   /// Kids Profile
   internal static var kidsProfileBannerTitle: String { return L10n.tr("Localizable", "kids_profile_banner_title") }
+  /// Something went wrong. Please try submitting your feedback again
+  internal static var kidsProfileSubmitError: String { return L10n.tr("Localizable", "kids_profile_submit_error") }
   /// Send
   internal static var kidsProfileSubmitFeedbackSendButton: String { return L10n.tr("Localizable", "kids_profile_submit_feedback_send_button") }
   /// What would you like to see in a Kids profile for Pocket Casts?

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4237,3 +4237,6 @@
 
 /* Kids Profile Toast message if feedback sent succeeded */
 "kids_profile_submit_success" = "Thank you for your feedback!";
+
+/* Kids Profile Toast message if feedback sent failed */
+"kids_profile_submit_error" = "Something went wrong. Please try submitting your feedback again";


### PR DESCRIPTION
| 📘 Part of: #1935 
|:---:|

Fixes #2001 

This PR adds a generic error message to display in the Toast if the send feedback action fails.

| Success | Error |
| -------- | ------- |
| ![IMG_2327](https://github.com/user-attachments/assets/ac03ac76-e318-4b0e-81b9-cf410eb8c639)  | ![IMG_2326](https://github.com/user-attachments/assets/5b5bbd22-2ce9-4963-b1cc-4bc9683efaf6)    |

## To test

> [!NOTE]
> make sure `kidsProfile` feature is enabled
> It's better to use a real device as you will need to quickly disable the network to generate an error

- Navigate to Profile
- You should see the Kids Banner
- Tap on `Request Early Access`
- Then tap on `Send Feedback`
- Write something
- Disbale you internet connection
- Send the message
- You should see the error prompt

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
