### PR TITLE
Transcripts: display "0" when there are no results

### DIFF
--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -438,8 +438,13 @@ class TranscriptViewController: PlayerItemViewController {
 
     @MainActor
     func updateNumberOfResults() {
-        if searchIndicesResult.isEmpty {
+        if searchTerm == nil {
             searchView.updateLabel("")
+            return
+        }
+
+        if searchIndicesResult.isEmpty {
+            searchView.updateLabel("0")
             return
         }
 


### PR DESCRIPTION
| 📘 Part of: #1848 |
|:---:|

Display "0" when there are no search results.

<img src="https://github.com/user-attachments/assets/4b7cddbe-3237-468f-9d66-009c2d0336d7" width="300">

## To test

1. Run the app and ensure **transcripts** feature flag is enabled
2. Play any episode with transcript
3. Display the transcript, then tap "Search"
4. Type any random keywords
5. ✅ You should see the number "0" being displayed
6. Tap "X" to clear the search
7. ✅ The number should go away

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
