### PR TITLE
Transcripts: remove empty lines

### DIFF
--- a/PocketCastsTests/Tests/Player/Transcripts/sample.vtt
+++ b/PocketCastsTests/Tests/Player/Transcripts/sample.vtt
@@ -33,7 +33,10 @@ WEBVTT - Lorem ipsum translated to English
 0:01:02.610 --> 0:01:07.610
 <v Speaker 1>to find fault with a man who chooses to enjoy a pleasure that has no annoying consequences,
 
-0:01:07.650 --> 0:01:11.810
+0:01:07.650 --> 0:01:07.651
+ 
+
+0:01:07.652 --> 0:01:11.810
 <v Speaker 1>or one who avoids a pain
 
 0:01:11.890 --> 0:01:15.490

--- a/podcasts/TranscriptFormat.swift
+++ b/podcasts/TranscriptFormat.swift
@@ -22,7 +22,7 @@ public enum TranscriptFormat: String {
     }
 
     // Transcript formats we support in order of priority of use
-    public static let supportedFormats: [TranscriptFormat] = [.jsonPodcastIndex, .vtt, .srt, .textHTML]
+    public static let supportedFormats: [TranscriptFormat] = [.vtt, .srt, .jsonPodcastIndex, .textHTML]
 
     public static func bestTranscript(from available: [Episode.Metadata.Transcript]) -> Episode.Metadata.Transcript? {
         for format in Self.supportedFormats {

--- a/podcasts/TranscriptModel.swift
+++ b/podcasts/TranscriptModel.swift
@@ -36,7 +36,9 @@ struct TranscriptModel: Sendable {
             let text = cue.text
 
             let filteredText: String = ComposeFilter.transcriptFilter.filter(text)
-
+            if filteredText.trim().isEmpty {
+                continue
+            }
             let attributedText = NSAttributedString(string: filteredText)
             let startPosition = resultText.length
             let endPosition = attributedText.length


### PR DESCRIPTION
| 📘 Part of: #1848  |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

This PR improves the layout of the transcripts by removing completely empty lines

## To test

- Start the app
- Ensure that you have the `transcripts` and `newShowNotesEndpoint` FF enabled
- Start playing an episode from a podcast with transcript supports. Ex:  One of this [list](https://lists.pocketcasts.com/b852a088-ccee-4e4b-a3c5-4bb7fd700a02)
- Open the full screen player
- Tap on the Transcript icon
- Check that transcript show correctly

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
