### PR TITLE
Transcripts: Optimise formatting of attributed string

### DIFF
--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -322,7 +322,7 @@ class TranscriptViewController: PlayerItemViewController {
 
     private func styleText(transcript: TranscriptModel, position: Double = -1) -> NSAttributedString {
         let formattedText = NSMutableAttributedString(attributedString: transcript.attributedText)
-
+        formattedText.beginEditing()
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.lineHeightMultiple = 1.2
         paragraphStyle.paragraphSpacing = 10
@@ -370,7 +370,7 @@ class TranscriptViewController: PlayerItemViewController {
 
             }
         }
-
+        formattedText.endEditing()
         return formattedText
     }
 


### PR DESCRIPTION
| 📘 Part of: #1848  |  <!-- project issue number, if applicable -->
|:---:|

This changes gives a hint to the system that multiple changes are being applied to the attributed string so we will only do final validations on the end.

## To test

- Start the app
- Ensure that you have the `transcripts` and `newShowNotesEndpoint` FF enabled
- Start playing an episode from a podcast with transcript supports. Ex:  One of this [list](https://lists.pocketcasts.com/b852a088-ccee-4e4b-a3c5-4bb7fd700a02)
- Open the full screen player
- Tap on the Transcript icon
- Check that transcript shows correctly
- Tap on Search
- Search for some word on the transcript
- Go next/previous on the search result (up/down) errors
- Check that selection moves correctly

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
