### PR TITLE
When searchTerm is emptied out cancel any pending search

### DIFF
--- a/podcasts/Debounce.swift
+++ b/podcasts/Debounce.swift
@@ -15,7 +15,7 @@ class Debounce {
         }
     }
 
-    func cancel(){
+    func cancel() {
         timer?.invalidate()
     }
 }

--- a/podcasts/Debounce.swift
+++ b/podcasts/Debounce.swift
@@ -14,4 +14,8 @@ class Debounce {
             callback()
         }
     }
+
+    func cancel(){
+        timer?.invalidate()
+    }
 }

--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -545,6 +545,7 @@ extension TranscriptViewController: TranscriptSearchAccessoryViewDelegate {
 
     func search(_ term: String) {
         if term.isEmpty {
+            debounce.cancel()
             resetSearch()
             return
         }


### PR DESCRIPTION
| 📘 Part of: #1848  |
|:---:|

Fixes #2006 

Update the debouncer code for search to cancel any pending search when search term is empty.

## To test

1. Start the app
2. Open a podcast with transcripts. Ex: Cautionary Tales
3. Play an episode
4. Open the full player view
5. Open the transcript view 
6. Tap on search
7. Write a word on the search term with three letters that is present on the transcript
8. Delete the characters one by one using the device keyboard
9. See that when the search term is empty no results are shown

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
