### PR TITLE
Transcripts: block scroll when dismissing keyboard

### DIFF
--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -432,6 +432,7 @@ class TranscriptViewController: PlayerItemViewController {
         addCustomObserver(Constants.Notifications.playbackTrackChanged, selector: #selector(update))
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow(_:)), name: UIResponder.keyboardWillShowNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide(_:)), name: UIResponder.keyboardWillHideNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardDidHide(_:)), name: UIResponder.keyboardDidHideNotification, object: nil)
         //We disabled the method bellow until we find a way to resync/shift transcript positions
         //addCustomObserver(Constants.Notifications.playbackProgress, selector: #selector(updateTranscriptPosition))
     }
@@ -513,7 +514,14 @@ class TranscriptViewController: PlayerItemViewController {
     }
 
     @objc func keyboardWillHide(_ notification: Notification) {
+        transcriptView.isScrollEnabled = false
         adjustTextViewForKeyboard(notification: notification, show: false)
+    }
+
+    @objc func keyboardDidHide(_ notification: Notification) {
+        Task { [weak self] in
+            self?.transcriptView.isScrollEnabled = true
+        }
     }
 
     func adjustTextViewForKeyboard(notification: Notification, show: Bool) {


### PR DESCRIPTION
| 📘 Part of: #1848 |
|:---:|

As reported by @pachlava [here](https://github.com/Automattic/pocket-casts-ios/pull/1982#issuecomment-2274295556) we have an issue where tapping outside the keyboard when the search is active activates the scroll on the transcript:


https://github.com/user-attachments/assets/57df34e0-a361-48cb-b870-2500f5075fa6

After some investigation, I was able to pinpoint that the issue is with the `TranscriptViewController.inputAcessoryView`. If we set it to `nil` this doesn't happen. However, it prevent it from appearing when you tap "Search".

I wasn't able to find a proper solution, so what I ended up doing was to block the scrollview from scrolling during keyboard hiding.

This causes a small glitch though:

https://github.com/user-attachments/assets/25202b8d-0db2-4b47-b1b5-bef7225c37aa

I still think this is better than having the issue which normally scrolls far away from where the user was.

----

I did some extra work on this and was able to found a way to fix the issue without the glitch.
From my investigation the issue was happening when we changed the bottom inset of the text view when the keyboard animated in/out.
My solution saves the scroll position before the keyboard is show/hide and keeps it in place while the animation is on going.

Here is a video:

https://github.com/user-attachments/assets/d87f23f9-1a32-4e77-9607-7ae4581718c8


## To test

1. Ensure **transcripts** is enabled
2. Play any episode with transcript
3. Open the transcript
4. Tap "Search"
5. Tap outside the keyboard
6. ✅ The transcript should not scroll to another position

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
