### PR TITLE
Reimagine Sharing: Add clip time labels

### DIFF
--- a/podcasts/Sharing/SharingView.swift
+++ b/podcasts/Sharing/SharingView.swift
@@ -51,10 +51,17 @@ struct SharingView: View {
             case .episode, .podcast, .currentPosition:
                 buttons
             case .clip(let episode, _):
-                VStack(spacing: 16) {
+                VStack(spacing: 12) {
                     MediaTrimBar(clipTime: clipTime, episode: episode)
                         .frame(height: 72)
                         .tint(color)
+                    HStack {
+                        Text(L10n.clipStartLabel(TimeFormatter.shared.playTimeFormat(time: clipTime.start)))
+                        Spacer()
+                        Text(L10n.clipDurationLabel(TimeFormatter.shared.playTimeFormat(time: clipTime.end - clipTime.start)))
+                    }
+                    .foregroundStyle(.white.opacity(0.5))
+                    .font(.caption.weight(.semibold))
                     Button(L10n.clip, action: {
                         withAnimation {
                             selectedOption = .clipShare(episode, clipTime)

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -440,6 +440,14 @@ internal enum L10n {
   internal static var clientErrorTokenDeauth: String { return L10n.tr("Localizable", "client_error_token_deauth") }
   /// Clip
   internal static var clip: String { return L10n.tr("Localizable", "clip") }
+  /// %@ Duration
+  internal static func clipDurationLabel(_ p1: Any) -> String {
+    return L10n.tr("Localizable", "clip_duration_label", String(describing: p1))
+  }
+  /// %@ Start
+  internal static func clipStartLabel(_ p1: Any) -> String {
+    return L10n.tr("Localizable", "clip_start_label", String(describing: p1))
+  }
   /// Close
   internal static var close: String { return L10n.tr("Localizable", "close") }
   /// Color

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4196,6 +4196,12 @@
 /* A title shown after editing a clip but before sharing */
 "share_clip" = "Share clip";
 
+/* A label shown with the clip start time */
+"clip_start_label" = "%@ Start";
+
+/* A label shown with the duration time of a clip */
+"clip_duration_label" = "%@ Duration";
+
 /* Title of the Pocket Casts champion screen, greeting an user that has been using Pocket Casts for a long time */
 "champion_title" = "You’re a true champion of Pocket Casts!";
 


### PR DESCRIPTION
| 📘 Part of: #1910 |
|:---:|

Adds new time labels for clip editing.

<img src="https://github.com/user-attachments/assets/7315e150-7afc-438f-97e6-162f06511c34" width=400>

## To test

> [!NOTE]
> Enable the `newSharing` feature flag to test this

1. Play an episode
2. Tap the "Share" button in the action bar
3. Tap the "Clip" option
4. Ensure that the "Start" and "Duration" labels are shown
5. Move the Trim handles and ensure values are correct

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
