### PR TITLE
[Give Rating] Make the rating view tappable

### DIFF
--- a/podcasts/Ratings/StarRatingView.swift
+++ b/podcasts/Ratings/StarRatingView.swift
@@ -37,6 +37,9 @@ struct StarRatingView: View {
                 ratingView(rating: viewModel.rating)
                     .frame(height: 16)
                     .animation(.easeIn(duration: Constants.animationDuration), value: shouldAnimate)
+                    .onTapGesture {
+                        viewModel.didTapRating()
+                    }
 
                 Spacer()
 


### PR DESCRIPTION
| 📘 Part of: #1879 
|:---:|

Fixes #2033 

This PR makes the Rating view tappable. We are going to keep the Rate button.

For context see: p1723652426719639/1723638851.314939-slack-C05RR9P9RAT


https://github.com/user-attachments/assets/bbaa5f2e-79c9-4b34-876f-db4cf4f6c18e


## To test

1. Open a podcast to rate
2. Tap on stars
3. ✅ Make sure the rate screen is open
4. Back to the previous screen
5. ✅ Tap on rating average
6. ✅ Make sure the rate screen is open

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
