### PR TITLE
Cancel button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Adds the ability to rate podcasts [#1879](https://github.com/Automattic/pocket-casts-ios/issues/1879)
 - Improve the sort by name algorithm [#1959](https://github.com/Automattic/pocket-casts-ios/issues/1959)
 - Attempt fixing rapidly tapping skip back results in skipping forward [#1950](https://github.com/Automattic/pocket-casts-ios/issues/1950)
+- Add the Cancel button to dismiss the Alert Controller in Help & Support [#2035](https://github.com/Automattic/pocket-casts-ios/issues/2035)
 
 7.69
 -----

--- a/podcasts/OnlineSupportController.swift
+++ b/podcasts/OnlineSupportController.swift
@@ -78,6 +78,8 @@ class OnlineSupportController: PCViewController, WKNavigationDelegate {
             self?.export(sender)
         }))
 
+        controller.addAction(.init(title: L10n.cancel, style: .destructive))
+
         present(controller, animated: true)
     }
 


### PR DESCRIPTION
Fixes #2035 

We got a report of an issue I found myself on the same day. We don't have a way to dismiss the `UIAlertController`, which makes it a dead end.
To quickly fix I added a cancel button to dismiss it.

![Simulator Screenshot - iPhone 15 Pro - 2024-08-15 at 11 18 36](https://github.com/user-attachments/assets/9ae9fb02-d4b7-4956-9ccc-68e26a834328)

## To test

- CI must be 🟢 
- Go to Profile -> Help & Feedback
- Tap the `•••`
- Observe the controller being showed
- Observe there's the Cancel button
- Tap on it to dismiss it

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
