### PR TITLE
Skip Back: do not allow skipping forward when skipping back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 7.71
 -----
 - Kids Profile banner implementation [#1935](https://github.com/Automattic/pocket-casts-ios/issues/1935)
+- Fix rapidly tapping skio back resulting in skip forward [#2041](https://github.com/Automattic/pocket-casts-ios/issues/2041)
 
 7.70
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 7.71
 -----
 - Kids Profile banner implementation [#1935](https://github.com/Automattic/pocket-casts-ios/issues/1935)
-- Fix rapidly tapping skio back resulting in skip forward [#2041](https://github.com/Automattic/pocket-casts-ios/issues/2041)
+- Fix rapidly tapping skip back resulting in skip forward [#2041](https://github.com/Automattic/pocket-casts-ios/issues/2041)
 
 7.70
 -----


### PR DESCRIPTION
Fixes https://github.com/Automattic/pocket-casts-ios/issues/1950

Adds a mechanism to ensure that rapidly tapping Skip Back do not result in skipping forward.

This doesn't actually fixes the issue but prevents it from happening.

## To test

I highly recommend testing on a real device. In order to reproduce the issue and test this PR you need:

1. To download an episode
2. To enable trim silence
3. Then, play the episode

Then:

1. Open the full screen player.
4. Tap the play button.
5. Tap the "skip back" button in rapid succession.
6. ✅ The audio should skip back, not forward
7. Skip forward
8. ✅ It should work
9. Skip forward, then back
10. ✅ It should work

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
