### PR TITLE
Reimagine Sharing: Static waveform lines + Preview scaling

### DIFF
--- a/podcasts/Sharing/AudioWaveformView.swift
+++ b/podcasts/Sharing/AudioWaveformView.swift
@@ -88,10 +88,10 @@ struct AudioWaveformView: View {
     }
 
     private func getLineHeight(for index: Int) -> LineHeight {
-        switch index % 16 {
+        switch index % 20 {
         case 0:
             return .tallest
-        case 4, 8, 12:
+        case 5, 10, 15:
             return .medium
         default:
             return .shortest

--- a/podcasts/Sharing/SharingView.swift
+++ b/podcasts/Sharing/SharingView.swift
@@ -26,6 +26,7 @@ struct SharingView: View {
 
     private enum Constants {
         static let descriptionMaxWidth: CGFloat = 200
+        static let tabViewPadding: CGFloat = 80 // A value which represents extra padding for UIPageControl of the TabView
     }
 
     let destinations: [ShareDestination]
@@ -133,14 +134,17 @@ struct SharingView: View {
     }
 
     @ViewBuilder var image: some View {
-        TabView(selection: $shareable.style) {
-            ForEach(ShareImageStyle.allCases, id: \.self) { style in
-                ShareImageView(info: shareable.option.imageInfo, style: style, angle: .constant(0))
-                    .clipShape(RoundedRectangle(cornerRadius: 12))
-                    .tabItem { Text(style.tabString) }
+        GeometryReader { proxy in
+            TabView(selection: $shareable.style) {
+                ForEach(ShareImageStyle.allCases, id: \.self) { style in
+                    ShareImageView(info: shareable.option.imageInfo, style: style, angle: .constant(0))
+                        .clipShape(RoundedRectangle(cornerRadius: 12))
+                        .tabItem { Text(style.tabString) }
+                        .scaleEffect((proxy.size.height - Constants.tabViewPadding) / ShareImageStyle.large.videoSize.height)
+                }
             }
+            .tabViewStyle(.page)
         }
-        .tabViewStyle(.page)
     }
 
     @ViewBuilder var buttons: some View {


### PR DESCRIPTION
| 📘 Part of: #1910 |
|:---:|

* Adds an additional line to the static waveform for clipping
* Scales the previews to fit better inside of the view

| Before | After |
| --- | --- |
| ![Simulator Screenshot - iPhone 15 Pro - 2024-08-15 at 17 41 55](https://github.com/user-attachments/assets/056ac66f-0a57-46f1-8b47-674238d9cc93) | ![Simulator Screenshot - iPhone 15 Pro - 2024-08-15 at 17 40 46](https://github.com/user-attachments/assets/5450b43c-2357-470b-a896-d852f15ccf79) |

## To test

> [!NOTE]
> Enable the `newSharing` feature flag to test this

* Play an episode
* Tap "Share" from the action shelf
* Tap "Clip"
* Verify that there are 4 small lines in the static waveform-like view
* Verify that preview images are scaled so that they do not overlap the page control dots

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
