### PR TITLE
[Give Ratings] Reload ratings ignoring cache

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/Ratings/PodcastRatingTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Ratings/PodcastRatingTask.swift
@@ -14,10 +14,10 @@ public struct PodcastRatingTask {
     }
 
     /// Retrieves the star rating and total for a single podcast
-    public func retrieve(for podcastUuid: String) async throws -> PodcastRating? {
+    public func retrieve(for podcastUuid: String, ignoringCache: Bool) async throws -> PodcastRating? {
         let urlString = "\(ServerConstants.Urls.cache())podcast/rating/\(podcastUuid)"
         let task = JSONDecodableURLTask<PodcastRating>(session: session)
-
-        return try await task.get(urlString: urlString)
+        let cachePolicy: URLRequest.CachePolicy = ignoringCache ? .reloadIgnoringLocalAndRemoteCacheData : .useProtocolCachePolicy
+        return try await task.get(urlString: urlString, cachePolicy: cachePolicy)
     }
 }

--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -177,7 +177,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
 
     lazy var ratingView: UIView = {
         let view = StarRatingView(viewModel: podcastRatingViewModel,
-                                  onDismiss: { [weak self] in
+                                  onRate: { [weak self] in
             self?.podcastRatingViewModel.update(podcast: self?.podcast, ignoringCache: true)
         })
             .padding(.top, 10)

--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -176,10 +176,12 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
     private var cancellables = Set<AnyCancellable>()
 
     lazy var ratingView: UIView = {
-        let view = StarRatingView(viewModel: podcastRatingViewModel)
+        let view = StarRatingView(viewModel: podcastRatingViewModel,
+                                  onDismiss: { [weak self] in
+            self?.podcastRatingViewModel.update(podcast: self?.podcast, ignoringCache: true)
+        })
             .padding(.top, 10)
             .themedUIView
-
         view.backgroundColor = .clear
         return view
     }()

--- a/podcasts/Ratings/PodcastRatingViewModel.swift
+++ b/podcasts/Ratings/PodcastRatingViewModel.swift
@@ -30,7 +30,12 @@ class PodcastRatingViewModel: ObservableObject {
 
     /// Updates the rating for the podcast.
     ///
-    func update(podcast: Podcast?) {
+    func update(podcast: Podcast?, ignoringCache: Bool = false) {
+        // If we want to reload and ignore the cache, let's reset the state to waiting and reload
+        if ignoringCache, state == .done {
+            state = .waiting
+        }
+
         self.podcast = podcast
 
         // Don't update if we have already finished or are currently updating
@@ -40,7 +45,7 @@ class PodcastRatingViewModel: ObservableObject {
         state = .loading
 
         Task {
-            let rating = try? await PodcastRatingTask().retrieve(for: uuid)
+            let rating = try? await PodcastRatingTask().retrieve(for: uuid, ignoringCache: ignoringCache)
 
             // Publish on main thread only
             await MainActor.run {

--- a/podcasts/Ratings/RatePodcastView.swift
+++ b/podcasts/Ratings/RatePodcastView.swift
@@ -143,6 +143,6 @@ struct RatePodcastView: View {
 }
 
 #Preview {
-    RatePodcastView(viewModel: RatePodcastViewModel(presented: .constant(true), dismissAction: .constant(.default), podcast: Podcast.previewPodcast(), onDismiss: {}))
+    RatePodcastView(viewModel: RatePodcastViewModel(presented: .constant(true), dismissAction: .constant(.default), podcast: Podcast.previewPodcast(), onRate: {}))
         .environmentObject(Theme.sharedTheme)
 }

--- a/podcasts/Ratings/RatePodcastView.swift
+++ b/podcasts/Ratings/RatePodcastView.swift
@@ -143,6 +143,6 @@ struct RatePodcastView: View {
 }
 
 #Preview {
-    RatePodcastView(viewModel: RatePodcastViewModel(presented: .constant(true), dismissAction: .constant(.default), podcast: Podcast.previewPodcast()))
+    RatePodcastView(viewModel: RatePodcastViewModel(presented: .constant(true), dismissAction: .constant(.default), podcast: Podcast.previewPodcast(), onDismiss: {}))
         .environmentObject(Theme.sharedTheme)
 }

--- a/podcasts/Ratings/RatePodcastViewModel.swift
+++ b/podcasts/Ratings/RatePodcastViewModel.swift
@@ -51,11 +51,14 @@ class RatePodcastViewModel: ObservableObject {
         return isButtonEnabled ? 1 : 0.8
     }
 
-    init(presented: Binding<Bool>, dismissAction: Binding<DismissAction>, podcast: Podcast, dataManager: DataManager = .sharedManager) {
+    private var onDismiss: () -> Void
+
+    init(presented: Binding<Bool>, dismissAction: Binding<DismissAction>, podcast: Podcast, dataManager: DataManager = .sharedManager, onDismiss: @escaping () -> Void) {
         self._presented = presented
         self._dismissAction = dismissAction
         self.podcast = podcast
         self.dataManager = dataManager
+        self.onDismiss = onDismiss
         checkIfUserCanRatePodcast(id: podcast.id, uuid: podcast.uuid)
     }
 
@@ -73,6 +76,7 @@ class RatePodcastViewModel: ObservableObject {
             let success = await ApiServerHandler.shared.addRating(uuid: self.podcast.uuid, rating: Int(self.stars))
             self.isSubmitting = false
             if success {
+                self.onDismiss()
                 self.dismiss(trackingEvent: false)
                 Toast.show(L10n.ratingThankYou)
             }

--- a/podcasts/Ratings/RatePodcastViewModel.swift
+++ b/podcasts/Ratings/RatePodcastViewModel.swift
@@ -51,14 +51,14 @@ class RatePodcastViewModel: ObservableObject {
         return isButtonEnabled ? 1 : 0.8
     }
 
-    private var onDismiss: () -> Void
+    private var onRate: () -> Void
 
-    init(presented: Binding<Bool>, dismissAction: Binding<DismissAction>, podcast: Podcast, dataManager: DataManager = .sharedManager, onDismiss: @escaping () -> Void) {
+    init(presented: Binding<Bool>, dismissAction: Binding<DismissAction>, podcast: Podcast, dataManager: DataManager = .sharedManager, onRate: @escaping () -> Void) {
         self._presented = presented
         self._dismissAction = dismissAction
         self.podcast = podcast
         self.dataManager = dataManager
-        self.onDismiss = onDismiss
+        self.onRate = onRate
         checkIfUserCanRatePodcast(id: podcast.id, uuid: podcast.uuid)
     }
 
@@ -76,7 +76,7 @@ class RatePodcastViewModel: ObservableObject {
             let success = await ApiServerHandler.shared.addRating(uuid: self.podcast.uuid, rating: Int(self.stars))
             self.isSubmitting = false
             if success {
-                self.onDismiss()
+                self.onRate()
                 self.dismiss(trackingEvent: false)
                 Toast.show(L10n.ratingThankYou)
             }

--- a/podcasts/Ratings/StarRatingView.swift
+++ b/podcasts/Ratings/StarRatingView.swift
@@ -8,6 +8,9 @@ struct StarRatingView: View {
 
     @State private var dismissAction: RatePodcastViewModel.DismissAction = .default
 
+    // To reload the view after dismissing the rating sheet
+    private var onDismiss: () -> Void
+
     /// Keeps track of when we appear to determine if we should animate
     private var startDate: Date = .now
 
@@ -18,8 +21,9 @@ struct StarRatingView: View {
         viewModel.rating != nil && Date().timeIntervalSince(startDate) > Constants.minTimeBeforeAnimating
     }
 
-    init(viewModel: PodcastRatingViewModel) {
+    init(viewModel: PodcastRatingViewModel, onDismiss: @escaping () -> Void) {
         self.viewModel = viewModel
+        self.onDismiss = onDismiss
     }
 
     var body: some View {
@@ -60,7 +64,7 @@ struct StarRatingView: View {
                 dismissAction = .default
             }, content: {
                 if let podcast = viewModel.podcast {
-                    RatePodcastView(viewModel: RatePodcastViewModel(presented: $viewModel.presentingGiveRatings, dismissAction: $dismissAction, podcast: podcast))
+                    RatePodcastView(viewModel: RatePodcastViewModel(presented: $viewModel.presentingGiveRatings, dismissAction: $dismissAction, podcast: podcast, onDismiss: onDismiss))
                 }
             })
 

--- a/podcasts/Ratings/StarRatingView.swift
+++ b/podcasts/Ratings/StarRatingView.swift
@@ -8,8 +8,8 @@ struct StarRatingView: View {
 
     @State private var dismissAction: RatePodcastViewModel.DismissAction = .default
 
-    // To reload the view after dismissing the rating sheet
-    private var onDismiss: () -> Void
+    // To reload the view after rate and dismiss the rating sheet
+    private var onRate: () -> Void
 
     /// Keeps track of when we appear to determine if we should animate
     private var startDate: Date = .now
@@ -21,9 +21,9 @@ struct StarRatingView: View {
         viewModel.rating != nil && Date().timeIntervalSince(startDate) > Constants.minTimeBeforeAnimating
     }
 
-    init(viewModel: PodcastRatingViewModel, onDismiss: @escaping () -> Void) {
+    init(viewModel: PodcastRatingViewModel, onRate: @escaping () -> Void) {
         self.viewModel = viewModel
-        self.onDismiss = onDismiss
+        self.onRate = onRate
     }
 
     var body: some View {
@@ -64,7 +64,7 @@ struct StarRatingView: View {
                 dismissAction = .default
             }, content: {
                 if let podcast = viewModel.podcast {
-                    RatePodcastView(viewModel: RatePodcastViewModel(presented: $viewModel.presentingGiveRatings, dismissAction: $dismissAction, podcast: podcast, onDismiss: onDismiss))
+                    RatePodcastView(viewModel: RatePodcastViewModel(presented: $viewModel.presentingGiveRatings, dismissAction: $dismissAction, podcast: podcast, onRate: onRate))
                 }
             })
 


### PR DESCRIPTION
| 📘 Part of: #1879 
|:---:|

Fixes #2047 
Ref. [Android PR](https://github.com/Automattic/pocket-casts-android/pull/2653)

We would like to show the user's rating on the podcast page as soon as they rate. This is done by refreshing after the rating has been sent and ignoring the cache on refresh.


https://github.com/user-attachments/assets/d2a7c760-f5a1-47c7-a790-25671cf21050

## To test

1. Search for a podcast that has no ratings
2. Open the podcast page
3. Wait for over 10 seconds (a server fix will remove this later)
4. Rate the podcast
5. ✅ Verify the rating changes
6. If you rate again, wait another 10 sec (I believe it's related to the point 3)

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
