### PR TITLE
[Tooling] Apply required CI checks too when setting branch protection settings on release branch

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -382,7 +382,7 @@ platform :ios do
     after_confirming_push(push_merge_branch: true) do
       trigger_beta_build(branch_to_build: release_branch_name)
 
-      set_branch_protection(repository: GHHELPER_REPO, branch: release_branch_name)
+      copy_branch_protection(repository: GHHELPER_REPO, from_branch: DEFAULT_BRANCH, to_branch: release_branch_name)
       set_milestone_frozen_marker(repository: GHHELPER_REPO, milestone: release_version_current)
     end
   end


### PR DESCRIPTION
Replication of Android's https://github.com/Automattic/pocket-casts-android/pull/2659
Context: p1723805743869889-slack-CC7L49W13

## Description

During code freeze, after creating the `release/N` branch, we set GitHub Branch Protection settings on it to require Pull Requests with at least one reviewer etc.

But until now, we were using our `set_branch_protection` action (from our `release-toolkit` fastlane plugin), which is nowadays legacy because this action were only setting a minimal set of branch protection settings on the branch. In particular, it didn't set any "required checks" from CI to pass before allowing a PR to be merged (which means that anyone could accidentally merge approved PRs to `release/N` even if CI was failing on it, and also that "Enable Auto-Merge" was not available on PRs targeting `release/N` branches).

This PR changes this to use the more recent `copy_branch_protection` action from our `release-toolkit`, which copies the same branch protection settings from `trunk` on the `release/N` branch instead, thus also copying the "required CI checks" from the trunk branch protection settings too.

## Testing Instructions

This could be tested after doing the next code freeze, checking that after the code freeze has happened and has created the next `release/N` branch, its branch protection settings on GitHub include the expected list of requested CI checks too before a PR to `release/N` can be merged.
