### PR TITLE
[Tooling] Revert branch protection change (#2050)

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -382,7 +382,7 @@ platform :ios do
     after_confirming_push(push_merge_branch: true) do
       trigger_beta_build(branch_to_build: release_branch_name)
 
-      copy_branch_protection(repository: GHHELPER_REPO, from_branch: DEFAULT_BRANCH, to_branch: release_branch_name)
+      set_branch_protection(repository: GHHELPER_REPO, branch: release_branch_name)
       set_milestone_frozen_marker(repository: GHHELPER_REPO, milestone: release_version_current)
     end
   end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -382,6 +382,9 @@ platform :ios do
     after_confirming_push(push_merge_branch: true) do
       trigger_beta_build(branch_to_build: release_branch_name)
 
+      # We cannot use the `copy_branch_protection` action here as it would create a branch protection rule with the same
+      # restrictions we have in `trunk`, and the release managers wouldn't be able to push due to permissions.
+      # This should be changed only when we have PCiOS releases done on CI, when the CI bot is the one running `git push`.
       set_branch_protection(repository: GHHELPER_REPO, branch: release_branch_name)
       set_milestone_frozen_marker(repository: GHHELPER_REPO, milestone: release_version_current)
     end


### PR DESCRIPTION
This PR reverts #2050.
We don't have releases on CI yet on PocketCasts iOS, so this change would prevent the release manager from pushing to a release branch.

See: https://github.com/Automattic/pocket-casts-android/pull/2659#issuecomment-2293569537
