### PR TITLE
Reimagine Sharing: Add video sharing to Instagram Stories

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -33,8 +33,8 @@
 		10756F882C59449C0089D34F /* Folder+Sortable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10756F872C59449C0089D34F /* Folder+Sortable.swift */; };
 		10756F892C59449C0089D34F /* Folder+Sortable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10756F872C59449C0089D34F /* Folder+Sortable.swift */; };
 		10756F8B2C5945C00089D34F /* KidsProfileSubmitScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10756F8A2C5945C00089D34F /* KidsProfileSubmitScreen.swift */; };
-		107836262C62816900DA3FF0 /* ABTestProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 107836252C62816900DA3FF0 /* ABTestProviderTests.swift */; };
 		107836232C5CDD5000DA3FF0 /* GiveRatingsWhatsNewHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 107836222C5CDD5000DA3FF0 /* GiveRatingsWhatsNewHeader.swift */; };
+		107836262C62816900DA3FF0 /* ABTestProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 107836252C62816900DA3FF0 /* ABTestProviderTests.swift */; };
 		10A4F7532C515D720084D783 /* KidsProfile.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 10A4F7522C515D720084D783 /* KidsProfile.xcassets */; };
 		10A4F7562C5162C90084D783 /* KidsProfileBannerTableCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10A4F7552C5162C90084D783 /* KidsProfileBannerTableCell.swift */; };
 		10A4F7582C52635F0084D783 /* KidsProfileBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10A4F7572C52635F0084D783 /* KidsProfileBannerView.swift */; };
@@ -1637,6 +1637,7 @@
 		F508F0FB2C4F1EC000822159 /* ClipPlaybackManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F508F0FA2C4F1EC000822159 /* ClipPlaybackManager.swift */; };
 		F5197A402B995A1E007C8D0A /* DownloadManager+Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5197A3F2B995A1E007C8D0A /* DownloadManager+Logging.swift */; };
 		F5197A412B995A1E007C8D0A /* DownloadManager+Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5197A3F2B995A1E007C8D0A /* DownloadManager+Logging.swift */; };
+		F51D90722C70FF7800F0A232 /* AVAsset+Crop.swift in Sources */ = {isa = PBXBuildFile; fileRef = F51D90712C70FF7800F0A232 /* AVAsset+Crop.swift */; };
 		F5235EE02C3CCB1D00C98739 /* RoundedCorner.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5235EDF2C3CCB1D00C98739 /* RoundedCorner.swift */; };
 		F5235EE22C3CE5B300C98739 /* MediaTrimBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5235EE12C3CE5B300C98739 /* MediaTrimBar.swift */; };
 		F5235EE82C3DE13100C98739 /* ScrollableScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5235EE72C3DE13100C98739 /* ScrollableScrollView.swift */; };
@@ -1921,8 +1922,8 @@
 		10756F842C5944660089D34F /* Podcast+Sortable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Podcast+Sortable.swift"; sourceTree = "<group>"; };
 		10756F872C59449C0089D34F /* Folder+Sortable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Folder+Sortable.swift"; sourceTree = "<group>"; };
 		10756F8A2C5945C00089D34F /* KidsProfileSubmitScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = KidsProfileSubmitScreen.swift; path = "Kids Profile/KidsProfileSubmitScreen.swift"; sourceTree = "<group>"; };
-		107836252C62816900DA3FF0 /* ABTestProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ABTestProviderTests.swift; sourceTree = "<group>"; };
 		107836222C5CDD5000DA3FF0 /* GiveRatingsWhatsNewHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiveRatingsWhatsNewHeader.swift; sourceTree = "<group>"; };
+		107836252C62816900DA3FF0 /* ABTestProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ABTestProviderTests.swift; sourceTree = "<group>"; };
 		10A4F7522C515D720084D783 /* KidsProfile.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = KidsProfile.xcassets; sourceTree = "<group>"; };
 		10A4F7552C5162C90084D783 /* KidsProfileBannerTableCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = KidsProfileBannerTableCell.swift; path = "Kids Profile/KidsProfileBannerTableCell.swift"; sourceTree = "<group>"; };
 		10A4F7572C52635F0084D783 /* KidsProfileBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = KidsProfileBannerView.swift; path = "Kids Profile/KidsProfileBannerView.swift"; sourceTree = "<group>"; };
@@ -3517,6 +3518,7 @@
 		EFBF99F57846D0E1AF8DE08D /* Pods-PocketCasts-PocketCastsTests.staging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PocketCasts-PocketCastsTests.staging.xcconfig"; path = "Pods/Target Support Files/Pods-PocketCasts-PocketCastsTests/Pods-PocketCasts-PocketCastsTests.staging.xcconfig"; sourceTree = "<group>"; };
 		F508F0FA2C4F1EC000822159 /* ClipPlaybackManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipPlaybackManager.swift; sourceTree = "<group>"; };
 		F5197A3F2B995A1E007C8D0A /* DownloadManager+Logging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DownloadManager+Logging.swift"; sourceTree = "<group>"; };
+		F51D90712C70FF7800F0A232 /* AVAsset+Crop.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AVAsset+Crop.swift"; sourceTree = "<group>"; };
 		F5235EDF2C3CCB1D00C98739 /* RoundedCorner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundedCorner.swift; sourceTree = "<group>"; };
 		F5235EE12C3CE5B300C98739 /* MediaTrimBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaTrimBar.swift; sourceTree = "<group>"; };
 		F5235EE72C3DE13100C98739 /* ScrollableScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollableScrollView.swift; sourceTree = "<group>"; };
@@ -7678,6 +7680,7 @@
 				F5FF61242BD0831200190711 /* PocketCastsLogoPill.swift */,
 				F533F19C2C24B8CB00EDE9AA /* ShareDestination.swift */,
 				F5AD9C4C2C3C705200A01896 /* AudioWaveformView.swift */,
+				F51D90712C70FF7800F0A232 /* AVAsset+Crop.swift */,
 			);
 			path = Sharing;
 			sourceTree = "<group>";
@@ -9300,6 +9303,7 @@
 				C76ECACE2A685FB300D9DB9E /* BookmarksListView.swift in Sources */,
 				4022A4C0236BA15800900734 /* SleepTimerViewController.swift in Sources */,
 				40F0DE8D22E45236001DAA52 /* PlusLockedInfoCell.swift in Sources */,
+				F51D90722C70FF7800F0A232 /* AVAsset+Crop.swift in Sources */,
 				4086511B23B1CE8400D7585A /* CreateSiriShortcutCell.swift in Sources */,
 				F5954D5E2C3F284D004A8C04 /* TrimSelectionView.swift in Sources */,
 				8B68C1CF2942134300CF25C5 /* BetaMenu.swift in Sources */,

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1638,6 +1638,7 @@
 		F5197A402B995A1E007C8D0A /* DownloadManager+Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5197A3F2B995A1E007C8D0A /* DownloadManager+Logging.swift */; };
 		F5197A412B995A1E007C8D0A /* DownloadManager+Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5197A3F2B995A1E007C8D0A /* DownloadManager+Logging.swift */; };
 		F51D90722C70FF7800F0A232 /* AVAsset+Crop.swift in Sources */ = {isa = PBXBuildFile; fileRef = F51D90712C70FF7800F0A232 /* AVAsset+Crop.swift */; };
+		F51D90742C71A0A100F0A232 /* SharingFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F51D90732C71A0A100F0A232 /* SharingFooterView.swift */; };
 		F5235EE02C3CCB1D00C98739 /* RoundedCorner.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5235EDF2C3CCB1D00C98739 /* RoundedCorner.swift */; };
 		F5235EE22C3CE5B300C98739 /* MediaTrimBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5235EE12C3CE5B300C98739 /* MediaTrimBar.swift */; };
 		F5235EE82C3DE13100C98739 /* ScrollableScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5235EE72C3DE13100C98739 /* ScrollableScrollView.swift */; };
@@ -3519,6 +3520,7 @@
 		F508F0FA2C4F1EC000822159 /* ClipPlaybackManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipPlaybackManager.swift; sourceTree = "<group>"; };
 		F5197A3F2B995A1E007C8D0A /* DownloadManager+Logging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DownloadManager+Logging.swift"; sourceTree = "<group>"; };
 		F51D90712C70FF7800F0A232 /* AVAsset+Crop.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AVAsset+Crop.swift"; sourceTree = "<group>"; };
+		F51D90732C71A0A100F0A232 /* SharingFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharingFooterView.swift; sourceTree = "<group>"; };
 		F5235EDF2C3CCB1D00C98739 /* RoundedCorner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundedCorner.swift; sourceTree = "<group>"; };
 		F5235EE12C3CE5B300C98739 /* MediaTrimBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaTrimBar.swift; sourceTree = "<group>"; };
 		F5235EE72C3DE13100C98739 /* ScrollableScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollableScrollView.swift; sourceTree = "<group>"; };
@@ -7674,6 +7676,7 @@
 			children = (
 				F5235EDA2C3CCAA100C98739 /* Clip */,
 				F52ADE432BD8B0F300AC647F /* SharingView.swift */,
+				F51D90732C71A0A100F0A232 /* SharingFooterView.swift */,
 				F5FF61282BD6D88C00190711 /* SharingModal.swift */,
 				F5FF61222BD07E3A00190711 /* ShareImageView.swift */,
 				F555980E2C503F1700C02EEB /* AnimatedShareImageView.swift */,
@@ -9252,6 +9255,7 @@
 				C7AF5791289D87CF0089E435 /* Analytics.swift in Sources */,
 				C7E99EFC2A5C856400E7CBAF /* BookmarkRow.swift in Sources */,
 				BDE7409A2060CE1B00FB22C7 /* EpisodeManager.swift in Sources */,
+				F51D90742C71A0A100F0A232 /* SharingFooterView.swift in Sources */,
 				BD240C43231F46F400FB2CDD /* PCSearchBarController+TextFieldDelegate.swift in Sources */,
 				4053CDF9214F3583001C92B1 /* PodcastFilterOverlayController.swift in Sources */,
 				BDF5FD1E1FD8D38900F2A339 /* DownloadsViewController+Table.swift in Sources */,

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1639,6 +1639,7 @@
 		F5197A412B995A1E007C8D0A /* DownloadManager+Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5197A3F2B995A1E007C8D0A /* DownloadManager+Logging.swift */; };
 		F51D90722C70FF7800F0A232 /* AVAsset+Crop.swift in Sources */ = {isa = PBXBuildFile; fileRef = F51D90712C70FF7800F0A232 /* AVAsset+Crop.swift */; };
 		F51D90742C71A0A100F0A232 /* SharingFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F51D90732C71A0A100F0A232 /* SharingFooterView.swift */; };
+		F51D90762C73141B00F0A232 /* CGSize+FittingSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = F51D90752C73141B00F0A232 /* CGSize+FittingSize.swift */; };
 		F5235EE02C3CCB1D00C98739 /* RoundedCorner.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5235EDF2C3CCB1D00C98739 /* RoundedCorner.swift */; };
 		F5235EE22C3CE5B300C98739 /* MediaTrimBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5235EE12C3CE5B300C98739 /* MediaTrimBar.swift */; };
 		F5235EE82C3DE13100C98739 /* ScrollableScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5235EE72C3DE13100C98739 /* ScrollableScrollView.swift */; };
@@ -3521,6 +3522,7 @@
 		F5197A3F2B995A1E007C8D0A /* DownloadManager+Logging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DownloadManager+Logging.swift"; sourceTree = "<group>"; };
 		F51D90712C70FF7800F0A232 /* AVAsset+Crop.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AVAsset+Crop.swift"; sourceTree = "<group>"; };
 		F51D90732C71A0A100F0A232 /* SharingFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharingFooterView.swift; sourceTree = "<group>"; };
+		F51D90752C73141B00F0A232 /* CGSize+FittingSize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CGSize+FittingSize.swift"; sourceTree = "<group>"; };
 		F5235EDF2C3CCB1D00C98739 /* RoundedCorner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundedCorner.swift; sourceTree = "<group>"; };
 		F5235EE12C3CE5B300C98739 /* MediaTrimBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaTrimBar.swift; sourceTree = "<group>"; };
 		F5235EE72C3DE13100C98739 /* ScrollableScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollableScrollView.swift; sourceTree = "<group>"; };
@@ -6719,6 +6721,7 @@
 				FF05C98E2C0A0BF800E41EB3 /* FileManager+Helper.swift */,
 				F55598102C534D4100C02EEB /* CMTimeScale+Common.swift */,
 				F57D8F172C66CDF40004C4DF /* View+CVPixelBuffer.swift */,
+				F51D90752C73141B00F0A232 /* CGSize+FittingSize.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -9403,6 +9406,7 @@
 				BDF9DDDB1B8AD29C00E77B35 /* TimeSliderLayer.swift in Sources */,
 				BDB1E4ED1B8C5BCF009AD30F /* FeaturedSummaryViewController.swift in Sources */,
 				BDD3018E1EFB9574004A9972 /* WatchConstants.swift in Sources */,
+				F51D90762C73141B00F0A232 /* CGSize+FittingSize.swift in Sources */,
 				8BD7A2382C04F0DD00CF84E8 /* UpNextHistoryViewController.swift in Sources */,
 				463538AE26E8F4AE00BA9D35 /* Server+Strings.swift in Sources */,
 				BD674B0B1F68F2BD00AC1B2B /* PlaylistManager.swift in Sources */,

--- a/podcasts/CGSize+FittingSize.swift
+++ b/podcasts/CGSize+FittingSize.swift
@@ -1,0 +1,17 @@
+extension CGSize {
+    func fitting(aspectRatio: CGSize) -> CGSize {
+        let targetAspectRatio = aspectRatio.width / aspectRatio.height
+
+        if self.width / self.height > targetAspectRatio {
+            // Original is wider, constrain height
+            let newHeight = self.height
+            let newWidth = newHeight * targetAspectRatio
+            return CGSize(width: newWidth, height: newHeight)
+        } else {
+            // Original is taller, constrain width
+            let newWidth = self.width
+            let newHeight = newWidth / targetAspectRatio
+            return CGSize(width: newWidth, height: newHeight)
+        }
+    }
+}

--- a/podcasts/Sharing/AVAsset+Crop.swift
+++ b/podcasts/Sharing/AVAsset+Crop.swift
@@ -1,23 +1,5 @@
 import AVFoundation
 
-extension CGSize {
-    func fitting(aspectRatio: CGSize) -> CGSize {
-        let targetAspectRatio = aspectRatio.width / aspectRatio.height
-
-        if self.width / self.height > targetAspectRatio {
-            // Original is wider, constrain height
-            let newHeight = self.height
-            let newWidth = newHeight * targetAspectRatio
-            return CGSize(width: newWidth, height: newHeight)
-        } else {
-            // Original is taller, constrain width
-            let newWidth = self.width
-            let newHeight = newWidth / targetAspectRatio
-            return CGSize(width: newWidth, height: newHeight)
-        }
-    }
-}
-
 extension AVAsset {
     enum CropError: Error {
         case failedVideoTrackCreation

--- a/podcasts/Sharing/AVAsset+Crop.swift
+++ b/podcasts/Sharing/AVAsset+Crop.swift
@@ -53,8 +53,4 @@ extension AVAsset {
 
         return outputURL
     }
-
-    func trim(start: TimeInterval, end: TimeInterval) -> URL {
-        
-    }
 }

--- a/podcasts/Sharing/AVAsset+Crop.swift
+++ b/podcasts/Sharing/AVAsset+Crop.swift
@@ -1,0 +1,71 @@
+import AVFoundation
+
+extension CGSize {
+    func fitting(aspectRatio: CGSize) -> CGSize {
+        let targetAspectRatio = aspectRatio.width / aspectRatio.height
+
+        if self.width / self.height > targetAspectRatio {
+            // Original is wider, constrain height
+            let newHeight = self.height
+            let newWidth = newHeight * targetAspectRatio
+            return CGSize(width: newWidth, height: newHeight)
+        } else {
+            // Original is taller, constrain width
+            let newWidth = self.width
+            let newHeight = newWidth / targetAspectRatio
+            return CGSize(width: newWidth, height: newHeight)
+        }
+    }
+}
+
+extension AVAsset {
+    enum CropError: Error {
+        case failedVideoTrackCreation
+        case failedExportSession
+    }
+
+    func crop(to size: CGSize) async throws -> URL {
+        let composition = AVMutableComposition()
+        guard let compositionTrack = composition.addMutableTrack(withMediaType: .video, preferredTrackID: kCMPersistentTrackID_Invalid) else {
+            throw CropError.failedVideoTrackCreation
+        }
+
+        let assetTrack = try await loadTracks(withMediaType: .video)[0]
+        try compositionTrack.insertTimeRange(CMTimeRangeMake(start: .zero, duration: duration), of: assetTrack, at: .zero)
+
+        let videoComposition = AVMutableVideoComposition()
+        videoComposition.renderSize = size
+        videoComposition.frameDuration = CMTimeMake(value: 1, timescale: 30)
+
+        let instruction = AVMutableVideoCompositionInstruction()
+        instruction.timeRange = CMTimeRangeMake(start: .zero, duration: duration)
+
+        let transformer = AVMutableVideoCompositionLayerInstruction(assetTrack: compositionTrack)
+
+        let assetTrackSize = try await assetTrack.load(.naturalSize)
+
+        // Calculate the offset to center the video
+        let xOffset = (assetTrackSize.width - size.width) / 2
+        let yOffset = (assetTrackSize.height - size.height) / 2
+
+        // Create a transform that moves the video to center it in the frame
+        let transform = CGAffineTransform(translationX: -xOffset, y: -yOffset)
+
+        transformer.setTransform(transform, at: .zero)
+        instruction.layerInstructions = [transformer]
+        videoComposition.instructions = [instruction]
+
+        guard let export = AVAssetExportSession(asset: composition, presetName: AVAssetExportPresetHighestQuality) else {
+            throw CropError.failedExportSession
+        }
+
+        let outputURL = FileManager.default.temporaryDirectory.appendingPathComponent("PCiOS-Cropped-share-\(UUID().uuidString)").appendingPathExtension(for: .mpeg4Movie)
+        export.videoComposition = videoComposition
+        export.outputURL = outputURL
+        export.outputFileType = .mp4
+
+        await export.export()
+
+        return outputURL
+    }
+}

--- a/podcasts/Sharing/AVAsset+Crop.swift
+++ b/podcasts/Sharing/AVAsset+Crop.swift
@@ -4,6 +4,7 @@ extension AVAsset {
     enum CropError: Error {
         case failedVideoTrackCreation
         case failedExportSession
+        case missingVideoTrack
     }
 
     func crop(to size: CGSize) async throws -> URL {
@@ -12,7 +13,9 @@ extension AVAsset {
             throw CropError.failedVideoTrackCreation
         }
 
-        let assetTrack = try await loadTracks(withMediaType: .video)[0]
+        guard let assetTrack = try await loadTracks(withMediaType: .video).first else {
+          throw CropError.missingVideoTrack
+        }
         try compositionTrack.insertTimeRange(CMTimeRangeMake(start: .zero, duration: duration), of: assetTrack, at: .zero)
 
         let videoComposition = AVMutableVideoComposition()
@@ -49,5 +52,9 @@ extension AVAsset {
         await export.export()
 
         return outputURL
+    }
+
+    func trim(start: TimeInterval, end: TimeInterval) -> URL {
+        
     }
 }

--- a/podcasts/Sharing/AnimatedShareImageView.swift
+++ b/podcasts/Sharing/AnimatedShareImageView.swift
@@ -15,6 +15,8 @@ struct AnimatedShareImageView: AnimatableContent {
     var body: some View {
         ZStack {
             ShareImageView(info: info, style: style, angle: $angle)
+                .frame(width: style.videoSize.width, height: style.videoSize.height)
+                .fixedSize()
                 .onReceive(animationProgress.$progress) { progress in
                     let calculatedAngle = calculateAngle(progress: Float(progress))
                     angle = Double(calculatedAngle)
@@ -28,7 +30,7 @@ struct AnimatedShareImageView: AnimatableContent {
     }
 
     private func calculateAngle(progress: Float) -> Float {
-        let speed: Float = 1
+        let speed: Float = 0.5
         let angle = (progress * 360 * speed).truncatingRemainder(dividingBy: 360)
         return angle
     }

--- a/podcasts/Sharing/Clip/VideoExporter.swift
+++ b/podcasts/Sharing/Clip/VideoExporter.swift
@@ -54,7 +54,6 @@ enum VideoExporter {
 
             // Clean up temporary file
             try? FileManager.default.removeItem(at: temporaryFileURL)
-            progress.completedUnitCount = progress.totalUnitCount
             FileLog.shared.addMessage("VideoExporter Ended: \(start.timeIntervalSinceNow)")
         } onCancel: {
             progress.cancel()

--- a/podcasts/Sharing/ShareDestination.swift
+++ b/podcasts/Sharing/ShareDestination.swift
@@ -79,7 +79,7 @@ struct ShareDestination: Hashable {
             let dataKey = type == .mpeg4Movie ? "com.instagram.sharedSticker.backgroundVideo" : "com.instagram.sharedSticker.backgroundImage"
             let pasteboardItems = [[dataKey: data,
                                     "com.instagram.sharedSticker.contentURL": attributionURL]]
-            let pasteboardOptions: [UIPasteboard.OptionsKey: Any] = [.expirationDate: Date().addingTimeInterval(60 * 5)]
+            let pasteboardOptions: [UIPasteboard.OptionsKey: Any] = [.expirationDate: Date().addingTimeInterval(5.minutes)]
 
             UIPasteboard.general.setItems(pasteboardItems, options: pasteboardOptions)
 

--- a/podcasts/Sharing/ShareDestination.swift
+++ b/podcasts/Sharing/ShareDestination.swift
@@ -87,7 +87,16 @@ struct ShareDestination: Hashable {
         }
 
         var isIncluded: Bool {
-            return true
+            switch self {
+            case .instagram:
+                if let url = URL(string: "instagram-stories://share"), UIApplication.shared.canOpenURL(url) {
+                    return true
+                } else {
+                    return false
+                }
+            default:
+                return true
+            }
         }
     }
 

--- a/podcasts/Sharing/ShareDestination.swift
+++ b/podcasts/Sharing/ShareDestination.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct ShareDestination: Hashable {
     let name: String
     let icon: Image
-    let action: ((SharingModal.Option, ShareImageStyle) -> Void)?
+    let action: (SharingModal.Option, ShareImageStyle) -> Void
 
     enum Constants {
         static let displayedAppsCount = 3
@@ -120,17 +120,13 @@ struct ShareDestination: Hashable {
     static func moreOption(vc: UIViewController) -> ShareDestination {
         let icon = Image(systemName: "ellipsis")
 
-        if #available(iOS 16, *) {
-            return ShareDestination(name: L10n.shareMoreActions, icon: icon, action: nil)
-        } else {
-            return ShareDestination(name: L10n.shareMoreActions, icon: icon, action: { option, style in
-                Task.detached {
-                    let activityItems = option.itemProviders(style: style)
-                    let activityViewController = await UIActivityViewController(activityItems: activityItems, applicationActivities: nil)
-                    await vc.presentedViewController?.present(activityViewController, animated: true, completion: nil)
-                }
-            })
-        }
+        return ShareDestination(name: L10n.shareMoreActions, icon: icon, action: { option, style in
+            Task.detached {
+                let activityItems = option.itemProviders(style: style)
+                let activityViewController = await UIActivityViewController(activityItems: activityItems, applicationActivities: nil)
+                await vc.presentedViewController?.present(activityViewController, animated: true, completion: nil)
+            }
+        })
     }
 
     static var copyLinkOption: ShareDestination {

--- a/podcasts/Sharing/ShareDestination.swift
+++ b/podcasts/Sharing/ShareDestination.swift
@@ -40,7 +40,7 @@ struct ShareDestination: Hashable {
         }
 
         func share(_ option: SharingModal.Option, style: ShareImageStyle) async throws {
-            let itemProviders = option.itemProviders(style: style)
+            let itemProviders = option.itemProviders(style: style, destination: self)
             let (type, data) = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<(UTType, Data), Error>) in
                 if let itemProvider = itemProviders.first(where: { $0.hasItemConformingToTypeIdentifier(UTType.mpeg4Movie.identifier) }) {
                     let type = UTType.mpeg4Movie

--- a/podcasts/Sharing/ShareImageView.swift
+++ b/podcasts/Sharing/ShareImageView.swift
@@ -162,15 +162,6 @@ struct KidneyShape: Shape {
     }
 }
 
-@available(iOS 16.0, *)
-extension ShareImageView: Transferable {
-    static var transferRepresentation: some TransferRepresentation {
-        DataRepresentation<Self>(exportedContentType: .png) { view in
-            try await view.snapshot().pngData().throwOnNil()
-        }
-    }
-}
-
 extension View {
     func itemProvider() -> NSItemProvider {
         let itemProvider = NSItemProvider()

--- a/podcasts/Sharing/ShareImageView.swift
+++ b/podcasts/Sharing/ShareImageView.swift
@@ -29,6 +29,10 @@ enum ShareImageStyle: CaseIterable {
     }
 
     var videoSize: CGSize {
+        CGSize(width: 390, height: 694)
+    }
+
+    var previewSize: CGSize {
         switch self {
         case .large:
             CGSize(width: 292, height: 438)
@@ -57,6 +61,7 @@ struct ShareImageView: View {
                 VStack(spacing: 32) {
                     image()
                         .aspectRatio(1, contentMode: .fit)
+                        .frame(maxWidth: 270)
                     text()
                     PocketCastsLogoPill()
                 }
@@ -85,8 +90,6 @@ struct ShareImageView: View {
                 Image("music")
             }
         }
-        .frame(width: style.videoSize.width, height: style.videoSize.height)
-        .fixedSize()
     }
 
     @ViewBuilder func background() -> some View {

--- a/podcasts/Sharing/SharingFooterView.swift
+++ b/podcasts/Sharing/SharingFooterView.swift
@@ -40,6 +40,8 @@ struct SharingFooterView: View {
             if clipResult.progress != 1 {
                 ProgressView(value: clipResult.progress) {
                     Text(L10n.clipLoadingLabel)
+                        .font(.headline)
+                        .padding(8)
                 }
                 .tint(color)
                 .padding()

--- a/podcasts/Sharing/SharingFooterView.swift
+++ b/podcasts/Sharing/SharingFooterView.swift
@@ -1,0 +1,94 @@
+import SwiftUI
+import PocketCastsUtils
+
+struct SharingFooterView: View {
+    @ObservedObject var clipTime: ClipTime
+    @Binding var option: SharingModal.Option
+    @Binding var isExporting: Bool
+    @ObservedObject var clipResult: ClipResult
+
+    let destinations: [ShareDestination]
+    let style: ShareImageStyle
+
+    @EnvironmentObject var theme: Theme
+
+    var body: some View {
+        switch option {
+        case .episode, .podcast, .currentPosition:
+            buttons
+        case .clip(let episode, _):
+            VStack(spacing: 12) {
+                MediaTrimBar(clipTime: clipTime, episode: episode)
+                    .frame(height: 72)
+                    .tint(color)
+                HStack {
+                    Text(L10n.clipStartLabel(TimeFormatter.shared.playTimeFormat(time: clipTime.start)))
+                    Spacer()
+                    Text(L10n.clipDurationLabel(TimeFormatter.shared.playTimeFormat(time: clipTime.end - clipTime.start)))
+                }
+                .foregroundStyle(.white.opacity(0.5))
+                .font(.caption.weight(.semibold))
+                Button(L10n.clip, action: {
+                    withAnimation {
+                        option = .clipShare(episode, clipTime, style, clipResult)
+                        isExporting = true
+                    }
+                }).buttonStyle(RoundedButtonStyle(theme: theme, backgroundColor: color))
+            }
+            .padding(.horizontal, 16)
+        case .clipShare:
+            if clipResult.progress != 1 {
+                ProgressView(value: clipResult.progress) {
+                    Text(L10n.clipLoadingLabel)
+                }
+                .tint(color)
+                .padding()
+            }
+            else {
+                buttons
+            }
+        }
+    }
+
+    @ViewBuilder var buttons: some View {
+        HStack(spacing: 24) {
+            ForEach(destinations, id: \.self) { destination in
+                button(destination: destination, style: style, action: destination.action)
+            }
+        }
+    }
+
+    @ViewBuilder func button(destination: ShareDestination, style: ShareImageStyle, action: @escaping ((SharingModal.Option, ShareImageStyle) -> Void)) -> some View {
+        Button {
+            action(option, style)
+        } label: {
+            view(for: destination)
+        }
+    }
+
+    var color: Color {
+        switch option {
+        case .clip(let episode, _), .clipShare(let episode, _, _, _):
+            PlayerColorHelper.backgroundColor(for: episode)?.color ?? PlayerColorHelper.playerBackgroundColor01(for: theme.activeTheme).color
+        default:
+            PlayerColorHelper.playerBackgroundColor01(for: theme.activeTheme).color
+        }
+    }
+
+    @ViewBuilder func view(for destination: ShareDestination) -> some View {
+        VStack {
+            destination.icon
+                .renderingMode(.template)
+                .font(size: 20, style: .body, weight: .bold)
+                .frame(width: 24, height: 24)
+                .padding(15)
+                .background {
+                    Circle()
+                        .foregroundStyle(.white.opacity(0.1))
+                }
+            Text(destination.name)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+}

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -444,6 +444,8 @@ internal enum L10n {
   internal static func clipDurationLabel(_ p1: Any) -> String {
     return L10n.tr("Localizable", "clip_duration_label", String(describing: p1))
   }
+  /// Creating Clip...
+  internal static var clipLoadingLabel: String { return L10n.tr("Localizable", "clip_loading_label") }
   /// %@ Start
   internal static func clipStartLabel(_ p1: Any) -> String {
     return L10n.tr("Localizable", "clip_start_label", String(describing: p1))

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4202,6 +4202,9 @@
 /* A label shown with the duration time of a clip */
 "clip_duration_label" = "%@ Duration";
 
+/* A label shown while the clip is being created */
+"clip_loading_label" = "Creating Clip...";
+
 /* Title of the Pocket Casts champion screen, greeting an user that has been using Pocket Casts for a long time */
 "champion_title" = "You’re a true champion of Pocket Casts!";
 


### PR DESCRIPTION
| 📘 Part of: #1910 |
|:---:|

* Adds sharing of the video clip to Instagram Stories
* Refactors sharing to avoid `NSItemProvider` which isn't supported by many third party apps
* Tweaks the cropped media export to produce a larger size for Instagram Stories

https://github.com/user-attachments/assets/0bdf7395-d4b9-4f08-9966-c1916477a2dc

## To test

> [!NOTE]
> Enable the `newSharing` feature flag to test this

At this time, the progress bar is not as accurate as it could be. This isn't new with this PR and is something I'm planning to tackle before release.

### Instagram Clip Share
* Play an episode
* Tap the share button from the action shelf
* Select the "Clip" share option
* Tap the "Clip" button
* Share to Instagram Stories
* Verify that the clip video is shared

### Standard Clip Share

* Play an episode
* Tap the share button from the action shelf
* Select the "Clip" share option
* Tap the "Clip" button
* Share "More"
* Verify that the clip is included as a shareable item. You can save the video to Photos, check that sharing to Tumblr shares the video file and link

### Standard Media Share (Regression)

* Play an episode
* Tap the share button from the action shelf
* Select the "Episode" share option
* Share "More"
* Verify that the image is included as a shareable item. You can save the image to Photos, check that sharing to Tumblr shares the video file and link
* Tap the "Stories" button
* Verify that the image is shared to Instagram

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
