### PR TITLE
Reimagine Sharing: Tweak share screen

### DIFF
--- a/podcasts/Sharing/AudioWaveformView.swift
+++ b/podcasts/Sharing/AudioWaveformView.swift
@@ -1,11 +1,10 @@
 import SwiftUI
 
 struct AudioWaveformView: View {
-    let scale: CGFloat
     let width: CGFloat
 
     private let baseLineWidth: CGFloat = 2
-    private let baseLineSpacing: CGFloat = 2
+    private let baseLineSpacing: CGFloat = 6
 
     enum LineHeight: CaseIterable {
         case shortest
@@ -29,11 +28,6 @@ struct AudioWaveformView: View {
             case .tallest: return 0.5
             }
         }
-
-        /// Determines how quickly each line type fades out
-        var fadeDuration: CGFloat {
-            return 0.5
-        }
     }
 
     var body: some View {
@@ -46,13 +40,11 @@ struct AudioWaveformView: View {
                     let x = CGFloat(index) * (lineWidth + lineSpacing)
                     let lineHeight = getLineHeight(for: index)
                     let barHeight = size.height * lineHeight.fraction
-                    let opacity = opacityForLine(at: index)
 
                     var path = Path()
                     path.move(to: CGPoint(x: x, y: midY - barHeight / 2))
                     path.addLine(to: CGPoint(x: x, y: midY + barHeight / 2))
 
-                    context.opacity = opacity
                     context.stroke(path, with: .color(.gray), lineWidth: lineWidth)
                 }
             }
@@ -65,26 +57,11 @@ struct AudioWaveformView: View {
     }
 
     private var lineSpacing: CGFloat {
-        baseLineSpacing * scale
+        baseLineSpacing
     }
 
     private var lineCount: Int {
         Int(width / (lineWidth + lineSpacing))
-    }
-
-    private func opacityForLine(at index: Int) -> Double {
-        let lineHeight = getLineHeight(for: index)
-
-        let fadeStartScale = lineHeight.fadeStartScale
-        let fadeEndScale = fadeStartScale + lineHeight.fadeDuration
-
-        if scale >= fadeEndScale {
-            return 1.0
-        } else if scale <= fadeStartScale {
-            return 0.0
-        } else {
-            return Double((scale - fadeStartScale) / lineHeight.fadeDuration)
-        }
     }
 
     private func getLineHeight(for index: Int) -> LineHeight {

--- a/podcasts/Sharing/Clip/MediaTrimView.swift
+++ b/podcasts/Sharing/Clip/MediaTrimView.swift
@@ -26,7 +26,7 @@ struct MediaTrimView: View {
     var body: some View {
         GeometryReader { geometry in
             ScrollableScrollView(scale: $scale, duration: duration, geometry: geometry) { scrollable in
-                AudioWaveformView(scale: scale, width: geometry.size.width * scale)
+                AudioWaveformView(width: geometry.size.width * scale)
                 borderView(in: geometry)
                 PlayheadView(position: scaledPosition($playPosition), validRange: scaledPosition($startPosition).wrappedValue...scaledPosition($endPosition).wrappedValue)
                     .onChange(of: playTime) { playTime in

--- a/podcasts/Sharing/ShareImageView.swift
+++ b/podcasts/Sharing/ShareImageView.swift
@@ -40,6 +40,15 @@ enum ShareImageStyle: CaseIterable {
             CGSize(width: 100, height: 100)
         }
     }
+
+    var shareDescription: String? {
+        switch self {
+        case .audio:
+            L10n.createAudioClipDescription
+        default:
+            nil
+        }
+    }
 }
 
 struct ShareImageView: View {

--- a/podcasts/Sharing/ShareImageView.swift
+++ b/podcasts/Sharing/ShareImageView.swift
@@ -41,9 +41,11 @@ enum ShareImageStyle: CaseIterable {
         }
     }
 
-    var shareDescription: String? {
-        switch self {
-        case .audio:
+    func shareDescription(option: SharingModal.Option) -> String? {
+        switch (option, self) {
+        case (.episode, _), (.podcast, _):
+            L10n.shareDescription
+        case (.clip, .audio):
             L10n.createAudioClipDescription
         default:
             nil

--- a/podcasts/Sharing/SharingModal.swift
+++ b/podcasts/Sharing/SharingModal.swift
@@ -25,7 +25,7 @@ enum SharingModal {
             }
         }
 
-        var shareTitle: String {
+        func shareTitle(style: ShareImageStyle) -> String {
             switch self {
             case .episode:
                 L10n.shareEpisode
@@ -34,7 +34,12 @@ enum SharingModal {
             case .podcast:
                 L10n.sharePodcast
             case .clip:
-                L10n.createClip
+                switch style {
+                case .audio:
+                    L10n.createAudioClipTitle
+                default:
+                    L10n.createClip
+                }
             case .clipShare:
                 L10n.shareClip
             }

--- a/podcasts/Sharing/SharingView.swift
+++ b/podcasts/Sharing/SharingView.swift
@@ -125,7 +125,7 @@ struct SharingView: View {
             default:
                 EmptyView()
             }
-            Text(shareable.style.shareDescription ?? "‏")
+            Text(shareable.style.shareDescription(option: shareable.option) ?? "‏")
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)

--- a/podcasts/Sharing/SharingView.swift
+++ b/podcasts/Sharing/SharingView.swift
@@ -140,8 +140,13 @@ struct SharingView: View {
                 switch shareable.option {
                 case .clipShare(_, _, let style, _):
                     image(style: style, containerHeight: proxy.size.height)
-                default:
+                case .clip:
                     ForEach(ShareImageStyle.allCases, id: \.self) { style in
+                        image(style: style, containerHeight: proxy.size.height)
+                    }
+                default:
+                    let styles = ShareImageStyle.allCases.filter { $0 != .audio }
+                    ForEach(styles, id: \.self) { style in
                         image(style: style, containerHeight: proxy.size.height)
                     }
                 }

--- a/podcasts/Sharing/SharingView.swift
+++ b/podcasts/Sharing/SharingView.swift
@@ -103,11 +103,9 @@ struct SharingView: View {
 
     @ViewBuilder var title: some View {
         VStack {
-            Text(shareable.option.shareTitle)
+            Text(shareable.option.shareTitle(style: shareable.style))
                 .font(.headline)
             switch shareable.option {
-            case .clip:
-                EmptyView() // Don't show the description to give extra space for trim view
             case .clipShare(let episode, let clipTime, _, _):
                 Button(action: {
                     isExporting = false
@@ -125,12 +123,13 @@ struct SharingView: View {
                 }
                 .padding(.top, 14)
             default:
-                Text(L10n.shareDescription)
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-                    .multilineTextAlignment(.center)
-                    .frame(maxWidth: Constants.descriptionMaxWidth)
+                EmptyView()
             }
+            Text(shareable.style.shareDescription ?? "‏")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: Constants.descriptionMaxWidth)
         }
     }
 

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -476,6 +476,10 @@ internal enum L10n {
   internal static var createAccountFreePrice: String { return L10n.tr("Localizable", "create_account_free_price") }
   /// Everything unlocked
   internal static var createAccountPlusDetails: String { return L10n.tr("Localizable", "create_account_plus_details") }
+  /// Create a .m4a audio file
+  internal static var createAudioClipDescription: String { return L10n.tr("Localizable", "create_audio_clip_description") }
+  /// Create audio file
+  internal static var createAudioClipTitle: String { return L10n.tr("Localizable", "create_audio_clip_title") }
   /// Create clip
   internal static var createClip: String { return L10n.tr("Localizable", "create_clip") }
   /// Create Filter

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4184,8 +4184,14 @@
 /* Current search results being displayed and the total number of results. Eg.: 1 of 10. %1$@ is the current result being shown, %2$@ is the total number of results */
 "search_results" = "%1$@ of %2$@";
 
-/* A title shown for a share option which creates an audio clip of an episode */
+/* A title shown for a share option which creates an animated video clip with audio of an episode */
 "create_clip" = "Create clip";
+
+/* A title shown for a share option which creates an audio clip of an episode */
+"create_audio_clip_title" = "Create audio file";
+
+/* A description shown for a share option which creates an audio clip of an episode. This produces a ".m4a" file which is like an mp3 */
+"create_audio_clip_description" = "Create a .m4a audio file";
 
 /* Shown in a button when creating a shareable audio clip of an episode */
 "clip" = "Clip";


### PR DESCRIPTION
| 📘 Part of: #1910 |
|:---:|

* Removes opacity change for static waveform lines

| Before | After |
| -- | -- |
| ![CleanShot 2024-08-18 at 23 27 34@2x](https://github.com/user-attachments/assets/ddee5e9d-dce1-4b65-a7be-619ee297fbc0) | ![CleanShot 2024-08-18 at 23 27 39@2x](https://github.com/user-attachments/assets/dd148742-cf60-4ca8-95e7-2036ffdf6078) |

* Exclude audio option from non-clip shares (note that we went from 4 to 3 options below)

| Before | After |
| -- | -- |
| ![IMG_4453](https://github.com/user-attachments/assets/e47cc2cd-f67f-45b5-bb60-5d69e16d83c7) | ![IMG_4457](https://github.com/user-attachments/assets/f5112b02-90f6-4c6d-84e5-bcdcb4aa81d1) |

* Adds audio clip title + description (check out the title + description)

| Before | After |
| -- | -- |
| ![IMG_4454](https://github.com/user-attachments/assets/be2bc995-05c7-400e-87da-a71894d7120e) | ![IMG_4456](https://github.com/user-attachments/assets/809095b0-520d-413f-ae7f-e41e66cbd8c4) |

## To test

1. Play an Episode
2. Tap the "Share" button in the action shelf
3. Tap "Episode"
4. Scroll through export formats and ensure there is no "Audio"
5. Back out and share again
6. Tap the "Clip" option
7. Swipe to the "Audio" export format at the end
8. Ensure that the title and description change
9. Verify that the Static Waveform / timeline bar at the bottom shows similar lines to those in the screenshot

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
