### PR TITLE
[Paywall Experiments] Create new Paywall container

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -84,7 +84,7 @@ public enum FeatureFlag: String, CaseIterable {
 
     /// Enables the Kids banner
     case kidsProfile
-    
+
     /// Enable the new Upgrade Experiments
     case upgradeExperiment
 

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -84,6 +84,9 @@ public enum FeatureFlag: String, CaseIterable {
 
     /// Enables the Kids banner
     case kidsProfile
+    
+    /// Enable the new Upgrade Experiments
+    case upgradeExperiment
 
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
@@ -148,6 +151,8 @@ public enum FeatureFlag: String, CaseIterable {
         case .gravatarChangeAvatar:
             true
         case .kidsProfile:
+            false
+        case .upgradeExperiment:
             false
         }
     }

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -33,8 +33,8 @@
 		10756F882C59449C0089D34F /* Folder+Sortable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10756F872C59449C0089D34F /* Folder+Sortable.swift */; };
 		10756F892C59449C0089D34F /* Folder+Sortable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10756F872C59449C0089D34F /* Folder+Sortable.swift */; };
 		10756F8B2C5945C00089D34F /* KidsProfileSubmitScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10756F8A2C5945C00089D34F /* KidsProfileSubmitScreen.swift */; };
-		107836262C62816900DA3FF0 /* ABTestProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 107836252C62816900DA3FF0 /* ABTestProviderTests.swift */; };
 		107836232C5CDD5000DA3FF0 /* GiveRatingsWhatsNewHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 107836222C5CDD5000DA3FF0 /* GiveRatingsWhatsNewHeader.swift */; };
+		107836262C62816900DA3FF0 /* ABTestProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 107836252C62816900DA3FF0 /* ABTestProviderTests.swift */; };
 		10A4F7532C515D720084D783 /* KidsProfile.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 10A4F7522C515D720084D783 /* KidsProfile.xcassets */; };
 		10A4F7562C5162C90084D783 /* KidsProfileBannerTableCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10A4F7552C5162C90084D783 /* KidsProfileBannerTableCell.swift */; };
 		10A4F7582C52635F0084D783 /* KidsProfileBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10A4F7572C52635F0084D783 /* KidsProfileBannerView.swift */; };
@@ -43,6 +43,8 @@
 		10A4F7652C540B400084D783 /* KidsProfileSheetHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10A4F7642C540B400084D783 /* KidsProfileSheetHost.swift */; };
 		10A4F7672C540DC00084D783 /* KidsProfileSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10A4F7662C540DC00084D783 /* KidsProfileSheet.swift */; };
 		10A4F7692C540EBE0084D783 /* KidsProfileSheetViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10A4F7682C540EBE0084D783 /* KidsProfileSheetViewModel.swift */; };
+		10C1D5502C737EEF009E1E98 /* PlusPaywallContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10C1D54E2C737EEF009E1E98 /* PlusPaywallContainer.swift */; };
+		10C1D5522C738725009E1E98 /* PlusPaywallFeaturesCarousell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10C1D5512C738725009E1E98 /* PlusPaywallFeaturesCarousell.swift */; };
 		10DFE9312C5A889700957D0A /* CategoryPodcastsTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10DFE9302C5A889700957D0A /* CategoryPodcastsTable.swift */; };
 		10DFE9362C5A8D1300957D0A /* ABTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10DFE9322C5A8D1300957D0A /* ABTest.swift */; };
 		10DFE9372C5A8D1300957D0A /* ABTestProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10DFE9332C5A8D1300957D0A /* ABTestProvider.swift */; };
@@ -1921,8 +1923,8 @@
 		10756F842C5944660089D34F /* Podcast+Sortable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Podcast+Sortable.swift"; sourceTree = "<group>"; };
 		10756F872C59449C0089D34F /* Folder+Sortable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Folder+Sortable.swift"; sourceTree = "<group>"; };
 		10756F8A2C5945C00089D34F /* KidsProfileSubmitScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = KidsProfileSubmitScreen.swift; path = "Kids Profile/KidsProfileSubmitScreen.swift"; sourceTree = "<group>"; };
-		107836252C62816900DA3FF0 /* ABTestProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ABTestProviderTests.swift; sourceTree = "<group>"; };
 		107836222C5CDD5000DA3FF0 /* GiveRatingsWhatsNewHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiveRatingsWhatsNewHeader.swift; sourceTree = "<group>"; };
+		107836252C62816900DA3FF0 /* ABTestProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ABTestProviderTests.swift; sourceTree = "<group>"; };
 		10A4F7522C515D720084D783 /* KidsProfile.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = KidsProfile.xcassets; sourceTree = "<group>"; };
 		10A4F7552C5162C90084D783 /* KidsProfileBannerTableCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = KidsProfileBannerTableCell.swift; path = "Kids Profile/KidsProfileBannerTableCell.swift"; sourceTree = "<group>"; };
 		10A4F7572C52635F0084D783 /* KidsProfileBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = KidsProfileBannerView.swift; path = "Kids Profile/KidsProfileBannerView.swift"; sourceTree = "<group>"; };
@@ -1935,6 +1937,8 @@
 		10B558EB2BA471DF0061847C /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		10B558EC2BA472E80061847C /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		10B558ED2BA476BA0061847C /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		10C1D54E2C737EEF009E1E98 /* PlusPaywallContainer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlusPaywallContainer.swift; sourceTree = "<group>"; };
+		10C1D5512C738725009E1E98 /* PlusPaywallFeaturesCarousell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlusPaywallFeaturesCarousell.swift; sourceTree = "<group>"; };
 		10DFE9302C5A889700957D0A /* CategoryPodcastsTable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryPodcastsTable.swift; sourceTree = "<group>"; };
 		10DFE9322C5A8D1300957D0A /* ABTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ABTest.swift; sourceTree = "<group>"; };
 		10DFE9332C5A8D1300957D0A /* ABTestProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ABTestProvider.swift; sourceTree = "<group>"; };
@@ -3800,6 +3804,15 @@
 				10756F812C57CFF00089D34F /* Screens */,
 			);
 			name = Scheet;
+			sourceTree = "<group>";
+		};
+		10C1D54F2C737EEF009E1E98 /* UpgradeExperiment */ = {
+			isa = PBXGroup;
+			children = (
+				10C1D54E2C737EEF009E1E98 /* PlusPaywallContainer.swift */,
+				10C1D5512C738725009E1E98 /* PlusPaywallFeaturesCarousell.swift */,
+			);
+			path = UpgradeExperiment;
 			sourceTree = "<group>";
 		};
 		10DFE9352C5A8D1300957D0A /* ABTest */ = {
@@ -6978,6 +6991,7 @@
 				F5E431D52B50888500A71DB3 /* PlusLabel.swift */,
 				FF8970752B5FFC5E004ADB23 /* SubscriptionPriceAndOfferView.swift */,
 				FF91A0FD2B6BC4BD002A0590 /* FeaturesCarousel.swift */,
+				10C1D54F2C737EEF009E1E98 /* UpgradeExperiment */,
 			);
 			path = Plus;
 			sourceTree = "<group>";
@@ -9100,6 +9114,7 @@
 				8BA55A1528CA8FEB002BECC5 /* PrivacySettingsViewController.swift in Sources */,
 				BD74F15127F28E6600222785 /* HomeGridDataHelper.swift in Sources */,
 				BDE954F22366900900CEB6DA /* PlayerTabsView.swift in Sources */,
+				10C1D5502C737EEF009E1E98 /* PlusPaywallContainer.swift in Sources */,
 				BDC5F25027B3997300A85C93 /* FolderModel.swift in Sources */,
 				BDBD2AC7202D66B300E0A79E /* OptionsPickerRootController.swift in Sources */,
 				4004F56524EB51F900FBEBE1 /* SceneHelper.swift in Sources */,
@@ -9824,6 +9839,7 @@
 				BD2DE2321E65224900BE21A4 /* ShowNotesUpdater.swift in Sources */,
 				C7B3C6142919F47A00054145 /* HorizontalScrollView.swift in Sources */,
 				BDA0E2A322DDB5550029EBEB /* ThemeColor.swift in Sources */,
+				10C1D5522C738725009E1E98 /* PlusPaywallFeaturesCarousell.swift in Sources */,
 				8BCB22B428F48282001A0315 /* EndOfYear.swift in Sources */,
 				BDCC55141CD0A448006BE239 /* AEXML.swift in Sources */,
 				8B1C974628FE1C7E00BD5EB9 /* ImageView.swift in Sources */,

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		10A4F7692C540EBE0084D783 /* KidsProfileSheetViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10A4F7682C540EBE0084D783 /* KidsProfileSheetViewModel.swift */; };
 		10C1D5502C737EEF009E1E98 /* PlusPaywallContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10C1D54E2C737EEF009E1E98 /* PlusPaywallContainer.swift */; };
 		10C1D5522C738725009E1E98 /* PlusPaywallFeaturesCarousell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10C1D5512C738725009E1E98 /* PlusPaywallFeaturesCarousell.swift */; };
+		10C1D5542C739043009E1E98 /* PlusPaywallSubscriptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10C1D5532C739043009E1E98 /* PlusPaywallSubscriptions.swift */; };
 		10DFE9312C5A889700957D0A /* CategoryPodcastsTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10DFE9302C5A889700957D0A /* CategoryPodcastsTable.swift */; };
 		10DFE9362C5A8D1300957D0A /* ABTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10DFE9322C5A8D1300957D0A /* ABTest.swift */; };
 		10DFE9372C5A8D1300957D0A /* ABTestProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10DFE9332C5A8D1300957D0A /* ABTestProvider.swift */; };
@@ -1939,6 +1940,7 @@
 		10B558ED2BA476BA0061847C /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		10C1D54E2C737EEF009E1E98 /* PlusPaywallContainer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlusPaywallContainer.swift; sourceTree = "<group>"; };
 		10C1D5512C738725009E1E98 /* PlusPaywallFeaturesCarousell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlusPaywallFeaturesCarousell.swift; sourceTree = "<group>"; };
+		10C1D5532C739043009E1E98 /* PlusPaywallSubscriptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlusPaywallSubscriptions.swift; sourceTree = "<group>"; };
 		10DFE9302C5A889700957D0A /* CategoryPodcastsTable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryPodcastsTable.swift; sourceTree = "<group>"; };
 		10DFE9322C5A8D1300957D0A /* ABTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ABTest.swift; sourceTree = "<group>"; };
 		10DFE9332C5A8D1300957D0A /* ABTestProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ABTestProvider.swift; sourceTree = "<group>"; };
@@ -3811,6 +3813,7 @@
 			children = (
 				10C1D54E2C737EEF009E1E98 /* PlusPaywallContainer.swift */,
 				10C1D5512C738725009E1E98 /* PlusPaywallFeaturesCarousell.swift */,
+				10C1D5532C739043009E1E98 /* PlusPaywallSubscriptions.swift */,
 			);
 			path = UpgradeExperiment;
 			sourceTree = "<group>";
@@ -9268,6 +9271,7 @@
 				4053CDF9214F3583001C92B1 /* PodcastFilterOverlayController.swift in Sources */,
 				BDF5FD1E1FD8D38900F2A339 /* DownloadsViewController+Table.swift in Sources */,
 				C72CED32289DA1900017883A /* TracksAdapter.swift in Sources */,
+				10C1D5542C739043009E1E98 /* PlusPaywallSubscriptions.swift in Sources */,
 				8BA55A0D28CA4540002BECC5 /* AnalyticsPlaybackHelper.swift in Sources */,
 				FF05C98F2C0A0BF800E41EB3 /* FileManager+Helper.swift in Sources */,
 				BDBD2AC5202D64D700E0A79E /* OptionsPicker.swift in Sources */,

--- a/podcasts/Onboarding/Plus/PlusLandingViewModel.swift
+++ b/podcasts/Onboarding/Plus/PlusLandingViewModel.swift
@@ -1,5 +1,6 @@
 import Foundation
 import PocketCastsServer
+import PocketCastsUtils
 import SwiftUI
 
 class PlusLandingViewModel: PlusPurchaseModel {
@@ -137,7 +138,15 @@ extension PlusLandingViewModel {
 
     @ViewBuilder
     private static func view(with viewModel: PlusLandingViewModel) -> some View {
-        UpgradeLandingView(viewModel: viewModel)
-            .setupDefaultEnvironment(theme: Theme.init(previewTheme: .light))
+        if FeatureFlag.upgradeExperiment.enabled {
+            //Include here the A/B test experiment:
+            // Control variant: UpgradeLandingView
+            // Features: PlusPaywallContainer(viewModel: viewModel, type: .features)
+            // Social: Social variant
+            PlusPaywallContainer(viewModel: viewModel, type: .features)
+        } else {
+            UpgradeLandingView(viewModel: viewModel)
+                .setupDefaultEnvironment(theme: Theme.init(previewTheme: .light))
+        }
     }
 }

--- a/podcasts/Onboarding/Plus/UpgradeExperiment/PlusPaywallContainer.swift
+++ b/podcasts/Onboarding/Plus/UpgradeExperiment/PlusPaywallContainer.swift
@@ -1,0 +1,107 @@
+import SwiftUI
+import PocketCastsUtils
+
+struct PlusPaywallContainer: View {
+    @ObservedObject var viewModel: PlusLandingViewModel
+
+    @State var presentSubscriptionView = false
+
+    private let type: ContainerType
+    private let subscriptionInfo: PlusPricingInfoModel.PlusProductPricingInfo?
+    private let tier = UpgradeTier.plus
+
+    private var hasBottomSafeArea: Bool {
+        !UIDevice.current.isiPad() && safeAreaBottomHeight > 0
+    }
+
+    private var safeAreaBottomHeight: CGFloat {
+        (SceneHelper.connectedScene()?.windows.first(where: \.isKeyWindow)?.safeAreaInsets.bottom ?? 0)
+    }
+
+    private var topBar: some View {
+        HStack(spacing: 0) {
+            Spacer()
+            Button(viewModel.source == .upsell ? L10n.eoyNotNow : L10n.plusSkip) {
+                viewModel.dismissTapped()
+            }
+            .foregroundColor(.white)
+            .font(style: .body, weight: .medium)
+            .padding()
+        }
+    }
+
+    private var footer: some View {
+        VStack(spacing: 0) {
+            Button(action: {
+                presentSubscriptionView.toggle()
+            }, label: {
+                Text("Get Pocket Casts Plus")
+            })
+            .buttonStyle(PlusOpaqueButtonStyle(isLoading: false, plan: .plus))
+            .padding(.horizontal, 20)
+
+            if let offer = subscriptionInfo?.offer {
+                Text(offer.title)
+                    .font(size: 14.0, style: .body)
+                    .multilineTextAlignment(.center)
+                    .foregroundStyle(.white)
+                    .padding(.top, 12)
+            }
+        }
+    }
+
+    init(viewModel: PlusLandingViewModel, type: ContainerType) {
+        self.viewModel = viewModel
+        self.type = type
+
+        let displayProduct = [viewModel.continuePurchasing, viewModel.initialProduct].compactMap { $0 }.first
+
+        self.subscriptionInfo = viewModel.pricingInfo(for: tier, frequency: displayProduct?.frequency ?? .yearly)
+    }
+
+    var body: some View {
+        ZStack {
+            VStack(spacing: 0) {
+                topBar
+                Spacer()
+                container()
+                Spacer()
+                footer
+            }
+            .padding(.bottom, hasBottomSafeArea ? 0 : 16)
+        }
+        .background(.black)
+        .sheet(isPresented: $presentSubscriptionView) {
+            Rectangle()
+                .fill(Color(hex: "282829"))
+                .modify {
+                    if #available(iOS 16.0, *) {
+                        $0.presentationDetents([.medium])
+                            .presentationDragIndicator(.visible)
+                    } else {
+                        $0
+                    }
+                }
+        }
+    }
+
+    @ViewBuilder
+    private func container() -> some View {
+        switch type {
+        case .features:
+            PlusPaywallFeaturesCarousell(viewModel: viewModel, tier: tier)
+        case .social:
+            Rectangle()
+                .fill(.yellow)
+        }
+    }
+
+    enum ContainerType {
+        case features
+        case social
+    }
+}
+
+#Preview {
+    PlusPaywallContainer(viewModel: PlusLandingViewModel(source: .login), type: .features)
+}

--- a/podcasts/Onboarding/Plus/UpgradeExperiment/PlusPaywallContainer.swift
+++ b/podcasts/Onboarding/Plus/UpgradeExperiment/PlusPaywallContainer.swift
@@ -41,7 +41,7 @@ struct PlusPaywallContainer: View {
             .padding(.horizontal, Constants.buttonHPadding)
 
             if let offer = subscriptionInfo?.offer {
-                Text(offer.title)
+                Text(offer.experimentDescription)
                     .font(size: Constants.offerTextSize, style: .body)
                     .multilineTextAlignment(.center)
                     .foregroundStyle(.white)
@@ -107,6 +107,17 @@ struct PlusPaywallContainer: View {
         static let offerTextTopPadding = 12.0
 
         static let buttonHPadding = 20.0
+    }
+}
+
+extension PlusPricingInfoModel.ProductOfferInfo {
+    fileprivate var experimentDescription: String {
+        switch type {
+        case .freeTrial:
+            return L10n.upgradeExperimentFreeMembershipFormat(duration)
+        case .discount:
+            return L10n.upgradeExperimentDiscountYearlyMembership
+        }
     }
 }
 

--- a/podcasts/Onboarding/Plus/UpgradeExperiment/PlusPaywallContainer.swift
+++ b/podcasts/Onboarding/Plus/UpgradeExperiment/PlusPaywallContainer.swift
@@ -35,17 +35,17 @@ struct PlusPaywallContainer: View {
             Button(action: {
                 presentSubscriptionView.toggle()
             }, label: {
-                Text("Get Pocket Casts Plus")
+                Text(L10n.upgradeExperimentPaywallButton)
             })
             .buttonStyle(PlusOpaqueButtonStyle(isLoading: false, plan: .plus))
-            .padding(.horizontal, 20)
+            .padding(.horizontal, Constants.buttonHPadding)
 
             if let offer = subscriptionInfo?.offer {
                 Text(offer.title)
-                    .font(size: 14.0, style: .body)
+                    .font(size: Constants.offerTextSize, style: .body)
                     .multilineTextAlignment(.center)
                     .foregroundStyle(.white)
-                    .padding(.top, 12)
+                    .padding(.top, Constants.offerTextTopPadding)
             }
         }
     }
@@ -68,12 +68,11 @@ struct PlusPaywallContainer: View {
                 Spacer()
                 footer
             }
-            .padding(.bottom, hasBottomSafeArea ? 0 : 16)
+            .padding(.bottom, hasBottomSafeArea ? 0 : Constants.bottomPadding)
         }
         .background(.black)
         .sheet(isPresented: $presentSubscriptionView) {
-            Rectangle()
-                .fill(Color(hex: "282829"))
+            PlusPaywallSubscriptions(viewModel: viewModel)
                 .modify {
                     if #available(iOS 16.0, *) {
                         $0.presentationDetents([.medium])
@@ -99,6 +98,15 @@ struct PlusPaywallContainer: View {
     enum ContainerType {
         case features
         case social
+    }
+
+    private enum Constants {
+        static let bottomPadding = 16.0
+
+        static let offerTextSize = 14.0
+        static let offerTextTopPadding = 12.0
+
+        static let buttonHPadding = 20.0
     }
 }
 

--- a/podcasts/Onboarding/Plus/UpgradeExperiment/PlusPaywallFeaturesCarousell.swift
+++ b/podcasts/Onboarding/Plus/UpgradeExperiment/PlusPaywallFeaturesCarousell.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+import PocketCastsServer
+
+struct PlusPaywallFeaturesCarousell: View {
+    @ObservedObject var viewModel: PlusLandingViewModel
+
+    let tier: UpgradeTier
+
+    private var title: some View {
+        Text(tier.header)
+            .font(size: 22.0, style: .body, weight: .bold)
+            .foregroundStyle(.white)
+            .multilineTextAlignment(.center)
+            .lineLimit(2)
+            .padding(.horizontal, 32)
+            .padding(.bottom, 40)
+    }
+
+    private var badge: some View {
+        SubscriptionBadge(tier: tier.tier, displayMode: .gradient, foregroundColor: .black)
+            .padding(.bottom, 12)
+    }
+
+    var body: some View {
+        ScrollView {
+            badge
+            title
+            Rectangle()
+                .fill(.red)
+                .frame(height: 394)
+        }
+    }
+}
+
+#Preview {
+    PlusPaywallFeaturesCarousell(viewModel: PlusLandingViewModel(source: .login), tier: .plus)
+}

--- a/podcasts/Onboarding/Plus/UpgradeExperiment/PlusPaywallFeaturesCarousell.swift
+++ b/podcasts/Onboarding/Plus/UpgradeExperiment/PlusPaywallFeaturesCarousell.swift
@@ -8,17 +8,17 @@ struct PlusPaywallFeaturesCarousell: View {
 
     private var title: some View {
         Text(tier.header)
-            .font(size: 22.0, style: .body, weight: .bold)
+            .font(size: Constants.titleSize, style: .body, weight: .bold)
             .foregroundStyle(.white)
             .multilineTextAlignment(.center)
-            .lineLimit(2)
-            .padding(.horizontal, 32)
-            .padding(.bottom, 40)
+            .lineLimit(Constants.titleLineLimit)
+            .padding(.horizontal, Constants.titleHPadding)
+            .padding(.bottom, Constants.bottomPadding)
     }
 
     private var badge: some View {
         SubscriptionBadge(tier: tier.tier, displayMode: .gradient, foregroundColor: .black)
-            .padding(.bottom, 12)
+            .padding(.bottom, Constants.badgeBottomPadding)
     }
 
     var body: some View {
@@ -29,6 +29,17 @@ struct PlusPaywallFeaturesCarousell: View {
                 .fill(.red)
                 .frame(height: 394)
         }
+    }
+
+    private enum Constants {
+        static let bottomPadding = 16.0
+
+        static let badgeBottomPadding = 12.0
+
+        static let titleSize = 22.0
+        static let titleLineLimit = 2
+        static let titleHPadding = 32.0
+        static let titleBottomPadding = 40.0
     }
 }
 

--- a/podcasts/Onboarding/Plus/UpgradeExperiment/PlusPaywallSubscriptions.swift
+++ b/podcasts/Onboarding/Plus/UpgradeExperiment/PlusPaywallSubscriptions.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+struct PlusPaywallSubscriptions: View {
+    @ObservedObject var viewModel: PlusLandingViewModel
+
+    var body: some View {
+        container {
+            Text("Placeholder for subscription")
+                .foregroundStyle(.white)
+                .padding(.horizontal, 20.0)
+        }
+        .background(
+            Color(hex: "282829")
+                .edgesIgnoringSafeArea(.all)
+        )
+    }
+
+    @ViewBuilder
+    func container(@ViewBuilder _ content: () -> some View) -> some View {
+        ZStack {
+            VStack {
+                Spacer()
+                HStack {
+                    Spacer()
+                    content()
+                    Spacer()
+                }
+                Spacer()
+            }
+        }
+    }
+}
+
+#Preview {
+    PlusPaywallSubscriptions(viewModel: PlusLandingViewModel(source: .login))
+}

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -3162,6 +3162,8 @@ internal enum L10n {
   internal static var upNextHistoryExplanation: String { return L10n.tr("Localizable", "up_next_history_explanation") }
   /// Upgrade Account
   internal static var upgradeAccount: String { return L10n.tr("Localizable", "upgrade_account") }
+  /// Get Pocket Casts Plus
+  internal static var upgradeExperimentPaywallButton: String { return L10n.tr("Localizable", "upgrade_experiment_paywall_button") }
   /// Upgrade to %1$@
   internal static func upgradeToPlan(_ p1: Any) -> String {
     return L10n.tr("Localizable", "upgrade_to_plan", String(describing: p1))

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -3162,6 +3162,12 @@ internal enum L10n {
   internal static var upNextHistoryExplanation: String { return L10n.tr("Localizable", "up_next_history_explanation") }
   /// Upgrade Account
   internal static var upgradeAccount: String { return L10n.tr("Localizable", "upgrade_account") }
+  /// Save 50%% off your first year
+  internal static var upgradeExperimentDiscountYearlyMembership: String { return L10n.tr("Localizable", "upgrade_experiment_discount_yearly_membership") }
+  /// Free %1$@ Plus trial
+  internal static func upgradeExperimentFreeMembershipFormat(_ p1: Any) -> String {
+    return L10n.tr("Localizable", "upgrade_experiment_free_membership_format", String(describing: p1))
+  }
   /// Get Pocket Casts Plus
   internal static var upgradeExperimentPaywallButton: String { return L10n.tr("Localizable", "upgrade_experiment_paywall_button") }
   /// Upgrade to %1$@

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4261,3 +4261,6 @@
 
 /* Transcript error message when transcript is empty*/
 "transcript_error_empty" = "Sorry, but it looks this transcript is empty";
+
+/* Upgrade Experiment Paywall button title */
+"upgrade_experiment_paywall_button" = "Get Pocket Casts Plus";

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4264,3 +4264,9 @@
 
 /* Upgrade Experiment Paywall button title */
 "upgrade_experiment_paywall_button" = "Get Pocket Casts Plus";
+
+/* Upgrade Experiment message informing the user that they have been granted a limited free membership. '%1$@' is a placeholder for a localized string for the free time period. */
+"upgrade_experiment_free_membership_format" = "Free %1$@ Plus trial";
+
+/* Upgrade Experiment message informing the user that they have been granted 50% discount. */
+"upgrade_experiment_discount_yearly_membership" = "Save 50%% off your first year";


### PR DESCRIPTION
| 📘 Part of: #1986 
|:---:|

Fixes #2030 

This PR creates a new Paywall container where we will display the 2 new variants.

## To test

> [!NOTE]
> Make sure to enable the `upgradeExperiment` feature flag

- CI must be green
- Use a non-Plus user
- Enable the FF
- Go to Settings
- Tap on Pocket Casts Plus
- Make sure the new Paywall appears
- Do a regression test by disabling the FF

https://github.com/user-attachments/assets/1a18d2bf-576c-4e2a-8d9b-03cddf7290a3

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
