### PR TITLE
Transcript: fix content jumping after tapping "Done"

### DIFF
--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -546,12 +546,19 @@ class TranscriptViewController: PlayerItemViewController {
         let previousContentOffset = transcriptView.contentOffset
         UIView.animate(withDuration: animationDuration, animations: { [weak self] in
             guard let self else { return }
+
+            if isSearching {
+                transcriptView.setContentOffset(previousContentOffset, animated: false)
+            }
+
             transcriptView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: adjustmentHeight, right: 0)
-            transcriptView.setContentOffset(previousContentOffset, animated: false)
             transcriptView.verticalScrollIndicatorInsets.bottom = show ? adjustmentHeight : bottomContainerInset
         }, completion: { [weak self] _ in
             guard let self else { return }
-            transcriptView.setContentOffset(previousContentOffset, animated: false)
+
+            if isSearching {
+                transcriptView.setContentOffset(previousContentOffset, animated: false)
+            }
         })
     }
 


### PR DESCRIPTION
Fixes #2056

Fixes an issue in which the content jumps when tapping "Done"

## To test

### Tapping "Done"

1. Play a podcast with transcript
2. Tap the transcript button
3. Search for a word
4. Once found, tap "Done"
5. ✅ Highlights should disappear and the content should not move

### Tapping the transcript

1. Dismiss the player
2. Open it again
3. Open the transcript
4. Ensure transcripts is enabled
5. Tap "Search"
6. Tap outside the keyboard
7. ✅ The transcript should not scroll to another position

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
