### PR TITLE
[Tooling][CI] Modernize Buildkite pipelines syntax to use shared values

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,22 +1,17 @@
-# Nodes with values to reuse in the pipeline.
-common_params:
-  # Common plugin settings to use with the `plugins` key.
-  - &common_plugins
-    - automattic/a8c-ci-toolkit#3.5.0
-  # Common environment values to use with the `env` key.
-  - &common_env
-    # If you update the image to a newer Xcode version, don't forget to also update the badge in the README.md file accordingly for consistency
-    IMAGE_ID: xcode-15.4
-  # Common agents values to use with the `agents` key.
-  - &common_agents
-    queue: mac
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+---
+
+# Variables used in this pipeline are defined in `shared-pipeline-vars`, which is `source`'d before calling `buidkite-agent pipeline upload`
+
+env:
+  IMAGE_ID: $IMAGE_ID
 
 steps:
   - label: Build and Test
     command: .buildkite/commands/build.sh
-    agents: *common_agents
-    env: *common_env
-    plugins: *common_plugins
+    agents:
+      queue: mac
+    plugins: [$CI_TOOLKIT]
 
   - group: "Linters"
     steps:
@@ -40,9 +35,9 @@ steps:
 
       - label: ":sleuth_or_spy: Lint Localized Strings Format"
         command: lint_localized_strings_format
-        agents: *common_agents
-        plugins: *common_plugins
-        env: *common_env
+        agents:
+          queue: mac
+        plugins: [$CI_TOOLKIT]
 
   - block: Deploy Prototype Build
     prompt: Share a Prototype Build via App Center?
@@ -59,9 +54,9 @@ steps:
         key: build_prototype
         depends_on: prototype_triggered
         command: .buildkite/commands/prototype-build.sh
-        agents: *common_agents
-        env: *common_env
-        plugins: *common_plugins
+        agents:
+          queue: mac
+        plugins: [$CI_TOOLKIT]
         # The folder name is are configured in Fastlane
         artifact_paths:
           - artifacts/*.ipa
@@ -73,9 +68,9 @@ steps:
       - label: Prototype Build - Upload
         depends_on: build_prototype
         command: .buildkite/commands/prototype-upload.sh
-        agents: *common_agents
-        env: *common_env
-        plugins: *common_plugins
+        agents:
+          queue: mac
+        plugins: [$CI_TOOLKIT]
         notify:
           - github_commit_status:
               context: Prototype Build - Upload

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -1,13 +1,11 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+---
+
+# Variables used in this pipeline are defined in `shared-pipeline-vars`, which is `source`'d before calling `buidkite-agent pipeline upload`
 # This pipeline is meant to be run via the Buildkite API, and is only used for release builds
 
-# Nodes with values to reuse in the pipeline.
-common_params:
-  # Common plugin settings to use with the `plugins` key.
-  - &common_plugins
-    - automattic/a8c-ci-toolkit#2.15.1
-  # Common environment values to use with the `env` key.
-  - &common_env
-    IMAGE_ID: xcode-15.4
+env:
+  IMAGE_ID: $IMAGE_ID
 
 steps:
 
@@ -16,7 +14,6 @@ steps:
     priority: 1
     agents:
       queue: mac
-    env: *common_env
-    plugins: *common_plugins
+    plugins: [$CI_TOOLKIT]
     notify:
     - slack: "#build-and-ship"

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# This file is `source`'d before calling `buildkite-agent pipeline upload`, and can be used
+# to set up some variables that will be interpolated in the `.yml` pipeline before uploading it.
+
+# 🎗️ If you update the image to a newer Xcode version, don't forget to also update the badge in the README.md file accordingly for consistency
+export IMAGE_ID="xcode-15.4"
+
+export CI_TOOLKIT="automattic/a8c-ci-toolkit#3.5.0"

--- a/README.md
+++ b/README.md
@@ -1,12 +1,17 @@
 <p align="center">
+    <!-- Pocket Casts brand image -->
     <img src="https://user-images.githubusercontent.com/308331/194037473-41ad7eba-8602-4be5-be73-49e3c0c48c12.svg#gh-light-mode-only" />
     <img src="https://user-images.githubusercontent.com/308331/194041226-4c6d8181-cafa-4ea8-8735-1d8106f5e5f6.svg#gh-dark-mode-only" />
 </p>
 
 <p align="center">
+    <!-- Badge: "build: {trunk CI status}" -->
     <a href="https://buildkite.com/automattic/pocket-casts-ios"><img src="https://badge.buildkite.com/6c995de3d1584006341cc4dfda1312619f375385f5c0319dfe.svg?branch=trunk" /></a>
+    <!-- Badge: "license: MPL" -->
     <a href="https://github.com/Automattic/pocket-casts-ios/blob/trunk/LICENSE.md"><img src="https://img.shields.io/badge/license-MPL-black" /></a>
+    <!-- Badge: "platform: ios|watchos" -->
     <img src="https://img.shields.io/badge/platform-ios%20%7C%20watchos-lightgrey" />
+    <!-- Badge: "Xcode: {version}+" -->
     <img src="https://img.shields.io/badge/Xcode-v15.4%2B-informational" />
 </p>
 


### PR DESCRIPTION
This improves the syntax we use in `.buildkite/*.yml` pipelines to rely on the `shared-pipeline-vars` file, which exports common values as env variables before the YAML files are evaluated by the `buildkite-agent`.

This will make the pipelines easier to read and maintain—and especially updating the Xcode version used by CI.

> [!NOTE]
> This is in preparation of facilitating the update of the Xcode image used by this project, to soon adopt the new Xcode 16.0b5 image (via https://github.com/Automattic/pocket-casts-ios/pull/2066) that we made available in our CI (ref: paaHJt-72d-p2)

> [!IMPORTANT]
> - [x] This PR requires https://github.com/Automattic/buildkite-ci/pull/496 to be deployed first

## To Test

If CI is green (which won't happen until we land https://github.com/Automattic/buildkite-ci/pull/496 and retry the build) we should be good to go.