### PR TITLE
[Tooling][CI] Update Xcode image to 16.0b5

### DIFF
--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -6,4 +6,10 @@
 # 🎗️ If you update the image to a newer Xcode version, don't forget to also update the badge in the README.md file accordingly for consistency
 export IMAGE_ID="xcode-15.4"
 
+# Uncomment this to experiment with an Xcode beta only on PRs and TestFlight beta builds
+# (while still using the latest stable Xcode declared above for final Release Builds)
+if [[ "$PIPELINE" == "pipeline.yml" || "$BETA_RELEASE" == "true" ]]; then
+  export IMAGE_ID="xcode-16.0-beta5"
+fi
+
 export CI_TOOLKIT="automattic/a8c-ci-toolkit#3.5.0"


### PR DESCRIPTION
This updates the VM image used by CI from the one using Xcode `15.4` to Xcode `16.0-beta-5`.

Ref: pdnsEh-1Oa-p2

> [!IMPORTANT]
> This PR is based on top of https://github.com/Automattic/pocket-casts-ios/pull/2065 and depends on it, so before we can hope for CI to go green on this PR, we need to:
> - [x] deploy https://github.com/Automattic/buildkite-ci/pull/496
> - [ ] then ideally land https://github.com/Automattic/pocket-casts-ios/pull/2065 first before this one (to keep the diffs separate)

### Note on potential ongoing WIP for features requiring Xcode 16.0+ APIs

This chain of PRs (https://github.com/Automattic/pocket-casts-ios/pull/2065 + this one) are all build on top of `trunk`.
@leandroalonso this means that if you already cut a branch locally to start working on the features that require the new API early, you'll have to rebase your feature branch on `trunk` once the whole thing has landed to benefit from the new image on CI.

## To test

 - CI is green
 - The CI logs show that it used the Xcode 16.0b5 VM image and Xcode version to do the build