### PR TITLE
Xcode 16: fix SIGABRT crash

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/Cache/ShowInfoDataRetriever.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Cache/ShowInfoDataRetriever.swift
@@ -51,7 +51,7 @@ public actor ShowInfoDataRetriever {
 
         FileLog.shared.addMessage("Show Info: requesting info for podcast \(podcastUuid)")
 
-        let task = Task<Data, Error> { [weak self] in
+        let task = Task<Data, Error> { [weak self, request] in
             guard let self else { throw TaskError.nilSelf }
 
             do {

--- a/Modules/Server/Sources/PocketCastsServer/Public/Cache/ShowInfoDataRetriever.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Cache/ShowInfoDataRetriever.swift
@@ -110,6 +110,6 @@ public actor ShowInfoDataRetriever {
     }
 }
 
-enum TaskError: Error {
+public enum TaskError: Error {
     case nilSelf
 }

--- a/Modules/Server/Sources/PocketCastsServer/Public/Cache/ShowInfoDataRetriever.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Cache/ShowInfoDataRetriever.swift
@@ -51,7 +51,9 @@ public actor ShowInfoDataRetriever {
 
         FileLog.shared.addMessage("Show Info: requesting info for podcast \(podcastUuid)")
 
-        let task = Task<Data, Error> {
+        let task = Task<Data, Error> { [weak self] in
+            guard let self else { throw TaskError.nilSelf }
+
             do {
                 let (data, response) = try await URLSession.shared.data(for: request)
 
@@ -60,22 +62,26 @@ public actor ShowInfoDataRetriever {
                     cache.storeCachedResponse(responseToCache, for: request)
                     FileLog.shared.addMessage("Show Info: request succeeded for podcast \(podcastUuid).")
                 } else if let data = cache.cachedResponse(for: request)?.data {
-                    dataRequestMap[podcastUuid] = nil
+                    await setDataRequestMapToNil(for: podcastUuid)
                     FileLog.shared.addMessage("Show Info: request failed for podcast \(podcastUuid). Returning cached data")
                     return data
                 }
 
-                dataRequestMap[podcastUuid] = nil
+                await setDataRequestMapToNil(for: podcastUuid)
                 return data
             } catch {
                 FileLog.shared.addMessage("Show Info: request failed for podcast \(podcastUuid): \(error.localizedDescription). Returning cached data")
-                dataRequestMap[podcastUuid] = nil
+                await setDataRequestMapToNil(for: podcastUuid)
                 throw error
             }
         }
         dataRequestMap[podcastUuid] = task
 
         return try await task.value
+    }
+
+    private func setDataRequestMapToNil(for podcastUuid: String) {
+        dataRequestMap[podcastUuid] = nil
     }
 
     private func loadEpisodeData(
@@ -102,4 +108,8 @@ public actor ShowInfoDataRetriever {
 
         return nil
     }
+}
+
+enum TaskError: Error {
+    case nilSelf
 }

--- a/podcasts/Episode Info Coordinator/ShowInfoCoordinator.swift
+++ b/podcasts/Episode Info Coordinator/ShowInfoCoordinator.swift
@@ -89,7 +89,7 @@ actor ShowInfoCoordinator: ShowInfoCoordinating {
         }
 
         let task = Task<Episode.Metadata?, Error> { [weak self] in
-            guard let self else { return nil }
+            guard let self else { throw TaskError.nilSelf }
 
             do {
                 let data = try await dataRetriever.loadEpisodeDataFromCache(for: podcastUuid, episodeUuid: episodeUuid)

--- a/podcasts/Episode Info Coordinator/ShowInfoCoordinator.swift
+++ b/podcasts/Episode Info Coordinator/ShowInfoCoordinator.swift
@@ -88,13 +88,15 @@ actor ShowInfoCoordinator: ShowInfoCoordinating {
             return try await task.value
         }
 
-        let task = Task<Episode.Metadata?, Error> { [unowned self] in
+        let task = Task<Episode.Metadata?, Error> { [weak self] in
+            guard let self else { return nil }
+
             do {
                 let data = try await dataRetriever.loadEpisodeDataFromCache(for: podcastUuid, episodeUuid: episodeUuid)
-                requestingShowInfo[episodeUuid] = nil
+                await setRequestingShowInfoToNil(for: episodeUuid)
                 return await getShowInfo(for: data?.data(using: .utf8))
             } catch {
-                requestingShowInfo[episodeUuid] = nil
+                await setRequestingShowInfoToNil(for: episodeUuid)
                 throw error
             }
         }
@@ -102,6 +104,10 @@ actor ShowInfoCoordinator: ShowInfoCoordinating {
         requestingShowInfo[episodeUuid] = task
 
         return try await task.value
+    }
+
+    private func setRequestingShowInfoToNil(for episodeUuid: String) {
+        requestingShowInfo[episodeUuid] = nil
     }
 
     private func getShowInfo(for data: Data?) async -> Episode.Metadata? {


### PR DESCRIPTION
When building the app with Xcode 16 (it doesn't matter if the destination is iOS 18 or 17) if you open/close the player you'll eventually face this crash:

<img width="1532" alt="Screenshot 2024-08-19 at 15 41 55" src="https://github.com/user-attachments/assets/44256935-ae0b-4f50-a166-fbb2caa345b3">

The code changes it to a weak var and handles it accordingly.

## To test

1. Build the app with Xcode 16 beta
2. Open and close the player a few times
3. ✅ Nothing should happen
4. Make sure you can still see transcripts, show notes, etc.
5. Play an episode from [Changelog](https://pca.st/changelog)
6. ✅ Ensure you can still see chapters

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
