### PR TITLE
[Bug Fix] Fix cancel subscription URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix auto-play when Skip Last setting is working [#2019](https://github.com/Automattic/pocket-casts-ios/pull/2037)
 - Kids Profile banner implementation [#1935](https://github.com/Automattic/pocket-casts-ios/issues/1935)
 - Fix rapidly tapping skip back resulting in skip forward [#2041](https://github.com/Automattic/pocket-casts-ios/issues/2041)
+- Subscription cancellation redirects now to a correct page. [#2070](https://github.com/Automattic/pocket-casts-ios/pull/2070)
 
 7.70
 -----

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerConstants.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerConstants.swift
@@ -39,7 +39,7 @@ public enum ServerConstants {
         }
 
         public static let support = "https://support.pocketcasts.com/ios/"
-        public static let cancelSubscription = "https://support.pocketcasts.com/article/subscription-info/"
+        public static let cancelSubscription = "https://support.pocketcasts.com/knowledge-base/how-to-cancel-a-subscription/"
         public static let termsOfUse = "https://support.pocketcasts.com/article/terms-of-use/"
         public static let privacyPolicy = "https://support.pocketcasts.com/article/privacy-policy/"
         public static let plusInfo = "https://pocketcasts.com/plus/"


### PR DESCRIPTION
Fixes the Cancel subscription URL

## To test

- Go to Profile -> Account -> Cancel Subscription
- Tap on `Yes, Cancel my Subscription -> Show Me How
- The webpage should load correctly

| Before | Now |
| -------- | ------- |
| ![Simulator Screenshot - iPhone 15 Pro - 2024-08-20 at 18 29 16](https://github.com/user-attachments/assets/411d8b88-8198-4c3d-8b7f-eddd3baeb88a)  | ![Simulator Screenshot - iPhone 15 Pro - 2024-08-20 at 18 39 34](https://github.com/user-attachments/assets/5084cbb6-fe4c-4632-a5e1-f784ddae321d)    |

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
