### PR TITLE
Update podcast list when episode is archived or marked as played from player

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 7.72
 -----
+- Update podcast list when episode is archived or marked as played from player [#1976](https://github.com/Automattic/pocket-casts-ios/issues/1976)
 
 
 7.71

--- a/podcasts/PodcastListViewController.swift
+++ b/podcasts/PodcastListViewController.swift
@@ -148,6 +148,8 @@ class PodcastListViewController: PCViewController, UIGestureRecognizerDelegate, 
         addCustomObserver(ServerNotifications.syncCompleted, selector: #selector(refreshGridItems))
         addCustomObserver(Constants.Notifications.playbackTrackChanged, selector: #selector(refreshGridItems))
         addCustomObserver(Constants.Notifications.playbackEnded, selector: #selector(refreshGridItems))
+        addCustomObserver(Constants.Notifications.episodeArchiveStatusChanged, selector: #selector(refreshGridItems))
+        addCustomObserver(Constants.Notifications.episodePlayStatusChanged, selector: #selector(refreshGridItems))
 
         addCustomObserver(Constants.Notifications.folderChanged, selector: #selector(refreshGridItems))
         addCustomObserver(Constants.Notifications.folderDeleted, selector: #selector(refreshGridItems))


### PR DESCRIPTION
Fixes #1976 

Updated `PodcastListViewController` to listen for episode state changes initiated by the user from the player screen (mark as played or archived). Previously the podcast list would remain out of date until you would tab away from the screen and then back (see video in issue).

## To test

1. Go to Podcast grid view
2. Play episode and open fullscreen player
3. Mark episode as played
4. Minimise player
5. Notice that the badges are not updated and the podcast order is not changed
6. Navigate away from and then back to the grid
7. Notice that the grid is now correct
8. Apply the change in this PR
9. Re-do steps above. Grid should now be correct without the need to navigate away and back.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
