### PR TITLE
Ensure that the profile header view always returns a minimum size that is visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix auto-play when Skip Last setting is working [#2019](https://github.com/Automattic/pocket-casts-ios/pull/2037)
 - Kids Profile banner implementation [#1935](https://github.com/Automattic/pocket-casts-ios/issues/1935)
 - Fix rapidly tapping skip back resulting in skip forward [#2041](https://github.com/Automattic/pocket-casts-ios/issues/2041)
+- Fix profile header view when using iPad multitask modes [#2074](https://github.com/Automattic/pocket-casts-ios/pull/2074) 
 
 7.70
 -----

--- a/podcasts/Profile - SwiftUI/Profile/ProfileHeaderView.swift
+++ b/podcasts/Profile - SwiftUI/Profile/ProfileHeaderView.swift
@@ -119,7 +119,13 @@ struct ProfileHeaderView: View {
             .padding(.bottom, Constants.paddingBottomAndSides)
             .padding(.horizontal, Constants.paddingBottomAndSides)
         } contentSizeUpdated: { size in
-            viewModel.contentSizeChanged(size)
+            var adjustedSize = size
+            // There is an issue with this view, that when the iPad multitask mode is used, the size returns zero,
+            // then the associated table view controller set a header size of zero and it never recovers from that
+            if size == .zero {
+                adjustedSize = Constants.minimumSize
+            }
+            viewModel.contentSizeChanged(adjustedSize)
         }
     }
 
@@ -217,6 +223,7 @@ struct ProfileHeaderView: View {
         static let imageSize = 104.0
         static let paddingTop = 30.0
         static let paddingBottomAndSides = 20.0
+        static let minimumSize = CGSize(width: 300, height: Constants.imageSize + Constants.paddingTop + Constants.paddingBottomAndSides + Constants.spacing)
     }
 }
 


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

When testing the subscription purchase flows on the profile on the iPad, I noticed that the profile view disappeared when multi-task / split mode where activated.

The reason is that the `ProfileHeaderView` returns a size of `zero` and that make the profile view controller header size method to set a zero height for the header and the view never recovers that.

The fix will ensure that a minimum size is always returned.

## To test

- Start the app on a iPad
- Go to Profile tab
- Activate multitask mode on the iPad and split view with Safari for example
- Check that on the different multitask modes the Account header is always visible

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
