### PR TITLE
Fix iPad crash on iOS18 and Xcode 16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Kids Profile banner implementation [#1935](https://github.com/Automattic/pocket-casts-ios/issues/1935)
 - Fix rapidly tapping skip back resulting in skip forward [#2041](https://github.com/Automattic/pocket-casts-ios/issues/2041)
 - Subscription cancellation redirects now to a correct page. [#2070](https://github.com/Automattic/pocket-casts-ios/pull/2070)
+- Fix crash on the iPad when running iOS18. [#2077](https://github.com/Automattic/pocket-casts-ios/pull/2077)
 
 7.70
 -----

--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -145,6 +145,11 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
             traitOverrides.horizontalSizeClass = .compact
             if let rootHorizontalSizeClass = view.window?.traitCollection.horizontalSizeClass {
                 tabBar.traitOverrides.horizontalSizeClass = rootHorizontalSizeClass
+                if let viewControllers {
+                    for vc in viewControllers {
+                        vc.traitOverrides.horizontalSizeClass = rootHorizontalSizeClass
+                    }
+                }
             }
         }
     }

--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -29,10 +29,7 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        if #available(iOS 18.0, *) {
-            traitOverrides.horizontalSizeClass = .compact
-            tabBar.traitOverrides.horizontalSizeClass = .regular
-        }
+        fixTarBarTraitCollectionOnIpadForiOS18()
 
         if FeatureFlag.upNextOnTabBar.enabled {
             pcTabs = [.podcasts, .filter, .discover, .upNext, .profile]
@@ -142,9 +139,19 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
         Settings.shouldShowInitialOnboardingFlow = false
     }
 
+    private func fixTarBarTraitCollectionOnIpadForiOS18() {
+        if #available(iOS 18.0, *),
+            UIDevice.current.userInterfaceIdiom == .pad {
+            traitOverrides.horizontalSizeClass = .compact
+            if let rootHorizontalSizeClass = view.window?.traitCollection.horizontalSizeClass {
+                tabBar.traitOverrides.horizontalSizeClass = rootHorizontalSizeClass
+            }
+        }
+    }
+
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
-
+        fixTarBarTraitCollectionOnIpadForiOS18()
         fireSystemThemeMayHaveChanged()
     }
 

--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -29,6 +29,11 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        if #available(iOS 18.0, *) {
+            traitOverrides.horizontalSizeClass = .compact
+            tabBar.traitOverrides.horizontalSizeClass = .regular
+        }
+
         if FeatureFlag.upNextOnTabBar.enabled {
             pcTabs = [.podcasts, .filter, .discover, .upNext, .profile]
         } else {


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes #2063

This PR avoid the crash resulting from the iPad Tab bar new design on iOS18 when using a TabViewController.

The way we are avoiding the crash is to force the TabBarController  to believe is always in the compact mode and keep using the regular tab bar on the bottom.

I tried to adapt to the new design but there are several issues with our current design of the app:

- Our mini-player is positioned above the tab bar ( this was reason for the crash because on the new design the tabbar is not in the same hierarchy as the mini-player)
- Our animations for the mini-player assume the tabbar is on the bottom
- The new tab bar design only allows to show 4 items on portrait mode and we currently 5 items so it show a chevron to display more options


## To test

- Using Xcode 16 beta 5 and an iOS 18 iPad device start the app
- Ensure that the app does not crash at startup
- Rotate the device and use the multiple split-view modes and check the app is working correctly
- Test on iOS 18 iPhone device to see if the tab bar shows correctly
- Repeat the tests on XCode 15.4 and iOS 17

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
