### PR TITLE
Xcode 16: prepare to have betas using Xcode 16 beta

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,7 +6,7 @@ common_params:
   # Common environment values to use with the `env` key.
   - &common_env
     # If you update the image to a newer Xcode version, don't forget to also update the badge in the README.md file accordingly for consistency
-    IMAGE_ID: xcode-15.4
+    IMAGE_ID: xcode-16.0-beta5
   # Common agents values to use with the `agents` key.
   - &common_agents
     queue: mac

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -7,7 +7,7 @@ common_params:
     - automattic/a8c-ci-toolkit#2.15.1
   # Common environment values to use with the `env` key.
   - &common_env
-    IMAGE_ID: xcode-15.4
+    IMAGE_ID: xcode-16.0-beta5
 
 steps:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Kids Profile banner implementation [#1935](https://github.com/Automattic/pocket-casts-ios/issues/1935)
 - Fix rapidly tapping skip back resulting in skip forward [#2041](https://github.com/Automattic/pocket-casts-ios/issues/2041)
 - Subscription cancellation redirects now to a correct page. [#2070](https://github.com/Automattic/pocket-casts-ios/pull/2070)
+- watchOS 11: add double-tap gesture to play/pause. [#2054](https://github.com/Automattic/pocket-casts-ios/pull/2054)
 
 7.70
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fix rapidly tapping skip back resulting in skip forward [#2041](https://github.com/Automattic/pocket-casts-ios/issues/2041)
 - Subscription cancellation redirects now to a correct page. [#2070](https://github.com/Automattic/pocket-casts-ios/pull/2070)
 - watchOS 11: add double-tap gesture to play/pause. [#2054](https://github.com/Automattic/pocket-casts-ios/pull/2054)
+- Build the app using Xcode 16. If you face any crashes or issues please let us know. [#2078](https://github.com/Automattic/pocket-casts-ios/pull/2078)
 
 7.70
 -----

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -427,6 +427,11 @@ platform :ios do
   lane :finalize_release do |options|
     UI.user_error!('To finalize a hotfix, please use the finalize_hotfix_release lane instead') if ios_current_branch_is_hotfix
 
+    # Temporarily: we should remove after moving to Xcode 16 in definitive
+    if !UI.confirm('Please ensure Xcode image is set to xcode-15.4 before moving forward, if it is, type y. If not, type n.')
+      UI.user_error!('Before submitting the app to release please change the CI image to xcode-15.4')
+    end
+
     require_env_vars!('GITHUB_TOKEN')
 
     # Verify that there's nothing in progress in the working copy

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -428,7 +428,7 @@ platform :ios do
     UI.user_error!('To finalize a hotfix, please use the finalize_hotfix_release lane instead') if ios_current_branch_is_hotfix
 
     # Temporarily: we should remove after moving to Xcode 16 in definitive
-    if !UI.confirm('Please ensure Xcode image is set to xcode-15.4 before moving forward, if it is, type y. If not, type n.')
+    unless UI.confirm('Please ensure Xcode image is set to xcode-15.4 before moving forward, if it is, type y. If not, type n.')
       UI.user_error!('Before submitting the app to release please change the CI image to xcode-15.4')
     end
 


### PR DESCRIPTION
* Changes the CI image to Xcode 16 beta
* Add a question on `finalize_release` to ensure the image is set back to Xcode 15

## To test

1. Run `bundle exec fastlane finalize_release`
2. When asked about the image type `n`
3. ✅ fastlane should fail with "Before submitting the app to release please change the CI image to xcode-15.4"

Also, CI must be 🟢. 

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
