### PR TITLE
Dismiss search if already active when double tap is performed on tab bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 7.72
 -----
 - Update podcast list when episode is archived or marked as played from player [#1976](https://github.com/Automattic/pocket-casts-ios/issues/1976)
-
+- Dismiss search if already active when double tap is performed on tab bar [#1652](https://github.com/Automattic/pocket-casts-ios/issues/1652)
 
 7.71
 -----

--- a/podcasts/DiscoverViewController.swift
+++ b/podcasts/DiscoverViewController.swift
@@ -95,7 +95,13 @@ class DiscoverViewController: PCViewController {
         if mainScrollView.contentOffset.y.rounded(.down) > defaultOffset.rounded(.down) {
             mainScrollView.setContentOffset(CGPoint(x: 0, y: defaultOffset), animated: true)
         } else {
-            searchController.searchTextField.becomeFirstResponder()
+            // When double-tapping on tab bar, dismiss the search if already active
+            // else give focus to the search field
+            if searchController.cancelButtonShowing {
+                searchController.cancelTapped(self)
+            } else {
+                searchController.searchTextField.becomeFirstResponder()
+            }
         }
     }
 

--- a/podcasts/PodcastListViewController.swift
+++ b/podcasts/PodcastListViewController.swift
@@ -230,7 +230,13 @@ class PodcastListViewController: PCViewController, UIGestureRecognizerDelegate, 
         if let index = notification.object as? Int, index == tabBarItem.tag, podcastsCollectionView.contentOffset.y.rounded(.down) > topOffset.rounded(.down) {
             podcastsCollectionView.setContentOffset(CGPoint(x: -horizontalMargin, y: topOffset), animated: true)
         } else {
-            searchController.searchTextField.becomeFirstResponder()
+            // When double-tapping on tab bar, dismiss the search if already active
+            // else give focus to the search field
+            if searchController.cancelButtonShowing {
+                searchController.cancelTapped(self)
+            } else {
+                searchController.searchTextField.becomeFirstResponder()
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #1652 

Search: tapping Discover/Podcasts with the search open should dismiss it

## To test

1. Tap Discover or Podcasts on the tab bar
2. Tap it again so the search starts
3. Dismiss the keyboard or search for something
4. Tap the tab bar item again
5. Search should be dismissed at this point. Old behaviour was for search to restart and the keyboard to be shown again, which should not happen

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
