### PR TITLE
Reimagine Sharing: Trim Handle offsets

### DIFF
--- a/podcasts/Sharing/Clip/MediaTrimView.swift
+++ b/podcasts/Sharing/Clip/MediaTrimView.swift
@@ -15,6 +15,7 @@ struct MediaTrimView: View {
     @State private var playPosition: CGFloat = 0
 
     private enum Constants {
+        static let trimHandleWidth: CGFloat = 17
         static let trimLineWidth: CGFloat = 4
         static let playLineWidth: CGFloat = 3
     }
@@ -25,18 +26,23 @@ struct MediaTrimView: View {
 
     var body: some View {
         GeometryReader { geometry in
-            ScrollableScrollView(scale: $scale, duration: duration, geometry: geometry) { scrollable in
+            ScrollableScrollView(scale: $scale,
+                                 startTime: $startTime,
+                                 endTime: $endTime,
+                                 duration: duration,
+                                 geometry: geometry,
+                                 additionalEdgeOffsets: UIEdgeInsets(top: 0, left: Constants.trimHandleWidth, bottom: 0, right: (Constants.trimHandleWidth * 2) + Constants.trimLineWidth + Constants.playLineWidth)) { scrollable in
                 AudioWaveformView(width: geometry.size.width * scale)
-                borderView(in: geometry)
+                    .border(Colors.trimBorderColor, width: Constants.trimLineWidth)
                 PlayheadView(position: scaledPosition($playPosition), validRange: scaledPosition($startPosition).wrappedValue...scaledPosition($endPosition).wrappedValue)
                     .onChange(of: playTime) { playTime in
-                        playPosition = durationRelative(value: playTime, for: geometry.size.width)
+                        playPosition = durationRelative(value: playTime, for: geometry.size.width).clamped(to: startPosition...endPosition)
                     }
                     .onChange(of: playPosition) { playPosition in
                         playTime = (playPosition * duration) / geometry.size.width
                     }
                     .frame(width: Constants.playLineWidth)
-                TrimSelectionView(leading: scaledPosition($startPosition), trailing: scaledPosition($endPosition), indicatorWidth: Constants.playLineWidth, changed: { position, side in
+                TrimSelectionView(leading: scaledPosition($startPosition), trailing: scaledPosition($endPosition), handleWidth: Constants.trimHandleWidth, indicatorWidth: Constants.playLineWidth, changed: { position, side in
                     update(position: position, for: side, in: geometry.size.width)
                 })
                 .onAppear {
@@ -55,12 +61,6 @@ struct MediaTrimView: View {
                 }
             }
         }
-    }
-
-    private func borderView(in geometry: GeometryProxy) -> some View {
-        RoundedRectangle(cornerRadius: 20)
-            .fill(Color.clear)
-            .border(Colors.trimBorderColor, width: Constants.trimLineWidth)
     }
 
     private func scaledPosition(_ position: Binding<CGFloat>) -> Binding<CGFloat> {
@@ -109,14 +109,24 @@ struct MediaTrimView: View {
     private func update(position: CGFloat, for side: TrimHandle.Side, in width: CGFloat) {
         let range: ClosedRange<CGFloat>
 
+        let playIndicatorWidth = Constants.playLineWidth / scale
+
         switch side {
         case .leading:
-            range = 0...endPosition
+            range = 0...(endPosition - playIndicatorWidth)
         case .trailing:
-            range = startPosition...width
+            range = (startPosition + playIndicatorWidth)...width
         }
 
-        let scaledPosition = position / scale
+        let modifier: CGFloat
+        switch side {
+        case .leading:
+            modifier = (Constants.trimHandleWidth / 2)
+        case .trailing:
+            modifier = -(Constants.trimHandleWidth / 2)
+        }
+
+        let scaledPosition = (position + modifier) / scale
         let newPosition = scaledPosition.clamped(to: range)
 
         let time = Double(newPosition / width) * duration
@@ -130,7 +140,10 @@ struct MediaTrimView: View {
             endPosition = newPosition
         }
 
-        playTime = playTime.clamped(to: startTime...endTime)
+        let endValue = (endPosition - playIndicatorWidth)
+        if startPosition <= endValue {
+            playPosition = playPosition.clamped(to: startPosition...endValue)
+        }
     }
 }
 

--- a/podcasts/Sharing/Clip/ScrollableScrollView.swift
+++ b/podcasts/Sharing/Clip/ScrollableScrollView.swift
@@ -14,12 +14,16 @@ struct Scrollable {
 struct ScrollableScrollView<Content: View>: View {
 
     @Binding var scale: CGFloat
+    @Binding var startTime: TimeInterval
+    @Binding var endTime: TimeInterval
     var duration: TimeInterval
     let geometry: GeometryProxy
 
-    @State private var lastScale: CGFloat?
+    let additionalEdgeOffsets: UIEdgeInsets
 
     @ViewBuilder let content: (Scrollable) -> Content
+
+    @State private var lastScale: CGFloat?
 
     private let scrollIDPrefix = "tick"
 
@@ -31,9 +35,34 @@ struct ScrollableScrollView<Content: View>: View {
                         .frame(width: geometry.size.width * scale)
                     content(Scrollable(prefix: scrollIDPrefix, scrollProxy: scrollProxy))
                 }
+                .offset(x: leftOffset)
+                .padding(.trailing, rightOffset)
+                .frame(width: totalWidth)
             }
             .clipped()
         }
+    }
+
+    private var contentWidth: CGFloat {
+        geometry.size.width * scale
+    }
+
+    private var leftOffset: CGFloat {
+        max(additionalEdgeOffsets.left - startTime, 0)
+    }
+
+    private var rightOffset: CGFloat {
+        let offset: CGFloat
+        if scale != 0 {
+            offset = max((endTime - (duration - additionalEdgeOffsets.right)), 0)
+        } else {
+            offset = 0
+        }
+        return offset
+    }
+
+    private var totalWidth: CGFloat {
+        contentWidth + leftOffset
     }
 
     /// A series of invisible "tick marks" used to mark positions in the scrollable view

--- a/podcasts/Sharing/Clip/TrimHandle.swift
+++ b/podcasts/Sharing/Clip/TrimHandle.swift
@@ -8,13 +8,12 @@ struct TrimHandle: View {
 
     @Binding var position: CGFloat
     let side: Side
-    let indicatorWidth: CGFloat
+    let width: CGFloat
     let onChanged: (CGFloat) -> Void
 
     private enum Constants {
         static let innerLineColor = Color(hex: "281313").opacity(0.2)
         static let innerLineWidth = 1.5
-        static let width: CGFloat = 17
         static let cornerRadius: CGFloat = 8
     }
 
@@ -37,7 +36,7 @@ struct TrimHandle: View {
                 }
             handleLine
         }
-        .frame(width: Constants.width)
+        .frame(width: width)
         .offset(x: offset)
         .onTapGesture {}
         .highPriorityGesture(
@@ -52,15 +51,15 @@ struct TrimHandle: View {
         RoundedRectangle(cornerRadius: Constants.cornerRadius)
             .fill(Constants.innerLineColor)
             .frame(width: Constants.innerLineWidth)
-            .padding(.vertical, Constants.width)
+            .padding(.vertical, width)
     }
 
     var offset: CGFloat {
         switch side {
         case .leading:
-            position - Constants.width
+            position - width
         case .trailing:
-            position + indicatorWidth
+            position
         }
     }
 

--- a/podcasts/Sharing/Clip/TrimSelectionView.swift
+++ b/podcasts/Sharing/Clip/TrimSelectionView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct TrimSelectionView: View {
     @Binding var leading: CGFloat
     @Binding var trailing: CGFloat
+    let handleWidth: CGFloat
     let indicatorWidth: CGFloat
 
     let changed: (CGFloat, TrimHandle.Side) -> Void
@@ -19,8 +20,8 @@ struct TrimSelectionView: View {
                 // Offset and frame are adjusted to hide this rectangle behind the Trim Handles
                 .frame(width: (trailing - leading + indicatorWidth) + (Constants.borderWidth * 2))
                 .offset(x: leading - Constants.borderWidth)
-            TrimHandle(position: $leading, side: .leading, indicatorWidth: indicatorWidth, onChanged: { changed($0, .leading) })
-            TrimHandle(position: $trailing, side: .trailing, indicatorWidth: indicatorWidth, onChanged: { changed( $0, .trailing) })
+            TrimHandle(position: $leading, side: .leading, width: handleWidth, onChanged: { changed($0, .leading) })
+            TrimHandle(position: $trailing, side: .trailing, width: handleWidth, onChanged: { changed( $0, .trailing) })
         }
     }
 }

--- a/podcasts/Sharing/SharingView.swift
+++ b/podcasts/Sharing/SharingView.swift
@@ -13,10 +13,10 @@ class ClipTime: ObservableObject {
     @Published var end: TimeInterval
     @Published var playback: TimeInterval
 
-    init(start: TimeInterval, end: TimeInterval) {
+    init(start: TimeInterval, end: TimeInterval, playback: TimeInterval? = nil) {
         self.start = start
         self.end = end
-        self.playback = start
+        self.playback = playback ?? start
     }
 }
 
@@ -46,8 +46,15 @@ struct SharingView: View {
         self.shareable = Shareable(option: selectedOption, style: selectedStyle)
 
         switch selectedOption {
-        case .clip(_, let time):
-            self.clipTime = ClipTime(start: time, end: time + 60)
+        case .clip(let episode, let time):
+            let clipDuration: TimeInterval = 60
+            var startTime = time
+            var endTime = time + clipDuration
+            if endTime > episode.duration {
+                startTime = episode.duration - clipDuration
+                endTime = episode.duration
+            }
+            self.clipTime = ClipTime(start: startTime, end: endTime, playback: time)
         default:
             self.clipTime = ClipTime(start: 0, end: 0)
         }


### PR DESCRIPTION
| 📘 Part of: #1910 |
|:---:|

Fixes #1948

* Extends the scrollable timeline when the handles reach the edge
* Refactors the Trim Handle positioning code
* Improves the default range to extend _back_ into the episode when selecting towards the end

https://github.com/user-attachments/assets/d746514a-7dd2-4873-b995-999223a73c09

## To test

> [!NOTE]
> Enable the `newSharing` feature flag to test this

#### Clip extension
* Play an Episode where the seek position is towards the beginning of the episode
* Tap the "Share" button in the action shelf
* Tap the "Clip" option
* Move the trim handles so it extends past the leading edge
* Close the Clip modal

* Seek to somewhere near the end of the episode
* Tap the "Share" button in the action shelf
* Tap the "Clip" option
* Ensure that the range does not exceed the timeline and that it extends backwards to create a 60 second clip

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
