### PR TITLE
[Give Rating] Add new source for rate tapping event

### DIFF
--- a/podcasts/Ratings/PodcastRatingViewModel.swift
+++ b/podcasts/Ratings/PodcastRatingViewModel.swift
@@ -59,12 +59,20 @@ class PodcastRatingViewModel: ObservableObject {
     private enum LoadingState {
         case waiting, loading, done
     }
+
+    enum RatingSource: String {
+        case button
+        case stars
+    }
 }
 
 // MARK: - View Interactions
 extension PodcastRatingViewModel {
-    func didTapRating() {
+    func didTapRating(source: RatingSource = .button) {
         if FeatureFlag.giveRatings.enabled {
+            Analytics.shared.track(.ratingStarsTapped,
+                                   properties: ["uuid": uuid ?? "unknown",
+                                                "source": source.rawValue])
             if SyncManager.isUserLoggedIn() {
                 presentingGiveRatings = true
             } else {
@@ -74,8 +82,8 @@ extension PodcastRatingViewModel {
             }
         } else {
             presentingGiveRatings = true
-        }
 
-        Analytics.shared.track(.ratingStarsTapped, properties: ["uuid": uuid ?? "unknown"])
+            Analytics.shared.track(.ratingStarsTapped, properties: ["uuid": uuid ?? "unknown"])
+        }
     }
 }

--- a/podcasts/Ratings/StarRatingView.swift
+++ b/podcasts/Ratings/StarRatingView.swift
@@ -42,7 +42,7 @@ struct StarRatingView: View {
                     .frame(height: 16)
                     .animation(.easeIn(duration: Constants.animationDuration), value: shouldAnimate)
                     .onTapGesture {
-                        viewModel.didTapRating()
+                        viewModel.didTapRating(source: .stars)
                     }
 
                 Spacer()


### PR DESCRIPTION
| 📘 Part of: #1879 
|:---:|

Fixes #2089 

We would like to track the source of the `rating_stars_tapped`. We added a `source` parameter with 2 different sources: `button` and `stars`

## To test

- Run the App and enable the event logging
- Open a podcast
- Expand the header
- Tap on Rate
- Make sure you see 🔵 Tracked: rating_stars_tapped ["source": "button", "uuid": PODCAST_UUID]
- Close the rate screen
- Tap on the stars
- Make sure you see 🔵 Tracked: rating_stars_tapped ["source": "stars", "uuid": PODCAST_UUID]

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
