### PR TITLE
Transcripts: Reset scroll position when changing transcript episode

### DIFF
--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -292,15 +292,18 @@ class TranscriptViewController: PlayerItemViewController {
         activityIndicatorView.stopAnimating()
     }
 
-    private var previousEpisodeUUID: String?
+    private var currentEpisodeUUID: String?
 
     private func loadTranscript() {
-        setupLoadingState()
         guard let episode = playbackManager.currentEpisode(), let podcast = playbackManager.currentPodcast else {
             return
         }
-        let shouldResetPosition = previousEpisodeUUID != episode.uuid
-        previousEpisodeUUID = episode.uuid
+
+        let shouldResetPosition = currentEpisodeUUID != episode.uuid
+        currentEpisodeUUID = episode.uuid
+
+        setupLoadingState()
+
         Task.detached { [weak self] in
             guard let self else {
                 return


### PR DESCRIPTION
| 📘 Part of: #1848  |  <!-- project issue number, if applicable -->
|:---:|

Fixes #2092 

This PR ensures that a new transcript is loaded we reset the transcript position to the beginning. 

## To test

 - Start the app
 - Ensure that you have `transcripts` and `newShowNotesEndpoint` FF enabled
 - Play an episode that as transcripts support. EX: "Cautionary Tales"
 - Add another episode with transcripts to be played in your UpNext Queue
 - Open the full screen player
 - Tap on transcripts option
 - Scroll around in the transcripts to the end of it
 - Await for the episode to get to the end and the new episode starts
 - Check that position is reset to the start.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
