### PR TITLE
Transcripts: Reset scroll position when changing transcript episode

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -33,8 +33,8 @@
 		10756F882C59449C0089D34F /* Folder+Sortable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10756F872C59449C0089D34F /* Folder+Sortable.swift */; };
 		10756F892C59449C0089D34F /* Folder+Sortable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10756F872C59449C0089D34F /* Folder+Sortable.swift */; };
 		10756F8B2C5945C00089D34F /* KidsProfileSubmitScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10756F8A2C5945C00089D34F /* KidsProfileSubmitScreen.swift */; };
-		107836262C62816900DA3FF0 /* ABTestProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 107836252C62816900DA3FF0 /* ABTestProviderTests.swift */; };
 		107836232C5CDD5000DA3FF0 /* GiveRatingsWhatsNewHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 107836222C5CDD5000DA3FF0 /* GiveRatingsWhatsNewHeader.swift */; };
+		107836262C62816900DA3FF0 /* ABTestProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 107836252C62816900DA3FF0 /* ABTestProviderTests.swift */; };
 		10A4F7532C515D720084D783 /* KidsProfile.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 10A4F7522C515D720084D783 /* KidsProfile.xcassets */; };
 		10A4F7562C5162C90084D783 /* KidsProfileBannerTableCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10A4F7552C5162C90084D783 /* KidsProfileBannerTableCell.swift */; };
 		10A4F7582C52635F0084D783 /* KidsProfileBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10A4F7572C52635F0084D783 /* KidsProfileBannerView.swift */; };
@@ -517,6 +517,7 @@
 		8B484F0228D25DB5001AFA97 /* UIViewController+requestReview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B484F0028D25D1E001AFA97 /* UIViewController+requestReview.swift */; };
 		8B4881E929A3AE6D00E7C016 /* SearchHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B4881E829A3AE6D00E7C016 /* SearchHistoryView.swift */; };
 		8B4C6FE52BD6EC2E00D0BB9D /* CustomStepper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B4C6FE42BD6EC2E00D0BB9D /* CustomStepper.swift */; };
+		8B53245D2C6FEBA200DC5423 /* TranscriptSyncModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B53245C2C6FEBA200DC5423 /* TranscriptSyncModel.swift */; };
 		8B5AB488290188F30018C637 /* IntroStory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B5AB487290188F30018C637 /* IntroStory.swift */; };
 		8B5AB48A29018A950018C637 /* EpilogueStory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B5AB48929018A950018C637 /* EpilogueStory.swift */; };
 		8B5AB48C29018EFA0018C637 /* StoriesConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B5AB48B29018EFA0018C637 /* StoriesConfiguration.swift */; };
@@ -1921,8 +1922,8 @@
 		10756F842C5944660089D34F /* Podcast+Sortable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Podcast+Sortable.swift"; sourceTree = "<group>"; };
 		10756F872C59449C0089D34F /* Folder+Sortable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Folder+Sortable.swift"; sourceTree = "<group>"; };
 		10756F8A2C5945C00089D34F /* KidsProfileSubmitScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = KidsProfileSubmitScreen.swift; path = "Kids Profile/KidsProfileSubmitScreen.swift"; sourceTree = "<group>"; };
-		107836252C62816900DA3FF0 /* ABTestProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ABTestProviderTests.swift; sourceTree = "<group>"; };
 		107836222C5CDD5000DA3FF0 /* GiveRatingsWhatsNewHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiveRatingsWhatsNewHeader.swift; sourceTree = "<group>"; };
+		107836252C62816900DA3FF0 /* ABTestProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ABTestProviderTests.swift; sourceTree = "<group>"; };
 		10A4F7522C515D720084D783 /* KidsProfile.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = KidsProfile.xcassets; sourceTree = "<group>"; };
 		10A4F7552C5162C90084D783 /* KidsProfileBannerTableCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = KidsProfileBannerTableCell.swift; path = "Kids Profile/KidsProfileBannerTableCell.swift"; sourceTree = "<group>"; };
 		10A4F7572C52635F0084D783 /* KidsProfileBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = KidsProfileBannerView.swift; path = "Kids Profile/KidsProfileBannerView.swift"; sourceTree = "<group>"; };
@@ -2430,6 +2431,7 @@
 		8B484F0028D25D1E001AFA97 /* UIViewController+requestReview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+requestReview.swift"; sourceTree = "<group>"; };
 		8B4881E829A3AE6D00E7C016 /* SearchHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchHistoryView.swift; sourceTree = "<group>"; };
 		8B4C6FE42BD6EC2E00D0BB9D /* CustomStepper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomStepper.swift; sourceTree = "<group>"; };
+		8B53245C2C6FEBA200DC5423 /* TranscriptSyncModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptSyncModel.swift; sourceTree = "<group>"; };
 		8B5AB487290188F30018C637 /* IntroStory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroStory.swift; sourceTree = "<group>"; };
 		8B5AB48929018A950018C637 /* EpilogueStory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EpilogueStory.swift; sourceTree = "<group>"; };
 		8B5AB48B29018EFA0018C637 /* StoriesConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoriesConfiguration.swift; sourceTree = "<group>"; };
@@ -7694,6 +7696,7 @@
 				8BF623002C53ED7C00D10F57 /* TranscriptSearchAccessoryView.swift */,
 				FF54BCA82C5A2F3900A342E5 /* TranscriptFormat.swift */,
 				FF40C0652C65175B003A9D93 /* TranscriptErrorView.swift */,
+				8B53245C2C6FEBA200DC5423 /* TranscriptSyncModel.swift */,
 			);
 			name = Transcripts;
 			sourceTree = "<group>";
@@ -9464,6 +9467,7 @@
 				403D1AB42281C36100CE7C9B /* AccountViewController+TableView.swift in Sources */,
 				BDD5CA002303E8FA005E133C /* ThemeableUIButton.swift in Sources */,
 				403946E9228587FC00F55162 /* AddCustomViewController+CollectionView.swift in Sources */,
+				8B53245D2C6FEBA200DC5423 /* TranscriptSyncModel.swift in Sources */,
 				BDB4E7D2240E3134005770E3 /* String+Differentiable.swift in Sources */,
 				BD2BE6791C5B11C20087EE1E /* ShiftyRoundButton.swift in Sources */,
 				8B0EEDE6290081E400075772 /* ListenedNumbersStory.swift in Sources */,

--- a/podcasts/AudioReadTask.swift
+++ b/podcasts/AudioReadTask.swift
@@ -123,7 +123,7 @@ class AudioReadTask {
         }
 
         if let result {
-            print("$$ \(result.bestTranscription)")
+            TranscriptSyncModel.shared.update(result.bestTranscription, offset: offset)
         }
     }
 

--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -1,4 +1,5 @@
 import PocketCastsDataModel
+import Speech
 import PocketCastsServer
 import SafariServices
 import UIKit
@@ -103,6 +104,10 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
         showInitialOnboardingIfNeeded()
 
         updateDatabaseIndexes()
+
+        SFSpeechRecognizer.requestAuthorization { SFSpeechRecognizerAuthorizationStatus in
+
+        }
     }
 
     /// Update database indexes and delete unused columns

--- a/podcasts/TranscriptSyncModel.swift
+++ b/podcasts/TranscriptSyncModel.swift
@@ -21,6 +21,13 @@ class TranscriptSyncModel {
         }
     }
 
+    func reset() {
+        words = []
+        reference = ""
+        matchedWords = []
+        timestamps = []
+    }
+
     // MARK: - Alignment algorithm
 
     var matchedWords: [Word] = []

--- a/podcasts/TranscriptSyncModel.swift
+++ b/podcasts/TranscriptSyncModel.swift
@@ -8,8 +8,6 @@ class TranscriptSyncModel {
     var words: [(TimeInterval, TimeInterval, String)] = [] {
         didSet {
             timestamps = words.map { ($0.0, $0.1) }
-
-            wordByWord()
         }
     }
 
@@ -195,8 +193,10 @@ class TranscriptSyncModel {
             return (alignedSubtitle.reversed(), alignedTranscript.reversed(), alignedTimestamps.reversed())
         }
 
-        // Example usage
-        let subtitle = reference
+        // We need to do A LOT of work in performance
+        // For testing purposed I limit the transcript to just 500 words
+        // otherwise the app crashes, becomes slow, etc etc
+        let subtitle = String(reference.prefix(500))
         let transcript = words.map { $0.2 }
 
         let (alignedSubtitle, alignedTranscript, alignedTimestamps) = alignSequences(subtitle: subtitle, transcript: transcript, transcriptTimestamps: timestamps)
@@ -206,6 +206,11 @@ class TranscriptSyncModel {
 
             return Word(timestamp: alignedTimestamps[index].timestamp, duration: alignedTimestamps[index].duration, characterRange: range)
         }
+    }
+
+    public func firstWord(containing secondsValue: TimeInterval) -> Word? {
+        matchedWords
+            .first { $0.contains(timeInSeconds: secondsValue) }
     }
 }
 

--- a/podcasts/TranscriptSyncModel.swift
+++ b/podcasts/TranscriptSyncModel.swift
@@ -16,9 +16,9 @@ class TranscriptSyncModel {
     func update(_ reference: SFTranscription, offset: TimeInterval) {
         reference.segments.forEach {
             words.append((offset + $0.timestamp, $0.duration, $0.substring))
-
-            wordByWord()
         }
+
+        wordByWord()
     }
 
     func reset() {

--- a/podcasts/TranscriptSyncModel.swift
+++ b/podcasts/TranscriptSyncModel.swift
@@ -35,39 +35,6 @@ class TranscriptSyncModel {
     var timestamps: [(TimeInterval, TimeInterval)] = []
 
     func wordByWord() {
-        // Calculate Levenshtein distance
-        func levenshtein(aStr: String, bStr: String) -> Int {
-            let a = Array(aStr)
-            let b = Array(bStr)
-            let m = a.count
-            let n = b.count
-
-            var dist = [[Int]](repeating: [Int](repeating: 0, count: n + 1), count: m + 1)
-
-            for i in 0...m {
-                dist[i][0] = i
-            }
-            for j in 0...n {
-                dist[0][j] = j
-            }
-
-            for i in 1...m {
-                for j in 1...n {
-                    if a[i-1] == b[j-1] {
-                        dist[i][j] = dist[i-1][j-1]
-                    } else {
-                        dist[i][j] = min(
-                            dist[i-1][j] + 1,
-                            dist[i][j-1] + 1,
-                            dist[i-1][j-1] + 1
-                        )
-                    }
-                }
-            }
-
-            return dist[m][n]
-        }
-
         // Define constants
         let matchScore = 1
         let mismatchScore = -1
@@ -121,8 +88,7 @@ class TranscriptSyncModel {
 
         // Define the scoring function
         func score(word1: String, word2: String) -> Int {
-            let distance = levenshtein(aStr: word1, bStr: word2)
-            return distance == 0 ? 1 : -distance
+            return word1 == word2 ? matchScore : mismatchScore
         }
 
         // Perform sequence alignment
@@ -203,7 +169,7 @@ class TranscriptSyncModel {
         // We need to do A LOT of work in performance
         // For testing purposed I limit the transcript to just 500 words
         // otherwise the app crashes, becomes slow, etc etc
-        let subtitle = String(reference.prefix(500))
+        let subtitle = String(reference)
         let transcript = words.map { $0.2 }
 
         let (alignedSubtitle, alignedTranscript, alignedTimestamps) = alignSequences(subtitle: subtitle, transcript: transcript, transcriptTimestamps: timestamps)

--- a/podcasts/TranscriptSyncModel.swift
+++ b/podcasts/TranscriptSyncModel.swift
@@ -1,0 +1,20 @@
+import Foundation
+import Speech
+
+class TranscriptSyncModel {
+    static let shared = TranscriptSyncModel()
+
+    var words: [[TimeInterval: String]] = [] {
+        didSet {
+            print("\n\n\n")
+            words.forEach { word in print("\(word.first!.key) \(word.first!.value)") }
+            print("\n\n\n")
+        }
+    }
+
+    func update(_ reference: SFTranscription, offset: TimeInterval) {
+        reference.segments.forEach {
+            words.append([offset + $0.timestamp: $0.substring])
+        }
+    }
+}

--- a/podcasts/TranscriptSyncModel.swift
+++ b/podcasts/TranscriptSyncModel.swift
@@ -1,20 +1,226 @@
 import Foundation
 import Speech
+import NaturalLanguage
 
 class TranscriptSyncModel {
     static let shared = TranscriptSyncModel()
 
-    var words: [[TimeInterval: String]] = [] {
+    var words: [(TimeInterval, TimeInterval, String)] = [] {
         didSet {
-            print("\n\n\n")
-            words.forEach { word in print("\(word.first!.key) \(word.first!.value)") }
-            print("\n\n\n")
+            timestamps = words.map { ($0.0, $0.1) }
+
+            wordByWord()
         }
     }
 
+    var reference: String = ""
+
     func update(_ reference: SFTranscription, offset: TimeInterval) {
         reference.segments.forEach {
-            words.append([offset + $0.timestamp: $0.substring])
+            words.append((offset + $0.timestamp, $0.duration, $0.substring))
+
+            wordByWord()
         }
+    }
+
+    // MARK: - Alignment algorithm
+
+    var matchedWords: [Word] = []
+
+    var timestamps: [(TimeInterval, TimeInterval)] = []
+
+    func wordByWord() {
+        // Calculate Levenshtein distance
+        func levenshtein(aStr: String, bStr: String) -> Int {
+            let a = Array(aStr)
+            let b = Array(bStr)
+            let m = a.count
+            let n = b.count
+
+            var dist = [[Int]](repeating: [Int](repeating: 0, count: n + 1), count: m + 1)
+
+            for i in 0...m {
+                dist[i][0] = i
+            }
+            for j in 0...n {
+                dist[0][j] = j
+            }
+
+            for i in 1...m {
+                for j in 1...n {
+                    if a[i-1] == b[j-1] {
+                        dist[i][j] = dist[i-1][j-1]
+                    } else {
+                        dist[i][j] = min(
+                            dist[i-1][j] + 1,
+                            dist[i][j-1] + 1,
+                            dist[i-1][j-1] + 1
+                        )
+                    }
+                }
+            }
+
+            return dist[m][n]
+        }
+
+        // Define constants
+        let matchScore = 1
+        let mismatchScore = -1
+        let gapPenalty = -2
+
+        struct TimedWord {
+            let word: String
+            let timestamp: TimeInterval
+            let duration: TimeInterval
+        }
+
+        // Tokenize the text while preserving punctuation
+        func tokenize(text: String) -> [String] {
+            var words = [String]()
+            let tokenizer = NLTokenizer(unit: .word)
+            tokenizer.string = text
+            tokenizer.enumerateTokens(in: text.startIndex..<text.endIndex) { tokenRange, _ in
+                let word = String(text[tokenRange])
+                words.append(word)
+                return true
+            }
+            return words
+        }
+
+        func tokenizeWithRange(text: String) -> [(String, NSRange)] {
+            var words = [(String, NSRange)]()
+            let tokenizer = NLTokenizer(unit: .word)
+            tokenizer.string = text
+            tokenizer.enumerateTokens(in: text.startIndex..<text.endIndex) { tokenRange, _ in
+                let word = String(text[tokenRange])
+                words.append((word, NSRange(tokenRange, in: text)))
+                return true
+            }
+            return words
+        }
+
+        // Preprocess subtitle words: return both original and normalized words
+        func preprocessSubtitleWords(text: String) -> [(normalized: String, range: NSRange)] {
+            let words = tokenizeWithRange(text: text)
+            return words.map { ($0.lowercased(), $1) }
+        }
+
+        // Preprocess timed words: tokenize and normalize, preserving timestamps
+        func preprocessTimedWords(text: [String], timestamps: [(timestamp: TimeInterval, duration: TimeInterval)]) -> [TimedWord] {
+            var timedWords = [TimedWord]()
+            for (index, word) in text.enumerated() {
+                timedWords.append(TimedWord(word: word.lowercased(), timestamp: timestamps[index].timestamp, duration: timestamps[index].duration))
+            }
+            return timedWords
+        }
+
+        // Define the scoring function
+        func score(word1: String, word2: String) -> Int {
+            let distance = levenshtein(aStr: word1, bStr: word2)
+            return distance == 0 ? 1 : -distance
+        }
+
+        // Perform sequence alignment
+        func alignSequences(subtitle: String, transcript: [String], transcriptTimestamps: [(timestamp: TimeInterval, duration: TimeInterval)]) -> ([NSRange?], [String], [(timestamp: TimeInterval, duration: TimeInterval)]) {
+            guard !subtitle.isEmpty, !transcript.isEmpty else { return ([], [], []) }
+
+            let subtitleWords = preprocessSubtitleWords(text: subtitle)
+            let transcriptTimedWords = preprocessTimedWords(text: transcript, timestamps: transcriptTimestamps)
+
+            let lenSub = subtitleWords.count
+            let lenTrans = transcriptTimedWords.count
+
+            // Initialize the scoring matrix
+            var S = Array(repeating: Array(repeating: 0, count: lenTrans + 1), count: lenSub + 1)
+
+            // Initialize first row and column with gap penalties
+            for i in 1...lenSub {
+                S[i][0] = S[i-1][0] + gapPenalty
+            }
+            for j in 1...lenTrans {
+                S[0][j] = S[0][j-1] + gapPenalty
+            }
+
+            // Populate the scoring matrix
+            for i in 1...lenSub {
+                for j in 1...lenTrans {
+                    let match = S[i-1][j-1] + score(word1: subtitleWords[i-1].normalized, word2: transcriptTimedWords[j-1].word)
+                    let delete = S[i-1][j] + gapPenalty
+                    let insert = S[i][j-1] + gapPenalty
+                    S[i][j] = max(match, delete, insert)
+                }
+            }
+
+            // Traceback to get the aligned sequences
+            var alignedSubtitle = [NSRange?]()
+            var alignedTranscript = [String]()
+            var alignedTimestamps = [(timestamp: TimeInterval, duration: TimeInterval)]()
+            var i = lenSub
+            var j = lenTrans
+
+            while i > 0 && j > 0 {
+                if S[i][j] == S[i-1][j-1] + score(word1: subtitleWords[i-1].normalized, word2: transcriptTimedWords[j-1].word) {
+                    alignedSubtitle.append(subtitleWords[i-1].range)
+                    alignedTranscript.append(transcriptTimedWords[j-1].word)
+                    alignedTimestamps.append((transcriptTimedWords[j-1].timestamp, transcriptTimedWords[j-1].duration))
+                    i -= 1
+                    j -= 1
+                } else if S[i][j] == S[i-1][j] + gapPenalty {
+                    alignedSubtitle.append(subtitleWords[i-1].range)
+                    alignedTranscript.append("-")
+                    alignedTimestamps.append((-1, -1))  // Indicate a gap with a negative timestamp
+                    i -= 1
+                } else {
+                    alignedSubtitle.append(nil)
+                    alignedTranscript.append(transcriptTimedWords[j-1].word)
+                    alignedTimestamps.append((transcriptTimedWords[j-1].timestamp, transcriptTimedWords[j-1].duration))
+                    j -= 1
+                }
+            }
+
+            while i > 0 {
+                alignedSubtitle.append(subtitleWords[i-1].range)
+                alignedTranscript.append("-")
+                alignedTimestamps.append((-1, -1))
+                i -= 1
+            }
+
+            while j > 0 {
+                alignedSubtitle.append(nil)
+                alignedTranscript.append(transcriptTimedWords[j-1].word)
+                alignedTimestamps.append((transcriptTimedWords[j-1].timestamp, transcriptTimedWords[j-1].duration))
+                j -= 1
+            }
+
+            return (alignedSubtitle.reversed(), alignedTranscript.reversed(), alignedTimestamps.reversed())
+        }
+
+        // Example usage
+        let subtitle = reference
+        let transcript = words.map { $0.2 }
+
+        let (alignedSubtitle, alignedTranscript, alignedTimestamps) = alignSequences(subtitle: subtitle, transcript: transcript, transcriptTimestamps: timestamps)
+
+        matchedWords = alignedSubtitle.enumerated().compactMap { index, range in
+            guard let range else { return nil }
+
+            return Word(timestamp: alignedTimestamps[index].timestamp, duration: alignedTimestamps[index].duration, characterRange: range)
+        }
+    }
+}
+
+class Word {
+    var timestamp: TimeInterval
+    var duration: TimeInterval
+    var characterRange: NSRange
+
+    init(timestamp: TimeInterval, duration: TimeInterval, characterRange: NSRange) {
+        self.timestamp = timestamp
+        self.duration = duration
+        self.characterRange = characterRange
+    }
+
+    func contains(timeInSeconds seconds: TimeInterval) -> Bool {
+        seconds >= timestamp && seconds <= (timestamp + duration)
     }
 }

--- a/podcasts/TranscriptSyncModel.swift
+++ b/podcasts/TranscriptSyncModel.swift
@@ -26,6 +26,7 @@ class TranscriptSyncModel {
         reference = ""
         matchedWords = []
         timestamps = []
+        previousWord = nil
     }
 
     // MARK: - Alignment algorithm

--- a/podcasts/TranscriptSyncModel.swift
+++ b/podcasts/TranscriptSyncModel.swift
@@ -199,7 +199,9 @@ class TranscriptSyncModel {
                     // Calculate the time difference between the next one and the current time
                     let difference = nextOne.timestamp - secondsValue
 
-                    if let previousWord {
+                    // Only highlight something if there was a previousWord
+                    // And if the time difference is less than a second
+                    if let previousWord, difference < 1.second {
                         let location = previousWord.characterRange.location + previousWord.characterRange.length
 
                         let nextOneLocation = nextOne.characterRange.location
@@ -208,7 +210,8 @@ class TranscriptSyncModel {
 
                         let test = reference[range]
 
-                        // Highlight whatever is in between
+                        // Highlight whatever is in between if it's bigger than 2 chars
+                        // This avoid highlighting breaklines and commas
                         if test.count > 2 {
                             return Word(timestamp: 0, duration: 0, characterRange: range)
                         }

--- a/podcasts/TranscriptSyncModel.swift
+++ b/podcasts/TranscriptSyncModel.swift
@@ -166,9 +166,6 @@ class TranscriptSyncModel {
             return (alignedSubtitle.reversed(), alignedTranscript.reversed(), alignedTimestamps.reversed())
         }
 
-        // We need to do A LOT of work in performance
-        // For testing purposed I limit the transcript to just 500 words
-        // otherwise the app crashes, becomes slow, etc etc
         let subtitle = String(reference)
         let transcript = words.map { $0.2 }
 

--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -478,9 +478,7 @@ class TranscriptViewController: PlayerItemViewController {
         if let word = syncModel.firstWord(containing: position) {
             transcriptView.attributedText = styleText(transcript: transcript, position: word.characterRange)
 
-            // adjusting the scroll to range so it shows more text
-            let scrollRange = NSRange(location: word.characterRange.location, length: word.characterRange.length)
-            transcriptView.scrollRangeToVisible(scrollRange)
+            transcriptView.scrollToRange(word.characterRange)
         }
     }
 

--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -285,6 +285,7 @@ class TranscriptViewController: PlayerItemViewController {
         resetKmp()
         resetSearch()
         loadTranscript()
+        syncModel.reset()
     }
 
     @objc private func closeTapped() {

--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -44,11 +44,18 @@ class TranscriptViewController: PlayerItemViewController {
         addObservers()
     }
 
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        PlaybackManager.shared.showingTranscript = true
+    }
+
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         parent?.view.overrideUserInterfaceStyle = .unspecified
         dismissSearch()
         resetSearch()
+        PlaybackManager.shared.showingTranscript = false
     }
 
     func didDisappear() {

--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -4,7 +4,11 @@ import PocketCastsUtils
 class TranscriptViewController: PlayerItemViewController {
 
     private let playbackManager: PlaybackManager
-    private var transcript: TranscriptModel?
+    private var transcript: TranscriptModel? {
+        didSet {
+            syncModel.reference = transcript?.attributedText.string ?? ""
+        }
+    }
     private var previousRange: NSRange?
 
     private var canScrollToDismiss = true
@@ -17,6 +21,8 @@ class TranscriptViewController: PlayerItemViewController {
     private let debounce = Debounce(delay: Constants.defaultDebounceTime)
 
     private var kmpSearch: KMPSearch?
+
+    private let syncModel: TranscriptSyncModel = .shared
 
     init(playbackManager: PlaybackManager) {
         self.playbackManager = playbackManager

--- a/podcasts/podcasts-Info.plist
+++ b/podcasts/podcasts-Info.plist
@@ -1030,6 +1030,8 @@
 	<string>Pocket Casts needs permission to save this image to your photo library.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Pocket Casts needs permission to save this image to your photo library.</string>
+	<key>NSSpeechRecognitionUsageDescription</key>
+	<string>Pocket Casts needs permission to transcribe audio that is playing to text.</string>
 	<key>NSUserActivityTypes</key>
 	<array>
 		<string>ChapterIntent</string>


### PR DESCRIPTION
| 📘 Part of: #1848  |
|:---:|

Fixes #2092 

This is the same as #2093, I just changed the solution slightly to be more simple.

This PR ensures that a new transcript is loaded we reset the transcript position to the beginning. 

## To test

 - Start the app
 - Ensure that you have `transcripts` and `newShowNotesEndpoint` FF enabled
 - Play an episode that as transcripts support. EX: "Cautionary Tales"
 - Add another episode with transcripts to be played in your UpNext Queue
 - Open the full screen player
 - Tap on transcripts option
 - Scroll around in the transcripts to the end of it
 - Await for the episode to get to the end and the new episode starts
 - Check that position is reset to the start.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
