### PR TITLE
Reimagine Sharing: Add analytics for sharing screen

### DIFF
--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -718,4 +718,10 @@ enum AnalyticsEvent: String {
 
     case widgetInstalled
     case widgetUninstalled
+
+    // MARK: - Share Screen
+    case shareScreenShown
+    case shareScreenPlayTapped
+    case shareScreenPauseTapped
+    case shareScreenClipShared
 }

--- a/podcasts/Bookmarks/Episode/BookmarkEpisodeListController.swift
+++ b/podcasts/Bookmarks/Episode/BookmarkEpisodeListController.swift
@@ -60,6 +60,8 @@ extension BookmarkEpisodeListController: BookmarkListRouter {
         }
         let controller = SharingHelper.shared.createActivityController(episode: episode, shareTime: bookmark.time)
 
+        Analytics.track(.podcastShared, source: "multi_select", properties: ["type": "bookmark_time"])
+
         present(controller, animated: true)
     }
 

--- a/podcasts/EpisodeDetailViewController.swift
+++ b/podcasts/EpisodeDetailViewController.swift
@@ -450,7 +450,7 @@ class EpisodeDetailViewController: FakeNavViewController, UIDocumentInteractionC
 
     @objc private func shareTapped(_ sender: UIButton) {
         guard FeatureFlag.newSharing.enabled == false else {
-            SharingModal.showModal(episode: episode, in: self)
+            SharingModal.showModal(episode: episode, from: analyticsSource, in: self)
             return
         }
 

--- a/podcasts/NowPlayingPlayerItemViewController+Shelf.swift
+++ b/podcasts/NowPlayingPlayerItemViewController+Shelf.swift
@@ -402,7 +402,7 @@ extension NowPlayingPlayerItemViewController: NowPlayingActionsDelegate {
         guard let episode = PlaybackManager.shared.currentEpisode() as? Episode else { return }
 
         guard FeatureFlag.newSharing.enabled == false else {
-            SharingModal.showModal(episode: episode, in: self)
+            SharingModal.showModal(episode: episode, from: analyticsSource, in: self)
             return
         }
 
@@ -435,9 +435,9 @@ extension NowPlayingPlayerItemViewController: NowPlayingActionsDelegate {
 
         if FeatureFlag.newSharing.enabled {
             if fromTime == 0 {
-                SharingModal.show(option: .episode(episode), in: self)
+                SharingModal.show(option: .episode(episode), from: analyticsSource, in: self)
             } else {
-                SharingModal.show(option: .currentPosition(episode, fromTime), in: self)
+                SharingModal.show(option: .currentPosition(episode, fromTime), from: analyticsSource, in: self)
             }
         } else {
             let sourceRect = buttonSuperview.convert(source.frame, to: view)
@@ -450,10 +450,10 @@ extension NowPlayingPlayerItemViewController: NowPlayingActionsDelegate {
 
         Analytics.track(.podcastShared, properties: ["type": "podcast", "source": "player"])
         if FeatureFlag.newSharing.enabled {
-            SharingModal.show(option: .podcast(podcast), in: self)
+            SharingModal.show(option: .podcast(podcast), from: analyticsSource, in: self)
         } else {
             let sourceRect = buttonSuperview.convert(source.frame, to: view)
-            SharingHelper.shared.shareLinkTo(podcast: podcast, fromController: self, sourceRect: sourceRect, sourceView: view)
+            SharingHelper.shared.shareLinkTo(podcast: podcast, fromController: self, fromSource: analyticsSource, sourceRect: sourceRect, sourceView: view)
         }
     }
 

--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -440,7 +440,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
         guard let podcast = podcast else { return }
 
         let sourceRect = sender.superview!.convert(sender.frame, to: view)
-        SharingHelper.shared.shareLinkTo(podcast: podcast, fromController: self, sourceRect: sourceRect, sourceView: view)
+        SharingHelper.shared.shareLinkTo(podcast: podcast, fromController: self, fromSource: analyticsSource, sourceRect: sourceRect, sourceView: view)
         Analytics.track(.podcastScreenShareTapped)
         Analytics.track(.podcastShared, properties: ["type": "podcast", "source": analyticsSource])
     }

--- a/podcasts/Sharing/Clip/MediaTrimBar.swift
+++ b/podcasts/Sharing/Clip/MediaTrimBar.swift
@@ -49,7 +49,7 @@ struct MediaTrimBar: View {
                     } else {
                         playbackManager.stop()
                     }
-                    let event: AnalyticsEvent = isPlaying ? .shareScreenPauseTapped : .shareScreenPlayTapped
+                    let event: AnalyticsEvent = isPlaying ? .shareScreenPlayTapped : .shareScreenPauseTapped
                     Analytics.track(event, source: analyticsSource, properties: ["podcast_uuid": episode.parentIdentifier(), "episode_uuid": episode.uuid, "clip_uuid": clipUUID])
                 }
                 .onDisappear {

--- a/podcasts/Sharing/Clip/MediaTrimBar.swift
+++ b/podcasts/Sharing/Clip/MediaTrimBar.swift
@@ -4,9 +4,11 @@ import PocketCastsDataModel
 struct MediaTrimBar: View {
     @ObservedObject var clipTime: ClipTime
 
-    let episode: any BaseEpisode
     @State var isPlaying: Bool = false
 
+    let episode: Episode
+    let clipUUID: String
+    let analyticsSource: AnalyticsSource
     private let playbackManager = ClipPlaybackManager.shared
 
     private enum Constants {
@@ -15,10 +17,12 @@ struct MediaTrimBar: View {
         static var height: CGFloat = 70
     }
 
-    init(clipTime: ClipTime, episode: any BaseEpisode) {
+    init(clipTime: ClipTime, episode: Episode, clipUUID: String, analyticsSource: AnalyticsSource) {
         self.clipTime = clipTime
         self.episode = episode
+        self.clipUUID = clipUUID
         self.isPlaying = false
+        self.analyticsSource = analyticsSource
     }
 
     var body: some View {
@@ -45,6 +49,8 @@ struct MediaTrimBar: View {
                     } else {
                         playbackManager.stop()
                     }
+                    let event: AnalyticsEvent = isPlaying ? .shareScreenPauseTapped : .shareScreenPlayTapped
+                    Analytics.track(event, source: analyticsSource, properties: ["podcast_uuid": episode.parentIdentifier(), "episode_uuid": episode.uuid, "clip_uuid": clipUUID])
                 }
                 .onDisappear {
                     playbackManager.stop()

--- a/podcasts/Sharing/ShareDestination.swift
+++ b/podcasts/Sharing/ShareDestination.swift
@@ -8,7 +8,7 @@ enum ShareDestination: Hashable {
     var name: String {
         switch self {
         case .instagram:
-            "Stories"
+            L10n.shareInstagramStories
         case .copyLink:
             L10n.shareCopyLink
         case .systemSheet:

--- a/podcasts/Sharing/ShareDestination.swift
+++ b/podcasts/Sharing/ShareDestination.swift
@@ -9,6 +9,11 @@ struct ShareDestination: Hashable {
         static let displayedAppsCount = 3
     }
 
+    enum Media {
+        case media
+        case link
+    }
+
     static func ==(lhs: ShareDestination, rhs: ShareDestination) -> Bool {
         lhs.name == rhs.name && lhs.icon == rhs.icon
     }

--- a/podcasts/Sharing/ShareDestination.swift
+++ b/podcasts/Sharing/ShareDestination.swift
@@ -1,53 +1,44 @@
 import SwiftUI
 
-struct ShareDestination: Hashable {
-    let name: String
-    let icon: Image
-    let action: (SharingModal.Option, ShareImageStyle) -> Void
+enum ShareDestination: Hashable {
+    case instagram
+    case copyLink
+    case systemSheet(vc: UIViewController)
 
-    enum Constants {
-        static let displayedAppsCount = 3
-    }
-
-    enum Media {
-        case media
-        case link
-    }
-
-    static func ==(lhs: ShareDestination, rhs: ShareDestination) -> Bool {
-        lhs.name == rhs.name && lhs.icon == rhs.icon
-    }
-
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(name)
-    }
-
-    enum Destination: CaseIterable {
-        case instagram
-
-        var name: String {
-            switch self {
-            case .instagram:
-                "Stories"
-            }
+    var name: String {
+        switch self {
+        case .instagram:
+            "Stories"
+        case .copyLink:
+            L10n.shareCopyLink
+        case .systemSheet:
+            L10n.shareMoreActions
         }
+    }
 
-        var icon: Image {
-            switch self {
-            case .instagram:
-                Image("instagram")
-            }
+    var icon: Image {
+        switch self {
+        case .instagram:
+            Image("instagram")
+        case .copyLink:
+            Image("pocketcasts")
+        case .systemSheet:
+            Image(systemName: "ellipsis")
         }
+    }
 
-        enum ShareError: Error {
-            case noMatchingItemIdentifier
-            case loadFailed(Error?)
-        }
+    enum ShareError: Error {
+        case noMatchingItemIdentifier
+        case loadFailed(Error?)
+    }
 
-        func share(_ option: SharingModal.Option, style: ShareImageStyle) async throws {
-            let item: (Data, UTType)? = await option.shareData(style: style, destination: self).mapFirst { shareItem in
+    @MainActor
+    func share(_ option: SharingModal.Option, style: ShareImageStyle, clipUUID: String, source: AnalyticsSource) async throws {
+        switch self {
+        case .instagram:
+            let item = option.shareData(style: style, destination: self).mapFirst { shareItem -> (Data, UTType)? in
                 if let data = shareItem as? Data {
-                    return (data, style == .audio ? .m4a : .mpeg4Movie)
+                    return (data, style == .audio ? UTType.m4a : .mpeg4Movie)
                 } else if let image = shareItem as? UIImage, let data = image.pngData() {
                     return (data, .png)
                 } else {
@@ -59,83 +50,175 @@ struct ShareDestination: Hashable {
                 throw ShareError.noMatchingItemIdentifier
             }
 
-            switch self {
-            case .instagram:
-                await instagramShare(data: item.0, type: item.1, url: option.shareURL)
+            instagramShare(data: item.0, type: item.1, url: option.shareURL)
+            ShareDestination.logClipShared(option: option, style: style, clipUUID: clipUUID, source: source)
+            ShareDestination.logPodcastShared(style: style, option: option, destination: self, source: source)
+        case .copyLink:
+            UIPasteboard.general.string = option.shareURL
+            Toast.show(L10n.shareCopiedToClipboard)
+            ShareDestination.logClipShared(option: option, style: style, clipUUID: clipUUID, source: source)
+            ShareDestination.logPodcastShared(style: style, option: option, destination: self, source: source)
+        case .systemSheet(let vc):
+            let data = option.shareData(style: style)
+            let activityViewController = UIActivityViewController(activityItems: data, applicationActivities: nil)
+            vc.presentedViewController?.present(activityViewController, animated: true, completion: {
+                ShareDestination.logClipShared(option: option, style: style, clipUUID: clipUUID, source: source)
+                ShareDestination.logPodcastShared(style: style, option: option, destination: self, source: source)
+            })
+        }
+    }
+
+    @MainActor
+    static fileprivate func shareImage(_ option: SharingModal.Option, style: ShareImageStyle) -> UIImage {
+        let imageView = ShareImageView(info: option.imageInfo, style: style, angle: .constant(0))
+        return imageView.snapshot()
+    }
+
+    @MainActor
+    private func instagramShare(data: Data, type: UTType, url: String) {
+        let attributionURL = url
+        let appID = ApiCredentials.instagramAppID
+
+        guard let urlScheme = URL(string: "instagram-stories://share?source_application=\(appID)"),
+            UIApplication.shared.canOpenURL(urlScheme) else {
+            return
+        }
+
+        let dataKey = type == .mpeg4Movie ? "com.instagram.sharedSticker.backgroundVideo" : "com.instagram.sharedSticker.backgroundImage"
+        let pasteboardItems = [[dataKey: data,
+                                "com.instagram.sharedSticker.contentURL": attributionURL]]
+        let pasteboardOptions: [UIPasteboard.OptionsKey: Any] = [.expirationDate: Date().addingTimeInterval(5.minutes)]
+
+        UIPasteboard.general.setItems(pasteboardItems, options: pasteboardOptions)
+
+        UIApplication.shared.open(urlScheme)
+    }
+
+    var isIncluded: Bool {
+        switch self {
+        case .instagram:
+            if let url = URL(string: "instagram-stories://share"), UIApplication.shared.canOpenURL(url) {
+                true
+            } else {
+                false
             }
+        default:
+            true
         }
+    }
 
-        @MainActor
-        static fileprivate func shareImage(_ option: SharingModal.Option, style: ShareImageStyle) -> UIImage {
-            let imageView = ShareImageView(info: option.imageInfo, style: style, angle: .constant(0))
-            return imageView.snapshot()
+    var analyticsDescription: String {
+        switch self {
+        case .instagram:
+            "ig_story"
+        case .copyLink:
+            "url"
+        case .systemSheet:
+            "system_sheet"
         }
+    }
 
-        @MainActor
-        private func instagramShare(data: Data, type: UTType, url: String) {
-            let attributionURL = url
-            let appID = ApiCredentials.instagramAppID
+    enum Constants {
+        static let displayedAppsCount = 3
+    }
 
-            guard let urlScheme = URL(string: "instagram-stories://share?source_application=\(appID)"),
-                UIApplication.shared.canOpenURL(urlScheme) else {
-                return
-            }
+    static func ==(lhs: ShareDestination, rhs: ShareDestination) -> Bool {
+        lhs.name == rhs.name && lhs.icon == rhs.icon
+    }
 
-            let dataKey = type == .mpeg4Movie ? "com.instagram.sharedSticker.backgroundVideo" : "com.instagram.sharedSticker.backgroundImage"
-            let pasteboardItems = [[dataKey: data,
-                                    "com.instagram.sharedSticker.contentURL": attributionURL]]
-            let pasteboardOptions: [UIPasteboard.OptionsKey: Any] = [.expirationDate: Date().addingTimeInterval(5.minutes)]
-
-            UIPasteboard.general.setItems(pasteboardItems, options: pasteboardOptions)
-
-            UIApplication.shared.open(urlScheme)
-        }
-
-        var isIncluded: Bool {
-            switch self {
-            case .instagram:
-                if let url = URL(string: "instagram-stories://share"), UIApplication.shared.canOpenURL(url) {
-                    return true
-                } else {
-                    return false
-                }
-            default:
-                return true
-            }
-        }
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(name)
     }
 
     static var displayedApps: Array<ShareDestination>.SubSequence {
         apps.prefix(Constants.displayedAppsCount)
     }
 
-    private static var apps: [ShareDestination] {
-        return Destination.allCases.compactMap({ destination in
+    private static var apps: [Self] {
+        let thirdPartyApps: [Self] = [.instagram]
+        return thirdPartyApps.compactMap({ destination -> Self? in
             guard destination.isIncluded else { return nil }
-            return ShareDestination(name: destination.name, icon: destination.icon, action: { option, style in
-                Task.detached {
-                    try await destination.share(option, style: style)
-                }
-            })
+            return destination
         })
     }
+}
 
-    static func moreOption(vc: UIViewController) -> ShareDestination {
-        let icon = Image(systemName: "ellipsis")
+// MARK: Analytics
 
-        return ShareDestination(name: L10n.shareMoreActions, icon: icon, action: { option, style in
-            Task.detached {
-                let data = await option.shareData(style: style)
-                let activityViewController = await UIActivityViewController(activityItems: data, applicationActivities: nil)
-                await vc.presentedViewController?.present(activityViewController, animated: true, completion: nil)
+extension ShareDestination {
+    private static func logClipShared(option: SharingModal.Option, style: ShareImageStyle, clipUUID: String, source: AnalyticsSource) {
+        // This event is specifically for clip shares and not other shares. These are handled by `podcastShared`
+        guard case let .clipShare(episode, clipTime, _, _) = option else {
+            return
+        }
+
+        var properties: Dictionary<String, Any> = [:]
+
+        properties["episode_uuid"] = episode.uuid
+        properties["podcast_uuid"] = episode.parentPodcast()?.uuid ?? "unknown"
+        properties["start"] = Int(clipTime.start)
+        properties["end"] = Int(clipTime.end)
+        properties["start_modified"] = clipTime.startChanged
+        properties["end_modified"] = clipTime.endChanged
+        properties["clip_uuid"] = clipUUID
+        properties["type"] = shareType(style: style, option: option)
+        properties["card_type"] = cardType(style: style)
+
+        Analytics.track(.shareScreenClipShared, source: source, properties: properties)
+    }
+
+    private static func cardType(style: ShareImageStyle) -> String {
+        switch style {
+        case .large:
+            "vertical"
+        case .medium:
+            "square"
+        case .small:
+            "horizontal"
+        case .audio:
+            "audio"
+        }
+    }
+
+    private static func shareType(style: ShareImageStyle, option: SharingModal.Option) -> String {
+        switch (style, option) {
+        case (.audio, _):
+            "audio"
+        case (_, .clip), (_, .clipShare):
+            "video"
+        default:
+            "link"
+        }
+    }
+
+    private static func type(style: ShareImageStyle, option: SharingModal.Option, destination: Self) -> String {
+        switch (style, option) {
+        case (_, .podcast):
+            return "podcast"
+        case (_, .episode):
+            return "episode"
+        case (_, .currentPosition):
+            return "current_time"
+        case (.audio, _):
+            return "clip_audio"
+        case (_, .clip), (_, .clipShare):
+            if case .copyLink = destination {
+                return "clip_link"
+            } else {
+                return "clip_video"
             }
-        })
+        default:
+            return "unknown"
+        }
     }
 
-    static var copyLinkOption: ShareDestination {
-        return ShareDestination(name: L10n.shareCopyLink, icon: Image("pocketcasts"), action: { option, _ in
-            UIPasteboard.general.string = option.shareURL
-            Toast.show(L10n.shareCopiedToClipboard)
-        })
+    private static func logPodcastShared(style: ShareImageStyle, option: SharingModal.Option, destination: Self, source: AnalyticsSource) {
+        let properties: [String: Any] = [
+            "type": type(style: style, option: option, destination: destination),
+            "action": destination.analyticsDescription,
+            "card_type": cardType(style: style)
+        ]
+
+        Analytics.track(.podcastShared, source: source, properties: properties)
     }
 }

--- a/podcasts/Sharing/SharingFooterView.swift
+++ b/podcasts/Sharing/SharingFooterView.swift
@@ -9,6 +9,8 @@ struct SharingFooterView: View {
 
     let destinations: [ShareDestination]
     let style: ShareImageStyle
+    let clipUUID: String
+    let source: AnalyticsSource
 
     @EnvironmentObject var theme: Theme
 
@@ -18,7 +20,7 @@ struct SharingFooterView: View {
             buttons
         case .clip(let episode, _):
             VStack(spacing: 12) {
-                MediaTrimBar(clipTime: clipTime, episode: episode)
+                MediaTrimBar(clipTime: clipTime, episode: episode, clipUUID: clipUUID, analyticsSource: source)
                     .frame(height: 72)
                     .tint(color)
                 HStack {

--- a/podcasts/Sharing/SharingFooterView.swift
+++ b/podcasts/Sharing/SharingFooterView.swift
@@ -57,14 +57,16 @@ struct SharingFooterView: View {
     @ViewBuilder var buttons: some View {
         HStack(spacing: 24) {
             ForEach(destinations, id: \.self) { destination in
-                button(destination: destination, style: style, action: destination.action)
+                button(destination: destination, style: style, clipUUID: clipUUID, source: source)
             }
         }
     }
 
-    @ViewBuilder func button(destination: ShareDestination, style: ShareImageStyle, action: @escaping ((SharingModal.Option, ShareImageStyle) -> Void)) -> some View {
+    @ViewBuilder func button(destination: ShareDestination, style: ShareImageStyle, clipUUID: String, source: AnalyticsSource) -> some View {
         Button {
-            action(option, style)
+            Task.detached {
+                try await destination.share(option, style: style, clipUUID: clipUUID, source: source)
+            }
         } label: {
             view(for: destination)
         }

--- a/podcasts/Sharing/SharingModal.swift
+++ b/podcasts/Sharing/SharingModal.swift
@@ -61,15 +61,15 @@ enum SharingModal {
         }
     }
 
-    static func showModal(episode: Episode, in viewController: UIViewController) {
+    static func showModal(episode: Episode, from source: AnalyticsSource, in viewController: UIViewController) {
         guard let podcast = episode.parentPodcast() else {
             assertionFailure("Podcast should exist for episode")
             return
         }
-        showModal(podcast: podcast, episode: episode, in: viewController)
+        showModal(podcast: podcast, episode: episode, from: source, in: viewController)
     }
 
-    static func showModal(podcast: Podcast, episode: Episode?, in viewController: UIViewController) {
+    static func showModal(podcast: Podcast, episode: Episode?, from source: AnalyticsSource, in viewController: UIViewController) {
         let colors = OptionsPickerRootController.Colors(title: UIColor.white.withAlphaComponent(0.5), background: PlayerColorHelper.playerBackgroundColor01())
 
         let optionPicker = OptionsPicker(title: L10n.share.uppercased(), themeOverride: .dark, colors: colors)
@@ -83,7 +83,7 @@ enum SharingModal {
 
         let actions: [OptionAction] = Option.allCases(episode: episode, podcast: podcast, currentTime: timeInterval).map { option in
                 .init(label: option.buttonTitle, action: {
-                show(option: option, in: viewController)
+                    show(option: option, from: source, in: viewController)
             })
         }
         optionPicker.addActions(actions)
@@ -96,9 +96,9 @@ enum SharingModal {
         optionPicker.show(statusBarStyle: AppTheme.defaultStatusBarStyle())
     }
 
-    static func show(option: Option, in viewController: UIViewController) {
+    static func show(option: Option, from source: AnalyticsSource, in viewController: UIViewController) {
         let sharingDestinations: [ShareDestination] = ShareDestination.displayedApps + [.copyLinkOption, .moreOption(vc: viewController)]
-        let sharingView = SharingView(destinations: sharingDestinations, selectedOption: option)
+        let sharingView = SharingView(destinations: sharingDestinations, selectedOption: option, source: source)
         let modalView = ModalView {
             sharingView
         } dismissAction: {

--- a/podcasts/Sharing/SharingModal.swift
+++ b/podcasts/Sharing/SharingModal.swift
@@ -97,7 +97,7 @@ enum SharingModal {
     }
 
     static func show(option: Option, from source: AnalyticsSource, in viewController: UIViewController) {
-        let sharingDestinations: [ShareDestination] = ShareDestination.displayedApps + [.copyLinkOption, .moreOption(vc: viewController)]
+        let sharingDestinations: [ShareDestination] = ShareDestination.displayedApps + [.copyLink, .systemSheet(vc: viewController)]
         let sharingView = SharingView(destinations: sharingDestinations, selectedOption: option, source: source)
         let modalView = ModalView {
             sharingView
@@ -168,14 +168,14 @@ extension SharingModal.Option {
     }
 
     @MainActor
-    func shareData(style: ShareImageStyle, destination: ShareDestination.Destination? = nil) -> [Any] {
+    func shareData(style: ShareImageStyle, destination: ShareDestination? = nil) -> [Any] {
         let url = URL(string: shareURL) as NSURL?
         let media = mediaData(style: style, destination: destination)
         return [url, media].compactMap({ $0 })
     }
 
     @MainActor
-    func mediaData(style: ShareImageStyle, destination: ShareDestination.Destination?) -> Any? {
+    func mediaData(style: ShareImageStyle, destination: ShareDestination?) -> Any? {
         switch self {
         case .clipShare(_, _, _, let progress):
             // Share video/audio clip. If sending to instagram or audio, send full file, otherwise send cropped version.

--- a/podcasts/Sharing/SharingView.swift
+++ b/podcasts/Sharing/SharingView.swift
@@ -180,52 +180,6 @@ struct SharingView: View {
             .scaleEffect((containerHeight - Constants.tabViewPadding) / ShareImageStyle.large.previewSize.height)
 	}
 
-    private func logShareAction(option: SharingModal.Option, style: ShareImageStyle) {
-        var properties: Dictionary<String, Any> = [:]
-
-        switch option {
-        case .clip(let episode, _):
-            properties["episode_uuid"] = episode.uuid
-        case .clipShare(let episode, let clipTime, _, _):
-            properties["episode_uuid"] = episode.uuid
-            properties["start"] = Int(clipTime.start)
-            properties["end"] = Int(clipTime.end)
-            properties["start_modified"] = clipTime.startChanged
-            properties["end_modified"] = clipTime.endChanged
-        case .episode(let episode):
-            properties["episode_uuid"] = episode.uuid
-        case .podcast(let podcast):
-            properties["podcast_uuid"] = podcast.uuid
-        case .currentPosition(let episode, _):
-            properties["episode_uuid"] = episode.uuid
-        }
-        properties["clip_uuid"] = clipUUID
-
-        switch style {
-        case .large:
-            properties["card_type"] = "vertical"
-        case .medium:
-            properties["card_type"] = "square"
-        case .small:
-            properties["card_type"] = "horizontal"
-        case .audio:
-            properties["card_type"] = "audio"
-        }
-
-        let shareType: String
-        switch (style, option) {
-        case (.audio, _):
-            shareType = "audio"
-        case (_, .clip), (_, .clipShare):
-            shareType = "video"
-        default:
-            shareType = "link"
-        }
-        properties["type"] = shareType
-
-        Analytics.track(.shareScreenClipShared, source: source, properties: properties)
-    }
-
     private func shareItems(style: ShareImageStyle) -> [Shareable] {
         var media = shareable
         media.shareType = style == .audio ? .audio : .video
@@ -305,6 +259,6 @@ struct SharingView: View {
 }
 
 #Preview {
-    SharingView(destinations: [.copyLinkOption], selectedOption: .podcast(Podcast.previewPodcast()), source: .player)
+    SharingView(destinations: [.copyLink], selectedOption: .podcast(Podcast.previewPodcast()), source: .player)
         .background(Color.black)
 }

--- a/podcasts/SharingHelper.swift
+++ b/podcasts/SharingHelper.swift
@@ -6,11 +6,11 @@ import PocketCastsUtils
 class SharingHelper: NSObject {
     static let shared = SharingHelper()
     var activityController: UIActivityViewController?
-    func shareLinkTo(podcast: Podcast, fromController: UIViewController, sourceRect: CGRect, sourceView: UIView) {
+    func shareLinkTo(podcast: Podcast, fromController: UIViewController, fromSource: AnalyticsSource, sourceRect: CGRect, sourceView: UIView) {
         AnalyticsHelper.sharedPodcast()
 
         if FeatureFlag.newSharing.enabled {
-            SharingModal.show(option: .podcast(podcast), in: fromController)
+            SharingModal.show(option: .podcast(podcast), from: fromSource, in: fromController)
         } else {
             let sharingUrl = podcast.shareURL
             activityController = UIActivityViewController(activityItems: [URL(string: sharingUrl)!], applicationActivities: nil)
@@ -48,11 +48,11 @@ class SharingHelper: NSObject {
         activityController.popoverPresentationController?.sourceRect = CGRect(x: fromController.view.bounds.midX, y: fromController.view.bounds.midY, width: 44, height: 44)
     }
 
-    func shareLinkTo(podcast: Podcast, fromController: UIViewController, barButtonItem: UIBarButtonItem?) {
+    func shareLinkTo(podcast: Podcast, fromController: UIViewController, fromSource: AnalyticsSource, barButtonItem: UIBarButtonItem?) {
         AnalyticsHelper.sharedPodcast()
 
         if FeatureFlag.newSharing.enabled {
-            SharingModal.show(option: .podcast(podcast), in: fromController)
+            SharingModal.show(option: .podcast(podcast), from: fromSource, in: fromController)
         } else {
             let sharingUrl = podcast.shareURL
             activityController = UIActivityViewController(activityItems: [URL(string: sharingUrl)!], applicationActivities: nil)
@@ -86,9 +86,9 @@ class SharingHelper: NSObject {
         activityController.popoverPresentationController?.barButtonItem = barButtonItem
     }
 
-    func shareLinkTo(episode: Episode, shareTime: TimeInterval, fromController: UIViewController, barButtonItem: UIBarButtonItem?) {
+    func shareLinkTo(episode: Episode, shareTime: TimeInterval, fromController: UIViewController, fromSource: AnalyticsSource, barButtonItem: UIBarButtonItem?) {
         guard FeatureFlag.newSharing.enabled == false else {
-            SharingModal.show(option: .episode(episode), in: fromController)
+            SharingModal.show(option: .episode(episode), from: fromSource, in: fromController)
             return
         }
 

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -2846,6 +2846,8 @@ internal enum L10n {
   }
   /// Share episode
   internal static var shareEpisodeTitle: String { return L10n.tr("Localizable", "share_episode_title") }
+  /// Stories
+  internal static var shareInstagramStories: String { return L10n.tr("Localizable", "share_instagram_stories") }
   /// Subscribing...
   internal static var shareListSubscribing: String { return L10n.tr("Localizable", "share_list_subscribing") }
   /// More

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4178,6 +4178,9 @@
 /* A title shown for a share option which copies a link to a podcast or episode */
 "share_copy_link" = "Copy link";
 
+/* A button title shown for a share option which shares a image or video clip to Instagram Stories */
+"share_instagram_stories" = "Stories";
+
 /* A common string used throughout the app. Often refers to the Transcript tab in the player. */
 "transcript" = "Transcript";
 


### PR DESCRIPTION
| 📘 Part of: #1910 |
|:---:|

Adds sharing events for the new sharing and clips screen:

* Adds the following events for the new sharing screen:
`share_screen_shown`
`share_screen_play_tapped`
`share_screen_pause_tapped`
`share_screen_clip_shared`

* Modifies the `podcast_shared` event to include new properties for Reimagine Sharing
* Adds `podcast_shared` event when sharing episode file

## To test

> [!NOTE]
> Enable the `newSharing` and `tracksLogging` feature flag to test this

### Clip Sharing

* Navigate to the Now Playing screen
* Tap the "Share" button in the action shelf
* Tap the "Clip" option
* Verify that the `share_screen_shown` event is logged
```
🔵 Tracked: share_screen_shown ["episode_uuid": "b4fe3410-ffeb-4d4c-b58a-d20265154a4a", "clip_uuid": "CE31E9A4-0476-488F-A5C2-37DD794E98B4", "source": "player", "type": "clip"]
```
* Tap the play button
* Verify that the `share_screen_play_tapped` event is logged
```
🔵 Tracked: share_screen_play_tapped ["podcast_uuid": "e70322a0-32fd-013d-1901-0acc26574db2", "episode_uuid": "b4fe3410-ffeb-4d4c-b58a-d20265154a4a", "source": "player", "clip_uuid": "3FDCC59D-E1D5-477F-9A42-9A0C0C62283B"]
```
* Tap the pause button
* Verify that the `share_screen_pause_tapped` event is logged
```
🔵 Tracked: share_screen_pause_tapped ["episode_uuid": "b4fe3410-ffeb-4d4c-b58a-d20265154a4a", "podcast_uuid": "e70322a0-32fd-013d-1901-0acc26574db2", "source": "player", "clip_uuid": "3FDCC59D-E1D5-477F-9A42-9A0C0C62283B"]
```
* Create the clip
* Tap the "Copy Link" button in the footer
* Verify that the `share_screen_clip_shared` event is logged:
```
🔵 Tracked: share_screen_clip_shared ["card_type": "vertical", "podcast_uuid": "e70322a0-32fd-013d-1901-0acc26574db2", "clip_uuid": "CE31E9A4-0476-488F-A5C2-37DD794E98B4", "end_modified": false, "episode_uuid": "b4fe3410-ffeb-4d4c-b58a-d20265154a4a", "type": "video", "source": "player", "end": 544, "start_modified": false, "start": 484]
```
* Verify that the `podcast_shared` event is logged with the `type: "clip_link"` and `action: "url"`:
```
🔵 Tracked: podcast_shared ["action": "url", "type": "clip_link", "source": "player", "card_type": "vertical"]
```
* Tap the "More" button
* Verify that the `share_screen_clip_shared` event is logged with the `type: "video"`
```
🔵 Tracked: share_screen_clip_shared ["type": "video", "episode_uuid": "b4fe3410-ffeb-4d4c-b58a-d20265154a4a", "start": 484, "source": "player", "start_modified": false, "clip_uuid": "3FDCC59D-E1D5-477F-9A42-9A0C0C62283B", "end": 544, "end_modified": false, "card_type": "horizontal"]
```
* Verify that the `podcast_shared` event is logged with the `type: "clip_video"` and `action: "system_sheet"`:
```
🔵 Tracked: podcast_shared ["action": "system_sheet", "source": "player", "type": "clip_video", "card_type": "vertical"]
```

### Clip Sharing Modifications

* Edit the clip and modify the start/end points
* Create the clip
* Tap the "Copy Link" button in the footer
* Verify that the `share_screen_clip_shared` event is logged and that `start_modified` or `end_modified` have been set as expected:
```
🔵 Tracked: share_screen_clip_shared ["clip_uuid": "CE31E9A4-0476-488F-A5C2-37DD794E98B4", "episode_uuid": "b4fe3410-ffeb-4d4c-b58a-d20265154a4a", "end": 544, "source": "player", "start": 458, "type": "video", "card_type": "vertical", "start_modified": true, "podcast_uuid": "e70322a0-32fd-013d-1901-0acc26574db2", "end_modified": false]
```

### Episode

* Navigate to the Play screen
* Tap the "Share" button in the action shelf
* Tap the "Episode" option
* Verify that the `share_screen_shown` event is logged with the `episode` type
```
🔵 Tracked: share_screen_shown ["clip_uuid": "CE8ED09D-13E1-4205-A4F4-678D25B8CAC2", "type": "episode", "source": "player", "episode_uuid": "b4fe3410-ffeb-4d4c-b58a-d20265154a4a"]
```
* Tap "Copy Link"
* Verify that the `podcast_shared` event is logged with `type: "episode"` and `action: "url"`
```
🔵 Tracked: podcast_shared ["source": "player", "type": "episode", "card_type": "vertical", "action": "url"]
```

### Podcast

* Navigate to the Play screen
* Tap the "Share" button in the action shelf
* Tap the "Podcast" option
* Verify that the `share_screen_shown` event is logged with the `podcast` type
```
🔵 Tracked: share_screen_shown ["type": "podcast", "clip_uuid": "06DB1217-4A90-4B6B-8295-93F1000060D8", "source": "player", "podcast_uuid": "e70322a0-32fd-013d-1901-0acc26574db2"]
```
* Tap "Copy Link"
* Verify that the `podcast_shared` event is logged with `type: "podcast"` and `action: "url"`
```
🔵 Tracked: podcast_shared ["action": "url", "card_type": "vertical", "type": "podcast", "source": "player"]
```

### Current Position

* Navigate to the Play screen
* Tap the "Share" button in the action shelf
* Tap the "Current Position" option
* Verify that the `share_screen_shown` event is logged with the `type: "episode_timestamp"`
```
🔵 Tracked: share_screen_shown ["episode_uuid": "b4fe3410-ffeb-4d4c-b58a-d20265154a4a", "type": "episode_timestamp", "source": "player", "clip_uuid": "E4C7086B-7F9E-412F-BB44-695D6BB34F54"]
```
* Tap "Copy Link"
* Verify that the `podcast_shared` event is logged with `type: "current_time"` and `action: "url"`
```
🔵 Tracked: podcast_shared ["card_type": "vertical", "action": "url", "type": "current_time", "source": "player"]
```
* Tap "More"
* Verify that the `podcast_shared` event is logged with `type: "current_time"` and `action: "system_sheet"`
```
🔵 Tracked: podcast_shared ["type": "current_time", "source": "player", "action": "system_sheet", "card_type": "vertical"]
```

### Episode File

* Download an episode
* Navigate to the episode's detail page
* Tap the Share button in the upper right
* Tap "Open File in..."
* Verify that the `podcast_shared` event is logged with the `type: "episode_file"` event is logged
```
🔵 Tracked: podcast_shared ["source": "episode_detail", "type": "episode_file"]
```

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
