### PR TITLE
Widgets: track interaction

### DIFF
--- a/WidgetExtension/Now Playing/NowPlayingEntryView.swift
+++ b/WidgetExtension/Now Playing/NowPlayingEntryView.swift
@@ -204,7 +204,7 @@ struct NowPlayingWidgetEntryView: View {
             }
             .padding(16)
         }
-        .widgetURL(URL(string: "pktc://discover"))
+        .widgetURL(URL(string: "pktc://discover?source=widget"))
         .clearBackground()
         .if(!showsWidgetBackground) { view in
             view
@@ -246,7 +246,7 @@ struct NowPlayingWidgetEntryView: View {
             }
             nothingPlayingText
         }
-        .widgetURL(URL(string: "pktc://discover"))
+        .widgetURL(URL(string: "pktc://discover?source=widget"))
         .clearBackground()
         .if(!showsWidgetBackground) { view in
             view

--- a/WidgetExtension/Now Playing/NowPlayingLockScreenWidget.swift
+++ b/WidgetExtension/Now Playing/NowPlayingLockScreenWidget.swift
@@ -32,7 +32,7 @@ struct NowPlayingLockscreenWidgetEntryView: View {
     }
 
     var widgetURL: String {
-        return entry.episode != nil ? "pktc://show_player" : "pktc://discover"
+        return entry.episode != nil ? "pktc://show_player" : "pktc://discover?source=widget"
     }
 
     var body: some View {

--- a/WidgetExtension/Up Next/HungryForMoreView.swift
+++ b/WidgetExtension/Up Next/HungryForMoreView.swift
@@ -5,7 +5,7 @@ struct HungryForMoreView: View {
     @Environment(\.widgetColorScheme) var colorScheme
 
     var body: some View {
-        Link(destination: URL(string: "pktc://discover")!) {
+        Link(destination: URL(string: "pktc://discover?source=widget")!) {
             VStack(alignment: .center, spacing: 3) {
                 Text(L10n.widgetsDiscoverPromptTitle)
                     .font(.footnote)
@@ -25,7 +25,7 @@ struct HungryForMoreLargeView: View {
     @Environment(\.widgetColorScheme) var colorScheme
 
     var body: some View {
-        Link(destination: URL(string: "pktc://discover")!) {
+        Link(destination: URL(string: "pktc://discover?source=widget")!) {
             VStack(alignment: .center, spacing: 4) {
                 Text(L10n.widgetsDiscoverPromptTitle)
                     .font(.footnote)

--- a/WidgetExtension/Up Next/UpNextLockScreenWidget.swift
+++ b/WidgetExtension/Up Next/UpNextLockScreenWidget.swift
@@ -100,7 +100,7 @@ struct UpNextRectangularWidgetView: View {
     }
 
     var widgetURL: String {
-        return nextEpisode != nil ? "pktc://upnext?source=lock_screen_widget" : "pktc://discover"
+        return nextEpisode != nil ? "pktc://upnext?source=lock_screen_widget" : "pktc://discover?source=widget"
     }
 
     var body: some View {

--- a/WidgetExtension/Up Next/UpNextLockScreenWidget.swift
+++ b/WidgetExtension/Up Next/UpNextLockScreenWidget.swift
@@ -46,7 +46,7 @@ struct UpNextCircularWidgetView: View {
     }
 
     var widgetURL: String {
-        return numberOfEpisodeInUpNext != 0 ? "pktc://upnext?source=lock_screen_widget" : "pktc://discover"
+        return numberOfEpisodeInUpNext != 0 ? "pktc://upnext?source=lock_screen_widget" : "pktc://discover?source=widget"
     }
 
     var font: Font {

--- a/WidgetExtension/Up Next/UpNextWidgetEntryView.swift
+++ b/WidgetExtension/Up Next/UpNextWidgetEntryView.swift
@@ -48,6 +48,7 @@ struct UpNextWidgetEntryView: View {
                 }
                 .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity)
                 .background(widgetColorScheme.filterViewBackgroundColor)
+                .widgetURL(URL(string: "pktc://last_opened"))
             }
         }
         .environment(\.widgetColorScheme, widgetColorScheme)

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -718,6 +718,7 @@ enum AnalyticsEvent: String {
 
     case widgetInstalled
     case widgetUninstalled
+    case widgetInteraction
 
     // MARK: - Share Screen
     case shareScreenShown

--- a/podcasts/AppDelegate+UrlHandling.swift
+++ b/podcasts/AppDelegate+UrlHandling.swift
@@ -245,6 +245,7 @@ extension AppDelegate {
         }
 
         JLRoutes.global().addRoute("/show_player") { [weak self] _ -> Bool in
+            Analytics.track(.widgetInteraction, properties: ["action": "now_playing"])
             self?.openPlayerWhenReadyFromExternalEvent()
             return true
         }
@@ -337,6 +338,7 @@ extension AppDelegate {
             var source: UpNextViewSource = .unknown
 
             if let sourceString = paramDict["source"] as? String {
+                Analytics.track(.widgetInteraction, properties: ["action": "up_next"])
                 source = UpNextViewSource(rawValue: sourceString) ?? .unknown
             }
 

--- a/podcasts/AppDelegate+UrlHandling.swift
+++ b/podcasts/AppDelegate+UrlHandling.swift
@@ -222,7 +222,9 @@ extension AppDelegate {
 
             if PlaybackManager.shared.isNowPlayingEpisode(episodeUuid: baseEpisode.uuid) {
                 strongSelf.openPlayerWhenReadyFromExternalEvent()
+                Analytics.track(.widgetInteraction, properties: ["action": "now_playing"])
             } else {
+                Analytics.track(.widgetInteraction, properties: ["action": "episode"])
                 if let episode = baseEpisode as? Episode {
                     NavigationManager.sharedManager.navigateTo(NavigationManager.episodePageKey, data: [NavigationManager.episodeUuidKey: episode.uuid])
                 } else if baseEpisode is UserEpisode {

--- a/podcasts/AppDelegate+UrlHandling.swift
+++ b/podcasts/AppDelegate+UrlHandling.swift
@@ -143,8 +143,13 @@ extension AppDelegate {
         }
 
         // Open to discover
-        JLRoutes.global().addRoute("/discover") { _ -> Bool in
+        JLRoutes.global().addRoute("/discover") { paramDict -> Bool in
+            if let sourceString = paramDict["source"] as? String, sourceString == "widget" {
+                Analytics.track(.widgetInteraction, properties: ["action": "discover"])
+            }
+
             NavigationManager.sharedManager.navigateTo(NavigationManager.discoverPageKey, data: nil)
+
             return true
         }
         // developer features:

--- a/podcasts/AppDelegate+UrlHandling.swift
+++ b/podcasts/AppDelegate+UrlHandling.swift
@@ -234,7 +234,10 @@ extension AppDelegate {
             return true
         }
 
-        JLRoutes.global().addRoute("/last_opened/*")
+        JLRoutes.global().addRoute("/last_opened/*") { _ in
+            Analytics.track(.widgetInteraction, properties: ["action": "open_app"])
+            return true
+        }
 
         JLRoutes.global().addRoute("/show_player") { [weak self] _ -> Bool in
             self?.openPlayerWhenReadyFromExternalEvent()

--- a/podcasts/AppPlayEpisodeIntentExtension.swift
+++ b/podcasts/AppPlayEpisodeIntentExtension.swift
@@ -15,12 +15,14 @@ extension PlayEpisodeIntent {
         let current = PlaybackManager.shared.currentEpisode()
 
         if current?.uuid == podcastEpisode.uuid {
+            Analytics.track(.widgetInteraction, properties: ["action": PlaybackManager.shared.playing() ? "pause" : "play"])
             PlaybackActionHelper.playPause()
         } else {
             // Ideally we should use PlaybackActionHelper here
             // However this can potentially trigger an UI and does a lot of other checks
             // that is not as performant as this call.
             PlaybackManager.shared.load(episode: podcastEpisode, autoPlay: true, overrideUpNext: false)
+            Analytics.track(.widgetInteraction, properties: ["action": "play"])
         }
     }
 }


### PR DESCRIPTION
This PR adds a new event `widget_interaction` that tracks interaction with the widgets.

## To test

## Lock screen

1. Run a clean install of the app and enable **tracksLogging**
2. Go to the Lock Screen and add the two medium widgets
3. Both will say "Tap to Discover"
4. Tap on both
5. ✅ `widget_interaction ["action": "discover"]` should be tracked
6. Add two items to your Up Next
7. Go back to Lock screen
8. Tap the "Now playing widget"
9. ✅ `widget_interaction ["action": "now_playing"]` should be tracked
10. Go back to lock screen, tap the up next medium widget
11. ✅ `widget_interaction ["action": "up_next"]` should be tracked
12. Go back to lock screen, remove those widgets and added the small ones
13. Tap the Pocket Casts icon
14. ✅ `widget_interaction ["action": "open_app"]` should be tracked
15. Go back to lock screen, tap the other (up next)
16. ✅ `widget_interaction ["action": "up_next"]` should be traacked
17. Clean your Up next, go back to lock screen, tap the Up next one again
18. ✅ `widget_interaction ["action": "discover"]` should be tracked

## Home widgets

1. Run a clean install of the app and enable **tracksLogging**
2. Go to your home and add all Pocket Casts widgets
3. Given your Up Next is empty and nothing is playing you'll either see a prompt to Discover or the app icon
4. Interact with those widgets
5. ✅ When discover is open `widget_interaction ["action": "discover"]` should be tracked
6. ✅ When the app opens `widget_interaction ["action": "open_app"]` should be tracked
7. Add a few items to your Up Next
8. Go back to widgets
9. Tap play/pause on episodes
10. ✅ `widget_interaction ["action": "play OR pause"]` should be tracked
11. Tap any episode
12. ✅ `widget_interaction ["action": "episode"]` should be tracked

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
