### PR TITLE
Reimagine Sharing: Add logo to all clip assets

### DIFF
--- a/podcasts/Sharing/ShareImageView.swift
+++ b/podcasts/Sharing/ShareImageView.swift
@@ -91,19 +91,21 @@ struct ShareImageView: View {
                 .aspectRatio(0.99, contentMode: .fit)
             case .small:
                 background()
-                HStack(spacing: 18) {
-                    image()
-                        .aspectRatio(1, contentMode: .fit)
-                    text(alignment: .leading, textAlignment: .leading, lineLimit: 3)
+                ZStack {
+                    HStack(spacing: 18) {
+                        image()
+                            .aspectRatio(1, contentMode: .fit)
+                        text(alignment: .leading, textAlignment: .leading, lineLimit: 3)
+                    }
+                    .padding(24)
+                    Image("family_pc_logo")
+                        .resizable()
+                        .frame(width: 24, height: 24)
+                        .padding(.top, 10)
+                        .padding(.trailing, 10)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
                 }
-                .padding(24)
                 .aspectRatio(1.97, contentMode: .fit)
-                Image("family_pc_logo")
-                    .resizable()
-                    .frame(width: 24, height: 24)
-                    .padding(.top, 10)
-                    .padding(.trailing, 10)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
             case .audio:
                 Image("music")
             }

--- a/podcasts/Sharing/ShareImageView.swift
+++ b/podcasts/Sharing/ShareImageView.swift
@@ -83,8 +83,9 @@ struct ShareImageView: View {
                 VStack(spacing: 24) {
                     image()
                         .aspectRatio(1, contentMode: .fit)
-                    text()
+                    text(lineLimit: 1)
                         .frame(alignment: .leading)
+                    PocketCastsLogoPill()
                 }
                 .padding(24)
                 .aspectRatio(0.99, contentMode: .fit)
@@ -97,6 +98,12 @@ struct ShareImageView: View {
                 }
                 .padding(24)
                 .aspectRatio(1.97, contentMode: .fit)
+                Image("family_pc_logo")
+                    .resizable()
+                    .frame(width: 24, height: 24)
+                    .padding(.top, 10)
+                    .padding(.trailing, 10)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
             case .audio:
                 Image("music")
             }

--- a/podcasts/Sharing/SharingModal.swift
+++ b/podcasts/Sharing/SharingModal.swift
@@ -113,16 +113,12 @@ enum SharingModal {
 }
 
 extension SharingModal.Option {
-    private var description: String {
+    private var description: String? {
         switch self {
         case .episode(let episode), .currentPosition(let episode, _), .clip(let episode, _), .clipShare(let episode, _, _, _):
-            if let date = episode.publishedDate {
-                return date.formatted(Date.FormatStyle(date: .abbreviated, time: .omitted))
-            } else {
-                return ""
-            }
+            episode.parentPodcast()?.title
         case .podcast(let podcast):
-            return [podcast.episodeCount, podcast.frequency].compactMap { $0 }.joined(separator: " ⋅ ")
+            [podcast.episodeCount, podcast.frequency].compactMap { $0 }.joined(separator: " ⋅ ")
         }
     }
 
@@ -138,9 +134,13 @@ extension SharingModal.Option {
     private var name: String? {
         switch self {
         case .episode(let episode), .currentPosition(let episode, _), .clip(let episode, _), .clipShare(let episode, _, _, _):
-            episode.parentPodcast()?.title
+            if let date = episode.publishedDate {
+                return date.formatted(Date.FormatStyle(date: .abbreviated, time: .omitted))
+            } else {
+                return ""
+            }
         case .podcast(let podcast):
-            podcast.author
+            return podcast.author
         }
     }
 
@@ -161,7 +161,7 @@ extension SharingModal.Option {
         let artwork = ImageManager.sharedManager.podcastUrl(imageSize: .page, uuid: podcast.uuid)
         let imageInfo = ShareImageInfo(name: name ?? "",
                                        title: title ?? "",
-                                       description: description,
+                                       description: description ?? "",
                                        artwork: artwork,
                                        gradient: gradient)
         return imageInfo


### PR DESCRIPTION
| 📘 Part of: #1910 |
|:---:|

* Added the logo to all clip assets
* Labels were changed to reflect the most recent designs

| Before | After |
| -- | -- |
| <img src="https://github.com/user-attachments/assets/279c72f4-0591-42a3-a62b-8c45ab1a8c74" width=300> | <img src="https://github.com/user-attachments/assets/0ec50afa-b160-4f46-97d1-cc41e9e8a65f" width=300> |
| <img src="https://github.com/user-attachments/assets/a7185513-4f71-465c-b0b1-e8e32decb0bd" width=300> |  <img src="https://github.com/user-attachments/assets/c7b1c941-c9d9-4dfc-8c57-41d8e13a924b" width=300> |
| <img src="https://github.com/user-attachments/assets/bdf367bd-1792-4310-ac39-2dec48af49f3" width=300> | <img src="https://github.com/user-attachments/assets/a0808c1e-f9cd-44f1-9d6c-74ebd36d4db9" width=300> |

## To test

> [!NOTE]
> Enable the `newSharing` feature flag to test this

* Play an episode
* Tap the share button from the action shelf
* Verify that the logo shows up in all of the previews
* Create clips for different preview sizes by swiping between them. Hit "Edit Clip" to create a new clip for each preview.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
