### PR TITLE
Stats: add checks to prevent decreasing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Update podcast list when episode is archived or marked as played from player [#1976](https://github.com/Automattic/pocket-casts-ios/issues/1976)
 - Dismiss search if already active when double tap is performed on tab bar [#1652](https://github.com/Automattic/pocket-casts-ios/issues/1652)
 - Show transcript for episodes that support it [#2102](https://github.com/Automattic/pocket-casts-ios/issues/2102)
+- Add a check to prevent stats from decreasing [#2106](https://github.com/Automattic/pocket-casts-ios/issues/2106)
 
 7.71
 -----

--- a/Modules/Server/Sources/PocketCastsServer/Public/StatsManager.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/StatsManager.swift
@@ -216,7 +216,7 @@ public class StatsManager {
     }
 
     private func saveTime(_ time: TimeInterval, key: String) {
-        if time < 0 { return }
+        if time < 0, time < timeForKey(key) { return }
 
         UserDefaults.standard.set(time, forKey: key)
     }

--- a/Modules/Server/Sources/PocketCastsServer/Public/StatsManager.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/StatsManager.swift
@@ -36,7 +36,7 @@ public class StatsManager {
 
     public func addTimeSavedDynamicSpeed(_ seconds: TimeInterval) {
         updateQueue.async { [weak self] in
-            self?.savedDynamicSpeed += seconds
+            self?.savedDynamicSpeed += max(seconds, 0)
             self?.isSynced = false
         }
     }
@@ -49,7 +49,7 @@ public class StatsManager {
 
     public func addTimeSavedVariableSpeed(_ seconds: TimeInterval) {
         updateQueue.async { [weak self] in
-            self?.savedVariableSpeed += seconds
+            self?.savedVariableSpeed += max(seconds, 0)
             self?.isSynced = false
         }
     }
@@ -62,7 +62,7 @@ public class StatsManager {
 
     public func addTotalListeningTime(_ seconds: TimeInterval) {
         updateQueue.async { [weak self] in
-            self?.totalListenedTo += seconds
+            self?.totalListenedTo += max(seconds, 0)
             self?.isSynced = false
         }
     }
@@ -75,7 +75,7 @@ public class StatsManager {
 
     public func addSkippedTime(_ seconds: TimeInterval) {
         updateQueue.async { [weak self] in
-            self?.totalSkipped += seconds
+            self?.totalSkipped += max(seconds, 0)
             self?.isSynced = false
         }
     }
@@ -88,7 +88,7 @@ public class StatsManager {
 
     public func addAutoSkipTime(_ seconds: TimeInterval) {
         updateQueue.async { [weak self] in
-            self?.savedAutoSkipping += seconds
+            self?.savedAutoSkipping += max(seconds, 0)
             self?.isSynced = false
         }
     }

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+LocalChanges.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+LocalChanges.swift
@@ -157,24 +157,23 @@ extension SyncTask {
     }
 
     func changedStats() -> Api_Record? {
-        let timeSavedDynamicSpeed = convertStat(StatsManager.shared.timeSavedDynamicSpeed())
-        let totalSkippedTime = convertStat(StatsManager.shared.totalSkippedTime())
-        let totalIntroSkippedTime = convertStat(StatsManager.shared.totalAutoSkippedTime())
-        let timeSavedVariableSpeed = convertStat(StatsManager.shared.timeSavedVariableSpeed())
-        let totalListeningTime = convertStat(StatsManager.shared.totalListeningTime())
-        let startSyncTime = Int64(StatsManager.shared.statsStartDate().timeIntervalSince1970)
-
-        // check to see if there's actually any stats we need to sync
-        if StatsManager.shared.syncStatus() != .notSynced || (timeSavedDynamicSpeed == nil && totalSkippedTime == nil && totalSkippedTime == nil && timeSavedVariableSpeed == nil && totalListeningTime == nil) {
+        guard StatsManager.shared.syncStatus() == .notSynced,
+              let timeSavedDynamicSpeed = convertStat(StatsManager.shared.timeSavedDynamicSpeed()),
+              let totalSkippedTime = convertStat(StatsManager.shared.totalSkippedTime()),
+              let totalIntroSkippedTime = convertStat(StatsManager.shared.totalAutoSkippedTime()),
+              let timeSavedVariableSpeed = convertStat(StatsManager.shared.timeSavedVariableSpeed()),
+              let totalListeningTime = convertStat(StatsManager.shared.totalListeningTime()) else {
             return nil
         }
 
+        let startSyncTime = Int64(StatsManager.shared.statsStartDate().timeIntervalSince1970)
+
         var deviceRecord = Api_SyncUserDevice()
-        deviceRecord.timeSilenceRemoval.value = timeSavedDynamicSpeed ?? 0
-        deviceRecord.timeSkipping.value = totalSkippedTime ?? 0
-        deviceRecord.timeIntroSkipping.value = totalIntroSkippedTime ?? 0
-        deviceRecord.timeVariableSpeed.value = timeSavedVariableSpeed ?? 0
-        deviceRecord.timeListened.value = totalListeningTime ?? 0
+        deviceRecord.timeSilenceRemoval.value = timeSavedDynamicSpeed
+        deviceRecord.timeSkipping.value = totalSkippedTime
+        deviceRecord.timeIntroSkipping.value = totalIntroSkippedTime
+        deviceRecord.timeVariableSpeed.value = timeSavedVariableSpeed
+        deviceRecord.timeListened.value = totalListeningTime
         deviceRecord.timesStartedAt.value = startSyncTime
         deviceRecord.deviceID.value = ServerConfig.shared.syncDelegate?.uniqueAppId() ?? ""
         deviceRecord.deviceType.value = ServerConstants.Values.deviceTypeiOS


### PR DESCRIPTION
We have a few reports from users that they stats decreased.

This PR adds a few checks to make that not possible:

1. If the time being saved is smaller than what we currently have on `UserDefaults` we do not save it
2. If any value smaller than zero is given, it's ignored

Ps.: in the case of corrupted UserDefaults this doesn't address it.

## To test

1. Run the app and login to an account
4. Check your stats
5. Listen for a episode for a few seconds
6. Profile > Refresh Now
7. Go to Stats
8. ✅ Your stats should increase

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
