### PR TITLE
Revert image id for release

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,7 +6,7 @@ common_params:
   # Common environment values to use with the `env` key.
   - &common_env
     # If you update the image to a newer Xcode version, don't forget to also update the badge in the README.md file accordingly for consistency
-    IMAGE_ID: xcode-16.0-beta6
+    IMAGE_ID: xcode-15.4
   # Common agents values to use with the `agents` key.
   - &common_agents
     queue: mac

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -7,7 +7,7 @@ common_params:
     - automattic/a8c-ci-toolkit#2.15.1
   # Common environment values to use with the `env` key.
   - &common_env
-    IMAGE_ID: xcode-16.0-beta6
+    IMAGE_ID: xcode-15.4
 
 steps:
 


### PR DESCRIPTION
Revert the` IMAGE ID` to `xcode-15.4`

## To test

- CI must be 🟢 

@leandroalonso do we need to revert anything to release the new version?
