### PR TITLE
Stats: sync from server if local stats are behind

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Private/API Tasks/RetrieveStatsTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Private/API Tasks/RetrieveStatsTask.swift
@@ -6,6 +6,8 @@ import SwiftProtobuf
 class RetrieveStatsTask: ApiBaseTask {
     var completion: ((RemoteStats?) -> Void)?
 
+    var getFullStatsData = false
+
     override func apiTokenAcquired(token: String) {
         let url = ServerConstants.Urls.api() + "user/stats/summary"
 
@@ -16,7 +18,7 @@ class RetrieveStatsTask: ApiBaseTask {
                 return
             }
 
-            statsRequest.deviceID = uniqueAppId
+            statsRequest.deviceID = getFullStatsData ? "" : uniqueAppId
             statsRequest.deviceType = ServerConstants.Values.deviceTypeiOS
             let data = try statsRequest.serializedData()
 

--- a/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler.swift
@@ -68,8 +68,9 @@ public class ApiServerHandler {
         apiQueue.addOperation(subscriptionStatusTask)
     }
 
-    public func loadStatsRequest(completion: @escaping (RemoteStats?) -> Void) {
+    public func loadStatsRequest(getFullData: Bool = false, completion: @escaping (RemoteStats?) -> Void) {
         let statsOperation = RetrieveStatsTask()
+        statsOperation.getFullStatsData = getFullData
         statsOperation.completion = completion
         apiQueue.addOperation(statsOperation)
     }

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
@@ -417,12 +417,12 @@ public struct DiscoverCategoryPromotion: Decodable {
 }
 
 public struct RemoteStats {
-    var silenceRemovalTime: Int64
-    var totalListenTime: Int64
-    var autoSkipTime: Int64
-    var variableSpeedTime: Int64
-    var skipTime: Int64
-    var startedStatsAt: Int64
+    public var silenceRemovalTime: Int64
+    public var totalListenTime: Int64
+    public var autoSkipTime: Int64
+    public var variableSpeedTime: Int64
+    public var skipTime: Int64
+    public var startedStatsAt: Int64
 }
 
 public struct PodcastCollectionColors: Codable {

--- a/Modules/Server/Sources/PocketCastsServer/Public/StatsManager.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/StatsManager.swift
@@ -1,5 +1,6 @@
 import Foundation
 import PocketCastsDataModel
+import PocketCastsUtils
 
 public class StatsManager {
     public static let shared = StatsManager()
@@ -144,6 +145,11 @@ public class StatsManager {
     }
 
     public func updateLocalStatsIfNeeded(completion: ((Bool) -> Void)?) {
+        guard FeatureFlag.syncStats.enabled else {
+            completion?(false)
+            return
+        }
+
         ApiServerHandler.shared.loadStatsRequest(getFullData: true) { [weak self] remoteStats in
             guard let self, let remoteStats = remoteStats else { return }
 

--- a/Modules/Server/Sources/PocketCastsServer/Public/StatsManager.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/StatsManager.swift
@@ -184,6 +184,10 @@ public class StatsManager {
                 }
             }
 
+            if didChange {
+                persistTimes()
+            }
+
             completion?(didChange)
         }
     }

--- a/Modules/Server/Sources/PocketCastsServer/Public/StatsManager.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/StatsManager.swift
@@ -143,6 +143,51 @@ public class StatsManager {
         }
     }
 
+    public func updateLocalStatsIfNeeded(completion: ((Bool) -> Void)?) {
+        ApiServerHandler.shared.loadStatsRequest(getFullData: true) { [weak self] remoteStats in
+            guard let self, let remoteStats = remoteStats else { return }
+
+            var didChange = false
+
+            if Int64(timeSavedDynamicSpeedInclusive()) < remoteStats.silenceRemovalTime {
+                didChange = true
+                updateQueue.sync {
+                    self.savedDynamicSpeed = Double(remoteStats.silenceRemovalTime) - self.timeSavedDynamicSpeedInclusive()
+                }
+            }
+
+            if Int64(totalAutoSkippedTimeInclusive()) < remoteStats.autoSkipTime {
+                didChange = true
+                updateQueue.sync {
+                    self.savedAutoSkipping = Double(remoteStats.autoSkipTime) - self.totalAutoSkippedTimeInclusive()
+                }
+            }
+
+            if Int64(totalSkippedTimeInclusive()) < remoteStats.skipTime {
+                didChange = true
+                updateQueue.sync {
+                    self.totalSkipped = Double(remoteStats.skipTime) - self.totalSkippedTimeInclusive()
+                }
+            }
+
+            if Int64(totalListeningTimeInclusive()) < remoteStats.totalListenTime {
+                didChange = true
+                updateQueue.sync {
+                    self.totalListenedTo = Double(remoteStats.totalListenTime) - self.totalListeningTimeInclusive()
+                }
+            }
+
+            if Int64(timeSavedVariableSpeedInclusive()) < remoteStats.variableSpeedTime {
+                didChange = true
+                updateQueue.sync {
+                    self.savedVariableSpeed = Double(remoteStats.variableSpeedTime) - self.timeSavedVariableSpeedInclusive()
+                }
+            }
+
+            completion?(didChange)
+        }
+    }
+
     public func statsStartedAt() -> Int64 {
         Int64(UserDefaults.standard.integer(forKey: ServerConstants.UserDefaults.statsStartedDateServer))
     }

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -98,6 +98,11 @@ public enum FeatureFlag: String, CaseIterable {
     /// Enable the Referrals feature
     case referrals
 
+    /// When accessing Stats, it checks if the local stats are behind remote
+    /// If it is, it updates it
+    /// This is meant to fix an issue for users that were losing stats
+    case syncStats
+
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -168,6 +173,8 @@ public enum FeatureFlag: String, CaseIterable {
             true
         case .referrals:
             false
+        case .syncStats:
+            true
         }
     }
 

--- a/podcasts/StatsViewController.swift
+++ b/podcasts/StatsViewController.swift
@@ -159,6 +159,14 @@ class StatsViewController: UIViewController, UITableViewDelegate, UITableViewDat
                 self?.statsTable.reloadData()
                 self?.requestReviewIfPossible()
             }
+
+            StatsManager.shared.updateLocalStatsIfNeeded { updated in
+                if updated {
+                    DispatchQueue.main.async { [weak self] in
+                        self?.statsTable.reloadData()
+                    }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
On #2106 I submitted a change to prevent stats from decreasing locally.

We also have an In-review PR for server changes that will not allow stats to decrease server-side once it's merged.

However, this might result in stats being "stuck":

1. If for any reason, any stat value decrease
2. It will be sent to the server and will be smaller than whatever the server has
3. Thus, it will be ignored

This will require the user to listen to the amount of time saved on the server + 1 to start syncing again.

This PR adds check to prevent this issue:

1. We compare our local stats with the full stats
2. If it's smaller, we update our local values

This ensure stats won't stuck.

## To test

You need to use an account that: 1) has Stats 2) has some local stats. You can simulate 2 though by doing this:

1. Go to `StatsManager` and change lines 22-28 to:

```swift
        updateQueue.sync {
            savedDynamicSpeed = 1000
            savedVariableSpeed = 1000
            totalListenedTo = 1000
            totalSkipped = 1000
            savedAutoSkipping = 1000
        }
```

2. Play/pause any episode
3. Close the app
4. Revert the change

### Testing

Now what we have to do is simulate that our stored time is now nil, so you can do:

```swift
        updateQueue.sync {
            savedDynamicSpeed = -1000
            savedVariableSpeed = -1000
            totalListenedTo = -1000
            totalSkipped = -1000
            savedAutoSkipping = -1000
        }
```

1. Run the app
2. Go to Profile > Stats
3. Notice how stats load
4. ✅ After a while the values should increase, because it will be corrected

## Additional info

When we display any stats, we show it as the value we have local + remote value (excluding values from this device). To update this info what we do is to request with an empty `deviceId`, resulting in the whole amount the server has.

We then compare local + remote with this "full stat". If any value is behind, it's updated.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
