### PR TITLE
Update GoogleCast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Dismiss search if already active when double tap is performed on tab bar [#1652](https://github.com/Automattic/pocket-casts-ios/issues/1652)
 - Show transcript for episodes that support it [#2102](https://github.com/Automattic/pocket-casts-ios/issues/2102)
 - Add a check to prevent stats from decreasing [#2106](https://github.com/Automattic/pocket-casts-ios/issues/2106)
+- Updated the Google Cast library to 4.8.3
 
 7.71
 -----

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - google-cast-sdk-no-bluetooth (1.1.0)
+  - google-cast-sdk-no-bluetooth (1.2.0)
   - PulseCore (4.2.4)
   - PulseUI (4.2.4):
     - PulseCore (~> 4.2)
@@ -30,7 +30,7 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   google-cast-sdk-no-bluetooth:
-    :commit: 5c7c5f91ef84a5c45d8edbfec1def6f117bc64b5
+    :commit: 6992eaf3fe4353e6992a2c35b5a879c490bba2d4
     :git: https://github.com/Automattic/google-cast
   PulseCore:
     :git: https://github.com/kean/Pulse.git
@@ -40,7 +40,7 @@ CHECKOUT OPTIONS:
     :tag: 4.2.4
 
 SPEC CHECKSUMS:
-  google-cast-sdk-no-bluetooth: 6ec820fdeea77ebaf18ea2c5d73418edfa2ec0b0
+  google-cast-sdk-no-bluetooth: 97f3b1286fa2fa158ec47975b4bb758908a27b2d
   PulseCore: a40e40555e355948829a4d3b5f997578098a49c4
   PulseUI: f7464009d4fca0c88de41f6153d7aef4ae0a906a
   SwiftGen: a6d22010845f08fe18fbdf3a07a8e380fd22e0ea


### PR DESCRIPTION
This updates the Google Cast library with the most up-to-date version.

Based on my tests this version don't have bitcode in the binaries. You can test that by running: `otool -l Pods/google-cast-sdk-no-bluetooth/GoogleCast.xcframework/ios-arm64/GoogleCast.framework/GoogleCast | grep __LLVM`

In this branch, it should return nothing. Without this change, you'll see a few lines in the output.

## To test

1. 🟢 CI is enough

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
