### PR TITLE
Reimagine Sharing: Export Tweaks for 7.72

### DIFF
--- a/podcasts/End of Year/Views/View+Snapshot.swift
+++ b/podcasts/End of Year/Views/View+Snapshot.swift
@@ -3,10 +3,10 @@ import SwiftUI
 extension View {
     /// Returns a `UIImage` from a SwiftUI View
     @MainActor
-    public func snapshot() -> UIImage {
+    public func snapshot(scale: CGFloat = 2) -> UIImage {
         if #available(iOS 16.0, *) {
             let renderer = ImageRenderer(content: self)
-            renderer.scale = 3
+            renderer.scale = scale
             guard let renderedImage = renderer.uiImage else {
                 assertionFailure("Rendered ImageRenderer image shouldn't be `nil`")
                 return UIImage()
@@ -20,7 +20,9 @@ extension View {
             view?.bounds = CGRect(origin: .zero, size: targetSize)
             view?.backgroundColor = .clear
 
-            let renderer = UIGraphicsImageRenderer(size: targetSize)
+            let format = UIGraphicsImageRendererFormat()
+            format.scale = scale
+            let renderer = UIGraphicsImageRenderer(size: targetSize, format: format)
 
             return renderer.image { _ in
                 view?.drawHierarchy(in: controller.view.bounds, afterScreenUpdates: true)

--- a/podcasts/Sharing/AnimatedShareImageView.swift
+++ b/podcasts/Sharing/AnimatedShareImageView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import PocketCastsDataModel
 
+@MainActor
 class AnimationProgress: ObservableObject {
     @Published var progress: Double = 0 // O-1
 }

--- a/podcasts/Sharing/AnimatedShareImageView.swift
+++ b/podcasts/Sharing/AnimatedShareImageView.swift
@@ -8,21 +8,20 @@ class AnimationProgress: ObservableObject {
 struct AnimatedShareImageView: AnimatableContent {
     let info: ShareImageInfo
     let style: ShareImageStyle
+    let size: CGSize
 
     @State var angle: Double = 0
     @ObservedObject var animationProgress: AnimationProgress = .init()
 
     var body: some View {
-        ZStack {
-            ShareImageView(info: info, style: style, angle: $angle)
-                .frame(width: style.previewSize.width * 2, height: style.previewSize.height)
-                .fixedSize()
-                .onReceive(animationProgress.$progress) { progress in
-                    let calculatedAngle = calculateAngle(progress: Float(progress))
-                    angle = Double(calculatedAngle)
-                }
-                .scaleEffect(CGSize(width: 2.0, height: 2.0))
-        }
+        ShareImageView(info: info, style: style, angle: $angle)
+            .frame(width: size.width, height: size.height)
+            .fixedSize()
+            .onReceive(animationProgress.$progress) { progress in
+                let calculatedAngle = calculateAngle(progress: Float(progress))
+                angle = Double(calculatedAngle)
+            }
+            .scaleEffect(CGSize(width: 2.0, height: 2.0))
     }
 
     func update(for progress: Double) {

--- a/podcasts/Sharing/AnimatedShareImageView.swift
+++ b/podcasts/Sharing/AnimatedShareImageView.swift
@@ -15,7 +15,7 @@ struct AnimatedShareImageView: AnimatableContent {
     var body: some View {
         ZStack {
             ShareImageView(info: info, style: style, angle: $angle)
-                .frame(width: style.videoSize.width, height: style.videoSize.height)
+                .frame(width: style.previewSize.width * 2, height: style.previewSize.height)
                 .fixedSize()
                 .onReceive(animationProgress.$progress) { progress in
                     let calculatedAngle = calculateAngle(progress: Float(progress))

--- a/podcasts/Sharing/Clip/VideoExporter.swift
+++ b/podcasts/Sharing/Clip/VideoExporter.swift
@@ -107,10 +107,12 @@ enum VideoExporter {
 
                 let buffer = try await self.pixelBuffer(for: view, size: size)
                 let frameTime = CMTime(seconds: Double(await counter.count) / Double(fps), preferredTimescale: CMTimeScale(NSEC_PER_SEC))
-                adaptor.append(buffer.wrappedValue, withPresentationTime: frameTime)
-                progress.completedUnitCount += 1
+                if videoWriterInput.isReadyForMoreMediaData {
+                    adaptor.append(buffer.wrappedValue, withPresentationTime: frameTime)
+                    progress.completedUnitCount += 1
 
-                await counter.increment()
+                    await counter.increment()
+                }
             }
 
             if await counter.count >= frameCount {

--- a/podcasts/Sharing/ShareDestination.swift
+++ b/podcasts/Sharing/ShareDestination.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import PocketCastsDataModel
 
 enum ShareDestination: Hashable {
     case instagram
@@ -33,10 +34,10 @@ enum ShareDestination: Hashable {
     }
 
     @MainActor
-    func share(_ option: SharingModal.Option, style: ShareImageStyle, clipUUID: String, source: AnalyticsSource) async throws {
+    func share(_ option: SharingModal.Option, style: ShareImageStyle, clipTime: ClipTime, clipUUID: String, progress: Binding<Float?>, source: AnalyticsSource) async throws {
         switch self {
         case .instagram:
-            let item = option.shareData(style: style, destination: self).mapFirst { shareItem -> (Data, UTType)? in
+            let item = try await option.shareData(style: style, destination: self, progress: progress).mapFirst { shareItem -> (Data, UTType)? in
                 if let data = shareItem as? Data {
                     return (data, style == .audio ? UTType.m4a : .mpeg4Movie)
                 } else if let image = shareItem as? UIImage, let data = image.pngData() {
@@ -59,7 +60,7 @@ enum ShareDestination: Hashable {
             ShareDestination.logClipShared(option: option, style: style, clipUUID: clipUUID, source: source)
             ShareDestination.logPodcastShared(style: style, option: option, destination: self, source: source)
         case .systemSheet(let vc):
-            let data = option.shareData(style: style)
+            let data = try await option.shareData(style: style, destination: self, progress: progress)
             let activityViewController = UIActivityViewController(activityItems: data, applicationActivities: nil)
             vc.presentedViewController?.present(activityViewController, animated: true, completion: {
                 ShareDestination.logClipShared(option: option, style: style, clipUUID: clipUUID, source: source)
@@ -84,8 +85,8 @@ enum ShareDestination: Hashable {
             return
         }
 
-        let backgroundTopColor = UIColor.black
-        let backgroundBottomColor = UIColor.white
+        let backgroundTopColor = UIColor.green
+        let backgroundBottomColor = UIColor.systemPink
 
         let dataKey = type == .mpeg4Movie ? "com.instagram.sharedSticker.backgroundVideo" : "com.instagram.sharedSticker.backgroundImage"
         let pasteboardItems = [[dataKey: data,
@@ -153,7 +154,7 @@ enum ShareDestination: Hashable {
 extension ShareDestination {
     private static func logClipShared(option: SharingModal.Option, style: ShareImageStyle, clipUUID: String, source: AnalyticsSource) {
         // This event is specifically for clip shares and not other shares. These are handled by `podcastShared`
-        guard case let .clipShare(episode, clipTime, _, _) = option else {
+        guard case let .clipShare(episode, clipTime, _) = option else {
             return
         }
 
@@ -225,5 +226,41 @@ extension ShareDestination {
         ]
 
         Analytics.track(.podcastShared, source: source, properties: properties)
+    }
+}
+
+extension ShareDestination {
+    enum VideoExportError: Error {
+        case failedToDownload
+    }
+
+    func export(info: ShareImageInfo, style: ShareImageStyle, episode: some BaseEpisode, startTime: CMTime, duration: CMTime, progress: Progress) async throws -> URL {
+        guard let playerItem = DownloadManager.shared.downloadParallelToStream(of: episode) else {
+            throw VideoExportError.failedToDownload
+        }
+
+        switch style {
+        case .audio:
+            let url = FileManager.default.temporaryDirectory.appendingPathComponent("audio_export-\(UUID().uuidString)", conformingTo: .m4a)
+            try await AudioClipExporter.exportAudioClip(from: playerItem.asset, startTime: startTime, duration: duration, to: url, progress: progress)
+            return url
+        default:
+            let size: CGSize
+            switch self {
+            case .instagram:
+                size = CGSize(width: style.videoSize.width * 2, height: style.videoSize.height * 2)
+            default:
+                size = CGSize(width: style.previewSize.width * 2, height: style.previewSize.height * 2)
+            }
+
+            guard #available(iOS 16, *) else { // iOS 15 support will be added in a separate PR just to keep the line count down
+                throw VideoExportError.failedToDownload
+            }
+            let parameters = VideoExporter.Parameters(duration: CMTimeGetSeconds(duration), size: size, episodeAsset: playerItem.asset, audioStartTime: startTime, audioDuration: duration, fileType: .mp4)
+            let url = FileManager.default.temporaryDirectory.appendingPathComponent("video_export-\(UUID().uuidString)", conformingTo: .mpeg4Movie)
+            try await VideoExporter.export(view: AnimatedShareImageView(info: info, style: style, size: size), with: parameters, to: url, progress: progress)
+
+            return url
+        }
     }
 }

--- a/podcasts/Sharing/ShareDestination.swift
+++ b/podcasts/Sharing/ShareDestination.swift
@@ -84,8 +84,13 @@ enum ShareDestination: Hashable {
             return
         }
 
+        let backgroundTopColor = UIColor.black
+        let backgroundBottomColor = UIColor.white
+
         let dataKey = type == .mpeg4Movie ? "com.instagram.sharedSticker.backgroundVideo" : "com.instagram.sharedSticker.backgroundImage"
         let pasteboardItems = [[dataKey: data,
+                                "com.instagram.sharedSticker.backgroundTopColor": backgroundTopColor.hexString(),
+                                "com.instagram.sharedSticker.backgroundBottomColor": backgroundBottomColor.hexString(),
                                 "com.instagram.sharedSticker.contentURL": attributionURL]]
         let pasteboardOptions: [UIPasteboard.OptionsKey: Any] = [.expirationDate: Date().addingTimeInterval(5.minutes)]
 

--- a/podcasts/Sharing/ShareImageView.swift
+++ b/podcasts/Sharing/ShareImageView.swift
@@ -28,10 +28,6 @@ enum ShareImageStyle: CaseIterable {
         }
     }
 
-    var videoSize: CGSize {
-        CGSize(width: 390, height: 694)
-    }
-
     var previewSize: CGSize {
         switch self {
         case .large:

--- a/podcasts/Sharing/ShareImageView.swift
+++ b/podcasts/Sharing/ShareImageView.swift
@@ -28,6 +28,10 @@ enum ShareImageStyle: CaseIterable {
         }
     }
 
+    var videoSize: CGSize {
+        CGSize(width: 390, height: 694)
+    }
+
     var previewSize: CGSize {
         switch self {
         case .large:

--- a/podcasts/Sharing/ShareImageView.swift
+++ b/podcasts/Sharing/ShareImageView.swift
@@ -77,7 +77,8 @@ struct ShareImageView: View {
                     PocketCastsLogoPill()
                 }
                 .padding(24)
-                .aspectRatio(0.66, contentMode: .fit)
+                .frame(height: style.previewSize.height)
+                .aspectRatio(style.previewSize.width/style.previewSize.height, contentMode: .fit)
             case .medium:
                 background()
                 VStack(spacing: 24) {
@@ -88,7 +89,8 @@ struct ShareImageView: View {
                     PocketCastsLogoPill()
                 }
                 .padding(24)
-                .aspectRatio(0.99, contentMode: .fit)
+                .frame(height: style.previewSize.height)
+                .aspectRatio(style.previewSize.width/style.previewSize.height, contentMode: .fit)
             case .small:
                 background()
                 ZStack {
@@ -105,7 +107,8 @@ struct ShareImageView: View {
                         .padding(.trailing, 10)
                         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
                 }
-                .aspectRatio(1.97, contentMode: .fit)
+                .frame(width: style.previewSize.width, height: style.previewSize.height)
+                .aspectRatio(style.previewSize.width/style.previewSize.height, contentMode: .fit)
             case .audio:
                 Image("music")
             }

--- a/podcasts/Sharing/ShareImageView.swift
+++ b/podcasts/Sharing/ShareImageView.swift
@@ -116,22 +116,26 @@ struct ShareImageView: View {
     }
 
     @ViewBuilder func background() -> some View {
-        LinearGradient(gradient: info.gradient, startPoint: .top, endPoint: .bottom)
-        let rotationFactor = sin(Angle(degrees: angle).radians)
-        KidneyShape()
-            .fill(info.gradient.stops.first?.color ?? .black)
-            .blur(radius: 50)
-            .opacity(0.15 + 0.5 * abs(rotationFactor))
-            .offset(x: -50, y: 0)
-            .rotationEffect(.degrees(180 * rotationFactor))
-        KidneyShape()
-            .fill(.white)
-            .blur(radius: 50)
-            .offset(x: 50, y: 0)
-            .opacity(0.15 + 0.5 * abs(rotationFactor))
-            .rotationEffect(.degrees(-180 * rotationFactor))
-            .blendMode(.softLight)
-        Color.black.opacity(0.2)
+        ZStack {
+            LinearGradient(gradient: info.gradient, startPoint: .top, endPoint: .bottom)
+            let rotationFactor = sin(Angle(degrees: angle).radians)
+            KidneyShape()
+                .fill(info.gradient.stops.first?.color ?? .black)
+                .blur(radius: 100)
+                .opacity(0.15 + 0.5 * abs(rotationFactor))
+                .frame(width: 230, height: 350)
+                .offset(x: -50, y: -20)
+                .rotationEffect(.degrees(180 * rotationFactor))
+            KidneyShape()
+                .fill(.white)
+                .blur(radius: 50)
+                .opacity(0.15 + 0.5 * abs(rotationFactor))
+                .frame(width: 300, height: 350)
+                .offset(x: 50, y: 40)
+                .rotationEffect(.degrees(-180 * rotationFactor))
+                .blendMode(.softLight)
+            Color.black.opacity(0.2)
+        }
     }
 
     @ViewBuilder func image() -> some View {

--- a/podcasts/Sharing/SharingFooterView.swift
+++ b/podcasts/Sharing/SharingFooterView.swift
@@ -74,7 +74,7 @@ struct SharingFooterView: View {
                 do {
                     try await destination.share(option, style: style, clipTime: clipTime, clipUUID: clipUUID, progress: $progress, source: source)
                 } catch let error {
-                    guard Task.isCancelled == false  else { return }
+                    if Task.isCancelled { return }
                     await MainActor.run {
                         Toast.show("Failed clip export: \(error.localizedDescription)")
                     }

--- a/podcasts/Sharing/SharingFooterView.swift
+++ b/podcasts/Sharing/SharingFooterView.swift
@@ -70,7 +70,7 @@ struct SharingFooterView: View {
     @ViewBuilder func button(destination: ShareDestination, style: ShareImageStyle, clipUUID: String, source: AnalyticsSource) -> some View {
         Button {
             isExporting = true
-            shareTask = Task.detached {
+            shareTask = Task.detached { @MainActor in
                 do {
                     try await destination.share(option, style: style, clipTime: clipTime, clipUUID: clipUUID, progress: $progress, source: source)
                 } catch let error {

--- a/podcasts/Sharing/SharingFooterView.swift
+++ b/podcasts/Sharing/SharingFooterView.swift
@@ -32,7 +32,7 @@ struct SharingFooterView: View {
                 }
                 .foregroundStyle(.white.opacity(0.5))
                 .font(.caption.weight(.semibold))
-                Button(L10n.clip, action: {
+                Button(L10n.next, action: {
                     withAnimation {
                         option = .clipShare(episode, clipTime, style)
                     }

--- a/podcasts/Sharing/SharingFooterView.swift
+++ b/podcasts/Sharing/SharingFooterView.swift
@@ -5,12 +5,14 @@ struct SharingFooterView: View {
     @ObservedObject var clipTime: ClipTime
     @Binding var option: SharingModal.Option
     @Binding var isExporting: Bool
-    @ObservedObject var clipResult: ClipResult
+    @State var progress: Float?
 
     let destinations: [ShareDestination]
     let style: ShareImageStyle
     let clipUUID: String
     let source: AnalyticsSource
+
+    @State var shareTask: Task<Void, Error>?
 
     @EnvironmentObject var theme: Theme
 
@@ -32,23 +34,26 @@ struct SharingFooterView: View {
                 .font(.caption.weight(.semibold))
                 Button(L10n.clip, action: {
                     withAnimation {
-                        option = .clipShare(episode, clipTime, style, clipResult)
-                        isExporting = true
+                        option = .clipShare(episode, clipTime, style)
                     }
                 }).buttonStyle(RoundedButtonStyle(theme: theme, backgroundColor: color))
             }
             .padding(.horizontal, 16)
+            .onAppear {
+                shareTask?.cancel()
+                progress = nil
+                isExporting = false
+            }
         case .clipShare:
-            if clipResult.progress != 1 {
-                ProgressView(value: clipResult.progress) {
+            if let progress {
+                ProgressView(value: progress) {
                     Text(L10n.clipLoadingLabel)
                         .font(.headline)
                         .padding(8)
                 }
                 .tint(color)
                 .padding()
-            }
-            else {
+            } else {
                 buttons
             }
         }
@@ -64,8 +69,16 @@ struct SharingFooterView: View {
 
     @ViewBuilder func button(destination: ShareDestination, style: ShareImageStyle, clipUUID: String, source: AnalyticsSource) -> some View {
         Button {
-            Task.detached {
-                try await destination.share(option, style: style, clipUUID: clipUUID, source: source)
+            isExporting = true
+            shareTask = Task.detached {
+                do {
+                    try await destination.share(option, style: style, clipTime: clipTime, clipUUID: clipUUID, progress: $progress, source: source)
+                } catch let error {
+                    guard Task.isCancelled == false  else { return }
+                    await MainActor.run {
+                        Toast.show("Failed clip export: \(error.localizedDescription)")
+                    }
+                }
             }
         } label: {
             view(for: destination)
@@ -74,7 +87,7 @@ struct SharingFooterView: View {
 
     var color: Color {
         switch option {
-        case .clip(let episode, _), .clipShare(let episode, _, _, _):
+        case .clip(let episode, _), .clipShare(let episode, _, _):
             PlayerColorHelper.backgroundColor(for: episode)?.color ?? PlayerColorHelper.playerBackgroundColor01(for: theme.activeTheme).color
         default:
             PlayerColorHelper.playerBackgroundColor01(for: theme.activeTheme).color

--- a/podcasts/Sharing/SharingModal.swift
+++ b/podcasts/Sharing/SharingModal.swift
@@ -10,7 +10,7 @@ enum SharingModal {
         case podcast(Podcast)
         case currentPosition(Episode, TimeInterval)
         case clip(Episode, TimeInterval)
-        case clipShare(Episode, ClipTime, ShareImageStyle, ClipResult)
+        case clipShare(Episode, ClipTime, ShareImageStyle)
 
         var buttonTitle: String {
             switch self {
@@ -115,7 +115,7 @@ enum SharingModal {
 extension SharingModal.Option {
     private var description: String? {
         switch self {
-        case .episode(let episode), .currentPosition(let episode, _), .clip(let episode, _), .clipShare(let episode, _, _, _):
+        case .episode(let episode), .currentPosition(let episode, _), .clip(let episode, _), .clipShare(let episode, _, _):
             episode.parentPodcast()?.title
         case .podcast(let podcast):
             [podcast.episodeCount, podcast.frequency].compactMap { $0 }.joined(separator: " ⋅ ")
@@ -124,7 +124,7 @@ extension SharingModal.Option {
 
     private var title: String? {
         switch self {
-        case .episode(let episode), .currentPosition(let episode, _), .clip(let episode, _), .clipShare(let episode, _, _, _):
+        case .episode(let episode), .currentPosition(let episode, _), .clip(let episode, _), .clipShare(let episode, _, _):
             episode.title
         case .podcast(let podcast):
             podcast.title
@@ -133,7 +133,7 @@ extension SharingModal.Option {
 
     private var name: String? {
         switch self {
-        case .episode(let episode), .currentPosition(let episode, _), .clip(let episode, _), .clipShare(let episode, _, _, _):
+        case .episode(let episode), .currentPosition(let episode, _), .clip(let episode, _), .clipShare(let episode, _, _):
             if let date = episode.publishedDate {
                 return date.formatted(Date.FormatStyle(date: .abbreviated, time: .omitted))
             } else {
@@ -146,10 +146,19 @@ extension SharingModal.Option {
 
     private var podcast: Podcast {
         switch self {
-        case .episode(let episode), .currentPosition(let episode, _), .clip(let episode, _), .clipShare(let episode, _, _, _):
+        case .episode(let episode), .currentPosition(let episode, _), .clip(let episode, _), .clipShare(let episode, _, _):
             return episode.parentPodcast()!
         case .podcast(let podcast):
             return podcast
+        }
+    }
+
+    private var episode: Episode? {
+        switch self {
+        case .episode(let episode), .currentPosition(let episode, _), .clip(let episode, _), .clipShare(let episode, _, _):
+            episode
+        default:
+            nil
         }
     }
 
@@ -168,30 +177,41 @@ extension SharingModal.Option {
     }
 
     @MainActor
-    func shareData(style: ShareImageStyle, destination: ShareDestination? = nil) -> [Any] {
+    func shareData(style: ShareImageStyle, destination: ShareDestination, progress: Binding<Float?>) async throws -> [Any] {
         let url = URL(string: shareURL) as NSURL?
-        let media = mediaData(style: style, destination: destination)
+
+        let media: Any?
+        switch self {
+        case .clipShare(let episode, let clipTime, _):
+            media = try await mediaData(imageInfo: imageInfo, style: style, episode: episode, clipTime: clipTime, destination: destination, progress: progress)
+        default:
+            media = nil
+        }
+
         return [url, media].compactMap({ $0 })
     }
 
     @MainActor
-    func mediaData(style: ShareImageStyle, destination: ShareDestination?) -> Any? {
+    func mediaData(imageInfo: ShareImageInfo, style: ShareImageStyle, episode: Episode, clipTime: ClipTime, destination: ShareDestination, progress: Binding<Float?>) async throws -> Any? {
         switch self {
-        case .clipShare(_, _, _, let progress):
-            // Share video/audio clip. If sending to instagram or audio, send full file, otherwise send cropped version.
-            let fileURL: URL?
-            switch (destination, style) {
-            case (.instagram, _):
-                fileURL = progress.exportURL
-            case (_, .audio):
-                fileURL = progress.exportURL
-            default:
-                fileURL = progress.exportURL
+        case .clipShare:
+            let nsProgress = Progress()
+            let observation = nsProgress.observe(\.completedUnitCount) { [progress] inProgress, change in
+                Task.detached { @MainActor in
+                    guard Task.isCancelled == false && inProgress.isCancelled == false else { return }
+                    progress.wrappedValue = Float(inProgress.completedUnitCount) / Float(inProgress.totalUnitCount)
+                }
             }
 
-            guard let fileURL else {
-                return ShareImageView(info: imageInfo, style: style, angle: .constant(0)).frame(width: style.previewSize.width, height: style.previewSize.height).snapshot()
-            }
+            let fileURL = try await destination.export(info: imageInfo,
+                                            style: style,
+                                            episode: episode,
+                                            startTime: CMTime(seconds: clipTime.start, preferredTimescale: 600),
+                                            duration: CMTime(seconds: clipTime.end - clipTime.start, preferredTimescale: 600),
+                                            progress: nsProgress
+            )
+
+            progress.wrappedValue = nil
 
             if destination == .instagram {
                 return try? Data(contentsOf: fileURL) // For some reason, I couldn't get this to work with just a URL
@@ -214,7 +234,7 @@ extension SharingModal.Option {
             return episode.shareURL + "?t=\(round(timeInterval))"
         case .clip(let episode, let timeInterval):
             return episode.shareURL + "?t=\(round(timeInterval))"
-        case .clipShare(let episode, let clipTime, _, _):
+        case .clipShare(let episode, let clipTime, _):
             return episode.shareURL + "?t=\(clipTime.start),\(clipTime.end)"
         }
     }

--- a/podcasts/Sharing/SharingModal.swift
+++ b/podcasts/Sharing/SharingModal.swift
@@ -186,7 +186,7 @@ extension SharingModal.Option {
             case (_, .audio):
                 fileURL = progress.exportURL
             default:
-                fileURL = progress.croppedURL
+                fileURL = progress.exportURL
             }
 
             guard let fileURL else {

--- a/podcasts/Sharing/SharingModal.swift
+++ b/podcasts/Sharing/SharingModal.swift
@@ -195,13 +195,16 @@ extension SharingModal.Option {
     func mediaData(imageInfo: ShareImageInfo, style: ShareImageStyle, episode: Episode, clipTime: ClipTime, destination: ShareDestination, progress: Binding<Float?>) async throws -> Any? {
         switch self {
         case .clipShare:
-            let nsProgress = Progress()
-            let observation = nsProgress.observe(\.completedUnitCount) { [progress] inProgress, change in
+            let nsProgress = Progress(totalUnitCount: 100)
+            let observation = nsProgress.observe(\.fractionCompleted) { [progress] inProgress, change in
                 Task.detached { @MainActor in
                     guard Task.isCancelled == false && inProgress.isCancelled == false else { return }
-                    progress.wrappedValue = Float(inProgress.completedUnitCount) / Float(inProgress.totalUnitCount)
+                    print("Fraction completed: \(inProgress.fractionCompleted)")
+                    progress.wrappedValue = Float(inProgress.fractionCompleted)
                 }
             }
+
+            progress.wrappedValue = 0.01
 
             let fileURL = try await destination.export(info: imageInfo,
                                             style: style,

--- a/podcasts/Sharing/SharingModal.swift
+++ b/podcasts/Sharing/SharingModal.swift
@@ -202,6 +202,10 @@ extension SharingModal.Option {
             }
         }
 
+        defer {
+            observation.invalidate()
+        }
+
         progress.wrappedValue = 0.01
 
         let fileURL = try await destination.export(info: imageInfo,

--- a/podcasts/Sharing/SharingModal.swift
+++ b/podcasts/Sharing/SharingModal.swift
@@ -197,7 +197,7 @@ extension SharingModal.Option {
         let observation = nsProgress.observe(\.fractionCompleted) { [progress] inProgress, change in
             Task.detached { @MainActor in
                 guard Task.isCancelled == false && inProgress.isCancelled == false else { return }
-                print("Fraction completed: \(inProgress.fractionCompleted)")
+                FileLog.shared.addMessage("Media Exporter: Fraction completed: \(inProgress.fractionCompleted)")
                 progress.wrappedValue = Float(inProgress.fractionCompleted)
             }
         }

--- a/podcasts/Sharing/SharingModal.swift
+++ b/podcasts/Sharing/SharingModal.swift
@@ -185,7 +185,7 @@ extension SharingModal.Option {
         case .clipShare(let episode, let clipTime, _):
             media = try await mediaData(imageInfo: imageInfo, style: style, episode: episode, clipTime: clipTime, destination: destination, progress: progress)
         default:
-            media = ShareImageView(info: imageInfo, style: style, angle: .constant(0)).frame(width: style.previewSize.width, height: style.previewSize.height).snapshot()
+            media = ShareImageView(info: imageInfo, style: style, angle: .constant(0)).frame(width: style.previewSize.width, height: style.previewSize.height).snapshot(scale: 3)
         }
 
         return [url, media].compactMap({ $0 })

--- a/podcasts/Sharing/SharingView.swift
+++ b/podcasts/Sharing/SharingView.swift
@@ -2,11 +2,6 @@ import SwiftUI
 import PocketCastsDataModel
 import PocketCastsUtils
 
-class ClipResult: ObservableObject {
-    @MainActor @Published var progress: Float = 0
-    @Published var exportURL: URL?
-}
-
 class ClipTime: ObservableObject {
     @Published var start: TimeInterval
     @Published var end: TimeInterval
@@ -52,7 +47,6 @@ struct SharingView: View {
     @State private var isExporting: Bool = false
 
     @ObservedObject var clipTime: ClipTime
-    @StateObject var clipResult = ClipResult()
 
     private let clipUUID = UUID().uuidString
 
@@ -81,11 +75,8 @@ struct SharingView: View {
         VStack {
             title
             tabView
-            SharingFooterView(clipTime: clipTime, option: $shareable.option, isExporting: $isExporting, clipResult: clipResult, destinations: destinations, style: shareable.style, clipUUID: clipUUID, source: source)
+            SharingFooterView(clipTime: clipTime, option: $shareable.option, isExporting: $isExporting, destinations: destinations, style: shareable.style, clipUUID: clipUUID, source: source)
         }
-        .task(id: isExporting, {
-            await exportIfNeeded()
-        })
         .onAppear {
             var properties = [:]
             let type: String
@@ -94,7 +85,7 @@ struct SharingView: View {
             case .clip(let episode, _):
                 properties["episode_uuid"] = episode.uuid
                 type = "clip"
-            case .clipShare(let episode, _, _, _):
+            case .clipShare(let episode, _, _):
                 properties["episode_uuid"] = episode.uuid
                 type = "clip"
             case .episode(let episode):
@@ -121,9 +112,8 @@ struct SharingView: View {
             Text(shareable.option.shareTitle(style: shareable.style))
                 .font(.headline)
             switch shareable.option {
-            case .clipShare(let episode, let clipTime, _, _):
+            case .clipShare(let episode, let clipTime, _):
                 Button(action: {
-                    isExporting = false
                     withAnimation {
                         shareable.option = .clip(episode, clipTime.playback)
                     }
@@ -152,7 +142,7 @@ struct SharingView: View {
         GeometryReader { proxy in
             TabView(selection: $shareable.style) {
                 switch shareable.option {
-                case .clipShare(_, _, let style, _):
+                case .clipShare(_, _, let style):
                     image(style: style, containerHeight: proxy.size.height)
                 case .clip:
                     ForEach(ShareImageStyle.allCases, id: \.self) { style in
@@ -186,70 +176,6 @@ struct SharingView: View {
         image.shareType = .image
 
         return [media, (style != .audio ? image : nil)].compactMap { $0 }
-    }
-
-    enum VideoExportError: Error {
-        case failedToDownload
-    }
-
-    private func exportIfNeeded() async {
-        guard isExporting,
-              case let .clipShare(episode, clipTime, shareable.style, _) = shareable.option
-        else {
-            return
-        }
-        defer {
-            isExporting = false
-        }
-        do {
-            try await Task.sleep(nanoseconds: 500_000_000) // Delay by half a second to let the UI update
-            clipResult.progress = Float.leastNormalMagnitude
-            let progress = Progress()
-            let observation = progress.observe(\.completedUnitCount) { progress, change in
-                Task.detached { @MainActor in
-                    clipResult.progress = Float(progress.completedUnitCount) / Float(progress.totalUnitCount)
-                }
-            }
-
-            let exportURL = try await export(info: shareable.option.imageInfo,
-                                            style: shareable.style,
-                                            episode: episode,
-                                            startTime: CMTime(seconds: clipTime.start, preferredTimescale: 600),
-                                            duration: CMTime(seconds: clipTime.end - clipTime.start, preferredTimescale: 600),
-                                            progress: progress
-            )
-
-            clipResult.exportURL = exportURL
-
-            shareable.option = .clipShare(episode, clipTime, shareable.style, clipResult)
-
-            progress.completedUnitCount = progress.totalUnitCount
-        } catch let error {
-            FileLog.shared.addMessage("Failed Clip Export: \(error)")
-        }
-    }
-
-    private func export(info: ShareImageInfo, style: ShareImageStyle, episode: some BaseEpisode, startTime: CMTime, duration: CMTime, progress: Progress) async throws -> URL {
-        guard let playerItem = DownloadManager.shared.downloadParallelToStream(of: episode) else {
-            throw VideoExportError.failedToDownload
-        }
-
-        switch style {
-        case .audio:
-            let url = FileManager.default.temporaryDirectory.appendingPathComponent("audio_export-\(UUID().uuidString)", conformingTo: .m4a)
-            try await AudioClipExporter.exportAudioClip(from: playerItem.asset, startTime: startTime, duration: duration, to: url, progress: progress)
-            return url
-        default:
-            let size = CGSize(width: style.previewSize.width * 2, height: style.previewSize.height * 2)
-            guard #available(iOS 16, *) else { // iOS 15 support will be added in a separate PR just to keep the line count down
-                throw VideoExportError.failedToDownload
-            }
-            let parameters = VideoExporter.Parameters(duration: CMTimeGetSeconds(duration), size: size, episodeAsset: playerItem.asset, audioStartTime: startTime, audioDuration: duration, fileType: .mp4)
-            let url = FileManager.default.temporaryDirectory.appendingPathComponent("video_export-\(UUID().uuidString)", conformingTo: .mpeg4Movie)
-            try await VideoExporter.export(view: AnimatedShareImageView(info: info, style: style), with: parameters, to: url, progress: progress)
-
-            return url
-        }
     }
 }
 

--- a/podcasts/View+CVPixelBuffer.swift
+++ b/podcasts/View+CVPixelBuffer.swift
@@ -7,7 +7,7 @@ enum CVPixelBufferError: Error {
 
 extension View {
     @MainActor @available(iOS 16.0, *)
-    func pixelBuffer(size: CGSize) throws -> CVPixelBuffer {
+    func pixelBuffer(size: CGSize, scale: CGFloat = 3) throws -> CVPixelBuffer {
         let attrs = [kCVPixelBufferCGImageCompatibilityKey: kCFBooleanTrue,
                      kCVPixelBufferCGBitmapContextCompatibilityKey: kCFBooleanTrue] as CFDictionary
         var pixelBuffer: CVPixelBuffer?
@@ -37,7 +37,7 @@ extension View {
         }
 
         let renderer = ImageRenderer(content: self)
-        renderer.scale = 2
+        renderer.scale = scale
         renderer.render { size, render in
             render(context)
         }

--- a/podcasts/View+CVPixelBuffer.swift
+++ b/podcasts/View+CVPixelBuffer.swift
@@ -37,6 +37,7 @@ extension View {
         }
 
         let renderer = ImageRenderer(content: self)
+        renderer.scale = 2
         renderer.render { size, render in
             render(context)
         }


### PR DESCRIPTION
| 📘 Part of: #1910 |
|:---:|

A duplicate of https://github.com/Automattic/pocket-casts-ios/pull/2112

This was merged targeting trunk but needs to go in 7.72

