### PR TITLE
Implement an adjustment variable to setup number of rows while animating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Add a check to prevent stats from decreasing [#2106](https://github.com/Automattic/pocket-casts-ios/issues/2106)
 - Updated the Google Cast library to 4.8.3
 - Adds new Sharing experience with clip creation [#1910](https://github.com/Automattic/pocket-casts-ios/issues/1910)
+- Fix crash when reordering shelf items on the player [#2122](https://github.com/Automattic/pocket-casts-ios/issues/2122)
 
 7.71
 -----

--- a/podcasts/ShelfActionsViewController+Table.swift
+++ b/podcasts/ShelfActionsViewController+Table.swift
@@ -21,7 +21,7 @@ extension ShelfActionsViewController: UITableViewDelegate, UITableViewDataSource
                 return Constants.Limits.maxShelfActions + maxShelfActionsAdjustment
             }
 
-            return allActions.count - ( Constants.Limits.maxShelfActions + maxShelfActionsAdjustment)
+            return allActions.count - (Constants.Limits.maxShelfActions + maxShelfActionsAdjustment)
         } else {
             return extraActions.count
         }

--- a/podcasts/ShelfActionsViewController+Table.swift
+++ b/podcasts/ShelfActionsViewController+Table.swift
@@ -18,10 +18,10 @@ extension ShelfActionsViewController: UITableViewDelegate, UITableViewDataSource
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         if tableView.isEditing {
             if section == ShelfActionsViewController.shortcutSection {
-                return Constants.Limits.maxShelfActions
+                return Constants.Limits.maxShelfActions + maxShelfActionsAdjustment
             }
 
-            return allActions.count - Constants.Limits.maxShelfActions
+            return allActions.count - ( Constants.Limits.maxShelfActions + maxShelfActionsAdjustment)
         } else {
             return extraActions.count
         }
@@ -143,17 +143,21 @@ extension ShelfActionsViewController: UITableViewDelegate, UITableViewDataSource
 
         // if someone has moved something into the shortcut section, move the bottom item out. Done async so that this method can return first
         if destinationIndexPath.section == ShelfActionsViewController.shortcutSection, sourceIndexPath.section != ShelfActionsViewController.shortcutSection {
-            DispatchQueue.main.async {
+            maxShelfActionsAdjustment = 1
+            DispatchQueue.main.async { [weak self] in
                 tableView.beginUpdates()
-                tableView.moveRow(at: IndexPath(row: 4, section: ShelfActionsViewController.shortcutSection), to: IndexPath(row: 0, section: ShelfActionsViewController.menuSection))
+                tableView.moveRow(at: IndexPath(row: Constants.Limits.maxShelfActions, section: ShelfActionsViewController.shortcutSection), to: IndexPath(row: 0, section: ShelfActionsViewController.menuSection))
+                self?.maxShelfActionsAdjustment = 0
                 tableView.endUpdates()
             }
         }
         // another option is they could move something out of the shortcut section into the menu section, which also requires a re-shuffle
         else if destinationIndexPath.section == ShelfActionsViewController.menuSection, sourceIndexPath.section == ShelfActionsViewController.shortcutSection {
-            DispatchQueue.main.async {
+            maxShelfActionsAdjustment = -1
+            DispatchQueue.main.async { [weak self] in
                 tableView.beginUpdates()
-                tableView.moveRow(at: IndexPath(row: 0, section: ShelfActionsViewController.menuSection), to: IndexPath(row: 3, section: ShelfActionsViewController.shortcutSection))
+                tableView.moveRow(at: IndexPath(row: 0, section: ShelfActionsViewController.menuSection), to: IndexPath(row: Constants.Limits.maxShelfActions-1, section: ShelfActionsViewController.shortcutSection))
+                self?.maxShelfActionsAdjustment = 0
                 tableView.endUpdates()
             }
         }

--- a/podcasts/ShelfActionsViewController.swift
+++ b/podcasts/ShelfActionsViewController.swift
@@ -45,6 +45,7 @@ class ShelfActionsViewController: UIViewController, CheckTranscriptAvailability 
 
     var allActions = Settings.playerActions()
     var extraActions = Settings.playerActions()
+    var maxShelfActionsAdjustment: Int = 0
 
     weak var playerActionsDelegate: NowPlayingActionsDelegate?
 


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes #2122 <!-- issue number, if applicable -->

Related to: https://a8c.sentry.io/share/issue/9432f9a8700e4ad7bc6a191f769cfc2e/

Adds a variable to reflect a temporary adjustment on the number items on the shelf while we are animating in/out any extra items to the shelf shortcut section

## To test

1. Start app
2. Start playing any episode
3. Open full screen player
4. Tap on the More (...) button on the player shelf action
5. Tap on Edit
6. Move items around from one section to another, `shortcut` to `in menu` and vice-versa
7. Check if no crash happens

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
