### PR TITLE
Fix #2126: Add reimagine sharing support to Multi Selection

### DIFF
--- a/podcasts/Analytics/Helpers/AnalyticsCoordinator.swift
+++ b/podcasts/Analytics/Helpers/AnalyticsCoordinator.swift
@@ -45,6 +45,8 @@ enum AnalyticsSource: String, AnalyticsDescribable {
     case watch
     case bookmark
     case interactiveWidget = "interactive_widget"
+    case multiSelect = "multi_select"
+    case episodeSwipeAction = "episode_swipe_action"
     case unknown
 
     var analyticsDescription: String { rawValue }

--- a/podcasts/EpisodeDetailViewController.swift
+++ b/podcasts/EpisodeDetailViewController.swift
@@ -500,9 +500,8 @@ class EpisodeDetailViewController: FakeNavViewController, UIDocumentInteractionC
         let shareTime = sharePosition ? episode.playedUpTo : 0
 
         let type = shareTime == 0 ? "episode" : "current_position"
-        Analytics.track(.podcastShared, properties: ["type": type, "source": analyticsSource])
 
-        SharingHelper.shared.shareLinkTo(episode: episode, shareTime: shareTime, fromController: self, sourceRect: sourceRect, sourceView: view)
+        SharingHelper.shared.shareLinkTo(episode: episode, shareTime: shareTime, fromController: self, sourceRect: sourceRect, sourceView: view, fromSource: analyticsSource, analyticsType: type)
     }
 
     func episodeFileAction(from sourceRect: CGRect) -> OptionAction? {

--- a/podcasts/MultiSelectHelper.swift
+++ b/podcasts/MultiSelectHelper.swift
@@ -326,8 +326,6 @@ class MultiSelectHelper {
             return
         }
 
-        Analytics.track(.podcastShared, properties: ["type": "episode", "source": "multi_select"])
-
         guard let sourceView = view ?? actionDelegate.multiSelectPresentingViewController().view else {
             return
         }
@@ -337,7 +335,9 @@ class MultiSelectHelper {
                                          fromController: actionDelegate.multiSelectPresentingViewController(),
                                          sourceRect: sourceView.bounds,
                                          sourceView: sourceView,
-                                         showArrow: view != nil)
+                                         showArrow: view != nil,
+                                         fromSource: .multiSelect
+        )
     }
 
     // MARK: - Selection Helpers

--- a/podcasts/NowPlayingPlayerItemViewController+Shelf.swift
+++ b/podcasts/NowPlayingPlayerItemViewController+Shelf.swift
@@ -431,9 +431,9 @@ extension NowPlayingPlayerItemViewController: NowPlayingActionsDelegate {
 
         let type = fromTime == 0 ? "episode" : "current_position"
 
-        Analytics.track(.podcastShared, properties: ["type": type, "source": "player"])
-
         if FeatureFlag.newSharing.enabled {
+            Analytics.track(.podcastShared, properties: ["type": type, "source": "player"])
+
             if fromTime == 0 {
                 SharingModal.show(option: .episode(episode), from: analyticsSource, in: self)
             } else {
@@ -441,7 +441,7 @@ extension NowPlayingPlayerItemViewController: NowPlayingActionsDelegate {
             }
         } else {
             let sourceRect = buttonSuperview.convert(source.frame, to: view)
-            SharingHelper.shared.shareLinkTo(episode: episode, shareTime: fromTime, fromController: self, sourceRect: sourceRect, sourceView: view)
+            SharingHelper.shared.shareLinkTo(episode: episode, shareTime: fromTime, fromController: self, sourceRect: sourceRect, sourceView: view, fromSource: .player, analyticsType: type)
         }
     }
 

--- a/podcasts/SharingHelper+swipeButton.swift
+++ b/podcasts/SharingHelper+swipeButton.swift
@@ -4,8 +4,7 @@ import PocketCastsDataModel
 extension SharingHelper {
     func shareLinkTo(episode: Episode, fromController: UIViewController, fromTableView tableView: UITableView, at indexPath: IndexPath) {
         let source = tableView.swipeButton(forLabel: L10n.share, at: indexPath) ?? tableView
-        Analytics.track(.podcastShared, properties: ["type": "episode", "source": "episode_swipe_action"])
-        shareLinkTo(episode: episode, shareTime: 0, fromController: fromController, sourceRect: source.bounds, sourceView: source)
+        shareLinkTo(episode: episode, shareTime: 0, fromController: fromController, sourceRect: source.bounds, sourceView: source, fromSource: .episodeSwipeAction)
     }
 }
 

--- a/podcasts/SharingHelper.swift
+++ b/podcasts/SharingHelper.swift
@@ -105,7 +105,14 @@ class SharingHelper: NSObject {
         activityController.popoverPresentationController?.barButtonItem = barButtonItem
     }
 
-    func shareLinkTo(episode: Episode, shareTime: TimeInterval, fromController: UIViewController, sourceRect: CGRect, sourceView: UIView?, showArrow: Bool = true) {
+    func shareLinkTo(episode: Episode, shareTime: TimeInterval, fromController: UIViewController, sourceRect: CGRect, sourceView: UIView?, showArrow: Bool = true, fromSource: AnalyticsSource, analyticsType: String = "episode") {
+        Analytics.track(.podcastShared, source: fromSource, properties: ["type": analyticsType])
+
+        guard FeatureFlag.newSharing.enabled == false else {
+            SharingModal.show(option: .episode(episode), from: fromSource, in: fromController)
+            return
+        }
+
         activityController = createActivityController(episode: episode, shareTime: shareTime)
         activityController?.completionWithItemsHandler = { _, _, _, _ in
             NotificationCenter.postOnMainThread(notification: Constants.Notifications.closedNonOverlayableWindow)


### PR DESCRIPTION
| 📘 Part of: #1910 |
|:---:|

Fixes #2126

This adds the reimagined sharing design from the multi-select bar & episode cell swipe.

https://github.com/user-attachments/assets/05d397f4-1b05-4e09-a13a-c478aada828b

https://github.com/user-attachments/assets/1c446792-8eea-46d8-9cc7-1dee2175def5

## To test

### Multi-Select
* Tap and hold an episode cell
* Tap the ellipsis in the bar at the bottom
* Tap "Share"
* Verify that the new Share Episode screen is shown

### Episode Cell Swipe
* Swipe to the left on the episode cell
* Tap the Share button
* Verify that the new Share Episode screen is shown

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
