### PR TITLE
Revert change stats

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+LocalChanges.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+LocalChanges.swift
@@ -157,23 +157,24 @@ extension SyncTask {
     }
 
     func changedStats() -> Api_Record? {
-        guard StatsManager.shared.syncStatus() == .notSynced,
-              let timeSavedDynamicSpeed = convertStat(StatsManager.shared.timeSavedDynamicSpeed()),
-              let totalSkippedTime = convertStat(StatsManager.shared.totalSkippedTime()),
-              let totalIntroSkippedTime = convertStat(StatsManager.shared.totalAutoSkippedTime()),
-              let timeSavedVariableSpeed = convertStat(StatsManager.shared.timeSavedVariableSpeed()),
-              let totalListeningTime = convertStat(StatsManager.shared.totalListeningTime()) else {
+        let timeSavedDynamicSpeed = convertStat(StatsManager.shared.timeSavedDynamicSpeed())
+        let totalSkippedTime = convertStat(StatsManager.shared.totalSkippedTime())
+        let totalIntroSkippedTime = convertStat(StatsManager.shared.totalAutoSkippedTime())
+        let timeSavedVariableSpeed = convertStat(StatsManager.shared.timeSavedVariableSpeed())
+        let totalListeningTime = convertStat(StatsManager.shared.totalListeningTime())
+        let startSyncTime = Int64(StatsManager.shared.statsStartDate().timeIntervalSince1970)
+
+        // check to see if there's actually any stats we need to sync
+        if StatsManager.shared.syncStatus() != .notSynced || (timeSavedDynamicSpeed == nil && totalSkippedTime == nil && totalSkippedTime == nil && timeSavedVariableSpeed == nil && totalListeningTime == nil) {
             return nil
         }
 
-        let startSyncTime = Int64(StatsManager.shared.statsStartDate().timeIntervalSince1970)
-
         var deviceRecord = Api_SyncUserDevice()
-        deviceRecord.timeSilenceRemoval.value = timeSavedDynamicSpeed
-        deviceRecord.timeSkipping.value = totalSkippedTime
-        deviceRecord.timeIntroSkipping.value = totalIntroSkippedTime
-        deviceRecord.timeVariableSpeed.value = timeSavedVariableSpeed
-        deviceRecord.timeListened.value = totalListeningTime
+        deviceRecord.timeSilenceRemoval.value = timeSavedDynamicSpeed ?? 0
+        deviceRecord.timeSkipping.value = totalSkippedTime ?? 0
+        deviceRecord.timeIntroSkipping.value = totalIntroSkippedTime ?? 0
+        deviceRecord.timeVariableSpeed.value = timeSavedVariableSpeed ?? 0
+        deviceRecord.timeListened.value = totalListeningTime ?? 0
         deviceRecord.timesStartedAt.value = startSyncTime
         deviceRecord.deviceID.value = ServerConfig.shared.syncDelegate?.uniqueAppId() ?? ""
         deviceRecord.deviceType.value = ServerConstants.Values.deviceTypeiOS


### PR DESCRIPTION
I reverted the small refactor introduced in #2106  The refactor prevented the sync even if only one value wasn't nil.

## To test

1. install app
2. register a new user
3. listen to an episode for a minute
4. make sure sync has happened (Profile > Refresh Now)
5. delete the app
6. install the app
7. sign in as the user
8. stats will show the 1 minute of listening time

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
