### PR TITLE
Transcripts: Improve transcript shelf button color and action when no transcripts is available.

### DIFF
--- a/podcasts/NowPlayingPlayerItemViewController+Shelf.swift
+++ b/podcasts/NowPlayingPlayerItemViewController+Shelf.swift
@@ -310,6 +310,10 @@ extension NowPlayingPlayerItemViewController: NowPlayingActionsDelegate {
     }
 
     @objc private func transcriptTapped(_ sender: UIButton) {
+        guard let transcriptButton = sender as? TranscriptShelfButton, transcriptButton.isTranscriptEnabled else {
+            Toast.show(TranscriptError.notAvailable.localizedDescription)
+            return
+        }
         shelfButtonTapped(.transcript)
 
         displayTranscript = true

--- a/podcasts/ShelfActionsViewController+Table.swift
+++ b/podcasts/ShelfActionsViewController+Table.swift
@@ -33,7 +33,8 @@ extension ShelfActionsViewController: UITableViewDelegate, UITableViewDataSource
         guard let playingEpisode = PlaybackManager.shared.currentEpisode() else { return cell }
 
         let action = actionAt(indexPath: indexPath, isEditing: tableView.isEditing)
-
+        cell.actionIcon.tintColor = ThemeColor.playerContrast02()
+        cell.actionName.textColor = ThemeColor.playerContrast02()
         if !tableView.isEditing {
             cell.actionName.text = action.title(episode: playingEpisode)
             if action != .routePicker {
@@ -54,8 +55,10 @@ extension ShelfActionsViewController: UITableViewDelegate, UITableViewDataSource
 
             // Disable transcript if not available
             let isTranscriptsAndIsDisable = action == .transcript && !isTranscriptEnabled
-            cell.actionIcon.layer.opacity = isTranscriptsAndIsDisable ? 0.8 : 1
-            cell.actionName.layer.opacity = isTranscriptsAndIsDisable ? 0.5 : 1
+            if isTranscriptsAndIsDisable {
+                cell.actionIcon.tintColor = ThemeColor.playerContrast06()
+                cell.actionName.textColor = ThemeColor.playerContrast06()
+            }
         } else {
             cell.actionName.text = action.title(episode: nil)
             cell.actionIcon.image = UIImage(named: action.iconName(episode: nil))

--- a/podcasts/ShelfActionsViewController+Table.swift
+++ b/podcasts/ShelfActionsViewController+Table.swift
@@ -81,6 +81,7 @@ extension ShelfActionsViewController: UITableViewDelegate, UITableViewDataSource
         let action = actionAt(indexPath: indexPath, isEditing: tableView.isEditing)
 
         if action == .transcript && !isTranscriptEnabled {
+            Toast.show(TranscriptError.notAvailable.localizedDescription)
             return
         }
 

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -3170,7 +3170,7 @@ internal enum L10n {
   internal static var transcriptErrorFailedToLoad: String { return L10n.tr("Localizable", "transcript_error_failed_to_load") }
   /// Sorry, but something went wrong while parsing this transcript
   internal static var transcriptErrorFailedToParse: String { return L10n.tr("Localizable", "transcript_error_failed_to_parse") }
-  /// Sorry, but a transcript is not available for this podcast
+  /// Sorry, but a transcript is not available for this episode.
   internal static var transcriptErrorNotAvailable: String { return L10n.tr("Localizable", "transcript_error_not_available") }
   /// Sorry, but this transcript format is not supported: %1$@
   internal static func transcriptErrorNotSupported(_ p1: Any) -> String {

--- a/podcasts/TranscriptShelfButton.swift
+++ b/podcasts/TranscriptShelfButton.swift
@@ -3,16 +3,13 @@ import PocketCastsDataModel
 
 class TranscriptShelfButton: UIButton, CheckTranscriptAvailability {
     var isTranscriptEnabled: Bool {
-        get {
-            isEnabled
-        }
-
-        set {
-            isEnabled = newValue
+        didSet {
+            imageView?.tintColor = isTranscriptEnabled ? ThemeColor.playerContrast02() : ThemeColor.playerContrast06()
         }
     }
 
     override init(frame: CGRect) {
+        isTranscriptEnabled = false
         super.init(frame: frame)
         addObservers()
         checkTranscriptAvailability()

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4262,8 +4262,8 @@
 /* Kids Profile Toast message if feedback sent failed */
 "kids_profile_submit_error" = "Something went wrong. Please try submitting your feedback again";
 
-/* Transcript error message when no transcript is available*/
-"transcript_error_not_available" = "Sorry, but a transcript is not available for this podcast";
+/* Transcript error message when a transcript is not available*/
+"transcript_error_not_available" = "Sorry, but a transcript is not available for this episode.";
 
 /* Transcript error message when transcript failed to load*/
 "transcript_error_failed_to_load" = "Sorry, but something went wrong while loading this transcript";


### PR DESCRIPTION
| 📘 Part of: #1848  |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

This PR updates the following:

- Transcript shelf icon is now using a better color to indicate that is disabled
- Transcript shelf icon will show a Toast when pressed if no transcript is available.


https://github.com/user-attachments/assets/cd0e2f37-5471-407f-b76c-fa15ff7420fd



## To test

1. Start the app
2. Ensure that you have the Transcript FF enabled
3. Start playing an episode without transcript support. For example: The Daily
4. Open full screen player
5. Check if the transcript icon shows disabled with good difference to the other shelf icons
6. Tap on it
7. See that a Toast is displayer
8. Tap on the ... (More) button
9. Move the Transcript button out of the shortcut section to in menu
10. Tap Done
11. Tap ... again
12. Tap on the Transcript row
13. Check that the toast message is shown
14. Now start playing an episode with Transcript support. Ex: Cautionary Tales
15. Open the full screen player
16. Check if the transcript icon shows correctly enabled
17. Tap on Transcript icon
18. Check that the Transcript is show

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
