### PR TITLE
Fix normal color on menu shelf actions

### DIFF
--- a/podcasts/ShelfActionsViewController+Table.swift
+++ b/podcasts/ShelfActionsViewController+Table.swift
@@ -33,8 +33,8 @@ extension ShelfActionsViewController: UITableViewDelegate, UITableViewDataSource
         guard let playingEpisode = PlaybackManager.shared.currentEpisode() else { return cell }
 
         let action = actionAt(indexPath: indexPath, isEditing: tableView.isEditing)
-        cell.actionIcon.tintColor = ThemeColor.playerContrast02()
-        cell.actionName.textColor = ThemeColor.playerContrast02()
+        cell.actionIcon.tintColor = ThemeColor.playerContrast01()
+        cell.actionName.textColor = ThemeColor.playerContrast01()
         if !tableView.isEditing {
             cell.actionName.text = action.title(episode: playingEpisode)
             if action != .routePicker {


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

When working on this [fix](https://github.com/Automattic/pocket-casts-ios/pull/2134/files) I accidentally changed the default active colours on the shelf more menu. This PR fixes the tint colors for the menu more actions.


| 1 | 2 | 3 | 4 |
| - | - | -  | - | 
| ![Simulator Screenshot - iPhone 15 Pro - 2024-09-05 at 19 09 58](https://github.com/user-attachments/assets/12da5f48-7b8e-4b20-9603-d9b30e9b0717) | ![Simulator Screenshot - iPhone 15 Pro - 2024-09-05 at 19 09 46](https://github.com/user-attachments/assets/7ff2f0de-115b-4f1c-87df-e2986b14a58d) | ![Simulator Screenshot - iPhone 15 Pro - 2024-09-05 at 19 07 43](https://github.com/user-attachments/assets/831d0ca6-a98d-4c76-8a2d-e26a0bea611d) | ![Simulator Screenshot - iPhone 15 Pro - 2024-09-05 at 19 07 16](https://github.com/user-attachments/assets/dde06f78-b727-4ab4-8b1b-4b5fdf3a33b8) |


## To test

1. Start the app
2. Play an episode
3. Open the full screen menu
4. Tap on more (...) option on the shelf
5. Check if the options have the same color as the Edit option on the top right of the sheet.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
