### PR TITLE
Referrals: Add animated background gradient view to card.

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1709,6 +1709,7 @@
 		FF05C9902C0A255600E41EB3 /* FileManager+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF05C98E2C0A0BF800E41EB3 /* FileManager+Helper.swift */; };
 		FF05C9922C0E044C00E41EB3 /* DBTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF05C9912C0E044C00E41EB3 /* DBTestCase.swift */; };
 		FF0A1D522C580CF5003931E6 /* TranscriptsDataRetriever.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF6BBCF12C578CE600604A01 /* TranscriptsDataRetriever.swift */; };
+		FF1DF01A2C8A206E0028B8D8 /* ReferralCardAnimatedGradientView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF1DF0192C8A206E0028B8D8 /* ReferralCardAnimatedGradientView.swift */; };
 		FF2142D42C07369200672D8D /* MediaExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF2142D32C07369200672D8D /* MediaExporter.swift */; };
 		FF2142D52C07369200672D8D /* MediaExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF2142D32C07369200672D8D /* MediaExporter.swift */; };
 		FF2CD57C2B9F4B2D009B58B5 /* PocketCastsDataModel in Frameworks */ = {isa = PBXBuildFile; productRef = FF2CD57B2B9F4B2D009B58B5 /* PocketCastsDataModel */; };
@@ -3602,6 +3603,7 @@
 		FF03F7C32C0E331E00369572 /* SourceInterfaceModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceInterfaceModel.swift; sourceTree = "<group>"; };
 		FF05C98E2C0A0BF800E41EB3 /* FileManager+Helper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FileManager+Helper.swift"; sourceTree = "<group>"; };
 		FF05C9912C0E044C00E41EB3 /* DBTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DBTestCase.swift; sourceTree = "<group>"; };
+		FF1DF0192C8A206E0028B8D8 /* ReferralCardAnimatedGradientView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReferralCardAnimatedGradientView.swift; sourceTree = "<group>"; };
 		FF2142D32C07369200672D8D /* MediaExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaExporter.swift; sourceTree = "<group>"; };
 		FF40C0652C65175B003A9D93 /* TranscriptErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptErrorView.swift; sourceTree = "<group>"; };
 		FF47245A2BA4749F00EA916B /* MenuRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuRow.swift; sourceTree = "<group>"; };
@@ -7770,6 +7772,7 @@
 				FF4A73D52C8745D200587128 /* ReferralSendPassView.swift */,
 				FF4A73D72C87694300587128 /* ReferralCardView.swift */,
 				FF4A73D92C876D5E00587128 /* ReferralSendPassVC.swift */,
+				FF1DF0192C8A206E0028B8D8 /* ReferralCardAnimatedGradientView.swift */,
 			);
 			path = Referrals;
 			sourceTree = "<group>";
@@ -9816,6 +9819,7 @@
 				BD8139D21FB95C3900DBF0EC /* ProfileViewController.swift in Sources */,
 				BD7114BF20E224BF003DF634 /* AutoArchiveViewController.swift in Sources */,
 				C7D6551428E5153200AD7174 /* Debounce.swift in Sources */,
+				FF1DF01A2C8A206E0028B8D8 /* ReferralCardAnimatedGradientView.swift in Sources */,
 				C7E99F002A5E099100E7CBAF /* MultiSelectListViewModel.swift in Sources */,
 				BD1C46DD27B9DD9C00B1D8BB /* FolderListCell.swift in Sources */,
 				BD998AD127B25A3300B38857 /* PodcastPickerModel.swift in Sources */,

--- a/podcasts/Referrals/ReferralCardAnimatedGradientView.swift
+++ b/podcasts/Referrals/ReferralCardAnimatedGradientView.swift
@@ -1,0 +1,120 @@
+import SwiftUI
+
+struct ReferralCardAnimatedGradientView: View {
+
+    enum AnimationPosition {
+        case topLeading
+        case bottomLeading
+        case bottomTrailing
+        case topTrailing
+
+        var verticalPosition: CGFloat {
+            switch self {
+            case .topLeading:
+                return -1
+            case .bottomLeading:
+                return +1
+            case .bottomTrailing:
+                return +1
+            case .topTrailing:
+                return -1
+            }
+        }
+
+        var horizontalPosition: CGFloat {
+            switch self {
+            case .topLeading:
+                return -1
+            case .bottomLeading:
+                return -1
+            case .bottomTrailing:
+                return +1
+            case .topTrailing:
+                return +1
+            }
+        }
+    }
+
+    let animationSequence: [AnimationPosition] = [.topLeading, .topTrailing, .bottomTrailing, .bottomLeading]
+
+    @State private var currentAnimationPosition: Int = 0
+    @State private var currentAnimation: AnimationPosition = .topLeading
+
+    private func nextAnimation() {
+        currentAnimationPosition += 1
+        if currentAnimationPosition < animationSequence.count {
+            currentAnimation = animationSequence[currentAnimationPosition]
+            return
+        }
+        currentAnimationPosition = 0
+        currentAnimation = animationSequence[currentAnimationPosition]
+    }
+
+    var body: some View {
+        GeometryReader(content: { geometry in
+            ZStack() {
+                LinearGradient(
+                    stops: Constants.gradientStops,
+                    startPoint: UnitPoint(x: 0.12, y: 0),
+                    endPoint: UnitPoint(x: 0.89, y: 0.95)
+                )
+                .clipShape(Circle())
+                .blur(radius: 30)
+                .opacity(0.75)
+                .ignoresSafeArea()
+                .offset(x: currentAnimation.horizontalPosition * geometry.size.width / 2,
+                        y: currentAnimation.verticalPosition * geometry.size.height / 2)
+                LinearGradient(
+                    stops: Constants.gradientStops,
+                    startPoint: UnitPoint(x: 0.29, y: 0.19),
+                    endPoint: UnitPoint(x: 0.87, y: 1.18)
+                )
+                .clipShape(Circle())
+                .blur(radius: 30)
+                .opacity(0.75)
+                .ignoresSafeArea()
+                .offset(x: -1 * currentAnimation.horizontalPosition * geometry.size.width / 2,
+                        y: -1 * currentAnimation.verticalPosition * geometry.size.height / 2)
+                .rotationEffect(Angle(degrees: 1.45))
+                .opacity(0.75)
+            }
+            .animation(.easeInOut(duration: Constants.animationDuration), value: currentAnimation)
+            .task {
+                Task {
+                    while true {
+                        nextAnimation()
+                        try await Task.sleep(nanoseconds: UInt64(Constants.animationDuration) * 1_000_000_000)
+                    }
+                }
+            }
+            .background(.black)
+        })
+        .clipped()
+    }
+
+    enum Constants {
+        static let gradientStops: [Gradient.Stop] = [
+            Gradient.Stop(color: Color(red: 0.25, green: 0.11, blue: 0.92), location: 0.00),
+            Gradient.Stop(color: Color(red: 0.68, green: 0.89, blue: 0.86), location: 0.24),
+            Gradient.Stop(color: Color(red: 0.87, green: 0.91, blue: 0.53), location: 0.50),
+            Gradient.Stop(color: Color(red: 0.91, green: 0.35, blue: 0.26), location: 0.76),
+            Gradient.Stop(color: Color(red: 0.1, green: 0.1, blue: 0.1), location: 1.00),
+        ]
+
+        static let animationDuration: TimeInterval = 5
+    }
+}
+
+#Preview {
+    Rectangle()
+        .foregroundColor(.blue.opacity(0.2))
+        .background {
+            ReferralCardAnimatedGradientView()
+        }
+        .overlay(alignment: .bottomLeading) {
+            Text("Sergio").padding()
+        }
+        .cornerRadius(15)
+        .frame(width: 315, height: 200)
+
+}

--- a/podcasts/Referrals/ReferralCardView.swift
+++ b/podcasts/Referrals/ReferralCardView.swift
@@ -5,8 +5,11 @@ struct ReferralCardView: View {
 
     var body: some View {
         Rectangle()
+            .background {
+                ReferralCardAnimatedGradientView()
+            }
             .cornerRadius(Constants.cardRadius)
-            .foregroundColor(Constants.cardBackgroundColor)
+            .foregroundColor(.clear)
             .overlay(alignment: .bottomLeading) {
                 Text(L10n.referralsGuestPassOffer(numberOfDaysOffered))
                     .font(size: 12, style: .body, weight: .semibold)


### PR DESCRIPTION
| 📘 Part of: #2083  |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

This PR implements the animated gradient view for the referrals card


https://github.com/user-attachments/assets/707b99e2-bee9-49f5-a233-ca659bbd1eaa



## To test

1. Start the app
2. Ensure that you have the `referrals` FF enabled
3. Ensure that you have a Plus or Patron account
4. Open profile
5. Tap on the gift icon on the top left
6. Check that you see the animation like in the video above.
7. Please test on a real device to see performance

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
