### PR TITLE
Skip bug: check if player is ready to play

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Updated the Google Cast library to 4.8.3
 - Adds new Sharing experience with clip creation [#1910](https://github.com/Automattic/pocket-casts-ios/issues/1910)
 - Fix crash when reordering shelf items on the player [#2122](https://github.com/Automattic/pocket-casts-ios/issues/2122)
+- Fix Skip button when switch player [#2141](https://github.com/Automattic/pocket-casts-ios/issues/2141)
 
 7.71
 -----

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -106,7 +106,10 @@ public enum FeatureFlag: String, CaseIterable {
     /// Enable the refactored discover collection view
     case discoverCollectionView
 
-    /// Preload the `EffectsPlayer` read task when assigned
+    /// Uses the `isReadyToPlay` function to decide what logic to use when skipping.
+    /// There's some scenario when the Default player switched to the Effects player when the stream is paused.
+    /// This makes the skip unusable as the player doesn't have its task set yet.
+    /// If the player is not ready to play, we should use the same logic we use when the player doesn't exist yet.
     case playerIsReadyToPlay
 
     public var enabled: Bool {
@@ -184,7 +187,7 @@ public enum FeatureFlag: String, CaseIterable {
         case .discoverCollectionView:
             false
         case .playerIsReadyToPlay:
-            false
+            true
         }
     }
 

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -106,6 +106,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// Enable the refactored discover collection view
     case discoverCollectionView
 
+    /// Preload the `EffectsPlayer` read task when assigned
+    case playerIsReadyToPlay
+
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -179,6 +182,8 @@ public enum FeatureFlag: String, CaseIterable {
         case .syncStats:
             true
         case .discoverCollectionView:
+            false
+        case .playerIsReadyToPlay:
             false
         }
     }

--- a/podcasts/DefaultPlayer.swift
+++ b/podcasts/DefaultPlayer.swift
@@ -75,6 +75,10 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
         configurePlayer(videoPodcast: episode.videoPodcast())
     }
 
+    func isReadyToPlay() -> Bool {
+        player != nil
+    }
+
     func playing() -> Bool {
         (player?.rate ?? 0) != 0
     }

--- a/podcasts/EffectsPlayer.swift
+++ b/podcasts/EffectsPlayer.swift
@@ -53,6 +53,10 @@ class EffectsPlayer: PlaybackProtocol, Hashable {
         self.episode = episode
     }
 
+    func isReadyToPlay() -> Bool {
+        audioReadTask != nil && audioPlayTask != nil
+    }
+
     func playing() -> Bool {
         if aboutToPlay.value { return true }
 

--- a/podcasts/EffectsPlayer.swift
+++ b/podcasts/EffectsPlayer.swift
@@ -45,6 +45,47 @@ class EffectsPlayer: PlaybackProtocol, Hashable {
 
     private lazy var episodeArtwork = EpisodeArtwork()
 
+    func readyToPlay(_ episode: BaseEpisode) {
+        episodePath = episode.pathToDownloadedFile(pathFinder: DownloadManager.shared)
+        self.episode = episode
+
+        DispatchQueue.global().async { [weak self] in
+            guard let strongSelf = self, let episode = strongSelf.episode else { return }
+
+            strongSelf.playerLock.lock()
+
+            strongSelf.effects = PlaybackManager.shared.effects()
+            strongSelf.playBufferManager = PlayBufferManager()
+
+            let fileURL = URL(fileURLWithPath: strongSelf.episodePath!)
+            do {
+                strongSelf.audioFile = try AVAudioFile(forReading: fileURL, commonFormat: AVAudioCommonFormat.pcmFormatFloat32, interleaved: false)
+
+                // AVAudioFile.length is an expensive operation (often in the seconds) so here we attempt to load a cached value instead
+                strongSelf.cachedFrameCount = DataManager.sharedManager.findFrameCount(episode: episode)
+                if strongSelf.cachedFrameCount == 0 {
+                    // we haven't cached a frame count for this episode, do that now
+                    strongSelf.cachedFrameCount = strongSelf.audioFile!.length
+                    if strongSelf.cachedFrameCount == 0 {
+                        // If don't have a frameCount we cannot use the effect player
+                        throw AVError(_nsError: NSError(domain: AVFoundationErrorDomain, code: AVError.fileFailedToParse.rawValue))
+                    }
+                    DataManager.sharedManager.saveFrameCount(episode: episode, frameCount: strongSelf.cachedFrameCount)
+                }
+                guard let audioFile = strongSelf.audioFile, let playBufferManager = strongSelf.playBufferManager else {
+                    strongSelf.playerLock.unlock()
+                    return
+                }
+                let requiredStartTime = PlaybackManager.shared.requiredStartingPosition()
+                strongSelf.audioReadTask = AudioReadTask(trimSilence: strongSelf.effects.trimSilence, audioFile: audioFile, outputFormat: audioFile.processingFormat, bufferManager: playBufferManager, playPositionHint: requiredStartTime, frameCount: strongSelf.cachedFrameCount)
+                strongSelf.playerLock.unlock()
+            } catch {
+                strongSelf.playerLock.unlock()
+                return
+            }
+        }
+    }
+    
     // MARK: - PlaybackProtocol Impl
 
     func loadEpisode(_ episode: BaseEpisode) {

--- a/podcasts/GoogleCastManager.swift
+++ b/podcasts/GoogleCastManager.swift
@@ -116,6 +116,10 @@ class GoogleCastManager: NSObject, GCKRemoteMediaClientListener, GCKSessionManag
         return false
     }
 
+    func hasCastSession() -> Bool {
+        return GCKCastContext.sharedInstance().sessionManager.currentCastSession != nil
+    }
+
     func buffering() -> Bool {
         if bufferingInitialPartOfEpisode { return true }
 

--- a/podcasts/GoogleCastPlayer.swift
+++ b/podcasts/GoogleCastPlayer.swift
@@ -23,6 +23,10 @@ class GoogleCastPlayer: PlaybackProtocol {
         castManager.playSingleEpisode(episode)
     }
 
+    func isReadyToPlay() -> Bool {
+        castManager.hasCastSession()
+    }
+
     func playing() -> Bool {
         castManager.playing()
     }

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -1169,11 +1169,7 @@ class PlaybackManager: ServerPlaybackDelegate {
                 player = GoogleCastPlayer()
             } else if playersSupported.first == EffectsPlayer.self {
                 FileLog.shared.addMessage("Using EffectsPlayer")
-                let player = EffectsPlayer()
-                if !aboutToPlay.value {
-                    player.readyToPlay(currEpisode)
-                }
-                self.player = player
+                player = EffectsPlayer()
             } else {
                 FileLog.shared.addMessage("Using DefaultPlayer")
                 player = DefaultPlayer()

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -432,7 +432,8 @@ class PlaybackManager: ServerPlaybackDelegate {
         seekingTo = time
         FileLog.shared.addMessage("seek to \(time) startPlaybackAfterSeek \(startPlaybackAfterSeek)")
 
-        if let player = player {
+        let isReadyToPlay = FeatureFlag.playerIsReadyToPlay.enabled ? (player?.isReadyToPlay() == true) : true
+        if let player = player, isReadyToPlay {
             player.seekTo(time, completion: { [weak self] () in
                 guard let strongSelf = self else { return }
 

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -1169,7 +1169,11 @@ class PlaybackManager: ServerPlaybackDelegate {
                 player = GoogleCastPlayer()
             } else if playersSupported.first == EffectsPlayer.self {
                 FileLog.shared.addMessage("Using EffectsPlayer")
-                player = EffectsPlayer()
+                let player = EffectsPlayer()
+                if !aboutToPlay.value {
+                    player.readyToPlay(currEpisode)
+                }
+                self.player = player
             } else {
                 FileLog.shared.addMessage("Using DefaultPlayer")
                 player = DefaultPlayer()

--- a/podcasts/PlaybackProtocol.swift
+++ b/podcasts/PlaybackProtocol.swift
@@ -19,6 +19,8 @@ import PocketCastsDataModel
 
     func effectsDidChange()
 
+    func isReadyToPlay() -> Bool
+
     func supportsSilenceRemoval() -> Bool
     func supportsVolumeBoost() -> Bool
     func supportsGoogleCast() -> Bool


### PR DESCRIPTION
Fixes #2141 

This PR introduces a new protocol function to identify if a player is ready to play. This should prevent the case where the player switches, breaking the skip back/forward functionalities.

## To test

Make sure you use a premium user or patron and use, so you can test it with also podcasts containing chapters.

Podcast with chapters: https://pca.st/podcast/e7abe050-6cc7-0130-f8c5-723c91aeae46

### Default Player
- Run the app
- Make sure you don't use effects
- Play any episode
- Make sure the skip back and forward always work

### Effects Player
- Run the app
- Make sure you use an effect
- Play any episode you never listen to before
- Pause it as soon t starts playing and move the progress bar to the middle
- Wait till the episode is downloaded so the player switches
- Make sure the skip back and forward always work while paused
- Play and re-test the skip buttons

### Effects Player & Chapters
- Same as the one above but this time use an episode with chapters
- Look if the chapters button work correctly when skipping. The time should be consistent

### No Player
- After these tests kill the app and restart it. Make sure your last episode listened was using the effect player.
- You should have the player minimized
- Expand it and start skipping back and forward without playing. It should work as expected.
- Now play and skip again. It should still work

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
