### PR TITLE
Fix #2139: Add export caching + improved file names

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1671,6 +1671,7 @@
 		F56295292C0FC14900C44E8A /* DBTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = F56295282C0FC14900C44E8A /* DBTestCase.swift */; };
 		F565602F2B7ACD9B003E76D5 /* DataManager+Import.swift in Sources */ = {isa = PBXBuildFile; fileRef = F565602E2B7ACD9B003E76D5 /* DataManager+Import.swift */; };
 		F56ADE562B7FE37500ADFE31 /* SettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5AD75442B7FDC2800D65C55 /* SettingsTests.swift */; };
+		F57626B62C8B56C7009C8225 /* String+SanitizedFileName.swift in Sources */ = {isa = PBXBuildFile; fileRef = F57626B52C8B56C7009C8225 /* String+SanitizedFileName.swift */; };
 		F57BAC672C00CD9C007B24BD /* URLSession+Episode.swift in Sources */ = {isa = PBXBuildFile; fileRef = F57BAC662C00CD9C007B24BD /* URLSession+Episode.swift */; };
 		F57BAC682C00E7E6007B24BD /* URLSession+Episode.swift in Sources */ = {isa = PBXBuildFile; fileRef = F57BAC662C00CD9C007B24BD /* URLSession+Episode.swift */; };
 		F57CD7D92C2624AD0035269A /* MediaTrimView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F57CD7D82C2624AD0035269A /* MediaTrimView.swift */; };
@@ -3565,6 +3566,7 @@
 		F55C4C752BCF064500A10352 /* DiscoverViewController+CategoryRedesign.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DiscoverViewController+CategoryRedesign.swift"; sourceTree = "<group>"; };
 		F56295282C0FC14900C44E8A /* DBTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DBTestCase.swift; sourceTree = "<group>"; };
 		F565602E2B7ACD9B003E76D5 /* DataManager+Import.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DataManager+Import.swift"; sourceTree = "<group>"; };
+		F57626B52C8B56C7009C8225 /* String+SanitizedFileName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+SanitizedFileName.swift"; sourceTree = "<group>"; };
 		F57BAC662C00CD9C007B24BD /* URLSession+Episode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLSession+Episode.swift"; sourceTree = "<group>"; };
 		F57CD7D82C2624AD0035269A /* MediaTrimView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaTrimView.swift; sourceTree = "<group>"; };
 		F57D8F132C66CA230004C4DF /* UnsafeWait.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnsafeWait.swift; sourceTree = "<group>"; };
@@ -6785,6 +6787,7 @@
 				F55598102C534D4100C02EEB /* CMTimeScale+Common.swift */,
 				F57D8F172C66CDF40004C4DF /* View+CVPixelBuffer.swift */,
 				F51D90752C73141B00F0A232 /* CGSize+FittingSize.swift */,
+				F57626B52C8B56C7009C8225 /* String+SanitizedFileName.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -9867,6 +9870,7 @@
 				10DFE9372C5A8D1300957D0A /* ABTestProvider.swift in Sources */,
 				400AB301220BA8DC0003EE21 /* UploadedViewController+Table.swift in Sources */,
 				4647623128F70CD0006D005A /* AuthenticationHelper.swift in Sources */,
+				F57626B62C8B56C7009C8225 /* String+SanitizedFileName.swift in Sources */,
 				BDDF8AA2240CE240009BA263 /* PlaylistViewController+Swipe.swift in Sources */,
 				BD9324742398BB6B004F19A1 /* TourViewController.swift in Sources */,
 				8BDDD2AC29770479009E4DD3 /* SyncLoadingAlert.swift in Sources */,

--- a/podcasts/Sharing/ShareDestination.swift
+++ b/podcasts/Sharing/ShareDestination.swift
@@ -44,7 +44,7 @@ enum ShareDestination: Hashable {
                source: AnalyticsSource) async throws {
         switch self {
         case .instagram:
-            let item = try await option.shareData(style: style, destination: self, progress: progress).mapFirst { shareItem -> (Data, UTType)? in
+            let item = try await option.shareData(style: style, destination: self, clipUUID: clipUUID, progress: progress).mapFirst { shareItem -> (Data, UTType)? in
                 if let data = shareItem as? Data {
                     return (data, .mpeg4Movie)
                 } else if let image = shareItem as? UIImage, let data = image.pngData() {
@@ -67,7 +67,7 @@ enum ShareDestination: Hashable {
             ShareDestination.logClipShared(option: option, style: style, clipUUID: clipUUID, source: source)
             ShareDestination.logPodcastShared(style: style, option: option, destination: self, source: source)
         case .systemSheet(let vc):
-            let data = try await option.shareData(style: style, destination: self, progress: progress)
+            let data = try await option.shareData(style: style, destination: self, clipUUID: clipUUID, progress: progress)
             let activityViewController = UIActivityViewController(activityItems: data, applicationActivities: nil)
             activityViewController.popoverPresentationController?.sourceView = vc.view
             activityViewController.popoverPresentationController?.sourceRect = rect.value
@@ -249,7 +249,7 @@ extension ShareDestination {
         case failedToDownload
     }
 
-    func export(info: ShareImageInfo, style: ShareImageStyle, episode: some BaseEpisode, startTime: CMTime, duration: CMTime, progress: Progress) async throws -> URL {
+    func export(info: ShareImageInfo, style: ShareImageStyle, episode: some BaseEpisode, startTime: CMTime, duration: CMTime, progress: Progress, to url: URL) async throws -> URL {
         guard let playerItem = DownloadManager.shared.downloadParallelToStream(of: episode) else {
             throw VideoExportError.failedToDownload
         }
@@ -267,7 +267,6 @@ extension ShareDestination {
                 throw VideoExportError.failedToDownload
             }
             let parameters = VideoExporter.Parameters(duration: CMTimeGetSeconds(duration), size: size, episodeAsset: playerItem.asset, audioStartTime: startTime, audioDuration: duration, fileType: .mp4)
-            let url = FileManager.default.temporaryDirectory.appendingPathComponent("video_export-\(UUID().uuidString)", conformingTo: .mpeg4Movie)
             try await VideoExporter.export(view: AnimatedShareImageView(info: info, style: style, size: size), with: parameters, to: url, progress: progress)
 
             return url

--- a/podcasts/Sharing/SharingModal.swift
+++ b/podcasts/Sharing/SharingModal.swift
@@ -226,14 +226,10 @@ extension SharingModal.Option {
         if destination == .instagram {
             return try? Data(contentsOf: fileURL) // For some reason, I couldn't get this to work with just a URL
         } else {
-            func format(time: TimeInterval) -> String {
-                String(format: "%.3f", time)
-            }
-
             let components = [
                 episode.parentPodcast()?.title,
                 episode.title,
-                "\(format(time: clipTime.start))-\(format(time: clipTime.end))"
+                "\(clipTime.start.secondsFormatted())-\(clipTime.end.secondsFormatted())"
             ].compactMap { $0 }
 
             let fileName = components.joined(separator: " - ").appending(".\(fileURL.pathExtension)").sanitizedFileName()
@@ -282,16 +278,8 @@ fileprivate extension Podcast {
     }
 }
 
-fileprivate extension String {
-    // Further explanation on character choices: https://superuser.com/a/358861
-    func sanitizedFileName() -> String {
-        let invalidCharacters = CharacterSet(charactersIn: "\\/:*?\"<>|")
-            .union(.newlines)
-            .union(.illegalCharacters)
-            .union(.controlCharacters)
-
-        return self
-            .components(separatedBy: invalidCharacters)
-            .joined(separator: "")
+fileprivate extension TimeInterval {
+    func secondsFormatted() -> String {
+        String(format: "%.3f", self)
     }
 }

--- a/podcasts/String+SanitizedFileName.swift
+++ b/podcasts/String+SanitizedFileName.swift
@@ -1,0 +1,13 @@
+extension String {
+    // Further explanation on character choices: https://superuser.com/a/358861
+    func sanitizedFileName() -> String {
+        let invalidCharacters = CharacterSet(charactersIn: "\\/:*?\"<>|")
+            .union(.newlines)
+            .union(.illegalCharacters)
+            .union(.controlCharacters)
+
+        return self
+            .components(separatedBy: invalidCharacters)
+            .joined(separator: "")
+    }
+}


### PR DESCRIPTION
| 📘 Part of: #1910 |
|:---:|

Fixes #2139

* Caches clip exports so they don't need to be recreated for a new share destination.
* Adds improved shared file name to `<Podcast> - <Episode> - <Start>-<End>` like `This American Life - 754 Spark Bird - 34.727-60.532`

## To test

* Play an episode
* Tap the "Share" icon
* Tap "Cip"
* Create a clip
* Tap the "More" button
* Share the asset
* Dismiss the system share sheet
* Tap the "More" button
* Verify that the clip is not re-exported and the cached version is used instead
* Verify that the file name is of the format `<Podcast> - <Episode> - <Start>-<End>`

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
