### PR TITLE
Reimagine Sharing: File export progress reporting

### DIFF
--- a/podcasts/Sharing/Clip/VideoExporter.swift
+++ b/podcasts/Sharing/Clip/VideoExporter.swift
@@ -192,12 +192,19 @@ enum VideoExporter {
         exportSession.outputFileType = fileType
         exportSession.timeRange = CMTimeRange(start: .zero, duration: CMTime(seconds: duration, preferredTimescale: 600))
 
+        let timer = Timer(timeInterval: 0.01, repeats: true) { _ in
+            progress.completedUnitCount = Int64(exportSession.progress * 100)
+        }
+        RunLoop.main.add(timer, forMode: .common)
+
         await withTaskCancellationHandler {
             await exportSession.export()
         } onCancel: {
             exportSession.cancelExport()
             progress.cancel()
         }
+
+        timer.invalidate()
 
         guard exportSession.status == .completed else {
             throw ExportError.exportFailed(exportSession.error)

--- a/podcasts/Sharing/SharingModal.swift
+++ b/podcasts/Sharing/SharingModal.swift
@@ -203,7 +203,6 @@ extension SharingModal.Option {
         let nsProgress = Progress(totalUnitCount: 100)
         let observation = nsProgress.publisher(for: \.fractionCompleted).receive(on: DispatchQueue.main).sink(receiveValue: { fractionCompleted in
             guard Task.isCancelled == false && nsProgress.isCancelled == false else { return }
-            FileLog.shared.addMessage("Media Exporter: Fraction completed: \(fractionCompleted)")
             progress.wrappedValue = Float(fractionCompleted)
         })
 


### PR DESCRIPTION
| 📘 Part of: #1910 |
|:---:|

Improves Progress Reporting while exporting the final file so that the last 30% is much smoother and typically feels mostly continuous. The audio download is the last remaining piece to track so that depends on whether the file has been cached already.

## To test

* Play an episode
* Tap share
* Tap "Clip"
* Share the clip to a destination
* Check that the last segment of the progress reporting updates

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
