### PR TITLE
Fix typo in Kids Profile banner

### DIFF
--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4233,7 +4233,7 @@
 "kids_profile_banner_badge" = "Soon";
 
 /* Kids Profile banner text */
-"kids_profile_banner_text" = "A new profile with only content for kids to keep you subscriptions tidy.";
+"kids_profile_banner_text" = "A new profile with only content for kids to keep your subscriptions tidy.";
 
 /* Kids Profile banner action button title */
 "kids_profile_banner_request_button" = "Request Early Access ";


### PR DESCRIPTION
Fixes a small copy error in the Kids Profile Banner

## To test

- CI must be 🟢 
- Run the app and go to your profile
- You should see the Kids Profile, if not enable the FF
- The copy should be `A new profile with only content for kids to keep your subscriptions tidy.`

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
