### PR TITLE
Referrals: User has no passes

### DIFF
--- a/podcasts/ProfileViewController.swift
+++ b/podcasts/ProfileViewController.swift
@@ -485,11 +485,11 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
     }
 
     @objc private func referralsTapped() {
-        updateReferrals()
         hideReferralsHint()
         Settings.shouldShowReferralsTip = false
-        let vc = ReferralSendPassVC()
+        let vc = ReferralSendPassVC(viewModel: ReferralSendPassModel(numberOfPasses: numberOfReferralsAvailable))
         present(vc, animated: true)
+        updateReferrals()
     }
 
     private enum ReferralsConstants {

--- a/podcasts/Referrals/ReferralSendPassVC.swift
+++ b/podcasts/Referrals/ReferralSendPassVC.swift
@@ -4,8 +4,8 @@ class ReferralSendPassVC: ThemedHostingController<ReferralSendPassView> {
 
     private let viewModel: ReferralSendPassModel
 
-    init() {
-        self.viewModel = ReferralSendPassModel()
+    init(viewModel: ReferralSendPassModel) {
+        self.viewModel = viewModel
         let screen = ReferralSendPassView(viewModel: viewModel)
         super.init(rootView: screen)
     }

--- a/podcasts/Referrals/ReferralSendPassView.swift
+++ b/podcasts/Referrals/ReferralSendPassView.swift
@@ -11,6 +11,30 @@ class ReferralSendPassModel {
         self.numberOfPasses = numberOfPasses
         self.onShareGuestPassTap = nil
     }
+
+    var title: String {
+        if numberOfPasses > 0 {
+            L10n.referralsTipMessage(numberOfDaysOffered)
+        } else {
+            L10n.referralsShareNoGuestPassTitle
+        }
+    }
+
+    var message: String {
+        if numberOfPasses > 0 {
+            L10n.referralsTipTitle(numberOfPasses)
+        } else {
+            L10n.referralsShareNoGuestPassMessage
+        }
+    }
+
+    var buttonTitle: String {
+        if numberOfPasses > 0 {
+            return L10n.referralsShareGuestPass
+        } else {
+            return L10n.gotIt
+        }
+    }
 }
 
 struct ReferralSendPassView: View {
@@ -21,11 +45,11 @@ struct ReferralSendPassView: View {
             ModalCloseButton(background: Color.gray.opacity(0.2), foreground: Color.white.opacity(0.5), action: { viewModel.onCloseTap?() })
             VStack(spacing: Constants.verticalSpacing) {
                 SubscriptionBadge(tier: .plus, displayMode: .gradient, foregroundColor: .black)
-                Text(L10n.referralsTipMessage(viewModel.numberOfDaysOffered))
+                Text(viewModel.title)
                     .font(size: 31, style: .title, weight: .bold)
                     .multilineTextAlignment(.center)
                     .foregroundColor(.white)
-                Text(L10n.referralsTipTitle(viewModel.numberOfPasses))
+                Text(viewModel.message)
                     .font(size: 14, style: .body, weight: .medium)
                     .multilineTextAlignment(.center)
                     .foregroundColor(.white)
@@ -38,8 +62,12 @@ struct ReferralSendPassView: View {
                 }
             }
             Spacer()
-            Button(L10n.referralsShareGuestPass) {
-                viewModel.onShareGuestPassTap?()
+            Button(viewModel.buttonTitle) {
+                if viewModel.numberOfPasses > 0 {
+                    viewModel.onShareGuestPassTap?()
+                } else {
+                    viewModel.onCloseTap?()
+                }
             }.buttonStyle(PlusGradientFilledButtonStyle(isLoading: false, plan: .plus))
         }
         .padding()
@@ -53,6 +81,14 @@ struct ReferralSendPassView: View {
     }
 }
 
-#Preview {
-    ReferralSendPassView(viewModel: ReferralSendPassModel())
+#Preview("With Passes") {
+    Group {
+        ReferralSendPassView(viewModel: ReferralSendPassModel())
+    }
+}
+
+#Preview("Without Passes") {
+    Group {
+        ReferralSendPassView(viewModel: ReferralSendPassModel(numberOfPasses: 0))
+    }
 }

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -2280,6 +2280,10 @@ internal enum L10n {
   }
   /// Share Guest Pass
   internal static var referralsShareGuestPass: String { return L10n.tr("Localizable", "referrals_share_guest_pass") }
+  /// Thanks for sharing Pocket Casts! We'll let you know when you have more passes to give.
+  internal static var referralsShareNoGuestPassMessage: String { return L10n.tr("Localizable", "referrals_share_no_guest_pass_message") }
+  /// You've shared all yours guest passes!
+  internal static var referralsShareNoGuestPassTitle: String { return L10n.tr("Localizable", "referrals_share_no_guest_pass_title") }
   /// Gift %1$@ days of Plus to friends and family
   internal static func referralsTipMessage(_ p1: Any) -> String {
     return L10n.tr("Localizable", "referrals_tip_message", String(describing: p1))

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4396,3 +4396,9 @@
 
 /* Referrals - Share Guest Pass button title*/
 "referrals_share_guest_pass" = "Share Guest Pass";
+
+/* Referrals - Share Guest Pass no more passes title*/
+"referrals_share_no_guest_pass_title" = "You've shared all yours guest passes!";
+
+/* Referrals - Share Guest Pass no more passes message*/
+"referrals_share_no_guest_pass_message" = "Thanks for sharing Pocket Casts! We'll let you know when you have more passes to give.";


### PR DESCRIPTION
| 📘 Part of: #2083  |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

This PR implements the Referrals view when there is no passes to send.

<img src="https://github.com/user-attachments/assets/e0d17779-bd7b-4510-bb0a-fa1f23701e0c" width=320>

## To test

1. Start the app
2. Ensure that you have the referrals FF is active and you are using a Plus/Patron account
3. Open the profile tab
4. Tap on the gift icon on the top left
5. Close the view
6. Repeat until you get zero( no badge on the gift)
7. See if you see the screen above, the no passes available, and it looks correct.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
