### PR TITLE
Reimagine Sharing: iOS 15 support

### DIFF
--- a/podcasts/Sharing/Clip/VideoExporter.swift
+++ b/podcasts/Sharing/Clip/VideoExporter.swift
@@ -4,6 +4,7 @@ import UIKit
 import PocketCastsUtils
 
 protocol AnimatableContent: View {
+    @MainActor
     func update(for progress: Double)
 }
 
@@ -105,7 +106,7 @@ enum VideoExporter {
                 }
 
                 let frameProgress = Double(await counter.count) / Double(frameCount)
-                view.update(for: frameProgress)
+                await view.update(for: frameProgress)
 
                 let buffer = try await self.pixelBuffer(for: view, size: size, scale: scale, with: adaptor)
                 let frameTime = CMTime(seconds: Double(await counter.count) / Double(fps), preferredTimescale: CMTimeScale(NSEC_PER_SEC))

--- a/podcasts/Sharing/Clip/VideoExporter.swift
+++ b/podcasts/Sharing/Clip/VideoExporter.swift
@@ -7,7 +7,6 @@ protocol AnimatableContent: View {
     func update(for progress: Double)
 }
 
-@available(iOS 16, *)
 enum VideoExporter {
 
     struct Parameters {
@@ -128,7 +127,6 @@ enum VideoExporter {
         }
     }
 
-    @available(iOS 16, *)
     @MainActor
     private static func pixelBuffer(for view: some View, size: CGSize, scale: CGFloat, with adaptor: AVAssetWriterInputPixelBufferAdaptor) throws -> UnsafeTransfer<CVPixelBuffer> {
         try UnsafeTransfer(view.frame(width: size.width, height: size.height).pixelBuffer(size: CGSize(width: size.width * scale, height: size.height * scale), scale: scale))

--- a/podcasts/Sharing/ShareButton.swift
+++ b/podcasts/Sharing/ShareButton.swift
@@ -27,6 +27,7 @@ struct ShareButton: View {
                     if Task.isCancelled { return }
                     await MainActor.run {
                         Toast.show("Failed clip export: \(error.localizedDescription)")
+                        progress = nil
                     }
                 }
             }

--- a/podcasts/Sharing/ShareDestination.swift
+++ b/podcasts/Sharing/ShareDestination.swift
@@ -263,7 +263,7 @@ extension ShareDestination {
                 size = CGSize(width: style.previewSize.width, height: style.previewSize.height)
             }
 
-            let parameters = VideoExporter.Parameters(duration: CMTimeGetSeconds(duration), size: size, scale: scale, episodeAsset: playerItem.asset, audioStartTime: startTime, audioDuration: duration, fileType: .mp4)
+            let parameters = await VideoExporter.Parameters(duration: CMTimeGetSeconds(duration), size: size, scale: scale, episodeAsset: playerItem.asset, audioStartTime: startTime, audioDuration: duration, fileType: .mp4)
             try await VideoExporter.export(view: AnimatedShareImageView(info: info, style: style, size: size), with: parameters, to: url, progress: progress)
 
             return url

--- a/podcasts/Sharing/ShareDestination.swift
+++ b/podcasts/Sharing/ShareDestination.swift
@@ -263,9 +263,6 @@ extension ShareDestination {
                 size = CGSize(width: style.previewSize.width, height: style.previewSize.height)
             }
 
-            guard #available(iOS 16, *) else { // iOS 15 support will be added in a separate PR just to keep the line count down
-                throw VideoExportError.failedToDownload
-            }
             let parameters = VideoExporter.Parameters(duration: CMTimeGetSeconds(duration), size: size, scale: scale, episodeAsset: playerItem.asset, audioStartTime: startTime, audioDuration: duration, fileType: .mp4)
             try await VideoExporter.export(view: AnimatedShareImageView(info: info, style: style, size: size), with: parameters, to: url, progress: progress)
 

--- a/podcasts/Sharing/SharingView.swift
+++ b/podcasts/Sharing/SharingView.swift
@@ -138,21 +138,22 @@ struct SharingView: View {
         }
     }
 
+    private func styles(for option: SharingModal.Option) -> [ShareImageStyle] {
+        switch shareable.option {
+        case .clipShare(_, _, let style):
+            [style]
+        case .clip:
+            ShareImageStyle.allCases
+        default:
+            ShareImageStyle.allCases.filter { $0 != .audio }
+        }
+    }
+
     @ViewBuilder var tabView: some View {
         GeometryReader { proxy in
             TabView(selection: $shareable.style) {
-                switch shareable.option {
-                case .clipShare(_, _, let style):
+                ForEach(styles(for: shareable.option), id: \.self) { style in
                     image(style: style, containerHeight: proxy.size.height)
-                case .clip:
-                    ForEach(ShareImageStyle.allCases, id: \.self) { style in
-                        image(style: style, containerHeight: proxy.size.height)
-                    }
-                default:
-                    let styles = ShareImageStyle.allCases.filter { $0 != .audio }
-                    ForEach(styles, id: \.self) { style in
-                        image(style: style, containerHeight: proxy.size.height)
-                    }
                 }
             }
             .tabViewStyle(.page)


### PR DESCRIPTION
| 📘 Part of: #1910 |
|:---:|

Adds iOS 15 support to clip sharing.

### Known Issues

There is an issue with the animation after selecting a clip style. This general animation is logged as an issue in https://github.com/Automattic/pocket-casts-ios/issues/1910 but it is a little more jumpy on iOS 15. I think we can follow up on this in a future release since iOS 15 represents under 3% daily usage and is likely to decrease further.

## To test

1. Build and run on an iOS 15 device
2. Play an episode
3. Share from the episode
4. Select "Clip" sharing option
5. Verify that clip sharing works and produces the expected asset

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
