### PR TITLE
Reimagine Sharing: Accessibility

### DIFF
--- a/podcasts/Sharing/Clip/MediaTrimView.swift
+++ b/podcasts/Sharing/Clip/MediaTrimView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import AVFoundation
+import PocketCastsUtils
 
 struct MediaTrimView: View {
     let duration: TimeInterval
@@ -42,7 +43,7 @@ struct MediaTrimView: View {
                         playTime = (playPosition * duration) / geometry.size.width
                     }
                     .frame(width: Constants.playLineWidth)
-                TrimSelectionView(leading: scaledPosition($startPosition), trailing: scaledPosition($endPosition), handleWidth: Constants.trimHandleWidth, indicatorWidth: Constants.playLineWidth, changed: { position, side in
+                TrimSelectionView(leading: scaledPosition($startPosition), leadingA11yValue: a11yLabel(time: $startTime), trailing: scaledPosition($endPosition), trailingA11yValue: a11yLabel(time: $endTime), handleWidth: Constants.trimHandleWidth, indicatorWidth: Constants.playLineWidth, changed: { position, side in
                     update(position: position, for: side, in: geometry.size.width)
                 })
                 .onAppear {
@@ -61,6 +62,15 @@ struct MediaTrimView: View {
             get: { position.wrappedValue * scale },
             set: { newValue in
                 position.wrappedValue = newValue / scale
+            }
+        )
+    }
+
+    private func a11yLabel(time: Binding<TimeInterval>) -> Binding<String> {
+        Binding<String>(
+            get: { time.wrappedValue.localizedTimeDescription ?? "Unknown" },
+            set: { newValue in
+                () // Read-only
             }
         )
     }

--- a/podcasts/Sharing/Clip/TrimSelectionView.swift
+++ b/podcasts/Sharing/Clip/TrimSelectionView.swift
@@ -2,7 +2,10 @@ import SwiftUI
 
 struct TrimSelectionView: View {
     @Binding var leading: CGFloat
+    @Binding var leadingA11yValue: String
     @Binding var trailing: CGFloat
+    @Binding var trailingA11yValue: String
+
     let handleWidth: CGFloat
     let indicatorWidth: CGFloat
 
@@ -21,7 +24,31 @@ struct TrimSelectionView: View {
                 .frame(width: (trailing - leading + indicatorWidth) + (Constants.borderWidth * 2))
                 .offset(x: leading - Constants.borderWidth)
             TrimHandle(position: $leading, side: .leading, width: handleWidth, onChanged: { changed($0, .leading) })
+                .accessibilityLabel(L10n.clipsEndTimeAccessibilityLabel)
+                .accessibilityValue(leadingA11yValue)
+                .accessibilityAdjustableAction { direction in
+                    switch direction {
+                    case .increment:
+                        changed(leading - (handleWidth/2) + 2, .leading)
+                    case .decrement:
+                        changed(leading - (handleWidth/2) - 2, .leading)
+                    @unknown default:
+                        break
+                    }
+                }
             TrimHandle(position: $trailing, side: .trailing, width: handleWidth, onChanged: { changed( $0, .trailing) })
+                .accessibilityLabel(L10n.clipsEndTimeAccessibilityLabel)
+                .accessibilityValue(trailingA11yValue)
+                .accessibilityAdjustableAction { direction in
+                    switch direction {
+                    case .increment:
+                        changed(trailing + (handleWidth/2) + 2, .trailing)
+                    case .decrement:
+                        changed(trailing + (handleWidth/2) - 2, .trailing)
+                    @unknown default:
+                        break
+                    }
+                }
         }
     }
 }

--- a/podcasts/Sharing/SharingFooterView.swift
+++ b/podcasts/Sharing/SharingFooterView.swift
@@ -27,8 +27,11 @@ struct SharingFooterView: View {
                     .tint(color)
                 HStack {
                     Text(L10n.clipStartLabel(TimeFormatter.shared.playTimeFormat(time: clipTime.start)))
+                        .accessibilityLabel(L10n.clipStartLabel(clipTime.start.localizedTimeDescription ?? ""))
                     Spacer()
-                    Text(L10n.clipDurationLabel(TimeFormatter.shared.playTimeFormat(time: clipTime.end - clipTime.start)))
+                    let duration = clipTime.end - clipTime.start
+                    Text(L10n.clipDurationLabel(TimeFormatter.shared.playTimeFormat(time: duration)))
+                        .accessibilityLabel(L10n.clipDurationLabel(duration.localizedTimeDescription ?? ""))
                 }
                 .foregroundStyle(.white.opacity(0.5))
                 .font(.caption.weight(.semibold))

--- a/podcasts/Sharing/SharingView.swift
+++ b/podcasts/Sharing/SharingView.swift
@@ -135,6 +135,7 @@ struct SharingView: View {
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
                 .frame(maxWidth: Constants.descriptionMaxWidth)
+                .accessibilityHidden(shareable.style.shareDescription(option: shareable.option) == nil)
         }
     }
 
@@ -150,13 +151,31 @@ struct SharingView: View {
     }
 
     @ViewBuilder var tabView: some View {
+        let styles = styles(for: shareable.option)
         GeometryReader { proxy in
+            let currentIndex = styles.firstIndex(of: shareable.style) ?? 0
             TabView(selection: $shareable.style) {
-                ForEach(styles(for: shareable.option), id: \.self) { style in
+                ForEach(styles, id: \.self) { style in
                     image(style: style, containerHeight: proxy.size.height)
                 }
             }
             .tabViewStyle(.page)
+            .accessibilityElement()
+            .accessibilityLabel(L10n.clipsShareableMediaA11yLabel)
+            .accessibilityValue(L10n.clipsShareableMediaItemA11yLabel(shareable.style.tabString, currentIndex + 1, styles.count))
+            .accessibilityAdjustableAction { direction in
+                let nextIndex: Int?
+                switch direction {
+                case .increment:
+                    nextIndex = currentIndex.advanced(by: 1) % styles.count
+                case .decrement:
+                    nextIndex = currentIndex.advanced(by: -1) % styles.count
+                default:
+                    nextIndex = nil
+                }
+
+                shareable.style = styles[nextIndex ?? 0]
+            }
         }
     }
 

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -452,6 +452,12 @@ internal enum L10n {
   }
   /// Clip end
   internal static var clipsEndTimeAccessibilityLabel: String { return L10n.tr("Localizable", "clips_end_time_accessibility_label") }
+  /// Shareable media options
+  internal static var clipsShareableMediaA11yLabel: String { return L10n.tr("Localizable", "clips_shareable_media_a11y_label") }
+  /// %1$@ format %2$@ of %3$@
+  internal static func clipsShareableMediaItemA11yLabel(_ p1: Any, _ p2: Any, _ p3: Any) -> String {
+    return L10n.tr("Localizable", "clips_shareable_media_item_a11y_label", String(describing: p1), String(describing: p2), String(describing: p3))
+  }
   /// Clip start
   internal static var clipsStartTimeAccessibilityLabel: String { return L10n.tr("Localizable", "clips_start_time_accessibility_label") }
   /// Got it
@@ -1953,6 +1959,8 @@ internal enum L10n {
   internal static func plusYearlyFrequencyPricingFormat(_ p1: Any) -> String {
     return L10n.tr("Localizable", "plus_yearly_frequency_pricing_format", String(describing: p1))
   }
+  /// Pocket Casts logo
+  internal static var pocketCastsLogo: String { return L10n.tr("Localizable", "pocket_casts_logo") }
   /// Pocket Casts Newsletter
   internal static var pocketCastsNewsletter: String { return L10n.tr("Localizable", "pocket_casts_newsletter") }
   /// Receive news, app updates, themed playlists, interviews, and more.

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -450,6 +450,10 @@ internal enum L10n {
   internal static func clipStartLabel(_ p1: Any) -> String {
     return L10n.tr("Localizable", "clip_start_label", String(describing: p1))
   }
+  /// Clip end
+  internal static var clipsEndTimeAccessibilityLabel: String { return L10n.tr("Localizable", "clips_end_time_accessibility_label") }
+  /// Clip start
+  internal static var clipsStartTimeAccessibilityLabel: String { return L10n.tr("Localizable", "clips_start_time_accessibility_label") }
   /// Got it
   internal static var clipsWhatsNewButtonTitle: String { return L10n.tr("Localizable", "clips_whats_new_button_title") }
   /// You can now share clips of your favorite bits from any episode. We’ve also made easier to share any content to all social media apps.

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4390,3 +4390,12 @@
 
 /* Clips - A label used for Voice Over to indicate the end time of a clip. The time will be read as a localized version of "20 minutes 30 seconds" after this label */
 "clips_end_time_accessibility_label" = "Clip end";
+
+/* A Voice Over label for element which represents the Pocket Casts Logo */
+"pocket_casts_logo" = "Pocket Casts logo";
+
+/* A Voice Over label used to identify a shareable media. This represents different image and video sizes such as "large, medium, small" as well as the "audio" format */
+"clips_shareable_media_a11y_label" = "Shareable media options";
+
+/* A Voice Over label used to identify the container for the shareable media options. This contains different image and video sizes such as "large, medium, small" as well as the "audio" format */
+"clips_shareable_media_item_a11y_label" = "%1$@ format %2$@ of %3$@";

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4384,3 +4384,9 @@
 
 /* Clips - Button title to show in What's New screen announcing the Clips feature */
 "clips_whats_new_button_title" = "Got it";
+
+/* Clips - A label used for Voice Over to indicate the start time of a clip. The time will be read as a localized version of "20 minutes 30 seconds" after this label */
+"clips_start_time_accessibility_label" = "Clip start";
+
+/* Clips - A label used for Voice Over to indicate the end time of a clip. The time will be read as a localized version of "20 minutes 30 seconds" after this label */
+"clips_end_time_accessibility_label" = "Clip end";


### PR DESCRIPTION
| 📘 Part of: #1910 |
|:---:|

Adds accessibility to the new sharing view:
* The `TabView` page control needed manual interaction handling
* The Clip controls have actions and labels to represent the position while using Voice Over

https://github.com/user-attachments/assets/b346df77-fab4-47a1-82b8-ac3945863fb8

## To test

* Play an episode
* Tap "Share"
* Select the "Clip" option
* Enable Voice Over using Siri
* Verify that navigation works properly through labels
* Verify that stopping on the media options allows swiping up and down to change media assets
* Verify that swiping to the trim handles properly reads the start and end timestamps
* Verify that swiping up and down with trim handles selected adjusts the start and end time

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
