### PR TITLE
Referrals :Update to unlimited passes

### DIFF
--- a/podcasts/ProfileViewController.swift
+++ b/podcasts/ProfileViewController.swift
@@ -89,6 +89,7 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
         updateDisplayedData()
         updateRefreshFooterColors()
         updateFooterFrame()
+        updateReferrals()
         setupRefreshControl()
         insetAdjuster.setupInsetAdjustmentsForMiniPlayer(scrollView: profileTable)
     }
@@ -446,7 +447,6 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
     // MARK: - Referrals
 
     private var referralsOfferInfo: ReferralsOfferInfo = ReferralsOfferInfoMock()
-    private var numberOfReferralsAvailable: Int = 3
 
     private var areReferralsAvailable: Bool {
         return FeatureFlag.referrals.enabled && SubscriptionHelper.hasActiveSubscription()
@@ -456,7 +456,7 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
         label.numberOfLines = 1
-        label.text = "\(numberOfReferralsAvailable)"
+        label.text = nil
         label.textAlignment = .center
         label.layer.borderWidth = 1
         label.layer.masksToBounds = true
@@ -487,15 +487,9 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
     }()
 
     private func updateReferrals() {
-        if numberOfReferralsAvailable > 0 {
-            numberOfReferralsAvailable -= 1
-            Settings.shouldShowReferralsTip = false
-        } else {
-            Settings.shouldShowReferralsTip = true
-            numberOfReferralsAvailable = 3
-        }
-        referralsBadge.text = "\(numberOfReferralsAvailable)"
-        referralsBadge.isHidden = numberOfReferralsAvailable == 0
+        Settings.shouldShowReferralsTip = !Settings.shouldShowReferralsTip
+        referralsBadge.text = ""
+        referralsBadge.isHidden = true
     }
 
     private func updateReferralsColors() {
@@ -507,12 +501,10 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
     @objc private func referralsTapped() {
         hideReferralsHint()
         let viewModel = ReferralSendPassModel(offerInfo: referralsOfferInfo,
-                                              numberOfPasses: numberOfReferralsAvailable,
                                               onShareGuestPassTap: { [weak self] in
             self?.updateReferrals()
             self?.dismiss(animated: true)
         }, onCloseTap: { [weak self] in
-            self?.updateReferrals()
             self?.dismiss(animated: true)
         })
         let vc = ReferralSendPassVC(viewModel: viewModel)
@@ -529,7 +521,7 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
     private var referralsTipVC: UIViewController?
 
     private func showReferralsHintIfNeeded() {
-        guard areReferralsAvailable, numberOfReferralsAvailable > 0, Settings.shouldShowReferralsTip else {
+        guard areReferralsAvailable, Settings.shouldShowReferralsTip else {
             return
         }
         let vc = makeReferralsHint()

--- a/podcasts/ProfileViewController.swift
+++ b/podcasts/ProfileViewController.swift
@@ -543,8 +543,8 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
 
     private func makeReferralsHint() -> UIViewController {
         let vc = UIHostingController(rootView: AnyView (EmptyView()) )
-        let tipView = TipView(title: L10n.referralsTipTitle(numberOfReferralsAvailable),
-                              message: L10n.referralsTipMessage(referralsOfferInfo.localizedOfferDurationNoun.lowercased()),
+        let tipView = TipView(title: L10n.referralsTipMessage(referralsOfferInfo.localizedOfferDurationNoun.lowercased()),
+                              message: nil,
                               sizeChanged: { size in
             vc.preferredContentSize = size
         } ).setupDefaultEnvironment()

--- a/podcasts/Referrals/ReferralSendPassView.swift
+++ b/podcasts/Referrals/ReferralSendPassView.swift
@@ -24,12 +24,15 @@ struct ReferralSendPassView: View {
     let viewModel: ReferralSendPassModel
 
     var body: some View {
-        VStack(alignment: .leading) {
-            Button(action: {
-                viewModel.onCloseTap?()
-            }, label: {
-                Image("close").foregroundColor(Color.white)
-            })
+        VStack {
+            HStack {
+                Button(action: {
+                    viewModel.onCloseTap?()
+                }, label: {
+                    Image("close").foregroundColor(Color.white)
+                })
+                Spacer()
+            }
             VStack(spacing: Constants.verticalSpacing) {
                 SubscriptionBadge(tier: .plus, displayMode: .gradient, foregroundColor: .black)
                 Text(viewModel.title)

--- a/podcasts/Referrals/ReferralSendPassView.swift
+++ b/podcasts/Referrals/ReferralSendPassView.swift
@@ -24,8 +24,12 @@ struct ReferralSendPassView: View {
     let viewModel: ReferralSendPassModel
 
     var body: some View {
-        VStack {
-            ModalCloseButton(background: Color.gray.opacity(0.2), foreground: Color.white.opacity(0.5), action: { viewModel.onCloseTap?() })
+        VStack(alignment: .leading) {
+            Button(action: {
+                viewModel.onCloseTap?()
+            }, label: {
+                Image("close").foregroundColor(Color.white)
+            })
             VStack(spacing: Constants.verticalSpacing) {
                 SubscriptionBadge(tier: .plus, displayMode: .gradient, foregroundColor: .black)
                 Text(viewModel.title)

--- a/podcasts/Referrals/ReferralSendPassView.swift
+++ b/podcasts/Referrals/ReferralSendPassView.swift
@@ -2,39 +2,21 @@ import SwiftUI
 
 class ReferralSendPassModel {
     let offerInfo: ReferralsOfferInfo
-    let numberOfPasses: Int
     var onShareGuestPassTap: (() -> ())?
     var onCloseTap: (() -> ())?
 
-    init(offerInfo: ReferralsOfferInfo, numberOfPasses: Int = 3, onShareGuestPassTap: (() -> ())? = nil, onCloseTap: (() -> ())? = nil) {
+    init(offerInfo: ReferralsOfferInfo, onShareGuestPassTap: (() -> ())? = nil, onCloseTap: (() -> ())? = nil) {
         self.offerInfo = offerInfo
-        self.numberOfPasses = numberOfPasses
         self.onShareGuestPassTap = onShareGuestPassTap
         self.onCloseTap = onCloseTap
     }
 
     var title: String {
-        if numberOfPasses > 0 {
-            L10n.referralsTipMessage(offerInfo.localizedOfferDurationNoun)
-        } else {
-            L10n.referralsShareNoGuestPassTitle
-        }
-    }
-
-    var message: String {
-        if numberOfPasses > 0 {
-            L10n.referralsTipTitle(numberOfPasses)
-        } else {
-            L10n.referralsShareNoGuestPassMessage
-        }
+        L10n.referralsTipMessage(offerInfo.localizedOfferDurationNoun)
     }
 
     var buttonTitle: String {
-        if numberOfPasses > 0 {
-            return L10n.referralsShareGuestPass
-        } else {
-            return L10n.gotIt
-        }
+        L10n.referralsShareGuestPass
     }
 }
 
@@ -50,25 +32,17 @@ struct ReferralSendPassView: View {
                     .font(size: 31, style: .title, weight: .bold)
                     .multilineTextAlignment(.center)
                     .foregroundColor(.white)
-                Text(viewModel.message)
-                    .font(size: 14, style: .body, weight: .medium)
-                    .multilineTextAlignment(.center)
-                    .foregroundColor(.white)
                 ZStack {
-                    ForEach(0..<viewModel.numberOfPasses, id: \.self) { i in
+                    ForEach(0..<Constants.numberOfPasses, id: \.self) { i in
                         ReferralCardView(offerDuration: viewModel.offerInfo.localizedOfferDurationAdjective)
-                            .frame(width: Constants.defaultCardSize.width - (CGFloat(viewModel.numberOfPasses-1-i) * Constants.cardInset.width), height: Constants.defaultCardSize.height)
-                            .offset(CGSize(width: 0, height: CGFloat(viewModel.numberOfPasses * i) * Constants.cardInset.height))
+                            .frame(width: Constants.defaultCardSize.width - (CGFloat(Constants.numberOfPasses-1-i) * Constants.cardInset.width), height: Constants.defaultCardSize.height)
+                            .offset(CGSize(width: 0, height: CGFloat(Constants.numberOfPasses * i) * Constants.cardInset.height))
                     }
                 }
             }
             Spacer()
             Button(viewModel.buttonTitle) {
-                if viewModel.numberOfPasses > 0 {
-                    viewModel.onShareGuestPassTap?()
-                } else {
-                    viewModel.onCloseTap?()
-                }
+                viewModel.onShareGuestPassTap?()
             }.buttonStyle(PlusGradientFilledButtonStyle(isLoading: false, plan: .plus))
         }
         .padding()
@@ -79,17 +53,12 @@ struct ReferralSendPassView: View {
         static let verticalSpacing = CGFloat(24)
         static let defaultCardSize = ReferralCardView.Constants.defaultCardSize
         static let cardInset = CGSize(width: 40, height: 5)
+        static let numberOfPasses: Int = 3
     }
 }
 
 #Preview("With Passes") {
     Group {
         ReferralSendPassView(viewModel: ReferralSendPassModel(offerInfo: ReferralsOfferInfoMock()))
-    }
-}
-
-#Preview("Without Passes") {
-    Group {
-        ReferralSendPassView(viewModel: ReferralSendPassModel(offerInfo: ReferralsOfferInfoMock(), numberOfPasses: 0))
     }
 }

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -2300,7 +2300,7 @@ internal enum L10n {
   internal static var referralsShareNoGuestPassMessage: String { return L10n.tr("Localizable", "referrals_share_no_guest_pass_message") }
   /// You've shared all yours guest passes!
   internal static var referralsShareNoGuestPassTitle: String { return L10n.tr("Localizable", "referrals_share_no_guest_pass_title") }
-  /// Gift %1$@ of Plus to friends and family
+  /// Gift %1$@ of Pocket Casts Plus!
   internal static func referralsTipMessage(_ p1: Any) -> String {
     return L10n.tr("Localizable", "referrals_tip_message", String(describing: p1))
   }

--- a/podcasts/TipView.swift
+++ b/podcasts/TipView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 struct TipView: View {
     let title: String
-    let message: String
+    let message: String?
     let sizeChanged: (CGSize)->()
     @EnvironmentObject var theme: Theme
 
@@ -18,12 +18,14 @@ struct TipView: View {
                             .lineLimit(2)
                             .multilineTextAlignment(.leading)
                             .fixedSize(horizontal: false, vertical: true)
-                        Text(message)
-                            .font(size: 14, style: .body, weight: .regular)
-                            .foregroundColor(theme.primaryText02)
-                            .lineLimit(4)
-                            .multilineTextAlignment(.leading)
-                            .fixedSize(horizontal: false, vertical: true)
+                        if let message {
+                            Text(message)
+                                .font(size: 14, style: .body, weight: .regular)
+                                .foregroundColor(theme.primaryText02)
+                                .lineLimit(4)
+                                .multilineTextAlignment(.leading)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
                     }
                     Spacer()
                 }

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4389,7 +4389,7 @@
 "referrals_tip_title" = "You have %1$@ passes to share";
 
 /* Referrals - Tip Message '%1$@' is a placeholder for the duration of free period on the Plus subscription*/
-"referrals_tip_message" = "Gift %1$@ of Plus to friends and family";
+"referrals_tip_message" = "Gift %1$@ of Pocket Casts Plus!";
 
 /* Referrals - Guest Pass Offer Message '%1$@' is a placeholder for the duration of free days on the Plus subscription. Ex: 2-Month Guest Pass*/
 "referrals_guest_pass_offer" = "%1$@ Guest Pass";


### PR DESCRIPTION
| 📘 Part of: #2083  |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

This PR updates the referrals UI code so that sending referrals is unlimited:
 - Updates tip message
 - Updates send pass view
 - Removes profile VC logic to handle limited referrals

| 1 | 2 | 3 |
| - | - | - |
| ![Simulator Screenshot - iPhone 15 Pro - 2024-09-12 at 15 02 24](https://github.com/user-attachments/assets/5fae6994-7dc9-45e0-b911-6d8e99347751) | ![Simulator Screenshot - iPhone 15 Pro - 2024-09-12 at 15 02 20](https://github.com/user-attachments/assets/7f7d250f-ab5b-4421-a783-d56ac3a8db59) | ![Simulator Screenshot - iPhone 15 Pro - 2024-09-12 at 15 02 13](https://github.com/user-attachments/assets/0a7f39aa-3d04-4942-9ae3-4a34d7cf9088) |

## To test

- Start the app
- Ensure that you have the Referrals FF enabled
- Open Profile
- Check if the Gift icon on the top left does not show a badge with the number of referrals
- Check if the referral tip has only a title
- Tap on the Gift icon
- Check if the send screen does not refer any limit on referrals

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.