### PR TITLE
Fix #2165: Exclude link from AirDrop export

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1679,6 +1679,7 @@
 		F57D8F162C66CBB80004C4DF /* UnsafeTransfer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F57D8F152C66CBB80004C4DF /* UnsafeTransfer.swift */; };
 		F57D8F182C66CDF40004C4DF /* View+CVPixelBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F57D8F172C66CDF40004C4DF /* View+CVPixelBuffer.swift */; };
 		F586959A2C04320100E0754A /* PodcastManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F58695992C04320100E0754A /* PodcastManagerTests.swift */; };
+		F59503B42C93590A007FB3C8 /* ActivityItemSourceItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = F59503B32C93590A007FB3C8 /* ActivityItemSourceItem.swift */; };
 		F5952FCA2C057C6400754BC3 /* FMDatabaseQueue+Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5952FC92C057C6400754BC3 /* FMDatabaseQueue+Test.swift */; };
 		F5952FCC2C05814100754BC3 /* DownloadManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5952FCB2C05814100754BC3 /* DownloadManagerTests.swift */; };
 		F5954D5E2C3F284D004A8C04 /* TrimSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5954D5D2C3F284D004A8C04 /* TrimSelectionView.swift */; };
@@ -3584,6 +3585,7 @@
 		F57D8F152C66CBB80004C4DF /* UnsafeTransfer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnsafeTransfer.swift; sourceTree = "<group>"; };
 		F57D8F172C66CDF40004C4DF /* View+CVPixelBuffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+CVPixelBuffer.swift"; sourceTree = "<group>"; };
 		F58695992C04320100E0754A /* PodcastManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PodcastManagerTests.swift; sourceTree = "<group>"; };
+		F59503B32C93590A007FB3C8 /* ActivityItemSourceItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityItemSourceItem.swift; sourceTree = "<group>"; };
 		F5952FC92C057C6400754BC3 /* FMDatabaseQueue+Test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FMDatabaseQueue+Test.swift"; sourceTree = "<group>"; };
 		F5952FCB2C05814100754BC3 /* DownloadManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadManagerTests.swift; sourceTree = "<group>"; };
 		F5954D5D2C3F284D004A8C04 /* TrimSelectionView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrimSelectionView.swift; sourceTree = "<group>"; };
@@ -7773,6 +7775,7 @@
 				F52ADE432BD8B0F300AC647F /* SharingView.swift */,
 				F51D90732C71A0A100F0A232 /* SharingFooterView.swift */,
 				F5FF61282BD6D88C00190711 /* SharingModal.swift */,
+				F59503B32C93590A007FB3C8 /* ActivityItemSourceItem.swift */,
 				F5FF61222BD07E3A00190711 /* ShareImageView.swift */,
 				F555980E2C503F1700C02EEB /* AnimatedShareImageView.swift */,
 				F5FF61242BD0831200190711 /* PocketCastsLogoPill.swift */,
@@ -10071,6 +10074,7 @@
 				C750EF7F28E3475600E06BA9 /* AnalyticsDescribable+Modules.swift in Sources */,
 				40A0A91124B5FE5300C29362 /* UITableView+MultiSelect.swift in Sources */,
 				BDC6DEBC1CBCD6C80030491D /* ReorderableFlowLayout.swift in Sources */,
+				F59503B42C93590A007FB3C8 /* ActivityItemSourceItem.swift in Sources */,
 				BD4098821B9EFF6E007F36BD /* PlayBufferManager.swift in Sources */,
 				4051A5812281B38100C13C12 /* NewsletterCell.swift in Sources */,
 				408426352134CBE60076D82E /* SmallListCell.swift in Sources */,

--- a/podcasts/Sharing/ActivityItemSourceItem.swift
+++ b/podcasts/Sharing/ActivityItemSourceItem.swift
@@ -1,0 +1,20 @@
+class ActivityItemSourceItem: NSObject, UIActivityItemSource {
+    let item: Any
+    let disallowedActivityTypes: [UIActivity.ActivityType]?
+
+    init(item: Any, disallowedActivityTypes: [UIActivity.ActivityType]? = nil) {
+        self.item = item
+        self.disallowedActivityTypes = disallowedActivityTypes
+    }
+
+    func activityViewControllerPlaceholderItem(_ activityViewController: UIActivityViewController) -> Any {
+        return item
+    }
+
+    func activityViewController(_ activityViewController: UIActivityViewController, itemForActivityType activityType: UIActivity.ActivityType?) -> Any? {
+        guard disallowedActivityTypes?.contains(where: { $0 == activityType }) != true else {
+            return nil
+        }
+        return item
+    }
+}

--- a/podcasts/Sharing/ShareDestination.swift
+++ b/podcasts/Sharing/ShareDestination.swift
@@ -45,9 +45,9 @@ enum ShareDestination: Hashable {
         switch self {
         case .instagram:
             let item = try await option.shareData(style: style, destination: self, clipUUID: clipUUID, progress: progress).mapFirst { shareItem -> (Data, UTType)? in
-                if let data = shareItem as? Data {
+                if let data = shareItem.item as? Data {
                     return (data, .mpeg4Movie)
-                } else if let image = shareItem as? UIImage, let data = image.pngData() {
+                } else if let image = shareItem.item as? UIImage, let data = image.pngData() {
                     return (data, .png)
                 } else {
                     return nil

--- a/podcasts/Sharing/SharingModal.swift
+++ b/podcasts/Sharing/SharingModal.swift
@@ -2,27 +2,6 @@ import PocketCastsDataModel
 import SwiftUI
 import PocketCastsUtils
 
-class ActivityItemSourceItem: NSObject, UIActivityItemSource {
-    let item: Any
-    let disallowedActivityTypes: [UIActivity.ActivityType]?
-
-    init(item: Any, disallowedActivityTypes: [UIActivity.ActivityType]? = nil) {
-        self.item = item
-        self.disallowedActivityTypes = disallowedActivityTypes
-    }
-
-    func activityViewControllerPlaceholderItem(_ activityViewController: UIActivityViewController) -> Any {
-        return item
-    }
-
-    func activityViewController(_ activityViewController: UIActivityViewController, itemForActivityType activityType: UIActivity.ActivityType?) -> Any? {
-        guard disallowedActivityTypes?.contains(where: { $0 == activityType }) != true else {
-            return nil
-        }
-        return item
-    }
-}
-
 enum SharingModal {
 
     /// Share options including which type of content will be shared


### PR DESCRIPTION
| 📘 Part of: #1910 |
|:---:|

Fixes #2165

AirDrop exporting doesn't support multiple items so we need to exclude these items from AirDrop shares

## To test

* Play an episode
* Tap "Share"
* Tap "Episode"
* Tap "More"
* Try AirDrop using a local computer or other device
* Ensure that the image file is shared
* Go back to the Now Playing screen
* Tap "Share"
* Tap "Clip" & create a clip
* Tap "More"
* Try AirDrop using a local computer or other device
* Ensure that a video file is shared

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
