### PR TITLE
Transcripts: Fix sending of transcript show event when transcript are not visible

### DIFF
--- a/podcasts/PlayerContainerViewController.swift
+++ b/podcasts/PlayerContainerViewController.swift
@@ -299,6 +299,7 @@ class PlayerContainerViewController: SimpleNotificationsViewController, PlayerTa
     }
 
     func hideTranscript() {
+        transcriptsItem.willBeRemovedFromPlayer()
         transcriptsItem.willMove(toParent: nil)
         transcriptsItem.removeFromParent()
         transcriptsItem.view.removeFromSuperview()

--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -35,7 +35,6 @@ class TranscriptViewController: PlayerItemViewController {
     public override func viewDidLoad() {
         super.viewDidLoad()
         setupViews()
-        addObservers()
     }
 
     override func viewWillDisappear(_ animated: Bool) {


### PR DESCRIPTION
| 📘 Part of: #1848  |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

This ensure that observers are removed when transcript is not visible so we don't load transcripts and do not send the transcripts show event

## To test

1. Start app
2. Ensure that you have transcripts FF enabled
3. Enable tracksLogging
4. Add a couple of episodes to UpNext queue that have transcripts, for example: Cautionary Tales
5. Start playing one of the episode
6. Open full screen player, tap the transcripts shelf
7. See if `transcriptShow` event is show
8. Close the transcripts view
9. Fast forward the current episode to the end and let the player switch to the next episode
10. Check that when the episode is loaded no `transcriptShow` event is show in the console
11. Tap on transcript shelf icon
12. Check that the event `transcriptShow` event is show in the console

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.