### PR TITLE
Fix: Episode sort setting on WatchOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 -----
 - Fix Sharing with AirDrop fails [#2165](https://github.com/Automattic/pocket-casts-ios/issues/2165)
 - Transcripts: Refactor scroll to range textKit code [#2155](https://github.com/Automattic/pocket-casts-ios/pull/2155)
-
+- Fix sorting of Episode list on WatchOS [#2172](https://github.com/Automattic/pocket-casts-ios/pull/2172)
 
 7.72
 -----

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Enums.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Enums.swift
@@ -92,7 +92,7 @@ public enum PodcastEpisodeSortOrder: Int32, Codable, CaseIterable {
     case longestToShortest
 
     public enum Old: Int32 {
-        case newestToOldest = 1, oldestToNewest, shortestToLongest, longestToShortest
+        case newestToOldest = 1, oldestToNewest, shortestToLongest, longestToShortest, titleAtoZ, titleZtoA
     }
 
     public init(old: Old) {
@@ -105,6 +105,10 @@ public enum PodcastEpisodeSortOrder: Int32, Codable, CaseIterable {
             self = .shortestToLongest
         case .longestToShortest:
             self = .longestToShortest
+        case .titleAtoZ:
+            self = .titleAtoZ
+        case .titleZtoA:
+            self = .titleZtoA
         }
     }
 
@@ -119,9 +123,9 @@ public enum PodcastEpisodeSortOrder: Int32, Codable, CaseIterable {
         case .longestToShortest:
             .longestToShortest
         case .titleAtoZ:
-            .newestToOldest
+            .titleAtoZ
         case .titleZtoA:
-            .newestToOldest
+            .titleZtoA
         }
     }
 }

--- a/Pocket Casts Watch App/PodcastEpisodeListViewModel.swift
+++ b/Pocket Casts Watch App/PodcastEpisodeListViewModel.swift
@@ -73,7 +73,7 @@ class PodcastEpisodeListViewModel: ObservableObject {
             podcast.settings.episodesSortOrder = option
             podcast.syncStatus = SyncStatus.notSynced.rawValue
         }
-        podcast.episodeSortOrder = option.rawValue
+        podcast.episodeSortOrder = option.old.rawValue
         DataManager.sharedManager.save(podcast: podcast)
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.podcastUpdated, object: podcast.uuid)
     }


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

This PR updates the old settings to have support for the new title sort options and also fixes the saving of the settings to respect the old settings on WatchOS.


## To test

- Start the app on WatchOS
- Open the Source Watch
- Open the Podcasts
- Select a podcasts
- Scroll up to see sort options
- Choose the different options and see that the sorting is done correctly

- Start the app on the iPhone
- Open a Podcast
- Tap on the ... button
- Tap on sort options
- Check that the sorting options shows correctly

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
