### PR TITLE
Update Xcode CI image from 15.4 to 16.0

### DIFF
--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -4,6 +4,6 @@
 # to set up some variables that will be interpolated in the `.yml` pipeline before uploading it.
 
 # 🎗️ If you update the image to a newer Xcode version, don't forget to also update the badge in the README.md file accordingly for consistency
-export IMAGE_ID="xcode-15.4"
+export IMAGE_ID="xcode-16.0"
 
 export CI_TOOLKIT="automattic/a8c-ci-toolkit#3.5.0"


### PR DESCRIPTION
This PR updates the CI image to Xcode 16.0. 

## To test

As long as CI is all green, this is good to go. 

## Checklist

- [X] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [X] I have considered adding unit tests for my changes.
- [X] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
