### PR TITLE
Fix crash on shelf actions

### DIFF
--- a/podcasts/ShelfActionsViewController+Table.swift
+++ b/podcasts/ShelfActionsViewController+Table.swift
@@ -198,7 +198,8 @@ extension ShelfActionsViewController: UITableViewDelegate, UITableViewDataSource
     private func actionAt(indexPath: IndexPath, isEditing: Bool) -> PlayerAction {
         let action: PlayerAction
         if isEditing {
-            action = allActions[indexPath.row + (indexPath.section == ShelfActionsViewController.menuSection ? Constants.Limits.maxShelfActions : 0)]
+            let pos = indexPath.row + (indexPath.section == ShelfActionsViewController.menuSection ? Constants.Limits.maxShelfActions + maxShelfActionsAdjustment : 0)
+            action = allActions[pos]
         } else {
             action = extraActions[indexPath.row]
         }


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes this [Sentry crash](https://a8c.sentry.io/issues/5857274229/?project=4503921846583296&query=release%3Aau.com.shiftyjelly.podcasts%407.72%2B7.72.0.8&referrer=release-issue-stream)

This PR takes in account adjustment on row when selecting action

## To test

1. Start the app
2. Start playing an episode
3. Open the Full player
4. Tap on the shelf actions [...] button
5. Tap on Edit
6. Move actions around
7. Check if no crash happens

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
