### PR TITLE
Add Mimetype lib and helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix Sharing with AirDrop fails [#2165](https://github.com/Automattic/pocket-casts-ios/issues/2165)
 - Transcripts: Refactor scroll to range textKit code [#2155](https://github.com/Automattic/pocket-casts-ios/pull/2155)
 - Fix sorting of Episode list on WatchOS [#2172](https://github.com/Automattic/pocket-casts-ios/pull/2172)
+- Fix issue when HTTP contentType and real file type do not match [#1933](https://github.com/Automattic/pocket-casts-ios/issues/1933)
 
 7.72
 -----

--- a/Modules/Server/Package.swift
+++ b/Modules/Server/Package.swift
@@ -16,6 +16,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.0.0"),
+        .package(url: "https://github.com/danielebogo/Swime", .branch("master")),
         .package(path: "../DataModel/"),
         .package(path: "../Utils/")
     ],
@@ -24,6 +25,7 @@ let package = Package(
             name: "PocketCastsServer",
             dependencies: [
                 .product(name: "SwiftProtobuf", package: "swift-protobuf"),
+                .product(name: "Swime", package: "Swime"),
                 .product(name: "PocketCastsDataModel", package: "DataModel"),
                 .product(name: "PocketCastsUtils", package: "Utils")
             ],

--- a/Modules/Server/Sources/PocketCastsServer/Private/MimetypeHelper.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Private/MimetypeHelper.swift
@@ -12,4 +12,3 @@ public struct MimetypeHelper {
         }
     }
 }
-

--- a/Modules/Server/Sources/PocketCastsServer/Private/MimetypeHelper.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Private/MimetypeHelper.swift
@@ -5,7 +5,7 @@ public struct MimetypeHelper {
     // The max number of bytes required to cover all the mimetypes
     // needed by `Swime`.
     private static let maxFileSize: Int = 4500
-    
+
     public static func contetType(for url: URL) -> String? {
         do {
             guard let fileSize = try url.resourceValues(forKeys: [.fileSizeKey]).fileSize,

--- a/Modules/Server/Sources/PocketCastsServer/Private/MimetypeHelper.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Private/MimetypeHelper.swift
@@ -1,0 +1,15 @@
+import Swime
+import Foundation
+
+public struct MimetypeHelper {
+    public static func contetType(for url: URL) -> String? {
+        do {
+            let data = try Data(contentsOf: url)
+            let mimeType = Swime.mimeType(data: data)
+            return mimeType?.mime ?? "application/octet-stream"
+        } catch {
+            return nil
+        }
+    }
+}
+

--- a/Modules/Server/Sources/PocketCastsServer/Private/MimetypeHelper.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Private/MimetypeHelper.swift
@@ -4,13 +4,13 @@ import Foundation
 public struct MimetypeHelper {
     // The max number of bytes required to cover all the mimetypes
     // needed by `Swime`.
-    private static let maxFileSize: Int = 4500
+    private static let maxBytesNeeded: Int = 4500
 
     public static func contetType(for url: URL) -> String? {
         do {
             guard let fileSize = try url.resourceValues(forKeys: [.fileSizeKey]).fileSize,
                   let fileHandle = FileHandle(forReadingAtPath: url.relativePath),
-                  let data = try fileHandle.read(upToCount: min(fileSize, Self.maxFileSize)) else {
+                  let data = try fileHandle.read(upToCount: min(fileSize, Self.maxBytesNeeded)) else {
                 return nil
             }
             let mimeType = Swime.mimeType(data: data)

--- a/Modules/Server/Sources/PocketCastsServer/Private/MimetypeHelper.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Private/MimetypeHelper.swift
@@ -4,8 +4,13 @@ import Foundation
 public struct MimetypeHelper {
     public static func contetType(for url: URL) -> String? {
         do {
-            let data = try Data(contentsOf: url)
+            guard let fileSize = try url.resourceValues(forKeys: [.fileSizeKey]).fileSize,
+                  let fileHandle = FileHandle(forReadingAtPath: url.relativePath),
+                  let data = try fileHandle.read(upToCount: min(fileSize, 4500)) else {
+                return nil
+            }
             let mimeType = Swime.mimeType(data: data)
+            fileHandle.closeFile()
             return mimeType?.mime ?? "application/octet-stream"
         } catch {
             return nil

--- a/Modules/Server/Sources/PocketCastsServer/Private/MimetypeHelper.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Private/MimetypeHelper.swift
@@ -2,11 +2,15 @@ import Swime
 import Foundation
 
 public struct MimetypeHelper {
+    // The max number of bytes required to cover all the mimetypes
+    // needed by `Swime`.
+    private static let maxFileSize: Int = 4500
+    
     public static func contetType(for url: URL) -> String? {
         do {
             guard let fileSize = try url.resourceValues(forKeys: [.fileSizeKey]).fileSize,
                   let fileHandle = FileHandle(forReadingAtPath: url.relativePath),
-                  let data = try fileHandle.read(upToCount: min(fileSize, 4500)) else {
+                  let data = try fileHandle.read(upToCount: min(fileSize, Self.maxFileSize)) else {
                 return nil
             }
             let mimeType = Swime.mimeType(data: data)

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -111,7 +111,8 @@ public enum FeatureFlag: String, CaseIterable {
     /// This makes the skip unusable as the player doesn't have its task set yet.
     /// If the player is not ready to play, we should use the same logic we use when the player doesn't exist yet.
     case playerIsReadyToPlay
-    
+
+    /// Use the Mimetype library to check the file mimetype
     case useMimetypePackage
 
     public var enabled: Bool {

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -192,7 +192,7 @@ public enum FeatureFlag: String, CaseIterable {
         case .playerIsReadyToPlay:
             true
         case .useMimetypePackage:
-            false
+            true
         }
     }
 

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -111,6 +111,8 @@ public enum FeatureFlag: String, CaseIterable {
     /// This makes the skip unusable as the player doesn't have its task set yet.
     /// If the player is not ready to play, we should use the same logic we use when the player doesn't exist yet.
     case playerIsReadyToPlay
+    
+    case useMimetypePackage
 
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
@@ -188,6 +190,8 @@ public enum FeatureFlag: String, CaseIterable {
             false
         case .playerIsReadyToPlay:
             true
+        case .useMimetypePackage:
+            false
         }
     }
 

--- a/podcasts.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/podcasts.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -209,30 +209,12 @@
         }
       },
       {
-        "package": "Nimble",
-        "repositoryURL": "https://github.com/Quick/Nimble",
-        "state": {
-          "branch": null,
-          "revision": "e9d769113660769a4d9dd3afb855562c0b7ae7b0",
-          "version": "7.3.4"
-        }
-      },
-      {
         "package": "Promises",
         "repositoryURL": "https://github.com/google/promises.git",
         "state": {
           "branch": null,
           "revision": "540318ecedd63d883069ae7f1ed811a2df00b6ac",
           "version": "2.4.0"
-        }
-      },
-      {
-        "package": "Quick",
-        "repositoryURL": "https://github.com/Quick/Quick",
-        "state": {
-          "branch": null,
-          "revision": "f2b5a06440ea87eba1a167cab37bf6496646c52e",
-          "version": "1.3.4"
         }
       },
       {
@@ -276,7 +258,7 @@
         "repositoryURL": "https://github.com/danielebogo/Swime",
         "state": {
           "branch": "master",
-          "revision": "89ab14c5c20dd71382ecd1b5eebd72c4efa4718f",
+          "revision": "51200c73c04cc9a8718d7d9ad70a3bf6c6f87dd1",
           "version": null
         }
       },

--- a/podcasts.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/podcasts.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -209,12 +209,30 @@
         }
       },
       {
+        "package": "Nimble",
+        "repositoryURL": "https://github.com/Quick/Nimble",
+        "state": {
+          "branch": null,
+          "revision": "e9d769113660769a4d9dd3afb855562c0b7ae7b0",
+          "version": "7.3.4"
+        }
+      },
+      {
         "package": "Promises",
         "repositoryURL": "https://github.com/google/promises.git",
         "state": {
           "branch": null,
           "revision": "540318ecedd63d883069ae7f1ed811a2df00b6ac",
           "version": "2.4.0"
+        }
+      },
+      {
+        "package": "Quick",
+        "repositoryURL": "https://github.com/Quick/Quick",
+        "state": {
+          "branch": null,
+          "revision": "f2b5a06440ea87eba1a167cab37bf6496646c52e",
+          "version": "1.3.4"
         }
       },
       {
@@ -251,6 +269,15 @@
           "branch": null,
           "revision": "751866f632ccf438025472eb1c1dccffbc5176a3",
           "version": "1.5.2"
+        }
+      },
+      {
+        "package": "Swime",
+        "repositoryURL": "https://github.com/danielebogo/Swime",
+        "state": {
+          "branch": "master",
+          "revision": "89ab14c5c20dd71382ecd1b5eebd72c4efa4718f",
+          "version": null
         }
       },
       {


### PR DESCRIPTION
Fixes #1933

This PR fixes the issue when the HTTP content type doesn't match the file type.
To fix it we read the first part of the file and match the correct mime type using `Swime`.
If the file and HTTP  types don't match, we update the episode metadata and store the file with the correct type and extension.

## To test

> [!NOTE]
> Make sure you have FF `useMimetypePackage` enabled

- CI must be 🟢 
- Try to download some episodes from:
https://play.pocketcasts.com/podcasts/f77f2320-60c8-0139-33f3-0acc26574db2
https://play.pocketcasts.com/podcasts/e8a4ad80-09e9-013c-f5ae-0acc26574db2
- After the download you should play it normally
- You can also try with https://rts-vod-dd.akamaized.net/ww/15153718/d3f6e99d-7bdb-37eb-96e1-aaa67fa0a582.mp4

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
