### PR TITLE
[Tooling] Use final Xcode 16.0 image version

### DIFF
--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -4,6 +4,9 @@
 # to set up some variables that will be interpolated in the `.yml` pipeline before uploading it.
 
 # 🎗️ If you update the image to a newer Xcode version, don't forget to also update the badge in the README.md file accordingly for consistency
-export IMAGE_ID="xcode-16.0"
+XCODE_VERSION="16.0"
+CI_TOOLKIT_PLUGIN_VERSION="3.7.1"
 
-export CI_TOOLKIT="automattic/a8c-ci-toolkit#3.5.0"
+# Note: `-v7` suffix added to use xcode-16.0-v7 image; remember to remove that suffix on next Xcode update
+export IMAGE_ID="xcode-$XCODE_VERSION-v7"
+export CI_TOOLKIT="automattic/a8c-ci-toolkit#$CI_TOOLKIT_PLUGIN_VERSION"


### PR DESCRIPTION
We built a new Xcode 16 image and are planning to delete the other `xcode-16.0-*` images, to avoid confusions.
This PR extract the version values in `shared-pipeline-vars` and uses the `-v7` suffix for Xcode.

**Testing**: CI needs to be 🟢