### PR TITLE
Update the now playing info when player is not seeking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix Sharing with AirDrop fails [#2165](https://github.com/Automattic/pocket-casts-ios/issues/2165)
 - Transcripts: Refactor scroll to range textKit code [#2155](https://github.com/Automattic/pocket-casts-ios/pull/2155)
 - Fix sorting of Episode list on WatchOS [#2172](https://github.com/Automattic/pocket-casts-ios/pull/2172)
+- Fix skip back button on lock screen media controls [#2186](https://github.com/Automattic/pocket-casts-ios/pull/2186)
 
 7.72
 -----

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -457,6 +457,7 @@ class PlaybackManager: ServerPlaybackDelegate {
                 NotificationCenter.postOnMainThread(notification: Constants.Notifications.playbackPositionSaved, object: playingEpisode.uuid)
                 checkForChapterChange()
                 fireProgressNotification()
+                updateNowPlayingInfo()
             } else {
                 seekingTo = PlaybackManager.notSeeking
             }


### PR DESCRIPTION
This was discovered while testing #2141 but is a bit different from the original issue.

The player `seekTo` completion was updating the now playing info but the `else` block (updating the episode timestamp directly without the player's involvement) was not.

## To test

* Play an episode 
* Lock the phone (or navigate to control center) to see the Media Controls
* Pause playback on the lock screen
* Tap the Skip Back button
* Notice that progress is reflected in the progress bar or timestamps

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
