### PR TITLE
Transcripts/decode html entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Fix Sharing with AirDrop fails [#2165](https://github.com/Automattic/pocket-casts-ios/issues/2165)
 - Transcripts: Refactor scroll to range textKit code [#2155](https://github.com/Automattic/pocket-casts-ios/pull/2155)
 - Fix sorting of Episode list on WatchOS [#2172](https://github.com/Automattic/pocket-casts-ios/pull/2172)
+- Fix crash on shelf actions [#2174](https://github.com/Automattic/pocket-casts-ios/pull/2174)
+- Fix display of html entities on transcripts [#2192](https://github.com/Automattic/pocket-casts-ios/pull/2192)
 
 7.72
 -----

--- a/PocketCastsTests/Tests/Player/Transcripts/ComposeFilterTests.swift
+++ b/PocketCastsTests/Tests/Player/Transcripts/ComposeFilterTests.swift
@@ -50,4 +50,21 @@ final class ComposeFilterTests: XCTestCase {
         XCTAssertEqual(filtered.trim(), expected.trim())
     }
 
+    func testHTMLFilter() {
+        let transcript = """
+        <strong>Speaker&nbsp;1<strong><br>It's a great day on Acme &amp; Acme.<br><em>Speaker 1<em><br>Folks say: &quot;What an amazing day&quot;.<br>
+        """
+
+        let filtered = ComposeFilter.htmlFilter.filter(transcript)
+
+        let expected = """
+        Speaker 1
+        It's a great day on Acme & Acme.
+        Speaker 1
+        Folks say: \"What an amazing day\".
+        """
+
+        XCTAssertEqual(filtered.trim(), expected.trim())
+    }
+
 }

--- a/podcasts/TranscriptFilter.swift
+++ b/podcasts/TranscriptFilter.swift
@@ -24,7 +24,7 @@ struct ComposeFilter: TranscriptFilter {
 
     static let htmlFilter = ComposeFilter(filters: [
         RegexFilter.breakLineFilter,
-        RegexFilter.nbspFilter,
+        HTMLEntititiesFilter(),
         RegexFilter.vttTagsFilter,
         RegexFilter.soundDescriptorFilter,
         RegexFilter.htmlSpeakerFilter,
@@ -93,4 +93,30 @@ struct SuffixFilter: TranscriptFilter {
 
 extension SuffixFilter {
     static let addSpaceWhenNotEndofLine = SuffixFilter(condition: ".\n", replacement: " ")
+}
+
+struct HTMLEntititiesFilter: TranscriptFilter {
+
+    private static let htmlEntities: [(String, String)] = [
+        ("&nbsp;", " "),
+        ("&#160;", " "),
+        ("&quot;", "\""),
+        ("&#34;", "\""),
+        ("&apos;", "'"),
+        ("&#39;", "'"),
+        ("&lt;", "<"),
+        ("&#60;", "<"),
+        ("&gt;", ">"),
+        ("&#62;", ">"),
+        ("&#38;", "&"),
+        ("&amp;", "&") // Do this last so that, e.g. @"&amp;lt;" goes to @"&lt;" not @"<"
+    ]
+
+    func filter(_ input: String) -> String {
+        var result = input
+        for entity in Self.htmlEntities {
+            result = result.replacingOccurrences(of: entity.0, with: entity.1)
+        }
+        return result
+    }
 }


### PR DESCRIPTION
| 📘 Part of: #1848  |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

Update Transcripts for the html format to decode HTML entities

## To test

1. Start the app
2. Open a podcast with Transcripts in the HTML format using html entities. Ex: https://pca.st/episode/1cb156bc-c05c-4e20-ada7-c3fb13c4d380
3. Play an episode of the podcast
4. Open the full screen player
5. Tap on Transcripts
6. Check if the transcript does not show any html entitities.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
