### PR TITLE
Fix: #2141: Skip Back issue when skipping from watch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fix crash on shelf actions [#2174](https://github.com/Automattic/pocket-casts-ios/pull/2174)
 - Fix display of html entities on transcripts [#2192](https://github.com/Automattic/pocket-casts-ios/pull/2192)
 - Fix issue when HTTP contentType and real file type do not match [#1933](https://github.com/Automattic/pocket-casts-ios/issues/1933)
+- Fix skip back issue after skipping back on the Apple Watch [#2197](https://github.com/Automattic/pocket-casts-ios/pull/2197)
 
 7.72
 -----

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -419,7 +419,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         guard let playingEpisode = currentEpisode() else { return } // nothing to actually seek
 
         if seekHint == .back, !isValidSeek(time: time) {
-            print("aborting seek because it's moving forward")
+            FileLog.shared.addMessage("aborting seek because it's moving forward from \(previousSeekTime ?? 0) to \(time)")
             return
         }
 

--- a/podcasts/WatchManager.swift
+++ b/podcasts/WatchManager.swift
@@ -79,7 +79,9 @@ class WatchManager: NSObject, WCSessionDelegate {
             }
         } else if WatchConstants.Messages.SkipBackRequest.type == messageType {
             AnalyticsPlaybackHelper.shared.currentSource = .watch
-            PlaybackManager.shared.skipBack()
+            DispatchQueue.main.async {
+                PlaybackManager.shared.skipBack()
+            }
         } else if WatchConstants.Messages.SkipForwardRequest.type == messageType {
             AnalyticsPlaybackHelper.shared.currentSource = .watch
             PlaybackManager.shared.skipForward()


### PR DESCRIPTION
Fixes #2141

In https://github.com/Automattic/pocket-casts-ios/pull/2041 we added logic to ignore skips which would skip ahead. However, the Watch `skipBack` function is called on a background thread and the timer never appears to fire, causing `previousSeekTime` to never be reset to `nil`, breaking all future skip backs.

## Considerations

I also considered adding the Debouncer to the Main RunLoop instead of scheduling on its current RunLoop. This would apply to other caller of `skipBack` but I checked all of these and I believe all will come from the main thread. I'm concerned this could cause race conditions if the callback relies on the original behavior.

## To test

* Play an episode on the phone
* Use the watch app to skip back
* Check that skip back worked
* Try skipping back on the phone
* Ensure that skipping worked

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
