### PR TITLE
Mark podcasts unsynced when user changes

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -66,6 +66,12 @@ public enum FeatureFlag: String, CaseIterable {
     /// When `true`, we only mark podcasts as unsynced if the user never signed in before
     case onlyMarkPodcastsUnsyncedForNewUsers
 
+    /// When a user sign in, we always marked ALL podcasts as unsynced
+    /// The `onlyMarkPodcastsUnsyncedForNewUsers` flag added a check that a user was new before marking unsynced
+    /// This _also_ caused issues with users who signed out and signed in to a new account, causing podcasts to remain unsynced
+    /// When `true`, we mark podcasts as unsynced if the user accounts changed
+    case onlyMarkPodcastsUnsyncedForChangedUsers
+
     /// Only update an episode if it fails playing
     /// If set to `false`, it will use the previous mechanism that always update
     /// but can lead to a bigger time between tapping play and actually playing it
@@ -192,6 +198,8 @@ public enum FeatureFlag: String, CaseIterable {
         case .playerIsReadyToPlay:
             true
         case .useMimetypePackage:
+            true
+        case .onlyMarkPodcastsUnsyncedForChangedUsers:
             true
         }
     }


### PR DESCRIPTION
Fixes # <!-- issue number, if applicable -->

When switching accounts, users can lose podcast subscriptions if we don't mark podcasts as unsynced. The  change in https://github.com/Automattic/pocket-casts-ios/pull/1778 made it so that only new accounts marked all podcasts as unsynced. Instead we want to sync all podcasts any time the current account doesn't match the previous account.

## To test

* Add several podcast subscriptions
* Login with an account
* Ensure that all podcasts are marked as unsynced and sent via the `https://api.pocketcasts.com/user/sync/update` call.
* Logout of that account
* Login with another account
* Ensure all podcasts are sent via the `https://api.pocketcasts.com/user/sync/update` call.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
