### PR TITLE
[Listening History] Add local search

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EpisodeDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EpisodeDataManager.swift
@@ -129,6 +129,19 @@ class EpisodeDataManager {
         loadMultiple(query: "SELECT * from \(DataManager.episodeTableName) WHERE \(columnName) IS NOT NULL", values: nil, dbQueue: dbQueue)
     }
 
+    func findEpisodesAndPodcastsWhere(customWhere: String, dbQueue: FMDatabaseQueue) -> [Episode] {
+        let query = """
+        SELECT episode.* FROM \(DataManager.episodeTableName) episode
+        LEFT JOIN \(DataManager.podcastTableName) podcast ON episode.podcast_id = podcast.id
+        WHERE lastPlaybackInteractionDate IS NOT NULL
+        AND lastPlaybackInteractionDate > 0
+        AND (UPPER(episode.title) LIKE '%' || UPPER(?) || '%'  ESCAPE '\\'
+         OR UPPER(podcast.title) LIKE '%' || UPPER(?) || '%'  ESCAPE '\\')
+        ORDER BY lastPlaybackInteractionDate DESC LIMIT 1000
+        """
+        return loadMultiple(query: query, values: [customWhere, customWhere], dbQueue: dbQueue)
+    }
+
     func findEpisodesWhere(customWhere: String, arguments: [Any]?, dbQueue: FMDatabaseQueue) -> [Episode] {
         loadMultiple(query: "SELECT * from \(DataManager.episodeTableName) WHERE \(customWhere)", values: arguments, dbQueue: dbQueue)
     }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -460,6 +460,10 @@ public class DataManager {
         episodeManager.findEpisodesWhere(customWhere: customWhere, arguments: arguments, dbQueue: dbQueue)
     }
 
+    public func findEpisodesAndPodcastsWhere(customWhere: String) -> [Episode] {
+        episodeManager.findEpisodesAndPodcastsWhere(customWhere: customWhere, dbQueue: dbQueue)
+    }
+
     public func findLatestEpisode(podcast: Podcast) -> Episode? {
         episodeManager.findLatestEpisode(podcast: podcast, dbQueue: dbQueue)
     }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/String+Escape.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/String+Escape.swift
@@ -1,0 +1,9 @@
+extension String {
+    public func escapeLike(escapeChar: Character) -> String {
+        let escapeCharStr = String(escapeChar)
+        return self
+            .replacingOccurrences(of: escapeCharStr, with: escapeCharStr + escapeCharStr)
+            .replacingOccurrences(of: "%", with: escapeCharStr + "%")
+            .replacingOccurrences(of: "_", with: escapeCharStr + "_")
+    }
+}

--- a/podcasts/EpisodeTableHelper.swift
+++ b/podcasts/EpisodeTableHelper.swift
@@ -69,4 +69,30 @@ struct EpisodeTableHelper {
 
         return [newData]
     }
+
+    static func searchSectionedEpisodes(for search: String, tintColor: UIColor = AppTheme.appTintColor(), episodeShortKey: (Episode) -> String) -> [ArraySection<String, ListEpisode>] {
+        let escapedSearch = search.escapeLike(escapeChar: "\\")
+        let loadedEpisodes = DataManager.sharedManager.findEpisodesAndPodcastsWhere(customWhere: escapedSearch)
+
+        var previousSectionName = ""
+        var currSectionIndex = -1
+        var newData = [ArraySection<String, ListEpisode>]()
+        for episode in loadedEpisodes {
+            let currSectionName = episodeShortKey(episode)
+
+            let isInUpNext = PlaybackManager.shared.inUpNext(episode: episode)
+            if previousSectionName == currSectionName {
+                var existingSection = newData[currSectionIndex]
+                let listEpisode = ListEpisode(episode: episode, tintColor: tintColor, isInUpNext: isInUpNext)
+                existingSection.elements.append(listEpisode)
+                newData[currSectionIndex] = existingSection
+            } else {
+                let listEpisode = ListEpisode(episode: episode, tintColor: tintColor, isInUpNext: isInUpNext)
+                newData.append(ArraySection(model: currSectionName, elements: [listEpisode]))
+                currSectionIndex += 1
+                previousSectionName = currSectionName
+            }
+        }
+        return newData
+    }
 }

--- a/podcasts/EpisodesDataManager.swift
+++ b/podcasts/EpisodesDataManager.swift
@@ -138,6 +138,12 @@ class EpisodesDataManager {
         })
     }
 
+    func searchEpisodes(for search: String) -> [ArraySection<String, ListEpisode>] {
+        return EpisodeTableHelper.searchSectionedEpisodes(for: search, episodeShortKey: { episode -> String in
+            episode.shortLastPlaybackInteractionDate()
+        })
+    }
+
     // MARK: - Starred
 
     func starredEpisodes() -> [ListEpisode] {

--- a/podcasts/ListeningHistoryViewController.swift
+++ b/podcasts/ListeningHistoryViewController.swift
@@ -13,6 +13,26 @@ class ListeningHistoryViewController: PCViewController {
     private let episodesDataManager = EpisodesDataManager()
     private var searchController: PCSearchBarController?
 
+    @IBOutlet weak var emptyStateView: ThemeableView! {
+        didSet {
+            emptyStateView.isHidden = true
+        }
+    }
+
+    @IBOutlet weak var emptyStateTitle: ThemeableLabel! {
+        didSet {
+            emptyStateTitle.style = .primaryText01
+            emptyStateTitle.text = L10n.listeningHistorySearchNoEpisodesTitle
+        }
+    }
+
+    @IBOutlet weak var emptyStateText: ThemeableLabel! {
+        didSet {
+            emptyStateText.style = .primaryText02
+            emptyStateText.text = L10n.listeningHistorySearchNoEpisodesText
+        }
+    }
+
     @IBOutlet var listeningHistoryTable: UITableView! {
         didSet {
             registerCells()
@@ -198,6 +218,7 @@ extension ListeningHistoryViewController: PCSearchBarDelegate {
 
     func searchDidEnd() {
         listeningHistoryTable.isHidden = tempEpisodes.isEmpty
+        emptyStateView.isHidden = true
         episodes = tempEpisodes
         listeningHistoryTable.reloadData()
         tempEpisodes.removeAll()
@@ -205,6 +226,7 @@ extension ListeningHistoryViewController: PCSearchBarDelegate {
 
     func searchWasCleared() {
         listeningHistoryTable.isHidden = tempEpisodes.isEmpty
+        emptyStateView.isHidden = true
         episodes = tempEpisodes
         listeningHistoryTable.reloadData()
     }
@@ -212,12 +234,16 @@ extension ListeningHistoryViewController: PCSearchBarDelegate {
     func searchTermChanged(_ searchTerm: String) { }
 
     func performSearch(searchTerm: String, triggeredByTimer: Bool, completion: @escaping (() -> Void)) {
+        let oldData = episodes
         let newData = episodesDataManager.searchEpisodes(for: searchTerm)
 
         listeningHistoryTable.isHidden = newData.isEmpty
-        episodes = newData
-        listeningHistoryTable.reloadData()
+        emptyStateView.isHidden = !newData.isEmpty
 
+        let changeSet = StagedChangeset(source: oldData, target: newData)
+        self.listeningHistoryTable.reload(using: changeSet, with: .none, setData: { data in
+            self.episodes = data
+        })
         completion()
     }
 

--- a/podcasts/ListeningHistoryViewController.swift
+++ b/podcasts/ListeningHistoryViewController.swift
@@ -249,6 +249,7 @@ extension ListeningHistoryViewController: PCSearchBarDelegate {
 
     private func setupSearchController() {
         searchController = PCSearchBarController()
+        searchController?.searchDebounce = 0.2
 
         guard let searchController else {
             return

--- a/podcasts/ListeningHistoryViewController.swift
+++ b/podcasts/ListeningHistoryViewController.swift
@@ -6,6 +6,7 @@ import UIKit
 
 class ListeningHistoryViewController: PCViewController {
     var episodes = [ArraySection<String, ListEpisode>]()
+    var tempEpisodes = [ArraySection<String, ListEpisode>]()
     private let operationQueue = OperationQueue()
     var cellHeights: [IndexPath: CGFloat] = [:]
 
@@ -192,20 +193,31 @@ extension ListeningHistoryViewController: AnalyticsSourceProvider {
 
 extension ListeningHistoryViewController: PCSearchBarDelegate {
     func searchDidBegin() {
-
+        tempEpisodes = episodes
     }
 
     func searchDidEnd() {
-
+        listeningHistoryTable.isHidden = tempEpisodes.isEmpty
+        episodes = tempEpisodes
+        listeningHistoryTable.reloadData()
+        tempEpisodes.removeAll()
     }
 
     func searchWasCleared() {
-
+        listeningHistoryTable.isHidden = tempEpisodes.isEmpty
+        episodes = tempEpisodes
+        listeningHistoryTable.reloadData()
     }
 
     func searchTermChanged(_ searchTerm: String) { }
 
     func performSearch(searchTerm: String, triggeredByTimer: Bool, completion: @escaping (() -> Void)) {
+        let newData = episodesDataManager.searchEpisodes(for: searchTerm)
+
+        listeningHistoryTable.isHidden = newData.isEmpty
+        episodes = newData
+        listeningHistoryTable.reloadData()
+
         completion()
     }
 

--- a/podcasts/ListeningHistoryViewController.xib
+++ b/podcasts/ListeningHistoryViewController.xib
@@ -1,15 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23094" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23084"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ListeningHistoryViewController" customModule="podcasts" customModuleProvider="target">
             <connections>
+                <outlet property="emptyStateText" destination="lM9-WS-Rr0" id="10P-21-GfP"/>
+                <outlet property="emptyStateTitle" destination="r4T-OR-jqf" id="bkD-cu-P81"/>
+                <outlet property="emptyStateView" destination="HOd-Ww-OXE" id="jHE-xg-ZNb"/>
                 <outlet property="listeningHistoryTable" destination="A8m-ib-xHF" id="Dhh-8A-WxM"/>
                 <outlet property="multiSelectFooter" destination="QnB-mS-nOl" id="igB-hs-H6a"/>
                 <outlet property="multiSelectFooterBottomConstraint" destination="5vw-fO-ZlE" id="8ao-4W-mKu"/>
@@ -21,6 +25,32 @@
             <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="HOd-Ww-OXE" userLabel="EmptyStateView" customClass="ThemeableView" customModule="podcasts" customModuleProvider="target">
+                    <rect key="frame" x="67" y="308.5" width="241" height="70"/>
+                    <subviews>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="No episodes found" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="r4T-OR-jqf" userLabel="Title" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
+                            <rect key="frame" x="0.0" y="0.0" width="241" height="21.5"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="We couldn't find any episode for that search. Try another keyword." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lM9-WS-Rr0" userLabel="Text" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
+                            <rect key="frame" x="0.0" y="36.5" width="241" height="33.5"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                    </subviews>
+                    <constraints>
+                        <constraint firstItem="lM9-WS-Rr0" firstAttribute="leading" secondItem="HOd-Ww-OXE" secondAttribute="leading" id="A1K-JB-KJ3"/>
+                        <constraint firstAttribute="bottom" secondItem="lM9-WS-Rr0" secondAttribute="bottom" id="LAJ-nK-5ws"/>
+                        <constraint firstItem="r4T-OR-jqf" firstAttribute="leading" secondItem="HOd-Ww-OXE" secondAttribute="leading" id="TmM-ZQ-hQl"/>
+                        <constraint firstAttribute="trailing" secondItem="r4T-OR-jqf" secondAttribute="trailing" id="eup-Vg-mGh"/>
+                        <constraint firstAttribute="trailing" secondItem="lM9-WS-Rr0" secondAttribute="trailing" id="ogv-YK-OX6"/>
+                        <constraint firstItem="lM9-WS-Rr0" firstAttribute="top" secondItem="r4T-OR-jqf" secondAttribute="bottom" constant="15" id="vap-oK-hm5"/>
+                        <constraint firstItem="r4T-OR-jqf" firstAttribute="top" secondItem="HOd-Ww-OXE" secondAttribute="top" id="zlr-on-IRM"/>
+                    </constraints>
+                </view>
                 <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" allowsSelectionDuringEditing="YES" allowsMultipleSelection="YES" allowsMultipleSelectionDuringEditing="YES" rowHeight="80" estimatedRowHeight="80" sectionHeaderHeight="45" estimatedSectionHeaderHeight="45" sectionFooterHeight="1" translatesAutoresizingMaskIntoConstraints="NO" id="A8m-ib-xHF" customClass="ThemeableTable" customModule="podcasts" customModuleProvider="target">
                     <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                     <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -32,24 +62,33 @@
                 </tableView>
                 <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="QnB-mS-nOl" customClass="MultiSelectFooterView" customModule="podcasts" customModuleProvider="target">
                     <rect key="frame" x="8" y="603" width="359" height="64"/>
-                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="64" id="RdT-wh-hYE"/>
                     </constraints>
                 </view>
             </subviews>
+            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="A8m-ib-xHF" firstAttribute="trailing" secondItem="fnl-2z-Ty3" secondAttribute="trailing" id="3Md-gV-ah7"/>
                 <constraint firstItem="A8m-ib-xHF" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="4F5-oG-IJr"/>
                 <constraint firstItem="A8m-ib-xHF" firstAttribute="bottom" secondItem="QnB-mS-nOl" secondAttribute="bottom" id="5vw-fO-ZlE"/>
                 <constraint firstItem="A8m-ib-xHF" firstAttribute="bottom" secondItem="fnl-2z-Ty3" secondAttribute="bottom" id="6xF-nj-xUx"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="HOd-Ww-OXE" secondAttribute="trailing" constant="67" id="VLb-ge-BND"/>
+                <constraint firstItem="HOd-Ww-OXE" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="67" id="gb8-mj-eks"/>
+                <constraint firstItem="HOd-Ww-OXE" firstAttribute="centerX" secondItem="fnl-2z-Ty3" secondAttribute="centerX" id="lUT-8O-vFx"/>
+                <constraint firstItem="HOd-Ww-OXE" firstAttribute="centerY" secondItem="fnl-2z-Ty3" secondAttribute="centerY" id="nYv-u1-sM2"/>
                 <constraint firstItem="QnB-mS-nOl" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" constant="8" id="uQa-1R-jHE"/>
                 <constraint firstItem="A8m-ib-xHF" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="z7n-3L-B2X"/>
                 <constraint firstAttribute="trailing" secondItem="QnB-mS-nOl" secondAttribute="trailing" constant="8" id="zdH-Yp-qq2"/>
             </constraints>
-            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
-            <point key="canvasLocation" x="25.5" y="51.5"/>
+            <point key="canvasLocation" x="24.800000000000001" y="50.824587706146929"/>
         </view>
     </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -1438,6 +1438,10 @@ internal enum L10n {
   internal static var learnMore: String { return L10n.tr("Localizable", "learn_more") }
   /// Listening History
   internal static var listeningHistory: String { return L10n.tr("Localizable", "listening_history") }
+  /// We couldn't find any episode for that search. Try another keyword.
+  internal static var listeningHistorySearchNoEpisodesText: String { return L10n.tr("Localizable", "listening_history_search_no_episodes_text") }
+  /// No episodes found
+  internal static var listeningHistorySearchNoEpisodesTitle: String { return L10n.tr("Localizable", "listening_history_search_no_episodes_title") }
   /// Loading...
   internal static var loading: String { return L10n.tr("Localizable", "loading") }
   /// Create an account to sync your listening experience across all your devices.

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -1168,6 +1168,12 @@
 /* A common string used throughout the app. Often refers to the Listening History screen. */
 "listening_history" = "Listening History";
 
+/* The empty state view title when searching, and no episodes are found */
+"listening_history_search_no_episodes_title" = "No episodes found";
+
+/* The empty state view text when searching, and no episodes are found */
+"listening_history_search_no_episodes_text" = "We couldn't find any episode for that search. Try another keyword.";
+
 /* Progress indicator informing the user that the selected item is still loading. */
 "loading" = "Loading...";
 


### PR DESCRIPTION
| 📘 Part of: #2181
|:---:|

Fixes #2199 

This PR adds the query to fetch the episode or podcast in the listening history vc.


https://github.com/user-attachments/assets/dbab85e5-bd4a-4cce-8c9c-f2622ca179fe

## To test

> [!NOTE]
> Make sure to enable the feature flag listeningHistorySearch

1. Login with an account with sufficient listening history
2. Go to Profile tab -> Listening History
3. Search for an episode that exists in listening history
4. ✅ Notice that the episode appears in the results if the search term exists in episode title or podcast title
5. Search for an episode that does not exists in listening history
6. ✅ Notice that empty results screen is displayed

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
