### PR TITLE
Referrals: Integrate api call for get redeem code

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Private/API Tasks/ReferralGetCodeTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Private/API Tasks/ReferralGetCodeTask.swift
@@ -1,0 +1,36 @@
+import Foundation
+import PocketCastsUtils
+import SwiftProtobuf
+
+public struct ReferralCode: Codable {
+    let code: String
+    let url: String
+}
+
+class ReferralGetCodeTask: ApiBaseTask, @unchecked Sendable {
+    var completion: ((ReferralCode?) -> Void)?
+
+    init() {
+    }
+
+    override func apiTokenAcquired(token: String) {
+        let urlString = "\(ServerConstants.Urls.api())referrals/code"
+
+        do {
+            let (data, httpResponse) = getToServer(url: urlString, token: token)
+
+            guard let responseData = data,
+                  httpResponse?.statusCode == ServerConstants.HttpConstants.ok
+            else {
+                FileLog.shared.addMessage("Failed to get referral code - server returned \(httpResponse?.statusCode ?? -1), firing refresh failed")
+                completion?(nil)
+                return
+            }
+            let apiCode = try Api_ReferralCode(jsonUTF8Data: responseData)
+            completion?(ReferralCode(code: apiCode.code, url: apiCode.url))
+        } catch {
+            FileLog.shared.addMessage("Failed to parse  Api_GetRererralCodeRequest \(error.localizedDescription)")
+            completion?(nil)
+        }
+    }
+}

--- a/Modules/Server/Sources/PocketCastsServer/Private/API Tasks/ReferralGetCodeTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Private/API Tasks/ReferralGetCodeTask.swift
@@ -10,9 +10,6 @@ public struct ReferralCode: Codable {
 class ReferralGetCodeTask: ApiBaseTask, @unchecked Sendable {
     var completion: ((ReferralCode?) -> Void)?
 
-    init() {
-    }
-
     override func apiTokenAcquired(token: String) {
         let urlString = "\(ServerConstants.Urls.api())referrals/code"
 

--- a/Modules/Server/Sources/PocketCastsServer/Private/API Tasks/ReferralGetCodeTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Private/API Tasks/ReferralGetCodeTask.swift
@@ -3,8 +3,8 @@ import PocketCastsUtils
 import SwiftProtobuf
 
 public struct ReferralCode: Codable {
-    let code: String
-    let url: String
+    public let code: String
+    public let url: String
 }
 
 class ReferralGetCodeTask: ApiBaseTask, @unchecked Sendable {
@@ -26,7 +26,7 @@ class ReferralGetCodeTask: ApiBaseTask, @unchecked Sendable {
                 completion?(nil)
                 return
             }
-            let apiCode = try Api_ReferralCode(jsonUTF8Data: responseData)
+            let apiCode = try Api_ReferralCode(serializedBytes: responseData)
             completion?(ReferralCode(code: apiCode.code, url: apiCode.url))
         } catch {
             FileLog.shared.addMessage("Failed to parse  Api_GetRererralCodeRequest \(error.localizedDescription)")

--- a/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+Referrals.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+Referrals.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+public extension ApiServerHandler {
+
+    func getReferralCode() async -> ReferralCode? {
+        return await withCheckedContinuation { continuation in
+            let operation = ReferralGetCodeTask()
+            operation.completion = { code in
+                continuation.resume(returning: code)
+            }
+            apiQueue.addOperation(operation)
+        }
+    }
+}

--- a/podcasts/ProfileViewController.swift
+++ b/podcasts/ProfileViewController.swift
@@ -491,7 +491,7 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
 
     @objc private func referralsTapped() {
         hideReferralsHint()
-        let viewModel = ReferralSendPassModel(offerInfo: ReferralsCoordinator.shared.referralsOfferInfo, referralURL: URL(string: ServerConstants.Urls.pocketcastsDotCom),
+        let viewModel = ReferralSendPassModel(offerInfo: ReferralsCoordinator.shared.referralsOfferInfo,
                                               onShareGuestPassTap: { [weak self] in
             self?.updateReferrals()
             self?.dismiss(animated: true)

--- a/podcasts/Referrals/ReferralCardAnimatedGradientView.swift
+++ b/podcasts/Referrals/ReferralCardAnimatedGradientView.swift
@@ -19,6 +19,7 @@ struct ReferralCardAnimatedGradientView: View {
             let motionScale = geometry.size.width / 10
             let circleSize = geometry.size.height * 1.3
             Rectangle()
+            .foregroundColor(.black)
             .background(.black)
             .overlay {
                 LinearGradient(

--- a/podcasts/Referrals/ReferralCardView.swift
+++ b/podcasts/Referrals/ReferralCardView.swift
@@ -9,6 +9,8 @@ struct ReferralCardView: View {
 
     var body: some View {
         Rectangle()
+            .foregroundColor(.black)
+            .background(.black)
             .overlay {
                 ReferralCardAnimatedGradientView()
             }

--- a/podcasts/Referrals/ReferralSendPassVC.swift
+++ b/podcasts/Referrals/ReferralSendPassVC.swift
@@ -84,6 +84,7 @@ class TextAndURLShareSource: NSObject, UIActivityItemSource {
 
 extension TextAndURLShareSource {
 
+    @MainActor
     static func makeFrom(viewModel: ReferralSendPassModel) -> TextAndURLShareSource {
         return TextAndURLShareSource(url: viewModel.referralURL, text: viewModel.shareText, subject: viewModel.shareSubject)
     }

--- a/podcasts/Referrals/ReferralSendPassView.swift
+++ b/podcasts/Referrals/ReferralSendPassView.swift
@@ -42,7 +42,7 @@ class ReferralSendPassModel: ObservableObject {
     }
 
     func loadData() async {
-        state = .loading        
+        state = .loading
         let code = await ApiServerHandler.shared.getReferralCode()
         if let code, let referralURL = URL(string: code.url) {
             self.referralURL = referralURL

--- a/podcasts/Referrals/ReferralSendPassView.swift
+++ b/podcasts/Referrals/ReferralSendPassView.swift
@@ -47,37 +47,43 @@ struct ReferralSendPassView: View {
     @State var showShareView: Bool = false
 
     var body: some View {
-        VStack {
-            HStack {
-                Button(action: {
-                    viewModel.onCloseTap?()
-                }, label: {
-                    Image("close").foregroundColor(Color.white)
-                })
-                Spacer()
-            }
-            VStack(spacing: Constants.verticalSpacing) {
-                SubscriptionBadge(tier: .plus, displayMode: .gradient, foregroundColor: .black)
-                Text(viewModel.title)
-                    .font(size: 31, style: .title, weight: .bold)
-                    .multilineTextAlignment(.center)
-                    .foregroundColor(.white)
-                ZStack {
-                    ForEach(0..<Constants.numberOfPasses, id: \.self) { i in
-                        ReferralCardView(offerDuration: viewModel.offerInfo.localizedOfferDurationAdjective)
-                            .frame(width: Constants.defaultCardSize.width - (CGFloat(Constants.numberOfPasses-1-i) * Constants.cardInset.width), height: Constants.defaultCardSize.height)
-                            .offset(CGSize(width: 0, height: CGFloat(Constants.numberOfPasses * i) * Constants.cardInset.height))
+        Group {
+            if viewModel.isLoading {
+                ProgressView()
+            } else {
+                VStack {
+                    HStack {
+                        Button(action: {
+                            viewModel.onCloseTap?()
+                        }, label: {
+                            Image("close").foregroundColor(Color.white)
+                        })
+                        Spacer()
                     }
+                    VStack(spacing: Constants.verticalSpacing) {
+                        SubscriptionBadge(tier: .plus, displayMode: .gradient, foregroundColor: .black)
+                        Text(viewModel.title)
+                            .font(size: 31, style: .title, weight: .bold)
+                            .multilineTextAlignment(.center)
+                            .foregroundColor(.white)
+                        ZStack {
+                            ForEach(0..<Constants.numberOfPasses, id: \.self) { i in
+                                ReferralCardView(offerDuration: viewModel.offerInfo.localizedOfferDurationAdjective)
+                                    .frame(width: Constants.defaultCardSize.width - (CGFloat(Constants.numberOfPasses-1-i) * Constants.cardInset.width), height: Constants.defaultCardSize.height)
+                                    .offset(CGSize(width: 0, height: CGFloat(Constants.numberOfPasses * i) * Constants.cardInset.height))
+                            }
+                        }
+                    }
+                    Spacer()
+                    Button(viewModel.buttonTitle) {
+                        viewModel.onShareGuestPassTap?()
+                    }
+                    .buttonStyle(PlusGradientFilledButtonStyle(isLoading: false, plan: .plus))
                 }
+                .padding()
+                .background(.black)
             }
-            Spacer()
-            Button(viewModel.buttonTitle) {
-                viewModel.onShareGuestPassTap?()
-            }
-            .buttonStyle(PlusGradientFilledButtonStyle(isLoading: false, plan: .plus))
         }
-        .padding()
-        .background(.black)
         .task {
             await viewModel.loadData()
         }

--- a/podcasts/Referrals/ReferralSendPassView.swift
+++ b/podcasts/Referrals/ReferralSendPassView.swift
@@ -42,8 +42,7 @@ class ReferralSendPassModel: ObservableObject {
     }
 
     func loadData() async {
-        state = .loading
-        try? await Task.sleep(nanoseconds: 2_000_000_000 )
+        state = .loading        
         let code = await ApiServerHandler.shared.getReferralCode()
         if let code, let referralURL = URL(string: code.url) {
             self.referralURL = referralURL

--- a/podcasts/Referrals/ReferralSendPassView.swift
+++ b/podcasts/Referrals/ReferralSendPassView.swift
@@ -1,15 +1,16 @@
 import SwiftUI
 import PocketCastsServer
 
-class ReferralSendPassModel {
+class ReferralSendPassModel: ObservableObject {
     let offerInfo: ReferralsOfferInfo
-    let referralURL: URL?
+    @Published var referralURL: URL?
     var onShareGuestPassTap: (() -> ())?
     var onCloseTap: (() -> ())?
 
-    init(offerInfo: ReferralsOfferInfo, referralURL: URL?, onShareGuestPassTap: (() -> ())? = nil, onCloseTap: (() -> ())? = nil) {
+    @Published var isLoading: Bool = false
+
+    init(offerInfo: ReferralsOfferInfo, onShareGuestPassTap: (() -> ())? = nil, onCloseTap: (() -> ())? = nil) {
         self.offerInfo = offerInfo
-        self.referralURL = referralURL
         self.onShareGuestPassTap = onShareGuestPassTap
         self.onCloseTap = onCloseTap
     }
@@ -30,6 +31,14 @@ class ReferralSendPassModel {
         L10n.referralsSharePassSubject(self.offerInfo.localizedOfferDurationAdjective)
     }
 
+    func loadData() async {
+        isLoading = true
+        let code = await ApiServerHandler.shared.getReferralCode()
+        if let code {
+            referralURL = URL(string: code.url)
+        }
+        isLoading = false
+    }
 }
 
 struct ReferralSendPassView: View {
@@ -69,6 +78,9 @@ struct ReferralSendPassView: View {
         }
         .padding()
         .background(.black)
+        .task {
+            await viewModel.loadData()
+        }
     }
 
     enum Constants {
@@ -81,6 +93,6 @@ struct ReferralSendPassView: View {
 
 #Preview("With Passes") {
     Group {
-        ReferralSendPassView(viewModel: ReferralSendPassModel(offerInfo: ReferralsOfferInfoMock(), referralURL: URL(string: ServerConstants.Urls.pocketcastsDotCom)))
+        ReferralSendPassView(viewModel: ReferralSendPassModel(offerInfo: ReferralsOfferInfoMock()))
     }
 }

--- a/podcasts/Referrals/ReferralSendPassView.swift
+++ b/podcasts/Referrals/ReferralSendPassView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import PocketCastsServer
 
+@MainActor
 class ReferralSendPassModel: ObservableObject {
     let offerInfo: ReferralsOfferInfo
     @Published var referralURL: URL?
@@ -42,14 +43,27 @@ class ReferralSendPassModel: ObservableObject {
 }
 
 struct ReferralSendPassView: View {
-    let viewModel: ReferralSendPassModel
+    @StateObject var viewModel: ReferralSendPassModel
 
     @State var showShareView: Bool = false
+
+    @ViewBuilder
+    var loadingView: some View {
+        VStack {
+            Spacer()
+            HStack {
+                Spacer()
+                ProgressView().tint(.white)
+                Spacer()
+            }
+            Spacer()
+        }
+    }
 
     var body: some View {
         Group {
             if viewModel.isLoading {
-                ProgressView()
+                loadingView
             } else {
                 VStack {
                     HStack {
@@ -80,10 +94,10 @@ struct ReferralSendPassView: View {
                     }
                     .buttonStyle(PlusGradientFilledButtonStyle(isLoading: false, plan: .plus))
                 }
-                .padding()
-                .background(.black)
             }
         }
+        .padding()
+        .background(.black)
         .task {
             await viewModel.loadData()
         }

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -2306,6 +2306,8 @@ internal enum L10n {
   internal static func referralsGuestPassOffer(_ p1: Any) -> String {
     return L10n.tr("Localizable", "referrals_guest_pass_offer", String(describing: p1))
   }
+  /// Guest Pass not available at the moment
+  internal static var referralsNotAvailableToSend: String { return L10n.tr("Localizable", "referrals_not_available_to_send") }
   /// This guest pass can only be redeemed once and is available for those without an active Plus or Patron subscription. Thanks for listening!
   internal static var referralsOfferNotAvailableDetail: String { return L10n.tr("Localizable", "referrals_offer_not_available_detail") }
   /// This offer isn’t available

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4445,3 +4445,5 @@
 /* Referrals - Detail message for screen saying that referral offer isn't available for user*/
 "referrals_offer_not_available_detail" = "This guest pass can only be redeemed once and is available for those without an active Plus or Patron subscription. Thanks for listening!";
 
+/* Referrals - Guest Pass not available*/
+"referrals_not_available_to_send" = "Guest Pass not available at the moment";


### PR DESCRIPTION
| 📘 Part of: #2083  |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

| 1 | 2 | 3 | 4 |
| - | - | - | - | 
| ![IMG_0146](https://github.com/user-attachments/assets/fc6e3ff3-aa22-4be3-9397-e226b0bbf244) | ![IMG_0147](https://github.com/user-attachments/assets/1a643a52-1ad1-42de-ad35-0871741408a1) | ![IMG_0149](https://github.com/user-attachments/assets/10a2d7ab-dd71-4130-93ac-6145f903a705) | ![IMG_0148](https://github.com/user-attachments/assets/f0c50b25-82fb-43a2-b562-a2e8e00a2847) |

## To test

1. Start the app
2. Ensure you the Referrals FF enabled and you are using a Plus or Patron account
3. Go to Profile
4. Tap on the gift icon on the top left
5. Tap On Share Guest Pass
6. See the Share system view
7. Choose different types of Share and check if they work correctly and show your custom referral URL: `https://pocketcasts.com/redeem/XXXXXX`
8. Share and see if you go back to the profile screen.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.