### PR TITLE
[Listening History] Add analytics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 7.74
 -----
 - Add Title episode sort options to iPhone app [2175](https://github.com/Automattic/pocket-casts-ios/pull/2175)
+- Add local search in listening history ([#2181](https://github.com/Automattic/pocket-casts-ios/issues/2181))
 
 7.73
 -----

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -599,6 +599,7 @@ enum AnalyticsEvent: String {
     case searchFailed
     case searchResultTapped
     case searchListShown
+    case searchCleared
 
     // MARK: - Chromecast
 

--- a/podcasts/ListeningHistoryViewController.swift
+++ b/podcasts/ListeningHistoryViewController.swift
@@ -225,6 +225,8 @@ extension ListeningHistoryViewController: PCSearchBarDelegate {
     }
 
     func searchWasCleared() {
+        Analytics.track(.searchCleared, source: analyticsSource)
+
         listeningHistoryTable.isHidden = tempEpisodes.isEmpty
         emptyStateView.isHidden = true
         episodes = tempEpisodes
@@ -234,6 +236,8 @@ extension ListeningHistoryViewController: PCSearchBarDelegate {
     func searchTermChanged(_ searchTerm: String) { }
 
     func performSearch(searchTerm: String, triggeredByTimer: Bool, completion: @escaping (() -> Void)) {
+        Analytics.track(.searchPerformed, source: analyticsSource)
+
         let oldData = episodes
         let newData = episodesDataManager.searchEpisodes(for: searchTerm)
 


### PR DESCRIPTION
| 📘 Part of: #2181
|:---:|

Fixes #2207 

This adds search analytics in Listening History.

## To test

1. Login with an account with some listening history
2. Go to Profile -> Listening History
3. Search for an episode
4. ✅ Notice in logs 🔵 Tracked: search_performed ["source": "listening_history"]
5. Clear search query
6. ✅ Notice in logs 🔵 Tracked: search_cleared ["source": "listening_history"]

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
