### PR TITLE
Fix crash if setter is called before the view being loaded

### DIFF
--- a/podcasts/PCSearchBarController.swift
+++ b/podcasts/PCSearchBarController.swift
@@ -45,7 +45,9 @@ class PCSearchBarController: UIViewController {
 
     var placeholderText = L10n.searchLabel {
         didSet {
-            updatePlaceholderColor()
+            if isViewLoaded {
+                updatePlaceholderColor()
+            }
         }
     }
 


### PR DESCRIPTION
Fix crash if setter is called before the view being loaded

## To test

- CI must be 🟢 
- Run the app
- Podcasts view
- Tap on the top left icon to open the folders
- Confirm the app doesn't crash

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
