### PR TITLE
Add search functionality to DiscoverCollectionViewController

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1648,6 +1648,7 @@
 		F51656D82C816FE6009446B4 /* ClipsWhatsNewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F51656D72C816FE6009446B4 /* ClipsWhatsNewView.swift */; };
 		F5197A402B995A1E007C8D0A /* DownloadManager+Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5197A3F2B995A1E007C8D0A /* DownloadManager+Logging.swift */; };
 		F5197A412B995A1E007C8D0A /* DownloadManager+Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5197A3F2B995A1E007C8D0A /* DownloadManager+Logging.swift */; };
+		F51D3A0C2CA62D3C000F3B78 /* DiscoverCollectionViewController+Search.swift in Sources */ = {isa = PBXBuildFile; fileRef = F51D3A0B2CA62D3C000F3B78 /* DiscoverCollectionViewController+Search.swift */; };
 		F51D90722C70FF7800F0A232 /* AVAsset+Crop.swift in Sources */ = {isa = PBXBuildFile; fileRef = F51D90712C70FF7800F0A232 /* AVAsset+Crop.swift */; };
 		F51D90742C71A0A100F0A232 /* SharingFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F51D90732C71A0A100F0A232 /* SharingFooterView.swift */; };
 		F51D90762C73141B00F0A232 /* CGSize+FittingSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = F51D90752C73141B00F0A232 /* CGSize+FittingSize.swift */; };
@@ -3561,6 +3562,7 @@
 		F508F0FA2C4F1EC000822159 /* ClipPlaybackManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipPlaybackManager.swift; sourceTree = "<group>"; };
 		F51656D72C816FE6009446B4 /* ClipsWhatsNewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipsWhatsNewView.swift; sourceTree = "<group>"; };
 		F5197A3F2B995A1E007C8D0A /* DownloadManager+Logging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DownloadManager+Logging.swift"; sourceTree = "<group>"; };
+		F51D3A0B2CA62D3C000F3B78 /* DiscoverCollectionViewController+Search.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DiscoverCollectionViewController+Search.swift"; sourceTree = "<group>"; };
 		F51D90712C70FF7800F0A232 /* AVAsset+Crop.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AVAsset+Crop.swift"; sourceTree = "<group>"; };
 		F51D90732C71A0A100F0A232 /* SharingFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharingFooterView.swift; sourceTree = "<group>"; };
 		F51D90752C73141B00F0A232 /* CGSize+FittingSize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CGSize+FittingSize.swift"; sourceTree = "<group>"; };
@@ -7716,6 +7718,7 @@
 				40B26AC6213FED4300386173 /* DiscoverPeekViewController.swift */,
 				C7BF5E46290832FD00733C1E /* DiscoverCoordinator.swift */,
 				F5BA5C992C7F701900BDA5B9 /* DiscoverCollectionViewController.swift */,
+				F51D3A0B2CA62D3C000F3B78 /* DiscoverCollectionViewController+Search.swift */,
 			);
 			name = Discovery;
 			sourceTree = "<group>";
@@ -9257,6 +9260,7 @@
 				BDF15A461B54E21B000EC323 /* PlaybackEffects.swift in Sources */,
 				8B630A332AFBF49400D65D25 /* PlayPauseAnimatableModifier.swift in Sources */,
 				F55449452B75935F00F68AE9 /* AppSettings+ImportUserDefaults.swift in Sources */,
+				F51D3A0C2CA62D3C000F3B78 /* DiscoverCollectionViewController+Search.swift in Sources */,
 				BDED930B251DC515000BF622 /* CarPlaySceneDelegate+Interaction.swift in Sources */,
 				BD21D4A522DED77900D5888B /* ThemeableButton.swift in Sources */,
 				BDD5CA042303FC45005E133C /* ThemeableTextView.swift in Sources */,

--- a/podcasts/DiscoverCollectionViewController+Search.swift
+++ b/podcasts/DiscoverCollectionViewController+Search.swift
@@ -1,0 +1,111 @@
+// All code needed for hooking up the search bar and related functionality to DiscoverCollectionViewController
+
+extension DiscoverCollectionViewController {
+    func setupSearchBar() {
+        addCustomObserver(Constants.Notifications.chartRegionChanged, selector: #selector(chartRegionDidChange))
+        addCustomObserver(Constants.Notifications.tappedOnSelectedTab, selector: #selector(checkForScrollTap(_:)))
+
+        searchController.view.translatesAutoresizingMaskIntoConstraints = false
+        addChild(searchController)
+        view.addSubview(searchController.view)
+        searchController.didMove(toParent: self)
+
+        let topAnchor = searchController.view.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: -PCSearchBarController.defaultHeight)
+        NSLayoutConstraint.activate([
+            searchController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            searchController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            searchController.view.heightAnchor.constraint(equalToConstant: PCSearchBarController.defaultHeight),
+            topAnchor
+        ])
+        searchController.searchControllerTopConstant = topAnchor
+
+        searchController.setupScrollView(collectionView, hideSearchInitially: false)
+        searchController.searchDebounce = Settings.podcastSearchDebounceTime()
+        searchController.searchDelegate = self
+    }
+}
+
+extension DiscoverCollectionViewController {
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        guard searchResultsController.view?.superview == nil else { return } // don't send scroll events while the search results are up
+
+        searchController.parentScrollViewDidScroll(scrollView)
+    }
+}
+
+extension DiscoverCollectionViewController: PCSearchBarDelegate {
+    func searchDidBegin() {
+        guard let searchView = searchResultsController.view, searchView.superview == nil else {
+            return
+        }
+
+        searchView.alpha = 0
+        addChild(searchResultsController)
+        view.addSubview(searchView)
+        searchResultsController.didMove(toParent: self)
+
+
+        searchView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            searchView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            searchView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            searchView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            searchView.topAnchor.constraint(equalTo: searchController.view.bottomAnchor)
+        ])
+
+        UIView.animate(withDuration: Constants.Animation.defaultAnimationTime) {
+            searchView.alpha = 1
+        }
+    }
+
+    func searchDidEnd() {
+        guard let searchView = searchResultsController.view else { return }
+
+        UIView.animate(withDuration: Constants.Animation.defaultAnimationTime, animations: {
+            searchView.alpha = 0
+        }) { _ in
+            searchView.removeFromSuperview()
+            self.resultsControllerDelegate.clearSearch()
+        }
+
+        Analytics.track(.searchDismissed, properties: ["source": AnalyticsSource.discover])
+    }
+
+    func searchWasCleared() {
+        resultsControllerDelegate.clearSearch()
+    }
+
+    func searchTermChanged(_ searchTerm: String) {}
+
+    func performSearch(searchTerm: String, triggeredByTimer: Bool, completion: @escaping (() -> Void)) {
+        resultsControllerDelegate.performSearch(searchTerm: searchTerm, triggeredByTimer: triggeredByTimer, completion: completion)
+    }
+}
+
+extension DiscoverCollectionViewController {
+    @objc private func chartRegionDidChange() {
+        reloadData()
+    }
+
+    @objc private func checkForScrollTap(_ notification: Notification) {
+        guard let index = notification.object as? Int, index == tabBarItem.tag else { return }
+
+        let defaultOffset = -PCSearchBarController.defaultHeight - view.safeAreaInsets.top
+        if collectionView.contentOffset.y.rounded(.down) > defaultOffset.rounded(.down) {
+            collectionView.setContentOffset(CGPoint(x: 0, y: defaultOffset), animated: true)
+        } else {
+            // When double-tapping on tab bar, dismiss the search if already active
+            // else give focus to the search field
+            if searchController.cancelButtonShowing {
+                searchController.cancelTapped(self)
+            } else {
+                searchController.searchTextField.becomeFirstResponder()
+            }
+        }
+    }
+
+    @objc private func searchRequested() {
+        collectionView.setContentOffset(CGPoint(x: 0, y: -PCSearchBarController.defaultHeight - view.safeAreaInsets.top), animated: false)
+        searchController.searchTextField.becomeFirstResponder()
+    }
+}

--- a/podcasts/DiscoverCollectionViewController.swift
+++ b/podcasts/DiscoverCollectionViewController.swift
@@ -1,4 +1,4 @@
-class DiscoverCollectionViewController: UIViewController, UICollectionViewDelegate {
+class DiscoverCollectionViewController: PCViewController, UICollectionViewDelegate {
 
     enum Cell {
         case list
@@ -11,9 +11,19 @@ class DiscoverCollectionViewController: UIViewController, UICollectionViewDelega
         }
     }
 
-    private lazy var collectionView: UICollectionView = {
+    private(set) lazy var collectionView: UICollectionView = {
         return UICollectionView(frame: view.bounds, collectionViewLayout: collectionViewLayout())
     }()
+
+    private(set) lazy var searchController: PCSearchBarController = {
+        PCSearchBarController()
+    }()
+
+    lazy var searchResultsController = SearchResultsViewController(source: .discover)
+
+    var resultsControllerDelegate: SearchResultsDelegate {
+        searchResultsController
+    }
 
     private let coordinator: DiscoverCoordinator
 
@@ -30,6 +40,11 @@ class DiscoverCollectionViewController: UIViewController, UICollectionViewDelega
         super.viewDidLoad()
 
         setupCollectionView()
+        setupSearchBar()
+    }
+
+    func reloadData() {
+        // Will be implemented in a future PR
     }
 
     private func setupCollectionView() {


### PR DESCRIPTION
| 📘 Part of: #2104 |
|:---:|

Adds search to refactored `DiscoverCollectionViewController`.

Most of this code is copied directly from DiscoverViewController but I tried to organize it by putting it in a separate file.

https://github.com/user-attachments/assets/e6edff1a-c620-4aba-a829-12b068b934f7

## To test

* Enable the `discoverCollectionView` feature flag
* Restart the app
* Visit the Discover tab
* You should see the search bar at the top but only the "Discover" title
* Tap the search bar and make sure everything works as expected

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
