### PR TITLE
Transcripts: Track the transcript type and if javascript is detected in it.

### DIFF
--- a/podcasts/TranscriptModel.swift
+++ b/podcasts/TranscriptModel.swift
@@ -21,11 +21,13 @@ struct TranscriptModel: Sendable {
 
     let attributedText: NSAttributedString
     let cues: [TranscriptCue]
+    let type: String
+    let hasJavascript: Bool
 
     static func makeModel(from transcriptText: String, format: TranscriptFormat) -> TranscriptModel? {
         if format == .textHTML {
             let filteredText = ComposeFilter.htmlFilter.filter(transcriptText).trim()
-            return TranscriptModel(attributedText: NSAttributedString(string: filteredText), cues: [])
+            return TranscriptModel(attributedText: NSAttributedString(string: filteredText), cues: [], type: format.rawValue, hasJavascript: transcriptText.contains("<script type=\"text/javascript\">"))
         }
         let subtitles: Subtitles? = {
             do {
@@ -64,7 +66,7 @@ struct TranscriptModel: Sendable {
             cues.append(entry)
         }
 
-        return TranscriptModel(attributedText: resultText, cues: cues)
+        return TranscriptModel(attributedText: resultText, cues: cues, type: format.rawValue, hasJavascript: false)
     }
 
     @inlinable public func firstCue(containing secondsValue: Double) -> TranscriptCue? {

--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -317,7 +317,7 @@ class TranscriptViewController: PlayerItemViewController {
 
             do {
                 let transcript = try await transcriptManager.loadTranscript()
-                await track(.transcriptShown)
+                await track(.transcriptShown, properties: ["type": transcript.type, "show_as_webpage": transcript.hasJavascript])
                 await show(transcript: transcript, resetPosition: shouldResetPosition)
             } catch {
                 await track(.transcriptError, properties: ["error_code": (error as NSError).code])


### PR DESCRIPTION
| 📘 Part of: #1848  |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

Add properties for the transcripts_show event to track the transcript type and if it's HTML if it has javascript on it.

## To test

1. Start the app
2. Enable the tracksLogging FF
3. Play an episode podcast with a transcript. Ex: Cautionary Tales
4. Open the full screen player
5. Tap on the transcript icon
6. Check on the console for the event: `transcript_show` with the properties `type=text/vtt` and `show_as_webpage=false`
7. Open the episode `You're an Scorpio I'm an adult` -> `https://pca.st/episode/3abf8b43-0ed0-4713-b073-37b379418378`
8. Play it
9. Open the transcript
10. Check on the console for the event: `transcript_show` with the properties `type=text/html` and `show_as_webpage=true`

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
