### PR TITLE
Referrals: Integrate api calls on claim referral

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Private/API Tasks/ReferralRedeemTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Private/API Tasks/ReferralRedeemTask.swift
@@ -1,0 +1,42 @@
+import Foundation
+import PocketCastsUtils
+import SwiftProtobuf
+
+class ReferralRedeemTask: ApiBaseTask, @unchecked Sendable {
+    var completion: ((Bool) -> Void)?
+
+    private let code: String
+
+    init(code: String) {
+        self.code = code
+    }
+
+    override func apiTokenAcquired(token: String) {
+        let urlString = "\(ServerConstants.Urls.api())referrals/redeem"
+
+        do {
+            var request = Api_ReferralRedemption()
+            request.code = code
+
+            let data = try request.serializedData()
+
+            let (response, httpStatus) = postToServer(url: urlString, token: token, data: data)
+
+            if response == nil {
+                FileLog.shared.addMessage("Referral failed to redeem offer \(code) because response is empty")
+                completion?(false)
+                return
+            }
+
+            if httpStatus == ServerConstants.HttpConstants.ok {
+                FileLog.shared.addMessage("Referral redeem successfull for code \(code)")
+            } else {
+                FileLog.shared.addMessage("Referral failed to redeem code \(code), http status \(httpStatus)")
+            }
+            completion?(httpStatus == ServerConstants.HttpConstants.ok)
+        } catch {
+            FileLog.shared.addMessage("Failed to serialize Api_ReferralRedemption \(error.localizedDescription) for code \(code)")
+            completion?(false)
+        }
+    }
+}

--- a/Modules/Server/Sources/PocketCastsServer/Private/API Tasks/ReferralValidateTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Private/API Tasks/ReferralValidateTask.swift
@@ -1,0 +1,39 @@
+import Foundation
+import PocketCastsUtils
+import SwiftProtobuf
+
+public struct ReferralValidate: Codable {
+    public let offer: String
+}
+
+class ReferralValidateTask: ApiBaseTask, @unchecked Sendable {
+
+    let code: String
+    var completion: ((ReferralValidate?) -> Void)?
+
+    init(code: String) {
+        self.code = code
+        super.init()
+    }
+
+    override func apiTokenAcquired(token: String) {
+        let urlString = "\(ServerConstants.Urls.api())referrals/validate?code=\(code)"
+
+        do {
+            let (data, httpResponse) = getToServer(url: urlString, token: token)
+
+            guard let responseData = data,
+                  httpResponse?.statusCode == ServerConstants.HttpConstants.ok
+            else {
+                FileLog.shared.addMessage("Failed to validate referral code - server returned \(httpResponse?.statusCode ?? -1)")
+                completion?(nil)
+                return
+            }
+            let apiCode = try Api_ReferralValidationResponse(serializedBytes: responseData)
+            completion?(ReferralValidate(offer: apiCode.offer))
+        } catch {
+            FileLog.shared.addMessage("Failed to parse  Api_ReferralValidationResponse \(error.localizedDescription)")
+            completion?(nil)
+        }
+    }
+}

--- a/Modules/Server/Sources/PocketCastsServer/Private/API Tasks/ReferralValidateTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Private/API Tasks/ReferralValidateTask.swift
@@ -4,6 +4,8 @@ import SwiftProtobuf
 
 public struct ReferralValidate: Codable {
     public let offer: String
+    public let platform: Int
+    public let details: String
 }
 
 class ReferralValidateTask: ApiBaseTask, @unchecked Sendable {
@@ -17,7 +19,7 @@ class ReferralValidateTask: ApiBaseTask, @unchecked Sendable {
     }
 
     override func apiTokenAcquired(token: String) {
-        let urlString = "\(ServerConstants.Urls.api())referrals/validate?code=\(code)"
+        let urlString = "\(ServerConstants.Urls.api())referrals/validate?code=\(code)&platform=ios"
 
         do {
             let (data, httpResponse) = getToServer(url: urlString, token: token)
@@ -29,8 +31,8 @@ class ReferralValidateTask: ApiBaseTask, @unchecked Sendable {
                 completion?(nil)
                 return
             }
-            let apiCode = try Api_ReferralValidationResponse(serializedBytes: responseData)
-            completion?(ReferralValidate(offer: apiCode.offer))
+            let validationResponse = try Api_ReferralValidationResponse(serializedBytes: responseData)
+            completion?(ReferralValidate(offer: validationResponse.offer, platform: Int(validationResponse.platform), details: validationResponse.details))
         } catch {
             FileLog.shared.addMessage("Failed to parse  Api_ReferralValidationResponse \(error.localizedDescription)")
             completion?(nil)

--- a/Modules/Server/Sources/PocketCastsServer/Private/Protobuffer/api.pb.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Private/Protobuffer/api.pb.swift
@@ -7383,6 +7383,10 @@ struct Api_ReferralValidationResponse: Sendable {
 
   var offer: String = String()
 
+  var platform: Int32 = 0
+
+  var details: String = String()
+
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
@@ -18315,6 +18319,8 @@ extension Api_ReferralValidationResponse: SwiftProtobuf.Message, SwiftProtobuf._
   static let protoMessageName: String = _protobuf_package + ".ReferralValidationResponse"
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .same(proto: "offer"),
+    2: .same(proto: "platform"),
+    3: .same(proto: "details"),
   ]
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -18324,6 +18330,8 @@ extension Api_ReferralValidationResponse: SwiftProtobuf.Message, SwiftProtobuf._
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
       case 1: try { try decoder.decodeSingularStringField(value: &self.offer) }()
+      case 2: try { try decoder.decodeSingularInt32Field(value: &self.platform) }()
+      case 3: try { try decoder.decodeSingularStringField(value: &self.details) }()
       default: break
       }
     }
@@ -18333,11 +18341,19 @@ extension Api_ReferralValidationResponse: SwiftProtobuf.Message, SwiftProtobuf._
     if !self.offer.isEmpty {
       try visitor.visitSingularStringField(value: self.offer, fieldNumber: 1)
     }
+    if self.platform != 0 {
+      try visitor.visitSingularInt32Field(value: self.platform, fieldNumber: 2)
+    }
+    if !self.details.isEmpty {
+      try visitor.visitSingularStringField(value: self.details, fieldNumber: 3)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: Api_ReferralValidationResponse, rhs: Api_ReferralValidationResponse) -> Bool {
     if lhs.offer != rhs.offer {return false}
+    if lhs.platform != rhs.platform {return false}
+    if lhs.details != rhs.details {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+Referrals.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+Referrals.swift
@@ -21,4 +21,14 @@ public extension ApiServerHandler {
             apiQueue.addOperation(operation)
         }
     }
+
+    func redeemCode(_ code: String) async -> Bool {
+        return await withCheckedContinuation { continuation in
+            let operation = ReferralRedeemTask(code: code)
+            operation.completion = { result in
+                continuation.resume(returning: result)
+            }
+            apiQueue.addOperation(operation)
+        }
+    }
 }

--- a/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+Referrals.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+Referrals.swift
@@ -11,4 +11,14 @@ public extension ApiServerHandler {
             apiQueue.addOperation(operation)
         }
     }
+
+    func validateCode(_ code: String) async -> ReferralValidate? {
+        return await withCheckedContinuation { continuation in
+            let operation = ReferralValidateTask(code: code)
+            operation.completion = { code in
+                continuation.resume(returning: code)
+            }
+            apiQueue.addOperation(operation)
+        }
+    }
 }

--- a/podcasts/ProfileViewController.swift
+++ b/podcasts/ProfileViewController.swift
@@ -350,7 +350,9 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
             break
         case .referralsClaim:
             dismiss(animated: true)
-            ReferralsCoordinator.shared.startClaimFlow(from: self)
+            ReferralsCoordinator.shared.startClaimFlow(from: self) {
+                tableView.reloadData()
+            }
         case .allStats:
             let statsViewController = StatsViewController()
             navigationController?.pushViewController(statsViewController, animated: true)

--- a/podcasts/Referrals/ReferralCardMiniView.swift
+++ b/podcasts/Referrals/ReferralCardMiniView.swift
@@ -4,6 +4,8 @@ struct ReferralCardMiniView: View {
 
     var body: some View {
         Rectangle()
+            .background(.black)
+            .foregroundColor(.black)
             .overlay {
                 ReferralCardAnimatedGradientView()
             }

--- a/podcasts/Referrals/ReferralsClaimPass.swift
+++ b/podcasts/Referrals/ReferralsClaimPass.swift
@@ -74,12 +74,23 @@ class ReferralClaimPassModel: ObservableObject {
         guard let components = referralURL?.pathComponents, let code = components.last else {
             return
         }
+        state = .claimVerify
         guard let result = await ApiServerHandler.shared.validateCode(code) else {
             state = .notAvailable
             return
         }
-        print(result.offer)
-        purchase(product: IAPProductID.patronYearly)
+        guard let productToBuy = translateToProduct(offer: result) else {
+            state = .notAvailable
+            return
+        }
+        purchase(product: productToBuy)
+    }
+
+    private func translateToProduct(offer: ReferralValidate) -> IAPProductID? {
+        if offer.offer == "two_months_free" {
+            return IAPProductID.patronYearly
+        }
+        return nil
     }
 
     func purchase(product: IAPProductID) {

--- a/podcasts/Referrals/ReferralsClaimPass.swift
+++ b/podcasts/Referrals/ReferralsClaimPass.swift
@@ -14,7 +14,7 @@ class ReferralClaimPassModel: ObservableObject {
         case start
         case notAvailable
         case claimVerify
-        case IAPPurchase
+        case iapPurchase
     }
 
     @Published var state: State
@@ -91,11 +91,11 @@ class ReferralClaimPassModel: ObservableObject {
             return
         }
 
-        state = .IAPPurchase
+        state = .iapPurchase
     }
 
     private func purchaseCompleted(success: Bool) async {
-        guard state == .IAPPurchase else {
+        guard state == .iapPurchase else {
             return
         }
         if success {
@@ -133,7 +133,7 @@ struct ReferralClaimPassView: View {
 
     var body: some View {
         switch viewModel.state {
-        case .start, .claimVerify, .IAPPurchase:
+        case .start, .claimVerify, .iapPurchase:
             VStack {
                 HStack {
                     Spacer()
@@ -166,7 +166,7 @@ struct ReferralClaimPassView: View {
                     switch viewModel.state {
                     case .start:
                         Text(L10n.referralsClaimGuestPassAction)
-                    case .claimVerify, .IAPPurchase, .notAvailable:
+                    case .claimVerify, .iapPurchase, .notAvailable:
                         loadingIndicator
                     }
                 })

--- a/podcasts/Referrals/ReferralsClaimPass.swift
+++ b/podcasts/Referrals/ReferralsClaimPass.swift
@@ -30,10 +30,6 @@ class ReferralClaimPassModel: ObservableObject {
         addObservers()
     }
 
-    private func updateState(to newState: State) async {
-        state = newState
-    }
-
     private var cancellables = Set<AnyCancellable>()
     private func addObservers() {
         Publishers.Merge4(

--- a/podcasts/Referrals/ReferralsClaimPass.swift
+++ b/podcasts/Referrals/ReferralsClaimPass.swift
@@ -2,12 +2,21 @@ import SwiftUI
 import PocketCastsServer
 
 @MainActor
-class ReferralClaimPassModel {
+class ReferralClaimPassModel: ObservableObject {
     let referralURL: URL?
     let offerInfo: ReferralsOfferInfo
     var canClaimPass: Bool
     var onClaimGuestPassTap: (() -> ())?
     var onCloseTap: (() -> ())?
+
+    enum State {
+        case start
+        case notAvailable
+        case claimVerify
+        case IAPPurchase
+    }
+
+    @Published var state: State
 
     init(referralURL: URL? = nil, offerInfo: ReferralsOfferInfo, canClaimPass: Bool = true, onClaimGuestPassTap: (() -> ())? = nil, onCloseTap: (() -> (()))? = nil) {
         self.referralURL = referralURL
@@ -15,6 +24,47 @@ class ReferralClaimPassModel {
         self.canClaimPass = canClaimPass
         self.onClaimGuestPassTap = onClaimGuestPassTap
         self.onCloseTap = onCloseTap
+        self.state = canClaimPass ? .start : .notAvailable
+
+        addObservers()
+    }
+
+    private func updateState(to newState: State) async {
+        state = newState
+    }
+
+    private func purchaseCompleted(success: Bool) async {
+        guard state == .IAPPurchase else {
+            return
+        }
+        if success {
+            state = .start
+        } else {
+            state = .start
+        }
+    }
+
+    private func addObservers() {
+        NotificationCenter.default.addObserver(forName: ServerNotifications.iapProductsFailed, object: nil, queue: .main) { [weak self] _ in
+            Task {
+                await self?.purchaseCompleted(success: false)
+            }
+        }
+        NotificationCenter.default.addObserver(forName: ServerNotifications.iapPurchaseFailed, object: nil, queue: .main) { [weak self] _ in
+            Task {
+                await self?.purchaseCompleted(success: false)
+            }
+        }
+        NotificationCenter.default.addObserver(forName: ServerNotifications.iapPurchaseCancelled, object: nil, queue: .main) { [weak self] _ in
+            Task {
+                await self?.purchaseCompleted(success: false)
+            }
+        }
+        NotificationCenter.default.addObserver(forName: ServerNotifications.iapPurchaseCompleted, object: nil, queue: .main) { [weak self] _ in
+            Task {
+                await self?.purchaseCompleted(success: true)
+            }
+        }
     }
 
     var claimPassTitle: String {
@@ -26,15 +76,39 @@ class ReferralClaimPassModel {
     }
 
     func claim() async {
-        let code = await ApiServerHandler.shared.validateCode("test")
+        guard let components = referralURL?.pathComponents, let code = components.last else {
+            return
+        }
+        guard let result = await ApiServerHandler.shared.validateCode(code) else {
+            state = .notAvailable
+            return
+        }
+        print(result.offer)
+        purchase(product: IAPProductID.patronYearly)
+    }
+
+    func purchase(product: IAPProductID) {
+        let purchaseHandler = IAPHelper.shared
+        guard purchaseHandler.canMakePurchases else {
+            state = .notAvailable
+            return
+        }
+
+        guard purchaseHandler.buyProduct(identifier: product) else {
+            state = .notAvailable
+            return
+        }
+
+        state = .IAPPurchase
     }
 }
 
 struct ReferralClaimPassView: View {
-    let viewModel: ReferralClaimPassModel
+    @StateObject var viewModel: ReferralClaimPassModel
 
     var body: some View {
-        if viewModel.canClaimPass {
+        switch viewModel.state {
+        case .start, .claimVerify, .IAPPurchase:
             VStack {
                 HStack {
                     Spacer()
@@ -59,13 +133,27 @@ struct ReferralClaimPassView: View {
                         .foregroundColor(.white.opacity(0.8))
                 }
                 Spacer()
-                Button(L10n.referralsClaimGuestPassAction) {
-                    viewModel.claim()
-                }.buttonStyle(PlusGradientFilledButtonStyle(isLoading: false, plan: .plus))
+                Button(action: {
+                    Task {
+                        await viewModel.claim()
+                    }
+                }, label: {
+                    switch viewModel.state {
+                    case .start:
+                        Text(L10n.referralsClaimGuestPassAction)
+                    case .claimVerify:
+                        ProgressView()
+                    case .IAPPurchase:
+                        ProgressView()
+                    case .notAvailable:
+                        ProgressView()
+                    }
+                })
+                .buttonStyle(PlusGradientFilledButtonStyle(isLoading: false, plan: .plus))
             }
             .padding()
             .background(.black)
-        } else {
+        case .notAvailable:
             ReferralsMessageView(title: L10n.referralsOfferNotAvailableTitle,
                                  detail: L10n.referralsOfferNotAvailableDetail) {
                 viewModel.onCloseTap?()

--- a/podcasts/Referrals/ReferralsClaimPass.swift
+++ b/podcasts/Referrals/ReferralsClaimPass.swift
@@ -112,6 +112,12 @@ class ReferralClaimPassModel: ObservableObject {
 struct ReferralClaimPassView: View {
     @StateObject var viewModel: ReferralClaimPassModel
 
+    @ViewBuilder
+    var loadingIndicator: some View {
+        ProgressView()
+            .tint(.black)
+    }
+
     var body: some View {
         switch viewModel.state {
         case .start, .claimVerify, .IAPPurchase:
@@ -147,12 +153,8 @@ struct ReferralClaimPassView: View {
                     switch viewModel.state {
                     case .start:
                         Text(L10n.referralsClaimGuestPassAction)
-                    case .claimVerify:
-                        ProgressView()
-                    case .IAPPurchase:
-                        ProgressView()
-                    case .notAvailable:
-                        ProgressView()
+                    case .claimVerify, .IAPPurchase, .notAvailable:
+                        loadingIndicator
                     }
                 })
                 .buttonStyle(PlusGradientFilledButtonStyle(isLoading: false, plan: .plus))

--- a/podcasts/Referrals/ReferralsClaimPass.swift
+++ b/podcasts/Referrals/ReferralsClaimPass.swift
@@ -65,6 +65,7 @@ class ReferralClaimPassModel: ObservableObject {
         }
         state = .claimVerify
         guard let result = await ApiServerHandler.shared.validateCode(code) else {
+            Settings.referralURL = nil
             state = .notAvailable
             return
         }
@@ -102,7 +103,23 @@ class ReferralClaimPassModel: ObservableObject {
             return
         }
         if success {
+            await redeemCode()
+            Settings.referralURL = nil
             onComplete?()
+        } else {
+            state = .start
+        }
+    }
+
+    private func redeemCode() async {
+        guard let components = referralURL?.pathComponents, let code = components.last else {
+            return
+        }
+        let result = await ApiServerHandler.shared.redeemCode(code)
+
+        if result {
+            onComplete?()
+            return
         } else {
             state = .start
         }

--- a/podcasts/Referrals/ReferralsClaimPass.swift
+++ b/podcasts/Referrals/ReferralsClaimPass.swift
@@ -34,17 +34,6 @@ class ReferralClaimPassModel: ObservableObject {
         state = newState
     }
 
-    private func purchaseCompleted(success: Bool) async {
-        guard state == .IAPPurchase else {
-            return
-        }
-        if success {
-            onComplete?()
-        } else {
-            state = .start
-        }
-    }
-
     private var cancellables = Set<AnyCancellable>()
     private func addObservers() {
         Publishers.Merge4(
@@ -93,7 +82,7 @@ class ReferralClaimPassModel: ObservableObject {
         return nil
     }
 
-    func purchase(product: IAPProductID) {
+    private func purchase(product: IAPProductID) {
         let purchaseHandler = IAPHelper.shared
         guard purchaseHandler.canMakePurchases else {
             state = .notAvailable
@@ -106,6 +95,17 @@ class ReferralClaimPassModel: ObservableObject {
         }
 
         state = .IAPPurchase
+    }
+
+    private func purchaseCompleted(success: Bool) async {
+        guard state == .IAPPurchase else {
+            return
+        }
+        if success {
+            onComplete?()
+        } else {
+            state = .start
+        }
     }
 }
 

--- a/podcasts/Referrals/ReferralsClaimPass.swift
+++ b/podcasts/Referrals/ReferralsClaimPass.swift
@@ -115,7 +115,7 @@ struct ReferralClaimPassView: View {
     @ViewBuilder
     var loadingIndicator: some View {
         ProgressView()
-            .tint(.black)
+            .progressViewStyle(CircularProgressViewStyle(tint: .black))
     }
 
     var body: some View {

--- a/podcasts/Referrals/ReferralsClaimPass.swift
+++ b/podcasts/Referrals/ReferralsClaimPass.swift
@@ -1,5 +1,7 @@
 import SwiftUI
+import PocketCastsServer
 
+@MainActor
 class ReferralClaimPassModel {
     let referralURL: URL?
     let offerInfo: ReferralsOfferInfo
@@ -21,6 +23,10 @@ class ReferralClaimPassModel {
 
     var claimPassDetail: String {
         L10n.referralsClaimGuestPassDetail(offerInfo.localizedPriceAfterOffer)
+    }
+
+    func claim() async {
+        let code = await ApiServerHandler.shared.validateCode("test")
     }
 }
 
@@ -54,7 +60,7 @@ struct ReferralClaimPassView: View {
                 }
                 Spacer()
                 Button(L10n.referralsClaimGuestPassAction) {
-                    viewModel.onClaimGuestPassTap?()
+                    viewModel.claim()
                 }.buttonStyle(PlusGradientFilledButtonStyle(isLoading: false, plan: .plus))
             }
             .padding()

--- a/podcasts/Referrals/ReferralsCoordinator.swift
+++ b/podcasts/Referrals/ReferralsCoordinator.swift
@@ -27,32 +27,31 @@ class ReferralsCoordinator {
     }
 
     func startClaimFlow(from viewController: UIViewController, referralURL: URL? = nil, onComplete: (() -> ())? = nil) {
-        Task {
-            await MainActor.run {
-                var url: URL?
-                if let referralURL {
-                    Settings.referralURL = referralURL.absoluteString
-                    url = referralURL
-                } else {
-                    if let urlString = Settings.referralURL {
-                        url = URL(string: urlString)
-                    }
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            var url: URL?
+            if let referralURL {
+                Settings.referralURL = referralURL.absoluteString
+                url = referralURL
+            } else {
+                if let urlString = Settings.referralURL {
+                    url = URL(string: urlString)
                 }
-
-                let viewModel = ReferralClaimPassModel(referralURL: url,
-                                                       offerInfo: referralsOfferInfo,
-                                                       canClaimPass: isReferralAvailableToClaim,
-                                                       onComplete: {
-                    viewController.dismiss(animated: true)
-                    onComplete?()
-                },
-                                                       onCloseTap: {
-                    viewController.dismiss(animated: true)
-                    onComplete?()
-                })
-                let referralClaimPassVC = ReferralClaimPassVC(viewModel: viewModel)
-                viewController.present(referralClaimPassVC, animated: true)
             }
+
+            let viewModel = ReferralClaimPassModel(referralURL: url,
+                                                   offerInfo: self.referralsOfferInfo,
+                                                   canClaimPass: self.isReferralAvailableToClaim,
+                                                   onComplete: {
+                viewController.dismiss(animated: true)
+                onComplete?()
+            },
+                                                   onCloseTap: {
+                viewController.dismiss(animated: true)
+                onComplete?()
+            })
+            let referralClaimPassVC = ReferralClaimPassVC(viewModel: viewModel)
+            viewController.present(referralClaimPassVC, animated: true)
         }
     }
 }

--- a/podcasts/Referrals/ReferralsCoordinator.swift
+++ b/podcasts/Referrals/ReferralsCoordinator.swift
@@ -26,20 +26,29 @@ class ReferralsCoordinator {
         startClaimFlow(from: viewController, referralURL: referralURL)
     }
 
-    func startClaimFlow(from viewController: UIViewController, referralURL: URL?) {
+    func startClaimFlow(from viewController: UIViewController, referralURL: URL? = nil, onComplete: (() -> ())? = nil) {
         Task {
             await MainActor.run {
+                var url: URL?
                 if let referralURL {
                     Settings.referralURL = referralURL.absoluteString
+                    url = referralURL
+                } else {
+                    if let urlString = Settings.referralURL {
+                        url = URL(string: urlString)
+                    }
                 }
-                let viewModel = ReferralClaimPassModel(referralURL: referralURL,
+
+                let viewModel = ReferralClaimPassModel(referralURL: url,
                                                        offerInfo: referralsOfferInfo,
                                                        canClaimPass: isReferralAvailableToClaim,
                                                        onComplete: {
                     viewController.dismiss(animated: true)
+                    onComplete?()
                 },
                                                        onCloseTap: {
                     viewController.dismiss(animated: true)
+                    onComplete?()
                 })
                 let referralClaimPassVC = ReferralClaimPassVC(viewModel: viewModel)
                 viewController.present(referralClaimPassVC, animated: true)

--- a/podcasts/Referrals/ReferralsCoordinator.swift
+++ b/podcasts/Referrals/ReferralsCoordinator.swift
@@ -27,13 +27,17 @@ class ReferralsCoordinator {
     }
 
     func startClaimFlow(from viewController: UIViewController, referralURL: URL?) {
-        if let referralURL {
-            Settings.referralURL = referralURL.absoluteString
+        Task {
+            await MainActor.run {
+                if let referralURL {
+                    Settings.referralURL = referralURL.absoluteString
+                }
+                let viewModel = ReferralClaimPassModel(referralURL: referralURL, offerInfo: referralsOfferInfo, canClaimPass: isReferralAvailableToClaim, onCloseTap: {
+                    viewController.dismiss(animated: true)
+                })
+                let referralClaimPassVC = ReferralClaimPassVC(viewModel: viewModel)
+                viewController.present(referralClaimPassVC, animated: true)
+            }
         }
-        let viewModel = ReferralClaimPassModel(referralURL: referralURL, offerInfo: referralsOfferInfo, canClaimPass: isReferralAvailableToClaim, onCloseTap: {
-            viewController.dismiss(animated: true)
-        })
-        let referralClaimPassVC = ReferralClaimPassVC(viewModel: viewModel)
-        viewController.present(referralClaimPassVC, animated: true)
     }
 }

--- a/podcasts/Referrals/ReferralsCoordinator.swift
+++ b/podcasts/Referrals/ReferralsCoordinator.swift
@@ -32,7 +32,13 @@ class ReferralsCoordinator {
                 if let referralURL {
                     Settings.referralURL = referralURL.absoluteString
                 }
-                let viewModel = ReferralClaimPassModel(referralURL: referralURL, offerInfo: referralsOfferInfo, canClaimPass: isReferralAvailableToClaim, onCloseTap: {
+                let viewModel = ReferralClaimPassModel(referralURL: referralURL,
+                                                       offerInfo: referralsOfferInfo,
+                                                       canClaimPass: isReferralAvailableToClaim,
+                                                       onComplete: {
+                    viewController.dismiss(animated: true)
+                },
+                                                       onCloseTap: {
                     viewController.dismiss(animated: true)
                 })
                 let referralClaimPassVC = ReferralClaimPassVC(viewModel: viewModel)


### PR DESCRIPTION
| 📘 Part of: #2083  |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

| 1 | 2 | 3 | 
| - | - | - |
| ![Simulator Screenshot - iPhone 16 Pro - 2024-09-30 at 14 53 44](https://github.com/user-attachments/assets/2d8c7420-7d98-43e7-a513-8a1b16368879) | ![Simulator Screenshot - iPhone 16 Pro - 2024-09-30 at 14 59 24](https://github.com/user-attachments/assets/c4ad8159-9373-473e-9359-f61622ce898b) | ![Simulator Screenshot - iPhone 16 Pro - 2024-09-30 at 14 59 27](https://github.com/user-attachments/assets/71ffd0bf-ac74-4d97-be26-26c014b7f4b6) |


Integrates the API calls to the claim referral flow:
- **validate**: before the IAP purchase is done
- **redeem**: after the IAP purchase is complete

Note at the moment this flow only works correctly for logged in users, for users without an account yet I will do a follow up PR to check for login.

## To test


1. Configure the podcast scheme to use the StoreKit Configuration file: `Pocket Casts Configuration.storekit`
2. Start the app
3. Ensure that you have the referrals FF enabled

### Get a referral url

1. Login with an account that has an Plus or Patron active
2. Go to Profile
3. Tap on the gift icon on the top left
4. Tap on the Send Pass
5. Send the URL to the reminders app
6. Save it in Reminders

### Use the referral url

1. Now login with an account that doesn't have a subscription
2. Switch to the Reminders app
3. Tap on the referral URL
4. The PocketCasts app should open an show the claim guest pass screen
5. Tap on Activate Pass
6. You should see a loading item on the button
7. Then you should see the IAP screen
8. Purchase the subscription ( This is using Xcode IAP simulator so no need to insert card)
9. The flow should finish and return you to main screen

### Test claim in again

1. Switch back to Reminders app
2. Tap on the deep link for referral
3. Check if Pocket Casts app open and show the claim guest pass screen
4. Tap on `Not Now`
5. Check if you see the claim referral cell on the Profile tab
6. Tap on it
7. Tap on Activate Pass
8. You should see `The offer isn't available screen`



## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
