### PR TITLE
Discover Collection View: Add collection view and view controller cells

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1662,6 +1662,7 @@
 		F52B4F8E2BB4A9ED00E87BE4 /* CategoriesSelectorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F52B4F8D2BB4A9ED00E87BE4 /* CategoriesSelectorView.swift */; };
 		F533F19D2C24B8CB00EDE9AA /* ShareDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = F533F19C2C24B8CB00EDE9AA /* ShareDestination.swift */; };
 		F543F6A42C0804FA00FEC8B6 /* AnyPublisher+Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = F543F6A32C0804FA00FEC8B6 /* AnyPublisher+Async.swift */; };
+		F54E72192CA722A000CD5C86 /* Array+DiscoverItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = F54E72182CA722A000CD5C86 /* Array+DiscoverItem.swift */; };
 		F55449422B758E8300F68AE9 /* PocketCastsUtils in Frameworks */ = {isa = PBXBuildFile; productRef = F55449412B758E8300F68AE9 /* PocketCastsUtils */; };
 		F55449432B758E8300F68AE9 /* PocketCastsUtils in Embed Frameworks */ = {isa = PBXBuildFile; productRef = F55449412B758E8300F68AE9 /* PocketCastsUtils */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		F55449452B75935F00F68AE9 /* AppSettings+ImportUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = F55449442B75935F00F68AE9 /* AppSettings+ImportUserDefaults.swift */; };
@@ -1689,6 +1690,8 @@
 		F5B312B42BF5B6D400290696 /* FirebaseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5B312B32BF5B6D400290696 /* FirebaseManager.swift */; };
 		F5B6F0DF2C18DF0900AF5150 /* AudioUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5B6F0DD2C18DF0900AF5150 /* AudioUtilsTests.swift */; };
 		F5BA5C9A2C7F701900BDA5B9 /* DiscoverCollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BA5C992C7F701900BDA5B9 /* DiscoverCollectionViewController.swift */; };
+		F5BA5C9C2C80F38200BDA5B9 /* UIViewControllerContentConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BA5C9B2C80F38200BDA5B9 /* UIViewControllerContentConfiguration.swift */; };
+		F5BA5C9E2C81254300BDA5B9 /* DiscoverCollectionViewController+DiscoverDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BA5C9D2C81254300BDA5B9 /* DiscoverCollectionViewController+DiscoverDelegate.swift */; };
 		F5BFF9892C6B0A9100A84561 /* Optional+ThrowOnNil.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BFF9882C6B0A9100A84561 /* Optional+ThrowOnNil.swift */; };
 		F5CFDB622C6DA2D600DE57B2 /* AudioClipExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5CFDB612C6DA2D600DE57B2 /* AudioClipExporter.swift */; };
 		F5D3A0D92B70950100EED067 /* MockURLHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5D3A0D82B70950100EED067 /* MockURLHandler.swift */; };
@@ -3576,6 +3579,7 @@
 		F52B4F8D2BB4A9ED00E87BE4 /* CategoriesSelectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoriesSelectorView.swift; sourceTree = "<group>"; };
 		F533F19C2C24B8CB00EDE9AA /* ShareDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareDestination.swift; sourceTree = "<group>"; };
 		F543F6A32C0804FA00FEC8B6 /* AnyPublisher+Async.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AnyPublisher+Async.swift"; sourceTree = "<group>"; };
+		F54E72182CA722A000CD5C86 /* Array+DiscoverItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+DiscoverItem.swift"; sourceTree = "<group>"; };
 		F55449442B75935F00F68AE9 /* AppSettings+ImportUserDefaults.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AppSettings+ImportUserDefaults.swift"; sourceTree = "<group>"; };
 		F555980A2C50242800C02EEB /* VideoExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoExporter.swift; sourceTree = "<group>"; };
 		F555980E2C503F1700C02EEB /* AnimatedShareImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimatedShareImageView.swift; sourceTree = "<group>"; };
@@ -3600,6 +3604,8 @@
 		F5B312B32BF5B6D400290696 /* FirebaseManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseManager.swift; sourceTree = "<group>"; };
 		F5B6F0DD2C18DF0900AF5150 /* AudioUtilsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AudioUtilsTests.swift; sourceTree = "<group>"; };
 		F5BA5C992C7F701900BDA5B9 /* DiscoverCollectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverCollectionViewController.swift; sourceTree = "<group>"; };
+		F5BA5C9B2C80F38200BDA5B9 /* UIViewControllerContentConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewControllerContentConfiguration.swift; sourceTree = "<group>"; };
+		F5BA5C9D2C81254300BDA5B9 /* DiscoverCollectionViewController+DiscoverDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DiscoverCollectionViewController+DiscoverDelegate.swift"; sourceTree = "<group>"; };
 		F5BFF9882C6B0A9100A84561 /* Optional+ThrowOnNil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Optional+ThrowOnNil.swift"; sourceTree = "<group>"; };
 		F5CFDB612C6DA2D600DE57B2 /* AudioClipExporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AudioClipExporter.swift; sourceTree = "<group>"; };
 		F5D3A0D82B70950100EED067 /* MockURLHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockURLHandler.swift; sourceTree = "<group>"; };
@@ -6813,6 +6819,7 @@
 				46851BB62790D5E00065C8B2 /* PodcastCollectionColors+Helpers.swift */,
 				8B484F0028D25D1E001AFA97 /* UIViewController+requestReview.swift */,
 				C7F4BABE28DB7F7C001C9785 /* DiscoverItem+Helper.swift */,
+				F54E72182CA722A000CD5C86 /* Array+DiscoverItem.swift */,
 				C7F87F0F2913242B00C15980 /* UIFont+FontStyle.swift */,
 				C7B7123929DC98BD00965BF7 /* SFSafariViewController+Creation.swift */,
 				C7D5E7F02A8BF3150039F4A1 /* UIViewController+Presenting.swift */,
@@ -7719,6 +7726,8 @@
 				C7BF5E46290832FD00733C1E /* DiscoverCoordinator.swift */,
 				F5BA5C992C7F701900BDA5B9 /* DiscoverCollectionViewController.swift */,
 				F51D3A0B2CA62D3C000F3B78 /* DiscoverCollectionViewController+Search.swift */,
+				F5BA5C9D2C81254300BDA5B9 /* DiscoverCollectionViewController+DiscoverDelegate.swift */,
+				F5BA5C9B2C80F38200BDA5B9 /* UIViewControllerContentConfiguration.swift */,
 			);
 			name = Discovery;
 			sourceTree = "<group>";
@@ -9273,6 +9282,7 @@
 				BDC5F25027B3997300A85C93 /* FolderModel.swift in Sources */,
 				BDBD2AC7202D66B300E0A79E /* OptionsPickerRootController.swift in Sources */,
 				4004F56524EB51F900FBEBE1 /* SceneHelper.swift in Sources */,
+				F5BA5C9E2C81254300BDA5B9 /* DiscoverCollectionViewController+DiscoverDelegate.swift in Sources */,
 				40FFAD8D2149E1C200024FCF /* EpisodeFilterChipCell.swift in Sources */,
 				BD6275BF27D1C5370020A28C /* TraceHelper.swift in Sources */,
 				4030D465249653B000BEC7D9 /* MultiSelectActionCell.swift in Sources */,
@@ -9409,6 +9419,7 @@
 				C7891DCE2A6B2C0F009DA661 /* SearchableListViewModel.swift in Sources */,
 				BDAA3CF321228A0D00649F81 /* ExpandCollapseButton.swift in Sources */,
 				407B9B72238B5D91008E7CA8 /* UpNextViewController+MultiSelectActions.swift in Sources */,
+				F5BA5C9C2C80F38200BDA5B9 /* UIViewControllerContentConfiguration.swift in Sources */,
 				40422D96251AF10500C80BE4 /* BundlePodcastCell.swift in Sources */,
 				C76ECAC22A67612F00D9DB9E /* EmptyStateView.swift in Sources */,
 				8B317BA028906A8900A26A13 /* main.swift in Sources */,
@@ -9459,6 +9470,7 @@
 				BD907DAB21533437004D7C02 /* PodcastEffectsViewController+Table.swift in Sources */,
 				BD5DD2E420109D650031B5DC /* FakeNavViewController.swift in Sources */,
 				BDC063D2246A66B900208446 /* DownloadManager+SessionManagement.swift in Sources */,
+				F54E72192CA722A000CD5C86 /* Array+DiscoverItem.swift in Sources */,
 				BDE954EC2366898900CEB6DA /* ChaptersViewController+Table.swift in Sources */,
 				BD874EF31C9A3A1B00F5B2A5 /* TopLevelSettingsCell.swift in Sources */,
 				C752F28A29D5F8F200681C33 /* StarRatingView.swift in Sources */,

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1663,6 +1663,7 @@
 		F533F19D2C24B8CB00EDE9AA /* ShareDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = F533F19C2C24B8CB00EDE9AA /* ShareDestination.swift */; };
 		F543F6A42C0804FA00FEC8B6 /* AnyPublisher+Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = F543F6A32C0804FA00FEC8B6 /* AnyPublisher+Async.swift */; };
 		F54E72192CA722A000CD5C86 /* Array+DiscoverItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = F54E72182CA722A000CD5C86 /* Array+DiscoverItem.swift */; };
+		F54E721D2CA7359800CD5C86 /* DiscoverCellType.swift in Sources */ = {isa = PBXBuildFile; fileRef = F54E721C2CA7359800CD5C86 /* DiscoverCellType.swift */; };
 		F55449422B758E8300F68AE9 /* PocketCastsUtils in Frameworks */ = {isa = PBXBuildFile; productRef = F55449412B758E8300F68AE9 /* PocketCastsUtils */; };
 		F55449432B758E8300F68AE9 /* PocketCastsUtils in Embed Frameworks */ = {isa = PBXBuildFile; productRef = F55449412B758E8300F68AE9 /* PocketCastsUtils */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		F55449452B75935F00F68AE9 /* AppSettings+ImportUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = F55449442B75935F00F68AE9 /* AppSettings+ImportUserDefaults.swift */; };
@@ -3580,6 +3581,7 @@
 		F533F19C2C24B8CB00EDE9AA /* ShareDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareDestination.swift; sourceTree = "<group>"; };
 		F543F6A32C0804FA00FEC8B6 /* AnyPublisher+Async.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AnyPublisher+Async.swift"; sourceTree = "<group>"; };
 		F54E72182CA722A000CD5C86 /* Array+DiscoverItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+DiscoverItem.swift"; sourceTree = "<group>"; };
+		F54E721C2CA7359800CD5C86 /* DiscoverCellType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverCellType.swift; sourceTree = "<group>"; };
 		F55449442B75935F00F68AE9 /* AppSettings+ImportUserDefaults.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AppSettings+ImportUserDefaults.swift"; sourceTree = "<group>"; };
 		F555980A2C50242800C02EEB /* VideoExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoExporter.swift; sourceTree = "<group>"; };
 		F555980E2C503F1700C02EEB /* AnimatedShareImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimatedShareImageView.swift; sourceTree = "<group>"; };
@@ -7724,6 +7726,7 @@
 				BD9FF6281B8EFC6F009F075E /* DiscoverSummaryProtocol.swift */,
 				40B26AC6213FED4300386173 /* DiscoverPeekViewController.swift */,
 				C7BF5E46290832FD00733C1E /* DiscoverCoordinator.swift */,
+				F54E721C2CA7359800CD5C86 /* DiscoverCellType.swift */,
 				F5BA5C992C7F701900BDA5B9 /* DiscoverCollectionViewController.swift */,
 				F51D3A0B2CA62D3C000F3B78 /* DiscoverCollectionViewController+Search.swift */,
 				F5BA5C9D2C81254300BDA5B9 /* DiscoverCollectionViewController+DiscoverDelegate.swift */,
@@ -9430,6 +9433,7 @@
 				C7AF5791289D87CF0089E435 /* Analytics.swift in Sources */,
 				C7E99EFC2A5C856400E7CBAF /* BookmarkRow.swift in Sources */,
 				BDE7409A2060CE1B00FB22C7 /* EpisodeManager.swift in Sources */,
+				F54E721D2CA7359800CD5C86 /* DiscoverCellType.swift in Sources */,
 				F51D90742C71A0A100F0A232 /* SharingFooterView.swift in Sources */,
 				BD240C43231F46F400FB2CDD /* PCSearchBarController+TextFieldDelegate.swift in Sources */,
 				4053CDF9214F3583001C92B1 /* PodcastFilterOverlayController.swift in Sources */,

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1688,6 +1688,8 @@
 		F5B312B42BF5B6D400290696 /* FirebaseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5B312B32BF5B6D400290696 /* FirebaseManager.swift */; };
 		F5B6F0DF2C18DF0900AF5150 /* AudioUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5B6F0DD2C18DF0900AF5150 /* AudioUtilsTests.swift */; };
 		F5BA5C9A2C7F701900BDA5B9 /* DiscoverCollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BA5C992C7F701900BDA5B9 /* DiscoverCollectionViewController.swift */; };
+		F5BA5C9C2C80F38200BDA5B9 /* UIViewControllerContentConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BA5C9B2C80F38200BDA5B9 /* UIViewControllerContentConfiguration.swift */; };
+		F5BA5C9E2C81254300BDA5B9 /* DiscoverCollectionViewController+DiscoverDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BA5C9D2C81254300BDA5B9 /* DiscoverCollectionViewController+DiscoverDelegate.swift */; };
 		F5BFF9892C6B0A9100A84561 /* Optional+ThrowOnNil.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BFF9882C6B0A9100A84561 /* Optional+ThrowOnNil.swift */; };
 		F5CFDB622C6DA2D600DE57B2 /* AudioClipExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5CFDB612C6DA2D600DE57B2 /* AudioClipExporter.swift */; };
 		F5D3A0D92B70950100EED067 /* MockURLHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5D3A0D82B70950100EED067 /* MockURLHandler.swift */; };
@@ -3598,6 +3600,8 @@
 		F5B312B32BF5B6D400290696 /* FirebaseManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseManager.swift; sourceTree = "<group>"; };
 		F5B6F0DD2C18DF0900AF5150 /* AudioUtilsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AudioUtilsTests.swift; sourceTree = "<group>"; };
 		F5BA5C992C7F701900BDA5B9 /* DiscoverCollectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverCollectionViewController.swift; sourceTree = "<group>"; };
+		F5BA5C9B2C80F38200BDA5B9 /* UIViewControllerContentConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewControllerContentConfiguration.swift; sourceTree = "<group>"; };
+		F5BA5C9D2C81254300BDA5B9 /* DiscoverCollectionViewController+DiscoverDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DiscoverCollectionViewController+DiscoverDelegate.swift"; sourceTree = "<group>"; };
 		F5BFF9882C6B0A9100A84561 /* Optional+ThrowOnNil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Optional+ThrowOnNil.swift"; sourceTree = "<group>"; };
 		F5CFDB612C6DA2D600DE57B2 /* AudioClipExporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AudioClipExporter.swift; sourceTree = "<group>"; };
 		F5D3A0D82B70950100EED067 /* MockURLHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockURLHandler.swift; sourceTree = "<group>"; };
@@ -7716,6 +7720,8 @@
 				40B26AC6213FED4300386173 /* DiscoverPeekViewController.swift */,
 				C7BF5E46290832FD00733C1E /* DiscoverCoordinator.swift */,
 				F5BA5C992C7F701900BDA5B9 /* DiscoverCollectionViewController.swift */,
+				F5BA5C9D2C81254300BDA5B9 /* DiscoverCollectionViewController+DiscoverDelegate.swift */,
+				F5BA5C9B2C80F38200BDA5B9 /* UIViewControllerContentConfiguration.swift */,
 			);
 			name = Discovery;
 			sourceTree = "<group>";
@@ -9269,6 +9275,7 @@
 				BDC5F25027B3997300A85C93 /* FolderModel.swift in Sources */,
 				BDBD2AC7202D66B300E0A79E /* OptionsPickerRootController.swift in Sources */,
 				4004F56524EB51F900FBEBE1 /* SceneHelper.swift in Sources */,
+				F5BA5C9E2C81254300BDA5B9 /* DiscoverCollectionViewController+DiscoverDelegate.swift in Sources */,
 				40FFAD8D2149E1C200024FCF /* EpisodeFilterChipCell.swift in Sources */,
 				BD6275BF27D1C5370020A28C /* TraceHelper.swift in Sources */,
 				4030D465249653B000BEC7D9 /* MultiSelectActionCell.swift in Sources */,
@@ -9405,6 +9412,7 @@
 				C7891DCE2A6B2C0F009DA661 /* SearchableListViewModel.swift in Sources */,
 				BDAA3CF321228A0D00649F81 /* ExpandCollapseButton.swift in Sources */,
 				407B9B72238B5D91008E7CA8 /* UpNextViewController+MultiSelectActions.swift in Sources */,
+				F5BA5C9C2C80F38200BDA5B9 /* UIViewControllerContentConfiguration.swift in Sources */,
 				40422D96251AF10500C80BE4 /* BundlePodcastCell.swift in Sources */,
 				C76ECAC22A67612F00D9DB9E /* EmptyStateView.swift in Sources */,
 				8B317BA028906A8900A26A13 /* main.swift in Sources */,

--- a/podcasts/Array+DiscoverItem.swift
+++ b/podcasts/Array+DiscoverItem.swift
@@ -1,0 +1,14 @@
+import PocketCastsServer
+
+extension Array<DiscoverItem> {
+    func makeDataSourceSnapshot(region: String, itemFilter: (DiscoverItem) -> Bool) -> NSDiffableDataSourceSnapshot<Int, DiscoverItem> {
+        var snapshot = NSDiffableDataSourceSnapshot<Int, DiscoverItem>()
+
+        let section = 0
+        snapshot.appendSections([section])
+        let items = filter({ (itemFilter($0)) && $0.regions.contains(region) })
+        snapshot.appendItems(items)
+
+        return snapshot
+    }
+}

--- a/podcasts/DiscoverCellType.swift
+++ b/podcasts/DiscoverCellType.swift
@@ -1,0 +1,84 @@
+import PocketCastsServer
+import PocketCastsUtils
+
+enum DiscoverCellType: CaseIterable {
+    case categoriesSelector
+    case featuredSummary
+    case smallPagedListSummary
+    case largeListSummary
+    case singlePodcast
+    case collectionSummary
+    case networkSummary
+    case categorySummary
+    case singleEpisode
+
+    func viewController(in region: String) -> (UIViewController & DiscoverSummaryProtocol) {
+        switch self {
+        case .categoriesSelector:
+            CategoriesSelectorViewController()
+        case .featuredSummary:
+            FeaturedSummaryViewController()
+        case .smallPagedListSummary:
+            SmallPagedListSummaryViewController()
+        case .largeListSummary:
+            LargeListSummaryViewController()
+        case .singlePodcast:
+            SinglePodcastViewController()
+        case .collectionSummary:
+            CollectionSummaryViewController()
+        case .networkSummary:
+            NetworkSummaryViewController()
+        case .categorySummary:
+            CategorySummaryViewController(regionCode: region)
+        case .singleEpisode:
+            SingleEpisodeViewController()
+        }
+    }
+
+    func createCellRegistration(region: String, delegate: DiscoverDelegate) -> UICollectionView.CellRegistration<UICollectionViewCell, DiscoverItem> {
+        return UICollectionView.CellRegistration<UICollectionViewCell, DiscoverItem> { cell, indexPath, item in
+
+            let existingViewController = (cell.contentConfiguration as? UIViewControllerContentConfiguration)?.viewController as? (UIViewController & DiscoverSummaryProtocol)
+
+            let vc = existingViewController ?? viewController(in: region)
+
+            if existingViewController == nil {
+                cell.contentConfiguration = UIViewControllerContentConfiguration(viewController: vc)
+            }
+
+            vc.registerDiscoverDelegate(delegate)
+            vc.populateFrom(item: item, region: region, category: nil)
+        }
+    }
+}
+
+extension DiscoverItem {
+    func cellType() -> DiscoverCellType? {
+        switch (type, summaryStyle, expandedStyle) {
+        case ("categories", "pills", _):
+            return .categoriesSelector
+        case ("podcast_list", "carousel", _):
+            return .featuredSummary
+        case ("podcast_list", "small_list", _):
+            return .smallPagedListSummary
+        case ("podcast_list", "large_list", _):
+            return .largeListSummary
+        case ("podcast_list", "single_podcast", _):
+            return .singlePodcast
+        case ("podcast_list", "collection", _):
+            return .collectionSummary
+        case ("network_list", _, _):
+            return .networkSummary
+        case ("categories", "category", _):
+            return .categorySummary
+        case ("episode_list", "single_episode", _):
+            return .singleEpisode
+        case ("episode_list", "collection", "plain_list"):
+            return .collectionSummary
+        default:
+            FileLog.shared.addMessage("Unknown Discover Item: \(type ?? "unknown") \(summaryStyle ?? "unknown")")
+            assertionFailure("Unknown Discover Item: \(type ?? "unknown") \(summaryStyle ?? "unknown")")
+            return nil
+        }
+    }
+}

--- a/podcasts/DiscoverCollectionViewController+DiscoverDelegate.swift
+++ b/podcasts/DiscoverCollectionViewController+DiscoverDelegate.swift
@@ -1,0 +1,129 @@
+import PocketCastsServer
+import PocketCastsDataModel
+
+extension DiscoverCollectionViewController: DiscoverDelegate {
+    func showExpanded(item: PocketCastsServer.DiscoverItem, category: PocketCastsServer.DiscoverCategory?) {
+//        if let category {
+//            if let categoryId = category.id, let categoryName = category.name, let discoverLayout {
+//                let currentRegion = Settings.discoverRegion(discoverLayout: discoverLayout)
+//                Analytics.track(.discoverCategoryShown, properties: ["name": categoryName, "region": currentRegion, "id": categoryId])
+//            }
+//            reload(except: [item], category: category)
+//        } else {
+//            reload(except: [item], category: nil)
+//        }
+    }
+
+    func show(podcastInfo: PodcastInfo, placeholderImage: UIImage?, isFeatured: Bool, listUuid: String?) {
+        let podcastController = PodcastViewController(podcastInfo: podcastInfo, existingImage: placeholderImage)
+        podcastController.featuredPodcast = isFeatured
+        podcastController.listUuid = listUuid
+
+        navigationController?.pushViewController(podcastController, animated: true)
+    }
+
+    func show(discoverPodcast: DiscoverPodcast, placeholderImage: UIImage?, isFeatured: Bool, listUuid: String?) {
+        var podcastInfo = PodcastInfo()
+        podcastInfo.populateFrom(discoverPodcast: discoverPodcast)
+        show(podcastInfo: podcastInfo, placeholderImage: placeholderImage, isFeatured: isFeatured, listUuid: listUuid)
+    }
+
+    func show(podcast: Podcast) {
+        let podcastController = PodcastViewController(podcast: podcast)
+        navigationController?.pushViewController(podcastController, animated: true)
+    }
+
+    func showExpanded(item: DiscoverItem, podcasts: [DiscoverPodcast], podcastCollection: PodcastCollection?) {
+        if let listId = item.uuid {
+            AnalyticsHelper.listShowAllTapped(listId: listId)
+        } else {
+            Analytics.track(.discoverShowAllTapped, properties: ["list_id": item.inferredListId])
+        }
+
+        if item.expandedStyle == "descriptive_list" || item.expandedStyle == "grid" {
+            let collectionListVC = ExpandedCollectionViewController(item: item, podcasts: podcasts)
+            collectionListVC.podcastCollection = podcastCollection
+            collectionListVC.registerDiscoverDelegate(self)
+            collectionListVC.cellStyle = (item.expandedStyle == "descriptive_list") ? CollectionCellStyle.descriptive_list : CollectionCellStyle.grid
+            navController()?.pushViewController(collectionListVC, animated: true)
+        } else { // item == expandedStylw == "plain_list" || item.expandedStyle == "ranked_list"
+            let listView = PodcastHeaderListViewController(podcasts: podcasts)
+            listView.title = replaceRegionName(string: item.title?.localized ?? "")
+            listView.showFeaturedCell = item.expandedStyle == "ranked_list"
+            listView.showRankingNumber = item.expandedStyle == "ranked_list"
+            listView.registerDiscoverDelegate(self)
+            navController()?.pushViewController(listView, animated: true)
+        }
+    }
+
+    func showExpanded(item: DiscoverItem, episodes: [DiscoverEpisode], podcastCollection: PodcastCollection?) {
+        guard let podcastCollection = podcastCollection else { return }
+
+        if let listId = item.uuid {
+            AnalyticsHelper.listShowAllTapped(listId: listId)
+        }
+
+        let listView = ExpandedEpisodeListViewController(podcastCollection: podcastCollection)
+        listView.delegate = self
+        navController()?.pushViewController(listView, animated: true)
+    }
+
+    func navController() -> UINavigationController? {
+        navigationController
+    }
+
+    func replaceRegionCode(string: String?) -> String? {
+        guard let fullString = string, let layout = discoverLayout else { return string }
+
+        let currentRegionCode = Settings.discoverRegion(discoverLayout: layout)
+        guard let serverRegion = layout.regions?[currentRegionCode] else { return fullString }
+
+        return fullString.replacingOccurrences(of: layout.regionCodeToken, with: serverRegion.code)
+    }
+
+    func replaceRegionName(string: String) -> String {
+        guard let layout = discoverLayout else { return string }
+
+        let currentRegionCode = Settings.discoverRegion(discoverLayout: layout)
+        guard let serverRegion = layout.regions?[currentRegionCode] else { return string }
+
+        if let localizedRegion = string.localized(with: serverRegion.name.localized) {
+            return localizedRegion
+        }
+
+        return string.replacingOccurrences(of: layout.regionNameToken, with: serverRegion.name)
+    }
+
+    func isSubscribed(podcast: DiscoverPodcast) -> Bool {
+        if let uuid = podcast.uuid {
+            if let _ = DataManager.sharedManager.findPodcast(uuid: uuid) {
+                return true
+            }
+        }
+        return false
+    }
+
+    func subscribe(podcast: DiscoverPodcast) {
+        if podcast.iTunesOnly() {
+            ServerPodcastManager.shared.addFromiTunesId(Int(podcast.iTunesId!)!, subscribe: true, completion: nil)
+        } else if let uuid = podcast.uuid {
+            ServerPodcastManager.shared.addFromUuid(podcastUuid: uuid, subscribe: true, completion: nil)
+        }
+
+        HapticsHelper.triggerSubscribedHaptic()
+
+        let uuid = podcast.uuid ?? podcast.iTunesId ?? "unknown"
+        Analytics.track(.podcastSubscribed, properties: ["source": analyticsSource, "uuid": uuid])
+    }
+
+    func show(discoverEpisode: DiscoverEpisode, podcast: Podcast) {
+        guard let uuid = discoverEpisode.uuid else { return }
+        let episodeController = EpisodeDetailViewController(episodeUuid: uuid, podcast: podcast, source: .discover)
+        episodeController.modalPresentationStyle = .formSheet
+        present(episodeController, animated: true)
+    }
+
+    func failedToLoadEpisode() {
+        SJUIUtils.showAlert(title: L10n.error, message: L10n.discoverFeaturedEpisodeErrorNotFound, from: self)
+    }
+}

--- a/podcasts/DiscoverCollectionViewController+DiscoverDelegate.swift
+++ b/podcasts/DiscoverCollectionViewController+DiscoverDelegate.swift
@@ -1,0 +1,121 @@
+import PocketCastsServer
+import PocketCastsDataModel
+
+extension DiscoverCollectionViewController: DiscoverDelegate {
+    func showExpanded(item: PocketCastsServer.DiscoverItem, category: PocketCastsServer.DiscoverCategory?) {
+        //TODO: Implement this in a separate PR
+    }
+
+    func show(podcastInfo: PodcastInfo, placeholderImage: UIImage?, isFeatured: Bool, listUuid: String?) {
+        let podcastController = PodcastViewController(podcastInfo: podcastInfo, existingImage: placeholderImage)
+        podcastController.featuredPodcast = isFeatured
+        podcastController.listUuid = listUuid
+
+        navigationController?.pushViewController(podcastController, animated: true)
+    }
+
+    func show(discoverPodcast: DiscoverPodcast, placeholderImage: UIImage?, isFeatured: Bool, listUuid: String?) {
+        var podcastInfo = PodcastInfo()
+        podcastInfo.populateFrom(discoverPodcast: discoverPodcast)
+        show(podcastInfo: podcastInfo, placeholderImage: placeholderImage, isFeatured: isFeatured, listUuid: listUuid)
+    }
+
+    func show(podcast: Podcast) {
+        let podcastController = PodcastViewController(podcast: podcast)
+        navigationController?.pushViewController(podcastController, animated: true)
+    }
+
+    func showExpanded(item: DiscoverItem, podcasts: [DiscoverPodcast], podcastCollection: PodcastCollection?) {
+        if let listId = item.uuid {
+            AnalyticsHelper.listShowAllTapped(listId: listId)
+        } else {
+            Analytics.track(.discoverShowAllTapped, properties: ["list_id": item.inferredListId])
+        }
+
+        if item.expandedStyle == "descriptive_list" || item.expandedStyle == "grid" {
+            let collectionListVC = ExpandedCollectionViewController(item: item, podcasts: podcasts)
+            collectionListVC.podcastCollection = podcastCollection
+            collectionListVC.registerDiscoverDelegate(self)
+            collectionListVC.cellStyle = (item.expandedStyle == "descriptive_list") ? CollectionCellStyle.descriptive_list : CollectionCellStyle.grid
+            navController()?.pushViewController(collectionListVC, animated: true)
+        } else { // item == expandedStylw == "plain_list" || item.expandedStyle == "ranked_list"
+            let listView = PodcastHeaderListViewController(podcasts: podcasts)
+            listView.title = replaceRegionName(string: item.title?.localized ?? "")
+            listView.showFeaturedCell = item.expandedStyle == "ranked_list"
+            listView.showRankingNumber = item.expandedStyle == "ranked_list"
+            listView.registerDiscoverDelegate(self)
+            navController()?.pushViewController(listView, animated: true)
+        }
+    }
+
+    func showExpanded(item: DiscoverItem, episodes: [DiscoverEpisode], podcastCollection: PodcastCollection?) {
+        guard let podcastCollection = podcastCollection else { return }
+
+        if let listId = item.uuid {
+            AnalyticsHelper.listShowAllTapped(listId: listId)
+        }
+
+        let listView = ExpandedEpisodeListViewController(podcastCollection: podcastCollection)
+        listView.delegate = self
+        navController()?.pushViewController(listView, animated: true)
+    }
+
+    func navController() -> UINavigationController? {
+        navigationController
+    }
+
+    func replaceRegionCode(string: String?) -> String? {
+        guard let fullString = string, let layout = discoverLayout else { return string }
+
+        let currentRegionCode = Settings.discoverRegion(discoverLayout: layout)
+        guard let serverRegion = layout.regions?[currentRegionCode] else { return fullString }
+
+        return fullString.replacingOccurrences(of: layout.regionCodeToken, with: serverRegion.code)
+    }
+
+    func replaceRegionName(string: String) -> String {
+        guard let layout = discoverLayout else { return string }
+
+        let currentRegionCode = Settings.discoverRegion(discoverLayout: layout)
+        guard let serverRegion = layout.regions?[currentRegionCode] else { return string }
+
+        if let localizedRegion = string.localized(with: serverRegion.name.localized) {
+            return localizedRegion
+        }
+
+        return string.replacingOccurrences(of: layout.regionNameToken, with: serverRegion.name)
+    }
+
+    func isSubscribed(podcast: DiscoverPodcast) -> Bool {
+        if let uuid = podcast.uuid {
+            if let _ = DataManager.sharedManager.findPodcast(uuid: uuid) {
+                return true
+            }
+        }
+        return false
+    }
+
+    func subscribe(podcast: DiscoverPodcast) {
+        if podcast.iTunesOnly() {
+            ServerPodcastManager.shared.addFromiTunesId(Int(podcast.iTunesId!)!, subscribe: true, completion: nil)
+        } else if let uuid = podcast.uuid {
+            ServerPodcastManager.shared.addFromUuid(podcastUuid: uuid, subscribe: true, completion: nil)
+        }
+
+        HapticsHelper.triggerSubscribedHaptic()
+
+        let uuid = podcast.uuid ?? podcast.iTunesId ?? "unknown"
+        Analytics.track(.podcastSubscribed, properties: ["source": analyticsSource, "uuid": uuid])
+    }
+
+    func show(discoverEpisode: DiscoverEpisode, podcast: Podcast) {
+        guard let uuid = discoverEpisode.uuid else { return }
+        let episodeController = EpisodeDetailViewController(episodeUuid: uuid, podcast: podcast, source: .discover)
+        episodeController.modalPresentationStyle = .formSheet
+        present(episodeController, animated: true)
+    }
+
+    func failedToLoadEpisode() {
+        SJUIUtils.showAlert(title: L10n.error, message: L10n.discoverFeaturedEpisodeErrorNotFound, from: self)
+    }
+}

--- a/podcasts/DiscoverCollectionViewController+Search.swift
+++ b/podcasts/DiscoverCollectionViewController+Search.swift
@@ -2,6 +2,8 @@
 
 extension DiscoverCollectionViewController {
     func setupSearchBar() {
+        collectionView.delegate = self // For the UIScrollViewDelegate callbacks
+
         addCustomObserver(Constants.Notifications.chartRegionChanged, selector: #selector(chartRegionDidChange))
         addCustomObserver(Constants.Notifications.tappedOnSelectedTab, selector: #selector(checkForScrollTap(_:)))
 
@@ -25,7 +27,7 @@ extension DiscoverCollectionViewController {
     }
 }
 
-extension DiscoverCollectionViewController {
+extension DiscoverCollectionViewController: UICollectionViewDelegate {
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         guard searchResultsController.view?.superview == nil else { return } // don't send scroll events while the search results are up
 

--- a/podcasts/DiscoverCollectionViewController.swift
+++ b/podcasts/DiscoverCollectionViewController.swift
@@ -130,8 +130,8 @@ extension DiscoverCollectionViewController {
             partialResult[cellType] = cellType.createCellRegistration(region: currentRegion, delegate: self)
         }
 
-        dataSource = UICollectionViewDiffableDataSource<Section, Item>(collectionView: collectionView) { [weak self] collectionView, indexPath, item in
-            guard let self, let cellType = item.cellType() else { return UICollectionViewCell() }
+        dataSource = UICollectionViewDiffableDataSource<Section, Item>(collectionView: collectionView) { collectionView, indexPath, item in
+            guard let cellType = item.cellType() else { return UICollectionViewCell() }
             let cellRegistration = registrations[cellType]!
             return collectionView.dequeueConfiguredReusableCell(using: cellRegistration, for: indexPath, item: item)
         }

--- a/podcasts/DiscoverCollectionViewController.swift
+++ b/podcasts/DiscoverCollectionViewController.swift
@@ -1,37 +1,34 @@
+import PocketCastsServer
+import PocketCastsUtils
+
 class DiscoverCollectionViewController: PCViewController, UICollectionViewDelegate {
 
-    enum Cell {
-        case list
-
-        var reuseIdentifier: String {
-            switch self {
-            case .list:
-                "listCell"
-            }
-        }
-    }
+    typealias Section = Int
+    typealias Item = DiscoverItem
 
     private(set) lazy var collectionView: UICollectionView = {
-        return UICollectionView(frame: view.bounds, collectionViewLayout: collectionViewLayout())
+        UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
     }()
+
+    private var dataSource: UICollectionViewDiffableDataSource<Section, Item>!
+    private let coordinator: DiscoverCoordinator
+    private var loadingContent = false
+    private(set) var discoverLayout: DiscoverLayout?
 
     private(set) lazy var searchController: PCSearchBarController = {
         PCSearchBarController()
     }()
-
     lazy var searchResultsController = SearchResultsViewController(source: .discover)
 
     var resultsControllerDelegate: SearchResultsDelegate {
         searchResultsController
     }
 
-    private let coordinator: DiscoverCoordinator
-
     init(coordinator: DiscoverCoordinator) {
         self.coordinator = coordinator
-
         super.init(nibName: nil, bundle: nil)
     }
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -39,49 +36,201 @@ class DiscoverCollectionViewController: PCViewController, UICollectionViewDelega
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        title = L10n.discover
+
         setupCollectionView()
         setupSearchBar()
+
+        reloadData()
+
+//        addCustomObserver(Constants.Notifications.chartRegionChanged, selector: #selector(chartRegionDidChange))
+//        addCustomObserver(Constants.Notifications.tappedOnSelectedTab, selector: #selector(checkForScrollTap(_:)))
+//
+//        addCustomObserver(Constants.Notifications.miniPlayerDidDisappear, selector: #selector(miniPlayerStatusDidChange))
+//        addCustomObserver(Constants.Notifications.miniPlayerDidAppear, selector: #selector(miniPlayerStatusDidChange))
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        AnalyticsHelper.navigatedToDiscover()
+        Analytics.track(.discoverShown)
+
+        miniPlayerStatusDidChange()
     }
 
     func reloadData() {
-        // Will be implemented in a future PR
+        showPageLoading()
+
+        DiscoverServerHandler.shared.discoverPage { [weak self] discoverLayout, _ in
+            DispatchQueue.main.async {
+                guard let self else { return }
+                self.populateFrom(discoverLayout: discoverLayout)
+            }
+        }
     }
 
+    private func populateFrom(discoverLayout: DiscoverLayout?, shouldInclude: ((DiscoverItem) -> Bool)? = nil) {
+        loadingContent = false
+
+        guard let discoverLayout, let items = discoverLayout.layout, let _ = discoverLayout.regions, items.count > 0 else {
+            handleLoadFailed()
+            return
+        }
+
+        let itemFilter = shouldInclude ?? { item in
+            item.categoryID == nil
+        }
+
+        self.discoverLayout = discoverLayout
+
+        configureDataSource()
+
+        collectionView.collectionViewLayout = createCompositionalLayout(with: discoverLayout)
+
+        let currentRegion = Settings.discoverRegion(discoverLayout: discoverLayout)
+
+        let snapshot = discoverLayout.layout?.makeDataSourceSnapshot(region: currentRegion, itemFilter: itemFilter)
+
+        if let snapshot {
+            dataSource.apply(snapshot)
+        }
+    }
+
+    private func showPageLoading() {
+        //TODO: Imlement this in a separate PR
+    }
+
+    private func handleLoadFailed() {
+        //TODO: Implement this in a separate PR
+    }
+}
+
+extension DiscoverCollectionViewController {
     private func setupCollectionView() {
-        collectionView.backgroundColor = .white
-        collectionView.dataSource = self
+        let layout = createCompositionalLayout(with: discoverLayout)
+        collectionView.collectionViewLayout = layout
+        collectionView.translatesAutoresizingMaskIntoConstraints = false
         collectionView.delegate = self
-        collectionView.register(UICollectionViewListCell.self, forCellWithReuseIdentifier: Cell.list.reuseIdentifier)
         view.addSubview(collectionView)
+        NSLayoutConstraint.activate([
+            collectionView.topAnchor.constraint(equalTo: view.topAnchor),
+            collectionView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            collectionView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            collectionView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
     }
 
-    private func collectionViewLayout() -> UICollectionViewLayout {
-        return UICollectionViewCompositionalLayout { (sectionIndex, layoutEnvironment) -> NSCollectionLayoutSection? in
-            let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .absolute(100))
+    private func configureDataSource() {
+        let viewControllerCellRegistration = UICollectionView.CellRegistration<UICollectionViewCell, DiscoverItem> { cell, indexPath, item in
+              //TODO: Change this to be passed in by `item`
+           let currentRegion = Settings.discoverRegion(discoverLayout: self.discoverLayout!)
+            guard let vc = item.viewController(in: currentRegion) else { return }
+
+            cell.contentConfiguration = UIViewControllerContentConfiguration(viewController: vc)
+
+            vc.registerDiscoverDelegate(self)
+            vc.populateFrom(item: item, region: currentRegion, category: nil)
+        }
+
+        let footerRegistration = UICollectionView.SupplementaryRegistration<UICollectionViewListCell>(elementKind: UICollectionView.elementKindSectionFooter) { [weak self] supplementaryView, elementKind, indexPath in
+
+            guard let self else { return }
+
+            let countrySummary = CountrySummaryViewController()
+            countrySummary.discoverLayout = self.discoverLayout
+            countrySummary.registerDiscoverDelegate(self)
+
+            supplementaryView.contentConfiguration = UIViewControllerContentConfiguration(viewController: countrySummary)
+        }
+
+        dataSource = UICollectionViewDiffableDataSource<Section, Item>(collectionView: collectionView) { collectionView, indexPath, item in
+            collectionView.dequeueConfiguredReusableCell(using: viewControllerCellRegistration, for: indexPath, item: item)
+        }
+
+        dataSource.supplementaryViewProvider = { collectionView, kind, indexPath in
+            return collectionView.dequeueConfiguredReusableSupplementary(using: footerRegistration,
+                                                                         for: indexPath)
+        }
+    }
+
+    private func createCompositionalLayout(with layout: DiscoverLayout?) -> UICollectionViewCompositionalLayout {
+        return UICollectionViewCompositionalLayout { (sectionIndex: Int,
+                                                      layoutEnvironment: NSCollectionLayoutEnvironment) -> NSCollectionLayoutSection? in
+            let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),
+                                                  heightDimension: .estimated(100))
+
             let item = NSCollectionLayoutItem(layoutSize: itemSize)
-            let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .absolute(100))
-            let group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, subitems: [item])
+            let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),
+                                                   heightDimension: .estimated(100))
+            let group: NSCollectionLayoutGroup
+            if #available(iOS 16, *) {
+                group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, repeatingSubitem: item, count: layout?.layout?.count ?? 0)
+            } else {
+                group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, subitems: layout?.layout?.map({ _ in item }) ?? [])
+            }
+
             let section = NSCollectionLayoutSection(group: group)
+
+            // Create a size for the header accessory view
+            let footerSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),
+                                                    heightDimension: .estimated(44))
+
+            // Create a boundary supplementary item for the footer
+            let sectionFooter = NSCollectionLayoutBoundarySupplementaryItem(
+                layoutSize: footerSize,
+                elementKind: UICollectionView.elementKindSectionFooter,
+                alignment: .bottom
+            )
+
+            // Add the header to the section's boundary supplementary items
+            section.boundarySupplementaryItems = [sectionFooter]
+
             return section
         }
     }
 }
 
-// MARK: - UICollectionViewDataSource
-
-extension DiscoverCollectionViewController: UICollectionViewDataSource {
-    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return 1
+extension DiscoverCollectionViewController: AnalyticsSourceProvider {
+    var analyticsSource: AnalyticsSource {
+        .discover
     }
+}
 
-    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: Cell.list.reuseIdentifier, for: indexPath) as! UICollectionViewListCell
+private extension DiscoverItem {
+    func viewController(in region: String) -> (UIViewController & DiscoverSummaryProtocol)? {
+        switch (type, summaryStyle, expandedStyle) {
+        case ("categories", "pills", _):
+            return CategoriesSelectorViewController()
+        case ("podcast_list", "carousel", _):
+            return FeaturedSummaryViewController()
+        case ("podcast_list", "small_list", _):
+            return SmallPagedListSummaryViewController()
+        case ("podcast_list", "large_list", _):
+            return LargeListSummaryViewController()
+        case ("podcast_list", "single_podcast", _):
+            return SinglePodcastViewController()
+        case ("podcast_list", "collection", _):
+            return CollectionSummaryViewController()
+        case ("network_list", _, _):
+            return NetworkSummaryViewController()
+        case ("categories", "category", _):
+            return CategorySummaryViewController(regionCode: region)
+        case ("episode_list", "single_episode", _):
+            return SingleEpisodeViewController()
+        case ("episode_list", "collection", "plain_list"):
+            return CollectionSummaryViewController()
+        default:
+            FileLog.shared.addMessage("Unknown Discover Item: \(type) \(summaryStyle)")
+            return nil
+        }
+    }
+}
 
-        // Configure the cell with a label
-        var content = cell.defaultContentConfiguration()
-        content.text = L10n.discover
-        cell.contentConfiguration = content
-
-        return cell
+extension DiscoverCollectionViewController {
+    @objc func miniPlayerStatusDidChange() {
+        let miniPlayerOffset: CGFloat = PlaybackManager.shared.currentEpisode() == nil ? 0 : Constants.Values.miniPlayerOffset
+        collectionView.contentInset = UIEdgeInsets(top: PCSearchBarController.defaultHeight, left: 0, bottom: miniPlayerOffset, right: 0)
+        collectionView.verticalScrollIndicatorInsets = UIEdgeInsets(top: 0, left: 0, bottom: miniPlayerOffset, right: 0)
     }
 }

--- a/podcasts/DiscoverCollectionViewController.swift
+++ b/podcasts/DiscoverCollectionViewController.swift
@@ -99,13 +99,18 @@ class DiscoverCollectionViewController: PCViewController {
     typealias Section = Int
     typealias Item = DiscoverItem
 
-    private var collectionView: UICollectionView!
+    private lazy var collectionView: UICollectionView = {
+        UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
+    }()
+
     private var dataSource: UICollectionViewDiffableDataSource<Section, Item>!
     private let coordinator: DiscoverCoordinator
     private var loadingContent = false
     private(set) var discoverLayout: DiscoverLayout?
 
-    private var searchController: PCSearchBarController!
+    private lazy var searchController: PCSearchBarController = {
+        PCSearchBarController()
+    }()
     lazy var searchResultsController = SearchResultsViewController(source: .discover)
 
     var resultsControllerDelegate: SearchResultsDelegate {
@@ -197,7 +202,7 @@ class DiscoverCollectionViewController: PCViewController {
 extension DiscoverCollectionViewController {
     private func setupCollectionView() {
         let layout = createCompositionalLayout(with: discoverLayout)
-        collectionView = UICollectionView(frame: view.bounds, collectionViewLayout: layout)
+        collectionView.collectionViewLayout = layout
         collectionView.translatesAutoresizingMaskIntoConstraints = false
         collectionView.delegate = self
         view.addSubview(collectionView)
@@ -345,7 +350,6 @@ extension DiscoverCollectionViewController {
 
 extension DiscoverCollectionViewController {
     func setupSearchBar() {
-        searchController = PCSearchBarController()
         searchController.view.translatesAutoresizingMaskIntoConstraints = false
         addChild(searchController)
         view.addSubview(searchController.view)

--- a/podcasts/DiscoverCollectionViewController.swift
+++ b/podcasts/DiscoverCollectionViewController.swift
@@ -1,6 +1,6 @@
 import PocketCastsServer
 
-class DiscoverCollectionViewController: PCViewController, UICollectionViewDelegate {
+class DiscoverCollectionViewController: PCViewController {
 
     typealias Section = Int
     typealias Item = DiscoverItem
@@ -78,15 +78,11 @@ class DiscoverCollectionViewController: PCViewController, UICollectionViewDelega
         }
 
         self.discoverLayout = discoverLayout
-
         configureDataSource()
-
         collectionView.collectionViewLayout = createCompositionalLayout(with: discoverLayout)
 
         let currentRegion = Settings.discoverRegion(discoverLayout: discoverLayout)
-
         let snapshot = discoverLayout.layout?.makeDataSourceSnapshot(region: currentRegion, itemFilter: itemFilter)
-
         if let snapshot {
             dataSource.apply(snapshot)
         }
@@ -107,7 +103,6 @@ extension DiscoverCollectionViewController {
         let layout = createCompositionalLayout(with: discoverLayout)
         collectionView.collectionViewLayout = layout
         collectionView.translatesAutoresizingMaskIntoConstraints = false
-        collectionView.delegate = self
         view.addSubview(collectionView)
         NSLayoutConstraint.activate([
             collectionView.topAnchor.constraint(equalTo: view.topAnchor),
@@ -165,18 +160,15 @@ extension DiscoverCollectionViewController {
 
             let section = NSCollectionLayoutSection(group: group)
 
-            // Create a size for the header accessory view
             let footerSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),
                                                     heightDimension: .estimated(44))
 
-            // Create a boundary supplementary item for the footer
             let sectionFooter = NSCollectionLayoutBoundarySupplementaryItem(
                 layoutSize: footerSize,
                 elementKind: UICollectionView.elementKindSectionFooter,
                 alignment: .bottom
             )
 
-            // Add the header to the section's boundary supplementary items
             section.boundarySupplementaryItems = [sectionFooter]
 
             return section

--- a/podcasts/DiscoverCollectionViewController.swift
+++ b/podcasts/DiscoverCollectionViewController.swift
@@ -1,5 +1,4 @@
 import PocketCastsServer
-import PocketCastsUtils
 
 class DiscoverCollectionViewController: PCViewController, UICollectionViewDelegate {
 
@@ -43,11 +42,7 @@ class DiscoverCollectionViewController: PCViewController, UICollectionViewDelega
 
         reloadData()
 
-//        addCustomObserver(Constants.Notifications.chartRegionChanged, selector: #selector(chartRegionDidChange))
-//        addCustomObserver(Constants.Notifications.tappedOnSelectedTab, selector: #selector(checkForScrollTap(_:)))
-//
-//        addCustomObserver(Constants.Notifications.miniPlayerDidDisappear, selector: #selector(miniPlayerStatusDidChange))
-//        addCustomObserver(Constants.Notifications.miniPlayerDidAppear, selector: #selector(miniPlayerStatusDidChange))
+        setupMiniPlayerObservers()
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -106,6 +101,7 @@ class DiscoverCollectionViewController: PCViewController, UICollectionViewDelega
     }
 }
 
+// MARK: - Collection View
 extension DiscoverCollectionViewController {
     private func setupCollectionView() {
         let layout = createCompositionalLayout(with: discoverLayout)
@@ -122,17 +118,6 @@ extension DiscoverCollectionViewController {
     }
 
     private func configureDataSource() {
-        let viewControllerCellRegistration = UICollectionView.CellRegistration<UICollectionViewCell, DiscoverItem> { cell, indexPath, item in
-              //TODO: Change this to be passed in by `item`
-           let currentRegion = Settings.discoverRegion(discoverLayout: self.discoverLayout!)
-            guard let vc = item.viewController(in: currentRegion) else { return }
-
-            cell.contentConfiguration = UIViewControllerContentConfiguration(viewController: vc)
-
-            vc.registerDiscoverDelegate(self)
-            vc.populateFrom(item: item, region: currentRegion, category: nil)
-        }
-
         let footerRegistration = UICollectionView.SupplementaryRegistration<UICollectionViewListCell>(elementKind: UICollectionView.elementKindSectionFooter) { [weak self] supplementaryView, elementKind, indexPath in
 
             guard let self else { return }
@@ -144,8 +129,16 @@ extension DiscoverCollectionViewController {
             supplementaryView.contentConfiguration = UIViewControllerContentConfiguration(viewController: countrySummary)
         }
 
-        dataSource = UICollectionViewDiffableDataSource<Section, Item>(collectionView: collectionView) { collectionView, indexPath, item in
-            collectionView.dequeueConfiguredReusableCell(using: viewControllerCellRegistration, for: indexPath, item: item)
+        let currentRegion = Settings.discoverRegion(discoverLayout: self.discoverLayout!)
+
+        let registrations: [DiscoverCellType: UICollectionView.CellRegistration] = DiscoverCellType.allCases.reduce(into: [:]) { partialResult, cellType in
+            partialResult[cellType] = cellType.createCellRegistration(region: currentRegion, delegate: self)
+        }
+
+        dataSource = UICollectionViewDiffableDataSource<Section, Item>(collectionView: collectionView) { [weak self] collectionView, indexPath, item in
+            guard let self, let cellType = item.cellType() else { return UICollectionViewCell() }
+            let cellRegistration = registrations[cellType]!
+            return collectionView.dequeueConfiguredReusableCell(using: cellRegistration, for: indexPath, item: item)
         }
 
         dataSource.supplementaryViewProvider = { collectionView, kind, indexPath in
@@ -197,37 +190,13 @@ extension DiscoverCollectionViewController: AnalyticsSourceProvider {
     }
 }
 
-private extension DiscoverItem {
-    func viewController(in region: String) -> (UIViewController & DiscoverSummaryProtocol)? {
-        switch (type, summaryStyle, expandedStyle) {
-        case ("categories", "pills", _):
-            return CategoriesSelectorViewController()
-        case ("podcast_list", "carousel", _):
-            return FeaturedSummaryViewController()
-        case ("podcast_list", "small_list", _):
-            return SmallPagedListSummaryViewController()
-        case ("podcast_list", "large_list", _):
-            return LargeListSummaryViewController()
-        case ("podcast_list", "single_podcast", _):
-            return SinglePodcastViewController()
-        case ("podcast_list", "collection", _):
-            return CollectionSummaryViewController()
-        case ("network_list", _, _):
-            return NetworkSummaryViewController()
-        case ("categories", "category", _):
-            return CategorySummaryViewController(regionCode: region)
-        case ("episode_list", "single_episode", _):
-            return SingleEpisodeViewController()
-        case ("episode_list", "collection", "plain_list"):
-            return CollectionSummaryViewController()
-        default:
-            FileLog.shared.addMessage("Unknown Discover Item: \(type) \(summaryStyle)")
-            return nil
-        }
-    }
-}
-
+// MARK: - Mini Player
 extension DiscoverCollectionViewController {
+    fileprivate func setupMiniPlayerObservers() {
+        addCustomObserver(Constants.Notifications.miniPlayerDidDisappear, selector: #selector(miniPlayerStatusDidChange))
+        addCustomObserver(Constants.Notifications.miniPlayerDidAppear, selector: #selector(miniPlayerStatusDidChange))
+    }
+
     @objc func miniPlayerStatusDidChange() {
         let miniPlayerOffset: CGFloat = PlaybackManager.shared.currentEpisode() == nil ? 0 : Constants.Values.miniPlayerOffset
         collectionView.contentInset = UIEdgeInsets(top: PCSearchBarController.defaultHeight, left: 0, bottom: miniPlayerOffset, right: 0)

--- a/podcasts/DiscoverCollectionViewController.swift
+++ b/podcasts/DiscoverCollectionViewController.swift
@@ -149,7 +149,7 @@ class DiscoverCollectionViewController: PCViewController {
     }
 
     private func reloadData() {
-//        showPageLoading()
+        showPageLoading()
 
         DiscoverServerHandler.shared.discoverPage { [weak self] discoverLayout, _ in
             DispatchQueue.main.async {
@@ -185,19 +185,12 @@ class DiscoverCollectionViewController: PCViewController {
         }
     }
 
-//    private func setupChildViewControllers() {
-//        // Create and add child view controllers
-//        categoryViewControllers = (0..<5).map { _ in CategoryViewController() }
-//        featuredViewControllers = (0..<3).map { _ in FeaturedViewController() }
-//        searchViewController = SearchViewController()
-//
-//        let allChildViewControllers = categoryViewControllers + featuredViewControllers + [searchViewController]
-//        allChildViewControllers.forEach { addChild($0) }
-//    }
+    private func showPageLoading() {
+        //TODO: Imlement this in a separate PR
+    }
 
     private func handleLoadFailed() {
-//        loadingIndicator.stopAnimating()
-//        noNetworkView.isHidden = false
+        //TODO: Implement this in a separate PR
     }
 }
 

--- a/podcasts/DiscoverCollectionViewController.swift
+++ b/podcasts/DiscoverCollectionViewController.swift
@@ -1,27 +1,115 @@
-class DiscoverCollectionViewController: UIViewController, UICollectionViewDelegate {
+import UIKit
+import SwiftUI
+import PocketCastsServer
+import PocketCastsUtils
 
-    enum Cell {
-        case list
+protocol SnakeCaseRepresentable: RawRepresentable where RawValue == String {
+    static func snakeCasedString(from string: String) -> String
+    init?(snakeCasedRawValue: String)
+}
 
-        var reuseIdentifier: String {
-            switch self {
-            case .list:
-                "listCell"
+extension SnakeCaseRepresentable {
+    static func snakeCasedString(from string: String) -> String {
+        var result = ""
+        for character in string {
+            if character.isUppercase {
+                // Add an underscore before uppercase letters, except for the first character
+                if !result.isEmpty {
+                    result += "_"
+                }
+                result += character.lowercased()
+            } else {
+                result += String(character)
             }
         }
+        return result
     }
 
-    private lazy var collectionView: UICollectionView = {
-        return UICollectionView(frame: view.bounds, collectionViewLayout: collectionViewLayout())
-    }()
+    var snakeCasedRawValue: String {
+        return Self.snakeCasedString(from: String(describing: self))
+    }
 
+    init?(snakeCasedRawValue: String) {
+        let camelCasedString = Self.camelCasedString(from: snakeCasedRawValue)
+        self.init(rawValue: camelCasedString)
+    }
+
+    private static func camelCasedString(from snakeCasedString: String) -> String {
+        let components = snakeCasedString.split(separator: "_")
+        return components.enumerated().map { (index, element) in
+            index == 0 ? element.lowercased() : element.capitalized
+        }.joined()
+    }
+}
+
+extension Array<DiscoverItem> {
+    func makeDataSourceSnapshot(region: String, itemFilter: (DiscoverItem) -> Bool) -> NSDiffableDataSourceSnapshot<Int, DiscoverItem> {
+        var snapshot = NSDiffableDataSourceSnapshot<Int, DiscoverItem>()
+
+        let section = 0
+        snapshot.appendSections([section])
+        let items = filter({ (itemFilter($0)) && $0.regions.contains(region) })
+        snapshot.appendItems(items)
+
+        return snapshot
+    }
+}
+
+extension DiscoverItem {
+
+    var itemType: ItemType? {
+        guard let type else { return nil }
+        return ItemType(snakeCasedRawValue: type)
+    }
+
+    enum ItemType: String, SnakeCaseRepresentable {
+        case categories
+        case podcastList
+        case networkList
+        case episodeList
+    }
+
+    var summaryStyleEnum: SummaryStyle? {
+        guard let summaryStyle else { return nil }
+        return SummaryStyle(snakeCasedRawValue: summaryStyle)
+    }
+
+    enum SummaryStyle: String, SnakeCaseRepresentable {
+        case pills
+        case carousel
+        case smallList
+        case largeList
+        case singlePodcast
+        case collection
+        case category
+        case singleEpisode
+    }
+
+    var expandedStyleEnum: ExpandedStyle? {
+        guard let summaryStyle else { return nil }
+        return ExpandedStyle(snakeCasedRawValue: summaryStyle)
+    }
+
+    enum ExpandedStyle: String, SnakeCaseRepresentable {
+        case plainList
+    }
+}
+
+class DiscoverCollectionViewController: UIViewController {
+    typealias Section = Int
+    typealias Item = DiscoverItem
+
+    private var collectionView: UICollectionView!
+    private var dataSource: UICollectionViewDiffableDataSource<Section, Item>!
     private let coordinator: DiscoverCoordinator
+    private var loadingContent = false
+    private(set) var discoverLayout: DiscoverLayout?
 
     init(coordinator: DiscoverCoordinator) {
         self.coordinator = coordinator
-
         super.init(nibName: nil, bundle: nil)
     }
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -29,44 +117,148 @@ class DiscoverCollectionViewController: UIViewController, UICollectionViewDelega
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        title = L10n.discover
+
         setupCollectionView()
+        configureDataSource()
+
+        reloadData()
     }
 
+    private func reloadData() {
+//        showPageLoading()
+
+        DiscoverServerHandler.shared.discoverPage { [weak self] discoverLayout, _ in
+            DispatchQueue.main.async {
+                guard let strongSelf = self else { return }
+                strongSelf.populateFrom(discoverLayout: discoverLayout)
+            }
+        }
+    }
+
+    private func populateFrom(discoverLayout: DiscoverLayout?, shouldInclude: ((DiscoverItem) -> Bool)? = nil) {
+        loadingContent = false
+
+        guard let discoverLayout, let items = discoverLayout.layout, let _ = discoverLayout.regions, items.count > 0 else {
+            handleLoadFailed()
+            return
+        }
+
+        let itemFilter = shouldInclude ?? { item in
+            item.categoryID == nil
+        }
+
+        self.discoverLayout = discoverLayout
+//        loadingIndicator.stopAnimating()
+
+        collectionView.collectionViewLayout = createCompositionalLayout(with: discoverLayout)
+
+        let currentRegion = Settings.discoverRegion(discoverLayout: discoverLayout)
+
+        let snapshot = discoverLayout.layout?.makeDataSourceSnapshot(region: currentRegion, itemFilter: itemFilter)
+
+        if let snapshot {
+            dataSource.apply(snapshot)
+        }
+    }
+
+//    private func setupChildViewControllers() {
+//        // Create and add child view controllers
+//        categoryViewControllers = (0..<5).map { _ in CategoryViewController() }
+//        featuredViewControllers = (0..<3).map { _ in FeaturedViewController() }
+//        searchViewController = SearchViewController()
+//
+//        let allChildViewControllers = categoryViewControllers + featuredViewControllers + [searchViewController]
+//        allChildViewControllers.forEach { addChild($0) }
+//    }
+
+    private func handleLoadFailed() {
+//        loadingIndicator.stopAnimating()
+//        noNetworkView.isHidden = false
+    }
+}
+
+extension DiscoverCollectionViewController {
     private func setupCollectionView() {
-        collectionView.backgroundColor = .white
-        collectionView.dataSource = self
-        collectionView.delegate = self
-        collectionView.register(UICollectionViewListCell.self, forCellWithReuseIdentifier: Cell.list.reuseIdentifier)
+        let layout = createCompositionalLayout(with: discoverLayout)
+        collectionView = UICollectionView(frame: view.bounds, collectionViewLayout: layout)
+        collectionView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         view.addSubview(collectionView)
     }
 
-    private func collectionViewLayout() -> UICollectionViewLayout {
-        return UICollectionViewCompositionalLayout { (sectionIndex, layoutEnvironment) -> NSCollectionLayoutSection? in
-            let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .absolute(100))
+    private func configureDataSource() {
+        let viewControllerCellRegistration = UICollectionView.CellRegistration<UICollectionViewCell, DiscoverItem> { cell, indexPath, item in
+              //TODO: Change this to be passed in by `item`
+           let currentRegion = Settings.discoverRegion(discoverLayout: self.discoverLayout!)
+            guard let vc = item.viewController(in: currentRegion) else { return }
+
+            cell.contentConfiguration = UIViewControllerContentConfiguration(viewController: vc)
+
+            vc.registerDiscoverDelegate(self)
+            vc.populateFrom(item: item, region: currentRegion, category: nil)
+        }
+
+        dataSource = UICollectionViewDiffableDataSource<Section, Item>(collectionView: collectionView) { collectionView, indexPath, item in
+            collectionView.dequeueConfiguredReusableCell(using: viewControllerCellRegistration, for: indexPath, item: item)
+        }
+    }
+
+    private func createCompositionalLayout(with layout: DiscoverLayout?) -> UICollectionViewCompositionalLayout {
+        return UICollectionViewCompositionalLayout { (sectionIndex: Int,
+                                                            layoutEnvironment: NSCollectionLayoutEnvironment) -> NSCollectionLayoutSection? in
+            let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),
+                                                    heightDimension: .estimated(100))
+
             let item = NSCollectionLayoutItem(layoutSize: itemSize)
-            let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .absolute(100))
-            let group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, subitems: [item])
+            let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),
+                                                     heightDimension: .estimated(100))
+            let group: NSCollectionLayoutGroup
+            if #available(iOS 16, *) {
+                group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, repeatingSubitem: item, count: layout?.layout?.count ?? 0)
+            } else {
+                group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, subitems: layout?.layout?.map({ _ in item }) ?? [])
+            }
+
             let section = NSCollectionLayoutSection(group: group)
+
             return section
         }
     }
 }
 
-// MARK: - UICollectionViewDataSource
-
-extension DiscoverCollectionViewController: UICollectionViewDataSource {
-    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return 1
+extension DiscoverCollectionViewController: AnalyticsSourceProvider {
+    var analyticsSource: AnalyticsSource {
+        .discover
     }
+}
 
-    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: Cell.list.reuseIdentifier, for: indexPath) as! UICollectionViewListCell
-
-        // Configure the cell with a label
-        var content = cell.defaultContentConfiguration()
-        content.text = L10n.discover
-        cell.contentConfiguration = content
-
-        return cell
+private extension DiscoverItem {
+    func viewController(in region: String) -> (UIViewController & DiscoverSummaryProtocol)? {
+        switch (type, summaryStyle, expandedStyle) {
+        case ("categories", "pills", _):
+            return CategoriesSelectorViewController()
+        case ("podcast_list", "carousel", _):
+            return FeaturedSummaryViewController()
+        case ("podcast_list", "small_list", _):
+            return SmallPagedListSummaryViewController()
+        case ("podcast_list", "large_list", _):
+            return LargeListSummaryViewController()
+        case ("podcast_list", "single_podcast", _):
+            return SinglePodcastViewController()
+        case ("podcast_list", "collection", _):
+            return CollectionSummaryViewController()
+        case ("network_list", _, _):
+            return NetworkSummaryViewController()
+        case ("categories", "category", _):
+            return CategorySummaryViewController(regionCode: region)
+        case ("episode_list", "single_episode", _):
+            return SingleEpisodeViewController()
+        case ("episode_list", "collection", "plain_list"):
+            return CollectionSummaryViewController()
+        default:
+            FileLog.shared.addMessage("Unknown Discover Item: \(type) \(summaryStyle)")
+            assertionFailure("Unknown Discover Item: \(type) \(summaryStyle)")
+            return nil
+        }
     }
 }

--- a/podcasts/FeaturedSummaryViewController.swift
+++ b/podcasts/FeaturedSummaryViewController.swift
@@ -243,6 +243,7 @@ class FeaturedSummaryViewController: SimpleNotificationsViewController, GridLayo
     }
 
     private func updateCurrentPage() {
+        guard featuredCollectionView.frame.width != .zero else { return }
         let currentPage = Int(round(featuredCollectionView.contentOffset.x / featuredCollectionView.frame.width))
 
         if currentPage == pageControl.currentPage { return }

--- a/podcasts/FeaturedSummaryViewController.xib
+++ b/podcasts/FeaturedSummaryViewController.xib
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23094" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23084"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -18,9 +16,8 @@
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT" customClass="ThemeableView" customModule="podcasts" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="420" height="256"/>
-            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="i5M-Pr-FkT" customClass="ThemeableView" customModule="podcasts" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="420" height="222"/>
             <subviews>
                 <collectionView multipleTouchEnabled="YES" contentMode="scaleToFill" pagingEnabled="YES" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="KmW-Fw-G4b" customClass="ThemeableCollectionView" customModule="podcasts" customModuleProvider="target">
                     <rect key="frame" x="0.0" y="0.0" width="420" height="193"/>
@@ -48,7 +45,7 @@
                 <constraint firstAttribute="trailing" secondItem="KmW-Fw-G4b" secondAttribute="trailing" id="RAU-St-G3Q"/>
                 <constraint firstItem="Ux1-AI-rdb" firstAttribute="top" secondItem="KmW-Fw-G4b" secondAttribute="bottom" constant="4" id="WsI-O7-bFz"/>
                 <constraint firstItem="KmW-Fw-G4b" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="Xse-cR-wcQ"/>
-                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="Ux1-AI-rdb" secondAttribute="bottom" id="aK0-Gy-RSr"/>
+                <constraint firstAttribute="bottom" secondItem="Ux1-AI-rdb" secondAttribute="bottom" id="aK0-Gy-RSr"/>
             </constraints>
             <nil key="simulatedStatusBarMetrics"/>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>

--- a/podcasts/LargeListCell.xib
+++ b/podcasts/LargeListCell.xib
@@ -14,7 +14,7 @@
             <rect key="frame" x="0.0" y="0.0" width="160" height="250"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
-                <rect key="frame" x="0.0" y="0.0" width="160" height="250"/>
+                <rect key="frame" x="0.0" y="0.0" width="160" height="211"/>
                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                 <subviews>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Podcast title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4Qw-eq-tYg" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
@@ -75,7 +75,7 @@
                 <constraint firstAttribute="trailing" secondItem="nBx-mo-aDN" secondAttribute="trailing" id="b7M-Bk-yhL"/>
                 <constraint firstItem="1Gb-8A-zQV" firstAttribute="bottom" secondItem="nBx-mo-aDN" secondAttribute="bottom" constant="-4" id="cOB-Ih-NY8"/>
                 <constraint firstItem="4Qw-eq-tYg" firstAttribute="leading" secondItem="nBx-mo-aDN" secondAttribute="leading" id="fPL-60-yYf"/>
-                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="2wE-0A-zrE" secondAttribute="bottom" constant="8" id="hvJ-wY-w6T"/>
+                <constraint firstAttribute="bottom" secondItem="2wE-0A-zrE" secondAttribute="bottom" id="hvJ-wY-w6T"/>
                 <constraint firstItem="4Qw-eq-tYg" firstAttribute="trailing" secondItem="nBx-mo-aDN" secondAttribute="trailing" id="kfc-qw-a5d"/>
                 <constraint firstItem="1Gb-8A-zQV" firstAttribute="trailing" secondItem="nBx-mo-aDN" secondAttribute="trailing" constant="-4" id="nHw-ba-ihn"/>
                 <constraint firstItem="2wE-0A-zrE" firstAttribute="leading" secondItem="4Qw-eq-tYg" secondAttribute="leading" id="zFW-RE-G6q"/>
@@ -86,7 +86,7 @@
                 <outlet property="podcastTitle" destination="4Qw-eq-tYg" id="Nfd-Qh-8gn"/>
                 <outlet property="subscribeButton" destination="1Gb-8A-zQV" id="0aA-kz-6Rh"/>
             </connections>
-            <point key="canvasLocation" x="139" y="154"/>
+            <point key="canvasLocation" x="137.59999999999999" y="136.28185907046478"/>
         </collectionViewCell>
     </objects>
 </document>

--- a/podcasts/LargeListSummaryViewController.xib
+++ b/podcasts/LargeListSummaryViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23094" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22684"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23084"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -20,11 +20,10 @@
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="Fw0-IT-oEE" customClass="ThemeableView" customModule="podcasts" customModuleProvider="target">
+        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Fw0-IT-oEE" customClass="ThemeableView" customModule="podcasts" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="370" height="275"/>
-            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <stackView opaque="NO" contentMode="scaleToFill" alignment="lastBaseline" translatesAutoresizingMaskIntoConstraints="NO" id="X56-LC-Q5n">
+                <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" alignment="lastBaseline" translatesAutoresizingMaskIntoConstraints="NO" id="X56-LC-Q5n">
                     <rect key="frame" x="16" y="30" width="338" height="20"/>
                     <subviews>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Featured" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0VX-rs-RFl" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
@@ -60,7 +59,7 @@
                     <rect key="frame" x="16" y="66" width="350" height="169"/>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <constraints>
-                        <constraint firstAttribute="height" constant="169" id="O9B-Ec-Krr"/>
+                        <constraint firstAttribute="height" priority="999" constant="169" id="O9B-Ec-Krr"/>
                     </constraints>
                     <collectionViewLayout key="collectionViewLayout" id="lnF-WW-rcz" customClass="GridLayout" customModule="podcasts" customModuleProvider="target"/>
                     <connections>

--- a/podcasts/SingleEpisodeViewController.xib
+++ b/podcasts/SingleEpisodeViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23094" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21678"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23084"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -19,12 +19,11 @@
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="Yf6-rN-8KF" customClass="ThemeableView" customModule="podcasts" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="408" height="198"/>
-            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Yf6-rN-8KF" customClass="ThemeableView" customModule="podcasts" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="408" height="132.5"/>
             <subviews>
                 <view autoresizesSubviews="NO" contentMode="scaleToFill" verticalHuggingPriority="1000" verticalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="XLj-4B-d8V">
-                    <rect key="frame" x="0.0" y="0.0" width="408" height="198"/>
+                    <rect key="frame" x="0.0" y="0.0" width="408" height="132.5"/>
                     <subviews>
                         <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Featured episode" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VQv-lQ-Swz">
                             <rect key="frame" x="126" y="16" width="110" height="16"/>
@@ -54,7 +53,7 @@
                             </constraints>
                         </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XNc-kA-lJg" customClass="ThemeDividerView" customModule="podcasts" customModuleProvider="target">
-                            <rect key="frame" x="16" y="197" width="376" height="1"/>
+                            <rect key="frame" x="16" y="131.5" width="376" height="1"/>
                             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="1" id="djY-Ct-VuE"/>
@@ -84,7 +83,7 @@
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <constraints>
                         <constraint firstItem="XfO-Aq-DlI" firstAttribute="leading" secondItem="0h6-zE-KNg" secondAttribute="trailing" constant="8" id="2u2-c4-MOf"/>
-                        <constraint firstItem="XNc-kA-lJg" firstAttribute="top" relation="greaterThanOrEqual" secondItem="0h6-zE-KNg" secondAttribute="bottom" constant="16" id="2vs-ks-9Bj"/>
+                        <constraint firstItem="XNc-kA-lJg" firstAttribute="top" secondItem="0h6-zE-KNg" secondAttribute="bottom" constant="16" id="2vs-ks-9Bj"/>
                         <constraint firstAttribute="trailing" secondItem="XNc-kA-lJg" secondAttribute="trailing" constant="16" id="3kP-kw-57m"/>
                         <constraint firstItem="0h6-zE-KNg" firstAttribute="top" secondItem="ycZ-JL-S7v" secondAttribute="bottom" constant="8" id="ExO-Fb-gqZ"/>
                         <constraint firstItem="VQv-lQ-Swz" firstAttribute="top" secondItem="LZo-mu-n1i" secondAttribute="top" id="LFW-71-01m"/>
@@ -115,7 +114,7 @@
                 <constraint firstAttribute="bottom" secondItem="XLj-4B-d8V" secondAttribute="bottom" id="wMS-JU-hJo"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-            <point key="canvasLocation" x="13" y="77"/>
+            <point key="canvasLocation" x="11.594202898550726" y="52.232142857142854"/>
         </view>
     </objects>
 </document>

--- a/podcasts/UIViewControllerContentConfiguration.swift
+++ b/podcasts/UIViewControllerContentConfiguration.swift
@@ -1,0 +1,71 @@
+final class UIViewControllerContentConfiguration: UIContentConfiguration {
+    let viewController: UIViewController
+
+    init(viewController: UIViewController) {
+        self.viewController = viewController
+    }
+
+    func makeContentView() -> UIView & UIContentView {
+        return ViewControllerContainerContentView(configuration: self)
+    }
+
+    func updated(for state: UIConfigurationState) -> UIViewControllerContentConfiguration {
+        return self
+    }
+}
+
+class ViewControllerContainerContentView: UIView, UIContentView {
+    var configuration: UIContentConfiguration {
+        didSet {
+            subviews.first?.removeFromSuperview()
+            setupConstraints()
+        }
+    }
+
+    init(configuration: UIViewControllerContentConfiguration) {
+        self.configuration = configuration
+        super.init(frame: .zero)
+        setupConstraints()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setupConstraints() {
+        guard let configuration = configuration as? UIViewControllerContentConfiguration else { return }
+
+        let viewController = configuration.viewController
+//        viewController.view.autoresizingMask = [.flexibleWidth]
+        addSubview(viewController.view)
+        viewController.view.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+            viewController.view.topAnchor.constraint(equalTo: topAnchor),
+            viewController.view.leadingAnchor.constraint(equalTo: leadingAnchor),
+            viewController.view.trailingAnchor.constraint(equalTo: trailingAnchor),
+            viewController.view.bottomAnchor.constraint(equalTo: bottomAnchor)
+        ])
+    }
+
+    override func systemLayoutSizeFitting(_ targetSize: CGSize, withHorizontalFittingPriority horizontalFittingPriority: UILayoutPriority, verticalFittingPriority: UILayoutPriority) -> CGSize {
+        if let vc = (configuration as? UIViewControllerContentConfiguration)?.viewController {
+            vc.view.layoutSubviews()
+            var size = vc.view.systemLayoutSizeFitting(targetSize, withHorizontalFittingPriority: horizontalFittingPriority, verticalFittingPriority: verticalFittingPriority)
+            if size.height == CGFloat.greatestFiniteMagnitude || size.width == CGFloat.greatestFiniteMagnitude {
+//                vc.view.setNeedsLayout()
+//                vc.view.layoutIfNeeded()
+                size = vc.view.frame.size
+            }
+
+            if horizontalFittingPriority >= UILayoutPriority.defaultHigh {
+                size.width = targetSize.width
+            }
+
+            print("Layout size: \(size) for vc: \(vc)")
+            return size
+        } else {
+            return super.systemLayoutSizeFitting(targetSize, withHorizontalFittingPriority: horizontalFittingPriority, verticalFittingPriority: verticalFittingPriority)
+        }
+    }
+}

--- a/podcasts/UIViewControllerContentConfiguration.swift
+++ b/podcasts/UIViewControllerContentConfiguration.swift
@@ -36,7 +36,6 @@ class ViewControllerContainerContentView: UIView, UIContentView {
         guard let configuration = configuration as? UIViewControllerContentConfiguration else { return }
 
         let viewController = configuration.viewController
-//        viewController.view.autoresizingMask = [.flexibleWidth]
         addSubview(viewController.view)
         viewController.view.translatesAutoresizingMaskIntoConstraints = false
 

--- a/podcasts/UIViewControllerContentConfiguration.swift
+++ b/podcasts/UIViewControllerContentConfiguration.swift
@@ -48,23 +48,23 @@ class ViewControllerContainerContentView: UIView, UIContentView {
     }
 
     override func systemLayoutSizeFitting(_ targetSize: CGSize, withHorizontalFittingPriority horizontalFittingPriority: UILayoutPriority, verticalFittingPriority: UILayoutPriority) -> CGSize {
-        if let vc = (configuration as? UIViewControllerContentConfiguration)?.viewController {
-            vc.view.layoutSubviews()
-
-            let fittingSize = CGSize(width: targetSize.width, height: UIView.layoutFittingCompressedSize.height)
-            var size = vc.view.systemLayoutSizeFitting(fittingSize, withHorizontalFittingPriority: horizontalFittingPriority, verticalFittingPriority: verticalFittingPriority)
-
-            if size.height == CGFloat.greatestFiniteMagnitude || size.width == CGFloat.greatestFiniteMagnitude {
-                size = vc.view.frame.size
-            }
-
-            if horizontalFittingPriority >= UILayoutPriority.defaultHigh {
-                size.width = targetSize.width
-            }
-
-            return size
-        } else {
+        guard let vc = (configuration as? UIViewControllerContentConfiguration)?.viewController else {
             return super.systemLayoutSizeFitting(targetSize, withHorizontalFittingPriority: horizontalFittingPriority, verticalFittingPriority: verticalFittingPriority)
         }
+
+        vc.view.layoutSubviews()
+
+        let fittingSize = CGSize(width: targetSize.width, height: UIView.layoutFittingCompressedSize.height)
+        var size = vc.view.systemLayoutSizeFitting(fittingSize, withHorizontalFittingPriority: horizontalFittingPriority, verticalFittingPriority: verticalFittingPriority)
+
+        if size.height == CGFloat.greatestFiniteMagnitude || size.width == CGFloat.greatestFiniteMagnitude {
+            size = vc.view.frame.size
+        }
+
+        if horizontalFittingPriority >= UILayoutPriority.defaultHigh {
+            size.width = targetSize.width
+        }
+
+        return size
     }
 }

--- a/podcasts/UIViewControllerContentConfiguration.swift
+++ b/podcasts/UIViewControllerContentConfiguration.swift
@@ -1,0 +1,71 @@
+final class UIViewControllerContentConfiguration: UIContentConfiguration {
+    let viewController: UIViewController
+
+    init(viewController: UIViewController) {
+        self.viewController = viewController
+    }
+
+    func makeContentView() -> UIView & UIContentView {
+        return ViewControllerContainerContentView(configuration: self)
+    }
+
+    func updated(for state: UIConfigurationState) -> UIViewControllerContentConfiguration {
+        return self
+    }
+}
+
+class ViewControllerContainerContentView: UIView, UIContentView {
+    var configuration: UIContentConfiguration {
+        didSet {
+            subviews.first?.removeFromSuperview()
+            setupConstraints()
+        }
+    }
+
+    init(configuration: UIViewControllerContentConfiguration) {
+        self.configuration = configuration
+        super.init(frame: .zero)
+        setupConstraints()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setupConstraints() {
+        guard let configuration = configuration as? UIViewControllerContentConfiguration else { return }
+
+        let viewController = configuration.viewController
+//        viewController.view.autoresizingMask = [.flexibleWidth]
+        addSubview(viewController.view)
+        viewController.view.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+            viewController.view.topAnchor.constraint(equalTo: topAnchor),
+            viewController.view.leadingAnchor.constraint(equalTo: leadingAnchor),
+            viewController.view.trailingAnchor.constraint(equalTo: trailingAnchor),
+            viewController.view.bottomAnchor.constraint(equalTo: bottomAnchor)
+        ])
+    }
+
+    override func systemLayoutSizeFitting(_ targetSize: CGSize, withHorizontalFittingPriority horizontalFittingPriority: UILayoutPriority, verticalFittingPriority: UILayoutPriority) -> CGSize {
+        if let vc = (configuration as? UIViewControllerContentConfiguration)?.viewController {
+            vc.view.layoutSubviews()
+
+            let fittingSize = CGSize(width: targetSize.width, height: UIView.layoutFittingCompressedSize.height)
+            var size = vc.view.systemLayoutSizeFitting(fittingSize, withHorizontalFittingPriority: horizontalFittingPriority, verticalFittingPriority: verticalFittingPriority)
+
+            if size.height == CGFloat.greatestFiniteMagnitude || size.width == CGFloat.greatestFiniteMagnitude {
+                size = vc.view.frame.size
+            }
+
+            if horizontalFittingPriority >= UILayoutPriority.defaultHigh {
+                size.width = targetSize.width
+            }
+
+            return size
+        } else {
+            return super.systemLayoutSizeFitting(targetSize, withHorizontalFittingPriority: horizontalFittingPriority, verticalFittingPriority: verticalFittingPriority)
+        }
+    }
+}

--- a/podcasts/UIViewControllerContentConfiguration.swift
+++ b/podcasts/UIViewControllerContentConfiguration.swift
@@ -51,10 +51,11 @@ class ViewControllerContainerContentView: UIView, UIContentView {
     override func systemLayoutSizeFitting(_ targetSize: CGSize, withHorizontalFittingPriority horizontalFittingPriority: UILayoutPriority, verticalFittingPriority: UILayoutPriority) -> CGSize {
         if let vc = (configuration as? UIViewControllerContentConfiguration)?.viewController {
             vc.view.layoutSubviews()
-            var size = vc.view.systemLayoutSizeFitting(targetSize, withHorizontalFittingPriority: horizontalFittingPriority, verticalFittingPriority: verticalFittingPriority)
+
+            let fittingSize = CGSize(width: targetSize.width, height: UIView.layoutFittingCompressedSize.height)
+            var size = vc.view.systemLayoutSizeFitting(fittingSize, withHorizontalFittingPriority: horizontalFittingPriority, verticalFittingPriority: verticalFittingPriority)
+
             if size.height == CGFloat.greatestFiniteMagnitude || size.width == CGFloat.greatestFiniteMagnitude {
-//                vc.view.setNeedsLayout()
-//                vc.view.layoutIfNeeded()
                 size = vc.view.frame.size
             }
 


### PR DESCRIPTION
| 📘 Part of: #2104 |
|:---:|

This adds the collection view for Discover.

**Categories and regions are not hooked up yet**

https://github.com/user-attachments/assets/022645d0-5fbb-4f60-911c-823d11543cd2

## To test

* Enable the `discoverCollectionView` feature flag
* Restart the app
* Visit the Discover tab
* Verify that everything except for categories and region switching works. Tap on a few podcasts, try subscribing, searching, and scroll around for example.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
