### PR TITLE
Listening History Search enable Feature Flag

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -195,7 +195,7 @@ public enum FeatureFlag: String, CaseIterable {
         case .playerIsReadyToPlay:
             true
         case .listeningHistorySearch:
-            false
+            true
         case .useMimetypePackage:
             true
         }


### PR DESCRIPTION
| 📘 Part of: #2181
|:---:|

Enable FF

## To test

- CI must be 🟢 
- Go to Profile -> LIstening History
- You should see the Search

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
