### PR TITLE
Update sorting by title to match Android

### DIFF
--- a/podcasts/EpisodesDataManager.swift
+++ b/podcasts/EpisodesDataManager.swift
@@ -84,9 +84,23 @@ class EpisodesDataManager {
         let sortOrder = episodeSortOrder ?? PodcastEpisodeSortOrder.newestToOldest
         switch sortOrder {
         case .titleAtoZ:
-            sortStr = "ORDER BY title ASC, addedDate"
+            sortStr = """
+            ORDER BY (CASE
+            WHEN UPPER(title) LIKE 'THE %' THEN SUBSTR(UPPER(title), 5)
+            WHEN UPPER(title) LIKE 'A %' THEN SUBSTR(UPPER(title), 3)
+            WHEN UPPER(title) LIKE 'AN %' THEN SUBSTR(UPPER(title), 4)
+            ELSE UPPER(title)
+            END) ASC, addedDate
+            """
         case .titleZtoA:
-            sortStr = "ORDER BY title DESC, addedDate"
+            sortStr = """
+            ORDER BY (CASE
+            WHEN UPPER(title) LIKE 'THE %' THEN SUBSTR(UPPER(title), 5)
+            WHEN UPPER(title) LIKE 'A %' THEN SUBSTR(UPPER(title), 3)
+            WHEN UPPER(title) LIKE 'AN %' THEN SUBSTR(UPPER(title), 4)
+            ELSE UPPER(title)
+            END) DESC, addedDate
+            """
         case .newestToOldest:
             sortStr = "ORDER BY publishedDate DESC, addedDate DESC"
         case .oldestToNewest:


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
Change sorting so it ignores THE A AN on start of titles and also is case insensitive.

## To test

1. Start the app
2. Open a Podcast
3. Tap on the ... button
4. Select the Sort row
5. Check if you see the options to sort for TitleAtoZ and TitleZtoA
6. Select each of the sorts and see if they sort correctly in a case insensitive way, and ignoring titles suffixes: A, AN, THE

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
