### PR TITLE
Discover Collection View: Category and Region switching support

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1664,6 +1664,7 @@
 		F543F6A42C0804FA00FEC8B6 /* AnyPublisher+Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = F543F6A32C0804FA00FEC8B6 /* AnyPublisher+Async.swift */; };
 		F54E72192CA722A000CD5C86 /* Array+DiscoverItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = F54E72182CA722A000CD5C86 /* Array+DiscoverItem.swift */; };
 		F54E721D2CA7359800CD5C86 /* DiscoverCellType.swift in Sources */ = {isa = PBXBuildFile; fileRef = F54E721C2CA7359800CD5C86 /* DiscoverCellType.swift */; };
+		F54E721F2CA749AA00CD5C86 /* DiscoverCollectionViewController+Categories.swift in Sources */ = {isa = PBXBuildFile; fileRef = F54E721E2CA749AA00CD5C86 /* DiscoverCollectionViewController+Categories.swift */; };
 		F55449422B758E8300F68AE9 /* PocketCastsUtils in Frameworks */ = {isa = PBXBuildFile; productRef = F55449412B758E8300F68AE9 /* PocketCastsUtils */; };
 		F55449432B758E8300F68AE9 /* PocketCastsUtils in Embed Frameworks */ = {isa = PBXBuildFile; productRef = F55449412B758E8300F68AE9 /* PocketCastsUtils */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		F55449452B75935F00F68AE9 /* AppSettings+ImportUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = F55449442B75935F00F68AE9 /* AppSettings+ImportUserDefaults.swift */; };
@@ -3582,6 +3583,7 @@
 		F543F6A32C0804FA00FEC8B6 /* AnyPublisher+Async.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AnyPublisher+Async.swift"; sourceTree = "<group>"; };
 		F54E72182CA722A000CD5C86 /* Array+DiscoverItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+DiscoverItem.swift"; sourceTree = "<group>"; };
 		F54E721C2CA7359800CD5C86 /* DiscoverCellType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverCellType.swift; sourceTree = "<group>"; };
+		F54E721E2CA749AA00CD5C86 /* DiscoverCollectionViewController+Categories.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DiscoverCollectionViewController+Categories.swift"; sourceTree = "<group>"; };
 		F55449442B75935F00F68AE9 /* AppSettings+ImportUserDefaults.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AppSettings+ImportUserDefaults.swift"; sourceTree = "<group>"; };
 		F555980A2C50242800C02EEB /* VideoExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoExporter.swift; sourceTree = "<group>"; };
 		F555980E2C503F1700C02EEB /* AnimatedShareImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimatedShareImageView.swift; sourceTree = "<group>"; };
@@ -7730,6 +7732,7 @@
 				F5BA5C992C7F701900BDA5B9 /* DiscoverCollectionViewController.swift */,
 				F51D3A0B2CA62D3C000F3B78 /* DiscoverCollectionViewController+Search.swift */,
 				F5BA5C9D2C81254300BDA5B9 /* DiscoverCollectionViewController+DiscoverDelegate.swift */,
+				F54E721E2CA749AA00CD5C86 /* DiscoverCollectionViewController+Categories.swift */,
 				F5BA5C9B2C80F38200BDA5B9 /* UIViewControllerContentConfiguration.swift */,
 			);
 			name = Discovery;
@@ -9749,6 +9752,7 @@
 				FFC293992B6173400059F3BB /* IAPTypes.swift in Sources */,
 				8B67A26929A7D8690076886D /* PodcastCarouselView.swift in Sources */,
 				C76400552A0EDFB90092A74B /* UserInfo.swift in Sources */,
+				F54E721F2CA749AA00CD5C86 /* DiscoverCollectionViewController+Categories.swift in Sources */,
 				46C3D556275EA6C400DDE116 /* DiscoverEpisodeViewModel.swift in Sources */,
 				BD054A7A1E3EDEB300D9195B /* SharedConstants.swift in Sources */,
 				C72CED36289DB8690017883A /* AppDelegate+Analytics.swift in Sources */,

--- a/podcasts/Array+DiscoverItem.swift
+++ b/podcasts/Array+DiscoverItem.swift
@@ -1,13 +1,18 @@
 import PocketCastsServer
 
 extension Array<DiscoverItem> {
-    func makeDataSourceSnapshot(region: String, itemFilter: (DiscoverItem) -> Bool) -> NSDiffableDataSourceSnapshot<Int, DiscoverItem> {
-        var snapshot = NSDiffableDataSourceSnapshot<Int, DiscoverItem>()
+    func makeDataSourceSnapshot(region: String, selectedCategory: DiscoverCategory?, itemFilter: (DiscoverItem) -> Bool) -> NSDiffableDataSourceSnapshot<Int, DiscoverCellType.ItemType> {
+        var snapshot = NSDiffableDataSourceSnapshot<Int, DiscoverCellType.ItemType>()
 
-        let section = 0
-        snapshot.appendSections([section])
         let items = filter({ (itemFilter($0)) && $0.regions.contains(region) })
-        snapshot.appendItems(items)
+
+        let models = items.map { item in
+            let selectedCategory = item.cellType() != .categoriesSelector ? selectedCategory : nil
+            return DiscoverCellModel(item: item, region: region, selectedCategory: selectedCategory)
+        }
+
+        snapshot.appendSections([0])
+        snapshot.appendItems(models)
 
         return snapshot
     }

--- a/podcasts/Categories/CategoriesSelectorViewController.swift
+++ b/podcasts/Categories/CategoriesSelectorViewController.swift
@@ -53,8 +53,10 @@ class CategoriesSelectorViewController: ThemedHostingController<CategoriesSelect
         }
         view.backgroundColor = nil
 
-        observable.$selectedCategory.sink { [weak self] category in
-            guard let item = observable.item else { return }
+        self.observable.$selectedCategory
+            .delay(for: .milliseconds(20), scheduler: DispatchQueue.main)
+            .sink { [weak self] category in
+            guard let item = self?.observable.item else { return }
             self?.delegate?.showExpanded(item: item, category: category)
         }.store(in: &cancellables)
     }

--- a/podcasts/CategoryPodcastsViewController.swift
+++ b/podcasts/CategoryPodcastsViewController.swift
@@ -31,7 +31,7 @@ class CategoryPodcastsViewController: PCViewController, UITableViewDelegate, UIT
     private var podcasts = [DiscoverPodcast]()
     private var promotion: DiscoverCategoryPromotion?
     fileprivate var region: String?
-    
+
     init(category: DiscoverCategory? = nil, region: String?, skipCount: Int = 0) {
         self.category = category
         self.region = region

--- a/podcasts/CategoryPodcastsViewController.swift
+++ b/podcasts/CategoryPodcastsViewController.swift
@@ -22,18 +22,21 @@ class CategoryPodcastsViewController: PCViewController, UITableViewDelegate, UIT
 
     fileprivate var item: DiscoverItem?
 
-    fileprivate var category: DiscoverCategory
+    fileprivate var category: DiscoverCategory? {
+        didSet {
+            title = category?.name?.localized
+        }
+    }
     private var skipCount: Int
     private var podcasts = [DiscoverPodcast]()
     private var promotion: DiscoverCategoryPromotion?
     fileprivate var region: String?
-    init(category: DiscoverCategory, region: String?, skipCount: Int = 0) {
+    
+    init(category: DiscoverCategory? = nil, region: String?, skipCount: Int = 0) {
         self.category = category
         self.region = region
         self.skipCount = skipCount
         super.init(nibName: "CategoryPodcastsViewController", bundle: nil)
-
-        title = category.name?.localized
     }
 
     @available(*, unavailable)
@@ -96,7 +99,7 @@ class CategoryPodcastsViewController: PCViewController, UITableViewDelegate, UIT
         if let cell = tableView.cellForRow(at: indexPath) as? DiscoverPodcastTableCell {
             let podcast = podcasts[indexPath.row]
 
-            let categoryName = category.name ?? "unknown"
+            let categoryName = category?.name ?? "unknown"
             let listUuid = "category-\(categoryName.lowercased())-\(region ?? "unknown")"
 
             delegate.show(discoverPodcast: podcast, placeholderImage: cell.podcastImage.image, isFeatured: false, listUuid: listUuid)
@@ -123,7 +126,7 @@ class CategoryPodcastsViewController: PCViewController, UITableViewDelegate, UIT
     // MARK: - Loading
 
     private func loadPodcasts() {
-        guard let delegate = delegate, let source = delegate.replaceRegionCode(string: category.source) else { return }
+        guard let delegate = delegate, let category, let source = delegate.replaceRegionCode(string: category.source) else { return }
         if loadingIndicator.isAnimating || podcasts.count > 0 { return }
 
         noNetworkView.isHidden = true

--- a/podcasts/CategoryPodcastsViewController.xib
+++ b/podcasts/CategoryPodcastsViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23094" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22685"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23084"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -20,7 +20,7 @@
             <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="65" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="Yvg-p2-keL" customClass="CategoryPodcastsTable" customModule="podcasts" customModuleProvider="target">
+                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" scrollEnabled="NO" style="plain" separatorStyle="default" rowHeight="65" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="Yvg-p2-keL" customClass="CategoryPodcastsTable" customModule="podcasts" customModuleProvider="target">
                     <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                     <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <connections>

--- a/podcasts/CountryChooserViewController.swift
+++ b/podcasts/CountryChooserViewController.swift
@@ -4,6 +4,7 @@ import UIKit
 class CountryChooserViewController: PCViewController, UITableViewDataSource, UITableViewDelegate {
     private static let cellId = "CountryCell"
 
+    var changed: ((String) -> Void)?
     var regions = [DiscoverRegion]()
     var selectedRegion = ""
 
@@ -52,6 +53,7 @@ class CountryChooserViewController: PCViewController, UITableViewDataSource, UIT
         selectedRegion = region.code
         Settings.setDiscoverRegion(region: selectedRegion)
         countriesTable.reloadData()
+        changed?(selectedRegion)
     }
 
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {

--- a/podcasts/CountrySummaryViewController.swift
+++ b/podcasts/CountrySummaryViewController.swift
@@ -46,6 +46,9 @@ class CountrySummaryViewController: UIViewController, DiscoverSummaryProtocol {
 
     @objc private func changeCountryTapped() {
         let countryChooser = CountryChooserViewController()
+        countryChooser.changed = { [weak self] region in
+            self?.updateRegion(region)
+        }
         let regions = Array(serverRegions().values.map { $0 })
         countryChooser.regions = regions.sorted(by: { region1, region2 -> Bool in
             region1.name.localized.compare(region2.name.localized) == .orderedAscending

--- a/podcasts/DiscoverCellType.swift
+++ b/podcasts/DiscoverCellType.swift
@@ -21,7 +21,7 @@ enum DiscoverCellType: CaseIterable {
 
     typealias ItemType = DiscoverCellModel
 
-    func viewController(in region: String, for category: DiscoverCategory?) -> (UIViewController & DiscoverSummaryProtocol) {
+    func viewController(in region: String) -> (UIViewController & DiscoverSummaryProtocol) {
         switch self {
         case .categoriesSelector:
             CategoriesSelectorViewController()
@@ -42,7 +42,7 @@ enum DiscoverCellType: CaseIterable {
         case .singleEpisode:
             SingleEpisodeViewController()
         case .categoryPodcasts:
-            CategoryPodcastsViewController(category: category!, region: region)
+            CategoryPodcastsViewController(region: region)
         }
     }
 
@@ -51,7 +51,7 @@ enum DiscoverCellType: CaseIterable {
 
             let existingViewController = (cell.contentConfiguration as? UIViewControllerContentConfiguration)?.viewController as? (UIViewController & DiscoverSummaryProtocol)
 
-            let vc = existingViewController ?? viewController(in: item.region, for: item.selectedCategory)
+            let vc = existingViewController ?? viewController(in: item.region)
 
             if existingViewController == nil {
                 cell.contentConfiguration = UIViewControllerContentConfiguration(viewController: vc)

--- a/podcasts/DiscoverCellType.swift
+++ b/podcasts/DiscoverCellType.swift
@@ -1,6 +1,12 @@
 import PocketCastsServer
 import PocketCastsUtils
 
+struct DiscoverCellModel: Hashable {
+    let item: DiscoverItem
+    let region: String
+    let selectedCategory: DiscoverCategory?
+}
+
 enum DiscoverCellType: CaseIterable {
     case categoriesSelector
     case featuredSummary
@@ -11,8 +17,11 @@ enum DiscoverCellType: CaseIterable {
     case networkSummary
     case categorySummary
     case singleEpisode
+    case categoryPodcasts
 
-    func viewController(in region: String) -> (UIViewController & DiscoverSummaryProtocol) {
+    typealias ItemType = DiscoverCellModel
+
+    func viewController(in region: String, for category: DiscoverCategory?) -> (UIViewController & DiscoverSummaryProtocol) {
         switch self {
         case .categoriesSelector:
             CategoriesSelectorViewController()
@@ -32,22 +41,24 @@ enum DiscoverCellType: CaseIterable {
             CategorySummaryViewController(regionCode: region)
         case .singleEpisode:
             SingleEpisodeViewController()
+        case .categoryPodcasts:
+            CategoryPodcastsViewController(category: category!, region: region)
         }
     }
 
-    func createCellRegistration(region: String, delegate: DiscoverDelegate) -> UICollectionView.CellRegistration<UICollectionViewCell, DiscoverItem> {
-        return UICollectionView.CellRegistration<UICollectionViewCell, DiscoverItem> { cell, indexPath, item in
+    func createCellRegistration(delegate: DiscoverDelegate) -> UICollectionView.CellRegistration<UICollectionViewCell, ItemType> {
+        return UICollectionView.CellRegistration<UICollectionViewCell, ItemType> { cell, indexPath, item in
 
             let existingViewController = (cell.contentConfiguration as? UIViewControllerContentConfiguration)?.viewController as? (UIViewController & DiscoverSummaryProtocol)
 
-            let vc = existingViewController ?? viewController(in: region)
+            let vc = existingViewController ?? viewController(in: item.region, for: item.selectedCategory)
 
             if existingViewController == nil {
                 cell.contentConfiguration = UIViewControllerContentConfiguration(viewController: vc)
             }
 
             vc.registerDiscoverDelegate(delegate)
-            vc.populateFrom(item: item, region: region, category: nil)
+            vc.populateFrom(item: item.item, region: item.region, category: item.selectedCategory)
         }
     }
 }
@@ -75,6 +86,8 @@ extension DiscoverItem {
             return .singleEpisode
         case ("episode_list", "collection", "plain_list"):
             return .collectionSummary
+        case ("category_podcast_list", _, _):
+            return .categoryPodcasts
         default:
             FileLog.shared.addMessage("Unknown Discover Item: \(type ?? "unknown") \(summaryStyle ?? "unknown")")
             assertionFailure("Unknown Discover Item: \(type ?? "unknown") \(summaryStyle ?? "unknown")")

--- a/podcasts/DiscoverCollectionViewController+Categories.swift
+++ b/podcasts/DiscoverCollectionViewController+Categories.swift
@@ -18,7 +18,7 @@ extension DiscoverCollectionViewController {
             newLayout = discoverLayout
         }
 
-        populateFrom(discoverLayout: newLayout, shouldInclude: {
+        populateFrom(discoverLayout: newLayout, selectedCategory: category, shouldInclude: {
             ($0.categoryID == category?.id) || items.contains($0)
         })
     }
@@ -28,7 +28,7 @@ extension DiscoverCollectionViewController {
         let popularID = "category-popular-\(category.id ?? 0)"
 
         // Only add if we haven't already added
-        guard layout?.layout?.contains(where: { $0.id == popularID }) == false else { return layout }
+        guard let layout, layout.layout?.contains(where: { $0.id == popularID }) == false else { return layout }
 
         let source = replaceRegionCode(string: category.source)
 
@@ -39,6 +39,8 @@ extension DiscoverCollectionViewController {
             title = L10n.mostPopular
         }
 
+        let regions = layout.regions?.map({ $0.key }) ?? []
+
         let item = DiscoverItem(
             id: popularID,
             title: title,
@@ -46,12 +48,16 @@ extension DiscoverCollectionViewController {
             summaryStyle: "large_list",
             summaryItemCount: Constants.popularItemsCount,
             source: source,
-            regions: layout!.regions!.map({ $0.key }),
+            regions: regions,
             categoryID: category.id
         )
 
         var newLayout = layout
-        newLayout?.layout?.insert(item, at: layout?.layout?.startIndex.advanced(by: 1) ?? 0)
+        newLayout.layout?.insert(item, at: layout.layout?.startIndex.advanced(by: 1) ?? 0)
+
+        let categoryListItem = DiscoverItem(id: "category-\(category.id ?? 0)", title: category.name, type: "category_podcast_list", source: category.source, regions: regions, categoryID: category.id)
+        newLayout.layout?.append(categoryListItem)
+
         return newLayout
     }
 }

--- a/podcasts/DiscoverCollectionViewController+Categories.swift
+++ b/podcasts/DiscoverCollectionViewController+Categories.swift
@@ -1,0 +1,57 @@
+import PocketCastsServer
+
+extension DiscoverCollectionViewController {
+    private enum Constants {
+        static let popularItemsCount = 5
+    }
+
+    /// Reloads discover, keeping the items listed in `exclude`
+    /// - Parameters:
+    ///   - items: Items to exclude from the reload process. These items will REMAIN in Discover
+    ///   - category: The `DiscoverCategory` to add to the layout. This is sort of an artifical `DiscoverLayout`.
+    func reload(except items: [DiscoverItem], category: DiscoverCategory?) {
+        let newLayout: DiscoverLayout?
+
+        if let category {
+            newLayout = modified(layout: discoverLayout, for: category, with: items)
+        } else {
+            newLayout = discoverLayout
+        }
+
+        populateFrom(discoverLayout: newLayout, shouldInclude: {
+            ($0.categoryID == category?.id) || items.contains($0)
+        })
+    }
+
+    private func modified(layout: DiscoverLayout?, for category: DiscoverCategory, with items: [DiscoverItem]) -> DiscoverLayout? {
+
+        let popularID = "category-popular-\(category.id ?? 0)"
+
+        // Only add if we haven't already added
+        guard layout?.layout?.contains(where: { $0.id == popularID }) == false else { return layout }
+
+        let source = replaceRegionCode(string: category.source)
+
+        let title: String
+        if let name = category.name {
+            title = L10n.mostPopularWithName(name)
+        } else {
+            title = L10n.mostPopular
+        }
+
+        let item = DiscoverItem(
+            id: popularID,
+            title: title,
+            type: "podcast_list",
+            summaryStyle: "large_list",
+            summaryItemCount: Constants.popularItemsCount,
+            source: source,
+            regions: layout!.regions!.map({ $0.key }),
+            categoryID: category.id
+        )
+
+        var newLayout = layout
+        newLayout?.layout?.insert(item, at: layout?.layout?.startIndex.advanced(by: 1) ?? 0)
+        return newLayout
+    }
+}

--- a/podcasts/DiscoverCollectionViewController+DiscoverDelegate.swift
+++ b/podcasts/DiscoverCollectionViewController+DiscoverDelegate.swift
@@ -2,6 +2,14 @@ import PocketCastsServer
 import PocketCastsDataModel
 
 extension DiscoverCollectionViewController: DiscoverDelegate {
+    func invalidate(item: PocketCastsServer.DiscoverItem) {
+        let context = UICollectionViewLayoutInvalidationContext()
+        let item = dataSource.snapshot().itemIdentifiers.first(where: { $0.item == item })!
+        let indexPath = dataSource!.indexPath(for: item)!
+        context.invalidateItems(at: [indexPath])
+        collectionView.collectionViewLayout.invalidateLayout(with: context)
+    }
+
     func showExpanded(item: PocketCastsServer.DiscoverItem, category: PocketCastsServer.DiscoverCategory?) {
         if let category {
             if let categoryId = category.id, let categoryName = category.name, let discoverLayout {

--- a/podcasts/DiscoverCollectionViewController+DiscoverDelegate.swift
+++ b/podcasts/DiscoverCollectionViewController+DiscoverDelegate.swift
@@ -3,7 +3,15 @@ import PocketCastsDataModel
 
 extension DiscoverCollectionViewController: DiscoverDelegate {
     func showExpanded(item: PocketCastsServer.DiscoverItem, category: PocketCastsServer.DiscoverCategory?) {
-        //TODO: Implement this in a separate PR
+        if let category {
+            if let categoryId = category.id, let categoryName = category.name, let discoverLayout {
+                let currentRegion = Settings.discoverRegion(discoverLayout: discoverLayout)
+                Analytics.track(.discoverCategoryShown, properties: ["name": categoryName, "region": currentRegion, "id": categoryId])
+            }
+            reload(except: [item], category: category)
+        } else {
+            reload(except: [item], category: nil)
+        }
     }
 
     func show(podcastInfo: PodcastInfo, placeholderImage: UIImage?, isFeatured: Bool, listUuid: String?) {

--- a/podcasts/DiscoverCollectionViewController+DiscoverDelegate.swift
+++ b/podcasts/DiscoverCollectionViewController+DiscoverDelegate.swift
@@ -4,8 +4,11 @@ import PocketCastsDataModel
 extension DiscoverCollectionViewController: DiscoverDelegate {
     func invalidate(item: PocketCastsServer.DiscoverItem) {
         let context = UICollectionViewLayoutInvalidationContext()
-        let item = dataSource.snapshot().itemIdentifiers.first(where: { $0.item == item })!
-        let indexPath = dataSource!.indexPath(for: item)!
+        let item = dataSource.snapshot().itemIdentifiers.first(where: { $0.item == item })
+        guard let item,
+              let indexPath = dataSource?.indexPath(for: item) else {
+            return
+        }
         context.invalidateItems(at: [indexPath])
         collectionView.collectionViewLayout.invalidateLayout(with: context)
     }

--- a/podcasts/DiscoverCollectionViewController+Search.swift
+++ b/podcasts/DiscoverCollectionViewController+Search.swift
@@ -86,7 +86,13 @@ extension DiscoverCollectionViewController: PCSearchBarDelegate {
 
 extension DiscoverCollectionViewController {
     @objc private func chartRegionDidChange() {
-        reloadData()
+        reloadData { [weak self] in
+            guard let self else { return }
+            if let item = dataSource.snapshot().itemIdentifiers.last,
+               let lastIndexPath = dataSource.indexPath(for: item) {
+                collectionView.scrollToItem(at: lastIndexPath, at: .top, animated: true)
+            }
+        }
     }
 
     @objc private func checkForScrollTap(_ notification: Notification) {

--- a/podcasts/DiscoverCollectionViewController.swift
+++ b/podcasts/DiscoverCollectionViewController.swift
@@ -89,10 +89,6 @@ class DiscoverCollectionViewController: PCViewController {
         if let snapshot {
             dataSource.apply(snapshot)
         }
-
-        let context = UICollectionViewLayoutInvalidationContext()
-        context.invalidateSupplementaryElements(ofKind: UICollectionView.elementKindSectionFooter, at: [IndexPath(row: 0, section: 0)])
-        collectionView.collectionViewLayout.invalidateLayout(with: context)
     }
 
     private func showPageLoading() {

--- a/podcasts/DiscoverCollectionViewController.swift
+++ b/podcasts/DiscoverCollectionViewController.swift
@@ -40,6 +40,7 @@ class DiscoverCollectionViewController: PCViewController {
         setupCollectionView()
         setupSearchBar()
 
+        configureDataSource()
         reloadData()
 
         setupMiniPlayerObservers()
@@ -65,7 +66,7 @@ class DiscoverCollectionViewController: PCViewController {
         }
     }
 
-    private func populateFrom(discoverLayout: DiscoverLayout?, shouldInclude: ((DiscoverItem) -> Bool)? = nil) {
+    func populateFrom(discoverLayout: DiscoverLayout?, shouldInclude: ((DiscoverItem) -> Bool)? = nil) {
         loadingContent = false
 
         guard let discoverLayout, let items = discoverLayout.layout, let _ = discoverLayout.regions, items.count > 0 else {
@@ -78,8 +79,6 @@ class DiscoverCollectionViewController: PCViewController {
         }
 
         self.discoverLayout = discoverLayout
-        configureDataSource()
-        collectionView.collectionViewLayout = createCompositionalLayout(with: discoverLayout)
 
         let currentRegion = Settings.discoverRegion(discoverLayout: discoverLayout)
         let snapshot = discoverLayout.layout?.makeDataSourceSnapshot(region: currentRegion, itemFilter: itemFilter)
@@ -100,7 +99,7 @@ class DiscoverCollectionViewController: PCViewController {
 // MARK: - Collection View
 extension DiscoverCollectionViewController {
     private func setupCollectionView() {
-        let layout = createCompositionalLayout(with: discoverLayout)
+        let layout = createCompositionalLayout()
         collectionView.collectionViewLayout = layout
         collectionView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(collectionView)
@@ -142,7 +141,7 @@ extension DiscoverCollectionViewController {
         }
     }
 
-    private func createCompositionalLayout(with layout: DiscoverLayout?) -> UICollectionViewCompositionalLayout {
+    private func createCompositionalLayout() -> UICollectionViewCompositionalLayout {
         return UICollectionViewCompositionalLayout { (sectionIndex: Int,
                                                       layoutEnvironment: NSCollectionLayoutEnvironment) -> NSCollectionLayoutSection? in
             let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),
@@ -152,11 +151,7 @@ extension DiscoverCollectionViewController {
             let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),
                                                    heightDimension: .estimated(100))
             let group: NSCollectionLayoutGroup
-            if #available(iOS 16, *) {
-                group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, repeatingSubitem: item, count: layout?.layout?.count ?? 0)
-            } else {
-                group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, subitems: layout?.layout?.map({ _ in item }) ?? [])
-            }
+            group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, subitems: [item])
 
             let section = NSCollectionLayoutSection(group: group)
 

--- a/podcasts/DiscoverCollectionViewController.swift
+++ b/podcasts/DiscoverCollectionViewController.swift
@@ -57,13 +57,14 @@ class DiscoverCollectionViewController: PCViewController {
         miniPlayerStatusDidChange()
     }
 
-    func reloadData() {
+    func reloadData(completion: (() -> Void)? = nil) {
         showPageLoading()
 
         DiscoverServerHandler.shared.discoverPage { [weak self] discoverLayout, _ in
             DispatchQueue.main.async {
                 guard let self else { return }
                 self.populateFrom(discoverLayout: discoverLayout)
+                completion?()
             }
         }
     }

--- a/podcasts/DiscoverSummaryProtocol.swift
+++ b/podcasts/DiscoverSummaryProtocol.swift
@@ -24,4 +24,6 @@ protocol DiscoverDelegate: AnyObject {
     func show(discoverEpisode: DiscoverEpisode, podcast: Podcast)
 
     func failedToLoadEpisode()
+
+    func invalidate(item: DiscoverItem)
 }

--- a/podcasts/DiscoverViewController+DiscoverDelegate.swift
+++ b/podcasts/DiscoverViewController+DiscoverDelegate.swift
@@ -3,6 +3,10 @@ import PocketCastsDataModel
 import PocketCastsServer
 
 extension DiscoverViewController: DiscoverDelegate {
+    func invalidate(item: PocketCastsServer.DiscoverItem) {
+        // No-op for this older implementation.
+    }
+
     func showExpanded(item: PocketCastsServer.DiscoverItem, category: PocketCastsServer.DiscoverCategory?) {
         if let category {
             if let categoryId = category.id, let categoryName = category.name, let discoverLayout {

--- a/podcasts/LargeListSummaryViewController.swift
+++ b/podcasts/LargeListSummaryViewController.swift
@@ -148,7 +148,7 @@ class LargeListSummaryViewController: DiscoverPeekViewController, DiscoverSummar
     func populateFrom(item: DiscoverItem, region: String?, category: DiscoverCategory?) {
         podcasts = []
         collectionView.reloadData()
-        
+
         guard let source = item.source else { return }
         guard let title = item.title?.localized else { return }
 

--- a/podcasts/LargeListSummaryViewController.swift
+++ b/podcasts/LargeListSummaryViewController.swift
@@ -146,6 +146,9 @@ class LargeListSummaryViewController: DiscoverPeekViewController, DiscoverSummar
     // MARK: - Populate From Data
 
     func populateFrom(item: DiscoverItem, region: String?, category: DiscoverCategory?) {
+        podcasts = []
+        collectionView.reloadData()
+        
         guard let source = item.source else { return }
         guard let title = item.title?.localized else { return }
 

--- a/podcasts/SmallPagedListSummaryViewController.swift
+++ b/podcasts/SmallPagedListSummaryViewController.swift
@@ -159,6 +159,9 @@ class SmallPagedListSummaryViewController: DiscoverPeekViewController, GridLayou
     // MARK: - DiscoverSummaryProtocol
 
     func populateFrom(item: DiscoverItem, region: String?, category: DiscoverCategory?) {
+        podcasts = []
+        self.collectionView.reloadData()
+
         guard let source = delegate?.replaceRegionCode(string: item.source), let title = item.title?.localized else { return }
 
         self.item = item

--- a/podcasts/ThemeableCollectionView.swift
+++ b/podcasts/ThemeableCollectionView.swift
@@ -37,6 +37,7 @@ class ThemeableCollectionView: UICollectionView, AutoScrollCollectionViewDelegat
     var timer: Timer?
 
     func initializeAutoScrollTimer() {
+        timer?.invalidate()
         timer = Timer.scheduledTimer(timeInterval: 3.0, target: self, selector: #selector(scrolltoNextItem), userInfo: nil, repeats: true)
     }
 


### PR DESCRIPTION
| 📘 Part of: #2104 |
|:---:|

Adds Category and Region switching functionality.

https://github.com/user-attachments/assets/23ff750c-413d-4819-b392-57130fd3fb5a

## To test

1. Enable the `discoverCollectionView` feature flag
2. Restart the app
3. Navigate to Discover
4. Scroll around and ensure everything on the main screen works
5. Try changing the region in the footer at the bottom. This should update the `Popular in ...` section.
6. Scroll up to the top
7. Try navigating between Categories by tapping the pills at the top. Verify the following:
    - Region switching footer should be hidden in these section
    - Animation should be relatively smooth, fading between sections

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
