### PR TITLE
Discover Collection View: Loading states

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1691,6 +1691,7 @@
 		F5AD9C4D2C3C705200A01896 /* AudioWaveformView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5AD9C4C2C3C705200A01896 /* AudioWaveformView.swift */; };
 		F5B312B42BF5B6D400290696 /* FirebaseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5B312B32BF5B6D400290696 /* FirebaseManager.swift */; };
 		F5B6F0DF2C18DF0900AF5150 /* AudioUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5B6F0DD2C18DF0900AF5150 /* AudioUtilsTests.swift */; };
+		F5B6FDAD2CADFEFB00356909 /* ContentUnavailableConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5B6FDAC2CADFEF200356909 /* ContentUnavailableConfiguration.swift */; };
 		F5BA5C9A2C7F701900BDA5B9 /* DiscoverCollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BA5C992C7F701900BDA5B9 /* DiscoverCollectionViewController.swift */; };
 		F5BA5C9C2C80F38200BDA5B9 /* UIViewControllerContentConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BA5C9B2C80F38200BDA5B9 /* UIViewControllerContentConfiguration.swift */; };
 		F5BA5C9E2C81254300BDA5B9 /* DiscoverCollectionViewController+DiscoverDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BA5C9D2C81254300BDA5B9 /* DiscoverCollectionViewController+DiscoverDelegate.swift */; };
@@ -3607,6 +3608,7 @@
 		F5AD9C4C2C3C705200A01896 /* AudioWaveformView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioWaveformView.swift; sourceTree = "<group>"; };
 		F5B312B32BF5B6D400290696 /* FirebaseManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseManager.swift; sourceTree = "<group>"; };
 		F5B6F0DD2C18DF0900AF5150 /* AudioUtilsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AudioUtilsTests.swift; sourceTree = "<group>"; };
+		F5B6FDAC2CADFEF200356909 /* ContentUnavailableConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentUnavailableConfiguration.swift; sourceTree = "<group>"; };
 		F5BA5C992C7F701900BDA5B9 /* DiscoverCollectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverCollectionViewController.swift; sourceTree = "<group>"; };
 		F5BA5C9B2C80F38200BDA5B9 /* UIViewControllerContentConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewControllerContentConfiguration.swift; sourceTree = "<group>"; };
 		F5BA5C9D2C81254300BDA5B9 /* DiscoverCollectionViewController+DiscoverDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DiscoverCollectionViewController+DiscoverDelegate.swift"; sourceTree = "<group>"; };
@@ -5119,6 +5121,7 @@
 		BD2A49E31701A66E00C2F192 /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				F5B6FDAC2CADFEF200356909 /* ContentUnavailableConfiguration.swift */,
 				10DFE9352C5A8D1300957D0A /* ABTest */,
 				C7811D812A9008F500FC68B4 /* Unlockable */,
 				C7BDECAC2A15311000BECF02 /* Haptics */,
@@ -9371,6 +9374,7 @@
 				8BF622FF2C529F3C00D10F57 /* ChampionView.swift in Sources */,
 				408B932C216EFD9B00B57B78 /* TextEntryCell.swift in Sources */,
 				BDF9DDD91B8AD29C00E77B35 /* TimeSlider.swift in Sources */,
+				F5B6FDAD2CADFEFB00356909 /* ContentUnavailableConfiguration.swift in Sources */,
 				8B4881E929A3AE6D00E7C016 /* SearchHistoryView.swift in Sources */,
 				C7BDECAB2A15310800BECF02 /* SwiftUI+Accessibility.swift in Sources */,
 				403B5AFE2179670F00821A54 /* MediaFilterOverlayController.swift in Sources */,

--- a/podcasts/Array+DiscoverItem.swift
+++ b/podcasts/Array+DiscoverItem.swift
@@ -1,14 +1,14 @@
 import PocketCastsServer
 
 extension Array<DiscoverItem> {
-    func makeDataSourceSnapshot(region: String, selectedCategory: DiscoverCategory?, itemFilter: (DiscoverItem) -> Bool) -> NSDiffableDataSourceSnapshot<Int, DiscoverCellType.ItemType> {
-        var snapshot = NSDiffableDataSourceSnapshot<Int, DiscoverCellType.ItemType>()
+    func makeDataSourceSnapshot(region: String, selectedCategory: DiscoverCategory?, itemFilter: (DiscoverItem) -> Bool) -> NSDiffableDataSourceSnapshot<Int, DiscoverCollectionViewController.Item> {
+        var snapshot = NSDiffableDataSourceSnapshot<Int, DiscoverCollectionViewController.Item>()
 
         let items = filter({ (itemFilter($0)) && $0.regions.contains(region) })
 
         let models = items.map { item in
             let selectedCategory = item.cellType() != .categoriesSelector ? selectedCategory : nil
-            return DiscoverCellModel(item: item, region: region, selectedCategory: selectedCategory)
+            return DiscoverCollectionViewController.Item.item(DiscoverCellModel(item: item, region: region, selectedCategory: selectedCategory))
         }
 
         snapshot.appendSections([0])

--- a/podcasts/ContentUnavailableConfiguration.swift
+++ b/podcasts/ContentUnavailableConfiguration.swift
@@ -1,0 +1,76 @@
+import SwiftUI
+
+@available(iOS 16, *)
+// Many of these can be replaced with UIContentUnavailableConfigurations in iOS 17
+struct ContentUnavailableConfiguration {
+    static func loading() -> UIContentConfiguration {
+        UIHostingConfiguration {
+            LoadingView().environmentObject(Theme.sharedTheme)
+        }
+    }
+
+    static func noNetwork(tryAgainHandler: @escaping () -> Void) -> UIContentConfiguration {
+        UIHostingConfiguration {
+            NoNetworkView(tryAgainHandler: tryAgainHandler).environmentObject(Theme.sharedTheme)
+        }
+    }
+
+    static func noResults() -> UIContentConfiguration {
+        UIHostingConfiguration {
+            NoResultsView().environmentObject(Theme.sharedTheme)
+        }
+    }
+}
+
+struct LoadingView: View {
+    @EnvironmentObject private var theme: Theme
+    var body: some View {
+        VStack {
+            ProgressView()
+                .progressViewStyle(CircularProgressViewStyle())
+                .padding()
+                .tint(theme.primaryIcon01)
+        }
+    }
+}
+
+struct NoNetworkView: View {
+    let tryAgainHandler: () -> Void
+
+    @EnvironmentObject private var theme: Theme
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Image("discover_nointernet", label: Text("No Internet"))
+            VStack(spacing: 10) {
+                Text(L10n.discoverUnableToLoad)
+                    .font(Font.system(size: 17))
+                Text(L10n.checkInternetConnection)
+                    .font(Font.system(size: 14))
+            }
+            .foregroundStyle(theme.primaryText01)
+            Button(L10n.tryAgain) {
+                tryAgainHandler()
+            }
+            .font(Font.system(size: 15))
+            .foregroundStyle(theme.primaryInteractive01)
+        }
+    }
+}
+
+struct NoResultsView: View {
+    @EnvironmentObject private var theme: Theme
+
+    var body: some View {
+        VStack(spacing: 12) {
+            Image("discover_noresult", label: Text("No Results"))
+            VStack(spacing: 10) {
+                Text(L10n.discoverNoPodcastsFound)
+                    .font(Font.system(size: 17))
+                Text(L10n.discoverNoPodcastsFoundMsg)
+                    .font(Font.system(size: 14))
+            }
+            .foregroundStyle(theme.primaryText01)
+        }
+    }
+}

--- a/podcasts/DiscoverCollectionViewController+DiscoverDelegate.swift
+++ b/podcasts/DiscoverCollectionViewController+DiscoverDelegate.swift
@@ -4,7 +4,13 @@ import PocketCastsDataModel
 extension DiscoverCollectionViewController: DiscoverDelegate {
     func invalidate(item: PocketCastsServer.DiscoverItem) {
         let context = UICollectionViewLayoutInvalidationContext()
-        let item = dataSource.snapshot().itemIdentifiers.first(where: { $0.item == item })
+        let item = dataSource.snapshot().itemIdentifiers.first(where: {
+            if case .item(let item) = $0 {
+                item == item
+            } else {
+                false
+            }
+        })
         guard let item,
               let indexPath = dataSource?.indexPath(for: item) else {
             return

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -408,6 +408,8 @@ internal enum L10n {
   internal static var changePasswordLengthError: String { return L10n.tr("Localizable", "change_password_length_error") }
   /// Chapters
   internal static var chapters: String { return L10n.tr("Localizable", "chapters") }
+  /// Please check your Internet connection
+  internal static var checkInternetConnection: String { return L10n.tr("Localizable", "check_internet_connection") }
   /// %1$@ Podcasts Chosen
   internal static func chosenPodcastsPluralFormat(_ p1: Any) -> String {
     return L10n.tr("Localizable", "chosen_podcasts_plural_format", String(describing: p1))
@@ -736,6 +738,8 @@ internal enum L10n {
   internal static var discoverSponsored: String { return L10n.tr("Localizable", "discover_sponsored") }
   /// Trending
   internal static var discoverTrending: String { return L10n.tr("Localizable", "discover_trending") }
+  /// Unable to load Discover
+  internal static var discoverUnableToLoad: String { return L10n.tr("Localizable", "discover_unable_to_load") }
   /// Done
   internal static var done: String { return L10n.tr("Localizable", "done") }
   /// Download

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -571,6 +571,12 @@
 /* Informative label letting the users know that the displayed podcast is a featured new podcast. */
 "discover_fresh_pick" = "FRESH PICK";
 
+/* Informative label letting users know when the Discover page has failed to load due to a network error. */
+"discover_unable_to_load" = "Unable to load Discover";
+
+/* A description and call to action to check your internet connection state when content has failed to load. */
+"check_internet_connection" = "Please check your Internet connection";
+
 /* Informational title when the search succeeds but returns no results. */
 "discover_no_podcasts_found" = "No podcasts found";
 


### PR DESCRIPTION
| 📘 Part of: #2104 |
|:---:|

Adds loading indicator, No Results, and Network Failure views:

| Loading | No Results | Network Failure |
| -- | -- | -- |
| ![Simulator Screenshot - iPhone 16 - 2024-10-02 at 22 56 08](https://github.com/user-attachments/assets/06a45c6f-0b9e-4a87-a77c-6691bde7e739) | ![Simulator Screenshot - iPhone 16 - 2024-10-02 at 22 52 29](https://github.com/user-attachments/assets/e3c9b3bd-3c1f-45a1-b3ff-c5b5c828dc1c) | ![Simulator Screenshot - iPhone 16 - 2024-10-02 at 22 52 00](https://github.com/user-attachments/assets/f42e5507-ac70-4575-96b4-0f10e379168c) |

I added several new SwiftUI views with `UIContentConfiguration`s similar to those in `UIContentUnavailableConfiguration`. These aren't completely reusable since the text isn't configurable but I'd rather add this later when needed.

New SwiftUI views:
* `LoadingView`
* `NoNetworkView`
* `NoResultsView`

New `ContentUnavailableConfiguration` with static methods for:
* `loading`
* `noNetwork`
* `noResults`

## To test

* Enable the `discoverCollectionView` feature flag
* Throttle network to see the loading spinner or apply [this patch](https://github.com/user-attachments/files/17239371/discover_loading.patch)
* Block the request to `https://static.pocketcasts.com/discover/ios/content_v2.json` or Apply [this patch](https://github.com/user-attachments/files/17239375/Discover_load_failed.patch) to see the Network Failure view
* Apply [this patch](https://github.com/user-attachments/files/17239369/discover_no_results.patch) to see the Empty Results view
* Try switching themes with any of these views

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
