### PR TITLE
Enable `discoverCollectionView` feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 7.75
 -----
-
+- Refactors the Discover view to improve impressions tracking [#2104](https://github.com/Automattic/pocket-casts-ios/issues/2104)
 
 7.74
 -----

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -191,7 +191,7 @@ public enum FeatureFlag: String, CaseIterable {
         case .syncStats:
             true
         case .discoverCollectionView:
-            false
+            true
         case .playerIsReadyToPlay:
             true
         case .listeningHistorySearch:


### PR DESCRIPTION
| 📘 Part of: #2104 |
|:---:|

Enables the `discoverCollectionView` feature flag

## To test

* Navigate to "Discover" and make sure everything works as expected
* Disable the `discoverCollectionView` feature flag + restart the app
* Navigate to "Discover" and make sure everything works as expected (just to make sure the old version works)

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
