### PR TITLE
Discover Collection View: Call appearance methods on cells

### DIFF
--- a/podcasts/DiscoverCellType.swift
+++ b/podcasts/DiscoverCellType.swift
@@ -58,7 +58,6 @@ enum DiscoverCellType: CaseIterable {
             }
 
             vc.registerDiscoverDelegate(delegate)
-            vc.populateFrom(item: item.item, region: item.region, category: item.selectedCategory)
         }
     }
 }

--- a/podcasts/DiscoverCollectionViewController+Search.swift
+++ b/podcasts/DiscoverCollectionViewController+Search.swift
@@ -33,6 +33,27 @@ extension DiscoverCollectionViewController: UICollectionViewDelegate {
 
         searchController.parentScrollViewDidScroll(scrollView)
     }
+
+    func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
+        let item = dataSource.itemIdentifier(for: indexPath)
+
+        switch item {
+        case .item(let item):
+            let viewController = (cell.contentConfiguration as? UIViewControllerContentConfiguration)?.viewController as? DiscoverSummaryProtocol & UIViewController
+            viewController?.populateFrom(item: item.item, region: item.region, category: item.selectedCategory)
+            viewController?.beginAppearanceTransition(true, animated: false)
+            viewController?.endAppearanceTransition()
+        default:
+            ()
+        }
+    }
+
+    func collectionView(_ collectionView: UICollectionView, didEndDisplaying cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
+
+        let viewController = (cell.contentConfiguration as? UIViewControllerContentConfiguration)?.viewController
+        viewController?.beginAppearanceTransition(false, animated: false)
+        viewController?.endAppearanceTransition()
+    }
 }
 
 extension DiscoverCollectionViewController: PCSearchBarDelegate {

--- a/podcasts/DiscoverCollectionViewController.swift
+++ b/podcasts/DiscoverCollectionViewController.swift
@@ -129,6 +129,10 @@ class DiscoverCollectionViewController: PCViewController {
         snapshot.appendItems([CellType.noResults])
         dataSource.apply(snapshot)
     }
+
+    override var shouldAutomaticallyForwardAppearanceMethods: Bool {
+        return false
+    }
 }
 
 // MARK: - Collection View


### PR DESCRIPTION
| 📘 Part of: #2104 |
|:---:|

Modifies the Discover collection view cells to call `viewWillAppear`, `viewDidAppear`, `viewWillDisappear`, and `viewDidDisappear` (indirectly via `beginAppearanceTransition` and `endAppearanceTransition`) when the cell is shown or hidden according to UICollectionView delegate methods. This behavior reuses our existing code for each Discover view controller which loads content, triggers analytics events, and handles some timer additions (for the Featured Summary cell).

## To test

1. Enable `tracksLogging`
2. Navigate to Discover
3. Verify that the `discover_list_impression` event is called when a cell is _just_ about to be shown.
4. Ensure that cells are correctly loaded
5. Navigate to a category
6. Ensure that the `discover_featured_page_changed` event is not being logged while in a category
7. Close the category
8. Ensure that the `discover_featured_page_changed` event is logged again

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
