### PR TITLE
Referrals: Add analytics when share pass screen is dismissed

### DIFF
--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -732,6 +732,7 @@ enum AnalyticsEvent: String {
     case referralTooltipShow
     case referralTooltipTapped
     case referralShareScreenShown
+    case referralShareScreenDismissed
     case referralPassShared
     case referralClaimScreenShown
     case referralActivateTapped

--- a/podcasts/Referrals/ReferralSendPassView.swift
+++ b/podcasts/Referrals/ReferralSendPassView.swift
@@ -82,12 +82,14 @@ struct ReferralSendPassView: View {
             loadingView
         case .failed:
             ReferralsMessageView(title: L10n.referralsNotAvailableToSend, detail: L10n.pleaseTryAgainLater) {
+                Analytics.track(.referralShareScreenDismissed)
                 viewModel.onCloseTap?()
             }
         case .loaded:
             VStack {
                 HStack {
                     Button(action: {
+                        Analytics.track(.referralShareScreenDismissed)
                         viewModel.onCloseTap?()
                     }, label: {
                         Image("close").foregroundColor(Color.white)


### PR DESCRIPTION
| 📘 Part of: #2083  |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
Adds a  new track event when the Referrals Send Pass screen is closed

## To test

1. Delete the app from the simulator if you already have it installed
2. Start the app
3. Ensure that you have the `referrals` FF enabled
4. Ensure that you have `tracks logging` enabled in the FF

### Share Guest Pass

1. Login with an account that has an Plus or Patron active
2. Go to Profilec
4. Tap on the gift icon on the top left.
6. Tap on Close button. Check event: `referral_share_screen_dismissed ` is show.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
