### PR TITLE
Add missing type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 7.74
 -----
 - Add Title episode sort options to iPhone app [2175](https://github.com/Automattic/pocket-casts-ios/pull/2175)
-- Add local search in listening history ([#2181](https://github.com/Automattic/pocket-casts-ios/issues/2181))
+- Add local search in listening history [#2181](https://github.com/Automattic/pocket-casts-ios/issues/2181)
+- Fix missing content type [#2241](https://github.com/Automattic/pocket-casts-ios/pull/2241)
 
 7.73
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 7.74
 -----
-- Add Title episode sort options to iPhone app [2175](https://github.com/Automattic/pocket-casts-ios/pull/2175)
+- Add Title episode sort options to iPhone app [#2175](https://github.com/Automattic/pocket-casts-ios/pull/2175)
 - Add local search in listening history [#2181](https://github.com/Automattic/pocket-casts-ios/issues/2181)
 - Fix missing content type [#2241](https://github.com/Automattic/pocket-casts-ios/pull/2241)
 

--- a/podcasts/FileTypeUtil.swift
+++ b/podcasts/FileTypeUtil.swift
@@ -30,6 +30,7 @@ class FileTypeUtil {
         else if type.contains("audio/wav") { return ".wav" }
         else if type.contains("audio/x-wav") { return ".wav" }
         else if type.contains("audio/x-m4a") { return ".m4a" }
+        else if type.contains("audio/m4a") { return ".m4a" }
         else if type.contains("audio/x-m4b") { return ".m4b" }
         else if type.contains("audio/x-m4p") { return ".m4p" }
 


### PR DESCRIPTION
This PR adds the `audio/m4a` to our FileTypeUtil.

## To test

- CI must be 🍏 
- Download this [episode](https://pca.st/ruiumpav)
- Make sure it plays

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
