### PR TITLE
[Widget] iOS 18: Now Playing Widget support Tint Color

### DIFF
--- a/WidgetExtension/Common/ArtworkViews.swift
+++ b/WidgetExtension/Common/ArtworkViews.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 
 struct LargeArtworkView: View {
+    @Environment(\.isAccentedRenderingMode) var isAccentedRenderingMode
+
     @State var imageData: Data?
     var size: CGFloat = 74
 
@@ -15,11 +17,13 @@ struct LargeArtworkView: View {
                     .frame(maxHeight: size)
                     .cornerRadius(9)
                     .secondaryShadow()
+                    .backwardWidgetAccentable(isAccentedRenderingMode)
             }
 
             if let imageData = imageData, let uiImage = UIImage(data: imageData) {
                 Image(uiImage: uiImage)
                     .resizable()
+                    .backwardWidgetFullColorRenderingMode()
                     .aspectRatio(1, contentMode: .fit)
                     .frame(maxHeight: size)
                     .cornerRadius(8)
@@ -29,6 +33,7 @@ struct LargeArtworkView: View {
             } else {
                 Image("no-podcast-artwork")
                     .resizable()
+                    .backwardWidgetFullColorRenderingMode()
                     .aspectRatio(1, contentMode: .fit)
                     .frame(maxHeight: size)
                     .cornerRadius(8)
@@ -41,6 +46,8 @@ struct LargeArtworkView: View {
 }
 
 struct SmallArtworkView: View {
+    @Environment(\.isAccentedRenderingMode) var isAccentedRenderingMode
+
     @State var imageData: Data?
     var body: some View {
         ZStack {
@@ -49,15 +56,18 @@ struct SmallArtworkView: View {
                 .aspectRatio(1, contentMode: .fit)
                 .cornerRadius(5)
                 .secondaryShadow()
+                .backwardWidgetAccentable(isAccentedRenderingMode)
             if let imageData = imageData, let uiImage = UIImage(data: imageData) {
                 Image(uiImage: uiImage)
                     .resizable()
+                    .backwardWidgetFullColorRenderingMode()
                     .aspectRatio(1, contentMode: .fit)
                     .cornerRadius(4)
                     .artworkShadow()
             } else {
                 Image("no-podcast-artwork")
                     .resizable()
+                    .backwardWidgetFullColorRenderingMode()
                     .aspectRatio(1, contentMode: .fit)
                     .cornerRadius(4)
                     .artworkShadow()

--- a/WidgetExtension/Common/Widget+Accentable.swift
+++ b/WidgetExtension/Common/Widget+Accentable.swift
@@ -1,0 +1,57 @@
+import SwiftUI
+import WidgetKit
+
+extension View {
+    @ViewBuilder
+    func backwardWidgetAccentable(_ accentable: Bool = true) -> some View {
+        if #available(iOS 16.0, *) {
+            self.widgetAccentable(accentable)
+        } else {
+            self
+        }
+    }
+}
+
+extension Image {
+    @ViewBuilder
+    func backwardWidgetAccentedRenderingMode(_ isAccentedRenderingMode: Bool = true) -> some View {
+        if #available(iOS 18.0, *) {
+            self.widgetAccentedRenderingMode(isAccentedRenderingMode ? .accented : .fullColor)
+        }
+        else {
+            self
+        }
+    }
+
+    @ViewBuilder
+    func backwardWidgetAccentedDesaturatedRenderingMode() -> some View {
+        if #available(iOS 18.0, *) {
+            self.widgetAccentedRenderingMode(.accentedDesaturated)
+        }
+        else {
+            self
+        }
+    }
+
+    @ViewBuilder
+    func backwardWidgetFullColorRenderingMode() -> some View {
+        backwardWidgetAccentedRenderingMode(false)
+    }
+}
+
+extension EnvironmentValues {
+    var isAccentedRenderingMode: Bool {
+        get {
+            if #available(iOS 16.0, *) {
+                widgetRenderingMode == .accented
+            }
+            else {
+                self[AccentedWidgetKey.self]
+            }
+        }
+    }
+}
+
+private enum AccentedWidgetKey: EnvironmentKey {
+    static let defaultValue = false
+}

--- a/WidgetExtension/Now Playing/NowPlayingEntryView.swift
+++ b/WidgetExtension/Now Playing/NowPlayingEntryView.swift
@@ -9,12 +9,19 @@ struct NowPlayingWidgetEntryView: View {
     @Environment(\.widgetFamily) var family
 
     @Environment(\.colorScheme) var colorScheme
+
+    @Environment(\.isAccentedRenderingMode) var isAccentedRenderingMode
+
     var widgetColorSchemeLight: PCWidgetColorScheme
     var widgetColorSchemeDark: PCWidgetColorScheme
     var widgetColorScheme: PCWidgetColorScheme {
         get {
             colorScheme == .dark ? widgetColorSchemeDark : widgetColorSchemeLight
         }
+    }
+
+    private var iconAssetName: String {
+        isAccentedRenderingMode ? PCWidgetColorScheme.boldNowPlaying.iconAssetName : widgetColorScheme.iconAssetName
     }
 
     var body: some View {
@@ -35,6 +42,7 @@ struct NowPlayingWidgetEntryView: View {
                 ZStack {
                     Image(CommonWidgetHelper.loadAppIconName())
                         .resizable()
+                        .backwardWidgetAccentedDesaturatedRenderingMode()
                 }
                 .widgetURL(URL(string: "pktc://last_opened"))
                 .clearBackground()
@@ -46,7 +54,7 @@ struct NowPlayingWidgetEntryView: View {
 
     private func smallWidget(playingEpisode: WidgetEpisode) -> some View {
         ZStack {
-            if showsWidgetBackground {
+            if showsWidgetBackground, !isAccentedRenderingMode {
                 Rectangle().fill(widgetColorScheme.bottomBackgroundColor)
             }
             VStack(alignment: .leading, spacing: 10) {
@@ -68,7 +76,7 @@ struct NowPlayingWidgetEntryView: View {
 
     private func mediumWidget(playingEpisode: WidgetEpisode) -> some View {
         ZStack {
-            if showsWidgetBackground {
+            if showsWidgetBackground, !isAccentedRenderingMode {
                 Rectangle().fill(widgetColorScheme.bottomBackgroundColor)
             }
 
@@ -82,8 +90,10 @@ struct NowPlayingWidgetEntryView: View {
                             .textCase(.uppercase)
                             .padding(topPadding)
                             .foregroundColor(widgetColorScheme.bottomTextColor.opacity(0.6))
+                            .backwardWidgetAccentable(isAccentedRenderingMode)
                         Spacer()
-                        Image(widgetColorScheme.iconAssetName)
+                        Image(iconAssetName)
+                            .backwardWidgetAccentedRenderingMode(isAccentedRenderingMode)
                             .frame(width: CommonWidgetHelper.iconSize, height: CommonWidgetHelper.iconSize)
                             .unredacted()
                     }
@@ -113,7 +123,8 @@ struct NowPlayingWidgetEntryView: View {
             LargeArtworkView(imageData: playingEpisode.imageData)
                 .frame(width: 64, height: 64)
             Spacer()
-            Image(widgetColorScheme.iconAssetName)
+            Image(iconAssetName)
+                .backwardWidgetAccentedRenderingMode(isAccentedRenderingMode)
                 .frame(width: CommonWidgetHelper.iconSize, height: CommonWidgetHelper.iconSize)
                 .unredacted()
         }
@@ -129,6 +140,7 @@ struct NowPlayingWidgetEntryView: View {
             .frame(height: 12, alignment: .center)
             .layoutPriority(1)
             .padding(episodeTitlePadding)
+            .backwardWidgetAccentable(isAccentedRenderingMode)
     }
 
     private func episodeTitle(playingEpisode: WidgetEpisode) -> some View {
@@ -140,6 +152,7 @@ struct NowPlayingWidgetEntryView: View {
             .frame(height: 12, alignment: .center)
             .layoutPriority(1)
             .padding(episodeTitlePadding)
+            .backwardWidgetAccentable(isAccentedRenderingMode)
     }
 
     @ViewBuilder
@@ -152,12 +165,14 @@ struct NowPlayingWidgetEntryView: View {
                         .font(.caption2)
                         .fontWeight(.bold)
                         .foregroundColor(widgetColorScheme.topButtonTextColor)
+                        .backwardWidgetAccentable(isAccentedRenderingMode)
                 } else {
                     Text(L10n.podcastTimeLeft(CommonWidgetHelper.durationString(duration: playingEpisode.duration)))
                         .font(.caption2)
                         .fontWeight(.bold)
                         .foregroundColor(widgetColorScheme.topButtonTextColor)
                         .layoutPriority(1)
+                        .backwardWidgetAccentable(isAccentedRenderingMode)
                 }
             }
             .toggleStyle(WidgetFirstEpisodePlayToggleStyle(colorScheme: widgetColorScheme))
@@ -182,7 +197,7 @@ struct NowPlayingWidgetEntryView: View {
 
     private var nothingPlayingMedium: some View {
         ZStack {
-            if showsWidgetBackground {
+            if showsWidgetBackground, !isAccentedRenderingMode {
                 Rectangle().fill(widgetColorScheme.bottomBackgroundColor)
             }
 
@@ -193,7 +208,8 @@ struct NowPlayingWidgetEntryView: View {
                 VStack(alignment: .leading) {
                     HStack(alignment: .top) {
                         Spacer()
-                        Image(widgetColorScheme.iconAssetName)
+                        Image(iconAssetName)
+                            .backwardWidgetAccentedRenderingMode(isAccentedRenderingMode)
                             .frame(width: CommonWidgetHelper.iconSize, height: CommonWidgetHelper.iconSize)
                             .unredacted()
                     }
@@ -223,6 +239,7 @@ struct NowPlayingWidgetEntryView: View {
                 .frame(height: 38, alignment: .center)
                 .layoutPriority(1)
                 .padding(episodeTitlePadding)
+                .backwardWidgetAccentable(isAccentedRenderingMode)
             Text(L10n.widgetsDiscoverPromptMsg)
                 .font(.caption2)
                 .fontWeight(.medium)
@@ -230,6 +247,7 @@ struct NowPlayingWidgetEntryView: View {
                 .lineLimit(2)
                 .padding(bottomTextPadding)
                 .layoutPriority(1)
+                .backwardWidgetAccentable(isAccentedRenderingMode)
         }
     }
 
@@ -241,8 +259,10 @@ struct NowPlayingWidgetEntryView: View {
                         .opacity(0.5)
                     Spacer()
                     Image("logo-transparent")
+                        .backwardWidgetAccentedRenderingMode(isAccentedRenderingMode)
                         .frame(width: CommonWidgetHelper.iconSize, height: CommonWidgetHelper.iconSize)
-                }.padding(topPadding)
+                }
+                .padding(topPadding)
             }
             nothingPlayingText
         }

--- a/WidgetExtension/Up Next/EpisodeView.swift
+++ b/WidgetExtension/Up Next/EpisodeView.swift
@@ -58,6 +58,8 @@ struct EpisodeView: View {
 struct WidgetFirstEpisodePlayToggleStyle: ToggleStyle {
     let colorScheme: PCWidgetColorScheme
 
+    @Environment(\.isAccentedRenderingMode) var isAccentedRenderingMode
+
     func makeBody(configuration: Configuration) -> some View {
         HStack(spacing: 0) {
             Group {
@@ -65,10 +67,12 @@ struct WidgetFirstEpisodePlayToggleStyle: ToggleStyle {
                 Image("icon-pause")
                     .resizable()
                     .foregroundStyle(colorScheme.topButtonTextColor)
+                    .backwardWidgetAccentable(isAccentedRenderingMode)
                 :
                 Image("icon-play")
                     .resizable()
                     .foregroundStyle(colorScheme.topButtonTextColor)
+                    .backwardWidgetAccentable(isAccentedRenderingMode)
             }
             .frame(width: 28, height: 28)
 
@@ -81,6 +85,8 @@ struct WidgetFirstEpisodePlayToggleStyle: ToggleStyle {
         .background(
             RoundedRectangle(cornerRadius: 100)
                 .foregroundColor(colorScheme.topButtonBackgroundColor)
+                .backwardWidgetAccentable(isAccentedRenderingMode)
+                .opacity(isAccentedRenderingMode ? 0.2 : 1.0)
         )
     }
 }

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		107836232C5CDD5000DA3FF0 /* GiveRatingsWhatsNewHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 107836222C5CDD5000DA3FF0 /* GiveRatingsWhatsNewHeader.swift */; };
 		107836262C62816900DA3FF0 /* ABTestProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 107836252C62816900DA3FF0 /* ABTestProviderTests.swift */; };
 		107AF94C2C77947600DD0FA7 /* PlusPaywallReviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 107AF94B2C77947600DD0FA7 /* PlusPaywallReviews.swift */; };
+		10980CAE2CB6DD55002C8779 /* Widget+Accentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10980CAD2CB6DD55002C8779 /* Widget+Accentable.swift */; };
 		10A4F7532C515D720084D783 /* KidsProfile.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 10A4F7522C515D720084D783 /* KidsProfile.xcassets */; };
 		10A4F7562C5162C90084D783 /* KidsProfileBannerTableCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10A4F7552C5162C90084D783 /* KidsProfileBannerTableCell.swift */; };
 		10A4F7582C52635F0084D783 /* KidsProfileBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10A4F7572C52635F0084D783 /* KidsProfileBannerView.swift */; };
@@ -1969,6 +1970,7 @@
 		107836222C5CDD5000DA3FF0 /* GiveRatingsWhatsNewHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiveRatingsWhatsNewHeader.swift; sourceTree = "<group>"; };
 		107836252C62816900DA3FF0 /* ABTestProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ABTestProviderTests.swift; sourceTree = "<group>"; };
 		107AF94B2C77947600DD0FA7 /* PlusPaywallReviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlusPaywallReviews.swift; sourceTree = "<group>"; };
+		10980CAD2CB6DD55002C8779 /* Widget+Accentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Widget+Accentable.swift"; sourceTree = "<group>"; };
 		10A4F7522C515D720084D783 /* KidsProfile.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = KidsProfile.xcassets; sourceTree = "<group>"; };
 		10A4F7552C5162C90084D783 /* KidsProfileBannerTableCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = KidsProfileBannerTableCell.swift; path = "Kids Profile/KidsProfileBannerTableCell.swift"; sourceTree = "<group>"; };
 		10A4F7572C52635F0084D783 /* KidsProfileBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = KidsProfileBannerView.swift; path = "Kids Profile/KidsProfileBannerView.swift"; sourceTree = "<group>"; };
@@ -5474,6 +5476,7 @@
 				4090978625236B0400CED68C /* CommonWidgetHelper.swift */,
 				8B7065A22AB0D5D200FE04CB /* View+clearBackground.swift */,
 				8B7065A42AB0E14200FE04CB /* Widget+contentMarginsDisabled.swift */,
+				10980CAD2CB6DD55002C8779 /* Widget+Accentable.swift */,
 				4520AC282C1B7CE70043E701 /* PCWidgetColorScheme.swift */,
 			);
 			path = Common;
@@ -9122,6 +9125,7 @@
 				BD422EC426840EDD0078B799 /* WidgetData.swift in Sources */,
 				8B71829128CF755D00B98F04 /* UpNextLockScreenWidget.swift in Sources */,
 				8B7065A32AB0D5D200FE04CB /* View+clearBackground.swift in Sources */,
+				10980CAE2CB6DD55002C8779 /* Widget+Accentable.swift in Sources */,
 				8BC060112AB35D1200A4FEC6 /* View+if.swift in Sources */,
 				BD422ED226841BF10078B799 /* HungryForMoreView.swift in Sources */,
 				4031466D252568970085E76B /* WidgetEpisode.swift in Sources */,


### PR DESCRIPTION
Ref #2212 

This PR fixes the accent color when a user select the tint color in iOS 18

| No Play Short | No Play Medium | No Play Medium No BG |
| -------- | ------- | ------- |
| ![Simulator Screenshot - iPhone 16 - 2024-10-09 at 16 38 01](https://github.com/user-attachments/assets/da0adf78-6047-4783-9f18-c86d93829cd0) |  ![Simulator Screenshot - iPhone 16 - 2024-10-09 at 16 38 15](https://github.com/user-attachments/assets/676ffb51-2492-4812-b5ad-4bd161270027) | ![Simulator Screenshot - iPhone 16 - 2024-10-09 at 16 40 58](https://github.com/user-attachments/assets/06d2ea54-4928-466d-b03f-386c060d51ed) |
| Now Play Short | Now Play Medium |
| ![Simulator Screenshot - iPhone 16 - 2024-10-09 at 16 41 52](https://github.com/user-attachments/assets/f0b95b12-3f27-41ac-b131-173b3a595d7d) |  ![Simulator Screenshot - iPhone 16 - 2024-10-09 at 16 42 03](https://github.com/user-attachments/assets/c36156d1-cb5d-426f-a4af-7f28089aaa8c) |


## To test

- CI must be 🟢 
- Try the Now Playing widget with all the appearances, light, dark and tint

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
