### PR TITLE
[Widget] iOS 18: Up Next Widget support Tint Color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add Title episode sort options to iPhone app [#2175](https://github.com/Automattic/pocket-casts-ios/pull/2175)
 - Add local search in listening history [#2181](https://github.com/Automattic/pocket-casts-ios/issues/2181)
 - Fix missing content type [#2241](https://github.com/Automattic/pocket-casts-ios/pull/2241)
+- Fix tint mode in iOS 18 widgets [#2212](https://github.com/Automattic/pocket-casts-ios/issues/2212)
 
 7.73
 -----

--- a/WidgetExtension/Up Next/EpisodeView.swift
+++ b/WidgetExtension/Up Next/EpisodeView.swift
@@ -9,6 +9,7 @@ struct EpisodeView: View {
 
     @Environment(\.dynamicTypeSize) var typeSize
     @Environment(\.widgetColorScheme) var colorScheme
+    @Environment(\.isAccentedRenderingMode) var isAccentedRenderingMode
 
     var body: some View {
         let textColor = isFirstEpisode ? colorScheme.topTextColor : colorScheme.bottomTextColor
@@ -24,6 +25,7 @@ struct EpisodeView: View {
                         .foregroundColor(textColor)
                         .lineLimit(1)
                         .frame(maxWidth: .infinity, alignment: .leading)
+                        .backwardWidgetAccentable(isAccentedRenderingMode)
                     if isFirstEpisode, #available(iOS 17, *) {
                         Spacer()
                         Toggle(isOn: isPlaying, intent: PlayEpisodeIntent(episodeUuid: episode.episodeUuid)) {
@@ -31,6 +33,7 @@ struct EpisodeView: View {
                                 .font(.caption)
                                 .fontWeight(.medium)
                                 .foregroundColor(colorScheme.topButtonTextColor)
+                                .backwardWidgetAccentable(isAccentedRenderingMode)
                         }
                         .toggleStyle(WidgetFirstEpisodePlayToggleStyle(colorScheme: colorScheme))
                     } else {
@@ -39,6 +42,8 @@ struct EpisodeView: View {
                         topText
                             .font(.caption2)
                             .foregroundColor(textColor.opacity(0.6))
+                            .backwardWidgetAccentable(isAccentedRenderingMode)
+                            .opacity(isAccentedRenderingMode ? 0.6 : 1.0)
                     }
                 }
                 if !isFirstEpisode, #available(iOS 17, *) {
@@ -92,6 +97,7 @@ struct WidgetFirstEpisodePlayToggleStyle: ToggleStyle {
 }
 
 struct WidgetPlayToggleStyle: ToggleStyle {
+    @Environment(\.isAccentedRenderingMode) var isAccentedRenderingMode
     let colorScheme: PCWidgetColorScheme
 
     func makeBody(configuration: Configuration) -> some View {
@@ -100,14 +106,18 @@ struct WidgetPlayToggleStyle: ToggleStyle {
                 Circle()
                     .foregroundStyle(colorScheme.bottomButtonBackgroundColor)
                     .frame(width: 24, height: 24)
+                    .backwardWidgetAccentable(isAccentedRenderingMode)
+                    .opacity(isAccentedRenderingMode ? 0.2 : 1.0)
                 Group {
                     configuration.isOn ?
                     Image("icon-pause")
                         .resizable()
+                        .backwardWidgetAccentable(isAccentedRenderingMode)
                         .foregroundStyle(colorScheme.bottomButtonTextColor)
                     :
                     Image("icon-play")
                         .resizable()
+                        .backwardWidgetAccentable(isAccentedRenderingMode)
                         .foregroundStyle(colorScheme.bottomButtonTextColor)
                 }
                 .frame(width: 24, height: 24)

--- a/WidgetExtension/Up Next/HungryForMoreView.swift
+++ b/WidgetExtension/Up Next/HungryForMoreView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 struct HungryForMoreView: View {
     @Environment(\.widgetColorScheme) var colorScheme
+    @Environment(\.isAccentedRenderingMode) var isAccentedRenderingMode
 
     var body: some View {
         Link(destination: URL(string: "pktc://discover?source=widget")!) {
@@ -12,17 +13,21 @@ struct HungryForMoreView: View {
                     .fontWeight(.semibold)
                     .foregroundColor(colorScheme.bottomTextColor)
                     .lineLimit(1)
+                    .backwardWidgetAccentable(isAccentedRenderingMode)
                 Text(L10n.widgetsDiscoverPromptMsg)
                     .font(.caption2)
                     .foregroundColor(colorScheme.bottomTextColor.opacity(0.8))
                     .lineLimit(1)
-            }.offset(x: -8, y: 0)
+                    .backwardWidgetAccentable(isAccentedRenderingMode)
+            }
+            .offset(x: -8, y: 0)
         }
     }
 }
 
 struct HungryForMoreLargeView: View {
     @Environment(\.widgetColorScheme) var colorScheme
+    @Environment(\.isAccentedRenderingMode) var isAccentedRenderingMode
 
     var body: some View {
         Link(destination: URL(string: "pktc://discover?source=widget")!) {
@@ -32,10 +37,12 @@ struct HungryForMoreLargeView: View {
                     .fontWeight(.semibold)
                     .foregroundColor(colorScheme.bottomTextColor)
                     .lineLimit(1)
+                    .backwardWidgetAccentable(isAccentedRenderingMode)
                 Text(L10n.widgetsDiscoverPromptMsg)
                     .font(.caption2)
                     .foregroundColor(colorScheme.bottomTextColor.opacity(0.8))
                     .lineLimit(1)
+                    .backwardWidgetAccentable(isAccentedRenderingMode)
             }
         }
     }

--- a/WidgetExtension/Up Next/UpNextLargeWidgetView.swift
+++ b/WidgetExtension/Up Next/UpNextLargeWidgetView.swift
@@ -19,6 +19,7 @@ struct LargeUpNextWidgetView: View {
     @Binding var episodes: [WidgetEpisode]
     @Binding var isPlaying: Bool
     @Environment(\.widgetColorScheme) var colorScheme
+    @Environment(\.isAccentedRenderingMode) var isAccentedRenderingMode
 
     var body: some View {
         ZStack {
@@ -26,13 +27,17 @@ struct LargeUpNextWidgetView: View {
                 GeometryReader { geometry in
                     VStack(alignment: .leading, spacing: 0) {
                         ZStack {
-                            Rectangle().fill(colorScheme.topBackgroundColor)
+                            Rectangle()
+                                .fill(colorScheme.topBackgroundColor)
                                 .lightBackgroundShadow()
                                 .frame(width: .infinity, height: .infinity)
+                                .backwardWidgetAccentable(isAccentedRenderingMode)
+                                .opacity(isAccentedRenderingMode ? 0.1 : 1)
                             HStack(alignment: .top) {
                                 EpisodeView(episode: firstEpisode, topText: isPlaying ? Text(L10n.nowPlaying.localizedCapitalized) : Text(L10n.podcastTimeLeft(CommonWidgetHelper.durationString(duration: firstEpisode.duration))), isPlaying: isPlaying, isFirstEpisode: true)
                                 Spacer()
                                 Image(colorScheme.iconAssetName)
+                                    .backwardWidgetAccentedRenderingMode(isAccentedRenderingMode)
                                     .frame(width: CommonWidgetHelper.iconSize, height: CommonWidgetHelper.iconSize)
                                     .unredacted()
                             }
@@ -41,7 +46,10 @@ struct LargeUpNextWidgetView: View {
                         .frame(height: geometry.size.height * 82 / 345)
 
                         ZStack {
-                            Rectangle().fill(colorScheme.bottomBackgroundColor)
+                            if !isAccentedRenderingMode {
+                                Rectangle()
+                                    .fill(colorScheme.bottomBackgroundColor)
+                            }
 
                             VStack(alignment: .leading, spacing: 10) {
                                 if episodes.count > 1 {
@@ -81,6 +89,7 @@ struct LargeFilterView: View {
 
     @Environment(\.widgetColorScheme) var colorScheme
     @Environment(\.showsWidgetContainerBackground) var showsWidgetBackground
+    @Environment(\.isAccentedRenderingMode) var isAccentedRenderingMode
 
     var body: some View {
         guard episodes.first != nil else {
@@ -89,7 +98,7 @@ struct LargeFilterView: View {
 
         return AnyView(
             ZStack {
-                if showsWidgetBackground {
+                if showsWidgetBackground, !isAccentedRenderingMode {
                     Rectangle().fill(colorScheme.filterViewBackgroundColor)
                 }
                 VStack(alignment: .leading, spacing: 0) {
@@ -100,9 +109,11 @@ struct LargeFilterView: View {
                                 .fontWeight(.regular)
                                 .foregroundColor(colorScheme.filterViewTextColor)
                                 .frame(height: 18)
+                                .backwardWidgetAccentable(isAccentedRenderingMode)
                         }
                         Spacer()
                         Image(colorScheme.filterViewIconAssetName)
+                            .backwardWidgetAccentedRenderingMode(isAccentedRenderingMode)
                             .frame(width: CommonWidgetHelper.iconSize, height: CommonWidgetHelper.iconSize)
                             .unredacted()
                     }

--- a/WidgetExtension/Up Next/UpNextLargeWidgetView.swift
+++ b/WidgetExtension/Up Next/UpNextLargeWidgetView.swift
@@ -21,6 +21,10 @@ struct LargeUpNextWidgetView: View {
     @Environment(\.widgetColorScheme) var colorScheme
     @Environment(\.isAccentedRenderingMode) var isAccentedRenderingMode
 
+    private var iconAssetName: String {
+        isAccentedRenderingMode ? PCWidgetColorScheme.boldNowPlaying.iconAssetName : colorScheme.iconAssetName
+    }
+
     var body: some View {
         ZStack {
             if let firstEpisode = episodes.first {
@@ -36,7 +40,7 @@ struct LargeUpNextWidgetView: View {
                             HStack(alignment: .top) {
                                 EpisodeView(episode: firstEpisode, topText: isPlaying ? Text(L10n.nowPlaying.localizedCapitalized) : Text(L10n.podcastTimeLeft(CommonWidgetHelper.durationString(duration: firstEpisode.duration))), isPlaying: isPlaying, isFirstEpisode: true)
                                 Spacer()
-                                Image(colorScheme.iconAssetName)
+                                Image(iconAssetName)
                                     .backwardWidgetAccentedRenderingMode(isAccentedRenderingMode)
                                     .frame(width: CommonWidgetHelper.iconSize, height: CommonWidgetHelper.iconSize)
                                     .unredacted()

--- a/WidgetExtension/Up Next/UpNextMediumWidgetView.swift
+++ b/WidgetExtension/Up Next/UpNextMediumWidgetView.swift
@@ -26,6 +26,10 @@ struct MediumUpNextView: View {
     @Environment(\.widgetColorScheme) var colorScheme
     @Environment(\.isAccentedRenderingMode) var isAccentedRenderingMode
 
+    private var iconAssetName: String {
+        isAccentedRenderingMode ? PCWidgetColorScheme.boldNowPlaying.iconAssetName : colorScheme.iconAssetName
+    }
+
     var body: some View {
         GeometryReader { geometry in
             VStack(alignment: .leading, spacing: 0) {
@@ -38,7 +42,7 @@ struct MediumUpNextView: View {
                     HStack(alignment: .top) {
                         EpisodeView(episode: firstEpisode, topText: isPlaying ? Text(L10n.nowPlaying) : Text(L10n.podcastTimeLeft(CommonWidgetHelper.durationString(duration: firstEpisode.duration))), isPlaying: isPlaying, isFirstEpisode: true)
                         Spacer()
-                        Image(colorScheme.iconAssetName)
+                        Image(iconAssetName)
                             .backwardWidgetAccentedRenderingMode(isAccentedRenderingMode)
                             .frame(width: CommonWidgetHelper.iconSize, height: CommonWidgetHelper.iconSize)
                             .accessibility(hidden: true)

--- a/WidgetExtension/Up Next/UpNextMediumWidgetView.swift
+++ b/WidgetExtension/Up Next/UpNextMediumWidgetView.swift
@@ -24,17 +24,22 @@ struct MediumUpNextView: View {
     var secondEpisode: WidgetEpisode?
     var isPlaying: Bool
     @Environment(\.widgetColorScheme) var colorScheme
+    @Environment(\.isAccentedRenderingMode) var isAccentedRenderingMode
 
     var body: some View {
         GeometryReader { geometry in
             VStack(alignment: .leading, spacing: 0) {
                 ZStack {
-                    Rectangle().fill(colorScheme.topBackgroundColor)
+                    Rectangle()
+                        .fill(colorScheme.topBackgroundColor)
                         .lightBackgroundShadow()
+                        .backwardWidgetAccentable(isAccentedRenderingMode)
+                        .opacity(isAccentedRenderingMode ? 0.1 : 1)
                     HStack(alignment: .top) {
                         EpisodeView(episode: firstEpisode, topText: isPlaying ? Text(L10n.nowPlaying) : Text(L10n.podcastTimeLeft(CommonWidgetHelper.durationString(duration: firstEpisode.duration))), isPlaying: isPlaying, isFirstEpisode: true)
                         Spacer()
                         Image(colorScheme.iconAssetName)
+                            .backwardWidgetAccentedRenderingMode(isAccentedRenderingMode)
                             .frame(width: CommonWidgetHelper.iconSize, height: CommonWidgetHelper.iconSize)
                             .accessibility(hidden: true)
                             .unredacted()
@@ -55,7 +60,7 @@ struct MediumUpNextView: View {
                     }
                 }
                 .frame(width: geometry.size.width, height: geometry.size.height / 2)
-                .background(colorScheme.bottomBackgroundColor)
+                .background(colorScheme.bottomBackgroundColor.opacity(isAccentedRenderingMode ? 0.0 : 1))
             }
         }
     }
@@ -68,12 +73,13 @@ struct MediumFilterView: View {
 
     @Environment(\.widgetColorScheme) var colorScheme
     @Environment(\.showsWidgetContainerBackground) var showsWidgetBackground
+    @Environment(\.isAccentedRenderingMode) var isAccentedRenderingMode
 
     private let logoHeight: CGFloat = 28
 
     var body: some View {
         ZStack {
-            if showsWidgetBackground {
+            if showsWidgetBackground, !isAccentedRenderingMode {
                 Rectangle().fill(colorScheme.filterViewBackgroundColor)
             }
             VStack(alignment: .leading, spacing: 0) {
@@ -83,8 +89,10 @@ struct MediumFilterView: View {
                         .fontWeight(.regular)
                         .foregroundColor(colorScheme.filterViewTextColor)
                         .frame(height: 18)
+                        .backwardWidgetAccentable(isAccentedRenderingMode)
                     Spacer()
                     Image(colorScheme.filterViewIconAssetName)
+                        .backwardWidgetAccentedRenderingMode(isAccentedRenderingMode)
                         .frame(width: CommonWidgetHelper.iconSize, height: CommonWidgetHelper.iconSize)
                         .unredacted()
                 }

--- a/WidgetExtension/Up Next/UpNextWidgetEntryView.swift
+++ b/WidgetExtension/Up Next/UpNextWidgetEntryView.swift
@@ -5,6 +5,7 @@ struct UpNextWidgetEntryView: View {
     @State var entry: UpNextProvider.Entry
     @Environment(\.widgetFamily) var family
     @Environment(\.colorScheme) var colorScheme
+    @Environment(\.isAccentedRenderingMode) var isAccentedRenderingMode
     var widgetColorSchemeLight: PCWidgetColorScheme
     var widgetColorSchemeDark: PCWidgetColorScheme
     var widgetColorScheme: PCWidgetColorScheme {
@@ -29,8 +30,10 @@ struct UpNextWidgetEntryView: View {
                             .fontWeight(.regular)
                             .foregroundColor(widgetColorScheme.filterViewTextColor)
                             .lineLimit(1)
+                            .backwardWidgetAccentable(isAccentedRenderingMode)
                         Spacer()
                         Image(widgetColorScheme.filterViewIconAssetName)
+                            .backwardWidgetAccentedRenderingMode(isAccentedRenderingMode)
                             .frame(width: CommonWidgetHelper.iconSize, height: CommonWidgetHelper.iconSize, alignment: .topTrailing)
                             .accessibility(hidden: true)
                     }
@@ -47,7 +50,7 @@ struct UpNextWidgetEntryView: View {
                     Spacer()
                 }
                 .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity)
-                .background(widgetColorScheme.filterViewBackgroundColor)
+                .background(widgetColorScheme.filterViewBackgroundColor.opacity(isAccentedRenderingMode ? 0.0 : 1))
                 .widgetURL(URL(string: "pktc://last_opened"))
             }
         }


### PR DESCRIPTION
Fixes #2212 

This PR fixes the accent color when a user select the tint color in iOS 18

| Up Next no podcasts medium | Up Next no podcasts large |
| -------- | ------- |
| ![Simulator Screenshot - iPhone 16 - 2024-10-09 at 17 16 28](https://github.com/user-attachments/assets/4d43efd3-8f02-404f-b613-c1cdb1a61343) |  ![Simulator Screenshot - iPhone 16 - 2024-10-09 at 17 17 12](https://github.com/user-attachments/assets/eee85254-3b89-491d-805e-ae05ab3fa691) |
| Up Next medium | Up Next large |
| ![Simulator Screenshot - iPhone 16 - 2024-10-09 at 17 47 00](https://github.com/user-attachments/assets/6ea1e195-8aa7-4320-9cff-80690f0ba851) |  ![Simulator Screenshot - iPhone 16 - 2024-10-09 at 17 41 45](https://github.com/user-attachments/assets/ace89c80-06c7-49ac-8214-c1222c2ed66a) |
| Up Next Filter medium | Up Next Filter large |
| ![Simulator Screenshot - iPhone 16 - 2024-10-09 at 17 38 11](https://github.com/user-attachments/assets/1a8067be-bbde-4293-bc95-0c408461b961) |  ![Simulator Screenshot - iPhone 16 - 2024-10-09 at 17 45 57](https://github.com/user-attachments/assets/ebfdadcd-fd63-4acc-9816-4b45d914cbfb) |

## To test

- CI must be 🟢 
- Try the Now Playing widget with all the appearances, light, dark and tint

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
