### PR TITLE
Update transcript not available string

### DIFF
--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -3234,7 +3234,7 @@ internal enum L10n {
   internal static var transcriptErrorFailedToLoad: String { return L10n.tr("Localizable", "transcript_error_failed_to_load") }
   /// Sorry, but something went wrong while parsing this transcript
   internal static var transcriptErrorFailedToParse: String { return L10n.tr("Localizable", "transcript_error_failed_to_parse") }
-  /// Sorry, but a transcript is not available for this episode.
+  /// Sorry, but this episode has no transcript available
   internal static var transcriptErrorNotAvailable: String { return L10n.tr("Localizable", "transcript_error_not_available") }
   /// Sorry, but this transcript format is not supported: %1$@
   internal static func transcriptErrorNotSupported(_ p1: Any) -> String {

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4269,7 +4269,7 @@
 "kids_profile_submit_error" = "Something went wrong. Please try submitting your feedback again";
 
 /* Transcript error message when a transcript is not available*/
-"transcript_error_not_available" = "Sorry, but a transcript is not available for this episode.";
+"transcript_error_not_available" = "Sorry, but this episode has no transcript available";
 
 /* Transcript error message when transcript failed to load*/
 "transcript_error_failed_to_load" = "Sorry, but something went wrong while loading this transcript";


### PR DESCRIPTION
| 📘 Part of: #1848  |  <!-- project issue number, if applicable -->
|:---:|

Fixes #2251 <!-- issue number, if applicable -->

Update the transcript not available message.

<img src="https://github.com/user-attachments/assets/6552d199-3b5f-460d-88da-38da54b9fe70" width=320>

## To test

1. Start the app
2. Open an episode without a Transcript available. Ex: "The Daily"
3. Play the episode
4. Open the player full screen
5. Tap on the transcript icon
6. Check if the message match the one above.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
