### PR TITLE
Discover Collection View: Auto Layout & cell reuse warnings

### DIFF
--- a/podcasts/CollectionSummaryViewController.xib
+++ b/podcasts/CollectionSummaryViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23094" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="ipad11_0rounded" orientation="portrait" layout="fullscreen" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23084"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -67,7 +67,7 @@
                             <rect key="frame" x="16" y="32" width="382" height="254.5"/>
                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <constraints>
-                                <constraint firstAttribute="width" secondItem="eKY-wc-aIB" secondAttribute="height" multiplier="1.5" id="fjn-fq-xCz"/>
+                                <constraint firstAttribute="width" secondItem="eKY-wc-aIB" secondAttribute="height" multiplier="1.5" priority="999" id="fjn-fq-xCz"/>
                             </constraints>
                         </imageView>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BzE-oZ-KK2" customClass="ThemeableView" customModule="podcasts" customModuleProvider="target">
@@ -100,7 +100,7 @@
                                 <constraint firstItem="vyg-bv-c0j" firstAttribute="centerY" secondItem="BzE-oZ-KK2" secondAttribute="centerY" id="mBi-vQ-j7T"/>
                             </constraints>
                         </view>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="GUEST NAME" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Fz8-de-HrX" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" text="GUEST NAME" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Fz8-de-HrX" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
                             <rect key="frame" x="16" y="320.5" width="382" height="26.5"/>
                             <fontDescription key="fontDescription" type="boldSystem" pointSize="22"/>
                             <nil key="textColor"/>

--- a/podcasts/CountrySummaryViewController.xib
+++ b/podcasts/CountrySummaryViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23094" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23084"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -70,7 +70,7 @@
                 <constraint firstItem="sP1-02-h75" firstAttribute="centerX" secondItem="i5M-Pr-FkT" secondAttribute="centerX" id="a8R-CF-oSy"/>
                 <constraint firstItem="sP1-02-h75" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" constant="20" id="x9G-Aq-vQF"/>
                 <constraint firstAttribute="bottom" secondItem="WxJ-0n-BDv" secondAttribute="bottom" constant="20" id="y75-qi-HAh"/>
-                <constraint firstItem="WxJ-0n-BDv" firstAttribute="top" secondItem="sP1-02-h75" secondAttribute="bottom" constant="16" id="yYe-Hs-gR3"/>
+                <constraint firstItem="WxJ-0n-BDv" firstAttribute="top" secondItem="sP1-02-h75" secondAttribute="bottom" priority="999" constant="16" id="yYe-Hs-gR3"/>
             </constraints>
             <nil key="simulatedStatusBarMetrics"/>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>

--- a/podcasts/DiscoverCollectionViewController.swift
+++ b/podcasts/DiscoverCollectionViewController.swift
@@ -151,24 +151,24 @@ extension DiscoverCollectionViewController {
     }
 
     private func configureDataSource() {
-        let footerRegistration = UICollectionView.SupplementaryRegistration<UICollectionViewListCell>(elementKind: UICollectionView.elementKindSectionFooter) { [weak self] supplementaryView, elementKind, indexPath in
 
-            guard let self else { return }
+        let footerRegistrationCountrySummary = UICollectionView.SupplementaryRegistration<UICollectionViewListCell>(elementKind: UICollectionView.elementKindSectionFooter) { [weak self] supplementaryView, elementKind, indexPath in
+            guard let self = self else { return }
 
-            if selectedCategory == nil && discoverLayout != nil {
-                let countrySummary = CountrySummaryViewController()
-                countrySummary.discoverLayout = self.discoverLayout
-                countrySummary.registerDiscoverDelegate(self)
+            let countrySummary = CountrySummaryViewController()
+            countrySummary.discoverLayout = self.discoverLayout
+            countrySummary.registerDiscoverDelegate(self)
 
-                supplementaryView.contentConfiguration = UIViewControllerContentConfiguration(viewController: countrySummary)
-            } else {
-                if #available(iOS 16.0, *) {
-                    supplementaryView.contentConfiguration = UIHostingConfiguration {
-                        EmptyView()
-                    }
-                } else {
-                    supplementaryView.contentConfiguration = UIListContentConfiguration.plainFooter()
+            supplementaryView.contentConfiguration = UIViewControllerContentConfiguration(viewController: countrySummary)
+        }
+
+        let footerRegistrationEmpty = UICollectionView.SupplementaryRegistration<UICollectionViewListCell>(elementKind: UICollectionView.elementKindSectionFooter) { supplementaryView, elementKind, indexPath in
+            if #available(iOS 16.0, *) {
+                supplementaryView.contentConfiguration = UIHostingConfiguration {
+                    EmptyView()
                 }
+            } else {
+                supplementaryView.contentConfiguration = UIListContentConfiguration.plainFooter()
             }
         }
 
@@ -225,9 +225,17 @@ extension DiscoverCollectionViewController {
             }
         }
 
-        dataSource.supplementaryViewProvider = { collectionView, kind, indexPath in
-            return collectionView.dequeueConfiguredReusableSupplementary(using: footerRegistration,
-                                                                         for: indexPath)
+        dataSource.supplementaryViewProvider = { [weak self] collectionView, elementKind, indexPath in
+            guard let self = self else { return nil }
+
+            if elementKind == UICollectionView.elementKindSectionFooter {
+                if self.selectedCategory == nil && self.discoverLayout != nil {
+                    return collectionView.dequeueConfiguredReusableSupplementary(using: footerRegistrationCountrySummary, for: indexPath)
+                } else {
+                    return collectionView.dequeueConfiguredReusableSupplementary(using: footerRegistrationEmpty, for: indexPath)
+                }
+            }
+            return nil
         }
     }
 

--- a/podcasts/FeaturedSummaryViewController.xib
+++ b/podcasts/FeaturedSummaryViewController.xib
@@ -23,7 +23,7 @@
                     <rect key="frame" x="0.0" y="0.0" width="420" height="193"/>
                     <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <constraints>
-                        <constraint firstAttribute="height" constant="193" id="nYf-BO-wnO"/>
+                        <constraint firstAttribute="height" priority="999" constant="193" id="nYf-BO-wnO"/>
                     </constraints>
                     <collectionViewLayout key="collectionViewLayout" id="08u-0C-oHP" customClass="GridLayout" customModule="podcasts" customModuleProvider="target"/>
                     <connections>

--- a/podcasts/LargeListCell.xib
+++ b/podcasts/LargeListCell.xib
@@ -11,14 +11,14 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <collectionViewCell opaque="NO" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="LargeListCell" id="gTV-IL-0wX" customClass="LargeListCell" customModule="podcasts" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="160" height="250"/>
+            <rect key="frame" x="0.0" y="0.0" width="199" height="250"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
-                <rect key="frame" x="0.0" y="0.0" width="160" height="211"/>
+                <rect key="frame" x="0.0" y="0.0" width="199" height="250"/>
                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                 <subviews>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Podcast title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4Qw-eq-tYg" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                        <rect key="frame" x="0.0" y="168" width="160" height="20"/>
+                        <rect key="frame" x="0.0" y="207" width="199" height="20"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="20" id="spU-kL-e3s"/>
                         </constraints>
@@ -27,14 +27,14 @@
                         <nil key="highlightedColor"/>
                     </label>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nBx-mo-aDN" customClass="PodcastImageView" customModule="podcasts" customModuleProvider="target">
-                        <rect key="frame" x="0.0" y="0.0" width="160" height="160"/>
+                        <rect key="frame" x="0.0" y="0.0" width="199" height="199"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstAttribute="width" secondItem="nBx-mo-aDN" secondAttribute="height" multiplier="1:1" id="llg-HT-uWA"/>
+                            <constraint firstAttribute="width" secondItem="nBx-mo-aDN" secondAttribute="height" multiplier="1:1" priority="999" id="llg-HT-uWA"/>
                         </constraints>
                     </view>
                     <button opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1Gb-8A-zQV" customClass="BouncyButton" customModule="podcasts" customModuleProvider="target">
-                        <rect key="frame" x="128" y="128" width="28" height="28"/>
+                        <rect key="frame" x="167" y="167" width="28" height="28"/>
                         <color key="backgroundColor" red="0.60835868120000003" green="0.8194983602" blue="0.82352894539999999" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="28" id="6ES-gf-noE"/>
@@ -54,7 +54,7 @@
                         </connections>
                     </button>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" text="Author" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2wE-0A-zrE" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                        <rect key="frame" x="0.0" y="191" width="160" height="20"/>
+                        <rect key="frame" x="0.0" y="230" width="199" height="20"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="20" id="Nga-E5-dZf"/>
                         </constraints>
@@ -80,13 +80,14 @@
                 <constraint firstItem="1Gb-8A-zQV" firstAttribute="trailing" secondItem="nBx-mo-aDN" secondAttribute="trailing" constant="-4" id="nHw-ba-ihn"/>
                 <constraint firstItem="2wE-0A-zrE" firstAttribute="leading" secondItem="4Qw-eq-tYg" secondAttribute="leading" id="zFW-RE-G6q"/>
             </constraints>
+            <size key="customSize" width="199" height="250"/>
             <connections>
                 <outlet property="podcastAuthor" destination="2wE-0A-zrE" id="nPR-3i-RWZ"/>
                 <outlet property="podcastImage" destination="nBx-mo-aDN" id="CH0-cC-vIk"/>
                 <outlet property="podcastTitle" destination="4Qw-eq-tYg" id="Nfd-Qh-8gn"/>
                 <outlet property="subscribeButton" destination="1Gb-8A-zQV" id="0aA-kz-6Rh"/>
             </connections>
-            <point key="canvasLocation" x="137.59999999999999" y="136.28185907046478"/>
+            <point key="canvasLocation" x="168.80000000000001" y="135.832083958021"/>
         </collectionViewCell>
     </objects>
 </document>

--- a/podcasts/SmallPagedListSummaryViewController.xib
+++ b/podcasts/SmallPagedListSummaryViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23094" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23084"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -57,7 +57,7 @@
                     <rect key="frame" x="16" y="78.5" width="350" height="169"/>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <constraints>
-                        <constraint firstAttribute="height" constant="169" id="kCW-dW-QNU"/>
+                        <constraint firstAttribute="height" priority="999" constant="169" id="kCW-dW-QNU"/>
                     </constraints>
                     <collectionViewLayout key="collectionViewLayout" id="CM8-gK-Lhv" customClass="GridLayout" customModule="podcasts" customModuleProvider="target"/>
                     <connections>


### PR DESCRIPTION
| 📘 Part of: #2104 |
|:---:|

* Fixes issues with Auto Layout constraint warnings. In the collection view, the cell height is not immediately reflected, so constraints should be a little less strict. I've lowered the priority of some constraints to ensure the correct constraint breaks and these warnings are not shown.

* Fixes a warning about a reuse issue between with the Empty footer switching to the Country Summary footer.

## To test

* Navigate to the Discover tab
* Look for a unsatisfiable constraint warning or set a symbolic breakpoint on `UIViewAlertForUnsatisfiableConstraints`
* Look for this warning or set a symbolic breakpoint on `UIContentConfigurationAlertForReplacedContentView`:
```
Warning: You are setting a new content configuration to a cell that has an existing content configuration, but the existing content view does not support the new configuration. This means the existing content view must be replaced with a new content view created from the new configuration, instead of updating the existing content view directly, which is expensive. Use separate registrations or reuse identifiers for different types of cells to avoid this. Make a symbolic breakpoint at UIContentConfigurationAlertForReplacedContentView to catch this in the debugger.
Cell: <UICollectionViewListCell: 0x102342f20; frame = (0 4581; 393 26); layer = <CALayer: 0x6000002f5b40>>;
Existing content configuration: UIHostingConfiguration<EmptyView, EmptyView>(rootView: SwiftUI.EmptyView(), backgroundView: SwiftUI.EmptyView(), wantsBackground: false, margins: SwiftUI.OptionalEdgeInsets(top: nil, leading: nil, bottom: nil, trailing: nil), _minSize: (width: nil, height: nil), createsUIInteractions: true, disablesAnimatedSizeInvalidation: false);
New content configuration: podcasts.UIViewControllerContentConfiguration
```
* Scroll around and make sure nothing is cut off

### Check previous behavior
* Disable the `discoverCollectionView` feature flag
* Restart the app
* Visit Discover and ensure items are properly shown

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
