### PR TITLE
[Custom Playback Settings]  Feature Flag & Segmented Control

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -118,6 +118,10 @@ public enum FeatureFlag: String, CaseIterable {
     /// Use the Mimetype library to check the file mimetype
     case useMimetypePackage
 
+    /// Enable the Segmented Control into the Effects Player panel
+    /// to apply the Global or local settings
+    case customPlaybackSettings
+
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -198,6 +202,8 @@ public enum FeatureFlag: String, CaseIterable {
             true
         case .useMimetypePackage:
             true
+        case .customPlaybackSettings:
+            false
         }
     }
 

--- a/podcasts/EffectsViewController.swift
+++ b/podcasts/EffectsViewController.swift
@@ -131,15 +131,12 @@ class EffectsViewController: SimpleNotificationsViewController {
         }
     }
 
-    @IBOutlet weak var playbackSettingsSegmentedControl: CustomSegmentedControl! {
+    @IBOutlet weak var playbackSettingsSegmentedControl: UISegmentedControl! {
         didSet {
             playbackSettingsSegmentedControl.isHidden = !FeatureFlag.customPlaybackSettings.enabled
 
-            let firstAction = SegmentedAction(title: L10n.playbackEffectAllPodcasts)
-            let secondAction = SegmentedAction(title: L10n.playbackEffectThisPodcast)
-            playbackSettingsSegmentedControl.setActions([firstAction, secondAction])
-
-            playbackSettingsSegmentedControl.unselectedBgColor = UIColor.clear
+            playbackSettingsSegmentedControl.setTitle(L10n.playbackEffectAllPodcasts, forSegmentAt: 0)
+            playbackSettingsSegmentedControl.setTitle(L10n.playbackEffectThisPodcast, forSegmentAt: 1)
 
             playbackSettingsSegmentedControl.addTarget(self, action: #selector(playbackSettingsDestinationChanged), for: .valueChanged)
         }
@@ -268,7 +265,7 @@ class EffectsViewController: SimpleNotificationsViewController {
     }
 
     @objc private func playbackSettingsDestinationChanged() {
-        
+        // TO IMPLEMENT
     }
 
     @IBAction func volumeBoostChanged(_ sender: UISwitch) {
@@ -360,10 +357,13 @@ class EffectsViewController: SimpleNotificationsViewController {
         trimSilenceAmountControl.selectedBgColor = ThemeColor.playerContrast01()
         trimSilenceAmountControl.selectedItemColor = PlayerColorHelper.playerBackgroundColor01()
 
-        playbackSettingsSegmentedControl.lineColor = ThemeColor.playerContrast02()
-        playbackSettingsSegmentedControl.unselectedItemColor = ThemeColor.playerContrast01()
-        playbackSettingsSegmentedControl.selectedBgColor = ThemeColor.playerContrast01()
-        playbackSettingsSegmentedControl.selectedItemColor = PlayerColorHelper.playerBackgroundColor01()
+        playbackSettingsSegmentedControl.backgroundColor = ThemeColor.playerContrast06()
+        playbackSettingsSegmentedControl.selectedSegmentTintColor = ThemeColor.playerContrast01()
+
+        let normalAttribute = [NSAttributedString.Key.foregroundColor: ThemeColor.playerContrast02()]
+        playbackSettingsSegmentedControl.setTitleTextAttributes(normalAttribute, for: .normal)
+        let selectedAttribute = [NSAttributedString.Key.foregroundColor: PlayerColorHelper.playerBackgroundColor01()]
+        playbackSettingsSegmentedControl.setTitleTextAttributes(selectedAttribute, for: .selected)
 
         updateSpeedBtn()
 

--- a/podcasts/EffectsViewController.swift
+++ b/podcasts/EffectsViewController.swift
@@ -125,7 +125,12 @@ class EffectsViewController: SimpleNotificationsViewController {
             let highAction = SegmentedAction(title: TrimSilenceAmount.high.description)
             trimSilenceAmountControl.setActions([lowAction, mediumAction, highAction])
 
-            trimSilenceAmountControl.unselectedBgColor = UIColor.clear
+            if FeatureFlag.customPlaybackSettings.enabled {
+                trimSilenceAmountControl.backgroundColor = ThemeColor.playerContrast06()
+            } else {
+                trimSilenceAmountControl.backgroundColor = .clear
+                trimSilenceAmountControl.unselectedBgColor = .clear
+            }
 
             trimSilenceAmountControl.addTarget(self, action: #selector(trimSilenceAmountChanged), for: .valueChanged)
         }
@@ -352,18 +357,25 @@ class EffectsViewController: SimpleNotificationsViewController {
         volumeBoostSwitch.onTintColor = PlayerColorHelper.playerHighlightColor02(for: .dark)
         trimSilenceSwitch.onTintColor = PlayerColorHelper.playerHighlightColor02(for: .dark)
 
-        trimSilenceAmountControl.lineColor = ThemeColor.playerContrast02()
-        trimSilenceAmountControl.unselectedItemColor = ThemeColor.playerContrast01()
-        trimSilenceAmountControl.selectedBgColor = ThemeColor.playerContrast01()
-        trimSilenceAmountControl.selectedItemColor = PlayerColorHelper.playerBackgroundColor01()
+        if FeatureFlag.customPlaybackSettings.enabled {
+            trimSilenceAmountControl.lineColor = .clear
+            trimSilenceAmountControl.unselectedItemColor = ThemeColor.playerContrast02()
+            trimSilenceAmountControl.selectedBgColor = ThemeColor.playerContrast01()
+            trimSilenceAmountControl.selectedItemColor = PlayerColorHelper.playerBackgroundColor01()
 
-        playbackSettingsSegmentedControl.backgroundColor = ThemeColor.playerContrast06()
-        playbackSettingsSegmentedControl.selectedSegmentTintColor = ThemeColor.playerContrast01()
+            playbackSettingsSegmentedControl.backgroundColor = ThemeColor.playerContrast06()
+            playbackSettingsSegmentedControl.selectedSegmentTintColor = ThemeColor.playerContrast01()
 
-        let normalAttribute = [NSAttributedString.Key.foregroundColor: ThemeColor.playerContrast02()]
-        playbackSettingsSegmentedControl.setTitleTextAttributes(normalAttribute, for: .normal)
-        let selectedAttribute = [NSAttributedString.Key.foregroundColor: PlayerColorHelper.playerBackgroundColor01()]
-        playbackSettingsSegmentedControl.setTitleTextAttributes(selectedAttribute, for: .selected)
+            let normalAttribute = [NSAttributedString.Key.foregroundColor: ThemeColor.playerContrast02()]
+            playbackSettingsSegmentedControl.setTitleTextAttributes(normalAttribute, for: .normal)
+            let selectedAttribute = [NSAttributedString.Key.foregroundColor: PlayerColorHelper.playerBackgroundColor01()]
+            playbackSettingsSegmentedControl.setTitleTextAttributes(selectedAttribute, for: .selected)
+        } else {
+            trimSilenceAmountControl.lineColor = ThemeColor.playerContrast02()
+            trimSilenceAmountControl.unselectedItemColor = ThemeColor.playerContrast01()
+            trimSilenceAmountControl.selectedBgColor = ThemeColor.playerContrast01()
+            trimSilenceAmountControl.selectedItemColor = PlayerColorHelper.playerBackgroundColor01()
+        }
 
         updateSpeedBtn()
 

--- a/podcasts/EffectsViewController.swift
+++ b/podcasts/EffectsViewController.swift
@@ -135,13 +135,13 @@ class EffectsViewController: SimpleNotificationsViewController {
         didSet {
             playbackSettingsSegmentedControl.isHidden = !FeatureFlag.customPlaybackSettings.enabled
 
-            let firstAction = SegmentedAction(title: "All podcasts")
-            let secondAction = SegmentedAction(title: "This podcast")
+            let firstAction = SegmentedAction(title: L10n.playbackEffectAllPodcasts)
+            let secondAction = SegmentedAction(title: L10n.playbackEffectThisPodcast)
             playbackSettingsSegmentedControl.setActions([firstAction, secondAction])
 
             playbackSettingsSegmentedControl.unselectedBgColor = UIColor.clear
-            
-//            playbackSettingsSegmentedControl.addTarget(self, action: #selector(trimSilenceAmountChanged), for: .valueChanged)
+
+            playbackSettingsSegmentedControl.addTarget(self, action: #selector(playbackSettingsDestinationChanged), for: .valueChanged)
         }
     }
 
@@ -265,6 +265,10 @@ class EffectsViewController: SimpleNotificationsViewController {
 
         analyticsPlaybackHelper.currentSource = analyticsSource
         analyticsPlaybackHelper.trimSilenceAmountChanged(amount: amount)
+    }
+
+    @objc private func playbackSettingsDestinationChanged() {
+        
     }
 
     @IBAction func volumeBoostChanged(_ sender: UISwitch) {

--- a/podcasts/EffectsViewController.swift
+++ b/podcasts/EffectsViewController.swift
@@ -131,8 +131,28 @@ class EffectsViewController: SimpleNotificationsViewController {
         }
     }
 
+    @IBOutlet weak var playbackSettingsSegmentedControl: CustomSegmentedControl! {
+        didSet {
+            playbackSettingsSegmentedControl.isHidden = !FeatureFlag.customPlaybackSettings.enabled
+
+            let firstAction = SegmentedAction(title: "All podcasts")
+            let secondAction = SegmentedAction(title: "This podcast")
+            playbackSettingsSegmentedControl.setActions([firstAction, secondAction])
+
+            playbackSettingsSegmentedControl.unselectedBgColor = UIColor.clear
+            
+//            playbackSettingsSegmentedControl.addTarget(self, action: #selector(trimSilenceAmountChanged), for: .valueChanged)
+        }
+    }
+
     @IBOutlet var minusBtn: UIButton!
     @IBOutlet var plusBtn: UIButton!
+
+    @IBOutlet weak var speedControlTopConstraint: NSLayoutConstraint! {
+        didSet {
+            speedControlTopConstraint.isActive = FeatureFlag.customPlaybackSettings.enabled
+        }
+    }
 
     @IBOutlet var trimSilenceSpeedsToLabelConstraint: NSLayoutConstraint! {
         didSet {
@@ -335,6 +355,11 @@ class EffectsViewController: SimpleNotificationsViewController {
         trimSilenceAmountControl.unselectedItemColor = ThemeColor.playerContrast01()
         trimSilenceAmountControl.selectedBgColor = ThemeColor.playerContrast01()
         trimSilenceAmountControl.selectedItemColor = PlayerColorHelper.playerBackgroundColor01()
+
+        playbackSettingsSegmentedControl.lineColor = ThemeColor.playerContrast02()
+        playbackSettingsSegmentedControl.unselectedItemColor = ThemeColor.playerContrast01()
+        playbackSettingsSegmentedControl.selectedBgColor = ThemeColor.playerContrast01()
+        playbackSettingsSegmentedControl.selectedItemColor = PlayerColorHelper.playerBackgroundColor01()
 
         updateSpeedBtn()
 

--- a/podcasts/EffectsViewController.xib
+++ b/podcasts/EffectsViewController.xib
@@ -20,10 +20,10 @@
                 <outlet property="headingLbl" destination="2fF-ad-Nz3" id="oVU-VC-7d1"/>
                 <outlet property="headingView" destination="xDY-er-QkI" id="bE1-Ff-NCK"/>
                 <outlet property="minusBtn" destination="X9d-OS-tJn" id="RGS-X6-KQy"/>
-                <outlet property="playbackSettingsSegmentedControl" destination="Mzb-Ed-AKd" id="Awh-cZ-0i4"/>
+                <outlet property="playbackSettingsSegmentedControl" destination="036-xZ-lLC" id="Ldg-mZ-AGq"/>
                 <outlet property="plusBtn" destination="ZiH-JO-EJn" id="I5D-cu-ZKf"/>
                 <outlet property="speedBtn" destination="OiT-SV-8zG" id="IOT-2x-xXg"/>
-                <outlet property="speedControlTopConstraint" destination="jCF-Lb-gIL" id="bIo-Ua-CNR"/>
+                <outlet property="speedControlTopConstraint" destination="xXB-B8-zSM" id="2sX-py-ThG"/>
                 <outlet property="speedIcon" destination="l8T-5d-1fK" id="Tzl-6x-QZ7"/>
                 <outlet property="speedLbl" destination="7Mt-Tq-MwW" id="gub-Un-YVc"/>
                 <outlet property="trimIcon" destination="vd7-K4-6oP" id="OIP-Wt-uht"/>
@@ -41,7 +41,7 @@
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="547"/>
+            <rect key="frame" x="0.0" y="0.0" width="320" height="598"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xDY-er-QkI" userLabel="Popup Heading">
@@ -93,16 +93,20 @@
                     </constraints>
                 </view>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gSi-1e-Tle">
-                    <rect key="frame" x="20" y="68" width="280" height="479"/>
+                    <rect key="frame" x="20" y="68" width="280" height="530"/>
                     <subviews>
-                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Mzb-Ed-AKd" userLabel="Settings Segmented" customClass="CustomSegmentedControl" customModule="podcasts" customModuleProvider="target">
-                            <rect key="frame" x="0.0" y="28" width="280" height="28"/>
+                        <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="036-xZ-lLC" userLabel="Playback Settings Segmented">
+                            <rect key="frame" x="0.0" y="28" width="280" height="25"/>
                             <constraints>
-                                <constraint firstAttribute="height" constant="28" id="LHG-1Q-yrp"/>
+                                <constraint firstAttribute="height" constant="24" id="Hg5-29-bhj"/>
                             </constraints>
-                        </view>
+                            <segments>
+                                <segment title="First"/>
+                                <segment title="Second"/>
+                            </segments>
+                        </segmentedControl>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5iH-XX-TB6" userLabel="Speed View">
-                            <rect key="frame" x="0.0" y="86" width="280" height="44"/>
+                            <rect key="frame" x="0.0" y="82" width="280" height="44"/>
                             <subviews>
                                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="player_speed" translatesAutoresizingMaskIntoConstraints="NO" id="l8T-5d-1fK" customClass="TintableImageView" customModule="podcasts" customModuleProvider="target">
                                     <rect key="frame" x="0.0" y="10" width="24" height="24"/>
@@ -177,14 +181,14 @@
                             </constraints>
                         </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="W33-7F-lgX" userLabel="Divider" customClass="ThemeableView" customModule="podcasts" customModuleProvider="target">
-                            <rect key="frame" x="0.0" y="146" width="280" height="1"/>
+                            <rect key="frame" x="0.0" y="142" width="280" height="1"/>
                             <color key="backgroundColor" red="0.41960784313725491" green="0.33743089437484741" blue="0.22742205858230591" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="1" id="koq-fY-Mbi"/>
                             </constraints>
                         </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9Im-sp-Xss" userLabel="Trim Silence Switch View">
-                            <rect key="frame" x="0.0" y="163" width="280" height="44"/>
+                            <rect key="frame" x="0.0" y="159" width="280" height="44"/>
                             <subviews>
                                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" image="player_trim" translatesAutoresizingMaskIntoConstraints="NO" id="vd7-K4-6oP" customClass="TintableImageView" customModule="podcasts" customModuleProvider="target">
                                     <rect key="frame" x="0.0" y="0.0" width="24" height="24"/>
@@ -216,26 +220,26 @@
                             </constraints>
                         </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lSS-An-PYk" userLabel="Trim Silence Segmented Control" customClass="CustomSegmentedControl" customModule="podcasts" customModuleProvider="target">
-                            <rect key="frame" x="44" y="207" width="236" height="38"/>
+                            <rect key="frame" x="44" y="203" width="236" height="38"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="38" id="joY-sc-tBY"/>
                             </constraints>
                         </view>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalCompressionResistancePriority="1000" text="Makes episodes shorter by trimming silence when no one is talking." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gLf-fa-jTA" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                            <rect key="frame" x="44" y="257" width="236" height="27"/>
+                            <rect key="frame" x="44" y="253" width="236" height="82"/>
                             <fontDescription key="fontDescription" type="system" pointSize="15"/>
                             <color key="textColor" red="1" green="1" blue="1" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="displayP3"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ufB-9R-Vqg" userLabel="Divider" customClass="ThemeableView" customModule="podcasts" customModuleProvider="target">
-                            <rect key="frame" x="0.0" y="300" width="280" height="1"/>
+                            <rect key="frame" x="0.0" y="351" width="280" height="1"/>
                             <color key="backgroundColor" red="0.41960784309999999" green="0.33743089440000001" blue="0.2274220586" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="1" id="T4l-sT-XYD"/>
                             </constraints>
                         </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="OpL-dz-bb5" userLabel="Volume Boost View">
-                            <rect key="frame" x="0.0" y="317" width="280" height="60"/>
+                            <rect key="frame" x="0.0" y="368" width="280" height="60"/>
                             <subviews>
                                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" image="player_volumeboost" translatesAutoresizingMaskIntoConstraints="NO" id="pxa-gz-sJt" customClass="TintableImageView" customModule="podcasts" customModuleProvider="target">
                                     <rect key="frame" x="0.0" y="0.0" width="24" height="24"/>
@@ -275,7 +279,7 @@
                             </constraints>
                         </view>
                         <view hidden="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IPm-dg-nP6" userLabel="Custom Effects View">
-                            <rect key="frame" x="0.0" y="395" width="280" height="64"/>
+                            <rect key="frame" x="0.0" y="446" width="280" height="64"/>
                             <subviews>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mmt-Tp-FF7" customClass="PodcastImageView" customModule="podcasts" customModuleProvider="target">
                                     <rect key="frame" x="17" y="17" width="30" height="30"/>
@@ -323,13 +327,12 @@
                     <constraints>
                         <constraint firstItem="ufB-9R-Vqg" firstAttribute="top" secondItem="gLf-fa-jTA" secondAttribute="bottom" constant="16" id="0E6-mX-jLj"/>
                         <constraint firstAttribute="trailing" secondItem="W33-7F-lgX" secondAttribute="trailing" id="1uw-SL-wDZ"/>
-                        <constraint firstItem="Mzb-Ed-AKd" firstAttribute="leading" secondItem="gSi-1e-Tle" secondAttribute="leading" id="5QP-X3-L1Q"/>
                         <constraint firstItem="9Im-sp-Xss" firstAttribute="top" secondItem="W33-7F-lgX" secondAttribute="bottom" constant="16" id="6D0-mc-NKI"/>
                         <constraint firstItem="gLf-fa-jTA" firstAttribute="top" secondItem="lSS-An-PYk" secondAttribute="bottom" constant="12" id="7ZB-GF-U7Y"/>
                         <constraint firstItem="OpL-dz-bb5" firstAttribute="top" secondItem="ufB-9R-Vqg" secondAttribute="bottom" constant="16" id="Abm-cd-8LP"/>
                         <constraint firstAttribute="trailing" secondItem="ufB-9R-Vqg" secondAttribute="trailing" id="BSC-ua-8cr"/>
                         <constraint firstItem="W33-7F-lgX" firstAttribute="leading" secondItem="gSi-1e-Tle" secondAttribute="leading" id="CHp-qt-6Zy"/>
-                        <constraint firstItem="Mzb-Ed-AKd" firstAttribute="top" secondItem="gSi-1e-Tle" secondAttribute="top" constant="28" id="FeF-IP-xJZ"/>
+                        <constraint firstAttribute="trailing" secondItem="036-xZ-lLC" secondAttribute="trailing" id="EJv-6L-und"/>
                         <constraint firstAttribute="trailing" secondItem="9Im-sp-Xss" secondAttribute="trailing" id="Hxz-mG-gjx"/>
                         <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="OpL-dz-bb5" secondAttribute="bottom" priority="750" constant="30" id="MWt-9l-w5z"/>
                         <constraint firstItem="gLf-fa-jTA" firstAttribute="leading" secondItem="gSi-1e-Tle" secondAttribute="leading" constant="44" id="PSD-IO-Uq5"/>
@@ -344,14 +347,15 @@
                         <constraint firstAttribute="trailing" secondItem="5iH-XX-TB6" secondAttribute="trailing" id="ce7-YF-Nmp"/>
                         <constraint firstItem="ufB-9R-Vqg" firstAttribute="leading" secondItem="gSi-1e-Tle" secondAttribute="leading" id="eak-eP-DVP"/>
                         <constraint firstItem="W33-7F-lgX" firstAttribute="top" secondItem="5iH-XX-TB6" secondAttribute="bottom" constant="16" id="idz-0B-3MO"/>
-                        <constraint firstItem="5iH-XX-TB6" firstAttribute="top" secondItem="Mzb-Ed-AKd" secondAttribute="bottom" constant="30" id="jCF-Lb-gIL"/>
                         <constraint firstItem="lSS-An-PYk" firstAttribute="top" secondItem="9Im-sp-Xss" secondAttribute="bottom" id="jVa-Ec-UuN"/>
                         <constraint firstItem="IPm-dg-nP6" firstAttribute="top" secondItem="OpL-dz-bb5" secondAttribute="bottom" constant="18" id="lhS-F2-gsF"/>
+                        <constraint firstItem="036-xZ-lLC" firstAttribute="leading" secondItem="gSi-1e-Tle" secondAttribute="leading" id="p1R-mH-jRl"/>
                         <constraint firstAttribute="trailing" secondItem="gLf-fa-jTA" secondAttribute="trailing" id="snK-ju-S4Y"/>
                         <constraint firstItem="lSS-An-PYk" firstAttribute="leading" secondItem="gSi-1e-Tle" secondAttribute="leading" constant="44" id="tRJ-aI-cQ6"/>
                         <constraint firstAttribute="trailing" secondItem="IPm-dg-nP6" secondAttribute="trailing" id="vR8-bB-yTY"/>
+                        <constraint firstItem="036-xZ-lLC" firstAttribute="top" secondItem="gSi-1e-Tle" secondAttribute="top" constant="28" id="wRn-O1-auf"/>
                         <constraint firstItem="9Im-sp-Xss" firstAttribute="leading" secondItem="gSi-1e-Tle" secondAttribute="leading" id="wiP-QQ-J2B"/>
-                        <constraint firstAttribute="trailing" secondItem="Mzb-Ed-AKd" secondAttribute="trailing" id="yJQ-C2-SnP"/>
+                        <constraint firstItem="5iH-XX-TB6" firstAttribute="top" secondItem="036-xZ-lLC" secondAttribute="bottom" constant="30" id="xXB-B8-zSM"/>
                     </constraints>
                 </view>
             </subviews>
@@ -366,7 +370,7 @@
                 <constraint firstAttribute="trailing" secondItem="gSi-1e-Tle" secondAttribute="trailing" constant="20" id="aoy-Yd-Uo1"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-            <point key="canvasLocation" x="-1526.0869565217392" y="-152.34375"/>
+            <point key="canvasLocation" x="-1526.0869565217392" y="-135.26785714285714"/>
         </view>
     </objects>
     <resources>

--- a/podcasts/EffectsViewController.xib
+++ b/podcasts/EffectsViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23094" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21678"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23084"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -20,8 +20,10 @@
                 <outlet property="headingLbl" destination="2fF-ad-Nz3" id="oVU-VC-7d1"/>
                 <outlet property="headingView" destination="xDY-er-QkI" id="bE1-Ff-NCK"/>
                 <outlet property="minusBtn" destination="X9d-OS-tJn" id="RGS-X6-KQy"/>
+                <outlet property="playbackSettingsSegmentedControl" destination="Mzb-Ed-AKd" id="Awh-cZ-0i4"/>
                 <outlet property="plusBtn" destination="ZiH-JO-EJn" id="I5D-cu-ZKf"/>
                 <outlet property="speedBtn" destination="OiT-SV-8zG" id="IOT-2x-xXg"/>
+                <outlet property="speedControlTopConstraint" destination="jCF-Lb-gIL" id="bIo-Ua-CNR"/>
                 <outlet property="speedIcon" destination="l8T-5d-1fK" id="Tzl-6x-QZ7"/>
                 <outlet property="speedLbl" destination="7Mt-Tq-MwW" id="gub-Un-YVc"/>
                 <outlet property="trimIcon" destination="vd7-K4-6oP" id="OIP-Wt-uht"/>
@@ -39,7 +41,7 @@
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="520"/>
+            <rect key="frame" x="0.0" y="0.0" width="320" height="547"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xDY-er-QkI" userLabel="Popup Heading">
@@ -91,10 +93,16 @@
                     </constraints>
                 </view>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gSi-1e-Tle">
-                    <rect key="frame" x="20" y="68" width="280" height="452"/>
+                    <rect key="frame" x="20" y="68" width="280" height="479"/>
                     <subviews>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Mzb-Ed-AKd" userLabel="Settings Segmented" customClass="CustomSegmentedControl" customModule="podcasts" customModuleProvider="target">
+                            <rect key="frame" x="0.0" y="28" width="280" height="28"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="28" id="LHG-1Q-yrp"/>
+                            </constraints>
+                        </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5iH-XX-TB6" userLabel="Speed View">
-                            <rect key="frame" x="0.0" y="16" width="280" height="44"/>
+                            <rect key="frame" x="0.0" y="86" width="280" height="44"/>
                             <subviews>
                                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="player_speed" translatesAutoresizingMaskIntoConstraints="NO" id="l8T-5d-1fK" customClass="TintableImageView" customModule="podcasts" customModuleProvider="target">
                                     <rect key="frame" x="0.0" y="10" width="24" height="24"/>
@@ -169,14 +177,14 @@
                             </constraints>
                         </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="W33-7F-lgX" userLabel="Divider" customClass="ThemeableView" customModule="podcasts" customModuleProvider="target">
-                            <rect key="frame" x="0.0" y="76" width="280" height="1"/>
+                            <rect key="frame" x="0.0" y="146" width="280" height="1"/>
                             <color key="backgroundColor" red="0.41960784313725491" green="0.33743089437484741" blue="0.22742205858230591" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="1" id="koq-fY-Mbi"/>
                             </constraints>
                         </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9Im-sp-Xss" userLabel="Trim Silence Switch View">
-                            <rect key="frame" x="0.0" y="93" width="280" height="44"/>
+                            <rect key="frame" x="0.0" y="163" width="280" height="44"/>
                             <subviews>
                                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" image="player_trim" translatesAutoresizingMaskIntoConstraints="NO" id="vd7-K4-6oP" customClass="TintableImageView" customModule="podcasts" customModuleProvider="target">
                                     <rect key="frame" x="0.0" y="0.0" width="24" height="24"/>
@@ -208,26 +216,26 @@
                             </constraints>
                         </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lSS-An-PYk" userLabel="Trim Silence Segmented Control" customClass="CustomSegmentedControl" customModule="podcasts" customModuleProvider="target">
-                            <rect key="frame" x="44" y="137" width="236" height="38"/>
+                            <rect key="frame" x="44" y="207" width="236" height="38"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="38" id="joY-sc-tBY"/>
                             </constraints>
                         </view>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalCompressionResistancePriority="1000" text="Makes episodes shorter by trimming silence when no one is talking." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gLf-fa-jTA" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                            <rect key="frame" x="44" y="187" width="236" height="70"/>
+                            <rect key="frame" x="44" y="257" width="236" height="27"/>
                             <fontDescription key="fontDescription" type="system" pointSize="15"/>
                             <color key="textColor" red="1" green="1" blue="1" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="displayP3"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ufB-9R-Vqg" userLabel="Divider" customClass="ThemeableView" customModule="podcasts" customModuleProvider="target">
-                            <rect key="frame" x="0.0" y="273" width="280" height="1"/>
+                            <rect key="frame" x="0.0" y="300" width="280" height="1"/>
                             <color key="backgroundColor" red="0.41960784309999999" green="0.33743089440000001" blue="0.2274220586" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="1" id="T4l-sT-XYD"/>
                             </constraints>
                         </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="OpL-dz-bb5" userLabel="Volume Boost View">
-                            <rect key="frame" x="0.0" y="290" width="280" height="60"/>
+                            <rect key="frame" x="0.0" y="317" width="280" height="60"/>
                             <subviews>
                                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" image="player_volumeboost" translatesAutoresizingMaskIntoConstraints="NO" id="pxa-gz-sJt" customClass="TintableImageView" customModule="podcasts" customModuleProvider="target">
                                     <rect key="frame" x="0.0" y="0.0" width="24" height="24"/>
@@ -267,7 +275,7 @@
                             </constraints>
                         </view>
                         <view hidden="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IPm-dg-nP6" userLabel="Custom Effects View">
-                            <rect key="frame" x="0.0" y="368" width="280" height="64"/>
+                            <rect key="frame" x="0.0" y="395" width="280" height="64"/>
                             <subviews>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mmt-Tp-FF7" customClass="PodcastImageView" customModule="podcasts" customModuleProvider="target">
                                     <rect key="frame" x="17" y="17" width="30" height="30"/>
@@ -315,16 +323,18 @@
                     <constraints>
                         <constraint firstItem="ufB-9R-Vqg" firstAttribute="top" secondItem="gLf-fa-jTA" secondAttribute="bottom" constant="16" id="0E6-mX-jLj"/>
                         <constraint firstAttribute="trailing" secondItem="W33-7F-lgX" secondAttribute="trailing" id="1uw-SL-wDZ"/>
+                        <constraint firstItem="Mzb-Ed-AKd" firstAttribute="leading" secondItem="gSi-1e-Tle" secondAttribute="leading" id="5QP-X3-L1Q"/>
                         <constraint firstItem="9Im-sp-Xss" firstAttribute="top" secondItem="W33-7F-lgX" secondAttribute="bottom" constant="16" id="6D0-mc-NKI"/>
                         <constraint firstItem="gLf-fa-jTA" firstAttribute="top" secondItem="lSS-An-PYk" secondAttribute="bottom" constant="12" id="7ZB-GF-U7Y"/>
                         <constraint firstItem="OpL-dz-bb5" firstAttribute="top" secondItem="ufB-9R-Vqg" secondAttribute="bottom" constant="16" id="Abm-cd-8LP"/>
                         <constraint firstAttribute="trailing" secondItem="ufB-9R-Vqg" secondAttribute="trailing" id="BSC-ua-8cr"/>
                         <constraint firstItem="W33-7F-lgX" firstAttribute="leading" secondItem="gSi-1e-Tle" secondAttribute="leading" id="CHp-qt-6Zy"/>
+                        <constraint firstItem="Mzb-Ed-AKd" firstAttribute="top" secondItem="gSi-1e-Tle" secondAttribute="top" constant="28" id="FeF-IP-xJZ"/>
                         <constraint firstAttribute="trailing" secondItem="9Im-sp-Xss" secondAttribute="trailing" id="Hxz-mG-gjx"/>
                         <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="OpL-dz-bb5" secondAttribute="bottom" priority="750" constant="30" id="MWt-9l-w5z"/>
                         <constraint firstItem="gLf-fa-jTA" firstAttribute="leading" secondItem="gSi-1e-Tle" secondAttribute="leading" constant="44" id="PSD-IO-Uq5"/>
                         <constraint firstItem="OpL-dz-bb5" firstAttribute="leading" secondItem="gSi-1e-Tle" secondAttribute="leading" id="R7C-M9-5xX"/>
-                        <constraint firstItem="5iH-XX-TB6" firstAttribute="top" secondItem="gSi-1e-Tle" secondAttribute="top" constant="16" id="RVs-bC-UFy"/>
+                        <constraint firstItem="5iH-XX-TB6" firstAttribute="top" secondItem="gSi-1e-Tle" secondAttribute="top" priority="750" constant="16" id="RVs-bC-UFy"/>
                         <constraint firstItem="IPm-dg-nP6" firstAttribute="leading" secondItem="gSi-1e-Tle" secondAttribute="leading" id="UV3-c0-Il8"/>
                         <constraint firstAttribute="trailing" secondItem="lSS-An-PYk" secondAttribute="trailing" id="VaJ-eF-hMT"/>
                         <constraint firstAttribute="bottom" secondItem="IPm-dg-nP6" secondAttribute="bottom" constant="20" id="Vl3-DJ-fyS"/>
@@ -334,12 +344,14 @@
                         <constraint firstAttribute="trailing" secondItem="5iH-XX-TB6" secondAttribute="trailing" id="ce7-YF-Nmp"/>
                         <constraint firstItem="ufB-9R-Vqg" firstAttribute="leading" secondItem="gSi-1e-Tle" secondAttribute="leading" id="eak-eP-DVP"/>
                         <constraint firstItem="W33-7F-lgX" firstAttribute="top" secondItem="5iH-XX-TB6" secondAttribute="bottom" constant="16" id="idz-0B-3MO"/>
+                        <constraint firstItem="5iH-XX-TB6" firstAttribute="top" secondItem="Mzb-Ed-AKd" secondAttribute="bottom" constant="30" id="jCF-Lb-gIL"/>
                         <constraint firstItem="lSS-An-PYk" firstAttribute="top" secondItem="9Im-sp-Xss" secondAttribute="bottom" id="jVa-Ec-UuN"/>
                         <constraint firstItem="IPm-dg-nP6" firstAttribute="top" secondItem="OpL-dz-bb5" secondAttribute="bottom" constant="18" id="lhS-F2-gsF"/>
                         <constraint firstAttribute="trailing" secondItem="gLf-fa-jTA" secondAttribute="trailing" id="snK-ju-S4Y"/>
                         <constraint firstItem="lSS-An-PYk" firstAttribute="leading" secondItem="gSi-1e-Tle" secondAttribute="leading" constant="44" id="tRJ-aI-cQ6"/>
                         <constraint firstAttribute="trailing" secondItem="IPm-dg-nP6" secondAttribute="trailing" id="vR8-bB-yTY"/>
                         <constraint firstItem="9Im-sp-Xss" firstAttribute="leading" secondItem="gSi-1e-Tle" secondAttribute="leading" id="wiP-QQ-J2B"/>
+                        <constraint firstAttribute="trailing" secondItem="Mzb-Ed-AKd" secondAttribute="trailing" id="yJQ-C2-SnP"/>
                     </constraints>
                 </view>
             </subviews>
@@ -354,7 +366,7 @@
                 <constraint firstAttribute="trailing" secondItem="gSi-1e-Tle" secondAttribute="trailing" constant="20" id="aoy-Yd-Uo1"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-            <point key="canvasLocation" x="-1525.3623188405797" y="-161.38392857142856"/>
+            <point key="canvasLocation" x="-1526.0869565217392" y="-152.34375"/>
         </view>
     </objects>
     <resources>

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -1721,6 +1721,10 @@ internal enum L10n {
   internal static var playLast: String { return L10n.tr("Localizable", "play_last") }
   /// Play Next
   internal static var playNext: String { return L10n.tr("Localizable", "play_next") }
+  /// All podcasts
+  internal static var playbackEffectAllPodcasts: String { return L10n.tr("Localizable", "playback_effect_all_podcasts") }
+  /// This podcast
+  internal static var playbackEffectThisPodcast: String { return L10n.tr("Localizable", "playback_effect_this_podcast") }
   /// Mad Max
   internal static var playbackEffectTrimSilenceMax: String { return L10n.tr("Localizable", "playback_effect_trim_silence_max") }
   /// Medium

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -1426,6 +1426,12 @@
 /* A common string used throughout the app. Generic message informing the user that playback failed. */
 "playback_failed" = "Playback Failed";
 
+/* Playback settings option in the Effects Player panel */
+"playback_effect_all_podcasts" = "All podcasts";
+
+/* Playback settings option in the Effects Player panel */
+"playback_effect_this_podcast" = "This podcast";
+
 /* Label indicating the current value for the playback speed. '%1$@' is a placeholder for the playback speed and 'x' is meant to read as 'times' as in '1.1 times' for '1.1x' */
 "playback_speed" = "%1$@x";
 


### PR DESCRIPTION
| 📘 Part of: #2253
|:---:|

Fixes #2254

This PR adds the `customPlaybackSettings` Feature Flag and the Segmented Control into the Effects Player VC

| FF Off | FF On |
| -------- | ------- |
| ![RocketSim_Screenshot_iPhone_16_6 1_2024-10-11_14 54 02](https://github.com/user-attachments/assets/cc4cb9bb-96ae-496c-9fd6-2ea2a681bc09) | ![RocketSim_Screenshot_iPhone_16_6 1_2024-10-14_12 06 17](https://github.com/user-attachments/assets/d42f9d8e-417e-4615-8cac-2dbbfe7b4740) |



## To test

> [!NOTE]
> FF is `customPlaybackSettings`

- CI must be 🟢 
- Enable the FF
- Play an episode and open the Effects VC
- Check the Segmented appears at the top
- Disable the FF
- Re-open the Effects VC and check everything works as expected
- Confirm in both scenarios there are no autolayout warnings

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
