### PR TITLE
[Custom Playback Settings] Add main logic to switch between global and local settings

### DIFF
--- a/podcasts/EffectsViewController.swift
+++ b/podcasts/EffectsViewController.swift
@@ -182,6 +182,10 @@ class EffectsViewController: SimpleNotificationsViewController {
 
         updateColors()
         updateControls()
+
+        if FeatureFlag.customPlaybackSettings.enabled {
+            playbackSettingsSegmentedControl.selectedSegmentIndex = PlaybackManager.shared.isCurrentEffectGlobal() ? 0 : 1
+        }
         if let episode = PlaybackManager.shared.currentEpisode() as? Episode, let podcast = episode.parentPodcast() {
             clearForPodcastImage.setPodcast(uuid: podcast.uuid, size: .list)
         }
@@ -270,7 +274,10 @@ class EffectsViewController: SimpleNotificationsViewController {
     }
 
     @objc private func playbackSettingsDestinationChanged() {
-        // TO IMPLEMENT
+        let applyLocalSettings = playbackSettingsSegmentedControl.selectedSegmentIndex == 1
+        PlaybackManager.shared.effectsChangedExternally()
+        PlaybackManager.shared.overrideEffectsToggled(applyLocalSettings: applyLocalSettings)
+        updateControls()
     }
 
     @IBAction func volumeBoostChanged(_ sender: UISwitch) {
@@ -304,6 +311,10 @@ class EffectsViewController: SimpleNotificationsViewController {
     }
 
     private func updateClearView() {
+        // We don't need a clear view if the FF is enbaled
+        if FeatureFlag.customPlaybackSettings.enabled {
+            return
+        }
         guard let episode = PlaybackManager.shared.currentEpisode() as? Episode, let podcast = episode.parentPodcast() else {
             clearForPodcastView.isHidden = true
             customEffectsToVolumeBoostConstraint.isActive = false

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -844,6 +844,22 @@ class PlaybackManager: ServerPlaybackDelegate {
         handlePlaybackEffectsChanged(effects: newEffects)
     }
 
+    func overrideEffectsToggled(applyLocalSettings: Bool) {
+        guard let episode = currentEpisode() as? Episode,
+              let podcast = episode.parentPodcast() else {
+            return
+        }
+        podcast.isEffectsOverridden = applyLocalSettings
+
+        DataManager.sharedManager.save(podcast: podcast)
+        NotificationCenter.postOnMainThread(notification: Constants.Notifications.podcastUpdated, object: podcast.uuid)
+        effectsChangedExternally()
+    }
+
+    func isCurrentEffectGlobal() -> Bool {
+        return effects().isGlobal
+    }
+
     private func handlePlaybackEffectsChanged(effects: PlaybackEffects) {
         guard let episode = currentEpisode() else { return }
 


### PR DESCRIPTION
| 📘 Part of: #2253 
|:---:|

Fixes #2266

Implement the main logic to switch between global and local settings


https://github.com/user-attachments/assets/2a1a0145-abf6-42bd-b76d-d3592a85377b

## To test

> [!NOTE]
> FF is `customPlaybackSettings`

- CI must be 🟢 
- Enable the FF

### Test Global Effects Settings
- Play an episode and open the Effects view
- Make sure the `All Podcasts` is selected
- Apply some changes
- Verify that selecting `This podcast` updates the view by changing the settings
- Verify that tapping back to `All podcasts` the previous settings are applied
- Verify the global settings are applied to all podcasts episode and that the selected tab is always `All podcasts`
- Navigate to the podcast page settings and verify that the local effects settings switch is off

### Test Local Effects Settings
- Play an episode and open the Effects view
- Make sure the `All Podcasts` is selected
- Select `This podcast` tab
- Apply some changes
- Verify that selecting `All podcasts` updates the view by changing the settings
- Verify that tapping back to `This podcast` the previous settings are applied
- Verify that the settings are applied to this podcast only
- Verify that when opening the Effects view in this podcast, the tab selected is always `This podcast`
- Navigate to the podcast page settings and verify that the local effects settings switch is on

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
