### PR TITLE
Fix iOS 18 Share Extension: Call openURL on cast version of UIApplication

### DIFF
--- a/Share Extension/ShareViewController.swift
+++ b/Share Extension/ShareViewController.swift
@@ -25,14 +25,13 @@ class ShareViewController: UIViewController {
             return
         }
 
-        let selectorOpenURL = sel_registerName("openURL:")
         let context = NSExtensionContext()
         context.open(url as URL, completionHandler: nil)
         var responder = self as UIResponder?
 
         while responder != nil {
-            if responder?.responds(to: selectorOpenURL) == true {
-                responder?.perform(selectorOpenURL, with: url)
+            if let application = responder as? UIApplication {
+                application.open(url, options: [:], completionHandler: nil)
             }
             responder = responder?.next
         }


### PR DESCRIPTION
Fixes #2263

This bug is a bit odd since the original solution was dynamically dispatching the `openURL` call, which appears to have been [a workaround](https://stackoverflow.com/questions/27506413/share-extension-to-open-containing-app) for calling the app from the share extension. Apple seems to indicate you shouldn't do this:
> A Today widget (and no other app extension type) can ask the system to open its containing app by calling the [openURL:completionHandler:](https://developer.apple.com/documentation/foundation/nsextensioncontext/1416791-open) method of the [NSExtensionContext](https://developer.apple.com/documentation/foundation/nsextensioncontext) class.

Adding the share UI and saving of files is going to require a lot more work, though, and we should tackle that as a separate project.

## To test

* Add an MP3 file (use [FileSamplesHub](https://filesampleshub.com/format/audio/mp3)) to the Files app. You can run this script to open the folder for the simulator's files
```bash
#!/bin/bash
open "$(xcrun simctl get_app_container booted com.apple.DocumentsApp groups | grep LocalStorage | awk -F'\t' '{print $2 "/File Provider Storage"}')"
```
* Long press on the file and share to Pocket Casts
* Ensure that the Add File screen shows up

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
