### PR TITLE
Revert paywall title

### DIFF
--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -1899,7 +1899,7 @@ internal enum L10n {
   internal static var plusMarketingSubtitle: String { return L10n.tr("Localizable", "plus_marketing_subtitle") }
   /// Themes & Icons
   internal static var plusMarketingThemesIconsTitle: String { return L10n.tr("Localizable", "plus_marketing_themes_icons_title") }
-  /// Unlock exclusive features with Pocket Casts Plus
+  /// Everything you love about Pocket Casts, plus more
   internal static var plusMarketingTitle: String { return L10n.tr("Localizable", "plus_marketing_title") }
   /// Upload your files to cloud storage and have it available everywhere
   internal static var plusMarketingUpdatedCloudStorageDescription: String { return L10n.tr("Localizable", "plus_marketing_updated_cloud_storage_description") }

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -3795,7 +3795,7 @@
 "login_subtitle" = "Create an account to sync your listening experience across all your devices.";
 
 /* Title of the plus marketing view */
-"plus_marketing_title" = "Unlock exclusive features with Pocket Casts Plus";
+"plus_marketing_title" = "Everything you love about Pocket Casts, plus more";
 
 /* Subtitle of the plus marketing view */
 "plus_marketing_subtitle" = "Get access to exclusive features and customisation options";


### PR DESCRIPTION
This PR reverts the Paywall title to `Everything you love about Pocket Casts, plus more`

| Default | Feature Variant |
| -------- | ------- |
| ![RocketSim_Screenshot_iPhone_16_6 1_2024-10-15_11 00 28](https://github.com/user-attachments/assets/61ccc9ac-700e-4893-9263-aa8114216666) | ![RocketSim_Screenshot_iPhone_16_6 1_2024-10-15_11 02 40](https://github.com/user-attachments/assets/a04d6c82-914b-48b7-a036-e9b736c3efa5) |


## To test

- CI must be 🟢 
- Use a non plus account
- Open the paywall and check the current title
- In `PlusLandingViewModel`, `func view(with viewModel: PlusLandingViewModel) -> some View`, update the func to return only `PlusPaywallContainer(viewModel: viewModel, type: .features)`
- Run and open the paywall
- Check the title in the feature variant

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
