### PR TITLE
[Sentry] [NSConcreteFileHandle writeData:]: No space left on device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 7.75
 -----
 - Refactors the Discover view to improve impressions tracking [#2104](https://github.com/Automattic/pocket-casts-ios/issues/2104)
+- Attempt to fix the crash when a device run oout of space [#2275](https://github.com/Automattic/pocket-casts-ios/pull/2275)
 
 7.74
 -----

--- a/Modules/Utils/Sources/PocketCastsUtils/Logging/PersistentTextWriting.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Logging/PersistentTextWriting.swift
@@ -41,7 +41,7 @@ struct LogFileWriter: PersistentTextWriting {
 
         do {
             try fileHandle.seekToEnd()
-            fileHandle.write(encodedText)
+            try fileHandle.write(contentsOf: encodedText)
         } catch {
             logger?.error("Failed to seek to end of file at path <\(targetFilePath)>. Error: \(error)")
         }

--- a/Modules/Utils/Sources/PocketCastsUtils/Logging/PersistentTextWriting.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Logging/PersistentTextWriting.swift
@@ -43,7 +43,7 @@ struct LogFileWriter: PersistentTextWriting {
             try fileHandle.seekToEnd()
             try fileHandle.write(contentsOf: encodedText)
         } catch {
-            logger?.error("Failed to seek to end of file at path <\(targetFilePath)>. Error: \(error)")
+            handle(fileHandleWriteError: error, encounteredWriting: text)
         }
 
         do {
@@ -70,6 +70,8 @@ struct LogFileWriter: PersistentTextWriting {
             } catch {
                 logger?.error("Failed to create directory structure for logs at <\(targetFilePath)>. Error: \(error)")
             }
+        case NSFileWriteOutOfSpaceError:
+            logger?.debug("Attempted to write to log file but disk is full. Error: \(fileHandleWriteError)")
 
         default:
             logger?.debug("Unable to write to file. Error: \(fileHandleWriteError)")


### PR DESCRIPTION
Fixes 5942010655-sentry

Attempt to fix the crash if the device run out of disk space. It replaces the write deprecated function using the latest one which throws an exception if the device run out of space.

## To test

- CI should be 🟢 
- Run the app to write some logs
- Check if the file log works as expected

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
