### PR TITLE
Remove Gravatar feature flag

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -79,9 +79,6 @@ public enum FeatureFlag: String, CaseIterable {
     /// Enable the transcripts feature on podcasts episodes
     case transcripts
 
-    /// Makes the "Change Avatar" button visible in the Account Settings.
-    case gravatarChangeAvatar
-
     /// Enables the Kids banner
     case kidsProfile
 
@@ -181,8 +178,6 @@ public enum FeatureFlag: String, CaseIterable {
         case .newSharing:
             true
         case .transcripts:
-            true
-        case .gravatarChangeAvatar:
             true
         case .kidsProfile:
             false

--- a/podcasts/AccountViewController.swift
+++ b/podcasts/AccountViewController.swift
@@ -107,7 +107,7 @@ class AccountViewController: UIViewController, ChangeEmailDelegate {
         } else {
             accountOptions = [upgradeRow, .newsletter].compactMap { $0 }
         }
-        if FeatureFlag.gravatarChangeAvatar.enabled && headerViewModel.profile.isLoggedIn {
+        if headerViewModel.profile.isLoggedIn {
             accountOptions.insert(.changeAvatar, safelyAt: 0)
         }
         if SubscriptionHelper.hasActiveSubscription() {


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

This PR removes the Feature Flag for the Change Avatar option using Gravatar web view.

Android has already done this some time ago:
https://github.com/Automattic/pocket-casts-android/pull/2839

## To test

Smoke test changing avatar.

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
