### PR TITLE
Hot Fix: Fix Sponsored Podcast ordering in the Featured section

### DIFF
--- a/podcasts/FeaturedSummaryViewController.swift
+++ b/podcasts/FeaturedSummaryViewController.swift
@@ -211,8 +211,8 @@ class FeaturedSummaryViewController: SimpleNotificationsViewController, GridLayo
             // Add featured podcasts
             self.podcasts = Array(podcastsToShow.prefix(self.maxFeaturedItems))
 
-            // Add sponsored podcasts
-            for sponsoredPodcastToAdd in sponsoredPodcastsToAdd {
+            // Add sponsored podcasts - note that these must be ordered to end up at the proper positions
+            for sponsoredPodcastToAdd in sponsoredPodcastsToAdd.sorted(by: { $0.key < $1.key }) {
                 self.podcasts.insert(sponsoredPodcastToAdd.value, safelyAt: sponsoredPodcastToAdd.key)
             }
             self.sponsoredPodcasts = sponsoredPodcastsToAdd.map { $0.value }


### PR DESCRIPTION
**HOT FIX FOR 7.74.1**

Fixes an issue with Sponsored Podcast ordering in the Featured section.

`sponsoredPodcastsToAdd` are stored in a Dictionary, which is unordered. If the insertions aren't performed in order, the sponsored podcasts will not end up in the correct final positions.


| Correct Order | Incorrect Order |
| -- | -- |
| <video src="https://github.com/user-attachments/assets/004b8041-5306-4084-b260-48dd63066f4c"/> | <video src="https://github.com/user-attachments/assets/4b0cc283-6e11-443f-884c-dbb38f14beaf"> |

## To test

* Load Discover
* Change the region several times
* Make sure that the Sponsored Podcasts are always shown in the correct position

You can also invert the sort function to `$0.key > $1.key` to see the unordered behavior every time.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
