### PR TITLE
Referrals Show welcome screen after purchase with referral

### DIFF
--- a/podcasts/Onboarding/LoginCoordinator.swift
+++ b/podcasts/Onboarding/LoginCoordinator.swift
@@ -172,7 +172,7 @@ extension LoginCoordinator: SyncSigninDelegate, CreateAccountDelegate {
 
     func handleAccountCreated() {
         Analytics.track(.userAccountCreated, properties: ["source": socialAuthProvider ?? "password"])
-
+        OnboardingFlow.shared.accountCreated?(true)
         if OnboardingFlow.shared.currentFlow.shouldDismiss {
             handleDismiss()
             return

--- a/podcasts/Onboarding/OnboardingFlow.swift
+++ b/podcasts/Onboarding/OnboardingFlow.swift
@@ -8,9 +8,12 @@ struct OnboardingFlow {
     private(set) var currentFlow: Flow = .none
     private var source: String? = nil
 
-    mutating func begin(flow: Flow, in controller: UIViewController? = nil, source: String? = nil, context: Context? = nil, customTitle: String? = nil) -> UIViewController {
+    private(set) var accountCreated: ((Bool)->())?
+
+    mutating func begin(flow: Flow, in controller: UIViewController? = nil, source: String? = nil, context: Context? = nil, customTitle: String? = nil, accountCreated: ((Bool)->())? = nil) -> UIViewController {
         self.currentFlow = flow
         self.source = source
+        self.accountCreated = accountCreated
 
         let navigationController = controller as? UINavigationController
 

--- a/podcasts/Referrals/ReferralsClaimPass.swift
+++ b/podcasts/Referrals/ReferralsClaimPass.swift
@@ -11,6 +11,8 @@ class ReferralClaimPassModel: ObservableObject {
     var onComplete: (() -> ())?
     var onCloseTap: (() -> ())?
 
+    private(set) var accountCreated: Bool = false
+
     enum State {
         case loading
         case start
@@ -141,7 +143,9 @@ class ReferralClaimPassModel: ObservableObject {
     }
 
     private func signup() {
-        let onboardVC = OnboardingFlow.shared.begin(flow: .referralCode)
+        let onboardVC = OnboardingFlow.shared.begin(flow: .referralCode) { [weak self] accountCreated in
+            self?.accountCreated = accountCreated
+        }
 
         presentationController?.present(onboardVC, animated: true)
     }

--- a/podcasts/Referrals/ReferralsClaimPass.swift
+++ b/podcasts/Referrals/ReferralsClaimPass.swift
@@ -20,6 +20,7 @@ class ReferralClaimPassModel: ObservableObject {
         case claimVerify
         case iapPurchase
         case signup
+        case done
     }
 
     @Published var state: State
@@ -172,6 +173,7 @@ class ReferralClaimPassModel: ObservableObject {
             await redeemCode()
             coordinator.cleanReferalURL()
             onComplete?()
+            state = .done
         } else {
             state = .start
         }
@@ -211,7 +213,7 @@ struct ReferralClaimPassView: View {
                 }
             }
 
-        case .start, .claimVerify, .iapPurchase, .signup:
+        case .start, .claimVerify, .iapPurchase, .signup, .done:
             VStack {
                 HStack {
                     Spacer()
@@ -245,7 +247,7 @@ struct ReferralClaimPassView: View {
                     switch viewModel.state {
                     case .start:
                         Text(L10n.referralsClaimGuestPassAction)
-                    case .claimVerify, .iapPurchase, .notAvailable, .signup, .loading:
+                    case .claimVerify, .iapPurchase, .notAvailable, .signup, .loading, .done:
                         loadingIndicator
                     }
                 })

--- a/podcasts/Referrals/ReferralsCoordinator.swift
+++ b/podcasts/Referrals/ReferralsCoordinator.swift
@@ -64,14 +64,20 @@ class ReferralsCoordinator {
             let viewModel = ReferralClaimPassModel(referralURL: url,
                                                    coordinator: self,
                                                    canClaimPass: true,
-                                                   onComplete: {
-                viewController.dismiss(animated: true)
-                onComplete?()
-            },
+                                                   onComplete: nil,
                                                    onCloseTap: {
                 viewController.dismiss(animated: true)
                 onComplete?()
             })
+            viewModel.onComplete = {
+                viewController.dismiss(animated: true) {
+                    if viewModel.accountCreated {
+                        let welcomeVC = WelcomeViewModel.make(in: nil, displayType: .newAccount)
+                        viewController.present(welcomeVC, animated: true)
+                    }
+                }
+                onComplete?()
+            }
             let referralClaimPassVC = ReferralClaimPassVC(viewModel: viewModel)
             viewController.present(referralClaimPassVC, animated: true)
         }


### PR DESCRIPTION
| 📘 Part of: #2083  |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

Referrals Show welcome screen after purchase with referral

## To test

1. Start the app using the Staging scheme on a real device with no user logged in
2. Ensure you have the Referrals FF enabled
3. Open an referral URL for staging ( Ping me if you need one)
4. Tap on Activate My Pass
5. Check if you see the login/signup screen
6. SignUp for a new account
7. Purchase the subscription
8. Check that after the purchase when you return to Profile View Controller you see the Welcome Screen

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
