### PR TITLE
[Custom Playback Settings] Apply global to local

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/PodcastDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/PodcastDataManager.swift
@@ -59,6 +59,7 @@ class PodcastDataManager {
         "showArchived",
         "refreshAvailable",
         "folderUuid",
+        "usedCustomEffectsBefore",
     ]
 
     func setup(dbQueue: FMDatabaseQueue) {
@@ -675,6 +676,7 @@ class PodcastDataManager {
         values.append(podcast.showArchived)
         values.append(podcast.refreshAvailable)
         values.append(DBUtils.nullIfNil(value: podcast.folderUuid))
+        values.append(podcast.usedCustomEffectsBefore)
 
         if includeIdForWhere {
             values.append(podcast.id)

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseHelper.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseHelper.swift
@@ -775,6 +775,16 @@ class DatabaseHelper {
             }
         }
 
+        if schemaVersion < 53 {
+            do {
+                try db.executeUpdate("ALTER TABLE SJPodcast ADD COLUMN usedCustomEffectsBefore INTEGER NOT NULL DEFAULT 0;", values: nil)
+                schemaVersion = 53
+            } catch {
+                failedAt(53)
+                return
+            }
+        }
+
         db.commit()
     }
 }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Podcast+fromDatabase.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Podcast+fromDatabase.swift
@@ -54,6 +54,7 @@ extension Podcast {
         podcast.showArchived = rs.bool(forColumn: "showArchived")
         podcast.refreshAvailable = rs.bool(forColumn: "refreshAvailable")
         podcast.folderUuid = rs.string(forColumn: "folderUuid")
+        podcast.usedCustomEffectsBefore = rs.bool(forColumn: "usedCustomEffectsBefore")
 
         return podcast
     }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Podcast.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Podcast.swift
@@ -51,6 +51,7 @@ public class Podcast: NSObject, Identifiable {
     @objc public var showArchived = false
     @objc public var refreshAvailable = false
     @objc public var folderUuid: String?
+    @objc public var usedCustomEffectsBefore = false
 
     public var settings: PodcastSettings = PodcastSettings.defaults
 

--- a/podcasts/EffectsViewController.swift
+++ b/podcasts/EffectsViewController.swift
@@ -275,7 +275,6 @@ class EffectsViewController: SimpleNotificationsViewController {
 
     @objc private func playbackSettingsDestinationChanged() {
         let applyLocalSettings = playbackSettingsSegmentedControl.selectedSegmentIndex == 1
-        PlaybackManager.shared.effectsChangedExternally()
         PlaybackManager.shared.overrideEffectsToggled(applyLocalSettings: applyLocalSettings)
         updateControls()
     }

--- a/podcasts/PlaybackEffects.swift
+++ b/podcasts/PlaybackEffects.swift
@@ -54,6 +54,14 @@ class PlaybackEffects {
 
         effects.isGlobal = false
 
+        if FeatureFlag.customPlaybackSettings.enabled && !podcast.usedCustomEffectsBefore {
+            let globalEffect = globalEffects()
+            effects.trimSilence = globalEffect.trimSilence
+            effects.volumeBoost = globalEffect.volumeBoost
+            effects.playbackSpeed = globalEffect.playbackSpeed
+            return effects
+        }
+
         if FeatureFlag.newSettingsStorage.enabled {
             effects.trimSilence = podcast.settings.trimSilence.amount
             effects.volumeBoost = podcast.settings.boostVolume

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -851,9 +851,13 @@ class PlaybackManager: ServerPlaybackDelegate {
         }
         podcast.isEffectsOverridden = applyLocalSettings
 
-        DataManager.sharedManager.save(podcast: podcast)
-        NotificationCenter.postOnMainThread(notification: Constants.Notifications.podcastUpdated, object: podcast.uuid)
-        effectsChangedExternally()
+        let newEffects = loadEffects()
+
+        if FeatureFlag.customPlaybackSettings.enabled && !podcast.usedCustomEffectsBefore {
+            podcast.usedCustomEffectsBefore = true
+        }
+
+        changeEffects(newEffects)
     }
 
     func isCurrentEffectGlobal() -> Bool {

--- a/podcasts/PodcastEffectsViewController+Table.swift
+++ b/podcasts/PodcastEffectsViewController+Table.swift
@@ -209,6 +209,9 @@ extension PodcastEffectsViewController: UITableViewDataSource, UITableViewDelega
     @objc private func overrideEffectsToggled(_ sender: UISwitch) {
         podcast.isEffectsOverridden = sender.isOn
         podcast.syncStatus = SyncStatus.notSynced.rawValue
+        if FeatureFlag.customPlaybackSettings.enabled && !podcast.usedCustomEffectsBefore {
+            podcast.usedCustomEffectsBefore = true
+        }
         saveUpdates()
 
         Analytics.track(.podcastSettingsCustomPlaybackEffectsToggled, properties: ["enabled": sender.isOn])


### PR DESCRIPTION
| 📘 Part of: #2253
|:---:|

Fixes #2283 

This PR introduces a new Podcast property to locally store if a local settings has been applied before. The property determines if the global settings is auto applied to the local settings when switching.

## To test

> [!NOTE]
> FF is `customPlaybackSettings`

#### Make sure I applied the right changes to the Podcast data model and db. ENsure I didn't miss any.
- CI must be 🟢 
- Enable the FF
- Play an episode and open the Effects view
- Apply some global effects change to a podcast that doesn't have local settings
- Swith to For this podcast
- Make sure the effects are the same
- Switch to a new episode and open the effect view
- The global settings should be applied (as you applied some before)
- Change the global settings
- Switch back to the previous episode and open the effects view
- Confirm the local settings are applied
- Switch to global
- Confirm the last global settings are applied

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
