### PR TITLE
End of Year 2024: Add of end_of_year_2024 feature flag

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -122,6 +122,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// to apply the Global or local settings
     case customPlaybackSettings
 
+    /// Enable the End of Year 2024 recap
+    case endOfYear2024
+
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -203,6 +206,8 @@ public enum FeatureFlag: String, CaseIterable {
         case .useMimetypePackage:
             true
         case .customPlaybackSettings:
+            false
+        case .endOfYear2024:
             false
         }
     }


### PR DESCRIPTION
| 📘 Part of: #2250 |
|:---:|

Implements #2287

Nothing happens yet. The showing of the modal is a bit more complex and I'm working on refactoring it for multi-year support.

## To test

* Visit the Developer section
* Make sure `endOfYear2024` appears
* Make sure toggle works

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
