### PR TITLE
Referrals: Enable by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Refactors the Discover view to improve impressions tracking [#2104](https://github.com/Automattic/pocket-casts-ios/issues/2104)
 - Attempt to fix the crash when a device run oout of space [#2275](https://github.com/Automattic/pocket-casts-ios/pull/2275)
 - Fix Share Extension in iOS 18 [#2263](https://github.com/Automattic/pocket-casts-ios/issues/2263)
+- Adding Referrals feature [#2083](https://github.com/Automattic/pocket-casts-ios/issues/2083)
 
 7.74
 -----

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -191,7 +191,7 @@ public enum FeatureFlag: String, CaseIterable {
         case .ignoreRouteDisconnectedInterruption:
             true
         case .referrals:
-            false
+            true
         case .syncStats:
             true
         case .discoverCollectionView:


### PR DESCRIPTION
| 📘 Part of: #2083  |  <!-- project issue number, if applicable -->
|:---:|

Just ensuring that referrals is enabled by default in order to be easily tested.
I'm also adding an entry to the changelog.

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

## To test

- Clean up any previous version of the app
- Start the app
- Ensure you have logged with a Patron or Plus user
- Go to Profile
- Check that you see on the top left the gift icon for referrals

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
