### PR TITLE
Vacuum on all releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Attempt to fix the crash when a device run oout of space [#2275](https://github.com/Automattic/pocket-casts-ios/pull/2275)
 - Fix Share Extension in iOS 18 [#2263](https://github.com/Automattic/pocket-casts-ios/issues/2263)
 - Adding Referrals feature [#2083](https://github.com/Automattic/pocket-casts-ios/issues/2083)
+- Optimize database on startup [#2301](https://github.com/Automattic/pocket-casts-ios/issues/2301)
 
 7.74
 -----

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -122,6 +122,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// to apply the Global or local settings
     case customPlaybackSettings
 
+    /// Run a vacuum process on the database in order to optimize data fetch
+    case runVacuumOnVersionUpdate
+
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -204,6 +207,8 @@ public enum FeatureFlag: String, CaseIterable {
             true
         case .customPlaybackSettings:
             false
+        case .runVacuumOnVersionUpdate:
+            true
         }
     }
 

--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -110,6 +110,7 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
         showInitialOnboardingIfNeeded()
 
         updateDatabaseIndexes()
+        optimizeDatabaseIfNeeded()
     }
 
     /// Update database indexes and delete unused columns
@@ -129,6 +130,25 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
             DataManager.sharedManager.cleanUp()
             self.dismissLoader()
             Settings.upgradedIndexes = true
+        }
+    }
+
+    private func optimizeDatabaseIfNeeded() {
+        guard
+            let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String,
+            appVersion != Settings.lastAppVersionThatRunVacuum,
+            FeatureFlag.runVacuumOnVersionUpdate.enabled
+        else {
+            return
+        }
+        Settings.lastAppVersionThatRunVacuum = appVersion
+        DispatchQueue.global(qos: .background).async { [weak self] in
+            guard let self else { return }
+            if DataManager.sharedManager.podcastCount() > 100 {
+                presentLoader()
+            }
+            DataManager.sharedManager.vacuumDatabase()
+            dismissLoader()
         }
     }
 

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -1312,6 +1312,16 @@ class Settings: NSObject {
         }
     }
 
+    class var lastAppVersionThatRunVacuum: String? {
+        set {
+            UserDefaults.standard.setValue(newValue, forKey: "last_app_version_that_run_vacuum")
+        }
+
+        get {
+            UserDefaults.standard.string(forKey: "last_app_version_that_run_vacuum")
+        }
+    }
+
     // MARK: - Variables that are loaded/changed through Firebase
 
     #if !os(watchOS)


### PR DESCRIPTION
| 📘 Part of: #2289  |  <!-- project issue number, if applicable -->
|:---:|

Fixes #2289

This PR changes the startup of the app and run a DB vacuum every time there is a new version.

## To test

- Start the app
- Check if all starts correctly
- If the database you are running has more than 100 podcasts you should see a loader view
- After the app started move around
- Restart the app
- Check that on the second time the vacuum time is not started.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
