### PR TITLE
Fix/1644 show dynamic island on player

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fix Share Extension in iOS 18 [#2263](https://github.com/Automattic/pocket-casts-ios/issues/2263)
 - Adding Referrals feature [#2083](https://github.com/Automattic/pocket-casts-ios/issues/2083)
 - Optimize database on startup [#2301](https://github.com/Automattic/pocket-casts-ios/issues/2301)
+- Show dynamic island on full screen player, and ajust layout [#2304](https://github.com/Automattic/pocket-casts-ios/pull/2304)
 
 7.74
 -----

--- a/podcasts/PCViewController.swift
+++ b/podcasts/PCViewController.swift
@@ -179,10 +179,6 @@ class PCViewController: SimpleNotificationsViewController {
         AppTheme.defaultStatusBarStyle()
     }
 
-    override var prefersHomeIndicatorAutoHidden: Bool {
-        appDelegate()?.miniPlayer()?.playerOpenState == .open
-    }
-
     @objc private func appWasBackgrounded() {
         handleAppDidEnterBackground()
     }

--- a/podcasts/PlayerContainerViewController.swift
+++ b/podcasts/PlayerContainerViewController.swift
@@ -270,10 +270,6 @@ class PlayerContainerViewController: SimpleNotificationsViewController, PlayerTa
         .lightContent
     }
 
-    override var prefersHomeIndicatorAutoHidden: Bool {
-        true
-    }
-
     // MARK: - App Backgrounding
 
     @objc func handleAppWillBecomeActive() {

--- a/podcasts/PlayerContainerViewController.swift
+++ b/podcasts/PlayerContainerViewController.swift
@@ -248,7 +248,7 @@ class PlayerContainerViewController: SimpleNotificationsViewController, PlayerTa
     private func adjustHeaderConstraintIfNeeded() {
         guard let window = view.window else { return }
 
-        let requiredHeight = 45 + UIUtil.statusBarHeight(in: window)
+        let requiredHeight = 50 + UIUtil.statusBarHeight(in: window)
 
         if headerHeightConstraint.constant != requiredHeight {
             headerHeightConstraint.constant = requiredHeight


### PR DESCRIPTION
| 📘 Part of: #1644 |  <!-- project issue number, if applicable -->
|:---:|

Fixes #1644 #2203  <!-- issue number, if applicable -->

This PR fixes the two issues above regarding the dynamic island:
- Increases the spacing from the top tab bar in the player and the dynamic island
- Keep the dynamic island visible ( and also the Home Indicator)

## To test

1. Start the app on a device that support the dynamic island ( iPhone 12 and above)
2. Switch to the clock app and start a timer
3. Go back to the app
4. Play an episode
5. Open the full screen player
6. Check that the dynamic island and the timer on the island stays visible
7. Check that the spacing to the tab component on top of the full player is good.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
