### PR TITLE
Playback 2024: Add multi-year support for End of Year/Playback

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -1087,47 +1087,47 @@ public extension DataManager {
 // MARK: - End of Year stats
 
 public extension DataManager {
-    func isEligibleForEndOfYearStories() -> Bool {
-        endOfYearManager.isEligible(dbQueue: dbQueue)
+    func isEligibleForEndOfYearStories(in year: Int) -> Bool {
+        endOfYearManager.isEligible(in: year, dbQueue: dbQueue)
     }
 
-    func isFullListeningHistory() -> Bool {
-        endOfYearManager.isFullListeningHistory(dbQueue: dbQueue)
+    func isFullListeningHistory(in year: Int) -> Bool {
+        endOfYearManager.isFullListeningHistory(in: year, dbQueue: dbQueue)
     }
 
-    func numberOfEpisodes(year: Int32) -> Int {
+    func numberOfEpisodes(year: Int) -> Int {
         endOfYearManager.numberOfEpisodes(year: year, dbQueue: dbQueue)
     }
 
-    func listeningTime() -> Double? {
-        endOfYearManager.listeningTime(dbQueue: dbQueue)
+    func listeningTime(in year: Int) -> Double? {
+        endOfYearManager.listeningTime(in: year, dbQueue: dbQueue)
     }
 
-    func listenedCategories() -> [ListenedCategory] {
-        endOfYearManager.listenedCategories(dbQueue: dbQueue)
+    func listenedCategories(in year: Int) -> [ListenedCategory] {
+        endOfYearManager.listenedCategories(in: year, dbQueue: dbQueue)
     }
 
-    func listenedNumbers() -> ListenedNumbers {
-        endOfYearManager.listenedNumbers(dbQueue: dbQueue)
+    func listenedNumbers(in year: Int) -> ListenedNumbers {
+        endOfYearManager.listenedNumbers(in: year, dbQueue: dbQueue)
     }
 
-    func topPodcasts(limit: Int = 5) -> [TopPodcast] {
-        endOfYearManager.topPodcasts(dbQueue: dbQueue, limit: limit)
+    func topPodcasts(in year: Int, limit: Int = 5) -> [TopPodcast] {
+        endOfYearManager.topPodcasts(in: year, dbQueue: dbQueue, limit: limit)
     }
 
-    func longestEpisode() -> Episode? {
-        endOfYearManager.longestEpisode(dbQueue: dbQueue)
+    func longestEpisode(in year: Int) -> Episode? {
+        endOfYearManager.longestEpisode(in: year, dbQueue: dbQueue)
     }
 
-    func episodesThatExist(year: Int32, uuids: [String]) -> [String] {
+    func episodesThatExist(year: Int, uuids: [String]) -> [String] {
         endOfYearManager.episodesThatExist(year: year, dbQueue: dbQueue, uuids: uuids)
     }
 
-    func yearOverYearListeningTime() -> YearOverYearListeningTime {
-        endOfYearManager.yearOverYearListeningTime(dbQueue: dbQueue)
+    func yearOverYearListeningTime(in year: Int) -> YearOverYearListeningTime {
+        endOfYearManager.yearOverYearListeningTime(in: year, dbQueue: dbQueue)
     }
 
-    func episodesStartedAndCompleted() -> EpisodesStartedAndCompleted {
-        endOfYearManager.episodesStartedAndCompleted(dbQueue: dbQueue)
+    func episodesStartedAndCompleted(in year: Int) -> EpisodesStartedAndCompleted {
+        endOfYearManager.episodesStartedAndCompleted(in: year, dbQueue: dbQueue)
     }
 }

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncYearListeningHistoryTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncYearListeningHistoryTask.swift
@@ -73,7 +73,7 @@ class SyncYearListeningHistoryTask: ApiBaseTask {
         do {
             let response = try Api_YearHistoryResponse(serializedData: serverData)
 
-            let localNumberOfEpisodes = DataManager.sharedManager.numberOfEpisodes(year: yearToSync)
+            let localNumberOfEpisodes = DataManager.sharedManager.numberOfEpisodes(year: Int(yearToSync))
 
             if response.count > localNumberOfEpisodes, let token {
                 print("SyncYearListeningHistory: \(Int(response.count) - localNumberOfEpisodes) episodes missing, adding them...")
@@ -108,7 +108,7 @@ class SyncYearListeningHistoryTask: ApiBaseTask {
 
         // Get the list of missing episodes in the database
         let uuids = updates.map { $0.episode }
-        let episodesThatExist = DataManager.sharedManager.episodesThatExist(year: yearToSync, uuids: uuids)
+        let episodesThatExist = DataManager.sharedManager.episodesThatExist(year: Int(yearToSync), uuids: uuids)
         let missingEpisodes = updates.filter { !episodesThatExist.contains($0.episode) }
 
         SyncYearListeningProgress.shared.episodesToSync += Double(missingEpisodes.count)

--- a/PocketCastsTests/Mocks/EndOfYearManagerMock.swift
+++ b/PocketCastsTests/Mocks/EndOfYearManagerMock.swift
@@ -20,35 +20,35 @@ class EndOfYearManagerMock: EndOfYearDataManager {
 
     var episodesStartedAndCompleted: EpisodesStartedAndCompleted?
 
-    override func listeningTime(dbQueue: FMDatabaseQueue) -> Double? {
+    override func listeningTime(in year: Int, dbQueue: FMDatabaseQueue) -> Double? {
         listeningTimeToReturn
     }
 
-    override func listenedCategories(dbQueue: FMDatabaseQueue) -> [ListenedCategory] {
+    override func listenedCategories(in year: Int, dbQueue: FMDatabaseQueue) -> [ListenedCategory] {
         listenedCategoriesToReturn
     }
 
-    override func listenedNumbers(dbQueue: FMDatabaseQueue) -> ListenedNumbers {
+    override func listenedNumbers(in year: Int, dbQueue: FMDatabaseQueue) -> ListenedNumbers {
         listenedNumbersToReturn ?? ListenedNumbers(numberOfPodcasts: 0, numberOfEpisodes: 0)
     }
 
-    override func topPodcasts(dbQueue: FMDatabaseQueue, limit: Int = 5) -> [TopPodcast] {
+    override func topPodcasts(in year: Int, dbQueue: FMDatabaseQueue, limit: Int = 5) -> [TopPodcast] {
         topPodcastsToReturn
     }
 
-    override func longestEpisode(dbQueue: FMDatabaseQueue) -> Episode? {
+    override func longestEpisode(in year: Int, dbQueue: FMDatabaseQueue) -> Episode? {
         return longestEpisodeToReturn
     }
 
-    override func isFullListeningHistory(dbQueue: FMDatabaseQueue) -> Bool {
+    override func isFullListeningHistory(in year: Int, dbQueue: FMDatabaseQueue) -> Bool {
         return isFullListeningHistoryToReturn
     }
 
-    override func yearOverYearListeningTime(dbQueue: FMDatabaseQueue) -> YearOverYearListeningTime {
+    override func yearOverYearListeningTime(in year: Int, dbQueue: FMDatabaseQueue) -> YearOverYearListeningTime {
         return yearOverYearToReturn ?? YearOverYearListeningTime(totalPlayedTimeThisYear: 0, totalPlayedTimeLastYear: 0)
     }
 
-    override func episodesStartedAndCompleted(dbQueue: FMDatabaseQueue) -> EpisodesStartedAndCompleted {
+    override func episodesStartedAndCompleted(in year: Int, dbQueue: FMDatabaseQueue) -> EpisodesStartedAndCompleted {
         episodesStartedAndCompleted ?? EpisodesStartedAndCompleted(started: 0, completed: 0)
     }
 }

--- a/PocketCastsTests/Tests/End of Year/EndOfYearStoriesBuilderTests.swift
+++ b/PocketCastsTests/Tests/End of Year/EndOfYearStoriesBuilderTests.swift
@@ -52,7 +52,7 @@ class EndOfYearStoriesBuilderTests: XCTestCase {
         ]
         let stories = await builder.build()
 
-        XCTAssertEqual(stories.0.first, EndOfYearStory.topCategories)
+        XCTAssertEqual(stories.0.first, EndOfYear2023Story.topCategories)
         XCTAssertEqual(stories.1.listenedCategories.first?.numberOfPodcasts, 1)
         XCTAssertEqual(stories.1.listenedCategories.first?.totalPlayedTime, 500)
         XCTAssertEqual(stories.1.listenedCategories.first?.numberOfEpisodes, 5)
@@ -83,7 +83,7 @@ class EndOfYearStoriesBuilderTests: XCTestCase {
         endOfYearManager.listenedNumbersToReturn = ListenedNumbers(numberOfPodcasts: 3, numberOfEpisodes: 10)
         let stories = await builder.build()
 
-        XCTAssertEqual(stories.0.first, EndOfYearStory.numberOfPodcastsAndEpisodesListened)
+        XCTAssertEqual(stories.0.first, EndOfYear2023Story.numberOfPodcastsAndEpisodesListened)
         XCTAssertEqual(stories.1.listenedNumbers.numberOfPodcasts, 3)
         XCTAssertEqual(stories.1.listenedNumbers.numberOfEpisodes, 10)
     }
@@ -112,7 +112,7 @@ class EndOfYearStoriesBuilderTests: XCTestCase {
         ]
         let stories = await builder.build()
 
-        XCTAssertEqual(stories.0.first, EndOfYearStory.topOnePodcast)
+        XCTAssertEqual(stories.0.first, EndOfYear2023Story.topOnePodcast)
         XCTAssertEqual(stories.1.topPodcasts.count, 1)
         XCTAssertNotNil(stories.1.topPodcasts.first?.podcast)
         XCTAssertEqual(stories.1.topPodcasts.first?.numberOfPlayedEpisodes, 3)
@@ -146,7 +146,7 @@ class EndOfYearStoriesBuilderTests: XCTestCase {
         ]
         let stories = await builder.build()
 
-        XCTAssertEqual(stories.0[1], EndOfYearStory.topFivePodcasts)
+        XCTAssertEqual(stories.0[1], EndOfYear2023Story.topFivePodcasts)
         XCTAssertEqual(stories.1.topPodcasts.count, 2)
     }
 
@@ -159,7 +159,7 @@ class EndOfYearStoriesBuilderTests: XCTestCase {
         endOfYearManager.longestEpisodeToReturn = episode
         let stories = await builder.build()
 
-        XCTAssertEqual(stories.0.first, EndOfYearStory.longestEpisode)
+        XCTAssertEqual(stories.0.first, EndOfYear2023Story.longestEpisode)
         XCTAssertNotNil(stories.1.longestEpisode)
         XCTAssertNotNil(stories.1.longestEpisodePodcast)
     }

--- a/PocketCastsTests/Tests/End of Year/EndOfYearStoriesBuilderTests.swift
+++ b/PocketCastsTests/Tests/End of Year/EndOfYearStoriesBuilderTests.swift
@@ -7,7 +7,7 @@ import XCTest
 class EndOfYearStoriesBuilderTests: XCTestCase {
     override func setUp() {
         // Do not sync for episodes
-        Settings.hasSyncedEpisodesForPlayback2023 = true
+        Settings.setHasSyncedEpisodesForPlayback(true, year: 2023)
 
         // Pretend we're logged in
         ServerSettings.setSyncingEmail(email: "test@test.com")
@@ -16,7 +16,8 @@ class EndOfYearStoriesBuilderTests: XCTestCase {
     func testReturnListeningTimeStoryIfBiggerThanZero() async {
         let endOfYearManager = EndOfYearManagerMock()
         let dataManager = DataManagerMock(endOfYearManager: endOfYearManager)
-        let builder = EndOfYearStoriesBuilder(dataManager: dataManager)
+        let model = EndOfYear2023StoriesModel()
+        let builder = EndOfYearStoriesBuilder(dataManager: dataManager, model: model)
 
         endOfYearManager.topPodcastsToReturn = [
             TopPodcast(podcast: Podcast.previewPodcast(),
@@ -24,56 +25,60 @@ class EndOfYearStoriesBuilderTests: XCTestCase {
                        totalPlayedTime: 3000)
         ]
         endOfYearManager.listeningTimeToReturn = 3000
-        let stories = await builder.build()
+        await builder.build()
 
-        XCTAssertTrue(stories.0.contains(.listeningTime))
-        XCTAssertEqual(stories.1.listeningTime, 3000)
+        XCTAssertTrue(model.stories.contains(.listeningTime))
+        XCTAssertEqual(model.data.listeningTime, 3000)
     }
 
     func testDontReturnListeningTimeStoryIfZero() async {
         let endOfYearManager = EndOfYearManagerMock()
         let dataManager = DataManagerMock(endOfYearManager: endOfYearManager)
-        let builder = EndOfYearStoriesBuilder(dataManager: dataManager)
+        let model = EndOfYear2023StoriesModel()
+        let builder = EndOfYearStoriesBuilder(dataManager: dataManager, model: model)
 
         endOfYearManager.listeningTimeToReturn = 0
-        let stories = await builder.build()
+        await builder.build()
 
-        XCTAssertFalse(stories.0.contains(.listeningTime))
-        XCTAssertEqual(stories.1.listeningTime, 0)
+        XCTAssertFalse(model.stories.contains(.listeningTime))
+        XCTAssertEqual(model.data.listeningTime, 0)
     }
 
     func testReturnListenedCategories() async {
         let endOfYearManager = EndOfYearManagerMock()
         let dataManager = DataManagerMock(endOfYearManager: endOfYearManager)
-        let builder = EndOfYearStoriesBuilder(dataManager: dataManager)
+        let model = EndOfYear2023StoriesModel()
+        let builder = EndOfYearStoriesBuilder(dataManager: dataManager, model: model)
 
         endOfYearManager.listenedCategoriesToReturn = [
             ListenedCategory(numberOfPodcasts: 1, categoryTitle: "title", mostListenedPodcast: Podcast.previewPodcast(), totalPlayedTime: 500, numberOfEpisodes: 5)
         ]
-        let stories = await builder.build()
+        await builder.build()
 
-        XCTAssertEqual(stories.0.first, EndOfYear2023Story.topCategories)
-        XCTAssertEqual(stories.1.listenedCategories.first?.numberOfPodcasts, 1)
-        XCTAssertEqual(stories.1.listenedCategories.first?.totalPlayedTime, 500)
-        XCTAssertEqual(stories.1.listenedCategories.first?.numberOfEpisodes, 5)
+        XCTAssertEqual(model.stories.first, EndOfYear2023Story.topCategories)
+        XCTAssertEqual(model.data.listenedCategories.first?.numberOfPodcasts, 1)
+        XCTAssertEqual(model.data.listenedCategories.first?.totalPlayedTime, 500)
+        XCTAssertEqual(model.data.listenedCategories.first?.numberOfEpisodes, 5)
     }
 
     func testDontReturnListenedCategoriesIfEmpty() async {
         let endOfYearManager = EndOfYearManagerMock()
         let dataManager = DataManagerMock(endOfYearManager: endOfYearManager)
-        let builder = EndOfYearStoriesBuilder(dataManager: dataManager)
+        let model = EndOfYear2023StoriesModel()
+        let builder = EndOfYearStoriesBuilder(dataManager: dataManager, model: model)
 
         endOfYearManager.listenedCategoriesToReturn = []
-        let stories = await builder.build()
+        await builder.build()
 
-        XCTAssertFalse(stories.0.contains(.topCategories))
-        XCTAssertTrue(stories.1.listenedCategories.isEmpty)
+        XCTAssertFalse(model.stories.contains(.topCategories))
+        XCTAssertTrue(model.data.listenedCategories.isEmpty)
     }
 
     func testReturnListenedPodcastsAndEpisodes() async {
         let endOfYearManager = EndOfYearManagerMock()
         let dataManager = DataManagerMock(endOfYearManager: endOfYearManager)
-        let builder = EndOfYearStoriesBuilder(dataManager: dataManager)
+        let model = EndOfYear2023StoriesModel()
+        let builder = EndOfYearStoriesBuilder(dataManager: dataManager, model: model)
 
         endOfYearManager.topPodcastsToReturn = [
             TopPodcast(podcast: Podcast.previewPodcast(),
@@ -81,60 +86,64 @@ class EndOfYearStoriesBuilderTests: XCTestCase {
                        totalPlayedTime: 3000)
         ]
         endOfYearManager.listenedNumbersToReturn = ListenedNumbers(numberOfPodcasts: 3, numberOfEpisodes: 10)
-        let stories = await builder.build()
+        await builder.build()
 
-        XCTAssertEqual(stories.0.first, EndOfYear2023Story.numberOfPodcastsAndEpisodesListened)
-        XCTAssertEqual(stories.1.listenedNumbers.numberOfPodcasts, 3)
-        XCTAssertEqual(stories.1.listenedNumbers.numberOfEpisodes, 10)
+        XCTAssertEqual(model.stories.first, EndOfYear2023Story.numberOfPodcastsAndEpisodesListened)
+        XCTAssertEqual(model.data.listenedNumbers.numberOfPodcasts, 3)
+        XCTAssertEqual(model.data.listenedNumbers.numberOfEpisodes, 10)
     }
 
     func testDontReturnListenedPodcastsAndEpisodes() async {
         let endOfYearManager = EndOfYearManagerMock()
         let dataManager = DataManagerMock(endOfYearManager: endOfYearManager)
-        let builder = EndOfYearStoriesBuilder(dataManager: dataManager)
+        let model = EndOfYear2023StoriesModel()
+        let builder = EndOfYearStoriesBuilder(dataManager: dataManager, model: model)
 
         endOfYearManager.listenedNumbersToReturn = ListenedNumbers(numberOfPodcasts: 0, numberOfEpisodes: 0)
-        let stories = await builder.build()
+        await builder.build()
 
-        XCTAssertFalse(stories.0.contains(.numberOfPodcastsAndEpisodesListened))
-        XCTAssertNil(stories.1.listenedNumbers)
+        XCTAssertFalse(model.stories.contains(.numberOfPodcastsAndEpisodesListened))
+        XCTAssertNil(model.data.listenedNumbers)
     }
 
     func testReturnTopOnePodcast() async {
         let endOfYearManager = EndOfYearManagerMock()
         let dataManager = DataManagerMock(endOfYearManager: endOfYearManager)
-        let builder = EndOfYearStoriesBuilder(dataManager: dataManager)
+        let model = EndOfYear2023StoriesModel()
+        let builder = EndOfYearStoriesBuilder(dataManager: dataManager, model: model)
 
         endOfYearManager.topPodcastsToReturn = [
             TopPodcast(podcast: Podcast.previewPodcast(),
                        numberOfPlayedEpisodes: 3,
                        totalPlayedTime: 3000)
         ]
-        let stories = await builder.build()
+        await builder.build()
 
-        XCTAssertEqual(stories.0.first, EndOfYear2023Story.topOnePodcast)
-        XCTAssertEqual(stories.1.topPodcasts.count, 1)
-        XCTAssertNotNil(stories.1.topPodcasts.first?.podcast)
-        XCTAssertEqual(stories.1.topPodcasts.first?.numberOfPlayedEpisodes, 3)
-        XCTAssertEqual(stories.1.topPodcasts.first?.totalPlayedTime, 3000)
+        XCTAssertEqual(model.stories.first, EndOfYear2023Story.topOnePodcast)
+        XCTAssertEqual(model.data.topPodcasts.count, 1)
+        XCTAssertNotNil(model.data.topPodcasts.first?.podcast)
+        XCTAssertEqual(model.data.topPodcasts.first?.numberOfPlayedEpisodes, 3)
+        XCTAssertEqual(model.data.topPodcasts.first?.totalPlayedTime, 3000)
     }
 
     func testDontReturnTopOnePodcast() async {
         let endOfYearManager = EndOfYearManagerMock()
         let dataManager = DataManagerMock(endOfYearManager: endOfYearManager)
-        let builder = EndOfYearStoriesBuilder(dataManager: dataManager)
+        let model = EndOfYear2023StoriesModel()
+        let builder = EndOfYearStoriesBuilder(dataManager: dataManager, model: model)
 
         endOfYearManager.topPodcastsToReturn = []
         let stories = await builder.build()
 
-        XCTAssertFalse(stories.0.contains(.topOnePodcast))
-        XCTAssertEqual(stories.1.topPodcasts.count, 0)
+        XCTAssertFalse(model.stories.contains(.topOnePodcast))
+        XCTAssertEqual(model.data.topPodcasts.count, 0)
     }
 
     func testReturnTopFivePodcasts() async {
         let endOfYearManager = EndOfYearManagerMock()
         let dataManager = DataManagerMock(endOfYearManager: endOfYearManager)
-        let builder = EndOfYearStoriesBuilder(dataManager: dataManager)
+        let model = EndOfYear2023StoriesModel()
+        let builder = EndOfYearStoriesBuilder(dataManager: dataManager, model: model)
 
         endOfYearManager.topPodcastsToReturn = [
             TopPodcast(podcast: Podcast.previewPodcast(),
@@ -144,79 +153,84 @@ class EndOfYearStoriesBuilderTests: XCTestCase {
                        numberOfPlayedEpisodes: 10,
                        totalPlayedTime: 4000)
         ]
-        let stories = await builder.build()
+        await builder.build()
 
-        XCTAssertEqual(stories.0[1], EndOfYear2023Story.topFivePodcasts)
-        XCTAssertEqual(stories.1.topPodcasts.count, 2)
+        XCTAssertEqual(model.stories[1], EndOfYear2023Story.topFivePodcasts)
+        XCTAssertEqual(model.data.topPodcasts.count, 2)
     }
 
     func testReturnLongestEpisode() async {
         let endOfYearManager = EndOfYearManagerMock()
         let dataManager = DataManagerMock(endOfYearManager: endOfYearManager)
-        let builder = EndOfYearStoriesBuilder(dataManager: dataManager)
+        let model = EndOfYear2023StoriesModel()
+        let builder = EndOfYearStoriesBuilder(dataManager: dataManager, model: model)
 
         let episode = EpisodeMock()
         endOfYearManager.longestEpisodeToReturn = episode
-        let stories = await builder.build()
+        await builder.build()
 
-        XCTAssertEqual(stories.0.first, EndOfYear2023Story.longestEpisode)
-        XCTAssertNotNil(stories.1.longestEpisode)
-        XCTAssertNotNil(stories.1.longestEpisodePodcast)
+        XCTAssertEqual(model.stories.first, EndOfYear2023Story.longestEpisode)
+        XCTAssertNotNil(model.data.longestEpisode)
+        XCTAssertNotNil(model.data.longestEpisodePodcast)
     }
 
     func testDontReturnLongestEpisode() async {
         let endOfYearManager = EndOfYearManagerMock()
         let dataManager = DataManagerMock(endOfYearManager: endOfYearManager)
-        let builder = EndOfYearStoriesBuilder(dataManager: dataManager)
+        let model = EndOfYear2023StoriesModel()
+        let builder = EndOfYearStoriesBuilder(dataManager: dataManager, model: model)
 
         endOfYearManager.longestEpisodeToReturn = nil
-        let stories = await builder.build()
+        await builder.build()
 
-        XCTAssertFalse(stories.0.contains(.longestEpisode))
-        XCTAssertNil(stories.1.longestEpisode)
-        XCTAssertNil(stories.1.longestEpisodePodcast)
+        XCTAssertFalse(model.stories.contains(.longestEpisode))
+        XCTAssertNil(model.data.longestEpisode)
+        XCTAssertNil(model.data.longestEpisodePodcast)
     }
 
     func testReturnYearOverYearListeningTime() async {
         let endOfYearManager = EndOfYearManagerMock()
         let dataManager = DataManagerMock(endOfYearManager: endOfYearManager)
-        let builder = EndOfYearStoriesBuilder(dataManager: dataManager)
+        let model = EndOfYear2023StoriesModel()
+        let builder = EndOfYearStoriesBuilder(dataManager: dataManager, model: model)
 
         endOfYearManager.yearOverYearToReturn = YearOverYearListeningTime(
             totalPlayedTimeThisYear: 153,
             totalPlayedTimeLastYear: 100
         )
 
-        let stories = await builder.build()
+        await builder.build()
 
-        XCTAssertTrue(stories.0.contains(.yearOverYearListeningTime))
+        XCTAssertTrue(model.stories.contains(.yearOverYearListeningTime))
         XCTAssertEqual(endOfYearManager.yearOverYearToReturn?.percentage, 53.0)
-        XCTAssertNotNil(stories.1.yearOverYearListeningTime)
+        XCTAssertNotNil(model.data.yearOverYearListeningTime)
     }
 
     func testReturnCompletionRate() async {
         let endOfYearManager = EndOfYearManagerMock()
         let dataManager = DataManagerMock(endOfYearManager: endOfYearManager)
-        let builder = EndOfYearStoriesBuilder(dataManager: dataManager)
+        let model = EndOfYear2023StoriesModel()
+        let builder = EndOfYearStoriesBuilder(dataManager: dataManager, model: model)
 
         endOfYearManager.episodesStartedAndCompleted = EpisodesStartedAndCompleted(
             started: 10,
             completed: 5
         )
 
-        let stories = await builder.build()
+        await builder.build()
 
-        XCTAssertTrue(stories.0.contains(.completionRate))
+        XCTAssertTrue(model.stories.contains(.completionRate))
         XCTAssertEqual(endOfYearManager.episodesStartedAndCompleted?.percentage, 0.5)
-        XCTAssertNotNil(stories.1.episodesStartedAndCompleted)
+        XCTAssertNotNil(model.data.episodesStartedAndCompleted)
     }
 
     func testSyncWhenNeeded() async {
         var syncCalled = false
         let endOfYearManager = EndOfYearManagerMock()
         let dataManager = DataManagerMock(endOfYearManager: endOfYearManager)
-        let builder = EndOfYearStoriesBuilder(dataManager: dataManager, sync: { syncCalled = true; return true })
-        Settings.hasSyncedEpisodesForPlayback2023 = false
+        let model = EndOfYear2023StoriesModel()
+        let builder = EndOfYearStoriesBuilder(dataManager: dataManager, model: model, sync: { syncCalled = true; return true })
+        Settings.setHasSyncedEpisodesForPlayback(true, year: 2023)
 
         endOfYearManager.isFullListeningHistoryToReturn = false
         _ = await builder.build()
@@ -228,8 +242,9 @@ class EndOfYearStoriesBuilderTests: XCTestCase {
         var syncCalled = false
         let endOfYearManager = EndOfYearManagerMock()
         let dataManager = DataManagerMock(endOfYearManager: endOfYearManager)
-        let builder = EndOfYearStoriesBuilder(dataManager: dataManager, sync: { syncCalled = true; return true })
-        Settings.hasSyncedEpisodesForPlayback2023 = true
+        let model = EndOfYear2023StoriesModel()
+        let builder = EndOfYearStoriesBuilder(dataManager: dataManager, model: model, sync: { syncCalled = true; return true })
+        Settings.setHasSyncedEpisodesForPlayback(true, year: 2023)
 
         endOfYearManager.isFullListeningHistoryToReturn = false
         _ = await builder.build()
@@ -245,8 +260,9 @@ class EndOfYearStoriesBuilderTests: XCTestCase {
         var plusUser = false
         let endOfYearManager = EndOfYearManagerMock()
         let dataManager = DataManagerMock(endOfYearManager: endOfYearManager)
-        let builder = EndOfYearStoriesBuilder(dataManager: dataManager, sync: { syncCalledTimes += 1; return true }, hasActiveSubscription: { plusUser })
-        Settings.hasSyncedEpisodesForPlayback2023 = false
+        let model = EndOfYear2023StoriesModel()
+        let builder = EndOfYearStoriesBuilder(dataManager: dataManager, model: model, sync: { syncCalledTimes += 1; return true }, hasActiveSubscription: { plusUser })
+        Settings.setHasSyncedEpisodesForPlayback(false, year: 2023)
         endOfYearManager.isFullListeningHistoryToReturn = false
         _ = await builder.build()
 
@@ -261,8 +277,9 @@ class EndOfYearStoriesBuilderTests: XCTestCase {
         let plusUser = false
         let endOfYearManager = EndOfYearManagerMock()
         let dataManager = DataManagerMock(endOfYearManager: endOfYearManager)
-        let builder = EndOfYearStoriesBuilder(dataManager: dataManager, sync: { syncCalledTimes += 1; return true }, hasActiveSubscription: { plusUser })
-        Settings.hasSyncedEpisodesForPlayback2023 = false
+        let model = EndOfYear2023StoriesModel()
+        let builder = EndOfYearStoriesBuilder(dataManager: dataManager, model: model, sync: { syncCalledTimes += 1; return true }, hasActiveSubscription: { plusUser })
+        Settings.setHasSyncedEpisodesForPlayback(false, year: 2023)
         endOfYearManager.isFullListeningHistoryToReturn = false
         _ = await builder.build()
 

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1667,6 +1667,7 @@
 		F54E72192CA722A000CD5C86 /* Array+DiscoverItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = F54E72182CA722A000CD5C86 /* Array+DiscoverItem.swift */; };
 		F54E721D2CA7359800CD5C86 /* DiscoverCellType.swift in Sources */ = {isa = PBXBuildFile; fileRef = F54E721C2CA7359800CD5C86 /* DiscoverCellType.swift */; };
 		F54E721F2CA749AA00CD5C86 /* DiscoverCollectionViewController+Categories.swift in Sources */ = {isa = PBXBuildFile; fileRef = F54E721E2CA749AA00CD5C86 /* DiscoverCollectionViewController+Categories.swift */; };
+		F55275B82CB74E230012B705 /* EndOfYear2023Story.swift in Sources */ = {isa = PBXBuildFile; fileRef = F55275B72CB74E230012B705 /* EndOfYear2023Story.swift */; };
 		F55449422B758E8300F68AE9 /* PocketCastsUtils in Frameworks */ = {isa = PBXBuildFile; productRef = F55449412B758E8300F68AE9 /* PocketCastsUtils */; };
 		F55449432B758E8300F68AE9 /* PocketCastsUtils in Embed Frameworks */ = {isa = PBXBuildFile; productRef = F55449412B758E8300F68AE9 /* PocketCastsUtils */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		F55449452B75935F00F68AE9 /* AppSettings+ImportUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = F55449442B75935F00F68AE9 /* AppSettings+ImportUserDefaults.swift */; };
@@ -1704,6 +1705,7 @@
 		F5E3DAA72BDD5567002BD4E4 /* PCBundleDoc.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5E3DAA62BDD5567002BD4E4 /* PCBundleDoc.swift */; };
 		F5E431D62B50888500A71DB3 /* PlusLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5E431D52B50888500A71DB3 /* PlusLabel.swift */; };
 		F5E949DA2B61762E002DAFC3 /* TokenHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5E949D92B61762E002DAFC3 /* TokenHelperTests.swift */; };
+		F5EA21F42CC1DBFE0043C780 /* EndOfYear2023StoriesModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5EA21F32CC1DBFE0043C780 /* EndOfYear2023StoriesModel.swift */; };
 		F5F479A62C3EF8AB002B4475 /* PlayheadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5F479A52C3EF8AB002B4475 /* PlayheadView.swift */; };
 		F5F69D802C07C867000B3C87 /* FMDatabaseQueue+Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5F69D7F2C07C867000B3C87 /* FMDatabaseQueue+Test.swift */; };
 		F5F6DA702BBE1109009B1934 /* CategoryButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5F6DA6F2BBE1109009B1934 /* CategoryButtonStyle.swift */; };
@@ -3593,6 +3595,7 @@
 		F54E72182CA722A000CD5C86 /* Array+DiscoverItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+DiscoverItem.swift"; sourceTree = "<group>"; };
 		F54E721C2CA7359800CD5C86 /* DiscoverCellType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverCellType.swift; sourceTree = "<group>"; };
 		F54E721E2CA749AA00CD5C86 /* DiscoverCollectionViewController+Categories.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DiscoverCollectionViewController+Categories.swift"; sourceTree = "<group>"; };
+		F55275B72CB74E230012B705 /* EndOfYear2023Story.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndOfYear2023Story.swift; sourceTree = "<group>"; };
 		F55449442B75935F00F68AE9 /* AppSettings+ImportUserDefaults.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AppSettings+ImportUserDefaults.swift"; sourceTree = "<group>"; };
 		F555980A2C50242800C02EEB /* VideoExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoExporter.swift; sourceTree = "<group>"; };
 		F555980E2C503F1700C02EEB /* AnimatedShareImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimatedShareImageView.swift; sourceTree = "<group>"; };
@@ -3627,6 +3630,7 @@
 		F5E3DAA62BDD5567002BD4E4 /* PCBundleDoc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PCBundleDoc.swift; sourceTree = "<group>"; };
 		F5E431D52B50888500A71DB3 /* PlusLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlusLabel.swift; sourceTree = "<group>"; };
 		F5E949D92B61762E002DAFC3 /* TokenHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenHelperTests.swift; sourceTree = "<group>"; };
+		F5EA21F32CC1DBFE0043C780 /* EndOfYear2023StoriesModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndOfYear2023StoriesModel.swift; sourceTree = "<group>"; };
 		F5F479A52C3EF8AB002B4475 /* PlayheadView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayheadView.swift; sourceTree = "<group>"; };
 		F5F69D7F2C07C867000B3C87 /* FMDatabaseQueue+Test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FMDatabaseQueue+Test.swift"; sourceTree = "<group>"; };
 		F5F6DA6F2BBE1109009B1934 /* CategoryButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryButtonStyle.swift; sourceTree = "<group>"; };
@@ -4830,6 +4834,7 @@
 				8B723754291185B300FA8219 /* Analytics+story.swift */,
 				8BCB22B328F48282001A0315 /* EndOfYear.swift */,
 				8B23193E2902C84A0001C3DE /* EndOfYearStoriesBuilder.swift */,
+				F5EA21F52CC1DC100043C780 /* End of Year 2023 */,
 				8B5AB48B29018EFA0018C637 /* StoriesConfiguration.swift */,
 				8B6B68E428F744520032BFFF /* StoriesDataSource.swift */,
 				8B5AB48D2901A8BD0018C637 /* StoriesController.swift */,
@@ -7799,6 +7804,15 @@
 			path = Effects;
 			sourceTree = "<group>";
 		};
+		F5EA21F52CC1DC100043C780 /* End of Year 2023 */ = {
+			isa = PBXGroup;
+			children = (
+				F55275B72CB74E230012B705 /* EndOfYear2023Story.swift */,
+				F5EA21F32CC1DBFE0043C780 /* EndOfYear2023StoriesModel.swift */,
+			);
+			path = "End of Year 2023";
+			sourceTree = "<group>";
+		};
 		F5F6DA6E2BBE10E2009B1934 /* Categories */ = {
 			isa = PBXGroup;
 			children = (
@@ -9356,6 +9370,7 @@
 				C7DA8D272923DA4500C1B08B /* PlusPricingInfoModel.swift in Sources */,
 				C7BDECB52A15327000BECF02 /* PatronUnlockButton.swift in Sources */,
 				BDA206601BB3D4D600D38389 /* DownloadsViewController.swift in Sources */,
+				F5EA21F42CC1DBFE0043C780 /* EndOfYear2023StoriesModel.swift in Sources */,
 				407502B6240DCBF200437528 /* NetworkUtils+Helpers.swift in Sources */,
 				8BB4AA632BD17EC10091480A /* FadeOutManager.swift in Sources */,
 				C741D9D428ADBA23006CFBE7 /* AppLifecyleAnalytics.swift in Sources */,
@@ -10099,6 +10114,7 @@
 				408971AF2512F57100783253 /* BundleImageView.swift in Sources */,
 				BD65E51C1CD9BDE000B90A67 /* OnlineSupportController.swift in Sources */,
 				BDCF60EA22EFECA60051EDB3 /* ThemeableCell.swift in Sources */,
+				F55275B82CB74E230012B705 /* EndOfYear2023Story.swift in Sources */,
 				C7C4F8832A71E1B7002139B2 /* BookmarkEpisodeListController.swift in Sources */,
 				408C088E23155B34008C9667 /* WhatsNewHelper.swift in Sources */,
 				463538A726E16CD100BA9D35 /* Strings+L10n.swift in Sources */,

--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -152,10 +152,10 @@ struct Constants {
 
         static let reviewRequestDates = "reviewRequestDates"
 
-        static let showBadgeFor2023EndOfYear = "showBadgeFor2023EndOfYear"
-        static let modal2023HasBeenShown = "modal2023HasBeenShown"
-        static let hasSyncedEpisodesForPlayback2023 = "hasSyncedEpisodesForPlayback2023"
-        static let hasSyncedEpisodesForPlayback2023AsPlusUser = "hasSyncedEpisodesForPlayback2023AsPlusUser"
+        static let showBadgeForEndOfYear = "showBadgeFor%dEndOfYear"
+        static let modalHasBeenShown = "modal%dHasBeenShown"
+        static let hasSyncedEpisodesForPlayback = "hasSyncedEpisodesForPlayback%d"
+        static let hasSyncedEpisodesForPlaybackAsPlusUser = "hasSyncedEpisodesForPlayback%dAsPlusUser"
         static let top5PodcastsListLink = "top5PodcastsListLink2023_2"
         static let shouldShowInitialOnboardingFlow = "shouldShowInitialOnboardingFlow"
 

--- a/podcasts/DeveloperMenu.swift
+++ b/podcasts/DeveloperMenu.swift
@@ -286,8 +286,7 @@ struct DeveloperMenu: View {
 
             Section {
                 Button("Reset modal/profile badge") {
-                    Settings.endOfYearModalHasBeenShown = false
-                    Settings.showBadgeForEndOfYear = true
+                    Settings.setHasShownModalForEndOfYear(false, year: 2023)
                 }
             } header: {
                 Text("End of Year")

--- a/podcasts/End of Year/End of Year 2023/EndOfYear2023StoriesModel.swift
+++ b/podcasts/End of Year/End of Year 2023/EndOfYear2023StoriesModel.swift
@@ -1,0 +1,141 @@
+import PocketCastsDataModel
+import PocketCastsServer
+
+class EndOfYear2023StoriesModel: StoryModel {
+    let year = 2023
+    var stories = [EndOfYear2023Story]()
+    var data = EndOfYear2023StoriesData()
+
+    func populate(with dataManager: DataManager) {
+        // First, search for top 10 podcasts to use throughout different stories
+        let topPodcasts = dataManager.topPodcasts(in: year, limit: 10)
+        if !topPodcasts.isEmpty {
+            data.topPodcasts = Array(topPodcasts.prefix(5))
+            data.top10Podcasts = Array(topPodcasts.suffix(8)).map { $0.podcast }.reversed()
+        }
+
+        // Listening time
+        if let listeningTime = dataManager.listeningTime(in: year),
+           listeningTime > 0, !data.top10Podcasts.isEmpty {
+            stories.append(.listeningTime)
+            data.listeningTime = listeningTime
+        }
+
+        // Listened categories
+        let listenedCategories = dataManager.listenedCategories(in: year)
+        if !listenedCategories.isEmpty {
+            data.listenedCategories = listenedCategories
+            stories.append(.topCategories)
+        }
+
+        // Listened podcasts and episodes
+        let listenedNumbers = dataManager.listenedNumbers(in: year)
+        if listenedNumbers.numberOfEpisodes > 0
+            && listenedNumbers.numberOfPodcasts > 0
+            && !data.top10Podcasts.isEmpty {
+            data.listenedNumbers = listenedNumbers
+            stories.append(.numberOfPodcastsAndEpisodesListened)
+        }
+
+        // Top podcasts
+        if !data.topPodcasts.isEmpty {
+            stories.append(.topOnePodcast)
+        }
+
+        // Top 5 podcasts
+        if topPodcasts.count > 1 {
+            stories.append(.topFivePodcasts)
+        }
+
+        // Longest episode
+        if let longestEpisode = dataManager.longestEpisode(in: year),
+           let podcast = longestEpisode.parentPodcast() {
+            data.longestEpisode = longestEpisode
+            data.longestEpisodePodcast = podcast
+            stories.append(.longestEpisode)
+        }
+
+        // Year over year listening time
+        let yearOverYearListeningTime = dataManager.yearOverYearListeningTime(in: year)
+        if yearOverYearListeningTime.totalPlayedTimeThisYear != 0 ||
+            yearOverYearListeningTime.totalPlayedTimeLastYear != 0 {
+            data.yearOverYearListeningTime = yearOverYearListeningTime
+            stories.append(.yearOverYearListeningTime)
+        }
+
+        data.episodesStartedAndCompleted = dataManager.episodesStartedAndCompleted(in: year)
+        stories.append(.completionRate)
+    }
+
+    func story(for storyNumber: Int) -> any StoryView {
+        switch stories[storyNumber] {
+        case .intro:
+            return IntroStory()
+        case .listeningTime:
+            return ListeningTimeStory(listeningTime: data.listeningTime, podcasts: data.top10Podcasts)
+        case .topCategories:
+            return TopListenedCategoriesStory(listenedCategories: data.listenedCategories)
+        case .numberOfPodcastsAndEpisodesListened:
+            return ListenedNumbersStory(listenedNumbers: data.listenedNumbers, podcasts: data.top10Podcasts)
+        case .topOnePodcast:
+            return TopOnePodcastStory(podcasts: data.topPodcasts)
+        case .topFivePodcasts:
+            return TopFivePodcastsStory(topPodcasts: data.topPodcasts)
+        case .longestEpisode:
+            return LongestEpisodeStory(episode: data.longestEpisode, podcast: data.longestEpisodePodcast)
+        case .yearOverYearListeningTime:
+            return YearOverYearStory(data: data.yearOverYearListeningTime)
+        case .completionRate:
+            return CompletionRateStory(subscriptionTier: SubscriptionHelper.activeTier, startedAndCompleted: data.episodesStartedAndCompleted)
+        case .epilogue:
+            return EpilogueStory()
+        }
+    }
+
+    func isInteractiveView(for storyNumber: Int) -> Bool {
+        switch stories[storyNumber] {
+        case .epilogue:
+            return true
+        default:
+            return false
+        }
+    }
+
+    func isReady() -> Bool {
+        if !stories.isEmpty {
+            stories.append(.intro)
+            stories.append(.epilogue)
+
+            stories.sortByCaseIterableIndex()
+
+            return true
+        }
+
+        return false
+    }
+
+    var numberOfStories: Int {
+        stories.count
+    }
+}
+
+/// An entity that holds data to present EoY 2023 stories
+class EndOfYear2023StoriesData {
+    var listeningTime: Double = 0
+
+    var listenedCategories: [ListenedCategory] = []
+
+    var listenedNumbers: ListenedNumbers!
+
+    var topPodcasts: [TopPodcast] = []
+
+    var longestEpisode: Episode!
+
+    var longestEpisodePodcast: Podcast!
+
+    var top10Podcasts: [Podcast] = []
+
+    var yearOverYearListeningTime: YearOverYearListeningTime!
+
+    var episodesStartedAndCompleted: EpisodesStartedAndCompleted!
+}

--- a/podcasts/End of Year/End of Year 2023/EndOfYear2023StoriesModel.swift
+++ b/podcasts/End of Year/End of Year 2023/EndOfYear2023StoriesModel.swift
@@ -2,34 +2,36 @@ import PocketCastsDataModel
 import PocketCastsServer
 
 class EndOfYear2023StoriesModel: StoryModel {
-    let year = 2023
+    static let year = 2023
     var stories = [EndOfYear2023Story]()
     var data = EndOfYear2023StoriesData()
 
+    required init() {}
+
     func populate(with dataManager: DataManager) {
         // First, search for top 10 podcasts to use throughout different stories
-        let topPodcasts = dataManager.topPodcasts(in: year, limit: 10)
+        let topPodcasts = dataManager.topPodcasts(in: Self.year, limit: 10)
         if !topPodcasts.isEmpty {
             data.topPodcasts = Array(topPodcasts.prefix(5))
             data.top10Podcasts = Array(topPodcasts.suffix(8)).map { $0.podcast }.reversed()
         }
 
         // Listening time
-        if let listeningTime = dataManager.listeningTime(in: year),
+        if let listeningTime = dataManager.listeningTime(in: Self.year),
            listeningTime > 0, !data.top10Podcasts.isEmpty {
             stories.append(.listeningTime)
             data.listeningTime = listeningTime
         }
 
         // Listened categories
-        let listenedCategories = dataManager.listenedCategories(in: year)
+        let listenedCategories = dataManager.listenedCategories(in: Self.year)
         if !listenedCategories.isEmpty {
             data.listenedCategories = listenedCategories
             stories.append(.topCategories)
         }
 
         // Listened podcasts and episodes
-        let listenedNumbers = dataManager.listenedNumbers(in: year)
+        let listenedNumbers = dataManager.listenedNumbers(in: Self.year)
         if listenedNumbers.numberOfEpisodes > 0
             && listenedNumbers.numberOfPodcasts > 0
             && !data.top10Podcasts.isEmpty {
@@ -48,7 +50,7 @@ class EndOfYear2023StoriesModel: StoryModel {
         }
 
         // Longest episode
-        if let longestEpisode = dataManager.longestEpisode(in: year),
+        if let longestEpisode = dataManager.longestEpisode(in: Self.year),
            let podcast = longestEpisode.parentPodcast() {
             data.longestEpisode = longestEpisode
             data.longestEpisodePodcast = podcast
@@ -56,14 +58,14 @@ class EndOfYear2023StoriesModel: StoryModel {
         }
 
         // Year over year listening time
-        let yearOverYearListeningTime = dataManager.yearOverYearListeningTime(in: year)
+        let yearOverYearListeningTime = dataManager.yearOverYearListeningTime(in: Self.year)
         if yearOverYearListeningTime.totalPlayedTimeThisYear != 0 ||
             yearOverYearListeningTime.totalPlayedTimeLastYear != 0 {
             data.yearOverYearListeningTime = yearOverYearListeningTime
             stories.append(.yearOverYearListeningTime)
         }
 
-        data.episodesStartedAndCompleted = dataManager.episodesStartedAndCompleted(in: year)
+        data.episodesStartedAndCompleted = dataManager.episodesStartedAndCompleted(in: Self.year)
         stories.append(.completionRate)
     }
 

--- a/podcasts/End of Year/End of Year 2023/EndOfYear2023Story.swift
+++ b/podcasts/End of Year/End of Year 2023/EndOfYear2023Story.swift
@@ -1,0 +1,15 @@
+/// The available stories for EoY
+/// Order is important, as the stories will be displayed
+/// in the order listed here.
+enum EndOfYear2023Story: CaseIterable {
+    case intro
+    case numberOfPodcastsAndEpisodesListened
+    case topOnePodcast
+    case topFivePodcasts
+    case topCategories
+    case listeningTime
+    case longestEpisode
+    case yearOverYearListeningTime
+    case completionRate
+    case epilogue
+}

--- a/podcasts/End of Year/EndOfYear.swift
+++ b/podcasts/End of Year/EndOfYear.swift
@@ -14,17 +14,17 @@ struct EndOfYear {
         case y2022
         case y2023
 
-        var model: StoryModel? {
+        var modelType: StoryModel.Type? {
             switch self {
             case .y2022:
                 nil
             case .y2023:
-                EndOfYear2023StoriesModel()
+                EndOfYear2023StoriesModel.self
             }
         }
 
         var year: Int? {
-            model?.year
+            modelType?.year
         }
     }
 
@@ -56,7 +56,7 @@ struct EndOfYear {
         }
     }
 
-    private(set) var model: StoryModel?
+    private(set) var storyModelType: StoryModel.Type?
 
     static var requireAccount: Bool = Settings.endOfYearRequireAccount {
         didSet {
@@ -80,11 +80,11 @@ struct EndOfYear {
     init() {
         Self.requireAccount = Settings.endOfYearRequireAccount
 
-        model = Self.currentYear.model
+        storyModelType = Self.currentYear.modelType
     }
 
     func showPrompt(in viewController: UIViewController) {
-        guard Self.isEligible, let model, !Settings.hasShownModalForEndOfYear(model.year) else {
+        guard Self.isEligible, let storyModelType, !Settings.hasShownModalForEndOfYear(storyModelType.year) else {
             return
         }
 
@@ -112,7 +112,7 @@ struct EndOfYear {
     }
 
     func showStories(in viewController: UIViewController, from source: EndOfYearPresentationSource) {
-        guard let model else { return }
+        guard let storyModelType else { return }
 
         if Self.requireAccount && !SyncManager.isUserLoggedIn() {
             Self.state = .waitingForLogin
@@ -123,7 +123,9 @@ struct EndOfYear {
         }
 
         // Don't show the prompt if the user is has already viewed the stories.
-        Settings.setHasShownModalForEndOfYear(true, year: model.year)
+        Settings.setHasShownModalForEndOfYear(true, year: storyModelType.year)
+
+        let model = storyModelType.init()
 
         let storiesViewController = StoriesHostingController(rootView: StoriesView(dataSource: EndOfYearStoriesDataSource(model: model)).padding(storiesPadding))
         storiesViewController.view.backgroundColor = .black
@@ -174,8 +176,8 @@ struct EndOfYear {
     func resetStateIfNeeded() {
         // When a user logs in (or creates an account) we mark the EOY modal as not
         // shown to show it again.
-        if Self.state == .showModalIfNeeded, let model {
-            Settings.setHasShownModalForEndOfYear(false, year: model.year)
+        if Self.state == .showModalIfNeeded, let storyModelType {
+            Settings.setHasShownModalForEndOfYear(false, year: storyModelType.year)
             return
         }
 

--- a/podcasts/End of Year/EndOfYearStoriesBuilder.swift
+++ b/podcasts/End of Year/EndOfYearStoriesBuilder.swift
@@ -23,13 +23,15 @@ class EndOfYearStoriesBuilder {
     func build() async {
         await withCheckedContinuation { continuation in
 
+            let modelType = type(of: model)
+
             // Check if the user has the full listening history for this year
-            if SyncManager.isUserLoggedIn(), !Settings.hasSyncedEpisodesForPlayback(year: model.year) || (Settings.hasSyncedEpisodesForPlayback(year: model.year) && Settings.hasSyncedEpisodesForPlaybackAsPlusUser(year: model.year) != hasActiveSubscription()) {
+            if SyncManager.isUserLoggedIn(), !Settings.hasSyncedEpisodesForPlayback(year: modelType.year) || (Settings.hasSyncedEpisodesForPlayback(year: modelType.year) && Settings.hasSyncedEpisodesForPlaybackAsPlusUser(year: modelType.year) != hasActiveSubscription()) {
                 let syncedWithSuccess = sync?()
 
                 if syncedWithSuccess == true {
-                    Settings.setHasSyncedEpisodesForPlayback(true, year: model.year)
-                    Settings.setHasSyncedEpisodesForPlaybackAsPlusUser(hasActiveSubscription(), year: model.year)
+                    Settings.setHasSyncedEpisodesForPlayback(true, year: modelType.year)
+                    Settings.setHasSyncedEpisodesForPlaybackAsPlusUser(hasActiveSubscription(), year: modelType.year)
                 } else {
                     continuation.resume()
                     return
@@ -44,7 +46,8 @@ class EndOfYearStoriesBuilder {
 }
 
 protocol StoryModel {
-    var year: Int { get }
+    init()
+    static var year: Int { get }
     var numberOfStories: Int { get }
     func populate(with dataManager: DataManager)
     func story(for storyNumber: Int) -> any StoryView

--- a/podcasts/End of Year/EndOfYearStoriesBuilder.swift
+++ b/podcasts/End of Year/EndOfYearStoriesBuilder.swift
@@ -2,138 +2,52 @@ import Foundation
 import PocketCastsDataModel
 import PocketCastsServer
 
-/// The available stories for EoY
-/// Order is important, as the stories will be displayed
-/// in the order listed here.
-enum EndOfYearStory: CaseIterable {
-    case intro
-    case numberOfPodcastsAndEpisodesListened
-    case topOnePodcast
-    case topFivePodcasts
-    case topCategories
-    case listeningTime
-    case longestEpisode
-    case yearOverYearListeningTime
-    case completionRate
-    case epilogue
-}
-
 /// Build the list of stories for End of Year alongside the data
 class EndOfYearStoriesBuilder {
     private let dataManager: DataManager
 
-    private var stories: [EndOfYearStory] = []
-
-    private let data = EndOfYearStoriesData()
+    private var model: StoryModel
 
     private var hasActiveSubscription: () -> Bool
 
     private let sync: (() -> Bool)?
 
-    init(dataManager: DataManager = DataManager.sharedManager, sync: (() -> Bool)? = YearListeningHistory.sync, hasActiveSubscription: @escaping () -> Bool = SubscriptionHelper.hasActiveSubscription) {
+    init(dataManager: DataManager = DataManager.sharedManager, model: StoryModel, sync: (() -> Bool)? = YearListeningHistory.sync, hasActiveSubscription: @escaping () -> Bool = SubscriptionHelper.hasActiveSubscription) {
         self.dataManager = dataManager
+        self.model = model
         self.sync = sync
         self.hasActiveSubscription = hasActiveSubscription
     }
 
     /// Call this method to build the list of stories and the data provider
-    func build() async -> ([EndOfYearStory], EndOfYearStoriesData) {
+    func build() async {
         await withCheckedContinuation { continuation in
 
             // Check if the user has the full listening history for this year
-            if SyncManager.isUserLoggedIn(), !Settings.hasSyncedEpisodesForPlayback2023 || (Settings.hasSyncedEpisodesForPlayback2023 && Settings.hasSyncedEpisodesForPlayback2023AsPlusUser != hasActiveSubscription()) {
+            if SyncManager.isUserLoggedIn(), !Settings.hasSyncedEpisodesForPlayback(year: model.year) || (Settings.hasSyncedEpisodesForPlayback(year: model.year) && Settings.hasSyncedEpisodesForPlaybackAsPlusUser(year: model.year) != hasActiveSubscription()) {
                 let syncedWithSuccess = sync?()
 
                 if syncedWithSuccess == true {
-                    Settings.hasSyncedEpisodesForPlayback2023 = true
-                    Settings.hasSyncedEpisodesForPlayback2023AsPlusUser = hasActiveSubscription()
+                    Settings.setHasSyncedEpisodesForPlayback(true, year: model.year)
+                    Settings.setHasSyncedEpisodesForPlaybackAsPlusUser(hasActiveSubscription(), year: model.year)
                 } else {
-                    continuation.resume(returning: ([], data))
+                    continuation.resume()
                     return
                 }
             }
 
-            // First, search for top 10 podcasts to use throughout different stories
-            let topPodcasts = dataManager.topPodcasts(limit: 10)
-            if !topPodcasts.isEmpty {
-                data.topPodcasts = Array(topPodcasts.prefix(5))
-                data.top10Podcasts = Array(topPodcasts.suffix(8)).map { $0.podcast }.reversed()
-            }
+            model.populate(with: dataManager)
 
-            // Listening time
-            if let listeningTime = dataManager.listeningTime(),
-               listeningTime > 0, !data.top10Podcasts.isEmpty {
-                stories.append(.listeningTime)
-                data.listeningTime = listeningTime
-            }
-
-            // Listened categories
-            let listenedCategories = dataManager.listenedCategories()
-            if !listenedCategories.isEmpty {
-                data.listenedCategories = listenedCategories
-                stories.append(.topCategories)
-            }
-
-            // Listened podcasts and episodes
-            let listenedNumbers = dataManager.listenedNumbers()
-            if listenedNumbers.numberOfEpisodes > 0
-                && listenedNumbers.numberOfPodcasts > 0
-                && !data.top10Podcasts.isEmpty {
-                data.listenedNumbers = listenedNumbers
-                stories.append(.numberOfPodcastsAndEpisodesListened)
-            }
-
-            // Top podcasts
-            if !data.topPodcasts.isEmpty {
-                stories.append(.topOnePodcast)
-            }
-
-            // Top 5 podcasts
-            if topPodcasts.count > 1 {
-                stories.append(.topFivePodcasts)
-            }
-
-            // Longest episode
-            if let longestEpisode = dataManager.longestEpisode(),
-               let podcast = longestEpisode.parentPodcast() {
-                data.longestEpisode = longestEpisode
-                data.longestEpisodePodcast = podcast
-                stories.append(.longestEpisode)
-            }
-
-            // Year over year listening time
-            let yearOverYearListeningTime = dataManager.yearOverYearListeningTime()
-            if yearOverYearListeningTime.totalPlayedTimeThisYear != 0 ||
-                yearOverYearListeningTime.totalPlayedTimeLastYear != 0 {
-                data.yearOverYearListeningTime = yearOverYearListeningTime
-                stories.append(.yearOverYearListeningTime)
-            }
-
-            data.episodesStartedAndCompleted = dataManager.episodesStartedAndCompleted()
-            stories.append(.completionRate)
-
-            continuation.resume(returning: (stories, data))
+            continuation.resume()
         }
     }
 }
 
-/// An entity that holds data to present EoY stories
-class EndOfYearStoriesData {
-    var listeningTime: Double = 0
-
-    var listenedCategories: [ListenedCategory] = []
-
-    var listenedNumbers: ListenedNumbers!
-
-    var topPodcasts: [TopPodcast] = []
-
-    var longestEpisode: Episode!
-
-    var longestEpisodePodcast: Podcast!
-
-    var top10Podcasts: [Podcast] = []
-
-    var yearOverYearListeningTime: YearOverYearListeningTime!
-
-    var episodesStartedAndCompleted: EpisodesStartedAndCompleted!
+protocol StoryModel {
+    var year: Int { get }
+    var numberOfStories: Int { get }
+    func populate(with dataManager: DataManager)
+    func story(for storyNumber: Int) -> any StoryView
+    func isInteractiveView(for storyNumber: Int) -> Bool
+    func isReady() -> Bool
 }

--- a/podcasts/End of Year/Stories/EndOfYearStoriesDataSource.swift
+++ b/podcasts/End of Year/Stories/EndOfYearStoriesDataSource.swift
@@ -33,7 +33,7 @@ class EndOfYearStoriesDataSource: StoriesDataSource {
     }
 
     func refresh() async -> Bool {
-        Settings.setHasSyncedEpisodesForPlayback(false, year: model.year)
+        Settings.setHasSyncedEpisodesForPlayback(false, year: type(of: model).year)
 
         await SyncYearListeningProgress.shared.reset()
 

--- a/podcasts/End of Year/Stories/EndOfYearStoriesDataSource.swift
+++ b/podcasts/End of Year/Stories/EndOfYearStoriesDataSource.swift
@@ -3,37 +3,18 @@ import PocketCastsServer
 import PocketCastsDataModel
 
 class EndOfYearStoriesDataSource: StoriesDataSource {
-    var numberOfStories: Int {
-        stories.count
+    var model: StoryModel
+
+    init(model: StoryModel) {
+        self.model = model
     }
 
-    var stories: [EndOfYearStory] = []
-
-    var data: EndOfYearStoriesData!
+    var numberOfStories: Int {
+        model.numberOfStories
+    }
 
     func story(for storyNumber: Int) -> any StoryView {
-        switch stories[storyNumber] {
-        case .intro:
-            return IntroStory()
-        case .listeningTime:
-            return ListeningTimeStory(listeningTime: data.listeningTime, podcasts: data.top10Podcasts)
-        case .topCategories:
-            return TopListenedCategoriesStory(listenedCategories: data.listenedCategories)
-        case .numberOfPodcastsAndEpisodesListened:
-            return ListenedNumbersStory(listenedNumbers: data.listenedNumbers, podcasts: data.top10Podcasts)
-        case .topOnePodcast:
-            return TopOnePodcastStory(podcasts: data.topPodcasts)
-        case .topFivePodcasts:
-            return TopFivePodcastsStory(topPodcasts: data.topPodcasts)
-        case .longestEpisode:
-            return LongestEpisodeStory(episode: data.longestEpisode, podcast: data.longestEpisodePodcast)
-        case .yearOverYearListeningTime:
-            return YearOverYearStory(data: data.yearOverYearListeningTime)
-        case .completionRate:
-            return CompletionRateStory(subscriptionTier: SubscriptionHelper.activeTier, startedAndCompleted: data.episodesStartedAndCompleted)
-        case .epilogue:
-            return EpilogueStory()
-        }
+        model.story(for: storyNumber)
     }
 
     func shareableStory(for storyNumber: Int) -> (any ShareableStory)? {
@@ -42,31 +23,17 @@ class EndOfYearStoriesDataSource: StoriesDataSource {
 
     /// The only interactive view we have is the last one, with the replay button
     func isInteractiveView(for storyNumber: Int) -> Bool {
-        switch stories[storyNumber] {
-        case .epilogue:
-            return true
-        default:
-            return false
-        }
+        model.isInteractiveView(for: storyNumber)
     }
 
     func isReady() async -> Bool {
-        (stories, data) = await EndOfYearStoriesBuilder().build()
+        await EndOfYearStoriesBuilder(model: model).build()
 
-        if !stories.isEmpty {
-            stories.append(.intro)
-            stories.append(.epilogue)
-
-            stories.sort()
-
-            return true
-        }
-
-        return false
+        return model.isReady()
     }
 
     func refresh() async -> Bool {
-        Settings.hasSyncedEpisodesForPlayback2023 = false
+        Settings.setHasSyncedEpisodesForPlayback(false, year: model.year)
 
         await SyncYearListeningProgress.shared.reset()
 
@@ -74,9 +41,15 @@ class EndOfYearStoriesDataSource: StoriesDataSource {
     }
 }
 
-extension [EndOfYearStory] {
-    mutating func sort() {
-        let allCases = EndOfYearStory.allCases
-        self = sorted { allCases.firstIndex(of: $0) ?? 0 < allCases.firstIndex(of: $1) ?? 0 }
+extension Array where Element: CaseIterable & Equatable {
+    mutating func sortByCaseIterableIndex() {
+        let allCases = Element.allCases
+        self = sorted {
+            guard let firstIndex0 = allCases.firstIndex(of: $0),
+                  let firstIndex1 = allCases.firstIndex(of: $1) else {
+                return false
+            }
+            return firstIndex0 < firstIndex1
+        }
     }
 }

--- a/podcasts/End of Year/StoriesModel.swift
+++ b/podcasts/End of Year/StoriesModel.swift
@@ -221,7 +221,7 @@ class StoriesModel: ObservableObject {
         guard let assets = sharingAssets() else { return }
 
         pause()
-        EndOfYear().share(assets: assets, storyIdentifier: currentStoryIdentifier, onDismiss: { [weak self] in
+        EndOfYear.share(assets: assets, storyIdentifier: currentStoryIdentifier, onDismiss: { [weak self] in
             self?.start()
         })
     }

--- a/podcasts/End of Year/Views/EndOfYearModal.swift
+++ b/podcasts/End of Year/Views/EndOfYearModal.swift
@@ -32,7 +32,7 @@ struct EndOfYearModal: View {
         .frame(maxWidth: Constants.maxWidth)
         .applyDefaultThemeOptions()
         .onAppear {
-            Settings.endOfYearModalHasBeenShown = true
+            Settings.setHasShownModalForEndOfYear(true, year: 2023)
             Analytics.track(.endOfYearModalShown)
         }
     }

--- a/podcasts/End of Year/Views/StoriesView.swift
+++ b/podcasts/End of Year/Views/StoriesView.swift
@@ -310,6 +310,6 @@ struct StoryViewContainer<Content: View>: View {
 
 struct StoriesView_Previews: PreviewProvider {
     static var previews: some View {
-        StoriesView(dataSource: EndOfYearStoriesDataSource())
+        StoriesView(dataSource: EndOfYearStoriesDataSource(model: EndOfYear2023StoriesModel()))
     }
 }

--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -546,7 +546,7 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
 
     @objc private func profileSeen() {
         profileTabBarItem.badgeValue = nil
-        if let year = endOfYear.model?.year {
+        if let year = endOfYear.storyModelType?.year {
             Settings.setShowBadgeForEndOfYear(false, year: year)
         }
     }
@@ -615,7 +615,7 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
     }
 
     private func displayEndOfYearBadgeIfNeeded() {
-        if EndOfYear.isEligible, let year = endOfYear.model?.year, Settings.showBadgeForEndOfYear(year) {
+        if EndOfYear.isEligible, let year = endOfYear.storyModelType?.year, Settings.showBadgeForEndOfYear(year) {
             profileTabBarItem.badgeValue = "●"
         }
     }

--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -12,7 +12,7 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
 
     let playPauseCommand = UIKeyCommand(title: L10n.keycommandPlayPause, action: #selector(handlePlayPauseKey), input: " ", modifierFlags: [])
 
-    private lazy var endOfYear = EndOfYear()
+    lazy var endOfYear = EndOfYear()
 
     private lazy var profileTabBarItem = UITabBarItem(title: L10n.profile, image: UIImage(named: "profile_tab"), tag: pcTabs.firstIndex(of: .profile) ?? -1)
 
@@ -546,7 +546,9 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
 
     @objc private func profileSeen() {
         profileTabBarItem.badgeValue = nil
-        Settings.showBadgeForEndOfYear = false
+        if let year = endOfYear.model?.year {
+            Settings.setShowBadgeForEndOfYear(false, year: year)
+        }
     }
 
     func observersForEndOfYearStats() {
@@ -613,7 +615,7 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
     }
 
     private func displayEndOfYearBadgeIfNeeded() {
-        if EndOfYear.isEligible, Settings.showBadgeForEndOfYear {
+        if EndOfYear.isEligible, let year = endOfYear.model?.year, Settings.showBadgeForEndOfYear(year) {
             profileTabBarItem.badgeValue = "●"
         }
     }

--- a/podcasts/PodcastListViewController.swift
+++ b/podcasts/PodcastListViewController.swift
@@ -205,7 +205,7 @@ class PodcastListViewController: PCViewController, UIGestureRecognizerDelegate, 
             imageView.heightAnchor.constraint(equalToConstant: avatarSize),
         ])
 
-        if EndOfYear.isEligible, Settings.showBadgeForEndOfYear {
+        if EndOfYear.isEligible, EndOfYear.shouldShowBadge {
             let badgeSize = CGFloat(10)
             let badge = makeBadge(size: badgeSize)
             imageView.addSubview(badge)

--- a/podcasts/ProfileViewController.swift
+++ b/podcasts/ProfileViewController.swift
@@ -378,7 +378,11 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
             present(navController, animated: true, completion: nil)
         case .endOfYearPrompt:
             Analytics.track(.endOfYearProfileCardTapped)
-            EndOfYear().showStories(in: self, from: .profile)
+            if let endOfYear = (tabBarController as? MainTabBarController)?.endOfYear {
+                endOfYear.showStories(in: self, from: .profile)
+            } else {
+                assertionFailure("End of Year should exist. Something is wrong with the tabBarController")
+            }
         case .bookmarks:
             let bookmarksController = BookmarksProfileListController()
             navigationController?.pushViewController(bookmarksController, animated: true)

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -946,45 +946,45 @@ class Settings: NSObject {
 
     // MARK: - End of Year 2022
 
-    class var showBadgeForEndOfYear: Bool {
-        set {
-            UserDefaults.standard.set(newValue, forKey: Constants.UserDefaults.showBadgeFor2023EndOfYear)
-        }
-
-        get {
-            (UserDefaults.standard.value(forKey: Constants.UserDefaults.showBadgeFor2023EndOfYear) as? Bool) ?? true
-        }
+    class func showBadgeForEndOfYear(_ year: Int) -> Bool {
+        let key = String(format: Constants.UserDefaults.showBadgeForEndOfYear, year)
+        return UserDefaults.standard.bool(forKey: key)
     }
 
-    class var endOfYearModalHasBeenShown: Bool {
-        set {
-            UserDefaults.standard.set(newValue, forKey: Constants.UserDefaults.modal2023HasBeenShown)
-        }
-
-        get {
-            UserDefaults.standard.bool(forKey: Constants.UserDefaults.modal2023HasBeenShown)
-        }
+    class func setShowBadgeForEndOfYear(_ newValue: Bool, year: Int) {
+        let key = String(format: Constants.UserDefaults.showBadgeForEndOfYear, year)
+        UserDefaults.standard.set(newValue, forKey: key)
     }
 
-    class var hasSyncedEpisodesForPlayback2023: Bool {
-        set {
-            UserDefaults.standard.set(newValue, forKey: Constants.UserDefaults.hasSyncedEpisodesForPlayback2023)
-        }
+    class func hasShownModalForEndOfYear(_ year: Int) -> Bool {
+        let key = String(format: Constants.UserDefaults.modalHasBeenShown, year)
+        return UserDefaults.standard.bool(forKey: key)
+    }
 
-        get {
-            UserDefaults.standard.bool(forKey: Constants.UserDefaults.hasSyncedEpisodesForPlayback2023)
-        }
+    class func setHasShownModalForEndOfYear(_ newValue: Bool, year: Int) {
+        let key = String(format: Constants.UserDefaults.modalHasBeenShown, year)
+        UserDefaults.standard.set(newValue, forKey: key)
+    }
+
+    class func hasSyncedEpisodesForPlayback(year: Int) -> Bool {
+        let key = String(format: Constants.UserDefaults.hasSyncedEpisodesForPlayback, year)
+        return UserDefaults.standard.bool(forKey: key)
+    }
+
+    class func setHasSyncedEpisodesForPlayback(_ newValue: Bool, year: Int) {
+        let key = String(format: Constants.UserDefaults.hasSyncedEpisodesForPlayback, year)
+        UserDefaults.standard.set(newValue, forKey: key)
+    }
+
+    class func hasSyncedEpisodesForPlaybackAsPlusUser(year: Int) -> Bool {
+        let key = String(format: Constants.UserDefaults.hasSyncedEpisodesForPlaybackAsPlusUser, year)
+        return UserDefaults.standard.bool(forKey: key)
     }
 
     /// Whether the user was plus or not by the time the sync happened
-    class var hasSyncedEpisodesForPlayback2023AsPlusUser: Bool {
-        set {
-            UserDefaults.standard.set(newValue, forKey: Constants.UserDefaults.hasSyncedEpisodesForPlayback2023AsPlusUser)
-        }
-
-        get {
-            UserDefaults.standard.bool(forKey: Constants.UserDefaults.hasSyncedEpisodesForPlayback2023AsPlusUser)
-        }
+    class func setHasSyncedEpisodesForPlaybackAsPlusUser(_ newValue: Bool, year: Int) {
+        let key = String(format: Constants.UserDefaults.hasSyncedEpisodesForPlaybackAsPlusUser, year)
+        UserDefaults.standard.set(newValue, forKey: key)
     }
 
     class var top5PodcastsListLink: String? {


### PR DESCRIPTION
| 📘 Part of: #2250 |
|:---:|

Part of #2305

This refactors `EndOfYear` to include support for multiple years.

The intent is that this PR changes nothing with regards to the previous end of year projects. 2024 support will be in a separate PR due to line count.

## To test

> [!NOTE]  
> You will need to have sufficient listening history. Ping me if you want a database to import to speed that up.

* Enable `endOfYear` feature flag
* Tap the Reset modal/profile badge option in Developer menu
* Restart the app
* Navigate to Profile and ensure "Your Year in Podcasts" 2023 banner is showing
* Tap the banner and ensure Stories load and you can tap through them

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
