### PR TITLE
Set search view bottom constraint to safe area

### DIFF
--- a/podcasts/DiscoverCollectionViewController+Search.swift
+++ b/podcasts/DiscoverCollectionViewController+Search.swift
@@ -72,7 +72,7 @@ extension DiscoverCollectionViewController: PCSearchBarDelegate {
         NSLayoutConstraint.activate([
             searchView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             searchView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            searchView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            searchView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
             searchView.topAnchor.constraint(equalTo: searchController.view.bottomAnchor)
         ])
 

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -784,7 +784,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         guard let currentEffects else { return }
         changeEffects(currentEffects)
     }
-    
+
     func changeEffects(_ effects: PlaybackEffects) {
         guard let episode = currentEpisode() else { return }
 


### PR DESCRIPTION
Fixes bottom inset of the search results controller on Discover which started with the Discover Collection View (#2104) change in 7.75.

| Before | After |
| -- | -- |
| <video src="https://github.com/user-attachments/assets/92c8f418-f698-4a4a-9f53-c161e26c3352"> | <video src="https://github.com/user-attachments/assets/d1c7c105-ccd6-4f31-ae6f-d79a5bfb5d6c"> |

## To test

* Open Discover
* Search for anything in the top search bar
* Ensure the bottom of search results is above the mini player

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
