### PR TITLE
[Up next shuffle] Modify modal

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -125,6 +125,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// Enable the End of Year 2024 recap
     case endOfYear2024
 
+    /// Enable the Up Next shuffle button
+    case upNextShuffle
+
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -208,6 +211,8 @@ public enum FeatureFlag: String, CaseIterable {
         case .runVacuumOnVersionUpdate:
             true
         case .endOfYear2024:
+            false
+        case .upNextShuffle:
             false
         }
     }

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -2256,6 +2256,8 @@ internal enum L10n {
   internal static func queueClearEpisodeQueuePlural(_ p1: Any) -> String {
     return L10n.tr("Localizable", "queue_clear_episode_queue_plural", String(describing: p1))
   }
+  /// Clear 1 Episode
+  internal static var queueClearEpisodeQueueSingular: String { return L10n.tr("Localizable", "queue_clear_episode_queue_singular") }
   /// CLEAR QUEUE
   internal static var queueClearQueue: String { return L10n.tr("Localizable", "queue_clear_queue") }
   /// Queue For Later

--- a/podcasts/UpNextViewController.swift
+++ b/podcasts/UpNextViewController.swift
@@ -182,11 +182,11 @@ class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
     @objc func clearQueueTapped() {
         let queueCount = PlaybackManager.shared.queue.upNextCount()
 
-        if queueCount <= Constants.Limits.upNextClearWithoutWarning {
+        if queueCount <= Constants.Limits.upNextClearWithoutWarning && !FeatureFlag.upNextShuffle.enabled {
             performClearAll()
         } else {
             let clearOptions = OptionsPicker(title: nil, themeOverride: themeOverride)
-            let actionLabel = L10n.queueClearEpisodeQueuePlural(queueCount.localized())
+            let actionLabel = actionLabelText(queueCount)
             let clearAllAction = OptionAction(label: actionLabel, icon: nil, action: { [weak self] in
                 self?.performClearAll()
             })
@@ -198,6 +198,13 @@ class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
 
         selectedPlayListEpisodes.removeAll()
         isMultiSelectEnabled = false
+    }
+
+    private func actionLabelText(_ queueCount: Int) -> String {
+        if FeatureFlag.upNextShuffle.enabled, queueCount == 1 {
+            return L10n.queueClearEpisodeQueueSingular
+        }
+        return L10n.queueClearEpisodeQueuePlural(queueCount.localized())
     }
 
     private func performClearAll() {

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -2023,6 +2023,9 @@
 /* Confirmation message to clear the give number of episodes from the queue. '%1$@' is a placeholder for the number of episodes, this will be more than one. */
 "queue_clear_episode_queue_plural" = "Clear %1$@ Episodes";
 
+/* Confirmation message to clear one episode from the queue. */
+"queue_clear_episode_queue_singular" = "Clear 1 Episode";
+
 /* Prompt to allow the user to clear their queue. */
 "queue_clear_queue" = "CLEAR QUEUE";
 


### PR DESCRIPTION
| 📘 Part of: [Up Next Shuffle](https://github.com/orgs/Automattic/projects/1179/views/1)
|:---:|

Fixes #2309 

This PR adds the new feature flag and always enable the modal when tapping _Clear Queue_

| One Episode | More Episodes |
| -------- | ------- |
| ![Simulator Screenshot - iPhone 16 - 2024-10-21 at 17 09 00](https://github.com/user-attachments/assets/85433a92-7dcc-47d9-b18d-a51b010480a7) | ![Simulator Screenshot - iPhone 16 - 2024-10-21 at 17 09 18](https://github.com/user-attachments/assets/44bed153-200d-411f-b728-2ba3752da5df) |
 

## To test

- CI must be 🟢 
- Run the app and clear your queue
- Enable the `upNextShuffle` FF

### Test 1 Episode
- Add one episode to the queue
- Got to Up Next
-  Tap Clear queue
- Observe the Modal with the text `Clear 1 Episode`

### Test 2 Episodes
- Add 2 episodes to the queue
- Got to Up Next
- Tap Clear Queue
- Observe the Modal with the text `Clear 2 Episodes`

### Test more than 2 Episodes
- Add more than 2 episodes to the queue
- Got to Up Next
- Tap Clear Queue
- Observe the Modal with the text `Clear N Episodes`

### Test FF off
- If you have up to 2 episodes in the queue you should not see the modal
- If you have more than 2 you should see the modal

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
