### PR TITLE
Auto-Downloading of Episode: Add logic for auto downloads limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 7.76
 -----
 - Implements a new stream and download mechanism to address playback skipping issues [#2247](https://github.com/Automattic/pocket-casts-ios/pull/2247)
+- Implement limits for auto-downloads of new episodes. [#2318](https://github.com/Automattic/pocket-casts-ios/pull/2318)
 
 7.75
 -----

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EpisodeDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EpisodeDataManager.swift
@@ -162,6 +162,10 @@ class EpisodeDataManager {
         loadSingle(query: "SELECT * from \(DataManager.episodeTableName) WHERE podcast_id = ? ORDER BY publishedDate DESC, addedDate DESC LIMIT 1", values: [podcast.id], dbQueue: dbQueue)
     }
 
+    func findLatestEpisodes(podcast: Podcast, limit: Int, dbQueue: FMDatabaseQueue) -> [Episode] {
+        loadMultiple(query: "SELECT * from \(DataManager.episodeTableName) WHERE podcast_id = ? ORDER BY publishedDate DESC, addedDate DESC LIMIT ?", values: [podcast.id, limit], dbQueue: dbQueue)
+    }
+
     func allUpNextEpisodes(dbQueue: FMDatabaseQueue) -> [Episode] {
         let upNextTableName = DataManager.playlistEpisodeTableName
         let episodeTableName = DataManager.episodeTableName

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -465,7 +465,11 @@ public class DataManager {
     }
 
     public func findLatestEpisode(podcast: Podcast) -> Episode? {
-        episodeManager.findLatestEpisode(podcast: podcast, dbQueue: dbQueue)
+        episodeManager.findLatestEpisode(podcast: podcast, dbQueue: dbQueue)        
+    }
+
+    public func findLatestEpisodes(podcast: Podcast, limit: Int) -> [Episode] {
+        episodeManager.findLatestEpisodes(podcast: podcast, limit: limit, dbQueue: dbQueue)
     }
 
     public func unsyncedEpisodes(limit: Int) -> [Episode] {

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -465,7 +465,7 @@ public class DataManager {
     }
 
     public func findLatestEpisode(podcast: Podcast) -> Episode? {
-        episodeManager.findLatestEpisode(podcast: podcast, dbQueue: dbQueue)        
+        episodeManager.findLatestEpisode(podcast: podcast, dbQueue: dbQueue)
     }
 
     public func findLatestEpisodes(podcast: Podcast, limit: Int) -> [Episode] {

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Podcast.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Podcast.swift
@@ -102,6 +102,10 @@ public class Podcast: NSObject, Identifiable {
         DataManager.sharedManager.findLatestEpisode(podcast: self)
     }
 
+    public func latestEpisodes(limit: Int = 1) -> [Episode] {
+        DataManager.sharedManager.findLatestEpisodes(podcast: self, limit: limit)
+    }
+
     public func isSubscribed() -> Bool {
         subscribed != 0
     }

--- a/Modules/Server/Sources/PocketCastsServer/Public/ServerPodcastManager+Update.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/ServerPodcastManager+Update.swift
@@ -216,7 +216,7 @@ extension ServerPodcastManager {
         if totalCount > 0, autoDownloadCount >= totalCount {
             podcast.autoDownloadSetting = AutoDownloadSetting.latest.rawValue
             if let latestEpisode = latestEpisode {
-                ServerConfig.shared.syncDelegate?.autoDownloadLatestEpisode(episode: latestEpisode)
+                ServerConfig.shared.syncDelegate?.autoDownloadLatestEpisodes(uuids: [latestEpisode.uuid])
             }
         } else {
             podcast.autoDownloadSetting = AutoDownloadSetting.off.rawValue

--- a/Modules/Server/Sources/PocketCastsServer/Public/ServerPodcastManager+Update.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/ServerPodcastManager+Update.swift
@@ -191,8 +191,9 @@ extension ServerPodcastManager {
         }
     }
 
-    public func updateLatestEpisodeInfo(podcast: Podcast, setDefaults: Bool) {
-        guard let latestEpisode = podcast.latestEpisode() else { return }
+    public func updateLatestEpisodeInfo(podcast: Podcast, setDefaults: Bool, autoDownloadLimit: Int = 1) {
+        let latestEpisodes = podcast.latestEpisodes(limit: autoDownloadLimit)
+        guard let latestEpisode = latestEpisodes.first else { return }
 
         // no need to re-save one we already have
         if !setDefaults, podcast.latestEpisodeUuid == latestEpisode.uuid { return }
@@ -202,21 +203,25 @@ extension ServerPodcastManager {
         DataManager.sharedManager.save(podcast: podcast)
 
         if setDefaults {
-            setDefaultsAndLoadMetadataForNewlyAddedPodcast(podcast, latestEpisode: latestEpisode)
+            setDefaultsAndLoadMetadataForNewlyAddedPodcast(podcast, latestEpisodes: latestEpisodes)
         }
     }
 
-    private func setDefaultsAndLoadMetadataForNewlyAddedPodcast(_ podcast: Podcast, latestEpisode: Episode?) {
+    private func setDefaultsAndLoadMetadataForNewlyAddedPodcast(_ podcast: Podcast, latestEpisodes: [Episode]) {
         // if all the podcasts the user currently has are auto download, set this one to be as well
         let autoDownloadQuery = "SELECT COUNT(*) FROM \(DataManager.podcastTableName) WHERE subscribed = 1 AND autoDownloadSetting = 1"
         let totalQuery = "SELECT COUNT(*) FROM \(DataManager.podcastTableName) WHERE subscribed = 1"
 
         let autoDownloadCount = DataManager.sharedManager.count(query: autoDownloadQuery, values: nil)
         let totalCount = (DataManager.sharedManager.count(query: totalQuery, values: nil) - 1) // -1 because the podcast we're currently adding could be returned by this query
-        if totalCount > 0, autoDownloadCount >= totalCount {
+        var shouldTriggerAutoDownload = (totalCount > 0) && (autoDownloadCount >= totalCount)
+        if FeatureFlag.autoDownloadOnSubscribe.enabled {
+            shouldTriggerAutoDownload = (AutoDownloadSetting(rawValue: podcast.autoDownloadSetting) ?? .off) != .off
+        }
+        if shouldTriggerAutoDownload {
             podcast.autoDownloadSetting = AutoDownloadSetting.latest.rawValue
-            if let latestEpisode = latestEpisode {
-                ServerConfig.shared.syncDelegate?.autoDownloadLatestEpisodes(uuids: [latestEpisode.uuid])
+            if !latestEpisodes.isEmpty {
+                ServerConfig.shared.syncDelegate?.autoDownloadLatestEpisodes(uuids: latestEpisodes.map(\.uuid))
             }
         } else {
             podcast.autoDownloadSetting = AutoDownloadSetting.off.rawValue
@@ -228,7 +233,7 @@ extension ServerPodcastManager {
         DataManager.sharedManager.save(podcast: podcast)
         DataManager.sharedManager.setPushDefaultForNewPodcast(podcast)
         #if !os(watchOS)
-            if let latestEpisode = latestEpisode {
+        if let latestEpisode = latestEpisodes.first {
                 MetadataUpdater.shared.updatedMetadata(episodeUuid: latestEpisode.uuid)
             }
         #endif

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/ServerSyncDelegateProtocol.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/ServerSyncDelegateProtocol.swift
@@ -17,7 +17,7 @@ public protocol ServerSyncDelegate {
     func markEpisodeAsPlayedExternal(episode: Episode)
     func deselectedChaptersChanged()
     func episodeCanBeCleanedUp(episode: Episode) -> Bool
-    func autoDownloadLatestEpisode(episode: Episode)
+    func autoDownloadLatestEpisodes(uuids: [String])
     func cleanupAllUnusedEpisodeBuffers()
 
     func deleteFromDevice(userEpisode: UserEpisode)

--- a/Pocket Casts Watch App/WatchSyncManager+ServerSyncDelegate.swift
+++ b/Pocket Casts Watch App/WatchSyncManager+ServerSyncDelegate.swift
@@ -98,7 +98,7 @@ extension WatchSyncManager: ServerSyncDelegate {
         "Pocket Casts/iOS/" + Settings.appVersion()
     }
 
-    func autoDownloadLatestEpisode(episode: Episode) {}
+    func autoDownloadLatestEpisodes(uuids: [String]) {}
 
     func minTimeBetweenProgressSaves() -> Double {
         2.minutes

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1777,6 +1777,7 @@
 		FFF024CF2B62B13A00457373 /* Pocket Casts Configuration.storekit in Resources */ = {isa = PBXBuildFile; fileRef = C7547F77286F571900DC1C9E /* Pocket Casts Configuration.storekit */; };
 		FFF17EC42B97930700E116C8 /* BookmarksProfileListController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFF17EC32B97930700E116C8 /* BookmarksProfileListController.swift */; };
 		FFF17EC62B979B5500E116C8 /* BookmarksProfileListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFF17EC52B979B5500E116C8 /* BookmarksProfileListView.swift */; };
+		FFF23E8A2CC91E370046D3AD /* ServerPodcastManager+Subscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFF23E892CC91E2A0046D3AD /* ServerPodcastManager+Subscription.swift */; };
 		FFFCD23F2C7768F900A345ED /* Referrals.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FFFCD23E2C7768F900A345ED /* Referrals.xcassets */; };
 /* End PBXBuildFile section */
 
@@ -3688,6 +3689,7 @@
 		FFF024CD2B62AC9400457373 /* IAPHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IAPHelperTests.swift; sourceTree = "<group>"; };
 		FFF17EC32B97930700E116C8 /* BookmarksProfileListController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksProfileListController.swift; sourceTree = "<group>"; };
 		FFF17EC52B979B5500E116C8 /* BookmarksProfileListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksProfileListView.swift; sourceTree = "<group>"; };
+		FFF23E892CC91E2A0046D3AD /* ServerPodcastManager+Subscription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ServerPodcastManager+Subscription.swift"; sourceTree = "<group>"; };
 		FFFCD23E2C7768F900A345ED /* Referrals.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Referrals.xcassets; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -5729,6 +5731,7 @@
 				BDCE1D601FBC1C4100100A86 /* UrlHelper.swift */,
 				BDD6297E200EE26200168DF7 /* PlaybackActionHelper.swift */,
 				BD24E6F220E3474600A712E3 /* ArchiveHelper.swift */,
+				FFF23E892CC91E2A0046D3AD /* ServerPodcastManager+Subscription.swift */,
 				4041FE562181751F0089D4A1 /* SiriShortcutsManager.swift */,
 				BDB206A92191734D00C1E456 /* NowPlayingHelper.swift */,
 				BDE48A352410D4BB00ECA6CA /* WatchNowPlayingHelper.swift */,
@@ -10114,6 +10117,7 @@
 				BDB1DC632316964E00119B81 /* HowToUploadViewController.swift in Sources */,
 				4084F68624DCE2F6006E5D97 /* StarredViewController+Multiselect.swift in Sources */,
 				400E3D1123F0E6D900ADAA63 /* PromotionFinishedViewController.swift in Sources */,
+				FFF23E8A2CC91E370046D3AD /* ServerPodcastManager+Subscription.swift in Sources */,
 				BD6F1645219AB82700F34D14 /* UISearchBar+TextColor.swift in Sources */,
 				BDA028621C74466500476B28 /* GoogleCastPlayer.swift in Sources */,
 				BDB5F0CD20450FDC00437669 /* Enumerations.swift in Sources */,

--- a/podcasts/AppDelegate+Defaults.swift
+++ b/podcasts/AppDelegate+Defaults.swift
@@ -29,7 +29,7 @@ extension AppDelegate {
         performUpdateIfRequired(updateKey: "v6Run") {
             let query = "SELECT COUNT(*) FROM \(DataManager.podcastTableName) WHERE autoDownloadSetting == 1 AND subscribed == 1"
             let podcastsWithAutoDownloadOn = dataManager.count(query: query, values: nil)
-            let autoDownloadEnabled = podcastsWithAutoDownloadOn > 0
+            let autoDownloadEnabled = podcastsWithAutoDownloadOn > 0 || FeatureFlag.autoDownloadOnSubscribe.enabled
             Settings.setAutoDownloadEnabled(autoDownloadEnabled)
         }
 

--- a/podcasts/BundlePodcastCell.swift
+++ b/podcasts/BundlePodcastCell.swift
@@ -91,9 +91,9 @@ class BundlePodcastCell: ThemeableCell {
         guard let discoverPodcast = discoverPodcast else { return }
 
         if discoverPodcast.iTunesOnly() {
-            ServerPodcastManager.shared.addFromiTunesId(Int(discoverPodcast.iTunesId!)!, subscribe: true, completion: nil)
+            ServerPodcastManager.shared.subscribeFromItunesId(Int(discoverPodcast.iTunesId!)!, completion: nil)
         } else if let uuid = discoverPodcast.uuid {
-            ServerPodcastManager.shared.addFromUuid(podcastUuid: uuid, subscribe: true, completion: nil)
+            ServerPodcastManager.shared.subscribe(to: uuid, completion: nil)
         }
     }
 

--- a/podcasts/CategorySponsoredCell.swift
+++ b/podcasts/CategorySponsoredCell.swift
@@ -87,7 +87,7 @@ class CategorySponsoredCell: ThemeableCell {
         guard let discoverPromotion = discoverPromotion else { return }
 
         if let uuid = discoverPromotion.podcast_uuid {
-            ServerPodcastManager.shared.addFromUuid(podcastUuid: uuid, subscribe: true, completion: nil)
+            ServerPodcastManager.shared.subscribe(to: uuid, completion: nil)
         }
     }
 

--- a/podcasts/DiscoverCollectionViewController+DiscoverDelegate.swift
+++ b/podcasts/DiscoverCollectionViewController+DiscoverDelegate.swift
@@ -122,9 +122,9 @@ extension DiscoverCollectionViewController: DiscoverDelegate {
 
     func subscribe(podcast: DiscoverPodcast) {
         if podcast.iTunesOnly() {
-            ServerPodcastManager.shared.addFromiTunesId(Int(podcast.iTunesId!)!, subscribe: true, completion: nil)
+            ServerPodcastManager.shared.subscribeFromItunesId(Int(podcast.iTunesId!)!, completion: nil)
         } else if let uuid = podcast.uuid {
-            ServerPodcastManager.shared.addFromUuid(podcastUuid: uuid, subscribe: true, completion: nil)
+            ServerPodcastManager.shared.subscribe(to: uuid, completion: nil)
         }
 
         HapticsHelper.triggerSubscribedHaptic()

--- a/podcasts/DiscoverPodcastTableCell.swift
+++ b/podcasts/DiscoverPodcastTableCell.swift
@@ -98,9 +98,9 @@ class DiscoverPodcastTableCell: ThemeableCell {
         guard let discoverPodcast = discoverPodcast else { return }
 
         if discoverPodcast.iTunesOnly() {
-            ServerPodcastManager.shared.addFromiTunesId(Int(discoverPodcast.iTunesId!)!, subscribe: true, completion: nil)
+            ServerPodcastManager.shared.subscribeFromItunesId(Int(discoverPodcast.iTunesId!)!, completion: nil)
         } else if let uuid = discoverPodcast.uuid {
-            ServerPodcastManager.shared.addFromUuid(podcastUuid: uuid, subscribe: true, completion: nil)
+            ServerPodcastManager.shared.subscribe(to: uuid, completion: nil)
         }
 
         let uuid = discoverPodcast.uuid ?? discoverPodcast.iTunesId ?? "unknown"

--- a/podcasts/DiscoverViewController+DiscoverDelegate.swift
+++ b/podcasts/DiscoverViewController+DiscoverDelegate.swift
@@ -110,9 +110,9 @@ extension DiscoverViewController: DiscoverDelegate {
 
     func subscribe(podcast: DiscoverPodcast) {
         if podcast.iTunesOnly() {
-            ServerPodcastManager.shared.addFromiTunesId(Int(podcast.iTunesId!)!, subscribe: true, completion: nil)
+            ServerPodcastManager.shared.subscribeFromItunesId(Int(podcast.iTunesId!)!, completion: nil)
         } else if let uuid = podcast.uuid {
-            ServerPodcastManager.shared.addFromUuid(podcastUuid: uuid, subscribe: true, completion: nil)
+            ServerPodcastManager.shared.subscribe(to: uuid, completion: nil)
         }
 
         HapticsHelper.triggerSubscribedHaptic()

--- a/podcasts/IncomingShareListViewController.swift
+++ b/podcasts/IncomingShareListViewController.swift
@@ -127,7 +127,7 @@ class IncomingShareListViewController: PCViewController, UITableViewDelegate, UI
             return
         }
 
-        ServerPodcastManager.shared.addFromUuid(podcastUuid: uuid, subscribe: true, completion: { _ in
+        ServerPodcastManager.shared.subscribe(to: uuid, completion: { _ in
             Analytics.track(.podcastSubscribed, properties: ["source": self.analyticsSource, "uuid": uuid])
             self.subscribeNext(loadingAlert: loadingAlert)
         })

--- a/podcasts/NetworkViewController.swift
+++ b/podcasts/NetworkViewController.swift
@@ -98,7 +98,7 @@ class NetworkViewController: PCViewController, UITableViewDataSource, UITableVie
         let cell = notification.object as! PodcastGroupCell
         let indexPath = networksTable.indexPath(for: cell)
         if let indexPath = indexPath, indexPath.row < podcasts?.count ?? 0, let podcastUuid = podcasts?[indexPath.row].uuid {
-            ServerPodcastManager.shared.addFromUuid(podcastUuid: podcastUuid, subscribe: true, completion: nil)
+            ServerPodcastManager.shared.subscribe(to: podcastUuid, completion: nil)
         }
     }
 

--- a/podcasts/New Search/Views/Results/RoundedSubscribeButtonView.swift
+++ b/podcasts/New Search/Views/Results/RoundedSubscribeButtonView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import PocketCastsDataModel
 import PocketCastsServer
+import PocketCastsUtils
 
 struct RoundedSubscribeButtonView: View {
     @ObservedObject var model: SubscribeButtonModel
@@ -80,7 +81,7 @@ class SubscribeButtonModel: ObservableObject {
     }
 
     func subscribe() {
-        ServerPodcastManager.shared.addFromUuid(podcastUuid: podcastUuid, subscribe: true, completion: nil)
+        ServerPodcastManager.shared.subscribe(to: podcastUuid, completion: nil)
         Analytics.track(.podcastSubscribed, properties: ["source": source, "uuid": podcastUuid])
     }
 

--- a/podcasts/PodcastManager.swift
+++ b/podcasts/PodcastManager.swift
@@ -145,11 +145,11 @@ class PodcastManager: NSObject {
 
     private func checkForEpisodesToDownload(podcast: Podcast) {
         if !podcast.autoDownloadOn() { return }
+        let episodesLimit = FeatureFlag.autoDownloadOnSubscribe.enabled ? Settings.autoDownloadLimits().rawValue : 4
+        let latestEpisodes = dataManager.findEpisodesWhere(customWhere: "podcast_id == ? ORDER BY publishedDate DESC, addedDate DESC LIMIT ?", arguments: [podcast.id, episodesLimit])
+        guard let latestEpisode = latestEpisodes.first else { return } // no episodes to download
 
-        let topFourEpisodes = dataManager.findEpisodesWhere(customWhere: "podcast_id == ? ORDER BY publishedDate DESC, addedDate DESC LIMIT 4", arguments: [podcast.id])
-        guard let latestEpisode = topFourEpisodes.first else { return } // no episodes to download
-
-        for episode in topFourEpisodes {
+        for episode in latestEpisodes {
             if episode.played() || episode.archived { return } // as soon as we hit a played or archived episode don't look any further
 
             // as soon as we hit an episode that's too old to download don't look any further

--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -615,7 +615,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
 
         podcast.subscribed = 1
         podcast.syncStatus = SyncStatus.notSynced.rawValue
-        podcast.autoDownloadSetting = (FeatureFlag.autoDownloadOnSubscribe.enabled && Settings.autoDownloadEnabled() ? AutoDownloadSetting.latest : AutoDownloadSetting.off).rawValue        
+        podcast.autoDownloadSetting = (FeatureFlag.autoDownloadOnSubscribe.enabled && Settings.autoDownloadEnabled() ? AutoDownloadSetting.latest : AutoDownloadSetting.off).rawValue
         DataManager.sharedManager.save(podcast: podcast)
         ServerPodcastManager.shared.updateLatestEpisodeInfo(podcast: podcast, setDefaults: true, autoDownloadLimit: Settings.autoDownloadLimits().rawValue)
         loadLocalEpisodes(podcast: podcast, animated: true)

--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -615,8 +615,9 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
 
         podcast.subscribed = 1
         podcast.syncStatus = SyncStatus.notSynced.rawValue
+        podcast.autoDownloadSetting = (FeatureFlag.autoDownloadOnSubscribe.enabled && Settings.autoDownloadEnabled() ? AutoDownloadSetting.latest : AutoDownloadSetting.off).rawValue        
         DataManager.sharedManager.save(podcast: podcast)
-        ServerPodcastManager.shared.updateLatestEpisodeInfo(podcast: podcast, setDefaults: true)
+        ServerPodcastManager.shared.updateLatestEpisodeInfo(podcast: podcast, setDefaults: true, autoDownloadLimit: Settings.autoDownloadLimits().rawValue)
         loadLocalEpisodes(podcast: podcast, animated: true)
 
         if featuredPodcast {

--- a/podcasts/ServerPodcastManager+Subscription.swift
+++ b/podcasts/ServerPodcastManager+Subscription.swift
@@ -1,0 +1,15 @@
+import PocketCastsServer
+import PocketCastsUtils
+
+extension ServerPodcastManager {
+
+    func subscribe(to podcastUuid: String, completion: ((Bool) -> ())?) {
+        let limits = Settings.autoDownloadEnabled() && FeatureFlag.autoDownloadOnSubscribe.enabled ? Settings.autoDownloadLimits().rawValue : 0
+        self.addFromUuid(podcastUuid: podcastUuid, subscribe: true, autoDownloads: limits, completion: completion)
+    }
+
+    func subscribeFromItunesId(_ itunesId: Int, completion: ((Bool, String?) -> ())?) {
+        let limits = Settings.autoDownloadEnabled() && FeatureFlag.autoDownloadOnSubscribe.enabled ? Settings.autoDownloadLimits().rawValue : 0
+        self.addFromiTunesId(itunesId, subscribe: true, autoDownloads: limits, completion: completion)
+    }
+}

--- a/podcasts/ServerSyncManager.swift
+++ b/podcasts/ServerSyncManager.swift
@@ -131,10 +131,12 @@ class ServerSyncManager: ServerSyncDelegate {
         "Pocket Casts/iOS/" + Settings.appVersion()
     }
 
-    func autoDownloadLatestEpisode(episode: Episode) {
+    func autoDownloadLatestEpisodes(uuids: [String]) {
         if Settings.autoDownloadEnabled() {
             if Settings.autoDownloadMobileDataAllowed() || NetworkUtils.shared.isConnectedToWifi() {
-                DownloadManager.shared.addToQueue(episodeUuid: episode.uuid)
+                for uuid in uuids {
+                    DownloadManager.shared.addToQueue(episodeUuid: uuid)
+                }
             }
         }
     }

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -132,7 +132,10 @@ class Settings: NSObject {
 
     private static let autoDownloadEnabledKey = "AutoDownloadEnabled"
     class func autoDownloadEnabled() -> Bool {
-        UserDefaults.standard.bool(forKey: Settings.autoDownloadEnabledKey)
+        guard UserDefaults.standard.object(forKey: Settings.autoDownloadEnabledKey) != nil else {
+            return FeatureFlag.autoDownloadOnSubscribe.enabled
+        }
+        return UserDefaults.standard.bool(forKey: Settings.autoDownloadEnabledKey)
     }
 
     class func setAutoDownloadEnabled(_ allow: Bool, userInitiated: Bool = false) {

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -144,7 +144,7 @@ class Settings: NSObject {
 
     private static let autoDownloadLimitKey = "AutoDownloadLimit"
     class func autoDownloadLimits() -> AutoDownloadLimit {
-        AutoDownloadLimit(rawValue: UserDefaults.standard.integer(forKey: Settings.autoDownloadLimitKey)) ?? .one
+        AutoDownloadLimit(rawValue: UserDefaults.standard.integer(forKey: Settings.autoDownloadLimitKey)) ?? .two
     }
 
     class func setAutoDownloadLimits(_ limit: AutoDownloadLimit) {


### PR DESCRIPTION
| 📘 Part of: #2284  |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

| 1 | 2 | 3 | 4 |
| - | - | - | - | 
| ![Simulator Screenshot - iPhone 16 Pro - 2024-10-22 at 14 44 05](https://github.com/user-attachments/assets/040129dd-67b4-4db2-b860-89efafff3d9b) | ![Simulator Screenshot - iPhone 16 Pro - 2024-10-22 at 14 44 51](https://github.com/user-attachments/assets/73d11fb4-6193-4fb4-862a-fd3ade015483) | ![Simulator Screenshot - iPhone 16 Pro - 2024-10-23 at 14 21 12](https://github.com/user-attachments/assets/d55bc5ff-0e4f-4684-ad26-39df45fb4963) | ![Simulator Screenshot - iPhone 16 Pro - 2024-10-23 at 14 21 03](https://github.com/user-attachments/assets/79a7a5f1-7ed5-4e8c-a859-05a8d523f419) |



This PR adds the necessary logic to implement auto-downloads of episodes when subscribing following the set limits of auto-downloads.

## To test

### Setup
1. Delete the app of a device
2. Start the app
3. Ensure that you have the FF `autoDownloadOnSubscribe` enabled
4. Go to Profile -> Settings -> AutoDownload
5. Check that you have by default Auto-Download enabled ( this is for new installs of the app)
6. Check that the default limit for auto-downloads is two episodes

### Subscribe on Episode
1. Go to discover
2. Open a podcast there
3. Press the subscribe button
4. Check that you see the download of the latest x amount of episodes you have set on Auto-Downloads limits
5. Play the episodes

### Subscribe on Discover directly
1. Go to discover
2. Scroll around 
3. On the trending list tap directly on +
4. Open the podcast and see if downloads are triggered
5. Scroll more on discover and find a podcast with an image and a plus button
6. Tap on plus button
7. Check that the downloads are triggered

### Disable auto-download setting
1. Disable auto-download settings on Settings
2. Repeat the subscriptions above and see that no auto-downloads are triggered.

### Disable the FF for `autoDownloadOnSubscribe`
1. Check that no downloads are triggered on subscribe of podcasts
2. Note that there was na exception on the old code that if all your podcasts are on auto-download a new subscription will also be part of auto-downloads.




## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
