### PR TITLE
Add FFs to control referrals send and claim flows separately

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -98,6 +98,12 @@ public enum FeatureFlag: String, CaseIterable {
     /// Enable the Referrals feature
     case referrals
 
+    /// Enables the referrals Send Flow
+    case referralsSend
+
+    /// Enables the referrals Claim Flow
+    case referralsClaim
+
     /// When accessing Stats, it checks if the local stats are behind remote
     /// If it is, it updates it
     /// This is meant to fix an issue for users that were losing stats
@@ -195,6 +201,10 @@ public enum FeatureFlag: String, CaseIterable {
             true
         case .referrals:
             true
+        case .referralsClaim:
+            true
+        case .referralsSend:
+            false
         case .syncStats:
             true
         case .discoverCollectionView:

--- a/podcasts/Referrals/ReferralsCoordinator.swift
+++ b/podcasts/Referrals/ReferralsCoordinator.swift
@@ -17,11 +17,11 @@ class ReferralsCoordinator {
     }
 
     var areReferralsAvailableToSend: Bool {
-        return FeatureFlag.referrals.enabled && SubscriptionHelper.hasActiveSubscription()
+        return FeatureFlag.referrals.enabled && FeatureFlag.referralsSend.enabled && SubscriptionHelper.hasActiveSubscription()
     }
 
     var isReferralAvailableToClaim: Bool {
-        return FeatureFlag.referrals.enabled &&
+        return FeatureFlag.referrals.enabled && FeatureFlag.referralsClaim.enabled &&
         !SubscriptionHelper.hasActiveSubscription() &&
         Settings.referralURL != nil
     }
@@ -49,6 +49,10 @@ class ReferralsCoordinator {
     }
 
     func startClaimFlow(from viewController: UIViewController, referralURL: URL? = nil, onComplete: (() -> ())? = nil) {
+        guard FeatureFlag.referrals.enabled && FeatureFlag.referralsClaim.enabled else {
+            onComplete?()
+            return
+        }
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
             var url: URL?


### PR DESCRIPTION
| 📘 Part of: #2083  |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

This PR enables FF to control the claim and sending of referrals.

## To test

1. Start the app
2. By default Referrals sends should be disabled and claim enabled
3. Login with a account with a Plus or Patron subscription
4. Go to Profile tab
5. You should not see the gift icon on the top left of Profile
6. Enable the Referrals Send FF on Settings -> Beta Features
7. Reopen the app
8. You should know see the gift icon on the top left profile
9. Tap on it
10. Tap on Send Pass
11. Share the referral URL to the reminders app
12. Now logout from your account
13. Login with an account with no Subscription
14. Go to Reminders and Tap on the referral URL
15. The app should open the referral claim flow
16. Press Not Now
17. Disable the Referrals Claim FF 
18. Switch to Reminders and press the referral URL
19. The app should not start the claim flow.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
