### PR TITLE
[Up Next Shuffle] Add Tracks event

### DIFF
--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -336,6 +336,7 @@ enum AnalyticsEvent: String {
     case upNextMultiSelectExited
     case upNextQueueReordered
     case upNextDismissed
+    case upNextShuffleToggled
 
     // MARK: - Privacy
 

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -336,7 +336,7 @@ enum AnalyticsEvent: String {
     case upNextMultiSelectExited
     case upNextQueueReordered
     case upNextDismissed
-    case upNextShuffleToggled
+    case upNextShuffleEnabled
 
     // MARK: - Privacy
 

--- a/podcasts/UpNextViewController.swift
+++ b/podcasts/UpNextViewController.swift
@@ -217,7 +217,7 @@ class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
         if !showingInTab {
             updateShuffleButtonState()
         }
-        track(.upNextShuffleToggled, properties: ["enabled": Settings.upNextShuffleEnabled()])
+        track(.upNextShuffleEnabled, properties: ["enabled": Settings.upNextShuffleEnabled()])
     }
 
     @objc private func themeDidChange() {

--- a/podcasts/UpNextViewController.swift
+++ b/podcasts/UpNextViewController.swift
@@ -217,6 +217,7 @@ class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
         if !showingInTab {
             updateShuffleButtonState()
         }
+        track(.upNextShuffleToggled, properties: ["enabled": Settings.upNextShuffleEnabled()])
     }
 
     @objc private func themeDidChange() {

--- a/podcasts/UpNextViewController.swift
+++ b/podcasts/UpNextViewController.swift
@@ -217,7 +217,7 @@ class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
         if !showingInTab {
             updateShuffleButtonState()
         }
-        track(.upNextShuffleEnabled, properties: ["enabled": Settings.upNextShuffleEnabled()])
+        track(.upNextShuffleEnabled, properties: ["value": Settings.upNextShuffleEnabled()])
     }
 
     @objc private func themeDidChange() {


### PR DESCRIPTION
| 📘 Part of: [Up Next Shuffle](https://github.com/orgs/Automattic/projects/1179/views/1)
|:---:|

Fixes #2328 

Add `up_next_shuffle_enabled ` tracks event

## To test

- CI must be 🟢 
- Make sure you have the FF on and tracks logger on
- Navigate to Up next in tab
- Tap the shuffle button to enable/disable it
- Check `🔵 Tracked: up_next_shuffle_enabled ["source": "tab_bar", "value": VALUE]` is logged
- Navigate to Up next in modal (from the mini player)
- Tap the shuffle button to enable/disable it
- Check `🔵 Tracked: up_next_shuffle_enabled ["source": "mini_player", "value": VALUE]` is logged
- Navigate to Up next in modal (from the player fullscreen)
- Tap the shuffle button to enable/disable it
- Check `🔵 Tracked: up_next_shuffle_enabled ["source": "now_playing", "value": VALUE]` is logged
## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
