### PR TITLE
Referrals: Simplify sharing by just sharing text and url

### DIFF
--- a/podcasts/Referrals/ReferralSendPassVC.swift
+++ b/podcasts/Referrals/ReferralSendPassVC.swift
@@ -79,7 +79,7 @@ class TextAndURLShareSource: NSObject, UIActivityItemSource {
     }
 
     func activityViewController(_ activityViewController: UIActivityViewController, itemForActivityType activityType: UIActivity.ActivityType?) -> Any? {
-        return "\(text)\n\n\(url?.absoluteString ?? "")"
+        return text
     }
 
     func activityViewController(_ activityViewController: UIActivityViewController, subjectForActivityType activityType: UIActivity.ActivityType?) -> String {


### PR DESCRIPTION
| 📘 Part of: #2083  |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

Simplify the sharing of the referral message by avoiding the duplication of the link URL.
Majority of standard system share ( Email, Message, Reminders, Notes)  are able to handle the text and url as separate items so this removes the duplication of URL on the text part.

Some other systems like Instagran/Tumblr only handle the URL so no need to add the URL to the text item.

## To test

1. Start the app and login with a Plus/Patron account
2. Ensure that you have the Referrals FF enabled
3. Go to profile
4. Tap on the gift icon on the top left
5. Tap on `Share guest pass`
6. Share on multiple systems and see one of the following:
    - The sharing shows the text followed by the URL, no duplication of the URL. Ex: mail, messages, reminders, WhatsApp
    - The sharing shows only the URL. Ex: Instagram
## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
