### PR TITLE
[Custom Playback Settings] Hide segmented for local Files

### DIFF
--- a/podcasts/EffectsViewController.swift
+++ b/podcasts/EffectsViewController.swift
@@ -138,7 +138,9 @@ class EffectsViewController: SimpleNotificationsViewController {
 
     @IBOutlet weak var playbackSettingsSegmentedControl: UISegmentedControl! {
         didSet {
-            playbackSettingsSegmentedControl.isHidden = !FeatureFlag.customPlaybackSettings.enabled
+            let isUserEpisode = PlaybackManager.shared.currentEpisode()?.isUserEpisode == true
+            let shouldDisplaySegmentedControl = FeatureFlag.customPlaybackSettings.enabled && !isUserEpisode
+            playbackSettingsSegmentedControl.isHidden = !shouldDisplaySegmentedControl
 
             playbackSettingsSegmentedControl.setTitle(L10n.playbackEffectAllPodcasts, forSegmentAt: 0)
             playbackSettingsSegmentedControl.setTitle(L10n.playbackEffectThisPodcast, forSegmentAt: 1)
@@ -152,7 +154,8 @@ class EffectsViewController: SimpleNotificationsViewController {
 
     @IBOutlet weak var speedControlTopConstraint: NSLayoutConstraint! {
         didSet {
-            speedControlTopConstraint.isActive = FeatureFlag.customPlaybackSettings.enabled
+            let isUserEpisode = PlaybackManager.shared.currentEpisode()?.isUserEpisode == true
+            speedControlTopConstraint.isActive = FeatureFlag.customPlaybackSettings.enabled && !isUserEpisode
         }
     }
 


### PR DESCRIPTION
| 📘 Part of: #2253
|:---:|

hides the custom playback settings for local files. As they are UserEpisode, they don't belong to a specific podcast.

## To test

- CI must be 🟢 
- Run the App
- Open a podcast and play an episode
- COnfirm you see the top segmented with All podcasts and This podcast
- Change some effects for global settings
- Go to your profile and open Files
- Play one file
- Confirm you don't see the top segmented 
- Confirm the global effects you changed before are applied here
- Disable the feature flag
- Test everything is currently working as in production and the segmented beverage appears

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
