### PR TITLE
[Custom Playback Settings] Apply same logic for when a user enable the podcast settings

### DIFF
--- a/podcasts/EffectsViewController.swift
+++ b/podcasts/EffectsViewController.swift
@@ -186,6 +186,7 @@ class EffectsViewController: SimpleNotificationsViewController {
         updateControls()
 
         if FeatureFlag.customPlaybackSettings.enabled {
+            PlaybackManager.shared.updateIfPodcastUsedCustomEffectsBefore()
             playbackSettingsSegmentedControl.selectedSegmentIndex = PlaybackManager.shared.isCurrentEffectGlobal() ? 0 : 1
         }
         if let episode = PlaybackManager.shared.currentEpisode() as? Episode, let podcast = episode.parentPodcast() {

--- a/podcasts/PlaybackEffects.swift
+++ b/podcasts/PlaybackEffects.swift
@@ -55,7 +55,7 @@ class PlaybackEffects {
         effects.isGlobal = false
 
         if FeatureFlag.customPlaybackSettings.enabled &&
-            !podcast.usedCustomEffectsBefore {
+            shouldReflectGlobalSettings(for: podcast) {
             let globalEffect = globalEffects()
             effects.trimSilence = globalEffect.trimSilence
             effects.volumeBoost = globalEffect.volumeBoost
@@ -132,5 +132,15 @@ class PlaybackEffects {
         }
 
         return value > 0 ? .low : .off
+    }
+
+    private class func shouldReflectGlobalSettings(for podcast: Podcast) -> Bool {
+        let globalEffect = globalEffects()
+        let trimSilence = podcast.settings.trimSilence.amount
+        let volumeBoost = podcast.settings.boostVolume
+        let playbackSpeed = podcast.settings.playbackSpeed
+        return globalEffect.trimSilence == trimSilence &&
+        globalEffect.volumeBoost == volumeBoost &&
+        globalEffect.playbackSpeed == playbackSpeed
     }
 }

--- a/podcasts/PlaybackEffects.swift
+++ b/podcasts/PlaybackEffects.swift
@@ -55,7 +55,7 @@ class PlaybackEffects {
         effects.isGlobal = false
 
         if FeatureFlag.customPlaybackSettings.enabled &&
-            shouldReflectGlobalSettings(for: podcast) {
+            !podcast.usedCustomEffectsBefore {
             let globalEffect = globalEffects()
             effects.trimSilence = globalEffect.trimSilence
             effects.volumeBoost = globalEffect.volumeBoost
@@ -132,15 +132,5 @@ class PlaybackEffects {
         }
 
         return value > 0 ? .low : .off
-    }
-
-    private class func shouldReflectGlobalSettings(for podcast: Podcast) -> Bool {
-        let globalEffect = globalEffects()
-        let trimSilence = podcast.settings.trimSilence.amount
-        let volumeBoost = podcast.settings.boostVolume
-        let playbackSpeed = podcast.settings.playbackSpeed
-        return globalEffect.trimSilence == trimSilence &&
-        globalEffect.volumeBoost == volumeBoost &&
-        globalEffect.playbackSpeed == playbackSpeed
     }
 }

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -859,6 +859,10 @@ class PlaybackManager: ServerPlaybackDelegate {
               let podcast = episode.parentPodcast() else {
             return
         }
+        overrideEffectsToggled(applyLocalSettings: applyLocalSettings, for: podcast)
+    }
+
+    func overrideEffectsToggled(applyLocalSettings: Bool, for podcast: Podcast) {
         podcast.isEffectsOverridden = applyLocalSettings
 
         DataManager.sharedManager.save(podcast: podcast)

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -864,9 +864,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         DataManager.sharedManager.save(podcast: podcast)
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.podcastUpdated, object: podcast.uuid)
 
-        let newEffects = loadEffects()
-        currentEffects = newEffects
-        handlePlaybackEffectsChanged(effects: newEffects)
+        effectsChangedExternally()
     }
 
     func isCurrentEffectGlobal() -> Bool {

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -871,6 +871,15 @@ class PlaybackManager: ServerPlaybackDelegate {
         effectsChangedExternally()
     }
 
+    func updateIfPodcastUsedCustomEffectsBefore() {
+        if let episode = currentEpisode() as? Episode, let podcast = episode.parentPodcast() {
+            if podcast.overrideGlobalEffects, !podcast.usedCustomEffectsBefore {
+                podcast.usedCustomEffectsBefore = true
+                DataManager.sharedManager.save(podcast: podcast)
+            }
+        }
+    }
+
     func isCurrentEffectGlobal() -> Bool {
         return effects().isGlobal
     }

--- a/podcasts/PodcastEffectsViewController+Table.swift
+++ b/podcasts/PodcastEffectsViewController+Table.swift
@@ -236,7 +236,7 @@ extension PodcastEffectsViewController: UITableViewDataSource, UITableViewDelega
 
     @objc private func overrideEffectsToggled(_ sender: UISwitch) {
         if FeatureFlag.customPlaybackSettings.enabled {
-            PlaybackManager.shared.overrideEffectsToggled(applyLocalSettings: sender.isOn)
+            PlaybackManager.shared.overrideEffectsToggled(applyLocalSettings: sender.isOn, for: podcast)
             effectsTable.reloadData()
         } else {
             podcast.isEffectsOverridden = sender.isOn

--- a/podcasts/PodcastEffectsViewController+Table.swift
+++ b/podcasts/PodcastEffectsViewController+Table.swift
@@ -57,7 +57,7 @@ extension PodcastEffectsViewController: UITableViewDataSource, UITableViewDelega
             cell.timeStepper.maximumValue = 5
             cell.timeStepper.smallIncrements = 0.1
             cell.timeStepper.smallIncrementThreshold = TimeInterval.greatestFiniteMagnitude
-            
+
             if FeatureFlag.customPlaybackSettings.enabled,
                !podcast.usedCustomEffectsBefore {
                 let effect = PlaybackManager.shared.effects()

--- a/podcasts/PodcastEffectsViewController+Table.swift
+++ b/podcasts/PodcastEffectsViewController+Table.swift
@@ -45,7 +45,11 @@ extension PodcastEffectsViewController: UITableViewDataSource, UITableViewDelega
         case .playbackSpeed:
             let cell = tableView.dequeueReusableCell(withIdentifier: PodcastEffectsViewController.timeStepperCellId, for: indexPath) as! TimeStepperCell
             cell.cellLabel?.text = L10n.settingsPlaySpeed
-            if FeatureFlag.newSettingsStorage.enabled {
+            if FeatureFlag.customPlaybackSettings.enabled,
+               !podcast.usedCustomEffectsBefore {
+                let effect = PlaybackManager.shared.effects()
+                cell.cellSecondaryLabel.text = L10n.playbackSpeed(effect.playbackSpeed.localized())
+            } else if FeatureFlag.newSettingsStorage.enabled {
                 cell.cellSecondaryLabel.text = L10n.playbackSpeed(podcast.settings.playbackSpeed.localized())
             } else {
                 cell.cellSecondaryLabel.text = L10n.playbackSpeed(podcast.playbackSpeed.localized())


### PR DESCRIPTION
| 📘 Part of: #2253
|:---:|

Apply the same logic if a user enables the Local settings from the podcast settings

## To test

- CI must be 🟢 

### Scenario 1
1. Run the App and make sure the FF is off
2. Subscribe to a podcast you didn't subscribe before
3. Go to the podcast settings (cog icon in the podcast page) and enable the local settings for this podcast
4. Play an episode and make sure the local settings are applied
5. Enable the FF
6. Restart the app
7. Play the same episode
8. Make sure the new segmented "This podcast" is selected with the applied settings

### Scenario 2
1. Play an episode for a podcast for which local podcast playback settings are not configured yet
9. Change global playback effects settings (2x, off, off)
10. Switch to "This podcast" in playback effects view
11. Notice that playback effects in "This podcast" is (2x, off, off), i.e. it displays last changed global effects on this view
12. Unsubscribe from the podcast and re-subscribe
13. Go to podcast settings and toggle custom for this podcast
14. Notice that playback effects in custom effects reflects the global one

### Scenario 3
1. Play an episode for a podcast for which local podcast playback settings are not configured yet
2. Change global playback effects settings (2x, off, off). Do not switch to "This podcast" effects view yet
3. Go to podcast settings and toggle custom for this podcast
4. Notice that playback effects in custom effects reflects the global one
5. Now open "This podcast" effects view. Notice that it reflects the global one

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
