### PR TITLE
Remove long press gesture on referrals banner view

### DIFF
--- a/podcasts/Referrals/Banner/ReferralsClaimBannerView.swift
+++ b/podcasts/Referrals/Banner/ReferralsClaimBannerView.swift
@@ -36,9 +36,6 @@ struct ReferralsClaimBannerView: View {
             .padding(.top, 4)
             .padding(.trailing, 4)
         }
-        .onLongPressGesture {
-            viewModel.onCloseTap?()
-        }
         .frame(minHeight: Constants.minHeight)
     }
 


### PR DESCRIPTION
This was interfering with the table view did select row code

| 📘 Part of: #2083  |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

## To test

1. Start the app with a non subscription account
2. Tap on a referral link outside the app. Ping me if you need one
3. Check if the referral page opens
4. Tap on Not Now
5. Check if tapping on the row with the referral banner opens the referral claim page.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
