### PR TITLE
[Custom Playback Settings] Fix old local settings applied

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseHelper.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseHelper.swift
@@ -785,6 +785,18 @@ class DatabaseHelper {
             }
         }
 
+        if schemaVersion < 54 {
+            do {
+                // In case the column doesn't exist due to the previous migration
+                try? db.executeUpdate("ALTER TABLE SJPodcast ADD COLUMN usedCustomEffectsBefore INTEGER NOT NULL DEFAULT 0;", values: nil)
+                try db.executeUpdate("UPDATE SJPodcast SET usedCustomEffectsBefore = CASE WHEN overrideGlobalEffects = 1 OR playbackSpeed != 1.0 OR trimSilenceAmount != 0 OR boostVolume != 0 THEN 1 ELSE 0 END;", values: nil)
+                schemaVersion = 54
+            } catch {
+                failedAt(54)
+                return
+            }
+        }
+
         db.commit()
     }
 }

--- a/podcasts/EffectsViewController.swift
+++ b/podcasts/EffectsViewController.swift
@@ -189,8 +189,6 @@ class EffectsViewController: SimpleNotificationsViewController {
         updateControls()
 
         if FeatureFlag.customPlaybackSettings.enabled {
-            PlaybackManager.shared.updateIfPodcastUsedCustomEffectsBefore()
-            PlaybackManager.shared.effectsChangedExternally()
             playbackSettingsSegmentedControl.selectedSegmentIndex = PlaybackManager.shared.isCurrentEffectGlobal() ? 0 : 1
         }
         if let episode = PlaybackManager.shared.currentEpisode() as? Episode, let podcast = episode.parentPodcast() {

--- a/podcasts/EffectsViewController.swift
+++ b/podcasts/EffectsViewController.swift
@@ -190,6 +190,7 @@ class EffectsViewController: SimpleNotificationsViewController {
 
         if FeatureFlag.customPlaybackSettings.enabled {
             PlaybackManager.shared.updateIfPodcastUsedCustomEffectsBefore()
+            PlaybackManager.shared.effectsChangedExternally()
             playbackSettingsSegmentedControl.selectedSegmentIndex = PlaybackManager.shared.isCurrentEffectGlobal() ? 0 : 1
         }
         if let episode = PlaybackManager.shared.currentEpisode() as? Episode, let podcast = episode.parentPodcast() {

--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -257,8 +257,6 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
             return
         }
 
-        PlaybackManager.shared.updatePodcastUsedCustomEffectsBeforeIfNecessary()
-
         setupForEpisode(episodePlaying)
         showMiniPlayer()
         playbackProgressDidChange()

--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -257,6 +257,8 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
             return
         }
 
+        PlaybackManager.shared.updatePodcastUsedCustomEffectsBeforeIfNecessary()
+
         setupForEpisode(episodePlaying)
         showMiniPlayer()
         playbackProgressDidChange()

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -890,6 +890,20 @@ class PlaybackManager: ServerPlaybackDelegate {
         effectsChangedExternally()
     }
 
+    func updatePodcastUsedCustomEffectsBeforeIfNecessary() {
+        guard FeatureFlag.customPlaybackSettings.enabled,
+              let episode = queue.currentEpisode() as? Episode,
+              let podcast = episode.parentPodcast() else {
+            return
+        }
+        // Apply old local settings if needed when the effect is loaded.
+        // This will update when the player starts
+        if podcast.overrideGlobalEffects, !podcast.usedCustomEffectsBefore {
+            podcast.usedCustomEffectsBefore = true
+            DataManager.sharedManager.save(podcast: podcast)
+        }
+    }
+
     func isCurrentEffectGlobal() -> Bool {
         return effects().isGlobal
     }
@@ -1335,16 +1349,6 @@ class PlaybackManager: ServerPlaybackDelegate {
         guard let episode = queue.currentEpisode() as? Episode, let podcast = episode.parentPodcast() else {
             return PlaybackEffects.globalEffects()
         }
-
-        // Apply old local settings if needed when the effect is loaded.
-        // This will update when the player starts
-        if FeatureFlag.customPlaybackSettings.enabled,
-           podcast.overrideGlobalEffects,
-           !podcast.usedCustomEffectsBefore {
-            podcast.usedCustomEffectsBefore = true
-            DataManager.sharedManager.save(podcast: podcast)
-        }
-
         return PlaybackEffects.effectsFor(podcast: podcast)
     }
 

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -791,6 +791,10 @@ class PlaybackManager: ServerPlaybackDelegate {
         return currentEffects!
     }
 
+    func effectsFor(podcast: Podcast) -> PlaybackEffects {
+        return PlaybackEffects.effectsFor(podcast: podcast)
+    }
+
     func applyCurrentEffect() {
         guard let currentEffects else { return }
         changeEffects(currentEffects)
@@ -814,19 +818,7 @@ class PlaybackManager: ServerPlaybackDelegate {
                 UserDefaults.standard.set(effects.playbackSpeed, forKey: Constants.UserDefaults.globalPlaybackSpeed)
             }
         } else if let episode = episode as? Episode, let podcast = episode.parentPodcast() {
-            if FeatureFlag.newSettingsStorage.enabled {
-                podcast.settings.trimSilence = TrimSilence(amount: effects.trimSilence)
-                podcast.settings.playbackSpeed = effects.playbackSpeed
-                podcast.settings.boostVolume = effects.volumeBoost
-                podcast.syncStatus = SyncStatus.notSynced.rawValue
-            }
-            podcast.trimSilenceAmount = Int32(effects.trimSilence.rawValue)
-            podcast.playbackSpeed = effects.playbackSpeed
-            podcast.boostVolume = effects.volumeBoost
-
-            if FeatureFlag.customPlaybackSettings.enabled, !podcast.usedCustomEffectsBefore {
-                podcast.usedCustomEffectsBefore = true
-            }
+            changeLocalEffects(effects, for: podcast)
 
             DataManager.sharedManager.save(podcast: podcast)
             NotificationCenter.postOnMainThread(notification: Constants.Notifications.podcastUpdated, object: podcast.uuid)
@@ -834,6 +826,22 @@ class PlaybackManager: ServerPlaybackDelegate {
 
         currentEffects = effects
         handlePlaybackEffectsChanged(effects: effects)
+    }
+    
+    func changeLocalEffects(_ effects: PlaybackEffects, for podcast: Podcast) {
+        if FeatureFlag.newSettingsStorage.enabled {
+            podcast.settings.trimSilence = TrimSilence(amount: effects.trimSilence)
+            podcast.settings.playbackSpeed = effects.playbackSpeed
+            podcast.settings.boostVolume = effects.volumeBoost
+            podcast.syncStatus = SyncStatus.notSynced.rawValue
+        }
+        podcast.trimSilenceAmount = Int32(effects.trimSilence.rawValue)
+        podcast.playbackSpeed = effects.playbackSpeed
+        podcast.boostVolume = effects.volumeBoost
+
+        if FeatureFlag.customPlaybackSettings.enabled, !podcast.usedCustomEffectsBefore {
+            podcast.usedCustomEffectsBefore = true
+        }
     }
 
     func decreasePlaybackSpeed() {

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -827,7 +827,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         currentEffects = effects
         handlePlaybackEffectsChanged(effects: effects)
     }
-    
+
     func changeLocalEffects(_ effects: PlaybackEffects, for podcast: Podcast) {
         if FeatureFlag.newSettingsStorage.enabled {
             podcast.settings.trimSilence = TrimSilence(amount: effects.trimSilence)
@@ -888,16 +888,6 @@ class PlaybackManager: ServerPlaybackDelegate {
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.podcastUpdated, object: podcast.uuid)
 
         effectsChangedExternally()
-    }
-
-    func updateIfPodcastUsedCustomEffectsBefore() {
-        if let episode = currentEpisode() as? Episode,
-           let podcast = episode.parentPodcast(),
-           podcast.overrideGlobalEffects,
-           !podcast.usedCustomEffectsBefore {
-            podcast.usedCustomEffectsBefore = true
-            DataManager.sharedManager.save(podcast: podcast)
-        }
     }
 
     func isCurrentEffectGlobal() -> Bool {
@@ -1344,6 +1334,15 @@ class PlaybackManager: ServerPlaybackDelegate {
     private func loadEffects() -> PlaybackEffects {
         guard let episode = queue.currentEpisode() as? Episode, let podcast = episode.parentPodcast() else {
             return PlaybackEffects.globalEffects()
+        }
+
+        // Apply old local settings if needed when the effect is loaded.
+        // This will update when the player starts
+        if FeatureFlag.customPlaybackSettings.enabled,
+           podcast.overrideGlobalEffects,
+           !podcast.usedCustomEffectsBefore {
+            podcast.usedCustomEffectsBefore = true
+            DataManager.sharedManager.save(podcast: podcast)
         }
 
         return PlaybackEffects.effectsFor(podcast: podcast)

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -890,20 +890,6 @@ class PlaybackManager: ServerPlaybackDelegate {
         effectsChangedExternally()
     }
 
-    func updatePodcastUsedCustomEffectsBeforeIfNecessary() {
-        guard FeatureFlag.customPlaybackSettings.enabled,
-              let episode = queue.currentEpisode() as? Episode,
-              let podcast = episode.parentPodcast() else {
-            return
-        }
-        // Apply old local settings if needed when the effect is loaded.
-        // This will update when the player starts
-        if podcast.overrideGlobalEffects, !podcast.usedCustomEffectsBefore {
-            podcast.usedCustomEffectsBefore = true
-            DataManager.sharedManager.save(podcast: podcast)
-        }
-    }
-
     func isCurrentEffectGlobal() -> Bool {
         return effects().isGlobal
     }

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -891,11 +891,12 @@ class PlaybackManager: ServerPlaybackDelegate {
     }
 
     func updateIfPodcastUsedCustomEffectsBefore() {
-        if let episode = currentEpisode() as? Episode, let podcast = episode.parentPodcast() {
-            if podcast.overrideGlobalEffects, !podcast.usedCustomEffectsBefore {
-                podcast.usedCustomEffectsBefore = true
-                DataManager.sharedManager.save(podcast: podcast)
-            }
+        if let episode = currentEpisode() as? Episode,
+           let podcast = episode.parentPodcast(),
+           podcast.overrideGlobalEffects,
+           !podcast.usedCustomEffectsBefore {
+            podcast.usedCustomEffectsBefore = true
+            DataManager.sharedManager.save(podcast: podcast)
         }
     }
 

--- a/podcasts/PodcastEffectsViewController+Table.swift
+++ b/podcasts/PodcastEffectsViewController+Table.swift
@@ -250,7 +250,7 @@ extension PodcastEffectsViewController: UITableViewDataSource, UITableViewDelega
 
     @objc private func overrideEffectsToggled(_ sender: UISwitch) {
         if FeatureFlag.customPlaybackSettings.enabled {
-            PlaybackManager.shared.overrideEffectsToggled(applyLocalSettings: sender.isOn, for: podcast)
+            localEffectsProvider?.overrideEffectsToggled(applyLocalSettings: sender.isOn, for: podcast)
             effectsTable.reloadData()
         } else {
             podcast.isEffectsOverridden = sender.isOn

--- a/podcasts/PodcastEffectsViewController+Table.swift
+++ b/podcasts/PodcastEffectsViewController+Table.swift
@@ -46,9 +46,8 @@ extension PodcastEffectsViewController: UITableViewDataSource, UITableViewDelega
             let cell = tableView.dequeueReusableCell(withIdentifier: PodcastEffectsViewController.timeStepperCellId, for: indexPath) as! TimeStepperCell
             cell.cellLabel?.text = L10n.settingsPlaySpeed
             if FeatureFlag.customPlaybackSettings.enabled,
-               !podcast.usedCustomEffectsBefore {
-                let effect = PlaybackManager.shared.effects()
-                cell.cellSecondaryLabel.text = L10n.playbackSpeed(effect.playbackSpeed.localized())
+               let effects = viewModel?.effects {
+                cell.cellSecondaryLabel.text = L10n.playbackSpeed(effects.playbackSpeed.localized())
             } else if FeatureFlag.newSettingsStorage.enabled {
                 cell.cellSecondaryLabel.text = L10n.playbackSpeed(podcast.settings.playbackSpeed.localized())
             } else {
@@ -63,9 +62,8 @@ extension PodcastEffectsViewController: UITableViewDataSource, UITableViewDelega
             cell.timeStepper.smallIncrementThreshold = TimeInterval.greatestFiniteMagnitude
 
             if FeatureFlag.customPlaybackSettings.enabled,
-               !podcast.usedCustomEffectsBefore {
-                let effect = PlaybackManager.shared.effects()
-                cell.timeStepper.currentValue = effect.playbackSpeed
+               let effects = viewModel?.effects {
+                cell.timeStepper.currentValue = effects.playbackSpeed
             } else if FeatureFlag.newSettingsStorage.enabled {
                 cell.timeStepper.currentValue = podcast.settings.playbackSpeed
             } else {
@@ -83,9 +81,8 @@ extension PodcastEffectsViewController: UITableViewDataSource, UITableViewDelega
             cell.cellSwitch.onTintColor = podcast.switchTintColor()
             cell.setImage(imageName: "player_trim")
             if FeatureFlag.customPlaybackSettings.enabled,
-               !podcast.usedCustomEffectsBefore {
-                let effect = PlaybackManager.shared.effects()
-                cell.cellSwitch.isOn = effect.trimSilence != .off
+               let effects = viewModel?.effects {
+                cell.cellSwitch.isOn = effects.trimSilence != .off
             } else if FeatureFlag.newSettingsStorage.enabled {
                 cell.cellSwitch.isOn = podcast.settings.trimSilence != .off
             } else {
@@ -104,9 +101,8 @@ extension PodcastEffectsViewController: UITableViewDataSource, UITableViewDelega
             let trimAmount: TrimSilenceAmount
 
             if FeatureFlag.customPlaybackSettings.enabled,
-               !podcast.usedCustomEffectsBefore {
-                let effect = PlaybackManager.shared.effects()
-                trimAmount = effect.trimSilence
+               let effects = viewModel?.effects {
+                trimAmount = effects.trimSilence
             } else if FeatureFlag.newSettingsStorage.enabled {
                 trimAmount = podcast.settings.trimSilence.amount
             } else {
@@ -121,9 +117,8 @@ extension PodcastEffectsViewController: UITableViewDataSource, UITableViewDelega
             cell.cellSwitch.onTintColor = podcast.switchTintColor()
             cell.setImage(imageName: "player_volumeboost")
             if FeatureFlag.customPlaybackSettings.enabled,
-               !podcast.usedCustomEffectsBefore {
-                let effect = PlaybackManager.shared.effects()
-                cell.cellSwitch.isOn = effect.volumeBoost
+               let effects = viewModel?.effects {
+                cell.cellSwitch.isOn = effects.volumeBoost
             } else if FeatureFlag.newSettingsStorage.enabled {
                 cell.cellSwitch.isOn = podcast.settings.boostVolume
             } else {
@@ -196,9 +191,13 @@ extension PodcastEffectsViewController: UITableViewDataSource, UITableViewDelega
             podcast.settings.playbackSpeed = roundedSpeed
             podcast.syncStatus = SyncStatus.notSynced.rawValue
         }
-        podcast.playbackSpeed = roundedSpeed
+        if FeatureFlag.customPlaybackSettings.enabled {
+            viewModel?.effects.playbackSpeed = roundedSpeed
+            viewModel?.applyLocalEffets(for: podcast)
+        } else {
+            podcast.playbackSpeed = roundedSpeed
+        }
         saveUpdates()
-
         playbackSpeedDebouncer.call {
             AnalyticsPlaybackHelper.shared.currentSource = self.analyticsSource
             if FeatureFlag.customPlaybackSettings.enabled {
@@ -215,7 +214,13 @@ extension PodcastEffectsViewController: UITableViewDataSource, UITableViewDelega
             podcast.settings.trimSilence = TrimSilence(amount: sender.isOn ? (defaultAmount ?? .off) : .off)
             podcast.syncStatus = SyncStatus.notSynced.rawValue
         }
-        podcast.trimSilenceAmount = sender.isOn ? Int32(PlaybackEffects.defaultRemoveSilenceAmount) : 0
+        if FeatureFlag.customPlaybackSettings.enabled {
+            let amount = sender.isOn ? Int32(PlaybackEffects.defaultRemoveSilenceAmount) : 0
+            viewModel?.effects.trimSilence = TrimSilenceAmount(rawValue: amount) ?? .off
+            viewModel?.applyLocalEffets(for: podcast)
+        } else {
+            podcast.trimSilenceAmount = sender.isOn ? Int32(PlaybackEffects.defaultRemoveSilenceAmount) : 0
+        }
         saveUpdates()
         if FeatureFlag.customPlaybackSettings.enabled {
             AnalyticsPlaybackHelper.shared.trimSilenceToggled(enabled: sender.isOn, currentSettings: "local")
@@ -229,7 +234,12 @@ extension PodcastEffectsViewController: UITableViewDataSource, UITableViewDelega
             podcast.settings.boostVolume = sender.isOn
             podcast.syncStatus = SyncStatus.notSynced.rawValue
         }
-        podcast.boostVolume = sender.isOn
+        if FeatureFlag.customPlaybackSettings.enabled {
+            viewModel?.effects.volumeBoost = sender.isOn
+            viewModel?.applyLocalEffets(for: podcast)
+        } else {
+            podcast.boostVolume = sender.isOn
+        }
         saveUpdates()
         if FeatureFlag.customPlaybackSettings.enabled {
             AnalyticsPlaybackHelper.shared.volumeBoostToggled(enabled: sender.isOn, currentSettings: "local")
@@ -254,9 +264,8 @@ extension PodcastEffectsViewController: UITableViewDataSource, UITableViewDelega
     private func tableData() -> [[TableRow]] {
         let hasTrimSilence: Bool
         if FeatureFlag.customPlaybackSettings.enabled,
-           !podcast.usedCustomEffectsBefore {
-            let effect = PlaybackManager.shared.effects()
-            hasTrimSilence = effect.trimSilence != .off
+           let effects = viewModel?.effects {
+            hasTrimSilence = effects.trimSilence != .off
         } else {
             hasTrimSilence = FeatureFlag.newSettingsStorage.enabled ? podcast.settings.trimSilence != .off : podcast.trimSilenceAmount > 0
         }

--- a/podcasts/PodcastEffectsViewController+Table.swift
+++ b/podcasts/PodcastEffectsViewController+Table.swift
@@ -46,7 +46,7 @@ extension PodcastEffectsViewController: UITableViewDataSource, UITableViewDelega
             let cell = tableView.dequeueReusableCell(withIdentifier: PodcastEffectsViewController.timeStepperCellId, for: indexPath) as! TimeStepperCell
             cell.cellLabel?.text = L10n.settingsPlaySpeed
             if FeatureFlag.customPlaybackSettings.enabled,
-               let effects = viewModel?.effects {
+               let effects = localEffectsProvider?.effects {
                 cell.cellSecondaryLabel.text = L10n.playbackSpeed(effects.playbackSpeed.localized())
             } else if FeatureFlag.newSettingsStorage.enabled {
                 cell.cellSecondaryLabel.text = L10n.playbackSpeed(podcast.settings.playbackSpeed.localized())
@@ -62,7 +62,7 @@ extension PodcastEffectsViewController: UITableViewDataSource, UITableViewDelega
             cell.timeStepper.smallIncrementThreshold = TimeInterval.greatestFiniteMagnitude
 
             if FeatureFlag.customPlaybackSettings.enabled,
-               let effects = viewModel?.effects {
+               let effects = localEffectsProvider?.effects {
                 cell.timeStepper.currentValue = effects.playbackSpeed
             } else if FeatureFlag.newSettingsStorage.enabled {
                 cell.timeStepper.currentValue = podcast.settings.playbackSpeed
@@ -81,7 +81,7 @@ extension PodcastEffectsViewController: UITableViewDataSource, UITableViewDelega
             cell.cellSwitch.onTintColor = podcast.switchTintColor()
             cell.setImage(imageName: "player_trim")
             if FeatureFlag.customPlaybackSettings.enabled,
-               let effects = viewModel?.effects {
+               let effects = localEffectsProvider?.effects {
                 cell.cellSwitch.isOn = effects.trimSilence != .off
             } else if FeatureFlag.newSettingsStorage.enabled {
                 cell.cellSwitch.isOn = podcast.settings.trimSilence != .off
@@ -101,7 +101,7 @@ extension PodcastEffectsViewController: UITableViewDataSource, UITableViewDelega
             let trimAmount: TrimSilenceAmount
 
             if FeatureFlag.customPlaybackSettings.enabled,
-               let effects = viewModel?.effects {
+               let effects = localEffectsProvider?.effects {
                 trimAmount = effects.trimSilence
             } else if FeatureFlag.newSettingsStorage.enabled {
                 trimAmount = podcast.settings.trimSilence.amount
@@ -117,7 +117,7 @@ extension PodcastEffectsViewController: UITableViewDataSource, UITableViewDelega
             cell.cellSwitch.onTintColor = podcast.switchTintColor()
             cell.setImage(imageName: "player_volumeboost")
             if FeatureFlag.customPlaybackSettings.enabled,
-               let effects = viewModel?.effects {
+               let effects = localEffectsProvider?.effects {
                 cell.cellSwitch.isOn = effects.volumeBoost
             } else if FeatureFlag.newSettingsStorage.enabled {
                 cell.cellSwitch.isOn = podcast.settings.boostVolume
@@ -192,8 +192,8 @@ extension PodcastEffectsViewController: UITableViewDataSource, UITableViewDelega
             podcast.syncStatus = SyncStatus.notSynced.rawValue
         }
         if FeatureFlag.customPlaybackSettings.enabled {
-            viewModel?.effects.playbackSpeed = roundedSpeed
-            viewModel?.applyLocalEffets(for: podcast)
+            localEffectsProvider?.effects.playbackSpeed = roundedSpeed
+            localEffectsProvider?.applyLocalEffets(for: podcast)
         } else {
             podcast.playbackSpeed = roundedSpeed
         }
@@ -216,8 +216,8 @@ extension PodcastEffectsViewController: UITableViewDataSource, UITableViewDelega
         }
         if FeatureFlag.customPlaybackSettings.enabled {
             let amount = sender.isOn ? Int32(PlaybackEffects.defaultRemoveSilenceAmount) : 0
-            viewModel?.effects.trimSilence = TrimSilenceAmount(rawValue: amount) ?? .off
-            viewModel?.applyLocalEffets(for: podcast)
+            localEffectsProvider?.effects.trimSilence = TrimSilenceAmount(rawValue: amount) ?? .off
+            localEffectsProvider?.applyLocalEffets(for: podcast)
         } else {
             podcast.trimSilenceAmount = sender.isOn ? Int32(PlaybackEffects.defaultRemoveSilenceAmount) : 0
         }
@@ -235,8 +235,8 @@ extension PodcastEffectsViewController: UITableViewDataSource, UITableViewDelega
             podcast.syncStatus = SyncStatus.notSynced.rawValue
         }
         if FeatureFlag.customPlaybackSettings.enabled {
-            viewModel?.effects.volumeBoost = sender.isOn
-            viewModel?.applyLocalEffets(for: podcast)
+            localEffectsProvider?.effects.volumeBoost = sender.isOn
+            localEffectsProvider?.applyLocalEffets(for: podcast)
         } else {
             podcast.boostVolume = sender.isOn
         }
@@ -264,7 +264,7 @@ extension PodcastEffectsViewController: UITableViewDataSource, UITableViewDelega
     private func tableData() -> [[TableRow]] {
         let hasTrimSilence: Bool
         if FeatureFlag.customPlaybackSettings.enabled,
-           let effects = viewModel?.effects {
+           let effects = localEffectsProvider?.effects {
             hasTrimSilence = effects.trimSilence != .off
         } else {
             hasTrimSilence = FeatureFlag.newSettingsStorage.enabled ? podcast.settings.trimSilence != .off : podcast.trimSilenceAmount > 0

--- a/podcasts/PodcastEffectsViewController.swift
+++ b/podcasts/PodcastEffectsViewController.swift
@@ -22,6 +22,18 @@ class PodcastLocalEffectsProvider {
     func applyLocalEffets(for podcast: Podcast) {
         PlaybackManager.shared.changeLocalEffects(effects, for: podcast)
     }
+
+    func applyLocalEffetsAndSave(for podcast: Podcast) {
+        applyLocalEffets(for: podcast)
+
+        DataManager.sharedManager.save(podcast: podcast)
+        NotificationCenter.postOnMainThread(notification: Constants.Notifications.podcastUpdated, object: podcast.uuid)
+
+        // if we're actively playing this episode, let the player know
+        if let episode = PlaybackManager.shared.currentEpisode() as? Episode, podcast.uuid == episode.parentIdentifier() {
+            PlaybackManager.shared.effectsChangedExternally()
+        }
+    }
 }
 
 class PodcastEffectsViewController: PCViewController {
@@ -67,6 +79,15 @@ class PodcastEffectsViewController: PCViewController {
 
         addCustomObserver(Constants.Notifications.podcastColorsDownloaded, selector: #selector(podcastUpdated(_:)))
         addCustomObserver(Constants.Notifications.podcastUpdated, selector: #selector(podcastUpdated(_:)))
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+
+        if FeatureFlag.customPlaybackSettings.enabled {
+            localEffectsProvider?.applyLocalEffetsAndSave(for: podcast)
+            return
+        }
     }
 
     override func viewDidDisappear(_ animated: Bool) {

--- a/podcasts/PodcastEffectsViewController.swift
+++ b/podcasts/PodcastEffectsViewController.swift
@@ -15,7 +15,7 @@ class PodcastLocalEffectsProvider {
         self.effects = playbackManager.effectsFor(podcast: podcast)
     }
 
-    func update(podcast: Podcast) {
+    func updateEffects(for podcast: Podcast) {
         effects = playbackManager.effectsFor(podcast: podcast)
     }
 
@@ -25,7 +25,15 @@ class PodcastLocalEffectsProvider {
 
     func applyLocalEffetsAndSave(for podcast: Podcast) {
         applyLocalEffets(for: podcast)
+        save(podcast: podcast)
+    }
 
+    func overrideEffectsToggled(applyLocalSettings: Bool, for podcast: Podcast) {
+        podcast.isEffectsOverridden = applyLocalSettings
+        save(podcast: podcast)
+    }
+
+    private func save(podcast: Podcast) {
         DataManager.sharedManager.save(podcast: podcast)
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.podcastUpdated, object: podcast.uuid)
 
@@ -79,6 +87,9 @@ class PodcastEffectsViewController: PCViewController {
 
         addCustomObserver(Constants.Notifications.podcastColorsDownloaded, selector: #selector(podcastUpdated(_:)))
         addCustomObserver(Constants.Notifications.podcastUpdated, selector: #selector(podcastUpdated(_:)))
+        if FeatureFlag.customPlaybackSettings.enabled {
+            addCustomObserver(Constants.Notifications.playbackEffectsChanged, selector: #selector(effectsUpdated))
+        }
     }
 
     override func viewWillDisappear(_ animated: Bool) {
@@ -106,11 +117,16 @@ class PodcastEffectsViewController: PCViewController {
         if podcast.uuid == uuidLoaded {
             if let updatedPodcast = DataManager.sharedManager.findPodcast(uuid: podcast.uuid) {
                 podcast = updatedPodcast
-                localEffectsProvider?.update(podcast: updatedPodcast)
+                localEffectsProvider?.updateEffects(for: updatedPodcast)
                 updateColors()
                 effectsTable.reloadData()
             }
         }
+    }
+
+    @objc private func effectsUpdated() {
+        localEffectsProvider?.updateEffects(for: podcast)
+        effectsTable.reloadData()
     }
 
     private func updateColors() {

--- a/podcasts/PodcastEffectsViewController.swift
+++ b/podcasts/PodcastEffectsViewController.swift
@@ -1,5 +1,28 @@
 import PocketCastsDataModel
 import UIKit
+import PocketCastsUtils
+
+class PodcastEffectsViewModel {
+    private(set) var effects: PlaybackEffects
+
+    private let playbackManager: PlaybackManager = .shared
+
+    init(podcast: Podcast) {
+        if podcast.overrideGlobalEffects, !podcast.usedCustomEffectsBefore {
+            podcast.usedCustomEffectsBefore = true
+            DataManager.sharedManager.save(podcast: podcast)
+        }
+        self.effects = playbackManager.effectsFor(podcast: podcast)
+    }
+
+    func update(podcast: Podcast) {
+        effects = playbackManager.effectsFor(podcast: podcast)
+    }
+
+    func applyLocalEffets(for podcast: Podcast) {
+        PlaybackManager.shared.changeLocalEffects(effects, for: podcast)
+    }
+}
 
 class PodcastEffectsViewController: PCViewController {
     @IBOutlet var effectsTable: UITableView! {
@@ -11,6 +34,7 @@ class PodcastEffectsViewController: PCViewController {
     var playbackSpeedDebouncer: Debounce = .init(delay: 1)
 
     var podcast: Podcast
+    var viewModel: PodcastEffectsViewModel?
 
     init(podcast: Podcast) {
         self.podcast = podcast
@@ -26,6 +50,10 @@ class PodcastEffectsViewController: PCViewController {
         super.viewDidLoad()
 
         title = PlayerAction.effects.title()
+
+        if FeatureFlag.customPlaybackSettings.enabled {
+            viewModel = PodcastEffectsViewModel(podcast: podcast)
+        }
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -57,6 +85,7 @@ class PodcastEffectsViewController: PCViewController {
         if podcast.uuid == uuidLoaded {
             if let updatedPodcast = DataManager.sharedManager.findPodcast(uuid: podcast.uuid) {
                 podcast = updatedPodcast
+                viewModel?.update(podcast: updatedPodcast)
                 updateColors()
                 effectsTable.reloadData()
             }

--- a/podcasts/PodcastEffectsViewController.swift
+++ b/podcasts/PodcastEffectsViewController.swift
@@ -2,7 +2,7 @@ import PocketCastsDataModel
 import UIKit
 import PocketCastsUtils
 
-class PodcastEffectsViewModel {
+class PodcastLocalEffectsProvider {
     private(set) var effects: PlaybackEffects
 
     private let playbackManager: PlaybackManager = .shared
@@ -34,7 +34,7 @@ class PodcastEffectsViewController: PCViewController {
     var playbackSpeedDebouncer: Debounce = .init(delay: 1)
 
     var podcast: Podcast
-    var viewModel: PodcastEffectsViewModel?
+    var localEffectsProvider: PodcastLocalEffectsProvider?
 
     init(podcast: Podcast) {
         self.podcast = podcast
@@ -52,7 +52,7 @@ class PodcastEffectsViewController: PCViewController {
         title = PlayerAction.effects.title()
 
         if FeatureFlag.customPlaybackSettings.enabled {
-            viewModel = PodcastEffectsViewModel(podcast: podcast)
+            localEffectsProvider = PodcastLocalEffectsProvider(podcast: podcast)
         }
     }
 
@@ -85,7 +85,7 @@ class PodcastEffectsViewController: PCViewController {
         if podcast.uuid == uuidLoaded {
             if let updatedPodcast = DataManager.sharedManager.findPodcast(uuid: podcast.uuid) {
                 podcast = updatedPodcast
-                viewModel?.update(podcast: updatedPodcast)
+                localEffectsProvider?.update(podcast: updatedPodcast)
                 updateColors()
                 effectsTable.reloadData()
             }


### PR DESCRIPTION
| 📘 Part of: #2253 
|:---:|

This PR fixes the old local settings application when the new custom playback settings feature is on.
It also introduces a new provider in the local settings to provide the correct effects for the specific podcast, aligning the business logic to the one used by the playback manager.

## To test

### Before migration

1. `git checkout tags/7.74 -b 7.74`
2. Fresh install the app from `7.74 tag
3. Subscribe to a podcast (`Podcast A`)
4. Play an episode from this podcast
5. Tap effects icon
6. Change global playback speed to 2.0
7. Go to `Podcast A` settings
8. Turn on custom playback settings (do not change any effect so that they remain at `1x, off, off`)
9. Subscribe to another podcast (`Podcast B`)
10. Go to `Podcast B` settings
11. Turn on custom playback settings (change playback speed to 1.1x)

### After migration

1. checkout this branch
2. Install the app without unstalling the previous one
3. Play selected episode from `Podcast B`
4. Tap effects icon on the player
5. Notice that `This podcast` is selected and playback effects are set to local (`1.1x, off, off`)
6. Go to `Podcast A` podcast settings
7. Tap Playback effects
8. Notice that `Custom for this podcast` is selected and playback effects are set to local (`1x, off, off`)

### Apply Global to local
1. Select a `Podcast C` and subscribe
2. Go to its podcast settings
3. Tap Playback effects and enable `Custom for this podcast`
4. Notice the global effects are applied
5. Don't touch anything
6. Navigate back and play an episode of `Podcast C`
7. Open the effects view
8. Notice that `This podcast` is selected with the correct settings applied (same as global)
9. Change some values
10. Go back to the `Podcast C` podcast settings -> Playback effects
11. Notice that the latest changes are reflected

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
