### PR TITLE
[Enhancement] Replace Subscribe with Follow

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -233,7 +233,7 @@ public enum FeatureFlag: String, CaseIterable {
         case .autoDownloadOnSubscribe:
             true
         case .useFollowNaming:
-            false
+            true
         }
     }
 

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -137,6 +137,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// Push two auto downloads on subscribe of a podcast
     case autoDownloadOnSubscribe
 
+    /// Replace Subscribe/Unsubscribe with Follow/Unfollow
+    case useFollowNaming
+
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -229,6 +232,8 @@ public enum FeatureFlag: String, CaseIterable {
             true
         case .autoDownloadOnSubscribe:
             true
+        case .useFollowNaming:
+            false
         }
     }
 

--- a/podcasts/BundlePodcastCell.swift
+++ b/podcasts/BundlePodcastCell.swift
@@ -28,8 +28,8 @@ class BundlePodcastCell: ThemeableCell {
             subscribeButton.onImage = UIImage(named: "discover_tick")?.tintedImage(ThemeColor.support02())
             subscribeButton.offImage = UIImage(named: "discover_add")?.tintedImage(ThemeColor.primaryIcon02())
 
-            subscribeButton.offAccessibilityLabel = L10n.subscribe
-            subscribeButton.onAccessibilityLabel = L10n.subscribed
+            subscribeButton.offAccessibilityLabel = L10n.follow
+            subscribeButton.onAccessibilityLabel = L10n.unfollow
 
             NotificationCenter.default.addObserver(self, selector: #selector(podcastWasAdded), name: Constants.Notifications.podcastAdded, object: nil)
         }

--- a/podcasts/BundlePodcastCell.swift
+++ b/podcasts/BundlePodcastCell.swift
@@ -1,5 +1,6 @@
 import PocketCastsDataModel
 import PocketCastsServer
+import PocketCastsUtils
 import UIKit
 
 class BundlePodcastCell: ThemeableCell {
@@ -28,8 +29,8 @@ class BundlePodcastCell: ThemeableCell {
             subscribeButton.onImage = UIImage(named: "discover_tick")?.tintedImage(ThemeColor.support02())
             subscribeButton.offImage = UIImage(named: "discover_add")?.tintedImage(ThemeColor.primaryIcon02())
 
-            subscribeButton.offAccessibilityLabel = L10n.follow
-            subscribeButton.onAccessibilityLabel = L10n.unfollow
+            subscribeButton.offAccessibilityLabel = FeatureFlag.useFollowNaming.enabled ? L10n.follow : L10n.subscribe
+            subscribeButton.onAccessibilityLabel = FeatureFlag.useFollowNaming.enabled ? L10n.unfollow : L10n.subscribed
 
             NotificationCenter.default.addObserver(self, selector: #selector(podcastWasAdded), name: Constants.Notifications.podcastAdded, object: nil)
         }

--- a/podcasts/CategorySponsoredCell.swift
+++ b/podcasts/CategorySponsoredCell.swift
@@ -39,8 +39,8 @@ class CategorySponsoredCell: ThemeableCell {
             subscribeButton.onImage = UIImage(named: "discover_tick")
             subscribeButton.offImage = UIImage(named: "discover_add")
             subscribeButton.tintColor = ThemeColor.secondaryIcon01()
-            subscribeButton.offAccessibilityLabel = L10n.subscribe
-            subscribeButton.onAccessibilityLabel = L10n.subscribed
+            subscribeButton.offAccessibilityLabel = L10n.follow
+            subscribeButton.onAccessibilityLabel = L10n.unfollow
 
             NotificationCenter.default.addObserver(self, selector: #selector(podcastWasAdded), name: Constants.Notifications.podcastAdded, object: nil)
         }

--- a/podcasts/CategorySponsoredCell.swift
+++ b/podcasts/CategorySponsoredCell.swift
@@ -1,5 +1,6 @@
 import PocketCastsDataModel
 import PocketCastsServer
+import PocketCastsUtils
 import UIKit
 
 class CategorySponsoredCell: ThemeableCell {
@@ -39,8 +40,8 @@ class CategorySponsoredCell: ThemeableCell {
             subscribeButton.onImage = UIImage(named: "discover_tick")
             subscribeButton.offImage = UIImage(named: "discover_add")
             subscribeButton.tintColor = ThemeColor.secondaryIcon01()
-            subscribeButton.offAccessibilityLabel = L10n.follow
-            subscribeButton.onAccessibilityLabel = L10n.unfollow
+            subscribeButton.offAccessibilityLabel = FeatureFlag.useFollowNaming.enabled ? L10n.follow : L10n.subscribe
+            subscribeButton.onAccessibilityLabel = FeatureFlag.useFollowNaming.enabled ? L10n.unfollow : L10n.subscribed
 
             NotificationCenter.default.addObserver(self, selector: #selector(podcastWasAdded), name: Constants.Notifications.podcastAdded, object: nil)
         }

--- a/podcasts/DescriptiveCollectionCell.swift
+++ b/podcasts/DescriptiveCollectionCell.swift
@@ -8,8 +8,8 @@ class DescriptiveCollectionCell: ThemeableCollectionCell {
             subscribeButton.onImage = UIImage(named: "discover_tick")?.tintedImage(ThemeColor.support02())
             subscribeButton.offImage = UIImage(named: "discover_add")?.tintedImage(ThemeColor.primaryIcon02())
 
-            subscribeButton.offAccessibilityLabel = L10n.subscribe
-            subscribeButton.onAccessibilityLabel = L10n.subscribed
+            subscribeButton.offAccessibilityLabel = L10n.follow
+            subscribeButton.onAccessibilityLabel = L10n.unfollow
         }
     }
 

--- a/podcasts/DescriptiveCollectionCell.swift
+++ b/podcasts/DescriptiveCollectionCell.swift
@@ -1,4 +1,5 @@
 import PocketCastsServer
+import PocketCastsUtils
 import UIKit
 
 class DescriptiveCollectionCell: ThemeableCollectionCell {
@@ -8,8 +9,8 @@ class DescriptiveCollectionCell: ThemeableCollectionCell {
             subscribeButton.onImage = UIImage(named: "discover_tick")?.tintedImage(ThemeColor.support02())
             subscribeButton.offImage = UIImage(named: "discover_add")?.tintedImage(ThemeColor.primaryIcon02())
 
-            subscribeButton.offAccessibilityLabel = L10n.follow
-            subscribeButton.onAccessibilityLabel = L10n.unfollow
+            subscribeButton.offAccessibilityLabel = FeatureFlag.useFollowNaming.enabled ? L10n.follow : L10n.subscribe
+            subscribeButton.onAccessibilityLabel = FeatureFlag.useFollowNaming.enabled ? L10n.unfollow : L10n.subscribed
         }
     }
 

--- a/podcasts/DiscoverFeaturedView.swift
+++ b/podcasts/DiscoverFeaturedView.swift
@@ -32,8 +32,8 @@ class DiscoverFeaturedView: ThemeableView {
             subscribeButton.offImage = UIImage(named: "discover_add")
             subscribeButton.tintColor = ThemeColor.contrast02()
 
-            subscribeButton.offAccessibilityLabel = L10n.subscribe
-            subscribeButton.onAccessibilityLabel = L10n.subscribed
+            subscribeButton.offAccessibilityLabel = L10n.follow
+            subscribeButton.onAccessibilityLabel = L10n.unfollow
         }
     }
 

--- a/podcasts/DiscoverFeaturedView.swift
+++ b/podcasts/DiscoverFeaturedView.swift
@@ -1,5 +1,6 @@
 import PocketCastsDataModel
 import PocketCastsServer
+import PocketCastsUtils
 import UIKit
 
 class DiscoverFeaturedView: ThemeableView {
@@ -32,8 +33,8 @@ class DiscoverFeaturedView: ThemeableView {
             subscribeButton.offImage = UIImage(named: "discover_add")
             subscribeButton.tintColor = ThemeColor.contrast02()
 
-            subscribeButton.offAccessibilityLabel = L10n.follow
-            subscribeButton.onAccessibilityLabel = L10n.unfollow
+            subscribeButton.offAccessibilityLabel = FeatureFlag.useFollowNaming.enabled ? L10n.follow : L10n.subscribe
+            subscribeButton.onAccessibilityLabel = FeatureFlag.useFollowNaming.enabled ? L10n.unfollow : L10n.subscribed
         }
     }
 

--- a/podcasts/DiscoverPodcastTableCell.swift
+++ b/podcasts/DiscoverPodcastTableCell.swift
@@ -35,8 +35,8 @@ class DiscoverPodcastTableCell: ThemeableCell {
             subscribeButton.offImage = UIImage(named: "discover_add")
             subscribeButton.tintColor = ThemeColor.secondaryIcon01()
 
-            subscribeButton.offAccessibilityLabel = L10n.subscribe
-            subscribeButton.onAccessibilityLabel = L10n.subscribed
+            subscribeButton.offAccessibilityLabel = L10n.follow
+            subscribeButton.onAccessibilityLabel = L10n.unfollow
 
             NotificationCenter.default.addObserver(self, selector: #selector(podcastWasAdded), name: Constants.Notifications.podcastAdded, object: nil)
         }

--- a/podcasts/DiscoverPodcastTableCell.swift
+++ b/podcasts/DiscoverPodcastTableCell.swift
@@ -1,5 +1,6 @@
 import PocketCastsDataModel
 import PocketCastsServer
+import PocketCastsUtils
 import UIKit
 
 class DiscoverPodcastTableCell: ThemeableCell {
@@ -35,8 +36,8 @@ class DiscoverPodcastTableCell: ThemeableCell {
             subscribeButton.offImage = UIImage(named: "discover_add")
             subscribeButton.tintColor = ThemeColor.secondaryIcon01()
 
-            subscribeButton.offAccessibilityLabel = L10n.follow
-            subscribeButton.onAccessibilityLabel = L10n.unfollow
+            subscribeButton.offAccessibilityLabel = FeatureFlag.useFollowNaming.enabled ? L10n.follow : L10n.subscribe
+            subscribeButton.onAccessibilityLabel = FeatureFlag.useFollowNaming.enabled ? L10n.unfollow : L10n.subscribed
 
             NotificationCenter.default.addObserver(self, selector: #selector(podcastWasAdded), name: Constants.Notifications.podcastAdded, object: nil)
         }

--- a/podcasts/FilterPreviewViewController.swift
+++ b/podcasts/FilterPreviewViewController.swift
@@ -81,7 +81,7 @@ class FilterPreviewViewController: LargeNavBarViewController, FilterChipActionDe
     @IBOutlet var noEpisodeCriteriaLabel: ThemeableLabel! {
         didSet {
             noEpisodeCriteriaLabel.style = .primaryText02
-            noEpisodeCriteriaLabel.text = L10n.filterCreateNoEpisodesDescriptionExplanation
+            noEpisodeCriteriaLabel.text = FeatureFlag.useFollowNaming.enabled ? L10n.filterCreateNoEpisodesDescriptionExplanationNew : L10n.filterCreateNoEpisodesDescriptionExplanation
         }
     }
 

--- a/podcasts/ImportExportViewController.swift
+++ b/podcasts/ImportExportViewController.swift
@@ -1,5 +1,6 @@
 import PocketCastsDataModel
 import PocketCastsServer
+import PocketCastsUtils
 import UIKit
 
 class ImportExportViewController: PCViewController, UIDocumentInteractionControllerDelegate {
@@ -15,7 +16,7 @@ class ImportExportViewController: PCViewController, UIDocumentInteractionControl
 
     @IBOutlet var importPodcastsDescription: ThemeableLabel! {
         didSet {
-            importPodcastsDescription.text = L10n.importPodcastsDescription
+            importPodcastsDescription.text = FeatureFlag.useFollowNaming.enabled ? L10n.importPodcastsDescriptionNew : L10n.importPodcastsDescription
         }
     }
 

--- a/podcasts/LargeListCell.swift
+++ b/podcasts/LargeListCell.swift
@@ -1,4 +1,5 @@
 import PocketCastsServer
+import PocketCastsUtils
 import UIKit
 
 class LargeListCell: ThemeableCollectionCell {
@@ -18,8 +19,8 @@ class LargeListCell: ThemeableCollectionCell {
             subscribeButton.tintColor = ThemeColor.contrast01()
             subscribeButton.backgroundColor = ThemeColor.veil()
 
-            subscribeButton.offAccessibilityLabel = L10n.follow
-            subscribeButton.onAccessibilityLabel = L10n.unfollow
+            subscribeButton.offAccessibilityLabel = FeatureFlag.useFollowNaming.enabled ? L10n.follow : L10n.subscribe
+            subscribeButton.onAccessibilityLabel = FeatureFlag.useFollowNaming.enabled ? L10n.unfollow : L10n.subscribed
         }
     }
 

--- a/podcasts/LargeListCell.swift
+++ b/podcasts/LargeListCell.swift
@@ -18,8 +18,8 @@ class LargeListCell: ThemeableCollectionCell {
             subscribeButton.tintColor = ThemeColor.contrast01()
             subscribeButton.backgroundColor = ThemeColor.veil()
 
-            subscribeButton.offAccessibilityLabel = L10n.subscribe
-            subscribeButton.onAccessibilityLabel = L10n.subscribed
+            subscribeButton.offAccessibilityLabel = L10n.follow
+            subscribeButton.onAccessibilityLabel = L10n.unfollow
         }
     }
 

--- a/podcasts/Onboarding/Import/ImportViewModel.swift
+++ b/podcasts/Onboarding/Import/ImportViewModel.swift
@@ -1,5 +1,6 @@
 import Foundation
 import SwiftUI
+import PocketCastsUtils
 
 class ImportViewModel: OnboardingModel {
     var navigationController: UINavigationController?
@@ -33,7 +34,7 @@ class ImportViewModel: OnboardingModel {
         .init(id: .castro, displayName: "Castro", steps: L10n.importInstructionsCastro),
         .init(id: .castbox, displayName: "Castbox", steps: L10n.importInstructionsCastbox),
         .init(id: .overcast, displayName: "Overcast", steps: L10n.importInstructionsOvercast),
-        .init(id: .other, displayName: "other apps", steps: L10n.importPodcastsDescription),
+        .init(id: .other, displayName: "other apps", steps: FeatureFlag.useFollowNaming.enabled ? L10n.importPodcastsDescriptionNew : L10n.importPodcastsDescription),
         .init(id: .opmlFromURL, displayName: "URL", steps: L10n.importOpmlFromUrl)
     ]
 

--- a/podcasts/PodcastFilterOverlayController.swift
+++ b/podcasts/PodcastFilterOverlayController.swift
@@ -1,4 +1,5 @@
 import PocketCastsDataModel
+import PocketCastsUtils
 import UIKit
 
 class PodcastFilterOverlayController: PodcastChooserViewController, PodcastSelectionDelegate {
@@ -144,9 +145,9 @@ class PodcastFilterOverlayController: PodcastChooserViewController, PodcastSelec
     func setSwitchSubtitle() {
         let allSelected = selectedUuids.count == allPodcasts.count
         if allSelected {
-            headerView.subtitleLabel.text = L10n.filterAutoAddSubtitle
+            headerView.subtitleLabel.text = FeatureFlag.useFollowNaming.enabled ? L10n.filterAutoAddSubtitleNew : L10n.filterAutoAddSubtitle
         } else {
-            headerView.subtitleLabel.text = L10n.filterManualAddSubtitle
+            headerView.subtitleLabel.text = FeatureFlag.useFollowNaming.enabled ? L10n.filterManualAddSubtitleNew : L10n.filterManualAddSubtitle
         }
     }
 

--- a/podcasts/PodcastGroupCell.swift
+++ b/podcasts/PodcastGroupCell.swift
@@ -20,8 +20,8 @@ class PodcastGroupCell: ThemeableCell {
         didSet {
             subscribeButton.onImage = UIImage(named: "discover_tick")
             subscribeButton.offImage = UIImage(named: "discover_add")
-            subscribeButton.offAccessibilityLabel = L10n.subscribe
-            subscribeButton.onAccessibilityLabel = L10n.subscribed
+            subscribeButton.offAccessibilityLabel = L10n.follow
+            subscribeButton.onAccessibilityLabel = L10n.unfollow
 
             subscribeButton.tintColor = ThemeColor.secondaryIcon01()
         }

--- a/podcasts/PodcastGroupCell.swift
+++ b/podcasts/PodcastGroupCell.swift
@@ -1,5 +1,6 @@
 import PocketCastsDataModel
 import PocketCastsServer
+import PocketCastsUtils
 import UIKit
 
 class PodcastGroupCell: ThemeableCell {
@@ -20,8 +21,8 @@ class PodcastGroupCell: ThemeableCell {
         didSet {
             subscribeButton.onImage = UIImage(named: "discover_tick")
             subscribeButton.offImage = UIImage(named: "discover_add")
-            subscribeButton.offAccessibilityLabel = L10n.follow
-            subscribeButton.onAccessibilityLabel = L10n.unfollow
+            subscribeButton.offAccessibilityLabel = FeatureFlag.useFollowNaming.enabled ? L10n.follow : L10n.subscribe
+            subscribeButton.onAccessibilityLabel = FeatureFlag.useFollowNaming.enabled ? L10n.unfollow : L10n.subscribed
 
             subscribeButton.tintColor = ThemeColor.secondaryIcon01()
         }

--- a/podcasts/PodcastHeadingTableCell.swift
+++ b/podcasts/PodcastHeadingTableCell.swift
@@ -357,7 +357,7 @@ class PodcastHeadingTableCell: ThemeableCell, SubscribeButtonDelegate, Expandabl
         guard let podcast = delegate?.displayedPodcast(), let _ = delegate?.isSummaryExpanded() else { return }
 
         subscribeButton.isSelected = podcast.isSubscribed()
-        subscribeButton.accessibilityLabel = podcast.isSubscribed() ? L10n.subscribed : L10n.subscribe
+        subscribeButton.accessibilityLabel = podcast.isSubscribed() ? L10n.unfollow : L10n.follow
         subscribeButton.setBackgroundColors()
         if subscribeButton.isSelected {
             folderButton.isHidden = !showFolderButton()
@@ -506,7 +506,7 @@ class PodcastHeadingTableCell: ThemeableCell, SubscribeButtonDelegate, Expandabl
                 self.layoutIfNeeded()
             }, completion: { _ in
                 self.isAnimatingToSubscribed = false
-                self.subscribeButton.accessibilityLabel = L10n.subscribed
+                self.subscribeButton.accessibilityLabel = L10n.unfollow
             })
         }
     }

--- a/podcasts/PodcastHeadingTableCell.swift
+++ b/podcasts/PodcastHeadingTableCell.swift
@@ -356,8 +356,11 @@ class PodcastHeadingTableCell: ThemeableCell, SubscribeButtonDelegate, Expandabl
     private func setupButtons() {
         guard let podcast = delegate?.displayedPodcast(), let _ = delegate?.isSummaryExpanded() else { return }
 
+        let subscribedLabel = FeatureFlag.useFollowNaming.enabled ? L10n.unfollow : L10n.subscribed
+        let unsubscribedLabel = FeatureFlag.useFollowNaming.enabled ? L10n.follow : L10n.subscribe
+
         subscribeButton.isSelected = podcast.isSubscribed()
-        subscribeButton.accessibilityLabel = podcast.isSubscribed() ? L10n.unfollow : L10n.follow
+        subscribeButton.accessibilityLabel = podcast.isSubscribed() ? subscribedLabel : unsubscribedLabel
         subscribeButton.setBackgroundColors()
         if subscribeButton.isSelected {
             folderButton.isHidden = !showFolderButton()
@@ -506,7 +509,7 @@ class PodcastHeadingTableCell: ThemeableCell, SubscribeButtonDelegate, Expandabl
                 self.layoutIfNeeded()
             }, completion: { _ in
                 self.isAnimatingToSubscribed = false
-                self.subscribeButton.accessibilityLabel = L10n.unfollow
+                self.subscribeButton.accessibilityLabel = FeatureFlag.useFollowNaming.enabled ? L10n.unfollow : L10n.subscribed
             })
         }
     }

--- a/podcasts/PodcastSettingsViewController+Table.swift
+++ b/podcasts/PodcastSettingsViewController+Table.swift
@@ -185,7 +185,7 @@ extension PodcastSettingsViewController: UITableViewDataSource, UITableViewDeleg
             }
         case .unsubscribe:
             let cell = tableView.dequeueReusableCell(withIdentifier: PodcastSettingsViewController.destructiveButtonCellId, for: indexPath) as! DestructiveButtonCell
-            cell.buttonTitle.text = L10n.unsubscribe
+            cell.buttonTitle.text = L10n.unfollow
             cell.buttonTitle.textColor = ThemeColor.support05()
             return cell
         }

--- a/podcasts/PodcastSettingsViewController+Table.swift
+++ b/podcasts/PodcastSettingsViewController+Table.swift
@@ -1,6 +1,7 @@
 import IntentsUI
 import PocketCastsDataModel
 import PocketCastsServer
+import PocketCastsUtils
 import UIKit
 
 extension PodcastSettingsViewController: UITableViewDataSource, UITableViewDelegate {
@@ -185,7 +186,7 @@ extension PodcastSettingsViewController: UITableViewDataSource, UITableViewDeleg
             }
         case .unsubscribe:
             let cell = tableView.dequeueReusableCell(withIdentifier: PodcastSettingsViewController.destructiveButtonCellId, for: indexPath) as! DestructiveButtonCell
-            cell.buttonTitle.text = L10n.unfollow
+            cell.buttonTitle.text = FeatureFlag.useFollowNaming.enabled ? L10n.unfollow : L10n.unsubscribe
             cell.buttonTitle.textColor = ThemeColor.support05()
             return cell
         }

--- a/podcasts/PodcastSettingsViewController.swift
+++ b/podcasts/PodcastSettingsViewController.swift
@@ -1,5 +1,6 @@
 import DifferenceKit
 import PocketCastsDataModel
+import PocketCastsUtils
 import UIKit
 
 class PodcastSettingsViewController: PCViewController {
@@ -98,7 +99,8 @@ class PodcastSettingsViewController: PCViewController {
             }
         }
         let optionPicker = OptionsPicker(title: downloadedCount > 0 ? nil : L10n.areYouSure)
-        let unsubscribeAction = OptionAction(label: L10n.unfollow, icon: nil, action: { [weak self] in
+        let label = FeatureFlag.useFollowNaming.enabled ? L10n.unfollow : L10n.unsubscribe
+        let unsubscribeAction = OptionAction(label: label, icon: nil, action: { [weak self] in
             self?.performUnsubscribe()
         })
         if downloadedCount > 0 {

--- a/podcasts/PodcastSettingsViewController.swift
+++ b/podcasts/PodcastSettingsViewController.swift
@@ -105,7 +105,8 @@ class PodcastSettingsViewController: PCViewController {
         })
         if downloadedCount > 0 {
             unsubscribeAction.destructive = true
-            optionPicker.addDescriptiveActions(title: L10n.downloadedFilesConf(downloadedCount), message: L10n.downloadedFilesConfMessage, icon: "option-alert", actions: [unsubscribeAction])
+            let message = FeatureFlag.useFollowNaming.enabled ? L10n.downloadedFilesConfMessageNew : L10n.downloadedFilesConfMessage
+            optionPicker.addDescriptiveActions(title: L10n.downloadedFilesConf(downloadedCount), message: message, icon: "option-alert", actions: [unsubscribeAction])
         } else {
             optionPicker.addAction(action: unsubscribeAction)
         }

--- a/podcasts/PodcastSettingsViewController.swift
+++ b/podcasts/PodcastSettingsViewController.swift
@@ -98,7 +98,7 @@ class PodcastSettingsViewController: PCViewController {
             }
         }
         let optionPicker = OptionsPicker(title: downloadedCount > 0 ? nil : L10n.areYouSure)
-        let unsubscribeAction = OptionAction(label: L10n.unsubscribe, icon: nil, action: { [weak self] in
+        let unsubscribeAction = OptionAction(label: L10n.unfollow, icon: nil, action: { [weak self] in
             self?.performUnsubscribe()
         })
         if downloadedCount > 0 {

--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -588,7 +588,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
         }
 
         let optionPicker = OptionsPicker(title: downloadedCount > 0 ? nil : L10n.areYouSure)
-        let unsubscribeAction = OptionAction(label: L10n.unsubscribe, icon: nil, action: { [weak self] in
+        let unsubscribeAction = OptionAction(label: L10n.unfollow, icon: nil, action: { [weak self] in
             self?.performUnsubscribe()
         })
         if downloadedCount > 0 {

--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -594,7 +594,8 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
         })
         if downloadedCount > 0 {
             unsubscribeAction.destructive = true
-            optionPicker.addDescriptiveActions(title: L10n.downloadedFilesConf(downloadedCount), message: L10n.downloadedFilesConfMessage, icon: "option-alert", actions: [unsubscribeAction])
+            let message = FeatureFlag.useFollowNaming.enabled ? L10n.downloadedFilesConfMessageNew : L10n.downloadedFilesConfMessage
+            optionPicker.addDescriptiveActions(title: L10n.downloadedFilesConf(downloadedCount), message: message, icon: "option-alert", actions: [unsubscribeAction])
         } else {
             optionPicker.addAction(action: unsubscribeAction)
         }

--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -588,7 +588,8 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
         }
 
         let optionPicker = OptionsPicker(title: downloadedCount > 0 ? nil : L10n.areYouSure)
-        let unsubscribeAction = OptionAction(label: L10n.unfollow, icon: nil, action: { [weak self] in
+        let label = FeatureFlag.useFollowNaming.enabled ? L10n.unfollow : L10n.unsubscribe
+        let unsubscribeAction = OptionAction(label: label, icon: nil, action: { [weak self] in
             self?.performUnsubscribe()
         })
         if downloadedCount > 0 {

--- a/podcasts/SinglePodcastViewController.swift
+++ b/podcasts/SinglePodcastViewController.swift
@@ -1,4 +1,5 @@
 import PocketCastsServer
+import PocketCastsUtils
 import UIKit
 
 class SinglePodcastViewController: UIViewController, DiscoverSummaryProtocol {
@@ -23,8 +24,8 @@ class SinglePodcastViewController: UIViewController, DiscoverSummaryProtocol {
             subscribeButton.onImage = UIImage(named: "discover_tick")?.tintedImage(ThemeColor.support02())
             subscribeButton.offImage = UIImage(named: "discover_add")?.tintedImage(ThemeColor.primaryIcon02())
 
-            subscribeButton.offAccessibilityLabel = L10n.follow
-            subscribeButton.onAccessibilityLabel = L10n.unfollow
+            subscribeButton.offAccessibilityLabel = FeatureFlag.useFollowNaming.enabled ? L10n.follow : L10n.subscribe
+            subscribeButton.onAccessibilityLabel = FeatureFlag.useFollowNaming.enabled ? L10n.unfollow : L10n.subscribed
         }
     }
 

--- a/podcasts/SinglePodcastViewController.swift
+++ b/podcasts/SinglePodcastViewController.swift
@@ -23,8 +23,8 @@ class SinglePodcastViewController: UIViewController, DiscoverSummaryProtocol {
             subscribeButton.onImage = UIImage(named: "discover_tick")?.tintedImage(ThemeColor.support02())
             subscribeButton.offImage = UIImage(named: "discover_add")?.tintedImage(ThemeColor.primaryIcon02())
 
-            subscribeButton.offAccessibilityLabel = L10n.subscribe
-            subscribeButton.onAccessibilityLabel = L10n.subscribed
+            subscribeButton.offAccessibilityLabel = L10n.follow
+            subscribeButton.onAccessibilityLabel = L10n.unfollow
         }
     }
 

--- a/podcasts/SmallListCell.swift
+++ b/podcasts/SmallListCell.swift
@@ -9,8 +9,8 @@ class SmallListCell: ThemeableCollectionCell {
             subscribeButton.onImage = UIImage(named: "discover_tick")?.tintedImage(ThemeColor.support02())
             subscribeButton.offImage = UIImage(named: "discover_add")?.tintedImage(ThemeColor.primaryIcon02())
 
-            subscribeButton.offAccessibilityLabel = L10n.subscribe
-            subscribeButton.onAccessibilityLabel = L10n.subscribed
+            subscribeButton.offAccessibilityLabel = L10n.follow
+            subscribeButton.onAccessibilityLabel = L10n.unfollow
         }
     }
 

--- a/podcasts/SmallListCell.swift
+++ b/podcasts/SmallListCell.swift
@@ -1,5 +1,6 @@
 import PocketCastsDataModel
 import PocketCastsServer
+import PocketCastsUtils
 import UIKit
 
 class SmallListCell: ThemeableCollectionCell {
@@ -9,8 +10,8 @@ class SmallListCell: ThemeableCollectionCell {
             subscribeButton.onImage = UIImage(named: "discover_tick")?.tintedImage(ThemeColor.support02())
             subscribeButton.offImage = UIImage(named: "discover_add")?.tintedImage(ThemeColor.primaryIcon02())
 
-            subscribeButton.offAccessibilityLabel = L10n.follow
-            subscribeButton.onAccessibilityLabel = L10n.unfollow
+            subscribeButton.offAccessibilityLabel = FeatureFlag.useFollowNaming.enabled ? L10n.follow : L10n.subscribe
+            subscribeButton.onAccessibilityLabel = FeatureFlag.useFollowNaming.enabled ? L10n.unfollow : L10n.subscribed
         }
     }
 

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -1101,8 +1101,10 @@ internal enum L10n {
   internal static var filesHowToTitle: String { return L10n.tr("Localizable", "files_how_to_title") }
   /// Sort Files
   internal static var filesSort: String { return L10n.tr("Localizable", "files_sort") }
-  /// New podcasts you follow to will be automatically added
+  /// New podcasts you subscribe to will be automatically added
   internal static var filterAutoAddSubtitle: String { return L10n.tr("Localizable", "filter_auto_add_subtitle") }
+  /// New podcasts you follow to will be automatically added
+  internal static var filterAutoAddSubtitleNew: String { return L10n.tr("Localizable", "filter_auto_add_subtitle_new") }
   /// All Your Podcasts
   internal static var filterChipsAllPodcasts: String { return L10n.tr("Localizable", "filter_chips_all_podcasts") }
   /// Duration
@@ -1117,8 +1119,10 @@ internal enum L10n {
   internal static var filterCreateInstructions: String { return L10n.tr("Localizable", "filter_create_instructions") }
   /// No Matching Episodes
   internal static var filterCreateNoEpisodes: String { return L10n.tr("Localizable", "filter_create_no_episodes") }
-  /// The criteria you selected doesn’t match any current episodes in your podcasts
+  /// The criteria you selected doesn’t match any current episodes in your subscriptions
   internal static var filterCreateNoEpisodesDescriptionExplanation: String { return L10n.tr("Localizable", "filter_create_no_episodes_description_explanation") }
+  /// The criteria you selected doesn’t match any current episodes in your podcasts
+  internal static var filterCreateNoEpisodesDescriptionExplanationNew: String { return L10n.tr("Localizable", "filter_create_no_episodes_description_explanation_new") }
   /// Choose different criteria, or save this filter if you think it will match episodes in the future.
   internal static var filterCreateNoEpisodesDescriptionPrompt: String { return L10n.tr("Localizable", "filter_create_no_episodes_description_prompt") }
   /// All Podcasts
@@ -1143,8 +1147,10 @@ internal enum L10n {
   internal static var filterEpisodeStatus: String { return L10n.tr("Localizable", "filter_episode_status") }
   /// Longer than
   internal static var filterLongerThanLabel: String { return L10n.tr("Localizable", "filter_longer_than_label") }
-  /// New podcasts you follow to will not be automatically added
+  /// New podcasts you subscribe to will not be automatically added
   internal static var filterManualAddSubtitle: String { return L10n.tr("Localizable", "filter_manual_add_subtitle") }
+  /// New podcasts you follow to will not be automatically added
+  internal static var filterManualAddSubtitleNew: String { return L10n.tr("Localizable", "filter_manual_add_subtitle_new") }
   /// Media Type
   internal static var filterMediaType: String { return L10n.tr("Localizable", "filter_media_type") }
   /// Audio
@@ -1416,10 +1422,14 @@ internal enum L10n {
   internal static var importInstructionsOvercast: String { return L10n.tr("Localizable", "import_instructions_overcast") }
   /// Import your podcasts from an OPML file using a URL
   internal static var importOpmlFromUrl: String { return L10n.tr("Localizable", "import_opml_from_url") }
-  /// You can import your podcasts to Pocket Casts using the widely supported OPML format. Export the file from another app and choose open in Pocket Casts.
+  /// You can import your podcasts subscriptions to Pocket Casts using the widely supported OPML format. Export the file from another app and choose open in Pocket Casts.
   /// 
   /// Note: You may need to email the OPML file to yourself, long press on the attachment and select Pocket Casts.
   internal static var importPodcastsDescription: String { return L10n.tr("Localizable", "import_podcasts_description") }
+  /// You can import your podcasts to Pocket Casts using the widely supported OPML format. Export the file from another app and choose open in Pocket Casts.
+  /// 
+  /// Note: You may need to email the OPML file to yourself, long press on the attachment and select Pocket Casts.
+  internal static var importPodcastsDescriptionNew: String { return L10n.tr("Localizable", "import_podcasts_description_new") }
   /// IMPORT TO POCKET CASTS
   internal static var importPodcastsTitle: String { return L10n.tr("Localizable", "import_podcasts_title") }
   /// Coming from another app? Import your podcasts and get listening. You can always do this later in settings.

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -794,6 +794,8 @@ internal enum L10n {
   internal static var downloadedFilesCleanupConfirmation: String { return L10n.tr("Localizable", "downloaded_files_cleanup_confirmation") }
   /// Unsubscribing will delete all downloaded files in this Podcast, are you sure?
   internal static var downloadedFilesConfMessage: String { return L10n.tr("Localizable", "downloaded_files_conf_message") }
+  /// Unfollowing will delete all downloaded files in this Podcast, are you sure?
+  internal static var downloadedFilesConfMessageNew: String { return L10n.tr("Localizable", "downloaded_files_conf_message_new") }
   /// %1$@ Downloaded Files
   internal static func downloadedFilesConfPluralFormat(_ p1: Any) -> String {
     return L10n.tr("Localizable", "downloaded_files_conf_plural_format", String(describing: p1))

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -1101,7 +1101,7 @@ internal enum L10n {
   internal static var filesHowToTitle: String { return L10n.tr("Localizable", "files_how_to_title") }
   /// Sort Files
   internal static var filesSort: String { return L10n.tr("Localizable", "files_sort") }
-  /// New podcasts you subscribe to will be automatically added
+  /// New podcasts you follow to will be automatically added
   internal static var filterAutoAddSubtitle: String { return L10n.tr("Localizable", "filter_auto_add_subtitle") }
   /// All Your Podcasts
   internal static var filterChipsAllPodcasts: String { return L10n.tr("Localizable", "filter_chips_all_podcasts") }
@@ -1117,7 +1117,7 @@ internal enum L10n {
   internal static var filterCreateInstructions: String { return L10n.tr("Localizable", "filter_create_instructions") }
   /// No Matching Episodes
   internal static var filterCreateNoEpisodes: String { return L10n.tr("Localizable", "filter_create_no_episodes") }
-  /// The criteria you selected doesn’t match any current episodes in your subscriptions
+  /// The criteria you selected doesn’t match any current episodes in your podcasts
   internal static var filterCreateNoEpisodesDescriptionExplanation: String { return L10n.tr("Localizable", "filter_create_no_episodes_description_explanation") }
   /// Choose different criteria, or save this filter if you think it will match episodes in the future.
   internal static var filterCreateNoEpisodesDescriptionPrompt: String { return L10n.tr("Localizable", "filter_create_no_episodes_description_prompt") }
@@ -1143,7 +1143,7 @@ internal enum L10n {
   internal static var filterEpisodeStatus: String { return L10n.tr("Localizable", "filter_episode_status") }
   /// Longer than
   internal static var filterLongerThanLabel: String { return L10n.tr("Localizable", "filter_longer_than_label") }
-  /// New podcasts you subscribe to will not be automatically added
+  /// New podcasts you follow to will not be automatically added
   internal static var filterManualAddSubtitle: String { return L10n.tr("Localizable", "filter_manual_add_subtitle") }
   /// Media Type
   internal static var filterMediaType: String { return L10n.tr("Localizable", "filter_media_type") }
@@ -1247,6 +1247,8 @@ internal enum L10n {
   internal static var foldersHistory: String { return L10n.tr("Localizable", "folders_history") }
   /// A list of podcasts that were removed from folders as a result of a sync.
   internal static var foldersHistoryExplanation: String { return L10n.tr("Localizable", "folders_history_explanation") }
+  /// Follow
+  internal static var follow: String { return L10n.tr("Localizable", "follow") }
   /// No Payment Now – Cancel Anytime
   internal static var freeTrialDetailLabel: String { return L10n.tr("Localizable", "free_trial_detail_label") }
   /// %1$@ FREE
@@ -1414,7 +1416,7 @@ internal enum L10n {
   internal static var importInstructionsOvercast: String { return L10n.tr("Localizable", "import_instructions_overcast") }
   /// Import your podcasts from an OPML file using a URL
   internal static var importOpmlFromUrl: String { return L10n.tr("Localizable", "import_opml_from_url") }
-  /// You can import your podcasts subscriptions to Pocket Casts using the widely supported OPML format. Export the file from another app and choose open in Pocket Casts.
+  /// You can import your podcasts to Pocket Casts using the widely supported OPML format. Export the file from another app and choose open in Pocket Casts.
   /// 
   /// Note: You may need to email the OPML file to yourself, long press on the attachment and select Pocket Casts.
   internal static var importPodcastsDescription: String { return L10n.tr("Localizable", "import_podcasts_description") }
@@ -3303,6 +3305,8 @@ internal enum L10n {
   internal static var tryItNow: String { return L10n.tr("Localizable", "try_it_now") }
   /// Unarchive
   internal static var unarchive: String { return L10n.tr("Localizable", "unarchive") }
+  /// Unfollow
+  internal static var unfollow: String { return L10n.tr("Localizable", "unfollow") }
   /// ? m
   internal static var unknownDuration: String { return L10n.tr("Localizable", "unknown_duration") }
   /// Unstar

--- a/podcasts/SubscribeButton.swift
+++ b/podcasts/SubscribeButton.swift
@@ -1,4 +1,5 @@
 import UIKit
+import PocketCastsUtils
 
 protocol SubscribeButtonDelegate: AnyObject {
     func subscribeButtonTapped()
@@ -15,7 +16,7 @@ class SubscribeButton: ThemeableView {
 
     @IBOutlet var titleLabel: ThemeableLabel! {
         didSet {
-            titleLabel.text = L10n.follow
+            titleLabel.text =  FeatureFlag.useFollowNaming.enabled ? L10n.follow : L10n.subscribe
             titleLabel.style = .primaryInteractive02
         }
     }

--- a/podcasts/SubscribeButton.swift
+++ b/podcasts/SubscribeButton.swift
@@ -15,7 +15,7 @@ class SubscribeButton: ThemeableView {
 
     @IBOutlet var titleLabel: ThemeableLabel! {
         didSet {
-            titleLabel.text = L10n.subscribe
+            titleLabel.text = L10n.follow
             titleLabel.style = .primaryInteractive02
         }
     }

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -941,7 +941,7 @@
 "files_how_to_title" = "How to save a file";
 
 /* Subtitle informing the user that new podcasts will be automatically added to this filter. */
-"filter_auto_add_subtitle" = "New podcasts you subscribe to will be automatically added";
+"filter_auto_add_subtitle" = "New podcasts you follow to will be automatically added";
 
 /* Title for the filter option that indicates all podcasts will be included. */
 "filter_chips_all_podcasts" = "All Your Podcasts";
@@ -965,7 +965,7 @@
 "filter_create_no_episodes" = "No Matching Episodes";
 
 /* Used on the screen to create a new filter. The description about why the list of filtered episodes is empty. */
-"filter_create_no_episodes_description_explanation" = "The criteria you selected doesn’t match any current episodes in your subscriptions";
+"filter_create_no_episodes_description_explanation" = "The criteria you selected doesn’t match any current episodes in your podcasts";
 
 /* Used on the screen to create a new filter. The prompt about what they can do in order to make sure their filter returns results. */
 "filter_create_no_episodes_description_prompt" = "Choose different criteria, or save this filter if you think it will match episodes in the future.";
@@ -1001,7 +1001,7 @@
 "filter_episode_status" = "Episode Status";
 
 /* Subtitle informing the user that new podcasts will not be automatically added to this filter. */
-"filter_manual_add_subtitle" = "New podcasts you subscribe to will not be automatically added";
+"filter_manual_add_subtitle" = "New podcasts you follow to will not be automatically added";
 
 /* Title for filter options related to media type settings. */
 "filter_media_type" = "Media Type";
@@ -1145,7 +1145,7 @@
 "how_to_upload_summary" = "That's it, you're done. Change any details you want, hit save and play!";
 
 /* Describes the process about how to import podcasts to Pocket Casts. '\\n\\n' Is a line break format to separate the description from the following note. */
-"import_podcasts_description" = "You can import your podcasts subscriptions to Pocket Casts using the widely supported OPML format. Export the file from another app and choose open in Pocket Casts.\n\nNote: You may need to email the OPML file to yourself, long press on the attachment and select Pocket Casts.";
+"import_podcasts_description" = "You can import your podcasts to Pocket Casts using the widely supported OPML format. Export the file from another app and choose open in Pocket Casts.\n\nNote: You may need to email the OPML file to yourself, long press on the attachment and select Pocket Casts.";
 
 /* Description for importing opml from URL*/
 "import_opml_from_url" = "Import your podcasts from an OPML file using a URL";
@@ -3009,6 +3009,12 @@
 
 /* Label indicating that the user is currently subscribed to the selected podcast. */
 "subscribed" = "Subscribed";
+
+/* Prompt to follow to the selected podcast. */
+"follow" = "Follow";
+
+/* Label indicating that the user is currently following to the selected podcast. */
+"unfollow" = "Unfollow";
 
 /* Prompt to subscribe to all of the selected podcast. */
 "subscribe_all" = "Subscribe All";

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -941,7 +941,10 @@
 "files_how_to_title" = "How to save a file";
 
 /* Subtitle informing the user that new podcasts will be automatically added to this filter. */
-"filter_auto_add_subtitle" = "New podcasts you follow to will be automatically added";
+"filter_auto_add_subtitle" = "New podcasts you subscribe to will be automatically added";
+
+/* Subtitle informing the user that new podcasts will be automatically added to this filter. */
+"filter_auto_add_subtitle_new" = "New podcasts you follow to will be automatically added";
 
 /* Title for the filter option that indicates all podcasts will be included. */
 "filter_chips_all_podcasts" = "All Your Podcasts";
@@ -965,7 +968,10 @@
 "filter_create_no_episodes" = "No Matching Episodes";
 
 /* Used on the screen to create a new filter. The description about why the list of filtered episodes is empty. */
-"filter_create_no_episodes_description_explanation" = "The criteria you selected doesn’t match any current episodes in your podcasts";
+"filter_create_no_episodes_description_explanation" = "The criteria you selected doesn’t match any current episodes in your subscriptions";
+
+/* Used on the screen to create a new filter. The description about why the list of filtered episodes is empty. */
+"filter_create_no_episodes_description_explanation_new" = "The criteria you selected doesn’t match any current episodes in your podcasts";
 
 /* Used on the screen to create a new filter. The prompt about what they can do in order to make sure their filter returns results. */
 "filter_create_no_episodes_description_prompt" = "Choose different criteria, or save this filter if you think it will match episodes in the future.";
@@ -1001,7 +1007,10 @@
 "filter_episode_status" = "Episode Status";
 
 /* Subtitle informing the user that new podcasts will not be automatically added to this filter. */
-"filter_manual_add_subtitle" = "New podcasts you follow to will not be automatically added";
+"filter_manual_add_subtitle" = "New podcasts you subscribe to will not be automatically added";
+
+/* Subtitle informing the user that new podcasts will not be automatically added to this filter. */
+"filter_manual_add_subtitle_new" = "New podcasts you follow to will not be automatically added";
 
 /* Title for filter options related to media type settings. */
 "filter_media_type" = "Media Type";
@@ -1145,7 +1154,10 @@
 "how_to_upload_summary" = "That's it, you're done. Change any details you want, hit save and play!";
 
 /* Describes the process about how to import podcasts to Pocket Casts. '\\n\\n' Is a line break format to separate the description from the following note. */
-"import_podcasts_description" = "You can import your podcasts to Pocket Casts using the widely supported OPML format. Export the file from another app and choose open in Pocket Casts.\n\nNote: You may need to email the OPML file to yourself, long press on the attachment and select Pocket Casts.";
+"import_podcasts_description" = "You can import your podcasts subscriptions to Pocket Casts using the widely supported OPML format. Export the file from another app and choose open in Pocket Casts.\n\nNote: You may need to email the OPML file to yourself, long press on the attachment and select Pocket Casts.";
+
+/* Describes the process about how to import podcasts to Pocket Casts. '\\n\\n' Is a line break format to separate the description from the following note. */
+"import_podcasts_description_new" = "You can import your podcasts to Pocket Casts using the widely supported OPML format. Export the file from another app and choose open in Pocket Casts.\n\nNote: You may need to email the OPML file to yourself, long press on the attachment and select Pocket Casts.";
 
 /* Description for importing opml from URL*/
 "import_opml_from_url" = "Import your podcasts from an OPML file using a URL";

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -793,6 +793,9 @@
 /* Message for an unsubscribe message box that informs the user that unsubscribing will remove downloaded files. */
 "downloaded_files_conf_message" = "Unsubscribing will delete all downloaded files in this Podcast, are you sure?";
 
+/* Message for an unfollow message box that informs the user that unfollowing will remove downloaded files. */
+"downloaded_files_conf_message_new" = "Unfollowing will delete all downloaded files in this Podcast, are you sure?";
+
 /* Title for an unsubscribe message box that informs the user that unsubscribing will remove downloaded files. Informs the user how many files have been downloaded. '%1$@' is a placeholder for the number of downloaded files, will be more than one. */
 "downloaded_files_conf_plural_format" = "%1$@ Downloaded Files";
 


### PR DESCRIPTION
As discussed in our P2 we want to update some texts in few screens, to replace the word `Subscribe` with `Follow`

| Podcast Page | Podcast Page Unsubscribe | Podcast Settings | Podcast Page Unsubscribe Download |
| :------: | :------: | :------: | :------: |
| ![RocketSim_Screenshot_iPhone_16_6 1_2024-10-29_16 31 23](https://github.com/user-attachments/assets/163821db-571b-4477-8edd-56c8d5c4bb54) | ![RocketSim_Screenshot_iPhone_16_6 1_2024-10-29_16 31 13](https://github.com/user-attachments/assets/35836865-3d87-47f8-815d-521be7459ad1) | ![RocketSim_Screenshot_iPhone_16_6 1_2024-10-29_16 31 59](https://github.com/user-attachments/assets/87face04-feaa-4b29-891d-d7378ad4ab54) | ![RocketSim_Screenshot_iPhone_16_6 1_2024-10-30_09 37 02](https://github.com/user-attachments/assets/6d5fcac6-6e99-4f27-ba3a-24c5be35244f)
| Filters All Podcast | Apply Criteria | Export Settings |
| ![RocketSim_Screenshot_iPhone_16_6 1_2024-10-29_16 32 27](https://github.com/user-attachments/assets/ede6fae3-08d2-49d8-8e28-99d84d46ac9b) | ![RocketSim_Screenshot_iPhone_16_6 1_2024-10-29_16 30 55](https://github.com/user-attachments/assets/c840c519-6b1a-4e4b-a76a-52ca567eff22) | ![RocketSim_Screenshot_iPhone_16_6 1_2024-10-29_16 32 44](https://github.com/user-attachments/assets/3bf9da1e-8717-4fb2-9f5e-99c06d0a748a) |


## To test

- CI musty be 🟢 
- Run the app
- Check the above screens
- Switch off the FF `useFollowNaming`
- Run the app to see if the changes are reverted

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
