### PR TITLE
Fix glitch on podcast header animation on subscribe

### DIFF
--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -426,9 +426,6 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
     @objc private func refreshEpisodes() {
         guard let podcast = podcast else { return }
 
-        if episodesTable.numberOfSections > 0 {
-            episodesTable.reloadSections([0], with: .none)
-        }
         loadLocalEpisodes(podcast: podcast, animated: true)
     }
 


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
Stop reloading the header when refreshing episodes.

I considered another approach that was not recycle the header and block changes to the buttons while the animation is running but I think that will be more complex and even have more changes.

https://github.com/user-attachments/assets/15f7b09c-78c1-4c9a-ba03-e3f5a83baa29


## To test

 - Start the app
 - Open a Podcast that you don't subscribe too
 - Tap on subscribe
 - See that the animation to the subscribed mode works normally without any glitch


## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
