### PR TITLE
Playback 2024: Listened Count

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1683,6 +1683,7 @@
 		F56295292C0FC14900C44E8A /* DBTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = F56295282C0FC14900C44E8A /* DBTestCase.swift */; };
 		F565602F2B7ACD9B003E76D5 /* DataManager+Import.swift in Sources */ = {isa = PBXBuildFile; fileRef = F565602E2B7ACD9B003E76D5 /* DataManager+Import.swift */; };
 		F56ADE562B7FE37500ADFE31 /* SettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5AD75442B7FDC2800D65C55 /* SettingsTests.swift */; };
+		F56C030C2CCEEF7100E515FF /* NumberListened2024.swift in Sources */ = {isa = PBXBuildFile; fileRef = F56C030B2CCEEF6700E515FF /* NumberListened2024.swift */; };
 		F57626B62C8B56C7009C8225 /* String+SanitizedFileName.swift in Sources */ = {isa = PBXBuildFile; fileRef = F57626B52C8B56C7009C8225 /* String+SanitizedFileName.swift */; };
 		F57BAC672C00CD9C007B24BD /* URLSession+Episode.swift in Sources */ = {isa = PBXBuildFile; fileRef = F57BAC662C00CD9C007B24BD /* URLSession+Episode.swift */; };
 		F57BAC682C00E7E6007B24BD /* URLSession+Episode.swift in Sources */ = {isa = PBXBuildFile; fileRef = F57BAC662C00CD9C007B24BD /* URLSession+Episode.swift */; };
@@ -3622,6 +3623,7 @@
 		F55C4C752BCF064500A10352 /* DiscoverViewController+CategoryRedesign.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DiscoverViewController+CategoryRedesign.swift"; sourceTree = "<group>"; };
 		F56295282C0FC14900C44E8A /* DBTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DBTestCase.swift; sourceTree = "<group>"; };
 		F565602E2B7ACD9B003E76D5 /* DataManager+Import.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DataManager+Import.swift"; sourceTree = "<group>"; };
+		F56C030B2CCEEF6700E515FF /* NumberListened2024.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberListened2024.swift; sourceTree = "<group>"; };
 		F57626B52C8B56C7009C8225 /* String+SanitizedFileName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+SanitizedFileName.swift"; sourceTree = "<group>"; };
 		F57BAC662C00CD9C007B24BD /* URLSession+Episode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLSession+Episode.swift"; sourceTree = "<group>"; };
 		F57CD7D82C2624AD0035269A /* MediaTrimView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaTrimView.swift; sourceTree = "<group>"; };
@@ -7874,6 +7876,7 @@
 			children = (
 				F5F8F3172CC314250071DD0E /* IntroStory2024.swift */,
 				F53C3E822CC73538004F3581 /* TopSpotStory2024.swift */,
+				F56C030B2CCEEF6700E515FF /* NumberListened2024.swift */,
 				F581ED412CC6F19300A19860 /* ListeningTime2024Story.swift */,
 				F5D527372CC81AA700682CD5 /* EpilogueStory2024.swift */,
 				F5F884642CCA86AA002BED2C /* LongestEpisode2024Story.swift */,
@@ -9582,6 +9585,7 @@
 				BD874EF31C9A3A1B00F5B2A5 /* TopLevelSettingsCell.swift in Sources */,
 				C752F28A29D5F8F200681C33 /* StarRatingView.swift in Sources */,
 				BD47E7FA1DD57F7B00C18EE7 /* ShowNotesFormatter.swift in Sources */,
+				F56C030C2CCEEF7100E515FF /* NumberListened2024.swift in Sources */,
 				8B67A26329A7D6B60076886D /* SearchHistoryCell.swift in Sources */,
 				BD9A2B521C851577003BA898 /* NavigationManager.swift in Sources */,
 				BDEC9AB32051118900088D76 /* PCViewController.swift in Sources */,

--- a/podcasts/End of Year/End of Year 2024/EndOfYear2024StoriesModel.swift
+++ b/podcasts/End of Year/End of Year 2024/EndOfYear2024StoriesModel.swift
@@ -11,10 +11,12 @@ class EndOfYear2024StoriesModel: StoryModel {
 
     func populate(with dataManager: DataManager) {
         // First, search for top 5 podcasts
-        let topPodcasts = dataManager.topPodcasts(in: Self.year, limit: 5)
+        let topPodcasts = dataManager.topPodcasts(in: Self.year, limit: 10)
+
         if !topPodcasts.isEmpty {
-            stories.append(.top5Podcasts)
+            data.top8Podcasts = Array(topPodcasts.suffix(8)).map { $0.podcast }.reversed()
             data.topPodcasts = Array(topPodcasts.prefix(5))
+            stories.append(.top5Podcasts)
         }
 
         // Listening time
@@ -30,6 +32,15 @@ class EndOfYear2024StoriesModel: StoryModel {
             data.longestEpisode = longestEpisode
             data.longestEpisodePodcast = podcast
             stories.append(.longestEpisode)
+
+        //TODO: Select 8 random shows
+        // Listened podcasts and episodes
+        let listenedNumbers = dataManager.listenedNumbers(in: Self.year)
+        if listenedNumbers.numberOfEpisodes > 0
+            && listenedNumbers.numberOfPodcasts > 0
+            && !topPodcasts.isEmpty {
+            data.listenedNumbers = listenedNumbers
+            stories.append(.numberOfPodcastsAndEpisodesListened)
         }
     }
 
@@ -37,6 +48,8 @@ class EndOfYear2024StoriesModel: StoryModel {
         switch stories[storyNumber] {
         case .intro:
             return IntroStory2024()
+        case .numberOfPodcastsAndEpisodesListened:
+            return NumberListened2024(listenedNumbers: data.listenedNumbers, podcasts: data.top8Podcasts)
         case .top5Podcasts:
             return Top5Podcasts2024Story(top5Podcasts: data.topPodcasts)
         case .listeningTime:
@@ -105,4 +118,7 @@ class EndOfYear2024StoriesData {
 
     var longestEpisodePodcast: Podcast!
 
+    var listenedNumbers: ListenedNumbers!
+
+    var top8Podcasts: [Podcast] = []
 }

--- a/podcasts/End of Year/End of Year 2024/EndOfYear2024StoriesModel.swift
+++ b/podcasts/End of Year/End of Year 2024/EndOfYear2024StoriesModel.swift
@@ -33,14 +33,14 @@ class EndOfYear2024StoriesModel: StoryModel {
             data.longestEpisodePodcast = podcast
             stories.append(.longestEpisode)
 
-        //TODO: Select 8 random shows
-        // Listened podcasts and episodes
-        let listenedNumbers = dataManager.listenedNumbers(in: Self.year)
-        if listenedNumbers.numberOfEpisodes > 0
-            && listenedNumbers.numberOfPodcasts > 0
-            && !topPodcasts.isEmpty {
-            data.listenedNumbers = listenedNumbers
-            stories.append(.numberOfPodcastsAndEpisodesListened)
+            // Listened podcasts and episodes
+            let listenedNumbers = dataManager.listenedNumbers(in: Self.year)
+            if listenedNumbers.numberOfEpisodes > 0
+                && listenedNumbers.numberOfPodcasts > 0
+                && !topPodcasts.isEmpty {
+                data.listenedNumbers = listenedNumbers
+                stories.append(.numberOfPodcastsAndEpisodesListened)
+            }
         }
     }
 

--- a/podcasts/End of Year/End of Year 2024/EndOfYear2024Story.swift
+++ b/podcasts/End of Year/End of Year 2024/EndOfYear2024Story.swift
@@ -1,5 +1,6 @@
 enum EndOfYear2024Story: CaseIterable {
     case intro
+    case numberOfPodcastsAndEpisodesListened
     case top5Podcasts
     case listeningTime
     case longestEpisode

--- a/podcasts/End of Year/Stories/2024/NumberListened2024.swift
+++ b/podcasts/End of Year/Stories/2024/NumberListened2024.swift
@@ -33,10 +33,11 @@ struct NumberListened2024: ShareableStory {
         GeometryReader { geometry in
             PodcastCoverContainer(geometry: geometry, alignment: .center) {
                 VStack(spacing: -28) {
-                    podcastMarquee(size: geometry.size, shadow: false, scale: 0.4, indices: [0, 1, 2, 3, 0, 1, 2, 3])
+                    let scale = 0.48
+                    podcastMarquee(size: geometry.size, shadow: false, scale: scale * 0.8, indices: [0, 1, 2, 3, 0, 1, 2, 3])
                         .offset(x: topRowXOffset)
                         .modifier(animationViewModel.animate($topRowXOffset, to: -300))
-                    podcastMarquee(size: geometry.size, shadow: true, scale: 0.5, indices: [4, 5, 6, 7, 4, 5, 6, 7])
+                    podcastMarquee(size: geometry.size, shadow: true, scale: scale, indices: [4, 5, 6, 7, 4, 5, 6, 7])
                         .padding(.leading, geometry.size.width * 0.35)
                         .offset(x: bottomRowXOffset)
                         .modifier(animationViewModel.animate($bottomRowXOffset, to: 300))

--- a/podcasts/End of Year/Stories/2024/NumberListened2024.swift
+++ b/podcasts/End of Year/Stories/2024/NumberListened2024.swift
@@ -14,6 +14,7 @@ struct NumberListened2024: ShareableStory {
     @State var topRowXOffset: Double = 0
     @State var bottomRowXOffset: Double = 0
 
+    private let foregroundColor = Color.black
     private let backgroundColor = Color(hex: "#EFECAD")
     let identifier: String = "number_of_podcasts_and_episodes_listened"
 
@@ -24,6 +25,7 @@ struct NumberListened2024: ShareableStory {
             Spacer()
             footerView()
         }
+        .foregroundStyle(foregroundColor)
         .background(backgroundColor)
     }
 

--- a/podcasts/End of Year/Stories/2024/NumberListened2024.swift
+++ b/podcasts/End of Year/Stories/2024/NumberListened2024.swift
@@ -1,0 +1,96 @@
+import SwiftUI
+import PocketCastsDataModel
+
+struct NumberListened2024: ShareableStory {
+
+    @Environment(\.renderForSharing) var renderForSharing: Bool
+    @Environment(\.animated) var animated: Bool
+
+    @ObservedObject private var animationViewModel = PlayPauseAnimationViewModel(duration: EndOfYear.defaultDuration)
+
+    let listenedNumbers: ListenedNumbers
+    let podcasts: [Podcast]
+
+    @State var topRowXOffset: Double = 0
+    @State var bottomRowXOffset: Double = 0
+
+    private let backgroundColor = Color(hex: "#EFECAD")
+
+    var body: some View {
+        VStack {
+            GeometryReader { geometry in
+                PodcastCoverContainer(geometry: geometry) {
+                    VStack(spacing: -20) {
+                        HStack(spacing: 16) {
+                            Group {
+                                let shadow = true
+                                podcastCover(0, shadow: shadow)
+                                podcastCover(1, shadow: shadow)
+                                podcastCover(2, shadow: shadow)
+                                podcastCover(3, shadow: shadow)
+                                podcastCover(0, shadow: shadow)
+                                podcastCover(1, shadow: shadow)
+                                podcastCover(2, shadow: shadow)
+                                podcastCover(3, shadow: shadow)
+                            }
+                            .frame(width: geometry.size.width * 0.4, height: geometry.size.width * 0.4)
+                        }
+                        .offset(x: topRowXOffset)
+                        .modifier(animationViewModel.animate($topRowXOffset, to: -300))
+
+                        HStack(spacing: 16) {
+                            Group {
+                                let shadow = false
+                                podcastCover(4, shadow: shadow)
+                                podcastCover(5, shadow: shadow)
+                                podcastCover(6, shadow: shadow)
+                                podcastCover(7, shadow: shadow)
+                                podcastCover(4, shadow: shadow)
+                                podcastCover(5, shadow: shadow)
+                                podcastCover(6, shadow: shadow)
+                                podcastCover(7, shadow: shadow)
+                            }
+                            .frame(width: geometry.size.width * 0.4, height: geometry.size.width * 0.4)
+                        }
+                        .padding(.leading, geometry.size.width * 0.35)
+                        .offset(x: bottomRowXOffset)
+                        .modifier(animationViewModel.animate($bottomRowXOffset, to: 300))
+                    }
+                    .rotationEffect(Angle(degrees: -15))
+                    .padding(.top, geometry.size.height * 0.1)
+                }
+                .onAppear {
+                    if animated {
+                        animationViewModel.play()
+                    }
+                }
+            }
+            footerView()
+        }
+        .background(backgroundColor)
+    }
+
+    @ViewBuilder func footerView() -> some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("You listened to \(listenedNumbers.numberOfPodcasts) different shows and \(listenedNumbers.numberOfEpisodes) episodes in total")
+                .font(.system(size: 31, weight: .bold))
+            Text("But there was one show you kept coming back to...")
+                .font(.system(size: 15, weight: .light))
+        }
+        .padding(.horizontal, 24)
+    }
+
+    @ViewBuilder
+    func podcastCover(_ index: Int, shadow: Bool) -> some View {
+        let podcast = podcasts[safe: index] ?? podcasts[safe: index % 2 == 0 ? 0 : 1] ?? podcasts[0]
+        PodcastImage(uuid: podcast.uuid, size: .grid)
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+            .modify {
+                if shadow {
+                    $0.shadow(color: Color.black.opacity(0.2), radius: 75, x: 0, y: 2.5)
+                } else {
+                    $0
+                }
+            }
+    }
+}

--- a/podcasts/End of Year/Stories/2024/NumberListened2024.swift
+++ b/podcasts/End of Year/Stories/2024/NumberListened2024.swift
@@ -34,10 +34,13 @@ struct NumberListened2024: ShareableStory {
             PodcastCoverContainer(geometry: geometry, alignment: .center) {
                 VStack(spacing: -28) {
                     let scale = 0.48
-                    podcastMarquee(size: geometry.size, shadow: false, scale: scale * 0.8, indices: [0, 1, 2, 3, 0, 1, 2, 3])
+                    let marqueeItemsCount = 4
+                    let topIndices = (0..<4*2).map { ($0 % marqueeItemsCount) % podcasts.endIndex }
+                    let bottomIndices = (0..<4*2).map { (($0 + marqueeItemsCount) % (marqueeItemsCount + marqueeItemsCount)) % podcasts.endIndex }
+                    podcastMarquee(size: geometry.size, shadow: false, scale: scale * 0.8, indices: topIndices)
                         .offset(x: topRowXOffset)
                         .modifier(animationViewModel.animate($topRowXOffset, to: -300))
-                    podcastMarquee(size: geometry.size, shadow: true, scale: scale, indices: [4, 5, 6, 7, 4, 5, 6, 7])
+                    podcastMarquee(size: geometry.size, shadow: true, scale: scale, indices: bottomIndices)
                         .padding(.leading, geometry.size.width * 0.35)
                         .offset(x: bottomRowXOffset)
                         .modifier(animationViewModel.animate($bottomRowXOffset, to: 300))

--- a/podcasts/End of Year/Stories/2024/NumberListened2024.swift
+++ b/podcasts/End of Year/Stories/2024/NumberListened2024.swift
@@ -15,59 +15,49 @@ struct NumberListened2024: ShareableStory {
     @State var bottomRowXOffset: Double = 0
 
     private let backgroundColor = Color(hex: "#EFECAD")
+    let identifier: String = "number_of_podcasts_and_episodes_listened"
 
     var body: some View {
-        VStack {
-            GeometryReader { geometry in
-                PodcastCoverContainer(geometry: geometry) {
-                    VStack(spacing: -20) {
-                        HStack(spacing: 16) {
-                            Group {
-                                let shadow = true
-                                podcastCover(0, shadow: shadow)
-                                podcastCover(1, shadow: shadow)
-                                podcastCover(2, shadow: shadow)
-                                podcastCover(3, shadow: shadow)
-                                podcastCover(0, shadow: shadow)
-                                podcastCover(1, shadow: shadow)
-                                podcastCover(2, shadow: shadow)
-                                podcastCover(3, shadow: shadow)
-                            }
-                            .frame(width: geometry.size.width * 0.4, height: geometry.size.width * 0.4)
-                        }
-                        .offset(x: topRowXOffset)
-                        .modifier(animationViewModel.animate($topRowXOffset, to: -300))
-
-                        HStack(spacing: 16) {
-                            Group {
-                                let shadow = false
-                                podcastCover(4, shadow: shadow)
-                                podcastCover(5, shadow: shadow)
-                                podcastCover(6, shadow: shadow)
-                                podcastCover(7, shadow: shadow)
-                                podcastCover(4, shadow: shadow)
-                                podcastCover(5, shadow: shadow)
-                                podcastCover(6, shadow: shadow)
-                                podcastCover(7, shadow: shadow)
-                            }
-                            .frame(width: geometry.size.width * 0.4, height: geometry.size.width * 0.4)
-                        }
-                        .padding(.leading, geometry.size.width * 0.35)
-                        .offset(x: bottomRowXOffset)
-                        .modifier(animationViewModel.animate($bottomRowXOffset, to: 300))
-                    }
-                    .rotationEffect(Angle(degrees: -15))
-                    .padding(.top, geometry.size.height * 0.1)
-                }
-                .onAppear {
-                    if animated {
-                        animationViewModel.play()
-                    }
-                }
-            }
+        VStack(alignment: .leading) {
+            Spacer()
+            podcastMarquees()
+            Spacer()
             footerView()
         }
         .background(backgroundColor)
+    }
+
+    @ViewBuilder func podcastMarquees() -> some View {
+        GeometryReader { geometry in
+            PodcastCoverContainer(geometry: geometry, alignment: .center) {
+                VStack(spacing: -28) {
+                    podcastMarquee(size: geometry.size, shadow: false, scale: 0.4, indices: [0, 1, 2, 3, 0, 1, 2, 3])
+                        .offset(x: topRowXOffset)
+                        .modifier(animationViewModel.animate($topRowXOffset, to: -300))
+                    podcastMarquee(size: geometry.size, shadow: true, scale: 0.5, indices: [4, 5, 6, 7, 4, 5, 6, 7])
+                        .padding(.leading, geometry.size.width * 0.35)
+                        .offset(x: bottomRowXOffset)
+                        .modifier(animationViewModel.animate($bottomRowXOffset, to: 300))
+                }
+                .rotationEffect(Angle(degrees: -15))
+            }
+            .onAppear {
+                if animated {
+                    animationViewModel.play()
+                }
+            }
+        }
+    }
+
+    @ViewBuilder func podcastMarquee(size: CGSize, shadow: Bool, scale: Double, indices: [Int]) -> some View {
+        HStack(spacing: 16) {
+            Group {
+                ForEach(indices, id: \.self) { index in
+                    podcastCover(index, shadow: shadow)
+                }
+            }
+            .frame(width: size.width * scale, height: size.width * scale)
+        }
     }
 
     @ViewBuilder func footerView() -> some View {
@@ -78,6 +68,7 @@ struct NumberListened2024: ShareableStory {
                 .font(.system(size: 15, weight: .light))
         }
         .padding(.horizontal, 24)
+        .padding(.vertical, 6)
     }
 
     @ViewBuilder
@@ -92,5 +83,16 @@ struct NumberListened2024: ShareableStory {
                     $0
                 }
             }
+    }
+
+    func onAppear() {
+        Analytics.track(.endOfYearStoryShown, story: identifier)
+    }
+
+    func sharingAssets() -> [Any] {
+        [
+            StoryShareableProvider.new(AnyView(self)),
+            StoryShareableText(L10n.eoyStoryListenedToNumbersShareText(listenedNumbers.numberOfPodcasts, listenedNumbers.numberOfEpisodes))
+        ]
     }
 }

--- a/podcasts/End of Year/Stories/Views/CommonStoryViews.swift
+++ b/podcasts/End of Year/Stories/Views/CommonStoryViews.swift
@@ -267,15 +267,17 @@ extension View {
 
 struct PodcastCoverContainer<Content: View>: View {
     private var content: () -> Content
+    private let alignment: Alignment
     private let geometry: GeometryProxy
 
     let topPaddingSmall = 0.03
     let topPaddingLarge = 0.045
     let smallDeviceHeight = 700.0
 
-    init(geometry: GeometryProxy, @ViewBuilder _ content: @escaping () -> Content) {
+    init(geometry: GeometryProxy, alignment: Alignment = .top, @ViewBuilder _ content: @escaping () -> Content) {
         self.geometry = geometry
         self.content = content
+        self.alignment = alignment
     }
 
     var body: some View {
@@ -283,8 +285,20 @@ struct PodcastCoverContainer<Content: View>: View {
         let padding = geometry.size.height <= smallDeviceHeight ? topPaddingSmall : topPaddingLarge
         let topPadding = geometry.size.height * padding
         VStack(spacing: 0) {
-            content()
-            Spacer()
+            switch alignment {
+            case .top:
+                content()
+                Spacer()
+            case .center:
+                Spacer()
+                content()
+                Spacer()
+            case .bottom:
+                Spacer()
+                content()
+            default:
+                content()
+            }
         }.frame(width: geometry.size.width).padding(.top, topPadding)
     }
 }


### PR DESCRIPTION
| 📘 Part of: #2250 |
|:---:|

Part of #2351

| | |
|--|--|
| <video src="https://github.com/user-attachments/assets/9e8ef2c1-4fed-41e4-9be1-fb7dc94d2cd1"> | <video src="https://github.com/user-attachments/assets/f94b830d-18e2-4758-9e23-af07d5871d97"> |

## To test

1. Enable the `endOfYear2024` feature flag & restart the app
2. Navigate to the Profile and tap Playback 2024 Prompt
3. Navigate through the stories until you hit this Number Listened screen
4. Verify layout and animations work properly

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
