### PR TITLE
Additional Logging for Upload file task, 401 handling, keychain clearing, and sign out

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Private/API Tasks/ApiBaseTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Private/API Tasks/ApiBaseTask.swift
@@ -57,11 +57,13 @@ class ApiBaseTask: Operation {
             guard let httpResponse = response as? HTTPURLResponse else { return (nil, ServerConstants.HttpConstants.serverError) }
             if httpResponse.statusCode == ServerConstants.HttpConstants.unauthorized {
                 if retryOnUnauthorized, let newToken = tokenHelper.acquireToken() {
+                    FileLog.shared.addMessage("ApiBaseTask: Retrying 401 unauthorized POST to \(url)")
                     return performPostToServer(url: url, token: newToken, data: data, retryOnUnauthorized: false)
                 }
 
                 // our token may have expired, remove it so next time a sync happens we'll acquire a new one
                 KeychainHelper.removeKey(ServerConstants.Values.syncingV2TokenKey)
+                FileLog.shared.addMessage("ApiBaseTask: Removed syncingV2TokenKey due to 401 unauthorized POST from \(url)")
                 return (nil, httpResponse.statusCode)
             }
 
@@ -92,11 +94,13 @@ class ApiBaseTask: Operation {
             guard let httpResponse = response as? HTTPURLResponse else { return (nil, nil) }
             if httpResponse.statusCode == ServerConstants.HttpConstants.unauthorized {
                 if retryOnUnauthorized, let newToken = tokenHelper.acquireToken() {
+                    FileLog.shared.addMessage("ApiBaseTask: Retrying 401 unauthorized GET to \(url)")
                     return performGetToServer(url: url, token: newToken, retryOnUnauthorized: false, customHeaders: customHeaders)
                 }
 
                 // our token may have expired, remove it so next time a sync happens we'll acquire a new one
                 KeychainHelper.removeKey(ServerConstants.Values.syncingV2TokenKey)
+                FileLog.shared.addMessage("ApiBaseTask: Removed syncingV2TokenKey due to 401 unauthorized GET from \(url)")
                 return (nil, httpResponse)
             }
 
@@ -120,6 +124,7 @@ class ApiBaseTask: Operation {
             if httpResponse.statusCode == ServerConstants.HttpConstants.unauthorized {
                 // our token may have expired, remove it so next time a sync happens we'll acquire a new one
                 KeychainHelper.removeKey(ServerConstants.Values.syncingV2TokenKey)
+                FileLog.shared.addMessage("ApiBaseTask: Removed syncingV2TokenKey due to 401 unauthorized DELETE from \(url)")
                 return (nil, httpResponse.statusCode)
             }
 

--- a/Modules/Server/Sources/PocketCastsServer/Private/API Tasks/UploadFilePlayRequestTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Private/API Tasks/UploadFilePlayRequestTask.swift
@@ -18,14 +18,19 @@ class UploadFilePlayRequestTask: ApiBaseTask {
         do {
             let (response, httpStatus) = getToServer(url: url, token: token)
 
-            guard let responseData = response, httpStatus?.statusCode == ServerConstants.HttpConstants.ok else {
-                FileLog.shared.addMessage("Upload file play request failed \(httpStatus?.statusCode ?? -1)")
+            guard let responseData = response else {
+                FileLog.shared.addMessage("Upload file play request missing response data \(httpStatus?.statusCode ?? -1)")
                 completion?(nil)
                 return
             }
 
             do {
                 let playResponse = try Files_FilePlayResponse(serializedData: responseData)
+                guard httpStatus?.statusCode == ServerConstants.HttpConstants.ok else {
+                    FileLog.shared.addMessage("Upload file play request failed \(httpStatus?.statusCode ?? -1) with message: \(playResponse.textFormatString())")
+                    completion?(nil)
+                    return
+                }
                 FileLog.shared.addMessage("Upload play response successful)")
                 completion?(URL(string: playResponse.url))
             } catch {

--- a/Modules/Server/Sources/PocketCastsServer/Private/TokenHelper.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Private/TokenHelper.swift
@@ -47,6 +47,7 @@ class TokenHelper {
             if httpResponse.statusCode == ServerConstants.HttpConstants.unauthorized {
                 if SyncManager.isUserLoggedIn(), retryOnUnauthorized {
                     KeychainHelper.removeKey(ServerConstants.Values.syncingV2TokenKey)
+                    FileLog.shared.addMessage("TokenHelper: Removed syncingV2TokenKey due to 401 unauthorized retrying url: \(request.url?.absoluteString ?? "unknown")")
                     self?.performCallSecureUrl(request: request, retryOnUnauthorized: false, completion: completion)
                 } else {
                     completion(httpResponse, nil, error)

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncManager.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncManager.swift
@@ -35,6 +35,7 @@ public class SyncManager {
         NotificationCenter.postOnMainThread(notification: .serverUserWillBeSignedOut, userInfo: ["user_initiated": userInitiated])
 
         clearTokensFromKeyChain()
+        FileLog.shared.addMessage("SyncManager.signout clearTokensFromKeyChain")
 
         ServerSettings.setSyncingEmail(email: nil)
         ServerSettings.userId = nil

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncManager.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncManager.swift
@@ -31,6 +31,8 @@ public class SyncManager {
     /// Signs the user out
     /// - Parameter userInitiated: Whether the user initiated the sign out or not
     public class func signout(userInitiated: Bool = false) {
+        FileLog.shared.addMessage("SyncManager.signout – userInitiated: \(userInitiated)")
+
         // Notify any listeners that the user login state will be changing
         NotificationCenter.postOnMainThread(notification: .serverUserWillBeSignedOut, userInfo: ["user_initiated": userInitiated])
 

--- a/podcasts/AppDelegate+Defaults.swift
+++ b/podcasts/AppDelegate+Defaults.swift
@@ -11,6 +11,7 @@ extension AppDelegate {
         performUpdateIfRequired(updateKey: "v5Run") {
             // these are considered defaults for a new app install
             SyncManager.clearTokensFromKeyChain()
+            FileLog.shared.addMessage("AppDelegate.checkDefaults v5Run clearTokensFromKeyChain")
             ServerSettings.setSkipBackTime(10, syncChange: false)
             ServerSettings.setSkipForwardTime(45, syncChange: false)
 

--- a/podcasts/AuthenticationHelper.swift
+++ b/podcasts/AuthenticationHelper.swift
@@ -59,6 +59,7 @@ class AuthenticationHelper {
 
     private static func handleSuccessfulSignIn(_ response: AuthenticationResponse) {
         SyncManager.clearTokensFromKeyChain()
+        FileLog.shared.addMessage("AuthenticationHelper.handleSuccessfulSignIn clearTokensFromKeyChain")
 
         ServerSettings.userId = response.uuid
         ServerSettings.syncingV2Token = response.token

--- a/podcasts/SyncSigninViewController.swift
+++ b/podcasts/SyncSigninViewController.swift
@@ -294,6 +294,7 @@ class SyncSigninViewController: PCViewController, UITextFieldDelegate {
                 self.progressAlert?.showAlert(self, hasProgress: false, completion: {
                     // clear any previously stored tokens as we're signing in again and we might have one in Keychain already
                     SyncManager.clearTokensFromKeyChain()
+                    FileLog.shared.addMessage("SyncSigninViewController.startSignIn clearTokensFromKeyChain")
 
                     self.handleSuccessfulSignIn(username, password: password, userId: userId)
                     RefreshManager.shared.refreshPodcasts(forceEvenIfRefreshedRecently: true)


### PR DESCRIPTION
* Adds additional logging for upload file task failures

    ```
    Upload file play request failed 401 with message: \(playResponse.textFormatString())
    ```

* Adds additional logging for any 401 handling in `ApiBaseTask`. On all `POST`, `GET`, and `DELETE` tasks we now log:

    ```
    ApiBaseTask: Retrying 401 unauthorized GET to https://pocketcast.com/someurl
    ```

    ```
    ApiBaseTask: Removed syncingV2TokenKey due to 401 unauthorized GET from https://pocketcast.com/someurl
    ```

* Logs all calls to `clearTokensFromKeychain` with information about where they originated from

    ```
    SyncManager.signout clearTokensFromKeyChain
    ```

    ```
    AppDelegate.checkDefaults v5Run clearTokensFromKeyChain
    ```

    ```
    AuthenticationHelper.handleSuccessfulSignIn clearTokensFromKeyChain
    ```

    ```
    SyncSigninViewController.startSignIn clearTokensFromKeyChain
    ```

* Adds logs to TokenHelper when `syncingV2TokenKey` is erased due to 401s:

    ```
    TokenHelper: Removed syncingV2TokenKey due to 401 unauthorized retrying url: \(request.url?.absoluteString ?? "unknown")"
    ```

* Adds log when `SyncManager.signout` is called:

    ```
    SyncManager.signout – userInitiated: \(userInitiated)
    ```

## To test

I'm not 100% sure how best to test this, especially with the protobuf message.

1. Use a non-plus account but set to Plus client side or set up a Proxyman script to fail the `https://api.pocketcasts.com/files` endpoint
```
async function onResponse(context, url, request, response) {
  response.statusCode = 404;
  response.body = "";
  return response;
}
```
2. Set account to Plus
3. Visit the Files page
4. Verify that the following are logged:

```
ApiBaseTask: Retrying 401 unauthorized GET to https://api.pocketcasts.com/files
ApiBaseTask: Removed syncingV2TokenKey due to 401 unauthorized GET from https://api.pocketcasts.com/files
```

## Checklist
- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.