### PR TITLE
Use a single icon for folders upsell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 7.77
 -----
-
+- Use a single icon for folders upsell. [$2362](https://github.com/Automattic/pocket-casts-ios/pull/2362)
 
 7.76
 -----

--- a/podcasts/PodcastHeadingTableCell.swift
+++ b/podcasts/PodcastHeadingTableCell.swift
@@ -238,7 +238,7 @@ class PodcastHeadingTableCell: ThemeableCell, SubscribeButtonDelegate, Expandabl
         supporterHeartView.isHidden = !(podcast.isPaid && podcast.isSubscribed())
         supporterView.isHidden = !podcast.isPaid
 
-        let folderImage = (podcast.folderUuid?.isEmpty ?? true) ? "folder-empty" : "folder-check"
+        let folderImage = (podcast.folderUuid?.isEmpty ?? true) ? "folder-create" : "folder-check"
         folderButton.setImage(UIImage(named: folderImage), for: .normal)
 
         if !isAnimatingToSubscribed {

--- a/podcasts/PodcastHeadingTableCell.swift
+++ b/podcasts/PodcastHeadingTableCell.swift
@@ -238,7 +238,7 @@ class PodcastHeadingTableCell: ThemeableCell, SubscribeButtonDelegate, Expandabl
         supporterHeartView.isHidden = !(podcast.isPaid && podcast.isSubscribed())
         supporterView.isHidden = !podcast.isPaid
 
-        let folderImage = (podcast.folderUuid?.isEmpty ?? true) ? "folder-create" : "folder-check"
+        let folderImage = SubscriptionHelper.hasActiveSubscription() ? (podcast.folderUuid?.isEmpty ?? true) ? "folder-empty" : "folder-check" : "folder-create"
         folderButton.setImage(UIImage(named: folderImage), for: .normal)
 
         if !isAnimatingToSubscribed {

--- a/podcasts/PodcastHeadingTableCell.swift
+++ b/podcasts/PodcastHeadingTableCell.swift
@@ -378,7 +378,7 @@ class PodcastHeadingTableCell: ThemeableCell, SubscribeButtonDelegate, Expandabl
     }
 
     private func showFolderButton() -> Bool {
-        SubscriptionHelper.hasActiveSubscription()
+        return true
     }
 
     @IBAction func manageSupportTapped(_ sender: Any) {

--- a/podcasts/PodcastHeadingTableCell.xib
+++ b/podcasts/PodcastHeadingTableCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22138.1" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23094" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22113"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23084"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -94,7 +94,7 @@
                                 </constraints>
                                 <color key="tintColor" red="0.72156862749999995" green="0.76470588240000004" blue="0.78823529410000004" alpha="1" colorSpace="calibratedRGB"/>
                                 <inset key="imageEdgeInsets" minX="12" minY="0.0" maxX="0.0" maxY="0.0"/>
-                                <state key="normal" image="folder-empty"/>
+                                <state key="normal" image="folder-create"/>
                                 <connections>
                                     <action selector="folderBtnTapped:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="ptp-7e-8vc"/>
                                 </connections>
@@ -473,7 +473,7 @@
         </tableViewCell>
     </objects>
     <resources>
-        <image name="folder-empty" width="24" height="24"/>
+        <image name="folder-create" width="24" height="24"/>
         <image name="podcast-author" width="24" height="24"/>
         <image name="podcast-expand" width="13" height="9"/>
         <image name="podcast-link" width="24" height="24"/>

--- a/podcasts/PodcastListViewController.swift
+++ b/podcasts/PodcastListViewController.swift
@@ -218,7 +218,7 @@ class PodcastListViewController: PCViewController, UIGestureRecognizerDelegate, 
     }
 
     private func updateNavigationButtons() {
-        let folderImage = SubscriptionHelper.hasActiveSubscription() ? UIImage(named: "folder-create") : UIImage(named: AppTheme.folderLockedImageName())
+        let folderImage = UIImage(named: "folder-create")
         let folderButton = UIBarButtonItem(image: folderImage, style: .plain, target: self, action: #selector(createFolderTapped(_:)))
         folderButton.accessibilityLabel = L10n.folderCreateNew
         navigationItem.leftBarButtonItem = folderButton


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR removes the locked folders icon and uses an icon with the plus instead.

## To test

### Free user

1. Open the app as a free user.
2. Go to the podcasts screen.
3. You should see a folders icon with a plus.
4. Tap on the icon.
5. An upsell flow should start.
6. Go back and open any podcast.
7. You should see a folder icon with a plus.
8. Tap on the icon.
9. An upsell flow should start.

###  Subscribed user

1. Open the app as a subscribed user.
2. Go to the podcasts screen.
3. You should see a folders icon with a plus.
4. Tap on the icon.
5. Folder creation flow should start.
6. Go back and open any podcast.
7. You should see a folder icon if the podcast does not belong to a folder or folder with checkmark if belongs to a folder
8. Tap on the icon.
9. An folder selection flow should start.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
