### PR TITLE
[Custom Playback Settings] Simplify logic

### DIFF
--- a/podcasts/EffectsViewController.swift
+++ b/podcasts/EffectsViewController.swift
@@ -189,7 +189,6 @@ class EffectsViewController: SimpleNotificationsViewController {
         updateControls()
 
         if FeatureFlag.customPlaybackSettings.enabled {
-            PlaybackManager.shared.updateIfPodcastUsedCustomEffectsBefore()
             playbackSettingsSegmentedControl.selectedSegmentIndex = PlaybackManager.shared.isCurrentEffectGlobal() ? 0 : 1
         }
         if let episode = PlaybackManager.shared.currentEpisode() as? Episode, let podcast = episode.parentPodcast() {

--- a/podcasts/PlaybackEffects.swift
+++ b/podcasts/PlaybackEffects.swift
@@ -54,15 +54,6 @@ class PlaybackEffects {
 
         effects.isGlobal = false
 
-        if FeatureFlag.customPlaybackSettings.enabled &&
-            !podcast.usedCustomEffectsBefore {
-            let globalEffect = globalEffects()
-            effects.trimSilence = globalEffect.trimSilence
-            effects.volumeBoost = globalEffect.volumeBoost
-            effects.playbackSpeed = globalEffect.playbackSpeed
-            return effects
-        }
-
         if FeatureFlag.newSettingsStorage.enabled {
             effects.trimSilence = podcast.settings.trimSilence.amount
             effects.volumeBoost = podcast.settings.boostVolume

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -824,10 +824,6 @@ class PlaybackManager: ServerPlaybackDelegate {
             podcast.playbackSpeed = effects.playbackSpeed
             podcast.boostVolume = effects.volumeBoost
 
-            if FeatureFlag.customPlaybackSettings.enabled, !podcast.usedCustomEffectsBefore {
-                podcast.usedCustomEffectsBefore = true
-            }
-
             DataManager.sharedManager.save(podcast: podcast)
             NotificationCenter.postOnMainThread(notification: Constants.Notifications.podcastUpdated, object: podcast.uuid)
         }
@@ -880,15 +876,6 @@ class PlaybackManager: ServerPlaybackDelegate {
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.podcastUpdated, object: podcast.uuid)
 
         effectsChangedExternally()
-    }
-
-    func updateIfPodcastUsedCustomEffectsBefore() {
-        if let episode = currentEpisode() as? Episode, let podcast = episode.parentPodcast() {
-            if podcast.overrideGlobalEffects, !podcast.usedCustomEffectsBefore {
-                podcast.usedCustomEffectsBefore = true
-                DataManager.sharedManager.save(podcast: podcast)
-            }
-        }
     }
 
     func isCurrentEffectGlobal() -> Bool {


### PR DESCRIPTION
| 📘 Part of: #2253
|:---:|

This PR simplify the logic introduced in the previous PRs. We decided to keep the previous logic to return the global or local effects based on the podcast `overrideGlobalEffects` property

## To test

### Pre scenario

1. git checkout `tags/7.74 -b 7.74`
2. Fresh install the app from `7.74` tag
3. Subscribe to a podcast (Podcast A)
4. Play an episode from this podcast
5. Tap effects icon
6. Change global playback speed to 2.0
7. Go to Podcast A settings
8. Turn on custom playback settings (do not change any effect so that they remain at 1x, off, off)
9. Subscribe to another podcast (Podcast B)
10. Go to Podcast B settings
11. Turn on custom playback settings (change playback speed to 1.1x)

### Scenario 1

1. checkout this branch
2. Install the app without unstalling the previous one
3. Play selected episode from Podcast B
4. Tap effects icon on the player
5. Notice that `This podcast` is selected and playback effects are set to local (1.1x, off, off)
6. Go to Podcast A podcast settings
7. Tap Playback effects
8. Notice that Custom for this podcast is selected and playback effects are set to local (1x, off, off)

### Scenario 2

1. Subscribe to a podcast (Podcast C)
2. Play an episode
3. Tap effects icon on the player
4. Notice that `All podcasts` is selected and the settings should be 2x, Off, Off (unless you changed before)
5. Switch to `This podcast`
6. Notice the settings should be 1x, Off, Off
7. Go to Podcast C podcast settings
8. Tap Playback effects
9. Notice that Custom for this podcast is selected and playback effects are set to local (1x, off, off)
10. Enable Volume boost
11. Go back to the player and tap the effects icon
12. Notice that `This podcast` is selected and playback effects are set to local (1x, off, on)

### Scenario 3

1. Play an episode of Podcast C
2. Tap effects icon on the player
3. `This podcast` should be selected (unless you changed before).
4. Switch to `All podcasts`
5. Go to another podcast and play an episode
6. Now go back to the Podcast C
7. Play an episode
8. Tap effects icon on the player
9. `All podcast` should be applied

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
