### PR TITLE
Playback 2024: Fix indicator color in EoY 2024 Stories

### DIFF
--- a/PocketCastsTests/Tests/End of Year/StoriesModelTests.swift
+++ b/PocketCastsTests/Tests/End of Year/StoriesModelTests.swift
@@ -151,6 +151,8 @@ class StoriesModelTests: XCTestCase {
 }
 
 class MockStoriesDataSource: StoriesDataSource {
+    var indicatorColor: Color = .white
+
     var numberOfStories: Int = 2
 
     var didCallStoryForWithStoryNumber: Int?
@@ -192,6 +194,8 @@ class MockStoriesDataSource: StoriesDataSource {
 }
 
 class MockStoriesWithPlusDataSource: StoriesDataSource {
+    var indicatorColor: Color = .white
+
     var numberOfStories: Int = 4
 
     var didCallStoryForWithStoryNumber: Int?

--- a/podcasts/End of Year/End of Year 2023/EndOfYear2023StoriesModel.swift
+++ b/podcasts/End of Year/End of Year 2023/EndOfYear2023StoriesModel.swift
@@ -7,6 +7,10 @@ class EndOfYear2023StoriesModel: StoryModel {
     var stories = [EndOfYear2023Story]()
     var data = EndOfYear2023StoriesData()
 
+    var indicatorColor: Color {
+        .white
+    }
+
     required init() {}
 
     func populate(with dataManager: DataManager) {

--- a/podcasts/End of Year/End of Year 2024/EndOfYear2024StoriesModel.swift
+++ b/podcasts/End of Year/End of Year 2024/EndOfYear2024StoriesModel.swift
@@ -7,6 +7,10 @@ class EndOfYear2024StoriesModel: StoryModel {
     var stories = [EndOfYear2024Story]()
     var data = EndOfYear2024StoriesData()
 
+    var indicatorColor: Color {
+        .black
+    }
+
     required init() { }
 
     func populate(with dataManager: DataManager) {

--- a/podcasts/End of Year/EndOfYearStoriesBuilder.swift
+++ b/podcasts/End of Year/EndOfYearStoriesBuilder.swift
@@ -59,4 +59,5 @@ protocol StoryModel {
     func overlaidShareView() -> AnyView?
     /// Shown at the bottom of the story as an additional safe area
     func footerShareView() -> AnyView?
+    var indicatorColor: Color { get }
 }

--- a/podcasts/End of Year/Stories/EndOfYearStoriesDataSource.swift
+++ b/podcasts/End of Year/Stories/EndOfYearStoriesDataSource.swift
@@ -51,6 +51,10 @@ class EndOfYearStoriesDataSource: StoriesDataSource {
     func footerShareView() -> AnyView? {
         model.footerShareView()
     }
+
+    var indicatorColor: Color {
+        model.indicatorColor
+    }
 }
 
 extension Array where Element: CaseIterable & Equatable {

--- a/podcasts/End of Year/StoriesDataSource.swift
+++ b/podcasts/End of Year/StoriesDataSource.swift
@@ -37,6 +37,8 @@ protocol StoriesDataSource {
     func overlaidShareView() -> AnyView?
     /// Shown at the bottom of the story as an additional safe area
     func footerShareView() -> AnyView?
+
+    var indicatorColor: Color { get }
 }
 
 extension StoriesDataSource {

--- a/podcasts/End of Year/StoriesModel.swift
+++ b/podcasts/End of Year/StoriesModel.swift
@@ -246,6 +246,10 @@ class StoriesModel: ObservableObject {
     func footerShareView() -> AnyView? {
         dataSource.footerShareView()
     }
+
+    var indicatorColor: Color {
+        dataSource.indicatorColor
+    }
 }
 
 private extension StoriesModel {

--- a/podcasts/End of Year/Views/StoriesView.swift
+++ b/podcasts/End of Year/Views/StoriesView.swift
@@ -62,6 +62,7 @@ struct StoriesView: View {
             }
 
             header
+                .foregroundStyle(model.indicatorColor)
 
             // Hide the share button if needed
             if model.showShareButton(index: model.currentStoryIndex) && !model.shouldShowUpsell(), let shareView = model.overlaidShareView() {
@@ -256,8 +257,8 @@ private struct CloseButtonStyle: ButtonStyle {
 
     func makeBody(configuration: Configuration) -> some View {
         Image("eoy-close")
+            .renderingMode(.template)
             .font(style: .body, maxSizeCategory: .extraExtraExtraLarge)
-            .foregroundColor(.white)
             .padding(Constants.closeButtonPadding)
             .background(showButtonShapes ? Color.white.opacity(0.2) : nil)
             .cornerRadius(Constants.closeButtonRadius)

--- a/podcasts/End of Year/Views/StoryIndicator.swift
+++ b/podcasts/End of Year/Views/StoryIndicator.swift
@@ -9,12 +9,12 @@ struct StoryIndicator: View {
         GeometryReader { geometry in
                 ZStack(alignment: .leading) {
                     Rectangle()
-                        .foregroundColor(Color.white.opacity(Constants.storyIndicatorBackgroundOpacity))
+                        .opacity(Constants.storyIndicatorBackgroundOpacity)
                         .cornerRadius(Constants.storyIndicatorBorderRadius)
 
                     Rectangle()
                         .frame(width: geometry.size.width * (model.progress - CGFloat(index)).clamped(to: 0.0 ..< 1.0), height: nil, alignment: .leading)
-                        .foregroundColor(Color.white.opacity(Constants.storyIndicatorForegroundOpacity))
+                        .opacity(Constants.storyIndicatorForegroundOpacity)
                         .cornerRadius(Constants.storyIndicatorBorderRadius)
                 }
             }


### PR DESCRIPTION
| 📘 Part of: #2367 |
|:---:|

Makes the indicator and close buttons black for Playback 2024

| Before | After |
|--|--|
| ![CleanShot 2024-10-30 at 20 49 29@2x](https://github.com/user-attachments/assets/258cc996-2a3d-43e7-93fd-cecd790deb18) | ![CleanShot 2024-10-30 at 20 46 22@2x](https://github.com/user-attachments/assets/53010124-7eff-4b75-a898-39811d5857a9) |

## To test

* Enable the `endOfYear2024` feature flag
* Restart app
* Visit Profile and tap the Playback 2024 cell
* Ensure that indicators and close button are black

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
