### PR TITLE
Playback 2024: Localize Number Listened

### DIFF
--- a/podcasts/End of Year/Stories/2024/NumberListened2024.swift
+++ b/podcasts/End of Year/Stories/2024/NumberListened2024.swift
@@ -68,9 +68,9 @@ struct NumberListened2024: ShareableStory {
 
     @ViewBuilder func footerView() -> some View {
         VStack(alignment: .leading, spacing: 16) {
-            Text("You listened to \(listenedNumbers.numberOfPodcasts) different shows and \(listenedNumbers.numberOfEpisodes) episodes in total")
+            Text(L10n.eoyStoryListenedToNumbers(listenedNumbers.numberOfPodcasts, listenedNumbers.numberOfEpisodes))
                 .font(.system(size: 31, weight: .bold))
-            Text("But there was one show you kept coming back to...")
+            Text(L10n.eoyStoryListenedToNumbersSubtitle)
                 .font(.system(size: 15, weight: .light))
         }
         .padding(.horizontal, 24)


### PR DESCRIPTION
| 📘 Part of: #2250 |
|:---:|

Part of #2374

Localizes some strings in the Number Listened.

## To test

1. Enable the `endOfYear2024` feature flag
2. Restart app
3. Visit Profile and tap "Playback 2024"
4. Navigate to the Number Listened screen
5. Verify that text appears on this screen

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
