### PR TITLE
Playback 2024: Analytics

### DIFF
--- a/podcasts/End of Year/Stories/2024/CompletionRate2024Story.swift
+++ b/podcasts/End of Year/Stories/2024/CompletionRate2024Story.swift
@@ -101,6 +101,10 @@ struct CompletionRate2024Story: ShareableStory {
         Analytics.track(.endOfYearStoryShown, story: identifier)
     }
 
+    func willShare() {
+        Analytics.track(.endOfYearStoryShare, story: identifier)
+    }
+
     func onPause() {
         animationViewModel.pause()
     }

--- a/podcasts/End of Year/Stories/2024/EpilogueStory2024.swift
+++ b/podcasts/End of Year/Stories/2024/EpilogueStory2024.swift
@@ -23,6 +23,8 @@ struct EpilogueStory2024: StoryView {
 
     private let separator = Image("playback-24-heart")
 
+    var identifier: String = "ending"
+
     var body: some View {
         VStack {
             Spacer()
@@ -59,6 +61,10 @@ struct EpilogueStory2024: StoryView {
         }
         .padding(.horizontal, 24)
         .padding(.vertical, 6)
+    }
+
+    func onAppear() {
+        Analytics.track(.endOfYearStoryShown, story: identifier)
     }
 }
 

--- a/podcasts/End of Year/Stories/2024/IntroStory2024.swift
+++ b/podcasts/End of Year/Stories/2024/IntroStory2024.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct IntroStory2024: StoryView {
-    let identifier: String = "intro"
+    let identifier: String = "cover"
 
     let backgroundColor = Color(hex: "EE661C")
     let backgroundTextColor = Color(hex: "EEB1F4")

--- a/podcasts/End of Year/Stories/2024/ListeningTime2024Story.swift
+++ b/podcasts/End of Year/Stories/2024/ListeningTime2024Story.swift
@@ -51,6 +51,10 @@ struct ListeningTime2024Story: ShareableStory {
         Analytics.track(.endOfYearStoryShown, story: identifier)
     }
 
+    func willShare() {
+        Analytics.track(.endOfYearStoryShare, story: identifier)
+    }
+
     func sharingAssets() -> [Any] {
         [
             StoryShareableProvider.new(AnyView(self)),

--- a/podcasts/End of Year/Stories/2024/ListeningTime2024Story.swift
+++ b/podcasts/End of Year/Stories/2024/ListeningTime2024Story.swift
@@ -8,6 +8,8 @@ struct ListeningTime2024Story: ShareableStory {
     private let foregroundColor = Color.black
     private let backgroundColor = Color(hex: "#EDB0F3")
 
+    let identifier: String = "total_time"
+
     enum Constants {
         static let wayToGoStickerSize: CGSize = .init(width: 197, height: 165)
     }
@@ -43,6 +45,10 @@ struct ListeningTime2024Story: ShareableStory {
         .foregroundStyle(foregroundColor)
         .background(backgroundColor)
         .enableProportionalValueScaling()
+    }
+
+    func onAppear() {
+        Analytics.track(.endOfYearStoryShown, story: identifier)
     }
 
     func sharingAssets() -> [Any] {

--- a/podcasts/End of Year/Stories/2024/NumberListened2024.swift
+++ b/podcasts/End of Year/Stories/2024/NumberListened2024.swift
@@ -16,7 +16,7 @@ struct NumberListened2024: ShareableStory {
 
     private let foregroundColor = Color.black
     private let backgroundColor = Color(hex: "#EFECAD")
-    let identifier: String = "number_of_podcasts_and_episodes_listened"
+    let identifier: String = "number_of_shows"
 
     var body: some View {
         VStack(alignment: .leading) {

--- a/podcasts/End of Year/Stories/2024/NumberListened2024.swift
+++ b/podcasts/End of Year/Stories/2024/NumberListened2024.swift
@@ -95,6 +95,10 @@ struct NumberListened2024: ShareableStory {
         Analytics.track(.endOfYearStoryShown, story: identifier)
     }
 
+    func willShare() {
+        Analytics.track(.endOfYearStoryShare, story: identifier)
+    }
+
     func sharingAssets() -> [Any] {
         [
             StoryShareableProvider.new(AnyView(self)),

--- a/podcasts/End of Year/Stories/2024/PaidStoryWallView2024.swift
+++ b/podcasts/End of Year/Stories/2024/PaidStoryWallView2024.swift
@@ -20,6 +20,8 @@ struct PaidStoryWallView2024: View {
     private let backgroundColor = Color(hex: "#EFECAD")
     private let foregroundColor = Color(hex: "#F9BC48")
 
+    let identifier = "plus_interstitial"
+
     var body: some View {
         GeometryReader { geometry in
             VStack {
@@ -65,6 +67,7 @@ struct PaidStoryWallView2024: View {
         }
         .onAppear {
             Analytics.track(.endOfYearUpsellShown)
+            Analytics.track(.endOfYearStoryShown, story: identifier)
         }
     }
 }

--- a/podcasts/End of Year/Stories/2024/Ratings2024Story.swift
+++ b/podcasts/End of Year/Stories/2024/Ratings2024Story.swift
@@ -13,6 +13,8 @@ struct Ratings2024Story: ShareableStory {
     @Environment(\.animated) var animated: Bool
     @Environment(\.pauseState) var pauseState
 
+    let identifier: String = "ratings"
+
     @State var scale: Double = 1
     @State var openURL = false
 
@@ -136,6 +138,10 @@ struct Ratings2024Story: ShareableStory {
         }
         .padding(.horizontal, 24)
         .padding(.bottom, 12)
+    }
+
+    func onAppear() {
+        Analytics.track(.endOfYearStoryShown, story: identifier)
     }
 
     func sharingAssets() -> [Any] {

--- a/podcasts/End of Year/Stories/2024/Ratings2024Story.swift
+++ b/podcasts/End of Year/Stories/2024/Ratings2024Story.swift
@@ -144,6 +144,10 @@ struct Ratings2024Story: ShareableStory {
         Analytics.track(.endOfYearStoryShown, story: identifier)
     }
 
+    func willShare() {
+        Analytics.track(.endOfYearStoryShare, story: identifier)
+    }
+
     func sharingAssets() -> [Any] {
         let totalRatings = ratings.values.reduce(0, +)
         return [

--- a/podcasts/End of Year/Stories/2024/Top5Podcasts2024Story.swift
+++ b/podcasts/End of Year/Stories/2024/Top5Podcasts2024Story.swift
@@ -7,7 +7,7 @@ struct Top5Podcasts2024Story: ShareableStory {
 
     let top5Podcasts: [TopPodcast]
 
-    let identifier: String = "top_five_podcast"
+    let identifier: String = "top_5_shows"
 
     private let shapeColor = Color.green
 

--- a/podcasts/End of Year/Stories/2024/Top5Podcasts2024Story.swift
+++ b/podcasts/End of Year/Stories/2024/Top5Podcasts2024Story.swift
@@ -119,6 +119,10 @@ struct Top5Podcasts2024Story: ShareableStory {
         animationViewModel.play()
     }
 
+    func willShare() {
+        Analytics.track(.endOfYearStoryShare, story: identifier)
+    }
+
     private func setInitialAnimationValues() {
         itemScale = 0
         itemOpacity = 0

--- a/podcasts/End of Year/Stories/2024/TopSpotStory2024.swift
+++ b/podcasts/End of Year/Stories/2024/TopSpotStory2024.swift
@@ -10,7 +10,7 @@ struct TopSpotStory2024: ShareableStory {
 
     @State private var rotation: Double = 360
 
-    let identifier: String = "top_one_podcast"
+    let identifier: String = "top_1_show"
 
     var body: some View {
         VStack(spacing: 0) {

--- a/podcasts/End of Year/Stories/2024/YearOverYearCompare2024Story.swift
+++ b/podcasts/End of Year/Stories/2024/YearOverYearCompare2024Story.swift
@@ -92,6 +92,10 @@ struct YearOverYearCompare2024Story: ShareableStory {
         Analytics.track(.endOfYearStoryShown, story: identifier)
     }
 
+    func willShare() {
+        Analytics.track(.endOfYearStoryShare, story: identifier)
+    }
+
     func sharingAssets() -> [Any] {
         [
             StoryShareableProvider.new(AnyView(self)),


### PR DESCRIPTION
| 📘 Part of: #2250 |
|:---:|

Completes #2372

* Several of the `story` identifiers were changed to match Android and the spreadsheet.
* Tracking for the `end_of_year_story_share` event was added to the Share button

## To test

* Enable the `endOfYear2024` & `tracksLogging` feature flags
* Restart the app
* Navigate to "Playback 2024" through the Profile
* Tap through all stories and verify analytics events with the tracking spreadsheet

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
