### PR TITLE
Playback 2024: Explicitly set Foreground Color

### DIFF
--- a/podcasts/End of Year/Stories/2024/CompletionRate2024Story.swift
+++ b/podcasts/End of Year/Stories/2024/CompletionRate2024Story.swift
@@ -13,6 +13,7 @@ struct CompletionRate2024Story: ShareableStory {
 
     let identifier: String = "completion_rate"
 
+    private let foregroundColor = Color.black
     private let backgroundColor = Color(hex: "#E0EFAD")
 
     @ObservedObject private var animationViewModel = PlayPauseAnimationViewModel(duration: 0.3, animation: Animation.linear(duration:))
@@ -36,6 +37,7 @@ struct CompletionRate2024Story: ShareableStory {
                 animationViewModel.play()
             }
         }
+        .foregroundStyle(foregroundColor)
         .background(backgroundColor)
     }
 

--- a/podcasts/End of Year/Stories/2024/EpilogueStory2024.swift
+++ b/podcasts/End of Year/Stories/2024/EpilogueStory2024.swift
@@ -10,8 +10,9 @@ struct StoryShareButton: View {
 
 struct EpilogueStory2024: StoryView {
 
-    let marqueeTextColor = Color(hex: "#EEB1F4")
-    let backgroundColor = Color(hex: "#EE661C")
+    private let foregroundColor = Color.black
+    private let marqueeTextColor = Color(hex: "#EEB1F4")
+    private let backgroundColor = Color(hex: "#EE661C")
 
     private let words = [
         "Thanks",
@@ -36,6 +37,7 @@ struct EpilogueStory2024: StoryView {
             footerView()
         }
         .minimumScaleFactor(0.8)
+        .foregroundStyle(foregroundColor)
         .background {
             backgroundColor
                 .ignoresSafeArea()

--- a/podcasts/End of Year/Stories/2024/PaidStoryWallView2024.swift
+++ b/podcasts/End of Year/Stories/2024/PaidStoryWallView2024.swift
@@ -17,8 +17,9 @@ struct PaidStoryWallView2024: View {
 
     private let separator = Image("playback-24-union")
 
+    private let foregroundColor = Color.black
     private let backgroundColor = Color(hex: "#EFECAD")
-    private let foregroundColor = Color(hex: "#F9BC48")
+    private let marqueeColor = Color(hex: "#F9BC48")
 
     var body: some View {
         GeometryReader { geometry in
@@ -31,7 +32,7 @@ struct PaidStoryWallView2024: View {
                         MarqueeTextView(words: words, separator: separator, separatorPadding: separatorPadding, direction: .trailing)
                     }
                     .minimumScaleFactor(0.9)
-                    .foregroundStyle(foregroundColor)
+                    .foregroundStyle(marqueeColor)
                     .rotationEffect(.degrees(-15))
                     .frame(width: geometry.size.width + 200, height: geometry.size.width - 50)
                     .offset(x: -50)
@@ -58,6 +59,7 @@ struct PaidStoryWallView2024: View {
                 .padding(.bottom, 6)
             }
         }
+        .foregroundStyle(foregroundColor)
         .background {
             backgroundColor
                 .ignoresSafeArea()

--- a/podcasts/End of Year/Stories/2024/Top5Podcasts2024Story.swift
+++ b/podcasts/End of Year/Stories/2024/Top5Podcasts2024Story.swift
@@ -11,6 +11,7 @@ struct Top5Podcasts2024Story: ShareableStory {
 
     private let shapeColor = Color.green
 
+    private let foregroundColor = Color.black
     private let backgroundColor = Color(hex: "#E0EFAD")
     private let shapeImages = ["playback-2024-shape-pentagon",
                                "playback-2024-shape-two-ovals",
@@ -54,6 +55,7 @@ struct Top5Podcasts2024Story: ShareableStory {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
         .ignoresSafeArea()
+        .foregroundStyle(foregroundColor)
         .background(
             Rectangle()
                 .fill(backgroundColor)


### PR DESCRIPTION
| 📘 Part of: #2250 |
|:---:|

Prevent the dark appearance from overriding the foreground color of the stories by explicitly setting them.

| Before | After |
|--|--|
| ![Simulator Screenshot - iPhone 16 - 2024-11-01 at 21 14 31](https://github.com/user-attachments/assets/f5822db5-6e1d-4ba4-b6e5-b469c1698d24) | ![Simulator Screenshot - iPhone 16 - 2024-11-01 at 21 12 20](https://github.com/user-attachments/assets/aaeadb23-ed45-4442-9238-5f0e1fbe2ecd) |

## To test

#### Non-Plus
* Use a normal non-plus user account
* Enable the `endOfYear2024` feature flag
* Set the iOS appearance to dark mode
* Restart the app
* Navigate to the "Playback 2024" section through Profile
* Tap through all stories

#### Plus
* Set account to Plus and repeat

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
