### PR TITLE
Playback 2024: Enable FF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 7.77
 -----
 - Implement shuffle button in Up Next view [#1179](https://github.com/orgs/Automattic/projects/1179/views/1)
-- Use a single icon for folders upsell. [$2362](https://github.com/Automattic/pocket-casts-ios/pull/2362)
+- Use a single icon for folders upsell. [#2362](https://github.com/Automattic/pocket-casts-ios/pull/2362)
+- Adds Playback 2024 [#2250](https://github.com/Automattic/pocket-casts-ios/issues/2250)
 
 7.76
 -----

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -227,7 +227,7 @@ public enum FeatureFlag: String, CaseIterable {
         case .runVacuumOnVersionUpdate:
             true
         case .endOfYear2024:
-            false
+            true
         case .upNextShuffle:
             false
         case .autoDownloadOnSubscribe:


### PR DESCRIPTION
| 📘 Part of: #2250 |
|:---:|

- Enables the FF
- Update CHANGELOG

## To test

- CI must be 🟢 
- Playback 24 should appear in Profile

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
