### PR TITLE
Referrals Force FF Referrals Send to default value true

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -208,7 +208,7 @@ public enum FeatureFlag: String, CaseIterable {
         case .referralsClaim:
             true
         case .referralsSend:
-            false
+            true
         case .syncStats:
             true
         case .discoverCollectionView:


### PR DESCRIPTION
| 📘 Part of: #2083  |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

Ensure that the FF for referrals Send is true by default on 7.76

## To test

1. Start the app with a Patron or Plus account
2. Open the Profile Tab
3. Check that the Gift icon on the top left is present and works correctly

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
