### PR TITLE
Watch sync issue

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/Refresh/MainServerHandler.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Refresh/MainServerHandler.swift
@@ -201,6 +201,7 @@ public class MainServerHandler {
     }
 
     public func refresh(podcasts: [Podcast], completion: @escaping (PodcastRefreshResponse?) -> Void) {
+        FileLog.shared.addMessage("Refresh - Started)")
         guard let request = createRefreshRequest(podcasts: podcasts) else {
             completion(PodcastRefreshResponse.failedResponse())
             return
@@ -218,7 +219,7 @@ public class MainServerHandler {
                 completion(PodcastRefreshResponse.failedResponse())
                 return
             }
-
+            FileLog.shared.addMessage("Decoding Refresh Response)")
             let refreshResponse = ServerHelper.decodeRefreshResponse(from: data)
             completion(refreshResponse)
         }

--- a/Modules/Server/Sources/PocketCastsServer/Public/Refresh/RefreshManager.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Refresh/RefreshManager.swift
@@ -51,6 +51,7 @@ public class RefreshManager {
         if !forceEvenIfRefreshedRecently {
             if let lastRefreshStartTime = ServerSettings.lastRefreshStartTime(), fabs(lastRefreshStartTime.timeIntervalSinceNow) < RefreshManager.minTimeBetweenRefreshes {
                 // if it's been less than minTimeBetweenRefreshes since our last refresh, don't do another one. Effectively throttling user refreshes a little bit
+                FileLog.shared.addMessage("Refresh - Throtled")
                 DispatchQueue.global().async {
                     Thread.sleep(forTimeInterval: 1.second)
                     ServerNotificationsHelper.shared.firePodcastsUpdated()

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/BackgroundSyncManager+URLSession.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/BackgroundSyncManager+URLSession.swift
@@ -50,8 +50,10 @@ extension BackgroundSyncManager: URLSessionDelegate, URLSessionDownloadDelegate 
             FileLog.shared.addMessage("Processing queue complete, firing sync completed and completing task")
             ServerNotificationsHelper.shared.fireSyncCompleted()
             #if os(watchOS)
-                self.pendingWatchBackgroundTask?.setTaskCompletedWithSnapshot(true)
-                self.pendingWatchBackgroundTask = nil
+            if  let identifier = session.configuration.identifier, let pendingWatchBackgroundTask = self.pendingWatchBackgroundTasks[identifier] {
+                pendingWatchBackgroundTask.setTaskCompletedWithSnapshot(true)
+                self.pendingWatchBackgroundTasks[identifier] = nil
+            }
             #endif
 
             session.invalidateAndCancel()

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/BackgroundSyncManager.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/BackgroundSyncManager.swift
@@ -12,11 +12,11 @@ public class BackgroundSyncManager: NSObject {
     public static let shared = BackgroundSyncManager()
 
     #if os(watchOS)
-        var pendingWatchBackgroundTask: WKURLSessionRefreshBackgroundTask?
-        public func processBackgroundTaskCallback(task: WKURLSessionRefreshBackgroundTask, identifier: String) {
-            pendingWatchBackgroundTask = task
-            _ = createUrlSession(identifier: identifier)
-        }
+    var pendingWatchBackgroundTasks: [String: WKURLSessionRefreshBackgroundTask] = [:]
+    public func processBackgroundTaskCallback(task: WKURLSessionRefreshBackgroundTask, identifier: String) {
+        pendingWatchBackgroundTasks[identifier] = task
+        _ = createUrlSession(identifier: identifier)
+    }
     #endif
 
     let refreshTaskId = "refresh"

--- a/Pocket Casts Watch App/ExtensionDelegate.swift
+++ b/Pocket Casts Watch App/ExtensionDelegate.swift
@@ -35,10 +35,12 @@ class ExtensionDelegate: NSObject, WKApplicationDelegate {
 
     func handle(_ backgroundTasks: Set<WKRefreshBackgroundTask>) {
         // Sent when the system needs to launch the application in the background to process tasks. Tasks arrive in a set, so loop through and process each one.
+        FileLog.shared.addMessage("Watch Extension Delegate start handle background task")
         for task in backgroundTasks {
             switch task {
             case let refreshTask as WKApplicationRefreshBackgroundTask:
                 if WatchSyncManager.shared.isPlusUser() {
+                    FileLog.shared.addMessage("Watch Extension Delegate start application refresh background task")
                     beginRefreshTask()
                     scheduleNextRefresh()
                 }
@@ -48,10 +50,13 @@ class ExtensionDelegate: NSObject, WKApplicationDelegate {
             case let connectivityTask as WKWatchConnectivityRefreshBackgroundTask:
                 connectivityTask.setTaskCompletedWithSnapshot(true)
             case let urlSessionTask as WKURLSessionRefreshBackgroundTask:
+                FileLog.shared.addMessage("Watch Extension Delegate start url session refresh background task")
                 let identifier = urlSessionTask.sessionIdentifier
                 if identifier == DownloadManager.cellBackgroundSessionId {
+                    FileLog.shared.addMessage("Watch Extension Delegate start url session download refresh background task")
                     DownloadManager.shared.processBackgroundTaskCallback(task: urlSessionTask)
                 } else if identifier.startsWith(string: BackgroundSyncManager.sessionIdPrefix) {
+                    FileLog.shared.addMessage("Watch Extension Delegate start url session upnext refresh background task")
                     BackgroundSyncManager.shared.processBackgroundTaskCallback(task: urlSessionTask, identifier: identifier)
                 } else {
                     urlSessionTask.setTaskCompletedWithSnapshot(true)

--- a/Pocket Casts Watch App/WatchSyncManager.swift
+++ b/Pocket Casts Watch App/WatchSyncManager.swift
@@ -211,6 +211,7 @@ class WatchSyncManager {
 
     private func periodicRefresh() {
         if DateUtil.hasEnoughTimePassed(since: ServerSettings.lastRefreshEndTime(), time: WatchSyncManager.watchMinTimeBetweenPeriodicRefreshes) {
+            FileLog.shared.addMessage("Periodic Refresh - Starting")
             RefreshManager.shared.refreshPodcasts(forceEvenIfRefreshedRecently: false)
         }
     }

--- a/Pocket Casts Watch App/WatchSyncManager.swift
+++ b/Pocket Casts Watch App/WatchSyncManager.swift
@@ -79,9 +79,12 @@ class WatchSyncManager {
         if updateLoginDetailsIfRequired() {
             return
         } else {
-            if isPlusUser(), WKApplication.shared().applicationState == .background, compareUpNextLists() == .watchNeedsUpdate, !SyncManager.isFirstSyncInProgress() {
-                let subscribedPodcasts = DataManager.sharedManager.allPodcasts(includeUnsubscribed: false)
-                BackgroundSyncManager.shared.performBackgroundRefresh(subscribedPodcasts: subscribedPodcasts)
+            if isPlusUser(),
+               WKApplication.shared().applicationState == .background,
+               compareUpNextLists() == .watchNeedsUpdate,
+               !SyncManager.isFirstSyncInProgress() {
+               let subscribedPodcasts = DataManager.sharedManager.allPodcasts(includeUnsubscribed: false)
+               BackgroundSyncManager.shared.performBackgroundRefresh(subscribedPodcasts: subscribedPodcasts)
             } else {
                 loginAndRefreshIfRequired()
             }

--- a/podcasts/DownloadManager+SessionManagement.swift
+++ b/podcasts/DownloadManager+SessionManagement.swift
@@ -9,6 +9,8 @@ extension DownloadManager {
     #if os(watchOS)
         func processBackgroundTaskCallback(task: WKURLSessionRefreshBackgroundTask) {
             if task.sessionIdentifier == DownloadManager.cellBackgroundSessionId {
+                // If there was a previous task for the same identifier let's set it to complete
+                pendingWatchBackgroundTask?.setTaskCompletedWithSnapshot(false)
                 pendingWatchBackgroundTask = task
             } else {
                 task.setTaskCompletedWithSnapshot(true)


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes #2242  <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR changes to things:
- Ensures that all background tasks are set to complete to avoid running out of background tasks
- Adds extra logging to the refresh process in the background so we can better debug issues
 
## To test

- Start the watch app connected to a phone with a patron/plus account
- Tap on refresh account if needed on the watch app
- Start an episode playing in the watch
- Put the app on the watch in the background
- Open the phone app and change the up next queue
- Check if all is working

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
