### PR TITLE
Update strings for auto-downloads row to match other settings rows

### DIFF
--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -282,7 +282,7 @@ internal enum L10n {
   internal static var autoDownloadLimitAutoDownloads: String { return L10n.tr("Localizable", "auto_download_limit_auto_downloads") }
   /// Limit downloads
   internal static var autoDownloadLimitDownloads: String { return L10n.tr("Localizable", "auto_download_limit_downloads") }
-  /// %1$@ episodes
+  /// %1$@ Episodes
   internal static func autoDownloadLimitNumberOfEpisodes(_ p1: Any) -> String {
     return L10n.tr("Localizable", "auto_download_limit_number_of_episodes", String(describing: p1))
   }
@@ -290,7 +290,7 @@ internal enum L10n {
   internal static func autoDownloadLimitNumberOfEpisodesShow(_ p1: Any) -> String {
     return L10n.tr("Localizable", "auto_download_limit_number_of_episodes_show", String(describing: p1))
   }
-  /// latest episode
+  /// Latest Episode
   internal static var autoDownloadLimitOneEpisode: String { return L10n.tr("Localizable", "auto_download_limit_one_episode") }
   /// Latest Episode per Show
   internal static var autoDownloadLimitOneEpisodeShow: String { return L10n.tr("Localizable", "auto_download_limit_one_episode_show") }

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4506,10 +4506,10 @@
 "auto_download_limit_auto_downloads" = "Limit auto downloads";
 
 /* Auto Downloads Setting - Limits downloads to a number of episodes. `%1$@' is a placeholder for the number of episodes*/
-"auto_download_limit_number_of_episodes" = "%1$@ episodes";
+"auto_download_limit_number_of_episodes" = "%1$@ Episodes";
 
 /* Auto Downloads Setting - Limits downloads to one episodes. */
-"auto_download_limit_one_episode" = "latest episode";
+"auto_download_limit_one_episode" = "Latest Episode";
 
 /* Auto Downloads Setting - Limits downloads to the latest episode*/
 "auto_download_limit_one_episode_show" = "Latest Episode per Show";


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

Update strings for auto-downloads row to match other settings rows

| 1 | 2 |
| - | - | 
| ![Simulator Screenshot - iPhone 16 Pro - 2024-11-05 at 10 40 16](https://github.com/user-attachments/assets/441fbd4f-aba8-4b59-8c98-f4a5988ca9f4) | ![Simulator Screenshot - iPhone 16 Pro - 2024-11-05 at 10 40 12](https://github.com/user-attachments/assets/30b60f1f-5aa5-41f1-a701-52122d290f11) |

## To test

1. Start the app
2. Go to Profile -> Downloads -> Auto Download Settings
3. Enable the option to download new episodes.
4. Check if the row for auto-download limits shows the initial letter uppercased

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
