### PR TITLE
EOY 2024: Fix header and duration issues

### DIFF
--- a/podcasts/End of Year/EndOfYear.swift
+++ b/podcasts/End of Year/EndOfYear.swift
@@ -206,6 +206,10 @@ struct EndOfYear {
     }
 }
 
+extension EndOfYear {
+    static var defaultDuration = 10.seconds
+}
+
 class StoriesHostingController<ContentView: View>: UIHostingController<ContentView> {
     override var preferredStatusBarStyle: UIStatusBarStyle {
         .lightContent

--- a/podcasts/End of Year/EndOfYear.swift
+++ b/podcasts/End of Year/EndOfYear.swift
@@ -207,7 +207,7 @@ struct EndOfYear {
 }
 
 extension EndOfYear {
-    static var defaultDuration = {
+    static var defaultDuration: TimeInterval {
         switch currentYear {
         case .y2024: return 10.seconds
         default: return 7.seconds

--- a/podcasts/End of Year/EndOfYear.swift
+++ b/podcasts/End of Year/EndOfYear.swift
@@ -207,12 +207,20 @@ struct EndOfYear {
 }
 
 extension EndOfYear {
-    static var defaultDuration = 10.seconds
+    static var defaultDuration = {
+        switch currentYear {
+        case .y2024: return 10.seconds
+        default: return 7.seconds
+        }
+    }
 }
 
 class StoriesHostingController<ContentView: View>: UIHostingController<ContentView> {
     override var preferredStatusBarStyle: UIStatusBarStyle {
-        .darkContent
+        switch EndOfYear.currentYear {
+        case .y2024: return .darkContent
+        default: return .lightContent
+        }
     }
 
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {

--- a/podcasts/End of Year/EndOfYear.swift
+++ b/podcasts/End of Year/EndOfYear.swift
@@ -212,7 +212,7 @@ extension EndOfYear {
 
 class StoriesHostingController<ContentView: View>: UIHostingController<ContentView> {
     override var preferredStatusBarStyle: UIStatusBarStyle {
-        .lightContent
+        .darkContent
     }
 
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {

--- a/podcasts/End of Year/Stories/2023/IntroStory2023.swift
+++ b/podcasts/End of Year/Stories/2023/IntroStory2023.swift
@@ -123,10 +123,6 @@ private struct TwentyThreeParallaxModifier: ViewModifier {
     }
 }
 
-extension EndOfYear {
-    static var defaultDuration = 7.seconds
-}
-
 struct IntroStory2023_Previews: PreviewProvider {
     static var previews: some View {
         IntroStory2023()

--- a/podcasts/End of Year/Views/StoriesView.swift
+++ b/podcasts/End of Year/Views/StoriesView.swift
@@ -154,6 +154,7 @@ struct StoriesView: View {
             .padding(.trailing, Constants.storyIndicatorVerticalPadding)
 
             closeButton
+                .foregroundColor(model.indicatorColor)
         }
         .padding(.top, Constants.headerTopPadding)
     }


### PR DESCRIPTION
| 📘 Part of: #2250  |  <!-- project issue number, if applicable -->
|:---:|

Fixes #2385 #2386 <!-- issue number, if applicable -->

| 1 | 2 | 
| - | - |
| ![Simulator Screenshot - iPhone 16 Pro - 2024-11-05 at 12 24 20](https://github.com/user-attachments/assets/05589aef-13e2-4cad-a2e1-4007d72a1b6f) | ![Simulator Screenshot - iPhone 16 Pro - 2024-11-05 at 12 24 16](https://github.com/user-attachments/assets/9274974f-81b4-421c-afc5-fbbea20e4b08) |

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

This PR fixes three issues on the EOY 2024:

- Status bar always black
- Close button black on loading
- Duration for each story before moving on increased 3s

## To test

1. Start the app
2. Ensure that you the FF end of year 2024 enabled. If not after enabling it you need to restart the app
3. Go to Profile tab
4. Tap on the EOY banner
5. Check that the loading screen show a black x close button 
6. Check that all the EOY screens have the status bar black
7. Check that the duration is 10s for each story

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
