### PR TITLE
Update to support day hour minutes stats

### DIFF
--- a/podcasts/End of Year/Stories/2024/ListeningTime2024Story.swift
+++ b/podcasts/End of Year/Stories/2024/ListeningTime2024Story.swift
@@ -84,18 +84,18 @@ fileprivate extension Double {
         let components = dateComponents()
         let formatter = DateComponentsFormatter()
         formatter.unitsStyle = .full
-        formatter.maximumUnitCount = 2
+        formatter.maximumUnitCount = 3
         formatter.allowsFractionalUnits = false
         formatter.allowedUnits = [.day, .hour, .minute, .second]
 
-        if let days = components.day, days != 0 {
-            if let hours = components.hour, hours != 0 {
-                formatter.allowedUnits = [.day, .hour]
+        if let days = components.day {
+            if days > 3 {
+                formatter.allowedUnits = [.day, .hour, .minute]
             } else {
-                formatter.allowedUnits = [.day]
+                formatter.allowedUnits = [.hour, .minute]
             }
         } else if let hours = components.hour, hours != 0 {
-            formatter.allowedUnits = [.hour]
+            formatter.allowedUnits = [.hour, .minute]
         } else if let minutes = components.minute, minutes != 0 {
             formatter.allowedUnits = [.minute]
         } else if let seconds = components.second, seconds != 0 {
@@ -107,9 +107,29 @@ fileprivate extension Double {
 }
 
 #Preview("Days") {
-    ListeningTime2024Story(listeningTime: 500*60)
+    ListeningTime2024Story(listeningTime: 4.day + 5.hour + 20.minutes)
+}
+
+#Preview("Days hour min") {
+    ListeningTime2024Story(listeningTime: 1.day + 5.hour + 20.minutes)
+}
+
+#Preview("Day and min") {
+    ListeningTime2024Story(listeningTime: 1.day + 20.minutes)
 }
 
 #Preview("Hours") {
+    ListeningTime2024Story(listeningTime: 5.hours + 20.minutes)
+}
+
+#Preview("Minutes") {
     ListeningTime2024Story(listeningTime: 60)
+}
+
+#Preview("Seconds") {
+    ListeningTime2024Story(listeningTime: 30)
+}
+
+#Preview("Zero") {
+    ListeningTime2024Story(listeningTime: 0)
 }


### PR DESCRIPTION
| 📘 Part of: #1145  |  <!-- project issue number, if applicable -->
|:---:|

Fixes #2396 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
For the EOY 2024 Listening time story only show days if we have more than 4 days (98h) of listening time, and if we have minutes show them.

| 1 | 2 | 3 | 4 |
| - | - | - | - |
| <img width="302" alt="Screenshot 2024-11-07 at 14 46 19" src="https://github.com/user-attachments/assets/79d9f281-25e5-4ee6-9e86-2740e1a4630f"> | <img width="301" alt="Screenshot 2024-11-07 at 14 45 52" src="https://github.com/user-attachments/assets/85b10ee8-b8f3-4fff-80ed-178572008c16"> | <img width="307" alt="Screenshot 2024-11-07 at 14 44 50" src="https://github.com/user-attachments/assets/bb696072-b4e7-4aab-a003-9d88388514b5"> | <img width="303" alt="Screenshot 2024-11-07 at 14 45 09" src="https://github.com/user-attachments/assets/a6fef3d2-ca2e-47f5-8dfd-96a93f3b0ea9"> |

## To test

1. Start the app
2. Ensure that you have the EOY 2024 FF enabled
3. Tap on the EOY 2024 banner on Profile
4. Wait/Tap until the listening time story
5. Check if it displays correctly
6. If you want test multiple different times you can force a value on `EndOfYear2024StoriesModel` swift file on line 35

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
