### PR TITLE
EOY 2024: Add logic to show eoy stories on image tap and on account sign in

### DIFF
--- a/podcasts/End of Year/End of Year 2024/EndOfYear2024StoriesModel.swift
+++ b/podcasts/End of Year/End of Year 2024/EndOfYear2024StoriesModel.swift
@@ -18,6 +18,7 @@ class EndOfYear2024StoriesModel: StoryModel {
     required init() { }
 
     func populate(with dataManager: DataManager) {
+        var stories = [EndOfYear2024Story]()
         // First, search for top 5 podcasts
         let topPodcasts = dataManager.topPodcasts(in: Self.year, limit: 10)
 
@@ -69,6 +70,8 @@ class EndOfYear2024StoriesModel: StoryModel {
         // Completion Rate
         data.episodesStartedAndCompleted = dataManager.episodesStartedAndCompleted(in: Self.year)
         stories.append(.completionRate)
+
+        self.stories = stories
     }
 
     func story(for storyNumber: Int) -> any StoryView {

--- a/podcasts/End of Year/Views/EndOfYearModal.swift
+++ b/podcasts/End of Year/Views/EndOfYearModal.swift
@@ -24,7 +24,9 @@ struct EndOfYearModal: View {
                     .resizable()
                     .scaledToFit()
                     .clipShape(RoundedRectangle(cornerRadius: 16))
-
+                    .buttonize {
+                        NavigationManager.sharedManager.navigateTo(NavigationManager.endOfYearStories, data: nil)
+                    }
                 Text(model.description)
                     .font(style: .callout, weight: .medium, maxSizeCategory: .accessibilityMedium)
                     .multilineTextAlignment(.center)

--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -572,7 +572,7 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
     }
 
     func observersForEndOfYearStats() {
-        guard FeatureFlag.endOfYear.enabled else {
+        guard FeatureFlag.endOfYear.enabled || FeatureFlag.endOfYear2024.enabled else {
             return
         }
 


### PR DESCRIPTION
| 📘 Part of: #2250  |  <!-- project issue number, if applicable -->
|:---:|

Fixes #2387 #2388 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR change the code to allow tapping on the EOY image on the modal to present the stories.
It also ensure that the observer for sign in are properly set if you have the EOY 2024 FF enabled but not the EOY flag.
## To test

1. Delete the app from device/simulator
2. Start the app without a login
3. Enable the eoy 2024 FF
4. Restart the app
5. Go to profile
6. Tap on Account
7. Sign in to a user
8. Check that after sign the modal for the EOY 2024 is show
9. Tap on the image on the modal and see if it takes you to the stories
10. Exit the Stories modal 
11. Sign out from the account
12. Exit the app
13. Start again the app
14. Sign in and see if the modal shows again.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
