### PR TITLE
[Sentry] Avoid force unwrap

### DIFF
--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -784,11 +784,12 @@ class PlaybackManager: ServerPlaybackDelegate {
     }
 
     func effects() -> PlaybackEffects {
-        if currentEffects == nil {
-            currentEffects = loadEffects()
+        if let currentEffects {
+            return currentEffects
         }
-
-        return currentEffects!
+        let effects = loadEffects()
+        currentEffects = effects
+        return effects
     }
 
     func applyCurrentEffect() {


### PR DESCRIPTION
Fixes: sentry-6058987144

Ensure to avoid force unwrap when requesting for the current effect

## To test

- CI must be 🟢 
- Playback effects should work as before. Test local and global effects.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
