### PR TITLE
[Playback 2024] Prompt Playback 24 sheet after sign in with Google or Apple

### DIFF
--- a/podcasts/Onboarding/LoginCoordinator.swift
+++ b/podcasts/Onboarding/LoginCoordinator.swift
@@ -2,6 +2,7 @@ import Foundation
 import PocketCastsServer
 import SwiftUI
 import PocketCastsDataModel
+import PocketCastsUtils
 
 class LoginCoordinator: NSObject, OnboardingModel {
     weak var navigationController: UINavigationController? = nil
@@ -121,6 +122,10 @@ extension LoginCoordinator {
 
                 if !newAccountCreated {
                     Analytics.track(.userSignedIn, properties: ["source": provider])
+                }
+
+                if FeatureFlag.endOfYear2024.enabled {
+                    NotificationCenter.postOnMainThread(notification: .userSignedIn)
                 }
 
                 listenToSync()


### PR DESCRIPTION
| 📘 Part of: #2250
|:---:|

Fixes #2410

Fire the `userSignedIn` notification when the user sign in with Google or Apple

## To test

- CI must be 🟢 
- Run a fresh install
- Make sure the `endOfYear2024` FF is on
- Sign in with Goolge or Apple
- When the modal is dismissed confirm you see the EOY sheet being prompted, same behaviour in #2407

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
