### PR TITLE
Download manager fix issues when streaming and downloading

### DIFF
--- a/podcasts/DownloadManager.swift
+++ b/podcasts/DownloadManager.swift
@@ -259,7 +259,8 @@ class DownloadManager: NSObject, FilePathProtocol {
               !episode.videoPodcast(),
               !episode.isUserEpisode,
               let urlAsset = playbackItem.asset as? AVURLAsset,
-              !urlAsset.url.isFileURL // only  start download if it's a remote file that we are playing
+              !urlAsset.url.isFileURL, // only  start download if it's a remote file that we are playing
+              (FileManager.deviceRemainingFreeSpaceInBytes ?? 0) > episode.sizeInBytes
         else {
             return playbackItem
         }

--- a/podcasts/FileManager+Helper.swift
+++ b/podcasts/FileManager+Helper.swift
@@ -9,4 +9,14 @@ extension FileManager {
         }
         return Int64(fileSize)
     }
+
+    static var deviceRemainingFreeSpaceInBytes: Int64? {
+        let fileURL = URL(fileURLWithPath: NSHomeDirectory() as String)
+        do {
+            let values = try fileURL.resourceValues(forKeys: [.volumeAvailableCapacityKey])
+            return Int64(values.volumeAvailableCapacity ?? 0)
+        } catch {
+            return nil
+        }
+    }
 }

--- a/podcasts/MediaExporterResourceLoaderDelegate.swift
+++ b/podcasts/MediaExporterResourceLoaderDelegate.swift
@@ -132,8 +132,13 @@ final class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoader
             return
         }
 
-        if bufferData.count > 0 {
-            fileHandle.append(data: bufferData)
+        if bufferData.isEmpty == false {
+            do {
+                try fileHandle.append(data: bufferData)
+            } catch {
+                downloadFailed(with: error)
+                return
+            }
         }
 
         let error = verifyResponse()
@@ -227,8 +232,12 @@ final class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoader
 
         guard bufferData.count >= downloadBufferLimit else { return }
 
-        fileHandle.append(data: bufferData)
-        bufferData = Data()
+        do {
+            try fileHandle.append(data: bufferData)
+            bufferData = Data()
+        } catch {
+            invalidateAndCancelSession()
+        }
     }
 
     private func downloadComplete() {

--- a/podcasts/MediaExporterResourceLoaderDelegate.swift
+++ b/podcasts/MediaExporterResourceLoaderDelegate.swift
@@ -132,7 +132,7 @@ final class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoader
             return
         }
 
-        if bufferData.isEmpty == false {
+        if !bufferData.isEmpty {
             do {
                 try fileHandle.append(data: bufferData)
             } catch {

--- a/podcasts/MediaFileHandle.swift
+++ b/podcasts/MediaFileHandle.swift
@@ -50,14 +50,14 @@ extension MediaFileHandle {
         return readHandle?.readData(ofLength: length)
     }
 
-    func append(data: Data) {
+    func append(data: Data) throws {
         lock.lock()
         defer { lock.unlock() }
 
         guard let writeHandle = writeHandle else { return }
 
         writeHandle.seekToEndOfFile()
-        writeHandle.write(data)
+        try writeHandle.write(contentsOf: data)
     }
 
     func synchronize() {


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

This PR improves the stream and download feature with two fixes:

- Check if there is available space to download episodes before starting to stream and download
- Improve error handling when saving data buffers to disk to avoid exceptions

## To test

1. Start the app
2. Ensure that you have the `StreamAndCachePlayingEpisode` FF active
3. Start playing any episode that you didn't download before
4. Check if playing and download happens correctly

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
