### PR TITLE
[UpNextShuffle] Dismiss the UpNext vc to present the paywall

### DIFF
--- a/podcasts/UpNextViewController.swift
+++ b/podcasts/UpNextViewController.swift
@@ -208,7 +208,15 @@ class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
 
     @objc private func shuffleButtonTapped() {
         if !SubscriptionHelper.hasActiveSubscription() {
-            NavigationManager.sharedManager.showUpsellView(from: self, source: .upNextShuffle)
+            // Edge case where the UpNext is presented by the player container with a free user.
+            // In this case we need to dismiss the UpNext to present the paywall
+            if let mainTabBar = presentingViewController?.presentingViewController, presentingViewController is PlayerContainerViewController {
+                dismiss(animated: true) {
+                    NavigationManager.sharedManager.showUpsellView(from: mainTabBar, source: .upNextShuffle)
+                }
+            } else {
+                NavigationManager.sharedManager.showUpsellView(from: self, source: .upNextShuffle)
+            }
             return
         }
         Settings.upNextShuffleToggle()


### PR DESCRIPTION
This PR cover the edge case to present the paywall if the UpNext view is already presented from the player container.
The system in this case doesn't allow us to present over another vc. To cover this case we dismiss the UpNext and present the paywall.

## To test

- CI must be 🟢 
- Run the app with a non plus/patron user
- Open the player fullscreen and swipe up to show the UpNext
- Tap the golden shuffle icon
- The UpNext view should dismiss and the paywall should be presented
- Try the same from the UpNext tab and from the mini player
- The. Paywall should always be presented without dismissing the UpNext

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
