### PR TITLE
[Crash] Default Player crash with MTAudioProcessingTapCallbacks

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -139,7 +139,7 @@ public enum FeatureFlag: String, CaseIterable {
 
     /// Replace Subscribe/Unsubscribe with Follow/Unfollow
     case useFollowNaming
-    
+
     /// Use a cookie to manage `MTAudioProcessingTap` deallocation
     case useDefaultPlayerTapCookie
 

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -139,6 +139,9 @@ public enum FeatureFlag: String, CaseIterable {
 
     /// Replace Subscribe/Unsubscribe with Follow/Unfollow
     case useFollowNaming
+    
+    /// Use a cookie to manage `MTAudioProcessingTap` deallocation
+    case useDefaultPlayerTapCookie
 
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
@@ -233,6 +236,8 @@ public enum FeatureFlag: String, CaseIterable {
         case .autoDownloadOnSubscribe:
             true
         case .useFollowNaming:
+            true
+        case .useDefaultPlayerTapCookie:
             true
         }
     }

--- a/Modules/Utils/Sources/PocketCastsUtils/Logging/FileLog.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Logging/FileLog.swift
@@ -40,6 +40,10 @@ actor LogBuffer {
         logBuffer.append(LogEntry(message, timestamp: date))
     }
 
+    func console(_ message: String) {
+        logger?.log("\(message, privacy: .public)")
+    }
+
     private func writeLogBufferToDisk() {
         let newLogChunk = logBuffer.sorted(by: { $0.timestamp.compare($1.timestamp) == .orderedAscending }).reduce(into: "") { resultChunk, logEntry in
             resultChunk.append("\(logEntry.formattedForLog)\n")
@@ -128,6 +132,12 @@ public final class FileLog {
         Task {
             await logBuffer.append(message, date: date)
             publisher.send(message)
+        }
+    }
+
+    public func console(_ message: String) {
+        Task {
+            await logBuffer.console(message)
         }
     }
 


### PR DESCRIPTION
Related to #1711

An attempt to fix the crashes related to `MTAudioProcessingTapCallbacks`.

As a tap can not be synchronously stopped, I suspect we try to access the unretained instance already deallocated.  

This solution introduces basically 3 things:
- An `AudioProcessingTapProxy` which wraps as weak the reference to the current player
- When the `MTAudioProcessingTapCallbacks` is created, the `clientInfo` is now an `UnsafeMutableRawPointer` created with the retained instance of the proxy
- We now implement the `finalize` closure where we release the previously retained tap instance

## To test

- CI must be 🟢 
- Try to play and change episodes while playing
- When the system decides to finalize the tap you will see 2 logs in this order:
1. The log from the finalize closure: `[AudioProcessingTapProxy] Finalize tap: <MTAudioProcessingTap 0x6000030513b0> Retain count 3 Created with i/f/p/u/t callbacks = {0x10aa14448/0x10aa14600/0x10aa149b4/0x10aa14d08/0x10aa15330} flags = 0x1`
2. The log from the proxy deinit: `[AudioProcessingTapProxy] Deinit proxy`
• Switch the FF off to check everything still works as before

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
