### PR TITLE
Playback 2024: Remove duration from ending story in Playback 2024

### DIFF
--- a/podcasts/End of Year/Stories/2024/EpilogueStory2024.swift
+++ b/podcasts/End of Year/Stories/2024/EpilogueStory2024.swift
@@ -22,6 +22,8 @@ struct EpilogueStory2024: StoryView {
         "Gratki"
     ].map { $0.uppercased() }
 
+    var duration: TimeInterval = 0.01
+
     private let separator = Image("playback-24-heart")
 
     var identifier: String = "ending"


### PR DESCRIPTION
| 📘 Part of: #2250 |
|:---:|

Fixes #2417

| Before | After |
| -- | -- |
| <video src="https://github.com/user-attachments/assets/c678e722-ad2c-44bb-aea6-7b9461542ff0"> | <video src="https://github.com/user-attachments/assets/3c9f04e0-9ed9-4d1c-8b6d-1e4972008c49"> |

## To test

* Tap through the Playback 2024 stories
* On the final story with the "Thanks" scrolling text, verify that the progress bar doesn't animate.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
