### PR TITLE
Playback 2024: Add periods to story descriptions

### DIFF
--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -820,7 +820,7 @@ internal enum L10n {
   internal static var editClip: String { return L10n.tr("Localizable", "edit_clip") }
   /// Enable it now
   internal static var enableItNow: String { return L10n.tr("Localizable", "enable_it_now") }
-  /// Don’t forget to share with friends and give a shout out to your favourite podcasts and creators
+  /// Don’t forget to share with friends and give a shout out to your favourite podcasts and creators.
   internal static var eoy2024EpilogueDescription: String { return L10n.tr("Localizable", "eoy_2024_epilogue_description") }
   /// Thank you for listening with us this year.
   /// See you in 2025!
@@ -845,7 +845,7 @@ internal enum L10n {
   internal static var eoyStartYourFreeTrial: String { return L10n.tr("Localizable", "eoy_start_your_free_trial") }
   /// Failed to load stories.
   internal static var eoyStoriesFailed: String { return L10n.tr("Localizable", "eoy_stories_failed") }
-  /// Don't forget to share with your friends and give a shout out to your favorite podcast creators
+  /// Don't forget to share with your friends and give a shout out to your favorite podcast creators.
   internal static var eoyStoryEpilogueSubtitle: String { return L10n.tr("Localizable", "eoy_story_epilogue_subtitle") }
   /// Thank you for listening with us this year.
   /// See you in 2024!
@@ -1780,7 +1780,7 @@ internal enum L10n {
   internal static var playLast: String { return L10n.tr("Localizable", "play_last") }
   /// Play Next
   internal static var playNext: String { return L10n.tr("Localizable", "play_next") }
-  /// From the %1$@ episodes you started you listened fully to a total of %2$@
+  /// From the %1$@ episodes you started you listened fully to a total of %2$@.
   internal static func playback2024CompletionRateDescription(_ p1: Any, _ p2: Any) -> String {
     return L10n.tr("Localizable", "playback_2024_completion_rate_description", String(describing: p1), String(describing: p2))
   }
@@ -1798,7 +1798,7 @@ internal enum L10n {
   internal static func playback2024ListeningTimeDescription(_ p1: Any) -> String {
     return L10n.tr("Localizable", "playback_2024_listening_time_description", String(describing: p1))
   }
-  /// It was "%1$@" from "%2$@"
+  /// It was "%1$@" from "%2$@".
   internal static func playback2024LongestEpisodeDescription(_ p1: Any, _ p2: Any) -> String {
     return L10n.tr("Localizable", "playback_2024_longest_episode_description", String(describing: p1), String(describing: p2))
   }
@@ -1820,11 +1820,11 @@ internal enum L10n {
   }
   /// Did you know that you can rate shows now? Share the love for your favorite creators and help them get noticed!
   internal static var playback2024RatingsEmptyDescription: String { return L10n.tr("Localizable", "playback_2024_ratings_empty_description") }
-  /// Oh-oh! No podcast ratings to show you yet
+  /// Oh-oh! No podcast ratings to show you yet.
   internal static var playback2024RatingsEmptyTitle: String { return L10n.tr("Localizable", "playback_2024_ratings_empty_title") }
   /// Let’s see your ratings!
   internal static var playback2024RatingsTitle: String { return L10n.tr("Localizable", "playback_2024_ratings_title") }
-  /// You listened to %1$@ episodes for a total of %2$@ of "%3$@"
+  /// You listened to %1$@ episodes for a total of %2$@ of "%3$@".
   internal static func playback2024TopSpotDescription(_ p1: Any, _ p2: Any, _ p3: Any) -> String {
     return L10n.tr("Localizable", "playback_2024_top_spot_description", String(describing: p1), String(describing: p2), String(describing: p3))
   }

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -3582,7 +3582,7 @@
 "playback_2024_longest_episode_title" = "The longest episode you listened to was %1$@";
 
 /* A description shown on the Longest Episode screen of Playback 2024 with the episode title and podcast title */
-"playback_2024_longest_episode_description" = "It was \"%1$@\" from \"%2$@\"";
+"playback_2024_longest_episode_description" = "It was \"%1$@\" from \"%2$@\".";
 
 /* A title shown in the button on the upsell screen to check out Pocket Casts Plus */
 "playback_2024_plus_upsell_button_title" = "Check out Pocket Casts Plus";
@@ -3597,7 +3597,7 @@
 "playback_2024_completion_rate_title" = "You completion rate this year was %1$@";
 
 /* A description shown in the Completion Rate screen for Playback 2024 */
-"playback_2024_completion_rate_description" = "From the %1$@ episodes you started you listened fully to a total of %2$@";
+"playback_2024_completion_rate_description" = "From the %1$@ episodes you started you listened fully to a total of %2$@.";
 
 /*A title used for the Playback 2024 Top Podcast screen */
 "playback_2024_top_spot_title" = "This was your top podcast in 2024";
@@ -3611,7 +3611,7 @@
 /* A description shown in Playback 2024 when the user has only made ratings of 1-3/5 for Podcasts */
 "playback_2024_ratings_description_1_to_3" = "Thanks for sharing your feedback with the creator community";
 
-"playback_2024_top_spot_description" = "You listened to %1$@ episodes for a total of %2$@ of \"%3$@\"";
+"playback_2024_top_spot_description" = "You listened to %1$@ episodes for a total of %2$@ of \"%3$@\".";
 
 /* A title shown on the Year over Year Comparison screen for a small decrease in listening time from 2023 in Playback 2024 */
 "playback_2024_year_over_year_compare_title_down_little" = "Compared to 2023, your listening time went down a little";
@@ -3644,7 +3644,7 @@
 "playback_2024_year_over_year_compare_description_up" = "Ready to top it in 2025?";
 
 /* A title shown in Playback 2024 when the user has not made any ratings. */
-"playback_2024_ratings_empty_title" = "Oh-oh! No podcast ratings to show you yet";
+"playback_2024_ratings_empty_title" = "Oh-oh! No podcast ratings to show you yet.";
 
 /* A description shown in Playback 2024 to describe the new Podcast Ratings feature */
 "playback_2024_ratings_empty_description" = "Did you know that you can rate shows now? Share the love for your favorite creators and help them get noticed!";
@@ -3830,7 +3830,7 @@
 "eoy_2024_epilogue_title" = "Thank you for listening with us this year.\nSee you in 2025!";
 
 /* Description shown on the final End of Year story for 2024 */
-"eoy_2024_epilogue_description" = "Don’t forget to share with friends and give a shout out to your favourite podcasts and creators";
+"eoy_2024_epilogue_description" = "Don’t forget to share with friends and give a shout out to your favourite podcasts and creators.";
 
 /* Message of an alert displayed to the user asking if they want to share the current story */
 "eoy_share_this_story_message" = "Paste this image to your socials and give a shout out to your favorite shows and creators";


### PR DESCRIPTION
| 📘 Part of: #2250 |
|:---:|

Fixes #2423

Adds periods to all description text in the 2024 stories

| | | | | |
|--|--|--|--|--|
| ![Simulator Screenshot - iPhone 16 - 2024-11-14 at 17 14 08](https://github.com/user-attachments/assets/8b7392e4-94e6-4d7f-91ed-c2d76a5f79db) | ![Simulator Screenshot - iPhone 16 - 2024-11-14 at 17 14 12](https://github.com/user-attachments/assets/66651330-b06a-4d0a-9ed0-4b707614f214) | ![Simulator Screenshot - iPhone 16 - 2024-11-14 at 17 14 19](https://github.com/user-attachments/assets/7c42d2d7-7117-459c-b145-49f51251ab40) | ![Simulator Screenshot - iPhone 16 - 2024-11-14 at 17 14 21](https://github.com/user-attachments/assets/64ac3e3d-7956-47af-a6db-a24461513e8a) | ![Simulator Screenshot - iPhone 16 - 2024-11-14 at 17 20 40](https://github.com/user-attachments/assets/13e07328-d642-4eab-a349-a3509a0513dc) |

## To test

* Tap through the 2024 stories
* Verify that there are periods at the end of all descriptions in the stories

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
