### PR TITLE
Playback 2024: Top Podcasts Title spacing

### DIFF
--- a/podcasts/End of Year/Stories/2024/Top5Podcasts2024Story.swift
+++ b/podcasts/End of Year/Stories/2024/Top5Podcasts2024Story.swift
@@ -48,9 +48,8 @@ struct Top5Podcasts2024Story: ShareableStory {
                 .padding(.horizontal, 24)
                 .disabled(!isSmallScreen) // Disable scrolling on larger where we shouldn't be clipping.
                 .frame(height: geometry.size.height * 0.65)
-                VStack {
-                    StoryFooter2024(title: L10n.eoyStoryTopPodcastsTitle, description: nil)
-                }
+                StoryFooter2024(title: L10n.eoyStoryTopPodcastsTitle, description: nil)
+                .padding(.bottom, 2)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         }


### PR DESCRIPTION
| 📘 Part of: #2250 |
|:---:|

Fixes #2422

![CleanShot 2024-11-14 at 18 32 35@2x](https://github.com/user-attachments/assets/beb6116e-c132-45b7-96e5-a6c7463e17a7)

## To test

* Tap through the Playback 2024 stories
* Verify the spacing of the 

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
