### PR TITLE
Playback 2024: Fix hashtag year reference

### DIFF
--- a/podcasts/End of Year/Stories/2023/CompletionRateStory2023.swift
+++ b/podcasts/End of Year/Stories/2023/CompletionRateStory2023.swift
@@ -101,7 +101,7 @@ struct CompletionRateStory2023: ShareableStory {
     func sharingAssets() -> [Any] {
         [
             StoryShareableProvider.new(AnyView(self)),
-            StoryShareableText(L10n.eoyYearCompletionRateShareText("2023"))
+            StoryShareableText(L10n.eoyYearCompletionRateShareText("2023"), year: .y2023)
         ]
     }
 }

--- a/podcasts/End of Year/Stories/2023/ListenedNumbersStory2023.swift
+++ b/podcasts/End of Year/Stories/2023/ListenedNumbersStory2023.swift
@@ -104,7 +104,7 @@ struct ListenedNumbersStory2023: ShareableStory {
     func sharingAssets() -> [Any] {
         [
             StoryShareableProvider.new(AnyView(self)),
-            StoryShareableText(L10n.eoyStoryListenedToNumbersShareText(listenedNumbers.numberOfPodcasts, listenedNumbers.numberOfEpisodes))
+            StoryShareableText(L10n.eoyStoryListenedToNumbersShareText(listenedNumbers.numberOfPodcasts, listenedNumbers.numberOfEpisodes), year: .y2023)
         ]
     }
 }

--- a/podcasts/End of Year/Stories/2023/ListeningTimeStory2023.swift
+++ b/podcasts/End of Year/Stories/2023/ListeningTimeStory2023.swift
@@ -68,7 +68,7 @@ struct ListeningTimeStory2023: ShareableStory {
     func sharingAssets() -> [Any] {
         [
             StoryShareableProvider.new(AnyView(self)),
-            StoryShareableText(L10n.eoyStoryListenedToShareText(listeningTime.storyTimeDescriptionForSharing))
+            StoryShareableText(L10n.eoyStoryListenedToShareText(listeningTime.storyTimeDescriptionForSharing), year: .y2023)
         ]
     }
 }

--- a/podcasts/End of Year/Stories/2023/LongestEpisodeStory2023.swift
+++ b/podcasts/End of Year/Stories/2023/LongestEpisodeStory2023.swift
@@ -100,7 +100,7 @@ struct LongestEpisodeStory2023: ShareableStory {
     func sharingAssets() -> [Any] {
         [
             StoryShareableProvider.new(AnyView(self)),
-            StoryShareableText(L10n.eoyStoryLongestEpisodeShareText("%1$@"), episode: episode)
+            StoryShareableText(L10n.eoyStoryLongestEpisodeShareText("%1$@"), episode: episode, year: .y2023)
         ]
     }
 

--- a/podcasts/End of Year/Stories/2023/TopFivePodcastsStory2023.swift
+++ b/podcasts/End of Year/Stories/2023/TopFivePodcastsStory2023.swift
@@ -132,7 +132,7 @@ struct TopFivePodcastsStory2023: ShareableStory {
     func sharingAssets() -> [Any] {
         [
             StoryShareableProvider.new(AnyView(self)),
-            StoryShareableText(L10n.eoyStoryTopPodcastsShareText("%1$@"), podcasts: topPodcasts.map { $0.podcast })
+            StoryShareableText(L10n.eoyStoryTopPodcastsShareText("%1$@"), podcasts: topPodcasts.map { $0.podcast }, year: .y2023)
         ]
     }
 }

--- a/podcasts/End of Year/Stories/2023/TopListenedCategoriesStory2023.swift
+++ b/podcasts/End of Year/Stories/2023/TopListenedCategoriesStory2023.swift
@@ -92,7 +92,7 @@ struct TopListenedCategoriesStory2023: ShareableStory {
     func sharingAssets() -> [Any] {
         [
             StoryShareableProvider.new(AnyView(self)),
-            StoryShareableText(L10n.eoyStoryTopCategoriesShareText)
+            StoryShareableText(L10n.eoyStoryTopCategoriesShareText, year: .y2023)
         ]
     }
 }

--- a/podcasts/End of Year/Stories/2023/TopOnePodcastStory2023.swift
+++ b/podcasts/End of Year/Stories/2023/TopOnePodcastStory2023.swift
@@ -106,7 +106,7 @@ struct TopOnePodcastStory2023: ShareableStory {
     func sharingAssets() -> [Any] {
         [
             StoryShareableProvider.new(AnyView(self)),
-            StoryShareableText(L10n.eoyStoryTopPodcastShareText("%1$@"), podcast: topPodcast.podcast)
+            StoryShareableText(L10n.eoyStoryTopPodcastShareText("%1$@"), podcast: topPodcast.podcast, year: .y2023)
         ]
     }
 }

--- a/podcasts/End of Year/Stories/2023/YearOverYearStory2023.swift
+++ b/podcasts/End of Year/Stories/2023/YearOverYearStory2023.swift
@@ -216,7 +216,7 @@ struct YearOverYearStory2023: ShareableStory {
     func sharingAssets() -> [Any] {
         [
             StoryShareableProvider.new(AnyView(self)),
-            StoryShareableText(L10n.eoyYearOverShareText("2023", "2022"))
+            StoryShareableText(L10n.eoyYearOverShareText("2023", "2022"), year: .y2023)
         ]
     }
 }

--- a/podcasts/End of Year/Stories/2024/CompletionRate2024Story.swift
+++ b/podcasts/End of Year/Stories/2024/CompletionRate2024Story.swift
@@ -121,7 +121,7 @@ struct CompletionRate2024Story: ShareableStory {
     func sharingAssets() -> [Any] {
         [
             StoryShareableProvider.new(AnyView(self)),
-            StoryShareableText(L10n.eoyYearCompletionRateShareText("2024"))
+            StoryShareableText(L10n.eoyYearCompletionRateShareText("2024"), year: .y2024)
         ]
     }
 }

--- a/podcasts/End of Year/Stories/2024/ListeningTime2024Story.swift
+++ b/podcasts/End of Year/Stories/2024/ListeningTime2024Story.swift
@@ -57,7 +57,7 @@ struct ListeningTime2024Story: ShareableStory {
     func sharingAssets() -> [Any] {
         [
             StoryShareableProvider.new(AnyView(self)),
-            StoryShareableText(L10n.eoyStoryListenedToShareText(listeningTime.formattedTime() ?? ""))
+            StoryShareableText(L10n.eoyStoryListenedToShareText(listeningTime.formattedTime() ?? ""), year: .y2024)
         ]
     }
 }

--- a/podcasts/End of Year/Stories/2024/LongestEpisode2024Story.swift
+++ b/podcasts/End of Year/Stories/2024/LongestEpisode2024Story.swift
@@ -111,7 +111,7 @@ struct LongestEpisode2024Story: ShareableStory {
     func sharingAssets() -> [Any] {
         [
             StoryShareableProvider.new(AnyView(self)),
-            StoryShareableText(L10n.eoyStoryLongestEpisodeShareText("%1$@"), episode: episode)
+            StoryShareableText(L10n.eoyStoryLongestEpisodeShareText("%1$@"), episode: episode, year: .y2024)
         ]
     }
 

--- a/podcasts/End of Year/Stories/2024/NumberListened2024.swift
+++ b/podcasts/End of Year/Stories/2024/NumberListened2024.swift
@@ -96,7 +96,7 @@ struct NumberListened2024: ShareableStory {
     func sharingAssets() -> [Any] {
         [
             StoryShareableProvider.new(AnyView(self)),
-            StoryShareableText(L10n.eoyStoryListenedToNumbersShareText(listenedNumbers.numberOfPodcasts, listenedNumbers.numberOfEpisodes))
+            StoryShareableText(L10n.eoyStoryListenedToNumbersShareText(listenedNumbers.numberOfPodcasts, listenedNumbers.numberOfEpisodes), year: .y2024)
         ]
     }
 }

--- a/podcasts/End of Year/Stories/2024/Ratings2024Story.swift
+++ b/podcasts/End of Year/Stories/2024/Ratings2024Story.swift
@@ -145,7 +145,7 @@ struct Ratings2024Story: ShareableStory {
         let totalRatings = ratings.values.reduce(0, +)
         return [
             StoryShareableProvider.new(AnyView(self)),
-            StoryShareableText(L10n.eoyYearRatingsShareText(totalRatings, "2024", mostCommonRating))
+            StoryShareableText(L10n.eoyYearRatingsShareText(totalRatings, "2024", mostCommonRating), year: .y2024)
         ]
     }
 

--- a/podcasts/End of Year/Stories/2024/Top5Podcasts2024Story.swift
+++ b/podcasts/End of Year/Stories/2024/Top5Podcasts2024Story.swift
@@ -132,7 +132,7 @@ struct Top5Podcasts2024Story: ShareableStory {
     func sharingAssets() -> [Any] {
         [
             StoryShareableProvider.new(AnyView(self)),
-            StoryShareableText(L10n.eoyStoryTopPodcastsShareText("%1$@"), podcasts: top5Podcasts.map { $0.podcast })
+            StoryShareableText(L10n.eoyStoryTopPodcastsShareText("%1$@"), podcasts: top5Podcasts.map { $0.podcast }, year: .y2024)
         ]
     }
 }

--- a/podcasts/End of Year/Stories/2024/TopSpotStory2024.swift
+++ b/podcasts/End of Year/Stories/2024/TopSpotStory2024.swift
@@ -55,7 +55,7 @@ struct TopSpotStory2024: ShareableStory {
     func sharingAssets() -> [Any] {
         [
             StoryShareableProvider.new(AnyView(self)),
-            StoryShareableText(L10n.eoyStoryTopPodcastShareText("%1$@"), podcast: topPodcast.podcast)
+            StoryShareableText(L10n.eoyStoryTopPodcastShareText("%1$@"), podcast: topPodcast.podcast, year: .y2024)
         ]
     }
 }

--- a/podcasts/End of Year/Stories/2024/YearOverYearCompare2024Story.swift
+++ b/podcasts/End of Year/Stories/2024/YearOverYearCompare2024Story.swift
@@ -90,7 +90,7 @@ struct YearOverYearCompare2024Story: ShareableStory {
     func sharingAssets() -> [Any] {
         [
             StoryShareableProvider.new(AnyView(self)),
-            StoryShareableText(L10n.eoyYearOverShareText("2024", "2023"))
+            StoryShareableText(L10n.eoyYearOverShareText("2024", "2023"), year: .y2024)
         ]
     }
 

--- a/podcasts/End of Year/StoryShareableText.swift
+++ b/podcasts/End of Year/StoryShareableText.swift
@@ -13,35 +13,45 @@ class StoryShareableText: UIActivityItemProvider, ShareableMetadataDataSource {
 
     var shareableMetadataProvider = ShareableMetadataProvider()
 
+    private var year: EndOfYear.Year
+
     var hashtags: [String] {
-        ["pocketcasts", "playback2023"]
+        var hashtags = ["pocketcasts"]
+        if let year = year.year {
+            hashtags.append("playback\(year)")
+        }
+        return hashtags
     }
 
     var shareableLink: String {
         return [shortenedURL, longURL, podcastListURL].compactMap { $0 }.first ?? pocketCastsUrl
     }
 
-    init(_ text: String) {
+    init(_ text: String, year: EndOfYear.Year) {
         self.text = text
+        self.year = year
         super.init(placeholderItem: self.text)
     }
 
-    init(_ text: String, podcast: Podcast) {
+    init(_ text: String, podcast: Podcast, year: EndOfYear.Year) {
         self.text = text
+        self.year = year
         super.init(placeholderItem: self.text)
         self.longURL = podcast.shareURL
         requestShortenedURL()
     }
 
-    init(_ text: String, episode: Episode) {
+    init(_ text: String, episode: Episode, year: EndOfYear.Year) {
         self.text = text
+        self.year = year
         super.init(placeholderItem: self.text)
         self.longURL = episode.shareURL
         requestShortenedURL()
     }
 
-    init(_ text: String, podcasts: [Podcast]) {
+    init(_ text: String, podcasts: [Podcast], year: EndOfYear.Year) {
         self.text = text
+        self.year = year
         super.init(placeholderItem: self.text)
         podcastListURL = ""
         createList(from: podcasts)


### PR DESCRIPTION
| 📘 Part of: #2250 |
|:---:|

Fixes #2449

## To test

* Navigate to the Playback 2024
* Share stories from Playback to a social network like Tumblr or Slack and verify the text contains `#pocketcasts #playback2024` hashtags

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
