### PR TITLE
Replaced GitHub 'Discussions' link to Pocket Casts Forum in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,8 @@ Before anything else, please take a moment to read our [Code of Conduct](CODE-OF
 
 ## Reporting Bugs, Asking Questions, and Suggesting Features
 
+Have a suggestion or feedback? Please visit the [Pocket Casts Forum](https://forums.pocketcasts.com).
+
 For bugs, please head to [Issues](https://github.com/Automattic/pocket-casts-ios/issues) and [open a new issue](https://github.com/Automattic/pocket-casts-ios/issues/new). Screenshots help us resolve issues and answer questions faster, so thanks for including some if you can.
 
 ## Translating

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,8 +8,6 @@ Before anything else, please take a moment to read our [Code of Conduct](CODE-OF
 
 ## Reporting Bugs, Asking Questions, and Suggesting Features
 
-Have a suggestion or feedback? Please go to [Discussions](https://github.com/Automattic/pocket-casts-ios/discussions) and [open a new discussion](https://github.com/Automattic/pocket-casts-ios/discussions/new). 
-
 For bugs, please head to [Issues](https://github.com/Automattic/pocket-casts-ios/issues) and [open a new issue](https://github.com/Automattic/pocket-casts-ios/issues/new). Screenshots help us resolve issues and answer questions faster, so thanks for including some if you can.
 
 ## Translating


### PR DESCRIPTION
Removed sentences pointing people to the pocket-casts-ios repo's 'Discussions' section, as they're no longer available.

Ideally, a replacement forum (Pocket Casts Slack workspace?) should be offered. I personally needed a bit of help setting up my environment before I contributed.
