### PR TITLE
Ensure dismiss of referral tip is done before presenting EOY 2024

### DIFF
--- a/podcasts/ProfileViewController.swift
+++ b/podcasts/ProfileViewController.swift
@@ -377,6 +377,7 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
             let navController = SJUIUtils.navController(for: OnlineSupportController())
             present(navController, animated: true, completion: nil)
         case .endOfYearPrompt:
+            dismiss(animated: true)
             Analytics.track(.endOfYearProfileCardTapped)
             if let endOfYear = (tabBarController as? MainTabBarController)?.endOfYear {
                 endOfYear.showStories(in: self, from: .profile)


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes #2456 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR just ensures that the referral tip is dismissed before present the eoy screen.

## To test

1. Start the app by doing a clean install
2. Login with an account that as a subscription, Plus or Patron and enough info to show EOY 2024
3. Go to Profile tab
4. You should see the referral tip on the top left
5. Tap on the EOY banner 
6. Check that the tip banner is dismissed and the EOY screen is show correctly

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
