### PR TITLE
Manage downloads: show modal on auto-downloads and storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 7.78
 -----
 - File downloads use switch instead of check box for include starred [#2455](https://github.com/Automattic/pocket-casts-ios/pull/2455)
+- Show download management banner and modal when running low in disk space [#2430](https://github.com/Automattic/pocket-casts-ios/pull/2430)
 
 7.77
 -----

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -253,7 +253,7 @@ public enum FeatureFlag: String, CaseIterable {
         case .winback:
             false
         case .manageDownloadedEpisodes:
-            false
+            true
         }
     }
 

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1750,6 +1750,7 @@
 		FF06AFA82CB692D30099EC9B /* MediaFileHandle.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF06AFA62CB692D30099EC9B /* MediaFileHandle.swift */; };
 		FF09982E2CDA996D00C1647B /* MarqueeTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF09982D2CDA996D00C1647B /* MarqueeTextView.swift */; };
 		FF0998302CE79C8F00C1647B /* ManageDownloadsBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF09982F2CE79C7500C1647B /* ManageDownloadsBannerView.swift */; };
+		FF0998322CEC026D00C1647B /* ManageDownloadsModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0998312CEC026D00C1647B /* ManageDownloadsModalView.swift */; };
 		FF0A1D522C580CF5003931E6 /* TranscriptsDataRetriever.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF6BBCF12C578CE600604A01 /* TranscriptsDataRetriever.swift */; };
 		FF1D0CB82C9CE11300F600C6 /* ReferralsMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF1D0CB72C9CE11300F600C6 /* ReferralsMessageView.swift */; };
 		FF1D0CBA2C9DC62200F600C6 /* ReferralsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF1D0CB92C9DC62200F600C6 /* ReferralsCoordinator.swift */; };
@@ -3695,6 +3696,7 @@
 		FF06AFA62CB692D30099EC9B /* MediaFileHandle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaFileHandle.swift; sourceTree = "<group>"; };
 		FF09982D2CDA996D00C1647B /* MarqueeTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarqueeTextView.swift; sourceTree = "<group>"; };
 		FF09982F2CE79C7500C1647B /* ManageDownloadsBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManageDownloadsBannerView.swift; sourceTree = "<group>"; };
+		FF0998312CEC026D00C1647B /* ManageDownloadsModalView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ManageDownloadsModalView.swift; sourceTree = "<group>"; };
 		FF1D0CB72C9CE11300F600C6 /* ReferralsMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReferralsMessageView.swift; sourceTree = "<group>"; };
 		FF1D0CB92C9DC62200F600C6 /* ReferralsCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReferralsCoordinator.swift; sourceTree = "<group>"; };
 		FF1DF0192C8A206E0028B8D8 /* ReferralCardAnimatedGradientView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReferralCardAnimatedGradientView.swift; sourceTree = "<group>"; };
@@ -5947,6 +5949,7 @@
 			isa = PBXGroup;
 			children = (
 				FF09982F2CE79C7500C1647B /* ManageDownloadsBannerView.swift */,
+				FF0998312CEC026D00C1647B /* ManageDownloadsModalView.swift */,
 				BDA2065E1BB3D4D600D38389 /* DownloadsViewController.swift */,
 				BDF5FD1D1FD8D38900F2A339 /* DownloadsViewController+Table.swift */,
 				BDDF8AA7240CEBF9009BA263 /* DownloadsViewController+Swipe.swift */,
@@ -10149,6 +10152,7 @@
 				40164A6B23DAAF8B0043907B /* PromotionAcknowledgementViewController.swift in Sources */,
 				10756F852C5944660089D34F /* Podcast+Sortable.swift in Sources */,
 				C7ADDD202AD73DD000471853 /* BookmarksAnnouncement.swift in Sources */,
+				FF0998322CEC026D00C1647B /* ManageDownloadsModalView.swift in Sources */,
 				107836232C5CDD5000DA3FF0 /* GiveRatingsWhatsNewHeader.swift in Sources */,
 				C7A110E6291EF2DF00887A90 /* PlusLandingViewModel.swift in Sources */,
 				8B484EF528D23BEF001AFA97 /* PlaybackTimeHelper.swift in Sources */,

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1758,6 +1758,7 @@
 		FF1DF0202C8F411E0028B8D8 /* ReferralsClaimPass.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF1DF01F2C8F411E0028B8D8 /* ReferralsClaimPass.swift */; };
 		FF1DF0222C8F4D160028B8D8 /* ReferralClaimPassVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF1DF0212C8F4D160028B8D8 /* ReferralClaimPassVC.swift */; };
 		FF1DF0252C8F4E2F0028B8D8 /* ReferralsClaimBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF1DF0242C8F4E2F0028B8D8 /* ReferralsClaimBannerView.swift */; };
+		FF1EC6862CECBC7D006FBF9B /* ManageDownloadsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF1EC6852CECBC73006FBF9B /* ManageDownloadsCoordinator.swift */; };
 		FF2142D42C07369200672D8D /* MediaExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF2142D32C07369200672D8D /* MediaExporter.swift */; };
 		FF2142D52C07369200672D8D /* MediaExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF2142D32C07369200672D8D /* MediaExporter.swift */; };
 		FF2CD57C2B9F4B2D009B58B5 /* PocketCastsDataModel in Frameworks */ = {isa = PBXBuildFile; productRef = FF2CD57B2B9F4B2D009B58B5 /* PocketCastsDataModel */; };
@@ -3703,6 +3704,7 @@
 		FF1DF01F2C8F411E0028B8D8 /* ReferralsClaimPass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReferralsClaimPass.swift; sourceTree = "<group>"; };
 		FF1DF0212C8F4D160028B8D8 /* ReferralClaimPassVC.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReferralClaimPassVC.swift; sourceTree = "<group>"; };
 		FF1DF0242C8F4E2F0028B8D8 /* ReferralsClaimBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReferralsClaimBannerView.swift; sourceTree = "<group>"; };
+		FF1EC6852CECBC73006FBF9B /* ManageDownloadsCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManageDownloadsCoordinator.swift; sourceTree = "<group>"; };
 		FF2142D32C07369200672D8D /* MediaExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaExporter.swift; sourceTree = "<group>"; };
 		FF3DF62E2CA42F1B007CF697 /* UIView+Nib.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Nib.swift"; sourceTree = "<group>"; };
 		FF40C0652C65175B003A9D93 /* TranscriptErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptErrorView.swift; sourceTree = "<group>"; };
@@ -5948,6 +5950,7 @@
 		BD7516E01C0FC8180099F53E /* Downloads */ = {
 			isa = PBXGroup;
 			children = (
+				FF1EC6852CECBC73006FBF9B /* ManageDownloadsCoordinator.swift */,
 				FF09982F2CE79C7500C1647B /* ManageDownloadsBannerView.swift */,
 				FF0998312CEC026D00C1647B /* ManageDownloadsModalView.swift */,
 				BDA2065E1BB3D4D600D38389 /* DownloadsViewController.swift */,
@@ -9786,6 +9789,7 @@
 				408C08872314BB50008C9667 /* WhatsNewThemeableImageView.swift in Sources */,
 				409C793A223899A500386495 /* AllArchivedPlaceholder.swift in Sources */,
 				FF91A0F62B64159D002A0590 /* UIScreen+Sizes.swift in Sources */,
+				FF1EC6862CECBC7D006FBF9B /* ManageDownloadsCoordinator.swift in Sources */,
 				FF91A0FE2B6BC4BD002A0590 /* FeaturesCarousel.swift in Sources */,
 				4047E1782419B2F800B79177 /* ServerSyncManager.swift in Sources */,
 				BD9FF6241B8EF81A009F075E /* CategoryCell.swift in Sources */,

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -164,6 +164,8 @@ enum AnalyticsEvent: String {
     case downloadsOptionsModalOptionTapped
     case freeUpSpaceBannerShown
     case freeUpSpaceManageDownloadsTapped
+    case freeUpSpaceModalShown
+    case freeUpSpaceMaybeLaterTapped
 
     case downloadsMultiSelectEntered
     case downloadsSelectAllButtonTapped

--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -199,6 +199,11 @@ struct Constants {
             static let showTip = "referrals.showtip"
             static let claimURL = "referrals.claimURL"
         }
+
+        enum manageDownloads {
+            static let lastCheckDate = "manageDownloadsLastCheckDate"
+        }
+
     }
 
     enum Values {

--- a/podcasts/DownloadSettingsViewController.swift
+++ b/podcasts/DownloadSettingsViewController.swift
@@ -255,10 +255,11 @@ class DownloadSettingsViewController: PCViewController, UITableViewDataSource, U
         else {
             return
         }
-        Analytics.track(.freeUpSpaceBannerShown)
+        Analytics.track(.freeUpSpaceModalShown, properties: ["source": "auto_download"])
         let modalView = ManageDownloadsBannerModel(initialSize: "", onManageTap: {
-
+            Analytics.track(.freeUpSpaceManageDownloadsTapped, properties: ["source": "auto_download"])
         }, onNotNowTap: { [weak self] in
+            Analytics.track(.freeUpSpaceMaybeLaterTapped)
             self?.dismiss(animated: true)
         })
         let vc = ThemedHostingController(rootView: ManageDownloadsModalView(dataModel: modalView))

--- a/podcasts/DownloadSettingsViewController.swift
+++ b/podcasts/DownloadSettingsViewController.swift
@@ -25,7 +25,7 @@ class DownloadSettingsViewController: PCViewController, UITableViewDataSource, U
         NotificationCenter.default.addObserver(self, selector: #selector(podcastUpdated(_:)), name: Constants.Notifications.podcastUpdated, object: nil)
         insetAdjuster.setupInsetAdjustmentsForMiniPlayer(scrollView: settingsTable)
         Analytics.track(.settingsAutoDownloadShown)
-        showManageDownloadsModal()
+        ManageDownloadsCoordinator.showModalIfNeeded(from: self, source: "auto_download")
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -248,31 +248,6 @@ class DownloadSettingsViewController: PCViewController, UITableViewDataSource, U
         }
         return data
     }
-
-    private func showManageDownloadsModal() {
-        guard FeatureFlag.manageDownloadedEpisodes.enabled,
-              ManageDownloadsModel.shouldShowBanner
-        else {
-            return
-        }
-        Analytics.track(.freeUpSpaceModalShown, properties: ["source": "auto_download"])
-        let modalView = ManageDownloadsModel(initialSize: "", onManageTap: { [weak self] in
-            Analytics.track(.freeUpSpaceManageDownloadsTapped, properties: ["source": "auto_download"])
-            self?.dismiss(animated: true, completion: {
-                self?.navigationController?.pushViewController(DownloadedFilesViewController(), animated: true)
-            })
-        }, onNotNowTap: { [weak self] in
-            Analytics.track(.freeUpSpaceMaybeLaterTapped)
-            self?.dismiss(animated: true)
-        })
-        let vc = ThemedHostingController(rootView: ManageDownloadsModalView(dataModel: modalView))
-        if let sheet = vc.sheetPresentationController {
-            sheet.detents = [.medium()]
-            sheet.prefersGrabberVisible = true
-        }
-        present(vc, animated: true)
-    }
-
 }
 
 extension AutoDownloadLimit {

--- a/podcasts/DownloadSettingsViewController.swift
+++ b/podcasts/DownloadSettingsViewController.swift
@@ -25,6 +25,7 @@ class DownloadSettingsViewController: PCViewController, UITableViewDataSource, U
         NotificationCenter.default.addObserver(self, selector: #selector(podcastUpdated(_:)), name: Constants.Notifications.podcastUpdated, object: nil)
         insetAdjuster.setupInsetAdjustmentsForMiniPlayer(scrollView: settingsTable)
         Analytics.track(.settingsAutoDownloadShown)
+        showManageDownloadsModal()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -247,6 +248,27 @@ class DownloadSettingsViewController: PCViewController, UITableViewDataSource, U
         }
         return data
     }
+
+    private func showManageDownloadsModal() {
+        guard FeatureFlag.manageDownloadedEpisodes.enabled,
+              ManageDownloadsBannerModel.shouldShowBanner
+        else {
+            return
+        }
+        Analytics.track(.freeUpSpaceBannerShown)
+        let modalView = ManageDownloadsBannerModel(initialSize: "", onManageTap: {
+
+        }, onNotNowTap: { [weak self] in
+            self?.dismiss(animated: true)
+        })
+        let vc = ThemedHostingController(rootView: ManageDownloadsModalView(dataModel: modalView))
+        if let sheet = vc.sheetPresentationController {
+            sheet.detents = [.medium()]
+            sheet.prefersGrabberVisible = true
+        }
+        present(vc, animated: true)
+    }
+
 }
 
 extension AutoDownloadLimit {

--- a/podcasts/DownloadSettingsViewController.swift
+++ b/podcasts/DownloadSettingsViewController.swift
@@ -251,12 +251,12 @@ class DownloadSettingsViewController: PCViewController, UITableViewDataSource, U
 
     private func showManageDownloadsModal() {
         guard FeatureFlag.manageDownloadedEpisodes.enabled,
-              ManageDownloadsBannerModel.shouldShowBanner
+              ManageDownloadsModel.shouldShowBanner
         else {
             return
         }
         Analytics.track(.freeUpSpaceModalShown, properties: ["source": "auto_download"])
-        let modalView = ManageDownloadsBannerModel(initialSize: "", onManageTap: { [weak self] in
+        let modalView = ManageDownloadsModel(initialSize: "", onManageTap: { [weak self] in
             Analytics.track(.freeUpSpaceManageDownloadsTapped, properties: ["source": "auto_download"])
             self?.dismiss(animated: true, completion: {
                 self?.navigationController?.pushViewController(DownloadedFilesViewController(), animated: true)

--- a/podcasts/DownloadSettingsViewController.swift
+++ b/podcasts/DownloadSettingsViewController.swift
@@ -256,8 +256,11 @@ class DownloadSettingsViewController: PCViewController, UITableViewDataSource, U
             return
         }
         Analytics.track(.freeUpSpaceModalShown, properties: ["source": "auto_download"])
-        let modalView = ManageDownloadsBannerModel(initialSize: "", onManageTap: {
+        let modalView = ManageDownloadsBannerModel(initialSize: "", onManageTap: { [weak self] in
             Analytics.track(.freeUpSpaceManageDownloadsTapped, properties: ["source": "auto_download"])
+            self?.dismiss(animated: true, completion: {
+                self?.navigationController?.pushViewController(DownloadedFilesViewController(), animated: true)
+            })
         }, onNotNowTap: { [weak self] in
             Analytics.track(.freeUpSpaceMaybeLaterTapped)
             self?.dismiss(animated: true)

--- a/podcasts/DownloadsViewController.swift
+++ b/podcasts/DownloadsViewController.swift
@@ -141,7 +141,7 @@ class DownloadsViewController: PCViewController {
 
     private func showManageDownloadsBanner() {
         guard FeatureFlag.manageDownloadedEpisodes.enabled,
-              ManageDownloadsBannerModel.shouldShowBanner
+              ManageDownloadsModel.shouldShowBanner
         else {
             downloadsTable.tableHeaderView = nil
             return
@@ -151,7 +151,7 @@ class DownloadsViewController: PCViewController {
     }
 
     private lazy var bannerView: UIView = {
-        let banner = ManageDownloadsBannerView(dataModel: ManageDownloadsBannerModel(initialSize: "", onManageTap: { [weak self] in
+        let banner = ManageDownloadsBannerView(dataModel: ManageDownloadsModel(initialSize: "", onManageTap: { [weak self] in
             Analytics.track(.freeUpSpaceManageDownloadsTapped, properties: ["source": "downloads"])
             self?.navigationController?.pushViewController(DownloadedFilesViewController(), animated: true)
         })).themedUIView

--- a/podcasts/DownloadsViewController.swift
+++ b/podcasts/DownloadsViewController.swift
@@ -140,8 +140,7 @@ class DownloadsViewController: PCViewController {
     }
 
     private func showManageDownloadsBanner() {
-        guard FeatureFlag.manageDownloadedEpisodes.enabled,
-              ManageDownloadsModel.shouldShowBanner
+        guard ManageDownloadsCoordinator.shouldShowBanner
         else {
             downloadsTable.tableHeaderView = nil
             return

--- a/podcasts/EpisodeManager.swift
+++ b/podcasts/EpisodeManager.swift
@@ -414,6 +414,12 @@ class EpisodeManager: NSObject {
         }
     }
 
+    class func hasDownloadedEpisodes() -> Bool {
+        let query = "episodeStatus == \(DownloadStatus.downloaded.rawValue) LIMIT 1"
+        let list = DataManager.sharedManager.findEpisodesWhere(customWhere: query, arguments: nil)
+        return !list.isEmpty
+    }
+
     private class func allDownloadedEpisodes() -> [Episode] {
         let query = "episodeStatus == \(DownloadStatus.downloaded.rawValue)"
 

--- a/podcasts/ManageDownloadsBannerView.swift
+++ b/podcasts/ManageDownloadsBannerView.swift
@@ -28,15 +28,6 @@ class ManageDownloadsModel: ObservableObject {
             }
         }
     }
-
-    static var shouldShowBanner: Bool {
-        guard let percentage = FileManager.devicePercentageFreeSpace,
-              EpisodeManager.hasDownloadedEpisodes()
-        else {
-            return false
-        }
-        return percentage < 0.1
-    }
 }
 
 struct ManageDownloadsBannerView: View {

--- a/podcasts/ManageDownloadsBannerView.swift
+++ b/podcasts/ManageDownloadsBannerView.swift
@@ -7,10 +7,12 @@ class ManageDownloadsBannerModel: ObservableObject {
     @Published var sizeOccupied: String = ""
 
     let onManageTap: (() -> ())?
+    let onNotNowTap: (() -> ())?
 
-    init(initialSize: String, onManageTap: (() -> ())? = nil) {
+    init(initialSize: String, onManageTap: (() -> ())? = nil, onNotNowTap: (() -> ())? = nil) {
         _sizeOccupied = .init(initialValue: initialSize)
         self.onManageTap = onManageTap
+        self.onNotNowTap = onNotNowTap
         loadData()
     }
 

--- a/podcasts/ManageDownloadsBannerView.swift
+++ b/podcasts/ManageDownloadsBannerView.swift
@@ -30,7 +30,9 @@ class ManageDownloadsModel: ObservableObject {
     }
 
     static var shouldShowBanner: Bool {
-        guard let percentage = FileManager.devicePercentageFreeSpace else {
+        guard let percentage = FileManager.devicePercentageFreeSpace,
+              EpisodeManager.hasDownloadedEpisodes()
+        else {
             return false
         }
         return percentage < 0.1

--- a/podcasts/ManageDownloadsBannerView.swift
+++ b/podcasts/ManageDownloadsBannerView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import PocketCastsUtils
 import Combine
 
-class ManageDownloadsBannerModel: ObservableObject {
+class ManageDownloadsModel: ObservableObject {
 
     @Published var sizeOccupied: String = ""
 
@@ -41,7 +41,7 @@ struct ManageDownloadsBannerView: View {
 
     @EnvironmentObject var theme: Theme
 
-    @ObservedObject var dataModel: ManageDownloadsBannerModel
+    @ObservedObject var dataModel: ManageDownloadsModel
 
     var body: some View {
         HStack(alignment: .top) {

--- a/podcasts/ManageDownloadsCoordinator.swift
+++ b/podcasts/ManageDownloadsCoordinator.swift
@@ -12,15 +12,16 @@ class ManageDownloadsCoordinator {
         else {
             return false
         }
-        if let lastCheckDate = Settings.manageDownloadsLastCheckDate, fabs(lastCheckDate.timeIntervalSince(Date.now)) > 7.days {
-            return false
-        }
         return percentage < 0.1
     }
 
     static func showModalIfNeeded(from presentationVC: UIViewController, source: String) {
         guard Self.shouldShowBanner
         else {
+            return
+        }
+        if let lastCheckDate = Settings.manageDownloadsLastCheckDate,
+           fabs(lastCheckDate.timeIntervalSince(Date.now)) < 7.days {
             return
         }
         Analytics.track(.freeUpSpaceModalShown, properties: ["source": source])

--- a/podcasts/ManageDownloadsCoordinator.swift
+++ b/podcasts/ManageDownloadsCoordinator.swift
@@ -1,0 +1,45 @@
+import Foundation
+import UIKit
+import SwiftUI
+import PocketCastsUtils
+
+class ManageDownloadsCoordinator {
+
+    static var shouldShowBanner: Bool {
+        guard FeatureFlag.manageDownloadedEpisodes.enabled,
+              let percentage = FileManager.devicePercentageFreeSpace,
+              EpisodeManager.hasDownloadedEpisodes()
+        else {
+            return false
+        }
+        if let lastCheckDate = Settings.manageDownloadsLastCheckDate, fabs(lastCheckDate.timeIntervalSince(Date.now)) > 7.days {
+            return false
+        }
+        return percentage < 0.1
+    }
+
+    static func showModalIfNeeded(from presentationVC: UIViewController, source: String) {
+        guard Self.shouldShowBanner
+        else {
+            return
+        }
+        Analytics.track(.freeUpSpaceModalShown, properties: ["source": source])
+        let modalView = ManageDownloadsModel(initialSize: "", onManageTap: { [weak presentationVC] in
+            Analytics.track(.freeUpSpaceManageDownloadsTapped, properties: ["source": source])
+            presentationVC?.dismiss(animated: true, completion: {
+                presentationVC?.navigationController?.pushViewController(DownloadedFilesViewController(), animated: true)
+            })
+        }, onNotNowTap: { [weak presentationVC] in
+            Analytics.track(.freeUpSpaceMaybeLaterTapped)
+            Settings.manageDownloadsLastCheckDate = Date.now
+            presentationVC?.dismiss(animated: true)
+        })
+        let themedVC = ThemedHostingController(rootView: ManageDownloadsModalView(dataModel: modalView))
+        if let sheet = themedVC.sheetPresentationController {
+            sheet.detents = [.medium()]
+            sheet.prefersGrabberVisible = true
+        }
+        presentationVC.present(themedVC, animated: true)
+    }
+
+}

--- a/podcasts/ManageDownloadsModalView.swift
+++ b/podcasts/ManageDownloadsModalView.swift
@@ -1,0 +1,57 @@
+import SwiftUI
+import PocketCastsUtils
+import Combine
+
+struct ManageDownloadsModalView: View {
+
+    @EnvironmentObject var theme: Theme
+
+    @ObservedObject var dataModel: ManageDownloadsBannerModel
+
+    var body: some View {
+        VStack(alignment: .center, spacing: 8) {
+            Image("cleanup")
+                .foregroundColor(theme.primaryText02Selected)
+                .frame(width: 40, height: 40)
+            Text(L10n.manageDownloadsTitle)
+                .font(.system(size: 23, weight: .bold))
+                .foregroundColor(theme.primaryText01)
+            Text(L10n.manageDownloadsDetail(dataModel.sizeOccupied))
+                .lineLimit(nil)
+                .fixedSize(horizontal: false, vertical: true)
+                .multilineTextAlignment(.leading)
+                .font(.system(size: 14, weight: .medium))
+                .foregroundColor(theme.primaryText01)
+            Spacer()
+            Button() {
+                dataModel.onManageTap?()
+            } label: {
+                Text(L10n.manageDownloadsAction)
+                    .font(.system(size: 14, weight: .medium))
+            }
+            .buttonStyle(RoundedButtonStyle(theme: theme))
+            Button() {
+                dataModel.onNotNowTap?()
+            } label: {
+                Text(L10n.maybeLater)
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundColor(theme.primaryText01)
+            }.frame(height: 56)
+        }
+        .background(theme.primaryUi01)
+    }
+}
+
+#Preview("Light") {
+    ManageDownloadsModalView(dataModel: .init(initialSize: "100 MB"))
+        .environmentObject(Theme(previewTheme: .light))
+        .padding(16)
+        .frame(height: 132)
+}
+
+#Preview("Dark") {
+    ManageDownloadsModalView(dataModel: .init(initialSize: "100 MB"))
+        .environmentObject(Theme(previewTheme: .dark))
+        .padding(16)
+        .frame(height: 132)
+}

--- a/podcasts/ManageDownloadsModalView.swift
+++ b/podcasts/ManageDownloadsModalView.swift
@@ -6,7 +6,7 @@ struct ManageDownloadsModalView: View {
 
     @EnvironmentObject var theme: Theme
 
-    @ObservedObject var dataModel: ManageDownloadsBannerModel
+    @ObservedObject var dataModel: ManageDownloadsModel
 
     var body: some View {
         VStack(alignment: .center, spacing: 8) {

--- a/podcasts/ManageDownloadsModalView.swift
+++ b/podcasts/ManageDownloadsModalView.swift
@@ -10,9 +10,11 @@ struct ManageDownloadsModalView: View {
 
     var body: some View {
         VStack(alignment: .center, spacing: 8) {
+            Spacer()
             Image("cleanup")
-                .foregroundColor(theme.primaryText02Selected)
+                .resizable()
                 .frame(width: 40, height: 40)
+                .foregroundColor(theme.primaryText02Selected)
             Text(L10n.manageDownloadsTitle)
                 .font(.system(size: 23, weight: .bold))
                 .foregroundColor(theme.primaryText01)
@@ -38,6 +40,8 @@ struct ManageDownloadsModalView: View {
                     .foregroundColor(theme.primaryText01)
             }.frame(height: 56)
         }
+        .padding()
+        .ignoresSafeArea()
         .background(theme.primaryUi01)
     }
 }
@@ -46,12 +50,10 @@ struct ManageDownloadsModalView: View {
     ManageDownloadsModalView(dataModel: .init(initialSize: "100 MB"))
         .environmentObject(Theme(previewTheme: .light))
         .padding(16)
-        .frame(height: 132)
 }
 
 #Preview("Dark") {
     ManageDownloadsModalView(dataModel: .init(initialSize: "100 MB"))
         .environmentObject(Theme(previewTheme: .dark))
         .padding(16)
-        .frame(height: 132)
 }

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -1330,6 +1330,18 @@ class Settings: NSObject {
         }
     }
 
+    // MARK: - Manage Downloads
+
+    class var manageDownloadsLastCheckDate: Date? {
+        set {
+            UserDefaults.standard.set(newValue, forKey: Constants.UserDefaults.manageDownloads.lastCheckDate)
+        }
+
+        get {
+            UserDefaults.standard.object(forKey: Constants.UserDefaults.manageDownloads.lastCheckDate) as? Date
+        }
+    }
+
     // MARK: - Database (internal)
 
     class var upgradedIndexes: Bool {

--- a/podcasts/StorageAndDataUseViewController.swift
+++ b/podcasts/StorageAndDataUseViewController.swift
@@ -89,12 +89,12 @@ class StorageAndDataUseViewController: PCViewController, UITableViewDelegate, UI
 
     private func showManageDownloadsModal() {
         guard FeatureFlag.manageDownloadedEpisodes.enabled,
-              ManageDownloadsBannerModel.shouldShowBanner
+              ManageDownloadsModel.shouldShowBanner
         else {
             return
         }
         Analytics.track(.freeUpSpaceModalShown, properties: ["source": "storage_and_data_usage"])
-        let modalView = ManageDownloadsBannerModel(initialSize: "", onManageTap: { [weak self] in
+        let modalView = ManageDownloadsModel(initialSize: "", onManageTap: { [weak self] in
             Analytics.track(.freeUpSpaceManageDownloadsTapped, properties: ["source": "storage_and_data_usage"])
             self?.dismiss(animated: true, completion: {
                 self?.navigationController?.pushViewController(DownloadedFilesViewController(), animated: true)

--- a/podcasts/StorageAndDataUseViewController.swift
+++ b/podcasts/StorageAndDataUseViewController.swift
@@ -19,7 +19,7 @@ class StorageAndDataUseViewController: PCViewController, UITableViewDelegate, UI
 
         title = L10n.settingsStorage
         Analytics.track(.settingsStorageShown)
-        showManageDownloadsModal()
+        ManageDownloadsCoordinator.showModalIfNeeded(from: self, source: "storage_and_data_usage")
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -85,29 +85,5 @@ class StorageAndDataUseViewController: PCViewController, UITableViewDelegate, UI
 
     @objc private func warnWhenNotOnWifiToggled(_ sender: UISwitch) {
         Settings.setMobileDataAllowed(!sender.isOn, userInitiated: true)
-    }
-
-    private func showManageDownloadsModal() {
-        guard FeatureFlag.manageDownloadedEpisodes.enabled,
-              ManageDownloadsModel.shouldShowBanner
-        else {
-            return
-        }
-        Analytics.track(.freeUpSpaceModalShown, properties: ["source": "storage_and_data_usage"])
-        let modalView = ManageDownloadsModel(initialSize: "", onManageTap: { [weak self] in
-            Analytics.track(.freeUpSpaceManageDownloadsTapped, properties: ["source": "storage_and_data_usage"])
-            self?.dismiss(animated: true, completion: {
-                self?.navigationController?.pushViewController(DownloadedFilesViewController(), animated: true)
-            })
-        }, onNotNowTap: { [weak self] in
-            Analytics.track(.freeUpSpaceMaybeLaterTapped)
-            self?.dismiss(animated: true)
-        })
-        let vc = ThemedHostingController(rootView: ManageDownloadsModalView(dataModel: modalView))
-        if let sheet = vc.sheetPresentationController {
-            sheet.detents = [.medium()]
-            sheet.prefersGrabberVisible = true
-        }
-        present(vc, animated: true)
     }
 }


### PR DESCRIPTION
| 📘 Part of: #2430  |  <!-- project issue number, if applicable -->
|:---:|

Fixes #2432 #2433 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR adds the display of the modal for managing download on the following screens: Storage & Data Use and Auto Download settings

| 1 | 2 |
| - | - |
| ![Simulator Screenshot - iPhone 16 Pro - 2024-11-19 at 12 01 01](https://github.com/user-attachments/assets/1a57bc90-bc48-4026-ab67-3536dd3fe8dc) | ![Simulator Screenshot - iPhone 16 Pro - 2024-11-19 at 12 00 49](https://github.com/user-attachments/assets/6bf12544-3436-4cb6-8ff7-c8dbbae8837f) |

## To test

1. Start the app
2. Ensure that you have the `manageDownloadedEpisodes` FF active and the `tracksLogging` FF
3. Download some episode files
4. Go to Profile -> Settings
5. Tap on Auto-Download
6. Check if you see the modal on the top and the event `freeUpSpaceModalShown` on the console with the source property `auto_download`
7. Tap on `Manage Downloads`
8. Check if the files screen is show.
9. Check if the event: `freeUpSpaceManageDownloadsTapped` is show in console with the source: `auto_download` property
10. Go to Profile -> Settings
11. Tap on Storage & Data Usage
12. Check if you see the modal on the top and the event `freeUpSpaceModalShown` on the console with the source property `storage_and_data_usage`
13. Tap on `Manage Downloads`
14. Check if the files screen is show.
15. Check if the event: `freeUpSpaceManageDownloadsTapped` is show in console with the source: `storage_and_data_usage` property
16. Go back to Profile and Tap on Storage & Data Usage
17. Tap on Not Now
18. Check if f the event: `freeUpSpaceMaybeLaterTapped` is show in console with the source: `storage_and_data_usage` property
19. Go back to the Auto Downloads and Storage & Data Usage screen and ensure that the manage downloads modal is not show


## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
