### PR TITLE
Fix download date for stream downloads

### DIFF
--- a/podcasts/DownloadManager+URLSessionDelegate.swift
+++ b/podcasts/DownloadManager+URLSessionDelegate.swift
@@ -165,7 +165,7 @@ extension DownloadManager: URLSessionDelegate, URLSessionDownloadDelegate {
 
             let newDownloadStatus: DownloadStatus = autoDownloadStatus == .playerDownloadedForStreaming ? .downloadedForStreaming : .downloaded
             dataManager.saveEpisode(downloadStatus: newDownloadStatus, sizeInBytes: fileSize, downloadTaskId: nil, episode: episode)
-
+            dataManager.saveEpisode(downloadStatus: newDownloadStatus, lastDownloadAttemptDate: Date.now, autoDownloadStatus: autoDownloadStatus, episode: episode)
             EpisodeFileSizeUpdater.updateEpisodeDuration(episode: episode)
             NotificationCenter.postOnMainThread(notification: Constants.Notifications.episodeDownloaded, object: episode.uuid)
         } catch {

--- a/podcasts/DownloadManager.swift
+++ b/podcasts/DownloadManager.swift
@@ -294,7 +294,7 @@ class DownloadManager: NSObject, FilePathProtocol {
         }
         downloadingEpisodesCache[downloadTaskUUID] = episode
         episode.downloadTaskId = downloadTaskUUID
-
+        episode.lastDownloadAttemptDate = Date.now
         DataManager.sharedManager.save(episode: episode)
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.episodeDownloadStatusChanged, object: episode.uuid)
 

--- a/podcasts/EpisodesDataManager.swift
+++ b/podcasts/EpisodesDataManager.swift
@@ -132,7 +132,7 @@ class EpisodesDataManager {
     // MARK: - Downloads
 
     func downloadedEpisodes() -> [ArraySection<String, ListEpisode>] {
-        let query = "( (downloadTaskId IS NOT NULL OR episodeStatus = \(DownloadStatus.downloaded.rawValue) OR episodeStatus = \(DownloadStatus.waitingForWifi.rawValue)) OR (episodeStatus = \(DownloadStatus.downloadFailed.rawValue) AND lastDownloadAttemptDate > ?) ) ORDER BY lastDownloadAttemptDate DESC LIMIT 1000"
+        let query = "( ((downloadTaskId IS NOT NULL AND autoDownloadStatus <> \(AutoDownloadStatus.playerDownloadedForStreaming.rawValue) ) OR episodeStatus = \(DownloadStatus.downloaded.rawValue) OR episodeStatus = \(DownloadStatus.waitingForWifi.rawValue)) OR (episodeStatus = \(DownloadStatus.downloadFailed.rawValue) AND lastDownloadAttemptDate > ?) ) ORDER BY lastDownloadAttemptDate DESC LIMIT 1000"
         let arguments = [Date().weeksAgo(1)] as [Any]
 
         let newData = EpisodeTableHelper.loadSectionedEpisodes(query: query, arguments: arguments, episodeShortKey: { episode -> String in


### PR DESCRIPTION
| 📘 Part of: #44 #2430  |  <!-- project issue number, if applicable -->
|:---:|

Fixes #2434  <!-- issue number, if applicable -->

While testing the download management banners/modals I found two bugs on the downloads views:

- Downloads done by our new `downloadParallelToStream` method where not updating the `lastDownloadAttemptDate` and by consequence where not being grouped correctly on the downloads screen
- Downloads that were done because of the need to stream and apply effects, `playerDownloadedForStreaming` where showing in the Downloads screen while they were being download and then dissapeared from there after.

This PR solves the two issues above:
- Downloads now have the date set correctly
- Automatic downloads because of effects or our new feature of having a single download for streaming are now excluded from the downloads screen, unless the user explicitly say that they want to download the episode.

## To test

1. Start the app
2. Do some downloads of episodes and check if they show correctly on the Profile -> Downloads screen
3. Start playing an long episode
4. Go to the download screen and check it does not show in the Downloads screen
5. Go back to the episode details
6. Tap on download of episode
7. Go back to the Downloads screen and check if the episode is there.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
