### PR TITLE
[Tooling] Update release branch to `xcode-16.0-v10` VM on CI

### DIFF
--- a/.buildkite/commands/release-upload.sh
+++ b/.buildkite/commands/release-upload.sh
@@ -22,6 +22,7 @@ set -e
 
 if [[ $SENTRY_UPLOAD_STATUS -ne 0 ]]; then
   echo "^^^ +++ Failed to upload dSYM to Sentry! Make sure to download dSYM from the build step artifacts and upload manually."
+  buildkite-agent annotate --style error --context sentry-failure 'Failed to upload dSYM to Sentry! Make sure to download dSYM from the build step artifacts and upload manually.'
 fi
 
 echo "--- :github: Creating GitHub Release"

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -7,6 +7,6 @@
 XCODE_VERSION="16.0"
 CI_TOOLKIT_PLUGIN_VERSION="3.7.1"
 
-# Note: `-v7` suffix added to use xcode-16.0-v7 image; remember to remove that suffix on next Xcode update
+# Note: `-v10` suffix added to use xcode-16.0-v10 image; remember to remove that suffix on next Xcode update
 export IMAGE_ID="xcode-$XCODE_VERSION-v10"
 export CI_TOOLKIT="automattic/a8c-ci-toolkit#$CI_TOOLKIT_PLUGIN_VERSION"

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -8,5 +8,5 @@ XCODE_VERSION="16.0"
 CI_TOOLKIT_PLUGIN_VERSION="3.7.1"
 
 # Note: `-v7` suffix added to use xcode-16.0-v7 image; remember to remove that suffix on next Xcode update
-export IMAGE_ID="xcode-$XCODE_VERSION-v7"
+export IMAGE_ID="xcode-$XCODE_VERSION-v10"
 export CI_TOOLKIT="automattic/a8c-ci-toolkit#$CI_TOOLKIT_PLUGIN_VERSION"


### PR DESCRIPTION
This is a follow-up on https://github.com/Automattic/pocket-casts-ios/pull/2461
See also conversation at p1732024512924269/1731315753.070789-slack-C06CKSPHYA1 and paaHJt-7uj-p2

Recently the `dSYM` upload to Sentry have failed randomly on recent release builds, due to a "no space left on device" errror.
Updating the Xcode VM used from `xcode-16.0-v7` to `xcode-16.0-v10` should fix this problem, as `-v7` only had 92GB of disk space while `-v10` was purposely created with extra space of 120GB disk size to avoid this recurring issue.

> [!NOTE]
> This PR targets `release/7.77` in order to avoid dSYM upload errors due to no-space-left issue to occur again during the release tasks of `7.77`. The VM has already been updated to `xcode-16.0-v10` on `master` in a commit from 2 days ago, which I've cherry-picked as part of this PR targeting `release/7.77`.

I also took the occasion to make any dSYM upload error be reported as a Buildkite annotation, as discussed in https://github.com/Automattic/pocket-casts-ios/pull/2461#discussion_r1849357365

## To test

As long as CI is green we should be good to go.

## Checklist

- [x] ~~I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.~~
- [x] ~~I have considered adding unit tests for my changes.~~
- [x] ~~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~~
- [ ] 