### PR TITLE
Install only necessary setup for `release-upload.sh`

### DIFF
--- a/.buildkite/commands/release-upload.sh
+++ b/.buildkite/commands/release-upload.sh
@@ -1,12 +1,13 @@
 #!/bin/bash -eu
 
-"$(dirname "${BASH_SOURCE[0]}")/shared_setup.sh"
-
 echo "--- :arrow_down: Downloading Artifacts"
 ARTIFACTS_DIR='artifacts' # Defined in Fastlane, see ARTIFACTS_FOLDER
 STEP=testflight_build
 buildkite-agent artifact download "$ARTIFACTS_DIR/*.ipa" . --step $STEP
 buildkite-agent artifact download "$ARTIFACTS_DIR/*.zip" . --step $STEP
+
+echo "--- :rubygems: Setting up Gems"
+install_gems
 
 echo "--- :closed_lock_with_key: Installing Secrets"
 bundle exec fastlane run configure_apply


### PR DESCRIPTION
Follow-up on https://github.com/Automattic/pocket-casts-ios/pull/2461#discussion_r1849365404

The `release-upload.sh` script only need gems to be installed (to run `bundle exec fastlane` commands), while it was calling the whole `shared_setup.sh` script, which not only installs Gems but also installs CocoaPods and SwiftPM dependencies, which we don't need for the `release-upload.sh` step—as that step downloads already-compiled `.ipa` and artifacts from previous build job.

> [!NOTE]
> This PR targets `release/7.77` so that we can validate it works during the current sprint already.

## To test

Manually bump the version in this PR's branch, then trigger a dummy beta build from it, and validate the upload to TestFlight and Sentry and GitHub still works as expected.
_(I have not run this test steps myself, so as the reviewer please carry them out)_

## Checklist

- [x] ~~I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.~~
- [x] ~~I have considered adding unit tests for my changes.~~
- [x] ~~I have updated (or requested that someone edit) [the spreadsheet]~~(https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~~