### PR TITLE
[Winback] Link row to Help & Feedback

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		102864A92CECEDB20098B2A9 /* CancelSubscriptionViewRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 102864A82CECEDB20098B2A9 /* CancelSubscriptionViewRow.swift */; };
 		102864AB2CED1F990098B2A9 /* CancelSubscription.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 102864AA2CED1F990098B2A9 /* CancelSubscription.xcassets */; };
 		102D1C882C7648680088DB89 /* PlusPaywallFeatureCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 102D1C872C7648680088DB89 /* PlusPaywallFeatureCard.swift */; };
+		1035FFED2CEE5F4E00C1E80D /* CancelSubscriptionOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1035FFEC2CEE5F4E00C1E80D /* CancelSubscriptionOption.swift */; };
 		105A6C422BAA0B2C0025B855 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 10B558EB2BA471DF0061847C /* PrivacyInfo.xcprivacy */; };
 		105A6C432BAA0B3B0025B855 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 10B558EA2BA364420061847C /* PrivacyInfo.xcprivacy */; };
 		105A6C442BAA0B3E0025B855 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 10B558EC2BA472E80061847C /* PrivacyInfo.xcprivacy */; };
@@ -2005,6 +2006,7 @@
 		102864A82CECEDB20098B2A9 /* CancelSubscriptionViewRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancelSubscriptionViewRow.swift; sourceTree = "<group>"; };
 		102864AA2CED1F990098B2A9 /* CancelSubscription.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = CancelSubscription.xcassets; sourceTree = "<group>"; };
 		102D1C872C7648680088DB89 /* PlusPaywallFeatureCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlusPaywallFeatureCard.swift; sourceTree = "<group>"; };
+		1035FFEC2CEE5F4E00C1E80D /* CancelSubscriptionOption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancelSubscriptionOption.swift; sourceTree = "<group>"; };
 		10756F822C57D00B0089D34F /* KidsProfileThankYouScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = KidsProfileThankYouScreen.swift; path = "Kids Profile/KidsProfileThankYouScreen.swift"; sourceTree = "<group>"; };
 		10756F842C5944660089D34F /* Podcast+Sortable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Podcast+Sortable.swift"; sourceTree = "<group>"; };
 		10756F872C59449C0089D34F /* Folder+Sortable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Folder+Sortable.swift"; sourceTree = "<group>"; };
@@ -3902,6 +3904,7 @@
 		100C99512CE7B7A2008D73E9 /* Cancel Subscription */ = {
 			isa = PBXGroup;
 			children = (
+				1035FFEC2CEE5F4E00C1E80D /* CancelSubscriptionOption.swift */,
 				109446752CEB3A7E00977161 /* CancelSubscriptionViewModel.swift */,
 				100C99542CE7B801008D73E9 /* CancelSubscriptionView.swift */,
 				102864A82CECEDB20098B2A9 /* CancelSubscriptionViewRow.swift */,
@@ -9987,6 +9990,7 @@
 				C7AF7B992926B307002F0025 /* OnboardingHostingViewController.swift in Sources */,
 				462EE0AD26FCC081003D67DC /* ZenDeskHelpers.swift in Sources */,
 				403B5B0621812E6000821A54 /* AppDelegate+SiriShortcuts.swift in Sources */,
+				1035FFED2CEE5F4E00C1E80D /* CancelSubscriptionOption.swift in Sources */,
 				BD9086AC204E413800C0C78D /* PodcastSearchCell.swift in Sources */,
 				BD2F3BA42366C0F900416633 /* PlayerContainerViewController+Gestures.swift in Sources */,
 				BDDA72D21C9B898C003A3BEB /* StorageAndDataUseViewController.swift in Sources */,

--- a/podcasts/Cancel Subscription/CancelSubscriptionOption.swift
+++ b/podcasts/Cancel Subscription/CancelSubscriptionOption.swift
@@ -1,0 +1,44 @@
+enum CancelSubscriptionOption: CaseIterable, Hashable, Identifiable {
+    static var allCases: [CancelSubscriptionOption] = [.promotion(price: ""), .availablePlans, .help]
+
+    case promotion(price: String)
+    case availablePlans
+    case help
+
+    var id: Self {
+        return self
+    }
+
+    var title: String {
+        switch self {
+        case .promotion:
+            return L10n.cancelSubscriptionPromotionTitle
+        case .availablePlans:
+            return L10n.cancelSubscriptionNewPlanTitle
+        case .help:
+            return L10n.cancelSubscriptionHelpTitle
+        }
+    }
+
+    var subtitle: String {
+        switch self {
+        case .promotion(let price):
+            return L10n.cancelSubscriptionPromotionDescription(price)
+        case .availablePlans:
+            return L10n.cancelSubscriptionNewPlanDescription
+        case .help:
+            return L10n.cancelSubscriptionHelpDescription
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .promotion:
+            return "cs-heart"
+        case .availablePlans:
+            return "cs-skipbackward"
+        case .help:
+            return "cs-help"
+        }
+    }
+}

--- a/podcasts/Cancel Subscription/CancelSubscriptionView.swift
+++ b/podcasts/Cancel Subscription/CancelSubscriptionView.swift
@@ -23,9 +23,11 @@ struct CancelSubscriptionView: View {
                             .padding(.horizontal, 34.0)
 
                         ForEach(CancelSubscriptionOption.allCases, id: \.id) { option in
-                            if case .promotion = option, let price = viewModel.monthlyPrice() {
-                                CancelSubscriptionViewRow(option: .promotion(price: price),
-                                                          viewModel: viewModel)
+                            if case .promotion = option {
+                                if viewModel.isEligibleForOffer, case .promotion = option, let price = viewModel.monthlyPrice() {
+                                    CancelSubscriptionViewRow(option: .promotion(price: price),
+                                                              viewModel: viewModel)
+                                }
                             } else {
                                 CancelSubscriptionViewRow(option: option,
                                                           viewModel: viewModel)

--- a/podcasts/Cancel Subscription/CancelSubscriptionViewModel.swift
+++ b/podcasts/Cancel Subscription/CancelSubscriptionViewModel.swift
@@ -4,6 +4,10 @@ import PocketCastsServer
 class CancelSubscriptionViewModel: PlusPurchaseModel {
     let navigationController: UINavigationController
 
+    var isEligibleForOffer: Bool {
+        purchaseHandler.isEligibleForOffer
+    }
+
     init(purchaseHandler: IAPHelper = .shared, navigationController: UINavigationController) {
         self.navigationController = navigationController
 
@@ -30,6 +34,16 @@ class CancelSubscriptionViewModel: PlusPurchaseModel {
 
     func claimOffer() {
         //TODO: Apply one month free
+    }
+
+    func showPlans() {
+        //TODO: Show plans
+    }
+
+    func showHelp() {
+        let controller = OnlineSupportController()
+        navigationController.navigationBar.isHidden = false
+        navigationController.pushViewController(controller, animated: true)
     }
 
     override func didAppear() {

--- a/podcasts/Cancel Subscription/CancelSubscriptionViewRow.swift
+++ b/podcasts/Cancel Subscription/CancelSubscriptionViewRow.swift
@@ -1,55 +1,10 @@
 import SwiftUI
 
-enum CancelSubscriptionOption: CaseIterable, Hashable, Identifiable {
-    static var allCases: [CancelSubscriptionOption] = [.promotion(price: ""), .newPlan, .help]
-
-    case promotion(price: String)
-    case newPlan
-    case help
-
-    var id: Self {
-        return self
-    }
-
-    var title: String {
-        switch self {
-        case .promotion:
-            return L10n.cancelSubscriptionPromotionTitle
-        case .newPlan:
-            return L10n.cancelSubscriptionNewPlanTitle
-        case .help:
-            return L10n.cancelSubscriptionHelpTitle
-        }
-    }
-
-    var subtitle: String {
-        switch self {
-        case .promotion(let price):
-            return L10n.cancelSubscriptionPromotionDescription(price)
-        case .newPlan:
-            return L10n.cancelSubscriptionNewPlanDescription
-        case .help:
-            return L10n.cancelSubscriptionHelpDescription
-        }
-    }
-
-    var icon: String {
-        switch self {
-        case .promotion:
-            return "cs-heart"
-        case .newPlan:
-            return "cs-skipbackward"
-        case .help:
-            return "cs-help"
-        }
-    }
-}
-
 struct CancelSubscriptionViewRow: View {
-    let option: CancelSubscriptionOption
-    let viewModel: CancelSubscriptionViewModel
-
     @EnvironmentObject var theme: Theme
+
+    private let option: CancelSubscriptionOption
+    private let viewModel: CancelSubscriptionViewModel
 
     init(option: CancelSubscriptionOption, viewModel: CancelSubscriptionViewModel) {
         self.option = option
@@ -134,9 +89,20 @@ struct CancelSubscriptionViewRow: View {
             }
             .padding(.top, 24.0)
 
-            if option == .newPlan || option == .help {
+            if option == .availablePlans || option == .help {
                 chevron
                     .padding(.trailing, 20.0)
+            }
+        }
+        .contentShape(Rectangle())
+        .onTapGesture {
+            switch option {
+            case .help:
+                viewModel.showHelp()
+            case .availablePlans:
+                viewModel.showPlans()
+            default:
+                break
             }
         }
     }
@@ -148,7 +114,7 @@ struct CancelSubscriptionViewRow_Previews: PreviewProvider {
         VStack(spacing: 0) {
             CancelSubscriptionViewRow(option: .promotion(price: "$3.99"), viewModel: viewModel)
                 .environmentObject(Theme.sharedTheme)
-            CancelSubscriptionViewRow(option: .newPlan, viewModel: viewModel)
+            CancelSubscriptionViewRow(option: .availablePlans, viewModel: viewModel)
                 .environmentObject(Theme.sharedTheme)
             CancelSubscriptionViewRow(option: .help, viewModel: viewModel)
                 .environmentObject(Theme.sharedTheme)


### PR DESCRIPTION
| 📘 Part of: #2435 
|:---:|

Fixes #2440 

This PR linked the Help & Feedback screen to the specific row

https://github.com/user-attachments/assets/c2eac8e3-b415-47f0-977f-1f5393272c12

## To test

- CI must be 🟢 
- Make sure the `winback` FF is on
- Use a Plus/Patron user
- Go to Account -> Cancel Subscription
- Tap on the `Need help with Pocket Casts?` row
- Confirm the Help & Feedback view is pushed into the nav stack

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
