### PR TITLE
Set End of Year Modal shown immediately on presentation

### DIFF
--- a/podcasts/End of Year/EndOfYear.swift
+++ b/podcasts/End of Year/EndOfYear.swift
@@ -89,6 +89,10 @@ struct EndOfYear {
     }
 
     func showPrompt(in viewController: UIViewController) {
+        if let presented = viewController.presentedViewController {
+            presented.dismiss(animated: true)
+        }
+
         guard Self.isEligible, let storyModelType, !Settings.hasShownModalForEndOfYear(storyModelType.year) else {
             return
         }

--- a/podcasts/End of Year/EndOfYear.swift
+++ b/podcasts/End of Year/EndOfYear.swift
@@ -88,11 +88,8 @@ struct EndOfYear {
         storyModelType = Self.currentYear.modelType
     }
 
-    func showPrompt(in viewController: UIViewController) {
-        if let presented = viewController.presentedViewController {
-            presented.dismiss(animated: true)
-        }
 
+    func showPrompt(in viewController: UIViewController) {
         guard Self.isEligible, let storyModelType, !Settings.hasShownModalForEndOfYear(storyModelType.year) else {
             return
         }
@@ -109,6 +106,7 @@ struct EndOfYear {
         }
 
         BottomSheetSwiftUIWrapper.present(EndOfYearModal(year: storyModelType.year, model: viewModel), autoSize: true, in: viewController)
+        Settings.setHasShownModalForEndOfYear(true, year: storyModelType.year)
     }
 
     func showPromptBasedOnState(in viewController: UIViewController) {


### PR DESCRIPTION
Sets the modal shown setting to `true` immediately when the modal is shown. This prevents duplicate calls from triggering multiple modals.

## To test

* Delete & Reinstall the app
* Log in with a Google account set to Plus (you can add Plus using gifting in the admin)
* Verify that only one modal is shown

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
