### PR TITLE
Restore using `install_swift_dependencies` and SwiftPM cache

### DIFF
--- a/.buildkite/commands/shared_setup.sh
+++ b/.buildkite/commands/shared_setup.sh
@@ -7,11 +7,4 @@ echo "--- :cocoapods: Setting up Pods"
 install_cocoapods
 
 echo "--- :swift: Installing Swift Package Manager Dependencies"
-# Temporarily disable `install_swiftpm_dependencies` and calling `xcodebuild -resolvePackageDependencies`
-# command directly instead until we move the `.xcodeproj` to a folder other than the project root to workaround
-# an issue with `xcodebuild` not using the right `Package.resolved` file (`*.xcworkspace/*` vs `*.xcodeproj/*`)
-#
-# install_swiftpm_dependencies
-xcodebuild -resolvePackageDependencies \
-  -workspace podcasts.xcworkspace \
-  -scheme pocketcasts
+install_swiftpm_dependencies


### PR DESCRIPTION
Restore using `install_swift_dependencies` and SwiftPM cache

We disabled this because of an issue with package resolution, see https://github.com/Automattic/pocket-casts-ios/issues/1990

Since then, a fix has been implemented in the command, see https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/pull/105 so we can re-enable it.


## To test

See screenshots below of green CI with command running and correct packages resolution

![image](https://github.com/user-attachments/assets/b70a7ce8-a1a2-4a21-b330-bd0c544503c1)

![image](https://github.com/user-attachments/assets/d8183cc9-e630-4abf-9756-b92a3ed93314)


## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary. – N.A.
- [x] I have considered adding unit tests for my changes. – N.A.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics. – N.A.
