### PR TITLE
Playback 2024: Instagram share fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 7.78
 -----
 
+7.77.1
+-----
+- Fix sharing Playback stories to Instagram [#2482](https://github.com/Automattic/pocket-casts-ios/pull/2482)
 
 7.77
 -----

--- a/podcasts/End of Year/StoryShareableProvider.swift
+++ b/podcasts/End of Year/StoryShareableProvider.swift
@@ -12,6 +12,8 @@ class StoryShareableProvider: UIActivityItemProvider {
 
     var generatedItem: Any?
 
+    var generatedItemURL: Any?
+
     var view: AnyView?
 
     static func new(_ view: AnyView) -> StoryShareableProvider {
@@ -26,7 +28,11 @@ class StoryShareableProvider: UIActivityItemProvider {
 
     override var item: Any {
         get {
-            generatedItem ?? UIImage()
+            if activityType?.rawValue.contains("instagram") == true {
+                generatedItemURL ?? NSURL()
+            } else {
+                generatedItem ?? UIImage()
+            }
         }
     }
 
@@ -44,8 +50,26 @@ class StoryShareableProvider: UIActivityItemProvider {
         .frame(width: 370, height: 800)
         .snapshot()
 
+        let snapshotURL = save(snapshot: snapshot)
+        generatedItemURL = snapshotURL
         generatedItem = snapshot
         self.view = nil
+    }
+
+    private func save(snapshot: UIImage) -> URL? {
+        guard let imageData = snapshot.pngData() else { return nil }
+
+        let tempDir = FileManager.default.temporaryDirectory
+        let uuid = UUID().uuidString
+        let url = tempDir.appendingPathComponent("pocket-casts-share-image-\(uuid).png")
+
+        do {
+           try imageData.write(to: url)
+        } catch {
+            return nil
+        }
+
+        return url
     }
 }
 


### PR DESCRIPTION
| 📘 Part of: #2250 |
|:---:|

Fixes #2481

Apparently Instagram expects a URL for the image instead of a `UIImage` or `NSData` object. I've included this only for the Instagram app for now so we don't accidentally break something else.

## To test

* Install the app on a device with Instagram installed
* Open Playback 2024 from Profile
* Tap "Share this story" to share the image
* Share to Instagram
* Select "Story" and ensure the image is shared
* Try the same but with other share options and apps and ensure they also work.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
