### PR TITLE
Fix shares on radioactivity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - File downloads use switch instead of check box for include starred [#2455](https://github.com/Automattic/pocket-casts-ios/pull/2455)
 - Show download management banner and modal when running low in disk space [#2430](https://github.com/Automattic/pocket-casts-ios/pull/2430)
 - Referrals: update share message and add image [#2468](https://github.com/Automattic/pocket-casts-ios/pull/2468)
+- Fix sharing of Referrals, Episodes and EOY when using the radioactivity theme [#2485](https://github.com/Automattic/pocket-casts-ios/pull/2485)
 
 7.77
 -----

--- a/podcasts/End of Year/EndOfYear.swift
+++ b/podcasts/End of Year/EndOfYear.swift
@@ -169,6 +169,7 @@ struct EndOfYear {
         activityViewController.popoverPresentationController?.sourceView = presenter?.view
 
         activityViewController.completionWithItemsHandler = { activity, success, _, _ in
+            NotificationCenter.postOnMainThread(notification: Constants.Notifications.closedNonOverlayableWindow)
             if !success && activity == nil {
                 fakeViewController.dismiss(animated: false)
             }
@@ -182,6 +183,7 @@ struct EndOfYear {
         // Present the fake view controller first to avoid issues with stories being dismissed
         presenter?.present(fakeViewController, animated: false) { [weak fakeViewController] in
             // Present the share sheet
+            NotificationCenter.postOnMainThread(notification: Constants.Notifications.openingNonOverlayableWindow)
             fakeViewController?.present(activityViewController, animated: true) {
                 // After the share sheet is presented we take the snapshot
                 // This action needs to happen on the main thread because

--- a/podcasts/Referrals/ReferralSendPassVC.swift
+++ b/podcasts/Referrals/ReferralSendPassVC.swift
@@ -43,6 +43,7 @@ class ReferralSendPassVC: ThemedHostingController<ReferralSendPassView> {
             }
             let viewController = UIActivityViewController(activityItems: items, applicationActivities: nil)
             viewController.completionWithItemsHandler = { _, completed, _, _ in
+                NotificationCenter.postOnMainThread(notification: Constants.Notifications.closedNonOverlayableWindow)
                 if completed {
                     originalOnShareGuestPassTap?()
                 }
@@ -52,6 +53,7 @@ class ReferralSendPassVC: ThemedHostingController<ReferralSendPassView> {
                 popoverVC.sourceView = self.view
                 popoverVC.sourceRect = centerBottomSourceRect
             }
+            NotificationCenter.postOnMainThread(notification: Constants.Notifications.openingNonOverlayableWindow)
             present(viewController, animated: true)
         }
         view.backgroundColor = .clear

--- a/podcasts/Sharing/ShareDestination.swift
+++ b/podcasts/Sharing/ShareDestination.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import PocketCastsDataModel
 import Combine
+import PocketCastsUtils
 
 enum ShareDestination: Hashable {
     case instagram
@@ -75,8 +76,10 @@ enum ShareDestination: Hashable {
                 activityViewController.popoverPresentationController?.sourceRect = rect
             }
             activityViewController.completionWithItemsHandler = { activityType, completed, returnedItems, activityError in
+                NotificationCenter.postOnMainThread(notification: podcasts.Constants.Notifications.closedNonOverlayableWindow)
                 receiver.cancel()
             }
+            NotificationCenter.postOnMainThread(notification: podcasts.Constants.Notifications.openingNonOverlayableWindow)
             vc.presentedViewController?.present(activityViewController, animated: true, completion: {
                 ShareDestination.logClipShared(option: option, style: style, clipUUID: clipUUID, source: source)
                 ShareDestination.logPodcastShared(style: style, option: option, destination: self, source: source)


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes #2411 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

This updates the recently added share interactions to send notifications to proper disable/enable the radioactivity layer when showing system share menus

## To test

1. Start the app using a iPhone (simulator or real device)
2. Enable the radioactivity theme ( you need to have a subscription)

### Share on referrals

4. Go Profile
5. Tap on the gift icon on the left
6. Tap on Share Guest Pass
7. Check that you can interact with the share screen and radioactivity is disabled
8. Finish the sharing
9. Check if radioactivity is back on

### Share on Eoy 2024

4. Go Profile
5. Tap on the EOY banner
6. Advance story until you see the share button
7. Tap on the share button
8. Check that you can interact with the share screen and radioactivity is disabled
9. Finish the sharing
10. Check if radioactivity is back on

### Share on episodes

11. Start playing an episode
12. Open the full screen player
13. Tap Share on the actions ( it may be hidden in the options)
14. Tap on Share again
15. Check that you can interact with the share screen and radioactivity is disabled
16. Finish the sharing
17. Check if radioactivity is back on
 
## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
