### PR TITLE
Ensure that the refresh of navigation buttons is made before the view appears

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - File downloads use switch instead of check box for include starred [#2455](https://github.com/Automattic/pocket-casts-ios/pull/2455)
 - Show download management banner and modal when running low in disk space [#2430](https://github.com/Automattic/pocket-casts-ios/pull/2430)
 - Referrals: update share message and add image [#2468](https://github.com/Automattic/pocket-casts-ios/pull/2468)
+- Fix refresh of the navigation bar buttons when switchin tabs [#2294](https://github.com/Automattic/pocket-casts-ios/issues/2294)
 
 7.77
 -----

--- a/podcasts/PCViewController.swift
+++ b/podcasts/PCViewController.swift
@@ -62,12 +62,11 @@ class PCViewController: SimpleNotificationsViewController {
         if let title = title, title.count > 0 {
             setupNavBar(animated: animated)
         }
+        refreshRightButtons()
     }
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-
-        refreshRightButtons()
 
         if supportsGoogleCast {
             NotificationCenter.default.addObserver(self, selector: #selector(refreshRightButtons), name: Constants.Notifications.googleCastStatusChanged, object: nil)


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes #2294 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

This change ensure that updates to the navigation buttons are done on view will appear so that buttons are present when animating in.

https://github.com/user-attachments/assets/8a089eb3-e87e-4626-92f2-ab3ef4808490

## To test

1. Start the app
2. Switch between the different tabs in the app
3. Notice if the buttons on the navigation bar show immediately when scrolling in. 

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
