### PR TITLE
Ensure display and play of bookmarks from podcasts not synced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fix playback of bookmarks when episode was previously marked as played [#2262](https://github.com/Automattic/pocket-casts-ios/pull/2262)
 - Fix refresh of the navigation bar buttons when switchin tabs [#2294](https://github.com/Automattic/pocket-casts-ios/issues/2294)
 - Fix sharing of Referrals, Episodes and EOY when using the radioactivity theme [#2485](https://github.com/Automattic/pocket-casts-ios/pull/2485)
+- Fix playback of bookmarks that are created on other platforms and never loaded locally [#1667](https://github.com/Automattic/pocket-casts-ios/issues/1667)
 
 7.77
 -----

--- a/Modules/Server/Sources/PocketCastsServer/Public/ServerPodcastManager.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/ServerPodcastManager.swift
@@ -144,7 +144,7 @@ public class ServerPodcastManager: NSObject {
         return nil
     }
 
-    public func addMissingPodcastAndEpisode(episodeUuid: String, podcastUuid: String) {
+    public func addMissingPodcastAndEpisode(episodeUuid: String, podcastUuid: String, completion: ((Episode?) -> ())? = nil) {
         let url = ServerConstants.Urls.cache() + "mobile/podcast/findbyepisode/\(podcastUuid)/\(episodeUuid)"
 
         if let info = loadFrom(url: url) {
@@ -153,7 +153,8 @@ public class ServerPodcastManager: NSObject {
                 _ = addPodcast(podcastInfo: info, subscribe: false, lastModified: nil)
             }
 
-            _ = addEpisode(podcastInfo: info)
+            let episode = addEpisode(podcastInfo: info)
+            completion?(episode)
         }
     }
 

--- a/podcasts/Bookmarks/List/BookmarkRow.swift
+++ b/podcasts/Bookmarks/List/BookmarkRow.swift
@@ -44,9 +44,15 @@ struct BookmarkRow<Style: BookmarksStyle>: View {
         .animation(.linear, value: selected)
     }
 
+    @ViewBuilder
     private var imageView: some View {
-        rowModel.episode.map {
-            EpisodeImage(episode: $0)
+        if let episode = rowModel.episode {
+            EpisodeImage(episode: episode)
+                .frame(width: imageSize, height: imageSize)
+                .cornerRadius(8)
+        } else {
+            Rectangle()
+                .foregroundColor(style.tertiaryText)
                 .frame(width: imageSize, height: imageSize)
                 .cornerRadius(8)
         }

--- a/podcasts/Bookmarks/List/BookmarkRowViewModel.swift
+++ b/podcasts/Bookmarks/List/BookmarkRowViewModel.swift
@@ -1,13 +1,14 @@
 import SwiftUI
 import PocketCastsUtils
 import PocketCastsDataModel
+import PocketCastsServer
 
 class BookmarkRowViewModel: ObservableObject {
-    let heading: String?
+    @Published var heading: String?
     let title: String
     let subtitle: String
     let playButton: String
-    let episode: BaseEpisode?
+    @Published var episode: BaseEpisode?
 
     init(bookmark: Bookmark) {
         self.episode = bookmark.episode
@@ -16,9 +17,32 @@ class BookmarkRowViewModel: ObservableObject {
         self.subtitle = DateFormatter.localizedString(from: bookmark.created,
                                                       dateStyle: .medium,
                                                       timeStyle: .short)
+        if let episode {
+            updateFromEpisode(episode)
+        } else {
+            loadEpisode(from: bookmark)
+        }
+    }
 
-        self.heading = (bookmark.episode as? Episode).flatMap {
-            $0.title
+    private func updateFromEpisode(_ episode: BaseEpisode) {
+        self.episode = episode
+        self.heading = episode.title
+    }
+
+    private func loadEpisode(from bookmark: Bookmark) {
+        // Get the bookmark's BaseEpisode so we can load it
+        let dataManager = DataManager.sharedManager
+        if let episode = bookmark.episode ?? dataManager.findBaseEpisode(uuid: bookmark.episodeUuid) {
+            updateFromEpisode(episode)
+        }
+        if let podcastUuid = bookmark.podcastUuid {
+            ServerPodcastManager.shared.addMissingPodcastAndEpisode(episodeUuid: bookmark.episodeUuid, podcastUuid: podcastUuid) { [weak self] episode in
+                if let episode {
+                    DispatchQueue.main.async {
+                        self?.updateFromEpisode(episode)
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes #1667 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR changes the code to ensure that an episode bookmark is loaded locally when it's display and played.

## To test

1. Open the Web Player
2. Find a unsubscribe podcast that hasn't been on the iOS device
3. Play the episode
4. Bookmark a position in the episode
5. Stop playing the episode
6. Remove the episode from the queues by selecting ... and selecting Mark as played
7. Click "History" in the side menu
8. Click the remove cross on the episode row
9. Open the iOS app
10. Tap the refresh button
11. Open the Profile -> Bookmarks page
12. Check if the image of the podcast and name of the episode is loaded
13. Tap on the bookmark play button

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
