### PR TITLE
Add setting to control auto-downloads on follow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fix refresh of the navigation bar buttons when switchin tabs [#2294](https://github.com/Automattic/pocket-casts-ios/issues/2294)
 - Fix sharing of Referrals, Episodes and EOY when using the radioactivity theme [#2485](https://github.com/Automattic/pocket-casts-ios/pull/2485)
 - Fix playback of bookmarks that are created on other platforms and never loaded locally [#1667](https://github.com/Automattic/pocket-casts-ios/issues/1667)
+- Add new setting on Auto-Downloads settings to define the on follow behaviour. [#2493](https://github.com/Automattic/pocket-casts-ios/pull/2493)
 
 7.77
 -----

--- a/Modules/Server/Sources/PocketCastsServer/Public/ServerPodcastManager+Update.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/ServerPodcastManager+Update.swift
@@ -215,15 +215,16 @@ extension ServerPodcastManager {
         let autoDownloadCount = DataManager.sharedManager.count(query: autoDownloadQuery, values: nil)
         let totalCount = (DataManager.sharedManager.count(query: totalQuery, values: nil) - 1) // -1 because the podcast we're currently adding could be returned by this query
         let shouldTriggerAutoDownload: Bool
-        if FeatureFlag.autoDownloadOnSubscribe.enabled, autoDownload {
-            shouldTriggerAutoDownload = (AutoDownloadSetting(rawValue: podcast.autoDownloadSetting) ?? .off) != .off
+        if FeatureFlag.autoDownloadOnSubscribe.enabled {
+            shouldTriggerAutoDownload = autoDownload
         } else {
             shouldTriggerAutoDownload = (totalCount > 0) && (autoDownloadCount >= totalCount)
         }
         if shouldTriggerAutoDownload {
-            podcast.autoDownloadSetting = AutoDownloadSetting.latest.rawValue
+            podcast.autoDownloadSetting = AutoDownloadSetting.off.rawValue
             if !latestEpisodes.isEmpty {
-                ServerConfig.shared.syncDelegate?.autoDownloadLatestEpisodes(uuids: latestEpisodes.map(\.uuid))
+                let range = Range<Int>(uncheckedBounds: (lower: 0, upper: min(2, latestEpisodes.count)))
+                ServerConfig.shared.syncDelegate?.autoDownloadLatestEpisodes(uuids: latestEpisodes[range].map(\.uuid))
             }
         } else {
             podcast.autoDownloadSetting = AutoDownloadSetting.off.rawValue

--- a/Modules/Server/Sources/PocketCastsServer/Public/ServerPodcastManager+Update.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/ServerPodcastManager+Update.swift
@@ -221,10 +221,9 @@ extension ServerPodcastManager {
             shouldTriggerAutoDownload = (totalCount > 0) && (autoDownloadCount >= totalCount)
         }
         if shouldTriggerAutoDownload {
-            podcast.autoDownloadSetting = AutoDownloadSetting.off.rawValue
+            podcast.autoDownloadSetting = AutoDownloadSetting.latest.rawValue
             if !latestEpisodes.isEmpty {
-                let range = Range<Int>(uncheckedBounds: (lower: 0, upper: min(2, latestEpisodes.count)))
-                ServerConfig.shared.syncDelegate?.autoDownloadLatestEpisodes(uuids: latestEpisodes[range].map(\.uuid))
+                ServerConfig.shared.syncDelegate?.autoDownloadLatestEpisodes(uuids: latestEpisodes.map(\.uuid))
             }
         } else {
             podcast.autoDownloadSetting = AutoDownloadSetting.off.rawValue

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -529,6 +529,7 @@ enum AnalyticsEvent: String {
     case settingsAutoDownloadShown
     case settingsAutoDownloadUpNextToggled
     case settingsAutoDownloadNewEpisodesToggled
+    case settingsAutoDownloadOnFollowToggled
     case settingsAutoDownloadLimitDownloadsChanged
     case settingsAutoDownloadPodcastsChanged
     case settingsAutoDownloadFiltersChanged

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -529,7 +529,7 @@ enum AnalyticsEvent: String {
     case settingsAutoDownloadShown
     case settingsAutoDownloadUpNextToggled
     case settingsAutoDownloadNewEpisodesToggled
-    case settingsAutoDownloadOnFollowToggled
+    case settingsAutoDownloadOnFollowPodcastToggled
     case settingsAutoDownloadLimitDownloadsChanged
     case settingsAutoDownloadPodcastsChanged
     case settingsAutoDownloadFiltersChanged

--- a/podcasts/AppDelegate+Defaults.swift
+++ b/podcasts/AppDelegate+Defaults.swift
@@ -23,7 +23,7 @@ extension AppDelegate {
 
             // Disable dark up next theme for new users
             Settings.darkUpNextTheme = false
-
+            Settings.setAutoDownloadOnFollow(true)
             setWhatsNewAcknowledgeToLatest()
         }
 

--- a/podcasts/DownloadSettingsViewController.swift
+++ b/podcasts/DownloadSettingsViewController.swift
@@ -54,15 +54,18 @@ class DownloadSettingsViewController: PCViewController, UITableViewDataSource, U
     func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
         let firstRowInSection = tableRows()[section][0]
 
-        if firstRowInSection == .upNext {
+        switch firstRowInSection {
+        case .upNext:
             return L10n.settingsAutoDownloadsSubtitleUpNext
-        } else if firstRowInSection == .podcastAutoDownload {
+        case .podcastAutoDownload:
             return L10n.settingsAutoDownloadsSubtitleNewEpisodes
-        } else if firstRowInSection == .filterSelection {
+        case .filterSelection:
             return L10n.settingsAutoDownloadsSubtitleFilters
+        case .downloadOnFollow:
+            return L10n.settingsAutoDownloadsOnFollowDetails
+        default:
+            return nil
         }
-
-        return nil
     }
 
     func tableView(_ tableView: UITableView, willDisplayFooterView view: UIView, forSection section: Int) {
@@ -108,7 +111,7 @@ class DownloadSettingsViewController: PCViewController, UITableViewDataSource, U
         case .downloadOnFollow:
             let cell = tableView.dequeueReusableCell(withIdentifier: DownloadSettingsViewController.switchCellId, for: indexPath) as! SwitchCell
 
-            cell.cellLabel.text = L10n.autoDownloadOnFollow
+            cell.cellLabel.text = L10n.settingsAutoDownloadsOnFollow
             cell.cellSwitch.isOn = Settings.autoDownloadOnFollow()
             cell.cellSwitch.removeTarget(self, action: nil, for: UIControl.Event.valueChanged)
             cell.cellSwitch.addTarget(self, action: #selector(automaticDownloadOnFollowToggled(_:)), for: UIControl.Event.valueChanged)
@@ -258,9 +261,13 @@ class DownloadSettingsViewController: PCViewController, UITableViewDataSource, U
         var data = autoDownloadPodcastsEnabled ? podcastDownloadOnData : podcastDownloadOffData
 
         if autoDownloadPodcastsEnabled, FeatureFlag.autoDownloadOnSubscribe.enabled {
-            data[1].append(.downloadOnFollow)
             data[1].append(.downloadLimits)
         }
+
+        if FeatureFlag.autoDownloadOnSubscribe.enabled {
+            data.insert([.downloadOnFollow], at: 2)
+        }
+
         return data
     }
 }

--- a/podcasts/DownloadSettingsViewController.swift
+++ b/podcasts/DownloadSettingsViewController.swift
@@ -61,8 +61,6 @@ class DownloadSettingsViewController: PCViewController, UITableViewDataSource, U
             return L10n.settingsAutoDownloadsSubtitleNewEpisodes
         case .filterSelection:
             return L10n.settingsAutoDownloadsSubtitleFilters
-        case .downloadOnFollow:
-            return L10n.settingsAutoDownloadsOnFollowDetails
         default:
             return nil
         }
@@ -261,11 +259,8 @@ class DownloadSettingsViewController: PCViewController, UITableViewDataSource, U
         var data = autoDownloadPodcastsEnabled ? podcastDownloadOnData : podcastDownloadOffData
 
         if autoDownloadPodcastsEnabled, FeatureFlag.autoDownloadOnSubscribe.enabled {
+            data[1].append(.downloadOnFollow)
             data[1].append(.downloadLimits)
-        }
-
-        if FeatureFlag.autoDownloadOnSubscribe.enabled {
-            data.insert([.downloadOnFollow], at: 2)
         }
 
         return data

--- a/podcasts/DownloadSettingsViewController.swift
+++ b/podcasts/DownloadSettingsViewController.swift
@@ -258,9 +258,13 @@ class DownloadSettingsViewController: PCViewController, UITableViewDataSource, U
 
         var data = autoDownloadPodcastsEnabled ? podcastDownloadOnData : podcastDownloadOffData
 
-        if autoDownloadPodcastsEnabled, FeatureFlag.autoDownloadOnSubscribe.enabled {
+        if FeatureFlag.autoDownloadOnSubscribe.enabled {
+            data = podcastDownloadOnData
             data[1].append(.downloadOnFollow)
             data[1].append(.downloadLimits)
+            if !autoDownloadPodcastsEnabled {
+                data[1].remove(at: 1)
+            }
         }
 
         return data

--- a/podcasts/DownloadSettingsViewController.swift
+++ b/podcasts/DownloadSettingsViewController.swift
@@ -14,7 +14,7 @@ class DownloadSettingsViewController: PCViewController, UITableViewDataSource, U
         }
     }
 
-    private enum TableRow { case upNext, podcastAutoDownload, podcastSelection, downloadLimits, filterSelection, onlyOnWifi }
+    private enum TableRow { case upNext, podcastAutoDownload, podcastSelection, downloadOnFollow, downloadLimits, filterSelection, onlyOnWifi }
     private let podcastDownloadOffData: [[TableRow]] = [[.upNext], [.podcastAutoDownload], [.filterSelection], [.onlyOnWifi]]
     private let podcastDownloadOnData: [[TableRow]] = [[.upNext], [.podcastAutoDownload, .podcastSelection], [.filterSelection], [.onlyOnWifi]]
 
@@ -103,6 +103,15 @@ class DownloadSettingsViewController: PCViewController, UITableViewDataSource, U
 
             cell.cellLabel.text = L10n.selectedPodcastCount(allWithAutoDownloadOn.count)
             cell.cellSecondaryLabel.text = ""
+
+            return cell
+        case .downloadOnFollow:
+            let cell = tableView.dequeueReusableCell(withIdentifier: DownloadSettingsViewController.switchCellId, for: indexPath) as! SwitchCell
+
+            cell.cellLabel.text = L10n.autoDownloadOnFollow
+            cell.cellSwitch.isOn = Settings.autoDownloadOnFollow()
+            cell.cellSwitch.removeTarget(self, action: nil, for: UIControl.Event.valueChanged)
+            cell.cellSwitch.addTarget(self, action: #selector(automaticDownloadOnFollowToggled(_:)), for: UIControl.Event.valueChanged)
 
             return cell
         case .downloadLimits:
@@ -228,6 +237,11 @@ class DownloadSettingsViewController: PCViewController, UITableViewDataSource, U
         settingsTable.reloadData()
     }
 
+    @objc private func automaticDownloadOnFollowToggled(_ slider: UISwitch) {
+        Settings.setAutoDownloadOnFollow(slider.isOn, userInitiated: true)
+        settingsTable.reloadData()
+    }
+
     @objc private func downloadUpNextToggled(_ slider: UISwitch) {
         Settings.setDownloadUpNextEpisodes(slider.isOn)
 
@@ -244,6 +258,7 @@ class DownloadSettingsViewController: PCViewController, UITableViewDataSource, U
         var data = autoDownloadPodcastsEnabled ? podcastDownloadOnData : podcastDownloadOffData
 
         if autoDownloadPodcastsEnabled, FeatureFlag.autoDownloadOnSubscribe.enabled {
+            data[1].append(.downloadOnFollow)
             data[1].append(.downloadLimits)
         }
         return data

--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -616,7 +616,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
         podcast.syncStatus = SyncStatus.notSynced.rawValue
         podcast.autoDownloadSetting = (FeatureFlag.autoDownloadOnSubscribe.enabled && Settings.autoDownloadEnabled() && Settings.autoDownloadOnFollow() ? AutoDownloadSetting.latest : AutoDownloadSetting.off).rawValue
         DataManager.sharedManager.save(podcast: podcast)
-        ServerPodcastManager.shared.updateLatestEpisodeInfo(podcast: podcast, setDefaults: true, autoDownloadLimit: Settings.autoDownloadOnFollow() ? 2 : 0)
+        ServerPodcastManager.shared.updateLatestEpisodeInfo(podcast: podcast, setDefaults: true, autoDownloadLimit: Settings.autoDownloadOnFollow() ? Settings.autoDownloadLimits().rawValue : 0)
         loadLocalEpisodes(podcast: podcast, animated: true)
 
         if featuredPodcast {

--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -616,7 +616,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
         podcast.syncStatus = SyncStatus.notSynced.rawValue
         podcast.autoDownloadSetting = (FeatureFlag.autoDownloadOnSubscribe.enabled && Settings.autoDownloadEnabled() && Settings.autoDownloadOnFollow() ? AutoDownloadSetting.latest : AutoDownloadSetting.off).rawValue
         DataManager.sharedManager.save(podcast: podcast)
-        ServerPodcastManager.shared.updateLatestEpisodeInfo(podcast: podcast, setDefaults: true, autoDownloadLimit: Settings.autoDownloadLimits().rawValue)
+        ServerPodcastManager.shared.updateLatestEpisodeInfo(podcast: podcast, setDefaults: true, autoDownloadLimit: Settings.autoDownloadOnFollow() ? 2 : 0)
         loadLocalEpisodes(podcast: podcast, animated: true)
 
         if featuredPodcast {

--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -614,7 +614,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
 
         podcast.subscribed = 1
         podcast.syncStatus = SyncStatus.notSynced.rawValue
-        podcast.autoDownloadSetting = (FeatureFlag.autoDownloadOnSubscribe.enabled && Settings.autoDownloadEnabled() ? AutoDownloadSetting.latest : AutoDownloadSetting.off).rawValue
+        podcast.autoDownloadSetting = (FeatureFlag.autoDownloadOnSubscribe.enabled && Settings.autoDownloadEnabled() && Settings.autoDownloadOnFollow() ? AutoDownloadSetting.latest : AutoDownloadSetting.off).rawValue
         DataManager.sharedManager.save(podcast: podcast)
         ServerPodcastManager.shared.updateLatestEpisodeInfo(podcast: podcast, setDefaults: true, autoDownloadLimit: Settings.autoDownloadLimits().rawValue)
         loadLocalEpisodes(podcast: podcast, animated: true)

--- a/podcasts/ServerPodcastManager+Subscription.swift
+++ b/podcasts/ServerPodcastManager+Subscription.swift
@@ -4,12 +4,12 @@ import PocketCastsUtils
 extension ServerPodcastManager {
 
     func subscribe(to podcastUuid: String, completion: ((Bool) -> ())?) {
-        let limits = Settings.autoDownloadEnabled() && FeatureFlag.autoDownloadOnSubscribe.enabled ? Settings.autoDownloadLimits().rawValue : 0
+        let limits = Settings.autoDownloadEnabled() && FeatureFlag.autoDownloadOnSubscribe.enabled && Settings.autoDownloadOnFollow() ? Settings.autoDownloadLimits().rawValue : 0
         self.addFromUuid(podcastUuid: podcastUuid, subscribe: true, autoDownloads: limits, completion: completion)
     }
 
     func subscribeFromItunesId(_ itunesId: Int, completion: ((Bool, String?) -> ())?) {
-        let limits = Settings.autoDownloadEnabled() && FeatureFlag.autoDownloadOnSubscribe.enabled ? Settings.autoDownloadLimits().rawValue : 0
+        let limits = Settings.autoDownloadEnabled() && FeatureFlag.autoDownloadOnSubscribe.enabled && Settings.autoDownloadOnFollow() ? Settings.autoDownloadLimits().rawValue : 0
         self.addFromiTunesId(itunesId, subscribe: true, autoDownloads: limits, completion: completion)
     }
 }

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -145,6 +145,21 @@ class Settings: NSObject {
         trackValueToggled(.settingsAutoDownloadNewEpisodesToggled, enabled: allow)
     }
 
+    private static let autoDownloadOnFollowKey = "AutoDownloadOnFollow"
+    class func autoDownloadOnFollow() -> Bool {
+        guard UserDefaults.standard.object(forKey: Settings.autoDownloadOnFollowKey) != nil else {
+            return FeatureFlag.autoDownloadOnSubscribe.enabled
+        }
+        return UserDefaults.standard.bool(forKey: Settings.autoDownloadOnFollowKey)
+    }
+
+    class func setAutoDownloadOnFollow(_ allow: Bool, userInitiated: Bool = false) {
+        UserDefaults.standard.set(allow, forKey: Settings.autoDownloadOnFollowKey)
+
+        guard userInitiated else { return }
+        trackValueToggled(.settingsAutoDownloadOnFollowToggled, enabled: allow)
+    }
+
     private static let autoDownloadLimitKey = "AutoDownloadLimit"
     class func autoDownloadLimits() -> AutoDownloadLimit {
         AutoDownloadLimit(rawValue: UserDefaults.standard.integer(forKey: Settings.autoDownloadLimitKey)) ?? .two

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -157,7 +157,7 @@ class Settings: NSObject {
         UserDefaults.standard.set(allow, forKey: Settings.autoDownloadOnFollowKey)
 
         guard userInitiated else { return }
-        trackValueToggled(.settingsAutoDownloadOnFollowToggled, enabled: allow)
+        trackValueToggled(.settingsAutoDownloadOnFollowPodcastToggled, enabled: allow)
     }
 
     private static let autoDownloadLimitKey = "AutoDownloadLimit"

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -148,7 +148,7 @@ class Settings: NSObject {
     private static let autoDownloadOnFollowKey = "AutoDownloadOnFollow"
     class func autoDownloadOnFollow() -> Bool {
         guard UserDefaults.standard.object(forKey: Settings.autoDownloadOnFollowKey) != nil else {
-            return FeatureFlag.autoDownloadOnSubscribe.enabled
+            return false
         }
         return UserDefaults.standard.bool(forKey: Settings.autoDownloadOnFollowKey)
     }

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -2756,8 +2756,6 @@ internal enum L10n {
   internal static var settingsAutoDownloadsNoPodcastsSelected: String { return L10n.tr("Localizable", "settings_auto_downloads_no_podcasts_selected") }
   /// On Follow
   internal static var settingsAutoDownloadsOnFollow: String { return L10n.tr("Localizable", "settings_auto_downloads_on_follow") }
-  /// Automatically download the latest two episodes from new shows you follow.
-  internal static var settingsAutoDownloadsOnFollowDetails: String { return L10n.tr("Localizable", "settings_auto_downloads_on_follow_details") }
   /// %1$@ podcasts selected
   internal static func settingsAutoDownloadsPodcastsSelectedFormat(_ p1: Any) -> String {
     return L10n.tr("Localizable", "settings_auto_downloads_podcasts_selected_format", String(describing: p1))
@@ -2766,7 +2764,7 @@ internal enum L10n {
   internal static var settingsAutoDownloadsPodcastsSelectedSingular: String { return L10n.tr("Localizable", "settings_auto_downloads_podcasts_selected_singular") }
   /// Download the top episodes in a filter.
   internal static var settingsAutoDownloadsSubtitleFilters: String { return L10n.tr("Localizable", "settings_auto_downloads_subtitle_filters") }
-  /// Automatically download new episodes as they’re released, and manage your storage by setting a limit on how many episodes are saved.
+  /// Automatically download new episodes, save episodes from newly followed shows, and manage your storage by setting a limit on how many episodes are saved.
   internal static var settingsAutoDownloadsSubtitleNewEpisodes: String { return L10n.tr("Localizable", "settings_auto_downloads_subtitle_new_episodes") }
   /// Download episodes added to Up Next.
   internal static var settingsAutoDownloadsSubtitleUpNext: String { return L10n.tr("Localizable", "settings_auto_downloads_subtitle_up_next") }

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -280,7 +280,7 @@ internal enum L10n {
   internal static var autoDownloadFirst: String { return L10n.tr("Localizable", "auto_download_first") }
   /// Limit auto downloads
   internal static var autoDownloadLimitAutoDownloads: String { return L10n.tr("Localizable", "auto_download_limit_auto_downloads") }
-  /// Limit downloads
+  /// Limit Downloads
   internal static var autoDownloadLimitDownloads: String { return L10n.tr("Localizable", "auto_download_limit_downloads") }
   /// %1$@ Episodes
   internal static func autoDownloadLimitNumberOfEpisodes(_ p1: Any) -> String {
@@ -296,6 +296,8 @@ internal enum L10n {
   internal static var autoDownloadLimitOneEpisodeShow: String { return L10n.tr("Localizable", "auto_download_limit_one_episode_show") }
   /// Enable to auto download episodes in this filter
   internal static var autoDownloadOffSubtitle: String { return L10n.tr("Localizable", "auto_download_off_subtitle") }
+  /// On Follow
+  internal static var autoDownloadOnFollow: String { return L10n.tr("Localizable", "auto_download_on_follow") }
   /// The first %1$@ episodes in this filter will be automatically downloaded
   internal static func autoDownloadOnPluralFormat(_ p1: Any) -> String {
     return L10n.tr("Localizable", "auto_download_on_plural_format", String(describing: p1))

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -296,8 +296,6 @@ internal enum L10n {
   internal static var autoDownloadLimitOneEpisodeShow: String { return L10n.tr("Localizable", "auto_download_limit_one_episode_show") }
   /// Enable to auto download episodes in this filter
   internal static var autoDownloadOffSubtitle: String { return L10n.tr("Localizable", "auto_download_off_subtitle") }
-  /// On Follow
-  internal static var autoDownloadOnFollow: String { return L10n.tr("Localizable", "auto_download_on_follow") }
   /// The first %1$@ episodes in this filter will be automatically downloaded
   internal static func autoDownloadOnPluralFormat(_ p1: Any) -> String {
     return L10n.tr("Localizable", "auto_download_on_plural_format", String(describing: p1))
@@ -2756,6 +2754,10 @@ internal enum L10n {
   internal static var settingsAutoDownloadsNoFiltersSelected: String { return L10n.tr("Localizable", "settings_auto_downloads_no_filters_selected") }
   /// No Podcasts Selected
   internal static var settingsAutoDownloadsNoPodcastsSelected: String { return L10n.tr("Localizable", "settings_auto_downloads_no_podcasts_selected") }
+  /// On Follow
+  internal static var settingsAutoDownloadsOnFollow: String { return L10n.tr("Localizable", "settings_auto_downloads_on_follow") }
+  /// Automatically download the latest two episodes from new shows you follow.
+  internal static var settingsAutoDownloadsOnFollowDetails: String { return L10n.tr("Localizable", "settings_auto_downloads_on_follow_details") }
   /// %1$@ podcasts selected
   internal static func settingsAutoDownloadsPodcastsSelectedFormat(_ p1: Any) -> String {
     return L10n.tr("Localizable", "settings_auto_downloads_podcasts_selected_format", String(describing: p1))

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4598,7 +4598,7 @@
 "week" = "week";
 
 /* Auto Downloads Setting - Limits downloads row title*/
-"auto_download_limit_downloads" = "Limit downloads";
+"auto_download_limit_downloads" = "Limit Downloads";
 
 /* Auto Downloads Setting - Limits downloads picker title*/
 "auto_download_limit_auto_downloads" = "Limit auto downloads";
@@ -4696,3 +4696,5 @@
 /* Referrals - Share Pass message. `%1$@' is a placeholder for the duration of free period offered on the Plus subscription*/
 "referrals_share_pass_long_message" = "Hi there!\n\nHere is a %1$@ guest pass for Pocket Casts Plus–my favorite podcast player. It's packed with unique features like bookmarks, folders, and more that you won't find anywhere else. I think you'll love it too!\n";
 
+/* Auto Downloads Setting - Auto download on follow of a blog*/
+"auto_download_on_follow" = "On Follow";

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4697,4 +4697,7 @@
 "referrals_share_pass_long_message" = "Hi there!\n\nHere is a %1$@ guest pass for Pocket Casts Plus–my favorite podcast player. It's packed with unique features like bookmarks, folders, and more that you won't find anywhere else. I think you'll love it too!\n";
 
 /* Auto Downloads Setting - Auto download on follow of a blog*/
-"auto_download_on_follow" = "On Follow";
+"settings_auto_downloads_on_follow" = "On Follow";
+
+/* Auto Downloads Setting - Auto download on follow of a blog details*/
+"settings_auto_downloads_on_follow_details" = "Automatically download the latest two episodes from new shows you follow.";

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -2318,7 +2318,7 @@
 "settings_auto_downloads_subtitle_filters" = "Download the top episodes in a filter.";
 
 /* Subtitle explaining the toggle to auto download New Episodes. */
-"settings_auto_downloads_subtitle_new_episodes" = "Automatically download new episodes as they’re released, and manage your storage by setting a limit on how many episodes are saved.";
+"settings_auto_downloads_subtitle_new_episodes" = "Automatically download new episodes, save episodes from newly followed shows, and manage your storage by setting a limit on how many episodes are saved.";
 
 /* Subtitle explaining the toggle to auto download items in the Up Next Queue. */
 "settings_auto_downloads_subtitle_up_next" = "Download episodes added to Up Next.";
@@ -4698,6 +4698,3 @@
 
 /* Auto Downloads Setting - Auto download on follow of a blog*/
 "settings_auto_downloads_on_follow" = "On Follow";
-
-/* Auto Downloads Setting - Auto download on follow of a blog details*/
-"settings_auto_downloads_on_follow_details" = "Automatically download the latest two episodes from new shows you follow.";


### PR DESCRIPTION
| 📘 Part of: #2284  |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

This PR updates the AutoDownload settings to explicit say if auto-downloads on follow are active or not.
It also separate the number of downloads on subscribe from the auto-download new episode limits.
It always be two episode downloaded.

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
<img src="https://github.com/user-attachments/assets/af8af8ab-838c-4773-85a4-926f095389fa" width=320>

## To test

1. Start the app
2. Go to Profile -> Downloads -> Auto-Download Settings
3. Check if you have the option New Episodes enabled, if not enable it
4. Check if you see the option On Follow
5. Enable the switch
6. Go to Discovery and find a podcast you don't follow
7. Subscribe to it
8. Check if you see a maximum of auto-downloads, depending on the limit set, happening for the podcast
9. Go back to Profile -> Downloads -> Auto-Download Settings
10. This time disable On Follow
11. Go to Discovery and find a podcast you don't follow
12. Subscribe to it
8. Check if you *don't* see auto-downloads happening for the podcast

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
