### PR TITLE
Increase Touch zone on close search results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Referrals: update share message and add image [#2468](https://github.com/Automattic/pocket-casts-ios/pull/2468)
 - Fix refresh of the navigation bar buttons when switchin tabs [#2294](https://github.com/Automattic/pocket-casts-ios/issues/2294)
 - Fix sharing of Referrals, Episodes and EOY when using the radioactivity theme [#2485](https://github.com/Automattic/pocket-casts-ios/pull/2485)
+- Increase tap area for button that removes previous searches [#2494](https://github.com/Automattic/pocket-casts-ios/pull/2494)
 
 7.77
 -----

--- a/podcasts/New Search/Views/History/SearchHistoryCell.swift
+++ b/podcasts/New Search/Views/History/SearchHistoryCell.swift
@@ -82,7 +82,9 @@ struct SearchHistoryCell: View {
                             searchAnalyticsHelper.historyItemDeleted(entry)
                         }
                     }) {
-                        Image("close")
+                        ZStack {
+                            Image("close")
+                        }
                         .frame(width: 48, height: 48)
                     }
                     .buttonStyle(SecondaryButtonStyle())

--- a/podcasts/New Search/Views/History/SearchHistoryCell.swift
+++ b/podcasts/New Search/Views/History/SearchHistoryCell.swift
@@ -83,9 +83,9 @@ struct SearchHistoryCell: View {
                         }
                     }) {
                         Image("close")
+                        .frame(width: 48, height: 48)
                     }
                     .buttonStyle(SecondaryButtonStyle())
-                    .frame(width: 48, height: 48)
                 }
                 ThemedDivider()
                     .frame(height: 1)


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

This PR just increases the touch zone are for the close button on the search results for discovery

| Before | After |
| - | - |
| ![simulator_screenshot_74ED7DAD-4242-4EF8-9AFC-2832790E1FD6](https://github.com/user-attachments/assets/6f32a06e-ba75-4867-a21c-571e04d960e2) | ![simulator_screenshot_2FF27734-C580-4B44-9C1F-10A2522A55C5](https://github.com/user-attachments/assets/34b00f52-f4c3-44fd-b842-a3440e5c24f3) |

## To test

1. Start the app on the iPad
2. Go to Discovery Tab
3. Tap on Search
4. Search for anything
5. Tap on a result
6. Go back
7. Tap on the search bar again
8. You should see a list of previous searches and result tapped
9. Tap around the close button, near to it but not necessary in the center of the x image.
10. Check if the close button removes the entry

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
