### PR TITLE
Fix typo in logs: `s/Throtled/Throttled`

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/Refresh/RefreshManager.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Refresh/RefreshManager.swift
@@ -51,7 +51,7 @@ public class RefreshManager {
         if !forceEvenIfRefreshedRecently {
             if let lastRefreshStartTime = ServerSettings.lastRefreshStartTime(), fabs(lastRefreshStartTime.timeIntervalSinceNow) < RefreshManager.minTimeBetweenRefreshes {
                 // if it's been less than minTimeBetweenRefreshes since our last refresh, don't do another one. Effectively throttling user refreshes a little bit
-                FileLog.shared.addMessage("Refresh - Throtled")
+                FileLog.shared.addMessage("Refresh - Throttled")
                 DispatchQueue.global().async {
                     Thread.sleep(forTimeInterval: 1.second)
                     ServerNotificationsHelper.shared.firePodcastsUpdated()


### PR DESCRIPTION
Fixes a typo I noticed when looking at the logs from 9118472-zd-a8c.

## To test

N.A. This is just a string change.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary. – N.A.
- [x] I have considered adding unit tests for my changes. – N.A.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics. – N.A.