### PR TITLE
Fix `CHANGELOG.md`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,3 @@
-7.80
------
-
-7.77.1
------
-- Fix sharing Playback stories to Instagram [#2482](https://github.com/Automattic/pocket-casts-ios/pull/2482)
-
 7.79
 -----
 
@@ -17,6 +10,10 @@
 - Referrals: update share message and add image [#2468](https://github.com/Automattic/pocket-casts-ios/pull/2468)
 - Fix refresh of the navigation bar buttons when switchin tabs [#2294](https://github.com/Automattic/pocket-casts-ios/issues/2294)
 - Fix sharing of Referrals, Episodes and EOY when using the radioactivity theme [#2485](https://github.com/Automattic/pocket-casts-ios/pull/2485)
+
+7.77.1
+-----
+- Fix sharing Playback stories to Instagram [#2482](https://github.com/Automattic/pocket-casts-ios/pull/2482)
 
 7.77
 -----


### PR DESCRIPTION
Our `CHANGELOG.md` is in an incorrect state. This PR:

1. Removes the `7.80` header which shouldn't be there
2. Move `7.77.1` to be between `7.78` and `7.77`

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
