### PR TITLE
[Hack Week] Downloads sort

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Enums.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Enums.swift
@@ -67,6 +67,10 @@ public enum PlaylistSort: Int32 {
     case newestToOldest = 0, oldestToNewest = 1, shortestToLongest = 2, longestToShortest = 3
 }
 
+public enum DownloadsSort: Int32 {
+    case newestToOldest = 0, oldestToNewest = 1, largestToSmallest = 2, smallestToLargest = 3
+}
+
 public struct EpisodeBasicData {
     public init() {}
 

--- a/podcasts/Analytics/AnalyticsDescribable+Modules.swift
+++ b/podcasts/Analytics/AnalyticsDescribable+Modules.swift
@@ -174,3 +174,18 @@ extension SocialAuthProvider: AnalyticsDescribable {
         }
     }
 }
+
+extension DownloadsSort: AnalyticsDescribable {
+    var analyticsDescription: String {
+        switch self {
+        case .newestToOldest:
+            return "newest_to_oldest"
+        case .oldestToNewest:
+            return "oldest_to_newest"
+        case .largestToSmallest:
+            return "largest_to_smallest"
+        case .smallestToLargest:
+            return "smallest_to_largest"
+        }
+    }
+}

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -170,6 +170,7 @@ enum AnalyticsEvent: String {
     case downloadsMultiSelectEntered
     case downloadsSelectAllButtonTapped
     case downloadsMultiSelectExited
+    case downloadsSortByChanged
 
     // MARK: - Downloads Clean Up View
 

--- a/podcasts/DownloadsViewController+Table.swift
+++ b/podcasts/DownloadsViewController+Table.swift
@@ -53,6 +53,7 @@ extension DownloadsViewController: UITableViewDelegate, UITableViewDataSource {
         if let episode = episodeAtIndexPath(indexPath) {
             cell.populateFrom(episode: episode, tintColor: ThemeColor.primaryIcon01())
             cell.shouldShowSelect = isMultiSelectEnabled
+            cell.showsFileSize = true
             if isMultiSelectEnabled {
                 cell.showTick = selectedEpisodesContains(uuid: episode.uuid)
             }

--- a/podcasts/DownloadsViewController.swift
+++ b/podcasts/DownloadsViewController.swift
@@ -207,7 +207,7 @@ class DownloadsViewController: PCViewController {
         operationQueue.addOperation { [weak self] in
             guard let self else { return }
 
-            let newData = self.episodesDataManager.downloadedEpisodes()
+            let newData = self.episodesDataManager.downloadedEpisodes(sort: sort)
 
             DispatchQueue.main.sync {
                 self.downloadsTable.isHidden = (newData.count == 0)
@@ -230,10 +230,38 @@ class DownloadsViewController: PCViewController {
         dismiss(animated: true, completion: nil)
     }
 
+    func showSortByPicker() {
+        let optionsPicker = OptionsPicker(title: L10n.sortBy.localizedUppercase)
+
+        addSortAction(to: optionsPicker, sortOrder: .newestToOldest)
+        addSortAction(to: optionsPicker, sortOrder: .oldestToNewest)
+        addSortAction(to: optionsPicker, sortOrder: .largestToSmallest)
+        addSortAction(to: optionsPicker, sortOrder: .smallestToLargest)
+
+        optionsPicker.show(statusBarStyle: AppTheme.defaultStatusBarStyle())
+    }
+
+    private var sort: DownloadsSort = .newestToOldest
+
+    private func addSortAction(to optionPicker: OptionsPicker, sortOrder: DownloadsSort) {
+        let action = OptionAction(label: sortOrder.description, selected: sort == sortOrder) {
+            Analytics.track(.downloadsSortByChanged, properties: ["sort_order": sortOrder])
+            self.sort = sortOrder
+            self.reloadEpisodes()
+        }
+        optionPicker.addAction(action: action)
+    }
+
     @objc private func menuTapped(_ sender: UIBarButtonItem) {
         Analytics.track(.downloadsOptionsButtonTapped)
 
         let optionsPicker = OptionsPicker(title: nil)
+
+        let sortAction = OptionAction(label: L10n.sortBy, secondaryLabel: sort.description, icon: "podcastlist_sort") { [weak self] in
+            Analytics.track(.downloadsOptionsModalOptionTapped, properties: ["option": "sort_by"])
+            self?.showSortByPicker()
+        }
+        optionsPicker.addAction(action: sortAction)
 
         let MultiSelectAction = OptionAction(label: L10n.selectEpisodes, icon: "option-multiselect") { [weak self] in
             Analytics.track(.downloadsOptionsModalOptionTapped, properties: ["option": "select_episodes"])
@@ -334,5 +362,20 @@ class DownloadsViewController: PCViewController {
 extension DownloadsViewController: AnalyticsSourceProvider {
     var analyticsSource: AnalyticsSource {
         .downloads
+    }
+}
+
+public extension DownloadsSort {
+    var description: String {
+        switch self {
+        case .newestToOldest:
+            return "Newest to Oldest"
+        case .oldestToNewest:
+            return "Oldest to Newest"
+        case .largestToSmallest:
+            return "Largest to Smallest"
+        case .smallestToLargest:
+            return "Smallest to Largest"
+        }
     }
 }

--- a/podcasts/EpisodeCell.swift
+++ b/podcasts/EpisodeCell.swift
@@ -79,6 +79,7 @@ class EpisodeCell: ThemeableSwipeCell, MainEpisodeActionViewDelegate {
     }
 
     var hidesArtwork = false
+    var showsFileSize = false
 
     var playlist: AutoplayHelper.Playlist?
 
@@ -258,9 +259,9 @@ class EpisodeCell: ThemeableSwipeCell, MainEpisodeActionViewDelegate {
         if episode.archived {
             informationLabel.text = L10n.podcastArchived + " • " + episode.displayableInfo(includeSize: false)
         } else if let userEpisode = episode as? UserEpisode {
-            informationLabel.text = userEpisode.displayableInfo(includeSize: Settings.primaryRowAction() == .download)
+            informationLabel.text = userEpisode.displayableInfo(includeSize: Settings.primaryRowAction() == .download || showsFileSize)
         } else {
-            informationLabel.text = episode.displayableInfo(includeSize: Settings.primaryRowAction() == .download)
+            informationLabel.text = episode.displayableInfo(includeSize: Settings.primaryRowAction() == .download || showsFileSize)
         }
 
         if episode.downloading(), !downloadingIndicator.isAnimating {

--- a/podcasts/EpisodesDataManager.swift
+++ b/podcasts/EpisodesDataManager.swift
@@ -17,7 +17,7 @@ class EpisodesDataManager {
                 return episodes(for: filter).map { $0.episode }
             }
         case .downloads:
-            return downloadedEpisodes().flatMap { $0.elements.map { $0.episode } }
+            return downloadedEpisodes(sort: .newestToOldest).flatMap { $0.elements.map { $0.episode } }
         case .files:
             return uploadedEpisodes()
         case .starred:
@@ -131,8 +131,27 @@ class EpisodesDataManager {
 
     // MARK: - Downloads
 
-    func downloadedEpisodes() -> [ArraySection<String, ListEpisode>] {
-        let query = "( ((downloadTaskId IS NOT NULL AND autoDownloadStatus <> \(AutoDownloadStatus.playerDownloadedForStreaming.rawValue) ) OR episodeStatus = \(DownloadStatus.downloaded.rawValue) OR episodeStatus = \(DownloadStatus.waitingForWifi.rawValue)) OR (episodeStatus = \(DownloadStatus.downloadFailed.rawValue) AND lastDownloadAttemptDate > ?) ) ORDER BY lastDownloadAttemptDate DESC LIMIT 1000"
+    func downloadedEpisodes(sort: DownloadsSort) -> [ArraySection<String, ListEpisode>] {
+        let orderByColumn: String
+        let orderByOrder: String
+
+        switch sort {
+        case .newestToOldest:
+            orderByColumn = "lastDownloadAttemptDate"
+            orderByOrder = "DESC"
+        case .oldestToNewest:
+            orderByColumn = "lastDownloadAttemptDate"
+            orderByOrder = "ASC"
+        case .largestToSmallest:
+            orderByColumn = "sizeInBytes"
+            orderByOrder = "DESC"
+        case .smallestToLargest:
+            orderByColumn = "sizeInBytes"
+            orderByOrder = "ASC"
+        }
+
+        let query = "( ((downloadTaskId IS NOT NULL AND autoDownloadStatus <> \(AutoDownloadStatus.playerDownloadedForStreaming.rawValue) ) OR episodeStatus = \(DownloadStatus.downloaded.rawValue) OR episodeStatus = \(DownloadStatus.waitingForWifi.rawValue)) OR (episodeStatus = \(DownloadStatus.downloadFailed.rawValue) AND lastDownloadAttemptDate > ?) ) ORDER BY \(orderByColumn) \(orderByOrder) LIMIT 1000"
+
         let arguments = [Date().weeksAgo(1)] as [Any]
 
         let newData = EpisodeTableHelper.loadSectionedEpisodes(query: query, arguments: arguments, episodeShortKey: { episode -> String in

--- a/podcasts/EpisodesDataManager.swift
+++ b/podcasts/EpisodesDataManager.swift
@@ -155,10 +155,42 @@ class EpisodesDataManager {
         let arguments = [Date().weeksAgo(1)] as [Any]
 
         let newData = EpisodeTableHelper.loadSectionedEpisodes(query: query, arguments: arguments, episodeShortKey: { episode -> String in
-            episode.shortLastDownloadAttemptDate()
+            switch sort {
+            case .newestToOldest, .oldestToNewest:
+                episode.shortLastDownloadAttemptDate()
+            case .smallestToLargest, .largestToSmallest:
+                categorizeFileSize(sizeInBytes: episode.sizeInBytes)
+            }
         })
 
         return newData
+    }
+
+    private func categorizeFileSize(sizeInBytes: Int64) -> String {
+        switch sizeInBytes {
+        case 0..<1_000_000: // Less than 1MB
+            return "< \(formattedFileSize(sizeInBytes: 1_000_000))"
+        case 1_000_000..<10_000_000: // 1MB to < 10MB
+            return "\(formattedFileSize(sizeInBytes: 1_000_000))-\(formattedFileSize(sizeInBytes: 10_000_000))"
+        case 10_000_000..<50_000_000: // 10MB to < 50MB
+            return "\(formattedFileSize(sizeInBytes: 10_000_000))-\(formattedFileSize(sizeInBytes: 50_000_000))"
+        case 50_000_000...100_000_000: // 50MB-100MB
+            return "\(formattedFileSize(sizeInBytes: 50_000_000))-\(formattedFileSize(sizeInBytes: 100_000_000))"
+        case 100_000_000...: // Greater than or equal to 100MB
+            return "> \(formattedFileSize(sizeInBytes: 100_000_000))"
+        default:
+            return ""
+        }
+    }
+
+    func formattedFileSize(sizeInBytes: Int) -> String {
+        let sizeInMB = Measurement(value: Double(sizeInBytes), unit: UnitInformationStorage.bytes).converted(to: .megabytes)
+
+        let formatter = MeasurementFormatter()
+        formatter.unitOptions = .providedUnit
+        formatter.numberFormatter.maximumFractionDigits = 2
+
+        return formatter.string(from: sizeInMB)
     }
 
     // MARK: - Listening History


### PR DESCRIPTION
Adds sorting options to Downloads including a new file size sort.

||||
|--|--|--|
| ![Simulator Screenshot - iPhone 16 - 2024-12-04 at 11 39 28](https://github.com/user-attachments/assets/b5a7a30e-4c8e-4096-bdea-ed94ee5ed69a) | ![Simulator Screenshot - iPhone 16 - 2024-12-04 at 11 39 31](https://github.com/user-attachments/assets/e81081d7-c255-441b-9fb2-bfc75c557fbd) | ![Simulator Screenshot - iPhone 16 - 2024-12-04 at 11 51 54](https://github.com/user-attachments/assets/e8a8db65-4287-4af1-a239-cd8e4a31f33e) |

## To test

* Download several episodes
* Open the Profiles > Downloads screen
* Tap the Ellipse
* Change the "Sort By" menu option

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
