### PR TITLE
[UpNextShuffle] Add Toast message

### DIFF
--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -3476,6 +3476,8 @@ internal enum L10n {
   internal static var upNextShuffleAnnouncementText: String { return L10n.tr("Localizable", "up_next_shuffle_announcement_text") }
   /// Introducing Shuffle
   internal static var upNextShuffleAnnouncementTitle: String { return L10n.tr("Localizable", "up_next_shuffle_announcement_title") }
+  /// Shuffle on. The next episode will be selected randomly.
+  internal static var upNextShuffleToastMessage: String { return L10n.tr("Localizable", "up_next_shuffle_toast_message") }
   /// Upgrade Account
   internal static var upgradeAccount: String { return L10n.tr("Localizable", "upgrade_account") }
   /// Save 50%% off your first year

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -3476,7 +3476,7 @@ internal enum L10n {
   internal static var upNextShuffleAnnouncementText: String { return L10n.tr("Localizable", "up_next_shuffle_announcement_text") }
   /// Introducing Shuffle
   internal static var upNextShuffleAnnouncementTitle: String { return L10n.tr("Localizable", "up_next_shuffle_announcement_title") }
-  /// Shuffle on. The next episode will be selected randomly.
+  /// Shuffle is on. Episodes will play in random order.
   internal static var upNextShuffleToastMessage: String { return L10n.tr("Localizable", "up_next_shuffle_toast_message") }
   /// Upgrade Account
   internal static var upgradeAccount: String { return L10n.tr("Localizable", "upgrade_account") }

--- a/podcasts/UpNextViewController.swift
+++ b/podcasts/UpNextViewController.swift
@@ -223,7 +223,11 @@ class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
         if !showingInTab {
             updateShuffleButtonState()
         }
-        track(.upNextShuffleEnabled, properties: ["value": Settings.upNextShuffleEnabled()])
+        let upNextShuffleEnabled = Settings.upNextShuffleEnabled()
+        if upNextShuffleEnabled {
+            Toast.show(L10n.upNextShuffleToastMessage)
+        }
+        track(.upNextShuffleEnabled, properties: ["value": upNextShuffleEnabled])
     }
 
     @objc private func themeDidChange() {

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4654,6 +4654,9 @@
 /* Up Next Shuffle Announcement sheet dismiss button title*/
 "up_next_shuffle_announcement_button" = "Got it";
 
+/* Toast message displayed when the user enables the Up NExt Shuffle option */
+"up_next_shuffle_toast_message" = "Shuffle on. The next episode will be selected randomly.";
+
 /* Title for manage downloads file space usage banner and modal */
 "manage_downloads_title" = "Need to free up space?";
 

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4654,8 +4654,8 @@
 /* Up Next Shuffle Announcement sheet dismiss button title*/
 "up_next_shuffle_announcement_button" = "Got it";
 
-/* Toast message displayed when the user enables the Up NExt Shuffle option */
-"up_next_shuffle_toast_message" = "Shuffle on. The next episode will be selected randomly.";
+/* Toast message displayed when the user enables the Up Next Shuffle option */
+"up_next_shuffle_toast_message" = "Shuffle is on. Episodes will play in random order.";
 
 /* Title for manage downloads file space usage banner and modal */
 "manage_downloads_title" = "Need to free up space?";


### PR DESCRIPTION
Fixes #2505

Adds a snackbar saying "Shuffle is on. Episodes will play in random order."

Context: p1733394295890409-slack-C07T08CTND9

## To test

- CI must be 🟢 
- Use a premium account
- Go to UpNext and enable the Shuffle
- Confirm you see the Toast being prompted 

<img src="https://github.com/user-attachments/assets/1300025e-6e44-4005-9d32-dd592cfd4f78" width=300 />

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
