### PR TITLE
Remove UpNextOnTabBar Feature Flag

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -52,9 +52,6 @@ public enum FeatureFlag: String, CaseIterable {
 
     case categoriesRedesign
 
-    /// show UpNext tab on the main tab bar
-    case upNextOnTabBar
-
     /// When enabled it updates the code on filter callback to use a safer method to convert unmanaged player references
     /// This is to fix this: https://a8c.sentry.io/share/issue/39a6d2958b674ec3b7a4d9248b4b5ffa/
     case defaultPlayerFilterCallbackFix
@@ -201,8 +198,6 @@ public enum FeatureFlag: String, CaseIterable {
             true
         case .defaultPlayerFilterCallbackFix:
             true
-        case .upNextOnTabBar:
-            true
         case .downloadFixes:
             true
         case .onlyMarkPodcastsUnsyncedForNewUsers:
@@ -287,9 +282,7 @@ public enum FeatureFlag: String, CaseIterable {
         case .categoriesRedesign:
             "categories_redesign"
         case .defaultPlayerFilterCallbackFix:
-            "default_player_filter_callback_fix"
-        case .upNextOnTabBar:
-            "up_next_on_tab_bar"
+            "default_player_filter_callback_fix"        
         default:
             rawValue.lowerSnakeCased()
         }

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -282,7 +282,7 @@ public enum FeatureFlag: String, CaseIterable {
         case .categoriesRedesign:
             "categories_redesign"
         case .defaultPlayerFilterCallbackFix:
-            "default_player_filter_callback_fix"        
+            "default_player_filter_callback_fix"
         default:
             rawValue.lowerSnakeCased()
         }

--- a/podcasts/MainTabBarController+shortcuts.swift
+++ b/podcasts/MainTabBarController+shortcuts.swift
@@ -34,18 +34,11 @@ extension MainTabBarController {
         let discoverCommand = UIKeyCommand(title: L10n.discover, action: #selector(handleDiscover), input: "3", modifierFlags: [.command])
         addKeyCommand(discoverCommand)
 
-        // If the feature flag is enabled then Up Next is in position 4 and Profile in position 5 on the tab bar.
-        // If disabled, then Profile remains in the original position 4. Set the keyboard shortcuts accordingly.
-        if FeatureFlag.upNextOnTabBar.enabled {
-            let upNextCommand = UIKeyCommand(title: L10n.upNext, action: #selector(handleUpNext), input: "4", modifierFlags: [.command])
-            addKeyCommand(upNextCommand)
+        let upNextCommand = UIKeyCommand(title: L10n.upNext, action: #selector(handleUpNext), input: "4", modifierFlags: [.command])
+        addKeyCommand(upNextCommand)
 
-            let profileCommand = UIKeyCommand(title: L10n.profile, action: #selector(handleProfile), input: "5", modifierFlags: [.command])
-            addKeyCommand(profileCommand)
-        } else {
-            let profileCommand = UIKeyCommand(title: L10n.profile, action: #selector(handleProfile), input: "4", modifierFlags: [.command])
-            addKeyCommand(profileCommand)
-        }
+        let profileCommand = UIKeyCommand(title: L10n.profile, action: #selector(handleProfile), input: "5", modifierFlags: [.command])
+        addKeyCommand(profileCommand)
 
         let searchCommand = UIKeyCommand(title: L10n.search, action: #selector(handleSearch), input: "f", modifierFlags: [.command])
         addKeyCommand(searchCommand)

--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -31,11 +31,7 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
 
         fixTarBarTraitCollectionOnIpadForiOS18()
 
-        if FeatureFlag.upNextOnTabBar.enabled {
-            pcTabs = [.podcasts, .filter, .discover, .upNext, .profile]
-        } else {
-            pcTabs = [.podcasts, .filter, .discover, .profile]
-        }
+        pcTabs = [.podcasts, .filter, .discover, .upNext, .profile]
 
         var vcsInTab = [UIViewController]()
 
@@ -56,13 +52,9 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
         let profileViewController = ProfileViewController()
         profileViewController.tabBarItem = profileTabBarItem
 
-        if FeatureFlag.upNextOnTabBar.enabled {
-            let upNextViewController = UpNextViewController(source: .tabBar, showingInTab: true)
-            upNextViewController.tabBarItem = UITabBarItem(title: L10n.upNext, image: UIImage(named: "upnext_tab"), tag: pcTabs.firstIndex(of: .upNext)!)
-            vcsInTab = [podcastsController, filtersViewController, discoverViewController, upNextViewController, profileViewController]
-        } else {
-            vcsInTab = [podcastsController, filtersViewController, discoverViewController, profileViewController]
-        }
+        let upNextViewController = UpNextViewController(source: .tabBar, showingInTab: true)
+        upNextViewController.tabBarItem = UITabBarItem(title: L10n.upNext, image: UIImage(named: "upnext_tab"), tag: pcTabs.firstIndex(of: .upNext)!)
+        vcsInTab = [podcastsController, filtersViewController, discoverViewController, upNextViewController, profileViewController]
 
         displayEndOfYearBadgeIfNeeded()
 


### PR DESCRIPTION
| 📘 Part of: #2509 |  <!-- project issue number, if applicable -->
|:---:|

Fixes #2511 <!-- issue number, if applicable -->

Remove the UpNextOnTabBar FF code.

## To test

1. Start the app
2. Check if UpNext shows on the Tab bar
3. Tap on that tab
4. Smoke test if it's working correctly

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
