### PR TITLE
Remove FF for transcripts

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -209,7 +209,7 @@ public enum FeatureFlag: String, CaseIterable {
         case .accelerateEffects:
             true
         case .newSharing:
-            true        
+            true
         case .kidsProfile:
             false
         case .upgradeExperiment:

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -76,9 +76,6 @@ public enum FeatureFlag: String, CaseIterable {
 
     case newSharing
 
-    /// Enable the transcripts feature on podcasts episodes
-    case transcripts
-
     /// Enables the Kids banner
     case kidsProfile
 
@@ -212,9 +209,7 @@ public enum FeatureFlag: String, CaseIterable {
         case .accelerateEffects:
             true
         case .newSharing:
-            true
-        case .transcripts:
-            true
+            true        
         case .kidsProfile:
             false
         case .upgradeExperiment:

--- a/PocketCastsTests/Tests/Utilities/SettingsTests.swift
+++ b/PocketCastsTests/Tests/Utilities/SettingsTests.swift
@@ -61,6 +61,7 @@ final class SettingsTests: XCTestCase {
 
         XCTAssertEqual([.addBookmark,
                         .markPlayed,
+                        .transcript,
                         .effects,
                         .sleepTimer,
                         .routePicker,
@@ -83,6 +84,7 @@ final class SettingsTests: XCTestCase {
 
         XCTAssertEqual([.addBookmark,
                         .markPlayed,
+                        .transcript,
                         .effects,
                         .sleepTimer,
                         .routePicker,
@@ -111,6 +113,7 @@ final class SettingsTests: XCTestCase {
 
         XCTAssertEqual([.addBookmark,
                         .markPlayed,
+                        .transcript,
                         .effects,
                         .sleepTimer,
                         .routePicker,

--- a/PocketCastsTests/Tests/Utilities/SettingsTests.swift
+++ b/PocketCastsTests/Tests/Utilities/SettingsTests.swift
@@ -13,7 +13,6 @@ final class SettingsTests: XCTestCase {
     override func setUp() {
         super.setUp()
         UserDefaults.standard.removePersistentDomain(forName: userDefaultsSuiteName)
-        try? override(flag: .transcripts, value: false)
     }
 
     private func override(flag: FeatureFlag, value: Bool) throws {

--- a/podcasts/Enumerations.swift
+++ b/podcasts/Enumerations.swift
@@ -436,8 +436,6 @@ extension PlayerAction: AnalyticsDescribable {
         switch self {
         case .starEpisode, .shareEpisode:
             return episode is Episode
-        case .transcript:
-            return FeatureFlag.transcripts.enabled
         default:
             return true
         }
@@ -447,8 +445,6 @@ extension PlayerAction: AnalyticsDescribable {
     /// If false, the action will be hidden from the player shelf and overflow menu
     var isAvailable: Bool {
         switch self {
-        case .transcript:
-            return FeatureFlag.transcripts.enabled
         default:
             return true
         }

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -783,7 +783,7 @@ class Settings: NSObject {
         }
 
         // Show transcript as the 4th item if it's not present
-        if FeatureFlag.transcripts.enabled && !playerActions.contains(.transcript) {
+        if !playerActions.contains(.transcript) {
             playerActions.insert(.transcript, safelyAt: 3)
         }
 

--- a/podcasts/ShowNotesUpdater.swift
+++ b/podcasts/ShowNotesUpdater.swift
@@ -10,10 +10,8 @@ class ShowNotesUpdater {
                 _ = try? await ShowInfoCoordinator.shared.loadChapters(podcastUuid: podcastUuid, episodeUuid: episodeUuid)
 
                 #if !os(watchOS)
-                if FeatureFlag.transcripts.enabled {
-                    let transcriptManager = TranscriptManager(episodeUUID: episodeUuid, podcastUUID: podcastUuid)
-                    _ = try? await transcriptManager.loadTranscript()
-                }
+                let transcriptManager = TranscriptManager(episodeUUID: episodeUuid, podcastUUID: podcastUuid)
+                _ = try? await transcriptManager.loadTranscript()
                 #endif
             }
             return


### PR DESCRIPTION
| 📘 Part of: #2509 |  <!-- project issue number, if applicable -->
|:---:|

Fixes #2510 <!-- issue number, if applicable -->

Removes the FF for transcripts.

## To test

1. Start the app
2. Open a podcast with transcripts support, for ex: Cautionary Tales,  and play an episode of it.
4. Check if the transcript button is visible on the action bar
5. Tap on it
6. Check if transcript shows up
7. Open a podcast without transcripts, Ex: The Daily, and play an episode of it.
8. Check if transcript button shows up disable
9. Tap on it and see if a toast is show saying that Transcript is not available.


## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
