### PR TITLE
Feature Flag: remove `newPlayerTransition` feature flag

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -23,9 +23,6 @@ public enum FeatureFlag: String, CaseIterable {
     /// Enable chapters to be loaded from the RSS feed
     case rssChapters
 
-    /// Enable a quicker and more responsive player transition
-    case newPlayerTransition
-
     /// Avoid logging out user on non-authorization HTTP errors
     case errorLogoutHandling
 
@@ -179,8 +176,6 @@ public enum FeatureFlag: String, CaseIterable {
             false
         case .rssChapters:
             false
-        case .newPlayerTransition:
-            true
         case .errorLogoutHandling:
             false
         case .giveRatings:

--- a/podcasts/AboutView.swift
+++ b/podcasts/AboutView.swift
@@ -112,7 +112,7 @@ struct AboutView: View {
     }
 
     private func openShareApp() {
-        guard let controller = FeatureFlag.newPlayerTransition.enabled ? SceneHelper.rootViewController() : SceneHelper.rootViewController()?.presentedViewController else { return }
+        guard let controller = SceneHelper.rootViewController() else { return }
 
         SharingHelper.shared.shareLinkToApp(fromController: controller)
     }

--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -302,13 +302,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func updateRemoteFeatureFlags() {
         guard BuildEnvironment.current != .debug else { return }
         do {
-            if FeatureFlag.newPlayerTransition.enabled != Settings.newPlayerTransition {
-                // If the player transition changes we dismiss the full screen player
-                // Otherwise this might lead to crashes or weird behavior
-                appDelegate()?.miniPlayer()?.closeFullScreenPlayer()
-                try FeatureFlagOverrideStore().override(FeatureFlag.newPlayerTransition, withValue: Settings.newPlayerTransition)
-            }
-
             if FeatureFlag.errorLogoutHandling.enabled != Settings.errorLogoutHandling {
                 ServerConfig.avoidLogoutOnError = FeatureFlag.errorLogoutHandling.enabled
                 try FeatureFlagOverrideStore().override(FeatureFlag.errorLogoutHandling, withValue: Settings.errorLogoutHandling)

--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -302,9 +302,6 @@ struct Constants {
         static let addMissingEpisodes = "add_missing_episodes"
         static let addMissingEpisodesDefault: Bool = true
 
-        static let newPlayerTransition = "new_player_transition"
-        static let newPlayerTransitionDefault: Bool = true
-
         static let errorLogoutHandling = "error_logout_handling"
         static let errorLogoutHandlingDefault: Bool = false
 

--- a/podcasts/End of Year/EndOfYear.swift
+++ b/podcasts/End of Year/EndOfYear.swift
@@ -159,7 +159,7 @@ struct EndOfYear {
     }
 
     static func share(assets: [Any], model: StoriesModel, storyIdentifier: String = "unknown", onDismiss: (() -> Void)? = nil) {
-        let presenter = FeatureFlag.newPlayerTransition.enabled ? SceneHelper.rootViewController() : SceneHelper.rootViewController()?.presentedViewController
+        let presenter = SceneHelper.rootViewController()
 
         let fakeViewController = FakeViewController()
         fakeViewController.onDismiss = onDismiss

--- a/podcasts/End of Year/Stories/2024/PaidStoryWallView2024.swift
+++ b/podcasts/End of Year/Stories/2024/PaidStoryWallView2024.swift
@@ -44,7 +44,7 @@ struct PaidStoryWallView2024: View {
                 VStack(alignment: .leading, spacing: 0) {
                     StoryFooter2024(title: L10n.playback2024PlusUpsellTitle, description: L10n.playback2024PlusUpsellDescription, subscriptionTier: .plus)
                     Button(L10n.playback2024PlusUpsellButtonTitle) {
-                        guard let storiesViewController = FeatureFlag.newPlayerTransition.enabled ? SceneHelper.rootViewController() : SceneHelper.rootViewController()?.presentedViewController else {
+                        guard let storiesViewController = SceneHelper.rootViewController() else {
                             return
                         }
 

--- a/podcasts/End of Year/Stories/Views/PaidStoryWallView.swift
+++ b/podcasts/End of Year/Stories/Views/PaidStoryWallView.swift
@@ -16,7 +16,7 @@ struct PaidStoryWallView: View {
                 .padding(.bottom, geometry.size.height * 0.06)
 
                 Button(L10n.upgradeToPlan(L10n.pocketCastsPlusShort)) {
-                    guard let storiesViewController = FeatureFlag.newPlayerTransition.enabled ? SceneHelper.rootViewController() : SceneHelper.rootViewController()?.presentedViewController else {
+                    guard let storiesViewController = SceneHelper.rootViewController() else {
                         return
                     }
 

--- a/podcasts/FirebaseManager.swift
+++ b/podcasts/FirebaseManager.swift
@@ -13,7 +13,6 @@ struct FirebaseManager {
             Constants.RemoteParams.endOfYearRequireAccount: NSNumber(value: Constants.RemoteParams.endOfYearRequireAccountDefault),
             Constants.RemoteParams.patronCloudStorageGB: NSNumber(value: Constants.RemoteParams.patronCloudStorageGBDefault),
             Constants.RemoteParams.addMissingEpisodes: NSNumber(value: Constants.RemoteParams.addMissingEpisodesDefault),
-            Constants.RemoteParams.newPlayerTransition: NSNumber(value: Constants.RemoteParams.newPlayerTransitionDefault),
             Constants.RemoteParams.errorLogoutHandling: NSNumber(value: Constants.RemoteParams.errorLogoutHandlingDefault),
             Constants.RemoteParams.slumberStudiosPromoCode: NSString(string: Constants.RemoteParams.slumberStudiosPromoCodeDefault)
         ]

--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -707,7 +707,7 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
     // This code simple checks if the tab bar is already presenting something and, if yes,
     // present the VC through the presentedViewController
     override func present(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)? = nil) {
-        if FeatureFlag.newPlayerTransition.enabled, let presentedViewController, !presentedViewController.isBeingDismissed {
+        if let presentedViewController, !presentedViewController.isBeingDismissed {
             presentedViewController.present(viewControllerToPresent, animated: flag, completion: completion)
             return
         }

--- a/podcasts/MiniPlayerViewController+Gestures.swift
+++ b/podcasts/MiniPlayerViewController+Gestures.swift
@@ -52,10 +52,6 @@ extension MiniPlayerViewController: UIGestureRecognizerDelegate {
 
             // didn't move far enough
             if abs(endPoint.y) < MiniPlayerViewController.minMoveAmount {
-                if !FeatureFlag.newPlayerTransition.enabled {
-                    closeFullScreenPlayer()
-                }
-
                 return
             }
 

--- a/podcasts/MiniPlayerViewController+Gestures.swift
+++ b/podcasts/MiniPlayerViewController+Gestures.swift
@@ -42,7 +42,6 @@ extension MiniPlayerViewController: UIGestureRecognizerDelegate {
         } else if recognizer.state == UIGestureRecognizer.State.changed {
             let currentPoint = recognizer.translation(in: view.superview)
 
-            moveWhileDragging(offsetFromTop: currentPoint.y)
             fullScreenPlayer?.view.moveTo(y: fullScreenPlayer!.view.bounds.height + currentPoint.y)
         } else if recognizer.state == UIGestureRecognizer.State.ended {
             rootViewController()?.view.isUserInteractionEnabled = true

--- a/podcasts/MiniPlayerViewController+Positioning.swift
+++ b/podcasts/MiniPlayerViewController+Positioning.swift
@@ -41,123 +41,46 @@ extension MiniPlayerViewController {
     func openFullScreenPlayer(completion: (() -> Void)? = nil) {
         guard PlaybackManager.shared.currentEpisode() != nil else { return }
 
-        guard !FeatureFlag.newPlayerTransition.enabled else {
-            if fullScreenPlayer?.presentingViewController != nil || fullScreenPlayer?.isBeingPresented == true { return }
+        if fullScreenPlayer?.presentingViewController != nil || fullScreenPlayer?.isBeingPresented == true { return }
 
-            aboutToDisplayFullScreenPlayer()
+        aboutToDisplayFullScreenPlayer()
 
-            fullScreenPlayer?.modalPresentationStyle = .custom
-            fullScreenPlayer?.transitioningDelegate = self
+        fullScreenPlayer?.modalPresentationStyle = .custom
+        fullScreenPlayer?.transitioningDelegate = self
 
-            guard let fullScreenPlayer else {
-                return
-            }
-
-            playerOpenState = .animating
-
-            presentFromRootController(fullScreenPlayer, animated: true) {
-                self.playerOpenState = .open
-                self.rootViewController()?.setNeedsStatusBarAppearanceUpdate()
-                self.rootViewController()?.setNeedsUpdateOfHomeIndicatorAutoHidden()
-                AnalyticsHelper.nowPlayingOpened()
-                Analytics.track(.playerShown)
-                completion?()
-            } failure: {
-                self.playerOpenState = .closed
-            }
-
+        guard let fullScreenPlayer else {
             return
         }
 
-        if playerOpenState == .open || playerOpenState == .animating { return }
-
         playerOpenState = .animating
-        aboutToDisplayFullScreenPlayer()
-        view.superview?.layoutIfNeeded()
-        fullScreenPlayer?.beginAppearanceTransition(true, animated: true)
-        UIView.animate(withDuration: 0.7, delay: 0, usingSpringWithDamping: 0.94, initialSpringVelocity: 0.7, options: UIView.AnimationOptions.curveEaseIn, animations: { () in
-            self.moveToHiddenTopPosition()
-            self.fullScreenPlayer?.view.moveTo(y: 0)
-        }) { _ in
-            self.fullScreenPlayer?.endAppearanceTransition()
-            self.view.isHidden = true
-            self.moveToHiddenTopPosition() // call this again in case the animation block wasn't called. It's ok to call this twice
+
+        presentFromRootController(fullScreenPlayer, animated: true) {
             self.playerOpenState = .open
             self.rootViewController()?.setNeedsStatusBarAppearanceUpdate()
             self.rootViewController()?.setNeedsUpdateOfHomeIndicatorAutoHidden()
             AnalyticsHelper.nowPlayingOpened()
+            Analytics.track(.playerShown)
             completion?()
+        } failure: {
+            self.playerOpenState = .closed
         }
     }
 
     func closeFullScreenPlayer(completion: (() -> Void)? = nil) {
-        guard !FeatureFlag.newPlayerTransition.enabled else {
-            if fullScreenPlayer?.presentingViewController == nil || fullScreenPlayer?.isBeingDismissed == true {
-                completion?()
-
-                return
-            }
-
-            playerOpenState = .animating
-
-            rootViewController()?.dismiss(animated: true) {
-                self.finishedWithFullScreenPlayer()
-                self.playerOpenState = .closed
-                Analytics.track(.playerDismissed)
-                completion?()
-            }
-            return
-        }
-
-        if playerOpenState == .closed || playerOpenState == .animating {
+        if fullScreenPlayer?.presentingViewController == nil || fullScreenPlayer?.isBeingDismissed == true {
             completion?()
 
             return
         }
 
-        fullScreenPlayer?.beginAppearanceTransition(false, animated: true)
         playerOpenState = .animating
-        DispatchQueue.main.async {
-            guard let parentView = self.view.superview else { return }
 
-            let isSomethingPlaying = PlaybackManager.shared.currentEpisode() != nil
-            self.view.isHidden = !isSomethingPlaying
-            let parentViewHeight = parentView.bounds.height
-            self.view.superview?.layoutIfNeeded()
-            UIView.animate(withDuration: 0.7, delay: 0, usingSpringWithDamping: 0.8, initialSpringVelocity: 0.5, options: UIView.AnimationOptions.curveEaseIn, animations: { () in
-                self.moveToShownPosition()
-                self.fullScreenPlayer?.view.moveTo(y: parentViewHeight)
-            }, completion: { _ in
-                self.moveToShownPosition() // call this again in case the animation block wasn't called. It's ok to call this twice
-                self.fullScreenPlayer?.endAppearanceTransition()
-
-                self.finishedWithFullScreenPlayer()
-                self.playerOpenState = .closed
-                completion?()
-            })
+        rootViewController()?.dismiss(animated: true) {
+            self.finishedWithFullScreenPlayer()
+            self.playerOpenState = .closed
+            Analytics.track(.playerDismissed)
+            completion?()
         }
-    }
-
-    func moveToHiddenTopPosition() {
-        guard !FeatureFlag.newPlayerTransition.enabled else {
-            return
-        }
-
-        guard let parentView = view.superview, let tabBar = rootViewController()?.tabBar else { return }
-
-        view.transform = CGAffineTransform(translationX: 0, y: tabBar.bounds.height - parentView.bounds.height)
-        view.superview?.layoutIfNeeded()
-    }
-
-    func moveWhileDragging(offsetFromTop: CGFloat) {
-        guard !FeatureFlag.newPlayerTransition.enabled else {
-            return
-        }
-
-        view.transform = CGAffineTransform.identity
-        let tabBarHeight = rootViewController()?.tabBar.bounds.height ?? 0
-        view.transform = offsetFromTop < -tabBarHeight ? CGAffineTransform(translationX: 0, y: offsetFromTop + tabBarHeight) : CGAffineTransform(translationX: 0, y: 0)
-        view.superview?.layoutIfNeeded()
     }
 
     private func moveToHiddenBottomPosition() {

--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -88,63 +88,19 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
     func aboutToDisplayFullScreenPlayer() {
         guard let rootVC = rootViewController() else { return }
 
-        guard !FeatureFlag.newPlayerTransition.enabled else {
-            if fullScreenPlayer == nil {
-                fullScreenPlayer = PlayerContainerViewController()
-            }
-
-            return
-        }
-
-        let viewSize = rootVC.view.bounds.size
-        let startingYPos = fullScreenPlayer?.view.frame.minY ?? viewSize.height
         if fullScreenPlayer == nil {
             fullScreenPlayer = PlayerContainerViewController()
-            rootVC.addChild(fullScreenPlayer!)
-            rootVC.view.addSubview(fullScreenPlayer!.view)
         }
-
-        fullScreenPlayer?.view.frame = CGRect(x: 0, y: startingYPos, width: viewSize.width, height: viewSize.height)
-
-        // prevent swipe to go back while the player is open
-        rootNavController()?.interactivePopGestureRecognizer?.isEnabled = false
     }
 
     func finishedWithFullScreenPlayer() {
         guard let rootVC = rootViewController() else { return }
 
-        guard !FeatureFlag.newPlayerTransition.enabled else {
-            rootViewController()?.setNeedsStatusBarAppearanceUpdate()
-            rootViewController()?.setNeedsUpdateOfHomeIndicatorAutoHidden()
-
-            fullScreenPlayer?.view.removeFromSuperview()
-            fullScreenPlayer = nil
-
-            // update the mini player on full screen player close
-            playbackStateDidChange()
-            playbackProgressDidChange()
-            return
-        }
-
-        if fullScreenPlayer?.presentedViewController != nil {
-            fullScreenPlayer?.dismiss(animated: false, completion: nil)
-        }
-
-        // there's a bug in iOS where because the player is added as a child controller to the tab bar, the tab bar adds it as a tab
-        // that would be fine, except if we call fullScreenPlayer.removeFromParent() it removes the controller but not the tab, so here we drop it manually
-        // if you ever change this, check that this bug hasn't come back: https://github.com/shiftyjelly/pocketcasts-ios/issues/3338
-        if rootVC.children.count == 5 {
-            rootVC.viewControllers = rootVC.viewControllers?.dropLast()
-        }
-        fullScreenPlayer?.removeFromParent() // still call this in case it has other special handling in it
-
         rootViewController()?.setNeedsStatusBarAppearanceUpdate()
         rootViewController()?.setNeedsUpdateOfHomeIndicatorAutoHidden()
+
         fullScreenPlayer?.view.removeFromSuperview()
         fullScreenPlayer = nil
-
-        // re-enable the disabled swipe back gesture
-        rootNavController()?.interactivePopGestureRecognizer?.isEnabled = true
 
         // update the mini player on full screen player close
         playbackStateDidChange()

--- a/podcasts/PlayerContainerViewController+Gestures.swift
+++ b/podcasts/PlayerContainerViewController+Gestures.swift
@@ -7,7 +7,7 @@ extension PlayerContainerViewController: UIGestureRecognizerDelegate {
     private static let minimumScreenRatioToHide: CGFloat = 0.1
 
     @IBAction func panGestureRecognizerHandler(_ sender: UIPanGestureRecognizer) {
-        FeatureFlag.newPlayerTransition.enabled ? newTransitionPanGestureRecognizerHandler(sender) : oldTransitionPanGestureRecognizerHandler(sender)
+        newTransitionPanGestureRecognizerHandler(sender)
     }
 
     func newTransitionPanGestureRecognizerHandler(_ sender: UIPanGestureRecognizer) {
@@ -50,34 +50,6 @@ extension PlayerContainerViewController: UIGestureRecognizerDelegate {
                 break
             }
         }
-
-    func oldTransitionPanGestureRecognizerHandler(_ sender: UIPanGestureRecognizer) {
-        guard let miniPlayer = appDelegate()?.miniPlayer(), !(miniPlayer.playerOpenState == .beingDragged || miniPlayer.playerOpenState == .animating) else { return }
-
-        if nowPlayingItem.timeSlider.isScrubbing() { return }
-
-        let touchPoint = sender.location(in: view?.window)
-
-        switch sender.state {
-        case .began:
-            initialTouchPoint = touchPoint
-        case .changed:
-            if touchPoint.y - initialTouchPoint.y > 0 {
-                let yPosition = touchPoint.y - initialTouchPoint.y
-                handleMoveTo(yPosition: yPosition, miniPlayer: miniPlayer)
-            }
-        case .ended, .cancelled:
-            if touchPoint.y - initialTouchPoint.y > PlayerContainerViewController.pullDownThreshold {
-                miniPlayer.closeFullScreenPlayer()
-            } else {
-                UIView.animate(withDuration: Constants.Animation.defaultAnimationTime) {
-                    self.view.moveTo(y: 0)
-                }
-            }
-        default:
-            break
-        }
-    }
 
     // this is used so that the player tab line only fades in when you tap something that isn't a control
     func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {

--- a/podcasts/PlayerContainerViewController+Gestures.swift
+++ b/podcasts/PlayerContainerViewController+Gestures.swift
@@ -7,49 +7,45 @@ extension PlayerContainerViewController: UIGestureRecognizerDelegate {
     private static let minimumScreenRatioToHide: CGFloat = 0.1
 
     @IBAction func panGestureRecognizerHandler(_ sender: UIPanGestureRecognizer) {
-        newTransitionPanGestureRecognizerHandler(sender)
-    }
+        guard let miniPlayer = appDelegate()?.miniPlayer(), !(miniPlayer.playerOpenState == .beingDragged || miniPlayer.playerOpenState == .animating) else { return }
 
-    func newTransitionPanGestureRecognizerHandler(_ sender: UIPanGestureRecognizer) {
-            guard let miniPlayer = appDelegate()?.miniPlayer(), !(miniPlayer.playerOpenState == .beingDragged || miniPlayer.playerOpenState == .animating) else { return }
+        if nowPlayingItem.timeSlider.isScrubbing() { return }
 
-            if nowPlayingItem.timeSlider.isScrubbing() { return }
+        let touchPoint = sender.location(in: view?.window)
 
-            let touchPoint = sender.location(in: view?.window)
-
-            switch sender.state {
-            case .began:
-                initialTouchPoint = touchPoint
-            case .changed:
-                if touchPoint.y > initialTouchPoint.y {
-                    view.frame.origin.y = touchPoint.y - initialTouchPoint.y
-                }
-            case .ended, .cancelled:
-                // If pan ended, decide it we should close or reset the view
-                // based on the final position and the speed of the gesture
-                // (https://stackoverflow.com/a/47339617)
-                // If the swipe is too quick, we dismiss
-                let translation = sender.translation(in: view)
-                let velocity = sender.velocity(in: view)
-                let closing = (translation.y > view.frame.size.height * Self.minimumScreenRatioToHide) ||
-                (velocity.y > Self.minimumVelocityToHide) || velocity.y > 1000
-                dismissVelocity = velocity.y
-
-                if closing {
-                    finalYPositionWhenDismissing = touchPoint.y - initialTouchPoint.y
-                    miniPlayer.closeFullScreenPlayer()
-                } else {
-                    UIView.animate(withDuration: 0.2, animations: {
-                        self.view.frame = CGRect(x: 0,
-                                                 y: 0,
-                                                 width: self.view.frame.size.width,
-                                                 height: self.view.frame.size.height)
-                    })
-                }
-            default:
-                break
+        switch sender.state {
+        case .began:
+            initialTouchPoint = touchPoint
+        case .changed:
+            if touchPoint.y > initialTouchPoint.y {
+                view.frame.origin.y = touchPoint.y - initialTouchPoint.y
             }
+        case .ended, .cancelled:
+            // If pan ended, decide it we should close or reset the view
+            // based on the final position and the speed of the gesture
+            // (https://stackoverflow.com/a/47339617)
+            // If the swipe is too quick, we dismiss
+            let translation = sender.translation(in: view)
+            let velocity = sender.velocity(in: view)
+            let closing = (translation.y > view.frame.size.height * Self.minimumScreenRatioToHide) ||
+            (velocity.y > Self.minimumVelocityToHide) || velocity.y > 1000
+            dismissVelocity = velocity.y
+
+            if closing {
+                finalYPositionWhenDismissing = touchPoint.y - initialTouchPoint.y
+                miniPlayer.closeFullScreenPlayer()
+            } else {
+                UIView.animate(withDuration: 0.2, animations: {
+                    self.view.frame = CGRect(x: 0,
+                                             y: 0,
+                                             width: self.view.frame.size.width,
+                                             height: self.view.frame.size.height)
+                })
+            }
+        default:
+            break
         }
+    }
 
     // this is used so that the player tab line only fades in when you tap something that isn't a control
     func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {

--- a/podcasts/PlayerContainerViewController+Gestures.swift
+++ b/podcasts/PlayerContainerViewController+Gestures.swift
@@ -72,7 +72,6 @@ extension PlayerContainerViewController: UIGestureRecognizerDelegate {
             } else {
                 UIView.animate(withDuration: Constants.Animation.defaultAnimationTime) {
                     self.view.moveTo(y: 0)
-                    miniPlayer.moveToHiddenTopPosition()
                 }
             }
         default:
@@ -88,9 +87,7 @@ extension PlayerContainerViewController: UIGestureRecognizerDelegate {
     func handleScrollViewDidScroll(scrollView: UIScrollView) {
         guard let miniPlayer = appDelegate()?.miniPlayer(), !(miniPlayer.playerOpenState == .beingDragged || miniPlayer.playerOpenState == .animating) else { return }
 
-        if scrollView.contentOffset.y >= 0 {
-            miniPlayer.moveToHiddenTopPosition()
-        } else {
+        if scrollView.contentOffset.y < 0 {
             let yPosition = floor(-scrollView.contentOffset.y)
             handleMoveTo(yPosition: yPosition, miniPlayer: miniPlayer)
         }
@@ -105,7 +102,6 @@ extension PlayerContainerViewController: UIGestureRecognizerDelegate {
             let bottomSafeAreaOffset = window.safeAreaInsets.bottom
             let deviceSpecificPadding = bottomSafeAreaOffset > 0 ? (bottomSafeAreaOffset / 2) : -UIUtil.statusBarHeight(in: window)
             let offset = view.frame.minY - view.frame.size.height + miniPlayer.view.bounds.height + deviceSpecificPadding
-            miniPlayer.moveWhileDragging(offsetFromTop: offset)
         }
 
         if yPosition > PlayerContainerViewController.pullDownThreshold {

--- a/podcasts/PlayerContainerViewController.swift
+++ b/podcasts/PlayerContainerViewController.swift
@@ -113,10 +113,6 @@ class PlayerContainerViewController: SimpleNotificationsViewController, PlayerTa
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-
-        if !FeatureFlag.newPlayerTransition.enabled {
-            Analytics.track(.playerShown)
-        }
     }
 
     override func viewDidDisappear(_ animated: Bool) {
@@ -124,10 +120,6 @@ class PlayerContainerViewController: SimpleNotificationsViewController, PlayerTa
 
         if nowPlayingItem.displayTranscript {
             transcriptsItem.didDisappear()
-        }
-
-        if !FeatureFlag.newPlayerTransition.enabled {
-            Analytics.track(.playerDismissed)
         }
     }
 

--- a/podcasts/SceneHelper.swift
+++ b/podcasts/SceneHelper.swift
@@ -24,24 +24,9 @@ class SceneHelper {
     }
 
     class func rootViewController() -> UIViewController? {
-        guard !FeatureFlag.newPlayerTransition.enabled else {
-            let appScene = connectedScene()?.windows.first(where: { $0.rootViewController is MainTabBarController })
-            let rootVC = appScene?.rootViewController
-            return rootVC?.topMostPresentedViewController ?? rootVC
-        }
-
-        if let scene = connectedScene() {
-            for window in scene.windows {
-                if let mainTabController = window.rootViewController as? MainTabBarController {
-                    return mainTabController
-                }
-            }
-        }
-
-        guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else {
-            return nil
-        }
-        return appDelegate.window?.rootViewController
+        let appScene = connectedScene()?.windows.first(where: { $0.rootViewController is MainTabBarController })
+        let rootVC = appScene?.rootViewController
+        return rootVC?.topMostPresentedViewController ?? rootVC
     }
 
     /// Returns the main window for the app from the AppDelegate

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -1404,11 +1404,6 @@ class Settings: NSObject {
             return remote.boolValue
         }
 
-        static var newPlayerTransition: Bool {
-            let remote = RemoteConfig.remoteConfig().configValue(forKey: Constants.RemoteParams.newPlayerTransition)
-            return remote.boolValue
-        }
-
         static var plusCloudStorageLimit: Int {
             RemoteConfig.remoteConfig().configValue(forKey: Constants.RemoteParams.customStorageLimitGB).numberValue.intValue
         }


### PR DESCRIPTION
Fixes #2516

Removes the `newPlayerTransition` given the new player transition is not new anymore. :D 

## To test

1. Run the app
2. Ensure mini player is appearing (if not, play any episode)
3. Tap miniplayer
4. ✅ Full player should appear and `player_shown` is tracked
5. Dismiss the full player
6. ✅ Full player should disappear and `player_dismissed` is tracked

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
