### PR TITLE
Hack Week: Change SwiftUI mini player padding to safe area inset

### DIFF
--- a/podcasts/Beta/BetaMenu.swift
+++ b/podcasts/Beta/BetaMenu.swift
@@ -8,7 +8,7 @@ struct BetaMenu: View {
                 Toggle(String(describing: feature), isOn: feature.isOn)
             }
         }
-        .modifier(MiniPlayerPadding())
+        .miniPlayerSafeAreaInset()
     }
 }
 

--- a/podcasts/DeveloperMenu.swift
+++ b/podcasts/DeveloperMenu.swift
@@ -297,7 +297,7 @@ struct DeveloperMenu: View {
                 Text("Bundle ID")
             }
         }
-        .modifier(MiniPlayerPadding())
+        .miniPlayerSafeAreaInset()
     }
 }
 

--- a/podcasts/New Search/Views/Results/SearchResultsListView.swift
+++ b/podcasts/New Search/Views/Results/SearchResultsListView.swift
@@ -51,7 +51,7 @@ struct SearchResultsListView: View {
         .onAppear {
             searchAnalyticsHelper.trackListShown(displayMode)
         }
-        .modifier(MiniPlayerPadding())
+        .miniPlayerSafeAreaInset()
         .applyDefaultThemeOptions()
     }
 }

--- a/podcasts/New Search/Views/SearchView.swift
+++ b/podcasts/New Search/Views/SearchView.swift
@@ -13,7 +13,7 @@ struct SearchView: View {
     var body: some View {
         searchView
         .ignoresSafeArea(.keyboard)
-        .modifier(MiniPlayerPadding())
+        .miniPlayerSafeAreaInset()
         .applyDefaultThemeOptions()
     }
 

--- a/podcasts/SwiftUI/MiniPlayerPaddingModifier.swift
+++ b/podcasts/SwiftUI/MiniPlayerPaddingModifier.swift
@@ -1,12 +1,15 @@
 import SwiftUI
 
 /// Apply a bottom padding whenever the mini player is visible
-public struct MiniPlayerPadding: ViewModifier {
+public struct MiniPlayerSafeAreaInset: ViewModifier {
     @State var isMiniPlayerVisible: Bool = false
 
     public func body(content: Content) -> some View {
         content
-            .padding(.bottom, isMiniPlayerVisible ? Constants.Values.miniPlayerOffset - 2 : 0).onAppear {
+            .safeAreaInset(edge: .bottom, spacing: 0) {
+                Color.clear.frame(height: Constants.Values.miniPlayerOffset) // Adjust the bottom inset
+            }
+            .onAppear {
                 isMiniPlayerVisible = (PlaybackManager.shared.currentEpisode() != nil)
             }
             .ignoresSafeArea(.keyboard)
@@ -16,5 +19,12 @@ public struct MiniPlayerPadding: ViewModifier {
             .onReceive(NotificationCenter.default.publisher(for: Constants.Notifications.miniPlayerDidDisappear), perform: { _ in
                 isMiniPlayerVisible = false
             })
+    }
+}
+
+// Create an extension for easier usage
+public extension View {
+    func miniPlayerSafeAreaInset() -> some View {
+        self.modifier(MiniPlayerSafeAreaInset())
     }
 }


### PR DESCRIPTION
Our Mini Player padding in SwiftUI lists should be a bottom safe area inset instead so that the list can be seen behind the player like in UIKit.

All of the uses I saw were inside of lists where we were applying padding instead of safe area insets

Check the area directly behind the mini player, it's most visible when content is being cut off and a line is shown.

| Before | After |
|--|--|
| <video src="https://github.com/user-attachments/assets/47ed37ee-aff5-4c94-885c-74403a28c432"> | <video src="https://github.com/user-attachments/assets/318df4d3-5aa7-4f75-b50a-abdc8dc279cd"> |

| Before | After |
|--|--|
| <video src="https://github.com/user-attachments/assets/8106b43f-e293-4d79-8154-1149804c24e0"> | <video src="https://github.com/user-attachments/assets/a38b9682-de4d-4396-8829-c00b4da5c9ed"> |

| Before | After |
|--|--|
| <video src="https://github.com/user-attachments/assets/6d634489-e38e-4098-af37-016e914c1441"> | <video src="https://github.com/user-attachments/assets/9a306c6f-0ffe-4868-a82f-14700ead6641"> |

| Before | After |
|--|--|
| <video src="https://github.com/user-attachments/assets/56ad0101-1e43-49fe-9e22-5865913c4a56"> | <video src="https://github.com/user-attachments/assets/92e007cf-483c-42a5-a611-a5476172af23">


## To test

* Visit the Developer Menu
* Scroll to the bottom and make sure all content is visible
* Visit the Beta Features Menu
* Scroll to the bottom and make sure all content is visible
* Visit the Podcast search results
* Scroll to the bottom and make sure all content is visible

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
