### PR TITLE
Update Player shelf overflow menu items order

### DIFF
--- a/podcasts.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/podcasts.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -222,8 +222,8 @@
         "repositoryURL": "https://github.com/getsentry/sentry-cocoa",
         "state": {
           "branch": null,
-          "revision": "54cc2e3e4fcbf9d4c7708ce00d3b6eee29aecbb1",
-          "version": "8.38.0"
+          "revision": "5421f94cc859eb65f5ae3866165a053aa634431e",
+          "version": "8.32.0"
         }
       },
       {
@@ -231,8 +231,8 @@
         "repositoryURL": "https://github.com/apple/swift-protobuf.git",
         "state": {
           "branch": null,
-          "revision": "ebc7251dd5b37f627c93698e4374084d98409633",
-          "version": "1.28.2"
+          "revision": "e17d61f26df0f0e06f58f6977ba05a097a720106",
+          "version": "1.27.1"
         }
       },
       {
@@ -249,8 +249,8 @@
         "repositoryURL": "https://github.com/dagronf/SwiftSubtitles",
         "state": {
           "branch": null,
-          "revision": "7cfb9cea6d7b85212de4f445dda17b8f5026c4ff",
-          "version": "1.7.0"
+          "revision": "42cae8baacbad363ee621107207829107ef3e6b2",
+          "version": "1.8.1"
         }
       },
       {
@@ -285,8 +285,8 @@
         "repositoryURL": "https://github.com/dagronf/TinyCSV",
         "state": {
           "branch": null,
-          "revision": "05d691ee7bab64f5ff075b97f47ef41d36a81f6f",
-          "version": "1.0.1"
+          "revision": "a354f61664eef13236f20c4eb5400b50a8844d5a",
+          "version": "1.0.0"
         }
       },
       {

--- a/podcasts.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/podcasts.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -222,8 +222,8 @@
         "repositoryURL": "https://github.com/getsentry/sentry-cocoa",
         "state": {
           "branch": null,
-          "revision": "5421f94cc859eb65f5ae3866165a053aa634431e",
-          "version": "8.32.0"
+          "revision": "54cc2e3e4fcbf9d4c7708ce00d3b6eee29aecbb1",
+          "version": "8.38.0"
         }
       },
       {
@@ -231,8 +231,8 @@
         "repositoryURL": "https://github.com/apple/swift-protobuf.git",
         "state": {
           "branch": null,
-          "revision": "e17d61f26df0f0e06f58f6977ba05a097a720106",
-          "version": "1.27.1"
+          "revision": "ebc7251dd5b37f627c93698e4374084d98409633",
+          "version": "1.28.2"
         }
       },
       {
@@ -249,8 +249,8 @@
         "repositoryURL": "https://github.com/dagronf/SwiftSubtitles",
         "state": {
           "branch": null,
-          "revision": "42cae8baacbad363ee621107207829107ef3e6b2",
-          "version": "1.8.1"
+          "revision": "7cfb9cea6d7b85212de4f445dda17b8f5026c4ff",
+          "version": "1.7.0"
         }
       },
       {
@@ -285,8 +285,8 @@
         "repositoryURL": "https://github.com/dagronf/TinyCSV",
         "state": {
           "branch": null,
-          "revision": "a354f61664eef13236f20c4eb5400b50a8844d5a",
-          "version": "1.0.0"
+          "revision": "05d691ee7bab64f5ff075b97f47ef41d36a81f6f",
+          "version": "1.0.1"
         }
       },
       {

--- a/podcasts/Enumerations.swift
+++ b/podcasts/Enumerations.swift
@@ -247,7 +247,7 @@ extension PlayerAction: AnalyticsDescribable {
         [
             .effects, .sleepTimer, .routePicker, .transcript, .download,
             .shareEpisode, .goToPodcast, .addBookmark, .markPlayed,
-            .chromecast, .archive
+            .starEpisode, .chromecast, .archive
         ]
     }
 

--- a/podcasts/Enumerations.swift
+++ b/podcasts/Enumerations.swift
@@ -246,8 +246,8 @@ extension PlayerAction: AnalyticsDescribable {
     static var defaultActions: [PlayerAction] {
         [
             .effects, .sleepTimer, .routePicker, .transcript, .download,
-            .starEpisode, .shareEpisode, .goToPodcast, .chromecast,
-            .markPlayed, .addBookmark, .archive
+            .shareEpisode, .goToPodcast, .addBookmark, .markPlayed,
+            .chromecast, .archive
         ]
     }
 


### PR DESCRIPTION
<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
Changes introduced when the shelf menu was updated to include transcripts logic (https://github.com/Automattic/pocket-casts-ios/pull/2004) and downloads have pushed the Add Bookmark action below the fold, resulting in a 117% drop in Plus promotion views.

This PR changes the order of default menu items to prioritize top actions based on usage. 

## Screenshots
| Before | After | Android |
|:---:|:---:|:---:|
|![IMG_BF541769760B-1](https://github.com/user-attachments/assets/6efc6689-4e1c-4b7e-9c5a-4c3efae227a6)|![Simulator Screenshot - iPhone 16 Pro - 2024-12-08 at 22 57 07](https://github.com/user-attachments/assets/5fe43d78-8bf0-44c9-98be-8058de7aa187)|![Screenshot_20241208-221103](https://github.com/user-attachments/assets/e27a0d09-f156-4b68-addb-75a6917b85de)|


## To test

<!-- Please include step by step instructions on how to test this PR. -->
1. Go to Player
2.   Make sure shelf menu items appear as expected
3. Tap on each shelf menu items to make sure they work as expected
4. Make sure over_flow menu items appear as expected and Bookmarks is above the fold in iPhone Pro
5. Tap on each over_flow menu items to make sure they work as expected

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
