### PR TITLE
Pass the reference of the proxy if needed

### DIFF
--- a/podcasts/DefaultPlayer.swift
+++ b/podcasts/DefaultPlayer.swift
@@ -356,13 +356,13 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
                 return
             }
 
-            guard let referenceToSelf = DefaultPlayer.unretainedDefaultPlayer(for: tap), let filter = referenceToSelf.createHighPassFilter(maxFrames: maxFrames, processingFormat: processingFormat.pointee) else {
+            guard let filter = referenceToSelf.createHighPassFilter(maxFrames: maxFrames, processingFormat: processingFormat.pointee, tap: tap) else {
                 referenceToSelf.handlePlaybackError("Setup high pass filter failed")
                 return
             }
             referenceToSelf.highPassFilter = filter
 
-            guard let limiter = referenceToSelf.createPeakLimiter(maxFrames: maxFrames, processingFormat: processingFormat.pointee) else {
+            guard let limiter = referenceToSelf.createPeakLimiter(maxFrames: maxFrames, processingFormat: processingFormat.pointee, tap: tap) else {
                 referenceToSelf.handlePlaybackError("Setup peak limiter failed")
                 return
             }
@@ -417,7 +417,7 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
 
         // MARK: - Peak Limter
 
-        func createPeakLimiter(maxFrames: CMItemCount, processingFormat: AudioStreamBasicDescription) -> AudioUnit? {
+        func createPeakLimiter(maxFrames: CMItemCount, processingFormat: AudioStreamBasicDescription, tap: MTAudioProcessingTap) -> AudioUnit? {
             var componentDescription = AudioComponentDescription(componentType: kAudioUnitType_Effect,
                                                                  componentSubType: kAudioUnitSubType_PeakLimiter,
                                                                  componentManufacturer: kAudioUnitManufacturer_Apple,
@@ -434,7 +434,14 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
             guard AudioUnitSetProperty(createdUnit, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Output, 0, &format, UInt32(MemoryLayout<AudioStreamBasicDescription>.stride)) == noErr else { return nil }
 
             // Set audio unit render callback
-            var renderCallback = AURenderCallbackStruct(inputProc: peakLimiterRenderCallback, inputProcRefCon: Unmanaged.passUnretained(self).toOpaque())
+            var renderCallback: AURenderCallbackStruct
+            if FeatureFlag.useDefaultPlayerTapCookie.enabled {
+                let inputProcRefCon = Unmanaged<AudioProcessingTapProxy>.fromOpaque(MTAudioProcessingTapGetStorage(tap))
+                renderCallback = AURenderCallbackStruct(inputProc: peakLimiterRenderCallback, inputProcRefCon: inputProcRefCon.toOpaque())
+            } else {
+                renderCallback = AURenderCallbackStruct(inputProc: peakLimiterRenderCallback, inputProcRefCon: Unmanaged.passUnretained(self).toOpaque())
+            }
+
             guard AudioUnitSetProperty(createdUnit, kAudioUnitProperty_SetRenderCallback, kAudioUnitScope_Input, 0, &renderCallback, UInt32(MemoryLayout<AURenderCallbackStruct>.stride)) == noErr else { return nil }
 
             // Set audio unit maximum frames per slice to max frames
@@ -455,23 +462,21 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
         }
 
         let peakLimiterRenderCallback: AURenderCallback = { inRefCon, _, _, _, inNumberFrames, ioData -> OSStatus in
-            if ioData == nil { return -1 }
-            let referenceToSelf: DefaultPlayer
-            if FeatureFlag.defaultPlayerFilterCallbackFix.enabled {
-                let reference = Unmanaged<DefaultPlayer>.fromOpaque(inRefCon)
-                referenceToSelf = reference.takeUnretainedValue()
-            } else {
-                referenceToSelf = unsafeBitCast(inRefCon, to: DefaultPlayer.self)
+            guard
+                let referenceToSelf = DefaultPlayer.unretainedDefaultPlayer(for: inRefCon),
+                let tap = referenceToSelf.audioMix?.inputParameters.first?.audioTapProcessor,
+                let ioData = ioData
+            else {
+                return -1
             }
-            guard let tap = referenceToSelf.audioMix?.inputParameters.first?.audioTapProcessor else { return -1 }
 
             // The peak limiter is at the end of the chain so just grab the processed audio
-            return MTAudioProcessingTapGetSourceAudio(tap, CMItemCount(inNumberFrames), ioData!, nil, nil, nil)
+            return MTAudioProcessingTapGetSourceAudio(tap, CMItemCount(inNumberFrames), ioData, nil, nil, nil)
         }
 
         // MARK: - High Pass Filter
 
-        func createHighPassFilter(maxFrames: CMItemCount, processingFormat: AudioStreamBasicDescription) -> AudioUnit? {
+    private func createHighPassFilter(maxFrames: CMItemCount, processingFormat: AudioStreamBasicDescription, tap: MTAudioProcessingTap) -> AudioUnit? {
             var componentDescription = AudioComponentDescription(componentType: kAudioUnitType_Effect,
                                                                  componentSubType: kAudioUnitSubType_HighPassFilter,
                                                                  componentManufacturer: kAudioUnitManufacturer_Apple,
@@ -488,7 +493,13 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
             guard AudioUnitSetProperty(createdUnit, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Output, 0, &format, UInt32(MemoryLayout<AudioStreamBasicDescription>.stride)) == noErr else { return nil }
 
             // Set audio unit render callback
-            var renderCallback = AURenderCallbackStruct(inputProc: highPassFilterRenderCallback, inputProcRefCon: Unmanaged.passUnretained(self).toOpaque())
+            var renderCallback: AURenderCallbackStruct
+            if FeatureFlag.useDefaultPlayerTapCookie.enabled {
+                let inputProcRefCon = Unmanaged<AudioProcessingTapProxy>.fromOpaque(MTAudioProcessingTapGetStorage(tap))
+                renderCallback = AURenderCallbackStruct(inputProc: highPassFilterRenderCallback, inputProcRefCon: inputProcRefCon.toOpaque())
+            } else {
+                renderCallback = AURenderCallbackStruct(inputProc: highPassFilterRenderCallback, inputProcRefCon: Unmanaged.passUnretained(self).toOpaque())
+            }
             guard AudioUnitSetProperty(createdUnit, kAudioUnitProperty_SetRenderCallback, kAudioUnitScope_Input, 0, &renderCallback, UInt32(MemoryLayout<AURenderCallbackStruct>.stride)) == noErr else { return nil }
 
             // Set audio unit maximum frames per slice to max frames


### PR DESCRIPTION
Ref. #2521

This PR should fix the crash in the Audio callback. Compared to the previous fix, we missed few spot where the unretained pointer was injected directly into the callback. This was causing a crash as the expected opaque type should always be the proxy and not the player.

## To test

- CI must be 🟢
- Run this branch and play an episode with the volume boost on
- Confirm the app won't crash
- Try to play and change episodes while playing
- When the system decides to finalize the tap you will see 2 logs in this order:

1. The log from the finalize closure: `[AudioProcessingTapProxy] Finalize tap: <MTAudioProcessingTap 0x6000030513b0> Retain count 3 Created with i/f/p/u/t callbacks = {0x10aa14448/0x10aa14600/0x10aa149b4/0x10aa14d08/0x10aa15330} flags = 0x1`
2. The log from the proxy deinit: `[AudioProcessingTapProxy] Deinit proxy`

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
