### PR TITLE
Folders: remove podcasts out of folders log

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/PodcastDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/PodcastDataManager.swift
@@ -324,11 +324,6 @@ class PodcastDataManager {
                 } else {
                     let setStatement = "\(self.columnNames.joined(separator: " = ?, ")) = ?"
                     try db.executeUpdate("UPDATE \(DataManager.podcastTableName) SET \(setStatement) WHERE id = ?", values: self.createValuesFrom(podcast: podcast, includeIdForWhere: true))
-
-                    // If changing folder, log it
-                    if podcast.folderUuid != existingPodcast?.folderUuid {
-                        FileLog.shared.foldersIssue("PodcastDataManager: update \(podcast.title ?? "") folder from \(existingPodcast?.folderUuid ?? "nil") to \(podcast.folderUuid ?? "nil")")
-                    }
                 }
             } catch {
                 FileLog.shared.addMessage("PodcastDataManager.save error: \(error)")

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+FullSync.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+FullSync.swift
@@ -92,7 +92,6 @@ extension SyncTask {
                 localPodcast.addedDate = addedDate
             }
 
-            FileLog.shared.foldersIssue("SyncTask processPodcast: changing \(localPodcast.title ?? "") folder from \(localPodcast.folderUuid ?? "nil") to \(podcast.folderUuid ?? "nil")")
             localPodcast.folderUuid = podcast.folderUuid
 
             if let sortOrder = podcast.sortPosition {

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
@@ -149,7 +149,6 @@ extension SyncTask {
         if podcastItem.hasFolderUuid {
             let folderUuid = podcastItem.folderUuid.value
 
-            FileLog.shared.foldersIssue("SyncTask importItem: \(podcast.title ?? "") changing folder from \(podcast.folderUuid ?? "nil") to \(((folderUuid == DataConstants.homeGridFolderUuid) ? nil : folderUuid) ?? "nil")")
 
             if folderUuid == DataConstants.homeGridFolderUuid, let originalFolderUuid = podcast.folderUuid {
                 FolderHistoryHelper.shared.add(podcastUuid: podcastItem.uuid, folderUuid: originalFolderUuid)
@@ -248,7 +247,6 @@ extension SyncTask {
         // if another device has deleted this folder, we need to delete it as well. No point in importing any of it's properties, so we return here as well
         if folderItem.isDeleted {
             DataManager.sharedManager.delete(folderUuid: folderUuid, markAsDeleted: false)
-            FileLog.shared.foldersIssue("SyncTask importFolder: delete folder \(folderUuid)")
 
             return
         }

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask.swift
@@ -92,8 +92,6 @@ class SyncTask: ApiBaseTask {
 
                     // If server's folderUuid is `nil` then we don't change
                     if podcast.folderUuid?.isEmpty == false {
-                        FileLog.shared.foldersIssue("SyncTask performHomeGridRefresh: changing \(localPodcast.title ?? "") folder from \(localPodcast.folderUuid ?? "nil") to \(podcast.folderUuid ?? "nil")")
-
                         localPodcast.folderUuid = podcast.folderUuid
                     }
 
@@ -246,23 +244,18 @@ class SyncTask: ApiBaseTask {
         var records = [Api_Record]()
         if let podcastChanges = changedPodcasts() {
             records += podcastChanges
-            FileLog.shared.foldersIssue("SyncTask: Number of changed podcasts: \(podcastChanges.count)")
         }
         if let episodeChanges = changedEpisodes(for: episodesToSync) {
             records += episodeChanges
-            FileLog.shared.foldersIssue("SyncTask: Number of changed episodes: \(episodeChanges.count)")
         }
         if let filterChanges = changedFilters() {
             records += filterChanges
-            FileLog.shared.foldersIssue("SyncTask: Number of changed filters: \(filterChanges.count)")
         }
         if let folderChanges = changedFolders() {
             records += folderChanges
-            FileLog.shared.foldersIssue("SyncTask: Number of changed folders: \(folderChanges.count)")
         }
         if let statsChanges = changedStats() {
             records.append(statsChanges)
-            FileLog.shared.foldersIssue("SyncTask: sending stats changes")
         }
 
         if let bookmarks = changedBookmarks() {

--- a/Modules/Utils/Sources/PocketCastsUtils/Logging/FileLog.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Logging/FileLog.swift
@@ -141,18 +141,6 @@ public final class FileLog {
         }
     }
 
-    // Just a shortcut for `addMessage` to be used specifically for
-    // the podcasts out of folders issue
-    // By doing so it will be easier to delete those logs once the issue is
-    // sorted.
-    //
-    // See: https://github.com/Automattic/pocket-casts-ios/issues/791
-    public func foldersIssue(_ message: String?) {
-        guard let message else { return }
-
-        addMessage("[Folders] \(message)")
-    }
-
     public func forceFlush() {
         Task {
             await logBuffer.forceFlush()

--- a/podcasts/PodcastManager+Delete.swift
+++ b/podcasts/PodcastManager+Delete.swift
@@ -17,7 +17,6 @@ extension PodcastManager {
                 EpisodeManager.deleteDownloadedFiles(episode: episode)
             }
 
-            FileLog.shared.foldersIssue("PodcastManager delete: setting \(podcast.title ?? "") folder to nil")
             podcast.folderUuid = nil
             podcast.subscribed = 0
             podcast.autoArchiveEpisodeLimit = 0


### PR DESCRIPTION
During last year we had an issue with podcasts popping out of their folders. The issue has been fixed but the logs remained there, this PR removes it.

## To test

1. 🟢 CI
2. Do a thorough code review

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
