### PR TITLE
Send logs by email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 7.79
 -----
 - Display the whole chapter title, without truncating it [#2499](https://github.com/Automattic/pocket-casts-ios/pull/2499)
+- Allow sending user logs using email [#2525](https://github.com/Automattic/pocket-casts-ios/pull/2525)
 
 7.78
 -----

--- a/Modules/Utils/Sources/PocketCastsUtils/Logging/FileLog.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Logging/FileLog.swift
@@ -166,6 +166,10 @@ public final class FileLog {
         }
     }
 
+    public func logFileAsString() async -> String {
+        return await logBuffer.loadLogFileAsString()        
+    }
+
     // Creates a merged file from `mainLogFilePath` and `backupLogFilePath` to be used for enquing the file upload.
     public func logFileForUpload() -> AnyPublisher<String, Error> {
         let file = LogFilePaths.debugUploadLog

--- a/Modules/Utils/Sources/PocketCastsUtils/Logging/FileLog.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Logging/FileLog.swift
@@ -167,7 +167,7 @@ public final class FileLog {
     }
 
     public func logFileAsString() async -> String {
-        return await logBuffer.loadLogFileAsString()        
+        return await logBuffer.loadLogFileAsString()
     }
 
     // Creates a merged file from `mainLogFilePath` and `backupLogFilePath` to be used for enquing the file upload.

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -672,8 +672,8 @@
 		8BFB434E2A1FFB4B00F3D409 /* StatusPageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BFB434D2A1FFB4B00F3D409 /* StatusPageViewModel.swift */; };
 		91319B0B2C171F69000220A4 /* GravatarSafariViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91319B0A2C171F69000220A4 /* GravatarSafariViewController.swift */; };
 		9A156AAD2CF60973007BA8D9 /* CancelSubscriptionPlansView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A156AAC2CF60973007BA8D9 /* CancelSubscriptionPlansView.swift */; };
-		9A156AB32CF8BEE3007BA8D9 /* CancelSubscriptionPlanRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A156AB22CF8BEE3007BA8D9 /* CancelSubscriptionPlanRow.swift */; };
 		9A156AB12CF7430A007BA8D9 /* UpNextAnnouncementView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A156AB02CF7430A007BA8D9 /* UpNextAnnouncementView.swift */; };
+		9A156AB32CF8BEE3007BA8D9 /* CancelSubscriptionPlanRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A156AB22CF8BEE3007BA8D9 /* CancelSubscriptionPlanRow.swift */; };
 		BD001B892174260B00504DD3 /* FilterManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD001B882174260B00504DD3 /* FilterManager.swift */; };
 		BD00CB2B24BD20CD00A10257 /* TimeStepperCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD00CB2924BD20CD00A10257 /* TimeStepperCell.swift */; };
 		BD00CB2C24BD20CD00A10257 /* TimeStepperCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = BD00CB2A24BD20CD00A10257 /* TimeStepperCell.xib */; };
@@ -1804,6 +1804,8 @@
 		FF91A0FA2B6BBFD1002A0590 /* UpgradeCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF91A0F92B6BBFD1002A0590 /* UpgradeCard.swift */; };
 		FF91A0FC2B6BC1D2002A0590 /* UpgradePrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF91A0FB2B6BC1D2002A0590 /* UpgradePrompt.swift */; };
 		FF91A0FE2B6BC4BD002A0590 /* FeaturesCarousel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF91A0FD2B6BC4BD002A0590 /* FeaturesCarousel.swift */; };
+		FF9B6B752D0732D40057A504 /* LogsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF9B6B742D0732CF0057A504 /* LogsViewController.swift */; };
+		FF9B6B772D0733670057A504 /* LogsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF9B6B762D0733650057A504 /* LogsView.swift */; };
 		FF9ED3552C86010F00B6E630 /* TipView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF9ED3542C86010F00B6E630 /* TipView.swift */; };
 		FFAA063E2C086DEA00FBC38F /* InsetAdjuster.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFAA063D2C086DEA00FBC38F /* InsetAdjuster.swift */; };
 		FFC293992B6173400059F3BB /* IAPTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFC293982B6173400059F3BB /* IAPTypes.swift */; };
@@ -2645,8 +2647,8 @@
 		8BFB434D2A1FFB4B00F3D409 /* StatusPageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusPageViewModel.swift; sourceTree = "<group>"; };
 		91319B0A2C171F69000220A4 /* GravatarSafariViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GravatarSafariViewController.swift; sourceTree = "<group>"; };
 		9A156AAC2CF60973007BA8D9 /* CancelSubscriptionPlansView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancelSubscriptionPlansView.swift; sourceTree = "<group>"; };
-		9A156AB22CF8BEE3007BA8D9 /* CancelSubscriptionPlanRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancelSubscriptionPlanRow.swift; sourceTree = "<group>"; };
 		9A156AB02CF7430A007BA8D9 /* UpNextAnnouncementView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpNextAnnouncementView.swift; sourceTree = "<group>"; };
+		9A156AB22CF8BEE3007BA8D9 /* CancelSubscriptionPlanRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancelSubscriptionPlanRow.swift; sourceTree = "<group>"; };
 		9A9517324EFFD2C905890193 /* Pods-podcasts.appstore.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-podcasts.appstore.xcconfig"; path = "Pods/Target Support Files/Pods-podcasts/Pods-podcasts.appstore.xcconfig"; sourceTree = "<group>"; };
 		9E6FEF10644B78313185D080 /* Pods-PocketCastsTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PocketCastsTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-PocketCastsTests/Pods-PocketCastsTests.release.xcconfig"; sourceTree = "<group>"; };
 		A251FE0E92E432C4EF0C8207 /* Pods-PocketCastsTests.staging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PocketCastsTests.staging.xcconfig"; path = "Pods/Target Support Files/Pods-PocketCastsTests/Pods-PocketCastsTests.staging.xcconfig"; sourceTree = "<group>"; };
@@ -3753,6 +3755,8 @@
 		FF91A0F92B6BBFD1002A0590 /* UpgradeCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpgradeCard.swift; sourceTree = "<group>"; };
 		FF91A0FB2B6BC1D2002A0590 /* UpgradePrompt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpgradePrompt.swift; sourceTree = "<group>"; };
 		FF91A0FD2B6BC4BD002A0590 /* FeaturesCarousel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturesCarousel.swift; sourceTree = "<group>"; };
+		FF9B6B742D0732CF0057A504 /* LogsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogsViewController.swift; sourceTree = "<group>"; };
+		FF9B6B762D0733650057A504 /* LogsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogsView.swift; sourceTree = "<group>"; };
 		FF9ED3542C86010F00B6E630 /* TipView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TipView.swift; sourceTree = "<group>"; };
 		FFAA063D2C086DEA00FBC38F /* InsetAdjuster.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsetAdjuster.swift; sourceTree = "<group>"; };
 		FFC293982B6173400059F3BB /* IAPTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IAPTypes.swift; sourceTree = "<group>"; };
@@ -5898,6 +5902,8 @@
 				46CD3CA02715E3E600F5EB8F /* SupportConfig.swift */,
 				8BD5A4E32A1E844D00F473C6 /* StatusPageView.swift */,
 				8BFB434D2A1FFB4B00F3D409 /* StatusPageViewModel.swift */,
+				FF9B6B742D0732CF0057A504 /* LogsViewController.swift */,
+				FF9B6B762D0733650057A504 /* LogsView.swift */,
 			);
 			name = Support;
 			sourceTree = "<group>";
@@ -10109,6 +10115,7 @@
 				BD35BB6C1CF697650018D63E /* AudioUtils.swift in Sources */,
 				C7B3C60A2919DCB700054145 /* ScrollViewIfNeeded.swift in Sources */,
 				C7252E142A71950500E7D3C0 /* EpisodeImage.swift in Sources */,
+				FF9B6B772D0733670057A504 /* LogsView.swift in Sources */,
 				BDA9668F2189805F00DF9370 /* UIScrollView+MiniPlayer.swift in Sources */,
 				BD48D5A6216DB26A00391F9E /* HapticsHelper.swift in Sources */,
 				F51656D82C816FE6009446B4 /* ClipsWhatsNewView.swift in Sources */,
@@ -10289,6 +10296,7 @@
 				BDE5B8D81E6401F80039B409 /* EpisodeFileSizeUpdater.swift in Sources */,
 				408971AF2512F57100783253 /* BundleImageView.swift in Sources */,
 				BD65E51C1CD9BDE000B90A67 /* OnlineSupportController.swift in Sources */,
+				FF9B6B752D0732D40057A504 /* LogsViewController.swift in Sources */,
 				BDCF60EA22EFECA60051EDB3 /* ThemeableCell.swift in Sources */,
 				F55275B82CB74E230012B705 /* EndOfYear2023Story.swift in Sources */,
 				C7C4F8832A71E1B7002139B2 /* BookmarkEpisodeListController.swift in Sources */,

--- a/podcasts/LogsView.swift
+++ b/podcasts/LogsView.swift
@@ -1,0 +1,55 @@
+import Foundation
+import SwiftUI
+import PocketCastsUtils
+
+struct LogsView: View {
+    @State var logs: String = ""
+
+    @EnvironmentObject var theme: Theme
+
+    private func load() async {
+        let result = await FileLog.shared.logFileAsString()
+        await MainActor.run {
+            self.logs = result
+        }
+    }
+
+    var body: some View {
+        VStack {
+            TextEditor(text: $logs)
+            Spacer()
+        }
+        .navigationTitle("Logs")
+        .toolbar(content: {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button(action: {
+
+                }, label: {
+                    Image("mail")
+                })
+            }
+        })
+        .applyDefaultThemeOptions()
+        .ignoresSafeArea()
+        .task {
+            await load()
+        }
+    }
+}
+
+#Preview {
+    LogsView(logs: """
+Line 1
+Line 2
+Line 3
+Line 4
+Line 5
+Line 6
+Line 7
+Line 8
+Line 9
+Line 10
+Line 11
+""")
+    .setupDefaultEnvironment()
+}

--- a/podcasts/LogsView.swift
+++ b/podcasts/LogsView.swift
@@ -25,10 +25,12 @@ class LogsViewModel: NSObject, ObservableObject, MFMailComposeViewControllerDele
         let mailVC = MFMailComposeViewController()
         mailVC.mailComposeDelegate = self
 
-        mailVC.setSubject("Logs")
+        mailVC.setSubject("iOS Logs \(Settings.appVersion())")
         mailVC.setToRecipients(["support@pocketcasts.com"])
-        mailVC.setMessageBody(logs, isHTML: false)
-
+        mailVC.setMessageBody("Please find attached my logs", isHTML: false)
+        if let data = logs.data(using: .utf8) {
+            mailVC.addAttachmentData(data, mimeType: UTType.plainText.preferredMIMEType ?? "plain/text", fileName: "logs.txt")
+        }
         presenter?.present(mailVC, animated: true)
     }
 

--- a/podcasts/LogsView.swift
+++ b/podcasts/LogsView.swift
@@ -52,7 +52,7 @@ struct LogsView: View {
             TextEditor(text: $model.logs)
             Spacer()
         }
-        .navigationTitle("Logs")
+        .navigationTitle(L10n.logs)
         .toolbar(content: {
             ToolbarItem(placement: .navigationBarTrailing) {
                 Button(action: {

--- a/podcasts/LogsView.swift
+++ b/podcasts/LogsView.swift
@@ -20,7 +20,7 @@ class LogsViewModel: NSObject, ObservableObject, MFMailComposeViewControllerDele
 
     func mailLogs() {
         guard MFMailComposeViewController.canSendMail() else {
-            Toast.show(L10n.logsNoEmailAccount)
+            Toast.show(L10n.logsNoEmailAccountConfigured)
             return
         }
         let mailVC = MFMailComposeViewController()

--- a/podcasts/LogsView.swift
+++ b/podcasts/LogsView.swift
@@ -20,6 +20,7 @@ class LogsViewModel: NSObject, ObservableObject, MFMailComposeViewControllerDele
 
     func mailLogs() {
         guard MFMailComposeViewController.canSendMail() else {
+            Toast.show(L10n.logsNoEmailAccount)
             return
         }
         let mailVC = MFMailComposeViewController()

--- a/podcasts/LogsViewController.swift
+++ b/podcasts/LogsViewController.swift
@@ -3,8 +3,10 @@ import Foundation
 class LogsViewController: ThemedHostingController<LogsView> {
 
     init() {
-        let screen = LogsView()
+        let model = LogsViewModel()
+        let screen = LogsView(model: model)
         super.init(rootView: screen)
+        model.presenter = self
     }
 
     @MainActor required dynamic init?(coder aDecoder: NSCoder) {
@@ -14,7 +16,7 @@ class LogsViewController: ThemedHostingController<LogsView> {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        Analytics.track(.referralClaimScreenShown)
+        //Analytics.track(.referralClaimScreenShown)
 
         setupUI()
     }

--- a/podcasts/LogsViewController.swift
+++ b/podcasts/LogsViewController.swift
@@ -15,9 +15,6 @@ class LogsViewController: ThemedHostingController<LogsView> {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        //Analytics.track(.referralClaimScreenShown)
-
         setupUI()
     }
 

--- a/podcasts/LogsViewController.swift
+++ b/podcasts/LogsViewController.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+class LogsViewController: ThemedHostingController<LogsView> {
+
+    init() {
+        let screen = LogsView()
+        super.init(rootView: screen)
+    }
+
+    @MainActor required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        Analytics.track(.referralClaimScreenShown)
+
+        setupUI()
+    }
+
+    private func setupUI() {
+        view.backgroundColor = .clear
+    }
+}

--- a/podcasts/OnlineSupportController.swift
+++ b/podcasts/OnlineSupportController.swift
@@ -78,7 +78,7 @@ class OnlineSupportController: PCViewController, WKNavigationDelegate {
             self?.export(sender)
         }))
 
-        controller.addAction(.init(title: "Logs", style: .default, handler: { [weak self] _ in
+        controller.addAction(.init(title: L10n.logs, style: .default, handler: { [weak self] _ in
             self?.viewLogs(sender)
         }))
 

--- a/podcasts/OnlineSupportController.swift
+++ b/podcasts/OnlineSupportController.swift
@@ -78,6 +78,10 @@ class OnlineSupportController: PCViewController, WKNavigationDelegate {
             self?.export(sender)
         }))
 
+        controller.addAction(.init(title: "Logs", style: .default, handler: { [weak self] _ in
+            self?.viewLogs(sender)
+        }))
+
         controller.addAction(.init(title: L10n.cancel, style: .destructive))
 
         present(controller, animated: true)
@@ -164,5 +168,14 @@ private extension OnlineSupportController {
         shareSheet.popoverPresentationController?.barButtonItem = sender
 
         present(shareSheet, animated: true, completion: nil)
+    }
+}
+
+// MARK: - Logs
+
+private extension OnlineSupportController {
+    func viewLogs(_ sender: UIBarButtonItem) {
+        let vc = LogsViewController()
+        self.navigationController?.pushViewController(vc, animated: true)
     }
 }

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -1525,8 +1525,8 @@ internal enum L10n {
   internal static var loginTitle: String { return L10n.tr("Localizable", "login_title") }
   /// Logs
   internal static var logs: String { return L10n.tr("Localizable", "logs") }
-  /// No email account configured to send the logs
-  internal static var logsNoEmailAccount: String { return L10n.tr("Localizable", "logs_no_email_account") }
+  /// You need to configure an email account on the device in order to send the logs
+  internal static var logsNoEmailAccountConfigured: String { return L10n.tr("Localizable", "logs_no_email_account_configured") }
   /// Manage downloads
   internal static var manageDownloadsAction: String { return L10n.tr("Localizable", "manage_downloads_action") }
   /// Save %1$@ by removing played episodes.

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -1523,6 +1523,8 @@ internal enum L10n {
   internal static var loginSubtitle: String { return L10n.tr("Localizable", "login_subtitle") }
   /// Discover your next favorite podcast
   internal static var loginTitle: String { return L10n.tr("Localizable", "login_title") }
+  /// Logs
+  internal static var logs: String { return L10n.tr("Localizable", "logs") }
   /// Manage downloads
   internal static var manageDownloadsAction: String { return L10n.tr("Localizable", "manage_downloads_action") }
   /// Save %1$@ by removing played episodes.

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -1525,6 +1525,8 @@ internal enum L10n {
   internal static var loginTitle: String { return L10n.tr("Localizable", "login_title") }
   /// Logs
   internal static var logs: String { return L10n.tr("Localizable", "logs") }
+  /// No email account configured to send the logs
+  internal static var logsNoEmailAccount: String { return L10n.tr("Localizable", "logs_no_email_account") }
   /// Manage downloads
   internal static var manageDownloadsAction: String { return L10n.tr("Localizable", "manage_downloads_action") }
   /// Save %1$@ by removing played episodes.

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4704,3 +4704,6 @@
 
 /* Auto Downloads Setting - Auto download on follow of a blog*/
 "settings_auto_downloads_on_follow" = "On Follow";
+
+/* Title of an option to see the users logs */
+"logs" = "Logs";

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4707,3 +4707,6 @@
 
 /* Title of an option to see the users logs */
 "logs" = "Logs";
+
+/* Message when no email account is configured to be able to send the logs*/
+"logs_no_email_account" = "No email account configured to send the logs";

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4709,4 +4709,4 @@
 "logs" = "Logs";
 
 /* Message when no email account is configured to be able to send the logs*/
-"logs_no_email_account" = "No email account configured to send the logs";
+"logs_no_email_account_configured" = "You need to configure an email account on the device in order to send the logs";


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

This PR adds new logs screen on the support screen and allows to see the logs and sends them by email.

https://github.com/user-attachments/assets/5a3c1bda-3a0b-49e8-a05b-a3a7619f3c7b


## To test

1. Start the app on a device that as an email account configured
2. Go to Profile Tab
3. Tap on Help & Feedback
4. Tap on the more (...) button on the top right
5. Tap on Log
6. Check if you can see the logs
7. Tap on the email button on the top right
8. Check if the email UI shows up with the correct info on: subjects, content, recipients and has the logs attached
9. Send the email to yourself
10. Check if the logs data is correctly received on your email.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
