### PR TITLE
Remove  new show notes endpoint FF

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -160,7 +160,7 @@ public enum FeatureFlag: String, CaseIterable {
         case .networkDebugging:
             false
         case .endOfYear:
-            false        
+            false
         case .episodeFeedArtwork:
             false
         case .rssChapters:

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -14,9 +14,6 @@ public enum FeatureFlag: String, CaseIterable {
     /// Whether End Of Year feature is enabled
     case endOfYear
 
-    /// Enable show notes using the new endpoint
-    case newShowNotesEndpoint
-
     /// Enable retrieving episode artwork from the RSS feed
     case episodeFeedArtwork
 
@@ -163,9 +160,7 @@ public enum FeatureFlag: String, CaseIterable {
         case .networkDebugging:
             false
         case .endOfYear:
-            false
-        case .newShowNotesEndpoint:
-            false
+            false        
         case .episodeFeedArtwork:
             false
         case .rssChapters:
@@ -263,8 +258,6 @@ public enum FeatureFlag: String, CaseIterable {
             shouldEnableSyncedSettings ? "new_settings_storage" : nil
         case .settingsSync:
             shouldEnableSyncedSettings ? "settings_sync" : nil
-        case .newShowNotesEndpoint:
-             "new_show_notes"
          case .episodeFeedArtwork:
              "episode_artwork"
          case .rssChapters:

--- a/podcasts/EpisodeArtwork.swift
+++ b/podcasts/EpisodeArtwork.swift
@@ -46,7 +46,7 @@ class EpisodeArtwork {
     }
 
     private func loadEpisodeArtworkFromUrl(podcastUuid: String, episodeUuid: String) {
-        guard FeatureFlag.newShowNotesEndpoint.enabled && FeatureFlag.episodeFeedArtwork.enabled else {
+        guard FeatureFlag.episodeFeedArtwork.enabled else {
             return
         }
 

--- a/podcasts/EpisodeDetailViewController+ShowNotes.swift
+++ b/podcasts/EpisodeDetailViewController+ShowNotes.swift
@@ -34,25 +34,12 @@ extension EpisodeDetailViewController: WKNavigationDelegate, SFSafariViewControl
         loadingIndicator.startAnimating()
         hideErrorMessage(hide: true)
 
-        if FeatureFlag.newShowNotesEndpoint.enabled {
-            Task { [weak self] in
-                guard let self else { return }
+        Task { [weak self] in
+            guard let self else { return }
 
-                let showNotes = try? await ShowInfoCoordinator.shared.loadShowNotes(podcastUuid: episode.parentIdentifier(), episodeUuid: episode.uuid)
-                downloadingShowNotes = false
-                showNotesDidLoad(showNotes: showNotes ?? CacheServerHandler.noShowNotesMessage)
-            }
-            return
-        }
-
-        CacheServerHandler.shared.loadShowNotes(podcastUuid: episode.parentIdentifier(), episodeUuid: episode.uuid, cached: { [weak self] cachedShowNotes in
-            self?.downloadingShowNotes = false
-            self?.showNotesDidLoad(showNotes: cachedShowNotes)
-        }) { [weak self] showNotes in
-            if let showNotes = showNotes {
-                self?.downloadingShowNotes = false
-                self?.showNotesDidLoad(showNotes: showNotes)
-            }
+            let showNotes = try? await ShowInfoCoordinator.shared.loadShowNotes(podcastUuid: episode.parentIdentifier(), episodeUuid: episode.uuid)
+            downloadingShowNotes = false
+            showNotesDidLoad(showNotes: showNotes ?? CacheServerHandler.noShowNotesMessage)
         }
     }
 

--- a/podcasts/ShowNotesPlayerItemViewController.swift
+++ b/podcasts/ShowNotesPlayerItemViewController.swift
@@ -129,26 +129,8 @@ class ShowNotesPlayerItemViewController: PlayerItemViewController, SFSafariViewC
 
         loadingIndicator.startAnimating()
 
-        if FeatureFlag.newShowNotesEndpoint.enabled {
-            Task { [weak self] in
-                if let showNotes = try? await ShowInfoCoordinator.shared.loadShowNotes(podcastUuid: episode.parentIdentifier(), episodeUuid: episode.uuid) {
-                    self?.downloadingShowNotes = false
-                    self?.displayShowNotes(showNotes)
-
-                    // if we get back the no show notes available message, make sure next update we try again
-                    if showNotes == CacheServerHandler.noShowNotesMessage {
-                        self?.lastEpisodeUuidRendered = ""
-                    }
-                }
-            }
-            return
-        }
-
-        CacheServerHandler.shared.loadShowNotes(podcastUuid: episode.parentIdentifier(), episodeUuid: episode.uuid, cached: { [weak self] cachedShowNotes in
-            self?.downloadingShowNotes = false
-            self?.displayShowNotes(cachedShowNotes)
-        }) { [weak self] showNotes in
-            if let showNotes = showNotes {
+        Task { [weak self] in
+            if let showNotes = try? await ShowInfoCoordinator.shared.loadShowNotes(podcastUuid: episode.parentIdentifier(), episodeUuid: episode.uuid) {
                 self?.downloadingShowNotes = false
                 self?.displayShowNotes(showNotes)
 

--- a/podcasts/ShowNotesUpdater.swift
+++ b/podcasts/ShowNotesUpdater.swift
@@ -4,22 +4,14 @@ import PocketCastsUtils
 
 class ShowNotesUpdater {
     class func updateShowNotesInBackground(podcastUuid: String, episodeUuid: String) {
-        if FeatureFlag.newShowNotesEndpoint.enabled {
-            Task {
-                // Load the show notes and any available chapters
-                _ = try? await ShowInfoCoordinator.shared.loadChapters(podcastUuid: podcastUuid, episodeUuid: episodeUuid)
+        Task {
+            // Load the show notes and any available chapters
+            _ = try? await ShowInfoCoordinator.shared.loadChapters(podcastUuid: podcastUuid, episodeUuid: episodeUuid)
 
-                #if !os(watchOS)
-                let transcriptManager = TranscriptManager(episodeUUID: episodeUuid, podcastUUID: podcastUuid)
-                _ = try? await transcriptManager.loadTranscript()
-                #endif
-            }
-            return
-        }
-
-        DispatchQueue.global().async {
-            // fire and forgot, this call will automatically cache the result
-            CacheServerHandler.shared.loadShowNotes(podcastUuid: podcastUuid, episodeUuid: episodeUuid, completion: nil)
+            #if !os(watchOS)
+            let transcriptManager = TranscriptManager(episodeUUID: episodeUuid, podcastUUID: podcastUuid)
+            _ = try? await transcriptManager.loadTranscript()
+            #endif
         }
     }
 }


### PR DESCRIPTION
| 📘 Part of: #2509  |  <!-- project issue number, if applicable -->
|:---:|

Fixes #2528  <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
Removes the FF for using the new show notes endpoint

## To test

1. Start the app
2. Open a podcast
3. Open an episode detail page
4. Check if information shows correctly
5. Open another podcast 
6. Tap on the more button
7. Tap on Select Episodes
8. Select one episode
9. Tap on download
10. Wait for download to finish
11. Go offline
12. Open the episode
13. Check if details show correctly.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
