### PR TITLE
Playback 2024: Image share dimensions

### DIFF
--- a/podcasts/End of Year/StoryShareableProvider.swift
+++ b/podcasts/End of Year/StoryShareableProvider.swift
@@ -47,7 +47,7 @@ class StoryShareableProvider: UIActivityItemProvider {
         let snapshot = AnyView(view)
         .modify(viewModifier)
         .environment(\.renderForSharing, true)
-        .frame(width: 370, height: 800)
+        .frame(width: 450, height: 800)
         .snapshot()
 
         let snapshotURL = save(snapshot: snapshot)


### PR DESCRIPTION
Fixes an issue with Instagram sharing where the image is cropped, cutting off the branding image at the bottom.

This changes the aspect ratio of the shared image to 9:16 for ALL sharing destinations.

https://github.com/user-attachments/assets/f1d22ca8-dd98-4a28-88dc-af95c9f82c34

## To test

* Open Playback 2024 from Profile
* Tap the "Share this story" button 
* Share to Instagram and select different options (mainly Story to verify the cropping)
* Verify that the full shared image is shown and the Pocket Casts logo is not cut off at the bottom

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
