### PR TITLE
[Tooling] Do some `Fastfile` cleanup

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,7 +20,7 @@ Metrics/BlockLength:
     - scripts/themes/generate_themes.rb
 
 Metrics/MethodLength:
-  Max: 30
+  Max: 50
   Exclude:
     - scripts/themes/generate_themes.rb
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1183,21 +1183,17 @@ inal copy, and try again.")
     message_root = lambda { |tag, display_name|
       ":announcement: <#{GITHUB_URL}/releases/tag/#{tag}|*#{display_name}*>"
     }
-    appstoreconnect_url = 'https://appstoreconnect.apple.com/apps/414834813'
-    testflight_submit_link = "<#{appstoreconnect_url}/testflight/ios|App Store Connect>"
-    appstore_submit_link = "<#{appstoreconnect_url}/appstore/ios/version/deliverable|App Store Connect>"
-    merge_pr_link = "<#{GITHUB_URL}/pulls?q=is%3Apr+is%3Aopen+#{build_number}+into|merge the PR>"
 
     if is_beta
       if (build_number_split[3] || '0') == '0'
-        "#{message_root.call(build_number, version)} code freeze is completed.\nPlease submit #{build_number} for testers on #{testflight_submit_link} and #{merge_pr_link} (<https://wp.me/PdeCcb-1ju|need help?>)"
+        "#{message_root.call(build_number, version)} code freeze is completed."
       else
-        "#{message_root.call(build_number, build_number)} beta has been submitted to Apple.\nPlease distribute #{build_number} to testers on #{testflight_submit_link} and #{merge_pr_link} (<https://wp.me/PdeCcb-1ku|need help?>)"
+        "#{message_root.call(build_number, build_number)} beta has been submitted to Apple."
       end
     elsif (build_number_split[2] || '0').to_i.positive?
-      "#{message_root.call(version, version)} hotfix has been uploaded to Apple.\nPlease submit it for review on #{appstore_submit_link} and #{merge_pr_link}."
+      "#{message_root.call(version, version)} hotfix has been uploaded to Apple."
     else
-      "#{message_root.call(version, version)} final build has been uploaded to Apple.\nPlease submit it for review on #{appstore_submit_link} and #{merge_pr_link}."
+      "#{message_root.call(version, version)} final build has been uploaded to Apple."
     end
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -513,40 +513,14 @@ platform :ios do
     trigger_buildkite_release_build(branch: branch_to_build, beta: false)
   end
 
-  # Builds the Pocket Casts app and uploads it to TestFlight, for beta-testing or final release
+  # Builds the app binary for distribution to App Store Connect
   #
-  # @param beta_release [Boolean] If true, the GitHub release will be marked as being a pre-release
-  # @param skip_prechecks [Boolean] If true, don't run the prechecks and ios_build_preflight (default: false)
-  # @param skip_confirm [Boolean] If true, avoids any interactive prompt (default: false)
-  # @param create_release [Boolean] If true, creates a GitHub Release draft after the upload, with zipped xcarchive as artefact
+  # Once the app binary is built by this lane, you might want to call:
+  #  - `upload_app_store_connect_build_to_testflight` to upload the binary to TestFlight
+  #  - `symbols_upload` to upload dSYMs to Sentry
+  #  - `create_release_on_github(beta_release: …)` to create the GitHub Release
   #
-  # @called_by CI
-  #
-  lane :build_and_upload_app_store_connect do |beta_release:, skip_prechecks: false, skip_confirm: false, create_release: false|
-    require_env_vars!('GITHUB_TOKEN', 'SLACK_WEBHOOK')
-
-    unless skip_prechecks
-      # Verify that there's nothing in progress in the working copy
-      ensure_git_status_clean unless is_ci
-
-      ios_build_preflight
-    end
-
-    UI.important("Building version #{release_version_current} (#{build_code_current}) and uploading to TestFlight")
-    UI.user_error!('Aborted by user request') unless skip_confirm || UI.confirm('Do you want to continue?')
-
-    sentry_check_cli_installed
-
-    build_app_store_connect
-
-    upload_app_store_connect_build_to_testflight
-
-    symbols_upload
-
-    create_release_on_github(beta_release: beta_release) if create_release
-  end
-
-  # Builds for distribution to App Store Connect
+  # @param fetch_code_signing [Boolean] If true, will call `configure_code_signing_app_store` before building. Recommended on CI.
   #
   lane :build_app_store_connect do |fetch_code_signing: true|
     configure_code_signing_app_store if fetch_code_signing
@@ -577,14 +551,28 @@ platform :ios do
     zip(path: APP_STORE_CONNECT_XCARCHIVE_PATH, output_path: APP_STORE_CONNECT_XCARCHIVE_ZIP_PATH)
   end
 
-  # Builds and distributes via Enterprise account (Prototype Build)
+  # Distributes the binary to TestFlight
   #
-  lane :build_and_upload_enterprise do
-    build_enterprise
-    upload_enterprise
+  # Typically called after having built the binary with `build_app_store_connect`
+  #
+  # @param ipa_path [String] Path to the `.ipa` file to upload to TestFlight
+  #
+  lane :upload_app_store_connect_build_to_testflight do |ipa_path: APP_STORE_CONNECT_BUILD_IPA_PATH|
+    require_env_vars!(*ASC_API_KEY_ENV_VARS)
+
+    upload_to_testflight(
+      ipa: ipa_path,
+      skip_waiting_for_build_processing: true,
+      team_id: TEAM_ID_APP_STORE,
+      api_key: app_store_connect_api_key
+    )
   end
 
-  # Builds for Enterprise distribution (Prototype Build)
+  # Builds the app binary for Enterprise distribution (Prototype Build)
+  #
+  # Once the app binary is built, you might want to call `upload_enterprise`
+  #
+  # @param fetch_code_signing [Boolean] If true, will call `configure_code_signing_app_store` before building. Recommended on CI.
   #
   lane :build_enterprise do |skip_code_sign_setup: false|
     if skip_code_sign_setup
@@ -617,26 +605,39 @@ platform :ios do
     )
   end
 
-  # Distributes a local app via Enterprise account (Prototype Build)
+  # Distributes the Prototype Build to App Center
+  #
+  # Typically called after having built the binary with `build_enterprise`
+  #
+  # @note Expects the `.ipa` and `.dSYM` files to be present in `ARTIFACTS_FOLDER/PROTOTYPE_BUILD_NAME.{ipa,app.dSYM.zip}`
   #
   lane :upload_enterprise do
-    upload_pocket_casts_to_appcenter
+    require_env_vars!('APPCENTER_API_TOKEN')
+
+    commit = ENV.fetch('BUILDKITE_COMMIT', 'Unknown')
+    pr = ENV.fetch('BUILDKITE_PULL_REQUEST', nil)
+    release_notes = <<~NOTES
+      - Branch: `#{ENV.fetch('BUILDKITE_BRANCH', 'Unknown')}`\n
+      - Commit: [#{commit[0...7]}](#{GITHUB_URL}/commit/#{commit})\n
+      - Pull Request: [##{pr}](#{GITHUB_URL}/pull/#{pr})\n
+    NOTES
+
+    appcenter_upload(
+      api_token: get_required_env!('APPCENTER_API_TOKEN'),
+      owner_name: APPCENTER_OWNER_NAME,
+      owner_type: APPCENTER_OWNER_TYPE,
+      app_name: APPCENTER_APP_SLUG,
+      file: File.join(ARTIFACTS_FOLDER, "#{PROTOTYPE_BUILD_NAME}.ipa"),
+      dsym: File.join(ARTIFACTS_FOLDER, "#{PROTOTYPE_BUILD_NAME}.app.dSYM.zip"),
+      release_notes: release_notes,
+      destinations: 'Collaborators',
+      notify_testers: false
+    )
 
     next unless is_ci
 
     annotate_pr_with_appcenter_link
     annotate_buildkite_with_appcenter_link
-  end
-
-  lane :upload_app_store_connect_build_to_testflight do |ipa_path: APP_STORE_CONNECT_BUILD_IPA_PATH|
-    require_env_vars!(*ASC_API_KEY_ENV_VARS)
-
-    upload_to_testflight(
-      ipa: ipa_path,
-      skip_waiting_for_build_processing: true,
-      team_id: TEAM_ID_APP_STORE,
-      api_key: app_store_connect_api_key
-    )
   end
 
   # Uploads DSYM Symbols
@@ -702,7 +703,6 @@ platform :ios do
   # @param skip_commit [Boolean] If true, does not commit the changes made to the `.strings` file (default: false)
   #
   # @note Uses `genstrings` under the hood.
-  # @called_by `code_freeze`.
   #
   lane :generate_strings_file_for_glotpress do |skip_commit: false|
     # For reference: Other apps run `cocoapods` here (equivalent to `bundle
@@ -1229,32 +1229,24 @@ platform :ios do
     )
   end
 
-  # Upload a Prototype Build to App Center
+  # Generate a build number for Prototype Builds, based on the PR number and short commit SHA1
   #
-  # Expects the `.ipa` and `.dSYM` files to be present in `ARTIFACTS_FOLDER/PROTOTYPE_BUILD_NAME.{ipa,app.dSYM.zip}`
+  # @note This function uses Buildkite-specific ENV vars
   #
-  def upload_pocket_casts_to_appcenter
-    require_env_vars!('APPCENTER_API_TOKEN')
+  def generate_prototype_build_number
+    if ENV['BUILDKITE']
+      commit = ENV.fetch('BUILDKITE_COMMIT', nil)[0, 7]
+      branch = ENV.fetch('BUILDKITE_BRANCH', nil)
+      pr_num = ENV.fetch('BUILDKITE_PULL_REQUEST', nil)
 
-    commit = ENV.fetch('BUILDKITE_COMMIT', 'Unknown')
-    pr = ENV.fetch('BUILDKITE_PULL_REQUEST', nil)
-    release_notes = <<~NOTES
-      - Branch: `#{ENV.fetch('BUILDKITE_BRANCH', 'Unknown')}`\n
-      - Commit: [#{commit[0...7]}](#{GITHUB_URL}/commit/#{commit})\n
-      - Pull Request: [##{pr}](#{GITHUB_URL}/pull/#{pr})\n
-    NOTES
+      pr_num == 'false' ? "#{branch}-#{commit}" : "pr#{pr_num}-#{commit}"
+    else
+      repo = Git.open(PROJECT_ROOT_FOLDER)
+      commit = repo.current_branch
+      branch = repo.revparse('HEAD')[0, 7]
 
-    appcenter_upload(
-      api_token: get_required_env!('APPCENTER_API_TOKEN'),
-      owner_name: APPCENTER_OWNER_NAME,
-      owner_type: APPCENTER_OWNER_TYPE,
-      app_name: APPCENTER_APP_SLUG,
-      file: File.join(ARTIFACTS_FOLDER, "#{PROTOTYPE_BUILD_NAME}.ipa"),
-      dsym: File.join(ARTIFACTS_FOLDER, "#{PROTOTYPE_BUILD_NAME}.app.dSYM.zip"),
-      release_notes: release_notes,
-      destinations: 'Collaborators',
-      notify_testers: false
-    )
+      "#{branch}-#{commit}"
+    end
   end
 
   # Post a comment on the PR with the info + QRCode to the Prototype Build in App Center
@@ -1282,27 +1274,12 @@ platform :ios do
     metadata = version_data.merge(build_type: 'Prototype', 'appcenter:id': appcenter_id)
     appcenter_install_url = "https://install.appcenter.ms/orgs/#{APPCENTER_OWNER_NAME}/apps/#{APPCENTER_APP_SLUG}/releases/#{appcenter_id}"
     list = metadata.map { |k, v| " - **#{k}**: #{v}" }.join("\n")
-    buildkite_annotate(context: 'appcenter-info-pocket-casts', style: 'info', message: "Pocket Casts iOS [App Center Build](#{appcenter_install_url}) Info:\n\n#{list}")
-  end
 
-  # Generate a build number for Prototype Builds, based on the PR number and short commit SHA1
-  #
-  # @note This function uses Buildkite-specific ENV vars
-  #
-  def generate_prototype_build_number
-    if ENV['BUILDKITE']
-      commit = ENV.fetch('BUILDKITE_COMMIT', nil)[0, 7]
-      branch = ENV.fetch('BUILDKITE_BRANCH', nil)
-      pr_num = ENV.fetch('BUILDKITE_PULL_REQUEST', nil)
-
-      pr_num == 'false' ? "#{branch}-#{commit}" : "pr#{pr_num}-#{commit}"
-    else
-      repo = Git.open(PROJECT_ROOT_FOLDER)
-      commit = repo.current_branch
-      branch = repo.revparse('HEAD')[0, 7]
-
-      "#{branch}-#{commit}"
-    end
+    buildkite_annotate(
+      context: 'appcenter-info-pocket-casts',
+      style: 'info',
+      message: "Pocket Casts iOS [App Center Build](#{appcenter_install_url}) Info:\n\n#{list}"
+    )
   end
 
   #####################################################################################

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -190,14 +190,19 @@ platform :ios do
   # See https://buildkite.com/automattic/pocket-casts-ios/builds/4875#018b7eea-e8d7-40a1-8ce5-515dd8feafce/666-805
   ENV['FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT'] = '120'
 
-  desc 'Run the unit tests'
+  # Run the unit tests
+  #
   lane :test do
     run_tests(
       scheme: SCHEME
     )
   end
 
-  desc 'Download and configure code signing certificates and provisioning profiles for the App Store build.'
+  # Download and configure code signing certificates and provisioning profiles for the App Store build.
+  #
+  # @param readonly [Boolean] Use `true` when you only want to **fetch** existing profiles and certificates from out S3 bucket via `match`
+  #                           Use `false` only if you need `match` to **regenerate** profiles and/or certificates in the Dev Portal and upload the updated ones to S3
+  #
   lane :configure_code_signing_app_store do |readonly: true|
     require_env_vars!(*ASC_API_KEY_ENV_VARS)
 
@@ -213,7 +218,11 @@ platform :ios do
     )
   end
 
-  desc 'Download and configure code signing certificates and provisioning profiles for the Enterprise build, i.e. Prototype Builds.'
+  # Download and configure code signing certificates and provisioning profiles for the Enterprise build, i.e. Prototype Builds.
+  #
+  # @param readonly [Boolean] Use `true` when you only want to **fetch** existing profiles and certificates from out S3 bucket via `match`
+  #                           Use `false` only if you need `match` to **regenerate** profiles and/or certificates in the Dev Portal and upload the updated ones to S3
+  #
   lane :configure_code_signing_enterprise do |readonly: true|
     require_env_vars!(*ASC_API_KEY_ENV_VARS)
 
@@ -260,7 +269,6 @@ platform :ios do
   #
   # @param skip_confirm [Boolean] If true, avoids any interactive prompt (default: false)
   #
-  desc 'Executes the initial steps needed during code freeze'
   lane :code_freeze do |skip_confirm: false|
     require_env_vars!('GITHUB_TOKEN')
     # Verify that there's nothing in progress in the working copy
@@ -326,7 +334,6 @@ platform :ios do
   #                              instead of using the current app version. Useful e.g. for triggering betas on hotfixes.
   # @param skip_confirm [Boolean] If true, avoids any interactive prompt (default: false)
   #
-  desc 'Trigger a new beta build on CI'
   lane :new_beta_release do |base_version: nil, skip_confirm: false|
     # Verify that there's nothing in progress in the working copy
     ensure_git_status_clean
@@ -382,7 +389,6 @@ platform :ios do
   #
   # @param skip_confirm [Boolean] If true, avoids any interactive prompt (default: false)
   #
-  desc 'Trigger the final release build on CI'
   lane :finalize_release do |skip_confirm: false|
     UI.user_error!('To finalize a hotfix, please use the finalize_hotfix_release lane instead') if current_version_hotfix?
 
@@ -428,7 +434,6 @@ platform :ios do
   # @param version [String] (required) The version number to use for the hotfix (`"x.y.z"`)
   # @param skip_confirm [Boolean] If true, avoids any interactive prompt (default: false)
   #
-  desc 'Creates a new hotfix branch for the given `version:x.y.z`. The branch will be cut from the `x.y` tag.'
   lane :new_hotfix_release do |version:, skip_confirm: false|
     # Verify that there's nothing in progress in the working copy
     ensure_git_status_clean
@@ -477,7 +482,6 @@ platform :ios do
 
   # Finalizes a hotfix, by triggering a release build on CI
   #
-  desc 'Performs the final checks and triggers a release build for the hotfix in the current branch'
   lane :finalize_hotfix_release do |skip_confirm: false|
     # Verify that the current branch is a release branch. Notice that `ensure_git_branch` expects a RegEx parameter
     ensure_git_branch(branch: '^release/')
@@ -518,7 +522,6 @@ platform :ios do
   #
   # @called_by CI
   #
-  desc 'Builds and uploads for distribution to App Store Connect'
   lane :build_and_upload_app_store_connect do |beta_release:, skip_prechecks: false, skip_confirm: false, create_release: false|
     require_env_vars!('GITHUB_TOKEN', 'SLACK_WEBHOOK')
 
@@ -543,7 +546,8 @@ platform :ios do
     create_release_on_github(beta_release: beta_release) if create_release
   end
 
-  desc 'Builds for distribution to App Store Connect'
+  # Builds for distribution to App Store Connect
+  #
   lane :build_app_store_connect do |fetch_code_signing: true|
     configure_code_signing_app_store if fetch_code_signing
 
@@ -573,13 +577,15 @@ platform :ios do
     zip(path: APP_STORE_CONNECT_XCARCHIVE_PATH, output_path: APP_STORE_CONNECT_XCARCHIVE_ZIP_PATH)
   end
 
-  desc 'Builds and distributes via Enterprise account (Prototype Build)'
+  # Builds and distributes via Enterprise account (Prototype Build)
+  #
   lane :build_and_upload_enterprise do
     build_enterprise
     upload_enterprise
   end
 
-  desc 'Builds for Enterprise distribution (Prototype Build)'
+  # Builds for Enterprise distribution (Prototype Build)
+  #
   lane :build_enterprise do |skip_code_sign_setup: false|
     if skip_code_sign_setup
       UI.message('Skipping fetch certificates and provisioning profiles as requested.')
@@ -611,7 +617,8 @@ platform :ios do
     )
   end
 
-  desc 'Distributes a local app via Enterprise account (Prototype Build)'
+  # Distributes a local app via Enterprise account (Prototype Build)
+  #
   lane :upload_enterprise do
     upload_pocket_casts_to_appcenter
 
@@ -632,7 +639,8 @@ platform :ios do
     )
   end
 
-  desc 'Uploads DSYM Symbols'
+  # Uploads DSYM Symbols
+  #
   lane :symbols_upload do |dsym_path: APP_STORE_CONNECT_BUILD_DSYMS_PATH|
     require_env_vars!('SENTRY_AUTH_TOKEN')
 
@@ -645,6 +653,12 @@ platform :ios do
     )
   end
 
+  # Create a GitHub Release for a beta or final build
+  #
+  # @param beta_release [Boolean] If true, the GitHub Release is for a beta and will be marked as prerelease and published immediately.
+  #                               If false, the GitHub Release is for a final build and will not be marked as prerelease but will be created as Draft (to be manually published only once approved by Apple)
+  # @param archive_zip_path [String] Path to the `.xcarchive.zip` file to attach as an asset to the created GitHub Release
+  #
   lane :create_release_on_github do |beta_release: true, archive_zip_path: APP_STORE_CONNECT_XCARCHIVE_ZIP_PATH|
     require_env_vars!('GITHUB_TOKEN', 'SLACK_WEBHOOK')
 
@@ -774,13 +788,15 @@ platform :ios do
     typos_count
   end
 
-  desc 'Downloads localized strings and App Store Connect metadata from GlotPress'
+  # Downloads localized strings and App Store Connect metadata from GlotPress
+  #
   lane :download_localized_strings_and_metadata_from_glotpress do
     download_localized_strings_from_glotpress
     download_localized_app_store_metadata_from_glotpress
   end
 
-  desc 'Lint the `.strings` files'
+  # Lint the `.strings` files
+  #
   lane :lint_localizations do
     ios_lint_localizations(
       input_dir: File.join(PROJECT_ROOT_FOLDER, 'podcasts'),
@@ -789,11 +805,8 @@ platform :ios do
     )
   end
 
-  # This lane updates the `AppStoreStrings.po` file for the Pocket Casts app
-  # with the latest content from the `release_notes.txt` file and the other
-  # text sources
+  # Updates the `AppStoreStrings.po` file using the content from the `release_notes.txt` file and other `.txt` sources
   #
-  desc 'Updates the `AppStoreStrings.po` file for the Pocket Casts app with the latest data'
   lane :update_app_store_strings do
     source_metadata_folder = File.join(APP_STORE_METADATA_FOLDER, 'default')
     version = get_version_number(xcodeproj: 'podcasts.xcodeproj', target: 'podcasts')
@@ -812,7 +825,8 @@ platform :ios do
     )
   end
 
-  desc 'Downloads localized `.strings` from GlotPress'
+  # Downloads localized `.strings` from GlotPress
+  #
   lane :download_localized_strings_from_glotpress do
     # Use the same name as the frozen strings source to make it explicit these
     # are not to be copied as-is in the `*.lproj/Localizable.strings`
@@ -843,7 +857,8 @@ platform :ios do
     )
   end
 
-  desc 'Downloads localized metadata for App Store Connect from GlotPress'
+  # Downloads localized metadata for App Store Connect from GlotPress
+  #
   lane :download_localized_app_store_metadata_from_glotpress do
     # FIXME: Replace this with a call to the future replacement of
     # `gp_downloadmetadata` once it's implemented in the release-toolkit (see
@@ -872,10 +887,10 @@ platform :ios do
       en_file_path = File.join(APP_STORE_METADATA_FOLDER, 'en-US', file)
       next unless File.exist?(en_file_path)
 
-      UI.user_error!("File `#{en_file_path}` would override the same one in `#{APP_STORE_METADATA_FOLDER}/default
-`, but `default/` is the source of truth. " \
-+ "Delete the `#{en_file_path}` file, ensure the `default/` one has the expected orig
-inal copy, and try again.")
+      UI.user_error! <<~ERROR
+        File `#{en_file_path}` would override the same one in `#{APP_STORE_METADATA_FOLDER}/default`, but `default/` is the source of truth.
+        Delete the `#{en_file_path}` file, ensure the `default/` one has the expected original copy, and try again.
+      ERROR
     end
 
     # Ensure even empty locale folders have an empty `.gitkeep` file (in case
@@ -904,7 +919,6 @@ inal copy, and try again.")
   # @param interactive [Boolean] If true, will pause and ask confirmation to continue
   #        if it found any locale translated below the threshold (default: false)
   #
-  desc 'Check translation progress for all GlotPress projects'
   lane :check_all_translations_progress do |interactive: false|
     abort_on_violations = false
     skip_confirm = interactive == false
@@ -930,7 +944,6 @@ inal copy, and try again.")
   #
   # @param with_screenshots [Boolean] If true, will also upload the latest screenshot files to ASC (default: false)
   #
-  desc 'Upload the localized metadata to App Store Connect, optionally including screenshots.'
   lane :update_metadata_on_app_store_connect do |with_screenshots: false|
     # Skip screenshots by default. The naming is "with" to make it clear that
     # callers need to opt-in to adding screenshots. The naming of the deliver
@@ -952,7 +965,6 @@ inal copy, and try again.")
 
   # Generates a HTML containing the libraries acknowledgments.
   #
-  desc 'Generates a HTML with the list of used libraries and their licenses'
   lane :acknowledgments do
     require 'commonmarker'
 
@@ -1003,10 +1015,10 @@ inal copy, and try again.")
   #####################################################################################
 
   # Generates localized screenshots for the iPhone, and iPad.
+  #
   # Tests run in the simulator so be sure to make any necessary Podfile changes such as
   # converting to use google-cast-sdk-no-bluetooth-mock
   #
-  desc 'Generates localized screenshots for the AppStore'
   lane :screenshots do
     iphone_devices = ['iPhone 12']
     ipad_devices = ['iPad (9th generation)']
@@ -1057,16 +1069,16 @@ inal copy, and try again.")
   end
 
   # Generates localized screenshots for the Apple Watch.
+  #
   # Tests run in the simulator so be sure to make any necessary Podfile changes such as
   # converting to use google-cast-sdk-no-bluetooth-mock
   #
   # Setup:
-  # - Log into an account with Plus. Run the test iPhone_GenerateScreenshots.test_watchSetup
-  # on a device that is connected to the watch mentioned in the test.
-  # - Ensure the data syncs to the simulated watch. Mocking out the ApplicationContext from
-  # the device can help ensure a consistent response.
+  #  - Log into an account with Plus. Run the test iPhone_GenerateScreenshots.test_watchSetup
+  #    on a device that is connected to the watch mentioned in the test.
+  #  - Ensure the data syncs to the simulated watch. Mocking out the ApplicationContext from
+  #    the device can help ensure a consistent response.
   #
-  desc 'Generates localized Watch screenshots for the AppStore'
   lane :watch_screenshots do
     watch_devices = ['Apple Watch Series 7 - 45mm']
 
@@ -1082,6 +1094,7 @@ inal copy, and try again.")
   #####################################################################################
 
   # Name of the `release/` branch for the current version
+  #
   def release_branch_name
     "release/#{release_version_current}"
   end
@@ -1104,9 +1117,13 @@ inal copy, and try again.")
     )
   end
 
-  # - Loop though all PRs which were still open and were assigned the milestones of the code-frozen version,
-  #   and move them to the next milestone + leaving a PR comment about it
+  # Update the milestone of still-open PRs
+  # 
+  # - Update the milestone of all still-open PRs that were assigned the milestone of the version being code-frozen,
+  #   to move them to the next milestone
+  # - Leaving a PR comment on each of the PRs for which we updated the miletsone
   # - Add the ❄️ frozen marker to the milestone being frozen
+  #
   def update_milestone
     require_env_vars!('GITHUB_TOKEN')
 
@@ -1131,7 +1148,16 @@ inal copy, and try again.")
     rescue StandardError => e
       moved_prs = []
 
-      report_milestone_error(error_title: "Error freezing milestone `#{new_version}`: #{e.message}")
+      error_message = <<-MESSAGE
+        Error freezing milestone `#{new_version}`: #{e.message}
+
+        - If this is not the first time you are running the release task (e.g. retrying because it failed on first attempt), the milestone might have already been closed and this error is expected.
+        - Otherwise if this is the first you are running the release task for this version, please investigate the error.
+      MESSAGE
+
+      UI.error(error_message)
+
+      buildkite_annotate(style: 'warning', context: 'error-with-milestone', message: error_message) if is_ci
     end
 
     UI.message("Moved the following PRs to milestone #{next_version}: #{moved_prs.join(', ')}")
@@ -1147,18 +1173,8 @@ inal copy, and try again.")
     buildkite_annotate(style: moved_prs.empty? ? 'success' : 'warning', context: 'start-code-freeze', message: moved_prs_info) if is_ci
   end
 
-  def report_milestone_error(error_title:)
-    error_message = <<-MESSAGE
-      #{error_title}
-      - If this is not the first time you are running the release task (e.g. retrying because it failed on first attempt), the milestone might have already been closed and this error is expected.
-      - Otherwise if this is the first you are running the release task for this version, please investigate the error.
-    MESSAGE
-
-    UI.error(error_message)
-
-    buildkite_annotate(style: 'warning', context: 'error-with-milestone', message: error_message) if is_ci
-  end
-
+  # Private helper to create backmerge Pull Requests after new betas or final build
+  #
   def create_backmerge_pr
     create_release_backmerge_pull_request(
       repository: GHHELPER_REPO,
@@ -1207,6 +1223,8 @@ inal copy, and try again.")
     UI.message "Checked out branch `#{git_branch}` as requested by user.\n"
   end
 
+  # Create a commit with the typical message to use for a version bump
+  #
   def commit_version_bump
     git_commit(
       path: VERSION_XCCONFIG_PATH,
@@ -1215,6 +1233,10 @@ inal copy, and try again.")
     )
   end
 
+  # Upload a Prototype Build to App Center
+  #
+  # Expects the `.ipa` and `.dSYM` files to be present in `ARTIFACTS_FOLDER/PROTOTYPE_BUILD_NAME.{ipa,app.dSYM.zip}`
+  #
   def upload_pocket_casts_to_appcenter
     require_env_vars!('APPCENTER_API_TOKEN')
 
@@ -1239,6 +1261,8 @@ inal copy, and try again.")
     )
   end
 
+  # Post a comment on the PR with the info + QRCode to the Prototype Build in App Center
+  #
   def annotate_pr_with_appcenter_link
     comment_body = prototype_build_details_comment(
       app_display_name: 'Pocket Casts Prototype Build',
@@ -1254,6 +1278,8 @@ inal copy, and try again.")
     )
   end
 
+  # Annotate a Buildkite CI build with info + links to the Prototype Build in App Center
+  #
   def annotate_buildkite_with_appcenter_link
     appcenter_id = lane_context.dig(SharedValues::APPCENTER_BUILD_INFORMATION, 'id')
     version_data = Xcodeproj::Config.new(File.new(VERSION_XCCONFIG_PATH)).to_hash
@@ -1263,7 +1289,7 @@ inal copy, and try again.")
     buildkite_annotate(context: 'appcenter-info-pocket-casts', style: 'info', message: "Pocket Casts iOS [App Center Build](#{appcenter_install_url}) Info:\n\n#{list}")
   end
 
-  # Generates a build number for Prototype Builds, based on the PR number and short commit SHA1
+  # Generate a build number for Prototype Builds, based on the PR number and short commit SHA1
   #
   # @note This function uses Buildkite-specific ENV vars
   #
@@ -1331,7 +1357,9 @@ inal copy, and try again.")
     BUILD_CODE_FORMATTER.build_code(version: build_code_code_freeze)
   end
 
-  # Returns the build code of the app for the code freeze. It is the hotfix version name plus sets the build number to 0
+  # Returns the build code of the app for a hotfix. It is the hotfix version name plus sets the build number to 0
+  #
+  # @param release_version [String] The `x.y.z` hotfix version we want to get the build code for
   #
   def build_code_hotfix(release_version:)
     version = VERSION_FORMATTER.parse(release_version)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1118,7 +1118,7 @@ platform :ios do
   end
 
   # Update the milestone of still-open PRs
-  # 
+  #
   # - Update the milestone of all still-open PRs that were assigned the milestone of the version being code-frozen,
   #   to move them to the next milestone
   # - Leaving a PR comment on each of the PRs for which we updated the miletsone
@@ -1135,9 +1135,7 @@ platform :ios do
         repository: GHHELPER_REPO,
         from_milestone: new_version,
         to_milestone: next_version,
-        comment: <<~COMMENT
-          Version `#{new_version}` has now entered code-freeze, so the milestone of this PR has been updated to `#{next_version}`.
-        COMMENT
+        comment: "Version `#{new_version}` has now entered code-freeze, so the milestone of this PR has been updated to `#{next_version}`."
       )
 
       # Add ❄️ marker to milestone title to indicate we entered code-freeze
@@ -1156,7 +1154,6 @@ platform :ios do
       MESSAGE
 
       UI.error(error_message)
-
       buildkite_annotate(style: 'warning', context: 'error-with-milestone', message: error_message) if is_ci
     end
 
@@ -1169,7 +1166,6 @@ platform :ios do
                        "#{moved_prs.count} PRs targeting `#{new_version}` were still open and thus moved to `#{next_version}`:\n" \
                          + moved_prs.map { |pr_num| "[##{pr_num}](https://github.com/#{GHHELPER_REPO}/pull/#{pr_num})" }.join(', ')
                      end
-
     buildkite_annotate(style: moved_prs.empty? ? 'success' : 'warning', context: 'start-code-freeze', message: moved_prs_info) if is_ci
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -306,15 +306,15 @@ platform :ios do
 
     generate_strings_file_for_glotpress
 
-    after_confirming_push do
-      trigger_beta_build(branch_to_build: release_branch_name)
-      create_backmerge_pr
+    push_to_git_remote(tags: false)
 
-      # We cannot use the `copy_branch_protection` action here yet, as it would create a branch protection rule with the same
-      # restrictions we have in `trunk`, and the release managers wouldn't be able to push due to permissions.
-      # This should be changed only when we have PCiOS releases done on CI, when the CI bot is the one running `git push`.
-      set_branch_protection(repository: GHHELPER_REPO, branch: release_branch_name)
-    end
+    trigger_beta_build(branch_to_build: release_branch_name)
+    create_backmerge_pr
+
+    # We cannot use the `copy_branch_protection` action here yet, as it would create a branch protection rule with the same
+    # restrictions we have in `trunk`, and the release managers wouldn't be able to push due to permissions.
+    # This should be changed only when we have PCiOS releases done on CI, when the CI bot is the one running `git push`.
+    set_branch_protection(repository: GHHELPER_REPO, branch: release_branch_name)
 
     # Move still-open PRs to next milestone, then add frozen marker to milestone title
     update_milestone
@@ -367,10 +367,10 @@ platform :ios do
     commit_version_bump
     UI.success "Done! New Build Code: #{build_code_current}"
 
-    after_confirming_push do
-      trigger_beta_build(branch_to_build: release_branch_name)
-      create_backmerge_pr
-    end
+    push_to_git_remote(tags: false)
+
+    trigger_beta_build(branch_to_build: release_branch_name)
+    create_backmerge_pr
   end
 
   # Finalizes a release at the end of a sprint to submit to the App Store
@@ -406,19 +406,18 @@ platform :ios do
     UI.message 'Bumping build code...'
     VERSION_FILE.write(version_long: build_code_next)
     commit_version_bump
+    push_to_git_remote(tags: false)
     UI.success "Done! New Build Code: #{build_code_current}"
 
     # Wrap up
     remove_branch_protection(repository: GHHELPER_REPO, branch: release_branch_name)
     set_milestone_frozen_marker(repository: GHHELPER_REPO, milestone: release_version_current, freeze: false)
-    create_new_milestone(repository: GHHELPER_REPO)
     close_milestone(repository: GHHELPER_REPO, milestone: release_version_current)
 
     # Start the build
-    after_confirming_push do
-      trigger_release_build(branch_to_build: release_branch_name)
-      create_backmerge_pr
-    end
+
+    trigger_release_build(branch_to_build: release_branch_name)
+    create_backmerge_pr
   end
 
   # Sets the stage to start working on a hotfix
@@ -1194,15 +1193,6 @@ inal copy, and try again.")
       "#{message_root.call(version, version)} hotfix has been uploaded to Apple."
     else
       "#{message_root.call(version, version)} final build has been uploaded to Apple."
-    end
-  end
-
-  def after_confirming_push(message: 'Push changes to the remote and trigger the build?')
-    if ENV.fetch('RELEASE_TOOLKIT_SKIP_PUSH_CONFIRM', false) || UI.confirm(message)
-      push_to_git_remote(tags: false)
-      yield
-    else
-      UI.message('Aborting push as requested.')
     end
   end
 


### PR DESCRIPTION
Just some cleanup and maintenance in preparation for some more upcoming automation work on the `Fastfile` soon

- Remove extra instructions from Slack message—because those instructions are now in the MC scenario and we prefer to only have one source of truth
- Remove `after_confirming_push` helper—because this will become obsolete once we migrate to the lanes being run by CI
- Clean up and standardize YARD doc for lanes

