### PR TITLE
Add flagged logout avoidance from background task

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Private/TokenHelper.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Private/TokenHelper.swift
@@ -85,17 +85,21 @@ class TokenHelper {
             ServerSettings.setRefreshToken(refreshedRefreshToken)
         }
         else {
-            if ServerConfig.avoidLogoutOnError {
-                // if the user doesn't have an email and password or SSO token, they aren't going to be able to acquire a sync token
-                switch error as? APIError {
-                case APIError.TOKEN_DEAUTH?, APIError.PERMISSION_DENIED?:
-                    tokenCleanUp()
-                default:
-                    // Do nothing so the user is not disrupted in the case of non-auth errors
-                    FileLog.shared.addMessage("TokenHelper: Unable to acquire token but avoided logout due to error: \(String(describing: error))")
-                }
+            if UIApplication.shared.applicationState == .background && ServerConfig.avoidLogoutInBackground {
+                FileLog.shared.addMessage("TokenHelper: Skipped logout in background due to error: \(String(describing: error))")
             } else {
-                tokenCleanUp()
+                if ServerConfig.avoidLogoutOnError {
+                    // if the user doesn't have an email and password or SSO token, they aren't going to be able to acquire a sync token
+                    switch error as? APIError {
+                    case APIError.TOKEN_DEAUTH?, APIError.PERMISSION_DENIED?:
+                        tokenCleanUp()
+                    default:
+                        // Do nothing so the user is not disrupted in the case of non-auth errors
+                        FileLog.shared.addMessage("TokenHelper: Unable to acquire token but avoided logout due to error: \(String(describing: error))")
+                    }
+                } else {
+                    tokenCleanUp()
+                }
             }
 
             return nil

--- a/Modules/Server/Sources/PocketCastsServer/Private/TokenHelper.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Private/TokenHelper.swift
@@ -1,5 +1,10 @@
 import Foundation
 import PocketCastsUtils
+#if os(iOS)
+import UIKit
+#elseif os(watchOS)
+import WatchKit
+#endif
 
 class TokenHelper {
 

--- a/Modules/Server/Sources/PocketCastsServer/Private/TokenHelper.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Private/TokenHelper.swift
@@ -85,7 +85,7 @@ class TokenHelper {
             ServerSettings.setRefreshToken(refreshedRefreshToken)
         }
         else {
-            if UIApplication.shared.applicationState == .background && ServerConfig.avoidLogoutInBackground {
+            if isApplicationBackgrounded() && ServerConfig.avoidLogoutInBackground {
                 FileLog.shared.addMessage("TokenHelper: Skipped logout in background due to error: \(String(describing: error))")
             } else {
                 if ServerConfig.avoidLogoutOnError {
@@ -106,6 +106,24 @@ class TokenHelper {
         }
 
         return refreshedToken
+    }
+
+    private func isApplicationBackgrounded() -> Bool {
+        let semaphore = DispatchSemaphore(value: 0)
+        var isBackgrounded = false
+
+        DispatchQueue.main.async {
+            #if os(iOS)
+            isBackgrounded = UIApplication.shared.applicationState == .background
+            #elseif os(watchOS)
+            isBackgrounded = WKExtension.shared().applicationState == .background
+            #endif
+
+            semaphore.signal()
+        }
+
+        semaphore.wait()
+        return isBackgrounded
     }
 
     // MARK: - Email / Password Token

--- a/Modules/Server/Sources/PocketCastsServer/Public/ServerConfig.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/ServerConfig.swift
@@ -4,6 +4,7 @@ public class ServerConfig {
     public static let shared = ServerConfig()
 
     public static var avoidLogoutOnError = false
+    public static var avoidLogoutInBackground = false
 
     private var backgroundSessionHandler: (() -> Void)?
 

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -143,6 +143,9 @@ public enum FeatureFlag: String, CaseIterable {
     ///Use html description for podcast details
     case usePodcastHTMLDescription
 
+    /// Disables logout / keychain clearing when errors occur in the background
+    case avoidLogoutInBackground
+
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -239,6 +242,8 @@ public enum FeatureFlag: String, CaseIterable {
             true
         case .usePodcastHTMLDescription:
             false
+        case .avoidLogoutInBackground:
+            true
         }
     }
 

--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -296,6 +296,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             self?.updateEndOfYearRemoteValue()
             self?.updateRemoteFeatureFlags()
             ServerConfig.avoidLogoutOnError = FeatureFlag.errorLogoutHandling.enabled
+            ServerConfig.avoidLogoutInBackground = FeatureFlag.avoidLogoutInBackground.enabled
         }
     }
 


### PR DESCRIPTION
Fixes #2529, an issue reported by users where they were logged out coming back to the app.

From the logs, we log users out during the background refresh task, potentially because data is not accessible due to encryption. This change only logs the user out if the app is currently foregrounded. One downside to this might be increased requests which result in 401s. However, I think it's a better user experience to avoid logout unless the app is foregrounded when we can be more sure stored data is available for access.

An alternative could be to pass through a value indicating that a particular request came from the background refresh task and only log out in that case.

This change is flagged with the `avoid_logout_in_background` flag in case we need to disable it.

## To test


* Apply this patch ([ForcedLogoutRefresh.patch](https://github.com/user-attachments/files/18131573/ForcedLogoutRefresh.patch)) to either this branch or `trunk`
* Add a breakpoint at `AppDelegate:110` in `didFinishLaunching` after `scheduleNextBackgroundRefresh()` is called.
* Build and run the app
* When the breakpoint is hit, background the app
* Execute this command in the debug console to trigger the scheduled background refresh task:
```
e -l objc -- (void)[[BGTaskScheduler sharedScheduler] _simulateLaunchForTaskWithIdentifier:@"au.com.shiftyjelly.podcasts.Refresh"]
```
* Before this change, you should have been logged out
* After this change, you should see `TokenHelper: Skipped logout in background due to error` logged

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
