### PR TITLE
Remove FF for episodeArtwork

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -14,9 +14,6 @@ public enum FeatureFlag: String, CaseIterable {
     /// Whether End Of Year feature is enabled
     case endOfYear
 
-    /// Enable retrieving episode artwork from the RSS feed
-    case episodeFeedArtwork
-
     /// Enable chapters to be loaded from the RSS feed
     case rssChapters
 
@@ -161,8 +158,6 @@ public enum FeatureFlag: String, CaseIterable {
             false
         case .endOfYear:
             false
-        case .episodeFeedArtwork:
-            false
         case .rssChapters:
             false
         case .errorLogoutHandling:
@@ -258,8 +253,6 @@ public enum FeatureFlag: String, CaseIterable {
             shouldEnableSyncedSettings ? "new_settings_storage" : nil
         case .settingsSync:
             shouldEnableSyncedSettings ? "settings_sync" : nil
-         case .episodeFeedArtwork:
-             "episode_artwork"
          case .rssChapters:
              "rss_chapters"
         case .categoriesRedesign:

--- a/podcasts/EpisodeArtwork.swift
+++ b/podcasts/EpisodeArtwork.swift
@@ -46,10 +46,6 @@ class EpisodeArtwork {
     }
 
     private func loadEpisodeArtworkFromUrl(podcastUuid: String, episodeUuid: String) {
-        guard FeatureFlag.episodeFeedArtwork.enabled else {
-            return
-        }
-
         Task { [weak self] in
             guard let self else {
                 return


### PR DESCRIPTION
| 📘 Part of: #2509  |  <!-- project issue number, if applicable -->
|:---:|

Fixes #2531  <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
| 1 | 2 |
| - | - |
| ![Simulator Screenshot - iPhone 16 Pro - 2024-12-11 at 14 31 47](https://github.com/user-attachments/assets/ca86da93-bead-4161-977b-e8cde5fe83fd) | ![Simulator Screenshot - iPhone 16 Pro - 2024-12-11 at 14 32 16](https://github.com/user-attachments/assets/9e6cfad4-092b-4b29-a1f7-c60bf3bb2578) |

## To test

- Start the app
- Go to Profile -> Settings -> Appearance 
- On the section Podcast Artwork ensure that you have Use Episode Artwork is enabled
- Go to Discover
- Search for the following podcast: The Daily
- Play an episode
- Open the full screen player
- Check if the episode artwork is show on top center

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
