### PR TITLE
Protobuf: ensure protoc and swift-protobuf is up-to-date

### DIFF
--- a/scripts/update_proto.sh
+++ b/scripts/update_proto.sh
@@ -13,5 +13,6 @@ then
     exit 1
 fi
 
+brew upgrade protobuf
 protoc --swift_out=./Modules/Server/Sources/PocketCastsServer/Private/Protobuffer --proto_path=$API_BASE_FOLDER/ $API_BASE_FOLDER/api.proto
 protoc --swift_out=./Modules/Server/Sources/PocketCastsServer/Private/Protobuffer --proto_path=$API_BASE_FOLDER/ $API_BASE_FOLDER/files.proto

--- a/scripts/update_proto.sh
+++ b/scripts/update_proto.sh
@@ -14,5 +14,7 @@ then
 fi
 
 brew upgrade protobuf
+brew upgrade swift-protobuf
+
 protoc --swift_out=./Modules/Server/Sources/PocketCastsServer/Private/Protobuffer --proto_path=$API_BASE_FOLDER/ $API_BASE_FOLDER/api.proto
 protoc --swift_out=./Modules/Server/Sources/PocketCastsServer/Private/Protobuffer --proto_path=$API_BASE_FOLDER/ $API_BASE_FOLDER/files.proto


### PR DESCRIPTION
While updating our protobuf files I noticed that a lot of changes were being reverted. After talking to the team I realized my libraries were completely outdated.

This PR ensures protoc and swift-protobuf are updated before updating the files.

## To test

1. Run `make update_proto` pointing to the correct pocket-casts-sync-api path in your machine
2. Check that `Sendable` stuff is not removed
3. Run `protoc --version`
4. Output should be `libprotoc 29.1`
5. Run brew upgrade swift-protobuf
6. Output should have `Warning: swift-protobuf 1.28.2_1 already installed`

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
