### PR TITLE
Stats: apply API changes to prevent reset

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Private/Protobuffer/api.pb.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Private/Protobuffer/api.pb.swift
@@ -3138,6 +3138,11 @@ struct Api_UserPodcastResponse: @unchecked Sendable {
   /// Clears the value of `settings`. Subsequent reads from it will return its default value.
   mutating func clearSettings() {_uniqueStorage()._settings = nil}
 
+  var descriptionHtml: String {
+    get {return _storage._descriptionHtml}
+    set {_uniqueStorage()._descriptionHtml = newValue}
+  }
+
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
@@ -4948,9 +4953,20 @@ struct Api_SyncUpdateRequest: Sendable {
 
   var records: [Api_Record] = []
 
+  var deviceType: SwiftProtobuf.Google_Protobuf_Int32Value {
+    get {return _deviceType ?? SwiftProtobuf.Google_Protobuf_Int32Value()}
+    set {_deviceType = newValue}
+  }
+  /// Returns true if `deviceType` has been explicitly set.
+  var hasDeviceType: Bool {return self._deviceType != nil}
+  /// Clears the value of `deviceType`. Subsequent reads from it will return its default value.
+  mutating func clearDeviceType() {self._deviceType = nil}
+
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
+
+  fileprivate var _deviceType: SwiftProtobuf.Google_Protobuf_Int32Value? = nil
 }
 
 struct Api_SyncUpdateResponse: Sendable {
@@ -10828,6 +10844,7 @@ extension Api_UserPodcastResponse: SwiftProtobuf.Message, SwiftProtobuf._Message
     15: .standard(proto: "sort_position"),
     16: .standard(proto: "date_added"),
     17: .same(proto: "settings"),
+    18: .standard(proto: "description_html"),
   ]
 
   fileprivate class _StorageClass {
@@ -10848,6 +10865,7 @@ extension Api_UserPodcastResponse: SwiftProtobuf.Message, SwiftProtobuf._Message
     var _sortPosition: SwiftProtobuf.Google_Protobuf_Int32Value? = nil
     var _dateAdded: SwiftProtobuf.Google_Protobuf_Timestamp? = nil
     var _settings: Api_PodcastSettings? = nil
+    var _descriptionHtml: String = String()
 
     #if swift(>=5.10)
       // This property is used as the initial default value for new instances of the type.
@@ -10879,6 +10897,7 @@ extension Api_UserPodcastResponse: SwiftProtobuf.Message, SwiftProtobuf._Message
       _sortPosition = source._sortPosition
       _dateAdded = source._dateAdded
       _settings = source._settings
+      _descriptionHtml = source._descriptionHtml
     }
   }
 
@@ -10914,6 +10933,7 @@ extension Api_UserPodcastResponse: SwiftProtobuf.Message, SwiftProtobuf._Message
         case 15: try { try decoder.decodeSingularMessageField(value: &_storage._sortPosition) }()
         case 16: try { try decoder.decodeSingularMessageField(value: &_storage._dateAdded) }()
         case 17: try { try decoder.decodeSingularMessageField(value: &_storage._settings) }()
+        case 18: try { try decoder.decodeSingularStringField(value: &_storage._descriptionHtml) }()
         default: break
         }
       }
@@ -10977,6 +10997,9 @@ extension Api_UserPodcastResponse: SwiftProtobuf.Message, SwiftProtobuf._Message
       try { if let v = _storage._settings {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 17)
       } }()
+      if !_storage._descriptionHtml.isEmpty {
+        try visitor.visitSingularStringField(value: _storage._descriptionHtml, fieldNumber: 18)
+      }
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -11003,6 +11026,7 @@ extension Api_UserPodcastResponse: SwiftProtobuf.Message, SwiftProtobuf._Message
         if _storage._sortPosition != rhs_storage._sortPosition {return false}
         if _storage._dateAdded != rhs_storage._dateAdded {return false}
         if _storage._settings != rhs_storage._settings {return false}
+        if _storage._descriptionHtml != rhs_storage._descriptionHtml {return false}
         return true
       }
       if !storagesAreEqual {return false}
@@ -14873,6 +14897,7 @@ extension Api_SyncUpdateRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageIm
     3: .same(proto: "country"),
     4: .standard(proto: "device_id"),
     5: .same(proto: "records"),
+    6: .standard(proto: "device_type"),
   ]
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -14886,12 +14911,17 @@ extension Api_SyncUpdateRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageIm
       case 3: try { try decoder.decodeSingularStringField(value: &self.country) }()
       case 4: try { try decoder.decodeSingularStringField(value: &self.deviceID) }()
       case 5: try { try decoder.decodeRepeatedMessageField(value: &self.records) }()
+      case 6: try { try decoder.decodeSingularMessageField(value: &self._deviceType) }()
       default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
     if self.deviceUtcTimeMs != 0 {
       try visitor.visitSingularInt64Field(value: self.deviceUtcTimeMs, fieldNumber: 1)
     }
@@ -14907,6 +14937,9 @@ extension Api_SyncUpdateRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageIm
     if !self.records.isEmpty {
       try visitor.visitRepeatedMessageField(value: self.records, fieldNumber: 5)
     }
+    try { if let v = self._deviceType {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 6)
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -14916,6 +14949,7 @@ extension Api_SyncUpdateRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageIm
     if lhs.country != rhs.country {return false}
     if lhs.deviceID != rhs.deviceID {return false}
     if lhs.records != rhs.records {return false}
+    if lhs._deviceType != rhs._deviceType {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Modules/Server/Sources/PocketCastsServer/Public/StatsManager.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/StatsManager.swift
@@ -30,7 +30,7 @@ public class StatsManager {
     }
 
     func updateStatsIfNeeded(savedDynamicSpeed: TimeInterval, savedVariableSpeed: TimeInterval, totalListenedTo: TimeInterval, totalSkipped: TimeInterval, savedAutoSkipping: TimeInterval) {
-        let minimumStatsChangeToUpdate = 100
+        let minimumStatsChangeToUpdate: TimeInterval = 100
 
         updateQueue.sync {
             if savedDynamicSpeed - self.savedDynamicSpeed > minimumStatsChangeToUpdate {

--- a/Modules/Server/Sources/PocketCastsServer/Public/StatsManager.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/StatsManager.swift
@@ -30,28 +30,30 @@ public class StatsManager {
     }
 
     func updateStatsIfNeeded(savedDynamicSpeed: TimeInterval, savedVariableSpeed: TimeInterval, totalListenedTo: TimeInterval, totalSkipped: TimeInterval, savedAutoSkipping: TimeInterval) {
+        let minimumStatsChangeToUpdate = 100
+
         updateQueue.sync {
-            if savedDynamicSpeed - self.savedDynamicSpeed > 100 {
+            if savedDynamicSpeed - self.savedDynamicSpeed > minimumStatsChangeToUpdate {
                 FileLog.shared.addMessage("[StatsManager] Changing savedDynamicSpeed from \(self.savedDynamicSpeed) to \(savedDynamicSpeed)")
                 self.savedDynamicSpeed = savedDynamicSpeed
             }
 
-            if savedVariableSpeed - self.savedVariableSpeed > 100 {
+            if savedVariableSpeed - self.savedVariableSpeed > minimumStatsChangeToUpdate {
                 FileLog.shared.addMessage("[StatsManager] Changing savedVariableSpeed from \(self.savedVariableSpeed) to \(savedVariableSpeed)")
                 self.savedVariableSpeed = savedVariableSpeed
             }
 
-            if totalListenedTo - self.totalListenedTo > 100 {
+            if totalListenedTo - self.totalListenedTo > minimumStatsChangeToUpdate {
                 FileLog.shared.addMessage("[StatsManager] Changing totalListenedTo from \(self.totalListenedTo) to \(totalListenedTo)")
                 self.totalListenedTo = totalListenedTo
             }
 
-            if totalSkipped - self.totalSkipped > 100 {
+            if totalSkipped - self.totalSkipped > minimumStatsChangeToUpdate {
                 FileLog.shared.addMessage("[StatsManager] Changing totalSkipped from \(self.totalSkipped) to \(totalSkipped)")
                 self.totalSkipped = totalSkipped
             }
 
-            if savedAutoSkipping - self.savedAutoSkipping > 100 {
+            if savedAutoSkipping - self.savedAutoSkipping > minimumStatsChangeToUpdate {
                 FileLog.shared.addMessage("[StatsManager] Changing savedAutoSkipping from \(self.savedAutoSkipping) to \(savedAutoSkipping)")
                 self.savedAutoSkipping = savedAutoSkipping
             }

--- a/Modules/Server/Sources/PocketCastsServer/Public/StatsManager.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/StatsManager.swift
@@ -29,6 +29,37 @@ public class StatsManager {
         }
     }
 
+    func updateStatsIfNeeded(savedDynamicSpeed: TimeInterval, savedVariableSpeed: TimeInterval, totalListenedTo: TimeInterval, totalSkipped: TimeInterval, savedAutoSkipping: TimeInterval) {
+        updateQueue.sync {
+            if savedDynamicSpeed - self.savedDynamicSpeed > 100 {
+                FileLog.shared.addMessage("[StatsManager] Changing savedDynamicSpeed from \(self.savedDynamicSpeed) to \(savedDynamicSpeed)")
+                self.savedDynamicSpeed = savedDynamicSpeed
+            }
+
+            if savedVariableSpeed - self.savedVariableSpeed > 100 {
+                FileLog.shared.addMessage("[StatsManager] Changing savedVariableSpeed from \(self.savedVariableSpeed) to \(savedVariableSpeed)")
+                self.savedVariableSpeed = savedVariableSpeed
+            }
+
+            if totalListenedTo - self.totalListenedTo > 100 {
+                FileLog.shared.addMessage("[StatsManager] Changing totalListenedTo from \(self.totalListenedTo) to \(totalListenedTo)")
+                self.totalListenedTo = totalListenedTo
+            }
+
+            if totalSkipped - self.totalSkipped > 100 {
+                FileLog.shared.addMessage("[StatsManager] Changing totalSkipped from \(self.totalSkipped) to \(totalSkipped)")
+                self.totalSkipped = totalSkipped
+            }
+
+            if savedAutoSkipping - self.savedAutoSkipping > 100 {
+                FileLog.shared.addMessage("[StatsManager] Changing savedAutoSkipping from \(self.savedAutoSkipping) to \(savedAutoSkipping)")
+                self.savedAutoSkipping = savedAutoSkipping
+            }
+
+            persistTimes()
+        }
+    }
+
     // MARK: - dynamic speed
 
     public func timeSavedDynamicSpeed() -> TimeInterval {
@@ -141,60 +172,6 @@ public class StatsManager {
             UserDefaults.standard.setValue(remoteStats.startedStatsAt, forKey: ServerConstants.UserDefaults.statsStartedDateServer)
 
             completion?(true)
-        }
-    }
-
-    public func updateLocalStatsIfNeeded(completion: ((Bool) -> Void)?) {
-        guard FeatureFlag.syncStats.enabled else {
-            completion?(false)
-            return
-        }
-
-        ApiServerHandler.shared.loadStatsRequest(getFullData: true) { [weak self] remoteStats in
-            guard let self, let remoteStats = remoteStats else { return }
-
-            var didChange = false
-
-            if Int64(timeSavedDynamicSpeedInclusive()) < remoteStats.silenceRemovalTime {
-                didChange = true
-                updateQueue.sync {
-                    self.savedDynamicSpeed = Double(remoteStats.silenceRemovalTime) - self.timeSavedDynamicSpeedInclusive()
-                }
-            }
-
-            if Int64(totalAutoSkippedTimeInclusive()) < remoteStats.autoSkipTime {
-                didChange = true
-                updateQueue.sync {
-                    self.savedAutoSkipping = Double(remoteStats.autoSkipTime) - self.totalAutoSkippedTimeInclusive()
-                }
-            }
-
-            if Int64(totalSkippedTimeInclusive()) < remoteStats.skipTime {
-                didChange = true
-                updateQueue.sync {
-                    self.totalSkipped = Double(remoteStats.skipTime) - self.totalSkippedTimeInclusive()
-                }
-            }
-
-            if Int64(totalListeningTimeInclusive()) < remoteStats.totalListenTime {
-                didChange = true
-                updateQueue.sync {
-                    self.totalListenedTo = Double(remoteStats.totalListenTime) - self.totalListeningTimeInclusive()
-                }
-            }
-
-            if Int64(timeSavedVariableSpeedInclusive()) < remoteStats.variableSpeedTime {
-                didChange = true
-                updateQueue.sync {
-                    self.savedVariableSpeed = Double(remoteStats.variableSpeedTime) - self.timeSavedVariableSpeedInclusive()
-                }
-            }
-
-            if didChange {
-                persistTimes()
-            }
-
-            completion?(didChange)
         }
     }
 

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
@@ -25,7 +25,13 @@ extension SyncTask {
             case .bookmark:
                 bookmarksToImport.append(item.bookmark)
             case .device:
-                continue // we aren't expecting the server to send us devices
+                StatsManager.shared.updateStatsIfNeeded(
+                    savedDynamicSpeed: TimeInterval(item.device.timeSilenceRemoval.value),
+                    savedVariableSpeed: TimeInterval(item.device.timeVariableSpeed.value),
+                    totalListenedTo: TimeInterval(item.device.timeListened.value),
+                    totalSkipped: TimeInterval(item.device.timeSkipping.value),
+                    savedAutoSkipping: TimeInterval(item.device.timeIntroSkipping.value)
+                )
             }
         }
 

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SwiftProtobuf
 import PocketCastsDataModel
 import PocketCastsUtils
 
@@ -287,6 +288,7 @@ class SyncTask: ApiBaseTask {
                 syncRequest.country = country
             }
             syncRequest.deviceID = ServerConfig.shared.syncDelegate?.uniqueAppId() ?? ""
+            syncRequest.deviceType = Google_Protobuf_Int32Value(ServerConstants.Values.deviceTypeiOS)
 
             return try syncRequest.serializedData()
         } catch {}

--- a/podcasts/StatsViewController.swift
+++ b/podcasts/StatsViewController.swift
@@ -160,11 +160,9 @@ class StatsViewController: UIViewController, UITableViewDelegate, UITableViewDat
                 self?.requestReviewIfPossible()
             }
 
-            StatsManager.shared.updateLocalStatsIfNeeded { updated in
-                if updated {
-                    DispatchQueue.main.async { [weak self] in
-                        self?.statsTable.reloadData()
-                    }
+            RefreshManager.shared.refreshPodcasts { _ in
+                DispatchQueue.main.async { [weak self] in
+                    self?.statsTable.reloadData()
                 }
             }
         }


### PR DESCRIPTION
We had a few instances of users' complaining that their Stats reset or reduced. This PR applies the latest changes deployed on Staging ensuring:

1. That the backend never "reduces" (or reset) any Stat;
2. That we pull back the stats in case we need

## To test

1. First, change the `Build Configuration` to `Staging` and run the app
2. Login to a staging account
3. Ensure this account has some Stats. If it doesn't, [manipulate these lines](https://github.com/Automattic/pocket-casts-ios/blob/trunk/Modules/Server/Sources/PocketCastsServer/Public/StatsManager.swift#L23-L29) and trigger a refresh (just add numbers there)
4. Then, remove all the `updateQueue.sync` block from the `StatsManager` `init` method. This will simulate having negative stats
5. Go to Stats
6. ✅ Reduced Stats should appear but it should update to the correct one
7. Re-run the app
8. Trigger a refresh from Profile
9. Go to Stats
10. ✅ Stats should be correct

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
