### PR TITLE
Fix highPassFilterRenderCallback callback

### DIFF
--- a/podcasts/DefaultPlayer.swift
+++ b/podcasts/DefaultPlayer.swift
@@ -519,14 +519,13 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
         }
 
         let highPassFilterRenderCallback: AURenderCallback = { inRefCon, _, inTimeStamp, _, inNumberFrames, ioData -> OSStatus in
-            let referenceToSelf: DefaultPlayer
-            if FeatureFlag.defaultPlayerFilterCallbackFix.enabled {
-                let reference = Unmanaged<DefaultPlayer>.fromOpaque(inRefCon)
-                referenceToSelf = reference.takeUnretainedValue()
-            } else {
-                referenceToSelf = unsafeBitCast(inRefCon, to: DefaultPlayer.self)
+            guard
+                let referenceToSelf = DefaultPlayer.unretainedDefaultPlayer(for: inRefCon),
+                let peakLimiter = referenceToSelf.peakLimiter,
+                let ioData = ioData
+            else {
+                return -1
             }
-            guard let peakLimiter = referenceToSelf.peakLimiter, let ioData = ioData else { return -1 }
 
             var audioTimeStamp = AudioTimeStamp()
             audioTimeStamp.mSampleTime = inTimeStamp.pointee.mSampleTime


### PR DESCRIPTION
Ref. #2522

This PR fixes the `highPassFilterRenderCallback` which was still using the `Unmanaged<DefaultPlayer>` and not the proxy.

## To test

- CI must be 🟢
- Clear your UpNext Queue and your downloaded episodes
- Add at least 4 episodes into the queue you never listened to
- Run this branch and play an episode with the volume boost on and trim silence as global settings
- Confirm the app won't crash
- Switch to a new episode
- Confirm the app won't crash
- Switch to a new episode and drag almost at the end to make it finishing and switching to a new episode
- Confirm the app won't crash
- Try to play and change episodes while playing
- When the system decides to finalize the tap you will see 2 logs in this order:

1. The log from the finalize closure: `[AudioProcessingTapProxy] Finalize tap: <MTAudioProcessingTap 0x6000030513b0> Retain count 3 Created with i/f/p/u/t callbacks = {0x10aa14448/0x10aa14600/0x10aa149b4/0x10aa14d08/0x10aa15330} flags = 0x1`
2. The log from the proxy deinit: `[AudioProcessingTapProxy] Deinit proxy`

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
