### PR TITLE
Remove Rss Chapters FF

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -14,9 +14,6 @@ public enum FeatureFlag: String, CaseIterable {
     /// Whether End Of Year feature is enabled
     case endOfYear
 
-    /// Enable chapters to be loaded from the RSS feed
-    case rssChapters
-
     /// Avoid logging out user on non-authorization HTTP errors
     case errorLogoutHandling
 
@@ -161,8 +158,6 @@ public enum FeatureFlag: String, CaseIterable {
             false
         case .endOfYear:
             false
-        case .rssChapters:
-            false
         case .errorLogoutHandling:
             false
         case .giveRatings:
@@ -257,9 +252,7 @@ public enum FeatureFlag: String, CaseIterable {
         case .newSettingsStorage:
             shouldEnableSyncedSettings ? "new_settings_storage" : nil
         case .settingsSync:
-            shouldEnableSyncedSettings ? "settings_sync" : nil
-         case .rssChapters:
-             "rss_chapters"
+            shouldEnableSyncedSettings ? "settings_sync" : nil         
         case .categoriesRedesign:
             "categories_redesign"
         case .defaultPlayerFilterCallbackFix:

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -252,7 +252,7 @@ public enum FeatureFlag: String, CaseIterable {
         case .newSettingsStorage:
             shouldEnableSyncedSettings ? "new_settings_storage" : nil
         case .settingsSync:
-            shouldEnableSyncedSettings ? "settings_sync" : nil         
+            shouldEnableSyncedSettings ? "settings_sync" : nil
         case .categoriesRedesign:
             "categories_redesign"
         case .defaultPlayerFilterCallbackFix:

--- a/podcasts/ChapterManager.swift
+++ b/podcasts/ChapterManager.swift
@@ -113,24 +113,8 @@ class ChapterManager {
         // store the last episode uuid we were asked to check chapters for, we use that below in case this method is called multiple times to not return old results
         lastEpisodeUuid = episode.uuid
 
-        guard !FeatureFlag.rssChapters.enabled else {
-            try? await parseLocalAndRemoteChapters(for: episode, duration: duration)
+        try? await parseLocalAndRemoteChapters(for: episode, duration: duration)
             return
-        }
-
-        if episode.downloaded(pathFinder: DownloadManager.shared) {
-            chapterParser.parseLocalFile(episode.pathToDownloadedFile(pathFinder: DownloadManager.shared), episodeDuration: duration) { [weak self] parsedChapters in
-                if self?.lastEpisodeUuid == episode.uuid {
-                    self?.handleChaptersLoaded(parsedChapters, for: episode)
-                }
-            }
-        } else if let url = EpisodeManager.urlForEpisode(episode) {
-            chapterParser.parseRemoteFile(url.absoluteString, episodeDuration: duration) { [weak self] parsedChapters in
-                if self?.lastEpisodeUuid == episode.uuid {
-                    self?.handleChaptersLoaded(parsedChapters, for: episode)
-                }
-            }
-        }
     }
 
     private func parseLocalAndRemoteChapters(for episode: BaseEpisode, duration: TimeInterval) async throws {

--- a/podcasts/ChapterManager.swift
+++ b/podcasts/ChapterManager.swift
@@ -114,7 +114,6 @@ class ChapterManager {
         lastEpisodeUuid = episode.uuid
 
         try? await parseLocalAndRemoteChapters(for: episode, duration: duration)
-            return
     }
 
     private func parseLocalAndRemoteChapters(for episode: BaseEpisode, duration: TimeInterval) async throws {


### PR DESCRIPTION
| 📘 Part of: #2509  |  <!-- project issue number, if applicable -->
|:---:|

Fixes #2547  <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
Removing the `rssChapters` FF

## To test


1. Start the app
2. Open a podcast with support for chapters. For ex: [Chaos Radio](https://pca.st/chaosradio)
3. Play an episode
4. Open the full screen player
5. Tap on chapters
6. See if they are displayed

We are giving priority to embedded chapters so to test the rss chapters loading go to line 133 of Chapter Manager and add the following ` && false` to the condition. This will force the use of rss chapters.

Now play another episode of Chaos Radio and see if the chapters show correctly

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
