### PR TITLE
[Tooling] Introduce `publish_release` lane

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -47,8 +47,8 @@ CODE_SIGNING_STORAGE_OPTIONS = {
   s3_region: 'us-east-2'
 }.freeze
 
-GHHELPER_REPO = 'Automattic/pocket-casts-ios'
-GITHUB_URL = "https://github.com/#{GHHELPER_REPO}".freeze
+GITHUB_REPO = 'Automattic/pocket-casts-ios'
+GITHUB_URL = "https://github.com/#{GITHUB_REPO}".freeze
 DEFAULT_BRANCH = 'trunk'
 
 SCHEME = 'pocketcasts'
@@ -331,7 +331,7 @@ platform :ios do
     # We cannot use the `copy_branch_protection` action here yet, as it would create a branch protection rule with the same
     # restrictions we have in `trunk`, and the release managers wouldn't be able to push due to permissions.
     # This should be changed only when we have PCiOS releases done on CI, when the CI bot is the one running `git push`.
-    set_branch_protection(repository: GHHELPER_REPO, branch: release_branch_name)
+    set_branch_protection(repository: GITHUB_REPO, branch: release_branch_name)
 
     # Move still-open PRs to next milestone, then add frozen marker to milestone title
     update_milestone
@@ -425,9 +425,9 @@ platform :ios do
     UI.success "Done! New Build Code: #{build_code_current}"
 
     # Wrap up
-    remove_branch_protection(repository: GHHELPER_REPO, branch: release_branch_name)
-    set_milestone_frozen_marker(repository: GHHELPER_REPO, milestone: release_version_current, freeze: false)
-    close_milestone(repository: GHHELPER_REPO, milestone: release_version_current)
+    remove_branch_protection(repository: GITHUB_REPO, branch: release_branch_name)
+    set_milestone_frozen_marker(repository: GITHUB_REPO, milestone: release_version_current, freeze: false)
+    close_milestone(repository: GITHUB_REPO, milestone: release_version_current)
 
     # Start the build
 
@@ -461,7 +461,7 @@ platform :ios do
     UI.important "Publishing release #{version_number} on GitHub"
 
     publish_github_release(
-      repository: GHHELPER_REPO,
+      repository: GITHUB_REPO,
       name: version_number
     )
 
@@ -734,7 +734,7 @@ platform :ios do
 
     UI.message("Creating #{version} release on GitHub...")
     set_github_release(
-      repository_name: GHHELPER_REPO,
+      repository_name: GITHUB_REPO,
       api_token: get_required_env!('GITHUB_TOKEN'),
       name: version,
       tag_name: version,
@@ -1193,7 +1193,7 @@ platform :ios do
     begin
       # Move PRs to next milestone
       moved_prs = update_assigned_milestone(
-        repository: GHHELPER_REPO,
+        repository: GITHUB_REPO,
         from_milestone: new_version,
         to_milestone: next_version,
         comment: "Version `#{new_version}` has now entered code-freeze, so the milestone of this PR has been updated to `#{next_version}`."
@@ -1201,7 +1201,7 @@ platform :ios do
 
       # Add ❄️ marker to milestone title to indicate we entered code-freeze
       set_milestone_frozen_marker(
-        repository: GHHELPER_REPO,
+        repository: GITHUB_REPO,
         milestone: new_version
       )
     rescue StandardError => e
@@ -1225,7 +1225,7 @@ platform :ios do
                        "👍 No open PR were targeting `#{new_version}` at the time of code-freeze"
                      else
                        "#{moved_prs.count} PRs targeting `#{new_version}` were still open and thus moved to `#{next_version}`:\n" \
-                         + moved_prs.map { |pr_num| "[##{pr_num}](https://github.com/#{GHHELPER_REPO}/pull/#{pr_num})" }.join(', ')
+                         + moved_prs.map { |pr_num| "[##{pr_num}](https://github.com/#{GITHUB_REPO}/pull/#{pr_num})" }.join(', ')
                      end
     buildkite_annotate(style: moved_prs.empty? ? 'success' : 'warning', context: 'start-code-freeze', message: moved_prs_info) if is_ci
   end
@@ -1234,7 +1234,7 @@ platform :ios do
   #
   def create_backmerge_pr
     create_release_backmerge_pull_request(
-      repository: GHHELPER_REPO,
+      repository: GITHUB_REPO,
       source_branch: release_branch_name,
       default_branch: DEFAULT_BRANCH,
       labels: ['Releases'],
@@ -1320,7 +1320,7 @@ platform :ios do
     )
 
     comment_on_pr(
-      project: GHHELPER_REPO,
+      project: GITHUB_REPO,
       pr_number: Integer(ENV.fetch('BUILDKITE_PULL_REQUEST', nil)),
       reuse_identifier: 'prototype-build-link-pocket-casts',
       body: comment_body

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -435,6 +435,46 @@ platform :ios do
     create_backmerge_pr
   end
 
+  # This lane publishes a release on GitHub and creates a PR to backmerge the current release branch into the next release/ branch
+  #
+  # @param [Boolean] skip_confirm (default: false) If set, will skip the confirmation prompt before running the rest of the lane
+  #
+  lane :publish_release do |skip_confirm: false|
+    ensure_git_status_clean
+    ensure_git_branch(branch: '^release/')
+
+    version_number = release_version_current
+
+    current_branch = "release/#{version_number}"
+    next_release_branch = "release/#{release_version_next}"
+
+    UI.important <<~PROMPT
+      Publish the #{version_number} release. This will:
+      - Publish the existing draft `#{version_number}` release on GitHub
+      - Which will also have GitHub create the associated git tag, pointing to the tip of the branch
+      - If the release branch for the next version `#{next_release_branch}` already exists, backmerge `#{current_branch}` into it
+      - If needed, backmerge `#{current_branch}` back into `#{DEFAULT_BRANCH}`
+      - Delete the `#{current_branch}` branch
+    PROMPT
+    UI.user_error!("Terminating as requested. Don't forget to run the remainder of this automation manually.") unless skip_confirm || UI.confirm('Do you want to continue?')
+
+    UI.important "Publishing release #{version_number} on GitHub"
+
+    publish_github_release(
+      repository: GHHELPER_REPO,
+      name: version_number
+    )
+
+    create_backmerge_pr
+
+    # At this point, an intermediate branch has been created by creating a backmerge PR to a hotfix or the next version release branch.
+    # This allows us to safely delete the `release/*` remote branch.
+    remove_branch_protection(repository: GITHUB_REPO, branch: current_branch)
+    Fastlane::Helper::GitHelper::delete_remote_branch_if_exists!(current_branch)
+    Fastlane::Helper::GitHelper::checkout_and_pull(DEFAULT_BRANCH)
+    Fastlane::Helper::GitHelper::delete_local_branch_if_exists!(current_branch)
+  end
+
   # Sets the stage to start working on a hotfix
   #
   # - Cuts a new `release/x.y.z` branch from the tag from the latest (`x.y`) version


### PR DESCRIPTION

## Description

Introduce a `publish_release` lane to automate:
 - The publication of the GitHub Release of the final build (once the version submitted to Google on Friday have been approved)
 - The creation of the final backmerge PR if needed(†)
 - The deletion of the release branch


<details><summary>(†) Note that in 95% of cases there won't be anything to backmerge—and the creation of that backmerge PR will be automatically skipped.</summary>

 - This is because there had already been a backmerge PR created during submission on Friday and no new commit should have been added to the `release/*` branch after submission.
  - But calling `create_release_backmerge_pull_request` anyway is more of safety net in case there would have been a new  commit on `release/*` anyway since, to make sure not lose it completely accidentally once we delete the `release/*` branch
  - Rare cases where this could happen is if a commit was added to change tooling-related files (`Fastlane`, `Gemfile.lock`, …) after the submission to fix issues encountered in the tooling, or update of the `CHANGELOG.md` file if one notice after having submitted the build that a PR was forgotten to be added to it, etc. Those seldom cases would not require a resubmission of the final build so that'd be ok for them to land even after the submission was done, and in those rare cases a backmerge PR would be created to propagate those properly instead of risking to lose those changes upon `release/*` branch deletion
</details>

This PR also renames `GHHELPER_REPO` constant to `GITHUB_REPO`, for consistency with our other repos

## Testing Instructions

Won't really be able to test those without doing a real final release publication as part of a Release Scenario, given this lane creates side-effects.

> [!NOTE]
> I've made this PR target `release/7.79` so that we could use the occasion of the `7.79` publication to test that this lane works as expected if we want

## Next Steps

I will create the corresponding diff for the Release Scenario to replace the corresponding manual tasks during "Release" milestone to just call this new lane instead.