### PR TITLE
Download copy error logging

### DIFF
--- a/podcasts/DownloadManager+URLSessionDelegate.swift
+++ b/podcasts/DownloadManager+URLSessionDelegate.swift
@@ -169,6 +169,7 @@ extension DownloadManager: URLSessionDelegate, URLSessionDownloadDelegate {
             EpisodeFileSizeUpdater.updateEpisodeDuration(episode: episode)
             NotificationCenter.postOnMainThread(notification: Constants.Notifications.episodeDownloaded, object: episode.uuid)
         } catch {
+            FileLog.shared.addMessage("DownloadManager: Failed to copy downloaded file from location: \(location.absoluteString) to destination:  \(destinationPath) error: \(error)")
             markEpisode(episode, asFailedWithMessage: L10n.downloadErrorNotEnoughSpace, reason: .badResponse)
         }
     }

--- a/podcasts/DownloadManager+URLSessionDelegate.swift
+++ b/podcasts/DownloadManager+URLSessionDelegate.swift
@@ -159,7 +159,7 @@ extension DownloadManager: URLSessionDelegate, URLSessionDownloadDelegate {
         let autoDownloadStatus = AutoDownloadStatus(rawValue: episode.autoDownloadStatus)!
         let destinationPath = autoDownloadStatus == .playerDownloadedForStreaming ? streamingBufferPathForEpisode(episode) : pathForEpisode(episode)
         let destinationUrl = URL(fileURLWithPath: destinationPath)
-        
+ 
         do {
             try StorageManager.copyItem(at: location, to: destinationUrl)
 

--- a/podcasts/DownloadManager+URLSessionDelegate.swift
+++ b/podcasts/DownloadManager+URLSessionDelegate.swift
@@ -159,7 +159,7 @@ extension DownloadManager: URLSessionDelegate, URLSessionDownloadDelegate {
         let autoDownloadStatus = AutoDownloadStatus(rawValue: episode.autoDownloadStatus)!
         let destinationPath = autoDownloadStatus == .playerDownloadedForStreaming ? streamingBufferPathForEpisode(episode) : pathForEpisode(episode)
         let destinationUrl = URL(fileURLWithPath: destinationPath)
- 
+
         do {
             try StorageManager.copyItem(at: location, to: destinationUrl)
 

--- a/podcasts/DownloadManager+URLSessionDelegate.swift
+++ b/podcasts/DownloadManager+URLSessionDelegate.swift
@@ -141,26 +141,26 @@ extension DownloadManager: URLSessionDelegate, URLSessionDownloadDelegate {
     }
 
     func processEpisode(_ episode: BaseEpisode, downloadedFile location: URL, reportedContentType: String?) {
+        var contentType = reportedContentType
+
+        if FeatureFlag.useMimetypePackage.enabled {
+            contentType = MimetypeHelper.contetType(for: location)
+            if let contentType, contentType != episode.contentType {
+                DataManager.sharedManager.saveEpisode(contentType: contentType, episode: episode)
+            }
+        }
+
+        let fileSize = FileManager.default.fileSize(of: location) ?? 0
+        guard isEpisodeFileValid(contentType: contentType, fileSize: fileSize) else {
+            markEpisode(episode, asFailedWithMessage: L10n.downloadErrorContactAuthorVersion2, reason: .suspiciousContent(fileSize))
+            return
+        }
+
+        let autoDownloadStatus = AutoDownloadStatus(rawValue: episode.autoDownloadStatus)!
+        let destinationPath = autoDownloadStatus == .playerDownloadedForStreaming ? streamingBufferPathForEpisode(episode) : pathForEpisode(episode)
+        let destinationUrl = URL(fileURLWithPath: destinationPath)
+        
         do {
-            var contentType = reportedContentType
-
-            if FeatureFlag.useMimetypePackage.enabled {
-                contentType = MimetypeHelper.contetType(for: location)
-                if let contentType, contentType != episode.contentType {
-                    DataManager.sharedManager.saveEpisode(contentType: contentType, episode: episode)
-                }
-            }
-
-            let fileSize = FileManager.default.fileSize(of: location) ?? 0
-            guard isEpisodeFileValid(contentType: contentType, fileSize: fileSize) else {
-                markEpisode(episode, asFailedWithMessage: L10n.downloadErrorContactAuthorVersion2, reason: .suspiciousContent(fileSize))
-                return
-            }
-
-            let autoDownloadStatus = AutoDownloadStatus(rawValue: episode.autoDownloadStatus)!
-            let destinationPath = autoDownloadStatus == .playerDownloadedForStreaming ? streamingBufferPathForEpisode(episode) : pathForEpisode(episode)
-            let destinationUrl = URL(fileURLWithPath: destinationPath)
-
             try StorageManager.copyItem(at: location, to: destinationUrl)
 
             let newDownloadStatus: DownloadStatus = autoDownloadStatus == .playerDownloadedForStreaming ? .downloadedForStreaming : .downloaded


### PR DESCRIPTION
* Moves non-throwing code out of the `do`/`catch` block so it's clear which code is throwing
* Adds error logging when we fail to copy the downloaded file. This is the point at which we show an error message saying "have you run out of space", which may not be accurate depending on the error.

## To test

* Ensure episode downloads still work
* In `StorageManager.copyItem(at: URL, to: URL)` you can add the following: `throw CocoaError(.fileNoSuchFile)` and ensure this error is logged when downloading:

```
DownloadManager: Failed to copy downloaded file from location: <path> to destination: <path>  error: Error Domain=NSCocoaErrorDomain Code=4 "The file doesn’t exist."
```

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
