### PR TITLE
Instantly update the view

### DIFF
--- a/podcasts/Onboarding/Plus/UpgradeExperiment/Reviews/PlusPaywallReviewsViewModel.swift
+++ b/podcasts/Onboarding/Plus/UpgradeExperiment/Reviews/PlusPaywallReviewsViewModel.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 class PlusPaywallReviewsViewModel: ObservableObject {
-    var appStoreInfo: AppStoreInfo?
+    @Published var appStoreInfo: AppStoreInfo?
 
     func parseAppStoreReview() {
         guard let filepath = Bundle.main.path(forResource: "appStoreInfo", ofType: "json") else {


### PR DESCRIPTION
Make sure the Paywall reviews variants instantly loads the local JSON

## To test

- CI must be 🟢 
- Make sure the paywall experiment FF is on
- Assign your self to the reviews variant
- Run the app with a free user and open the paywall from the Profile tab -> scroll down -> Tap on "Learn more..."
- You should see the reviews instantly loaded with no delay

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
