### PR TITLE
Remove deselect chapters FF

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -20,9 +20,6 @@ public enum FeatureFlag: String, CaseIterable {
     /// Enable the ability to rate podcasts
     case giveRatings
 
-    /// Enable selecting/deselecting episode chapters
-    case deselectChapters
-
     /// Store settings as JSON in User Defaults (global) or SQLite (podcast)
     case newSettingsStorage
 
@@ -165,8 +162,6 @@ public enum FeatureFlag: String, CaseIterable {
             false
         case .giveRatings:
             false
-        case .deselectChapters:
-            false
         case .newSettingsStorage:
             shouldEnableSyncedSettings
         case .settingsSync:
@@ -250,8 +245,6 @@ public enum FeatureFlag: String, CaseIterable {
     /// This should match a Firebase Remote Config Parameter name (key)
     public var remoteKey: String? {
         switch self {
-        case .deselectChapters:
-            "deselect_chapters_enabled"
         case .newAccountUpgradePromptFlow:
             "new_account_upgrade_prompt_flow"
         case .newSettingsStorage:

--- a/PocketCastsTests/Tests/Playback/Chapters/ChapterManagerTests.swift
+++ b/PocketCastsTests/Tests/Playback/Chapters/ChapterManagerTests.swift
@@ -25,7 +25,6 @@ class ChapterManagerTests: XCTestCase {
 
     /// Update the current chapter given a TimeInterval
     func testUpdateCurrentChapterBasedOnTime() async {
-        featureFlagMock.set(.deselectChapters, value: true)
         let parserMock = PodcastChapterParserMock()
         let showInfoCoordinatorMock = ShowInfoCoordinatorMock()
         parserMock.chapters = [
@@ -46,7 +45,6 @@ class ChapterManagerTests: XCTestCase {
 
     /// Update the current chapter given a TimeInterval
     func testReturnNextVisiblePlayableChapter() async {
-        featureFlagMock.set(.deselectChapters, value: true)
         let showInfoCoordinatorMock = ShowInfoCoordinatorMock()
         let parserMock = PodcastChapterParserMock()
         parserMock.chapters = [
@@ -68,7 +66,6 @@ class ChapterManagerTests: XCTestCase {
 
     /// Update the current chapter given a TimeInterval
     func testReturnPreviousVisiblePlayableChapter() async {
-        featureFlagMock.set(.deselectChapters, value: true)
         let showInfoCoordinatorMock = ShowInfoCoordinatorMock()
         let parserMock = PodcastChapterParserMock()
         parserMock.chapters = [
@@ -86,26 +83,6 @@ class ChapterManagerTests: XCTestCase {
         let nextVisiblePlayableChapter = chapterManager.previousVisibleChapter()
 
         XCTAssertEqual(nextVisiblePlayableChapter, chapterInfo(startTime: 201, duration: 300, shouldPlay: true))
-    }
-
-    /// If the Feature Flag is false then everything should be played
-    func testEverythingShouldPlay() async {
-        featureFlagMock.set(.deselectChapters, value: false)
-        let showInfoCoordinatorMock = ShowInfoCoordinatorMock()
-        let parserMock = PodcastChapterParserMock()
-        parserMock.chapters = [
-            chapterInfo(startTime: 0, duration: 100, shouldPlay: true),
-            chapterInfo(startTime: 101, duration: 200, shouldPlay: false),
-            chapterInfo(startTime: 201, duration: 300, shouldPlay: true),
-            chapterInfo(startTime: 301, duration: 400, shouldPlay: false),
-            chapterInfo(startTime: 401, duration: 500, shouldPlay: true),
-            chapterInfo(startTime: 501, duration: 600, shouldPlay: false)
-        ]
-        let chapterManager = ChapterManager(chapterParser: parserMock, showInfoCoordinator: showInfoCoordinatorMock)
-        await chapterManager.parseChapters(episode: EpisodeMock(), duration: 600)
-        chapterManager.updateCurrentChapter(time: 450)
-
-        XCTAssertEqual(chapterManager.playableChapterCount(), 6)
     }
 
     func chapterInfo(startTime: TimeInterval, duration: TimeInterval, shouldPlay: Bool) -> ChapterInfo {

--- a/podcasts/ChapterInfo.swift
+++ b/podcasts/ChapterInfo.swift
@@ -20,7 +20,7 @@ class ChapterInfo: Equatable {
     var shouldPlay = true
 
     func isPlayable() -> Bool {
-        FeatureFlag.deselectChapters.enabled && PaidFeature.deselectChapters.isUnlocked ? shouldPlay : true
+        PaidFeature.deselectChapters.isUnlocked ? shouldPlay : true
     }
 
     static func == (lhs: ChapterInfo, rhs: ChapterInfo) -> Bool {

--- a/podcasts/ChaptersViewController+Table.swift
+++ b/podcasts/ChaptersViewController+Table.swift
@@ -85,7 +85,7 @@ extension ChaptersViewController: UITableViewDataSource, UITableViewDelegate, UI
     }
 
     var shouldShowDeselectChaptersHeader: Bool {
-        FeatureFlag.deselectChapters.enabled && (PlaybackManager.shared.currentEpisode()?.isUserEpisode == false)
+        PlaybackManager.shared.currentEpisode()?.isUserEpisode == false
     }
 }
 

--- a/podcasts/Whats New/DeselectChaptersAnnouncementViewModel.swift
+++ b/podcasts/Whats New/DeselectChaptersAnnouncementViewModel.swift
@@ -4,22 +4,19 @@ import PocketCastsUtils
 
 class DeselectChaptersAnnouncementViewModel {
     var isPatronAnnouncementEnabled: Bool {
-        FeatureFlag.deselectChapters.enabled
-            && PaidFeature.deselectChapters.isUnlocked
+        PaidFeature.deselectChapters.isUnlocked
     }
 
     // Only for TestFlight early access
     var isPlusAnnouncementEnabled: Bool {
-        FeatureFlag.deselectChapters.enabled
-            && PaidFeature.deselectChapters.tier == .plus
-            && SubscriptionHelper.activeTier == .plus
+        PaidFeature.deselectChapters.tier == .plus
+        && SubscriptionHelper.activeTier == .plus
     }
 
     var isPlusFreeAnnouncementEnabled: Bool {
-        FeatureFlag.deselectChapters.enabled
-            && PaidFeature.deselectChapters.tier == .plus
-            && SubscriptionHelper.activeTier < .patron
-            && BuildEnvironment.current == .appStore
+        PaidFeature.deselectChapters.tier == .plus
+        && SubscriptionHelper.activeTier < .patron
+        && BuildEnvironment.current == .appStore
     }
 
     var plusFreeMessage: String {


### PR DESCRIPTION
| 📘 Part of: #2509  |  <!-- project issue number, if applicable -->
|:---:|

Fixes #2559  <!-- issue number, if applicable -->

Remove Deselect Chapters FF

## To test

1. Start the app with a subscription account
2. Open an episode with chapter support. Ex: ATP
3. Play the episode
4. Open the full screen player
5. Open the chapters tab
6. Select/Deselect some chapters
7. Forward and backward the episode and see if the chapters play according to the selection.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
