### PR TITLE
Add option to collapse again if tapped on ExpandableLabel

### DIFF
--- a/podcasts/ExpandableLabel.swift
+++ b/podcasts/ExpandableLabel.swift
@@ -3,6 +3,9 @@ import UIKit
 protocol ExpandableLabelDelegate: NSObjectProtocol {
     func willExpandLabel(_ label: ExpandableLabel)
     func didExpandLabel(_ label: ExpandableLabel)
+
+    func willCollapseLabel(_ label: ExpandableLabel)
+    func didCollapseLabel(_ label: ExpandableLabel)
 }
 
 class ExpandableLabel: ThemeableLabel {
@@ -65,11 +68,14 @@ class ExpandableLabel: ThemeableLabel {
         }
         if collapsed {
             delegate?.willExpandLabel(self)
-
             collapsed = false
-
             delegate?.didExpandLabel(self)
+        } else {
+            delegate?.willCollapseLabel(self)
+            collapsed = true
+            delegate?.didCollapseLabel(self)
         }
+        update()
     }
 
     private func update() {


### PR DESCRIPTION
| 📘 Part of: #2479  |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR adds the possibility to collapse the podcast description if tapped again. Check the video bellow


https://github.com/user-attachments/assets/3263ca21-a23b-4e9d-864a-5d3187a66444


## To test

1. Start the app
2. Ensure you have the `usePodcastHTMLDescription` FF enabled
3. Open a podcast with an HTML description: `DirtBag Rich`
4. Tap on the description to expand
5. Check if you can scroll the description
6. Tap on the description again to collapse
7. Check if layout is correct


## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
