### PR TITLE
Remove give ratings FF

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -17,9 +17,6 @@ public enum FeatureFlag: String, CaseIterable {
     /// Avoid logging out user on non-authorization HTTP errors
     case errorLogoutHandling
 
-    /// Enable the ability to rate podcasts
-    case giveRatings
-
     /// Store settings as JSON in User Defaults (global) or SQLite (podcast)
     case newSettingsStorage
 
@@ -159,8 +156,6 @@ public enum FeatureFlag: String, CaseIterable {
         case .endOfYear:
             false
         case .errorLogoutHandling:
-            false
-        case .giveRatings:
             false
         case .newSettingsStorage:
             shouldEnableSyncedSettings

--- a/podcasts/PodcastHeadingTableCell.swift
+++ b/podcasts/PodcastHeadingTableCell.swift
@@ -348,12 +348,7 @@ class PodcastHeadingTableCell: ThemeableCell, SubscribeButtonDelegate, Expandabl
 
         roundedBorder.isHidden = nextEpisodeView.isHidden && scheduleView.isHidden && linkView.isHidden && authorView.isHidden
 
-        if FeatureFlag.giveRatings.enabled {
-            ratingView?.isHidden = !expanded
-        } else {
-            let hasRating = delegate?.podcastRatingViewModel.rating != nil
-            ratingView?.isHidden = !hasRating || !expanded
-        }
+        ratingView?.isHidden = !expanded
     }
 
     private func setupButtons() {

--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -250,9 +250,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
         NotificationCenter.default.addObserver(self, selector: #selector(folderChanged(_:)), name: Constants.Notifications.folderChanged, object: nil)
 
         listenForBookmarkChanges()
-        if FeatureFlag.giveRatings.enabled {
-            setupLogin()
-        }
+        setupLogin()
     }
 
     private func setupLogin() {

--- a/podcasts/Ratings/PodcastRatingViewModel.swift
+++ b/podcasts/Ratings/PodcastRatingViewModel.swift
@@ -69,21 +69,15 @@ class PodcastRatingViewModel: ObservableObject {
 // MARK: - View Interactions
 extension PodcastRatingViewModel {
     func didTapRating(source: RatingSource = .button) {
-        if FeatureFlag.giveRatings.enabled {
-            Analytics.shared.track(.ratingStarsTapped,
-                                   properties: ["uuid": uuid ?? "unknown",
-                                                "source": source.rawValue])
-            if SyncManager.isUserLoggedIn() {
-                presentingGiveRatings = true
-            } else {
-                DispatchQueue.main.async {
-                    self.presentLogin?(self)
-                }
-            }
-        } else {
+        Analytics.shared.track(.ratingStarsTapped,
+                               properties: ["uuid": uuid ?? "unknown",
+                                            "source": source.rawValue])
+        if SyncManager.isUserLoggedIn() {
             presentingGiveRatings = true
-
-            Analytics.shared.track(.ratingStarsTapped, properties: ["uuid": uuid ?? "unknown"])
+        } else {
+            DispatchQueue.main.async {
+                self.presentLogin?(self)
+            }
         }
     }
 }

--- a/podcasts/Ratings/StarRatingView.swift
+++ b/podcasts/Ratings/StarRatingView.swift
@@ -27,11 +27,7 @@ struct StarRatingView: View {
     }
 
     var body: some View {
-        if FeatureFlag.giveRatings.enabled {
-            starsAndRate
-        } else {
-            onlyStars
-        }
+        starsAndRate
     }
 
     /// A view that returns stars and the "Rate" button
@@ -76,17 +72,6 @@ struct StarRatingView: View {
         }
     }
 
-    // A view that returns only the stars
-    var onlyStars: some View {
-        HStack(alignment: .center) {
-            ratingView(rating: viewModel.rating)
-                .animation(.easeIn(duration: Constants.animationDuration), value: shouldAnimate)
-
-            Spacer()
-        }
-        .frame(height: 15)
-    }
-
     @ViewBuilder
     private func ratingView(rating: PodcastRating?) -> some View {
         starsView(rating: rating?.average ?? 0)
@@ -97,21 +82,16 @@ struct StarRatingView: View {
     private func labelView(rating: PodcastRating?) -> some View {
         let defaultColor = AppTheme.color(for: .primaryText01, theme: theme)
         Group {
-            if !FeatureFlag.giveRatings.enabled {
-                Text("(\(rating?.total.abbreviated ?? ""))")
+            if let rating, viewModel.hasRatings {
+                Text("\(rating.average, specifier: "%.1f")")
+                    .font(size: 14, style: .footnote, weight: .semibold)
+                    .padding([.leading], -2)
+                Text("(\(rating.total.abbreviated))")
                     .font(size: 14, style: .footnote)
+                    .padding([.leading], -2)
             } else {
-                if let rating, viewModel.hasRatings {
-                    Text("\(rating.average, specifier: "%.1f")")
-                        .font(size: 14, style: .footnote, weight: .semibold)
-                        .padding([.leading], -2)
-                    Text("(\(rating.total.abbreviated))")
-                        .font(size: 14, style: .footnote)
-                        .padding([.leading], -2)
-                } else {
-                    Text(L10n.ratingNoRatings)
-                        .font(size: 14, style: .footnote)
-                }
+                Text(L10n.ratingNoRatings)
+                    .font(size: 14, style: .footnote)
             }
         }
         .foregroundColor(defaultColor)
@@ -125,7 +105,7 @@ struct StarRatingView: View {
         let stars = Int(rating)
         // Get the float value
         let half = rating.truncatingRemainder(dividingBy: 1)
-        let themeStyle = FeatureFlag.giveRatings.enabled ? ThemeStyle.primaryUi05Selected : ThemeStyle.filter03
+        let themeStyle = ThemeStyle.primaryUi05Selected
         let color = AppTheme.color(for: themeStyle, theme: theme)
 
         HStack(spacing: 3) {

--- a/podcasts/Whats New/Announcements.swift
+++ b/podcasts/Whats New/Announcements.swift
@@ -91,7 +91,7 @@ struct Announcements {
             action: {
                 SceneHelper.rootViewController()?.dismiss(animated: true)
             },
-            isEnabled: FeatureFlag.giveRatings.enabled,
+            isEnabled: true,
             fullModal: true
         ),
         .init(


### PR DESCRIPTION
| 📘 Part of: #2509  |  <!-- project issue number, if applicable -->
|:---:|

Fixes #2567 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
Remove the FF for giveRatings

## To test

1. Start the app and login with an account that can give ratings
2. Open a podcast that you already listened some episodes
3. Tap on the start to give a rating or update a rating

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
