### PR TITLE
Add event to track Podcasts list discover button tap

### DIFF
--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -87,6 +87,7 @@ enum AnalyticsEvent: String {
     case podcastsListSortOrderChanged
     case podcastsListLayoutChanged
     case podcastsListBadgesChanged
+    case podcastsListDiscoverButtonTapped
 
     // MARK: - Newsletter Opt In
 

--- a/podcasts/PodcastListViewController.swift
+++ b/podcasts/PodcastListViewController.swift
@@ -14,6 +14,7 @@ class PodcastListViewController: PCViewController, UIGestureRecognizerDelegate, 
         didSet {
             addPodcastBtn.buttonTitle = L10n.podcastGridDiscoverPodcasts
             addPodcastBtn.buttonTapped = {
+                Analytics.track(.podcastsListDiscoverButtonTapped)
                 NavigationManager.sharedManager.navigateTo(NavigationManager.discoverPageKey, data: nil)
             }
         }


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

Add event to track Podcasts list discover button tap

<img src="https://github.com/user-attachments/assets/bd865837-4669-484c-9135-d430b3e185ab" width=320>

## To test

1. Start the app from scratch without a user logged in
2. Enable the `tracksLogging` FF
3. Tap on the Podcasts tab
4. You should screen the screen above
5. Tap on the Discover Podcasts
6. Check if you see the event: `podcasts_list_discover_button_tapped` being logged in the console

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
