### PR TITLE
Remove categories redesign FF

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/Discover/DiscoverServerHandler.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Discover/DiscoverServerHandler.swift
@@ -29,13 +29,7 @@ public class DiscoverServerHandler {
     }
 
     public func discoverPage(completion: @escaping (DiscoverLayout?, Bool) -> Void) {
-        let contentPath: String
-        if FeatureFlag.categoriesRedesign.enabled {
-            contentPath = "ios/content_v2.json"
-        } else {
-            contentPath = "ios/content.json"
-        }
-
+        let contentPath = "ios/content_v2.json"
         discoverRequest(path: ServerConstants.Urls.discover() + contentPath, type: DiscoverLayout.self) { discoverItems, cachedResponse in
             completion(discoverItems, cachedResponse)
         }

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -32,8 +32,6 @@ public enum FeatureFlag: String, CaseIterable {
     /// Enable the AVExportSession parallel download of any playing episode
     case streamAndCachePlayingEpisode
 
-    case categoriesRedesign
-
     /// When enabled it updates the code on filter callback to use a safer method to convert unmanaged player references
     /// This is to fix this: https://a8c.sentry.io/share/issue/39a6d2958b674ec3b7a4d9248b4b5ffa/
     case defaultPlayerFilterCallbackFix
@@ -167,8 +165,6 @@ public enum FeatureFlag: String, CaseIterable {
             false
         case .streamAndCachePlayingEpisode:
             true
-        case .categoriesRedesign:
-            true
         case .defaultPlayerFilterCallbackFix:
             true
         case .downloadFixes:
@@ -245,9 +241,7 @@ public enum FeatureFlag: String, CaseIterable {
         case .newSettingsStorage:
             shouldEnableSyncedSettings ? "new_settings_storage" : nil
         case .settingsSync:
-            shouldEnableSyncedSettings ? "settings_sync" : nil
-        case .categoriesRedesign:
-            "categories_redesign"
+            shouldEnableSyncedSettings ? "settings_sync" : nil        
         case .defaultPlayerFilterCallbackFix:
             "default_player_filter_callback_fix"
         default:

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -241,7 +241,7 @@ public enum FeatureFlag: String, CaseIterable {
         case .newSettingsStorage:
             shouldEnableSyncedSettings ? "new_settings_storage" : nil
         case .settingsSync:
-            shouldEnableSyncedSettings ? "settings_sync" : nil        
+            shouldEnableSyncedSettings ? "settings_sync" : nil
         case .defaultPlayerFilterCallbackFix:
             "default_player_filter_callback_fix"
         default:


### PR DESCRIPTION
| 📘 Part of: #2509  |  <!-- project issue number, if applicable -->
|:---:|

Fixes #2570 <!-- issue number, if applicable -->

Remove the categories redesign FF

## To test

1. Start the app
2. Open Discover
3. Tap on Categories pill
4. Select one category
5. Check if all shows up correctly.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
