### PR TITLE
watchOS 10: fix crash

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/Refresh/RefreshManager.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Refresh/RefreshManager.swift
@@ -2,6 +2,9 @@ import Foundation
 import PocketCastsDataModel
 import PocketCastsUtils
 import UIKit
+#if os(watchOS)
+    import WatchKit
+#endif
 
 public class RefreshManager {
     public static let shared = RefreshManager()
@@ -65,6 +68,7 @@ public class RefreshManager {
         refresh(podcasts: DataManager.sharedManager.allPodcasts(includeUnsubscribed: false))
     }
 
+    #if !os(watchOS)
     private func refresh(podcasts: [Podcast], completion: (() -> Void)? = nil) {
         UserDefaults.standard.set(Date(), forKey: ServerConstants.UserDefaults.lastRefreshStartTime)
 
@@ -78,6 +82,40 @@ public class RefreshManager {
             }
         }
     }
+    #endif
+
+    #if os(watchOS)
+    // Watch OS 10 has a very very very weird issue that happened after using Xcode 16:
+    // if the refresh call uses a [weak self] the system kills the app.
+    // I'm not entirely sure why that happens but removing the weak part fixes the issue.
+    // We can safely remove this method once we remove support to watchOS 10.
+    private func refresh(podcasts: [Podcast], completion: (() -> Void)? = nil) {
+        UserDefaults.standard.set(Date(), forKey: ServerConstants.UserDefaults.lastRefreshStartTime)
+
+        DispatchQueue.global().async {
+            let watchOsMajorVersion = WKInterfaceDevice.current().systemVersion.split(separator: ".")[safe: 0]
+
+            if watchOsMajorVersion == "10" {
+                // Let's not use [weak self] so the app is not killed
+                MainServerHandler.shared.refresh(podcasts: podcasts) { refreshResponse in
+                    self.processPodcastRefreshResponse(refreshResponse) { _ in
+                        completion?()
+                    }
+                }
+
+                return
+            }
+
+            MainServerHandler.shared.refresh(podcasts: podcasts) { [weak self] refreshResponse in
+                guard let self = self else { return }
+
+                self.processPodcastRefreshResponse(refreshResponse) { _ in
+                    completion?()
+                }
+            }
+        }
+    }
+    #endif
 
     public func refreshPodcasts(completion: @escaping (RefreshFetchResult) -> Void) {
         DispatchQueue.global().async {


### PR DESCRIPTION
Since we started using Xcode 16, the app crashes every time for users on watchOS 10.6.1.

After a lot (A LOT, REALLY A LOT) of tries, I pinpointed the culprit to the `[weak self]`. I'm still very puzzled as to why this happens in first place.

I changed the code to remove the `[weak self]` for watchOS 10 and only watchOS 10.

## To test

1. Code review
2. I'll test this using a TestFlight build as Xcode builds don't present the issue

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
