### PR TITLE
Remove newSharing FF

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -51,8 +51,6 @@ public enum FeatureFlag: String, CaseIterable {
     /// Use the Accelerate framework to speed up custom effects
     case accelerateEffects
 
-    case newSharing
-
     /// Enables the Kids banner
     case kidsProfile
 
@@ -174,8 +172,6 @@ public enum FeatureFlag: String, CaseIterable {
         case .whenPlayingOnlyUpdateEpisodeIfPlaybackFails:
             true
         case .accelerateEffects:
-            true
-        case .newSharing:
             true
         case .kidsProfile:
             false

--- a/podcasts/EpisodeDetailViewController.swift
+++ b/podcasts/EpisodeDetailViewController.swift
@@ -449,29 +449,7 @@ class EpisodeDetailViewController: FakeNavViewController, UIDocumentInteractionC
     // MARK: - Sharing
 
     @objc private func shareTapped(_ sender: UIButton) {
-        guard FeatureFlag.newSharing.enabled == false else {
-            SharingModal.showModal(episode: episode, from: analyticsSource, in: self)
-            return
-        }
-
-        let shareOptions = OptionsPicker(title: nil)
-
-        let sourceRect = sender.superview!.convert(sender.frame, to: view)
-        let shareLinkAction = OptionAction(label: L10n.podcastShareEpisode, icon: nil) { [weak self] in
-            self?.shareLinkToEpisode(sharePosition: false, sourceRect: sourceRect)
-        }
-        shareOptions.addAction(action: shareLinkAction)
-
-        let sharePositionAction = OptionAction(label: L10n.shareCurrentPosition, icon: nil) { [weak self] in
-            self?.shareLinkToEpisode(sharePosition: true, sourceRect: sourceRect)
-        }
-        shareOptions.addAction(action: sharePositionAction)
-
-        if let fileAction = episodeFileAction(from: sourceRect) {
-            shareOptions.addAction(action: fileAction)
-        }
-
-        shareOptions.show(statusBarStyle: preferredStatusBarStyle)
+        SharingModal.showModal(episode: episode, from: analyticsSource, in: self)
     }
 
     @objc private func podcastNameTapped() {

--- a/podcasts/NowPlayingPlayerItemViewController+Shelf.swift
+++ b/podcasts/NowPlayingPlayerItemViewController+Shelf.swift
@@ -456,29 +456,7 @@ extension NowPlayingPlayerItemViewController: NowPlayingActionsDelegate {
     private func shareEpisode(sender: UIView) {
         guard let episode = PlaybackManager.shared.currentEpisode() as? Episode else { return }
 
-        guard FeatureFlag.newSharing.enabled == false else {
-            SharingModal.showModal(episode: episode, from: analyticsSource, in: self)
-            return
-        }
-
-        let shareOptions = OptionsPicker(title: L10n.playerShareHeader, themeOverride: .dark)
-
-        let sharePodcastAction = OptionAction(label: L10n.podcastSingular, icon: "chapter-link") {
-            self.sharePodcast(source: sender, podcast: episode.parentPodcast())
-        }
-        shareOptions.addAction(action: sharePodcastAction)
-
-        let shareLinkAction = OptionAction(label: L10n.episode, icon: "chapter-link") {
-            self.shareEpisode(source: sender, episode: episode, fromTime: 0)
-        }
-        shareOptions.addAction(action: shareLinkAction)
-
-        let sharePositionAction = OptionAction(label: L10n.shareCurrentPosition, icon: "chapter-link") {
-            self.shareEpisode(source: sender, episode: episode, fromTime: PlaybackManager.shared.currentTime())
-        }
-        shareOptions.addAction(action: sharePositionAction)
-
-        shareOptions.show(statusBarStyle: preferredStatusBarStyle)
+        SharingModal.showModal(episode: episode, from: analyticsSource, in: self)
     }
 
     private func shareEpisode(source: UIView, episode: Episode, fromTime: TimeInterval) {
@@ -486,17 +464,12 @@ extension NowPlayingPlayerItemViewController: NowPlayingActionsDelegate {
 
         let type = fromTime == 0 ? "episode" : "current_position"
 
-        if FeatureFlag.newSharing.enabled {
-            Analytics.track(.podcastShared, properties: ["type": type, "source": "player"])
+        Analytics.track(.podcastShared, properties: ["type": type, "source": "player"])
 
-            if fromTime == 0 {
-                SharingModal.show(option: .episode(episode), from: analyticsSource, in: self)
-            } else {
-                SharingModal.show(option: .currentPosition(episode, fromTime), from: analyticsSource, in: self)
-            }
+        if fromTime == 0 {
+            SharingModal.show(option: .episode(episode), from: analyticsSource, in: self)
         } else {
-            let sourceRect = buttonSuperview.convert(source.frame, to: view)
-            SharingHelper.shared.shareLinkTo(episode: episode, shareTime: fromTime, fromController: self, sourceRect: sourceRect, sourceView: view, fromSource: .player, analyticsType: type)
+            SharingModal.show(option: .currentPosition(episode, fromTime), from: analyticsSource, in: self)
         }
     }
 
@@ -504,12 +477,7 @@ extension NowPlayingPlayerItemViewController: NowPlayingActionsDelegate {
         guard let buttonSuperview = source.superview, let podcast = podcast else { return }
 
         Analytics.track(.podcastShared, properties: ["type": "podcast", "source": "player"])
-        if FeatureFlag.newSharing.enabled {
-            SharingModal.show(option: .podcast(podcast), from: analyticsSource, in: self)
-        } else {
-            let sourceRect = buttonSuperview.convert(source.frame, to: view)
-            SharingHelper.shared.shareLinkTo(podcast: podcast, fromController: self, fromSource: analyticsSource, sourceRect: sourceRect, sourceView: view)
-        }
+        SharingModal.show(option: .podcast(podcast), from: analyticsSource, in: self)        
     }
 
     // MARK: - Private Helpers

--- a/podcasts/NowPlayingPlayerItemViewController+Shelf.swift
+++ b/podcasts/NowPlayingPlayerItemViewController+Shelf.swift
@@ -477,7 +477,7 @@ extension NowPlayingPlayerItemViewController: NowPlayingActionsDelegate {
         guard let buttonSuperview = source.superview, let podcast = podcast else { return }
 
         Analytics.track(.podcastShared, properties: ["type": "podcast", "source": "player"])
-        SharingModal.show(option: .podcast(podcast), from: analyticsSource, in: self)        
+        SharingModal.show(option: .podcast(podcast), from: analyticsSource, in: self)
     }
 
     // MARK: - Private Helpers

--- a/podcasts/SharingHelper.swift
+++ b/podcasts/SharingHelper.swift
@@ -62,7 +62,7 @@ class SharingHelper: NSObject {
     func shareLinkTo(episode: Episode, shareTime: TimeInterval, fromController: UIViewController, sourceRect: CGRect, sourceView: UIView?, showArrow: Bool = true, fromSource: AnalyticsSource, analyticsType: String = "episode") {
         Analytics.track(.podcastShared, source: fromSource, properties: ["type": analyticsType])
 
-        SharingModal.show(option: .episode(episode), from: fromSource, in: fromController)        
+        SharingModal.show(option: .episode(episode), from: fromSource, in: fromController)
     }
 
     func createActivityController(episode: Episode, shareTime: TimeInterval) -> UIActivityViewController {

--- a/podcasts/SharingHelper.swift
+++ b/podcasts/SharingHelper.swift
@@ -9,23 +9,7 @@ class SharingHelper: NSObject {
     func shareLinkTo(podcast: Podcast, fromController: UIViewController, fromSource: AnalyticsSource, sourceRect: CGRect, sourceView: UIView) {
         AnalyticsHelper.sharedPodcast()
 
-        if FeatureFlag.newSharing.enabled {
-            SharingModal.show(option: .podcast(podcast), from: fromSource, in: fromController)
-        } else {
-            let sharingUrl = podcast.shareURL
-            activityController = UIActivityViewController(activityItems: [URL(string: sharingUrl)!], applicationActivities: nil)
-            activityController?.completionWithItemsHandler = { _, _, _, _ in
-                NotificationCenter.postOnMainThread(notification: Constants.Notifications.closedNonOverlayableWindow)
-            }
-
-            guard let activityController = activityController else { return }
-            fromController.present(activityController, animated: true, completion: {
-                NotificationCenter.postOnMainThread(notification: Constants.Notifications.openingNonOverlayableWindow)
-            })
-
-            activityController.popoverPresentationController?.sourceView = sourceView
-            activityController.popoverPresentationController?.sourceRect = sourceRect
-        }
+        SharingModal.show(option: .podcast(podcast), from: fromSource, in: fromController)
     }
 
     func shareLinkToApp(fromController: UIViewController) {
@@ -51,22 +35,7 @@ class SharingHelper: NSObject {
     func shareLinkTo(podcast: Podcast, fromController: UIViewController, fromSource: AnalyticsSource, barButtonItem: UIBarButtonItem?) {
         AnalyticsHelper.sharedPodcast()
 
-        if FeatureFlag.newSharing.enabled {
-            SharingModal.show(option: .podcast(podcast), from: fromSource, in: fromController)
-        } else {
-            let sharingUrl = podcast.shareURL
-            activityController = UIActivityViewController(activityItems: [URL(string: sharingUrl)!], applicationActivities: nil)
-            activityController?.completionWithItemsHandler = { _, _, _, _ in
-                NotificationCenter.postOnMainThread(notification: Constants.Notifications.closedNonOverlayableWindow)
-            }
-
-            guard let activityController = activityController else { return }
-
-            fromController.present(activityController, animated: true, completion: {
-                NotificationCenter.postOnMainThread(notification: Constants.Notifications.openingNonOverlayableWindow)
-            })
-            activityController.popoverPresentationController?.barButtonItem = barButtonItem
-        }
+        SharingModal.show(option: .podcast(podcast), from: fromSource, in: fromController)
     }
 
     func shareLinkToPodcastList(name: String, url: String, fromController: UIViewController, barButtonItem: UIBarButtonItem?, completionHandler: (() -> Void)?) {
@@ -87,49 +56,13 @@ class SharingHelper: NSObject {
     }
 
     func shareLinkTo(episode: Episode, shareTime: TimeInterval, fromController: UIViewController, fromSource: AnalyticsSource, barButtonItem: UIBarButtonItem?) {
-        guard FeatureFlag.newSharing.enabled == false else {
-            SharingModal.show(option: .episode(episode), from: fromSource, in: fromController)
-            return
-        }
-
-        activityController = createActivityController(episode: episode, shareTime: shareTime)
-        activityController?.completionWithItemsHandler = { _, _, _, _ in
-            NotificationCenter.postOnMainThread(notification: Constants.Notifications.closedNonOverlayableWindow)
-        }
-
-        guard let activityController = activityController else { return }
-
-        fromController.present(activityController, animated: true, completion: {
-            NotificationCenter.postOnMainThread(notification: Constants.Notifications.openingNonOverlayableWindow)
-        })
-        activityController.popoverPresentationController?.barButtonItem = barButtonItem
+        SharingModal.show(option: .episode(episode), from: fromSource, in: fromController)
     }
 
     func shareLinkTo(episode: Episode, shareTime: TimeInterval, fromController: UIViewController, sourceRect: CGRect, sourceView: UIView?, showArrow: Bool = true, fromSource: AnalyticsSource, analyticsType: String = "episode") {
         Analytics.track(.podcastShared, source: fromSource, properties: ["type": analyticsType])
 
-        guard FeatureFlag.newSharing.enabled == false else {
-            SharingModal.show(option: .episode(episode), from: fromSource, in: fromController)
-            return
-        }
-
-        activityController = createActivityController(episode: episode, shareTime: shareTime)
-        activityController?.completionWithItemsHandler = { _, _, _, _ in
-            NotificationCenter.postOnMainThread(notification: Constants.Notifications.closedNonOverlayableWindow)
-        }
-
-        guard let activityController = activityController else { return }
-
-        fromController.present(activityController, animated: true, completion: {
-            NotificationCenter.postOnMainThread(notification: Constants.Notifications.openingNonOverlayableWindow)
-
-        })
-        activityController.popoverPresentationController?.sourceView = sourceView
-        activityController.popoverPresentationController?.sourceRect = sourceRect
-
-        if !showArrow {
-            activityController.popoverPresentationController?.permittedArrowDirections = []
-        }
+        SharingModal.show(option: .episode(episode), from: fromSource, in: fromController)        
     }
 
     func createActivityController(episode: Episode, shareTime: TimeInterval) -> UIActivityViewController {

--- a/podcasts/Whats New/Announcements.swift
+++ b/podcasts/Whats New/Announcements.swift
@@ -103,7 +103,7 @@ struct Announcements {
             action: {
                 SceneHelper.rootViewController()?.dismiss(animated: true)
             },
-            isEnabled: FeatureFlag.newSharing.enabled,
+            isEnabled: true,
             fullModal: true
         ),
         .init(


### PR DESCRIPTION
| 📘 Part of: #2509  |  <!-- project issue number, if applicable -->
|:---:|

Fixes #2579  <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
Removes the newSharing FF from the project

## To test

1. Start the app
2. Start playing an episode
3. Open the full screen player
4. Tap on the share action
5. Try the different options in share
6. Check that they show the new share modal

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
