### PR TITLE
Disable private feed sharing

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/PodcastDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/PodcastDataManager.swift
@@ -61,6 +61,7 @@ class PodcastDataManager {
         "refreshAvailable",
         "folderUuid",
         "usedCustomEffectsBefore",
+        "isPrivate"
     ]
 
     func setup(dbQueue: FMDatabaseQueue) {
@@ -674,6 +675,7 @@ class PodcastDataManager {
         values.append(podcast.refreshAvailable)
         values.append(DBUtils.nullIfNil(value: podcast.folderUuid))
         values.append(podcast.usedCustomEffectsBefore)
+        values.append(podcast.isPrivate)
 
         if includeIdForWhere {
             values.append(podcast.id)

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseHelper.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseHelper.swift
@@ -795,6 +795,16 @@ class DatabaseHelper {
             }
         }
 
+        if schemaVersion < 55 {
+            do {
+                try db.executeUpdate("ALTER TABLE SJPodcast ADD COLUMN isPrivate INTEGER NOT NULL DEFAULT 0;", values: nil)
+                schemaVersion = 55
+            } catch {
+                failedAt(55)
+                return
+            }
+        }
+
         db.commit()
     }
 }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Podcast+fromDatabase.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Podcast+fromDatabase.swift
@@ -56,6 +56,7 @@ extension Podcast {
         podcast.refreshAvailable = rs.bool(forColumn: "refreshAvailable")
         podcast.folderUuid = rs.string(forColumn: "folderUuid")
         podcast.usedCustomEffectsBefore = rs.bool(forColumn: "usedCustomEffectsBefore")
+        podcast.isPrivate = rs.bool(forColumn: "isPrivate")
 
         return podcast
     }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Podcast.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Podcast.swift
@@ -53,6 +53,7 @@ public class Podcast: NSObject, Identifiable {
     @objc public var refreshAvailable = false
     @objc public var folderUuid: String?
     @objc public var usedCustomEffectsBefore = false
+    @objc public var isPrivate = false
 
     public var settings: PodcastSettings = PodcastSettings.defaults
 

--- a/Modules/Server/Sources/PocketCastsServer/Public/ServerPodcastManager+Update.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/ServerPodcastManager+Update.swift
@@ -75,6 +75,9 @@ extension ServerPodcastManager {
         if let refreshAvailable = podcastInfo["refresh_allowed"] as? Bool {
             podcast.refreshAvailable = refreshAvailable
         }
+        if let isPrivate = podcastJson["is_private"] as? Bool {
+            podcast.isPrivate = isPrivate
+        }
 
         DataManager.sharedManager.save(podcast: podcast)
 

--- a/Modules/Server/Sources/PocketCastsServer/Public/ServerPodcastManager.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/ServerPodcastManager.swift
@@ -246,6 +246,9 @@ public class ServerPodcastManager: NSObject {
         if let refreshAvailable = podcastInfo["refresh_allowed"] as? Bool {
             podcast.refreshAvailable = refreshAvailable
         }
+        if let isPrivate = podcastJson["is_private"] as? Bool {
+            podcast.isPrivate = isPrivate
+        }
 
         // we don't accept podcasts with no episodes
         guard let episodesJson = podcastJson["episodes"] as? [[String: Any]] else { return false }

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -135,6 +135,8 @@ public enum FeatureFlag: String, CaseIterable {
     /// Disables logout / keychain clearing when errors occur in the background
     case avoidLogoutInBackground
 
+    case disablePrivateFeedSharing
+
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -224,6 +226,8 @@ public enum FeatureFlag: String, CaseIterable {
         case .usePodcastHTMLDescription:
             false
         case .avoidLogoutInBackground:
+            true
+        case .disablePrivateFeedSharing:
             true
         }
     }

--- a/podcasts/NowPlayingPlayerItemViewController+Shelf.swift
+++ b/podcasts/NowPlayingPlayerItemViewController+Shelf.swift
@@ -456,6 +456,13 @@ extension NowPlayingPlayerItemViewController: NowPlayingActionsDelegate {
     private func shareEpisode(sender: UIView) {
         guard let episode = PlaybackManager.shared.currentEpisode() as? Episode else { return }
 
+        if FeatureFlag.disablePrivateFeedSharing.enabled {
+            guard episode.parentPodcast()?.isPrivate == false else {
+                Toast.show(L10n.sharePodcastPrivateNotAvailable)
+                return
+            }
+        }
+
         guard FeatureFlag.newSharing.enabled == false else {
             SharingModal.showModal(episode: episode, from: analyticsSource, in: self)
             return

--- a/podcasts/NowPlayingPlayerItemViewController+Shelf.swift
+++ b/podcasts/NowPlayingPlayerItemViewController+Shelf.swift
@@ -456,13 +456,6 @@ extension NowPlayingPlayerItemViewController: NowPlayingActionsDelegate {
     private func shareEpisode(sender: UIView) {
         guard let episode = PlaybackManager.shared.currentEpisode() as? Episode else { return }
 
-        if FeatureFlag.disablePrivateFeedSharing.enabled {
-            guard episode.parentPodcast()?.isPrivate == false else {
-                Toast.show(L10n.sharePodcastPrivateNotAvailable)
-                return
-            }
-        }
-
         guard FeatureFlag.newSharing.enabled == false else {
             SharingModal.showModal(episode: episode, from: analyticsSource, in: self)
             return

--- a/podcasts/Sharing/SharingModal.swift
+++ b/podcasts/Sharing/SharingModal.swift
@@ -76,7 +76,7 @@ enum SharingModal {
     static func showModal(podcast: Podcast, episode: Episode?, from source: AnalyticsSource, in viewController: UIViewController) {
 
         if FeatureFlag.disablePrivateFeedSharing.enabled {
-            guard !podcast.isPrivate else {
+            if podcast.isPrivate {
                 Toast.show(L10n.sharePodcastPrivateNotAvailable)
                 return
             }
@@ -111,11 +111,9 @@ enum SharingModal {
     static func show(option: Option, from source: AnalyticsSource, in viewController: UIViewController) {
 
         if FeatureFlag.disablePrivateFeedSharing.enabled {
-            if case let .podcast(podcast) = option {
-                guard !podcast.isPrivate else {
-                    Toast.show(L10n.sharePodcastPrivateNotAvailable)
-                    return
-                }
+            if case let .podcast(podcast) = option, podcast.isPrivate {
+                Toast.show(L10n.sharePodcastPrivateNotAvailable)
+                return
             }
         }
 

--- a/podcasts/Sharing/SharingModal.swift
+++ b/podcasts/Sharing/SharingModal.swift
@@ -101,6 +101,16 @@ enum SharingModal {
     }
 
     static func show(option: Option, from source: AnalyticsSource, in viewController: UIViewController) {
+
+        if FeatureFlag.disablePrivateFeedSharing.enabled {
+            if case let .podcast(podcast) = option {
+                guard !podcast.isPrivate else {
+                    Toast.show(L10n.sharePodcastPrivateNotAvailable)
+                    return
+                }
+            }
+        }
+
         let sharingDestinations: [ShareDestination] = ShareDestination.displayedApps + [.copyLink, .systemSheet(vc: viewController)]
         let sharingView = SharingView(destinations: sharingDestinations, selectedOption: option, source: source)
         let modalView = ModalView {

--- a/podcasts/Sharing/SharingModal.swift
+++ b/podcasts/Sharing/SharingModal.swift
@@ -111,7 +111,7 @@ enum SharingModal {
     static func show(option: Option, from source: AnalyticsSource, in viewController: UIViewController) {
 
         if FeatureFlag.disablePrivateFeedSharing.enabled {
-            if case let .podcast(podcast) = option, podcast.isPrivate {
+            if option.podcast.isPrivate {
                 Toast.show(L10n.sharePodcastPrivateNotAvailable)
                 return
             }
@@ -164,7 +164,7 @@ extension SharingModal.Option {
         }
     }
 
-    private var podcast: Podcast {
+    fileprivate var podcast: Podcast {
         switch self {
         case .episode(let episode), .currentPosition(let episode, _), .clip(let episode, _), .clipShare(let episode, _, _):
             return episode.parentPodcast()!

--- a/podcasts/Sharing/SharingModal.swift
+++ b/podcasts/Sharing/SharingModal.swift
@@ -74,6 +74,14 @@ enum SharingModal {
     }
 
     static func showModal(podcast: Podcast, episode: Episode?, from source: AnalyticsSource, in viewController: UIViewController) {
+
+        if FeatureFlag.disablePrivateFeedSharing.enabled {
+            guard !podcast.isPrivate else {
+                Toast.show(L10n.sharePodcastPrivateNotAvailable)
+                return
+            }
+        }
+
         let colors = OptionsPickerRootController.Colors(title: UIColor.white.withAlphaComponent(0.5), background: PlayerColorHelper.playerBackgroundColor01())
 
         let optionPicker = OptionsPicker(title: L10n.share.uppercased(), themeOverride: .dark, colors: colors)

--- a/podcasts/SharingHelper.swift
+++ b/podcasts/SharingHelper.swift
@@ -7,6 +7,14 @@ class SharingHelper: NSObject {
     static let shared = SharingHelper()
     var activityController: UIActivityViewController?
     func shareLinkTo(podcast: Podcast, fromController: UIViewController, fromSource: AnalyticsSource, sourceRect: CGRect, sourceView: UIView) {
+
+        if FeatureFlag.disablePrivateFeedSharing.enabled {
+            guard !podcast.isPrivate else {
+                Toast.show(L10n.sharePodcastPrivateNotAvailable)
+                return
+            }
+        }
+
         AnalyticsHelper.sharedPodcast()
 
         if FeatureFlag.newSharing.enabled {

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -3134,6 +3134,8 @@ internal enum L10n {
   internal static var shareMoreActions: String { return L10n.tr("Localizable", "share_more_actions") }
   /// Share podcast
   internal static var sharePodcast: String { return L10n.tr("Localizable", "share_podcast") }
+  /// Sharing is not available for private podcasts
+  internal static var sharePodcastPrivateNotAvailable: String { return L10n.tr("Localizable", "share_podcast_private_not_available") }
   /// Share podcast
   internal static var sharePodcastTitle: String { return L10n.tr("Localizable", "share_podcast_title") }
   /// ALL SELECTED

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -2779,6 +2779,9 @@
 /* Message indicating that the process to share a podcast list is in progress. */
 "share_podcasts_sharing" = "Sharing...";
 
+/* A message shown when trying to share a private podcast, which is disabled. */
+"share_podcast_private_not_available" = "Sharing is not available for private podcasts";
+
 /* Error message for when sharing fails. */
 "share_podcasts_sharing_failed_msg" = "Something went wrong creating your share page";
 


### PR DESCRIPTION
Disables sharing of private feeds with a Toast message shown when trying to share.

The core feature is flagged under `disable_private_feed_sharing` but I left the database changes unflagged.

https://github.com/user-attachments/assets/ea3ecd31-e997-49c3-aa71-5db3929743d5

## To test

1. Try sharing a podcast and make sure it works
2. Try sharing a private podcast (try this URL: `https://pca.st/private/707a8bf0-9abf-013c-74fe-027201e7e97f`)
3. Ensure this message appears in a toast: "Sharing is not available for private podcasts"

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
