### PR TITLE
GRDB: Podcast Data Manager

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/DataHelper+GRDB.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/DataHelper+GRDB.swift
@@ -1,0 +1,17 @@
+import GRDB
+import PocketCastsUtils
+
+extension DataHelper {
+    class func run(query: String, values: [Any]?, methodName: String, dbPool: DatabasePool? = nil) {
+        if let dbPool {
+            do {
+                try dbPool.write { db in
+                    try db.execute(sql: query, arguments: StatementArguments(values ?? [])!)
+                }
+            } catch {
+                FileLog.shared.addMessage("\(methodName) error: \(error)")
+            }
+            return
+        }
+    }
+}

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/PodcastDataManager+GRDB.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/PodcastDataManager+GRDB.swift
@@ -1,6 +1,33 @@
 import GRDB
+import PocketCastsUtils
 
 extension PodcastDataManager {
+    func setup(dbPool: DatabasePool) {
+        cachePodcasts(dbPool: dbPool)
+    }
+
+    // MARK: - Caching
+
+    private func cachePodcasts(dbPool: DatabasePool) {
+        let trace = TraceManager.shared.beginTracing(eventName: "DATABASE_PODCAST_CACHE")
+        defer { TraceManager.shared.endTracing(trace: trace) }
+
+        try! dbPool.read { db in
+            let rows = try Row.fetchCursor(db, sql: "SELECT * from \(DataManager.podcastTableName) ORDER BY sortOrder ASC")
+
+            var newPodcasts = [String: Podcast]()
+            while let row = try rows.next() {
+                let podcast = self.createPodcastFrom(row: row)
+                newPodcasts[podcast.uuid] = podcast
+            }
+            cachedPodcastsQueue.sync {
+                cachedPodcasts = newPodcasts
+            }
+        }
+
+        return
+    }
+
     // MARK: - Conversion
 
     private func createPodcastFrom(row: RowCursor.Element) -> Podcast {

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/PodcastDataManager+GRDB.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/PodcastDataManager+GRDB.swift
@@ -1,0 +1,9 @@
+import GRDB
+
+extension PodcastDataManager {
+    // MARK: - Conversion
+
+    private func createPodcastFrom(row: RowCursor.Element) -> Podcast {
+        Podcast.from(row: row)
+    }
+}

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/PodcastDataManager+GRDB.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/PodcastDataManager+GRDB.swift
@@ -1,5 +1,6 @@
 import GRDB
 import PocketCastsUtils
+import Foundation
 
 extension PodcastDataManager {
     func setup(dbPool: DatabasePool) {
@@ -27,6 +28,521 @@ extension PodcastDataManager {
 
         return
     }
+
+
+    // MARK: - Queries
+
+    func allPodcasts(includeUnsubscribed: Bool, reloadFromDatabase: Bool, dbPool: DatabasePool) -> [Podcast] {
+        if reloadFromDatabase { cachePodcasts(dbPool: dbPool) }
+
+        var allPodcasts = [Podcast]()
+        cachedPodcastsQueue.sync {
+            for podcast in cachedPodcasts.values {
+                if !podcast.isSubscribed(), !includeUnsubscribed { continue }
+
+                allPodcasts.append(podcast)
+            }
+        }
+
+        return allPodcasts
+    }
+
+    func allPodcastsOrderedByAddedDate(reloadFromDatabase: Bool, dbPool: DatabasePool) -> [Podcast] {
+        if reloadFromDatabase { cachePodcasts(dbPool: dbPool) }
+
+        var allPodcasts = [Podcast]()
+        cachedPodcastsQueue.sync {
+            for podcast in cachedPodcasts.values {
+                if !podcast.isSubscribed() { continue }
+
+                allPodcasts.append(podcast)
+            }
+        }
+
+        return allPodcasts.sorted(by: { podcast1, podcast2 -> Bool in
+            addedDateSort(p1: podcast1, p2: podcast2)
+        })
+    }
+
+    func allPodcastsOrderedByTitle(reloadFromDatabase: Bool, dbPool: DatabasePool) -> [Podcast] {
+        if reloadFromDatabase { cachePodcasts(dbPool: dbPool) }
+
+        var allPodcasts = [Podcast]()
+        cachedPodcastsQueue.sync {
+            for podcast in cachedPodcasts.values {
+                if !podcast.isSubscribed() { continue }
+
+                allPodcasts.append(podcast)
+            }
+        }
+
+        return allPodcasts.sorted(by: { podcast1, podcast2 -> Bool in
+            titleSort(p1: podcast1, p2: podcast2)
+        })
+    }
+
+    func allPodcastsOrderedByNewestEpisodes(reloadFromDatabase: Bool, inFolderUuid: String? = nil, dbPool: DatabasePool) -> [Podcast] {
+        if reloadFromDatabase { cachePodcasts(dbPool: dbPool) }
+
+        var allPodcasts = [Podcast]()
+
+        try? dbPool.read { db in
+            var values: [Any] = []
+            var whereClause = "WHERE p.subscribed = 1"
+            if let inFolderUuid = inFolderUuid {
+                whereClause += " AND p.folderUuid = ?"
+                values = [inFolderUuid]
+            }
+            let query = "SELECT DISTINCT p.id, p.* FROM \(DataManager.podcastTableName) p LEFT JOIN \(DataManager.episodeTableName) e ON p.id = e.podcast_id AND e.id = (SELECT e.id FROM \(DataManager.episodeTableName) e WHERE e.podcast_id = p.id AND e.playingStatus != 3 AND e.archived = 0 ORDER BY e.publishedDate DESC LIMIT 1) \(whereClause) ORDER BY CASE WHEN e.publishedDate IS NULL THEN 1 ELSE 0 END, e.publishedDate DESC, p.latestEpisodeDate DESC"
+
+            let rows = try Row.fetchCursor(db, sql: query, arguments: StatementArguments(values)!)
+
+            while let row = try rows.next() {
+                let podcast = self.createPodcastFrom(row: row)
+                allPodcasts.append(podcast)
+            }
+        }
+
+        return allPodcasts
+    }
+
+    /// Returns 5 random podcasts from the DB
+    /// This is here for development purposes.
+    func randomPodcasts(dbPool: DatabasePool) -> [Podcast] {
+        var allPodcasts = [Podcast]()
+        do {
+            try dbPool.read { db in
+                let query = "SELECT * FROM SJPodcast ORDER BY RANDOM() LIMIT 5"
+                let rows = try Row.fetchCursor(db, sql: query)
+
+                while let row = try rows.next() {
+                    let podcast = self.createPodcastFrom(row: row)
+                    allPodcasts.append(podcast)
+                }
+            }
+        } catch {
+            FileLog.shared.addMessage("PodcastDataManager.randomPodcasts error: \(error)")
+        }
+
+        return allPodcasts
+    }
+
+    func allUnsubscribedPodcastUuids(dbPool: DatabasePool) -> [String] {
+        var allUnsubscribed = [String]()
+        cachedPodcastsQueue.sync {
+            for podcast in cachedPodcasts.values {
+                if podcast.isSubscribed() { continue }
+
+                allUnsubscribed.append(podcast.uuid)
+            }
+        }
+
+        return allUnsubscribed
+    }
+
+    func allUnsubscribedPodcasts(dbPool: DatabasePool) -> [Podcast] {
+        var allUnsubscribed = [Podcast]()
+        cachedPodcastsQueue.sync {
+            for podcast in cachedPodcasts.values {
+                if podcast.isSubscribed() { continue }
+
+                allUnsubscribed.append(podcast)
+            }
+        }
+
+        return allUnsubscribed
+    }
+
+    func allPodcastsInFolder(folder: Folder, dbPool: DatabasePool) -> [Podcast] {
+        let sortOrder = folder.folderSort()
+
+        // newest episode release date is a special case we handle at the database level
+        if sortOrder == .episodeDateNewestToOldest {
+            return allPodcastsOrderedByNewestEpisodes(reloadFromDatabase: false, inFolderUuid: folder.uuid, dbPool: dbPool)
+        }
+
+        // the other 3 cases we do in memory
+        var allPodcastsInFolder: [Podcast] = []
+        cachedPodcastsQueue.sync {
+            allPodcastsInFolder = cachedPodcasts.values.filter { $0.isSubscribed() && $0.folderUuid == folder.uuid }
+        }
+
+        allPodcastsInFolder.sort { podcast1, podcast2 in
+            if sortOrder == .dateAddedNewestToOldest {
+                return addedDateSort(p1: podcast1, p2: podcast2)
+            } else if sortOrder == .titleAtoZ {
+                return titleSort(p1: podcast1, p2: podcast2)
+            }
+
+            return podcast1.sortOrder < podcast2.sortOrder
+        }
+
+        return allPodcastsInFolder
+    }
+
+    func countOfPodcastsInFolder(folder: Folder?, dbPool: DatabasePool) -> Int {
+        cachedPodcastsQueue.sync {
+            cachedPodcasts.values.filter { $0.isSubscribed() && $0.folderUuid == folder?.uuid }.count
+        }
+    }
+
+    func allPaidPodcasts(dbPool: DatabasePool) -> [Podcast] {
+        var allPaid = [Podcast]()
+        cachedPodcastsQueue.sync {
+            for podcast in cachedPodcasts.values {
+                if !podcast.isPaid { continue }
+
+                allPaid.append(podcast)
+            }
+        }
+
+        return allPaid
+    }
+
+    func allUnsynced(dbPool: DatabasePool) -> [Podcast] {
+        var unsyncedPodcasts = [Podcast]()
+        cachedPodcastsQueue.sync {
+            for podcast in cachedPodcasts.values {
+                if podcast.syncStatus == SyncStatus.notSynced.rawValue {
+                    unsyncedPodcasts.append(podcast)
+                }
+            }
+        }
+
+        return unsyncedPodcasts
+    }
+
+    func allOverrideGlobalArchivePodcasts(dbPool: DatabasePool) -> [Podcast] {
+        var podcastsOverrideArchive = [Podcast]()
+        cachedPodcastsQueue.sync {
+            for podcast in cachedPodcasts.values {
+                if podcast.isSubscribed(), podcast.isAutoArchiveOverridden {
+                    podcastsOverrideArchive.append(podcast)
+                }
+            }
+        }
+
+        return podcastsOverrideArchive
+    }
+
+    func find(uuid: String, includeUnsubscribed: Bool, dbPool: DatabasePool) -> Podcast? {
+        cachedPodcastsQueue.sync {
+            guard let podcast = cachedPodcasts[uuid] else { return nil }
+
+            if !includeUnsubscribed, !podcast.isSubscribed() { return nil }
+
+            return podcast
+        }
+    }
+
+    func count(dbPool: DatabasePool) -> Int {
+        var count = 0
+        cachedPodcastsQueue.sync {
+            for podcast in cachedPodcasts.values {
+                if !podcast.isSubscribed() { continue }
+
+                count += 1
+            }
+        }
+
+        return count
+    }
+
+    func unfinishedCounts(dbPool: DatabasePool) -> [String: Int32] {
+        var counts = [String: Int32]()
+        do {
+            try dbPool.read { db in
+                let query = "SELECT p.uuid as uuid, count(e.id) as count FROM \(DataManager.episodeTableName) e, \(DataManager.podcastTableName) p WHERE e.podcast_id = p.id AND playingStatus <> \(PlayingStatus.completed.rawValue) AND archived = 0 GROUP BY p.uuid"
+                let rows = try Row.fetchCursor(db, sql: query)
+
+                while let row = try rows.next() {
+                    guard let uuid: String = row["uuid"] else { continue }
+                    let count: Int32 = row["count"]
+
+                    counts[uuid] = count
+                }
+            }
+        } catch {
+            FileLog.shared.addMessage("PodcastDataManager.unfinishedCounts error: \(error)")
+        }
+
+        return counts
+    }
+
+    // MARK: - Updates
+
+    func save(podcast: Podcast, dbPool: DatabasePool) {
+        do {
+            try dbPool.write { db in
+                if podcast.id == 0 {
+                    podcast.id = DBUtils.generateUniqueId()
+                    try db.execute(sql: "INSERT INTO \(DataManager.podcastTableName) (\(self.columnNames.joined(separator: ","))) VALUES \(DBUtils.valuesQuestionMarks(amount: self.columnNames.count))", arguments: StatementArguments(self.createValuesFrom(podcast: podcast))!)
+                } else {
+                    let setStatement = "\(self.columnNames.joined(separator: " = ?, ")) = ?"
+                    try db.execute(sql: "UPDATE \(DataManager.podcastTableName) SET \(setStatement) WHERE id = ?", arguments: StatementArguments(self.createValuesFrom(podcast: podcast, includeIdForWhere: true))!)
+                }
+            }
+        } catch {
+            FileLog.shared.addMessage("PodcastDataManager.save error: \(error)")
+        }
+
+        cachePodcasts(dbPool: dbPool)
+    }
+
+    func bulkSetFolderUuid(folderUuid: String, podcastUuids: [String], dbPool: DatabasePool) {
+        do {
+            try dbPool.write { db in
+                // clear out any that shouldn't be in this folder
+                try db.execute(sql: "UPDATE \(DataManager.podcastTableName) SET folderUuid = NULL, syncStatus = \(SyncStatus.notSynced.rawValue) WHERE folderUuid = ?", arguments: [folderUuid])
+
+                // then set all the ones that should
+                if podcastUuids.count > 0 {
+                    try db.execute(sql: "UPDATE \(DataManager.podcastTableName) SET folderUuid = ?, syncStatus = \(SyncStatus.notSynced.rawValue) WHERE uuid IN (\(DataHelper.convertArrayToInString(podcastUuids)))", arguments: [folderUuid])
+                }
+            }
+        } catch {
+            FileLog.shared.addMessage("PodcastDataManager.bulkSetFolderUuid error: \(error)")
+        }
+
+        cachePodcasts(dbPool: dbPool)
+    }
+
+    func updatePodcastFolder(podcastUuid: String, sortOrder: Int32, folderUuid: String?, dbPool: DatabasePool) {
+        do {
+            try dbPool.write { db in
+                try db.execute(sql: "UPDATE \(DataManager.podcastTableName) SET folderUuid = ?, sortOrder = ?, syncStatus = \(SyncStatus.notSynced.rawValue) WHERE uuid = ?", arguments: [folderUuid ?? NSNull(), sortOrder, podcastUuid])
+            }
+        } catch {
+            FileLog.shared.addMessage("PodcastDataManager.updatePodcastFolder error: \(error)")
+        }
+
+        cachePodcasts(dbPool: dbPool)
+    }
+
+    func savePushSetting(podcast: Podcast, pushEnabled: Bool, dbPool: DatabasePool) {
+        podcast.isPushEnabled = pushEnabled
+        savePushSetting(podcastUuid: podcast.uuid, pushEnabled: pushEnabled, dbPool: dbPool)
+    }
+
+    func savePushSetting(podcastUuid: String, pushEnabled: Bool, dbPool: DatabasePool) {
+        if FeatureFlag.newSettingsStorage.enabled {
+            saveSingleSetting("notification", value: pushEnabled, podcastUuid: podcastUuid, dbPool: dbPool)
+        }
+        saveSingleValue(name: "pushEnabled", value: pushEnabled, podcastUuid: podcastUuid, dbPool: dbPool)
+    }
+
+    func saveAutoAddToUpNext(podcastUuid: String, autoAddToUpNext: Int32, dbPool: DatabasePool) {
+        if FeatureFlag.newSettingsStorage.enabled {
+            if let podcast = DataManager.sharedManager.findPodcast(uuid: podcastUuid) {
+                if let setting = AutoAddToUpNextSetting(rawValue: autoAddToUpNext) {
+                    podcast.setAutoAddToUpNext(setting: setting)
+                    podcast.syncStatus = SyncStatus.notSynced.rawValue
+                    save(podcast: podcast, dbPool: dbPool)
+                } else {
+                    FileLog.shared.addMessage("Podcast Data: Failed to create AutoAddToUpNextSetting type for saving")
+                }
+            } else {
+                FileLog.shared.addMessage("Podcast Data: Couldn't find podcast for saving AutoAddToUpNext with UUID: \(podcastUuid)")
+            }
+        }
+        saveSingleValue(name: "autoAddToUpNext", value: autoAddToUpNext, podcastUuid: podcastUuid, dbPool: dbPool)
+    }
+
+    func setPodcastImageVersion(podcastUuid: String, version: Int, dbPool: DatabasePool) {
+        saveSingleValue(name: "lastColorDownloadDate", value: NSNull(), podcastUuid: podcastUuid, dbPool: dbPool)
+        saveSingleValue(name: "colorVersion", value: version, podcastUuid: podcastUuid, dbPool: dbPool)
+    }
+
+    func savePodcastDownloadSetting(_ setting: AutoDownloadSetting, podcastUuid: String, dbPool: DatabasePool) {
+        saveSingleValue(name: "autoDownloadSetting", value: setting.rawValue, podcastUuid: podcastUuid, dbPool: dbPool)
+    }
+
+    func saveAutoArchiveLimit(podcast: Podcast, limit: Int32, dbPool: DatabasePool) {
+        podcast.autoArchiveEpisodeLimitCount = limit
+        podcast.settings.autoArchiveEpisodeLimit = limit
+        saveSingleValue(name: "episodeKeepSetting", value: limit, podcastUuid: podcast.uuid, dbPool: dbPool)
+    }
+
+    func delete(podcast: Podcast, dbPool: DatabasePool) {
+        DataHelper.run(query: "DELETE FROM \(DataManager.podcastTableName) WHERE uuid = ?", values: [podcast.uuid], methodName: "PodcastDataManager.delete", dbPool: dbPool)
+        cachePodcasts(dbPool: dbPool)
+    }
+
+    func markAllSynced(dbPool: DatabasePool) {
+        setOnAllPodcasts(value: SyncStatus.synced.rawValue, propertyName: "syncStatus", subscribedOnly: false, dbPool: dbPool)
+    }
+
+    func markAllUnsynced(dbPool: DatabasePool) {
+        setOnAllPodcasts(value: SyncStatus.notSynced.rawValue, propertyName: "syncStatus", subscribedOnly: true, dbPool: dbPool)
+    }
+
+    func markAllUnsyncedWhereLastSyncAtNot(_ lastSyncAt: String, dbPool: DatabasePool) {
+        let query = "UPDATE \(DataManager.podcastTableName) SET syncStatus = \(SyncStatus.notSynced.rawValue) WHERE subscribed = 1 AND fullSyncLastSyncAt <> ?"
+        DataHelper.run(query: query, values: [lastSyncAt], methodName: "PodcastDataManager.markAllUnsyncedWhereLastSyncAtNot", dbPool: dbPool)
+
+        cachePodcasts(dbPool: dbPool)
+    }
+
+    func setPushForAllPodcasts(pushEnabled: Bool, dbPool: DatabasePool) {
+        if FeatureFlag.newSettingsStorage.enabled {
+            setOnAllPodcasts(value: pushEnabled, settingName: "notification", subscribedOnly: true, dbPool: dbPool)
+        }
+        setOnAllPodcasts(value: pushEnabled, propertyName: "pushEnabled", subscribedOnly: true, dbPool: dbPool)
+    }
+
+    func saveAutoAddToUpNextForAllPodcasts(autoAddToUpNext: Int32, dbPool: DatabasePool) {
+        if FeatureFlag.newSettingsStorage.enabled {
+            setOnAllPodcasts(value: autoAddToUpNext, settingName: "addToUpNext", subscribedOnly: true, dbPool: dbPool)
+        }
+        setOnAllPodcasts(value: autoAddToUpNext, propertyName: "autoAddToUpNext", subscribedOnly: true, dbPool: dbPool)
+    }
+
+    func updateAutoAddToUpNext(to value: AutoAddToUpNextSetting, for podcasts: [Podcast], in dbPool: DatabasePool) {
+        do {
+            try dbPool.write { db in
+                let uuids = podcasts.map { $0.uuid }
+
+                if FeatureFlag.newSettingsStorage.enabled {
+                    let query = """
+                    SELECT json_patch('setting', '{\"addToUpNext\": {\"value\": \(value)}}')
+                    WHERE uuid IN (\(DataHelper.convertArrayToInString(uuids)))
+                    FROM \(DataManager.podcastTableName)"
+                    """
+                    try db.execute(sql: query, arguments: [value.rawValue])
+                }
+
+                let query = """
+                UPDATE \(DataManager.podcastTableName)
+                SET autoAddToUpNext = ?
+                AND uuid IN (\(DataHelper.convertArrayToInString(uuids)))
+                """
+                try db.execute(sql: query, arguments: [value.rawValue])
+            }
+        } catch {
+            FileLog.shared.addMessage("PodcastDataManager.setOnAllPodcasts error: \(error)")
+        }
+
+        cachePodcasts(dbPool: dbPool)
+    }
+
+    func setDownloadSettingForAllPodcasts(setting: AutoDownloadSetting, dbPool: DatabasePool) {
+        setOnAllPodcasts(value: setting.rawValue, propertyName: "autoDownloadSetting", subscribedOnly: true, dbPool: dbPool)
+    }
+
+    func setOnAllPodcasts<Value: Codable & Equatable>(value: Value, settingName: String, subscribedOnly: Bool, dbPool: DatabasePool) {
+        do {
+            try dbPool.write { db in
+                let modified = ModifiedDate(wrappedValue: value, modifiedAt: Date())
+                let json = try JSONEncoder().encode(modified)
+                guard let jsonString = String(data: json, encoding: .utf8) else {
+                    throw JSONError.failedStringConvert(settingName, json)
+                }
+
+                let query = """
+                UPDATE \(DataManager.podcastTableName)
+                SET settings = json_set(
+                    \(DataManager.podcastTableName).settings,
+                    '$.\(settingName)',
+                    json('\(jsonString)')
+                ), syncStatus = \(SyncStatus.notSynced.rawValue)
+                """
+                try db.execute(sql: query, arguments: [])
+            }
+        } catch {
+            FileLog.shared.addMessage("PodcastDataManager.setOnAllPodcasts error: \(error)")
+        }
+
+        cachePodcasts(dbPool: dbPool)
+    }
+
+    func setOnAllPodcasts(value: DatabaseValueConvertible, propertyName: String, subscribedOnly: Bool, dbPool: DatabasePool) {
+        do {
+            try dbPool.write { db in
+                var query = "UPDATE \(DataManager.podcastTableName) SET \(propertyName) = ?"
+                if subscribedOnly {
+                    query += " WHERE subscribed = 1"
+                }
+                try db.execute(sql: query, arguments: [value])
+            }
+        } catch {
+            FileLog.shared.addMessage("PodcastDataManager.setOnAllPodcasts error: \(error)")
+        }
+
+        cachePodcasts(dbPool: dbPool)
+    }
+
+    func saveSortOrders(podcasts: [Podcast], dbPool: DatabasePool) {
+        do {
+            try dbPool.write { db in
+                for podcast in podcasts {
+                    try db.execute(sql: "UPDATE \(DataManager.podcastTableName) SET sortOrder = ?, syncStatus = \(SyncStatus.notSynced.rawValue) WHERE id = ?", arguments: [podcast.sortOrder, podcast.id])
+                }
+            }
+        } catch {
+            FileLog.shared.addMessage("PodcastDataManager.saveSortOrders error: \(error)")
+        }
+
+        cachePodcasts(dbPool: dbPool)
+    }
+
+    func removeAllPodcastsFromFolder(folderUuid: String, dbPool: DatabasePool) {
+        DataHelper.run(query: "UPDATE \(DataManager.podcastTableName) SET folderUuid = NULL, syncStatus = \(SyncStatus.notSynced.rawValue) WHERE folderUuid = ?", values: [folderUuid], methodName: "PodcastDataManager.removeAllPodcastsFromFolder", dbPool: dbPool)
+
+        cachePodcasts(dbPool: dbPool)
+    }
+
+    func removeAllPodcastsFromAllFolders(dbPool: DatabasePool) {
+        DataHelper.run(query: "UPDATE \(DataManager.podcastTableName) SET folderUuid = NULL", values: nil, methodName: "PodcastDataManager.removeAllPodcastsFromAllFolders", dbPool: dbPool)
+
+        cachePodcasts(dbPool: dbPool)
+    }
+
+    func updateAllPodcastGrouping(to grouping: PodcastGrouping, dbPool: DatabasePool) {
+        setOnAllPodcasts(value: grouping.rawValue, propertyName: "episodeGrouping", subscribedOnly: true, dbPool: dbPool)
+    }
+
+    func updateAllShowArchived(to showArchived: Bool, dbPool: DatabasePool) {
+        setOnAllPodcasts(value: showArchived, propertyName: "showArchived", subscribedOnly: true, dbPool: dbPool)
+    }
+
+    func setAllPodcastImageVersions(to version: Int, dbPool: DatabasePool) {
+        setOnAllPodcasts(value: NSNull(), propertyName: "lastColorDownloadDate", subscribedOnly: true, dbPool: dbPool)
+        setOnAllPodcasts(value: version, propertyName: "colorVersion", subscribedOnly: true, dbPool: dbPool)
+    }
+
+    private func saveSingleValue(name: String, value: Any?, podcastUuid: String, dbPool: DatabasePool) {
+        DataHelper.run(query: "UPDATE \(DataManager.podcastTableName) SET \(name) = ? WHERE uuid = ?", values: [value ?? NSNull(), podcastUuid], methodName: "PodcastDataManager.saveSingleValue", dbPool: dbPool)
+
+        cachePodcasts(dbPool: dbPool)
+    }
+
+    private func saveSingleSetting<Value: Codable & Equatable>(_ name: String, value: Value, podcastUuid: String, dbPool: DatabasePool) {
+        do {
+            try dbPool.write { db in
+                let modified = ModifiedDate(wrappedValue: value, modifiedAt: Date())
+                let json = try JSONEncoder().encode(modified)
+                guard let jsonString = String(data: json, encoding: .utf8) else {
+                    throw JSONError.failedStringConvert(name, json)
+                }
+
+                let query = """
+                UPDATE \(DataManager.podcastTableName)
+                SET settings = json_set(
+                    \(DataManager.podcastTableName).settings,
+                    '$.notification',
+                    json('\(jsonString)')
+                ), syncStatus = \(SyncStatus.notSynced.rawValue)
+                WHERE uuid = '\(podcastUuid)'
+                """
+                try db.execute(sql: query, arguments: [])
+            }
+        } catch let error {
+            FileLog.shared.addMessage("PodcastDataManager.saveSingleSetting for \(name) error: \(error)")
+        }
+
+        cachePodcasts(dbPool: dbPool)
+    }
+
 
     // MARK: - Conversion
 

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/PodcastDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/PodcastDataManager.swift
@@ -2,8 +2,8 @@ import FMDB
 import PocketCastsUtils
 
 class PodcastDataManager {
-    private var cachedPodcasts = [String: Podcast]()
-    private lazy var cachedPodcastsQueue: DispatchQueue = {
+    var cachedPodcasts = [String: Podcast]()
+    lazy var cachedPodcastsQueue: DispatchQueue = {
         let queue = DispatchQueue(label: "au.com.pocketcasts.PodcastDataQueue")
 
         return queue

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/PodcastDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/PodcastDataManager.swift
@@ -9,7 +9,7 @@ class PodcastDataManager {
         return queue
     }()
 
-    private let columnNames = [
+    let columnNames = [
         "id",
         "addedDate",
         "autoDownloadSetting",
@@ -621,7 +621,7 @@ class PodcastDataManager {
         Podcast.from(resultSet: rs)
     }
 
-    private func createValuesFrom(podcast: Podcast, includeIdForWhere: Bool = false) -> [Any] {
+    func createValuesFrom(podcast: Podcast, includeIdForWhere: Bool = false) -> [Any] {
         var values = [Any]()
         values.append(podcast.id)
         values.append(DBUtils.nullIfNil(value: podcast.addedDate))
@@ -682,13 +682,13 @@ class PodcastDataManager {
         return values
     }
 
-    private func addedDateSort(p1: Podcast, p2: Podcast) -> Bool {
+    func addedDateSort(p1: Podcast, p2: Podcast) -> Bool {
         guard let date1 = p1.addedDate, let date2 = p2.addedDate else { return false }
 
         return PodcastSorter.dateAddedSort(date1: date1, date2: date2)
     }
 
-    private func titleSort(p1: Podcast, p2: Podcast) -> Bool {
+    func titleSort(p1: Podcast, p2: Podcast) -> Bool {
         guard let title1 = p1.title, let title2 = p2.title else { return false }
 
         return PodcastSorter.titleSort(title1: title1, title2: title2)

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseHelper.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseHelper.swift
@@ -604,6 +604,11 @@ class DatabaseHelper {
                     schemaVersion = 53
                 }
 
+                if schemaVersion < 54 {
+                    try db.execute(sql: "ALTER TABLE SJPodcast ADD COLUMN podcastHTMLDescription TEXT;")
+                    schemaVersion = 54
+                }
+
 
                 return .commit
             }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -66,7 +66,7 @@ public class DataManager {
         }
 
         // closing it above won't affect these calls, since they will re-open it
-        podcastManager.setup(dbQueue: dbQueue)
+        FeatureFlag.grdb.enabled ? podcastManager.setup(dbQueue: dbQueue) : podcastManager.setup(dbPool: dbPool)
         folderManager.setup(dbQueue: dbQueue)
         upNextManager.setup(dbQueue: dbQueue)
 
@@ -281,111 +281,192 @@ public class DataManager {
     // MARK: - Podcasts
 
     public func allPodcasts(includeUnsubscribed: Bool, reloadFromDatabase: Bool = false) -> [Podcast] {
-        podcastManager.allPodcasts(includeUnsubscribed: includeUnsubscribed, reloadFromDatabase: reloadFromDatabase, dbQueue: dbQueue)
+        !FeatureFlag.grdb.enabled ?
+            podcastManager.allPodcasts(includeUnsubscribed: includeUnsubscribed, reloadFromDatabase: reloadFromDatabase, dbQueue: dbQueue)
+        :
+        podcastManager.allPodcasts(includeUnsubscribed: includeUnsubscribed, reloadFromDatabase: reloadFromDatabase, dbPool: dbPool)
     }
 
     public func allPodcastsOrderedByTitle(reloadFromDatabase: Bool = false) -> [Podcast] {
+        !FeatureFlag.grdb.enabled ?
         podcastManager.allPodcastsOrderedByTitle(reloadFromDatabase: reloadFromDatabase, dbQueue: dbQueue)
+        :
+        podcastManager.allPodcastsOrderedByTitle(reloadFromDatabase: reloadFromDatabase, dbPool: dbPool)
     }
 
     public func allPodcastsOrderedByNewestEpisodes(reloadFromDatabase: Bool = false) -> [Podcast] {
+        !FeatureFlag.grdb.enabled ?
         podcastManager.allPodcastsOrderedByNewestEpisodes(reloadFromDatabase: reloadFromDatabase, dbQueue: dbQueue)
+        :
+        podcastManager.allPodcastsOrderedByNewestEpisodes(reloadFromDatabase: reloadFromDatabase, dbPool: dbPool)
     }
 
     public func allPodcastsOrderedByAddedDate(reloadFromDatabase: Bool = false) -> [Podcast] {
+        !FeatureFlag.grdb.enabled ?
         podcastManager.allPodcastsOrderedByAddedDate(reloadFromDatabase: reloadFromDatabase, dbQueue: dbQueue)
+        :
+        podcastManager.allPodcastsOrderedByAddedDate(reloadFromDatabase: reloadFromDatabase, dbPool: dbPool)
     }
 
     public func findPodcast(uuid: String, includeUnsubscribed: Bool = false) -> Podcast? {
+        !FeatureFlag.grdb.enabled ?
         podcastManager.find(uuid: uuid, includeUnsubscribed: includeUnsubscribed, dbQueue: dbQueue)
+        :
+        podcastManager.find(uuid: uuid, includeUnsubscribed: includeUnsubscribed, dbPool: dbPool)
     }
 
     public func allUnsubscribedPodcastUuids() -> [String] {
+        !FeatureFlag.grdb.enabled ?
         podcastManager.allUnsubscribedPodcastUuids(dbQueue: dbQueue)
+        :
+        podcastManager.allUnsubscribedPodcastUuids(dbPool: dbPool)
     }
 
     public func allUnsubscribedPodcasts() -> [Podcast] {
+        !FeatureFlag.grdb.enabled ?
         podcastManager.allUnsubscribedPodcasts(dbQueue: dbQueue)
+        :
+        podcastManager.allUnsubscribedPodcasts(dbPool: dbPool)
     }
 
     public func allPaidPodcasts() -> [Podcast] {
+        !FeatureFlag.grdb.enabled ?
         podcastManager.allPaidPodcasts(dbQueue: dbQueue)
+        :
+        podcastManager.allPaidPodcasts(dbPool: dbPool)
     }
 
     public func allOverrideGlobalArchivePodcasts() -> [Podcast] {
+        !FeatureFlag.grdb.enabled ?
         podcastManager.allOverrideGlobalArchivePodcasts(dbQueue: dbQueue)
+        :
+        podcastManager.allOverrideGlobalArchivePodcasts(dbPool: dbPool)
     }
 
     public func podcastCount() -> Int {
+        !FeatureFlag.grdb.enabled ?
         podcastManager.count(dbQueue: dbQueue)
+        :
+        podcastManager.count(dbPool: dbPool)
     }
 
     public func podcastUnfinishedCounts() -> [String: Int32] {
+        !FeatureFlag.grdb.enabled ?
         podcastManager.unfinishedCounts(dbQueue: dbQueue)
+        :
+        podcastManager.unfinishedCounts(dbPool: dbPool)
     }
 
     public func markAllPodcastsSynced() {
+        !FeatureFlag.grdb.enabled ?
         podcastManager.markAllSynced(dbQueue: dbQueue)
+        :
+        podcastManager.markAllSynced(dbPool: dbPool)
     }
 
     public func markAllPodcastsUnsynced() {
+        !FeatureFlag.grdb.enabled ?
         podcastManager.markAllUnsynced(dbQueue: dbQueue)
+        :
+        podcastManager.markAllUnsynced(dbPool: dbPool)
     }
 
     public func markAllPodcastsUnsyncedWhereLastSyncAtNot(_ lastSyncAt: String) {
+        !FeatureFlag.grdb.enabled ?
         podcastManager.markAllUnsyncedWhereLastSyncAtNot(lastSyncAt, dbQueue: dbQueue)
+        :
+        podcastManager.markAllUnsyncedWhereLastSyncAtNot(lastSyncAt, dbPool: dbPool)
     }
 
     public func setPushForAllPodcasts(pushEnabled: Bool) {
+        !FeatureFlag.grdb.enabled ?
         podcastManager.setPushForAllPodcasts(pushEnabled: pushEnabled, dbQueue: dbQueue)
+        :
+        podcastManager.setPushForAllPodcasts(pushEnabled: pushEnabled, dbPool: dbPool)
     }
 
     public func saveAutoAddToUpNextForAllPodcasts(autoAddToUpNext: Int32) {
+        !FeatureFlag.grdb.enabled ?
         podcastManager.saveAutoAddToUpNextForAllPodcasts(autoAddToUpNext: autoAddToUpNext, dbQueue: dbQueue)
+        :
+        podcastManager.saveAutoAddToUpNextForAllPodcasts(autoAddToUpNext: autoAddToUpNext, dbPool: dbPool)
     }
 
     public func updateAutoAddToUpNext(to value: AutoAddToUpNextSetting, for podcasts: [Podcast]) {
+        !FeatureFlag.grdb.enabled ?
         podcastManager.updateAutoAddToUpNext(to: value, for: podcasts, in: dbQueue)
+        :
+        podcastManager.updateAutoAddToUpNext(to: value, for: podcasts, in: dbPool)
     }
 
     public func setDownloadSettingForAllPodcasts(setting: AutoDownloadSetting) {
+        !FeatureFlag.grdb.enabled ?
         podcastManager.setDownloadSettingForAllPodcasts(setting: setting, dbQueue: dbQueue)
+        :
+        podcastManager.setDownloadSettingForAllPodcasts(setting: setting, dbPool: dbPool)
     }
 
     public func allUnsyncedPodcasts() -> [Podcast] {
+        !FeatureFlag.grdb.enabled ?
         podcastManager.allUnsynced(dbQueue: dbQueue)
+        :
+        podcastManager.allUnsynced(dbPool: dbPool)
     }
 
     public func delete(podcast: Podcast) {
+        !FeatureFlag.grdb.enabled ?
         podcastManager.delete(podcast: podcast, dbQueue: dbQueue)
+        :
+        podcastManager.delete(podcast: podcast, dbPool: dbPool)
     }
 
     public func save(podcast: Podcast) {
+        !FeatureFlag.grdb.enabled ?
         podcastManager.save(podcast: podcast, dbQueue: dbQueue)
+        :
+        podcastManager.save(podcast: podcast, dbPool: dbPool)
     }
 
     public func savePushSetting(podcast: Podcast, pushEnabled: Bool) {
+        !FeatureFlag.grdb.enabled ?
         podcastManager.savePushSetting(podcast: podcast, pushEnabled: pushEnabled, dbQueue: dbQueue)
+        :
+        podcastManager.savePushSetting(podcast: podcast, pushEnabled: pushEnabled, dbPool: dbPool)
     }
 
     public func savePushSetting(podcastUuid: String, pushEnabled: Bool) {
+        !FeatureFlag.grdb.enabled ?
         podcastManager.savePushSetting(podcastUuid: podcastUuid, pushEnabled: pushEnabled, dbQueue: dbQueue)
+        :
+        podcastManager.savePushSetting(podcastUuid: podcastUuid, pushEnabled: pushEnabled, dbPool: dbPool)
     }
 
     public func saveAutoAddToUpNext(podcastUuid: String, autoAddToUpNext: Int32) {
+        !FeatureFlag.grdb.enabled ?
         podcastManager.saveAutoAddToUpNext(podcastUuid: podcastUuid, autoAddToUpNext: autoAddToUpNext, dbQueue: dbQueue)
+        :
+        podcastManager.saveAutoAddToUpNext(podcastUuid: podcastUuid, autoAddToUpNext: autoAddToUpNext, dbPool: dbPool)
     }
 
     public func savePodcastDownloadSetting(_ setting: AutoDownloadSetting, podcastUuid: String) {
+        !FeatureFlag.grdb.enabled ?
         podcastManager.savePodcastDownloadSetting(setting, podcastUuid: podcastUuid, dbQueue: dbQueue)
+        :
+        podcastManager.savePodcastDownloadSetting(setting, podcastUuid: podcastUuid, dbPool: dbPool)
     }
 
     public func saveAutoArchiveLimit(podcast: Podcast, limit: Int32) {
+        !FeatureFlag.grdb.enabled ?
         podcastManager.saveAutoArchiveLimit(podcast: podcast, limit: limit, dbQueue: dbQueue)
+        :
+        podcastManager.saveAutoArchiveLimit(podcast: podcast, limit: limit, dbPool: dbPool)
     }
 
     public func saveSortOrders(podcasts: [Podcast]) {
+        !FeatureFlag.grdb.enabled ?
         podcastManager.saveSortOrders(podcasts: podcasts, dbQueue: dbQueue)
+        :
+        podcastManager.saveSortOrders(podcasts: podcasts, dbPool: dbPool)
     }
 
     public func markAllUnarchivedForPodcast(id: Int64) {
@@ -393,27 +474,45 @@ public class DataManager {
     }
 
     public func updateAllPodcastGrouping(to grouping: PodcastGrouping) {
+        !FeatureFlag.grdb.enabled ?
         podcastManager.updateAllPodcastGrouping(to: grouping, dbQueue: dbQueue)
+        :
+        podcastManager.updateAllPodcastGrouping(to: grouping, dbPool: dbPool)
     }
 
     public func updateAllShowArchived(to showArchived: Bool) {
+        !FeatureFlag.grdb.enabled ?
         podcastManager.updateAllShowArchived(to: showArchived, dbQueue: dbQueue)
+        :
+        podcastManager.updateAllShowArchived(to: showArchived, dbPool: dbPool)
     }
 
     public func setPodcastImageVersion(podcastUuid: String, version: Int) {
+        !FeatureFlag.grdb.enabled ?
         podcastManager.setPodcastImageVersion(podcastUuid: podcastUuid, version: version, dbQueue: dbQueue)
+        :
+        podcastManager.setPodcastImageVersion(podcastUuid: podcastUuid, version: version, dbPool: dbPool)
     }
 
     public func setAllPodcastImageVersions(to version: Int) {
+        !FeatureFlag.grdb.enabled ?
         podcastManager.setAllPodcastImageVersions(to: version, dbQueue: dbQueue)
+        :
+        podcastManager.setAllPodcastImageVersions(to: version, dbPool: dbPool)
     }
 
     public func bulkSetFolderUuid(folderUuid: String, podcastUuids: [String]) {
+        !FeatureFlag.grdb.enabled ?
         podcastManager.bulkSetFolderUuid(folderUuid: folderUuid, podcastUuids: podcastUuids, dbQueue: dbQueue)
+        :
+        podcastManager.bulkSetFolderUuid(folderUuid: folderUuid, podcastUuids: podcastUuids, dbPool: dbPool)
     }
 
     public func updatePodcastFolder(podcastUuid: String, to folderUuid: String?, sortOrder: Int32) {
+        !FeatureFlag.grdb.enabled ?
         podcastManager.updatePodcastFolder(podcastUuid: podcastUuid, sortOrder: sortOrder, folderUuid: folderUuid, dbQueue: dbQueue)
+        :
+        podcastManager.updatePodcastFolder(podcastUuid: podcastUuid, sortOrder: sortOrder, folderUuid: folderUuid, dbPool: dbPool)
     }
 
     // MARK: - Episodes

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -66,7 +66,7 @@ public class DataManager {
         }
 
         // closing it above won't affect these calls, since they will re-open it
-        FeatureFlag.grdb.enabled ? podcastManager.setup(dbQueue: dbQueue) : podcastManager.setup(dbPool: dbPool)
+        !FeatureFlag.grdb.enabled ? podcastManager.setup(dbQueue: dbQueue) : podcastManager.setup(dbPool: dbPool)
         folderManager.setup(dbQueue: dbQueue)
         upNextManager.setup(dbQueue: dbQueue)
 

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Podcast+fromDatabase.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Podcast+fromDatabase.swift
@@ -1,6 +1,7 @@
 import Foundation
 import PocketCastsUtils
 import FMDB
+import GRDB
 
 extension Podcast {
     static func from(resultSet rs: FMResultSet) -> Podcast {
@@ -56,6 +57,61 @@ extension Podcast {
         podcast.refreshAvailable = rs.bool(forColumn: "refreshAvailable")
         podcast.folderUuid = rs.string(forColumn: "folderUuid")
         podcast.usedCustomEffectsBefore = rs.bool(forColumn: "usedCustomEffectsBefore")
+
+        return podcast
+    }
+
+    static func from(row: RowCursor.Element) -> Podcast {
+        let podcast = Podcast()
+        podcast.id = row["id"]
+        podcast.addedDate = row["addedDate"]
+        podcast.autoDownloadSetting = row["autoDownloadSetting"]
+        podcast.autoAddToUpNext = row["autoAddToUpNext"]
+        podcast.autoArchiveEpisodeLimit = row["episodeKeepSetting"]
+        podcast.backgroundColor = row["backgroundColor"]
+        podcast.detailColor = row["detailColor"]
+        podcast.primaryColor = row["primaryColor"]
+        podcast.secondaryColor = row["secondaryColor"]
+        podcast.lastColorDownloadDate = row["lastColorDownloadDate"]
+        podcast.imageURL = row["imageURL"]
+        podcast.latestEpisodeUuid = row["latestEpisodeUuid"]
+        podcast.latestEpisodeDate = row["latestEpisodeDate"]
+        podcast.mediaType = row["mediaType"]
+        podcast.lastThumbnailDownloadDate = row["lastThumbnailDownloadDate"]
+        podcast.thumbnailStatus = row["thumbnailStatus"]
+        podcast.podcastUrl = row["podcastUrl"]
+        podcast.author = row["author"]
+        podcast.playbackSpeed = row["playbackSpeed"]
+        podcast.boostVolume = row["boostVolume"]
+        podcast.trimSilenceAmount = row["trimSilenceAmount"]
+        podcast.podcastCategory = row["podcastCategory"]
+        podcast.podcastDescription = row["podcastDescription"]
+        podcast.sortOrder = row["sortOrder"]
+        podcast.startFrom = row["startFrom"]
+        podcast.skipLast = row["skipLast"]
+        podcast.subscribed = row["subscribed"]
+        podcast.title = row["title"]
+        podcast.uuid = row["uuid"]
+        podcast.syncStatus = row["syncStatus"]
+        podcast.colorVersion = row["colorVersion"]
+        podcast.pushEnabled = row["pushEnabled"]
+        podcast.episodeSortOrder = row["episodeSortOrder"]
+        podcast.showType = row["showType"]
+        podcast.estimatedNextEpisode = row["estimatedNextEpisode"]
+        podcast.episodeFrequency = row["episodeFrequency"]
+        podcast.lastUpdatedAt = row["lastUpdatedAt"]
+        podcast.excludeFromAutoArchive = row["excludeFromAutoArchive"]
+        podcast.overrideGlobalEffects = row["overrideGlobalEffects"]
+        podcast.overrideGlobalArchive = row["overrideGlobalArchive"]
+        podcast.autoArchivePlayedAfter = row["autoArchivePlayedAfter"]
+        podcast.autoArchiveInactiveAfter = row["autoArchiveInactiveAfter"]
+        podcast.episodeGrouping = row["episodeGrouping"]
+        podcast.isPaid = row["isPaid"]
+        podcast.licensing = row["licensing"]
+        podcast.fullSyncLastSyncAt = row["fullSyncLastSyncAt"]
+        podcast.showArchived = row["showArchived"]
+        podcast.refreshAvailable = row["refreshAvailable"]
+        podcast.folderUuid = row["folderUuid"]
 
         return podcast
     }


### PR DESCRIPTION
This is another PR that adds a GRDB layer for `PodcastDataManager`. As the previous one, this works by duplicating and adapting the code.

We're having discussions in the initial PR about having a more generic layer that can work with both. I'm pushing this PR just so we can test GRDB.

## To test

1. Run the app
2. Open a few podcasts
3. ✅ Ensure everything works as usual

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
