### PR TITLE
Disable private feed in lists

### DIFF
--- a/podcasts/SharePodcastsViewController.swift
+++ b/podcasts/SharePodcastsViewController.swift
@@ -1,5 +1,6 @@
 import PocketCastsDataModel
 import UIKit
+import PocketCastsUtils
 
 protocol ShareListDelegate: AnyObject {
     func shareUrlAvailable(_ shareUrl: String, listName: String)
@@ -135,6 +136,9 @@ class SharePodcastsViewController: PCViewController, UICollectionViewDelegate, U
     private func loadPodcasts() {
         let loadedPodcasts = DataManager.sharedManager.allPodcastsOrderedByTitle()
         for podcast in loadedPodcasts {
+            if FeatureFlag.disablePrivateFeedSharing.enabled {
+                if podcast.isPrivate { continue } // Hide all private podcasts
+            }
             podcasts.append(podcast)
         }
 


### PR DESCRIPTION
Removes private podcasts from lists. We may eventually want to allow sharing with special treatment for private feeds but for now they should be removed.

See pdeCcb-7Yf-p2#comment-6356

https://github.com/user-attachments/assets/3e3807f7-b603-4bcc-8929-747d0434b409

## To test

1. Add a private feed to your subscriptions (use `https://pca.st/private/707a8bf0-9abf-013c-74fe-027201e7e97f` as an example)
2. Tap the Ellipsis button in the upper right and Share Podcasts in the modal
3. Notice that private podcasts are excluded from the list

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.