### PR TITLE
Move podcastShared analytics events

### DIFF
--- a/podcasts/NowPlayingPlayerItemViewController+Shelf.swift
+++ b/podcasts/NowPlayingPlayerItemViewController+Shelf.swift
@@ -499,11 +499,7 @@ extension NowPlayingPlayerItemViewController: NowPlayingActionsDelegate {
     }
 
     private func shareEpisode(source: UIView, episode: Episode, fromTime: TimeInterval) {
-        guard let buttonSuperview = source.superview else { return }
-
-        let type = fromTime == 0 ? "episode" : "current_position"
-
-        Analytics.track(.podcastShared, properties: ["type": type, "source": "player"])
+        guard let _ = source.superview else { return }
 
         if fromTime == 0 {
             SharingModal.show(option: .episode(episode), from: analyticsSource, in: self)
@@ -513,9 +509,8 @@ extension NowPlayingPlayerItemViewController: NowPlayingActionsDelegate {
     }
 
     private func sharePodcast(source: UIView, podcast: Podcast?) {
-        guard let buttonSuperview = source.superview, let podcast = podcast else { return }
+        guard let _ = source.superview, let podcast = podcast else { return }
 
-        Analytics.track(.podcastShared, properties: ["type": "podcast", "source": "player"])
         SharingModal.show(option: .podcast(podcast), from: analyticsSource, in: self)
     }
     #endif

--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -437,7 +437,6 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
         let sourceRect = sender.superview!.convert(sender.frame, to: view)
         SharingHelper.shared.shareLinkTo(podcast: podcast, fromController: self, fromSource: analyticsSource, sourceRect: sourceRect, sourceView: view)
         Analytics.track(.podcastScreenShareTapped)
-        Analytics.track(.podcastShared, properties: ["type": "podcast", "source": analyticsSource])
     }
 
     private func loadPodcastInfo() {

--- a/podcasts/Sharing/SharingModal.swift
+++ b/podcasts/Sharing/SharingModal.swift
@@ -129,10 +129,24 @@ enum SharingModal {
         let hostingController = ThemedHostingController(rootView: modalView, theme: Theme(previewTheme: .contrastLight))
         viewController.present(hostingController, animated: true)
 
+        Analytics.track(.podcastShared, source: source, properties: ["type": option.analyticsType])
     }
 }
 
 extension SharingModal.Option {
+    fileprivate var analyticsType: String {
+        switch self {
+        case .podcast:
+            "podcast"
+        case .episode:
+            "episode"
+        case .currentPosition:
+            "current_position"
+        case .clip, .clipShare:
+            "clip"
+        }
+    }
+
     private var description: String? {
         switch self {
         case .episode(let episode), .currentPosition(let episode, _), .clip(let episode, _), .clipShare(let episode, _, _):

--- a/podcasts/SharingHelper.swift
+++ b/podcasts/SharingHelper.swift
@@ -68,7 +68,6 @@ class SharingHelper: NSObject {
     }
 
     func shareLinkTo(episode: Episode, shareTime: TimeInterval, fromController: UIViewController, sourceRect: CGRect, sourceView: UIView?, showArrow: Bool = true, fromSource: AnalyticsSource, analyticsType: String = "episode") {
-        Analytics.track(.podcastShared, source: fromSource, properties: ["type": analyticsType])
 
         SharingModal.show(option: .episode(episode), from: fromSource, in: fromController)
     }


### PR DESCRIPTION
This handles the early returns added in #2582 so we don't log a `podcastShared` event when private podcasts are shared.

## To test

### Private Podcast

* Enable the `tracksLogging` feature flag

* Open the Podcast detail screen for a private podcast
* Tap "Share" and verify that only the following event is logged with no `podcast_shared` event:
```
🔵 Tracked: podcast_screen_share_tapped
```

* Open the episode detail page
* Verify that no event is logged when tapping share

* Play an episode from this podcast
* Open the player
* Tap the "Share" action button in the shelf
* Verify that no `podcast_shared` event is logged

### Public Podcast

* For a public podcast, do the following:
* Open the Podcast detail page
* Tap Share and see the following logged:
```
🔵 Tracked: podcast_shared ["type": "podcast", "source": "podcast_screen"]
```

* Open the Episode detail page
* Tap Share and select the options and you should see the following logged with the "type" swapped out as above:
```
🔵 Tracked: podcast_shared ["source": "episode_detail", "type": "episode"]
```

* Open the player
* Tap the "Share" action button in the shelf
* Select one of the options from the menu and you should see the following logged for each corresponding option:
```
🔵 Tracked: podcast_shared ["type": "episode", "source": "player"]
🔵 Tracked: podcast_shared ["type": "podcast", "source": "player"]
🔵 Tracked: podcast_shared ["type": "current_position", "source": "player"]
🔵 Tracked: podcast_shared ["type": "clip", "source": "player"]
```


## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
