### PR TITLE
Pass BETA_RELEASE to release-upload.sh invocation

### DIFF
--- a/.buildkite/commands/release-upload.sh
+++ b/.buildkite/commands/release-upload.sh
@@ -1,5 +1,9 @@
 #!/bin/bash -eu
 
+BETA_RELEASE=${1:-true} # use first call param, default to true for safety
+
+echo "Running $0 with BETA_RELEASE = $BETA_RELEASE..."
+
 echo "--- :arrow_down: Downloading Artifacts"
 ARTIFACTS_DIR='artifacts' # Defined in Fastlane, see ARTIFACTS_FOLDER
 STEP=testflight_build
@@ -27,5 +31,4 @@ if [[ $SENTRY_UPLOAD_STATUS -ne 0 ]]; then
 fi
 
 echo "--- :github: Creating GitHub Release"
-bundle exec fastlane create_release_on_github \
-  beta_release:${1:-true} # use first call param, default to true for safety
+bundle exec fastlane create_release_on_github beta_release:"$BETA_RELEASE"

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -25,7 +25,7 @@ steps:
 
   - label: ":testflight: Release Upload (TestFlight, Sentry, GitHub)"
     depends_on: testflight_build
-    command: .buildkite/commands/release-upload.sh
+    command: .buildkite/commands/release-upload.sh $BETA_RELEASE
     priority: 1
     plugins: [$CI_TOOLKIT]
     notify:


### PR DESCRIPTION
See discussion in p1734637168903759/1734636063.032259-slack-C029BMLUGRX

Fixes an issue I introduced by carelessness in https://github.com/Automattic/pocket-casts-ios/pull/2461 when splitting the build from upload script for release builds and forgetting to pass along the `$BETA_RELEASE` env var that CI receives to the new upload script.

## To test

This will be real world tested when a new release will run. As such, I opened this against the latest release branch, so we can check it sooner rather than later.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary. – N.A.
- [x] I have considered adding unit tests for my changes. – N.A.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics. – N.A.See discussion in p1734637168903759/1734636063.032259-slack-C029BMLUGRX