### PR TITLE
[Winback] Add Analytics events

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -676,6 +676,7 @@
 		9A156AB12CF7430A007BA8D9 /* UpNextAnnouncementView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A156AB02CF7430A007BA8D9 /* UpNextAnnouncementView.swift */; };
 		9A156AB32CF8BEE3007BA8D9 /* CancelSubscriptionPlanRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A156AB22CF8BEE3007BA8D9 /* CancelSubscriptionPlanRow.swift */; };
 		9A509DE02D14606100E8CEB1 /* CancelSubscriptionOfferSuccessView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A509DDF2D14606100E8CEB1 /* CancelSubscriptionOfferSuccessView.swift */; };
+		9AA3B6312D27F0B600A0E30E /* CancelSubscriptionPlansViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AA3B6302D27F0B600A0E30E /* CancelSubscriptionPlansViewModel.swift */; };
 		BD001B892174260B00504DD3 /* FilterManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD001B882174260B00504DD3 /* FilterManager.swift */; };
 		BD00CB2B24BD20CD00A10257 /* TimeStepperCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD00CB2924BD20CD00A10257 /* TimeStepperCell.swift */; };
 		BD00CB2C24BD20CD00A10257 /* TimeStepperCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = BD00CB2A24BD20CD00A10257 /* TimeStepperCell.xib */; };
@@ -2864,6 +2865,7 @@
 		9A156AB22CF8BEE3007BA8D9 /* CancelSubscriptionPlanRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancelSubscriptionPlanRow.swift; sourceTree = "<group>"; };
 		9A509DDF2D14606100E8CEB1 /* CancelSubscriptionOfferSuccessView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancelSubscriptionOfferSuccessView.swift; sourceTree = "<group>"; };
 		9A9517324EFFD2C905890193 /* Pods-podcasts.appstore.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-podcasts.appstore.xcconfig"; path = "Pods/Target Support Files/Pods-podcasts/Pods-podcasts.appstore.xcconfig"; sourceTree = "<group>"; };
+		9AA3B6302D27F0B600A0E30E /* CancelSubscriptionPlansViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancelSubscriptionPlansViewModel.swift; sourceTree = "<group>"; };
 		9E6FEF10644B78313185D080 /* Pods-PocketCastsTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PocketCastsTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-PocketCastsTests/Pods-PocketCastsTests.release.xcconfig"; sourceTree = "<group>"; };
 		A251FE0E92E432C4EF0C8207 /* Pods-PocketCastsTests.staging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PocketCastsTests.staging.xcconfig"; path = "Pods/Target Support Files/Pods-PocketCastsTests/Pods-PocketCastsTests.staging.xcconfig"; sourceTree = "<group>"; };
 		AA688FF113B87D7B363799D5 /* Pods-Pocket Casts App ClipTests.staging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Pocket Casts App ClipTests.staging.xcconfig"; path = "Pods/Target Support Files/Pods-Pocket Casts App ClipTests/Pods-Pocket Casts App ClipTests.staging.xcconfig"; sourceTree = "<group>"; };
@@ -5316,6 +5318,7 @@
 		9A156AAF2CF61025007BA8D9 /* Plans View */ = {
 			isa = PBXGroup;
 			children = (
+				9AA3B6302D27F0B600A0E30E /* CancelSubscriptionPlansViewModel.swift */,
 				9A156AAC2CF60973007BA8D9 /* CancelSubscriptionPlansView.swift */,
 				9A156AB22CF8BEE3007BA8D9 /* CancelSubscriptionPlanRow.swift */,
 			);
@@ -10396,6 +10399,7 @@
 				BD6B432A2755F516005E4017 /* AboutViewLogos.swift in Sources */,
 				C7AF7B992926B307002F0025 /* OnboardingHostingViewController.swift in Sources */,
 				462EE0AD26FCC081003D67DC /* ZenDeskHelpers.swift in Sources */,
+				9AA3B6312D27F0B600A0E30E /* CancelSubscriptionPlansViewModel.swift in Sources */,
 				403B5B0621812E6000821A54 /* AppDelegate+SiriShortcuts.swift in Sources */,
 				1035FFED2CEE5F4E00C1E80D /* CancelSubscriptionOption.swift in Sources */,
 				BD9086AC204E413800C0C78D /* PodcastSearchCell.swift in Sources */,

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -755,4 +755,16 @@ enum AnalyticsEvent: String {
     case referralPassBannerShown
     case referralPurchaseShown
     case referralPurchaseSuccess
+
+    // MARK: - Winback
+
+    case cancelSubscriptionShown
+    case cancelSubscriptionDismissed
+    case cancelSubscriptionContinueButtonTap
+    case cancelSubscriptionRowTap
+    case cancelSubscriptionClaimOfferSuccessShown
+    case cancelSubscriptionAvailablePlansShown
+    case cancelSubscriptionAvailablePlansDismissed
+    case cancelSubscriptionSelectPlan
+    case cancelSubscriptionNewPlanPurchaseSuccessful
 }

--- a/podcasts/Cancel Subscription/Cancel Subscription/Offer View/CancelSubscriptionOfferSuccessView.swift
+++ b/podcasts/Cancel Subscription/Cancel Subscription/Offer View/CancelSubscriptionOfferSuccessView.swift
@@ -22,7 +22,7 @@ struct CancelSubscriptionOfferSuccessView: View {
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, 24)
             Spacer()
-            Button(action: viewModel.closePlans) {
+            Button(action: viewModel.closeOffer) {
                 Text(L10n.done)
             }
             .buttonStyle(BasicButtonStyle(textColor: theme.primaryInteractive02, backgroundColor: theme.primaryInteractive01))

--- a/podcasts/Cancel Subscription/Cancel Subscription/Plans View/CancelSubscriptionPlansView.swift
+++ b/podcasts/Cancel Subscription/Cancel Subscription/Plans View/CancelSubscriptionPlansView.swift
@@ -3,9 +3,9 @@ import SwiftUI
 struct CancelSubscriptionPlansView: View {
     @EnvironmentObject var theme: Theme
 
-    @ObservedObject var viewModel: CancelSubscriptionViewModel
+    @ObservedObject var viewModel: CancelSubscriptionPlansViewModel
 
-    init(viewModel: CancelSubscriptionViewModel) {
+    init(viewModel: CancelSubscriptionPlansViewModel) {
         self.viewModel = viewModel
     }
 
@@ -90,6 +90,6 @@ struct CancelSubscriptionPlansView: View {
 }
 
 #Preview {
-    CancelSubscriptionPlansView(viewModel: CancelSubscriptionViewModel(navigationController: UINavigationController()))
+    CancelSubscriptionPlansView(viewModel: CancelSubscriptionPlansViewModel(navigationController: UINavigationController()))
         .environmentObject(Theme.sharedTheme)
 }

--- a/podcasts/Cancel Subscription/Cancel Subscription/Plans View/CancelSubscriptionPlansViewModel.swift
+++ b/podcasts/Cancel Subscription/Cancel Subscription/Plans View/CancelSubscriptionPlansViewModel.swift
@@ -1,0 +1,89 @@
+import SwiftUI
+import PocketCastsServer
+import PocketCastsUtils
+
+class CancelSubscriptionPlansViewModel: CancelSubscriptionViewModel {
+    private var lastPurchasedProductID: IAPProductID?
+
+    @Published var currentPricingProduct: PlusPricingInfoModel.PlusProductPricingInfo?
+    @State var currentProductAvailability: CurrentProductAvailability = .idle
+
+    override func handleNext() {
+        if let currentPricingProduct {
+            Analytics.track(.cancelSubscriptionNewPlanPurchaseSuccessful, properties: ["product": currentPricingProduct.identifier.rawValue])
+        } else {
+            Analytics.track(.cancelSubscriptionNewPlanPurchaseSuccessful)
+        }
+
+        if SubscriptionHelper.activeTier == .patron {
+            let controller = PatronWelcomeViewModel.make(in: navigationController)
+            navigationController?.pushViewController(controller, animated: true)
+        } else {
+            navigationController?.dismiss(animated: true)
+        }
+    }
+
+    override func didDismiss(type: OnboardingDismissType) {
+        // Since the view can only be dismissed via swipe, only check for that
+        guard type == .swipe else { return }
+
+        Analytics.track(.cancelSubscriptionAvailablePlansDismissed)
+        Analytics.track(.cancelSubscriptionDismissed)
+    }
+
+    func loadCurrentProduct() async {
+        if currentProductAvailability == .loading { return }
+
+        currentProductAvailability = .loading
+        if let transaction = await purchaseHandler.findLastSubscriptionPurchased(),
+           let productID = IAPProductID(rawValue: transaction.productID) {
+            await MainActor.run {
+                lastPurchasedProductID = productID
+                currentProductAvailability = .available
+                currentPricingProduct = pricingInfo.products.first { $0.identifier == productID }
+            }
+        } else {
+            currentProductAvailability = .unavailable
+            FileLog.shared.console("[CancelSubscriptionViewModel] Could not find last subscription purchased")
+        }
+    }
+
+    func purchase(product: PlusPricingInfoModel.PlusProductPricingInfo) {
+        Analytics.track(.cancelSubscriptionSelectPlan, properties: ["product": product.identifier.rawValue])
+
+        currentPricingProduct = product
+
+        if currentPricingProduct?.identifier != lastPurchasedProductID {
+            purchase(product: product.identifier)
+        }
+    }
+
+    func closePlans() {
+        didDismiss(type: .swipe)
+
+        navigationController?.dismiss(animated: true)
+    }
+
+    enum CurrentProductAvailability {
+        case idle
+        case loading
+        case available
+        case unavailable
+    }
+}
+
+extension CancelSubscriptionPlansViewModel {
+    static func make(in navigationController: UINavigationController?) -> UIViewController {
+        let navController = navigationController ?? UINavigationController()
+        let viewModel = CancelSubscriptionPlansViewModel(navigationController: navController)
+        viewModel.parentController = navController
+
+        let swiftUIView = CancelSubscriptionPlansView(viewModel: viewModel).setupDefaultEnvironment()
+
+        let controller = OnboardingHostingViewController(rootView: swiftUIView)
+        controller.navBarIsHidden = true
+        controller.viewModel = viewModel
+
+        return controller
+    }
+}

--- a/podcasts/Cancel Subscription/Cancel Subscription/Plans View/CancelSubscriptionPlansViewModel.swift
+++ b/podcasts/Cancel Subscription/Cancel Subscription/Plans View/CancelSubscriptionPlansViewModel.swift
@@ -23,6 +23,10 @@ class CancelSubscriptionPlansViewModel: CancelSubscriptionViewModel {
         }
     }
 
+    override func didAppear() {
+        Analytics.track(.cancelSubscriptionAvailablePlansShown)
+    }
+
     override func didDismiss(type: OnboardingDismissType) {
         // Since the view can only be dismissed via swipe, only check for that
         guard type == .swipe else { return }

--- a/podcasts/Cancel Subscription/CancelSubscriptionViewModel.swift
+++ b/podcasts/Cancel Subscription/CancelSubscriptionViewModel.swift
@@ -61,7 +61,6 @@ extension CancelSubscriptionViewModel {
 
     func showPlans() {
         Analytics.track(.cancelSubscriptionRowTap, properties: ["row": "plans"])
-        Analytics.track(.cancelSubscriptionAvailablePlansShown)
 
         let viewController = CancelSubscriptionPlansViewModel.make(in: navigationController)
         navigationController?.pushViewController(viewController, animated: true)

--- a/podcasts/Cancel Subscription/CancelSubscriptionViewModel.swift
+++ b/podcasts/Cancel Subscription/CancelSubscriptionViewModel.swift
@@ -9,11 +9,6 @@ class CancelSubscriptionViewModel: PlusPurchaseModel {
         purchaseHandler.isEligibleForOffer
     }
 
-    private var lastPurchasedProductID: IAPProductID?
-
-    @Published var currentPricingProduct: PlusPricingInfoModel.PlusProductPricingInfo?
-    @State var currentProductAvailability: CurrentProductAvailability = .idle
-
     init(purchaseHandler: IAPHelper = .shared, navigationController: UINavigationController?) {
         self.navigationController = navigationController
 
@@ -23,30 +18,14 @@ class CancelSubscriptionViewModel: PlusPurchaseModel {
     }
 
     override func didAppear() {
-        //TODO: Implement analytics
+        Analytics.track(.cancelSubscriptionShown)
     }
 
     override func didDismiss(type: OnboardingDismissType) {
         // Since the view can only be dismissed via swipe, only check for that
         guard type == .swipe else { return }
 
-        //TODO: Implement analytics
-    }
-
-    override func handleNext() {
-        if SubscriptionHelper.activeTier == .patron {
-            let controller = PatronWelcomeViewModel.make(in: navigationController)
-            navigationController?.pushViewController(controller, animated: true)
-        } else {
-            navigationController?.dismiss(animated: true)
-        }
-    }
-
-    enum CurrentProductAvailability {
-        case idle
-        case loading
-        case available
-        case unavailable
+        Analytics.track(.cancelSubscriptionDismissed)
     }
 }
 
@@ -63,32 +42,8 @@ extension CancelSubscriptionViewModel {
         }
     }
 
-    func loadCurrentProduct() async {
-        if currentProductAvailability == .loading { return }
-
-        currentProductAvailability = .loading
-        if let transaction = await purchaseHandler.findLastSubscriptionPurchased(),
-           let productID = IAPProductID(rawValue: transaction.productID) {
-            await MainActor.run {
-                lastPurchasedProductID = productID
-                currentProductAvailability = .available
-                currentPricingProduct = pricingInfo.products.first { $0.identifier == productID }
-            }
-        } else {
-            currentProductAvailability = .unavailable
-            FileLog.shared.console("[CancelSubscriptionViewModel] Could not find last subscription purchased")
-        }
-    }
-
-    func purchase(product: PlusPricingInfoModel.PlusProductPricingInfo) {
-        currentPricingProduct = product
-
-        if currentPricingProduct?.identifier != lastPurchasedProductID {
-            purchase(product: product.identifier)
-        }
-    }
-
     func claimOffer() {
+        Analytics.track(.cancelSubscriptionRowTap, properties: ["row": "claim_offer"])
         //TODO: Apply one month free
         //TODO: Purchase the offer and display the success view if succeeded
         showClaimOfferSuccess()
@@ -98,40 +53,43 @@ extension CancelSubscriptionViewModel {
 // Navigation
 extension CancelSubscriptionViewModel {
     func cancelSubscriptionTap() {
-        //TODO: Implement analytics
+        Analytics.track(.cancelSubscriptionContinueButtonTap)
+
         let viewController = CancelConfirmationViewModel.make(in: navigationController)
         navigationController?.pushViewController(viewController, animated: true)
     }
 
     func showPlans() {
-        //TODO: Implement analytics
-        let view = CancelSubscriptionPlansView(viewModel: self).setupDefaultEnvironment()
-        let controller = OnboardingHostingViewController(rootView: view)
-        controller.navBarIsHidden = true
-        navigationController?.pushViewController(controller, animated: true)
+        Analytics.track(.cancelSubscriptionRowTap, properties: ["row": "plans"])
+        Analytics.track(.cancelSubscriptionAvailablePlansShown)
+
+        let viewController = CancelSubscriptionPlansViewModel.make(in: navigationController)
+        navigationController?.pushViewController(viewController, animated: true)
     }
 
     func showHelp() {
-        //TODO: Implement analytics
+        Analytics.track(.cancelSubscriptionRowTap, properties: ["row": "help"])
+
         let controller = OnlineSupportController()
+        controller.didDismiss = { [weak self] in
+            self?.didDismiss(type: .swipe)
+        }
         navigationController?.navigationBar.isHidden = false
         navigationController?.pushViewController(controller, animated: true)
     }
 
     func showClaimOfferSuccess() {
+        Analytics.track(.cancelSubscriptionClaimOfferSuccessShown)
+
         let view = CancelSubscriptionOfferSuccessView(viewModel: self).setupDefaultEnvironment()
         let controller = OnboardingHostingViewController(rootView: view)
         controller.navBarIsHidden = true
         navigationController?.pushViewController(controller, animated: true)
     }
 
-    func closePlans() {
-        //TODO: Implement analytics
-        navigationController?.dismiss(animated: true)
-    }
-
     func closeOffer() {
-        //TODO: Implement analytics
+        didDismiss(type: .swipe)
+
         navigationController?.dismiss(animated: true)
     }
 }

--- a/podcasts/CancelConfirmationViewModel.swift
+++ b/podcasts/CancelConfirmationViewModel.swift
@@ -18,6 +18,11 @@ class CancelConfirmationViewModel: OnboardingModel {
 
     func goBackTapped() {
         Analytics.track(.cancelConfirmationStayButtonTapped)
+        if FeatureFlag.winback.enabled {
+            // To avoid repeating the event tracking,
+            // I forced passing the `swipe` type
+            didDismiss(type: .swipe)
+        }
         navigationController.dismiss(animated: true)
     }
 
@@ -36,6 +41,11 @@ class CancelConfirmationViewModel: OnboardingModel {
                     await ApiServerHandler.shared.retrieveSubscriptionStatus()
 
                     await MainActor.run {
+                        if FeatureFlag.winback.enabled {
+                            // To avoid repeating the event tracking,
+                            // I forced passing the `swipe` type
+                            didDismiss(type: .swipe)
+                        }
                         navigationController.dismiss(animated: true)
                     }
                 } catch {
@@ -59,6 +69,9 @@ class CancelConfirmationViewModel: OnboardingModel {
         guard type == .swipe else { return }
 
         Analytics.track(.cancelConfirmationViewDismissed)
+        if FeatureFlag.winback.enabled {
+            Analytics.track(.cancelSubscriptionDismissed)
+        }
     }
 }
 

--- a/podcasts/OnlineSupportController.swift
+++ b/podcasts/OnlineSupportController.swift
@@ -4,7 +4,7 @@ import PocketCastsServer
 import UIKit
 import WebKit
 
-class OnlineSupportController: PCViewController, WKNavigationDelegate {
+class OnlineSupportController: PCViewController, WKNavigationDelegate, UIAdaptivePresentationControllerDelegate {
     @IBOutlet var loadingIndicator: AngularActivityIndicator! {
         didSet {
             loadingIndicator.color = AppTheme.loadingActivityColor()
@@ -15,6 +15,8 @@ class OnlineSupportController: PCViewController, WKNavigationDelegate {
     private var supportWebView: WKWebView!
     private var databaseExport: DatabaseExport? = nil
     private var loadingAlert: ShiftyLoadingAlert?
+
+    var didDismiss: (() -> Void)? = nil
 
     var request: URLRequest
 
@@ -30,6 +32,9 @@ class OnlineSupportController: PCViewController, WKNavigationDelegate {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+
+        presentationController?.delegate = self
+        navigationController?.presentationController?.delegate = self
 
         title = L10n.settingsHelp
         loadingIndicator.startAnimating()
@@ -63,7 +68,7 @@ class OnlineSupportController: PCViewController, WKNavigationDelegate {
     }
 
     @objc private func doneTapped() {
-        dismiss(animated: true, completion: nil)
+        dismiss(animated: true, completion: didDismiss)
     }
 
     @objc private func showOptions(_ sender: UIBarButtonItem) {
@@ -129,6 +134,12 @@ class OnlineSupportController: PCViewController, WKNavigationDelegate {
 
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         .portrait // since this controller is presented modally it needs to tell iOS it only goes portrait
+    }
+
+    // MARK: - UIAdaptivePresentationControllerDelegate
+
+    func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+        didDismiss?()
     }
 }
 


### PR DESCRIPTION
| 📘 Part of: #2445
|:---:|

Fixes #2438

This PR adds the majority of the analytics events for the Winback.

## To test

• CI must be 🟢 
• Make sure you have the `winback` enabled and the event logger on
• Use a plus/patron user (if not assign a plan yourself within the app)

#### Cancel Subscription view
• Navigate to Profile -> Account -> Cancel Subscription
• You should see `🔵 Tracked: cancel_subscription_shown`
• Dismiss it and you should see `🔵 Tracked: cancel_subscription_dismissed`

#### Claim offer
• Navigate to Profile -> Account -> Cancel Subscription
• Tap on `Clam Offer`
• You should see `🔵 Tracked: cancel_subscription_row_tap ["row": "claim_offer"]`
• This part needs to be completed by adding the offer purchase so I will fix the remaining events in the next PR. For now you should see only `🔵 Tracked: cancel_subscription_claim_offer_success_shown` when the success screen appears.

#### Plans
• Navigate to Profile -> Account -> Cancel Subscription
• Tap on `Looking for a different plan?`
• You should see `🔵 Tracked: cancel_subscription_row_tap ["row": "plans"]`
• You should see `🔵 Tracked: cancel_subscription_available_plans_shown`
• Tap on a new plan: you should see `🔵 Tracked: cancel_subscription_select_plan ["product": "PRODUCT_ID"]`
• Purchase the new plan: you should see `🔵 Tracked: cancel_subscription_new_plan_purchase_successful ["product": "com.pocketcasts.plus.monthly"]`

#### Need help
• Navigate to Profile -> Account -> Cancel Subscription
• Tap on `Need help.....`
• You. should see `🔵 Tracked: cancel_subscription_row_tap ["row": "help"]`
• Also `🔵 Tracked: settings_help_shown`
• Dismiss it: you should see `🔵 Tracked: cancel_subscription_dismissed`

#### Cancel Subscription
• Navigate to Profile -> Account -> Cancel Subscription
• Tap on `Continue to cancellation`
• You should see `🔵 Tracked: cancel_subscription_continue_button_tap`
• Dismiss it: you should see `🔵 Tracked: cancel_subscription_dismissed`
• When pushing this view, all other vents were already implemented.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
