### PR TITLE
Add dismiss option to manage downloads banner

### DIFF
--- a/podcasts/DownloadsViewController.swift
+++ b/podcasts/DownloadsViewController.swift
@@ -157,6 +157,8 @@ class DownloadsViewController: PCViewController {
         }, onNotNowTap: { [weak self] in
             Analytics.track(.freeUpSpaceMaybeLaterTapped, properties: ["source": "downloads"])
             Settings.manageDownloadsLastCheckDate = Date.now
+            self?.showManageDownloadsBanner()
+            self?.downloadsTable.reloadData()
         })
         let banner = ManageDownloadsBannerView(dataModel: model).themedUIView
         banner.translatesAutoresizingMaskIntoConstraints = false

--- a/podcasts/DownloadsViewController.swift
+++ b/podcasts/DownloadsViewController.swift
@@ -150,10 +150,15 @@ class DownloadsViewController: PCViewController {
     }
 
     private lazy var bannerView: UIView = {
-        let banner = ManageDownloadsBannerView(dataModel: ManageDownloadsModel(initialSize: "", onManageTap: { [weak self] in
+        let model = ManageDownloadsModel(initialSize: "",
+                                         onManageTap: { [weak self] in
             Analytics.track(.freeUpSpaceManageDownloadsTapped, properties: ["source": "downloads"])
             self?.navigationController?.pushViewController(DownloadedFilesViewController(), animated: true)
-        })).themedUIView
+        }, onNotNowTap: { [weak self] in
+            Analytics.track(.freeUpSpaceMaybeLaterTapped, properties: ["source": "downloads"])
+            Settings.manageDownloadsLastCheckDate = Date.now
+        })
+        let banner = ManageDownloadsBannerView(dataModel: model).themedUIView
         banner.translatesAutoresizingMaskIntoConstraints = false
         let wrapperView = UIView(frame: CGRect(x: 116, y: 0, width: 200, height: 132))
         wrapperView.addSubview(banner)

--- a/podcasts/ManageDownloadsBannerView.swift
+++ b/podcasts/ManageDownloadsBannerView.swift
@@ -68,6 +68,16 @@ struct ManageDownloadsBannerView: View {
                 .inset(by: 0.25)
                 .stroke(theme.secondaryText02, lineWidth: 0.5)
         )
+        .overlay(alignment: .topTrailing) {
+            Button() {
+                dataModel.onNotNowTap?()
+            } label: {
+                Image("close")
+                    .renderingMode(.template)
+                    .foregroundColor(theme.secondaryText02)
+            }
+            .padding(8)
+        }
     }
 }
 

--- a/podcasts/ManageDownloadsCoordinator.swift
+++ b/podcasts/ManageDownloadsCoordinator.swift
@@ -12,16 +12,16 @@ class ManageDownloadsCoordinator {
         else {
             return false
         }
-        return percentage < 0.1
+        if let lastCheckDate = Settings.manageDownloadsLastCheckDate,
+           fabs(lastCheckDate.timeIntervalSince(Date.now)) < 14.days {
+           return false
+        }
+        return percentage < 1
     }
 
     static func showModalIfNeeded(from presentationVC: UIViewController, source: String) {
         guard Self.shouldShowBanner
         else {
-            return
-        }
-        if let lastCheckDate = Settings.manageDownloadsLastCheckDate,
-           fabs(lastCheckDate.timeIntervalSince(Date.now)) < 7.days {
             return
         }
         Analytics.track(.freeUpSpaceModalShown, properties: ["source": source])


### PR DESCRIPTION
| 📘 Part of:  |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
Add a dismiss option to manage downloads banner show in Downloads. 

| 1 | 2 | 3 | 4 |
| - | - | - | - |
| ![Simulator Screenshot - iPhone 16 Pro - 2025-01-03 at 20 04 50](https://github.com/user-attachments/assets/6c1215b3-5ec9-45b1-accc-ff35f345126b) |  ![Simulator Screenshot - iPhone 16 Pro - 2025-01-03 at 20 04 37](https://github.com/user-attachments/assets/21b63a72-2cd6-49ec-9942-523e39ce069d) | ![Simulator Screenshot - iPhone 16 Pro - 2025-01-03 at 20 04 21](https://github.com/user-attachments/assets/7bce9d15-af41-4570-9fd4-f459ebeca6d2) | ![Simulator Screenshot - iPhone 16 Pro - 2025-01-03 at 20 04 09](https://github.com/user-attachments/assets/5eeda1cf-3648-4c72-b6fd-e1f7320b4896) |

## To test

To make it easier to test change the time range on ManageDownloadsCoordinator to `5.seconds` and the `percentage` check to `< 1`

1. Start the app
2. Open Profile Tab
3. Tap on Downloads
4. Check if the banner shows up in the top
5. Tap on the close button 
6. Check if goes away
7. Exit the screen
8. Wait for 5 seconds
9. See if it shows up again.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
