### PR TITLE
App clip: Analytics logging updates

### DIFF
--- a/Pocket Casts App Clip/NowPlayingView.swift
+++ b/Pocket Casts App Clip/NowPlayingView.swift
@@ -68,6 +68,7 @@ struct NowPlayingView: View {
                 print("Loaded episode: \(episode.title)")
 
                 PlaybackManager.shared.load(episode: episode, autoPlay: true, overrideUpNext: false)
+                Analytics.track(.playbackPlay, source: AnalyticsSource.handleUserActivity, properties: ["url": incomingURL.absoluteString, "podcast": podcastUUID, "episode": episode.uuid])
             }
         }
     }

--- a/Pocket Casts App Clip/NowPlayingView.swift
+++ b/Pocket Casts App Clip/NowPlayingView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import PocketCastsDataModel
 import PocketCastsServer
 import StoreKit
+import PocketCastsUtils
 
 struct NowPlayingView: View {
     @State var presentAppStoreOverlay: Bool = false
@@ -44,28 +45,28 @@ struct NowPlayingView: View {
 
         PodcastManager.shared.importSharedItemFromUrl(importPath) { shareItem in
             guard let shareItem else {
-                print("Share Item")
+                FileLog.shared.addMessage("App Clip: Missing Share Item")
                 return
             }
 
             guard let episodeUUID = shareItem.episodeHeader?.uuid else {
-                print("No episode found in share item")
+                FileLog.shared.addMessage("App Clip: No episode found in share item")
                 return
             }
 
             guard let podcastUUID = shareItem.podcastHeader?.uuid else {
-                print("No podcast found in share item")
+                FileLog.shared.addMessage("App Clip: No podcast found in share item")
                 return
             }
 
 
             loadEpisode(episodeUuid: episodeUUID, podcastUuid: podcastUUID) {
                 guard let episode = DataManager.sharedManager.findEpisode(uuid: episodeUUID) else {
-                    print("Could not find Episode")
+                    FileLog.shared.addMessage("App Clip: Could not find Episode")
                     return
                 }
 
-                print("Loaded episode: \(episode.title)")
+                FileLog.shared.addMessage("App Clip: Loaded episode: \(episode.title ?? "unknown")")
 
                 PlaybackManager.shared.load(episode: episode, autoPlay: true, overrideUpNext: false)
                 Analytics.track(.playbackPlay, source: AnalyticsSource.handleUserActivity, properties: ["url": incomingURL.absoluteString, "podcast": podcastUUID, "episode": episode.uuid])

--- a/podcasts/Analytics/Helpers/AnalyticsCoordinator.swift
+++ b/podcasts/Analytics/Helpers/AnalyticsCoordinator.swift
@@ -48,6 +48,7 @@ enum AnalyticsSource: String, AnalyticsDescribable {
     case interactiveWidget = "interactive_widget"
     case multiSelect = "multi_select"
     case episodeSwipeAction = "episode_swipe_action"
+    case handleUserActivity = "handle_user_activity"
     case unknown
 
     var analyticsDescription: String { rawValue }


### PR DESCRIPTION
| 📘 Part of: #2575 |
|:---:|

Adds an explicit log for the `playback_play` event with a `handle_user_activity` source with some additional properties for `podcast`, `episode`, and `url` so we can track playback from the app clip.

This wasn't logged by default because the playback wasn't user initiated.

## To test

* Run the app clip target
* Look for `playback_play` events with `eventprops.device_info_app_name = "Pocket Casts App Clip"`

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
