### PR TITLE
[Winback] Remove close button

### DIFF
--- a/podcasts/Cancel Subscription/Cancel Subscription/Plans View/CancelSubscriptionPlansView.swift
+++ b/podcasts/Cancel Subscription/Cancel Subscription/Plans View/CancelSubscriptionPlansView.swift
@@ -15,7 +15,6 @@ struct CancelSubscriptionPlansView: View {
             case .loading:
                 showLoading()
             default:
-                closeButton
                 mainView
                 if viewModel.state == .purchasing {
                     showLoading(fullScreen: true)
@@ -28,27 +27,6 @@ struct CancelSubscriptionPlansView: View {
             }
         }
         .background(theme.primaryUi04)
-    }
-
-    var closeButton: some View {
-        VStack {
-            HStack {
-                Spacer()
-                Button(action: {
-                    viewModel.closePlans()
-                }) {
-                    Image(systemName: "xmark")
-                        .font(.system(size: 14).weight(.bold))
-                        .frame(width: 30, height: 30)
-                        .foregroundColor(theme.primaryIcon02Active)
-                        .background(theme.primaryUi05)
-                        .clipShape(Circle())
-                }
-            }
-            .padding(.trailing, 16.0)
-            .padding(.top, 16.0)
-            Spacer()
-        }
     }
 
     var mainView: some View {


### PR DESCRIPTION
| 📘 Part of: #2445 
|:---:|

Ref: C080ZKX4UCV-Slack-p1735932045645339

This PR removes the close button.

<img src="https://github.com/user-attachments/assets/e57d3d4a-5aeb-4ed6-8d47-992a82e291f5" width=350>


## To test

- CI must be 🟢 
- Enable `winback` FF
- Set your account as Plus/Patron
- Navigate to Account -> Cancel Subscription
- Tap to show the available plans
- Confirm you don't see the close button anymore

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
