### PR TITLE
Set correct color set for text for download banner

### DIFF
--- a/podcasts/ManageDownloadsBannerView.swift
+++ b/podcasts/ManageDownloadsBannerView.swift
@@ -49,7 +49,7 @@ struct ManageDownloadsBannerView: View {
                     .fixedSize(horizontal: false, vertical: true)
                     .multilineTextAlignment(.leading)
                     .font(.system(size: 14))
-                    .foregroundColor(theme.secondaryText02)
+                    .foregroundColor(theme.primaryText02)
                 Button() {
                     dataModel.onManageTap?()
                 } label: {
@@ -66,7 +66,7 @@ struct ManageDownloadsBannerView: View {
         .overlay(
             RoundedRectangle(cornerRadius: 8)
                 .inset(by: 0.25)
-                .stroke(theme.secondaryText02, lineWidth: 0.5)
+                .stroke(theme.primaryText02, lineWidth: 0.5)
         )
         .overlay(alignment: .topTrailing) {
             Button() {
@@ -74,7 +74,7 @@ struct ManageDownloadsBannerView: View {
             } label: {
                 Image("close")
                     .renderingMode(.template)
-                    .foregroundColor(theme.secondaryText02)
+                    .foregroundColor(theme.primaryIcon02)
             }
             .padding(8)
         }


### PR DESCRIPTION
| 📘 Part of: #2594 |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR is just to add a missing change on this PR.

| 1 | 2 | 3 | 4 |
| - | - | - | - |
| ![Simulator Screenshot - iPhone 16 Pro - 2025-01-03 at 20 04 50](https://github.com/user-attachments/assets/6c1215b3-5ec9-45b1-accc-ff35f345126b) |  ![Simulator Screenshot - iPhone 16 Pro - 2025-01-03 at 20 04 37](https://github.com/user-attachments/assets/21b63a72-2cd6-49ec-9942-523e39ce069d) | ![Simulator Screenshot - iPhone 16 Pro - 2025-01-03 at 20 04 21](https://github.com/user-attachments/assets/7bce9d15-af41-4570-9fd4-f459ebeca6d2) | ![Simulator Screenshot - iPhone 16 Pro - 2025-01-03 at 20 04 09](https://github.com/user-attachments/assets/5eeda1cf-3648-4c72-b6fd-e1f7320b4896) |

## To test

To make it easier to test change the time range on ManageDownloadsCoordinator to `5.seconds` and the `percentage` check to `< 1`

1. Start the app
2. Open Profile Tab
3. Activate the Classic Theme
4. Tap on Downloads
5. Check if the banner shows up in the top and all text is visible
6. Tap on the close button 
7. Check if goes away
8. Exit the screen
9. Wait for 5 seconds
10. See if it shows up again.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
