### PR TITLE
Ensure that podcast HTML description is active by default.

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -220,7 +220,7 @@ public enum FeatureFlag: String, CaseIterable {
         case .useSyncResponseEpisodeIDs:
             true
         case .usePodcastHTMLDescription:
-            false
+            true
         case .avoidLogoutInBackground:
             true
         case .disablePrivateFeedSharing:


### PR DESCRIPTION
| 📘 Part of: #2479  |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

Just to ensure that HTML description for podcast is active by default.

![Simulator Screenshot - iPhone 16 Pro - 2025-01-06 at 15 00 20](https://github.com/user-attachments/assets/246a1a57-2832-4f7b-883a-e93661afb062)


## To test

1. Start the app
2. Open a podcast that has a good HTML description. Ex: [Dirtbag Rich](https://pca.st/podcast/d3575bf0-7b53-013d-c887-0afffa6cd4b1)
3. Check that the HTML description is show. This is links are underline and formatting is correctly

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
