### PR TITLE
[Tooling] Fix `Fastfile` changes being accidentally reverted during a past conflict resolution

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -331,7 +331,7 @@ platform :ios do
     # We cannot use the `copy_branch_protection` action here yet, as it would create a branch protection rule with the same
     # restrictions we have in `trunk`, and the release managers wouldn't be able to push due to permissions.
     # This should be changed only when we have PCiOS releases done on CI, when the CI bot is the one running `git push`.
-    set_branch_protection(repository: GHHELPER_REPO, branch: release_branch_name)
+    set_branch_protection(repository: GITHUB_REPO, branch: release_branch_name)
 
     # Move still-open PRs to next milestone, then add frozen marker to milestone title
     update_milestone
@@ -425,9 +425,9 @@ platform :ios do
     UI.success "Done! New Build Code: #{build_code_current}"
 
     # Wrap up
-    remove_branch_protection(repository: GHHELPER_REPO, branch: release_branch_name)
-    set_milestone_frozen_marker(repository: GHHELPER_REPO, milestone: release_version_current, freeze: false)
-    close_milestone(repository: GHHELPER_REPO, milestone: release_version_current)
+    remove_branch_protection(repository: GITHUB_REPO, branch: release_branch_name)
+    set_milestone_frozen_marker(repository: GITHUB_REPO, milestone: release_version_current, freeze: false)
+    close_milestone(repository: GITHUB_REPO, milestone: release_version_current)
 
     # Start the build
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -435,6 +435,46 @@ platform :ios do
     create_backmerge_pr
   end
 
+  # This lane publishes a release on GitHub and creates a PR to backmerge the current release branch into the next release/ branch
+  #
+  # @param [Boolean] skip_confirm (default: false) If set, will skip the confirmation prompt before running the rest of the lane
+  #
+  lane :publish_release do |skip_confirm: false|
+    ensure_git_status_clean
+    ensure_git_branch(branch: '^release/')
+
+    version_number = release_version_current
+
+    current_branch = "release/#{version_number}"
+    next_release_branch = "release/#{release_version_next}"
+
+    UI.important <<~PROMPT
+      Publish the #{version_number} release. This will:
+      - Publish the existing draft `#{version_number}` release on GitHub
+      - Which will also have GitHub create the associated git tag, pointing to the tip of the branch
+      - If the release branch for the next version `#{next_release_branch}` already exists, backmerge `#{current_branch}` into it
+      - If needed, backmerge `#{current_branch}` back into `#{DEFAULT_BRANCH}`
+      - Delete the `#{current_branch}` branch
+    PROMPT
+    UI.user_error!("Terminating as requested. Don't forget to run the remainder of this automation manually.") unless skip_confirm || UI.confirm('Do you want to continue?')
+
+    UI.important "Publishing release #{version_number} on GitHub"
+
+    publish_github_release(
+      repository: GITHUB_REPO,
+      name: version_number
+    )
+
+    create_backmerge_pr
+
+    # At this point, an intermediate branch has been created by creating a backmerge PR to a hotfix or the next version release branch.
+    # This allows us to safely delete the `release/*` remote branch.
+    remove_branch_protection(repository: GITHUB_REPO, branch: current_branch)
+    Fastlane::Helper::GitHelper.delete_remote_branch_if_exists!(current_branch)
+    Fastlane::Helper::GitHelper.checkout_and_pull(DEFAULT_BRANCH)
+    Fastlane::Helper::GitHelper.delete_local_branch_if_exists!(current_branch)
+  end
+
   # Sets the stage to start working on a hotfix
   #
   # - Cuts a new `release/x.y.z` branch from the tag from the latest (`x.y`) version


### PR DESCRIPTION
Some changes in the `Fastfile` from https://github.com/Automattic/pocket-casts-ios/issues/2554 — especially the introduction of the `publish_release` lane and the renaming of a constant—were accidentally reverted during a git conflict resolution in [b97fd11ce1f9b4f5a11c93b8e804d3ee32482676](https://github.com/Automattic/pocket-casts-ios/commit/b97fd11ce1f9b4f5a11c93b8e804d3ee32482676#diff-dff4b99d4e651ab9d7597876ec8dbe92aa934e42c0fb55f4aadd6c106fc96688)

This PR restores the changes to fix the Fastlane crashes due to the incorrect constant name.

> [!NOTE]
> Targeting `release/7.80` so that the `publish_release` lane is restored in that branch, allowing us to potentially use/test it as part of version `7.80`'s "Release" tasks of the release scenario.