### PR TITLE
CarPlay: only cache the episode image if it exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 -----
 - Add setting for disabling the lock screen scrubber [#2536](https://github.com/Automattic/pocket-casts-ios/pull/2536)
 - Display podcast rich text descriptions [#2480](https://github.com/Automattic/pocket-casts-ios/pull/2480)
+- Fix an issue with episode images not appearing in CarPlay [#2610](https://github.com/Automattic/pocket-casts-ios/pull/2610)
 
 
 7.79

--- a/podcasts/CarPlayImageHelper.swift
+++ b/podcasts/CarPlayImageHelper.swift
@@ -52,9 +52,13 @@ class CarPlayImageHelper {
             image = ImageManager.sharedManager.cachedImageForUserEpisode(episode: userEpisode, size: .list)
         }
 
-        let adjustedImage = adjustImageIfRequired(image: image ?? UIImage(named: "noartwork-list-dark")!, maxSize: maxSize)
-        cacheImage(adjustedImage, for: cacheKey, maxSize: maxSize)
-        return adjustedImage
+        if let image {
+            let adjustedImage = adjustImageIfRequired(image: image, maxSize: maxSize)
+            cacheImage(adjustedImage, for: cacheKey, maxSize: maxSize)
+            return adjustedImage
+        }
+
+        return adjustImageIfRequired(image: UIImage(named: "noartwork-list-dark")!, maxSize: maxSize)
     }
 
     private class func adjustImageIfRequired(image: UIImage, maxSize: CGSize = CPListItem.maximumImageSize) -> UIImage {


### PR DESCRIPTION
A user contacted us about some episode images not appearing at all.

I was able to reproduce the issue with the podcasts they provided:

- https://pca.st/SeFq
- https://pca.st/eci3r72a
- https://pca.st/5o8rkr8q
- https://pca.st/hpu38ns1
- https://pca.st/R40E
- https://pca.st/cuma9pce
- https://pca.st/lbdkdt3w

This PR changes how we cache images so we don't cache the "default" image.

## To test

1. Add some of the podcasts to your account
2. Open the CarPlay simulator
3. Go to Filters > New Releases
4. Check that the images appear correctly

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
