### PR TITLE
Rename pride icon

### DIFF
--- a/podcasts/IconSelectorCell.swift
+++ b/podcasts/IconSelectorCell.swift
@@ -62,7 +62,7 @@ enum IconType: Int, CaseIterable, AnalyticsDescribable {
         case .patronDark:
             return L10n.appIconPatronDark
         case .pride2023:
-            return "Pride 2023"
+            return "Pride"
         }
     }
 


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

This change match the change done on Android here: https://github.com/Automattic/pocket-casts-android/pull/3407

![Simulator Screenshot - iPhone 16 Pro - 2025-01-07 at 14 50 11](https://github.com/user-attachments/assets/ff4c660b-6d2a-4e7c-bc2e-f42dc1b73e98)


## To test

- Start the app
- Tap on the Profile tab
- Tap on Settings
- Tap on Appearance
- Confirm that the Pride icon is now named Pride

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
