### PR TITLE
Streamline App Clip removal logic

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1434,6 +1434,10 @@ platform :ios do
     app_targets = native_targets.select { |t| t.product_type == 'com.apple.product-type.application' }
     app_clip_targets = native_targets.select { |t| t.product_type == 'com.apple.product-type.application.on-demand-install-capable' }
 
+    if app_clip_targets.empty?
+      UI.user_error!("No on-demand-install-capable targets found in #{project_path}. Has something changed in the project structure? Aborting App Clips removal.")
+    end
+
     app_targets.each do |app|
       # Delete any dependency of the app target that is an app_clip target
       app.dependencies.delete_if { |dep| app_clip_targets.include?(dep.target) }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1430,34 +1430,16 @@ platform :ios do
     project_path = '../podcasts.xcodeproj'
     project = Xcodeproj::Project.open(project_path)
 
-    app_target_name = 'podcasts'
-    app_target = project.targets.find { |t| t.name == app_target_name }
-    UI.user_error!("Could not find target named #{app_target_name} in #{project_path}") if app_target.nil?
+    native_targets = project.targets.select { |t| t.is_a?(Xcodeproj::Project::Object::PBXNativeTarget) }
+    app_targets = native_targets.select { |t| t.product_type == 'com.apple.product-type.application' }
+    app_clip_targets = native_targets.select { |t| t.product_type == 'com.apple.product-type.application.on-demand-install-capable' }
 
-    app_clip_target_name = 'Pocket Casts App Clip'
-    app_clip_target = project.targets.find { |t| t.name == app_clip_target_name }
-    UI.user_error!("Could not find clip_target named #{app_clip_target_name} in #{project_path}") if app_clip_target.nil?
-
-    app_clip_dependency_reference = app_target.dependencies.find { |d| d.target == app_clip_target }
-    UI.user_error!("Target #{app_target.name} does not have #{app_clip_target.name} as a dependency.") if app_clip_dependency_reference.nil?
-
-    UI.message("Removing #{app_clip_dependency_reference.target.name} as a dependency of #{app_target.name}...")
-    UI.verbose("Dependencies count before deletion #{app_target.dependencies.count}.")
-    app_target.dependencies.delete(app_clip_dependency_reference)
-    UI.verbose("Dependencies count after deletion #{app_target.dependencies.count}.")
-
-    embed_app_clips_phase_name = 'Embed App Clips'
-    embed_app_clips_phase = app_target.build_phases.find { |b| b.display_name == 'Embed App Clips' }
-    UI.user_error!("#{app_target.name} has no build phase with display name #{embed_app_clips_phase_name}") if embed_app_clips_phase.nil?
-
-    app_clip_path = 'Pocket Casts App Clip.app'
-    app_clip_file_reference = embed_app_clips_phase.files_references.find { |r| r.path == app_clip_path }
-    UI.user_error!("The #{embed_app_clips_phase.display_name} build phase in #{app_target.name} has no file reference with path #{app_clip_path}") if app_clip_file_reference.nil?
-
-    UI.message("Removing #{app_clip_file_reference.path} from #{embed_app_clips_phase.display_name}...")
-    UI.verbose("Paths to embed count before deletion #{embed_app_clips_phase.files_references.count}.")
-    embed_app_clips_phase.remove_file_reference(app_clip_file_reference)
-    UI.verbose("Paths to embed count after deletion #{embed_app_clips_phase.files_references.count}.")
+    app_targets.each do |app|
+      # Delete any dependency of the app target that is an app_clip target
+      app.dependencies.delete_if { |dep| app_clip_targets.include?(dep.target) }
+      # Delete the "Embed App Clips" build phase
+      app.build_phases.delete_if { |b| b.display_name == 'Embed App Clips' }
+    end
 
     UI.message('Saving the project file....')
     project.save

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -9,6 +9,7 @@ default_platform :ios
 
 # Paths that are re-used across multiple lanes
 PROJECT_ROOT_FOLDER = File.dirname(File.expand_path(__dir__))
+XCODE_PROJECT_PATH = File.join(PROJECT_ROOT_FOLDER, 'podcasts.xcodeproj')
 FASTLANE_FOLDER = File.join(PROJECT_ROOT_FOLDER, 'fastlane')
 APP_STORE_METADATA_FOLDER = File.join(FASTLANE_FOLDER, 'metadata')
 ARTIFACTS_FOLDER = File.join(PROJECT_ROOT_FOLDER, 'artifacts')
@@ -875,7 +876,7 @@ platform :ios do
   #
   lane :update_app_store_strings do
     source_metadata_folder = File.join(APP_STORE_METADATA_FOLDER, 'default')
-    version = get_version_number(xcodeproj: 'podcasts.xcodeproj', target: 'podcasts')
+    version = get_version_number(xcodeproj: XCODE_PROJECT_PATH, target: 'podcasts')
 
     files = {
       whats_new: File.join(source_metadata_folder, 'release_notes.txt'),
@@ -1427,7 +1428,7 @@ platform :ios do
   end
 
   def remove_app_clip_dependency!
-    project_path = '../podcasts.xcodeproj'
+    project_path = XCODE_PROJECT_PATH
     project = Xcodeproj::Project.open(project_path)
 
     native_targets = project.targets.select { |t| t.is_a?(Xcodeproj::Project::Object::PBXNativeTarget) }


### PR DESCRIPTION
Follows up on #2617 to address @AliSoftware 's suggestion to streamline the app clip removal code.

I used a dedicated PR instead of addressing in the original one because I wanted to add a failure message and was keen on feedback. This way, I merged the removal for other to benefit from, and can tackle this less crucial change without rush.

Notice CI built the Prototype Build alright, so we can trust the change works. 