### PR TITLE
Rename Lock Screen Scrubbing settings

### DIFF
--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -2896,7 +2896,7 @@ internal enum L10n {
   internal static var settingsGeneralLegacyBluetooth: String { return L10n.tr("Localizable", "settings_general_legacy_bluetooth") }
   /// If you have a Bluetooth Device or Car Stereo that seems to be pausing Pocket Casts while it's playing, or resetting the playback position to 0, try turning this setting on to fix it.
   internal static var settingsGeneralLegacyBluetoothSubtitle: String { return L10n.tr("Localizable", "settings_general_legacy_bluetooth_subtitle") }
-  /// Lock Screen Scrubbing
+  /// Enable Lock Screen Scrubbing
   internal static var settingsGeneralLockScreenDisabled: String { return L10n.tr("Localizable", "settings_general_lock_screen_disabled") }
   /// Multi-select Gesture
   internal static var settingsGeneralMultiSelectGesture: String { return L10n.tr("Localizable", "settings_general_multi_select_gesture") }

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -2516,7 +2516,7 @@
 "settings_general_smart_playback_subtitle" = "If on, Pocket Casts will go back a little in episodes you resume so you can catch up more comfortably.";
 
 /* Setting toggle to enable the feature that disables the lock screen scrubber. */
-"settings_general_lock_screen_disabled" = "Lock Screen Scrubbing";
+"settings_general_lock_screen_disabled" = "Enable Lock Screen Scrubbing";
 
 /* Setting option to choose how to handle swiping to add something to the queue. */
 "settings_general_up_next_swipe" = "Up Next Swipe";


### PR DESCRIPTION
Related to this thread `p2-short-link-pdeCcb-8kc#comment-6408`, we decided to rename the  settings to “Enable Lock Screen Scrubbing”.

<img src="https://github.com/user-attachments/assets/26727af6-0931-427c-aecf-e742bee9824a" width=350>


## To test

- CI must be 🟢 
- Run the app and navigate to Settings -> General
- Confirm the Settings matches `Enable Lock Screen Scrubbing`

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
