### PR TITLE
Podcast rich test: ensure html description main thread

### DIFF
--- a/podcasts/ExpandableLabel.swift
+++ b/podcasts/ExpandableLabel.swift
@@ -61,10 +61,13 @@ class ExpandableLabel: ThemeableLabel {
         guard let data = styledHTML.data(using: .utf8) else {
             return
         }
-        let result = try? NSAttributedString(data: data, options: [.documentType: NSAttributedString.DocumentType.html, .characterEncoding: NSUTF8StringEncoding], documentAttributes: nil)
-        attributedText = result
-        textColor = AppTheme.colorForStyle(style)
-        collapsed = linesRequired() > maxLines
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            let result = try? NSAttributedString(data: data, options: [.documentType: NSAttributedString.DocumentType.html, .characterEncoding: NSUTF8StringEncoding], documentAttributes: nil)
+            attributedText = result
+            textColor = AppTheme.colorForStyle(style)
+            collapsed = linesRequired() > maxLines
+        }
     }
 
     @objc private func labelTapped(gesture: UITapGestureRecognizer) {

--- a/podcasts/ExpandableLabel.swift
+++ b/podcasts/ExpandableLabel.swift
@@ -42,6 +42,10 @@ class ExpandableLabel: ThemeableLabel {
             }
             return
         }
+        // We detected that some scenarios when this code is run when the app is backgrounded, it crashes even on the main thread.
+        if UIApplication.shared.applicationState == .background {
+            return
+        }
         let styledHTML: String = """
         <html>
         <head>
@@ -61,13 +65,10 @@ class ExpandableLabel: ThemeableLabel {
         guard let data = styledHTML.data(using: .utf8) else {
             return
         }
-        DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
-            let result = try? NSAttributedString(data: data, options: [.documentType: NSAttributedString.DocumentType.html, .characterEncoding: NSUTF8StringEncoding], documentAttributes: nil)
-            attributedText = result
-            textColor = AppTheme.colorForStyle(style)
-            collapsed = linesRequired() > maxLines
-        }
+        let result = try? NSAttributedString(data: data, options: [.documentType: NSAttributedString.DocumentType.html, .characterEncoding: NSUTF8StringEncoding], documentAttributes: nil)
+        attributedText = result
+        textColor = AppTheme.colorForStyle(style)
+        collapsed = linesRequired() > maxLines
     }
 
     @objc private func labelTapped(gesture: UITapGestureRecognizer) {

--- a/podcasts/ExpandableLabel.swift
+++ b/podcasts/ExpandableLabel.swift
@@ -36,6 +36,12 @@ class ExpandableLabel: ThemeableLabel {
     }
 
     func setRichText(html: String) {
+        guard Thread.isMainThread else {
+            DispatchQueue.main.async { [weak self] in
+                self?.setRichText(html: html)
+            }
+            return
+        }
         let styledHTML: String = """
         <html>
         <head>


### PR DESCRIPTION
| 📘 Part of: #2480  |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
We've got [some crash reports indicating](https://a8c.sentry.io/issues/6200889637/?project=4503921846583296&query=release%3Aau.com.shiftyjelly.podcasts%407.80%2B7.80.0.0&referrer=release-issue-stream) that when setting the rich text using NSAttributedString is being done in the main thread and crashing the app.

This PR ensures that the method is always executed on the main thread.

## To test

1. Start the app
2. Search and Open the podcast: Dirt Bag Rich
3. Expand the description of the podcast
4. Background the app
5. Check that it does not crash.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
