### PR TITLE
Add remote keys as subtitle

### DIFF
--- a/podcasts/Beta/BetaMenu.swift
+++ b/podcasts/Beta/BetaMenu.swift
@@ -7,7 +7,24 @@ struct BetaMenu: View {
     var body: some View {
         List {
             ForEach(filteredFeatures, id: \.self) { feature in
-                Toggle(String(describing: feature), isOn: feature.isOn)
+                Toggle(isOn: feature.isOn) {
+                    VStack(alignment: .leading) {
+                        Text(String(describing: feature))
+                        Text(feature.remoteKey ?? "No Key")
+                            .font(.caption)
+                            .foregroundStyle(.gray)
+                    }
+                }
+                .onTapGesture { }
+                .onLongPressGesture(minimumDuration: 0.2) {
+                    if let key = feature.remoteKey {
+                        UIPasteboard.general.setValue(key,
+                                    forPasteboardType: UTType.plainText.identifier)
+                        Toast.show("Key \(key) copied!")
+                    } else {
+                        Toast.show("No key available")
+                    }
+                }
             }
         }
         .listStyle(.plain)


### PR DESCRIPTION
Small improvements of our FF panel.
It displays the remote keys for usage with Firebase and allows tooling press to copy it.

<img src="https://github.com/user-attachments/assets/11efdafd-6af0-4b4f-9f8c-21987f58659c" width=350>

## To test

- CI must be 🟢 
- Access the FF panel to look at it

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
