### PR TITLE
[App Clips] Add Associated Domains to App Clips

### DIFF
--- a/Pocket Casts App Clip/Pocket_Casts_App_Clip.entitlements
+++ b/Pocket Casts App Clip/Pocket_Casts_App_Clip.entitlements
@@ -2,6 +2,12 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>appclips:pca.st</string>
+		<string>appclips:pcast.pocketcasts.net</string>
+		<string>appclips:pocketcasts.com</string>
+	</array>
 	<key>com.apple.developer.parent-application-identifiers</key>
 	<array>
 		<string>$(AppIdentifierPrefix)au.com.shiftyjelly.podcasts</string>

--- a/podcasts/podcasts.entitlements
+++ b/podcasts/podcasts.entitlements
@@ -21,6 +21,7 @@
 		<string>applinks:pocket-casts-main-development.mystagingwebsite.com</string>
 		<string>appclips:pca.st</string>
 		<string>appclips:pcast.pocketcasts.net</string>
+		<string>appclips:pocketcasts.com</string>
 	</array>
 	<key>com.apple.developer.carplay-audio</key>
 	<true/>

--- a/podcasts/podcasts.prototype.entitlements
+++ b/podcasts/podcasts.prototype.entitlements
@@ -15,6 +15,7 @@
 		<string>applinks:pocket-casts-main-development.mystagingwebsite.com</string>
 		<string>appclips:pca.st</string>
 		<string>appclips:pcast.pocketcasts.net</string>
+		<string>appclips:pocketcasts.com</string>
 	</array>
 	<key>com.apple.developer.networking.wifi-info</key>
 	<true/>

--- a/podcasts/podcastsDebug.entitlements
+++ b/podcasts/podcastsDebug.entitlements
@@ -19,6 +19,7 @@
 		<string>applinks:pocket-casts-main-development.mystagingwebsite.com</string>
 		<string>appclips:pca.st</string>
 		<string>appclips:pcast.pocketcasts.net</string>
+		<string>appclips:pocketcasts.com</string>
 	</array>
 	<key>com.apple.developer.carplay-audio</key>
 	<true/>


### PR DESCRIPTION
| 📘 Part of: #2549 
|:---:|

Part of #2551 

[Based on Apple Documentation](https://developer.apple.com/documentation/appclip/associating-your-app-clip-with-your-website#Add-the-Associated-Domains-entitlement), we need to add and specify the Associated Domains to both the App and App Clips targets.

This PR adds:
• `appclips:pocketcasts.com` to the App entitlement
• `appclips:pca.st, appclips:pcast.pocketcasts.net,  appclips:pocketcasts.com` to the AppClips entitlement

## To test

- For now CI must be 🟢 
- Project should build and run

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
