### PR TITLE
Fix download button tint color when marking episode as played.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Add setting for disabling the lock screen scrubber [#2536](https://github.com/Automattic/pocket-casts-ios/pull/2536)
 - Display podcast rich text descriptions [#2480](https://github.com/Automattic/pocket-casts-ios/pull/2480)
 - Fix an issue with episode images not appearing in CarPlay [#2610](https://github.com/Automattic/pocket-casts-ios/pull/2610)
-
+- Fix update of download button color when mark as played [#2627](https://github.com/Automattic/pocket-casts-ios/pull/2627)
 
 7.79
 -----

--- a/podcasts/EpisodeDetailViewController.swift
+++ b/podcasts/EpisodeDetailViewController.swift
@@ -380,6 +380,7 @@ class EpisodeDetailViewController: FakeNavViewController, UIDocumentInteractionC
         updateButtonStates()
         updateProgress()
         updateMessageView()
+        updateColors()
     }
 
     @objc private func playbackProgressDidChange() {


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

Fix download button tint color when marking episode as played.

## To test

- Start the app
- Open a Podcast episode
- Tap on Download
- Wait for the download to complete
- Tap on Mark as played
- Check if Download button status and colors revert to regular color and says download again

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
