### PR TITLE
[Winback] Update copy and add Referral to plans list

### DIFF
--- a/podcasts/Cancel Subscription/Cancel Subscription/Plans View/CancelSubscriptionPlanRow.swift
+++ b/podcasts/Cancel Subscription/Cancel Subscription/Plans View/CancelSubscriptionPlanRow.swift
@@ -61,8 +61,10 @@ struct CancelSubscriptionPlanRow: View {
 extension PlusPricingInfoModel.PlusProductPricingInfo {
     fileprivate var planTitle: String {
         switch identifier {
-        case .yearly, .yearlyReferral:
+        case .yearly:
             return "Plus \(L10n.yearly.capitalized)"
+        case .yearlyReferral:
+            return "Plus \(L10n.yearly.capitalized) - Referral"
         case .monthly:
             return "Plus \(L10n.monthly.capitalized)"
         case .patronMonthly:

--- a/podcasts/Cancel Subscription/Cancel Subscription/Plans View/CancelSubscriptionPlansView.swift
+++ b/podcasts/Cancel Subscription/Cancel Subscription/Plans View/CancelSubscriptionPlansView.swift
@@ -30,23 +30,30 @@ struct CancelSubscriptionPlansView: View {
     }
 
     var mainView: some View {
-        VStack(spacing: 0) {
-            Image("cs-app-icon")
-                .frame(width: 80.0, height: 80.0)
-                .padding(.top, 88.0)
-                .padding(.bottom, 16.0)
-            Text(L10n.cancelSubscriptionAvailablePlansTitle)
-                .font(size: 28.0, style: .body, weight: .bold)
-                .foregroundStyle(theme.primaryText01)
-                .padding(.bottom, 28.0)
-            ForEach(viewModel.pricingInfo.products, id: \.id) { product in
-                CancelSubscriptionPlanRow(product: product,
-                                          selected: product.identifier == viewModel.currentPricingProduct?.identifier) { selectedProduct in
-                    viewModel.purchase(product: selectedProduct)
+        ScrollView {
+            VStack(spacing: 0) {
+                Image("cs-app-icon")
+                    .frame(width: 80.0, height: 80.0)
+                    .padding(.top, 88.0)
+                    .padding(.bottom, 16.0)
+                Text(L10n.cancelSubscriptionAvailablePlansTitle)
+                    .font(size: 28.0, style: .body, weight: .bold)
+                    .foregroundStyle(theme.primaryText01)
+                    .padding(.bottom, 28.0)
+                ForEach(viewModel.pricingInfo.products, id: \.id) { product in
+                    CancelSubscriptionPlanRow(product: product,
+                                              selected: product.identifier == viewModel.currentPricingProduct?.identifier) { selectedProduct in
+                        viewModel.purchase(product: selectedProduct)
+                    }
+                                              .padding(.bottom, 16.0)
                 }
-                                          .padding(.bottom, 16.0)
+                Text(L10n.cancelSubscriptionAvailablePlansFooter)
+                    .font(size: 14.0, style: .body, weight: .regular)
+                    .multilineTextAlignment(.center)
+                    .foregroundStyle(theme.primaryText02)
+                    .padding(.horizontal, 56.0)
+                Spacer()
             }
-            Spacer()
         }
     }
 

--- a/podcasts/Cancel Subscription/Cancel Subscription/Plans View/CancelSubscriptionPlansViewModel.swift
+++ b/podcasts/Cancel Subscription/Cancel Subscription/Plans View/CancelSubscriptionPlansViewModel.swift
@@ -8,6 +8,10 @@ class CancelSubscriptionPlansViewModel: CancelSubscriptionViewModel {
     @Published var currentPricingProduct: PlusPricingInfoModel.PlusProductPricingInfo?
     @State var currentProductAvailability: CurrentProductAvailability = .idle
 
+    override class var availableProductIds: [IAPProductID] {
+        return [.yearly, .monthly, .patronYearly, .patronMonthly, .yearlyReferral]
+    }
+
     override func handleNext() {
         if let currentPricingProduct {
             Analytics.track(.cancelSubscriptionNewPlanPurchaseSuccessful, properties: ["product": currentPricingProduct.identifier.rawValue])

--- a/podcasts/Onboarding/Models/PlusPricingInfoModel.swift
+++ b/podcasts/Onboarding/Models/PlusPricingInfoModel.swift
@@ -11,7 +11,7 @@ class PlusPricingInfoModel: ObservableObject {
 
     /// Determines whether prices are available
     @Published var priceAvailability: PriceAvailablity
-    
+
     class var availableProductIds: [IAPProductID] {
         return [.yearly, .monthly, .patronYearly, .patronMonthly]
     }

--- a/podcasts/Onboarding/Models/PlusPricingInfoModel.swift
+++ b/podcasts/Onboarding/Models/PlusPricingInfoModel.swift
@@ -11,6 +11,10 @@ class PlusPricingInfoModel: ObservableObject {
 
     /// Determines whether prices are available
     @Published var priceAvailability: PriceAvailablity
+    
+    class var availableProductIds: [IAPProductID] {
+        return [.yearly, .monthly, .patronYearly, .patronMonthly]
+    }
 
     init(purchaseHandler: IAPHelper = .shared) {
         self.purchaseHandler = purchaseHandler
@@ -19,11 +23,9 @@ class PlusPricingInfoModel: ObservableObject {
     }
 
     private static func getPricingInfo(from purchaseHandler: IAPHelper) -> PlusPricingInfo {
-        let products: [IAPProductID] = [.yearly, .monthly, .patronYearly, .patronMonthly]
-
         var pricing: [PlusProductPricingInfo] = []
 
-        for product in products {
+        for product in availableProductIds {
             let price = purchaseHandler.getPriceWithFrequency(for: product) ?? ""
             let rawPrice = purchaseHandler.getPrice(for: product)
             var offer: ProductOfferInfo?

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -386,6 +386,8 @@ internal enum L10n {
   internal static var cancelFailed: String { return L10n.tr("Localizable", "cancel_failed") }
   /// Cancel Subscription
   internal static var cancelSubscription: String { return L10n.tr("Localizable", "cancel_subscription") }
+  /// Your new plan will activate at the end of your current billing period.
+  internal static var cancelSubscriptionAvailablePlansFooter: String { return L10n.tr("Localizable", "cancel_subscription_available_plans_footer") }
   /// Available Plans
   internal static var cancelSubscriptionAvailablePlansTitle: String { return L10n.tr("Localizable", "cancel_subscription_available_plans_title") }
   /// Claim offer
@@ -406,7 +408,7 @@ internal enum L10n {
   internal static var cancelSubscriptionOfferSuccessViewDescription: String { return L10n.tr("Localizable", "cancel_subscription_offer_success_view_description") }
   /// Enjoy your free month!
   internal static var cancelSubscriptionOfferSuccessViewTitle: String { return L10n.tr("Localizable", "cancel_subscription_offer_success_view_title") }
-  /// Save %@ with your next month on us.
+  /// Save %@ at the start of your next billing cycle.
   internal static func cancelSubscriptionPromotionDescription(_ p1: Any) -> String {
     return L10n.tr("Localizable", "cancel_subscription_promotion_description", String(describing: p1))
   }

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4685,7 +4685,7 @@
 "cancel_subscription_promotion_title" = "Get your next month free";
 
 /* Cancel subscription: description for the promotion row */
-"cancel_subscription_promotion_description" = "Save %@ with your next month on us.";
+"cancel_subscription_promotion_description" = "Save %@ at the start of your next billing cycle.";
 
 /* Cancel subscription: title for the new plan row */
 "cancel_subscription_new_plan_title" = "Looking for a different plan?";
@@ -4704,6 +4704,9 @@
 
 /* Title of the Available Plans screen accessible from the Cancel Subscription view */
 "cancel_subscription_available_plans_title" = "Available Plans";
+
+/* Footer of the Available Plans screen accessible from the Cancel Subscription view */
+"cancel_subscription_available_plans_footer" = "Your new plan will activate at the end of your current billing period.";
 
 /* Title of the success screen when the cancel subscription offer is applied */
 "cancel_subscription_offer_success_view_title" = "Enjoy your free month!";


### PR DESCRIPTION
| 📘 Part of: #2445
|:---:|

Fixes #2623 

With this PR:
• Change the copy of the Offer subtitle in the main view
• Add the footer to the Plans
• Support the Referral Yearly as plan in the plans list

| Main | Plans List |
| -------- | ------- |
| ![IMG_0017](https://github.com/user-attachments/assets/bbecf6c9-af6d-49f2-9475-fdc07dc7014c) | ![IMG_0015](https://github.com/user-attachments/assets/75ab3364-e61f-460e-824d-8419fff15202) |

## To test

- CI must be 🟢 
- `winback` should be enabled
- Use a Plus account
- Go to account, Cancel subscription
- Check the Offer Subtitle: `Save YOUR_PRICE at the start of your next billing cycle.`
- Open Plans
- You should see a footer at the bottom
- The new Plan should be visible as well

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
