### PR TITLE
[Tooling] Fix hiccups in hotfix process

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -547,8 +547,8 @@ platform :ios do
     create_backmerge_pr
     begin
       close_milestone(repository: GITHUB_REPO, milestone: release_version_current)
-    rescue
-      UI.important("Could not find a GitHub milestone for hotfix #{release_version_current} to close.")
+    rescue StandardError => e
+      UI.important("Could not find a GitHub milestone for hotfix #{release_version_current} to close: #{e}")
     end
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -323,7 +323,7 @@ platform :ios do
 
     generate_strings_file_for_glotpress
 
-    push_to_git_remote(tags: false)
+    push_to_git_remote(set_upstream: true, tags: false)
 
     trigger_beta_build(branch_to_build: release_branch_name)
     create_backmerge_pr
@@ -527,6 +527,7 @@ platform :ios do
     UI.success "Done! New Release Version: #{release_version_current}. New Build Code: #{build_code_current}"
 
     commit_version_bump
+    push_to_git_remote(set_upstream: true, tags: false)
   end
 
   # Finalizes a hotfix, by triggering a release build on CI

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -545,6 +545,11 @@ platform :ios do
     trigger_release_build(branch_to_build: "release/#{release_version_current}")
 
     create_backmerge_pr
+    begin
+      close_milestone(repository: GITHUB_REPO, milestone: release_version_current)
+    rescue
+      UI.important("Could not find a GitHub milestone for hotfix #{release_version_current} to close.")
+    end
   end
 
   # Triggers a beta build on CI


### PR DESCRIPTION
_Note: [Android companion PR here](https://github.com/Automattic/pocket-casts-android/pull/3440)_

[Internal Ref] Slack Thread about the hotfix process feedback: p1736446222239659/1736258590.769169-slack-C029BMLUGRX 

## Description

Addressing some feedback reported by devs / release managers on the process during the last time they did a hotfix

- Ensure the hotfix branch is pushed to upstream after it has been created
- Ensure we close the GitHub hotfix milestone at the end of the hotfix

## To test

This won't really be testable until next time we do a hotfix, unfortunately, as testing those lanes would otherwise create side effects.
