### PR TITLE
Fix endless episode details scrolling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Display podcast rich text descriptions [#2480](https://github.com/Automattic/pocket-casts-ios/pull/2480)
 - Fix an issue with episode images not appearing in CarPlay [#2610](https://github.com/Automattic/pocket-casts-ios/pull/2610)
 - Fix update of download button color when mark as played [#2627](https://github.com/Automattic/pocket-casts-ios/pull/2627)
+- Fix endless episode details scrolling [#2634](https://github.com/Automattic/pocket-casts-ios/pull/2634)
 
 7.79
 -----

--- a/podcasts/PlayerContainerViewController.swift
+++ b/podcasts/PlayerContainerViewController.swift
@@ -124,6 +124,7 @@ class PlayerContainerViewController: SimpleNotificationsViewController, PlayerTa
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
+        showNotesItem.updateScrollSize()
     }
 
     override func viewDidDisappear(_ animated: Bool) {

--- a/podcasts/ShowNotesPlayerItemViewController.swift
+++ b/podcasts/ShowNotesPlayerItemViewController.swift
@@ -220,13 +220,17 @@ class ShowNotesPlayerItemViewController: PlayerItemViewController, SFSafariViewC
                   result == "complete" // ensure that the load of HTML is complete and not in another loading state
             else {
                 return
-            }
-            self.showNotesWebView.evaluateJavaScript("document.body.offsetHeight", completionHandler: { [weak self] height, _ in
-                guard let strongSelf = self, let cgHeight = height as? CGFloat else { return }
+            }            
+            updateScrollSize()
+        })
+    }
 
-                strongSelf.showNotesViewHeight.constant = CGFloat(cgHeight) + Constants.Values.extraShowNotesVerticalSpacing
-                strongSelf.view.layoutIfNeeded()
-            })
+    func updateScrollSize() {
+        showNotesWebView.evaluateJavaScript("document.body.scrollHeight", completionHandler: { [weak self] height, _ in
+            guard let strongSelf = self, let cgHeight = height as? CGFloat else { return }
+
+            strongSelf.showNotesViewHeight.constant = CGFloat(cgHeight) + Constants.Values.extraShowNotesVerticalSpacing
+            strongSelf.view.layoutIfNeeded()
         })
     }
 

--- a/podcasts/ShowNotesPlayerItemViewController.swift
+++ b/podcasts/ShowNotesPlayerItemViewController.swift
@@ -220,7 +220,7 @@ class ShowNotesPlayerItemViewController: PlayerItemViewController, SFSafariViewC
                   result == "complete" // ensure that the load of HTML is complete and not in another loading state
             else {
                 return
-            }            
+            }
             updateScrollSize()
         })
     }

--- a/podcasts/ShowNotesPlayerItemViewController.swift
+++ b/podcasts/ShowNotesPlayerItemViewController.swift
@@ -221,7 +221,9 @@ class ShowNotesPlayerItemViewController: PlayerItemViewController, SFSafariViewC
                 return
             }
             // Ensures that the web view as a frame in order to proper calculate the height of the web content
-            showNotesWebView.frame = view.frame
+            var frame = view.frame
+            frame.size.height = 1
+            showNotesWebView.frame = frame
             self.showNotesWebView.evaluateJavaScript("document.body.offsetHeight", completionHandler: { [weak self] height, _ in
                 guard let strongSelf = self, let cgHeight = height as? CGFloat else { return }
 

--- a/podcasts/ShowNotesPlayerItemViewController.swift
+++ b/podcasts/ShowNotesPlayerItemViewController.swift
@@ -214,9 +214,15 @@ class ShowNotesPlayerItemViewController: PlayerItemViewController, SFSafariViewC
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         showNotesWebView.evaluateJavaScript("document.readyState", completionHandler: { [weak self] complete, _ in
-            guard let _ = complete else { return }
-
-            self?.showNotesWebView.evaluateJavaScript("document.body.offsetHeight", completionHandler: { [weak self] height, _ in
+            guard let self = self,
+                  let result = complete as? String,
+                  result == "complete" // ensure that the load of HTML is complete and not in another loading state
+            else {
+                return
+            }
+            // Ensures that the web view as a frame in order to proper calculate the height of the web content
+            showNotesWebView.frame = view.frame
+            self.showNotesWebView.evaluateJavaScript("document.body.offsetHeight", completionHandler: { [weak self] height, _ in
                 guard let strongSelf = self, let cgHeight = height as? CGFloat else { return }
 
                 strongSelf.showNotesViewHeight.constant = CGFloat(cgHeight) + Constants.Values.extraShowNotesVerticalSpacing

--- a/podcasts/ShowNotesPlayerItemViewController.swift
+++ b/podcasts/ShowNotesPlayerItemViewController.swift
@@ -47,7 +47,7 @@ class ShowNotesPlayerItemViewController: PlayerItemViewController, SFSafariViewC
     }
 
     private func setupWebView() {
-        showNotesWebView = WKWebView()
+        showNotesWebView = WKWebView(frame: showNotesHolderView.bounds)
 
         showNotesWebView.translatesAutoresizingMaskIntoConstraints = false
         showNotesHolderView.addSubview(showNotesWebView)
@@ -57,6 +57,7 @@ class ShowNotesPlayerItemViewController: PlayerItemViewController, SFSafariViewC
         showNotesWebView.allowsLinkPreview = true
         showNotesWebView.navigationDelegate = self
         showNotesWebView.scrollView.isDirectionalLockEnabled = true
+        showNotesWebView.scrollView.isScrollEnabled = false
         showNotesWebView.allowsBackForwardNavigationGestures = true
 
         showNotesWebView.isOpaque = false
@@ -220,20 +221,11 @@ class ShowNotesPlayerItemViewController: PlayerItemViewController, SFSafariViewC
             else {
                 return
             }
-            // Ensures that the web view as a frame in order to proper calculate the height of the web content
-            var frame = view.frame
-            frame.size.height = 1
-            showNotesWebView.frame = frame
             self.showNotesWebView.evaluateJavaScript("document.body.offsetHeight", completionHandler: { [weak self] height, _ in
                 guard let strongSelf = self, let cgHeight = height as? CGFloat else { return }
 
                 strongSelf.showNotesViewHeight.constant = CGFloat(cgHeight) + Constants.Values.extraShowNotesVerticalSpacing
                 strongSelf.view.layoutIfNeeded()
-
-                if strongSelf.showNotesViewHeight.constant + strongSelf.showNotesHolderView.frame.origin.y < strongSelf.view.frame.height {
-                    // if the show notes aren't long enough, we need to add the pull down gesture
-                    strongSelf.showNotesWebView.scrollView.isScrollEnabled = false
-                }
             })
         })
     }


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes #1997 
Fixes #2626 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
Ensures that web view as correct size and HTML is fully loaded before calculating scroll size.

## To test

1. Start the app
2. Play an episode with long episode details
3. Open the full screen player by dragging up slowly the mini-player
4. Tap on the details tab
5. Scroll down and see if you don't see a large empty space on the details text at the bottom
6. Scroll up again and check if you can dismiss the player by scrolling all way up and continue

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
