### PR TITLE
Track audit - Add missing plus promotion flow events

### DIFF
--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -35,6 +35,7 @@ enum AnalyticsEvent: String {
     case plusPromotionDismissed
     case plusPromotionUpgradeButtonTapped
     case plusPromotionNotNowButtonTapped
+    case plusPromotionSubscriptionTierChanged
 
     // MARK: - Setup Account
 

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -36,6 +36,7 @@ enum AnalyticsEvent: String {
     case plusPromotionUpgradeButtonTapped
     case plusPromotionNotNowButtonTapped
     case plusPromotionSubscriptionTierChanged
+    case plusPromotionSubscriptionFrequencyChanged
 
     // MARK: - Setup Account
 

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -34,6 +34,7 @@ enum AnalyticsEvent: String {
     case plusPromotionShown
     case plusPromotionDismissed
     case plusPromotionUpgradeButtonTapped
+    case plusPromotionNotNowButtonTapped
 
     // MARK: - Setup Account
 

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -37,6 +37,8 @@ enum AnalyticsEvent: String {
     case plusPromotionNotNowButtonTapped
     case plusPromotionSubscriptionTierChanged
     case plusPromotionSubscriptionFrequencyChanged
+    case plusPromotionPrivacyPolicyTapped
+    case plusPromotionTermsAndConditionsTapped
 
     // MARK: - Setup Account
 

--- a/podcasts/IAPTypes.swift
+++ b/podcasts/IAPTypes.swift
@@ -43,7 +43,7 @@ enum Plan {
     }
 }
 
-enum PlanFrequency {
+enum PlanFrequency: String {
     case yearly, monthly
 
     var description: String {

--- a/podcasts/Onboarding/Plus/Account Prompt/UpgradePrompt.swift
+++ b/podcasts/Onboarding/Plus/Account Prompt/UpgradePrompt.swift
@@ -42,7 +42,7 @@ struct UpgradePrompt: View {
             VStack(spacing: 0) {
                 UpgradeRoundedSegmentedControl(selected: $currentSubscriptionPeriod)
                     .padding([.top, .bottom], 16)
-                FeaturesCarousel(currentIndex: $currentPage.animation(), currentSubscriptionPeriod: $currentSubscriptionPeriod, viewModel: self.viewModel, tiers: tiers, showInlinePurchaseButton: true).environmentObject(self.viewModel)
+                FeaturesCarousel(currentIndex: $currentPage.animation(), currentSubscriptionPeriod: $currentSubscriptionPeriod, viewModel: self.viewModel, tiers: tiers, showInlinePurchaseButton: true)
                     .padding([.bottom], 16)
                 if !tiers.isEmpty {
                     PageIndicatorView(numberOfItems: tiers.count, currentPage: currentPage)

--- a/podcasts/Onboarding/Plus/FeaturesCarousel.swift
+++ b/podcasts/Onboarding/Plus/FeaturesCarousel.swift
@@ -20,6 +20,7 @@ struct FeaturesCarousel: View {
 
         HorizontalCarousel(currentIndex: currentIndex, items: tiers) {
             UpgradeCard(tier: $0, currentPrice: currentSubscriptionPeriod, subscriptionInfo: viewModel.pricingInfo(for: $0, frequency: currentSubscriptionPeriod.wrappedValue), showPurchaseButton: showInlinePurchaseButton)
+                .environmentObject(viewModel)
                 .overlay(
                     // Calculate the height of the card after it's been laid out
                     GeometryReader { proxy in

--- a/podcasts/Onboarding/Plus/PlusLandingViewModel.swift
+++ b/podcasts/Onboarding/Plus/PlusLandingViewModel.swift
@@ -78,6 +78,10 @@ class PlusLandingViewModel: PlusPurchaseModel {
         OnboardingFlow.shared.track(.plusPromotionSubscriptionTierChanged, properties: ["value": tier.title.lowercased()])
     }
 
+    func changedSubscriptionPeriod(_ value: PlanFrequency) {
+        OnboardingFlow.shared.track(.plusPromotionSubscriptionFrequencyChanged, properties: ["value": value.rawValue])
+    }
+
     func pricingInfo(for tier: UpgradeTier, frequency: PlanFrequency) -> PlusProductPricingInfo? {
         guard let pricingInfo = product(for: tier.plan, frequency: frequency) else {
             return nil

--- a/podcasts/Onboarding/Plus/PlusLandingViewModel.swift
+++ b/podcasts/Onboarding/Plus/PlusLandingViewModel.swift
@@ -82,6 +82,15 @@ class PlusLandingViewModel: PlusPurchaseModel {
         OnboardingFlow.shared.track(.plusPromotionSubscriptionFrequencyChanged, properties: ["value": value.rawValue])
     }
 
+    func termsOfUseTapped() {
+        OnboardingFlow.shared.track(.plusPromotionTermsAndConditionsTapped)
+    }
+
+    func privacyPolicyTapped() {
+        OnboardingFlow.shared.track(.plusPromotionPrivacyPolicyTapped)
+    }
+
+
     func pricingInfo(for tier: UpgradeTier, frequency: PlanFrequency) -> PlusProductPricingInfo? {
         guard let pricingInfo = product(for: tier.plan, frequency: frequency) else {
             return nil

--- a/podcasts/Onboarding/Plus/PlusLandingViewModel.swift
+++ b/podcasts/Onboarding/Plus/PlusLandingViewModel.swift
@@ -73,6 +73,11 @@ class PlusLandingViewModel: PlusPurchaseModel {
         navigationController?.pushViewController(controller, animated: true)
     }
 
+    func changedSubscriptionTier(_ index: Int) {
+        let tier = displayedProducts[index]
+        OnboardingFlow.shared.track(.plusPromotionSubscriptionTierChanged, properties: ["value": tier.title.lowercased()])
+    }
+
     func pricingInfo(for tier: UpgradeTier, frequency: PlanFrequency) -> PlusProductPricingInfo? {
         guard let pricingInfo = product(for: tier.plan, frequency: frequency) else {
             return nil

--- a/podcasts/Onboarding/Plus/PlusLandingViewModel.swift
+++ b/podcasts/Onboarding/Plus/PlusLandingViewModel.swift
@@ -58,7 +58,10 @@ class PlusLandingViewModel: PlusPurchaseModel {
         navigationController?.pushViewController(controller, animated: true)
     }
 
-    func dismissTapped() {
+    func dismissTapped(buttonTapped: Bool = false) {
+        if buttonTapped {
+            OnboardingFlow.shared.track(.plusPromotionNotNowButtonTapped)
+        }
         OnboardingFlow.shared.track(.plusPromotionDismissed)
 
         guard source == .accountCreated else {

--- a/podcasts/Onboarding/Plus/UpgradeCard.swift
+++ b/podcasts/Onboarding/Plus/UpgradeCard.swift
@@ -103,6 +103,8 @@ struct UpgradeCard: View {
 
     @EnvironmentObject var theme: Theme
 
+    @Environment(\.openURL) private var openURL
+
     let tier: UpgradeTier
 
     let currentPrice: Binding<PlanFrequency>
@@ -173,6 +175,17 @@ struct UpgradeCard: View {
             Text(.init("[\(purchaseTerms[safe: 3] ?? "")](\(termsOfUse))")).underline()
         }
         .foregroundColor(theme.primaryText01)
+        .environment(\.openURL, OpenURLAction { url in
+            switch url.absoluteString {
+            case privacyPolicy:
+                viewModel.privacyPolicyTapped()
+            case termsOfUse:
+                viewModel.termsOfUseTapped()
+            default:
+                break
+            }
+            return .systemAction
+        })
     }
 
     @ViewBuilder

--- a/podcasts/Onboarding/Plus/UpgradeLandingView.swift
+++ b/podcasts/Onboarding/Plus/UpgradeLandingView.swift
@@ -104,6 +104,9 @@ struct UpgradeLandingView: View {
                         .onChange(of: currentPage) { value in
                             viewModel.changedSubscriptionTier(value)
                         }
+                        .onChange(of: currentSubscriptionPeriod) { value in
+                            viewModel.changedSubscriptionPeriod(value)
+                        }
                     }
                 }
 

--- a/podcasts/Onboarding/Plus/UpgradeLandingView.swift
+++ b/podcasts/Onboarding/Plus/UpgradeLandingView.swift
@@ -101,6 +101,9 @@ struct UpgradeLandingView: View {
                                 contentIsScrollable = true
                             }
                         }
+                        .onChange(of: currentPage) { value in
+                            viewModel.changedSubscriptionTier(value)
+                        }
                     }
                 }
 

--- a/podcasts/Onboarding/Plus/UpgradeLandingView.swift
+++ b/podcasts/Onboarding/Plus/UpgradeLandingView.swift
@@ -140,7 +140,7 @@ struct UpgradeLandingView: View {
         HStack(spacing: 0) {
             Spacer()
             Button(viewModel.source == .upsell ? L10n.eoyNotNow : L10n.plusSkip) {
-                viewModel.dismissTapped()
+                viewModel.dismissTapped(buttonTapped: true)
             }
             .foregroundColor(.white)
             .font(style: .body, weight: .medium)


### PR DESCRIPTION
| 📘 Part of: #2628  |  <!-- project issue number, if applicable -->
|:---:|

Fixes #2629 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR adds the tracking of the following events on the Plus upsell screen:

- plusPromotionNotNowButtonTapped
- plusPromotionSubscriptionTierChanged
- plusPromotionSubscriptionFrequencyChanged
- plusPromotionPrivacyPolicyTapped
- plusPromotionTermsAndConditionsTapped


## To test

1. Start the app and login with an user without an active subscription
2. Enable tracksLogging FF
3. Go to Podcasts
4. Tap on the folder icon on the top left
5. Check if the Plus UpSell  screen shows
6. Check the following events are tracked on the console
7. `plusPromotionNotNowButtonTapped` when tapping the Not Now button
8. `plusPromotionSubscriptionTierChanged` when switching between Plus and Patron
9.  `plusPromotionSubscriptionFrequencyChanged` when changing between Monthly and Yearly on both type of plans
10. `plusPromotionPrivacyPolicyTapped` when tapping on the Privacy Policy link
11. `plusPromotionTermsAndConditionsTapped` when tapping on the Terms of Use link

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
