### PR TITLE
Track audit - Add missing user files events

### DIFF
--- a/podcasts/AddCustomViewController.swift
+++ b/podcasts/AddCustomViewController.swift
@@ -332,6 +332,7 @@ class AddCustomViewController: PCViewController, UITextFieldDelegate {
     }
 
     @objc func saveTapped() {
+        Analytics.track(.userFileEditSave)
         nameTextfield.resignFirstResponder()
         nameTextfield.isHidden = true
         imageSaveErrorLabel.isHidden = true

--- a/podcasts/AddCustomViewController.swift
+++ b/podcasts/AddCustomViewController.swift
@@ -183,6 +183,7 @@ class AddCustomViewController: PCViewController, UITextFieldDelegate {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        Analytics.track(.userFileEditShown)
         if let mainView = view as? ThemeableView {
             mainView.style = .primaryUi04
         }
@@ -318,6 +319,7 @@ class AddCustomViewController: PCViewController, UITextFieldDelegate {
     // MARK: Actions
 
     @IBAction func cancelTapped() {
+        Analytics.track(.userFileEditDismissed)
         navigationController?.navigationBar.isHidden = false
         if episodeToEdit == nil {
             if let destinationUrl = destinationUrl {

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -121,8 +121,7 @@ enum AnalyticsEvent: String {
     case profileAccountButtonTapped
     case profileRefreshButtonTapped
     case profileBookmarksShow
-    case profileRefreshUpgradeBannerDismissed
-    
+
     case accountDetailsCancelTapped
     case accountDetailsShowTOS
     case accountDetailsShowPrivacyPolicy

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -220,6 +220,7 @@ enum AnalyticsEvent: String {
     case userFileDetailOptionTapped
     case userFileEditShown
     case userFileEditDismissed
+    case userFileEditSave
     case userFileDeleteShown
     case userFileDeleteDismissed
 

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -218,6 +218,10 @@ enum AnalyticsEvent: String {
     case userFileDetailShown
     case userFileDetailDismissed
     case userFileDetailOptionTapped
+    case userFileEditShown
+    case userFileEditDismissed
+    case userFileDeleteShown
+    case userFileDeleteDismissed
 
     case userFilePlayPauseButtonTapped
 

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -121,7 +121,8 @@ enum AnalyticsEvent: String {
     case profileAccountButtonTapped
     case profileRefreshButtonTapped
     case profileBookmarksShow
-
+    case profileRefreshUpgradeBannerDismissed
+    
     case accountDetailsCancelTapped
     case accountDetailsShowTOS
     case accountDetailsShowPrivacyPolicy

--- a/podcasts/ProfileViewController.swift
+++ b/podcasts/ProfileViewController.swift
@@ -592,6 +592,7 @@ extension ProfileViewController: PlusLockedInfoDelegate {
         Settings.setPlusInfoDismissedOnProfile(true)
         plusInfoView.isHidden = true
         updateFooterFrame()
+        Analytics.track(.profileRefreshUpgradeBannerDismissed)
     }
 
     var displayingViewController: UIViewController {

--- a/podcasts/ProfileViewController.swift
+++ b/podcasts/ProfileViewController.swift
@@ -592,7 +592,6 @@ extension ProfileViewController: PlusLockedInfoDelegate {
         Settings.setPlusInfoDismissedOnProfile(true)
         plusInfoView.isHidden = true
         updateFooterFrame()
-        Analytics.track(.profileRefreshUpgradeBannerDismissed)
     }
 
     var displayingViewController: UIViewController {

--- a/podcasts/UploadedViewController.swift
+++ b/podcasts/UploadedViewController.swift
@@ -318,7 +318,9 @@ class UploadedViewController: PCViewController, UserEpisodeDetailProtocol {
     }
 
     func showDeleteConfirmation(userEpisode: UserEpisode) {
-        UserEpisodeManager.presentDeleteOptions(episode: userEpisode, preferredStatusBarStyle: preferredStatusBarStyle, themeOverride: nil) { deletedLocal, deletedRemote in
+        UserEpisodeManager.presentDeleteOptions(episode: userEpisode, preferredStatusBarStyle: preferredStatusBarStyle, themeOverride: nil, dismissCallback: {
+            Analytics.track(.userFileDeleteDismissed)
+        }) { deletedLocal, deletedRemote in
             Analytics.track(.userFileDeleted, properties: ["local": deletedLocal, "remote": deletedRemote])
 
             if deletedRemote {

--- a/podcasts/UploadedViewController.swift
+++ b/podcasts/UploadedViewController.swift
@@ -318,6 +318,7 @@ class UploadedViewController: PCViewController, UserEpisodeDetailProtocol {
     }
 
     func showDeleteConfirmation(userEpisode: UserEpisode) {
+        Analytics.track(.userFileDeleteShown)
         UserEpisodeManager.presentDeleteOptions(episode: userEpisode, preferredStatusBarStyle: preferredStatusBarStyle, themeOverride: nil, dismissCallback: {
             Analytics.track(.userFileDeleteDismissed)
         }) { deletedLocal, deletedRemote in

--- a/podcasts/UploadedViewController.xib
+++ b/podcasts/UploadedViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22684"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -78,7 +78,6 @@ Share them with Pocket Casts,  and they’ll appear here</string>
                                     </state>
                                     <connections>
                                         <action selector="addFilesTapped:" destination="-1" eventType="touchUpInside" id="4mv-9L-KWH"/>
-                                        <action selector="howToTapped:" destination="-1" eventType="touchUpInside" id="bMR-nJ-NrV"/>
                                     </connections>
                                 </button>
                             </subviews>

--- a/podcasts/UserEpisodeManager.swift
+++ b/podcasts/UserEpisodeManager.swift
@@ -249,8 +249,12 @@ struct UserEpisodeManager {
     }
 
     #if !os(watchOS)
-        static func presentDeleteOptions(episode: UserEpisode, preferredStatusBarStyle: UIStatusBarStyle, themeOverride: Theme.ThemeType?, actionCallback: ((Bool, Bool) -> Void)? = nil) {
+    static func presentDeleteOptions(episode: UserEpisode, preferredStatusBarStyle: UIStatusBarStyle, themeOverride: Theme.ThemeType?, dismissCallback: (() -> ())? = nil, actionCallback: ((Bool, Bool) -> Void)? = nil) {
             let optionPicker = OptionsPicker(title: "", themeOverride: themeOverride)
+
+            if let dismissCallback {
+                optionPicker.setNoActionCallback(dismissCallback)
+            }
 
             let deleteCloudAction = OptionAction(label: L10n.deleteFromCloud, icon: nil, action: { [] in
                 UserEpisodeManager.deleteFromCloud(episode: episode)


### PR DESCRIPTION
| 📘 Part of: #2628  |  <!-- project issue number, if applicable -->
|:---:|

Fixes #2640 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

This PR adds the following events:

- userFileEditShown
- userFileEditDismissed
- userFileEditSave
- userFileDeleteShown
- userFileDeleteDismissed

It also fixes a duplicated call to the event `uploadedFilesHelpButtonTapped` when tapping Add Files when the list was empty

## To test

1. Start the app with a user with a subscription
2. Ensure that you have `tracksLogging` FF enable
3. Go to Profile Tab
4. Scroll down
5. Tap on Files
6. If you don't have any files you need to add them. If you are using the simulator the easiest way to add is to open Safary in a media file and then share it to PocketCasts
7. Tap on the file
8. Tap on the edit option and check if you see: `userFileEditShown` event on the console
9. Tap on cancel and check if you see: `userFileEditDismissed` event on the console
10. Tap on the edit gain option and check if you see: `userFileEditShown` event on the console
11. Now tap on Save  and check if you see: `userFileEditSave` event on the console
12. Tap on the file again
13. Tap on delete and check if you see: `userFileDeleteShown` event on the console
14. Dismiss by dragging the sheet down and check if you see: `userFileDeleteDismissed` event on the console

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
