### PR TITLE
Add event for dismissing upgrading banner

### DIFF
--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -127,6 +127,10 @@ enum AnalyticsEvent: String {
     case accountDetailsShowPrivacyPolicy
     case accountDetailsChangeAvatar
 
+    // MARK: - Upgrade banner
+
+    case upgradeBannerDismissed
+
     // MARK: - Stats View
 
     case statsShown

--- a/podcasts/PlusLockedInfoView.swift
+++ b/podcasts/PlusLockedInfoView.swift
@@ -63,6 +63,7 @@ class PlusLockedInfoView: ThemeableView {
     }
 
     @IBAction func closeTapped() {
+        Analytics.track(.upgradeBannerDismissed, properties: ["source": delegate?.displaySource.rawValue ?? PlusUpgradeViewSource.unknown.rawValue])
         if let delegate = delegate {
             delegate.closeInfoTapped()
         } else {


### PR DESCRIPTION
| 📘 Part of: #2628  |  <!-- project issue number, if applicable -->
|:---:|

Fixes #2647 
Fixes #2637  <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

Added a new event called `upgradeBannerDismissed`

## To test

1. Start app with an fresh install and with user without a subscription
2. Go to profile tab
3. Scroll down and you should see the promotion banner for Plus.
4. Tap on the `x` button
5. Check if you see a `upgradeBannerDismissed` event with the property `source=profile`
6. Tap on the Settings Cog up left
7. Open the Appearance view
8. Scroll down and you should see the promotion banner for Plus.
9. Tap on the `x` button
10. Check if you see a `upgradeBannerDismissed` event with the property `source=appearance`
11. Open the Watch Settings view
12. Scroll down and you should see the promotion banner for Plus.
13. Tap on the `x` button
14. Check if you see a `upgradeBannerDismissed` event with the property `source=watch`
15. Open the File Settings view
16. Scroll down and you should see the promotion banner for Plus.
17. Tap on the `x` button
18. Check if you see a `upgradeBannerDismissed` event with the property `source=files`

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
