### PR TITLE
Safe access array indexes

### DIFF
--- a/podcasts/PodcastViewController+TableData.swift
+++ b/podcasts/PodcastViewController+TableData.swift
@@ -208,7 +208,7 @@ extension PodcastViewController: UITableViewDataSource, UITableViewDelegate {
     }
 
     func episodeAtIndexPath(_ indexPath: IndexPath) -> Episode? {
-        guard let listEpisode = episodeInfo[indexPath.section].elements[indexPath.row] as? ListEpisode else { return nil }
+        guard let listEpisode = episodeInfo[safe: indexPath.section]?.elements[safe: indexPath.row] as? ListEpisode else { return nil }
 
         return listEpisode.episode
     }

--- a/podcasts/PodcastViewController+TableData.swift
+++ b/podcasts/PodcastViewController+TableData.swift
@@ -1,4 +1,5 @@
 import PocketCastsDataModel
+import PocketCastsUtils
 import UIKit
 
 extension PodcastViewController: UITableViewDataSource, UITableViewDelegate {
@@ -67,7 +68,10 @@ extension PodcastViewController: UITableViewDataSource, UITableViewDelegate {
             return cell
         }
 
-        let itemAtRow = episodeInfo[indexPath.section].elements[indexPath.row]
+        guard let itemAtRow = episodeInfo[safe: indexPath.section]?.elements[safe: indexPath.row] as? ListItem else {
+            FileLog.shared.addMessage("EpisodeInfo missing ListItem in section \(indexPath.section), row \(indexPath.row)")
+            return UITableViewCell()
+        }
         if let listEpisode = itemAtRow as? ListEpisode {
             let cell = tableView.dequeueReusableCell(withIdentifier: PodcastViewController.episodeCellId, for: indexPath) as! EpisodeCell
             cell.hidesArtwork = true


### PR DESCRIPTION
Attempt to fix sentry-6201115624 & sentry-6222774478

## To test

- CI must be 🟢 
- Try to archive or mark as played few episodes in podcasts

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
