### PR TITLE
Download banner copy change

### DIFF
--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -1533,7 +1533,7 @@ internal enum L10n {
   internal static var logsNoEmailAccountConfigured: String { return L10n.tr("Localizable", "logs_no_email_account_configured") }
   /// Manage downloads
   internal static var manageDownloadsAction: String { return L10n.tr("Localizable", "manage_downloads_action") }
-  /// Save %1$@ by removing played episodes.
+  /// Save %1$@ - by managing downloaded episodes.
   internal static func manageDownloadsDetail(_ p1: Any) -> String {
     return L10n.tr("Localizable", "manage_downloads_detail", String(describing: p1))
   }

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4667,7 +4667,7 @@
 "manage_downloads_title" = "Need to free up space?";
 
 /* Detail for manage downloads file space usage banner and modal. %1$@ is the disk space in Mb/GB that the episodes take */
-"manage_downloads_detail" = "Save %1$@ by removing played episodes.";
+"manage_downloads_detail" = "Save %1$@ - by managing downloaded episodes.";
 
 /* Button title for manage downloads file space usage banner and modal. */
 "manage_downloads_action" = "Manage downloads";


### PR DESCRIPTION
This PR updates the copy for the Download management banner to be aligned with Android

![IMG_E0022](https://github.com/user-attachments/assets/add6fbfe-bdc1-459f-a71c-2651fe89a901)

## To test

- If you need force to show the banner
- Open Download
- Check if the copy matches `Save X - by managing downloaded episodes`

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
