### PR TITLE
Use new share UI on bookmarks share

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 7.81
 -----
-
+- Use new Share UI for bookmarks sharing [#2656](https://github.com/Automattic/pocket-casts-ios/pull/2656)
 
 7.80
 -----

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -711,6 +711,7 @@ enum AnalyticsEvent: String {
     case bookmarkPlayTapped
     case bookmarksSortByChanged
     case bookmarkDeleted
+    case bookmarkShareTapped
 
     // MARK: - Headphone Controls
     case settingsHeadphoneControlsShown

--- a/podcasts/Bookmarks/Episode/BookmarkEpisodeListController.swift
+++ b/podcasts/Bookmarks/Episode/BookmarkEpisodeListController.swift
@@ -55,14 +55,12 @@ extension BookmarkEpisodeListController: BookmarkListRouter {
     }
 
     func bookmarkShare(_ bookmark: Bookmark) {
-        guard let episode = bookmark.episode as? Episode else {
+        guard let episode = viewModel.episode as? Episode else {
             return
         }
-        let controller = SharingHelper.shared.createActivityController(episode: episode, shareTime: bookmark.time)
+        Analytics.track(.bookmarkShareTapped, source: viewModel.analyticsSource, properties: ["podcast_uuid": episode.podcastUuid, "episode_uuid": bookmark.episodeUuid])
 
-        Analytics.track(.podcastShared, source: "multi_select", properties: ["type": "bookmark_time"])
-
-        present(controller, animated: true)
+        SharingModal.show(option: .currentPosition(episode, bookmark.time), from: .episodeDetail, in: self)
     }
 
     func dismissBookmarksList() {

--- a/podcasts/Bookmarks/Player/BookmarksPlayerTabController.swift
+++ b/podcasts/Bookmarks/Player/BookmarksPlayerTabController.swift
@@ -141,8 +141,7 @@ extension BookmarksPlayerTabController: BookmarkListRouter {
         guard let episode = viewModel.episode as? Episode else {
             return
         }
-        let controller = SharingHelper.shared.createActivityController(episode: episode, shareTime: bookmark.time)
-
-        present(controller, animated: true)
+        Analytics.track(.bookmarkShareTapped, source: viewModel.analyticsSource, properties: ["podcast_uuid": episode.podcastUuid, "episode_uuid": bookmark.episodeUuid])
+        SharingModal.show(option: .currentPosition(episode, bookmark.time), from: .player, in: self)
     }
 }

--- a/podcasts/Bookmarks/Podcast/BookmarksPodcastListController.swift
+++ b/podcasts/Bookmarks/Podcast/BookmarksPodcastListController.swift
@@ -49,9 +49,8 @@ extension BookmarksPodcastListController: BookmarkListRouter {
         guard let episode = bookmark.episode as? Episode else {
             return
         }
-        let controller = SharingHelper.shared.createActivityController(episode: episode, shareTime: bookmark.time)
-
-        present(controller, animated: true)
+        Analytics.track(.bookmarkShareTapped, source: viewModel.analyticsSource, properties: ["podcast_uuid": episode.podcastUuid, "episode_uuid": bookmark.episodeUuid])
+        SharingModal.show(option: .currentPosition(episode, bookmark.time), from: .podcastScreen, in: self)
     }
 
     func dismissBookmarksList() {

--- a/podcasts/Bookmarks/Profile/BookmarksProfileListController.swift
+++ b/podcasts/Bookmarks/Profile/BookmarksProfileListController.swift
@@ -52,9 +52,8 @@ extension BookmarksProfileListController: BookmarkListRouter {
         guard let episode = bookmark.episode as? Episode else {
             return
         }
-        let controller = SharingHelper.shared.createActivityController(episode: episode, shareTime: bookmark.time)
-
-        present(controller, animated: true)
+        Analytics.track(.bookmarkShareTapped, source: viewModel.analyticsSource, properties: ["podcast_uuid": episode.podcastUuid, "episode_uuid": bookmark.episodeUuid])
+        SharingModal.show(option: .currentPosition(episode, bookmark.time), from: .profile, in: self)
     }
 
     func dismissBookmarksList() {

--- a/podcasts/SharingHelper.swift
+++ b/podcasts/SharingHelper.swift
@@ -64,12 +64,13 @@ class SharingHelper: NSObject {
     }
 
     func shareLinkTo(episode: Episode, shareTime: TimeInterval, fromController: UIViewController, fromSource: AnalyticsSource, barButtonItem: UIBarButtonItem?) {
-        SharingModal.show(option: .episode(episode), from: fromSource, in: fromController)
+        let option: SharingModal.Option = shareTime == 0 ? .episode(episode) : .currentPosition(episode, shareTime)
+        SharingModal.show(option: option, from: fromSource, in: fromController)
     }
 
     func shareLinkTo(episode: Episode, shareTime: TimeInterval, fromController: UIViewController, sourceRect: CGRect, sourceView: UIView?, showArrow: Bool = true, fromSource: AnalyticsSource, analyticsType: String = "episode") {
-
-        SharingModal.show(option: .episode(episode), from: fromSource, in: fromController)
+        let option: SharingModal.Option = shareTime == 0 ? .episode(episode) : .currentPosition(episode, shareTime)
+        SharingModal.show(option: option, from: fromSource, in: fromController)
     }
 
     func createActivityController(episode: Episode, shareTime: TimeInterval) -> UIActivityViewController {


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
Add the missing analytics event when share is tapped.

## To test

1. Start the with an user with a subscription so it can use bookmarks
2. Create some bookmarks on episodes
3. Open the bookmarks screen on the multiple places available (Podcast Details, Episode Details, Player, Profile), select one bookmark and share it.
4. Check if the new Share UI is shown
5. Check if the event `bookmarkShareTapped` is logged with the properties for source, podcast_uuid, and episode_uuid available.


## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
