### PR TITLE
Track audit: Add missing filter events

### DIFF
--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -255,6 +255,8 @@ enum AnalyticsEvent: String {
     case filterListEditButtonToggled
     case filterListReordered
 
+    case filterCreateButtonTapped
+
     case filterDeleted
     case filterUpdated
     case filterCreated

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -276,6 +276,9 @@ enum AnalyticsEvent: String {
     case filterSiriShortcutAdded
     case filterSiriShortcutRemoved
 
+    case filterAutoDownloadUpdated
+    case filterAutoDownloadLimitUpdated
+
     // MARK: - Podcast screen
 
     case podcastScreenShown

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -265,6 +265,8 @@ enum AnalyticsEvent: String {
 
     case filterMultiSelectEntered
     case filterSelectAllButtonTapped
+    case filterSelectAllAbove
+    case filterSelectAllBelow
     case filterMultiSelectExited
 
     case filterOptionsButtonTapped

--- a/podcasts/Analytics/Helpers/AnalyticsCoordinator.swift
+++ b/podcasts/Analytics/Helpers/AnalyticsCoordinator.swift
@@ -8,6 +8,7 @@ protocol AnalyticsSourceProvider {
 
 enum AnalyticsSource: String, AnalyticsDescribable {
     case appIconMenu = "app_icon_menu"
+    case autoDownloadSettings = "auto_download_settings"
     case carPlay = "carplay"
     case chooseFolder = "choose_folder"
     case chromecast

--- a/podcasts/CreateFilterViewController.swift
+++ b/podcasts/CreateFilterViewController.swift
@@ -162,12 +162,15 @@ class CreateFilterViewController: PCViewController, UITextFieldDelegate, UIScrol
             "all_podcasts": filterToEdit.filterAllPodcasts,
             "media_type": AudioVideoFilter(rawValue: filterToEdit.filterAudioVideoType) ?? .all,
             "downloaded": filterToEdit.filterDownloaded,
+            "not_downloaded": filterToEdit.filterNotDownloaded,
             "episode_status_played": filterToEdit.filterFinished,
             "episode_status_unplayed": filterToEdit.filterUnplayed,
             "episode_status_in_progress": filterToEdit.filterPartiallyPlayed,
             "release_date": ReleaseDateFilterOption(rawValue: filterToEdit.filterHours) ?? .anytime,
             "starred": filterToEdit.filterStarred,
             "duration": filterToEdit.filterDuration,
+            "duration_longer_than": filterToEdit.longerThan,
+            "duration_shorter_than": filterToEdit.shorterThan,
             "color": filterToEdit.playlistColor().hexString(),
             "icon_name": filterToEdit.iconImageName() ?? "unknown"
         ])

--- a/podcasts/DownloadSettingsViewController.swift
+++ b/podcasts/DownloadSettingsViewController.swift
@@ -168,12 +168,14 @@ class DownloadSettingsViewController: PCViewController, UITableViewDataSource, U
                 }
                 filterSelectionViewController.selectedFilters = selectedFilters
                 filterSelectionViewController.filterSelected = { filter in
+                    Analytics.track(.filterAutoDownloadUpdated, properties: ["enabled": true, "source": AnalyticsSource.autoDownloadSettings])
                     filter.autoDownloadEpisodes = true
                     filter.autoDownloadLimit = filter.maxAutoDownloadEpisodes()
                     DataManager.sharedManager.save(filter: filter)
                     NotificationCenter.postOnMainThread(notification: Constants.Notifications.filterChanged, object: filter)
                 }
                 filterSelectionViewController.filterUnselected = { filter in
+                    Analytics.track(.filterAutoDownloadUpdated, properties: ["enabled": false, "source": AnalyticsSource.autoDownloadSettings])
                     filter.autoDownloadEpisodes = false
                     DataManager.sharedManager.save(filter: filter)
                     NotificationCenter.postOnMainThread(notification: Constants.Notifications.filterChanged, object: filter)

--- a/podcasts/FilterEditOptionsViewController.swift
+++ b/podcasts/FilterEditOptionsViewController.swift
@@ -196,6 +196,7 @@ class FilterEditOptionsViewController: PCViewController, UITableViewDelegate, UI
     }
 
     @objc private func switchChanged(_ sender: UISwitch) {
+        Analytics.track(.filterAutoDownloadUpdated, properties: ["enabled": sender.isOn, "source": AnalyticsSource.filters])
         filterToEdit.autoDownloadEpisodes = sender.isOn
         didChangeAutoDownload = true
         tableView.reloadData()
@@ -243,6 +244,7 @@ class FilterEditOptionsViewController: PCViewController, UITableViewDelegate, UI
 
     private func addAutoLimitOption(optionPicker: OptionsPicker, limit: Int32, currentLimit: Int32) {
         let action = OptionAction(label: L10n.episodeCountPluralFormat(limit.localized()), selected: currentLimit == limit) { [weak self] in
+            Analytics.track(.filterAutoDownloadLimitUpdated, properties: ["limit": limit])
             self?.didChangeEpisodeCount = true
             self?.filterToEdit.autoDownloadLimit = limit
             self?.tableView.reloadData()

--- a/podcasts/PlaylistViewController+TableData.swift
+++ b/podcasts/PlaylistViewController+TableData.swift
@@ -19,10 +19,12 @@ extension PlaylistViewController: UITableViewDelegate, UITableViewDataSource {
             if isMultiSelectEnabled {
                 let optionPicker = OptionsPicker(title: nil, iconTintStyle: .primaryInteractive01)
                 let allAboveAction = OptionAction(label: L10n.selectAllAbove, icon: "selectall-up", action: { [] in
+                    Analytics.track(.filterSelectAllAbove)
                     self.tableView.selectAllAbove(indexPath: indexPath)
                 })
 
                 let allBelowAction = OptionAction(label: L10n.selectAllBelow, icon: "selectall-down", action: { [] in
+                    Analytics.track(.filterSelectAllBelow)
                     self.tableView.selectAllBelow(indexPath: indexPath)
                 })
                 optionPicker.addAction(action: allAboveAction)

--- a/podcasts/PlaylistsViewController.swift
+++ b/podcasts/PlaylistsViewController.swift
@@ -110,6 +110,7 @@ class PlaylistsViewController: PCViewController, FilterCreatedDelegate {
     }
 
     @IBAction func addNewFilter() {
+        Analytics.track(.filterCreateButtonTapped)
         let createFilterVC = FilterPreviewViewController()
         createFilterVC.delegate = self
         let navVC = SJUIUtils.navController(for: createFilterVC)


### PR DESCRIPTION
| 📘 Part of: #2628  |  <!-- project issue number, if applicable -->
|:---:|

Fixes #2644 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
Adds tracking for the following events:

- filterCreateButtonTapped
- filterAutoDownloadUpdated
- filterAutoDownloadLimitUpdated

## To test

1. Start the app
2. Ensure that you have the `tracksLogging` FF enabled
3. Open the filters tab
4. Scroll to the end of the list of filters
5. Tap on the New Filter button
6. Check if `filterCreateButtonTapped` is show in the console
7. Customize the new filter with all different options and make sure to enable a duration filter
8. Create the new filter
9. Confirm in the console you see a `filterCreated` event with the following properties tracked "duration_shorter_than" , "not_downloaded", "duration_longer_than"
10. Tap on the ... button on the new filter
11. Select filter options
12. Enable Auto-Download
13. Chose a option to limit the number of downloads
14. Check in the console if you see  `filter_auto_download_updated ["enabled": true, "source": "filters"]` and 
`filter_auto_download_limit_updated` events

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
