### PR TITLE
[Winbck] Fix Plans view background colors

### DIFF
--- a/podcasts/Cancel Subscription/Cancel Subscription/Plans View/CancelSubscriptionPlanRow.swift
+++ b/podcasts/Cancel Subscription/Cancel Subscription/Plans View/CancelSubscriptionPlanRow.swift
@@ -7,15 +7,11 @@ struct CancelSubscriptionPlanRow: View {
     var selected: Bool
     let onTap: (PlusPricingInfoModel.PlusProductPricingInfo) -> Void
 
-    var backgroundColor: Color {
-        theme.activeTheme == .indigo ? .white : theme.primaryUi01
-    }
-
     var body: some View {
         ZStack {
             Rectangle()
                 .foregroundStyle(.clear)
-                .background(backgroundColor)
+                .background(theme.primaryUi01Active)
                 .cornerRadius(8.0)
                 .frame(height: 64)
             VStack(alignment: .leading, spacing: 0) {

--- a/podcasts/Cancel Subscription/Cancel Subscription/Plans View/CancelSubscriptionPlansView.swift
+++ b/podcasts/Cancel Subscription/Cancel Subscription/Plans View/CancelSubscriptionPlansView.swift
@@ -14,7 +14,7 @@ struct CancelSubscriptionPlansView: View {
         .onAppear {
             loadProducts()
         }
-        .background(theme.primaryUi04)
+        .background(theme.primaryUi01)
     }
 
     var plansView: some View {


### PR DESCRIPTION
| 📘 Part of: #2445 
|:---:|

This PR modify the bg colors used in the Plans view. See p1737112478618509-Slack-C080ZKX4UCV.

| 1 | 2 | 3 | 4 |
| -------- | ------- | ------- | ------- |
| ![IMG_0040](https://github.com/user-attachments/assets/321dd69f-1594-4476-940f-8e228b6fd10d) | ![IMG_0041](https://github.com/user-attachments/assets/d684226c-fbb0-4960-acc6-eebce7f61179) | ![IMG_0042](https://github.com/user-attachments/assets/9be6242c-afaa-41b7-8fb8-2aeb96dd7304) | ![IMG_0043](https://github.com/user-attachments/assets/42d5d18d-0910-4f1b-bf42-be87b74ba9a8) |

## To test

- CI must be 🟢 
- Make sure `winback` FF is on
- Use a plus account (you need to have a sub. purchased)
- Navigate to the cancel sub. view
- Open the Plans view and check it with different themes

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
