### PR TITLE
Remove the option to share bookmarks for user files.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 7.81
 -----
 - Use new Share UI for bookmarks sharing [#2656](https://github.com/Automattic/pocket-casts-ios/pull/2656)
+- Remove the option to share bookmarks from users file [#2661](https://github.com/Automattic/pocket-casts-ios/pull/2661)
 
 7.80
 -----

--- a/podcasts/Bookmarks/List/BookmarksListView.swift
+++ b/podcasts/Bookmarks/List/BookmarksListView.swift
@@ -143,11 +143,11 @@ struct BookmarksListView<ListStyle: BookmarksStyle>: View {
     private func actionBarView<Content: View>(_ content: @escaping () -> Content) -> some View {
         let title = L10n.selectedCountFormat(viewModel.numberOfSelectedItems)
         let editVisible = viewModel.numberOfSelectedItems == 1
-
+        let shareVisible = viewModel.selectedItems.first?.episode is Episode
         ActionBarOverlayView(actionBarVisible: actionBarVisible, title: title, style: style.actionBarStyle, content: {
             content()
         }, actions: [
-            .init(imageName: "podcast-share", title: L10n.share, visible: editVisible, action: {
+            .init(imageName: "podcast-share", title: L10n.share, visible: editVisible && shareVisible, action: {
                 viewModel.shareSelectedBookmarks()
             }),
             .init(imageName: "folder-edit", title: L10n.edit, visible: editVisible, action: {


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

This PR removes the option to share bookmarks that are for user files. Those files are private to the user so it does not make sense to share a link to file other users cannot open.

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

## To test

1. Start the app
2. Open the Profile tab
3. Tap on Files
4. Tap on one of the files
5. Tap on bookmark
6. Select one of the bookmarks
7. Check that no share option is show


## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
