### PR TITLE
[Analytics audit] Theme usage properties

### DIFF
--- a/PocketCastsTests/Tests/Analytics/AnalyticsAppThemeProviderTests.swift
+++ b/PocketCastsTests/Tests/Analytics/AnalyticsAppThemeProviderTests.swift
@@ -1,0 +1,45 @@
+import XCTest
+
+@testable import podcasts
+
+class AnalyticsAppThemeProviderTests: XCTestCase {
+    private var analytics = MockAnalytics()
+
+    override func setUp() {
+        analytics.analyticsAppThemeProvider = MockAnalyticsAppThemeProvider()
+    }
+
+    func testThemeProviderProperties() throws {
+        let expectation = expectation(description: "track method should be triggered")
+        analytics.didTrack = { _, properties in
+            expectation.fulfill()
+
+            guard let properties else {
+                XCTFail("Properties must not be nil")
+                return
+            }
+            XCTAssertEqual(properties["theme"] as? String, "dark")
+            XCTAssertEqual(properties["source"] as? String, "test")
+        }
+        analytics.track(.settingsAppearanceThemeChanged, properties: ["source": "test"])
+        waitForExpectations(timeout: 1)
+    }
+}
+
+private class MockAnalytics: Analytics {
+    var didTrack: ((_ event: AnalyticsEvent, _ properties: [AnyHashable: Any]?) -> Void)?
+
+    override func track(_ event: AnalyticsEvent, properties: [AnyHashable: Any]? = nil) {
+        var newProperties = properties ?? [:]
+        analyticsAppThemeProvider?.appThemeProperties.forEach { key, value in
+            newProperties[key] = value
+        }
+        didTrack?(event, newProperties)
+    }
+}
+
+private struct MockAnalyticsAppThemeProvider: AnalyticsAppThemeProviding {
+    var appThemeProperties: [String: Any] {
+        return ["theme": "dark"]
+    }
+}

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -674,6 +674,7 @@
 		9A156AAD2CF60973007BA8D9 /* CancelSubscriptionPlansView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A156AAC2CF60973007BA8D9 /* CancelSubscriptionPlansView.swift */; };
 		9A156AB12CF7430A007BA8D9 /* UpNextAnnouncementView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A156AB02CF7430A007BA8D9 /* UpNextAnnouncementView.swift */; };
 		9A156AB32CF8BEE3007BA8D9 /* CancelSubscriptionPlanRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A156AB22CF8BEE3007BA8D9 /* CancelSubscriptionPlanRow.swift */; };
+		9A4BB1E92D3AA4D600B68D94 /* AnalyticsAppThemeProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A4BB1E62D3AA4D600B68D94 /* AnalyticsAppThemeProvider.swift */; };
 		9A509DE02D14606100E8CEB1 /* CancelSubscriptionOfferSuccessView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A509DDF2D14606100E8CEB1 /* CancelSubscriptionOfferSuccessView.swift */; };
 		9AA3B6312D27F0B600A0E30E /* CancelSubscriptionPlansViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AA3B6302D27F0B600A0E30E /* CancelSubscriptionPlansViewModel.swift */; };
 		BD001B892174260B00504DD3 /* FilterManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD001B882174260B00504DD3 /* FilterManager.swift */; };
@@ -2835,6 +2836,7 @@
 		9A156AAC2CF60973007BA8D9 /* CancelSubscriptionPlansView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancelSubscriptionPlansView.swift; sourceTree = "<group>"; };
 		9A156AB02CF7430A007BA8D9 /* UpNextAnnouncementView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpNextAnnouncementView.swift; sourceTree = "<group>"; };
 		9A156AB22CF8BEE3007BA8D9 /* CancelSubscriptionPlanRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancelSubscriptionPlanRow.swift; sourceTree = "<group>"; };
+		9A4BB1E62D3AA4D600B68D94 /* AnalyticsAppThemeProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsAppThemeProvider.swift; sourceTree = "<group>"; };
 		9A509DDF2D14606100E8CEB1 /* CancelSubscriptionOfferSuccessView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancelSubscriptionOfferSuccessView.swift; sourceTree = "<group>"; };
 		9A9517324EFFD2C905890193 /* Pods-podcasts.appstore.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-podcasts.appstore.xcconfig"; path = "Pods/Target Support Files/Pods-podcasts/Pods-podcasts.appstore.xcconfig"; sourceTree = "<group>"; };
 		9AA3B6302D27F0B600A0E30E /* CancelSubscriptionPlansViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancelSubscriptionPlansViewModel.swift; sourceTree = "<group>"; };
@@ -7427,6 +7429,7 @@
 				C761300628E4CA060044C6C2 /* Helpers */,
 				C72CED30289DA17F0017883A /* Adapters */,
 				C7AF5790289D87CF0089E435 /* Analytics.swift */,
+				9A4BB1E62D3AA4D600B68D94 /* AnalyticsAppThemeProvider.swift */,
 				C72CED2C289DA14F0017883A /* AnalyticsEvent.swift */,
 				C72CED2E289DA1650017883A /* String+Analytics.swift */,
 				C741D9D328ADBA23006CFBE7 /* AppLifecyleAnalytics.swift */,
@@ -10063,6 +10066,7 @@
 				4053CE022150AC4B001C92B1 /* CheckboxCell.swift in Sources */,
 				BD96575B2469047600873BB5 /* CastToViewController+Table.swift in Sources */,
 				409C792C22237DD900386495 /* UserEpisodeDetailViewController+Table.swift in Sources */,
+				9A4BB1E92D3AA4D600B68D94 /* AnalyticsAppThemeProvider.swift in Sources */,
 				BD2E8ED31FB18A7C005E4B7C /* PodcastManager.swift in Sources */,
 				C7FF7717291D50880082A464 /* Motion.swift in Sources */,
 				BD83DE0C2068B8E000012C06 /* MiniPlayerViewController+Gestures.swift in Sources */,

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -675,6 +675,7 @@
 		9A156AB12CF7430A007BA8D9 /* UpNextAnnouncementView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A156AB02CF7430A007BA8D9 /* UpNextAnnouncementView.swift */; };
 		9A156AB32CF8BEE3007BA8D9 /* CancelSubscriptionPlanRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A156AB22CF8BEE3007BA8D9 /* CancelSubscriptionPlanRow.swift */; };
 		9A4BB1E92D3AA4D600B68D94 /* AnalyticsAppThemeProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A4BB1E62D3AA4D600B68D94 /* AnalyticsAppThemeProvider.swift */; };
+		9A4BB1ED2D3AB06700B68D94 /* AnalyticsAppThemeProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A4BB1EC2D3AB06700B68D94 /* AnalyticsAppThemeProviderTests.swift */; };
 		9A509DE02D14606100E8CEB1 /* CancelSubscriptionOfferSuccessView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A509DDF2D14606100E8CEB1 /* CancelSubscriptionOfferSuccessView.swift */; };
 		9AA3B6312D27F0B600A0E30E /* CancelSubscriptionPlansViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AA3B6302D27F0B600A0E30E /* CancelSubscriptionPlansViewModel.swift */; };
 		BD001B892174260B00504DD3 /* FilterManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD001B882174260B00504DD3 /* FilterManager.swift */; };
@@ -2837,6 +2838,7 @@
 		9A156AB02CF7430A007BA8D9 /* UpNextAnnouncementView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpNextAnnouncementView.swift; sourceTree = "<group>"; };
 		9A156AB22CF8BEE3007BA8D9 /* CancelSubscriptionPlanRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancelSubscriptionPlanRow.swift; sourceTree = "<group>"; };
 		9A4BB1E62D3AA4D600B68D94 /* AnalyticsAppThemeProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsAppThemeProvider.swift; sourceTree = "<group>"; };
+		9A4BB1EC2D3AB06700B68D94 /* AnalyticsAppThemeProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsAppThemeProviderTests.swift; sourceTree = "<group>"; };
 		9A509DDF2D14606100E8CEB1 /* CancelSubscriptionOfferSuccessView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancelSubscriptionOfferSuccessView.swift; sourceTree = "<group>"; };
 		9A9517324EFFD2C905890193 /* Pods-podcasts.appstore.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-podcasts.appstore.xcconfig"; path = "Pods/Target Support Files/Pods-podcasts/Pods-podcasts.appstore.xcconfig"; sourceTree = "<group>"; };
 		9AA3B6302D27F0B600A0E30E /* CancelSubscriptionPlansViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancelSubscriptionPlansViewModel.swift; sourceTree = "<group>"; };
@@ -7947,6 +7949,7 @@
 			children = (
 				C7D854F228ADD98700877E87 /* AppLifecyleAnalyticsTests.swift */,
 				8BA55A0F28CA6843002BECC5 /* AnalyticsPlaybackHelperTests.swift */,
+				9A4BB1EC2D3AB06700B68D94 /* AnalyticsAppThemeProviderTests.swift */,
 			);
 			path = Analytics;
 			sourceTree = "<group>";
@@ -9672,6 +9675,7 @@
 				10A4F75E2C52C7680084D783 /* KidsProfileBannerViewModelTests.swift in Sources */,
 				C7D8AE5F2A6056DA00C9EBAF /* MutliSelectListViewModel.swift in Sources */,
 				F5F69D802C07C867000B3C87 /* FMDatabaseQueue+Test.swift in Sources */,
+				9A4BB1ED2D3AB06700B68D94 /* AnalyticsAppThemeProviderTests.swift in Sources */,
 				8B484EFD28D2574D001AFA97 /* EpisodeBuilder.swift in Sources */,
 				F56ADE562B7FE37500ADFE31 /* SettingsTests.swift in Sources */,
 				8B484EFB28D25719001AFA97 /* Double+Ext.swift in Sources */,

--- a/podcasts/Analytics/Analytics.swift
+++ b/podcasts/Analytics/Analytics.swift
@@ -4,7 +4,7 @@ class Analytics {
     static let shared = Analytics()
     private var adapters: [AnalyticsAdapter]?
 #if !os(watchOS) && !APPCLIP
-    private var analyticsAppThemeProvider: AnalyticsAppThemeProviding?
+    var analyticsAppThemeProvider: AnalyticsAppThemeProviding?
 #endif
 
     // Whether we have adapters registered or not

--- a/podcasts/Analytics/Analytics.swift
+++ b/podcasts/Analytics/Analytics.swift
@@ -3,6 +3,9 @@ import Foundation
 class Analytics {
     static let shared = Analytics()
     private var adapters: [AnalyticsAdapter]?
+#if !os(watchOS) && !APPCLIP
+    private var analyticsAppThemeProvider: AnalyticsAppThemeProviding?
+#endif
 
     // Whether we have adapters registered or not
     var adaptersRegistered: Bool = false
@@ -17,6 +20,11 @@ class Analytics {
         Self.shared.adapters = nil
         shared.adaptersRegistered = false
     }
+#if !os(watchOS) && !APPCLIP
+    static func add(analyticsAppThemeProvider: AnalyticsAppThemeProviding) {
+        Self.shared.analyticsAppThemeProvider = analyticsAppThemeProvider
+    }
+#endif
 
     /// Convenience method to call Analytics.shared.track*
     static func track(_ event: AnalyticsEvent, properties: [AnyHashable: Any]? = nil) {
@@ -24,7 +32,12 @@ class Analytics {
     }
 
     func track(_ event: AnalyticsEvent, properties: [AnyHashable: Any]? = nil) {
-        let newProperties = properties?.mapValues { (($0 as? AnalyticsDescribable)?.analyticsDescription) ?? $0 }
+        var newProperties = (properties ?? [:]).mapValues { (($0 as? AnalyticsDescribable)?.analyticsDescription) ?? $0 }
+#if !os(watchOS) && !APPCLIP
+        analyticsAppThemeProvider?.appThemeProperties.forEach { key, value in
+            newProperties[key] = value
+        }
+#endif
         adapters?.forEach {
             $0.track(name: event.eventName, properties: newProperties)
         }

--- a/podcasts/Analytics/AnalyticsAppThemeProvider.swift
+++ b/podcasts/Analytics/AnalyticsAppThemeProvider.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+protocol AnalyticsAppThemeProviding {
+    var appThemeProperties: [String: Any] { get }
+}
+
+struct AnalyticsAppThemeProvider: AnalyticsAppThemeProviding {
+    var appThemeProperties: [String: Any] {
+        return [
+            "theme_selected": Theme.sharedTheme.activeTheme.analyticsDescription,
+            "theme_dark_preference": Theme.preferredDarkTheme().analyticsDescription,
+            "theme_light_preference": Theme.preferredLightTheme().analyticsDescription,
+            "theme_use_system_settings": Settings.shouldFollowSystemTheme()
+            ]
+    }
+}

--- a/podcasts/AppDelegate+Analytics.swift
+++ b/podcasts/AppDelegate+Analytics.swift
@@ -14,6 +14,7 @@ extension AppDelegate {
         }
 
         Analytics.register(adapters: [AnalyticsLoggingAdapter(), TracksAdapter(), CrashLoggingAdapter()])
+        Analytics.add(analyticsAppThemeProvider: AnalyticsAppThemeProvider())
     }
 
     func logActiveDownloadTasks() {


### PR DESCRIPTION
| 📘 Part of: #2628
|:---:|

Fixes #2655 

This PR adds these properties to all tracked events to track the theme usage:
• "theme_selected"
• "theme_dark_preference"
• "theme_light_preference"
• "theme_use_system_settings"


## To test

- CI must be 🟢 
- Run the app
- Make sure you have the tracks logger enabled
- Check all the events tracked and confirm they contain the theme events

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
