### PR TITLE
Analytics audit: Update podcast shared event uses

### DIFF
--- a/podcasts/Bookmarks/Episode/BookmarkEpisodeListController.swift
+++ b/podcasts/Bookmarks/Episode/BookmarkEpisodeListController.swift
@@ -60,7 +60,7 @@ extension BookmarkEpisodeListController: BookmarkListRouter {
         }
         Analytics.track(.bookmarkShareTapped, source: viewModel.analyticsSource, properties: ["podcast_uuid": episode.podcastUuid, "episode_uuid": bookmark.episodeUuid])
 
-        SharingModal.show(option: .currentPosition(episode, bookmark.time), from: .episodeDetail, in: self)
+        SharingModal.show(option: .bookmark(episode, bookmark.time), from: .episodeDetail, in: self)
     }
 
     func dismissBookmarksList() {

--- a/podcasts/Bookmarks/Player/BookmarksPlayerTabController.swift
+++ b/podcasts/Bookmarks/Player/BookmarksPlayerTabController.swift
@@ -142,6 +142,6 @@ extension BookmarksPlayerTabController: BookmarkListRouter {
             return
         }
         Analytics.track(.bookmarkShareTapped, source: viewModel.analyticsSource, properties: ["podcast_uuid": episode.podcastUuid, "episode_uuid": bookmark.episodeUuid])
-        SharingModal.show(option: .currentPosition(episode, bookmark.time), from: .player, in: self)
+        SharingModal.show(option: .bookmark(episode, bookmark.time), from: .player, in: self)
     }
 }

--- a/podcasts/Bookmarks/Podcast/BookmarksPodcastListController.swift
+++ b/podcasts/Bookmarks/Podcast/BookmarksPodcastListController.swift
@@ -50,7 +50,7 @@ extension BookmarksPodcastListController: BookmarkListRouter {
             return
         }
         Analytics.track(.bookmarkShareTapped, source: viewModel.analyticsSource, properties: ["podcast_uuid": episode.podcastUuid, "episode_uuid": bookmark.episodeUuid])
-        SharingModal.show(option: .currentPosition(episode, bookmark.time), from: .podcastScreen, in: self)
+        SharingModal.show(option: .bookmark(episode, bookmark.time), from: .podcastScreen, in: self)
     }
 
     func dismissBookmarksList() {

--- a/podcasts/Bookmarks/Profile/BookmarksProfileListController.swift
+++ b/podcasts/Bookmarks/Profile/BookmarksProfileListController.swift
@@ -53,7 +53,7 @@ extension BookmarksProfileListController: BookmarkListRouter {
             return
         }
         Analytics.track(.bookmarkShareTapped, source: viewModel.analyticsSource, properties: ["podcast_uuid": episode.podcastUuid, "episode_uuid": bookmark.episodeUuid])
-        SharingModal.show(option: .currentPosition(episode, bookmark.time), from: .profile, in: self)
+        SharingModal.show(option: .bookmark(episode, bookmark.time), from: .profile, in: self)
     }
 
     func dismissBookmarksList() {

--- a/podcasts/Sharing/ShareDestination.swift
+++ b/podcasts/Sharing/ShareDestination.swift
@@ -223,6 +223,8 @@ extension ShareDestination {
             return "episode"
         case (_, .currentPosition):
             return "current_time"
+        case (_, .bookmark):
+            return "bookmark_time"
         case (.audio, _):
             return "clip_audio"
         case (_, .clip), (_, .clipShare):

--- a/podcasts/Sharing/SharingFooterView.swift
+++ b/podcasts/Sharing/SharingFooterView.swift
@@ -18,7 +18,7 @@ struct SharingFooterView: View {
 
     var body: some View {
         switch option {
-        case .episode, .podcast, .currentPosition:
+        case .episode, .podcast, .currentPosition, .bookmark:
             buttons
         case .clip(let episode, _):
             VStack(spacing: 12) {

--- a/podcasts/Sharing/SharingModal.swift
+++ b/podcasts/Sharing/SharingModal.swift
@@ -9,6 +9,7 @@ enum SharingModal {
         case episode(Episode)
         case podcast(Podcast)
         case currentPosition(Episode, TimeInterval)
+        case bookmark(Episode, TimeInterval)
         case clip(Episode, TimeInterval)
         case clipShare(Episode, ClipTime, ShareImageStyle)
 
@@ -20,7 +21,7 @@ enum SharingModal {
             switch self {
             case .episode:
                 L10n.episode
-            case .currentPosition:
+            case .currentPosition, .bookmark:
                 L10n.shareCurrentPosition
             case .podcast:
                 L10n.podcastSingular
@@ -33,7 +34,7 @@ enum SharingModal {
             switch self {
             case .episode:
                 L10n.shareEpisode
-            case .currentPosition(_, let time):
+            case .currentPosition(_, let time), .bookmark(_, let time):
                 L10n.shareEpisodeAt(TimeFormatter.shared.playTimeFormat(time: time))
             case .podcast:
                 L10n.sharePodcast
@@ -147,7 +148,7 @@ extension SharingModal.Option {
 
     private var description: String? {
         switch self {
-        case .episode(let episode), .currentPosition(let episode, _), .clip(let episode, _), .clipShare(let episode, _, _):
+        case .episode(let episode), .currentPosition(let episode, _), .clip(let episode, _), .clipShare(let episode, _, _), .bookmark(let episode, _):
             episode.parentPodcast()?.title
         case .podcast(let podcast):
             [podcast.episodeCount, podcast.frequency].compactMap { $0 }.joined(separator: " ⋅ ")
@@ -156,7 +157,7 @@ extension SharingModal.Option {
 
     private var title: String? {
         switch self {
-        case .episode(let episode), .currentPosition(let episode, _), .clip(let episode, _), .clipShare(let episode, _, _):
+        case .episode(let episode), .currentPosition(let episode, _), .clip(let episode, _), .clipShare(let episode, _, _), .bookmark(let episode, _):
             episode.title
         case .podcast(let podcast):
             podcast.title
@@ -165,7 +166,7 @@ extension SharingModal.Option {
 
     private var name: String? {
         switch self {
-        case .episode(let episode), .currentPosition(let episode, _), .clip(let episode, _), .clipShare(let episode, _, _):
+        case .episode(let episode), .currentPosition(let episode, _), .clip(let episode, _), .clipShare(let episode, _, _), .bookmark(let episode, _):
             if let date = episode.publishedDate {
                 return date.formatted(Date.FormatStyle(date: .abbreviated, time: .omitted))
             } else {
@@ -178,7 +179,7 @@ extension SharingModal.Option {
 
     fileprivate var podcast: Podcast {
         switch self {
-        case .episode(let episode), .currentPosition(let episode, _), .clip(let episode, _), .clipShare(let episode, _, _):
+        case .episode(let episode), .currentPosition(let episode, _), .clip(let episode, _), .clipShare(let episode, _, _), .bookmark(let episode, _):
             return episode.parentPodcast()!
         case .podcast(let podcast):
             return podcast
@@ -187,7 +188,7 @@ extension SharingModal.Option {
 
     private var episode: Episode? {
         switch self {
-        case .episode(let episode), .currentPosition(let episode, _), .clip(let episode, _), .clipShare(let episode, _, _):
+        case .episode(let episode), .currentPosition(let episode, _), .clip(let episode, _), .clipShare(let episode, _, _), .bookmark(let episode, _):
             episode
         default:
             nil
@@ -292,6 +293,8 @@ extension SharingModal.Option {
         case .podcast(let podcast):
             return podcast.shareURL
         case .currentPosition(let episode, let timeInterval):
+            return episode.shareURL + "?t=\(round(timeInterval))"
+        case .bookmark(let episode, let timeInterval):
             return episode.shareURL + "?t=\(round(timeInterval))"
         case .clip(let episode, let timeInterval):
             return episode.shareURL + "?t=\(round(timeInterval))"

--- a/podcasts/Sharing/SharingModal.swift
+++ b/podcasts/Sharing/SharingModal.swift
@@ -133,18 +133,6 @@ enum SharingModal {
 }
 
 extension SharingModal.Option {
-    fileprivate var analyticsType: String {
-        switch self {
-        case .podcast:
-            "podcast"
-        case .episode:
-            "episode"
-        case .currentPosition:
-            "current_position"
-        case .clip, .clipShare:
-            "clip"
-        }
-    }
 
     private var description: String? {
         switch self {

--- a/podcasts/Sharing/SharingModal.swift
+++ b/podcasts/Sharing/SharingModal.swift
@@ -128,8 +128,6 @@ enum SharingModal {
 
         let hostingController = ThemedHostingController(rootView: modalView, theme: Theme(previewTheme: .contrastLight))
         viewController.present(hostingController, animated: true)
-
-        Analytics.track(.podcastShared, source: source, properties: ["type": option.analyticsType])
     }
 }
 

--- a/podcasts/Sharing/SharingView.swift
+++ b/podcasts/Sharing/SharingView.swift
@@ -94,7 +94,7 @@ struct SharingView: View {
             case .podcast(let podcast):
                 properties["podcast_uuid"] = podcast.uuid
                 type = "podcast"
-            case .currentPosition(let episode, _):
+            case .currentPosition(let episode, _), .bookmark(let episode, _):
                 properties["episode_uuid"] = episode.uuid
                 type = "episode_timestamp"
             }


### PR DESCRIPTION
| 📘 Part of: #2628  |  <!-- project issue number, if applicable -->
|:---:|

Fixes #2663 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
The `.podcastShared` was being sent twice, when when pressed the share button and then when the actual share was done.

This PR removes the duplication and only sends the event when the share is done and all selections are made.
It also update the properties to show the type `bookmark_time` when sharing from a bookmark.

## To test

1. Start the app
2. Ensure you have tracks logging FF active
3. Go to Profile Tab
4. Open Bookmarks
5. Select one bookmark
6. Tap Share. Check if you see the event: `bookmark_share_tapped` event and then `share_screen_shown`
7. Select the options to share and then tap Copy Link
8. Check if you see the event: `podcast_shared` with the `type` property set to `bookmark_time`

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
