### PR TITLE
Analytics audit: Implement bookmark editing missing events

### DIFF
--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -719,6 +719,12 @@ enum AnalyticsEvent: String {
     case bookmarksSortByChanged
     case bookmarkDeleted
     case bookmarkShareTapped
+    case bookmarkEditFormShown
+    case bookmarkEditFormDismissed
+    case bookmarkEditFormSubmitted
+    case bookmarkDeleteFormShown
+    case bookmarkDeleteFormDismissed
+    case bookmarkDeleteFormSubmitted
 
     // MARK: - Headphone Controls
     case settingsHeadphoneControlsShown

--- a/podcasts/Bookmarks/Editing/BookmarkEditTitleViewController.swift
+++ b/podcasts/Bookmarks/Editing/BookmarkEditTitleViewController.swift
@@ -4,6 +4,7 @@ import PocketCastsDataModel
 class BookmarkEditTitleViewController: ThemedHostingController<BookmarkEditTitleView> {
     private let viewModel: BookmarkEditViewModel
     let onDismiss: ((String, Bool) -> Void)?
+    var editSaved: Bool = false
 
     var source: BookmarkAnalyticsSource = .unknown {
         didSet {
@@ -34,7 +35,9 @@ class BookmarkEditTitleViewController: ThemedHostingController<BookmarkEditTitle
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        Analytics.track(.bookmarkEditFormDismissed, properties: ["source": source.rawValue])
+        if !editSaved {
+            Analytics.track(.bookmarkEditFormDismissed, properties: ["source": source.rawValue])
+        }
     }
 
     @MainActor required dynamic init?(coder aDecoder: NSCoder) {
@@ -49,6 +52,7 @@ extension BookmarkEditTitleViewController: BookmarkEditRouter {
     }
 
     func titleUpdated(title: String) {
+        editSaved = true
         Analytics.track(.bookmarkEditFormSubmitted, properties: ["source": source.rawValue])
         dismiss(animated: true)
         onDismiss?(title, false)

--- a/podcasts/Bookmarks/Editing/BookmarkEditTitleViewController.swift
+++ b/podcasts/Bookmarks/Editing/BookmarkEditTitleViewController.swift
@@ -28,7 +28,13 @@ class BookmarkEditTitleViewController: ThemedHostingController<BookmarkEditTitle
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
+        Analytics.track(.bookmarkEditFormShown, properties: ["source": source.rawValue])
         viewModel.viewDidAppear()
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        Analytics.track(.bookmarkEditFormDismissed, properties: ["source": source.rawValue])
     }
 
     @MainActor required dynamic init?(coder aDecoder: NSCoder) {
@@ -43,6 +49,7 @@ extension BookmarkEditTitleViewController: BookmarkEditRouter {
     }
 
     func titleUpdated(title: String) {
+        Analytics.track(.bookmarkEditFormSubmitted, properties: ["source": source.rawValue])
         dismiss(animated: true)
         onDismiss?(title, false)
     }

--- a/podcasts/Bookmarks/List/BookmarkListViewModel.swift
+++ b/podcasts/Bookmarks/List/BookmarkListViewModel.swift
@@ -100,7 +100,6 @@ extension BookmarkListViewModel {
 
     func editSelectedBookmarks() {
         guard let bookmark = selectedItems.first else { return }
-
         router?.bookmarkEdit(bookmark)
         toggleMultiSelection()
     }
@@ -171,16 +170,19 @@ extension BookmarkListViewModel {
 private extension BookmarkListViewModel {
     func confirmDeletion(_ delete: @escaping () -> Void) {
         guard let router else { return }
-
+        let source = analyticsSource
         let alert = UIAlertController(title: L10n.bookmarkDeleteWarningTitle,
                                       message: L10n.bookmarkDeleteWarningBody,
                                       preferredStyle: .alert)
 
-        alert.addAction(.init(title: L10n.cancel, style: .cancel))
+        alert.addAction(.init(title: L10n.cancel, style: .cancel, handler: { _ in
+            Analytics.track(.bookmarkDeleteFormDismissed, source: source)
+        }))
         alert.addAction(.init(title: L10n.delete, style: .destructive, handler: { _ in
+            Analytics.track(.bookmarkDeleteFormSubmitted, source: source)
             delete()
         }))
-
+        Analytics.track(.bookmarkDeleteFormShown, source: analyticsSource)
         router.presentBookmarkController(alert)
     }
 


### PR DESCRIPTION
| 📘 Part of: #2628 |  <!-- project issue number, if applicable -->
|:---:|

Fixes #2653 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

This PR adds the missing events for bookmark edit and delete:

- bookmarkEditFormShown
- bookmarkEditFormDismissed
- bookmarkEditFormSubmitted
- bookmarkDeleteFormShown
- bookmarkDeleteFormDismissed
- bookmarkDeleteFormSubmitted

## To test

1. Start the app
2. Ensure that you have the `tracksLogging` FF enabled.
3. Tap on Profile tab
4. Tap on Bookmarks
5. Select a bookmark
6. Tap on Edit on the bar, check if the event `bookmarkEditFormShown` is show
7. Tap on the X on top and check if the event `bookmarkEditFormDismissed` is show
8. Tap on Edit again
9. Change the title, and tap Change title, check if the event `bookmarkEditFormSubmitted` is show
10. Select a bookmark again
11. Tap on the delete icon, check if the alert is show and if the event `bookmarkDeleteFormShown` is show
12. Tap on cancel, check if the event `bookmarkDeleteFormDismissed` is show
13. Select the bookmark again
11. Tap on the delete icon, check if the alert is show and if the event `bookmarkDeleteFormShown` is show
12. Tap on Delete, check if the event `bookmarkDeleteFormSubmitted` is show
13. On the above check if the source property is correct
14. Try the above again using other sources: `Podcast view`, `Episode Detail`, `Full Screen Player` and see if the source property show the correct values.
 
## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
