### PR TITLE
Analytics audit: champion events

### DIFF
--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -789,4 +789,7 @@ enum AnalyticsEvent: String {
     case cancelSubscriptionAvailablePlansDismissed
     case cancelSubscriptionSelectPlan
     case cancelSubscriptionNewPlanPurchaseSuccessful
+
+    case pocketCastsChampionDialogShown
+    case pocketCastsChampionDialogRateButtonTapped
 }

--- a/podcasts/Profile - SwiftUI/Account/ChampionView.swift
+++ b/podcasts/Profile - SwiftUI/Account/ChampionView.swift
@@ -17,6 +17,7 @@ struct ChampionView: View {
                 .multilineTextAlignment(.center)
                 .foregroundStyle(theme.primaryUi05Selected)
             Button(action: {
+                Analytics.track(.pocketCastsChampionDialogRateButtonTapped)
                 openURL(URL(string: ServerConstants.Urls.appStoreReview)!)
             }, label: {
                 Text(L10n.ratePocketCasts)
@@ -25,6 +26,9 @@ struct ChampionView: View {
         }
         .padding()
         .applyDefaultThemeOptions()
+        .onAppear() {
+            Analytics.track(.pocketCastsChampionDialogShown)
+        }
     }
 }
 


### PR DESCRIPTION
| 📘 Part of: #2628 
|:---:|

Fixes #2667 

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
Adds missing event when interaction Pocket Casts Champion message on account.

## To test

1. Start the app
2. Ensure that you have `tracksLogging` FF enabled
3. Give yourself Lifetime support using Developer Tools
4. Tap on Profile Tab
5. Tap on Account
6. Tap on Pocket Casts Champion Message on the header, check if the event `pocketCastsChampionDialogShown ` is shown
7. Tap on Rate Pocket Casts button, check if the event `pocketCastsChampionDialogRateButtonTapped ` is shown
8. 
## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
