### PR TITLE
[Winback] Modify cancel confirmation screen

### DIFF
--- a/podcasts/CancelConfirmationView.swift
+++ b/podcasts/CancelConfirmationView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import PocketCastsUtils
 
 struct CancelConfirmationView: View {
     @EnvironmentObject var theme: Theme
@@ -24,43 +25,59 @@ struct CancelConfirmationView: View {
     var body: some View {
         ScrollViewIfNeeded {
             VStack(spacing: Constants.padding.vertical) {
+                let bottomPadding = FeatureFlag.winback.enabled ? 40.0 : 0.0
                 header
+                    .padding(.bottom, bottomPadding)
 
                 // List view
-                VStack(alignment: .leading, spacing: Constants.padding.vertical) {
+                let spacing = FeatureFlag.winback.enabled ? 0 : Constants.padding.vertical
+                VStack(alignment: .leading, spacing: spacing) {
                     ForEach(rows) { row in
+                        let bottomPadding: CGFloat = FeatureFlag.winback.enabled ? 24.0 : 0
                         ListRow(row.text, image: row.imageName, highlightedText: row.highlight)
+                            .padding(.bottom, bottomPadding)
                     }
                 }
 
                 Spacer()
 
                 // Bottom buttons
-                VStack {
-                    shadowDivider
+                let buttonsSpacing: CGFloat? = FeatureFlag.winback.enabled ? 0 : nil
+                VStack(spacing: buttonsSpacing) {
+                    if !FeatureFlag.winback.enabled {
+                        shadowDivider
+                    }
                     buttons
                 }
 
-            }.padding([.leading, .trailing], Constants.padding.horizontal)
-        }.background(color(for: .background).ignoresSafeArea())
+            }
+            .padding([.leading, .trailing], Constants.padding.horizontal)
+        }
+        .background(color(for: .background).ignoresSafeArea())
     }
 
     private var header: some View {
         VStack(spacing: 0) {
-            Image(AppTheme.paymentFailedImageName())
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .frame(height: 100)
-
+            if !FeatureFlag.winback.enabled {
+                Image(AppTheme.paymentFailedImageName())
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(height: 100)
+            }
+            let topPadding = FeatureFlag.winback.enabled ? 44.0 : 0.0
+            let bottomPadding = FeatureFlag.winback.enabled ? 4.0 : 5.0
             Text(L10n.cancelSubscription)
                 .font(style: .title, weight: .bold, maxSizeCategory: .extraExtraExtraLarge)
                 .multilineTextAlignment(.center)
                 .fixedSize(horizontal: false, vertical: true)
                 .foregroundColor(color(for: .text))
-                .padding(.bottom, 5)
-
+                .padding(.bottom, bottomPadding)
+                .padding(.top, topPadding)
+            let fontWeight: Font.Weight = FeatureFlag.winback.enabled ? .regular : .medium
+            let fontSize: Double? = FeatureFlag.winback.enabled ? 15.0 : nil
+            let style: Font.TextStyle = FeatureFlag.winback.enabled ? .body : .headline
             Text(L10n.cancelConfirmSubtitle)
-                .font(style: .headline, weight: .medium, maxSizeCategory: .extraExtraExtraLarge)
+                .font(size: fontSize, style: style, weight: fontWeight, maxSizeCategory: .extraExtraExtraLarge)
                 .multilineTextAlignment(.center)
                 .fixedSize(horizontal: false, vertical: true)
                 .foregroundColor(color(for: .subtitle))
@@ -71,14 +88,18 @@ struct CancelConfirmationView: View {
     private var buttons: some View {
         Button(L10n.cancelConfirmStayButtonTitle) {
             viewModel.goBackTapped()
-        }.buttonStyle(RoundedButtonStyle(theme: theme))
+        }
+        .buttonStyle(RoundedButtonStyle(theme: theme))
 
+        let topPadding = FeatureFlag.winback.enabled ? 15.0 : -5
+        let bottomPadding = FeatureFlag.winback.enabled ? 0.0 : -5
         Button(L10n.cancelConfirmCancelButtonTitle) {
             viewModel.cancelTapped()
         }
         .buttonStyle(SimpleTextButtonStyle(theme: theme, textColor: .cancelButton))
         // Reduce the padding a bit to make it look more visually centered
-        .padding([.top, .bottom], -5)
+        .padding(.top, topPadding)
+        .padding(.bottom, bottomPadding)
     }
 
     private var shadowDivider: some View {
@@ -162,18 +183,33 @@ private struct ListRow: View {
 
     var body: some View {
         HStack(alignment: .top, spacing: 20) {
+            let topPadding = FeatureFlag.winback.enabled ? 0.0 : 3.0
             Image(image)
                 .resizable()
                 .renderingMode(.template)
                 .aspectRatio(contentMode: .fill)
                 .frame(width: 24, height: 24)
                 .foregroundColor(AppTheme.color(for: .iconColor, theme: theme))
-                .padding(.top, 3)
+                .padding(.top, topPadding)
 
+            let font: Font = FeatureFlag.winback.enabled ? Font.system(size: 15, weight: .regular) : .body.leading(.loose)
             HighlightedText(title)
-                .font(.body.leading(.loose))
+                .font(font)
                 .highlight(highlightedText) { _ in
-                    .init(weight: .medium, color: AppTheme.color(for: .highlightColor, theme: theme))
+                    if FeatureFlag.winback.enabled {
+                        HighlightedText.HighlightStyle(weight: .regular, color: AppTheme.color(for: .highlightColor, theme: theme))
+                    } else {
+                        HighlightedText.HighlightStyle(weight: .medium, color: AppTheme.color(for: .highlightColor, theme: theme))
+                    }
+                }
+                .modify {
+                    if FeatureFlag.winback.enabled {
+                        // This is to apply the right font to the highlighted text,
+                        // even when the `highlightedText` is nil
+                        $0.font(size: 15.0, style: .body, weight: .regular)
+                    } else {
+                        $0
+                    }
                 }
                 .fixedSize(horizontal: false, vertical: true)
                 .foregroundColor(AppTheme.color(for: .text, theme: theme))


### PR DESCRIPTION
| 📘 Part of: #2445 
|:---:|

Fixes #2665 

This PR modify the Cancel Confirmation Screen by changing a bit the font size, padding and removing the top icon.

| Before | After |
| ------ | ------ |
| ![IMG_0047](https://github.com/user-attachments/assets/dec3ca57-b926-452e-a0e3-9b3f580130c1) | ![IMG_0048](https://github.com/user-attachments/assets/42448f98-ecbe-4d6f-a9e0-20c419982263) |


## To test

- CI must be 🟢 
- Run the app with the `winback` FF on and a Plus Account
- Navigate to Account -> Cancel Subscription
- Tap on Continue to Cancellation
- Verify the new screen
- Do the same test with the FF off and verify the screen

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
