### PR TITLE
Analytics audit: update transcript show event

### DIFF
--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -747,7 +747,7 @@ enum AnalyticsEvent: String {
     case transcriptShown
     case transcriptError
     case transcriptDismissed
-    case transcriptSearch
+    case transcriptSearchShown
     case transcriptSearchNextResult
     case transcriptSearchPreviousResult
 

--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -153,7 +153,7 @@ class TranscriptViewController: PlayerItemViewController {
         searchView.textField.becomeFirstResponder()
         searchView.enableUpDownButtons(false)
 
-        track(.transcriptSearch)
+        track(.transcriptSearchShown)
     }
 
     private func dismissSearch() {


### PR DESCRIPTION
| 📘 Part of: #2628 
|:---:|

Update event for transcript search show to match the name in Android

## To test

- Start the app
- Ensure you have transcripts logging enabled
- Open a podcast episode with a transcript. Ex: Cautionary Tales podcasts normally have transcript
- Start playing it
- Open the fullscreen player
- Tap on the transcript button
- Tap on Search, and check if the event `transcript_search_shown`

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
