### PR TITLE
Analytics audit: Implement select podcast events

### DIFF
--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -792,4 +792,11 @@ enum AnalyticsEvent: String {
 
     case pocketCastsChampionDialogShown
     case pocketCastsChampionDialogRateButtonTapped
+
+    //MARK: - Select/Choose Podcasts
+    case settingsSelectPodcastsShown
+    case settingsSelectPodcastsSelectAllTapped
+    case settingsSelectPodcastsSelectNoneTapped
+    case settingsSelectPodcastsPodcastToggled
+    case settingsSelectPodcastsSelectAllPodcastsToggled
 }

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -795,6 +795,7 @@ enum AnalyticsEvent: String {
 
     //MARK: - Select/Choose Podcasts
     case settingsSelectPodcastsShown
+    case settingsSelectPodcastsDismissed
     case settingsSelectPodcastsSelectAllTapped
     case settingsSelectPodcastsSelectNoneTapped
     case settingsSelectPodcastsPodcastToggled

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -793,7 +793,7 @@ enum AnalyticsEvent: String {
     case pocketCastsChampionDialogShown
     case pocketCastsChampionDialogRateButtonTapped
 
-    //MARK: - Select/Choose Podcasts
+    // MARK: - Select/Choose Podcasts
     case settingsSelectPodcastsShown
     case settingsSelectPodcastsDismissed
     case settingsSelectPodcastsSelectAllTapped

--- a/podcasts/Analytics/Helpers/AnalyticsCoordinator.swift
+++ b/podcasts/Analytics/Helpers/AnalyticsCoordinator.swift
@@ -8,6 +8,7 @@ protocol AnalyticsSourceProvider {
 
 enum AnalyticsSource: String, AnalyticsDescribable {
     case appIconMenu = "app_icon_menu"
+    case autoAdd = "auto_add"
     case autoDownloadSettings = "auto_download_settings"
     case carPlay = "carplay"
     case chooseFolder = "choose_folder"
@@ -28,6 +29,7 @@ enum AnalyticsSource: String, AnalyticsDescribable {
     case miniplayer
     case noFiles = "no_files"
     case noFilters = "no_filters"
+    case notifications
     case nowPlayingWidget = "now_playing_widget"
     case player
     case playerPlaybackEffects = "player_playback_effects"

--- a/podcasts/AutoAddToUpNextViewController+PodcastSelect.swift
+++ b/podcasts/AutoAddToUpNextViewController+PodcastSelect.swift
@@ -41,7 +41,7 @@ extension AutoAddToUpNextViewController: PodcastSelectionDelegate {
         mainTable.reloadData()
     }
 
-    func didChangePodcasts() {
-        Analytics.track(.settingsAutoAddUpNextPodcastsChanged)
+    func didChangePodcasts(numberSelected: Int) {
+        Analytics.track(.settingsAutoAddUpNextPodcastsChanged, properties: ["number_selected": numberSelected])
     }
 }

--- a/podcasts/AutoAddToUpNextViewController.swift
+++ b/podcasts/AutoAddToUpNextViewController.swift
@@ -90,6 +90,7 @@ class AutoAddToUpNextViewController: PCViewController, UITableViewDelegate, UITa
                 options.show(statusBarStyle: preferredStatusBarStyle)
             case .selectPodcasts:
                 let podcastSelectViewController = PodcastChooserViewController()
+                podcastSelectViewController.analyticsSource = .autoAdd
                 podcastSelectViewController.delegate = self
                 let allPodcasts = DataManager.sharedManager.allPodcasts(includeUnsubscribed: false)
                 podcastSelectViewController.selectedUuids = allPodcasts.filter { $0.autoAddToUpNextOn() }.map(\.uuid)

--- a/podcasts/DownloadSettingsViewController.swift
+++ b/podcasts/DownloadSettingsViewController.swift
@@ -230,8 +230,8 @@ class DownloadSettingsViewController: PCViewController, UITableViewDataSource, U
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.podcastUpdated, object: podcast)
     }
 
-    func didChangePodcasts() {
-        Analytics.track(.settingsAutoDownloadPodcastsChanged)
+    func didChangePodcasts(numberSelected: Int) {
+        Analytics.track(.settingsAutoDownloadPodcastsChanged, properties: ["number_selected": numberSelected])
     }
 
     // MARK: - Switch Settings

--- a/podcasts/DownloadSettingsViewController.swift
+++ b/podcasts/DownloadSettingsViewController.swift
@@ -154,6 +154,7 @@ class DownloadSettingsViewController: PCViewController, UITableViewDataSource, U
         switch row {
         case .podcastSelection:
             podcastChooserController = PodcastChooserViewController()
+            podcastChooserController?.analyticsSource = .downloads
             if let podcastSelectController = podcastChooserController {
                 podcastSelectController.delegate = self
                 let allPodcasts = DataManager.sharedManager.allPodcasts(includeUnsubscribed: false)

--- a/podcasts/FilterChipCollectionView.swift
+++ b/podcasts/FilterChipCollectionView.swift
@@ -62,6 +62,7 @@ class FilterChipCollectionView: UICollectionView, UICollectionViewDelegate, UICo
         switch chip {
         case .podcast:
             let filterSettingsVC = PodcastFilterOverlayController(nibName: "PodcastChooserViewController", bundle: nil)
+            filterSettingsVC.analyticsSource = .filters
             filterSettingsVC.filterToEdit = filter
             let navVC = SJUIUtils.navController(for: filterSettingsVC)
             chipActionDelegate?.presentingViewController().present(navVC, animated: true, completion: nil)

--- a/podcasts/NotificationsViewController.swift
+++ b/podcasts/NotificationsViewController.swift
@@ -124,8 +124,8 @@ class NotificationsViewController: PCViewController, UITableViewDataSource, UITa
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.podcastUpdated, object: podcast)
     }
 
-    func didChangePodcasts() {
-        Analytics.track(.settingsNotificationsPodcastsChanged)
+    func didChangePodcasts(numberSelected: Int) {
+        Analytics.track(.settingsNotificationsPodcastsChanged, properties: ["number_selected": numberSelected])
     }
 
     @objc private func pushToggled(_ sender: UISwitch) {

--- a/podcasts/NotificationsViewController.swift
+++ b/podcasts/NotificationsViewController.swift
@@ -76,6 +76,7 @@ class NotificationsViewController: PCViewController, UITableViewDataSource, UITa
         tableView.deselectRow(at: indexPath, animated: true)
         if indexPath.row == 1 { // choose podcasts for push
             podcastChooserController = PodcastChooserViewController()
+            podcastChooserController?.analyticsSource = .notifications
             if let podcastsController = podcastChooserController {
                 podcastsController.delegate = self
                 let allPodcasts = DataManager.sharedManager.allPodcasts(includeUnsubscribed: false)

--- a/podcasts/PodcastChooserViewController.swift
+++ b/podcasts/PodcastChooserViewController.swift
@@ -46,7 +46,7 @@ class PodcastChooserViewController: PCViewController, UITableViewDelegate, UITab
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-
+        Analytics.track(.settingsSelectPodcastsDismissed, properties: ["source": analyticsSource])
         if selectedUuidsUpdated {
             selectedUuidsUpdated = false
             loadPodcasts()

--- a/podcasts/PodcastChooserViewController.swift
+++ b/podcasts/PodcastChooserViewController.swift
@@ -46,7 +46,7 @@ class PodcastChooserViewController: PCViewController, UITableViewDelegate, UITab
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        Analytics.track(.settingsSelectPodcastsDismissed, properties: ["source": analyticsSource])
+
         if selectedUuidsUpdated {
             selectedUuidsUpdated = false
             loadPodcasts()
@@ -55,7 +55,7 @@ class PodcastChooserViewController: PCViewController, UITableViewDelegate, UITab
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-
+        Analytics.track(.settingsSelectPodcastsDismissed, properties: ["source": analyticsSource])
         if didChange {
             delegate?.didChangePodcasts(numberSelected: selectedUuids.count)
         }

--- a/podcasts/PodcastChooserViewController.swift
+++ b/podcasts/PodcastChooserViewController.swift
@@ -16,6 +16,7 @@ class PodcastChooserViewController: PCViewController, UITableViewDelegate, UITab
     var selectedUuids = [String]()
     var selectAllOnLoad = false
     var allowSelectAll = true
+    var analyticsSource: AnalyticsSource = .unknown
 
     private var didChange = false
 
@@ -40,6 +41,7 @@ class PodcastChooserViewController: PCViewController, UITableViewDelegate, UITab
         insetAdjuster.setupInsetAdjustmentsForMiniPlayer(scrollView: podcastTable)
 
         loadPodcasts()
+        Analytics.track(.settingsSelectPodcastsShown, properties: ["source": analyticsSource])
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -85,7 +87,7 @@ class PodcastChooserViewController: PCViewController, UITableViewDelegate, UITab
         let index = selectedUuids.firstIndex(of: podcastUuid)
         if let index = index {
             selectedUuids.remove(at: index)
-
+            Analytics.track(.settingsSelectPodcastsPodcastToggled, properties: ["uuid": podcastUuid, "enabled": false, "source": analyticsSource])
             // to support things like playlist editting that need to know about all/none selected events send a different event when it gets to 0
             if selectedUuids.count == 0, allowSelectAll {
                 delegate?.bulkSelectionChange(selected: false)
@@ -94,7 +96,7 @@ class PodcastChooserViewController: PCViewController, UITableViewDelegate, UITab
             }
         } else {
             selectedUuids.append(podcastUuid)
-
+            Analytics.track(.settingsSelectPodcastsPodcastToggled, properties: ["uuid": podcastUuid, "enabled": true, "source": analyticsSource])
             // to support things like playlist editting that need to know about all/none selected events send a different event when all are manually selected
             if selectedUuids.count == allPodcasts.count, allowSelectAll {
                 delegate?.bulkSelectionChange(selected: true)
@@ -126,9 +128,11 @@ class PodcastChooserViewController: PCViewController, UITableViewDelegate, UITab
 
     @objc private func selectBtnTapped() {
         if shouldSelectAll() {
+            Analytics.track(.settingsSelectPodcastsSelectAllTapped, properties: ["source": analyticsSource])
             selectedUuids = allPodcasts.map(\.uuid)
             delegate?.bulkSelectionChange(selected: true)
         } else {
+            Analytics.track(.settingsSelectPodcastsSelectNoneTapped, properties: ["source": analyticsSource])
             selectedUuids.removeAll()
             delegate?.bulkSelectionChange(selected: false)
         }

--- a/podcasts/PodcastChooserViewController.swift
+++ b/podcasts/PodcastChooserViewController.swift
@@ -5,7 +5,7 @@ import UIKit
     func bulkSelectionChange(selected: Bool)
     func podcastSelected(podcast: String)
     func podcastUnselected(podcast: String)
-    func didChangePodcasts()
+    func didChangePodcasts(numberSelected: Int)
 }
 
 class PodcastChooserViewController: PCViewController, UITableViewDelegate, UITableViewDataSource {
@@ -57,7 +57,7 @@ class PodcastChooserViewController: PCViewController, UITableViewDelegate, UITab
         super.viewWillDisappear(animated)
 
         if didChange {
-            delegate?.didChangePodcasts()
+            delegate?.didChangePodcasts(numberSelected: selectedUuids.count)
         }
     }
 

--- a/podcasts/PodcastFilterOverlayController.swift
+++ b/podcasts/PodcastFilterOverlayController.swift
@@ -13,7 +13,7 @@ class PodcastFilterOverlayController: PodcastChooserViewController, PodcastSelec
     let podcastFilterCellId = "PodcastFilterCell"
     var saveButton: UIButton!
 
-    override func viewDidLoad() {       
+    override func viewDidLoad() {
         super.viewDidLoad()
         delegate = self
         podcastTable.delegate = self

--- a/podcasts/PodcastFilterOverlayController.swift
+++ b/podcasts/PodcastFilterOverlayController.swift
@@ -188,7 +188,7 @@ class PodcastFilterOverlayController: PodcastChooserViewController, PodcastSelec
         updateRightBarBtn()
     }
 
-    func didChangePodcasts() {}
+    func didChangePodcasts(numberSelected: Int) {}
 
     // MARK: - TableView data source and delegate
 

--- a/podcasts/PodcastFilterOverlayController.swift
+++ b/podcasts/PodcastFilterOverlayController.swift
@@ -13,7 +13,7 @@ class PodcastFilterOverlayController: PodcastChooserViewController, PodcastSelec
     let podcastFilterCellId = "PodcastFilterCell"
     var saveButton: UIButton!
 
-    override func viewDidLoad() {
+    override func viewDidLoad() {       
         super.viewDidLoad()
         delegate = self
         podcastTable.delegate = self
@@ -132,7 +132,7 @@ class PodcastFilterOverlayController: PodcastChooserViewController, PodcastSelec
         dismiss(animated: true, completion: nil)
 
         if !filterToEdit.isNew {
-            Analytics.track(.filterUpdated, properties: ["group": "podcasts", "source": "filters"])
+            Analytics.track(.filterUpdated, properties: ["group": "podcasts", "source": analyticsSource])
         }
     }
 
@@ -168,6 +168,7 @@ class PodcastFilterOverlayController: PodcastChooserViewController, PodcastSelec
                 selectedUuids.append(podcast.uuid)
             }
         }
+        Analytics.track(.settingsSelectPodcastsSelectAllPodcastsToggled, properties: ["enabled": selectAllSwitch.isOn, "source": analyticsSource])
         setSwitchSubtitle()
         updateRightBarBtn()
         podcastTable.reloadData()


### PR DESCRIPTION
| 📘 Part of: #2628 |  <!-- project issue number, if applicable -->
|:---:|

Fixes #2645 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
Adds tracking event to track action on Podcast choose Picker:

- settingsSelectPodcastsShown
- settingsSelectPodcastsDismissed
- settingsSelectPodcastsSelectAllTapped
- settingsSelectPodcastsSelectNoneTapped
- settingsSelectPodcastsPodcastToggled
- settingsSelectPodcastsSelectAllPodcastsToggled

## To test

- Start the app
- Ensure you have tracksLogging FF enabled
- Go to Filters tab, and create a new filter
- Tap on All Your Podcasts pill
- Check if the event `settingsSelectPodcastsShown` is send and has the `source` property set to `filters`
- Tap on the All Podcasts switch and check if `settingsSelectPodcastsSelectAllPodcastsToggled` is send and have the `enable` property correctly set and `source` property set to `filters`
- Select a single podcast, check if `settingsSelectPodcastsPodcastToggled` is sent with the properties `uuid`, `enabled` and `source` correctly set
- Deselect the single podcast, check if `settingsSelectPodcastsPodcastToggled` is sent with the properties `uuid`, `enabled` and `source` correctly set
- Tap on Select All on the top right, check if `settingsSelectPodcastsSelectAllTapped` is sent with the property `source` correctly set
- Tap on Deselect All on the top right, , check if `settingsSelectPodcastsSelectNoneTapped` is sent with the property `source` correctly set
- Tap on X, check if `settingsSelectPodcastsDismissed` is sent

Check the same events are sent with the correct source when selecting podcasts on Auto-Downloads, Notifications and Auto-Add settings.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
