### PR TITLE
Analytics audit: Update general settings events

### DIFF
--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -507,6 +507,8 @@ enum AnalyticsEvent: String {
     case settingsGeneralEpisodeGroupingApplyToExisting
     case settingsGeneralEpisodeGroupingDoNotApplyToExisting
     case settingsGeneralArchivedEpisodesChanged
+    case settingsGeneralArchivedEpisodesApplyToExisting
+    case settingsGeneralArchivedEpisodesDoNotApplyToExisting
     case settingsGeneralUpNextSwipeChanged
     case settingsGeneralOpenLinksInBrowserToggled
     case settingsGeneralSkipForwardChanged

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -504,6 +504,8 @@ enum AnalyticsEvent: String {
     case settingsGeneralShown
     case settingsGeneralRowActionChanged
     case settingsGeneralEpisodeGroupingChanged
+    case settingsGeneralEpisodeGroupingApplyToExisting
+    case settingsGeneralEpisodeGroupingDoNotApplyToExisting
     case settingsGeneralArchivedEpisodesChanged
     case settingsGeneralUpNextSwipeChanged
     case settingsGeneralOpenLinksInBrowserToggled

--- a/podcasts/GeneralSettingsViewController.swift
+++ b/podcasts/GeneralSettingsViewController.swift
@@ -467,9 +467,11 @@ class GeneralSettingsViewController: PCViewController, UITableViewDelegate, UITa
         let groupingPrompt = OptionsPicker(title: nil)
 
         let applyToAllAction = OptionAction(label: L10n.settingsGeneralApplyAllConf, icon: nil) {
+            Analytics.track(.settingsGeneralArchivedEpisodesApplyToExisting)
             DataManager.sharedManager.updateAllShowArchived(to: showArchived)
         }
         let noAction = OptionAction(label: L10n.settingsGeneralNoThanks, icon: nil) {
+            Analytics.track(.settingsGeneralArchivedEpisodesDoNotApplyToExisting)
             // no need to do anything
         }
         noAction.outline = true

--- a/podcasts/GeneralSettingsViewController.swift
+++ b/podcasts/GeneralSettingsViewController.swift
@@ -448,9 +448,11 @@ class GeneralSettingsViewController: PCViewController, UITableViewDelegate, UITa
         let groupingPrompt = OptionsPicker(title: nil)
 
         let applyToAllAction = OptionAction(label: L10n.settingsGeneralApplyAllConf, icon: nil) {
+            Analytics.track(.settingsGeneralEpisodeGroupingApplyToExisting)
             DataManager.sharedManager.updateAllPodcastGrouping(to: grouping)
         }
         let noAction = OptionAction(label: L10n.settingsGeneralNoThanks, icon: nil) {
+            Analytics.track(.settingsGeneralEpisodeGroupingDoNotApplyToExisting)
             // no need to do anything
         }
         noAction.outline = true


### PR DESCRIPTION
| 📘 Part of: #2628 
|:---:|

Fixes #2674  <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
Adds the following missing events on general settings:

- settingsGeneralEpisodeGroupingApplyToExisting
- settingsGeneralEpisodeGroupingDoNotApplyToExisting
- settingsGeneralArchivedEpisodesApplyToExisting
- settingsGeneralArchivedEpisodesDoNotApplyToExisting

## To test

- Start the app
- Ensure you have tracksLogging FF enabled
- Tap on Profile tab
- Tap on Settings ( cog icon )
- Tap on General
- Tap on Podcast Episode Grouping
- Select one of the options
- Tap on Apply to existing, check if the event `settingsGeneralEpisodeGroupingApplyToExisting` is sent
- Tap again on Podcast Episode Grouping
- Select one of the options
- Tap on No Thanks, check if the event `settingsGeneralEpisodeGroupingDoNotApplyToExisting` is sent
- Tap on Archived Episodes
- Select one of the options
- Tap on Apply to existing, check if the event `settingsGeneralArchivedEpisodesApplyToExisting` is sent
- Tap again on Podcast Episode Grouping
- Select one of the options
- Tap on No Thanks, check if the event `settingsGeneralArchivedEpisodesDoNotApplyToExisting` is sent

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
