### PR TITLE
[Analytics Audit] Podcast view

### DIFF
--- a/podcasts/AboutView.swift
+++ b/podcasts/AboutView.swift
@@ -46,20 +46,25 @@ struct AboutView: View {
                         }
                         Section {
                             AboutRow(mainText: L10n.aboutRateUs) {
+                                model.track(action: .rateUs)
                                 openUrl(ServerConstants.Urls.appStoreReview)
                             }
                             AboutRow(mainText: L10n.aboutShareFriends) {
+                                model.track(action: .shareWithFriends)
                                 openShareApp()
                             }
                         }
                         Section {
                             AboutRow(mainText: L10n.aboutWebsite, secondaryText: L10n.websiteShort) {
+                                model.track(action: .website)
                                 openUrl(ServerConstants.Urls.pocketcastsDotCom)
                             }
                             AboutRow(mainText: L10n.instagram, secondaryText: L10n.socialHandle) {
+                                model.track(action: .instagram)
                                 SocialsHelper.openInstagram()
                             }
                             AboutRow(mainText: L10n.twitter, secondaryText: L10n.socialHandle) {
+                                model.track(action: .twitter)
                                 SocialsHelper.openTwitter()
                             }
                         }
@@ -85,6 +90,7 @@ struct AboutView: View {
                             }
                             .frame(height: familyCellHeight)
                             .onTapGesture {
+                                model.track(action: .automatticFamily)
                                 openUrl(ServerConstants.Urls.automatticDotCom)
                             }
                         }
@@ -98,6 +104,7 @@ struct AboutView: View {
                                     .font(.subheadline)
                             }
                             .onTapGesture {
+                                model.track(action: .workWithUs)
                                 openUrl(ServerConstants.Urls.automatticWorkWithUs)
                             }
                         }

--- a/podcasts/AboutViewModel.swift
+++ b/podcasts/AboutViewModel.swift
@@ -13,4 +13,33 @@ class AboutViewModel: ObservableObject {
 
         shouldShowWhatsNew = Settings.appVersion() == whatsNewInfo?.versionNo
     }
+
+    func track(action: AboutAction) {
+        switch action {
+        case .rateUs:
+            Analytics.track(.rateUsTapped, properties: ["source": "about"])
+        case .shareWithFriends:
+            Analytics.track(.settingsAboutShareWithFriendsTapped)
+        case .website:
+            Analytics.track(.settingsAboutWebsiteTapped)
+        case .instagram:
+            Analytics.track(.settingsAboutInstagramTapped)
+        case .twitter:
+            Analytics.track(.settingsAboutTwitterTapped)
+        case .automatticFamily:
+            Analytics.track(.settingsAboutAutomatticFamilyTapped)
+        case .workWithUs:
+            Analytics.track(.settingsAboutWorkWithUsTapped)
+        }
+    }
+
+    enum AboutAction {
+        case rateUs
+        case shareWithFriends
+        case website
+        case instagram
+        case twitter
+        case automatticFamily
+        case workWithUs
+    }
 }

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -311,6 +311,7 @@ enum AnalyticsEvent: String {
     // MARK: - App Store Review Request
 
     case appStoreReviewRequested
+    case rateUsTapped
 
     // MARK: - Signed out alert
 
@@ -618,6 +619,13 @@ enum AnalyticsEvent: String {
     // MARK: - Settings: About
 
     case settingsAboutShown
+    case settingsAboutShareWithFriendsTapped
+    case settingsAboutWebsiteTapped
+    case settingsAboutInstagramTapped
+    case settingsAboutTwitterTapped
+    case settingsAboutAutomatticFamilyTapped
+    case settingsAboutLegalAndMoreTapped
+    case settingsAboutWorkWithUsTapped
 
     // MARK: - OPML Import
 

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -303,6 +303,7 @@ enum AnalyticsEvent: String {
     case podcastScreenToggleArchived
     case podcastScreenShareTapped
     case podcastScreenToggleSummary
+    case podcastScreenPodcastDescriptionTapped
     case podcastsScreenSortOrderChanged
     case podcastsScreenEpisodeGroupingChanged
     case podcastsScreenTabTapped

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -419,6 +419,7 @@ enum AnalyticsEvent: String {
 
     case episodeUploadQueued
     case episodeUploadFinished
+    case episodeUploadFailed
     case episodeUploadCancelled
     case episodeDeletedFromCloud
 

--- a/podcasts/Analytics/Helpers/AnalyticsEpisodeHelper.swift
+++ b/podcasts/Analytics/Helpers/AnalyticsEpisodeHelper.swift
@@ -124,6 +124,10 @@ class AnalyticsEpisodeHelper: AnalyticsCoordinator {
         episodeEvent(.episodeUploadFinished, uuid: episodeUUID)
     }
 
+    func episodeUploadFailed(episodeUUID: String) {
+        episodeEvent(.episodeUploadFailed, uuid: episodeUUID)
+    }
+
     // MARK: - Up Next
 
     func episodeAddedToUpNext(episode: BaseEpisode, toTop: Bool) {
@@ -189,14 +193,20 @@ private extension AnalyticsEpisodeHelper {
                 // Verify that the file has finished uploading
                 guard
                     let episode = DataManager.sharedManager.findUserEpisode(uuid: uuid),
-                    let status = UploadStatus(rawValue: episode.uploadStatus),
-                    status == .uploaded
+                    let status = UploadStatus(rawValue: episode.uploadStatus)
                 else {
                     return
                 }
 
-                self.episodeUploadQueue.remove(uuid)
-                self.episodeUploadFinished(episodeUUID: uuid)
+                switch status {
+                case .uploaded:
+                    self.episodeUploadQueue.remove(uuid)
+                    self.episodeUploadFinished(episodeUUID: uuid)
+                case .uploadFailed:
+                    self.episodeUploadFailed(episodeUUID: uuid)
+                default:
+                    break
+                }
             }
         #endif
     }

--- a/podcasts/ExpandableLabel.swift
+++ b/podcasts/ExpandableLabel.swift
@@ -76,6 +76,7 @@ class ExpandableLabel: ThemeableLabel {
             UIApplication.shared.open(url)
             return
         }
+        Analytics.track(.podcastScreenPodcastDescriptionTapped)
         if collapsed {
             delegate?.willExpandLabel(self)
             collapsed = false

--- a/podcasts/LegalAndMoreView.swift
+++ b/podcasts/LegalAndMoreView.swift
@@ -14,12 +14,15 @@ struct LegalAndMore: View {
             List {
                 Section {
                     AboutRow(mainText: L10n.aboutTermsOfService, showChevronIcon: true) {
+                        track(row: "terms_of_service")
                         showTermsOfService = true
                     }
                     AboutRow(mainText: L10n.aboutPrivacyPolicy, showChevronIcon: true) {
+                        track(row: "privacy_policy")
                         showPrivacyPolicy = true
                     }
                     AboutRow(mainText: L10n.aboutAcknowledgements, showChevronIcon: true) {
+                        track(row: "acknowledgements")
                         showAcknowledgements = true
                     }
                 }
@@ -42,6 +45,10 @@ struct LegalAndMore: View {
             destination: WebView(url: Constants.acknowledgementsURL).navigationTitle(L10n.aboutAcknowledgements),
             isActive: $showAcknowledgements
         ) {}
+    }
+
+    private func track(row: String) {
+        Analytics.track(.settingsAboutLegalAndMoreTapped, properties: ["row": row])
     }
 
     private enum Constants {

--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -436,7 +436,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
 
         let sourceRect = sender.superview!.convert(sender.frame, to: view)
         SharingHelper.shared.shareLinkTo(podcast: podcast, fromController: self, fromSource: analyticsSource, sourceRect: sourceRect, sourceView: view)
-        Analytics.track(.podcastScreenShareTapped)
+        Analytics.track(.podcastScreenShareTapped, properties: ["podcast_uuid": podcast.uuid, "is_private": podcast.isPrivate])
     }
 
     private func loadPodcastInfo() {


### PR DESCRIPTION
| 📘 Part of: #2628 
|:---:|

This PR adds:
• the missing `podcast_screen_podcast_description_tapped` event
• the missing `podcast_uuid` & `is_private` params to `podcast_screen_share_tapped`

## To test

• Run the app with the trackers log on
• Go to a podcast screen
• tap on the share icon
• confirm `podcast_screen_share_tapped` is tracked with `podcast_uuid` & `is_private` params
•  expand and collapse the podcast description
• confirm `podcast_screen_podcast_description_tapped` is tracked
• Upload a file and upload to the cloud
• In `AnalyticsEpisodeHelper` add a break point at line 200 and force the status to be `uploadFailed`
• confirm you see `episode_upload_failed` tracked with the `episode_uuid`

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
