### PR TITLE
[Analytics Audit] Add events to the About Screen

### DIFF
--- a/podcasts/AboutView.swift
+++ b/podcasts/AboutView.swift
@@ -46,20 +46,25 @@ struct AboutView: View {
                         }
                         Section {
                             AboutRow(mainText: L10n.aboutRateUs) {
+                                model.track(action: .rateUs)
                                 openUrl(ServerConstants.Urls.appStoreReview)
                             }
                             AboutRow(mainText: L10n.aboutShareFriends) {
+                                model.track(action: .shareWithFriends)
                                 openShareApp()
                             }
                         }
                         Section {
                             AboutRow(mainText: L10n.aboutWebsite, secondaryText: L10n.websiteShort) {
+                                model.track(action: .website)
                                 openUrl(ServerConstants.Urls.pocketcastsDotCom)
                             }
                             AboutRow(mainText: L10n.instagram, secondaryText: L10n.socialHandle) {
+                                model.track(action: .instagram)
                                 SocialsHelper.openInstagram()
                             }
                             AboutRow(mainText: L10n.twitter, secondaryText: L10n.socialHandle) {
+                                model.track(action: .twitter)
                                 SocialsHelper.openTwitter()
                             }
                         }
@@ -85,6 +90,7 @@ struct AboutView: View {
                             }
                             .frame(height: familyCellHeight)
                             .onTapGesture {
+                                model.track(action: .automatticFamily)
                                 openUrl(ServerConstants.Urls.automatticDotCom)
                             }
                         }
@@ -98,6 +104,7 @@ struct AboutView: View {
                                     .font(.subheadline)
                             }
                             .onTapGesture {
+                                model.track(action: .workWithUs)
                                 openUrl(ServerConstants.Urls.automatticWorkWithUs)
                             }
                         }

--- a/podcasts/AboutViewModel.swift
+++ b/podcasts/AboutViewModel.swift
@@ -13,4 +13,33 @@ class AboutViewModel: ObservableObject {
 
         shouldShowWhatsNew = Settings.appVersion() == whatsNewInfo?.versionNo
     }
+
+    func track(action: AboutAction) {
+        switch action {
+        case .rateUs:
+            Analytics.track(.rateUsTapped, properties: ["source": "about"])
+        case .shareWithFriends:
+            Analytics.track(.settingsAboutShareWithFriendsTapped)
+        case .website:
+            Analytics.track(.settingsAboutWebsiteTapped)
+        case .instagram:
+            Analytics.track(.settingsAboutInstagramTapped)
+        case .twitter:
+            Analytics.track(.settingsAboutTwitterTapped)
+        case .automatticFamily:
+            Analytics.track(.settingsAboutAutomatticFamilyTapped)
+        case .workWithUs:
+            Analytics.track(.settingsAboutWorkWithUsTapped)
+        }
+    }
+
+    enum AboutAction {
+        case rateUs
+        case shareWithFriends
+        case website
+        case instagram
+        case twitter
+        case automatticFamily
+        case workWithUs
+    }
 }

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -311,6 +311,7 @@ enum AnalyticsEvent: String {
     // MARK: - App Store Review Request
 
     case appStoreReviewRequested
+    case rateUsTapped
 
     // MARK: - Signed out alert
 
@@ -618,6 +619,13 @@ enum AnalyticsEvent: String {
     // MARK: - Settings: About
 
     case settingsAboutShown
+    case settingsAboutShareWithFriendsTapped
+    case settingsAboutWebsiteTapped
+    case settingsAboutInstagramTapped
+    case settingsAboutTwitterTapped
+    case settingsAboutAutomatticFamilyTapped
+    case settingsAboutLegalAndMoreTapped
+    case settingsAboutWorkWithUsTapped
 
     // MARK: - OPML Import
 

--- a/podcasts/LegalAndMoreView.swift
+++ b/podcasts/LegalAndMoreView.swift
@@ -14,12 +14,15 @@ struct LegalAndMore: View {
             List {
                 Section {
                     AboutRow(mainText: L10n.aboutTermsOfService, showChevronIcon: true) {
+                        track(row: "terms_of_service")
                         showTermsOfService = true
                     }
                     AboutRow(mainText: L10n.aboutPrivacyPolicy, showChevronIcon: true) {
+                        track(row: "privacy_policy")
                         showPrivacyPolicy = true
                     }
                     AboutRow(mainText: L10n.aboutAcknowledgements, showChevronIcon: true) {
+                        track(row: "acknowledgements")
                         showAcknowledgements = true
                     }
                 }
@@ -42,6 +45,10 @@ struct LegalAndMore: View {
             destination: WebView(url: Constants.acknowledgementsURL).navigationTitle(L10n.aboutAcknowledgements),
             isActive: $showAcknowledgements
         ) {}
+    }
+
+    private func track(row: String) {
+        Analytics.track(.settingsAboutLegalAndMoreTapped, properties: ["row": row])
     }
 
     private enum Constants {


### PR DESCRIPTION
| 📘 Part of: #2628
|:---:|

Fixes #2676

Adds the following events:

- rateUsTapped
- settingsAboutShareWithFriendsTapped
- settingsAboutWebsiteTapped
- settingsAboutInstagramTapped
- settingsAboutTwitterTapped
- settingsAboutAutomatticFamilyTapped
- settingsAboutLegalAndMoreTapped
- settingsAboutWorkWithUsTapped

## To test

- Make sure the tracks logger is on
- Navigate to the About screen
- Tap on Rate US: confirm it tracks `🔵 Tracked: rate_us_tapped ["source": "about"]`
- Tap on Share With Friends: confirm it tracks `🔵 Tracked: settings_about_share_with_friends_tapped`
- Tap on Website: confirm it tracks `🔵 Tracked: settings_about_website_tapped`
- Tap on Instagram: confirm it tracks `🔵 Tracked: settings_about_instagram_tapped`
- Tap on Twitter: confirm it tracks `🔵 Tracked: settings_about_twitter_tapped`
- Tap on Legal and More
- Tap on Terms of Service: confirm it tracks `settings_about_legal_and_more_tapped ["row": "terms_of_service"]`
- Tap on Privacy Policy: confirm it tracks `settings_about_legal_and_more_tapped ["row": "privacy_policy"]`
- Tap on Acknowledgements: confirm it tracks `settings_about_legal_and_more_tapped ["row": "acknowledgements"]`
- Tap on Automattic Family: confirm it tracks `🔵 Tracked: settings_about_automattic_family_tapped`
- Tap on Work With Us: confirm it tracks `🔵 Tracked: settings_about_work_with_us_tapped`

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
