### PR TITLE
[Analytics Audit] Add missing share events

### DIFF
--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -772,6 +772,9 @@ enum AnalyticsEvent: String {
     case shareScreenPlayTapped
     case shareScreenPauseTapped
     case shareScreenClipShared
+    case shareScreenNavigationButtonTapped
+    case shareScreenEditButtonTapped
+    case shareScreenCloseButtonTapped
 
     // MARK: - Referrals
 

--- a/podcasts/Sharing/SharingFooterView.swift
+++ b/podcasts/Sharing/SharingFooterView.swift
@@ -36,6 +36,7 @@ struct SharingFooterView: View {
                 .foregroundStyle(.white.opacity(0.5))
                 .font(.caption.weight(.semibold))
                 Button(L10n.next, action: {
+                    Analytics.track(.shareScreenNavigationButtonTapped)
                     withAnimation {
                         option = .clipShare(episode, clipTime, style)
                     }

--- a/podcasts/Sharing/SharingModal.swift
+++ b/podcasts/Sharing/SharingModal.swift
@@ -123,6 +123,7 @@ enum SharingModal {
         let modalView = ModalView {
             sharingView
         } dismissAction: {
+            Analytics.track(.shareScreenCloseButtonTapped)
             viewController.dismiss(animated: true)
         }
         .background(Color(PlayerColorHelper.playerBackgroundColor01()))

--- a/podcasts/Sharing/SharingView.swift
+++ b/podcasts/Sharing/SharingView.swift
@@ -114,6 +114,7 @@ struct SharingView: View {
             switch shareable.option {
             case .clipShare(let episode, let clipTime, _):
                 Button(action: {
+                    Analytics.track(.shareScreenEditButtonTapped)
                     withAnimation {
                         shareable.option = .clip(episode, clipTime.playback)
                     }


### PR DESCRIPTION
| 📘 Part of: #2628 
|:---:|

Fixes #2678 

This PR adds the missing events for the Sharing action:

```
- share_screen_navigation_button_tapped
- share_screen_edit_button_tapped
- share_screen_close_button_tapped
```

## To test
- Run the app with the track log on
- Play an episode and tap Share -> Clip
- Tap on Next: confirm it tracks `🔵 Tracked: share_screen_navigation_button_tapped`
- Tap on Edit: confirm it tracks `🔵 Tracked: share_screen_edit_button_tapped`
- Tap on the close button (top right): confirm it tracks `🔵 Tracked: share_screen_close_button_tapped`

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
