### PR TITLE
Fix HTML description crash

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -244,6 +244,8 @@ public enum FeatureFlag: String, CaseIterable {
             shouldEnableSyncedSettings ? "settings_sync" : nil
         case .defaultPlayerFilterCallbackFix:
             "default_player_filter_callback_fix"
+        case .usePodcastHTMLDescription:
+            "use_podcast_html_description"
         default:
             rawValue.lowerSnakeCased()
         }

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1972,6 +1972,7 @@
 		FF91A0FE2B6BC4BD002A0590 /* FeaturesCarousel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF91A0FD2B6BC4BD002A0590 /* FeaturesCarousel.swift */; };
 		FF9B6B752D0732D40057A504 /* LogsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF9B6B742D0732CF0057A504 /* LogsViewController.swift */; };
 		FF9B6B772D0733670057A504 /* LogsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF9B6B762D0733650057A504 /* LogsView.swift */; };
+		FF9CD67F2D410E670046697B /* RichExpandableDescriptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF9CD67E2D410E480046697B /* RichExpandableDescriptionView.swift */; };
 		FF9ED3552C86010F00B6E630 /* TipView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF9ED3542C86010F00B6E630 /* TipView.swift */; };
 		FFAA063E2C086DEA00FBC38F /* InsetAdjuster.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFAA063D2C086DEA00FBC38F /* InsetAdjuster.swift */; };
 		FFC293992B6173400059F3BB /* IAPTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFC293982B6173400059F3BB /* IAPTypes.swift */; };
@@ -3963,6 +3964,7 @@
 		FF91A0FD2B6BC4BD002A0590 /* FeaturesCarousel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturesCarousel.swift; sourceTree = "<group>"; };
 		FF9B6B742D0732CF0057A504 /* LogsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogsViewController.swift; sourceTree = "<group>"; };
 		FF9B6B762D0733650057A504 /* LogsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogsView.swift; sourceTree = "<group>"; };
+		FF9CD67E2D410E480046697B /* RichExpandableDescriptionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RichExpandableDescriptionView.swift; sourceTree = "<group>"; };
 		FF9ED3542C86010F00B6E630 /* TipView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TipView.swift; sourceTree = "<group>"; };
 		FFAA063D2C086DEA00FBC38F /* InsetAdjuster.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsetAdjuster.swift; sourceTree = "<group>"; };
 		FFC293982B6173400059F3BB /* IAPTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IAPTypes.swift; sourceTree = "<group>"; };
@@ -5664,6 +5666,7 @@
 				BD5DD2E320109D650031B5DC /* FakeNavViewController.swift */,
 				BD93FDA020157B2000F6EF55 /* PodcastImageView.swift */,
 				BD1B32AA204CFA3800F06F67 /* ExpandableLabel.swift */,
+				FF9CD67E2D410E480046697B /* RichExpandableDescriptionView.swift */,
 				40842636213777580076D82E /* RoundedLabel.swift */,
 				BDAE72D72138FB32002810A2 /* ActionIconButton.swift */,
 				BDFFC9AE2148A1460026D875 /* PCRoutePickerView.swift */,
@@ -10666,6 +10669,7 @@
 				BD3334521FC67FBB0017C3A8 /* PlaylistRefreshOperation.swift in Sources */,
 				BDD3579027BCD33D0000D155 /* FolderViewController.swift in Sources */,
 				BDD71CF41BA935E8006D2CE3 /* NetworkViewController.swift in Sources */,
+				FF9CD67F2D410E670046697B /* RichExpandableDescriptionView.swift in Sources */,
 				8B723755291185B300FA8219 /* Analytics+story.swift in Sources */,
 				FF2142D42C07369200672D8D /* MediaExporter.swift in Sources */,
 				109446762CEB3A8100977161 /* CancelSubscriptionViewModel.swift in Sources */,

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -306,6 +306,7 @@ enum AnalyticsEvent: String {
     case podcastsScreenSortOrderChanged
     case podcastsScreenEpisodeGroupingChanged
     case podcastsScreenTabTapped
+    case podcastScreenPodcastDescriptionLinkTapped
 
     // MARK: - App Store Review Request
 

--- a/podcasts/ExpandableLabel.swift
+++ b/podcasts/ExpandableLabel.swift
@@ -75,7 +75,7 @@ class ExpandableLabel: ThemeableLabel {
 
     @objc private func labelTapped(gesture: UITapGestureRecognizer) {
         if let url = gesture.didTapLinkInLabel(label: self) {
-            UIApplication.shared.open(url)
+            delegate?.linkTapped(url: url)
             return
         }
         if collapsed {

--- a/podcasts/ExpandableLabel.swift
+++ b/podcasts/ExpandableLabel.swift
@@ -6,6 +6,8 @@ protocol ExpandableLabelDelegate: NSObjectProtocol {
 
     func willCollapseLabel(_ label: UIView)
     func didCollapseLabel(_ label: UIView)
+
+    func linkTapped(url: URL)
 }
 
 class ExpandableLabel: ThemeableLabel {

--- a/podcasts/ExpandableLabel.swift
+++ b/podcasts/ExpandableLabel.swift
@@ -1,11 +1,11 @@
 import UIKit
 
 protocol ExpandableLabelDelegate: NSObjectProtocol {
-    func willExpandLabel(_ label: ExpandableLabel)
-    func didExpandLabel(_ label: ExpandableLabel)
+    func willExpandLabel(_ label: UIView)
+    func didExpandLabel(_ label: UIView)
 
-    func willCollapseLabel(_ label: ExpandableLabel)
-    func didCollapseLabel(_ label: ExpandableLabel)
+    func willCollapseLabel(_ label: UIView)
+    func didCollapseLabel(_ label: UIView)
 }
 
 class ExpandableLabel: ThemeableLabel {

--- a/podcasts/ExpandableLabel.swift
+++ b/podcasts/ExpandableLabel.swift
@@ -77,8 +77,7 @@ class ExpandableLabel: ThemeableLabel {
         if let url = gesture.didTapLinkInLabel(label: self) {
             delegate?.linkTapped(url: url)
             return
-        }
-        Analytics.track(.podcastScreenPodcastDescriptionTapped)
+        }        
         if collapsed {
             delegate?.willExpandLabel(self)
             collapsed = false

--- a/podcasts/ExpandableLabel.swift
+++ b/podcasts/ExpandableLabel.swift
@@ -77,7 +77,7 @@ class ExpandableLabel: ThemeableLabel {
         if let url = gesture.didTapLinkInLabel(label: self) {
             delegate?.linkTapped(url: url)
             return
-        }        
+        }
         if collapsed {
             delegate?.willExpandLabel(self)
             collapsed = false

--- a/podcasts/PodcastHeadingTableCell.swift
+++ b/podcasts/PodcastHeadingTableCell.swift
@@ -454,6 +454,7 @@ class PodcastHeadingTableCell: ThemeableCell, SubscribeButtonDelegate, Expandabl
     // MARK: - ExpandableLabelDelegate
 
     func willExpandLabel(_ label: UIView) {
+        Analytics.track(.podcastScreenPodcastDescriptionTapped)
         delegate?.tableView().beginUpdates()
     }
 
@@ -463,6 +464,7 @@ class PodcastHeadingTableCell: ThemeableCell, SubscribeButtonDelegate, Expandabl
     }
 
     func willCollapseLabel(_ label: UIView) {
+        Analytics.track(.podcastScreenPodcastDescriptionTapped)
         delegate?.tableView().beginUpdates()
     }
 

--- a/podcasts/PodcastHeadingTableCell.swift
+++ b/podcasts/PodcastHeadingTableCell.swift
@@ -1,6 +1,7 @@
 import PocketCastsServer
 import PocketCastsUtils
 import UIKit
+import SafariServices
 
 class PodcastHeadingTableCell: ThemeableCell, SubscribeButtonDelegate, ExpandableLabelDelegate {
     @IBOutlet var podcastImageView: PodcastImageView! {
@@ -469,10 +470,33 @@ class PodcastHeadingTableCell: ThemeableCell, SubscribeButtonDelegate, Expandabl
         delegate?.setDescriptionExpanded(expanded: false)
     }
 
+    func linkTapped(url: URL) {
+        if let uuid = delegate?.displayedPodcast()?.uuid {
+            Analytics.track(.podcastScreenPodcastDescriptionLinkTapped, properties: ["podcast_uuid": uuid])
+        }
+        open(url: url)
+    }
+
     @objc private func websiteLinkTapped() {
         guard let website = delegate?.displayedPodcast()?.podcastUrl, let url = URL(string: website) else { return }
 
-        UIApplication.shared.open(url, options: [:], completionHandler: nil)
+        open(url: url)
+    }
+
+    private func open(url: URL) {
+        if Settings.openLinks {
+            UIApplication.shared.open(url, options: [:], completionHandler: nil)
+        } else {
+            if URLHelper.isValidScheme(url.scheme) {
+                let safariViewController = SFSafariViewController(with: url)
+                safariViewController.delegate = self
+
+                NotificationCenter.postOnMainThread(notification: Constants.Notifications.openingNonOverlayableWindow)
+                SceneHelper.rootViewController()?.present(safariViewController, animated: true, completion: nil)
+            } else if URLHelper.isMailtoScheme(url.scheme), UIApplication.shared.canOpenURL(url) {
+                UIApplication.shared.open(url, options: [:], completionHandler: nil)
+            }
+        }
     }
 
     private func artworkSize() -> CGFloat {
@@ -547,5 +571,12 @@ class PodcastHeadingTableCell: ThemeableCell, SubscribeButtonDelegate, Expandabl
         } else if gesture.state == .cancelled {
             subscribeButton.isHighlighted = false
         }
+    }
+}
+
+extension PodcastHeadingTableCell: SFSafariViewControllerDelegate {
+    func safariViewControllerDidFinish(_ controller: SFSafariViewController) {
+        NotificationCenter.postOnMainThread(notification: Constants.Notifications.closedNonOverlayableWindow)
+        controller.delegate = nil
     }
 }

--- a/podcasts/PodcastHeadingTableCell.swift
+++ b/podcasts/PodcastHeadingTableCell.swift
@@ -27,6 +27,12 @@ class PodcastHeadingTableCell: ThemeableCell, SubscribeButtonDelegate, Expandabl
         }
     }
 
+    @IBOutlet var richPodcastDescription: RichExpandableLabel! {
+        didSet {
+            richPodcastDescription.delegate = self
+        }
+    }
+
     @IBOutlet var scrollTopBackgroundVIew: UIView!
     @IBOutlet var topPodcastNameSpacer: UIView!
     @IBOutlet var topAuthorSpacer: UIView!
@@ -193,7 +199,7 @@ class PodcastHeadingTableCell: ThemeableCell, SubscribeButtonDelegate, Expandabl
         podcastName.text = podcast.title
         podcastCategory.text = podcast.podcastCategory?.localized(seperatingWith: \.isNewline)
         if FeatureFlag.usePodcastHTMLDescription.enabled, let html = podcast.podcastHTMLDescription {
-            podcastDescription.setRichText(html: html)
+            richPodcastDescription.setRichText(html: html)
         } else {
             podcastDescription.setTextKeepingExistingAttributes(text: podcast.podcastDescription)
         }
@@ -254,7 +260,7 @@ class PodcastHeadingTableCell: ThemeableCell, SubscribeButtonDelegate, Expandabl
             topSectionHeightConstraint.constant = tableViewWidth < 350 ? 183 : 203
             expandButton.setExpanded(delegate.isSummaryExpanded(), animated: false)
             podcastDescription.collapsed = !delegate.isDescriptionExpanded()
-
+            richPodcastDescription.collapsed = !delegate.isDescriptionExpanded()
             layoutIfNeeded()
         }
 
@@ -292,7 +298,13 @@ class PodcastHeadingTableCell: ThemeableCell, SubscribeButtonDelegate, Expandabl
 
         podcastName.isHidden = !expanded
         podcastCategory.isHidden = !expanded || podcastCategory.text == nil
-        podcastDescription.isHidden = !expanded
+        if FeatureFlag.usePodcastHTMLDescription.enabled {
+            richPodcastDescription.isHidden = !expanded
+            podcastDescription.isHidden = true
+        } else {
+            podcastDescription.isHidden = !expanded
+            richPodcastDescription.isHidden = true
+        }
 
         descriptionInfoSpacer.isHidden = !expanded
         categoryDescriptionSpacer.isHidden = !expanded
@@ -439,20 +451,20 @@ class PodcastHeadingTableCell: ThemeableCell, SubscribeButtonDelegate, Expandabl
 
     // MARK: - ExpandableLabelDelegate
 
-    func willExpandLabel(_ label: ExpandableLabel) {
+    func willExpandLabel(_ label: UIView) {
         delegate?.tableView().beginUpdates()
     }
 
-    func didExpandLabel(_ label: ExpandableLabel) {
+    func didExpandLabel(_ label: UIView) {
         delegate?.tableView().endUpdates()
         delegate?.setDescriptionExpanded(expanded: true)
     }
 
-    func willCollapseLabel(_ label: ExpandableLabel) {
+    func willCollapseLabel(_ label: UIView) {
         delegate?.tableView().beginUpdates()
     }
 
-    func didCollapseLabel(_ label: ExpandableLabel) {
+    func didCollapseLabel(_ label: UIView) {
         delegate?.tableView().endUpdates()
         delegate?.setDescriptionExpanded(expanded: false)
     }

--- a/podcasts/PodcastHeadingTableCell.swift
+++ b/podcasts/PodcastHeadingTableCell.swift
@@ -199,7 +199,8 @@ class PodcastHeadingTableCell: ThemeableCell, SubscribeButtonDelegate, Expandabl
 
         podcastName.text = podcast.title
         podcastCategory.text = podcast.podcastCategory?.localized(seperatingWith: \.isNewline)
-        if FeatureFlag.usePodcastHTMLDescription.enabled, let html = podcast.podcastHTMLDescription {
+        if FeatureFlag.usePodcastHTMLDescription.enabled {
+            let html = podcast.podcastHTMLDescription ?? podcast.podcastDescription ?? ""
             richPodcastDescription.setRichText(html: html)
         } else {
             podcastDescription.setTextKeepingExistingAttributes(text: podcast.podcastDescription)

--- a/podcasts/PodcastHeadingTableCell.xib
+++ b/podcasts/PodcastHeadingTableCell.xib
@@ -191,7 +191,7 @@
                             <wkWebView contentMode="scaleToFill" allowsLinkPreview="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QtY-1t-63o" customClass="RichExpandableLabel" customModule="podcasts" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="28" width="362" height="0.0"/>
                                 <wkWebViewConfiguration key="configuration" allowsAirPlayForMediaPlayback="NO" allowsPictureInPictureMediaPlayback="NO">
-                                    <dataDetectorTypes key="dataDetectorTypes" none="YES"/>
+                                    <dataDetectorTypes key="dataDetectorTypes" link="YES"/>
                                     <audiovisualMediaTypes key="mediaTypesRequiringUserActionForPlayback" none="YES"/>
                                     <wkPreferences key="preferences"/>
                                 </wkWebViewConfiguration>

--- a/podcasts/PodcastHeadingTableCell.xib
+++ b/podcasts/PodcastHeadingTableCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23094" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23084"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -188,6 +188,14 @@
                                 </attributedString>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <wkWebView contentMode="scaleToFill" allowsLinkPreview="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QtY-1t-63o" customClass="RichExpandableLabel" customModule="podcasts" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="28" width="362" height="0.0"/>
+                                <wkWebViewConfiguration key="configuration" allowsAirPlayForMediaPlayback="NO" allowsPictureInPictureMediaPlayback="NO">
+                                    <dataDetectorTypes key="dataDetectorTypes" none="YES"/>
+                                    <audiovisualMediaTypes key="mediaTypesRequiringUserActionForPlayback" none="YES"/>
+                                    <wkPreferences key="preferences"/>
+                                </wkWebViewConfiguration>
+                            </wkWebView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Nvw-qC-Dra" userLabel="Spacer">
                                 <rect key="frame" x="0.0" y="28" width="362" height="15"/>
                                 <constraints>
@@ -444,6 +452,7 @@
                 <outlet property="podcastImageHeightConstraint" destination="bkR-7q-5gT" id="Eq4-YG-Wxl"/>
                 <outlet property="podcastImageView" destination="Dq8-Kf-98T" id="cCI-oe-ERj"/>
                 <outlet property="podcastName" destination="YUN-pu-IO8" id="I0j-JG-392"/>
+                <outlet property="richPodcastDescription" destination="QtY-1t-63o" id="dQ9-ew-AYy"/>
                 <outlet property="roundedBorder" destination="CHK-bP-kvy" id="oit-TK-LHH"/>
                 <outlet property="schedule" destination="Vre-8d-djb" id="Daj-f0-O4v"/>
                 <outlet property="scheduleView" destination="xvp-7p-xGq" id="3EK-E0-7Qh"/>

--- a/podcasts/RichExpandableDescriptionView.swift
+++ b/podcasts/RichExpandableDescriptionView.swift
@@ -20,6 +20,7 @@ class RichExpandableLabel: WKWebView {
 
         translatesAutoresizingMaskIntoConstraints = false
         self.heightConstraint = heightAnchor.constraint(equalToConstant: 0)
+        heightConstraint.priority = .defaultLow
         NSLayoutConstraint.activate([
             heightConstraint
         ])

--- a/podcasts/RichExpandableDescriptionView.swift
+++ b/podcasts/RichExpandableDescriptionView.swift
@@ -9,6 +9,7 @@ class RichExpandableLabel: WKWebView {
     private var heightConstraint: NSLayoutConstraint!
     private var contentHeight: CGFloat = 0
     private var htmlReady: Bool = false
+    private var previousHTML: String = ""
 
     private lazy var linkTapGesture: UITapGestureRecognizer = {
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(labelTapped))
@@ -35,15 +36,24 @@ class RichExpandableLabel: WKWebView {
         ])
         isUserInteractionEnabled = true
         scrollView.isScrollEnabled = false
+        navigationDelegate = self
+        updateStyle()
+    }
+
+    private func updateStyle() {
+        isOpaque = false
         scrollView.backgroundColor = .clear
         backgroundColor = .clear
-        navigationDelegate = self
     }
 
     func setRichText(html: String) {
         let styledHTML = style(html: html)
+        guard previousHTML != styledHTML else {
+            return
+        }
+        htmlReady = false
+        previousHTML = styledHTML
         self.loadHTMLString(styledHTML, baseURL: nil)
-        collapsed = false
     }
 
     private func style(html: String) -> String {
@@ -152,6 +162,7 @@ extension RichExpandableLabel: WKNavigationDelegate {
             else {
                 return
             }
+            updateStyle()
             updateScrollSize()
             updateLinesRequired()
         })

--- a/podcasts/RichExpandableDescriptionView.swift
+++ b/podcasts/RichExpandableDescriptionView.swift
@@ -1,5 +1,5 @@
 import UIKit
-import WebKit
+@preconcurrency import WebKit
 
 class RichExpandableLabel: WKWebView {
 

--- a/podcasts/RichExpandableDescriptionView.swift
+++ b/podcasts/RichExpandableDescriptionView.swift
@@ -41,7 +41,7 @@ class RichExpandableLabel: WKWebView {
     func setRichText(html: String) {
         let styledHTML = style(html: html)
         self.loadHTMLString(styledHTML, baseURL: nil)
-        collapsed = linesRequired() > maxLines
+        collapsed = false
     }
 
     private func style(html: String) -> String {
@@ -52,6 +52,14 @@ class RichExpandableLabel: WKWebView {
         <html>
         <head>
         <meta name='viewport' content='width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no'>
+        <script>
+        function countLines() {
+           var el = document.body;
+           var divHeight = el.scrollHeight;
+           var lineHeight = parseInt(window.getComputedStyle(el).lineHeight);
+           return divHeight / lineHeight;
+        }
+        </script>
         <style>
         body {
             font-family: -apple-system;
@@ -61,6 +69,7 @@ class RichExpandableLabel: WKWebView {
             color: \(textColor.hexString());
             margin: 0;
             padding: 0;
+            display: inline;
         }
         a { 
             color:\(linkColor.hexString());
@@ -101,24 +110,13 @@ class RichExpandableLabel: WKWebView {
         sizeToFit()
     }
 
-    private func linesRequired() -> Int {
-//        if let attributedText {
-//            layoutIfNeeded()
-//            let labelSize = attributedText.boundingRect(with: CGSize(width: bounds.width, height: CGFloat.greatestFiniteMagnitude), context: nil)
-//
-//            return Int(ceil(CGFloat(labelSize.height) / (font.lineHeight * desiredLinedHeightMultiple)))
-//        } else {
-//            guard let text = text else { return 1 }
-//
-//            layoutIfNeeded()
-//
-//            let alteredText = "\(text)..."
-//            let attributes = [NSAttributedString.Key.font: font as UIFont]
-//            let labelSize = alteredText.boundingRect(with: CGSize(width: bounds.width, height: CGFloat.greatestFiniteMagnitude), options: NSStringDrawingOptions.usesLineFragmentOrigin, attributes: attributes, context: nil)
-//
-//            return Int(ceil(CGFloat(labelSize.height) / (font.lineHeight * desiredLinedHeightMultiple)))
-//        }
-        return 1
+    private func updateLinesRequired() {
+        evaluateJavaScript("countLines()", completionHandler: { [weak self] lines, error in
+            guard let self = self, let linesRequired = lines as? Int else { return }
+
+            print("Lines required: \(linesRequired)")
+            collapsed = linesRequired > self.maxLines
+        })
     }
 }
 
@@ -132,6 +130,7 @@ extension RichExpandableLabel: WKNavigationDelegate {
                 return
             }
             updateScrollSize()
+            updateLinesRequired()
         })
     }
 

--- a/podcasts/RichExpandableDescriptionView.swift
+++ b/podcasts/RichExpandableDescriptionView.swift
@@ -8,6 +8,13 @@ class RichExpandableLabel: WKWebView {
     var maxLines = 3
     private var heightConstraint: NSLayoutConstraint!
     private var contentHeight: CGFloat = 0
+    private lazy var linkTapGesture: UITapGestureRecognizer = {
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(labelTapped))
+        tapGesture.numberOfTapsRequired = 1
+        tapGesture.numberOfTouchesRequired = 1
+        tapGesture.delegate = self
+        return tapGesture
+    }()
 
     var collapsed = false {
         didSet {
@@ -25,15 +32,10 @@ class RichExpandableLabel: WKWebView {
             heightConstraint
         ])
         isUserInteractionEnabled = true
-        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(labelTapped))
-        tapGesture.numberOfTapsRequired = 1
-        tapGesture.numberOfTouchesRequired = 1
-        tapGesture.delegate = self
-        scrollView.addGestureRecognizer(tapGesture)
         scrollView.isScrollEnabled = false
         scrollView.backgroundColor = .clear
         backgroundColor = .clear
-        self.navigationDelegate = self
+        navigationDelegate = self
     }
 
     func setRichText(html: String) {
@@ -88,9 +90,11 @@ class RichExpandableLabel: WKWebView {
 
     private func update() {
         if collapsed {
+            addGestureRecognizer(linkTapGesture)
             let font = UIFont.preferredFont(forTextStyle: .body)
             heightConstraint.constant = font.lineHeight * desiredLinedHeightMultiple * CGFloat(maxLines)
         } else {
+            removeGestureRecognizer(linkTapGesture)
             heightConstraint.constant = contentHeight
         }
         setNeedsLayout()

--- a/podcasts/RichExpandableDescriptionView.swift
+++ b/podcasts/RichExpandableDescriptionView.swift
@@ -1,0 +1,144 @@
+import UIKit
+import WebKit
+
+class RichExpandableLabel: WKWebView {
+
+    weak var delegate: ExpandableLabelDelegate?
+    var desiredLinedHeightMultiple: CGFloat = 1.4
+    var maxLines = 3
+    private var heightConstraint: NSLayoutConstraint!
+    private var contentHeight: CGFloat = 0
+
+    var collapsed = false {
+        didSet {
+            update()
+        }
+    }
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+
+        translatesAutoresizingMaskIntoConstraints = false
+        self.heightConstraint = heightAnchor.constraint(equalToConstant: 0)
+        NSLayoutConstraint.activate([
+            heightConstraint
+        ])
+        isUserInteractionEnabled = true
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(labelTapped))
+        tapGesture.numberOfTapsRequired = 1
+        tapGesture.numberOfTouchesRequired = 1
+        tapGesture.delegate = self
+        scrollView.addGestureRecognizer(tapGesture)
+        scrollView.isScrollEnabled = false
+        self.navigationDelegate = self
+    }
+
+    func setRichText(html: String) {
+        guard Thread.isMainThread else {
+            DispatchQueue.main.async { [weak self] in
+                self?.setRichText(html: html)
+            }
+            return
+        }
+        // We detected that some scenarios when this code is run when the app is backgrounded, it crashes even on the main thread.
+        if UIApplication.shared.applicationState == .background {
+            return
+        }
+        let styledHTML: String = """
+        <html>
+        <head>
+        <meta name='viewport' content='width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no'>
+        <style>
+        body {
+            font-family: -apple-system;
+            font-size: 1em;
+            line-height: \(desiredLinedHeightMultiple);
+        background-color: #FFF;
+        margin: 0;
+        padding: 0;
+        }
+        </style>
+        </head>
+        <body>
+        \(html)
+        </body>
+        </html>
+        """
+        self.loadHTMLString(styledHTML, baseURL: nil)
+        collapsed = linesRequired() > maxLines
+    }
+
+    @objc private func labelTapped(gesture: UITapGestureRecognizer) {
+        if collapsed {
+            delegate?.willExpandLabel(self)
+            collapsed = false
+            delegate?.didExpandLabel(self)
+        } else {
+            delegate?.willCollapseLabel(self)
+            collapsed = true
+            delegate?.didCollapseLabel(self)
+        }
+        update()
+    }
+
+    private func update() {
+        if collapsed {
+            let font = UIFont.preferredFont(forTextStyle: .body)
+            heightConstraint.constant = font.lineHeight * desiredLinedHeightMultiple * CGFloat(maxLines)
+        } else {
+            heightConstraint.constant = contentHeight
+        }
+        setNeedsLayout()
+        sizeToFit()
+    }
+
+    private func linesRequired() -> Int {
+//        if let attributedText {
+//            layoutIfNeeded()
+//            let labelSize = attributedText.boundingRect(with: CGSize(width: bounds.width, height: CGFloat.greatestFiniteMagnitude), context: nil)
+//
+//            return Int(ceil(CGFloat(labelSize.height) / (font.lineHeight * desiredLinedHeightMultiple)))
+//        } else {
+//            guard let text = text else { return 1 }
+//
+//            layoutIfNeeded()
+//
+//            let alteredText = "\(text)..."
+//            let attributes = [NSAttributedString.Key.font: font as UIFont]
+//            let labelSize = alteredText.boundingRect(with: CGSize(width: bounds.width, height: CGFloat.greatestFiniteMagnitude), options: NSStringDrawingOptions.usesLineFragmentOrigin, attributes: attributes, context: nil)
+//
+//            return Int(ceil(CGFloat(labelSize.height) / (font.lineHeight * desiredLinedHeightMultiple)))
+//        }
+        return 1
+    }
+}
+
+extension RichExpandableLabel: WKNavigationDelegate {
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        evaluateJavaScript("document.readyState", completionHandler: { [weak self] complete, _ in
+            guard let self = self,
+                  let result = complete as? String,
+                  result == "complete" // ensure that the load of HTML is complete and not in another loading state
+            else {
+                return
+            }
+            updateScrollSize()
+        })
+    }
+
+    func updateScrollSize() {
+        evaluateJavaScript("document.body.scrollHeight", completionHandler: { [weak self] height, _ in
+            guard let self = self, let cgHeight = height as? CGFloat else { return }
+
+            contentHeight = CGFloat(cgHeight)
+            update()
+        })
+    }
+}
+
+extension RichExpandableLabel: UIGestureRecognizerDelegate {
+
+    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+        return true
+    }
+}

--- a/podcasts/RichExpandableDescriptionView.swift
+++ b/podcasts/RichExpandableDescriptionView.swift
@@ -50,6 +50,7 @@ class RichExpandableLabel: WKWebView {
         let  backgroundColor: UIColor = ThemeColor.primaryUi02()
         let textColor: UIColor = ThemeColor.primaryText01()
         let linkColor: UIColor = ThemeColor.primaryIcon01()
+        let font = UIFont.preferredFont(forTextStyle: .body)
         let styledHTML: String = """
         <html>
         <head>
@@ -73,7 +74,7 @@ class RichExpandableLabel: WKWebView {
         <style>
         body {
             font-family: -apple-system;
-            font-size: 1em;
+            font-size: \(font.pointSize)px;
             line-height: \(desiredLinedHeightMultiple);
             background-color: \(backgroundColor.hexString());
             color: \(textColor.hexString());

--- a/podcasts/RichExpandableDescriptionView.swift
+++ b/podcasts/RichExpandableDescriptionView.swift
@@ -31,20 +31,21 @@ class RichExpandableLabel: WKWebView {
         tapGesture.delegate = self
         scrollView.addGestureRecognizer(tapGesture)
         scrollView.isScrollEnabled = false
+        scrollView.backgroundColor = .clear
+        backgroundColor = .clear
         self.navigationDelegate = self
     }
 
     func setRichText(html: String) {
-        guard Thread.isMainThread else {
-            DispatchQueue.main.async { [weak self] in
-                self?.setRichText(html: html)
-            }
-            return
-        }
-        // We detected that some scenarios when this code is run when the app is backgrounded, it crashes even on the main thread.
-        if UIApplication.shared.applicationState == .background {
-            return
-        }
+        let styledHTML = style(html: html)
+        self.loadHTMLString(styledHTML, baseURL: nil)
+        collapsed = linesRequired() > maxLines
+    }
+
+    private func style(html: String) -> String {
+        let  backgroundColor: UIColor = ThemeColor.primaryUi02()
+        let textColor: UIColor = ThemeColor.primaryText01()
+        let linkColor: UIColor = ThemeColor.primaryIcon01()
         let styledHTML: String = """
         <html>
         <head>
@@ -52,11 +53,15 @@ class RichExpandableLabel: WKWebView {
         <style>
         body {
             font-family: -apple-system;
-            font-size: 1em;
+            font-size: 1.34em;
             line-height: \(desiredLinedHeightMultiple);
-        background-color: #FFF;
-        margin: 0;
-        padding: 0;
+            background-color: \(backgroundColor.hexString());
+            color: \(textColor.hexString());
+            margin: 0;
+            padding: 0;
+        }
+        a { 
+            color:\(linkColor.hexString());
         }
         </style>
         </head>
@@ -65,8 +70,7 @@ class RichExpandableLabel: WKWebView {
         </body>
         </html>
         """
-        self.loadHTMLString(styledHTML, baseURL: nil)
-        collapsed = linesRequired() > maxLines
+        return styledHTML
     }
 
     @objc private func labelTapped(gesture: UITapGestureRecognizer) {

--- a/podcasts/RichExpandableDescriptionView.swift
+++ b/podcasts/RichExpandableDescriptionView.swift
@@ -141,6 +141,16 @@ class RichExpandableLabel: WKWebView {
         sizeToFit()
     }
 
+    private func updateScrollSize() {
+        evaluateJavaScript("document.body.scrollHeight", completionHandler: { [weak self] height, _ in
+            guard let self = self, let cgHeight = height as? CGFloat else { return }
+
+            contentHeight = CGFloat(cgHeight)
+            htmlReady = true
+            update()
+        })
+    }
+
     private func updateLinesRequired() {
         evaluateJavaScript("countLines()", completionHandler: { [weak self] lines, error in
             guard let self = self, let linesRequired = lines as? Int else { return }
@@ -165,16 +175,6 @@ extension RichExpandableLabel: WKNavigationDelegate {
             updateStyle()
             updateScrollSize()
             updateLinesRequired()
-        })
-    }
-
-    func updateScrollSize() {
-        evaluateJavaScript("document.body.scrollHeight", completionHandler: { [weak self] height, _ in
-            guard let self = self, let cgHeight = height as? CGFloat else { return }
-
-            contentHeight = CGFloat(cgHeight)
-            htmlReady = true
-            update()
         })
     }
 

--- a/podcasts/RichExpandableDescriptionView.swift
+++ b/podcasts/RichExpandableDescriptionView.swift
@@ -1,5 +1,6 @@
 import UIKit
 import WebKit
+import SafariServices
 
 class RichExpandableLabel: WKWebView {
 
@@ -134,11 +135,43 @@ extension RichExpandableLabel: WKNavigationDelegate {
             update()
         })
     }
+
+    func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+        guard let url = navigationAction.request.url, navigationAction.navigationType == .linkActivated else {
+            decisionHandler(.allow)
+            return
+        }
+
+        if Settings.openLinks {
+            UIApplication.shared.open(url, options: [:], completionHandler: nil)
+        } else {
+            if URLHelper.isValidScheme(url.scheme) {
+                let safariViewController = SFSafariViewController(with: url)
+                safariViewController.delegate = self
+
+                NotificationCenter.postOnMainThread(notification: Constants.Notifications.openingNonOverlayableWindow)
+                SceneHelper.rootViewController()?.present(safariViewController, animated: true, completion: nil)
+
+                //Analytics.track(.playerShowNotesLinkTapped, properties: ["episode_uuid": lastEpisodeUuidRendered])
+            } else if URLHelper.isMailtoScheme(url.scheme), UIApplication.shared.canOpenURL(url) {
+                UIApplication.shared.open(url, options: [:], completionHandler: nil)
+            }
+        }
+
+        decisionHandler(.cancel)
+    }
 }
 
 extension RichExpandableLabel: UIGestureRecognizerDelegate {
 
     func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
         return true
+    }
+}
+
+extension RichExpandableLabel: SFSafariViewControllerDelegate {
+    func safariViewControllerDidFinish(_ controller: SFSafariViewController) {
+        NotificationCenter.postOnMainThread(notification: Constants.Notifications.closedNonOverlayableWindow)
+        controller.delegate = nil
     }
 }

--- a/podcasts/RichExpandableDescriptionView.swift
+++ b/podcasts/RichExpandableDescriptionView.swift
@@ -1,6 +1,5 @@
 import UIKit
 import WebKit
-import SafariServices
 
 class RichExpandableLabel: WKWebView {
 
@@ -142,21 +141,7 @@ extension RichExpandableLabel: WKNavigationDelegate {
             return
         }
 
-        if Settings.openLinks {
-            UIApplication.shared.open(url, options: [:], completionHandler: nil)
-        } else {
-            if URLHelper.isValidScheme(url.scheme) {
-                let safariViewController = SFSafariViewController(with: url)
-                safariViewController.delegate = self
-
-                NotificationCenter.postOnMainThread(notification: Constants.Notifications.openingNonOverlayableWindow)
-                SceneHelper.rootViewController()?.present(safariViewController, animated: true, completion: nil)
-
-                //Analytics.track(.playerShowNotesLinkTapped, properties: ["episode_uuid": lastEpisodeUuidRendered])
-            } else if URLHelper.isMailtoScheme(url.scheme), UIApplication.shared.canOpenURL(url) {
-                UIApplication.shared.open(url, options: [:], completionHandler: nil)
-            }
-        }
+        delegate?.linkTapped(url: url)
 
         decisionHandler(.cancel)
     }
@@ -166,12 +151,5 @@ extension RichExpandableLabel: UIGestureRecognizerDelegate {
 
     func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
         return true
-    }
-}
-
-extension RichExpandableLabel: SFSafariViewControllerDelegate {
-    func safariViewControllerDidFinish(_ controller: SFSafariViewController) {
-        NotificationCenter.postOnMainThread(notification: Constants.Notifications.closedNonOverlayableWindow)
-        controller.delegate = nil
     }
 }

--- a/podcasts/RichExpandableDescriptionView.swift
+++ b/podcasts/RichExpandableDescriptionView.swift
@@ -139,8 +139,7 @@ class RichExpandableLabel: WKWebView {
     }
 
     private func toggleColapseHTMLContent(on: Bool) {
-        evaluateJavaScript(on ? "toggleClipping(true)" : "toggleClipping(false)", completionHandler: { [weak self] _, error in
-        })
+        evaluateJavaScript(on ? "toggleClipping(true)" : "toggleClipping(false)", completionHandler: nil)
     }
 }
 

--- a/podcasts/RichExpandableDescriptionView.swift
+++ b/podcasts/RichExpandableDescriptionView.swift
@@ -8,6 +8,8 @@ class RichExpandableLabel: WKWebView {
     var maxLines = 3
     private var heightConstraint: NSLayoutConstraint!
     private var contentHeight: CGFloat = 0
+    private var htmlReady: Bool = false
+
     private lazy var linkTapGesture: UITapGestureRecognizer = {
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(labelTapped))
         tapGesture.numberOfTapsRequired = 1
@@ -58,26 +60,41 @@ class RichExpandableLabel: WKWebView {
            var divHeight = el.scrollHeight;
            var lineHeight = parseInt(window.getComputedStyle(el).lineHeight);
            return divHeight / lineHeight;
-        }
+        };
+        function toggleClipping(on) {
+            var container = document.getElementById("container");
+            if (on) {
+                container.classList.add("clipping");
+            } else {
+                container.classList.remove("clipping");
+            }
+        };
         </script>
         <style>
         body {
             font-family: -apple-system;
-            font-size: 1.34em;
+            font-size: 1em;
             line-height: \(desiredLinedHeightMultiple);
             background-color: \(backgroundColor.hexString());
             color: \(textColor.hexString());
             margin: 0;
             padding: 0;
-            display: inline;
         }
-        a { 
+        .clipping {
+          display: -webkit-box;
+          -webkit-line-clamp: \(maxLines);
+          -webkit-box-orient: vertical;
+          overflow: hidden;
+        }
+        a {
             color:\(linkColor.hexString());
         }
         </style>
         </head>
         <body>
+        <div id="container">
         \(html)
+        </div>
         </body>
         </html>
         """
@@ -106,6 +123,9 @@ class RichExpandableLabel: WKWebView {
             removeGestureRecognizer(linkTapGesture)
             heightConstraint.constant = contentHeight
         }
+        if htmlReady {
+            toggleColapseHTMLContent(on: collapsed)
+        }
         setNeedsLayout()
         sizeToFit()
     }
@@ -113,9 +133,12 @@ class RichExpandableLabel: WKWebView {
     private func updateLinesRequired() {
         evaluateJavaScript("countLines()", completionHandler: { [weak self] lines, error in
             guard let self = self, let linesRequired = lines as? Int else { return }
-
-            print("Lines required: \(linesRequired)")
             collapsed = linesRequired > self.maxLines
+        })
+    }
+
+    private func toggleColapseHTMLContent(on: Bool) {
+        evaluateJavaScript(on ? "toggleClipping(true)" : "toggleClipping(false)", completionHandler: { [weak self] _, error in
         })
     }
 }
@@ -139,6 +162,7 @@ extension RichExpandableLabel: WKNavigationDelegate {
             guard let self = self, let cgHeight = height as? CGFloat else { return }
 
             contentHeight = CGFloat(cgHeight)
+            htmlReady = true
             update()
         })
     }


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

Fix the crash when using Podcast HTML descriptions by using an WKWebView instead of NSAttributedString methods.

Some notes:

- In order to implement link detection and not conflict with the expand and collapse gesture, I disable collapse by tapping again
- I used the opportunity to improve the sizing of text so now the description respects dynamic text set in the system
- Clipping of the text is using HTML CSS, while it work it's not's 100% exactly the same as UIKit implementation. One notorious example is that if the paragraph text fits the limite but there is more text on following paragraphs the HTML implementation does not show the `...` character.

## To test

- Start the app
- Ensure that you have the `usePodcastHTMLDescription` FF enabled
- Open the podcast and check if the descriptions show correctly, and collapse and expand correctly.
- Test on the Podcasts tab and Discovery tab
- Tested on not followed podcasts, and press to follow to see if the animation works correctly
- Test on the iPad

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
