### PR TITLE
[Winback] Modify the layout to update the text based on the plan frequency and type

### DIFF
--- a/podcasts/Cancel Subscription/Cancel Subscription/CancelSubscriptionView.swift
+++ b/podcasts/Cancel Subscription/Cancel Subscription/CancelSubscriptionView.swift
@@ -23,10 +23,10 @@ struct CancelSubscriptionView: View {
                             .padding(.horizontal, 34.0)
 
                         ForEach(CancelSubscriptionOption.allCases, id: \.id) { option in
-                            if case .promotion = option {
-                                //TODO: Need to check the if the promotion can be applied
-                                if case .promotion = option, let price = viewModel.monthlyPrice() {
-                                    CancelSubscriptionViewRow(option: .promotion(price: price),
+                            if case .promotion = option, viewModel.canClaimOffer() {
+                                if let price = viewModel.monthlyPrice(),
+                                   let frequency = viewModel.subscriptionFrequency() {
+                                    CancelSubscriptionViewRow(option: .promotion(price: price, frequency: frequency),
                                                               viewModel: viewModel)
                                 }
                             } else {

--- a/podcasts/Cancel Subscription/Cancel Subscription/CancelSubscriptionView.swift
+++ b/podcasts/Cancel Subscription/Cancel Subscription/CancelSubscriptionView.swift
@@ -24,7 +24,7 @@ struct CancelSubscriptionView: View {
 
                         ForEach(CancelSubscriptionOption.allCases, id: \.id) { option in
                             if case .promotion = option, viewModel.canClaimOffer() {
-                                if let price = viewModel.monthlyPrice(),
+                                if let price = viewModel.price(),
                                    let frequency = viewModel.subscriptionFrequency() {
                                     CancelSubscriptionViewRow(option: .promotion(price: price, frequency: frequency),
                                                               viewModel: viewModel)

--- a/podcasts/Cancel Subscription/Cancel Subscription/CancelSubscriptionViewRow.swift
+++ b/podcasts/Cancel Subscription/Cancel Subscription/CancelSubscriptionViewRow.swift
@@ -112,7 +112,7 @@ struct CancelSubscriptionViewRow_Previews: PreviewProvider {
     static var viewModel = CancelSubscriptionViewModel(navigationController: UINavigationController())
     static var previews: some View {
         VStack(spacing: 0) {
-            CancelSubscriptionViewRow(option: .promotion(price: "$3.99"), viewModel: viewModel)
+            CancelSubscriptionViewRow(option: .promotion(price: "$3.99", frequency: .monthly), viewModel: viewModel)
                 .environmentObject(Theme.sharedTheme)
             CancelSubscriptionViewRow(option: .availablePlans, viewModel: viewModel)
                 .environmentObject(Theme.sharedTheme)

--- a/podcasts/Cancel Subscription/Cancel Subscription/Offer View/CancelSubscriptionOfferSuccessView.swift
+++ b/podcasts/Cancel Subscription/Cancel Subscription/Offer View/CancelSubscriptionOfferSuccessView.swift
@@ -5,18 +5,34 @@ struct CancelSubscriptionOfferSuccessView: View {
 
     @ObservedObject var viewModel: CancelSubscriptionViewModel
 
+    var title: String {
+        if viewModel.subscriptionFrequency() == .monthly {
+            return L10n.cancelSubscriptionOfferSuccessViewTitle
+        } else {
+            return L10n.cancelSubscriptionOfferYearlySuccessViewTitle
+        }
+    }
+
+    var description: String {
+        if viewModel.subscriptionFrequency() == .monthly {
+            return L10n.cancelSubscriptionOfferSuccessViewDescription
+        } else {
+            return L10n.cancelSubscriptionOfferYearlySuccessViewDescription
+        }
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             icon(for: theme.activeTheme)
                 .frame(width: 162, height: 162)
                 .padding(.top, 70)
                 .padding(.bottom, 21)
-            Text(L10n.cancelSubscriptionOfferSuccessViewTitle)
+            Text(title)
                 .font(size: 28.0, style: .body, weight: .bold)
                 .foregroundStyle(theme.primaryText01)
                 .padding(.horizontal, 12)
                 .padding(.bottom, 16.0)
-            Text(L10n.cancelSubscriptionOfferSuccessViewDescription)
+            Text(description)
                 .font(size: 18.0, style: .body, weight: .regular)
                 .foregroundStyle(theme.primaryText02)
                 .multilineTextAlignment(.center)

--- a/podcasts/Cancel Subscription/Cancel Subscription/Plans View/CancelSubscriptionPlansView.swift
+++ b/podcasts/Cancel Subscription/Cancel Subscription/Plans View/CancelSubscriptionPlansView.swift
@@ -87,6 +87,21 @@ struct CancelSubscriptionPlansView: View {
         case .available:
             ZStack {
                 plansView
+                VStack {
+                    HStack {
+                        Button(action: viewModel.popViewController) {
+                            Image(systemName: "chevron.left")
+                                .renderingMode(.template)
+                                .font(.system(size: 20))
+                                .foregroundStyle(theme.primaryIcon01)
+                                .frame(width: 32, height: 32)
+                        }
+                        .padding(.leading, 8)
+                        Spacer()
+                    }
+                    Spacer()
+                }
+                .padding(.top, 20)
                 if viewModel.state == .purchasing {
                     showLoading(fullScreen: true)
                 }

--- a/podcasts/Cancel Subscription/Cancel Subscription/Plans View/CancelSubscriptionPlansViewModel.swift
+++ b/podcasts/Cancel Subscription/Cancel Subscription/Plans View/CancelSubscriptionPlansViewModel.swift
@@ -74,6 +74,10 @@ class CancelSubscriptionPlansViewModel: CancelSubscriptionViewModel {
         navigationController?.dismiss(animated: true)
     }
 
+    func popViewController() {
+        navigationController?.popViewController(animated: true)
+    }
+
     enum CurrentProductAvailability {
         case idle
         case loading

--- a/podcasts/Cancel Subscription/CancelSubscriptionOption.swift
+++ b/podcasts/Cancel Subscription/CancelSubscriptionOption.swift
@@ -17,7 +17,7 @@ enum CancelSubscriptionOption: CaseIterable, Hashable, Identifiable {
             if frequency == .monthly {
                 return L10n.cancelSubscriptionPromotionTitle
             } else {
-                return "Get your next year half price!"
+                return L10n.cancelSubscriptionYearlyPromotionTitle
             }
         case .availablePlans:
             return L10n.cancelSubscriptionNewPlanTitle
@@ -28,12 +28,8 @@ enum CancelSubscriptionOption: CaseIterable, Hashable, Identifiable {
 
     var subtitle: String {
         switch self {
-        case .promotion(let price, let frequency):
-            if frequency == .monthly {
-                return L10n.cancelSubscriptionPromotionDescription(price)
-            } else {
-                return "50% off at the start of your next billing cycle."
-            }
+        case .promotion(let price, _):
+            return L10n.cancelSubscriptionPromotionDescription(price)
         case .availablePlans:
             return L10n.cancelSubscriptionNewPlanDescription
         case .help:

--- a/podcasts/Cancel Subscription/CancelSubscriptionOption.swift
+++ b/podcasts/Cancel Subscription/CancelSubscriptionOption.swift
@@ -1,7 +1,9 @@
-enum CancelSubscriptionOption: CaseIterable, Hashable, Identifiable {
-    static var allCases: [CancelSubscriptionOption] = [.promotion(price: ""), .availablePlans, .help]
+import PocketCastsServer
 
-    case promotion(price: String)
+enum CancelSubscriptionOption: CaseIterable, Hashable, Identifiable {
+    static var allCases: [CancelSubscriptionOption] = [.promotion(price: "", frequency: .none), .availablePlans, .help]
+
+    case promotion(price: String, frequency: SubscriptionFrequency)
     case availablePlans
     case help
 
@@ -11,8 +13,12 @@ enum CancelSubscriptionOption: CaseIterable, Hashable, Identifiable {
 
     var title: String {
         switch self {
-        case .promotion:
-            return L10n.cancelSubscriptionPromotionTitle
+        case .promotion(_, let frequency):
+            if frequency == .monthly {
+                return L10n.cancelSubscriptionPromotionTitle
+            } else {
+                return "Get your next year half price!"
+            }
         case .availablePlans:
             return L10n.cancelSubscriptionNewPlanTitle
         case .help:
@@ -22,8 +28,12 @@ enum CancelSubscriptionOption: CaseIterable, Hashable, Identifiable {
 
     var subtitle: String {
         switch self {
-        case .promotion(let price):
-            return L10n.cancelSubscriptionPromotionDescription(price)
+        case .promotion(let price, let frequency):
+            if frequency == .monthly {
+                return L10n.cancelSubscriptionPromotionDescription(price)
+            } else {
+                return "50% off at the start of your next billing cycle."
+            }
         case .availablePlans:
             return L10n.cancelSubscriptionNewPlanDescription
         case .help:

--- a/podcasts/Cancel Subscription/CancelSubscriptionViewModel.swift
+++ b/podcasts/Cancel Subscription/CancelSubscriptionViewModel.swift
@@ -14,6 +14,7 @@ class CancelSubscriptionViewModel: PlusPurchaseModel {
 
         super.init(purchaseHandler: purchaseHandler)
 
+        //TODO: Need to check the if the promotion can be applied
         self.loadPrices()
     }
 
@@ -42,11 +43,26 @@ extension CancelSubscriptionViewModel {
         }
     }
 
+    func subscriptionFrequency() -> SubscriptionFrequency? {
+        switch SubscriptionHelper.subscriptionFrequencyValue() {
+            case .monthly:
+            return .monthly
+        case .yearly:
+            return .yearly
+        default:
+            return nil
+        }
+    }
+
     func claimOffer() {
         Analytics.track(.cancelSubscriptionRowTap, properties: ["row": "claim_offer"])
         //TODO: Apply one month free
         //TODO: Purchase the offer and display the success view if succeeded
         showClaimOfferSuccess()
+    }
+    
+    func canClaimOffer() -> Bool {
+        return true
     }
 }
 

--- a/podcasts/Cancel Subscription/CancelSubscriptionViewModel.swift
+++ b/podcasts/Cancel Subscription/CancelSubscriptionViewModel.swift
@@ -64,7 +64,7 @@ extension CancelSubscriptionViewModel {
         //TODO: Purchase the offer and display the success view if succeeded
         showClaimOfferSuccess()
     }
-    
+
     func canClaimOffer() -> Bool {
         return true
     }

--- a/podcasts/Cancel Subscription/CancelSubscriptionViewModel.swift
+++ b/podcasts/Cancel Subscription/CancelSubscriptionViewModel.swift
@@ -32,20 +32,24 @@ class CancelSubscriptionViewModel: PlusPurchaseModel {
 
 // IAP
 extension CancelSubscriptionViewModel {
-    func monthlyPrice() -> String? {
-        switch SubscriptionHelper.activeTier {
-        case .plus:
+    func price() -> String? {
+        switch (SubscriptionHelper.activeTier, SubscriptionHelper.subscriptionFrequencyValue()) {
+        case (.plus, .monthly):
             return pricingInfo.products.first { $0.identifier == .monthly }?.rawPrice
-        case .patron:
+        case (.plus, .yearly):
+            return pricingInfo.products.first { $0.identifier == .yearly }?.rawPrice
+        case (.patron, .monthly):
             return pricingInfo.products.first { $0.identifier == .patronMonthly }?.rawPrice
-        case .none:
+        case (.patron, .yearly):
+            return pricingInfo.products.first { $0.identifier == .patronYearly }?.rawPrice
+        default:
             return nil
         }
     }
 
     func subscriptionFrequency() -> SubscriptionFrequency? {
         switch SubscriptionHelper.subscriptionFrequencyValue() {
-            case .monthly:
+        case .monthly:
             return .monthly
         case .yearly:
             return .yearly

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -410,6 +410,10 @@ internal enum L10n {
   internal static var cancelSubscriptionOfferSuccessViewDescription: String { return L10n.tr("Localizable", "cancel_subscription_offer_success_view_description") }
   /// Enjoy your free month!
   internal static var cancelSubscriptionOfferSuccessViewTitle: String { return L10n.tr("Localizable", "cancel_subscription_offer_success_view_title") }
+  /// Thanks for choosing Pocket Casts. Your discounted plan starts after your current billing period.
+  internal static var cancelSubscriptionOfferYearlySuccessViewDescription: String { return L10n.tr("Localizable", "cancel_subscription_offer_yearly_success_view_description") }
+  /// 50%% off your next year!
+  internal static var cancelSubscriptionOfferYearlySuccessViewTitle: String { return L10n.tr("Localizable", "cancel_subscription_offer_yearly_success_view_title") }
   /// Save %@ at the start of your next billing cycle.
   internal static func cancelSubscriptionPromotionDescription(_ p1: Any) -> String {
     return L10n.tr("Localizable", "cancel_subscription_promotion_description", String(describing: p1))
@@ -419,6 +423,8 @@ internal enum L10n {
   /// Before you cancel,
   /// check out these offers
   internal static var cancelSubscriptionTitle: String { return L10n.tr("Localizable", "cancel_subscription_title") }
+  /// Get 50%% off your next year
+  internal static var cancelSubscriptionYearlyPromotionTitle: String { return L10n.tr("Localizable", "cancel_subscription_yearly_promotion_title") }
   /// Canceling...
   internal static var canceling: String { return L10n.tr("Localizable", "canceling") }
   /// %1$@ of %2$@. %3$@

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4684,6 +4684,9 @@
 /* Cancel subscription: title for the promotion row */
 "cancel_subscription_promotion_title" = "Get your next month free";
 
+/* Cancel subscription: title for the yearly promotion row */
+"cancel_subscription_yearly_promotion_title" = "Get 50%% off your next year";
+
 /* Cancel subscription: description for the promotion row */
 "cancel_subscription_promotion_description" = "Save %@ at the start of your next billing cycle.";
 
@@ -4714,8 +4717,14 @@
 /* Title of the success screen when the cancel subscription offer is applied */
 "cancel_subscription_offer_success_view_title" = "Enjoy your free month!";
 
+/* Title of the success screen when the cancel yearly subscription offer is applied */
+"cancel_subscription_offer_yearly_success_view_title" = "50%% off your next year!";
+
 /* Description of the success screen when the cancel subscription offer is applied */
 "cancel_subscription_offer_success_view_description" = "Thanks for choosing Pocket Casts. Billing starts after your free month ends.";
+
+/* Description of the success screen when the cancel yearly subscription offer is applied */
+"cancel_subscription_offer_yearly_success_view_description" = "Thanks for choosing Pocket Casts. Your discounted plan starts after your current billing period.";
 
 /* Referrals - Share Pass message. `%1$@' is a placeholder for the duration of free period offered on the Plus subscription*/
 "referrals_share_pass_long_message" = "Hi there!\n\nHere is a %1$@ guest pass for Pocket Casts Plus–my favorite podcast player. It's packed with unique features like bookmarks, folders, and more that you won't find anywhere else. I think you'll love it too!\n";


### PR DESCRIPTION
| 📘 Part of: #2445
|:---:|

Fixes #2670

Since the offer will be different based on the plan type and frequency, this PR updates the layout to dynamically update the row title and description and the offer success screen.

Also this PR adds the back button to the Plans view

| Plus Monthly | Plus Yearly | Patron Monthly | Patron Yearly |
| :---: | :---: | :---: | :---: |
| ![IMG_0054](https://github.com/user-attachments/assets/6cc73f46-f338-4291-b366-f71b00991a3d) | ![IMG_0056](https://github.com/user-attachments/assets/e96b11da-3832-44cf-86df-27f9c28daf50) | ![IMG_0057](https://github.com/user-attachments/assets/01ad4d39-8fe8-4720-b206-b892be4acd1b) | ![IMG_0053](https://github.com/user-attachments/assets/134bb767-2fc9-4295-8842-17a954ee0c9c) |
| Success Monthly | Success Yearly |
| ![IMG_0055](https://github.com/user-attachments/assets/b8a66549-6fd1-47a3-82b4-c6ceadc49727) | ![IMG_0052](https://github.com/user-attachments/assets/13f4c1f8-2886-4152-bdf0-249ae9ca30d4) |


## To test

- Make sure you have the `winback` FF on
- Test the Cancel Subscription screen with both monthly/yearly plus/patron subscriptions
- The result of the first row and success screen should mach the screenshots
- **Important: right now for the yearly subscription we show the full price because we don't have the real offer**
- Tap on the Claim Offer button to show the success screen
- Confirm it matches the screenshots

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
