### PR TITLE
[Analytics Audit] OPML import finished property update

### DIFF
--- a/podcasts/OpmlImporter.swift
+++ b/podcasts/OpmlImporter.swift
@@ -78,7 +78,7 @@ class OpmlImporter: Operation, XMLParserDelegate {
                     NotificationCenter.postOnMainThread(notification: Constants.Notifications.opmlImportCompleted)
                     return
                 }
-                Analytics.track(.opmlImportFinished, properties: ["count": self.initialPodcastCount])
+                Analytics.track(.opmlImportFinished, properties: ["count": self.initialPodcastCount, "number_parsed": self.initialPodcastCount])
             }
         }
     }

--- a/podcasts/OpmlImporter.swift
+++ b/podcasts/OpmlImporter.swift
@@ -44,7 +44,6 @@ class OpmlImporter: Operation, XMLParserDelegate {
                         SJUIUtils.showAlert(title: L10n.opmlImportFailedTitle, message: L10n.opmlImportFailedMessage, from: controller)
                     } else {
                         NotificationCenter.postOnMainThread(notification: Constants.Notifications.opmlImportFailed)
-                        return
                     }
 
                     Analytics.track(.opmlImportFailed)
@@ -70,14 +69,11 @@ class OpmlImporter: Operation, XMLParserDelegate {
             DispatchQueue.main.async {
                 if let progressWindow = self.progressWindow {
                     NavigationManager.sharedManager.navigateTo(NavigationManager.podcastListPageKey, data: nil)
-
                     progressWindow.hideAlert(true)
-
-                    NotificationCenter.postOnMainThread(notification: Constants.Notifications.opmlImportCompleted)
-                } else {
-                    NotificationCenter.postOnMainThread(notification: Constants.Notifications.opmlImportCompleted)
-                    return
                 }
+
+                NotificationCenter.postOnMainThread(notification: Constants.Notifications.opmlImportCompleted)
+
                 Analytics.track(.opmlImportFinished, properties: ["count": self.initialPodcastCount, "number_parsed": self.initialPodcastCount])
             }
         }


### PR DESCRIPTION
| 📘 Part of: #2628 
|:---:|

Fixes #2677

Update the property for the `opml_import_finished` event.

## To test

- Make sure to have the tracks log enabled
- Import an OPML file
- Confirm it tracks `🔵 Tracked: opml_import_finished ["number_parsed": YOUR_NUMBER]`

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
