### PR TITLE
 Do not close episode details when archiving an episode

### DIFF
--- a/podcasts/EpisodeDetailViewController+Actions.swift
+++ b/podcasts/EpisodeDetailViewController+Actions.swift
@@ -41,7 +41,6 @@ extension EpisodeDetailViewController {
             EpisodeManager.unarchiveEpisode(episode: episode, fireNotification: true)
         } else {
             EpisodeManager.archiveEpisode(episode: episode, fireNotification: true)
-            dismiss(animated: true, completion: nil)
         }
     }
 


### PR DESCRIPTION
Fixes #2635 

This PR avoid to dismiss the episode detail screen when archive an episode

https://github.com/user-attachments/assets/d4ae447b-536d-4682-8129-45a626365d91

## To test

. Open a podcast
. Tap on Episode to open the episode detail
. Tap on Archive button
. The episode detail screen should not be closed ✅
. The Archive button text should be updated to Unarchive ✅

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
