### PR TITLE
[Analytics Audit] Add the Discover List share button tapped event

### DIFF
--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -334,6 +334,7 @@ enum AnalyticsEvent: String {
     case discoverListEpisodePlay
     case discoverListPodcastTapped
     case discoverListPodcastSubscribed
+    case discoverListShareTapped
 
     case discoverFeaturedPageChanged
     case discoverSmallListPageChanged

--- a/podcasts/DiscoverCollectionViewController+DiscoverDelegate.swift
+++ b/podcasts/DiscoverCollectionViewController+DiscoverDelegate.swift
@@ -64,7 +64,7 @@ extension DiscoverCollectionViewController: DiscoverDelegate {
             collectionListVC.cellStyle = (item.expandedStyle == "descriptive_list") ? CollectionCellStyle.descriptive_list : CollectionCellStyle.grid
             navController()?.pushViewController(collectionListVC, animated: true)
         } else { // item == expandedStylw == "plain_list" || item.expandedStyle == "ranked_list"
-            let listView = PodcastHeaderListViewController(podcasts: podcasts)
+            let listView = PodcastHeaderListViewController(podcasts: podcasts, source: item.source)
             listView.title = replaceRegionName(string: item.title?.localized ?? "")
             listView.showFeaturedCell = item.expandedStyle == "ranked_list"
             listView.showRankingNumber = item.expandedStyle == "ranked_list"

--- a/podcasts/DiscoverViewController+DiscoverDelegate.swift
+++ b/podcasts/DiscoverViewController+DiscoverDelegate.swift
@@ -52,7 +52,7 @@ extension DiscoverViewController: DiscoverDelegate {
             collectionListVC.cellStyle = (item.expandedStyle == "descriptive_list") ? CollectionCellStyle.descriptive_list : CollectionCellStyle.grid
             navController()?.pushViewController(collectionListVC, animated: true)
         } else { // item == expandedStylw == "plain_list" || item.expandedStyle == "ranked_list"
-            let listView = PodcastHeaderListViewController(podcasts: podcasts)
+            let listView = PodcastHeaderListViewController(podcasts: podcasts, source: item.source)
             listView.title = replaceRegionName(string: item.title?.localized ?? "")
             listView.showFeaturedCell = item.expandedStyle == "ranked_list"
             listView.showRankingNumber = item.expandedStyle == "ranked_list"

--- a/podcasts/ExpandedCollectionViewController.swift
+++ b/podcasts/ExpandedCollectionViewController.swift
@@ -61,6 +61,10 @@ class ExpandedCollectionViewController: PCViewController, CollectionHeaderLinkDe
             title = item.title?.localized.localizedCapitalized
         }
 
+        if item.source != nil {
+            customRightBtn = UIBarButtonItem(image: UIImage(named: "podcast-share"), style: .plain, target: self, action: #selector(handleShare))
+        }
+
         insetAdjuster.setupInsetAdjustmentsForMiniPlayer(scrollView: collectionView)
     }
 
@@ -103,5 +107,12 @@ class ExpandedCollectionViewController: PCViewController, CollectionHeaderLinkDe
 
     override var preferredStatusBarStyle: UIStatusBarStyle {
         AppTheme.defaultStatusBarStyle()
+    }
+
+    @objc func handleShare() {
+        guard let source = item.source, let url = URL(string: source)?.deletingPathExtension() else { return }
+        Analytics.track(.discoverListShareTapped)
+        let activityViewController = UIActivityViewController(activityItems: [url], applicationActivities: nil)
+        present(activityViewController, animated: true)
     }
 }

--- a/podcasts/PodcastHeaderListViewController.swift
+++ b/podcasts/PodcastHeaderListViewController.swift
@@ -13,9 +13,13 @@ class PodcastHeaderListViewController: PCViewController, UITableViewDataSource, 
     private weak var delegate: DiscoverDelegate?
     private static let cellId = "DiscoverCell"
     private static let featuredCellId = "FeaturedTableViewCell"
+    private var source: URL?
 
-    init(podcasts: [DiscoverPodcast]) {
+    init(podcasts: [DiscoverPodcast], source: String?) {
         self.podcasts = podcasts
+        if let source {
+            self.source = URL(string: source)
+        }
 
         super.init(nibName: "PodcastHeaderListViewController", bundle: nil)
     }
@@ -31,6 +35,10 @@ class PodcastHeaderListViewController: PCViewController, UITableViewDataSource, 
         chartsTable.register(UINib(nibName: "DiscoverPodcastTableCell", bundle: nil), forCellReuseIdentifier: PodcastHeaderListViewController.cellId)
         chartsTable.register(UINib(nibName: "FeaturedTableViewCell", bundle: nil), forCellReuseIdentifier: PodcastHeaderListViewController.featuredCellId)
 
+        if source != nil {
+            customRightBtn = UIBarButtonItem(image: UIImage(named: "podcast-share"), style: .plain, target: self, action: #selector(handleShare))
+        }
+
         insetAdjuster.setupInsetAdjustmentsForMiniPlayer(scrollView: chartsTable)
 
         chartsTable.updateContentInset(multiSelectEnabled: false)
@@ -40,6 +48,13 @@ class PodcastHeaderListViewController: PCViewController, UITableViewDataSource, 
         super.viewWillAppear(animated)
 
         chartsTable.reloadData()
+    }
+
+    @objc private func handleShare() {
+        guard let source = source?.deletingPathExtension() else { return }
+        Analytics.track(.discoverListShareTapped)
+        let activityViewController = UIActivityViewController(activityItems: [source], applicationActivities: nil)
+        present(activityViewController, animated: true)
     }
 
     // MARK: - UITableView Methods


### PR DESCRIPTION
| 📘 Part of: #2628 
|:---:|

Adds the share button and the track event `discover_list_share_tapped` to the Discover lists

## To test

- Make sure you have the tracks log enabled
- Go to discover
- Expand a list by tapping Show All
- Tap on the top right share icon
- confirm you see `🔵 Tracked: discover_list_share_tapped` tracked
- Confirm you can copy or share the url
- Open another list like BCG
- Tap on the top right share icon
- confirm you see `🔵 Tracked: discover_list_share_tapped` tracked
- Confirm you can copy or share the url

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
