### PR TITLE
[Analytics Audit] Add year param for all EOY events

### DIFF
--- a/podcasts/End of Year/Analytics+story.swift
+++ b/podcasts/End of Year/Analytics+story.swift
@@ -2,6 +2,6 @@ import Foundation
 
 extension Analytics {
     static func track(_ event: AnalyticsEvent, story: String) {
-        Analytics.track(event, properties: ["story": story])
+        Analytics.track(event, properties: ["story": story, "year": EndOfYear.currentYear.literalValue])
     }
 }

--- a/podcasts/End of Year/EndOfYear.swift
+++ b/podcasts/End of Year/EndOfYear.swift
@@ -29,6 +29,17 @@ struct EndOfYear {
         var year: Int? {
             modelType?.year
         }
+
+        var literalValue: String {
+            switch self {
+            case .y2022:
+                return "2022"
+            case .y2023:
+                return "2023"
+            case .y2024:
+                return "2024"
+            }
+        }
     }
 
     static var isEligible: Bool { eligibilityChecker?.isEligible ?? false }
@@ -155,7 +166,7 @@ struct EndOfYear {
         }
 
         viewController.present(storiesViewController, animated: true, completion: nil)
-        Analytics.track(.endOfYearStoriesShown, properties: ["source": source.rawValue])
+        Analytics.track(.endOfYearStoriesShown, properties: ["source": source.rawValue, "year": EndOfYear.currentYear.literalValue])
     }
 
     static func share(assets: [Any], model: StoriesModel, storyIdentifier: String = "unknown", onDismiss: (() -> Void)? = nil) {

--- a/podcasts/End of Year/Stories/2023/EpilogueStory2023.swift
+++ b/podcasts/End of Year/Stories/2023/EpilogueStory2023.swift
@@ -54,7 +54,7 @@ struct EpilogueStory2023: ShareableStory {
 
                     Button(L10n.eoyStoryReplay) {
                         StoriesController.shared.replay()
-                        Analytics.track(.endOfYearStoryReplayButtonTapped)
+                        Analytics.track(.endOfYearStoryReplayButtonTapped, properties: ["year": "2023"])
                     }
                     .buttonStyle(StoriesButtonStyle(color: Constants.backgroundColor, icon: Image("eoy-replay-icon")))
                     .opacity(renderForSharing ? 0 : 1)

--- a/podcasts/End of Year/Stories/2024/EpilogueStory2024.swift
+++ b/podcasts/End of Year/Stories/2024/EpilogueStory2024.swift
@@ -55,7 +55,7 @@ struct EpilogueStory2024: StoryView {
             StoryFooter2024(title: L10n.eoy2024EpilogueTitle, description: L10n.eoy2024EpilogueDescription)
             Button(L10n.eoyStoryReplay) {
                 StoriesController.shared.replay()
-                Analytics.track(.endOfYearStoryReplayButtonTapped)
+                Analytics.track(.endOfYearStoryReplayButtonTapped, properties: ["year": "2024"])
             }
             .buttonStyle(BasicButtonStyle(textColor: .black, backgroundColor: Color.clear, borderColor: .black))
             .allowsHitTesting(true)

--- a/podcasts/End of Year/Stories/2024/PaidStoryWallView2024.swift
+++ b/podcasts/End of Year/Stories/2024/PaidStoryWallView2024.swift
@@ -64,7 +64,7 @@ struct PaidStoryWallView2024: View {
                 .allowsHitTesting(false)
         }
         .onAppear {
-            Analytics.track(.endOfYearUpsellShown)
+            Analytics.track(.endOfYearUpsellShown, properties: ["year": "2024"])
             Analytics.track(.endOfYearStoryShown, story: identifier)
         }
     }

--- a/podcasts/End of Year/Stories/2024/Ratings2024Story.swift
+++ b/podcasts/End of Year/Stories/2024/Ratings2024Story.swift
@@ -77,7 +77,7 @@ struct Ratings2024Story: ShareableStory {
             Button(L10n.learnAboutRatings) {
                 pauseState.togglePause()
                 openURL = true
-                Analytics.track(.endOfYearLearnRatingsShown)
+                Analytics.track(.endOfYearLearnRatingsShown, properties: ["year": "2024"])
             }
             .buttonStyle(BasicButtonStyle(textColor: .black, backgroundColor: Color.clear, borderColor: .black))
             .allowsHitTesting(true)

--- a/podcasts/End of Year/Views/EndOfYearModal.swift
+++ b/podcasts/End of Year/Views/EndOfYearModal.swift
@@ -45,7 +45,7 @@ struct EndOfYearModal: View {
         .applyDefaultThemeOptions()
         .onAppear {
             Settings.setHasShownModalForEndOfYear(true, year: year)
-            Analytics.track(.endOfYearModalShown)
+            Analytics.track(.endOfYearModalShown, properties: ["year": EndOfYear.currentYear.literalValue])
         }
     }
 

--- a/podcasts/End of Year/Views/StoriesView.swift
+++ b/podcasts/End of Year/Views/StoriesView.swift
@@ -133,7 +133,7 @@ struct StoriesView: View {
         }
         .background(model.primaryBackgroundColor)
         .onAppear {
-            Analytics.track(.endOfYearStoriesFailedToLoad)
+            Analytics.track(.endOfYearStoriesFailedToLoad, properties: ["year": EndOfYear.currentYear.literalValue])
         }
     }
 


### PR DESCRIPTION
| 📘 Part of: #2628 
|:---:|

This adds the year param to all EOY events

## To test

- Make sure you have the tracks log enabled
- Enable the EOY 24 FF
- Restart the APP
- Go to profile and tap on the banner
- Go trough all cards and actions to check the events and if the `year` `2024` param gets tracked

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
