### PR TITLE
[Analytics Audit] Referral Banner dismiss event

### DIFF
--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -787,6 +787,7 @@ enum AnalyticsEvent: String {
     case referralPassBannerShown
     case referralPurchaseShown
     case referralPurchaseSuccess
+    case referralPassBannerHideTapped
 
     // MARK: - Winback
 

--- a/podcasts/Referrals/Banner/ReferralsClaimBannerTableCell.swift
+++ b/podcasts/Referrals/Banner/ReferralsClaimBannerTableCell.swift
@@ -8,6 +8,7 @@ class ReferralsClaimBannerTableCell: ThemeableCell {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         let viewModel = ReferralClaimPassModel()
         viewModel.onCloseTap = {
+            Analytics.track(.referralPassBannerHideTapped)
             ReferralsCoordinator.shared.cleanReferalURL()
         }
         let bannerView = ReferralsClaimBannerView(viewModel: viewModel).themedUIView


### PR DESCRIPTION
| 📘 Part of: #2628 
|:---:|

Adds the event when the Referral banner from the profile view is dismissed

## To test

- Make sure the tracker is on
- Use a non plus/patron user
- Force to set an URL string for the referral so the banner will show up in Profile
- When the banner shows tap on the `x` to close it
- confirm the `referral_pass_banner_hide_tapped` is tracked

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
