### PR TITLE
Analytics audit: update free up space event

### DIFF
--- a/podcasts/ManageDownloadsCoordinator.swift
+++ b/podcasts/ManageDownloadsCoordinator.swift
@@ -16,7 +16,7 @@ class ManageDownloadsCoordinator {
            fabs(lastCheckDate.timeIntervalSince(Date.now)) < 14.days {
            return false
         }
-        return percentage < 1
+        return percentage < 0.1
     }
 
     static func showModalIfNeeded(from presentationVC: UIViewController, source: String) {

--- a/podcasts/ManageDownloadsCoordinator.swift
+++ b/podcasts/ManageDownloadsCoordinator.swift
@@ -31,7 +31,7 @@ class ManageDownloadsCoordinator {
                 presentationVC?.navigationController?.pushViewController(DownloadedFilesViewController(), animated: true)
             })
         }, onNotNowTap: { [weak presentationVC] in
-            Analytics.track(.freeUpSpaceMaybeLaterTapped)
+            Analytics.track(.freeUpSpaceMaybeLaterTapped, properties: ["source": source])
             Settings.manageDownloadsLastCheckDate = Date.now
             presentationVC?.dismiss(animated: true)
         })


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

Add the missing source parameter when sending `freeUpSpaceMaybeLaterTapped` and set the check to percentage back to 10% of free space instead of 100%.

## To test

In order to test it easier change the check for percentage on ManageDownloadsCoordinator.shouldShowBanner to 0.1

1. Start the app fresh
2. Do some downloads of episodes
3. Go to Profile tab
4. Tap on Downloads
5. Tap on the X button
6. Check that the `freeUpSpaceMaybeLaterTapped` is sent and `source` parameter is set to `downloads`

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
