### PR TITLE
Analytics audit: Add missing sleep timer settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 -----
 - Use new Share UI for bookmarks sharing [#2656](https://github.com/Automattic/pocket-casts-ios/pull/2656)
 - Remove the option to share bookmarks from users file [#2661](https://github.com/Automattic/pocket-casts-ios/pull/2661)
+- Add direct access to sleep timer settings from player [#2698](https://github.com/Automattic/pocket-casts-ios/pull/2698)
 
 7.80
 -----

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -395,6 +395,7 @@ enum AnalyticsEvent: String {
     case playerSleepTimerExtended
     case playerSleepTimerCancelled
     case playerSleepTimerRestarted
+    case playerSleepTimerSettingsTapped
 
     // MARK: - Player: Shelf
 

--- a/podcasts/GeneralSettingsViewController.swift
+++ b/podcasts/GeneralSettingsViewController.swift
@@ -8,9 +8,11 @@ class GeneralSettingsViewController: PCViewController, UITableViewDelegate, UITa
     private let switchCellId = "SwitchCell"
     private let disclosureCellId = "DisclosureCell"
 
+    var scrollToRow: TableRow?
+
     let debounce = Debounce(delay: Constants.defaultDebounceTime)
 
-    private enum TableRow { case skipForward, skipBack, keepScreenAwake, openPlayer, intelligentPlaybackResumption, defaultRowAction, extraMediaActions, defaultAddToUpNextSwipe, defaultGrouping, defaultArchive, playUpNextOnTap, legacyBluetooth, multiSelectGesture, openLinksInBrowser, publishChapterTitles, autoplay, autoRestartSleepTimer, shakeToRestartSleepTimer, isLockScreenScrubberDisabled }
+    enum TableRow { case skipForward, skipBack, keepScreenAwake, openPlayer, intelligentPlaybackResumption, defaultRowAction, extraMediaActions, defaultAddToUpNextSwipe, defaultGrouping, defaultArchive, playUpNextOnTap, legacyBluetooth, multiSelectGesture, openLinksInBrowser, publishChapterTitles, autoplay, autoRestartSleepTimer, shakeToRestartSleepTimer, isLockScreenScrubberDisabled }
     private var tableData: [[TableRow]] = [[.defaultRowAction, .defaultGrouping, .defaultArchive, .defaultAddToUpNextSwipe, .openLinksInBrowser], [.skipForward, .skipBack, .keepScreenAwake, .openPlayer, .isLockScreenScrubberDisabled, .intelligentPlaybackResumption], [.autoRestartSleepTimer], [.shakeToRestartSleepTimer], [.playUpNextOnTap], [.extraMediaActions], [.legacyBluetooth], [.multiSelectGesture], [.publishChapterTitles], [.autoplay]]
 
     @IBOutlet var settingsTable: UITableView! {
@@ -29,6 +31,10 @@ class GeneralSettingsViewController: PCViewController, UITableViewDelegate, UITa
         insetAdjuster.setupInsetAdjustmentsForMiniPlayer(scrollView: settingsTable)
 
         Analytics.track(.settingsGeneralShown)
+
+        if let scrollToRow {
+            self.scrollToRow(scrollToRow)
+        }
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -40,6 +46,14 @@ class GeneralSettingsViewController: PCViewController, UITableViewDelegate, UITa
 
             // Finish the Autoplay option flow
             AnnouncementFlow.current = .none
+        }
+    }
+
+    private func scrollToRow(_ row: TableRow) {
+        for (sectionIndex, section) in tableData.enumerated() {
+            if let row = section.firstIndex(of: row) {
+                settingsTable.scrollToRow(at: IndexPath(row: row, section: sectionIndex), at: .middle, animated: true)
+            }
         }
     }
 

--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -6,6 +6,7 @@ import Combine
 import PocketCastsUtils
 
 class MainTabBarController: UITabBarController, NavigationProtocol {
+
     enum Tab { case podcasts, filter, discover, profile, upNext }
 
     var pcTabs = [Tab]()
@@ -158,7 +159,7 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
 
     private func fixTarBarTraitCollectionOnIpadForiOS18() {
         if #available(iOS 18.0, *),
-            UIDevice.current.userInterfaceIdiom == .pad {
+           UIDevice.current.userInterfaceIdiom == .pad {
             traitOverrides.horizontalSizeClass = .compact
             if let rootHorizontalSizeClass = view.window?.traitCollection.horizontalSizeClass {
                 tabBar.traitOverrides.horizontalSizeClass = rootHorizontalSizeClass
@@ -475,6 +476,24 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
             navController.popToRootViewController(animated: false)
             navController.pushViewController(SettingsViewController(), animated: false)
             navController.pushViewController(HeadphoneSettingsViewController(), animated: true)
+        }
+    }
+
+    func showGeneralSettings(row: GeneralSettingsViewController.TableRow?) {
+        let state = NavigationManager.sharedManager.miniPlayer?.playerOpenState
+
+        // Dismiss any presented views if the player is not already open/dismissing since it will dismiss itself
+        if state != .open, state != .animating {
+            dismissPresentedViewController()
+        }
+
+        switchToTab(.profile)
+        if let navController = selectedViewController as? UINavigationController {
+            navController.popToRootViewController(animated: false)
+            navController.pushViewController(SettingsViewController(), animated: false)
+            let generalSettingsController = GeneralSettingsViewController()
+            generalSettingsController.scrollToRow = row
+            navController.pushViewController(generalSettingsController, animated: true)
         }
     }
 

--- a/podcasts/NavigationManager.swift
+++ b/podcasts/NavigationManager.swift
@@ -61,6 +61,9 @@ class NavigationManager {
     static let endOfYearStories = "endOfYearStories"
     static let onboardingFlow = "onboardingFlow"
 
+    static let settingsGeneralKey = "generalSettingsPage"
+    static let settingsGeneralRowKey = "generalSettingsRow"
+
     static let sharedManager = NavigationManager()
 
     private weak var mainController: NavigationProtocol?
@@ -210,6 +213,8 @@ class NavigationManager {
         } else if place == NavigationManager.onboardingFlow {
             let flow: OnboardingFlow.Flow? = data?["flow"] as? OnboardingFlow.Flow
             mainController?.showOnboardingFlow(flow: flow)
+        } else if place == NavigationManager.settingsGeneralKey {
+            mainController?.showGeneralSettings(row: data?[NavigationManager.settingsGeneralRowKey] as? GeneralSettingsViewController.TableRow)
         }
     }
 }

--- a/podcasts/NavigationProtocol.swift
+++ b/podcasts/NavigationProtocol.swift
@@ -32,6 +32,7 @@ protocol NavigationProtocol: AnyObject {
     func showPromotionFinishedAcknowledge()
     func showProfilePage()
     func showHeadphoneSettings()
+    func showGeneralSettings(row: GeneralSettingsViewController.TableRow?)
     func showRedeemGuestPass(url: URL)
 
     func showSupporterSignIn(podcastInfo: PodcastInfo)

--- a/podcasts/SleepTimerViewController.swift
+++ b/podcasts/SleepTimerViewController.swift
@@ -2,6 +2,9 @@ import PocketCastsUtils
 import UIKit
 
 class SleepTimerViewController: SimpleNotificationsViewController {
+
+    @IBOutlet var settingsBtn: UIButton!
+
     @IBOutlet var plusFiveBtn: UIButton! {
         didSet {
             plusFiveBtn.setTitle(L10n.sleepTimerAdd5Mins, for: .normal)
@@ -210,6 +213,8 @@ class SleepTimerViewController: SimpleNotificationsViewController {
 
         customTimeStepper.tintColor = ThemeColor.playerContrast01()
         customEpisodeStepper.tintColor = ThemeColor.playerContrast01()
+
+        settingsBtn.tintColor = ThemeColor.playerContrast02()
     }
 
     private func updateSleepRemainingTime() {
@@ -271,6 +276,11 @@ class SleepTimerViewController: SimpleNotificationsViewController {
     }
 
     // MARK: - Sleep Timer Actions
+
+    @IBAction func settingsTapped(_ sender: Any) {
+        Analytics.track(.playerSleepTimerSettingsTapped)
+        NavigationManager.sharedManager.navigateTo(NavigationManager.settingsGeneralKey, data: [NavigationManager.settingsGeneralRowKey: GeneralSettingsViewController.TableRow.autoRestartSleepTimer])
+    }
 
     @IBAction func fiveMinutesTapped(_ sender: Any) {
         PlaybackManager.shared.setSleepTimerInterval(5.minutes)

--- a/podcasts/SleepTimerViewController.xib
+++ b/podcasts/SleepTimerViewController.xib
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="SleepTimerViewController" customModule="podcasts" customModuleProvider="target">
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="SleepTimerViewController" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
             <connections>
                 <outlet property="activeSleepAnimation" destination="E6q-a6-BhY" id="kPi-ro-gxZ"/>
                 <outlet property="cancelBtn" destination="EOQ-B1-4Zt" id="Foy-UE-E5X"/>
@@ -23,6 +23,7 @@
                 <outlet property="handleView" destination="EI8-00-9oQ" id="HWg-iD-en0"/>
                 <outlet property="oneHourBtn" destination="vbQ-1n-0Db" id="90U-dM-wYh"/>
                 <outlet property="plusFiveBtn" destination="TXG-Ts-uOu" id="BFF-EH-0zA"/>
+                <outlet property="settingsBtn" destination="Ulj-Qw-svb" id="E9v-MS-r8n"/>
                 <outlet property="sleepTimerActiveView" destination="nxz-IC-HCU" id="8yV-2y-vmJ"/>
                 <outlet property="sleepTimerOffHeading" destination="NpZ-qP-qnr" id="xMd-7E-urS"/>
                 <outlet property="sleepTimerOffHeadingLabel" destination="UQK-q4-qBY" id="Hd8-Ub-tYV"/>
@@ -45,7 +46,7 @@
                 <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nxz-IC-HCU" userLabel="Current Option">
                     <rect key="frame" x="0.0" y="0.0" width="408" height="454"/>
                     <subviews>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="E6q-a6-BhY" customClass="SleepTimerButton" customModule="podcasts" customModuleProvider="target">
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="E6q-a6-BhY" customClass="SleepTimerButton" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
                             <rect key="frame" x="170" y="60" width="68" height="68"/>
                             <accessibility key="accessibilityConfiguration">
                                 <accessibilityTraits key="traits" image="YES"/>
@@ -56,7 +57,7 @@
                                 <constraint firstAttribute="width" constant="68" id="PXS-kj-qzC"/>
                             </constraints>
                         </button>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="4:59" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vyF-KA-sb1" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="4:59" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vyF-KA-sb1" customClass="ThemeableLabel" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
                             <rect key="frame" x="144" y="119" width="120" height="65"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="65" id="K6U-Bm-L8g"/>
@@ -65,7 +66,7 @@
                             <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                             <nil key="highlightedColor"/>
                         </label>
-                        <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Sleeping when episode ends" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sWl-Fm-Fg5" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
+                        <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Sleeping when episode ends" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sWl-Fm-Fg5" customClass="ThemeableLabel" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
                             <rect key="frame" x="16" y="144" width="376" height="30"/>
                             <constraints>
                                 <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="27" id="ZGO-cQ-xa7"/>
@@ -146,18 +147,32 @@
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="VIr-G3-c6n" userLabel="List of Options">
                     <rect key="frame" x="0.0" y="0.0" width="408" height="488"/>
                     <subviews>
-                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NpZ-qP-qnr" userLabel="Popup Heading" customClass="ThemeableView" customModule="podcasts" customModuleProvider="target">
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NpZ-qP-qnr" userLabel="Popup Heading" customClass="ThemeableView" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
                             <rect key="frame" x="0.0" y="0.0" width="408" height="68"/>
                             <subviews>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="SLEEP TIMER" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UQK-q4-qBY" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="SLEEP TIMER" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UQK-q4-qBY" customClass="ThemeableLabel" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
                                     <rect key="frame" x="20" y="35" width="83.5" height="16"/>
                                     <fontDescription key="fontDescription" type="system" weight="medium" pointSize="13"/>
                                     <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                     <nil key="highlightedColor"/>
                                 </label>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ulj-Qw-svb" userLabel="Settings Button">
+                                    <rect key="frame" x="356" y="27" width="32" height="32"/>
+                                    <constraints>
+                                        <constraint firstAttribute="height" constant="32" id="6rL-dg-Rga"/>
+                                        <constraint firstAttribute="width" constant="32" id="a4h-al-jKL"/>
+                                    </constraints>
+                                    <state key="normal" title="Button"/>
+                                    <buttonConfiguration key="configuration" style="plain" image="profile-settings"/>
+                                    <connections>
+                                        <action selector="settingsTapped:" destination="-1" eventType="touchUpInside" id="ctf-Re-erO"/>
+                                    </connections>
+                                </button>
                             </subviews>
                             <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <constraints>
+                                <constraint firstAttribute="trailing" secondItem="Ulj-Qw-svb" secondAttribute="trailing" constant="20" id="0sj-4G-cJf"/>
+                                <constraint firstItem="Ulj-Qw-svb" firstAttribute="centerY" secondItem="UQK-q4-qBY" secondAttribute="centerY" id="6vh-ld-re3"/>
                                 <constraint firstAttribute="bottom" secondItem="UQK-q4-qBY" secondAttribute="bottom" constant="17" id="RQE-qp-YF6"/>
                                 <constraint firstAttribute="height" constant="68" id="kCY-k7-ghU"/>
                                 <constraint firstItem="UQK-q4-qBY" firstAttribute="leading" secondItem="NpZ-qP-qnr" secondAttribute="leading" constant="20" id="lpg-MM-g46"/>
@@ -166,7 +181,7 @@
                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="DJb-Yj-WkR">
                             <rect key="frame" x="20" y="68" width="368" height="395"/>
                             <subviews>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zpm-Yl-Ktn" customClass="ThemeableUIButton" customModule="podcasts" customModuleProvider="target">
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zpm-Yl-Ktn" customClass="ThemeableUIButton" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
                                     <rect key="frame" x="0.0" y="0.0" width="368" height="50"/>
                                     <constraints>
                                         <constraint firstAttribute="height" constant="50" id="tEi-6G-S1k"/>
@@ -179,7 +194,7 @@
                                         <action selector="fiveMinutesTapped:" destination="-1" eventType="touchUpInside" id="88y-BU-46f"/>
                                     </connections>
                                 </button>
-                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="sIu-pA-5h2" userLabel="Divider" customClass="ThemeableView" customModule="podcasts" customModuleProvider="target">
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="sIu-pA-5h2" userLabel="Divider" customClass="ThemeableView" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
                                     <rect key="frame" x="0.0" y="55" width="368" height="1"/>
                                     <viewLayoutGuide key="safeArea" id="Jww-DN-Lvl"/>
                                     <color key="backgroundColor" white="1" alpha="0.5" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -187,7 +202,7 @@
                                         <constraint firstAttribute="height" constant="1" id="ZFY-xz-L95"/>
                                     </constraints>
                                 </view>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Sls-sc-0oY" customClass="ThemeableUIButton" customModule="podcasts" customModuleProvider="target">
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Sls-sc-0oY" customClass="ThemeableUIButton" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
                                     <rect key="frame" x="0.0" y="61" width="368" height="50"/>
                                     <constraints>
                                         <constraint firstAttribute="height" constant="50" id="kZ7-ND-f8K"/>
@@ -200,7 +215,7 @@
                                         <action selector="fifteenMinutesTapped:" destination="-1" eventType="touchUpInside" id="Tc2-et-Pes"/>
                                     </connections>
                                 </button>
-                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="FTz-Q8-OOs" userLabel="Divider" customClass="ThemeableView" customModule="podcasts" customModuleProvider="target">
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="FTz-Q8-OOs" userLabel="Divider" customClass="ThemeableView" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
                                     <rect key="frame" x="0.0" y="116" width="368" height="1"/>
                                     <viewLayoutGuide key="safeArea" id="CvD-fP-r68"/>
                                     <color key="backgroundColor" white="1" alpha="0.5" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -208,7 +223,7 @@
                                         <constraint firstAttribute="height" constant="1" id="j1V-95-E9N"/>
                                     </constraints>
                                 </view>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QRn-De-Aso" customClass="ThemeableUIButton" customModule="podcasts" customModuleProvider="target">
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QRn-De-Aso" customClass="ThemeableUIButton" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
                                     <rect key="frame" x="0.0" y="122" width="368" height="50"/>
                                     <constraints>
                                         <constraint firstAttribute="height" constant="50" id="R3i-2r-Tdo"/>
@@ -221,7 +236,7 @@
                                         <action selector="thirtyMinutesTapped:" destination="-1" eventType="touchUpInside" id="LwQ-fv-tGN"/>
                                     </connections>
                                 </button>
-                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="CF0-CU-Mzc" userLabel="Divider" customClass="ThemeableView" customModule="podcasts" customModuleProvider="target">
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="CF0-CU-Mzc" userLabel="Divider" customClass="ThemeableView" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
                                     <rect key="frame" x="0.0" y="177" width="368" height="1"/>
                                     <viewLayoutGuide key="safeArea" id="1UJ-PX-Xuu"/>
                                     <color key="backgroundColor" white="1" alpha="0.5" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -229,7 +244,7 @@
                                         <constraint firstAttribute="height" constant="1" id="gHW-nz-P4a"/>
                                     </constraints>
                                 </view>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vbQ-1n-0Db" customClass="ThemeableUIButton" customModule="podcasts" customModuleProvider="target">
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vbQ-1n-0Db" customClass="ThemeableUIButton" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
                                     <rect key="frame" x="0.0" y="183" width="368" height="50"/>
                                     <constraints>
                                         <constraint firstAttribute="height" constant="50" id="URq-zY-lQC"/>
@@ -242,7 +257,7 @@
                                         <action selector="oneHourTapped:" destination="-1" eventType="touchUpInside" id="uce-ol-qjC"/>
                                     </connections>
                                 </button>
-                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="q2h-db-rHQ" userLabel="Divider" customClass="ThemeableView" customModule="podcasts" customModuleProvider="target">
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="q2h-db-rHQ" userLabel="Divider" customClass="ThemeableView" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
                                     <rect key="frame" x="0.0" y="238" width="368" height="1"/>
                                     <viewLayoutGuide key="safeArea" id="LW0-TZ-Lg2"/>
                                     <color key="backgroundColor" white="1" alpha="0.5" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -253,7 +268,7 @@
                                 <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="zV1-Fm-aS4">
                                     <rect key="frame" x="0.0" y="244" width="368" height="50"/>
                                     <subviews>
-                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BLE-pt-wSu" customClass="ThemeableUIButton" customModule="podcasts" customModuleProvider="target">
+                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BLE-pt-wSu" customClass="ThemeableUIButton" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
                                             <rect key="frame" x="0.0" y="0.0" width="273" height="50"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="50" id="yW9-43-SRc"/>
@@ -265,7 +280,7 @@
                                                 <action selector="endOfEpisodeTapped:" destination="-1" eventType="touchUpInside" id="6mR-JE-nH3"/>
                                             </connections>
                                         </button>
-                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5AT-lV-iMB" customClass="CustomStepper" customModule="podcasts" customModuleProvider="target">
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5AT-lV-iMB" customClass="CustomStepper" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
                                             <rect key="frame" x="278" y="3" width="90" height="44"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="44" id="LdZ-ff-sWl"/>
@@ -277,7 +292,7 @@
                                         <constraint firstAttribute="height" constant="50" id="eLb-K5-lUm"/>
                                     </constraints>
                                 </stackView>
-                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Odq-ql-AQB" userLabel="Divider" customClass="ThemeableView" customModule="podcasts" customModuleProvider="target">
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Odq-ql-AQB" userLabel="Divider" customClass="ThemeableView" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
                                     <rect key="frame" x="0.0" y="299" width="368" height="1"/>
                                     <viewLayoutGuide key="safeArea" id="0GV-bY-Dbn"/>
                                     <color key="backgroundColor" white="1" alpha="0.5" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -288,7 +303,7 @@
                                 <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="fMH-TT-nhn">
                                     <rect key="frame" x="0.0" y="305" width="368" height="50"/>
                                     <subviews>
-                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="C4v-GT-5g4" customClass="ThemeableUIButton" customModule="podcasts" customModuleProvider="target">
+                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="C4v-GT-5g4" customClass="ThemeableUIButton" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
                                             <rect key="frame" x="0.0" y="0.0" width="273" height="50"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="50" id="0hN-Ox-kKx"/>
@@ -300,7 +315,7 @@
                                                 <action selector="customTapped:" destination="-1" eventType="touchUpInside" id="M02-pz-RPz"/>
                                             </connections>
                                         </button>
-                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Nac-xX-8CP" customClass="CustomTimeStepper" customModule="podcasts" customModuleProvider="target">
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Nac-xX-8CP" customClass="CustomTimeStepper" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
                                             <rect key="frame" x="278" y="3" width="90" height="44"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="44" id="DuW-YP-rJw"/>
@@ -343,7 +358,7 @@
                         <action selector="closeTapped:" destination="-1" eventType="touchUpInside" id="B8Q-zW-nn9"/>
                     </connections>
                 </button>
-                <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="EI8-00-9oQ" customClass="ThemeableView" customModule="podcasts" customModuleProvider="target">
+                <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="EI8-00-9oQ" customClass="ThemeableView" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
                     <rect key="frame" x="176" y="8" width="56" height="4"/>
                     <color key="backgroundColor" red="0.6350919008" green="0.58443516490000003" blue="0.50978493690000004" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                     <accessibility key="accessibilityConfiguration">
@@ -384,4 +399,7 @@
             <point key="canvasLocation" x="4.3478260869565224" y="112.5"/>
         </view>
     </objects>
+    <resources>
+        <image name="profile-settings" width="24" height="24"/>
+    </resources>
 </document>


### PR DESCRIPTION
| 📘 Part of: #2628 
|:---:|

Fixes # <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
| 1 | 2 |
| - | - |
| ![Simulator Screenshot - iPhone 16 Pro Max - 2025-01-24 at 16 29 00](https://github.com/user-attachments/assets/15de80a3-04c3-4d2c-9695-afe946558a96) | ![Simulator Screenshot - iPhone 16 Pro Max - 2025-01-24 at 16 31 47](https://github.com/user-attachments/assets/16e36eb4-5ece-4d29-97eb-8f72eb34678f) |

## To test

- Start the app
- Ensure that you have tracksLogging FF enabled
- Start playing an episode
- Open the full screen player
- Tap on the Sleep Timer option
- Check that you see a new settings icon on the top right of the timer modal
- Tap on it
- Check that you navigate to Settings->General and have the Sleep Timer section in view
- Check that you see the event `player_sleep_timer_settings_tapped` on the console

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
