### PR TITLE
Fix slow loading of bookmarks

### DIFF
--- a/podcasts/Bookmarks/List/BookmarkRowViewModel.swift
+++ b/podcasts/Bookmarks/List/BookmarkRowViewModel.swift
@@ -34,8 +34,8 @@ class BookmarkRowViewModel: ObservableObject {
         let dataManager = DataManager.sharedManager
         if let episode = bookmark.episode ?? dataManager.findBaseEpisode(uuid: bookmark.episodeUuid) {
             updateFromEpisode(episode)
-        }
-        if let podcastUuid = bookmark.podcastUuid {
+
+        } else if let podcastUuid = bookmark.podcastUuid {
             ServerPodcastManager.shared.addMissingPodcastAndEpisode(episodeUuid: bookmark.episodeUuid, podcastUuid: podcastUuid) { [weak self] episode in
                 if let episode {
                     DispatchQueue.main.async {


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This update ensure that bookmark episodes that already cached in the database are not loaded again over the wire.

## To test

*Setup*

- Open the web app, and go to a new podcast and open an episode you never played before
- Create some bookmarks for it, around 25
- Now go to the mobile app

1. Start the app
2. Open the same episode where you created the bookmarks
3. Play the episode
4. Open the full screen player
5. Tap on Bookmarks tab
6. Scroll around and see if performance is ok.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
