### PR TITLE
Analytics audit: add remove from listening history events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Use new Share UI for bookmarks sharing [#2656](https://github.com/Automattic/pocket-casts-ios/pull/2656)
 - Remove the option to share bookmarks from users file [#2661](https://github.com/Automattic/pocket-casts-ios/pull/2661)
 - Add direct access to sleep timer settings from player [#2698](https://github.com/Automattic/pocket-casts-ios/pull/2698)
+- Add option to remove selected episodes from your listening history [#2702](https://github.com/Automattic/pocket-casts-ios/pull/2702)
 
 7.80
 -----

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -201,6 +201,8 @@ enum AnalyticsEvent: String {
 
     case listeningHistoryCleared
 
+    case listeningHistoryRemoveEpisode
+
     // MARK: - Uploaded Files
 
     case uploadedFilesShown

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -200,7 +200,8 @@ enum AnalyticsEvent: String {
     case listeningHistoryMultiSelectExited
 
     case listeningHistoryCleared
-
+    case listeningHistoryClearConfirmationShown
+    case listeningHistoryClearConfirmationDismissed
     case listeningHistoryRemoveEpisode
 
     // MARK: - Uploaded Files

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -202,7 +202,6 @@ enum AnalyticsEvent: String {
     case listeningHistoryCleared
     case listeningHistoryClearConfirmationShown
     case listeningHistoryClearConfirmationDismissed
-    case listeningHistoryRemoveEpisode
 
     // MARK: - Uploaded Files
 
@@ -449,6 +448,8 @@ enum AnalyticsEvent: String {
     case episodeBulkAddToUpNext
 
     case episodeRemovedFromUpNext
+
+    case episodeRemovedListeningHistory
 
     case podcastShared
 

--- a/podcasts/Analytics/Helpers/AnalyticsEpisodeHelper.swift
+++ b/podcasts/Analytics/Helpers/AnalyticsEpisodeHelper.swift
@@ -32,6 +32,7 @@ class AnalyticsEpisodeHelper: AnalyticsCoordinator {
         bulkEvent(.episodeBulkUnstarred, count: count)
     }
 
+
     // MARK: - Download
 
     func downloadCancelled(episodeUUID: String) {
@@ -85,6 +86,10 @@ class AnalyticsEpisodeHelper: AnalyticsCoordinator {
 
     func bulkMarkAsUnplayed(count: Int) {
         bulkEvent(.episodeBulkMarkedAsUnplayed, count: count)
+    }
+
+    func bulkRemoveFromListeningHistory(count: Int) {
+        bulkEvent(.episodeRemovedListeningHistory, count: count)
     }
 
     // MARK: - Archive

--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -58,6 +58,7 @@ struct Constants {
         static let episodeDownloadStatusChanged = NSNotification.Name(rawValue: "SJEpisodeDownloadChanged")
         static let manyEpisodesChanged = NSNotification.Name(rawValue: "SJManyEpisodesChanged")
         static let episodeTranscriptAvailabilityChanged = NSNotification.Name(rawValue: "SJEpisodeTranscriptAvailabilityChanged")
+        static let listeningHistoryChanged = NSNotification.Name(rawValue: "SJListeningHistoryChanged")
 
         // podcast notifications
         static let podcastUpdated = NSNotification.Name(rawValue: "SJPodcastUpdated")

--- a/podcasts/Enumerations.swift
+++ b/podcasts/Enumerations.swift
@@ -481,7 +481,7 @@ extension PlayerAction: AnalyticsDescribable {
 }
 
 enum MultiSelectAction: Int32, CaseIterable, AnalyticsDescribable {
-    case playLast = 1, playNext, download, archive, markAsPlayed, star, moveToTop, moveToBottom, removeFromUpNext, unstar, unarchive, removeDownload, markAsUnplayed, delete, share
+    case playLast = 1, playNext, download, archive, markAsPlayed, star, moveToTop, moveToBottom, removeFromUpNext, unstar, unarchive, removeDownload, markAsUnplayed, delete, share, removeListeningHistory
 
     func title() -> String {
         switch self {
@@ -515,6 +515,8 @@ enum MultiSelectAction: Int32, CaseIterable, AnalyticsDescribable {
             return L10n.delete
         case .share:
             return L10n.share
+        case .removeListeningHistory:
+            return L10n.listeningHistoryRemove
         }
     }
 
@@ -550,6 +552,8 @@ enum MultiSelectAction: Int32, CaseIterable, AnalyticsDescribable {
             return "episode-delete"
         case .share:
             return "podcast-share"
+        case .removeListeningHistory:
+            return "episode-delete"
         }
     }
 
@@ -585,6 +589,8 @@ enum MultiSelectAction: Int32, CaseIterable, AnalyticsDescribable {
             return "delete"
         case .share:
             return "share"
+        case .removeListeningHistory:
+            return "listening_history_remove_episode"
         }
     }
 

--- a/podcasts/EpisodeManager.swift
+++ b/podcasts/EpisodeManager.swift
@@ -242,6 +242,7 @@ class EpisodeManager: NSObject {
             DataManager.sharedManager.clearEpisodePlaybackInteractionDate(episodeUuid: episode.uuid)
         }
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.listeningHistoryChanged)
+        analyticsHelper.bulkRemoveFromListeningHistory(count: episodes.count)
     }
 
     class func deleteAllEpisodesInPodcast(id: Int64) {

--- a/podcasts/EpisodeManager.swift
+++ b/podcasts/EpisodeManager.swift
@@ -237,6 +237,13 @@ class EpisodeManager: NSObject {
         analyticsHelper.bulkUnarchiveEpisodes(count: episodes.count)
     }
 
+    class func removeListeningHistory(episodes: [BaseEpisode]) {
+        for episode in episodes {
+            DataManager.sharedManager.clearEpisodePlaybackInteractionDate(episodeUuid: episode.uuid)
+        }
+        NotificationCenter.postOnMainThread(notification: Constants.Notifications.listeningHistoryChanged)
+    }
+
     class func deleteAllEpisodesInPodcast(id: Int64) {
         let episodes = DataManager.sharedManager.allEpisodesForPodcast(id: id)
         if episodes.count < 1 { return }

--- a/podcasts/ListeningHistoryViewController.swift
+++ b/podcasts/ListeningHistoryViewController.swift
@@ -171,8 +171,12 @@ class ListeningHistoryViewController: PCViewController {
             self.refreshEpisodes(animated: true)
 
         })
+        optionPicker.setNoActionCallback {
+            Analytics.track(.listeningHistoryClearConfirmationDismissed)
+        }
         optionPicker.addDescriptiveActions(title: L10n.historyClearAllDetails, message: L10n.historyClearAllDetailsMsg, icon: "option-cleanup", actions: [clearAllAction])
         optionPicker.show(statusBarStyle: preferredStatusBarStyle)
+        Analytics.track(.listeningHistoryClearConfirmationShown)
     }
 
     func setupNavBar() {

--- a/podcasts/ListeningHistoryViewController.swift
+++ b/podcasts/ListeningHistoryViewController.swift
@@ -74,6 +74,8 @@ class ListeningHistoryViewController: PCViewController {
     @IBOutlet var multiSelectFooter: MultiSelectFooterView! {
         didSet {
             multiSelectFooter.delegate = self
+            multiSelectFooter.getActionsFunc = Settings.listeningHistoryMultiSelectActions
+            multiSelectFooter.setActionsFunc = Settings.updateListeningHistoryMultiSelectActions
         }
     }
 
@@ -117,6 +119,7 @@ class ListeningHistoryViewController: PCViewController {
         addCustomObserver(Constants.Notifications.episodePlayStatusChanged, selector: #selector(refreshEpisodesFromNotification))
         addCustomObserver(Constants.Notifications.episodeDownloadStatusChanged, selector: #selector(refreshEpisodesFromNotification))
         addCustomObserver(Constants.Notifications.manyEpisodesChanged, selector: #selector(refreshEpisodesFromNotification))
+        addCustomObserver(Constants.Notifications.listeningHistoryChanged, selector: #selector(refreshEpisodesFromNotification))
     }
 
     @objc private func refreshEpisodesFromNotification() {

--- a/podcasts/MultiSelectFooterView.swift
+++ b/podcasts/MultiSelectFooterView.swift
@@ -149,7 +149,7 @@ class MultiSelectFooterView: UIView, MultiSelectActionOrderDelegate {
             // is too large.
             let hostingControllerHeight = presentingVC.view.bounds.height
             let sheetDetentHeight = hostingControllerHeight * 0.45
-            if #available(iOS 16.0, *) {
+            if #available(iOS 16.0, *), actions.count < 7 {
                 sheetController.detents = [.custom(resolver: { _ in sheetDetentHeight }), ]
             } else {
                 sheetController.detents = [.medium()]

--- a/podcasts/MultiSelectHelper.swift
+++ b/podcasts/MultiSelectHelper.swift
@@ -345,7 +345,6 @@ class MultiSelectHelper {
         let selectedEpisodes = actionDelegate.multiSelectedBaseEpisodes()
         EpisodeManager.removeListeningHistory(episodes: selectedEpisodes)
         actionDelegate.multiSelectActionCompleted()
-        Analytics.track(AnalyticsEvent.listeningHistoryRemoveEpisode)
     }
 
 

--- a/podcasts/MultiSelectHelper.swift
+++ b/podcasts/MultiSelectHelper.swift
@@ -40,7 +40,8 @@ class MultiSelectHelper {
             delete(actionDelegate: actionDelegate)
         case .share:
             share(actionDelegate: actionDelegate, view: view)
-            return
+        case .removeListeningHistory:
+            removeListeningHistory(actionDelegate: actionDelegate)
         }
     }
 
@@ -339,6 +340,14 @@ class MultiSelectHelper {
                                          fromSource: .multiSelect
         )
     }
+
+    private class func removeListeningHistory(actionDelegate: MultiSelectActionDelegate) {
+        let selectedEpisodes = actionDelegate.multiSelectedBaseEpisodes()
+        EpisodeManager.removeListeningHistory(episodes: selectedEpisodes)
+        actionDelegate.multiSelectActionCompleted()
+        Analytics.track(AnalyticsEvent.listeningHistoryRemoveEpisode)
+    }
+
 
     // MARK: - Selection Helpers
 

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -860,6 +860,24 @@ class Settings: NSObject {
         UserDefaults.standard.set(actionInts, forKey: Settings.multiSelectActionsKey)
     }
 
+    private static let listeningHistoryMultiSelectActionsKey = "ListeningHistoryMultiSelectActions"
+    class func listeningHistoryMultiSelectActions() -> [MultiSelectAction] {
+        let defaultActions: [MultiSelectAction] = [.playNext, .playLast, .download, .archive, .share, .removeListeningHistory, .markAsPlayed, .star]
+        guard let savedInts = UserDefaults.standard.object(forKey: Settings.listeningHistoryMultiSelectActionsKey) as? [Int32] else {
+            return defaultActions
+        }
+
+        let actions = savedInts.compactMap { MultiSelectAction(rawValue: $0) }
+
+        // Make sure new items are shown
+        return actions + defaultActions.filter { !actions.contains($0) }
+    }
+
+    class func updateListeningHistoryMultiSelectActions(_ actions: [MultiSelectAction]) {
+        let actionInts = actions.map(\.rawValue)
+        UserDefaults.standard.set(actionInts, forKey: Settings.listeningHistoryMultiSelectActionsKey)
+    }
+
     private static let filesMultiSelectActionsKey = "FilesMultiSelectActionsV2"
     class func fileMultiSelectActions() -> [MultiSelectAction] {
         guard let savedInts = UserDefaults.standard.object(forKey: Settings.filesMultiSelectActionsKey) as? [Int32] else {

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -1522,6 +1522,8 @@ internal enum L10n {
   internal static var learnMore: String { return L10n.tr("Localizable", "learn_more") }
   /// Listening History
   internal static var listeningHistory: String { return L10n.tr("Localizable", "listening_history") }
+  /// Remove from history
+  internal static var listeningHistoryRemove: String { return L10n.tr("Localizable", "listening_history_remove") }
   /// We couldn't find any episode for that search. Try another keyword.
   internal static var listeningHistorySearchNoEpisodesText: String { return L10n.tr("Localizable", "listening_history_search_no_episodes_text") }
   /// No episodes found

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4728,3 +4728,6 @@
 
 /* Message when no email account is configured to be able to send the logs*/
 "logs_no_email_account_configured" = "You need to configure an email account on the device in order to send the logs";
+
+/* Title for action to remove episode from listening history */
+"listening_history_remove" = "Remove from history";


### PR DESCRIPTION
| 📘 Part of: #2628 
|:---:|

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
Adds missing action to remove selected episodes from the listening history.

| 1 | 2 |
| - | - |
| ![Simulator Screenshot - iPhone 16 Pro Max - 2025-01-27 at 14 54 33](https://github.com/user-attachments/assets/fb823364-59a8-476a-a837-c0505c6ee5d7) | ![Simulator Screenshot - iPhone 16 Pro Max - 2025-01-27 at 15 04 58](https://github.com/user-attachments/assets/dd9208e9-1422-4cc2-8ed9-5fced372e4f6) |

## To test

1. Start the app
2. Ensure that you have the `tracksLogging` FF enabled
3. Go to Profile Tab
4. Tap on Listening History
5. Select some episodes
6. Tap on ... more on the multi-select bar
7. Tap on Remove from History
8. Check if episode is removed from listening history and you see the event: `episodeRemovedListeningHistory`
9. Now tap on the ... button on the top right
10. Select the option Clear Listening History
11. Check if you see the event: `listeningHistoryClearConfirmationShown`
12. Dismiss the modal by tapping outside. Check if you see the event: `listeningHistoryClearConfirmationDismissed`
13. Select again the Clear Listening History
14. This time tap on on the option Clear All. Check if you see the event: `listeningHistoryCleared`

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
