### PR TITLE
[Podcast Feed Reload] Add Reload button

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -135,6 +135,9 @@ public enum FeatureFlag: String, CaseIterable {
 
     case disablePrivateFeedSharing
 
+    /// Enable/Disable the podcast feed reload feature
+    case podcastFeedUpdate
+
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -225,6 +228,8 @@ public enum FeatureFlag: String, CaseIterable {
             true
         case .disablePrivateFeedSharing:
             true
+        case .podcastFeedUpdate:
+            false
         }
     }
 

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -676,6 +676,7 @@
 		9A156AB32CF8BEE3007BA8D9 /* CancelSubscriptionPlanRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A156AB22CF8BEE3007BA8D9 /* CancelSubscriptionPlanRow.swift */; };
 		9A4BB1E92D3AA4D600B68D94 /* AnalyticsAppThemeProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A4BB1E62D3AA4D600B68D94 /* AnalyticsAppThemeProvider.swift */; };
 		9A4BB1ED2D3AB06700B68D94 /* AnalyticsAppThemeProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A4BB1EC2D3AB06700B68D94 /* AnalyticsAppThemeProviderTests.swift */; };
+		9A4BB1F12D48F05400B68D94 /* PodcastFeedViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A4BB1F02D48F05400B68D94 /* PodcastFeedViewModel.swift */; };
 		9A509DE02D14606100E8CEB1 /* CancelSubscriptionOfferSuccessView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A509DDF2D14606100E8CEB1 /* CancelSubscriptionOfferSuccessView.swift */; };
 		9AA3B6312D27F0B600A0E30E /* CancelSubscriptionPlansViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AA3B6302D27F0B600A0E30E /* CancelSubscriptionPlansViewModel.swift */; };
 		BD001B892174260B00504DD3 /* FilterManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD001B882174260B00504DD3 /* FilterManager.swift */; };
@@ -2840,6 +2841,7 @@
 		9A156AB22CF8BEE3007BA8D9 /* CancelSubscriptionPlanRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancelSubscriptionPlanRow.swift; sourceTree = "<group>"; };
 		9A4BB1E62D3AA4D600B68D94 /* AnalyticsAppThemeProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsAppThemeProvider.swift; sourceTree = "<group>"; };
 		9A4BB1EC2D3AB06700B68D94 /* AnalyticsAppThemeProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsAppThemeProviderTests.swift; sourceTree = "<group>"; };
+		9A4BB1F02D48F05400B68D94 /* PodcastFeedViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PodcastFeedViewModel.swift; sourceTree = "<group>"; };
 		9A509DDF2D14606100E8CEB1 /* CancelSubscriptionOfferSuccessView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancelSubscriptionOfferSuccessView.swift; sourceTree = "<group>"; };
 		9A9517324EFFD2C905890193 /* Pods-podcasts.appstore.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-podcasts.appstore.xcconfig"; path = "Pods/Target Support Files/Pods-podcasts/Pods-podcasts.appstore.xcconfig"; sourceTree = "<group>"; };
 		9AA3B6302D27F0B600A0E30E /* CancelSubscriptionPlansViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancelSubscriptionPlansViewModel.swift; sourceTree = "<group>"; };
@@ -6324,6 +6326,7 @@
 				BD907DA82153324D004D7C02 /* Podcast Settings */,
 				BD6D417B200C555000CA8993 /* Cells */,
 				BD780AE620049BFF00B5A442 /* PodcastViewController.swift */,
+				9A4BB1F02D48F05400B68D94 /* PodcastFeedViewModel.swift */,
 				BD5AE6821FE0E9A20009B8A1 /* PodcastViewController+TableData.swift */,
 				BDDF8AA5240CE85D009BA263 /* PodcastViewController+Swipe.swift */,
 				BD6D4186200C802900CA8993 /* PodcastViewController+NetworkLoad.swift */,
@@ -10151,6 +10154,7 @@
 				8BC862692B71690A000627B9 /* WhatsNewFullView.swift in Sources */,
 				4011B93B2164546E00661A7D /* FilterEditOptionsViewController.swift in Sources */,
 				4051A5762281A9DD00C13C12 /* AccountActionCell.swift in Sources */,
+				9A4BB1F12D48F05400B68D94 /* PodcastFeedViewModel.swift in Sources */,
 				BDC63BBC21A5051B00C31887 /* LayerAutoSizingView.swift in Sources */,
 				BD69EBBC1CD1D383007F273B /* SocialsHelper.swift in Sources */,
 				BDEDCF7124627F02005910C1 /* CustomSegmentedControl.swift in Sources */,

--- a/podcasts/EpisodeListSearchController.swift
+++ b/podcasts/EpisodeListSearchController.swift
@@ -132,6 +132,14 @@ class EpisodeListSearchController: SimpleNotificationsViewController, UISearchBa
 
         let optionPicker = OptionsPicker(title: nil)
 
+        if delegate.shouldDisplayPodcastFeedReloadButton() {
+            let reloadPodcastFeedAction = OptionAction(label: L10n.podcastFeedReloadButton, icon: "stats_skipping") { [weak self] in
+                guard let self = self else { return }
+                self.podcastDelegate?.reloadPodcastFeed()
+            }
+            optionPicker.addAction(action: reloadPodcastFeedAction)
+        }
+
         let MultiSelectAction = OptionAction(label: L10n.selectEpisodes, icon: "option-multiselect") { [weak self] in
             guard let strongSelf = self else { return }
             strongSelf.podcastDelegate?.enableMultiSelect()

--- a/podcasts/PodcastFeedViewModel.swift
+++ b/podcasts/PodcastFeedViewModel.swift
@@ -1,9 +1,43 @@
 import Foundation
 
 class PodcastFeedViewModel {
+    enum LoadingState {
+        case idle
+        case loading
+    }
+
     let uuid: String?
+
+    private(set) var loadingState: LoadingState = .idle
 
     init(uuid: String?) {
         self.uuid = uuid
     }
+
+    func checkIfNewEpisodesAreAvailable() async -> Bool {
+        // Test implementation to simulate the API
+        await MainActor.run {
+            loadingState = .loading
+        }
+        _ = await shouldReloadPodcasts()
+
+        try? await Task.sleep(nanoseconds: 3_000_000_000)
+
+        await MainActor.run {
+            Toast.show(L10n.podcastFeedReloadNoEpisodesFound)
+        }
+        await MainActor.run {
+            loadingState = .idle
+        }
+        return false
+    }
+
+    private func shouldReloadPodcasts() async -> Int {
+        await MainActor.run {
+            Toast.show(L10n.podcastFeedReloadLoading)
+        }
+        return 202
+    }
+
+    private func pollUpdatePodcast() async { }
 }

--- a/podcasts/PodcastFeedViewModel.swift
+++ b/podcasts/PodcastFeedViewModel.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+class PodcastFeedViewModel {
+    let uuid: String?
+
+    init(uuid: String?) {
+        self.uuid = uuid
+    }
+}

--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -942,7 +942,15 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
     }
 
     func reloadPodcastFeed() {
-        
+        if podcastFeedViewModel?.loadingState == .loading {
+            return
+        }
+        Task { @MainActor [weak self] in
+            let podcastNeedsReload = await self?.podcastFeedViewModel?.checkIfNewEpisodesAreAvailable() ?? false
+            if podcastNeedsReload {
+                self?.loadPodcastInfo()
+            }
+        }
     }
 
     // MARK: - Long press actions

--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -41,6 +41,9 @@ protocol PodcastActionsDelegate: AnyObject {
     var ratingView: UIView { get }
 
     func showBookmarks()
+
+    func shouldDisplayPodcastFeedReloadButton() -> Bool
+    func reloadPodcastFeed()
 }
 
 class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, SyncSigninDelegate, MultiSelectActionDelegate {
@@ -174,6 +177,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
 
     private var isSearching = false
     private var cancellables = Set<AnyCancellable>()
+    private var podcastFeedViewModel: PodcastFeedViewModel?
 
     lazy var ratingView: UIView = {
         let view = StarRatingView(viewModel: podcastRatingViewModel,
@@ -231,6 +235,10 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
 
     override func viewDidLoad() {
         super.viewDidLoad()
+
+        if FeatureFlag.podcastFeedUpdate.enabled {
+            podcastFeedViewModel = PodcastFeedViewModel(uuid: podcast?.uuid ?? podcastInfo?.uuid)
+        }
 
         closeTapped = { [weak self] in
             _ = self?.navigationController?.popViewController(animated: true)
@@ -925,6 +933,16 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
 
         let controller = BookmarksPodcastListController(podcast: podcast)
         present(controller, animated: true)
+    }
+
+    // MARK: - Podcast Feed Reload action
+
+    func shouldDisplayPodcastFeedReloadButton() -> Bool {
+        return FeatureFlag.podcastFeedUpdate.enabled && podcastFeedViewModel?.uuid != nil
+    }
+
+    func reloadPodcastFeed() {
+        
     }
 
     // MARK: - Long press actions

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -2261,6 +2261,14 @@ internal enum L10n {
   internal static var podcastFailedDownload: String { return L10n.tr("Localizable", "podcast_failed_download") }
   /// Failed to upload
   internal static var podcastFailedUpload: String { return L10n.tr("Localizable", "podcast_failed_upload") }
+  /// Refresh episode list
+  internal static var podcastFeedReloadButton: String { return L10n.tr("Localizable", "podcast_feed_reload_button") }
+  /// Refreshing episode list...
+  internal static var podcastFeedReloadLoading: String { return L10n.tr("Localizable", "podcast_feed_reload_loading") }
+  /// New episodes found!
+  internal static var podcastFeedReloadNewEpisodesFound: String { return L10n.tr("Localizable", "podcast_feed_reload_new_episodes_found") }
+  /// No episodes found.
+  internal static var podcastFeedReloadNoEpisodesFound: String { return L10n.tr("Localizable", "podcast_feed_reload_no_episodes_found") }
   /// Discover Podcasts
   internal static var podcastGridDiscoverPodcasts: String { return L10n.tr("Localizable", "podcast_grid_discover_podcasts") }
   /// Coming from another app? Import your podcasts via Profile > Settings > Import & Export.

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4737,3 +4737,15 @@
 
 /* Message when no email account is configured to be able to send the logs*/
 "logs_no_email_account_configured" = "You need to configure an email account on the device in order to send the logs";
+
+/* Button title we display in the podcast view sheet prompted */
+"podcast_feed_reload_button" = "Refresh episode list";
+
+/* Message showed in the toast menu or pull down to refresh control indicating the podcast feed is reloading */
+"podcast_feed_reload_loading" = "Refreshing episode list...";
+
+/* After the podcast feed reloading completes, this is the message we display if there's new episodes to load */
+"podcast_feed_reload_new_episodes_found" = "New episodes found!";
+
+/* After the podcast feed reloading completes, this is the message we display if there's no new episodes to load */
+"podcast_feed_reload_no_episodes_found" = "No episodes found.";


### PR DESCRIPTION
| 📘 Part of: #2703 
|:---:|

Fixes #2704 

This PR adds:
• The new Feature Flag
• The view model to handle the API call
• The button into the Podcast view sheet
• Simulates the API call

https://github.com/user-attachments/assets/5d27e54b-8425-45a5-a380-dd8a21ee191d

## To test

- Enable the `podcastFeedUpdate` FF
- Open a podcast detail
- Tap the `•••` button
- Confirm you see the `Refresh episode list` as first button
- Tap it
- You should see the Toast being displayed and after few seconds a second toast saying there's no new episodes

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
