### PR TITLE
Unarchive any bulk episodes marked as unplayed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 7.82
 -----
 - Add App Clips [#2549](https://github.com/Automattic/pocket-casts-ios/issues/2549)
+- Unarchived all episodes bulk marked as unplayed. [#2713](https://github.com/Automattic/pocket-casts-ios/pull/2713)
 
 7.81
 -----

--- a/podcasts/MultiSelectHelper.swift
+++ b/podcasts/MultiSelectHelper.swift
@@ -147,7 +147,6 @@ class MultiSelectHelper {
         actionDelegate.multiSelectActionBegan(status: status)
         DispatchQueue.global().async {
             EpisodeManager.bulkUnarchive(episodes: selectedEpisodes)
-
             actionDelegate.multiSelectActionCompleted()
         }
     }
@@ -195,12 +194,14 @@ class MultiSelectHelper {
     }
 
     private class func markAsUnplayedEpisodes(actionDelegate: MultiSelectActionDelegate) {
+        let selectedArchiveEpisodes = actionDelegate.multiSelectedBaseEpisodes().compactMap { $0 as? Episode }
         let selectedEpisodes = actionDelegate.multiSelectedBaseEpisodes()
         let status = selectedEpisodes.count == 1 ? L10n.multiSelectMarkEpisodesUnplayedSingular : L10n.multiSelectMarkEpisodesUnplayedPluralFormat(selectedEpisodes.count.localized())
         actionDelegate.multiSelectActionBegan(status: status)
 
         DispatchQueue.global().async {
             EpisodeManager.bulkMarkAsUnPlayed(selectedEpisodes)
+            EpisodeManager.bulkUnarchive(episodes: selectedArchiveEpisodes)
             actionDelegate.multiSelectActionCompleted()
         }
     }


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR updates the bulk mark as played action to unarchive the episodes too

https://github.com/user-attachments/assets/2220a847-f472-49ba-8eb1-bbe319b8e452


## To test

1. Start the app
2. Open a podcast
3. Tap the option to show archive episodes
4. Select some episodes
5. Tap to mark them as played
6. Tap to mark them as archived ( if needed)
7. Now select the same episodes
8. Select the option to mark as unplayed
9. Check if the episodes are marked as unplayed an unarchived.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
