### PR TITLE
[Podcast Feed Reload] Pull Down to Reload feed

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -677,6 +677,7 @@
 		9A4BB1E92D3AA4D600B68D94 /* AnalyticsAppThemeProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A4BB1E62D3AA4D600B68D94 /* AnalyticsAppThemeProvider.swift */; };
 		9A4BB1ED2D3AB06700B68D94 /* AnalyticsAppThemeProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A4BB1EC2D3AB06700B68D94 /* AnalyticsAppThemeProviderTests.swift */; };
 		9A4BB1F12D48F05400B68D94 /* PodcastFeedViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A4BB1F02D48F05400B68D94 /* PodcastFeedViewModel.swift */; };
+		9A4BB1F32D4A3F2A00B68D94 /* CustomRefreshControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A4BB1F22D4A3F2A00B68D94 /* CustomRefreshControl.swift */; };
 		9A509DE02D14606100E8CEB1 /* CancelSubscriptionOfferSuccessView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A509DDF2D14606100E8CEB1 /* CancelSubscriptionOfferSuccessView.swift */; };
 		9AA3B6312D27F0B600A0E30E /* CancelSubscriptionPlansViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AA3B6302D27F0B600A0E30E /* CancelSubscriptionPlansViewModel.swift */; };
 		BD001B892174260B00504DD3 /* FilterManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD001B882174260B00504DD3 /* FilterManager.swift */; };
@@ -2842,6 +2843,7 @@
 		9A4BB1E62D3AA4D600B68D94 /* AnalyticsAppThemeProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsAppThemeProvider.swift; sourceTree = "<group>"; };
 		9A4BB1EC2D3AB06700B68D94 /* AnalyticsAppThemeProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsAppThemeProviderTests.swift; sourceTree = "<group>"; };
 		9A4BB1F02D48F05400B68D94 /* PodcastFeedViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PodcastFeedViewModel.swift; sourceTree = "<group>"; };
+		9A4BB1F22D4A3F2A00B68D94 /* CustomRefreshControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomRefreshControl.swift; sourceTree = "<group>"; };
 		9A509DDF2D14606100E8CEB1 /* CancelSubscriptionOfferSuccessView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancelSubscriptionOfferSuccessView.swift; sourceTree = "<group>"; };
 		9A9517324EFFD2C905890193 /* Pods-podcasts.appstore.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-podcasts.appstore.xcconfig"; path = "Pods/Target Support Files/Pods-podcasts/Pods-podcasts.appstore.xcconfig"; sourceTree = "<group>"; };
 		9AA3B6302D27F0B600A0E30E /* CancelSubscriptionPlansViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancelSubscriptionPlansViewModel.swift; sourceTree = "<group>"; };
@@ -5662,6 +5664,7 @@
 				BD5C39531B5E0A2A00C3A499 /* ShiftyLoadingAlert.swift */,
 				BDC692821BA7B0B70023B9F2 /* TinyPageControl.swift */,
 				BD4DB9941CAB8CFF009E512F /* PCRefreshControl.swift */,
+				9A4BB1F22D4A3F2A00B68D94 /* CustomRefreshControl.swift */,
 				BDC6DEBB1CBCD6C80030491D /* ReorderableFlowLayout.swift */,
 				BDE6AB791CC4BB580087D195 /* RoundedBorderView.swift */,
 				BD78A1D61FBACD4800048EB2 /* SmartInvertImageView.swift */,
@@ -10689,6 +10692,7 @@
 				BD9A43EE1D067AF20012FD9B /* ColorManager.swift in Sources */,
 				BD9FF6291B8EFC6F009F075E /* DiscoverSummaryProtocol.swift in Sources */,
 				BDDF8AA4240CE598009BA263 /* ThemeableSwipeCell.swift in Sources */,
+				9A4BB1F32D4A3F2A00B68D94 /* CustomRefreshControl.swift in Sources */,
 				BD92323523629F7B00C1E118 /* PlayerItemViewController.swift in Sources */,
 				BDB1E4F61B8C5BF9009AD30F /* NetworkSummaryViewController.swift in Sources */,
 				F5F6DA702BBE1109009B1934 /* CategoryButtonStyle.swift in Sources */,

--- a/podcasts/CustomRefreshControl.swift
+++ b/podcasts/CustomRefreshControl.swift
@@ -1,0 +1,196 @@
+import Foundation
+
+class CustomRefreshControl: UIRefreshControl {
+    var perform: (() -> Void)?
+
+    private var refreshInnerImage = UIImageView()
+    private var refreshOuterImage = UIImageView()
+    private let innerStartingAngle = -90 as CGFloat
+    private let innerEndingAngle = 90 as CGFloat
+    private var innerRotationAngle = 0 as CGFloat
+    private var outerRotationAngle = 0 as CGFloat
+    private var pullDownAmountForRefresh = 170 as CGFloat
+    private var refreshLabel = UILabel()
+    private var isAnimating = false
+    private var didTriggerHaptic = true
+
+    override init() {
+        super.init(frame: .zero)
+        setupView()
+        setupLayout()
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    override func beginRefreshing() {
+        super.beginRefreshing()
+        isAnimating = true
+        refreshLabel.text = L10n.refreshControlFetchingEpisodes
+        startRefreshAnimation()
+        perform?()
+    }
+
+    override func endRefreshing() {
+        super.endRefreshing()
+
+        endRefreshAnimation()
+        isAnimating = false
+    }
+
+    private func setupView() {
+        tintColor = .clear
+
+        refreshLabel.text = L10n.refreshControlPullToRefresh
+        refreshLabel.textAlignment = NSTextAlignment.center
+        refreshLabel.font = UIFont.systemFont(ofSize: 12, weight: UIFont.Weight.semibold)
+        refreshLabel.textColor = UIColor(hex: "#B8C3C9")
+        addSubview(refreshLabel)
+
+        refreshInnerImage.image = UIImage(named: "refresh_inner")
+        addSubview(refreshInnerImage)
+
+        refreshOuterImage.image = UIImage(named: "refresh_outer")
+        addSubview(refreshOuterImage)
+
+        addTarget(self, action: #selector(beginRefreshing), for: .valueChanged)
+    }
+
+    private func setupLayout() {
+        refreshLabel.translatesAutoresizingMaskIntoConstraints = false
+        refreshLabel.leadingAnchor.constraint(equalTo: leadingAnchor).isActive = true
+        refreshLabel.trailingAnchor.constraint(equalTo: trailingAnchor).isActive = true
+        refreshLabel.topAnchor.constraint(equalTo: topAnchor, constant: 50).isActive = true
+
+        refreshInnerImage.translatesAutoresizingMaskIntoConstraints = false
+        refreshInnerImage.centerXAnchor.constraint(equalTo: centerXAnchor).isActive = true
+        refreshInnerImage.topAnchor.constraint(equalTo: topAnchor, constant: 15).isActive = true
+
+        refreshOuterImage.translatesAutoresizingMaskIntoConstraints = false
+        refreshOuterImage.centerXAnchor.constraint(equalTo: centerXAnchor).isActive = true
+        refreshOuterImage.topAnchor.constraint(equalTo: topAnchor, constant: 15).isActive = true
+    }
+
+    private func startRefreshAnimation() {
+        let cfDuration = CFTimeInterval(1.0)
+
+        let innerRotation = CABasicAnimation(keyPath: "transform.rotation.z")
+        innerRotation.fromValue = innerRotationAngle
+        innerRotation.toValue = Double(innerRotationAngle) + (Double.pi * 2)
+        innerRotation.duration = cfDuration
+        innerRotation.repeatCount = Float.infinity
+        refreshInnerImage.layer.add(innerRotation, forKey: nil)
+
+        let outerRotation = CABasicAnimation(keyPath: "transform.rotation.z")
+        outerRotation.fromValue = outerRotationAngle
+        outerRotation.toValue = Double(outerRotationAngle) + (Double.pi * 2)
+        outerRotation.duration = cfDuration * 1.5
+        outerRotation.repeatCount = Float.infinity
+        refreshOuterImage.layer.add(outerRotation, forKey: nil)
+    }
+
+    private func endRefreshAnimation() {
+        refreshInnerImage.layer.removeAllAnimations()
+        refreshOuterImage.layer.removeAllAnimations()
+    }
+}
+
+// MARK: - Notifications Handling
+
+extension CustomRefreshControl {
+    func parentViewControllerDidAppear() {
+        let notifCenter = NotificationCenter.default
+        notifCenter.addObserver(self, selector: #selector(loading), name: PodcastFeedReloadNotification.loading, object: nil)
+        notifCenter.addObserver(self, selector: #selector(episodesFound), name: PodcastFeedReloadNotification.episodesFound, object: nil)
+        notifCenter.addObserver(self, selector: #selector(noEpisodesFound), name: PodcastFeedReloadNotification.noEpisodesFound, object: nil)
+    }
+
+    func parentViewControllerDidDisappear() {
+        let notifCenter = NotificationCenter.default
+        notifCenter.removeObserver(self, name: PodcastFeedReloadNotification.loading, object: nil)
+        notifCenter.removeObserver(self, name: PodcastFeedReloadNotification.episodesFound, object: nil)
+        notifCenter.removeObserver(self, name: PodcastFeedReloadNotification.noEpisodesFound, object: nil)
+
+        if isAnimating {
+            endRefreshing()
+        }
+    }
+
+    private func processRefreshCompleted(_ message: String) {
+        refreshLabel.text = message.uppercased()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) { [weak self] in
+            self?.endRefreshing()
+        }
+    }
+
+    @objc private func loading() {
+        refreshLabel.text = L10n.podcastFeedReloadLoading.uppercased()
+    }
+
+    @objc private func episodesFound() {
+        processRefreshCompleted(L10n.podcastFeedReloadNewEpisodesFound)
+    }
+
+    @objc private func noEpisodesFound() {
+        processRefreshCompleted(L10n.podcastFeedReloadNoEpisodesFound)
+    }
+}
+
+// MARK: - Scroll Handling
+
+extension CustomRefreshControl {
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        let scrollAmount = -scrollView.contentOffset.y
+        if scrollAmount > 100 {
+            didPullDown(scrollAmount)
+        }
+    }
+
+    func scrollViewDidEndDragging(_ scrollView: UIScrollView) {
+        let scrollAmount = -scrollView.contentOffset.y
+        if scrollAmount > 0 {
+            didEndDraggingAt(scrollAmount)
+        }
+    }
+
+    private func didPullDown(_ amount: CGFloat) {
+        if isAnimating {
+            return
+        }
+
+        let adjustedAmount = min(pullDownAmountForRefresh, amount)
+        let alphaValue = amount / pullDownAmountForRefresh
+        if adjustedAmount < pullDownAmountForRefresh {
+            refreshLabel.text = L10n.refreshControlPullToRefresh
+            didTriggerHaptic = false
+        } else {
+            refreshLabel.text = L10n.refreshControlReleaseToRefresh
+
+            // Only fire the haptic once per "release" state
+            if !didTriggerHaptic {
+                didTriggerHaptic = true
+
+                HapticsHelper.triggerPullToRefreshHaptic()
+            }
+        }
+
+        innerRotationAngle = (amount * 4).degreesToRadians
+        refreshInnerImage.transform = CGAffineTransform(rotationAngle: innerRotationAngle)
+
+        outerRotationAngle = (amount * 2).degreesToRadians
+        refreshOuterImage.transform = CGAffineTransform(rotationAngle: outerRotationAngle)
+
+        alpha = amount >= 150.0 ? alphaValue : 0.0
+    }
+
+    private func didEndDraggingAt(_ position: CGFloat) {
+        if position > pullDownAmountForRefresh {
+            beginRefreshing()
+        }
+    }
+}

--- a/podcasts/CustomRefreshControl.swift
+++ b/podcasts/CustomRefreshControl.swift
@@ -18,6 +18,7 @@ class CustomRefreshControl: UIRefreshControl {
         super.init(frame: .zero)
         setupView()
         setupLayout()
+        alpha = 0
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -28,10 +29,9 @@ class CustomRefreshControl: UIRefreshControl {
         NotificationCenter.default.removeObserver(self)
     }
 
-    override func beginRefreshing() {
-        super.beginRefreshing()
+    func startRefreshing() {
+        beginRefreshing()
         isAnimating = true
-        refreshLabel.text = L10n.refreshControlFetchingEpisodes
         startRefreshAnimation()
         perform?()
     }
@@ -39,8 +39,11 @@ class CustomRefreshControl: UIRefreshControl {
     override func endRefreshing() {
         super.endRefreshing()
 
-        endRefreshAnimation()
-        isAnimating = false
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { [weak self] in
+            self?.endRefreshAnimation()
+            self?.isAnimating = false
+            self?.alpha = 0
+        }
     }
 
     private func setupView() {
@@ -124,7 +127,11 @@ extension CustomRefreshControl {
     private func processRefreshCompleted(_ message: String) {
         refreshLabel.text = message.uppercased()
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) { [weak self] in
-            self?.endRefreshing()
+            UIView.animate(withDuration: 0.2, animations: {
+                self?.alpha = 0
+            }, completion: { _ in
+                self?.endRefreshing()
+            })
         }
     }
 
@@ -184,13 +191,13 @@ extension CustomRefreshControl {
 
         outerRotationAngle = (amount * 2).degreesToRadians
         refreshOuterImage.transform = CGAffineTransform(rotationAngle: outerRotationAngle)
-
+        print("Amount: \(amount), Alpha: \(alphaValue)")
         alpha = amount >= 150.0 ? alphaValue : 0.0
     }
 
     private func didEndDraggingAt(_ position: CGFloat) {
         if position > pullDownAmountForRefresh {
-            beginRefreshing()
+            startRefreshing()
         }
     }
 }

--- a/podcasts/CustomRefreshControl.swift
+++ b/podcasts/CustomRefreshControl.swift
@@ -191,7 +191,7 @@ extension CustomRefreshControl {
 
         outerRotationAngle = (amount * 2).degreesToRadians
         refreshOuterImage.transform = CGAffineTransform(rotationAngle: outerRotationAngle)
-        print("Amount: \(amount), Alpha: \(alphaValue)")
+
         alpha = amount >= 150.0 ? alphaValue : 0.0
     }
 

--- a/podcasts/EpisodeListSearchController.swift
+++ b/podcasts/EpisodeListSearchController.swift
@@ -135,7 +135,7 @@ class EpisodeListSearchController: SimpleNotificationsViewController, UISearchBa
         if delegate.shouldDisplayPodcastFeedReloadButton() {
             let reloadPodcastFeedAction = OptionAction(label: L10n.podcastFeedReloadButton, icon: "stats_skipping") { [weak self] in
                 guard let self = self else { return }
-                self.podcastDelegate?.reloadPodcastFeed()
+                self.podcastDelegate?.reloadPodcastFeed(source: .menu)
             }
             optionPicker.addAction(action: reloadPodcastFeedAction)
         }

--- a/podcasts/PodcastFeedViewModel.swift
+++ b/podcasts/PodcastFeedViewModel.swift
@@ -1,5 +1,11 @@
 import Foundation
 
+enum PodcastFeedReloadNotification {
+    public static let loading = NSNotification.Name(rawValue: "PodcastFeedReloadNotificationLoading")
+    public static let episodesFound = NSNotification.Name(rawValue: "PodcastFeedReloadNotificationEpisodesFound")
+    public static let noEpisodesFound = NSNotification.Name(rawValue: "PodcastFeedReloadNotificationNoEpisodesFound")
+}
+
 class PodcastFeedViewModel {
     enum LoadingState {
         case idle
@@ -14,27 +20,33 @@ class PodcastFeedViewModel {
         self.uuid = uuid
     }
 
-    func checkIfNewEpisodesAreAvailable() async -> Bool {
+    func checkIfNewEpisodesAreAvailable(from source: PodcastFeedReloadSource) async -> Bool {
         // Test implementation to simulate the API
         await MainActor.run {
             loadingState = .loading
         }
-        _ = await shouldReloadPodcasts()
+        _ = await shouldReloadPodcasts(source: source)
 
         try? await Task.sleep(nanoseconds: 3_000_000_000)
 
         await MainActor.run {
-            Toast.show(L10n.podcastFeedReloadNoEpisodesFound)
-        }
-        await MainActor.run {
+            if source == .refreshControl {
+                NotificationCenter.default.post(name: PodcastFeedReloadNotification.noEpisodesFound, object: nil)
+            } else {
+                Toast.show(L10n.podcastFeedReloadNoEpisodesFound)
+            }
             loadingState = .idle
         }
         return false
     }
 
-    private func shouldReloadPodcasts() async -> Int {
+    private func shouldReloadPodcasts(source: PodcastFeedReloadSource) async -> Int {
         await MainActor.run {
-            Toast.show(L10n.podcastFeedReloadLoading)
+            if source == .refreshControl {
+                NotificationCenter.default.post(name: PodcastFeedReloadNotification.loading, object: nil)
+            } else {
+                Toast.show(L10n.podcastFeedReloadLoading)
+            }
         }
         return 202
     }

--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -6,6 +6,11 @@ import PocketCastsUtils
 import UIKit
 import UIDeviceIdentifier
 
+enum PodcastFeedReloadSource {
+    case menu
+    case refreshControl
+}
+
 protocol PodcastActionsDelegate: AnyObject {
     func isSummaryExpanded() -> Bool
     func setSummaryExpanded(expanded: Bool)
@@ -43,7 +48,7 @@ protocol PodcastActionsDelegate: AnyObject {
     func showBookmarks()
 
     func shouldDisplayPodcastFeedReloadButton() -> Bool
-    func reloadPodcastFeed()
+    func reloadPodcastFeed(source: PodcastFeedReloadSource)
 }
 
 class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, SyncSigninDelegate, MultiSelectActionDelegate {
@@ -178,6 +183,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
     private var isSearching = false
     private var cancellables = Set<AnyCancellable>()
     private var podcastFeedViewModel: PodcastFeedViewModel?
+    private var refreshControl: CustomRefreshControl?
 
     lazy var ratingView: UIView = {
         let view = StarRatingView(viewModel: podcastRatingViewModel,
@@ -259,6 +265,21 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
 
         listenForBookmarkChanges()
         setupLogin()
+
+        setupRefreshControl()
+    }
+
+    override func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        super.scrollViewDidScroll(scrollView)
+        if FeatureFlag.podcastFeedUpdate.enabled {
+            refreshControl?.scrollViewDidScroll(scrollView)
+        }
+    }
+
+    func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
+        if FeatureFlag.podcastFeedUpdate.enabled {
+            refreshControl?.scrollViewDidEndDragging(scrollView)
+        }
     }
 
     private func setupLogin() {
@@ -315,6 +336,10 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
         addCustomObserver(Constants.Notifications.podcastColorsDownloaded, selector: #selector(colorsDidDownload(_:)))
         updateColors()
 
+        if FeatureFlag.podcastFeedUpdate.enabled {
+            refreshControl?.parentViewControllerDidAppear()
+        }
+
         addCustomObserver(Constants.Notifications.episodeArchiveStatusChanged, selector: #selector(refreshEpisodes))
         addCustomObserver(Constants.Notifications.manyEpisodesChanged, selector: #selector(refreshEpisodes))
         addCustomObserver(Constants.Notifications.episodeStarredChanged, selector: #selector(refreshEpisodes))
@@ -355,6 +380,10 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
         super.viewDidDisappear(animated)
 
         removeAllCustomObservers()
+
+        if FeatureFlag.podcastFeedUpdate.enabled {
+            refreshControl?.parentViewControllerDidDisappear()
+        }
     }
 
     override func viewDidLayoutSubviews() {
@@ -935,22 +964,49 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
         present(controller, animated: true)
     }
 
-    // MARK: - Podcast Feed Reload action
+    // MARK: - Podcast Feed Reload
+
+    private func setupRefreshControl() {
+        if shouldDisplayPodcastFeedReloadButton() {
+            refreshControl = CustomRefreshControl()
+            refreshControl?.perform = { [weak self] in
+                self?.reloadPodcastFeed(source: .refreshControl)
+            }
+            episodesTable.refreshControl = refreshControl
+        }
+    }
 
     func shouldDisplayPodcastFeedReloadButton() -> Bool {
         return FeatureFlag.podcastFeedUpdate.enabled && podcastFeedViewModel?.uuid != nil
     }
 
-    func reloadPodcastFeed() {
+    func reloadPodcastFeed(source: PodcastFeedReloadSource) {
+        // In case the FF is switched off
+        guard shouldDisplayPodcastFeedReloadButton() else {
+            refreshControl?.endRefreshing()
+            return
+        }
         if podcastFeedViewModel?.loadingState == .loading {
             return
         }
+
+        //TODO: Add analytics based on source
+
         Task { @MainActor [weak self] in
-            let podcastNeedsReload = await self?.podcastFeedViewModel?.checkIfNewEpisodesAreAvailable() ?? false
+            let podcastNeedsReload = await self?.podcastFeedViewModel?.checkIfNewEpisodesAreAvailable(from: source) ?? false
             if podcastNeedsReload {
                 self?.loadPodcastInfo()
             }
         }
+    }
+
+    func refreshPodcastFeed() {
+        // In case the FF is switched off
+        guard shouldDisplayPodcastFeedReloadButton() else {
+            refreshControl?.endRefreshing()
+            return
+        }
+        reloadPodcastFeed(source: .refreshControl)
     }
 
     // MARK: - Long press actions


### PR DESCRIPTION
| 📘 Part of: #2703 
|:---:|

Fixes #2705 

This PR adds the pull down to reload to call the view model and invoke the API. The component used for the pull down is called `CustomRefreshControl`, which extends the system `UIRefreshControl`. The instance is set to the table view property `refreshControl` and it's not manually added as subview.

This because the `PCRefreshControl` does some computations to the scroll view edge inset which interferes with the view controller and its custom navigation bar and search controller.

https://github.com/user-attachments/assets/cc8b032d-2e49-4dfe-a490-2ee2ba1140ff

## To test

- Make sure you have the FF `podcastFeedUpdate` enabled 
- Open a podcast detail
- Pull down to reload
- Even here the view model simulates the response
- Confirm the UI is correct and the label correctly updates

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
