### PR TITLE
Introduce dismiss policy for Toast view

### DIFF
--- a/podcasts/Common SwiftUI/Toast/Toast.swift
+++ b/podcasts/Common SwiftUI/Toast/Toast.swift
@@ -19,13 +19,13 @@ class Toast {
     private var window: UIWindow? = nil
 
     /// Display the toast message with the given title and actions
-    static func show<Style: ToastTheme>(_ title: String, actions: [Action]? = nil, dismissAfter: TimeInterval = 5.0, theme: Style = .defaultTheme, aboveMiniPlayer: Bool = false) {
+    static func show<Style: ToastTheme>(_ title: String, actions: [Action]? = nil, dismissAfter: ToastViewDismissPolicy = .interval(5.0), theme: Style = .defaultTheme, aboveMiniPlayer: Bool = false) {
         // Hide any active toasts
         shared.toastDismissed()
 
         guard let scene = SceneHelper.connectedScene() else { return }
 
-        let viewModel = ToastViewModel(coordinator: shared, title: title, actions: actions, dismissTime: dismissAfter, aboveMiniPlayer: aboveMiniPlayer)
+        let viewModel = ToastViewModel(coordinator: shared, title: title, actions: actions, dismissPolicy: dismissAfter, aboveMiniPlayer: aboveMiniPlayer)
         let view = ToastView(viewModel: viewModel, style: theme)
         let controller = ThemedHostingController(rootView: view)
 

--- a/podcasts/Common SwiftUI/Toast/ToastView.swift
+++ b/podcasts/Common SwiftUI/Toast/ToastView.swift
@@ -194,7 +194,7 @@ struct ToastView_Previews: PreviewProvider {
         ToastView(viewModel: .init(coordinator: PreviewCoordinator(), title: "Hello World", actions: [
             .init(title: "Tap Me", action: {
                 print("Tapped")
-            })], dismissTime: .infinity), style: .defaultTheme)
+            })], dismissPolicy: .never), style: .defaultTheme)
     }
 
     private class PreviewCoordinator: ToastDelegate {

--- a/podcasts/Common SwiftUI/Toast/ToastViewModel.swift
+++ b/podcasts/Common SwiftUI/Toast/ToastViewModel.swift
@@ -5,6 +5,11 @@ protocol ToastDelegate: AnyObject {
     func toastDismissed()
 }
 
+enum ToastViewDismissPolicy {
+    case never
+    case interval(TimeInterval)
+}
+
 class ToastViewModel: ObservableObject {
     weak var coordinator: ToastDelegate?
 
@@ -13,7 +18,7 @@ class ToastViewModel: ObservableObject {
 
     let title: String
     let actions: [Toast.Action]
-    let dismissTime: TimeInterval
+    let dismissPolicy: ToastViewDismissPolicy
     let aboveMiniPlayer: Bool
 
     deinit {
@@ -24,11 +29,11 @@ class ToastViewModel: ObservableObject {
     /// When this is true the view should animate out and call `didDismiss`
     @Published var didAutoDismiss = false
 
-    init(coordinator: ToastDelegate, title: String, actions: [Toast.Action]?, dismissTime: TimeInterval, aboveMiniPlayer: Bool = false) {
+    init(coordinator: ToastDelegate, title: String, actions: [Toast.Action]?, dismissPolicy: ToastViewDismissPolicy, aboveMiniPlayer: Bool = false) {
         self.coordinator = coordinator
         self.title = title
         self.actions = actions ?? []
-        self.dismissTime = dismissTime
+        self.dismissPolicy = dismissPolicy
         self.aboveMiniPlayer = aboveMiniPlayer
     }
 
@@ -48,9 +53,14 @@ class ToastViewModel: ObservableObject {
 
     func didAppear() {
         // Start the auto dismiss timer
-        autoDismissTimer = Timer.scheduledTimer(withTimeInterval: dismissTime, repeats: false, block: { [weak self] _ in
-            self?.handleAutoDismiss()
-        })
+        switch dismissPolicy {
+        case .never:
+            return
+        case .interval(let dismissTime):
+            autoDismissTimer = Timer.scheduledTimer(withTimeInterval: dismissTime, repeats: false, block: { [weak self] _ in
+                self?.handleAutoDismiss()
+            })
+        }
     }
 
     // If the toast is already being dismiss, then cancel the timer


### PR DESCRIPTION
| 📘 Part of: #2703
|:---:|

To be able to decide whether or not the Toast menu should auto dismiss, I introduced a policy enum to handle both cases:
• never
• interval

If the policy is set to never, the timer is never associated.
By default the policy is the interval keeping the same value as before.

## To test

- Run the app
- Make sure the Toast continue working as before

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
