### PR TITLE
Fix/html description resize

### DIFF
--- a/podcasts/PodcastHeadingTableCell.swift
+++ b/podcasts/PodcastHeadingTableCell.swift
@@ -167,6 +167,10 @@ class PodcastHeadingTableCell: ThemeableCell, SubscribeButtonDelegate, Expandabl
     @IBOutlet var bookmarkTabsView: UIStackView!
     private var tabsViewController: ThemedHostingController<EpisodeBookmarksTabsView>? = nil
 
+    override func prepareForReuse() {
+        richPodcastDescription.frame = .zero
+    }
+
     private func addBookmarksTabView(parentController: UIViewController) {
         // Make sure the view reappears
         if let tabsViewController {

--- a/podcasts/PodcastHeadingTableCell.swift
+++ b/podcasts/PodcastHeadingTableCell.swift
@@ -168,7 +168,8 @@ class PodcastHeadingTableCell: ThemeableCell, SubscribeButtonDelegate, Expandabl
     private var tabsViewController: ThemedHostingController<EpisodeBookmarksTabsView>? = nil
 
     override func prepareForReuse() {
-        richPodcastDescription.frame = .zero
+        super.prepareForReuse()
+        richPodcastDescription.reset()
     }
 
     private func addBookmarksTabView(parentController: UIViewController) {

--- a/podcasts/PodcastViewController+TableData.swift
+++ b/podcasts/PodcastViewController+TableData.swift
@@ -62,7 +62,7 @@ extension PodcastViewController: UITableViewDataSource, UITableViewDelegate {
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         if indexPath.section == PodcastViewController.headerSection {
-            let cell = tableView.dequeueReusableCell(withIdentifier: PodcastViewController.headerCellId, for: indexPath) as! PodcastHeadingTableCell
+            let cell = podcastHeadingCell
             cell.populateFrom(tintColor: podcast?.iconTintColor(), delegate: self, parentController: self)
             cell.buttonsEnabled = !isMultiSelectEnabled
             return cell

--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -300,6 +300,12 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
         updateColors()
     }
 
+    lazy var podcastHeadingCell: PodcastHeadingTableCell = {
+         let nib = Bundle.main.loadNibNamed("PodcastHeadingTableCell", owner: self, options: nil)
+         let cell = nib?[0] as! PodcastHeadingTableCell
+         return cell
+    }()
+
     private var hasAppearedAlready = false
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)

--- a/podcasts/RichExpandableDescriptionView.swift
+++ b/podcasts/RichExpandableDescriptionView.swift
@@ -40,6 +40,13 @@ class RichExpandableLabel: WKWebView {
         updateStyle()
     }
 
+    func reset() {
+        htmlReady = false
+        previousHTML = ""
+        frame = .zero
+        heightConstraint.constant = 0
+    }
+
     private func updateStyle() {
         isOpaque = false
         scrollView.backgroundColor = .clear

--- a/podcasts/RichExpandableDescriptionView.swift
+++ b/podcasts/RichExpandableDescriptionView.swift
@@ -10,6 +10,7 @@ class RichExpandableLabel: WKWebView {
     private var contentHeight: CGFloat = 0
     private var htmlReady: Bool = false
     private var previousHTML: String = ""
+    private var isFirstTime = true
 
     private lazy var linkTapGesture: UITapGestureRecognizer = {
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(labelTapped))
@@ -155,6 +156,10 @@ class RichExpandableLabel: WKWebView {
             contentHeight = CGFloat(cgHeight)
             htmlReady = true
             update()
+            if isFirstTime {
+                isFirstTime = false
+                updateLinesRequired()
+            }
         })
     }
 
@@ -181,7 +186,6 @@ extension RichExpandableLabel: WKNavigationDelegate {
             }
             updateStyle()
             updateScrollSize()
-            updateLinesRequired()
         })
     }
 


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

Fixes a bug where background and foreground the podcast description caused a resize issue.

## To test

1. Start the app
2. Open podcast
3. Expand the description
4. Background the app
5. Foreground the app
6. Check that the description stays with the correct size/layout

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
