### PR TITLE
[Tooling] Introduce pipelines to trigger release tasks on CI

### DIFF
--- a/.buildkite/commands/release-build.sh
+++ b/.buildkite/commands/release-build.sh
@@ -1,5 +1,16 @@
 #!/bin/bash -eu
 
+echo "--- :git: Checkout Release Branch"
+# Buildkite, by default, checks out a specific commit. But given this step will be run on a CI build that will
+# first push a commit to do the version bump, before `pipeline upload`-ing the job calling this script, we need
+# to checkout the `release/` branch explicitly here, to ensure this job would include that extra commit
+# instead of running on the initial commit the whole CI build/pipeline was initially triggered on.
+RELEASE_VERSION="${1:?RELEASE_VERSION parameter missing}"
+BRANCH_NAME="release/${RELEASE_VERSION}"
+git fetch origin "$BRANCH_NAME"
+git checkout "$BRANCH_NAME"
+git pull
+
 "$(dirname "${BASH_SOURCE[0]}")/shared_setup.sh"
 
 echo "--- :closed_lock_with_key: Installing Secrets"

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -14,7 +14,7 @@ steps:
 
   - label: "🛠 Release Build (App Store Connect)"
     key: testflight_build
-    command: .buildkite/commands/release-build.sh
+    command: .buildkite/commands/release-build.sh "${RELEASE_VERSION}"
     priority: 1
     plugins: [$CI_TOOLKIT]
     artifact_paths:
@@ -25,7 +25,7 @@ steps:
 
   - label: ":testflight: Release Upload (TestFlight, Sentry, GitHub)"
     depends_on: testflight_build
-    command: .buildkite/commands/release-upload.sh $BETA_RELEASE
+    command: .buildkite/commands/release-upload.sh "${BETA_RELEASE}"
     priority: 1
     plugins: [$CI_TOOLKIT]
     notify:

--- a/.buildkite/release-pipelines/code-freeze.yml
+++ b/.buildkite/release-pipelines/code-freeze.yml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+---
+
+# This pipeline is meant to be triggered by the MC scenario in ReleasesV2
+
+env:
+  IMAGE_ID: $IMAGE_ID
+
+steps:
+  - label: "🚂 Code Freeze"
+    command: |
+      echo '--- 🤖 Use bot for Git operations'
+      source use-bot-for-git
+
+      echo '--- :ruby: Setup Ruby Tools'
+      install_gems
+
+      echo '--- 🔐 Access Secrets'
+      bundle exec fastlane run configure_apply
+
+      echo '--- ❄️ Code Freeze'
+      bundle exec fastlane code_freeze skip_confirm:true
+    plugins: [$CI_TOOLKIT]
+    agents:
+      queue: "mac"
+    retry:
+      manual:
+        allowed: false
+        reason: "If this job fails, please trigger a new build from ReleasesV2 instead of retrying this step" 

--- a/.buildkite/release-pipelines/code-freeze.yml
+++ b/.buildkite/release-pipelines/code-freeze.yml
@@ -26,4 +26,4 @@ steps:
     retry:
       manual:
         allowed: false
-        reason: "If this job fails, please trigger a new build from ReleasesV2 instead of retrying this step" 
+        reason: "If this job fails, please trigger a new build from ReleasesV2 instead of retrying this step"

--- a/.buildkite/release-pipelines/finalize-hotfix-release.yml
+++ b/.buildkite/release-pipelines/finalize-hotfix-release.yml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+---
+
+# This pipeline is meant to be triggered by the MC scenario in ReleasesV2
+
+env:
+  IMAGE_ID: $IMAGE_ID
+
+steps:
+  - label: "🚂 Finalize Hotfix Release"
+    command: |
+      echo '--- 🤖 Use bot for Git operations'
+      source use-bot-for-git
+
+      echo '--- :ruby: Setup Ruby Tools'
+      install_gems
+
+      echo '--- 🔐 Access Secrets'
+      bundle exec fastlane run configure_apply
+
+      echo '--- 🚀 Finalize Hotfix Release'
+      bundle exec fastlane finalize_hotfix_release skip_confirm:true
+    plugins: [$CI_TOOLKIT]
+    agents:
+      queue: "mac"
+    retry:
+      manual:
+        allowed: false
+        reason: "If this job fails, please trigger a new build from ReleasesV2 instead of retrying this step" 

--- a/.buildkite/release-pipelines/finalize-hotfix-release.yml
+++ b/.buildkite/release-pipelines/finalize-hotfix-release.yml
@@ -26,4 +26,4 @@ steps:
     retry:
       manual:
         allowed: false
-        reason: "If this job fails, please trigger a new build from ReleasesV2 instead of retrying this step" 
+        reason: "If this job fails, please trigger a new build from ReleasesV2 instead of retrying this step"

--- a/.buildkite/release-pipelines/finalize-release.yml
+++ b/.buildkite/release-pipelines/finalize-release.yml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+---
+
+# This pipeline is meant to be triggered by the MC scenario in ReleasesV2
+
+env:
+  IMAGE_ID: $IMAGE_ID
+
+steps:
+  - label: "🚂 Finalize Release"
+    command: |
+      echo '--- 🤖 Use bot for Git operations'
+      source use-bot-for-git
+
+      echo '--- :ruby: Setup Ruby Tools'
+      install_gems
+
+      echo '--- 🔐 Access Secrets'
+      bundle exec fastlane run configure_apply
+
+      echo '--- 🚀 Finalize Release'
+      bundle exec fastlane finalize_release skip_confirm:true
+    plugins: [$CI_TOOLKIT]
+    agents:
+      queue: "mac"
+    retry:
+      manual:
+        allowed: false
+        reason: "If this job fails, please trigger a new build from ReleasesV2 instead of retrying this step" 

--- a/.buildkite/release-pipelines/finalize-release.yml
+++ b/.buildkite/release-pipelines/finalize-release.yml
@@ -26,4 +26,4 @@ steps:
     retry:
       manual:
         allowed: false
-        reason: "If this job fails, please trigger a new build from ReleasesV2 instead of retrying this step" 
+        reason: "If this job fails, please trigger a new build from ReleasesV2 instead of retrying this step"

--- a/.buildkite/release-pipelines/new-beta-release.yml
+++ b/.buildkite/release-pipelines/new-beta-release.yml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+---
+
+# This pipeline is meant to be triggered by the MC scenario in ReleasesV2
+
+env:
+  IMAGE_ID: $IMAGE_ID
+
+steps:
+  - label: "🚂 New Beta Release"
+    command: |
+      echo '--- 🤖 Use bot for Git operations'
+      source use-bot-for-git
+
+      echo '--- :ruby: Setup Ruby Tools'
+      install_gems
+
+      echo '--- 🔐 Access Secrets'
+      bundle exec fastlane run configure_apply
+
+      echo '--- 🚀 New Beta Release'
+      bundle exec fastlane new_beta_release skip_confirm:true
+    plugins: [$CI_TOOLKIT]
+    agents:
+      queue: "mac"
+    retry:
+      manual:
+        allowed: false
+        reason: "If this job fails, please trigger a new build from ReleasesV2 instead of retrying this step" 

--- a/.buildkite/release-pipelines/new-beta-release.yml
+++ b/.buildkite/release-pipelines/new-beta-release.yml
@@ -26,4 +26,4 @@ steps:
     retry:
       manual:
         allowed: false
-        reason: "If this job fails, please trigger a new build from ReleasesV2 instead of retrying this step" 
+        reason: "If this job fails, please trigger a new build from ReleasesV2 instead of retrying this step"

--- a/.buildkite/release-pipelines/new-hotfix-release.yml
+++ b/.buildkite/release-pipelines/new-hotfix-release.yml
@@ -28,4 +28,4 @@ steps:
     retry:
       manual:
         allowed: false
-        reason: "If this job fails, please trigger a new build from ReleasesV2 instead of retrying this step" 
+        reason: "If this job fails, please trigger a new build from ReleasesV2 instead of retrying this step"

--- a/.buildkite/release-pipelines/new-hotfix-release.yml
+++ b/.buildkite/release-pipelines/new-hotfix-release.yml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+---
+
+# This pipeline is meant to be triggered by the MC scenario in ReleasesV2
+
+# Expected variables passed to the pipeline by ReleasesV2: `RELEASE_VERSION`
+
+env:
+  IMAGE_ID: $IMAGE_ID
+
+steps:
+  - label: "🚂 New Hotfix Release"
+    command: |
+      echo '--- 🤖 Use bot for Git operations'
+      source use-bot-for-git
+
+      echo '--- :ruby: Setup Ruby Tools'
+      install_gems
+
+      echo '--- 🔐 Access Secrets'
+      bundle exec fastlane run configure_apply
+
+      echo '--- 🚀 New Hotfix Release'
+      bundle exec fastlane new_hotfix_release version:"$RELEASE_VERSION" skip_confirm:true
+    plugins: [$CI_TOOLKIT]
+    agents:
+      queue: "mac"
+    retry:
+      manual:
+        allowed: false
+        reason: "If this job fails, please trigger a new build from ReleasesV2 instead of retrying this step" 

--- a/.buildkite/release-pipelines/publish-release.yml
+++ b/.buildkite/release-pipelines/publish-release.yml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+---
+
+# This pipeline is meant to be triggered by the MC scenario in ReleasesV2
+
+env:
+  IMAGE_ID: $IMAGE_ID
+
+steps:
+  - label: "🚂 Publish Release"
+    command: |
+      echo '--- 🤖 Use bot for Git operations'
+      source use-bot-for-git
+
+      echo '--- :ruby: Setup Ruby Tools'
+      install_gems
+
+      echo '--- 🔐 Access Secrets'
+      bundle exec fastlane run configure_apply
+
+      echo '--- :github: Publish Release'
+      bundle exec fastlane publish_release skip_confirm:true
+    plugins: [$CI_TOOLKIT]
+    agents:
+      queue: "mac"
+    retry:
+      manual:
+        allowed: false
+        reason: "If this job fails, please trigger a new build from ReleasesV2 instead of retrying this step" 

--- a/.buildkite/release-pipelines/publish-release.yml
+++ b/.buildkite/release-pipelines/publish-release.yml
@@ -26,4 +26,4 @@ steps:
     retry:
       manual:
         allowed: false
-        reason: "If this job fails, please trigger a new build from ReleasesV2 instead of retrying this step" 
+        reason: "If this job fails, please trigger a new build from ReleasesV2 instead of retrying this step"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -427,7 +427,6 @@ platform :ios do
     UI.success "Done! New Build Code: #{build_code_current}"
 
     # Wrap up
-    remove_branch_protection(repository: GITHUB_REPO, branch: release_branch_name)
     set_milestone_frozen_marker(repository: GITHUB_REPO, milestone: release_version_current, freeze: false)
     close_milestone(repository: GITHUB_REPO, milestone: release_version_current)
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1179,15 +1179,24 @@ platform :ios do
   # @return [String] The URL of the build that has been triggered
   #
   def trigger_buildkite_release_build(branch:, beta:)
-    require_env_vars!('BUILDKITE_TOKEN')
-
-    buildkite_trigger_build(
-      buildkite_organization: 'automattic',
-      buildkite_pipeline: 'pocket-casts-ios',
-      branch: branch,
-      environment: { BETA_RELEASE: beta },
-      pipeline_file: 'release-builds.yml'
-    )
+    pipeline_args = {
+      pipeline_file: 'release-builds.yml',
+      environment: {
+        RELEASE_VERSION: release_version_current,
+        BETA_RELEASE: beta
+      }
+    }
+    if is_ci?
+      buildkite_pipeline_upload(**pipeline_args)
+    else
+      require_env_vars!('BUILDKITE_TOKEN')
+      buildkite_trigger_build(
+        buildkite_organization: 'automattic',
+        buildkite_pipeline: 'pocket-casts-ios',
+        branch: branch,
+        **pipeline_args
+      )
+    end
   end
 
   # Update the milestone of still-open PRs


### PR DESCRIPTION
This is a mirroring of [the similar changes that were recently introduced in PCAndroid](https://github.com/Automattic/pocket-casts-android/pull/3514).

## Description

As part of this Project Thread: paaHJt-78B-p2, this introduces `.buildkite/release-pipelines/*.yml` files that will take care of calling `fastlane code_freeze` and similar lanes called during the release process.

Those lanes are currently called by the Release Manager on their own Mac, so the point of introducing those pipelines is to be able to instead switch to make those kicker lanes be run on CI instead.

### Created pipelines

List of `.buildkite/release-pipelines/*.yml` files calling their associated `fastlane` lane during ReleaseV2 scenario:

 - [x] `code_freeze`
 - [x] `new_beta_release`
 - [x] `finalize_release`
 - [x] `publish_release`
 - [x] `new_hotfix_release`
 - [x] `finalize_hotfix_release`

## Scenario steps update in ReleasesV2

Once this lands, we will be able to also land the companion PR in wpcom to update the Release Scenario in MC (Internal Ref: 171892-ghe-Automattic/wpcom) to replace the currently-**_manual_** tasks like "Call `bundle exec fastlane code_freeze`" and the likes with automated tasks instead—i.e. tasks that will present a clickable button on ReleasesV2 which, when clicked, will trigger those lanes on CI—thus not requiring Release Managers to run those from their personal Macs anymore.

## Testing Instructions

The only way to test this is during the next release process that will adopt those changes (hopefully during `7.82`)