### PR TITLE
[Podcast Feed Reload] Add Analytics

### DIFF
--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -833,4 +833,9 @@ enum AnalyticsEvent: String {
     case settingsSelectPodcastsSelectNoneTapped
     case settingsSelectPodcastsPodcastToggled
     case settingsSelectPodcastsSelectAllPodcastsToggled
+
+    // MARK: Podcast Feed Reload
+    case podcastScreenRefreshEpisodeList
+    case podcastScreenRefreshNoEpisodesFound
+    case podcastScreenRefreshNewEpisodeFound
 }

--- a/podcasts/PodcastFeedViewModel.swift
+++ b/podcasts/PodcastFeedViewModel.swift
@@ -42,6 +42,9 @@ class PodcastFeedViewModel {
             guard let self else { return false }
             await MainActor.run {
                 self.loadingState = .loading
+
+                Analytics.track(.podcastScreenRefreshEpisodeList, properties: ["action": source.analyticsValue, "podcast_uuid": uuid])
+
                 if source == .refreshControl {
                     NotificationCenter.default.post(name: PodcastFeedReloadNotification.loading, object: nil)
                 } else {
@@ -57,6 +60,10 @@ class PodcastFeedViewModel {
             }
             await MainActor.run {
                 if self.loadingState != .cancelled {
+
+                    let event: AnalyticsEvent = success ? .podcastScreenRefreshNewEpisodeFound : .podcastScreenRefreshNoEpisodesFound
+                    Analytics.track(event, properties: ["action": source.analyticsValue, "podcast_uuid": uuid])
+
                     if source == .refreshControl {
                         let notification = success ? PodcastFeedReloadNotification.episodesFound : PodcastFeedReloadNotification.noEpisodesFound
                         NotificationCenter.default.post(name: notification, object: nil)

--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -9,6 +9,15 @@ import UIDeviceIdentifier
 enum PodcastFeedReloadSource {
     case menu
     case refreshControl
+
+    var analyticsValue: String {
+        switch self {
+        case .menu:
+            return "refresh_button"
+        case .refreshControl:
+            return "pull_to_refresh"
+        }
+    }
 }
 
 protocol PodcastActionsDelegate: AnyObject {

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -2263,7 +2263,7 @@ internal enum L10n {
   internal static var podcastFailedDownload: String { return L10n.tr("Localizable", "podcast_failed_download") }
   /// Failed to upload
   internal static var podcastFailedUpload: String { return L10n.tr("Localizable", "podcast_failed_upload") }
-  /// Refresh episode list
+  /// Refresh Episode List
   internal static var podcastFeedReloadButton: String { return L10n.tr("Localizable", "podcast_feed_reload_button") }
   /// Refreshing episode list...
   internal static var podcastFeedReloadLoading: String { return L10n.tr("Localizable", "podcast_feed_reload_loading") }

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4742,7 +4742,7 @@
 "listening_history_remove" = "Remove from history";
 
 /* Button title we display in the podcast view sheet prompted */
-"podcast_feed_reload_button" = "Refresh episode list";
+"podcast_feed_reload_button" = "Refresh Episode List";
 
 /* Message showed in the toast menu or pull down to refresh control indicating the podcast feed is reloading */
 "podcast_feed_reload_loading" = "Refreshing episode list...";


### PR DESCRIPTION
| 📘 Part of: #2703 
|:---:|

Fixes #2708 

This PR adds the analytics events

## To test

• Make sure you have the `podcastFeedUpdate` FF enabled
• Make sure to enable the tracks logger
• Open a podcast detail
• Pull down to refresh
• Confirm you see `🔵 Tracked: podcast_screen_refresh_episode_list ["action": "pull_to_refresh", "podcast_uuid": UUID]`
• When the server finishes
• Confirm you see `🔵 Tracked: podcast_screen_refresh_no_episodes_found ["podcast_uuid": UUID, "action": "pull_to_refresh"]` if no episodes are found
• Confirm you see `🔵 Tracked: podcast_screen_refresh_new_episode_found ["podcast_uuid": UUID, "action": "pull_to_refresh"]` if an episode is found
• Do the same test by triggering the reload tapping the `•••` button
• Confirm you see the same events with the property `action` set as `refresh_button`

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
