### PR TITLE
[Winback] Update yearly offer description

### DIFF
--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -414,7 +414,7 @@ internal enum L10n {
   internal static var cancelSubscriptionOfferYearlySuccessViewDescription: String { return L10n.tr("Localizable", "cancel_subscription_offer_yearly_success_view_description") }
   /// 50%% off your next year!
   internal static var cancelSubscriptionOfferYearlySuccessViewTitle: String { return L10n.tr("Localizable", "cancel_subscription_offer_yearly_success_view_title") }
-  /// Save %@ at the start of your next billing cycle.
+  /// Pay %@ now for another year at 50%% off
   internal static func cancelSubscriptionPromotionDescription(_ p1: Any) -> String {
     return L10n.tr("Localizable", "cancel_subscription_promotion_description", String(describing: p1))
   }

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4688,7 +4688,7 @@
 "cancel_subscription_yearly_promotion_title" = "Get 50%% off your next year";
 
 /* Cancel subscription: description for the promotion row */
-"cancel_subscription_promotion_description" = "Save %@ at the start of your next billing cycle.";
+"cancel_subscription_promotion_description" = "Pay %@ now for another year at 50%% off";
 
 /* Cancel subscription: title for the new plan row */
 "cancel_subscription_new_plan_title" = "Looking for a different plan?";


### PR DESCRIPTION
| 📘 Part of: #2445
|:---:|

This PR updates the description text used in the Offer row in the main screen. Now we display `Pay %PRICE% now for another year at 50% off`

<img src="https://github.com/user-attachments/assets/9f4c08e3-5346-4f19-a630-ccca081d6934" width=350 >


## To test

- If you use a real device you will need to use a sandbox user for the IAP (ping me to use mine if needed)
- If you use the simulator then you need:
  - Edit the scheme and select the `Pocket Casts Configuration.storekit` in the `Run -> Option tab -> StoreKit Configuration`
- Make sure you have the `winback` feature flag on
  - You can find our feature flag under `Profile -> Top right cog icon -> Beta Features`
-  Run the app and purchase a year plan
- Navigate to `Profile -> Account -> Cancel Subscription`
- Confirm the text used on the first row is the one you see above
  - Just remember the price you see is the current price as the offer is not set yet

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
