### PR TITLE
Update analytics in welcome screen

### DIFF
--- a/podcasts/Onboarding/Welcome/WelcomeViewModel.swift
+++ b/podcasts/Onboarding/Welcome/WelcomeViewModel.swift
@@ -35,6 +35,7 @@ class WelcomeViewModel: ObservableObject, OnboardingModel {
             navigationController?.pushViewController(controller, animated: true)
 
         case .discover:
+            trackNewsletterOptIn()
             track(.welcomeDiscoverTapped)
             navigationController?.dismiss(animated: true)
             NavigationManager.sharedManager.navigateTo(NavigationManager.discoverPageKey, data: nil)
@@ -43,19 +44,22 @@ class WelcomeViewModel: ObservableObject, OnboardingModel {
 
     func doneTapped() {
         saveNewsletterOptIn()
+        trackNewsletterOptIn()
         track(.welcomeDismissed)
         navigationController?.dismiss(animated: true)
     }
 
     private func saveNewsletterOptIn() {
+        ServerSettings.setMarketingOptIn(newsletterOptIn)
+    }
+
+    private func trackNewsletterOptIn() {
         let source: String
         switch displayType {
         case .newAccount: source = "welcome_new_account"
         case .plus: source = "welcome_plus"
         }
-
         Analytics.track(.newsletterOptInChanged, properties: ["enabled": newsletterOptIn, "source": source])
-        ServerSettings.setMarketingOptIn(newsletterOptIn)
     }
 
     // MARK: - Configuration


### PR DESCRIPTION
Ref: p1738541291847189-Slack-C029BMLUGRX

This PR adjust how the `newsletter_opt_in_changed` is tracked. Aligning with Android we now track it:
• When the `Done` button is tapped
• When the `Discover option` is selected
• We don't track it when the view is dismissed or the Import option is selected

## To test

1. Run the app selecting the Staging scheme
2. If you have the app installed remove it and run Xcode to re-install it
3. Enable the Track logger:
  a. Navigate to `Profile -> Top Right cog icon -> Beta Features -> enable tracksLogging`
6. For easy check you can filter the console with `Tracked:`
5. Create a new user
6. Skip the Paywall
7. When you reach the Welcome screen confirm:
  a. Tap on Import doesn't track `🔵 Tracked: newsletter_opt_in_changed`
  b. Tap on `Done`  and confirm  `🔵 Tracked: newsletter_opt_in_changed` is tracked
  c. Logout
8. Repeat from step 5
9. When you reach the Welcome screen again tap on the Discover option
10. Confirm `🔵 Tracked: newsletter_opt_in_changed` is tracked

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
