### PR TITLE
[Winback] Implement offer API

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Private/API Tasks/WinbackOfferTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Private/API Tasks/WinbackOfferTask.swift
@@ -1,0 +1,42 @@
+import Foundation
+import PocketCastsUtils
+import SwiftProtobuf
+
+public struct WinbackOfferInfo: Codable {
+    public let offer: String
+    public let platform: Int
+    public let code: String
+    public let details: ReferralOfferDetail?
+    public var offerPrice: String?
+}
+
+class WinbackOfferTask: ApiBaseTask, @unchecked Sendable {
+    var completion: ((WinbackOfferInfo?) -> Void)?
+
+    override func apiTokenAcquired(token: String) {
+        let urlString = "\(ServerConstants.Urls.api())referrals/winback_offers?platform=ios"
+
+        do {
+            let (data, httpResponse) = getToServer(url: urlString, token: token)
+            guard let responseData = data,
+                  httpResponse?.statusCode == ServerConstants.HttpConstants.ok
+            else {
+                FileLog.shared.addMessage("Failed to get winback offer - server returned \(httpResponse?.statusCode ?? -1)")
+                completion?(nil)
+                return
+            }
+            let validationResponse = try Api_WinbackResponse(serializedBytes: responseData)
+            let details = try? JSONDecoder().decode(ReferralOfferDetail.self, from: validationResponse.details.data(using: .utf8)!)
+            let winbackOffer = WinbackOfferInfo(
+                offer: validationResponse.offer,
+                platform: Int(validationResponse.platform),
+                code: validationResponse.code,
+                details: details
+            )
+            completion?(winbackOffer)
+        } catch {
+            FileLog.shared.addMessage("Failed to parse Api_ReferralValidationResponse \(error.localizedDescription)")
+            completion?(nil)
+        }
+    }
+}

--- a/Modules/Server/Sources/PocketCastsServer/Private/Protobuffer/api.pb.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Private/Protobuffer/api.pb.swift
@@ -3143,6 +3143,15 @@ struct Api_UserPodcastResponse: @unchecked Sendable {
     set {_uniqueStorage()._descriptionHtml = newValue}
   }
 
+  var isPrivate: SwiftProtobuf.Google_Protobuf_BoolValue {
+    get {return _storage._isPrivate ?? SwiftProtobuf.Google_Protobuf_BoolValue()}
+    set {_uniqueStorage()._isPrivate = newValue}
+  }
+  /// Returns true if `isPrivate` has been explicitly set.
+  var hasIsPrivate: Bool {return _storage._isPrivate != nil}
+  /// Clears the value of `isPrivate`. Subsequent reads from it will return its default value.
+  mutating func clearIsPrivate() {_uniqueStorage()._isPrivate = nil}
+
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
@@ -7420,6 +7429,24 @@ struct Api_ReferralRedemption: Sendable {
   init() {}
 }
 
+struct Api_WinbackResponse: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  var offer: String = String()
+
+  var platform: Int32 = 0
+
+  var details: String = String()
+
+  var code: String = String()
+
+  var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  init() {}
+}
+
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
 fileprivate let _protobuf_package = "api"
@@ -10845,6 +10872,7 @@ extension Api_UserPodcastResponse: SwiftProtobuf.Message, SwiftProtobuf._Message
     16: .standard(proto: "date_added"),
     17: .same(proto: "settings"),
     18: .standard(proto: "description_html"),
+    19: .standard(proto: "is_private"),
   ]
 
   fileprivate class _StorageClass {
@@ -10866,6 +10894,7 @@ extension Api_UserPodcastResponse: SwiftProtobuf.Message, SwiftProtobuf._Message
     var _dateAdded: SwiftProtobuf.Google_Protobuf_Timestamp? = nil
     var _settings: Api_PodcastSettings? = nil
     var _descriptionHtml: String = String()
+    var _isPrivate: SwiftProtobuf.Google_Protobuf_BoolValue? = nil
 
     #if swift(>=5.10)
       // This property is used as the initial default value for new instances of the type.
@@ -10898,6 +10927,7 @@ extension Api_UserPodcastResponse: SwiftProtobuf.Message, SwiftProtobuf._Message
       _dateAdded = source._dateAdded
       _settings = source._settings
       _descriptionHtml = source._descriptionHtml
+      _isPrivate = source._isPrivate
     }
   }
 
@@ -10934,6 +10964,7 @@ extension Api_UserPodcastResponse: SwiftProtobuf.Message, SwiftProtobuf._Message
         case 16: try { try decoder.decodeSingularMessageField(value: &_storage._dateAdded) }()
         case 17: try { try decoder.decodeSingularMessageField(value: &_storage._settings) }()
         case 18: try { try decoder.decodeSingularStringField(value: &_storage._descriptionHtml) }()
+        case 19: try { try decoder.decodeSingularMessageField(value: &_storage._isPrivate) }()
         default: break
         }
       }
@@ -11000,6 +11031,9 @@ extension Api_UserPodcastResponse: SwiftProtobuf.Message, SwiftProtobuf._Message
       if !_storage._descriptionHtml.isEmpty {
         try visitor.visitSingularStringField(value: _storage._descriptionHtml, fieldNumber: 18)
       }
+      try { if let v = _storage._isPrivate {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 19)
+      } }()
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -11027,6 +11061,7 @@ extension Api_UserPodcastResponse: SwiftProtobuf.Message, SwiftProtobuf._Message
         if _storage._dateAdded != rhs_storage._dateAdded {return false}
         if _storage._settings != rhs_storage._settings {return false}
         if _storage._descriptionHtml != rhs_storage._descriptionHtml {return false}
+        if _storage._isPrivate != rhs_storage._isPrivate {return false}
         return true
       }
       if !storagesAreEqual {return false}
@@ -18419,6 +18454,56 @@ extension Api_ReferralRedemption: SwiftProtobuf.Message, SwiftProtobuf._MessageI
   }
 
   static func ==(lhs: Api_ReferralRedemption, rhs: Api_ReferralRedemption) -> Bool {
+    if lhs.code != rhs.code {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Api_WinbackResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  static let protoMessageName: String = _protobuf_package + ".WinbackResponse"
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "offer"),
+    2: .same(proto: "platform"),
+    3: .same(proto: "details"),
+    4: .same(proto: "code"),
+  ]
+
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self.offer) }()
+      case 2: try { try decoder.decodeSingularInt32Field(value: &self.platform) }()
+      case 3: try { try decoder.decodeSingularStringField(value: &self.details) }()
+      case 4: try { try decoder.decodeSingularStringField(value: &self.code) }()
+      default: break
+      }
+    }
+  }
+
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.offer.isEmpty {
+      try visitor.visitSingularStringField(value: self.offer, fieldNumber: 1)
+    }
+    if self.platform != 0 {
+      try visitor.visitSingularInt32Field(value: self.platform, fieldNumber: 2)
+    }
+    if !self.details.isEmpty {
+      try visitor.visitSingularStringField(value: self.details, fieldNumber: 3)
+    }
+    if !self.code.isEmpty {
+      try visitor.visitSingularStringField(value: self.code, fieldNumber: 4)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  static func ==(lhs: Api_WinbackResponse, rhs: Api_WinbackResponse) -> Bool {
+    if lhs.offer != rhs.offer {return false}
+    if lhs.platform != rhs.platform {return false}
+    if lhs.details != rhs.details {return false}
     if lhs.code != rhs.code {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true

--- a/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+Winback.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+Winback.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+extension ApiServerHandler {
+    public func loadWinbackOffer() async -> WinbackOfferInfo? {
+        return await withCheckedContinuation { continuation in
+            let operation = WinbackOfferTask()
+            operation.completion = { offerInfo in
+                continuation.resume(returning: offerInfo)
+            }
+            apiQueue.addOperation(operation)
+        }
+    }
+}

--- a/podcasts/Cancel Subscription/Cancel Subscription/CancelSubscriptionView.swift
+++ b/podcasts/Cancel Subscription/Cancel Subscription/CancelSubscriptionView.swift
@@ -11,8 +11,8 @@ struct CancelSubscriptionView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            switch viewModel.priceAvailability {
-            case .available:
+            switch (viewModel.priceAvailability, viewModel.offerLoadingState) {
+            case (.available, .loaded):
                 ScrollView {
                     LazyVStack(spacing: 0) {
                         Text(L10n.cancelSubscriptionTitle)
@@ -23,13 +23,15 @@ struct CancelSubscriptionView: View {
                             .padding(.horizontal, 34.0)
 
                         ForEach(CancelSubscriptionOption.allCases, id: \.id) { option in
-                            if case .promotion = option, viewModel.canClaimOffer() {
-                                if let price = viewModel.price(),
+                            switch option {
+                            case .promotion:
+                                if viewModel.canClaimOffer(),
+                                   let price = viewModel.price(),
                                    let frequency = viewModel.subscriptionFrequency() {
                                     CancelSubscriptionViewRow(option: .promotion(price: price, frequency: frequency),
                                                               viewModel: viewModel)
                                 }
-                            } else {
+                            default:
                                 CancelSubscriptionViewRow(option: option,
                                                           viewModel: viewModel)
                             }
@@ -48,21 +50,24 @@ struct CancelSubscriptionView: View {
                 .padding(.horizontal, 34.0)
                 .padding(.top, 10.0)
                 .padding(.bottom, 58.0)
-            case .loading, .unknown:
-                ProgressView()
-                    .tint(theme.primaryText01)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-            case .failed:
+            case (.failed, _):
                 Text(L10n.cancelSubscriptionGenericError)
                     .font(size: 18.0, style: .body, weight: .bold)
                     .foregroundStyle(theme.primaryText01)
                     .multilineTextAlignment(.center)
+            default:
+                ProgressView()
+                    .tint(theme.primaryText01)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
         }
         .background(
             color(for: .primaryUi01)
                 .ignoresSafeArea()
         )
+        .task {
+            await viewModel.loadWinbackOffer()
+        }
     }
 
     private func color(for style: ThemeStyle) -> Color {

--- a/podcasts/Cancel Subscription/Cancel Subscription/CancelSubscriptionView.swift
+++ b/podcasts/Cancel Subscription/Cancel Subscription/CancelSubscriptionView.swift
@@ -10,55 +10,66 @@ struct CancelSubscriptionView: View {
     }
 
     var body: some View {
-        VStack(spacing: 0) {
-            switch (viewModel.priceAvailability, viewModel.offerLoadingState) {
-            case (.available, .loaded):
-                ScrollView {
-                    LazyVStack(spacing: 0) {
-                        Text(L10n.cancelSubscriptionTitle)
-                            .font(size: 28.0, style: .body, weight: .bold)
-                            .foregroundStyle(theme.primaryText01)
-                            .multilineTextAlignment(.center)
-                            .padding(.top, 48.0)
-                            .padding(.horizontal, 34.0)
+        ZStack {
+            VStack(spacing: 0) {
+                switch (viewModel.priceAvailability, viewModel.offerLoadingState) {
+                case (.available, .loaded):
+                    ScrollView {
+                        LazyVStack(spacing: 0) {
+                            Text(L10n.cancelSubscriptionTitle)
+                                .font(size: 28.0, style: .body, weight: .bold)
+                                .foregroundStyle(theme.primaryText01)
+                                .multilineTextAlignment(.center)
+                                .padding(.top, 48.0)
+                                .padding(.horizontal, 34.0)
 
-                        ForEach(CancelSubscriptionOption.allCases, id: \.id) { option in
-                            switch option {
-                            case .promotion:
-                                if viewModel.canClaimOffer(),
-                                   let price = viewModel.price(),
-                                   let frequency = viewModel.subscriptionFrequency() {
-                                    CancelSubscriptionViewRow(option: .promotion(price: price, frequency: frequency),
+                            ForEach(CancelSubscriptionOption.allCases, id: \.id) { option in
+                                switch option {
+                                case .promotion:
+                                    if viewModel.canClaimOffer(),
+                                       let price = viewModel.price(),
+                                       let frequency = viewModel.subscriptionFrequency() {
+                                        CancelSubscriptionViewRow(option: .promotion(price: price, frequency: frequency),
+                                                                  viewModel: viewModel)
+                                    }
+                                default:
+                                    CancelSubscriptionViewRow(option: option,
                                                               viewModel: viewModel)
                                 }
-                            default:
-                                CancelSubscriptionViewRow(option: option,
-                                                          viewModel: viewModel)
                             }
                         }
                     }
-                }
 
-                Button(action: {
-                    viewModel.cancelSubscriptionTap()
-                }, label: {
-                    Text(L10n.cancelSubscriptionContinueButton)
+                    Button(action: {
+                        viewModel.cancelSubscriptionTap()
+                    }, label: {
+                        Text(L10n.cancelSubscriptionContinueButton)
+                            .font(size: 18.0, style: .body, weight: .bold)
+                            .foregroundStyle(theme.primaryText01)
+                            .multilineTextAlignment(.center)
+                    })
+                    .padding(.horizontal, 34.0)
+                    .padding(.top, 10.0)
+                    .padding(.bottom, 58.0)
+                case (.failed, _):
+                    Text(L10n.cancelSubscriptionGenericError)
                         .font(size: 18.0, style: .body, weight: .bold)
                         .foregroundStyle(theme.primaryText01)
                         .multilineTextAlignment(.center)
-                })
-                .padding(.horizontal, 34.0)
-                .padding(.top, 10.0)
-                .padding(.bottom, 58.0)
-            case (.failed, _):
-                Text(L10n.cancelSubscriptionGenericError)
-                    .font(size: 18.0, style: .body, weight: .bold)
-                    .foregroundStyle(theme.primaryText01)
-                    .multilineTextAlignment(.center)
-            default:
-                ProgressView()
-                    .tint(theme.primaryText01)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                default:
+                    ProgressView()
+                        .tint(theme.primaryText01)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                }
+            }
+            if viewModel.offerPurchasingState == .purchasing {
+                ZStack {
+                    theme.primaryUi05Selected
+                        .edgesIgnoringSafeArea(.all)
+                        .opacity(0.4)
+                    ProgressView()
+                        .tint(theme.primaryText01)
+                }
             }
         }
         .background(

--- a/podcasts/Cancel Subscription/CancelSubscriptionOption.swift
+++ b/podcasts/Cancel Subscription/CancelSubscriptionOption.swift
@@ -28,8 +28,12 @@ enum CancelSubscriptionOption: CaseIterable, Hashable, Identifiable {
 
     var subtitle: String {
         switch self {
-        case .promotion(let price, _):
-            return L10n.cancelSubscriptionPromotionDescription(price)
+        case .promotion(let price, let frequency):
+            if frequency == .monthly {
+                return L10n.cancelSubscriptionPromotionDescriptionMonthly(price)
+            } else {
+                return L10n.cancelSubscriptionPromotionDescriptionYearly(price)
+            }
         case .availablePlans:
             return L10n.cancelSubscriptionNewPlanDescription
         case .help:

--- a/podcasts/Cancel Subscription/CancelSubscriptionViewModel.swift
+++ b/podcasts/Cancel Subscription/CancelSubscriptionViewModel.swift
@@ -1,9 +1,11 @@
 import SwiftUI
+import Combine
 import PocketCastsServer
 import PocketCastsUtils
 
 class CancelSubscriptionViewModel: PlusPurchaseModel {
     @Published var offerLoadingState: WinbackOfferLoadingState = .idle
+    @Published var offerPurchasingState: WinbackOfferPurchasingState = .idle
 
     weak var navigationController: UINavigationController?
     var winbackOffer: WinbackOfferInfo?
@@ -17,7 +19,8 @@ class CancelSubscriptionViewModel: PlusPurchaseModel {
 
         super.init(purchaseHandler: purchaseHandler)
 
-        self.loadPrices()
+        loadPrices()
+        addObservers()
     }
 
     override func didAppear() {
@@ -39,8 +42,30 @@ class CancelSubscriptionViewModel: PlusPurchaseModel {
                                                                "frequency": frequency.analyticsDescription])
     }
 
+    private var cancellables = Set<AnyCancellable>()
+    private func addObservers() {
+        // Observe IAP flows notification
+        Publishers.Merge4(
+            NotificationCenter.default.publisher(for: ServerNotifications.iapProductsFailed),
+            NotificationCenter.default.publisher(for: ServerNotifications.iapPurchaseFailed),
+            NotificationCenter.default.publisher(for: ServerNotifications.iapPurchaseCancelled),
+            NotificationCenter.default.publisher(for: ServerNotifications.iapPurchaseCompleted)
+        )
+        .receive(on: OperationQueue.main)
+        .sink { [weak self] notification in
+            Task {
+                await self?.purchaseCompleted(success: notification.name == ServerNotifications.iapPurchaseCompleted)
+            }
+        }
+        .store(in: &cancellables)
+    }
+
     enum WinbackOfferLoadingState {
         case idle, loading, loaded
+    }
+
+    enum WinbackOfferPurchasingState {
+        case idle, purchasing
     }
 }
 
@@ -86,14 +111,71 @@ extension CancelSubscriptionViewModel {
     }
 
     func claimOffer() {
-        trackRow(option: .promotion(price: "", frequency: .none))
-        //TODO: Apply one month free
-        //TODO: Purchase the offer and display the success view if succeeded
-        showClaimOfferSuccess()
+        if let price = price(), let frequency = subscriptionFrequency() {
+            trackRow(option: .promotion(price: price, frequency: frequency))
+        }
+        purchaseOffer()
     }
 
     func canClaimOffer() -> Bool {
         return winbackOffer != nil
+    }
+
+    private func purchaseOffer() {
+        guard let productID = translateToProduct(), let discountInfo = makeDiscountInfo() else {
+            return
+        }
+        offerPurchasingState = .purchasing
+        guard purchaseHandler.buyProduct(identifier: productID, discount: discountInfo) else {
+            offerPurchasingState = .idle
+            return
+        }
+    }
+
+    private func translateToProduct() -> IAPProductID? {
+        guard let iap = winbackOffer?.details?.iap else {
+            return nil
+        }
+        return IAPProductID(rawValue: iap)
+    }
+
+    private func makeDiscountInfo() -> IAPDiscountInfo? {
+        guard let winbackOffer,
+              let details = winbackOffer.details,
+              details.type == "offer",
+              let offerID = details.offerId,
+              let uuidString = details.nonce,
+              let uuid = UUID(uuidString: uuidString),
+              let timestamp = details.timestampMs,
+              let key = details.keyIdentifier,
+              let signature = details.signature
+        else {
+            return nil
+        }
+        return IAPDiscountInfo(identifier: offerID, uuid: uuid, timestamp: timestamp, key: key, signature: signature)
+    }
+
+    private func purchaseCompleted(success: Bool) async {
+        if success {
+            let redeemSuccess = await redeemCode()
+            if redeemSuccess {
+                await MainActor.run {
+                    offerPurchasingState = .idle
+                    showClaimOfferSuccess()
+                }
+            }
+        } else {
+            await MainActor.run {
+                offerPurchasingState = .idle
+            }
+        }
+    }
+
+    private func redeemCode() async -> Bool {
+        guard let winbackOffer else {
+            return false
+        }
+        return await ApiServerHandler.shared.redeemCode(winbackOffer.code)
     }
 }
 

--- a/podcasts/Cancel Subscription/CancelSubscriptionViewModel.swift
+++ b/podcasts/Cancel Subscription/CancelSubscriptionViewModel.swift
@@ -20,7 +20,6 @@ class CancelSubscriptionViewModel: PlusPurchaseModel {
         super.init(purchaseHandler: purchaseHandler)
 
         loadPrices()
-        addObservers()
     }
 
     override func didAppear() {
@@ -58,6 +57,13 @@ class CancelSubscriptionViewModel: PlusPurchaseModel {
             }
         }
         .store(in: &cancellables)
+    }
+
+    private func removeObservers() {
+        cancellables.forEach {
+            $0.cancel()
+        }
+        cancellables.removeAll()
     }
 
     enum WinbackOfferLoadingState {
@@ -111,6 +117,9 @@ extension CancelSubscriptionViewModel {
     }
 
     func claimOffer() {
+        if offerPurchasingState == .purchasing {
+            return
+        }
         if let price = price(), let frequency = subscriptionFrequency() {
             trackRow(option: .promotion(price: price, frequency: frequency))
         }
@@ -126,8 +135,10 @@ extension CancelSubscriptionViewModel {
             return
         }
         offerPurchasingState = .purchasing
+        addObservers()
         guard purchaseHandler.buyProduct(identifier: productID, discount: discountInfo) else {
             offerPurchasingState = .idle
+            removeObservers()
             return
         }
     }
@@ -161,12 +172,14 @@ extension CancelSubscriptionViewModel {
             if redeemSuccess {
                 await MainActor.run {
                     offerPurchasingState = .idle
+                    removeObservers()
                     showClaimOfferSuccess()
                 }
             }
         } else {
             await MainActor.run {
                 offerPurchasingState = .idle
+                removeObservers()
             }
         }
     }

--- a/podcasts/Cancel Subscription/CancelSubscriptionViewModel.swift
+++ b/podcasts/Cancel Subscription/CancelSubscriptionViewModel.swift
@@ -3,7 +3,10 @@ import PocketCastsServer
 import PocketCastsUtils
 
 class CancelSubscriptionViewModel: PlusPurchaseModel {
+    @Published var offerLoadingState: WinbackOfferLoadingState = .idle
+
     weak var navigationController: UINavigationController?
+    var winbackOffer: WinbackOfferInfo?
 
     var isEligibleForOffer: Bool {
         purchaseHandler.isEligibleForOffer
@@ -14,7 +17,6 @@ class CancelSubscriptionViewModel: PlusPurchaseModel {
 
         super.init(purchaseHandler: purchaseHandler)
 
-        //TODO: Need to check the if the promotion can be applied
         self.loadPrices()
     }
 
@@ -36,6 +38,10 @@ class CancelSubscriptionViewModel: PlusPurchaseModel {
                                                                "tier": activeTier.analyticsDescription,
                                                                "frequency": frequency.analyticsDescription])
     }
+
+    enum WinbackOfferLoadingState {
+        case idle, loading, loaded
+    }
 }
 
 // IAP
@@ -44,12 +50,10 @@ extension CancelSubscriptionViewModel {
         switch (SubscriptionHelper.activeTier, SubscriptionHelper.subscriptionFrequencyValue()) {
         case (.plus, .monthly):
             return pricingInfo.products.first { $0.identifier == .monthly }?.rawPrice
-        case (.plus, .yearly):
-            return pricingInfo.products.first { $0.identifier == .yearly }?.rawPrice
         case (.patron, .monthly):
             return pricingInfo.products.first { $0.identifier == .patronMonthly }?.rawPrice
-        case (.patron, .yearly):
-            return pricingInfo.products.first { $0.identifier == .patronYearly }?.rawPrice
+        case (_, .yearly):
+            return winbackOffer?.offerPrice
         default:
             return nil
         }
@@ -66,6 +70,21 @@ extension CancelSubscriptionViewModel {
         }
     }
 
+    func loadWinbackOffer() async {
+        if offerLoadingState == .loading {
+            return
+        }
+        Task { @MainActor in
+            offerLoadingState = .loading
+            winbackOffer = await ApiServerHandler.shared.loadWinbackOffer()
+            if let iap = winbackOffer?.details?.iap,
+               let offerId = winbackOffer?.details?.offerId {
+                winbackOffer?.offerPrice = await purchaseHandler.winbackOfferPrice(for: iap, offerId: offerId)
+            }
+            offerLoadingState = .loaded
+        }
+    }
+
     func claimOffer() {
         trackRow(option: .promotion(price: "", frequency: .none))
         //TODO: Apply one month free
@@ -74,7 +93,7 @@ extension CancelSubscriptionViewModel {
     }
 
     func canClaimOffer() -> Bool {
-        return true
+        return winbackOffer != nil
     }
 }
 

--- a/podcasts/CancelConfirmationView.swift
+++ b/podcasts/CancelConfirmationView.swift
@@ -18,7 +18,6 @@ struct CancelConfirmationView: View {
             .init(imageName: "locked-large", text: L10n.cancelConfirmItemPlus),
             .init(imageName: "folder-locked", text: L10n.cancelConfirmItemFolders),
             .init(imageName: "remove_from_cloud", text: L10n.cancelConfirmItemUploads),
-            .init(imageName: "about_website", text: L10n.cancelConfirmItemWebPlayer),
         ]
     }
 

--- a/podcasts/IAPHelper.swift
+++ b/podcasts/IAPHelper.swift
@@ -70,6 +70,10 @@ class IAPHelper: NSObject {
         request.start()
     }
 
+    func requestProductsInfo(for ids: [String]) async throws -> [Product] {
+        return try await Product.products(for: ids)
+    }
+
     func getProduct(for identifier: IAPProductID) -> SKProduct! {
         guard productsArray.count > 0 else {
             requestProductInfo()
@@ -104,6 +108,15 @@ class IAPHelper: NSObject {
                 return $0.purchaseDate < $1.purchaseDate
             }
             .last
+    }
+
+    func winbackOfferPrice(for mainProductId: String, offerId: String) async -> String? {
+        do {
+            let product = try await requestProductsInfo(for: [mainProductId]).first
+            return product?.subscription?.promotionalOffers.first { $0.id == offerId }?.displayPrice
+        } catch {
+            return nil
+        }
     }
 
     func showManageSubscriptions(in windowScene: UIWindowScene) async throws {

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -414,9 +414,13 @@ internal enum L10n {
   internal static var cancelSubscriptionOfferYearlySuccessViewDescription: String { return L10n.tr("Localizable", "cancel_subscription_offer_yearly_success_view_description") }
   /// 50%% off your next year!
   internal static var cancelSubscriptionOfferYearlySuccessViewTitle: String { return L10n.tr("Localizable", "cancel_subscription_offer_yearly_success_view_title") }
+  /// Save %@ at the start of your next billing cycle.
+  internal static func cancelSubscriptionPromotionDescriptionMonthly(_ p1: Any) -> String {
+    return L10n.tr("Localizable", "cancel_subscription_promotion_description_monthly", String(describing: p1))
+  }
   /// Pay %@ now for another year at 50%% off
-  internal static func cancelSubscriptionPromotionDescription(_ p1: Any) -> String {
-    return L10n.tr("Localizable", "cancel_subscription_promotion_description", String(describing: p1))
+  internal static func cancelSubscriptionPromotionDescriptionYearly(_ p1: Any) -> String {
+    return L10n.tr("Localizable", "cancel_subscription_promotion_description_yearly", String(describing: p1))
   }
   /// Get your next month free
   internal static var cancelSubscriptionPromotionTitle: String { return L10n.tr("Localizable", "cancel_subscription_promotion_title") }

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4687,8 +4687,11 @@
 /* Cancel subscription: title for the yearly promotion row */
 "cancel_subscription_yearly_promotion_title" = "Get 50%% off your next year";
 
-/* Cancel subscription: description for the promotion row */
-"cancel_subscription_promotion_description" = "Pay %@ now for another year at 50%% off";
+/* Cancel subscription: description for the monthly promotion row. The %@ represents the price. */
+"cancel_subscription_promotion_description_monthly" = "Save %@ at the start of your next billing cycle.";
+
+/* Cancel subscription: description for the yearly promotion row. The %@ represents the price. */
+"cancel_subscription_promotion_description_yearly" = "Pay %@ now for another year at 50%% off";
 
 /* Cancel subscription: title for the new plan row */
 "cancel_subscription_new_plan_title" = "Looking for a different plan?";


### PR DESCRIPTION
| 📘 Part of: #2435
|:---:|

Fixes #2441

This PR adds the API implementation to consume the winback offer.

## To test

- Make sure you have the `winback` FF on
- You will need to:
  - Run the app in Staging
  - Create a new user for each plan to test. Remember you need to wait for at least 3 minutes  before having the offer available after the account creation.
- General step to test it:
  - Clean your sandbox user history and current subscription
  - Run the app and create a user
  - Purchase a plan (you will need to make one for each plan)
  - Open the Cancel Subscription panel
  - You should see the offer row
  - Tap on claim
  - Confirm the offer to apply is the right one (1 month off for monthly plans, 50% off for yearly plans)
  - Purchase it
  - Confirm at the end of the process you will see the correct Success screen
  - Dismiss it 
  - Return to the cancellation screen to confirm you won't see the offer row again 

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
