### PR TITLE
[Tooling] Protect the `release/*` branch with the same settings as `trunk`

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -330,10 +330,7 @@ platform :ios do
     trigger_beta_build(branch_to_build: release_branch_name)
     create_backmerge_pr
 
-    # We cannot use the `copy_branch_protection` action here yet, as it would create a branch protection rule with the same
-    # restrictions we have in `trunk`, and the release managers wouldn't be able to push due to permissions.
-    # This should be changed only when we have PCiOS releases done on CI, when the CI bot is the one running `git push`.
-    set_branch_protection(repository: GITHUB_REPO, branch: release_branch_name)
+    copy_branch_protection(repository: GITHUB_REPO, from_branch: DEFAULT_BRANCH, to_branch: release_branch_name)
 
     # Move still-open PRs to next milestone, then add frozen marker to milestone title
     update_milestone


### PR DESCRIPTION
## Description

During code freeze and after the creation of the new `release/*` branch, replaces the call to `set_branch_protection` with `copy_branch_protection` instead, so that it replicates the same branch protections as the ones set on the `trunk` branch.

In particular, this will require the same CI checks on PRs targeting the `release/*` branch than the ones set for the `trunk` branch

## How it's been tested

 - [x] Comment or delete all the lines in the `code_freeze` lane except the one calling `copy_branch_protection`
 - [x] Run the lane
 - [x] Observe that the [branch protection settings for `release/7.82`](https://github.com/Automattic/pocket-casts-ios/settings/branch_protection_rules/59272028) now have some required CI checks configured

<img width="788" alt="image" src="https://github.com/user-attachments/assets/85be2937-7ae9-4027-8060-15270c8629d3" />
