### PR TITLE
Fix downloads copies errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 -----
 - Add App Clips [#2549](https://github.com/Automattic/pocket-casts-ios/issues/2549)
 - Unarchived all episodes bulk marked as unplayed. [#2713](https://github.com/Automattic/pocket-casts-ios/pull/2713)
+- Fix downloads copies errors. [#2737](https://github.com/Automattic/pocket-casts-ios/pull/2737)
 
 7.81
 -----

--- a/podcasts/DownloadManager+URLSessionDelegate.swift
+++ b/podcasts/DownloadManager+URLSessionDelegate.swift
@@ -163,7 +163,7 @@ extension DownloadManager: URLSessionDelegate, URLSessionDownloadDelegate {
         let destinationUrl = URL(fileURLWithPath: destinationPath)
 
         do {
-            try StorageManager.copyItem(at: location, to: destinationUrl)
+            try StorageManager.copyItem(at: location, to: destinationUrl, options: [.overwriteExisting])
 
             let newDownloadStatus: DownloadStatus = autoDownloadStatus == .playerDownloadedForStreaming ? .downloadedForStreaming : .downloaded
             dataManager.saveEpisode(downloadStatus: newDownloadStatus, sizeInBytes: fileSize, downloadTaskId: nil, episode: episode)

--- a/podcasts/StorageManager.swift
+++ b/podcasts/StorageManager.swift
@@ -21,7 +21,10 @@ struct StorageManager {
     }
 
     @discardableResult
-    static func copyItem(at fromURL: URL, to toURL: URL, attributes: Attributes? = nil) throws -> Bool {
+    static func copyItem(at fromURL: URL, to toURL: URL, attributes: Attributes? = nil, options: Options? = nil) throws -> Bool {
+        if let options, options.contains(.overwriteExisting) {
+            removeItem(at: toURL)
+        }
         try copyItem(at: fromURL, to: toURL)
 
         let attrs = (attributes ?? [:]).merging(Constants.defaultAttributes) { current, _ in current }


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
Ensure that when copying a downloaded file we delete any previous existing file so everything works correctly if some older copy was left behind.


## To test

1. Start the app
2. Start playing an episode
3. While the episode is playing tap on download action
4. Check if when the download finishes the player continues correctly and no `DownloadManager: Failed to copy downloaded file from location: [path] to destination: [path]` are tracked on the console and also the UI does not show download errors.
5. Try the other way around, start downloading some episode directly without playing it
6. Start playing it while the download is happening
7. Check if play continues correctly and when finishing the download no logs about copy errors show and no UI errors show saying that was unable to download.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
