### PR TITLE
[Winback] Remove website line

### DIFF
--- a/podcasts/CancelConfirmationView.swift
+++ b/podcasts/CancelConfirmationView.swift
@@ -18,7 +18,6 @@ struct CancelConfirmationView: View {
             .init(imageName: "locked-large", text: L10n.cancelConfirmItemPlus),
             .init(imageName: "folder-locked", text: L10n.cancelConfirmItemFolders),
             .init(imageName: "remove_from_cloud", text: L10n.cancelConfirmItemUploads),
-            .init(imageName: "about_website", text: L10n.cancelConfirmItemWebPlayer),
         ]
     }
 


### PR DESCRIPTION
| 📘 Part of: #2435 
|:---:|

Remove the last line in the Cancel Confirmation Screen

| 1 | 2 |
| -------- | ------- |
| ![RocketSim_Screenshot_iPhone_16_6 1_2025-02-11_19 43 40](https://github.com/user-attachments/assets/a95989dd-bd07-4266-87eb-4a05df3b652f) | ![RocketSim_Screenshot_iPhone_16_6 1_2025-02-11_19 44 08](https://github.com/user-attachments/assets/8fd897cc-e568-49dd-b9ab-bcb39e3ad8af) |


## To test

- Use a plus account
- Make sure the `winback` FF is off
- Go to profile, Cancel Subscription
- Confirm the last line about the web page is not present (screen 1)
- Switch the FF on
- Go to profile, Cancel Subscription, Continue Cancellation
- Confirm the last line about the web page is not present (screen 2)

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
