### PR TITLE
[Tooling] Allow admins to push on release branch

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -330,7 +330,10 @@ platform :ios do
     trigger_beta_build(branch_to_build: release_branch_name)
     create_backmerge_pr
 
+    # Copy the branch protection settings from the default branch to the new release branch
     copy_branch_protection(repository: GITHUB_REPO, from_branch: DEFAULT_BRANCH, to_branch: release_branch_name)
+    # But allow admins to bypass restrictions, so that wpmobilebot can push to the release branch directly for beta version bumps
+    set_branch_protection(repository: GITHUB_REPO, branch: release_branch_name, enforce_admins: false)
 
     # Move still-open PRs to next milestone, then add frozen marker to milestone title
     update_milestone


### PR DESCRIPTION
This is especially so that `use-bot-for-git` can push version bumps and translation updates to the `release/*` branch directly during beta and final builds—so that when a new beta build is triggered from our ReleasesV2 tool it will be able to do everything needed from CI directly.

Internal refs:
 - p1739269381050279-slack-C029BMLUGRX
 - paaHJt-7R7-p2 

## How it has been tested

I've tested this by:
 - Commenting all the lines in the `code_freeze` lane except the ones calling `copy_branch_protection` and `set_branch_protection`
 - Modified the branch protection settings for the current `release/*` branch in GitHub Settings, to remove a couple of required CI checks and enable back "Do not allow bypassing the above settings"
 - Then running that stripped-out `bundle exec fastlane code_freeze` lane so that those `copy_branch_protection` + `set_branch_protection` actions are called
 - Then verified that the branch protection settings for the current `release/*` branch were back to the expected state in GitHub Settings, namely all the same settings (requires PR, # of reviewers, list of required CI checks, etc) except for "Do not allow bypassing the above settings" being unchecked (while it's checked on the branch protection settings for `trunk`)

> [!NOTE]
>
> Since the next time the `code_freeze` will be run it will be run from the `trunk` branch, it's ok for this PR to target `trunk` (no need for it to target `release/7.82`)