### PR TITLE
Default Player: Fix retain self

### DIFF
--- a/podcasts/DefaultPlayer.swift
+++ b/podcasts/DefaultPlayer.swift
@@ -418,6 +418,9 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
         // MARK: - Peak Limter
 
         func createPeakLimiter(maxFrames: CMItemCount, processingFormat: AudioStreamBasicDescription, tap: MTAudioProcessingTap) -> AudioUnit? {
+            guard let referenceToSelf = DefaultPlayer.unretainedDefaultPlayer(for: tap) else {
+                return nil
+            }
             var componentDescription = AudioComponentDescription(componentType: kAudioUnitType_Effect,
                                                                  componentSubType: kAudioUnitSubType_PeakLimiter,
                                                                  componentManufacturer: kAudioUnitManufacturer_Apple,
@@ -437,7 +440,7 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
             var renderCallback: AURenderCallbackStruct
             if FeatureFlag.useDefaultPlayerTapCookie.enabled {
                 let inputProcRefCon = Unmanaged<AudioProcessingTapProxy>.fromOpaque(MTAudioProcessingTapGetStorage(tap))
-                renderCallback = AURenderCallbackStruct(inputProc: peakLimiterRenderCallback, inputProcRefCon: inputProcRefCon.toOpaque())
+                renderCallback = AURenderCallbackStruct(inputProc: referenceToSelf.peakLimiterRenderCallback, inputProcRefCon: inputProcRefCon.toOpaque())
             } else {
                 renderCallback = AURenderCallbackStruct(inputProc: peakLimiterRenderCallback, inputProcRefCon: Unmanaged.passUnretained(self).toOpaque())
             }
@@ -477,6 +480,9 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
         // MARK: - High Pass Filter
 
     private func createHighPassFilter(maxFrames: CMItemCount, processingFormat: AudioStreamBasicDescription, tap: MTAudioProcessingTap) -> AudioUnit? {
+            guard let referenceToSelf = DefaultPlayer.unretainedDefaultPlayer(for: tap) else {
+                return nil
+            }
             var componentDescription = AudioComponentDescription(componentType: kAudioUnitType_Effect,
                                                                  componentSubType: kAudioUnitSubType_HighPassFilter,
                                                                  componentManufacturer: kAudioUnitManufacturer_Apple,
@@ -496,7 +502,7 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
             var renderCallback: AURenderCallbackStruct
             if FeatureFlag.useDefaultPlayerTapCookie.enabled {
                 let inputProcRefCon = Unmanaged<AudioProcessingTapProxy>.fromOpaque(MTAudioProcessingTapGetStorage(tap))
-                renderCallback = AURenderCallbackStruct(inputProc: highPassFilterRenderCallback, inputProcRefCon: inputProcRefCon.toOpaque())
+                renderCallback = AURenderCallbackStruct(inputProc: referenceToSelf.highPassFilterRenderCallback, inputProcRefCon: inputProcRefCon.toOpaque())
             } else {
                 renderCallback = AURenderCallbackStruct(inputProc: highPassFilterRenderCallback, inputProcRefCon: Unmanaged.passUnretained(self).toOpaque())
             }


### PR DESCRIPTION
Related #2544

We still see crashes due to the player not being release correctly. I believe the reason is that even if the `inputProcRefCon` is a reference to the proxy, correctly extracted while calling both blocks `peakLimiterRenderCallback` and `highPassFilterRenderCallback` , the 2 functions (in which the blocks are injected) refers to `self` and not to the proxy -> default player

## To test

I'm not able to reproduce the crash but to test it we should stress the player by playing episodes, switching between episodes, using the effect player as well etc...

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
