### PR TITLE
App Clip: Add loading and error states

### DIFF
--- a/Pocket Casts App Clip/NowPlayingView.swift
+++ b/Pocket Casts App Clip/NowPlayingView.swift
@@ -5,16 +5,36 @@ import StoreKit
 import PocketCastsUtils
 
 struct NowPlayingView: View {
+
+    enum ScreenState: Int {
+        case loading
+        case ready
+        case failed
+    }
+
     @State var presentAppStoreOverlay: Bool = false
+    @State var state: ScreenState = .loading
 
     var body: some View {
         VStack {
-            NowPlayingPlayerItemViewControllerRepresentable()
-                .onAppear {
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 10) {
-                        presentAppStoreOverlay = true
+            Spacer()
+            HStack { Spacer() }
+            switch state {
+            case .loading:
+                ProgressView()
+                    .progressViewStyle(.circular)
+                    .tint(Color(uiColor: PlayerColorHelper.playerHighlightColor02()))
+            case .ready:
+                NowPlayingPlayerItemViewControllerRepresentable()
+                    .onAppear {
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 10) {
+                            presentAppStoreOverlay = true
+                        }
                     }
-                }
+            case .failed:
+                EmptyView()
+            }
+            Spacer()
         }
         .appStoreOverlay(isPresented: $presentAppStoreOverlay, configuration: {
             SKOverlay.AppClipConfiguration(position: .bottom)
@@ -32,7 +52,10 @@ struct NowPlayingView: View {
             let path = components.path,
             path != "/get",
             path != "/get/"
-        else { return }
+        else {
+            showErrorMessage(userActivity: userActivity)
+            return
+        }
 
         // NOTE: This doesn't handle the redeem URL. See `AppDelegate.handleContinue(_ userActivity: NSUserActivity)` for this logic
 
@@ -46,16 +69,19 @@ struct NowPlayingView: View {
         PodcastManager.shared.importSharedItemFromUrl(importPath) { shareItem in
             guard let shareItem else {
                 FileLog.shared.addMessage("App Clip: Missing Share Item")
+                showErrorMessage(userActivity: userActivity)
                 return
             }
 
             guard let episodeUUID = shareItem.episodeHeader?.uuid else {
                 FileLog.shared.addMessage("App Clip: No episode found in share item")
+                showErrorMessage(userActivity: userActivity)
                 return
             }
 
             guard let podcastUUID = shareItem.podcastHeader?.uuid else {
                 FileLog.shared.addMessage("App Clip: No podcast found in share item")
+                showErrorMessage(userActivity: userActivity)
                 return
             }
 
@@ -63,21 +89,33 @@ struct NowPlayingView: View {
             loadEpisode(episodeUuid: episodeUUID, podcastUuid: podcastUUID) {
                 guard let episode = DataManager.sharedManager.findEpisode(uuid: episodeUUID) else {
                     FileLog.shared.addMessage("App Clip: Could not find Episode")
+                    showErrorMessage(userActivity: userActivity)
                     return
                 }
 
                 FileLog.shared.addMessage("App Clip: Loaded episode: \(episode.title ?? "unknown")")
-
+                state = .ready
                 PlaybackManager.shared.load(episode: episode, autoPlay: true, overrideUpNext: false)
                 Analytics.track(.playbackPlay, source: AnalyticsSource.handleUserActivity, properties: ["url": incomingURL.absoluteString, "podcast": podcastUUID, "episode": episode.uuid])
             }
         }
     }
 
+    private func showErrorMessage(userActivity: NSUserActivity) {
+        userActivity.invalidate()
+        state = .failed
+        DispatchQueue.main.async {
+            let rootViewController = (UIApplication.shared.connectedScenes.first as? UIWindowScene)?.windows.first?.rootViewController
+            SJUIUtils.showAlert(title: L10n.podcastShareErrorTitle, message: L10n.podcastShareErrorMsg, from: rootViewController)
+        }
+    }
+
     private func loadEpisode(episodeUuid: String, podcastUuid: String, timestamp: TimeInterval? = nil, completion: @escaping () -> Void) {
         if let podcast = DataManager.sharedManager.findPodcast(uuid: podcastUuid, includeUnsubscribed: true) {
             ServerPodcastManager.shared.updatePodcastIfRequired(podcast: podcast) { _ in
-                completion()
+                DispatchQueue.main.async {
+                    completion()
+                }
             }
 
             return
@@ -85,7 +123,9 @@ struct NowPlayingView: View {
 
         ServerPodcastManager.shared.addFromUuid(podcastUuid: podcastUuid, subscribe: false, completion: { success in
             if success, let _ = DataManager.sharedManager.findPodcast(uuid: podcastUuid, includeUnsubscribed: true) {
-                completion()
+                DispatchQueue.main.async {
+                    completion()
+                }
             } else {
                 DispatchQueue.main.async {
                     let rootViewController = (UIApplication.shared.connectedScenes.first as? UIWindowScene)?.windows.first?.rootViewController

--- a/Pocket Casts App Clip/NowPlayingView.swift
+++ b/Pocket Casts App Clip/NowPlayingView.swift
@@ -23,7 +23,7 @@ struct NowPlayingView: View {
             case .loading:
                 ProgressView()
                     .progressViewStyle(.circular)
-                    .tint(Color(uiColor: PlayerColorHelper.playerHighlightColor02()))
+                    .tint(UIColor.label.color)
             case .ready:
                 NowPlayingPlayerItemViewControllerRepresentable()
                     .onAppear {
@@ -36,10 +36,10 @@ struct NowPlayingView: View {
             }
             Spacer()
         }
+        .background(state != .ready ? UIColor.systemBackground.color : PlayerColorHelper.playerBackgroundColor01().color)
         .appStoreOverlay(isPresented: $presentAppStoreOverlay, configuration: {
             SKOverlay.AppClipConfiguration(position: .bottom)
         })
-        .background(Color(uiColor: PlayerColorHelper.playerBackgroundColor01()))
         .onContinueUserActivity(NSUserActivityTypeBrowsingWeb) { userActivity in
             handle(userActivity: userActivity)
         }

--- a/podcasts/PlayerColorHelper.swift
+++ b/podcasts/PlayerColorHelper.swift
@@ -17,14 +17,14 @@ struct PlayerColorHelper {
         return ThemeColor.playerBackground02(podcastColor: podcastBackgroundColor, for: theme)
     }
 
-    static func playerHighlightColor01(for theme: Theme.ThemeType,
+    static func playerHighlightColor01(for theme: Theme.ThemeType = Theme.sharedTheme.activeTheme,
                                        episode: BaseEpisode? = PlaybackManager.shared.currentEpisode()) -> UIColor {
         guard let podcastColor = tint(for: episode, with: theme) else { return UIColor.white }
 
         return ThemeColor.playerHighlight01(podcastColor: podcastColor)
     }
 
-    static func playerHighlightColor02(for theme: Theme.ThemeType,
+    static func playerHighlightColor02(for theme: Theme.ThemeType = Theme.sharedTheme.activeTheme,
                                        episode: BaseEpisode? = PlaybackManager.shared.currentEpisode()) -> UIColor {
         guard let podcastColor = tint(for: episode, with: theme) else { return UIColor.white }
 


### PR DESCRIPTION
| 📘 Part of: #2549  |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

This PR introduces a loading and error states to App Clips in order to not show an empty/non-configured clip to users.

For now it just shows a progress bar and then the player or if the episode loading failed an alert saying that an error existed.

Should we consider a small Pocket Casts banner with some text instead?

| Loading | Error | 
| - | - |
| ![Simulator Screenshot - iPhone 16 Pro Max - 2025-02-12 at 13 58 49](https://github.com/user-attachments/assets/8874ac90-07da-4d4e-9995-1f2a1df51613) | ![Simulator Screenshot - iPhone 16 Pro Max - 2025-02-12 at 13 57 59](https://github.com/user-attachments/assets/bbfc5b07-4593-4365-81eb-6a7f651dbf69) |

## To test

- Choose the App Clip target
- Tap run
- Check that on launch you see a loading indicator and then followed up by the player interface
- Stop the app
- Edit the App Clip scheme
- Open the Run Section
- Tap on Argument tabs
- Remove  the app clip invocation argument : `c2r28q2u`
- Start the app clip
- Check if the loading state shows up followed by the error state

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
