### PR TITLE
Update share icon and transcript positions

### DIFF
--- a/podcasts/Enumerations.swift
+++ b/podcasts/Enumerations.swift
@@ -245,8 +245,8 @@ extension PlayerAction: AnalyticsDescribable {
     /// Specify default actions and their order
     static var defaultActions: [PlayerAction] {
         [
-            .effects, .sleepTimer, .routePicker, .transcript, .download,
-            .shareEpisode, .goToPodcast, .addBookmark, .markPlayed,
+            .effects, .sleepTimer, .routePicker, .shareEpisode, .download,
+            .transcript, .goToPodcast, .addBookmark, .markPlayed,
             .starEpisode, .chromecast, .archive
         ]
     }

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -792,11 +792,6 @@ class Settings: NSObject {
             playerActions = UserDefaults.standard.playerActions ?? defaultActions
         }
 
-        // Show transcript as the 4th item if it's not present
-        if !playerActions.contains(.transcript) {
-            playerActions.insert(.transcript, safelyAt: 3)
-        }
-
         return playerActions + defaultActions.filter { !playerActions.contains($0) }
     }
 


### PR DESCRIPTION
Fixes #2727 

Replace Transcript icon with Share

| Shelf | More |
| -------- | ------- |
| ![RocketSim_Screenshot_iPhone_16_6 1_2025-02-13_09 16 55](https://github.com/user-attachments/assets/294f1154-3f03-480b-be57-a843fee0d51e) | ![RocketSim_Screenshot_iPhone_16_6 1_2025-02-13_09 17 42](https://github.com/user-attachments/assets/478ec426-83d3-4be2-aeda-a98b45485c44) |



## To test
1. Install the app from`trunk`.
2. Play something.
3. Change your shelf items order.
4. Install the app from this branch.
5. Go to the player. Notice that the order of shelf items has not changed.
6. Delete the app and restart.
7. Start the app.
8. Play something.
9. Confirm that share icon is the 4th item in the shelf
10. Tap the ••• in shelf and confirm transcript is the 2nd item in More Action.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
