### PR TITLE
[Podcast Feed Reload] Check app install state to skip tooltip

### DIFF
--- a/PocketCastsTests/Tests/Analytics/AppLifecyleAnalyticsTests.swift
+++ b/PocketCastsTests/Tests/Analytics/AppLifecyleAnalyticsTests.swift
@@ -16,7 +16,7 @@ class AppLifecycleAnalyticsTests: XCTestCase {
 
     // MARK: - Application Installed
 
-    func testApplicationInstalledEventFiresWhenLaunched() {
+    func testApplicationInstalledEventFiresWhenLaunched() throws {
         let expectation = expectation(description: "track method should be triggered")
         analytics.didTrack = { event, _ in
             expectation.fulfill()
@@ -24,12 +24,14 @@ class AppLifecycleAnalyticsTests: XCTestCase {
             XCTAssertEqual(event, .applicationInstalled)
         }
 
-        appLifecyleAnalytics.checkApplicationInstalledOrUpgraded()
+        let applicationInstallState = try XCTUnwrap(checkApplicationInstalledOrUpgraded())
+
+        XCTAssertEqual(applicationInstallState, .installed)
 
         waitForExpectations(timeout: 1)
     }
 
-    func testApplicationInstalledEventFiresOnlyOnce() {
+    func testApplicationInstalledEventFiresOnlyOnce() throws {
         let expectation = expectation(description: "track method should be triggered only once")
         expectation.expectedFulfillmentCount = 1
         expectation.assertForOverFulfill = true
@@ -41,17 +43,19 @@ class AppLifecycleAnalyticsTests: XCTestCase {
         }
 
         // First launch
-        appLifecyleAnalytics.checkApplicationInstalledOrUpgraded()
+        let applicationInstallState = try XCTUnwrap(checkApplicationInstalledOrUpgraded())
+
+        XCTAssertEqual(applicationInstallState, .installed)
 
         // Simulated second launch
-        appLifecyleAnalytics.checkApplicationInstalledOrUpgraded()
+        checkApplicationInstalledOrUpgraded()
 
         waitForExpectations(timeout: 1)
     }
 
     // MARK: - Application Updated
 
-    func testApplicationUpdatedEventFiresWhenLaunched() {
+    func testApplicationUpdatedEventFiresWhenLaunched() throws {
         let testVersion = "1.0"
         userDefaults.set(testVersion, forKey: Constants.UserDefaults.lastRunVersion)
 
@@ -70,12 +74,14 @@ class AppLifecycleAnalyticsTests: XCTestCase {
             XCTAssertEqual(testVersion, version)
         }
 
-        appLifecyleAnalytics.checkApplicationInstalledOrUpgraded()
+        let applicationInstallState = try XCTUnwrap(checkApplicationInstalledOrUpgraded())
+
+        XCTAssertEqual(applicationInstallState, .updated)
 
         waitForExpectations(timeout: 1)
     }
 
-    func testApplicationUpdatedEventIsNotTriggeredForSameVersion() {
+    func testApplicationUpdatedEventIsNotTriggeredForSameVersion() throws {
         userDefaults.set(Settings.appVersion(), forKey: Constants.UserDefaults.lastRunVersion)
 
         let expectation = expectation(description: "track method should not be triggered")
@@ -86,7 +92,9 @@ class AppLifecycleAnalyticsTests: XCTestCase {
             XCTFail("The track method should not be triggered")
         }
 
-        appLifecyleAnalytics.checkApplicationInstalledOrUpgraded()
+        let applicationInstallState = try XCTUnwrap(checkApplicationInstalledOrUpgraded())
+
+        XCTAssertEqual(applicationInstallState, .updated)
 
         waitForExpectations(timeout: 1)
     }
@@ -105,10 +113,10 @@ class AppLifecycleAnalyticsTests: XCTestCase {
         }
 
         // First launch after initial update, should trigger
-        appLifecyleAnalytics.checkApplicationInstalledOrUpgraded()
+        checkApplicationInstalledOrUpgraded()
 
         // Simulated second launch, should not trigger
-        appLifecyleAnalytics.checkApplicationInstalledOrUpgraded()
+        checkApplicationInstalledOrUpgraded()
 
         waitForExpectations(timeout: 1)
     }
@@ -132,7 +140,7 @@ class AppLifecycleAnalyticsTests: XCTestCase {
             expectation.fulfill()
         }
 
-        appLifecyleAnalytics.checkApplicationInstalledOrUpgraded()
+        checkApplicationInstalledOrUpgraded()
 
         waitForExpectations(timeout: 1)
     }
@@ -154,7 +162,7 @@ class AppLifecycleAnalyticsTests: XCTestCase {
             expectation.fulfill()
         }
 
-        appLifecyleAnalytics.checkApplicationInstalledOrUpgraded()
+        checkApplicationInstalledOrUpgraded()
 
         waitForExpectations(timeout: 1)
     }
@@ -171,7 +179,7 @@ class AppLifecycleAnalyticsTests: XCTestCase {
             expectation.fulfill()
         }
 
-        appLifecyleAnalytics.checkApplicationInstalledOrUpgraded()
+        checkApplicationInstalledOrUpgraded()
 
         waitForExpectations(timeout: 1)
     }
@@ -278,6 +286,11 @@ class AppLifecycleAnalyticsTests: XCTestCase {
         appLifecyleAnalytics.didEnterBackground()
 
         waitForExpectations(timeout: 3)
+    }
+
+    @discardableResult
+    private func checkApplicationInstalledOrUpgraded() -> AppLifecycleAnalytics.AppInstallState? {
+        appLifecyleAnalytics.checkApplicationInstalledOrUpgraded()
     }
 }
 

--- a/podcasts/Analytics/AppLifecyleAnalytics.swift
+++ b/podcasts/Analytics/AppLifecyleAnalytics.swift
@@ -56,15 +56,20 @@ extension AppLifecycleAnalytics {
 // MARK: - App Install/Updates
 
 extension AppLifecycleAnalytics {
+    enum AppInstallState {
+        case installed
+        case updated
+    }
+
     /// Checks whether we need to track an app install or app update
-    func checkApplicationInstalledOrUpgraded() {
+    func checkApplicationInstalledOrUpgraded() -> AppInstallState? {
         // Don't check for install or upgrade if protected data isn't available yet
         //
         // If the app is launched "in the background" and protected data is enabled then the analytics won't
         // be enabled and we may miss some events.
         // When the user opens the app directly the event will be tracked.
 
-        guard UIApplication.shared.isProtectedDataAvailable else { return }
+        guard UIApplication.shared.isProtectedDataAvailable else { return nil }
 
         let currentVersion = Settings.appVersion()
 
@@ -77,15 +82,17 @@ extension AppLifecycleAnalytics {
         // If there is no previous version, then record this as an install
         guard let lastRunVersion = tryToDetermineLastRunVersion() else {
             analytics.track(.applicationInstalled)
-            return
+            return .installed
         }
 
         // If the versions are not the same, then record this as an upgrade
         guard lastRunVersion != currentVersion else {
-            return
+            return .updated
         }
 
         analytics.track(.applicationUpdated, properties: ["previous_version": lastRunVersion])
+
+        return .updated
     }
 
     private func tryToDetermineLastRunVersion() -> String? {

--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -54,7 +54,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         setupSecrets()
         addAnalyticsObservers()
         setupAnalytics()
-        appLifecycleAnalytics.checkApplicationInstalledOrUpgraded()
+
+        if let appInstallState = appLifecycleAnalytics.checkApplicationInstalledOrUpgraded(),
+           appInstallState == .installed {
+            //Never show the podcast feed reload tooltip for fresh install
+            Settings.shouldShowPodcastFeeReloadTip = false
+        }
 
         let defaults = UserDefaults.standard
 


### PR DESCRIPTION
| 📘 Part of: #2703 
|:---:|

Use the `AppInstallState` to determine if we should skip presenting the tooltip for new install.

## To test

- Build and run `trunk` as fresh install 
- Login and go to a podcast detail, play something
- Build and run on top this branch
- Navigate to a podcast detail
- Confirm you see the tooltip
- Stop and delete the app
- Build and run this branch
- Go to a podcast detail
- Confirm the tooltip doesn't show

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
