### PR TITLE
Fix download analytics

### DIFF
--- a/podcasts/Analytics/Helpers/AnalyticsEpisodeHelper.swift
+++ b/podcasts/Analytics/Helpers/AnalyticsEpisodeHelper.swift
@@ -14,6 +14,10 @@ class AnalyticsEpisodeHelper: AnalyticsCoordinator {
         addNotificationObservers()
     }
 
+    func setup() {
+        // Empty method just to ensure that sigleton is initialized
+    }
+
     // MARK: - Star
 
     func star(episode: BaseEpisode) {

--- a/podcasts/DownloadManager.swift
+++ b/podcasts/DownloadManager.swift
@@ -7,7 +7,12 @@ import AVKit
     import WatchKit
 #endif
 class DownloadManager: NSObject, FilePathProtocol {
-    static let shared = DownloadManager(dataManager: DataManager.sharedManager)
+
+    static let shared: DownloadManager = {
+        let manager = DownloadManager(dataManager: DataManager.sharedManager)
+        AnalyticsEpisodeHelper.shared.setup()
+        return manager
+    }()
 
     static let cellBackgroundSessionId = "au.com.shiftyjelly.PCManualSession"
 

--- a/podcasts/ServerSyncManager.swift
+++ b/podcasts/ServerSyncManager.swift
@@ -147,6 +147,7 @@ class ServerSyncManager: ServerSyncDelegate {
         if Settings.autoDownloadEnabled() {
             if Settings.autoDownloadMobileDataAllowed() || NetworkUtils.shared.isConnectedToWifi() {
                 for uuid in uuids {
+                    AnalyticsEpisodeHelper.shared.downloaded(episodeUUID: uuid)
                     DownloadManager.shared.addToQueue(episodeUuid: uuid)
                 }
             }


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

This PR ensure that auto-downloads are tracked by the analytics events.


## To test

- Start the app
- Ensure that you the tracking analytics FF enabled
- Go to to discover
- Open a podcast that you don't follow
- Tap on follow
- Check that you see logged an `episode_download_queued` event and the when the download is complete a `episode_download_finished` event


## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
