### PR TITLE
[Tooling] Fix `finalize_release` and the `release/*` branch checkout

### DIFF
--- a/.buildkite/commands/checkout-release-branch.sh
+++ b/.buildkite/commands/checkout-release-branch.sh
@@ -1,0 +1,15 @@
+#!/bin/bash -eu
+
+# Script to checkout a specific release branch
+# Usage: ./checkout-release-branch.sh <RELEASE_VERSION>
+
+RELEASE_VERSION="${1:?RELEASE_VERSION parameter missing}"
+BRANCH_NAME="release/${RELEASE_VERSION}"
+
+# Buildkite, by default, checks out a specific commit. But given this step will be run on a CI build that will
+# first push a commit to do the version bump, before `pipeline upload`-ing the job calling this script, we need
+# to checkout the `release/` branch explicitly here, to ensure this job would include that extra commit
+# instead of running on the initial commit the whole CI build/pipeline was initially triggered on.
+git fetch origin "$BRANCH_NAME"
+git checkout "$BRANCH_NAME"
+git pull

--- a/.buildkite/commands/checkout-release-branch.sh
+++ b/.buildkite/commands/checkout-release-branch.sh
@@ -3,13 +3,17 @@
 # Script to checkout a specific release branch
 # Usage: ./checkout-release-branch.sh <RELEASE_VERSION>
 
+# Buildkite, by default, checks out a specific commit, ending up in a detached HEAD state.
+# But in some cases, we need to ensure to be checked out on the `release/*` branch instead, namely:
+# - When a `release-pipelines/*.yml` will end up needing to do a `git push` to the `release/*` branch (for version bumps)
+# - When doing a new `release-build.sh` from a job that was `pipeline upload`'d by such a pipeline,
+#   to ensure that the job doing the build would include that recent extra commit before starting doing the build.
+
+echo "--- :git: Checkout Release Branch"
+
 RELEASE_VERSION="${1:?RELEASE_VERSION parameter missing}"
 BRANCH_NAME="release/${RELEASE_VERSION}"
 
-# Buildkite, by default, checks out a specific commit. But given this step will be run on a CI build that will
-# first push a commit to do the version bump, before `pipeline upload`-ing the job calling this script, we need
-# to checkout the `release/` branch explicitly here, to ensure this job would include that extra commit
-# instead of running on the initial commit the whole CI build/pipeline was initially triggered on.
 git fetch origin "$BRANCH_NAME"
 git checkout "$BRANCH_NAME"
 git pull

--- a/.buildkite/commands/release-build.sh
+++ b/.buildkite/commands/release-build.sh
@@ -1,5 +1,8 @@
 #!/bin/bash -eu
 
+RELEASE_VERSION="${1:?RELEASE_VERSION parameter missing}"
+"$(dirname "${BASH_SOURCE[0]}")/checkout-release-branch.sh" "$RELEASE_VERSION"
+
 "$(dirname "${BASH_SOURCE[0]}")/shared_setup.sh"
 
 echo "--- :closed_lock_with_key: Installing Secrets"

--- a/.buildkite/commands/release-build.sh
+++ b/.buildkite/commands/release-build.sh
@@ -1,16 +1,5 @@
 #!/bin/bash -eu
 
-echo "--- :git: Checkout Release Branch"
-# Buildkite, by default, checks out a specific commit. But given this step will be run on a CI build that will
-# first push a commit to do the version bump, before `pipeline upload`-ing the job calling this script, we need
-# to checkout the `release/` branch explicitly here, to ensure this job would include that extra commit
-# instead of running on the initial commit the whole CI build/pipeline was initially triggered on.
-RELEASE_VERSION="${1:?RELEASE_VERSION parameter missing}"
-BRANCH_NAME="release/${RELEASE_VERSION}"
-git fetch origin "$BRANCH_NAME"
-git checkout "$BRANCH_NAME"
-git pull
-
 "$(dirname "${BASH_SOURCE[0]}")/shared_setup.sh"
 
 echo "--- :closed_lock_with_key: Installing Secrets"

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -14,7 +14,7 @@ steps:
 
   - label: "🛠 Release Build (App Store Connect)"
     key: testflight_build
-    command: .buildkite/commands/release-build.sh "${RELEASE_VERSION}"
+    command: .buildkite/commands/release-build.sh
     priority: 1
     plugins: [$CI_TOOLKIT]
     artifact_paths:

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -14,7 +14,7 @@ steps:
 
   - label: "🛠 Release Build (App Store Connect)"
     key: testflight_build
-    command: .buildkite/commands/release-build.sh
+    command: .buildkite/commands/release-build.sh "${RELEASE_VERSION}"
     priority: 1
     plugins: [$CI_TOOLKIT]
     artifact_paths:

--- a/.buildkite/release-pipelines/finalize-hotfix-release.yml
+++ b/.buildkite/release-pipelines/finalize-hotfix-release.yml
@@ -18,6 +18,9 @@ steps:
       echo '--- 🔐 Access Secrets'
       bundle exec fastlane run configure_apply
 
+      echo '--- :git: Checkout Release Branch'
+      .buildkite/commands/checkout-release-branch.sh "${RELEASE_VERSION}"
+
       echo '--- 🚀 Finalize Hotfix Release'
       bundle exec fastlane finalize_hotfix_release skip_confirm:true
     plugins: [$CI_TOOLKIT]

--- a/.buildkite/release-pipelines/finalize-hotfix-release.yml
+++ b/.buildkite/release-pipelines/finalize-hotfix-release.yml
@@ -18,7 +18,6 @@ steps:
       echo '--- 🔐 Access Secrets'
       bundle exec fastlane run configure_apply
 
-      echo '--- :git: Checkout Release Branch'
       .buildkite/commands/checkout-release-branch.sh "${RELEASE_VERSION}"
 
       echo '--- 🚀 Finalize Hotfix Release'

--- a/.buildkite/release-pipelines/finalize-hotfix-release.yml
+++ b/.buildkite/release-pipelines/finalize-hotfix-release.yml
@@ -12,13 +12,13 @@ steps:
       echo '--- 🤖 Use bot for Git operations'
       source use-bot-for-git
 
+      .buildkite/commands/checkout-release-branch.sh "${RELEASE_VERSION}"
+
       echo '--- :ruby: Setup Ruby Tools'
       install_gems
 
       echo '--- 🔐 Access Secrets'
       bundle exec fastlane run configure_apply
-
-      .buildkite/commands/checkout-release-branch.sh "${RELEASE_VERSION}"
 
       echo '--- 🚀 Finalize Hotfix Release'
       bundle exec fastlane finalize_hotfix_release skip_confirm:true

--- a/.buildkite/release-pipelines/finalize-release.yml
+++ b/.buildkite/release-pipelines/finalize-release.yml
@@ -12,13 +12,13 @@ steps:
       echo '--- 🤖 Use bot for Git operations'
       source use-bot-for-git
 
+      .buildkite/commands/checkout-release-branch.sh "${RELEASE_VERSION}"
+
       echo '--- :ruby: Setup Ruby Tools'
       install_gems
 
       echo '--- 🔐 Access Secrets'
       bundle exec fastlane run configure_apply
-
-      .buildkite/commands/checkout-release-branch.sh "${RELEASE_VERSION}"
 
       echo '--- 🚀 Finalize Release'
       bundle exec fastlane finalize_release skip_confirm:true

--- a/.buildkite/release-pipelines/finalize-release.yml
+++ b/.buildkite/release-pipelines/finalize-release.yml
@@ -18,7 +18,6 @@ steps:
       echo '--- 🔐 Access Secrets'
       bundle exec fastlane run configure_apply
 
-      echo '--- :git: Checkout Release Branch'
       .buildkite/commands/checkout-release-branch.sh "${RELEASE_VERSION}"
 
       echo '--- 🚀 Finalize Release'

--- a/.buildkite/release-pipelines/finalize-release.yml
+++ b/.buildkite/release-pipelines/finalize-release.yml
@@ -18,6 +18,9 @@ steps:
       echo '--- 🔐 Access Secrets'
       bundle exec fastlane run configure_apply
 
+      echo '--- :git: Checkout Release Branch'
+      .buildkite/commands/checkout-release-branch.sh "${RELEASE_VERSION}"
+
       echo '--- 🚀 Finalize Release'
       bundle exec fastlane finalize_release skip_confirm:true
     plugins: [$CI_TOOLKIT]

--- a/.buildkite/release-pipelines/new-beta-release.yml
+++ b/.buildkite/release-pipelines/new-beta-release.yml
@@ -18,7 +18,6 @@ steps:
       echo '--- 🔐 Access Secrets'
       bundle exec fastlane run configure_apply
 
-      echo '--- :git: Checkout Release Branch'
       .buildkite/commands/checkout-release-branch.sh "${RELEASE_VERSION}"
 
       echo '--- 🚀 New Beta Release'

--- a/.buildkite/release-pipelines/new-beta-release.yml
+++ b/.buildkite/release-pipelines/new-beta-release.yml
@@ -12,13 +12,13 @@ steps:
       echo '--- 🤖 Use bot for Git operations'
       source use-bot-for-git
 
+      .buildkite/commands/checkout-release-branch.sh "${RELEASE_VERSION}"
+
       echo '--- :ruby: Setup Ruby Tools'
       install_gems
 
       echo '--- 🔐 Access Secrets'
       bundle exec fastlane run configure_apply
-
-      .buildkite/commands/checkout-release-branch.sh "${RELEASE_VERSION}"
 
       echo '--- 🚀 New Beta Release'
       bundle exec fastlane new_beta_release skip_confirm:true

--- a/.buildkite/release-pipelines/new-beta-release.yml
+++ b/.buildkite/release-pipelines/new-beta-release.yml
@@ -18,6 +18,9 @@ steps:
       echo '--- 🔐 Access Secrets'
       bundle exec fastlane run configure_apply
 
+      echo '--- :git: Checkout Release Branch'
+      .buildkite/commands/checkout-release-branch.sh "${RELEASE_VERSION}"
+
       echo '--- 🚀 New Beta Release'
       bundle exec fastlane new_beta_release skip_confirm:true
     plugins: [$CI_TOOLKIT]

--- a/.buildkite/release-pipelines/new-hotfix-release.yml
+++ b/.buildkite/release-pipelines/new-hotfix-release.yml
@@ -20,7 +20,6 @@ steps:
       echo '--- 🔐 Access Secrets'
       bundle exec fastlane run configure_apply
 
-      echo '--- :git: Checkout Release Branch'
       .buildkite/commands/checkout-release-branch.sh "${RELEASE_VERSION}"
 
       echo '--- 🚀 New Hotfix Release'

--- a/.buildkite/release-pipelines/new-hotfix-release.yml
+++ b/.buildkite/release-pipelines/new-hotfix-release.yml
@@ -14,13 +14,13 @@ steps:
       echo '--- 🤖 Use bot for Git operations'
       source use-bot-for-git
 
+      .buildkite/commands/checkout-release-branch.sh "${RELEASE_VERSION}"
+
       echo '--- :ruby: Setup Ruby Tools'
       install_gems
 
       echo '--- 🔐 Access Secrets'
       bundle exec fastlane run configure_apply
-
-      .buildkite/commands/checkout-release-branch.sh "${RELEASE_VERSION}"
 
       echo '--- 🚀 New Hotfix Release'
       bundle exec fastlane new_hotfix_release version:"$RELEASE_VERSION" skip_confirm:true

--- a/.buildkite/release-pipelines/new-hotfix-release.yml
+++ b/.buildkite/release-pipelines/new-hotfix-release.yml
@@ -20,6 +20,9 @@ steps:
       echo '--- 🔐 Access Secrets'
       bundle exec fastlane run configure_apply
 
+      echo '--- :git: Checkout Release Branch'
+      .buildkite/commands/checkout-release-branch.sh "${RELEASE_VERSION}"
+
       echo '--- 🚀 New Hotfix Release'
       bundle exec fastlane new_hotfix_release version:"$RELEASE_VERSION" skip_confirm:true
     plugins: [$CI_TOOLKIT]


### PR DESCRIPTION
# Why?

During release process we need the lanes invoked from the `release-pipelines/*.yml` and that will require to do a `git push` to the release branch to actually `git fetch` + `git checkout` those release branches explicitly, otherwise the `git push` will fail (e.g. unknown `refspec`)

Example of a failure of such case: https://buildkite.com/automattic/pocket-casts-ios/builds/9594#019504fc-44dd-433a-a9fe-39cf81f67510

# How

 - We still need to checkout the `release/*` branch before the compilation in `release-build.sh`, because we want to ensure that we include the latest commit that was just pushed by the `new_beta_release` / `finalize_release` lanes from previous job, instead of building the commit that the CI build was initially created on
 - But we **also** need to checkout the `release/*` in `release-pipelines/*.yml` before calling any of the lanes that would do a version bump and push the commit, otherwise it won't try to do the commit on the branch but on the detached HEAD.

# Links

Internal ref: p1739547154659529/1739543498.075849-slack-CC7L49W13