### PR TITLE
Remove supporter badge UI code from Podcast detail

### DIFF
--- a/podcasts/PodcastHeadingTableCell.swift
+++ b/podcasts/PodcastHeadingTableCell.swift
@@ -72,31 +72,6 @@ class PodcastHeadingTableCell: ThemeableCell, SubscribeButtonDelegate, Expandabl
     @IBOutlet var settingsButtonTrailingConstraint: NSLayoutConstraint!
     @IBOutlet var contentViewBottomConstraint: NSLayoutConstraint!
 
-    @IBOutlet var supporterHeartView: ThemeableView! {
-        didSet {
-            supporterHeartView.style = .support02
-        }
-    }
-
-    @IBOutlet var supporterHeart: UIImageView!
-    @IBOutlet var supporterBadge: UIImageView!
-    @IBOutlet var supportDetailsView: ThemeableView! {
-        didSet {
-            supportDetailsView.style = .primaryUi06
-        }
-    }
-
-    @IBOutlet var supportMessageHeart: UIImageView!
-    @IBOutlet var supportMessage: ThemeableLabel!
-    @IBOutlet var supportDate: ThemeableLabel! {
-        didSet {
-            supportDate.style = .primaryText02
-        }
-    }
-
-    @IBOutlet var supporterDateImageView: UIImageView!
-    @IBOutlet var manageSupportBtn: ThemeableUIButton!
-
     @IBOutlet var roundedBorder: RoundedBorderView! {
         didSet {
             roundedBorder.cornerRadius = 8
@@ -133,13 +108,6 @@ class PodcastHeadingTableCell: ThemeableCell, SubscribeButtonDelegate, Expandabl
         }
     }
 
-    @IBOutlet var supporterView: UIView!
-    @IBOutlet var supporterLabel: ThemeableLabel! {
-        didSet {
-            supporterLabel.style = .contrast02
-        }
-    }
-
     @IBOutlet var expandButton: ExpandCollapseButton!
     private weak var delegate: PodcastActionsDelegate? {
         didSet {
@@ -155,7 +123,6 @@ class PodcastHeadingTableCell: ThemeableCell, SubscribeButtonDelegate, Expandabl
             expandButton.isEnabled = buttonsEnabled
             folderButton.isEnabled = buttonsEnabled
             settingsBtn.isEnabled = buttonsEnabled
-            manageSupportBtn.isEnabled = buttonsEnabled
             link.isUserInteractionEnabled = buttonsEnabled
         }
     }
@@ -212,47 +179,6 @@ class PodcastHeadingTableCell: ThemeableCell, SubscribeButtonDelegate, Expandabl
         }
         expandButton.tintColor = ThemeColor.contrast03()
         link.textColor = tintColor
-
-        if podcast.isPaid {
-            supporterView.isHidden = false
-            supporterBadge.tintColor = ThemeColor.contrast02()
-            supporterView.backgroundColor = ThemeColor.podcastUi05(podcastColor: podcastBgColor)
-            supporterHeart.tintColor = ThemeColor.primaryInteractive02()
-
-            supportMessage.text = SyncManager.isUserLoggedIn() ? L10n.subscriptionsThankYou : L10n.paidPodcastSupporterOnlyMsg
-            supporterLabel.text = L10n.supporter.localizedUppercase
-            if let subscription = SubscriptionHelper.subscriptionForPodcast(uuid: podcast.uuid) {
-                let expiryDate = Date(timeIntervalSince1970: subscription.expiryDate)
-                let expiryDateStr = DateFormatHelper.sharedHelper.longLocalizedFormat(expiryDate)
-                supporterDateImageView.image = UIImage(named: "support-date-calendar")
-                if subscription.autoRenewing {
-                    supportDate.text = L10n.nextPaymentFormat(expiryDateStr)
-                    supportMessage.style = .support02
-                    supportMessageHeart.tintColor = ThemeColor.support02()
-                } else {
-                    supportDate.text = podcast.displayableExpiryLanguage(expiryDate: expiryDate)
-                    supportMessage.style = .primaryText02
-                    supportMessageHeart.tintColor = ThemeColor.primaryText02()
-                }
-            } else {
-                supportMessage.style = .primaryText02
-
-                if SyncManager.isUserLoggedIn() {
-                    supportDate.text = L10n.paidPodcastGenericError
-                    manageSupportBtn.setTitle(L10n.paidPodcastManage, for: .normal)
-                } else {
-                    supportDate.text = L10n.paidPodcastSigninPromptTitle
-                    manageSupportBtn.setTitle(L10n.signIn, for: .normal)
-                    supporterBadge.image = UIImage(named: "podcast-supporter-warning")
-                    supporterBadge.tintColor = ThemeColor.contrast02()
-                    supporterLabel.text = L10n.paidPodcastSigninPromptMsg
-                    supporterDateImageView.image = UIImage(named: "podcast-supporter-signin")
-                }
-            }
-        }
-        supportDetailsView.isHidden = !podcast.isPaid
-        supporterHeartView.isHidden = !(podcast.isPaid && podcast.isSubscribed())
-        supporterView.isHidden = !podcast.isPaid
 
         let folderImage = SubscriptionHelper.hasActiveSubscription() ? (podcast.folderUuid?.isEmpty ?? true) ? "folder-empty" : "folder-check" : "folder-create"
         folderButton.setImage(UIImage(named: folderImage), for: .normal)

--- a/podcasts/PodcastHeadingTableCell.xib
+++ b/podcasts/PodcastHeadingTableCell.xib
@@ -5,7 +5,6 @@
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
-        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -24,29 +23,8 @@
                             <constraint firstAttribute="height" constant="137" id="C8a-LQ-u0M"/>
                         </constraints>
                     </view>
-                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6JF-62-6gD" userLabel="Supporter View">
-                        <rect key="frame" x="0.0" y="77" width="394" height="60"/>
-                        <subviews>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="podcast-supporter-small-heart" translatesAutoresizingMaskIntoConstraints="NO" id="6VZ-hI-qiW">
-                                <rect key="frame" x="203" y="24" width="14" height="12"/>
-                            </imageView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="SUPPORTER" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jNk-pP-LV2" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                                <rect key="frame" x="227" y="22" width="80.5" height="16"/>
-                                <fontDescription key="fontDescription" type="boldSystem" pointSize="13"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                        </subviews>
-                        <color key="backgroundColor" systemColor="systemIndigoColor"/>
-                        <constraints>
-                            <constraint firstItem="jNk-pP-LV2" firstAttribute="centerY" secondItem="6JF-62-6gD" secondAttribute="centerY" id="MYd-7l-FuI"/>
-                            <constraint firstItem="6VZ-hI-qiW" firstAttribute="centerY" secondItem="jNk-pP-LV2" secondAttribute="centerY" id="ZP8-ed-l9p"/>
-                            <constraint firstAttribute="height" constant="60" id="rbh-tA-XzA"/>
-                            <constraint firstItem="jNk-pP-LV2" firstAttribute="leading" secondItem="6VZ-hI-qiW" secondAttribute="trailing" constant="10" id="t7p-oH-Mqv"/>
-                        </constraints>
-                    </view>
                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" pointerInteraction="YES" translatesAutoresizingMaskIntoConstraints="NO" id="jf0-QS-TJi" userLabel="Expand Button" customClass="ExpandCollapseButton" customModule="podcasts" customModuleProvider="target">
-                        <rect key="frame" x="350" y="85" width="44" height="44"/>
+                        <rect key="frame" x="350" y="83" width="44" height="44"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="44" id="3g1-TS-taP"/>
                             <constraint firstAttribute="width" constant="44" id="6RT-H9-5Ys"/>
@@ -113,35 +91,13 @@
                                     <action selector="settingsTapped:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="PQt-Ua-rJS"/>
                                 </connections>
                             </button>
-                            <view hidden="YES" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="CKH-iN-xDU" customClass="ThemeableView" customModule="podcasts" customModuleProvider="target">
-                                <rect key="frame" x="328" y="150" width="34" height="34"/>
-                                <subviews>
-                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="supporter-heart-large" translatesAutoresizingMaskIntoConstraints="NO" id="oOy-3S-y2Z">
-                                        <rect key="frame" x="7.5" y="10" width="19" height="16"/>
-                                    </imageView>
-                                </subviews>
-                                <color key="backgroundColor" systemColor="systemPinkColor"/>
-                                <constraints>
-                                    <constraint firstItem="oOy-3S-y2Z" firstAttribute="centerY" secondItem="CKH-iN-xDU" secondAttribute="centerY" constant="1" id="50S-Qc-mE4"/>
-                                    <constraint firstItem="oOy-3S-y2Z" firstAttribute="centerX" secondItem="CKH-iN-xDU" secondAttribute="centerX" id="8US-Dv-n9T"/>
-                                    <constraint firstAttribute="width" constant="34" id="RGx-yg-bVQ"/>
-                                    <constraint firstAttribute="height" constant="34" id="k6g-sA-JnB"/>
-                                </constraints>
-                                <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
-                                        <integer key="value" value="17"/>
-                                    </userDefinedRuntimeAttribute>
-                                </userDefinedRuntimeAttributes>
-                            </view>
                         </subviews>
                         <constraints>
                             <constraint firstAttribute="trailing" secondItem="hc6-iH-U1U" secondAttribute="trailing" id="1zY-g2-hRH"/>
-                            <constraint firstAttribute="trailing" secondItem="CKH-iN-xDU" secondAttribute="trailing" id="AZ3-Hr-S4T"/>
                             <constraint firstItem="kT6-pE-SNX" firstAttribute="centerY" secondItem="0fo-iZ-Ty3" secondAttribute="centerY" id="GAl-YO-X0T"/>
                             <constraint firstItem="hc6-iH-U1U" firstAttribute="top" secondItem="5S4-8c-Ssa" secondAttribute="top" constant="151" id="H7b-2e-sxq"/>
                             <constraint firstItem="Dq8-Kf-98T" firstAttribute="top" secondItem="5S4-8c-Ssa" secondAttribute="top" constant="16" id="Nnr-XZ-PQp"/>
                             <constraint firstAttribute="height" priority="750" constant="203" id="Uzk-YX-q2W"/>
-                            <constraint firstItem="CKH-iN-xDU" firstAttribute="centerY" secondItem="0fo-iZ-Ty3" secondAttribute="centerY" id="XWN-43-ixJ"/>
                             <constraint firstItem="0fo-iZ-Ty3" firstAttribute="leading" secondItem="kT6-pE-SNX" secondAttribute="trailing" constant="4" id="hLg-zb-22f"/>
                             <constraint firstItem="Dq8-Kf-98T" firstAttribute="leading" secondItem="5S4-8c-Ssa" secondAttribute="leading" id="ixs-A1-fsw"/>
                             <constraint firstItem="0fo-iZ-Ty3" firstAttribute="centerY" secondItem="hc6-iH-U1U" secondAttribute="centerY" id="oBA-vP-6me"/>
@@ -158,25 +114,25 @@
                                 </constraints>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="750" text="Name Is really really really really looooong" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" minimumFontSize="18" translatesAutoresizingMaskIntoConstraints="NO" id="YUN-pu-IO8" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="14" width="362" height="3"/>
+                                <rect key="frame" x="0.0" y="14" width="362" height="74"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="31"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CEi-4K-8eu" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="17" width="362" height="0.0"/>
+                                <rect key="frame" x="0.0" y="88" width="362" height="17"/>
                                 <fontDescription key="fontDescription" type="system" weight="medium" pointSize="14"/>
                                 <color key="textColor" red="0.5607843137254902" green="0.59215686274509804" blue="0.63921568627450975" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="SGH-Lz-9LI" userLabel="Spacer">
-                                <rect key="frame" x="0.0" y="17" width="362" height="11"/>
+                                <rect key="frame" x="0.0" y="105" width="362" height="11"/>
                                 <constraints>
                                     <constraint firstAttribute="height" priority="750" constant="11" id="fcG-DT-YDl"/>
                                 </constraints>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" usesAttributedText="YES" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Vgd-qp-dvs" customClass="ExpandableLabel" customModule="podcasts" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="28" width="362" height="0.0"/>
+                                <rect key="frame" x="0.0" y="116" width="362" height="0.0"/>
                                 <attributedString key="attributedText">
                                     <fragment content="...">
                                         <attributes>
@@ -189,7 +145,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <wkWebView contentMode="scaleToFill" allowsLinkPreview="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QtY-1t-63o" customClass="RichExpandableLabel" customModule="podcasts" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="28" width="362" height="0.0"/>
+                                <rect key="frame" x="0.0" y="116" width="362" height="0.0"/>
                                 <wkWebViewConfiguration key="configuration" allowsAirPlayForMediaPlayback="NO" allowsPictureInPictureMediaPlayback="NO">
                                     <dataDetectorTypes key="dataDetectorTypes" link="YES"/>
                                     <audiovisualMediaTypes key="mediaTypesRequiringUserActionForPlayback" none="YES"/>
@@ -197,60 +153,10 @@
                                 </wkWebViewConfiguration>
                             </wkWebView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Nvw-qC-Dra" userLabel="Spacer">
-                                <rect key="frame" x="0.0" y="28" width="362" height="15"/>
+                                <rect key="frame" x="0.0" y="116" width="362" height="15"/>
                                 <constraints>
                                     <constraint firstAttribute="height" priority="750" constant="15" id="gZG-yc-I8w"/>
                                 </constraints>
-                            </view>
-                            <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Jvt-lK-ojm" userLabel="Support Details View" customClass="ThemeableView" customModule="podcasts" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="43" width="362" height="88"/>
-                                <subviews>
-                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="support-heart-outline" translatesAutoresizingMaskIntoConstraints="NO" id="8sQ-nU-7pj">
-                                        <rect key="frame" x="12" y="12" width="24" height="24"/>
-                                    </imageView>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Thanks for your support!" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aQz-47-RIr" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                                        <rect key="frame" x="44" y="15.5" width="159.5" height="17"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="support-date-calendar" translatesAutoresizingMaskIntoConstraints="NO" id="aIa-vQ-LCY">
-                                        <rect key="frame" x="12" y="48" width="24" height="24"/>
-                                    </imageView>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Thanks for your support!" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Nub-nR-EQ2" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                                        <rect key="frame" x="44" y="51.5" width="159.5" height="17"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1BJ-2S-GhB" customClass="ThemeableUIButton" customModule="podcasts" customModuleProvider="target">
-                                        <rect key="frame" x="298" y="45.5" width="52" height="29"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                        <state key="normal" title="Manage"/>
-                                        <connections>
-                                            <action selector="manageSupportTapped:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="XL1-Ms-07w"/>
-                                        </connections>
-                                    </button>
-                                </subviews>
-                                <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.059022887323943674" colorSpace="custom" customColorSpace="sRGB"/>
-                                <constraints>
-                                    <constraint firstItem="8sQ-nU-7pj" firstAttribute="leading" secondItem="Jvt-lK-ojm" secondAttribute="leading" constant="12" id="1pJ-20-BQ3"/>
-                                    <constraint firstAttribute="height" constant="88" id="IET-5c-qaJ"/>
-                                    <constraint firstItem="aQz-47-RIr" firstAttribute="leading" secondItem="8sQ-nU-7pj" secondAttribute="trailing" constant="8" id="MAg-7v-9DA"/>
-                                    <constraint firstItem="aIa-vQ-LCY" firstAttribute="top" secondItem="8sQ-nU-7pj" secondAttribute="bottom" constant="12" id="Ri7-3R-OGb"/>
-                                    <constraint firstItem="aIa-vQ-LCY" firstAttribute="centerX" secondItem="8sQ-nU-7pj" secondAttribute="centerX" id="Wvy-4h-L4P"/>
-                                    <constraint firstItem="1BJ-2S-GhB" firstAttribute="centerY" secondItem="Nub-nR-EQ2" secondAttribute="centerY" id="Ywb-Hv-QwX"/>
-                                    <constraint firstItem="aQz-47-RIr" firstAttribute="centerY" secondItem="8sQ-nU-7pj" secondAttribute="centerY" id="aja-PH-zxX"/>
-                                    <constraint firstItem="Nub-nR-EQ2" firstAttribute="leading" secondItem="aIa-vQ-LCY" secondAttribute="trailing" constant="8" id="bTf-SO-72K"/>
-                                    <constraint firstItem="8sQ-nU-7pj" firstAttribute="top" secondItem="Jvt-lK-ojm" secondAttribute="top" constant="12" id="bw9-wO-Rhu"/>
-                                    <constraint firstAttribute="trailing" secondItem="1BJ-2S-GhB" secondAttribute="trailing" constant="12" id="r3U-dg-aOj"/>
-                                    <constraint firstItem="Nub-nR-EQ2" firstAttribute="centerY" secondItem="aIa-vQ-LCY" secondAttribute="centerY" id="yvG-P8-nE3"/>
-                                </constraints>
-                                <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
-                                        <integer key="value" value="4"/>
-                                    </userDefinedRuntimeAttribute>
-                                </userDefinedRuntimeAttributes>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="enV-6h-bDJ" userLabel="Spacer">
                                 <rect key="frame" x="0.0" y="131" width="362" height="15"/>
@@ -407,26 +313,22 @@
                     <constraint firstAttribute="bottom" secondItem="TeM-KI-UI1" secondAttribute="bottom" constant="20" symbolic="YES" id="2yS-PS-SWG"/>
                     <constraint firstItem="xfv-Do-H5F" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="3zp-hz-mvr"/>
                     <constraint firstItem="wsF-Lm-vdp" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="6vs-0u-f4Y"/>
-                    <constraint firstAttribute="trailing" secondItem="6JF-62-6gD" secondAttribute="trailing" id="9Jv-G8-Era"/>
                     <constraint firstAttribute="trailing" secondItem="sd5-XC-dXM" secondAttribute="trailing" id="GUJ-1l-6Uk"/>
                     <constraint firstItem="sd5-XC-dXM" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="JXu-O9-nZI"/>
-                    <constraint firstItem="6JF-62-6gD" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="N6U-2i-62N"/>
                     <constraint firstAttribute="trailing" secondItem="TeM-KI-UI1" secondAttribute="trailing" constant="16" id="QYQ-TG-lc4"/>
                     <constraint firstItem="sd5-XC-dXM" firstAttribute="trailing" secondItem="jf0-QS-TJi" secondAttribute="trailing" id="RPG-6j-MEa"/>
                     <constraint firstAttribute="trailing" secondItem="5S4-8c-Ssa" secondAttribute="trailing" constant="16" id="UiH-wk-RIV"/>
                     <constraint firstItem="sd5-XC-dXM" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="VCV-mi-83g"/>
                     <constraint firstAttribute="trailing" secondItem="wsF-Lm-vdp" secondAttribute="trailing" id="aMd-TM-fXj"/>
-                    <constraint firstItem="jf0-QS-TJi" firstAttribute="centerY" secondItem="6JF-62-6gD" secondAttribute="centerY" id="b59-OP-gRA"/>
+                    <constraint firstItem="jf0-QS-TJi" firstAttribute="bottom" secondItem="sd5-XC-dXM" secondAttribute="bottom" constant="-10" id="b59-OP-gRA"/>
                     <constraint firstAttribute="bottom" secondItem="xfv-Do-H5F" secondAttribute="bottom" constant="6" id="bBU-Qa-Zaa"/>
                     <constraint firstItem="5S4-8c-Ssa" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="bhl-hO-mdd"/>
                     <constraint firstAttribute="trailingMargin" secondItem="xfv-Do-H5F" secondAttribute="trailing" id="dQp-hQ-LdM"/>
-                    <constraint firstItem="6JF-62-6gD" firstAttribute="bottom" secondItem="sd5-XC-dXM" secondAttribute="bottom" id="jpI-F1-Zhq"/>
                     <constraint firstItem="CHK-bP-kvy" firstAttribute="bottom" secondItem="Ypx-au-SZl" secondAttribute="bottom" constant="-1" id="kd8-Nr-Cur"/>
                     <constraint firstItem="TeM-KI-UI1" firstAttribute="top" secondItem="5S4-8c-Ssa" secondAttribute="bottom" id="nel-K1-cL3"/>
                     <constraint firstItem="5S4-8c-Ssa" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="oFY-jW-FUY"/>
                     <constraint firstItem="TeM-KI-UI1" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="r2k-Zf-dVb"/>
                     <constraint firstItem="CHK-bP-kvy" firstAttribute="trailing" secondItem="Ypx-au-SZl" secondAttribute="trailing" id="rlH-hA-3Up"/>
-                    <constraint firstItem="6VZ-hI-qiW" firstAttribute="leading" secondItem="Dq8-Kf-98T" secondAttribute="trailing" constant="16" id="rqk-5P-vgp"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
@@ -444,7 +346,6 @@
                 <outlet property="gradientHeightConstraint" destination="C8a-LQ-u0M" id="FYe-Sv-k12"/>
                 <outlet property="link" destination="pz6-3s-0F6" id="nZF-md-hcn"/>
                 <outlet property="linkView" destination="GlK-4F-IbG" id="jrX-ez-ex2"/>
-                <outlet property="manageSupportBtn" destination="1BJ-2S-GhB" id="4bD-Dt-oSt"/>
                 <outlet property="nextEpisode" destination="teN-zx-hwX" id="OYx-WW-ae2"/>
                 <outlet property="nextEpisodeView" destination="KZf-dt-k6x" id="svh-Bg-UaA"/>
                 <outlet property="podcastCategory" destination="CEi-4K-8eu" id="bZn-6s-TVs"/>
@@ -462,16 +363,6 @@
                 <outlet property="subscribeButton" destination="hc6-iH-U1U" id="bJt-sZ-xBR"/>
                 <outlet property="subscribeButtonTopConstraint" destination="H7b-2e-sxq" id="o5b-Kd-DRI"/>
                 <outlet property="subscribeButtonWidthConstraint" destination="by6-HH-pka" id="rk9-HY-iGQ"/>
-                <outlet property="supportDate" destination="Nub-nR-EQ2" id="d5a-9d-EfE"/>
-                <outlet property="supportDetailsView" destination="Jvt-lK-ojm" id="kBa-kN-MNa"/>
-                <outlet property="supportMessage" destination="aQz-47-RIr" id="aGQ-OG-7sW"/>
-                <outlet property="supportMessageHeart" destination="8sQ-nU-7pj" id="4A5-UG-hIe"/>
-                <outlet property="supporterBadge" destination="6VZ-hI-qiW" id="REr-i4-wwC"/>
-                <outlet property="supporterDateImageView" destination="aIa-vQ-LCY" id="bhb-AE-TjU"/>
-                <outlet property="supporterHeart" destination="oOy-3S-y2Z" id="1sd-To-Z6D"/>
-                <outlet property="supporterHeartView" destination="CKH-iN-xDU" id="kPJ-rO-CSU"/>
-                <outlet property="supporterLabel" destination="jNk-pP-LV2" id="nCs-XW-gAu"/>
-                <outlet property="supporterView" destination="6JF-62-6gD" id="8Wa-QP-6vn"/>
                 <outlet property="topAuthorSpacer" destination="Lfz-rK-i49" id="FEA-pB-EmT"/>
                 <outlet property="topBackgroundView" destination="sd5-XC-dXM" id="T3n-UE-Bjg"/>
                 <outlet property="topPodcastNameSpacer" destination="TCC-7i-Fyr" id="sZy-Dl-ftq"/>
@@ -489,15 +380,5 @@
         <image name="podcast-nextepisode" width="24" height="24"/>
         <image name="podcast-schedule" width="24" height="24"/>
         <image name="podcast-settings" width="24" height="24"/>
-        <image name="podcast-supporter-small-heart" width="14" height="12"/>
-        <image name="support-date-calendar" width="24" height="24"/>
-        <image name="support-heart-outline" width="24" height="24"/>
-        <image name="supporter-heart-large" width="19" height="16"/>
-        <systemColor name="systemIndigoColor">
-            <color red="0.34509803919999998" green="0.33725490200000002" blue="0.83921568629999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </systemColor>
-        <systemColor name="systemPinkColor">
-            <color red="1" green="0.1764705882" blue="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </systemColor>
     </resources>
 </document>

--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -216,7 +216,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
         self.podcast = podcast
 
         // show the expanded view for unsubscribed podcasts, as well as paid podcasts that have expired and you no longer have access to play/download
-        summaryExpanded = !podcast.isSubscribed() || (podcast.isPaid && podcast.licensing == PodcastLicensing.deleteEpisodesAfterExpiry.rawValue && (SubscriptionHelper.subscriptionForPodcast(uuid: podcast.uuid)?.isExpired() ?? false))
+        summaryExpanded = !podcast.isSubscribed()
 
         AnalyticsHelper.podcastOpened(uuid: podcast.uuid)
         podcastRatingViewModel.update(podcast: podcast)


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

This PR removes code from the podcast detail view related to supporter badge a feature no longer supported

## To test

1. Start the app
2. Open a podcast detail view
3. Check if header shows correctly
4. Expand header
5. Check if shows correctly

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
