### PR TITLE
[Tooling] Fix `publish-release.yml` and `release-upload.sh` not checking out the release branch first

### DIFF
--- a/.buildkite/commands/checkout-release-branch.sh
+++ b/.buildkite/commands/checkout-release-branch.sh
@@ -11,7 +11,14 @@
 
 echo "--- :git: Checkout Release Branch"
 
-RELEASE_VERSION="${1:?RELEASE_VERSION parameter missing}"
+if [[ -n "${1:-}" ]]; then
+  RELEASE_VERSION="$1"
+elif [[ "${BUILDKITE_BRANCH:-}" =~ ^release/ ]]; then
+  RELEASE_VERSION="${BUILDKITE_BRANCH#release/}"
+else
+  echo "Error: RELEASE_VERSION parameter missing and BUILDKITE_BRANCH is not a release branch"
+  exit 1
+fi
 BRANCH_NAME="release/${RELEASE_VERSION}"
 
 git fetch origin "$BRANCH_NAME"

--- a/.buildkite/commands/release-build.sh
+++ b/.buildkite/commands/release-build.sh
@@ -1,5 +1,6 @@
 #!/bin/bash -eu
 
+# Ensure we get the latest commit of the `release/*` branch, especially to get last version bump commit before building the release
 RELEASE_VERSION="${1:?RELEASE_VERSION parameter missing}"
 "$(dirname "${BASH_SOURCE[0]}")/checkout-release-branch.sh" "$RELEASE_VERSION"
 

--- a/.buildkite/commands/release-upload.sh
+++ b/.buildkite/commands/release-upload.sh
@@ -1,5 +1,9 @@
 #!/bin/bash -eu
 
+# Ensure we get the latest commit of the `release/*` branch, especially to get last version bump commit before publishing the GitHub Release and creating the git tag
+RELEASE_VERSION="${1:?RELEASE_VERSION parameter missing}"
+"$(dirname "${BASH_SOURCE[0]}")/checkout-release-branch.sh" "$RELEASE_VERSION"
+
 BETA_RELEASE=${1:-true} # use first call param, default to true for safety
 
 echo "Running $0 with BETA_RELEASE = $BETA_RELEASE..."

--- a/.buildkite/release-pipelines/new-hotfix-release.yml
+++ b/.buildkite/release-pipelines/new-hotfix-release.yml
@@ -3,8 +3,6 @@
 
 # This pipeline is meant to be triggered by the MC scenario in ReleasesV2
 
-# Expected variables passed to the pipeline by ReleasesV2: `RELEASE_VERSION`
-
 env:
   IMAGE_ID: $IMAGE_ID
 
@@ -13,8 +11,6 @@ steps:
     command: |
       echo '--- 🤖 Use bot for Git operations'
       source use-bot-for-git
-
-      .buildkite/commands/checkout-release-branch.sh "${RELEASE_VERSION}"
 
       echo '--- :ruby: Setup Ruby Tools'
       install_gems

--- a/.buildkite/release-pipelines/publish-release.yml
+++ b/.buildkite/release-pipelines/publish-release.yml
@@ -12,6 +12,8 @@ steps:
       echo '--- 🤖 Use bot for Git operations'
       source use-bot-for-git
 
+      .buildkite/commands/checkout-release-branch.sh "${RELEASE_VERSION}"
+
       echo '--- :ruby: Setup Ruby Tools'
       install_gems
 


### PR DESCRIPTION
## What

### Fix `new-hotfix-release.yml` pipeline

That pipeline is triggered from the default branch, as its goal is to _create_ the `release/x.y.z` branch. So this pipeline should not attempt to call `checkout-release-branch.sh`

### Make `publish-release.yml` as well as `release-upload.sh` check out the release branch

See p1739836633853429/1739805357.834669-slack-C029BMLUGRX [internal ref]

Failing to checkout the release branch first made the `release-upload.sh` script (calling `create_release_on_github` lane) on the detached `HEAD` commit that is prior to the version bump made by `new_beta_release` or `finalize_release`, since that command is called from the `release-builds.yml` pipeline which is itself `pipeline upload`'ed by `release-pipelines/{new-beta,finalize}-release.yml` after said pipeline created the version bump first.

As a consequence:
 - It created the GitHub Release with the wrong name, based on the version before the version bump
 - It created the git tag on the wrong commit

### Other

This commit also makes `checkout-release-branch.sh` fallback to derive the `RELEASE_VERSION` from the `BUILDKITE_BRANCH` if `RELEASE_VERSION` is not passed explicitly and the current branch name starts with `release/`.

This is so that those changes in this PR can still work once merged in the current `release/7.83` branch even as the `7.83` ReleasesV2 scenario does not pass the `RELEASE_VERSION => '%version%` value explicitly during the corresponding `Task::buildkite` yet.

I still followed-up with a PR to update the scenario templates in ReleasesV2 (Internal ref: 174131-ghe-Automattic/wpcom), but at least this trick should allow the `publish-release.yml` pipeline to still work as expected even in the current release for which a scenario is already in progress.

> [!NOTE]
> See also [PCAndroid counterpart PR](https://github.com/Automattic/pocket-casts-android/pull/3622)