### PR TITLE
[Tooling] Fix `release-upload.sh` parameters

### DIFF
--- a/.buildkite/commands/release-upload.sh
+++ b/.buildkite/commands/release-upload.sh
@@ -4,7 +4,7 @@
 RELEASE_VERSION="${1:?RELEASE_VERSION parameter missing}"
 "$(dirname "${BASH_SOURCE[0]}")/checkout-release-branch.sh" "$RELEASE_VERSION"
 
-BETA_RELEASE=${1:-true} # use first call param, default to true for safety
+BETA_RELEASE=${2:-true} # use second call param, default to true for safety
 
 echo "Running $0 with BETA_RELEASE = $BETA_RELEASE..."
 

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -25,7 +25,7 @@ steps:
 
   - label: ":testflight: Release Upload (TestFlight, Sentry, GitHub)"
     depends_on: testflight_build
-    command: .buildkite/commands/release-upload.sh "${BETA_RELEASE}"
+    command: .buildkite/commands/release-upload.sh "${RELEASE_VERSION}" "${BETA_RELEASE}"
     priority: 1
     plugins: [$CI_TOOLKIT]
     notify:


### PR DESCRIPTION
## What/Why

This fixes a tooling issue (hasty copy/paste) in `release-upload.sh` that was introduced in recent fix attempt #2761 

Indeed when we call that script from `release-builds.yml` pipeline, the first parameter we were passing was not the `${RELEASE_VERSION}` like the script expected, but instead the `${BETA_RELEASE}` boolean value. This led to the script trying to `git checkout release/true` and failing 🤦 

This fixes the call site to now pass _both_ `${RELEASE_VERSION}` and `${BETA_RELEASE}` parameters to the call site, and update the `release-upload.sh` script to properly fetch `$1` and `$2` instead of fetching `$1` for both (copy/paste issue from #2761)

Context: p1740048486774259/1739805357.834669-slack-C029BMLUGRX

## To test

This fix will be tested by @SergioEstevao by doing a new beta (i.e. retrying the failed step of the Intermediate Beta 1 in ReleasesV2 tool) after this PR lands in `release/7/83`.