### PR TITLE
Do proper return on analytics opt out when not an APPCLIP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 7.83
 -----
 
+7.82.1
+-----
+- Fix analytcs bug [#2769](https://github.com/Automattic/pocket-casts-ios/pull/2769)
+
 
 7.82
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 7.82.1
 -----
-- Fix analytcs bug [#2769](https://github.com/Automattic/pocket-casts-ios/pull/2769)
+- Fix analytics bug [#2769](https://github.com/Automattic/pocket-casts-ios/pull/2769)
 
 
 7.82

--- a/podcasts/AnalyticsHelper.swift
+++ b/podcasts/AnalyticsHelper.swift
@@ -11,9 +11,9 @@ class AnalyticsHelper {
     static var optedOut: Bool {
         #if APPCLIP
         return true
-        #else {
+        #else
         return Settings.analyticsOptOut()
-        }
+        #endif
     }
 
     class func openedCategory(categoryId: Int, region: String) {

--- a/podcasts/AnalyticsHelper.swift
+++ b/podcasts/AnalyticsHelper.swift
@@ -9,10 +9,11 @@ import PocketCastsUtils
 class AnalyticsHelper {
     /// Whether the user has opted out of analytics or not
     static var optedOut: Bool {
-        #if !APPCLIP
-        Settings.analyticsOptOut()
-        #endif
+        #if APPCLIP
         return true
+        #else {
+        return Settings.analyticsOptOut()
+        }
     }
 
     class func openedCategory(categoryId: Int, region: String) {


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
Do proper return on analytics opt out when not an APPCLIP

## To test

1. Add a breakpoint on the code changed
2. Run the regular 
3. Check if returned valued is the one stored in settings

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
