### PR TITLE
App Clip & Sharing: update for new URLs

### DIFF
--- a/Pocket Casts App Clip/Pocket_Casts_App_Clip.entitlements
+++ b/Pocket Casts App Clip/Pocket_Casts_App_Clip.entitlements
@@ -7,6 +7,8 @@
 		<string>appclips:pca.st</string>
 		<string>appclips:pcast.pocketcasts.net</string>
 		<string>appclips:pocketcasts.com</string>
+		<string>appclips:play.pocketcasts.com</string>
+		<string>appclips:play.pocketcasts.net</string>
 	</array>
 	<key>com.apple.developer.parent-application-identifiers</key>
 	<array>

--- a/podcasts/podcasts.entitlements
+++ b/podcasts/podcasts.entitlements
@@ -22,6 +22,8 @@
 		<string>appclips:pca.st</string>
 		<string>appclips:pcast.pocketcasts.net</string>
 		<string>appclips:pocketcasts.com</string>
+		<string>applinks:play.pocketcasts.net</string>
+		<string>applinks:play.pocketcasts.com</string>
 	</array>
 	<key>com.apple.developer.carplay-audio</key>
 	<true/>

--- a/podcasts/podcasts.prototype.entitlements
+++ b/podcasts/podcasts.prototype.entitlements
@@ -16,6 +16,8 @@
 		<string>appclips:pca.st</string>
 		<string>appclips:pcast.pocketcasts.net</string>
 		<string>appclips:pocketcasts.com</string>
+		<string>applinks:play.pocketcasts.net</string>
+		<string>applinks:play.pocketcasts.com</string>
 	</array>
 	<key>com.apple.developer.networking.wifi-info</key>
 	<true/>

--- a/podcasts/podcastsDebug.entitlements
+++ b/podcasts/podcastsDebug.entitlements
@@ -20,6 +20,8 @@
 		<string>appclips:pca.st</string>
 		<string>appclips:pcast.pocketcasts.net</string>
 		<string>appclips:pocketcasts.com</string>
+		<string>applinks:play.pocketcasts.net</string>
+		<string>applinks:play.pocketcasts.com</string>
 	</array>
 	<key>com.apple.developer.carplay-audio</key>
 	<true/>


### PR DESCRIPTION
This PR fixes issues with new URLs for sharing.

While an issue for App Clips is not fully fixed yet I'm adding it here in case we need it.

## How to test



## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
