### PR TITLE
[Suggested Folders] Show suggested folders in grid view

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1924,6 +1924,7 @@
 		FF06AFA42CB6928B0099EC9B /* MediaExporterResourceLoaderDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF06AFA22CB6928B0099EC9B /* MediaExporterResourceLoaderDelegate.swift */; };
 		FF06AFA72CB692D30099EC9B /* MediaFileHandle.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF06AFA62CB692D30099EC9B /* MediaFileHandle.swift */; };
 		FF06AFA82CB692D30099EC9B /* MediaFileHandle.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF06AFA62CB692D30099EC9B /* MediaFileHandle.swift */; };
+		FF0753842D69088E00BE8B3B /* GridFoldersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0753832D69087F00BE8B3B /* GridFoldersView.swift */; };
 		FF09982E2CDA996D00C1647B /* MarqueeTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF09982D2CDA996D00C1647B /* MarqueeTextView.swift */; };
 		FF0998302CE79C8F00C1647B /* ManageDownloadsBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF09982F2CE79C7500C1647B /* ManageDownloadsBannerView.swift */; };
 		FF0998322CEC026D00C1647B /* ManageDownloadsModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0998312CEC026D00C1647B /* ManageDownloadsModalView.swift */; };
@@ -3947,6 +3948,7 @@
 		FF05C9912C0E044C00E41EB3 /* DBTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DBTestCase.swift; sourceTree = "<group>"; };
 		FF06AFA22CB6928B0099EC9B /* MediaExporterResourceLoaderDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaExporterResourceLoaderDelegate.swift; sourceTree = "<group>"; };
 		FF06AFA62CB692D30099EC9B /* MediaFileHandle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaFileHandle.swift; sourceTree = "<group>"; };
+		FF0753832D69087F00BE8B3B /* GridFoldersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GridFoldersView.swift; sourceTree = "<group>"; };
 		FF09982D2CDA996D00C1647B /* MarqueeTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarqueeTextView.swift; sourceTree = "<group>"; };
 		FF09982F2CE79C7500C1647B /* ManageDownloadsBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManageDownloadsBannerView.swift; sourceTree = "<group>"; };
 		FF0998312CEC026D00C1647B /* ManageDownloadsModalView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ManageDownloadsModalView.swift; sourceTree = "<group>"; };
@@ -6945,6 +6947,7 @@
 			children = (
 				BD998AC927B2408500B38857 /* CreateFolderView.swift */,
 				FF146C2B2D674A5400D2FCCE /* SuggestedFoldersView.swift */,
+				FF0753832D69087F00BE8B3B /* GridFoldersView.swift */,
 				BD998ACB27B2436000B38857 /* NameFolderView.swift */,
 				BD998AD227B3430700B38857 /* ColorPreviewFolderView.swift */,
 				BD26AFD627BE09E8008CC973 /* EditFolderView.swift */,
@@ -10561,6 +10564,7 @@
 				8B99197729A686BA00A5C81C /* SearchResultsView.swift in Sources */,
 				40E1B4CA2255856C006C96CE /* FiltersShortcutsViewController.swift in Sources */,
 				BDED9312251DD5EB000BF622 /* CarPlayImageHelper.swift in Sources */,
+				FF0753842D69088E00BE8B3B /* GridFoldersView.swift in Sources */,
 				BDB206AA2191734D00C1E456 /* NowPlayingHelper.swift in Sources */,
 				10DFE9372C5A8D1300957D0A /* ABTestProvider.swift in Sources */,
 				400AB301220BA8DC0003EE21 /* UploadedViewController+Table.swift in Sources */,

--- a/podcasts/FolderPreviewView.swift
+++ b/podcasts/FolderPreviewView.swift
@@ -67,6 +67,10 @@ class FolderPreviewView: UIView {
         setup(folderName: model.nameForFolder(), folderColor: Int32(model.colorInt), topPodcastUuids: model.selectedPodcastUuids)
     }
 
+    func populateFrom(suggestedFolder folder: SuggestedFolder) {
+        setup(folderName: folder.name, folderColor: folder.color, topPodcastUuids: folder.topPodcastUuids)
+    }
+
     private func setup(folderName: String, folderColor: Int32, topPodcastUuids: [String]) {
         configureGradient()
         updateNameLabel(name: folderName)

--- a/podcasts/FolderPreviewWrapper.swift
+++ b/podcasts/FolderPreviewWrapper.swift
@@ -35,3 +35,16 @@ struct SearchFolderPreviewWrapper: UIViewRepresentable {
         }
     }
 }
+
+struct SuggestedFolderPreviewWrapper: UIViewRepresentable {
+    var folder: SuggestedFolder
+
+    func makeUIView(context: Context) -> FolderPreviewView {
+        FolderPreviewView()
+    }
+
+    func updateUIView(_ folderView: FolderPreviewView, context: Context) {
+        folderView.showFolderName = true
+        folderView.populateFrom(suggestedFolder: folder)
+    }
+}

--- a/podcasts/GridFoldersView.swift
+++ b/podcasts/GridFoldersView.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+struct SuggestedFolder: Identifiable {
+    var id: String {
+        return name
+    }
+
+    let name: String
+    let color: Int32
+    let topPodcastUuids: [String]
+}
+
+struct GridFoldersView: View {
+
+    var folders: [SuggestedFolder]
+
+    var body: some View {
+        ScrollView {
+            LazyVGrid(columns: [GridItem(.adaptive(minimum: 110, maximum: 160))], alignment: .center, spacing: 6) {
+                ForEach(folders) { folder in
+                    SuggestedFolderPreviewWrapper(folder: folder)
+                        .cornerRadius(4)
+                        .frame(minWidth: 110, maxWidth: 160)
+                        .aspectRatio(1, contentMode: .fit)
+                }
+            }
+        }
+    }
+}

--- a/podcasts/SuggestedFoldersView.swift
+++ b/podcasts/SuggestedFoldersView.swift
@@ -1,15 +1,20 @@
 import PocketCastsDataModel
 import SwiftUI
 
-struct SuggestedFolder {
-    let name: String
-    let color: Int32
-    let topPodcastUuids: [String]
+class SuggestedFoldersModel: ObservableObject {
+
+    var folders: [SuggestedFolder] = {
+        let result: [SuggestedFolder] = (0..<10).map { index in
+            SuggestedFolder(name: "Folder-\(index)", color: Int32(index), topPodcastUuids: [])
+        }
+        return result
+    }()
 }
 
 struct SuggestedFoldersView: View {
     @EnvironmentObject var theme: Theme
     @State private var createFolderActive = false
+    @ObservedObject var model: SuggestedFoldersModel = SuggestedFoldersModel()
 
     var dismissAction: (String?) -> Void
 
@@ -38,7 +43,7 @@ struct SuggestedFoldersView: View {
             Spacer().frame(height: 8)
             Text(L10n.suggestedFoldersDescription)
                 .textStyle(SecondaryText())
-            foldersView            
+            foldersView
             Button {
                 Analytics.track(.suggestedFoldersModalUseTheseFoldersTapped, properties: [:])
                 dismissAction(nil)
@@ -71,16 +76,7 @@ struct SuggestedFoldersView: View {
     }
 
     var foldersView: some View {
-        ScrollView {
-            LazyVGrid(columns: [GridItem(.adaptive(minimum: 110, maximum: 150))], alignment: .center, spacing: 6) {
-                ForEach(0..<100) { index in
-                    SuggestedFolderPreviewWrapper(folder: SuggestedFolder(name: "Folder-\(index)", color: Int32(index), topPodcastUuids: []))
-                        .cornerRadius(4)
-                        .frame(minWidth: 110, maxWidth: 150)
-                        .aspectRatio(1, contentMode: .fit)
-                }
-            }
-        }
+        GridFoldersView(folders: model.folders)
     }
 }
 

--- a/podcasts/SuggestedFoldersView.swift
+++ b/podcasts/SuggestedFoldersView.swift
@@ -1,6 +1,12 @@
 import PocketCastsDataModel
 import SwiftUI
 
+struct SuggestedFolder {
+    let name: String
+    let color: Int32
+    let topPodcastUuids: [String]
+}
+
 struct SuggestedFoldersView: View {
     @EnvironmentObject var theme: Theme
     @State private var createFolderActive = false
@@ -32,9 +38,7 @@ struct SuggestedFoldersView: View {
             Spacer().frame(height: 8)
             Text(L10n.suggestedFoldersDescription)
                 .textStyle(SecondaryText())
-            Spacer()
-            folderView
-            Spacer()
+            foldersView            
             Button {
                 Analytics.track(.suggestedFoldersModalUseTheseFoldersTapped, properties: [:])
                 dismissAction(nil)
@@ -48,6 +52,7 @@ struct SuggestedFoldersView: View {
                 Text(L10n.suggestedFoldersCreateCustomFolders)
                     .textStyle(BorderButton())
             }
+            Spacer()
         }
         .padding(.horizontal, 20)
         .navigationTitle(L10n.suggestedFoldersTitle)
@@ -65,11 +70,14 @@ struct SuggestedFoldersView: View {
         .applyDefaultThemeOptions()
     }
 
-    var folderView: some View {
+    var foldersView: some View {
         ScrollView {
-            LazyVGrid(columns: [GridItem(.adaptive(minimum: 100, maximum: 101))], spacing: 16) {
-                ForEach(0..<5) { _ in
-                    Rectangle().foregroundColor(Color.red)
+            LazyVGrid(columns: [GridItem(.adaptive(minimum: 110, maximum: 150))], alignment: .center, spacing: 6) {
+                ForEach(0..<100) { index in
+                    SuggestedFolderPreviewWrapper(folder: SuggestedFolder(name: "Folder-\(index)", color: Int32(index), topPodcastUuids: []))
+                        .cornerRadius(4)
+                        .frame(minWidth: 110, maxWidth: 150)
+                        .aspectRatio(1, contentMode: .fit)
                 }
             }
         }

--- a/podcasts/SuggestedFoldersView.swift
+++ b/podcasts/SuggestedFoldersView.swift
@@ -3,9 +3,11 @@ import SwiftUI
 
 class SuggestedFoldersModel: ObservableObject {
 
+    private static let somePodcastsUUIDs = ["e7abe050-6cc7-0130-f8c5-723c91aeae46", "ba993300-d71c-0137-1e26-0acc26574db2", "4eb5b260-c933-0134-10da-25324e2a541d", "71a77ab0-c8bf-0136-7b94-27f978dac4db", "467b49a0-c657-0138-e72e-0acc26574db2"]
+
     var folders: [SuggestedFolder] = {
         let result: [SuggestedFolder] = (0..<10).map { index in
-            SuggestedFolder(name: "Folder-\(index)", color: Int32(index), topPodcastUuids: [])
+            SuggestedFolder(name: "Folder-\(index)", color: Int32(index), topPodcastUuids: somePodcastsUUIDs.shuffled())
         }
         return result
     }()

--- a/podcasts/SuggestedFoldersView.swift
+++ b/podcasts/SuggestedFoldersView.swift
@@ -6,7 +6,7 @@ class SuggestedFoldersModel: ObservableObject {
     private static let somePodcastsUUIDs = ["e7abe050-6cc7-0130-f8c5-723c91aeae46", "ba993300-d71c-0137-1e26-0acc26574db2", "4eb5b260-c933-0134-10da-25324e2a541d", "71a77ab0-c8bf-0136-7b94-27f978dac4db", "467b49a0-c657-0138-e72e-0acc26574db2"]
 
     var folders: [SuggestedFolder] = {
-        let result: [SuggestedFolder] = (0..<10).map { index in
+        let result: [SuggestedFolder] = (0..<20).map { index in
             SuggestedFolder(name: "Folder-\(index)", color: Int32(index), topPodcastUuids: somePodcastsUUIDs.shuffled())
         }
         return result

--- a/podcasts/SuggestedFoldersView.swift
+++ b/podcasts/SuggestedFoldersView.swift
@@ -33,6 +33,8 @@ struct SuggestedFoldersView: View {
             Text(L10n.suggestedFoldersDescription)
                 .textStyle(SecondaryText())
             Spacer()
+            folderView
+            Spacer()
             Button {
                 Analytics.track(.suggestedFoldersModalUseTheseFoldersTapped, properties: [:])
                 dismissAction(nil)
@@ -63,6 +65,15 @@ struct SuggestedFoldersView: View {
         .applyDefaultThemeOptions()
     }
 
+    var folderView: some View {
+        ScrollView {
+            LazyVGrid(columns: [GridItem(.adaptive(minimum: 100, maximum: 101))], spacing: 16) {
+                ForEach(0..<5) { _ in
+                    Rectangle().foregroundColor(Color.red)
+                }
+            }
+        }
+    }
 }
 
 struct SuggestedFoldersView_Previews: PreviewProvider {


### PR DESCRIPTION
| 📘 Part of: https://github.com/orgs/Automattic/projects/1278 |  <!-- project issue number, if applicable -->
|:---:|

Fixes #2775 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR implements the Suggest Folders Grid UI. At the moment it's using mock data to simulate folders until we have the endpoint ready

| 1 | 2 | 3 | 4 | 5 |
| - | - | - | - | - |
| ![Simulator Screenshot - iPhone 16 Pro Max - 2025-02-24 at 10 55 34](https://github.com/user-attachments/assets/dd735dc9-1331-41a8-b9ed-e26650ef80da) | ![Simulator Screenshot - iPhone 16 Pro Max - 2025-02-24 at 10 55 20](https://github.com/user-attachments/assets/f0a5eff8-6ab7-4988-9537-a6d79e3d5870) | ![Simulator Screenshot - iPhone 16 Pro Max - 2025-02-24 at 10 55 04](https://github.com/user-attachments/assets/c7915788-cde1-48e1-afbe-7c1c0540d4b0) | ![Simulator Screenshot - iPhone 16 Pro Max - 2025-02-24 at 10 54 52](https://github.com/user-attachments/assets/61e3e37e-1041-4770-a419-e7480a1c91bb) |  ![Simulator Screenshot - iPhone 16 Pro Max - 2025-02-24 at 10 54 36](https://github.com/user-attachments/assets/742d4f39-822f-401e-b6fa-c64635c32bd7) |

## To test

- Start the app and login with a Plus or Patron user
- Ensure that you have the Feature Flag enabled. Profile -> Settings -> Beta Features -> SuggestedFolders
- Ensure that you also have the `trackLogging` FF enabled
- Go to Podcasts tab
- Tap on the Create Folder icon on the top
- Check if the suggested folder screen shows and you see a grid view like the above with the folder
- Scroll around in the folder to see if all is correct.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
