### PR TITLE
[Suggested folders] Show suggested folder podcast list

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1926,6 +1926,8 @@
 		FF06AFA82CB692D30099EC9B /* MediaFileHandle.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF06AFA62CB692D30099EC9B /* MediaFileHandle.swift */; };
 		FF0753842D69088E00BE8B3B /* GridFoldersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0753832D69087F00BE8B3B /* GridFoldersView.swift */; };
 		FF0753862D6CB70A00BE8B3B /* NavigationContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0753852D6CB70200BE8B3B /* NavigationContainer.swift */; };
+		FF0753882D6CB79600BE8B3B /* SuggestedFolderPodcastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0753872D6CB78D00BE8B3B /* SuggestedFolderPodcastView.swift */; };
+		FF07538A2D6CB7CA00BE8B3B /* PodcastImageViewWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0753892D6CB7C300BE8B3B /* PodcastImageViewWrapper.swift */; };
 		FF09982E2CDA996D00C1647B /* MarqueeTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF09982D2CDA996D00C1647B /* MarqueeTextView.swift */; };
 		FF0998302CE79C8F00C1647B /* ManageDownloadsBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF09982F2CE79C7500C1647B /* ManageDownloadsBannerView.swift */; };
 		FF0998322CEC026D00C1647B /* ManageDownloadsModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0998312CEC026D00C1647B /* ManageDownloadsModalView.swift */; };
@@ -3951,6 +3953,8 @@
 		FF06AFA62CB692D30099EC9B /* MediaFileHandle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaFileHandle.swift; sourceTree = "<group>"; };
 		FF0753832D69087F00BE8B3B /* GridFoldersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GridFoldersView.swift; sourceTree = "<group>"; };
 		FF0753852D6CB70200BE8B3B /* NavigationContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationContainer.swift; sourceTree = "<group>"; };
+		FF0753872D6CB78D00BE8B3B /* SuggestedFolderPodcastView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestedFolderPodcastView.swift; sourceTree = "<group>"; };
+		FF0753892D6CB7C300BE8B3B /* PodcastImageViewWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PodcastImageViewWrapper.swift; sourceTree = "<group>"; };
 		FF09982D2CDA996D00C1647B /* MarqueeTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarqueeTextView.swift; sourceTree = "<group>"; };
 		FF09982F2CE79C7500C1647B /* ManageDownloadsBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManageDownloadsBannerView.swift; sourceTree = "<group>"; };
 		FF0998312CEC026D00C1647B /* ManageDownloadsModalView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ManageDownloadsModalView.swift; sourceTree = "<group>"; };
@@ -6949,7 +6953,9 @@
 			children = (
 				BD998AC927B2408500B38857 /* CreateFolderView.swift */,
 				FF146C2B2D674A5400D2FCCE /* SuggestedFoldersView.swift */,
+				FF0753872D6CB78D00BE8B3B /* SuggestedFolderPodcastView.swift */,
 				FF0753832D69087F00BE8B3B /* GridFoldersView.swift */,
+				FF0753892D6CB7C300BE8B3B /* PodcastImageViewWrapper.swift */,
 				BD998ACB27B2436000B38857 /* NameFolderView.swift */,
 				BD998AD227B3430700B38857 /* ColorPreviewFolderView.swift */,
 				BD26AFD627BE09E8008CC973 /* EditFolderView.swift */,
@@ -9838,6 +9844,7 @@
 				10C1D5502C737EEF009E1E98 /* PlusPaywallContainer.swift in Sources */,
 				BDC5F25027B3997300A85C93 /* FolderModel.swift in Sources */,
 				BDBD2AC7202D66B300E0A79E /* OptionsPickerRootController.swift in Sources */,
+				FF07538A2D6CB7CA00BE8B3B /* PodcastImageViewWrapper.swift in Sources */,
 				4004F56524EB51F900FBEBE1 /* SceneHelper.swift in Sources */,
 				F5BA5C9E2C81254300BDA5B9 /* DiscoverCollectionViewController+DiscoverDelegate.swift in Sources */,
 				40FFAD8D2149E1C200024FCF /* EpisodeFilterChipCell.swift in Sources */,
@@ -10627,6 +10634,7 @@
 				C7B3C6142919F47A00054145 /* HorizontalScrollView.swift in Sources */,
 				BDA0E2A322DDB5550029EBEB /* ThemeColor.swift in Sources */,
 				10C1D5522C738725009E1E98 /* PlusPaywallFeaturesCarousell.swift in Sources */,
+				FF0753882D6CB79600BE8B3B /* SuggestedFolderPodcastView.swift in Sources */,
 				F53C3E832CC73549004F3581 /* TopSpotStory2024.swift in Sources */,
 				8BCB22B428F48282001A0315 /* EndOfYear.swift in Sources */,
 				BDCC55141CD0A448006BE239 /* AEXML.swift in Sources */,

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1925,6 +1925,7 @@
 		FF06AFA72CB692D30099EC9B /* MediaFileHandle.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF06AFA62CB692D30099EC9B /* MediaFileHandle.swift */; };
 		FF06AFA82CB692D30099EC9B /* MediaFileHandle.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF06AFA62CB692D30099EC9B /* MediaFileHandle.swift */; };
 		FF0753842D69088E00BE8B3B /* GridFoldersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0753832D69087F00BE8B3B /* GridFoldersView.swift */; };
+		FF0753862D6CB70A00BE8B3B /* NavigationContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0753852D6CB70200BE8B3B /* NavigationContainer.swift */; };
 		FF09982E2CDA996D00C1647B /* MarqueeTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF09982D2CDA996D00C1647B /* MarqueeTextView.swift */; };
 		FF0998302CE79C8F00C1647B /* ManageDownloadsBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF09982F2CE79C7500C1647B /* ManageDownloadsBannerView.swift */; };
 		FF0998322CEC026D00C1647B /* ManageDownloadsModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0998312CEC026D00C1647B /* ManageDownloadsModalView.swift */; };
@@ -3949,6 +3950,7 @@
 		FF06AFA22CB6928B0099EC9B /* MediaExporterResourceLoaderDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaExporterResourceLoaderDelegate.swift; sourceTree = "<group>"; };
 		FF06AFA62CB692D30099EC9B /* MediaFileHandle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaFileHandle.swift; sourceTree = "<group>"; };
 		FF0753832D69087F00BE8B3B /* GridFoldersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GridFoldersView.swift; sourceTree = "<group>"; };
+		FF0753852D6CB70200BE8B3B /* NavigationContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationContainer.swift; sourceTree = "<group>"; };
 		FF09982D2CDA996D00C1647B /* MarqueeTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarqueeTextView.swift; sourceTree = "<group>"; };
 		FF09982F2CE79C7500C1647B /* ManageDownloadsBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManageDownloadsBannerView.swift; sourceTree = "<group>"; };
 		FF0998312CEC026D00C1647B /* ManageDownloadsModalView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ManageDownloadsModalView.swift; sourceTree = "<group>"; };
@@ -7330,6 +7332,7 @@
 		C74887782919DC7B00EBC926 /* SwiftUI */ = {
 			isa = PBXGroup;
 			children = (
+				FF0753852D6CB70200BE8B3B /* NavigationContainer.swift */,
 				F5E16FE62CD47DE800C0372F /* SFSafariView.swift */,
 				F54E0F532CC764C0006D4DA2 /* PositionModifier.swift */,
 				C7B3C60B2919DCC800054145 /* ActionView.swift */,
@@ -10649,6 +10652,7 @@
 				4635390E26F3C42C00BA9D35 /* MessageSupportViewModel.swift in Sources */,
 				BD1C46E227BA269300B1D8BB /* FolderPreviewView.swift in Sources */,
 				40FFCDB322FA848D00395CA5 /* ThemeableSelectionView.swift in Sources */,
+				FF0753862D6CB70A00BE8B3B /* NavigationContainer.swift in Sources */,
 				BD74F1B621F0133B002EF774 /* MPFeedbackCommand+Title.swift in Sources */,
 				C72CED2D289DA14F0017883A /* AnalyticsEvent.swift in Sources */,
 				BD874EF71C9A428B00F5B2A5 /* GeneralSettingsViewController.swift in Sources */,

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1928,6 +1928,7 @@
 		FF0753862D6CB70A00BE8B3B /* NavigationContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0753852D6CB70200BE8B3B /* NavigationContainer.swift */; };
 		FF0753882D6CB79600BE8B3B /* SuggestedFolderPodcastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0753872D6CB78D00BE8B3B /* SuggestedFolderPodcastView.swift */; };
 		FF07538A2D6CB7CA00BE8B3B /* PodcastImageViewWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0753892D6CB7C300BE8B3B /* PodcastImageViewWrapper.swift */; };
+		FF07538C2D6CC4FA00BE8B3B /* CustomHorizontalMargin.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF07538B2D6CC4F400BE8B3B /* CustomHorizontalMargin.swift */; };
 		FF09982E2CDA996D00C1647B /* MarqueeTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF09982D2CDA996D00C1647B /* MarqueeTextView.swift */; };
 		FF0998302CE79C8F00C1647B /* ManageDownloadsBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF09982F2CE79C7500C1647B /* ManageDownloadsBannerView.swift */; };
 		FF0998322CEC026D00C1647B /* ManageDownloadsModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0998312CEC026D00C1647B /* ManageDownloadsModalView.swift */; };
@@ -3955,6 +3956,7 @@
 		FF0753852D6CB70200BE8B3B /* NavigationContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationContainer.swift; sourceTree = "<group>"; };
 		FF0753872D6CB78D00BE8B3B /* SuggestedFolderPodcastView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestedFolderPodcastView.swift; sourceTree = "<group>"; };
 		FF0753892D6CB7C300BE8B3B /* PodcastImageViewWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PodcastImageViewWrapper.swift; sourceTree = "<group>"; };
+		FF07538B2D6CC4F400BE8B3B /* CustomHorizontalMargin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomHorizontalMargin.swift; sourceTree = "<group>"; };
 		FF09982D2CDA996D00C1647B /* MarqueeTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarqueeTextView.swift; sourceTree = "<group>"; };
 		FF09982F2CE79C7500C1647B /* ManageDownloadsBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManageDownloadsBannerView.swift; sourceTree = "<group>"; };
 		FF0998312CEC026D00C1647B /* ManageDownloadsModalView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ManageDownloadsModalView.swift; sourceTree = "<group>"; };
@@ -7338,6 +7340,7 @@
 		C74887782919DC7B00EBC926 /* SwiftUI */ = {
 			isa = PBXGroup;
 			children = (
+				FF07538B2D6CC4F400BE8B3B /* CustomHorizontalMargin.swift */,
 				FF0753852D6CB70200BE8B3B /* NavigationContainer.swift */,
 				F5E16FE62CD47DE800C0372F /* SFSafariView.swift */,
 				F54E0F532CC764C0006D4DA2 /* PositionModifier.swift */,
@@ -10383,6 +10386,7 @@
 				C713D4F72A04C90500A78468 /* ProfileHeaderView.swift in Sources */,
 				F54E0F542CC764C0006D4DA2 /* PositionModifier.swift in Sources */,
 				8B67A26729A7D80E0076886D /* SearchResultCell.swift in Sources */,
+				FF07538C2D6CC4FA00BE8B3B /* CustomHorizontalMargin.swift in Sources */,
 				8BDE43062AC33BEE00C2D5C9 /* RatePodcastView.swift in Sources */,
 				10DFE9362C5A8D1300957D0A /* ABTest.swift in Sources */,
 				BD03DF881CACD9AB005A127E /* DownloadedFilesViewController.swift in Sources */,

--- a/podcasts/GridFoldersView.swift
+++ b/podcasts/GridFoldersView.swift
@@ -18,10 +18,12 @@ struct GridFoldersView: View {
         ScrollView {
             LazyVGrid(columns: [GridItem(.adaptive(minimum: 110, maximum: 160))], alignment: .center, spacing: 6) {
                 ForEach(folders) { folder in
-                    SuggestedFolderPreviewWrapper(folder: folder)
-                        .cornerRadius(4)
-                        .frame(minWidth: 110, maxWidth: 160)
-                        .aspectRatio(1, contentMode: .fit)
+                    NavigationLink(destination: SuggestedFolderPodcastView(folder: folder)) {
+                        SuggestedFolderPreviewWrapper(folder: folder)
+                            .cornerRadius(4)
+                            .frame(minWidth: 110, maxWidth: 160)
+                            .aspectRatio(1, contentMode: .fit)
+                    }
                 }
             }
         }

--- a/podcasts/PodcastImageViewWrapper.swift
+++ b/podcasts/PodcastImageViewWrapper.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+struct PodcastImageViewWrapper: UIViewRepresentable {
+    let podcastUUID: String
+    let size: PodcastThumbnailSize
+
+    func makeUIView(context: Context) -> PodcastImageView {
+        PodcastImageView()
+    }
+
+    func updateUIView(_ podcastImageView: PodcastImageView, context: Context) {
+        podcastImageView.setPodcast(uuid: podcastUUID, size: size)
+    }
+}

--- a/podcasts/Styles.swift
+++ b/podcasts/Styles.swift
@@ -222,11 +222,11 @@ struct BorderButton: ViewModifier {
         .padding()
         .background(ThemeColor.primaryUi01(for: theme.activeTheme).color)
         .cornerRadius(ViewConstants.buttonCornerRadius)
-        .frame(height: 44)
         .overlay(
             RoundedRectangle(cornerRadius: ViewConstants.buttonCornerRadius)
                 .stroke(ThemeColor.primaryInteractive01(for: theme.activeTheme).color, lineWidth: ViewConstants.buttonStrokeWidth)
         )
+        .frame(height: 44)
     }
 }
 

--- a/podcasts/SuggestedFolderPodcastView.swift
+++ b/podcasts/SuggestedFolderPodcastView.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+struct SuggestedFolderPodcastView: View {
+    @EnvironmentObject var theme: Theme
+    
+    let folder: SuggestedFolder
+
+    var body: some View {
+        ScrollView {
+            LazyVGrid(columns: [GridItem(.adaptive(minimum: 110, maximum: 160))], alignment: .center, spacing: 6) {
+                ForEach(folder.topPodcastUuids, id: \.self) { uuid in
+                    PodcastImageViewWrapper(podcastUUID: uuid, size: .grid)
+                        .frame(minWidth: 110, maxWidth: 160)
+                        .aspectRatio(1, contentMode: .fit)
+                }
+            }
+            .navigationTitle(folder.name)
+        }        
+        .padding()
+        .applyDefaultThemeOptions()
+    }
+}

--- a/podcasts/SuggestedFolderPodcastView.swift
+++ b/podcasts/SuggestedFolderPodcastView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct SuggestedFolderPodcastView: View {
     @EnvironmentObject var theme: Theme
-    
+
     let folder: SuggestedFolder
 
     var body: some View {
@@ -17,12 +17,7 @@ struct SuggestedFolderPodcastView: View {
             .navigationTitle(folder.name)
         }
         // hack to allow the scroll indicator to be visible without overlapping the content
-        .safeAreaInset(edge: .trailing) {
-            EmptyView().frame(width: 20)
-        }
-        .safeAreaInset(edge: .leading) {
-            EmptyView().frame(width: 20)
-        }
+        .customHorizontalMargin(margin: 20)
         .applyDefaultThemeOptions()
     }
 }

--- a/podcasts/SuggestedFolderPodcastView.swift
+++ b/podcasts/SuggestedFolderPodcastView.swift
@@ -17,7 +17,7 @@ struct SuggestedFolderPodcastView: View {
             .navigationTitle(folder.name)
         }
         // hack to allow the scroll indicator to be visible without overlapping the content
-        .customHorizontalMargin(margin: 20)
+        .customHorizontalMargin(margin: SuggestedFoldersView.Constants.margin)
         .applyDefaultThemeOptions()
     }
 }

--- a/podcasts/SuggestedFolderPodcastView.swift
+++ b/podcasts/SuggestedFolderPodcastView.swift
@@ -15,8 +15,14 @@ struct SuggestedFolderPodcastView: View {
                 }
             }
             .navigationTitle(folder.name)
-        }        
-        .padding()
+        }
+        // hack to allow the scroll indicator to be visible without overlapping the content
+        .safeAreaInset(edge: .trailing) {
+            EmptyView().frame(width: 20)
+        }
+        .safeAreaInset(edge: .leading) {
+            EmptyView().frame(width: 20)
+        }
         .applyDefaultThemeOptions()
     }
 }

--- a/podcasts/SuggestedFoldersView.swift
+++ b/podcasts/SuggestedFoldersView.swift
@@ -46,6 +46,14 @@ struct SuggestedFoldersView: View {
             Text(L10n.suggestedFoldersDescription)
                 .textStyle(SecondaryText())
             foldersView
+                .padding(.horizontal, -20)
+                // hack to allow the scroll indicators to be visible without overlapping the content
+                .safeAreaInset(edge: .trailing) {
+                    EmptyView().frame(width: 20)
+                }
+                .safeAreaInset(edge: .leading) {
+                    EmptyView().frame(width: 20)
+                }
             Button {
                 Analytics.track(.suggestedFoldersModalUseTheseFoldersTapped, properties: [:])
                 dismissAction(nil)

--- a/podcasts/SuggestedFoldersView.swift
+++ b/podcasts/SuggestedFoldersView.swift
@@ -21,7 +21,7 @@ struct SuggestedFoldersView: View {
     var dismissAction: (String?) -> Void
 
     var body: some View {
-        NavigationView {
+        NavigationContainer {
             mainBody
                 .toolbar {
                     ToolbarItem(placement: .navigationBarLeading) {

--- a/podcasts/SuggestedFoldersView.swift
+++ b/podcasts/SuggestedFoldersView.swift
@@ -14,6 +14,11 @@ class SuggestedFoldersModel: ObservableObject {
 }
 
 struct SuggestedFoldersView: View {
+
+    enum Constants {
+        static var margin: CGFloat = 20
+    }
+
     @EnvironmentObject var theme: Theme
     @State private var createFolderActive = false
     @ObservedObject var model: SuggestedFoldersModel = SuggestedFoldersModel()
@@ -46,9 +51,9 @@ struct SuggestedFoldersView: View {
             Text(L10n.suggestedFoldersDescription)
                 .textStyle(SecondaryText())
             foldersView
-                .padding(.horizontal, -20)
+                .padding(.horizontal, -Constants.margin)
                 // hack to allow the scroll indicator to be visible without overlapping the content
-                .customHorizontalMargin(margin: 20)
+                .customHorizontalMargin(margin: Constants.margin)
             Button {
                 Analytics.track(.suggestedFoldersModalUseTheseFoldersTapped, properties: [:])
                 dismissAction(nil)
@@ -64,7 +69,7 @@ struct SuggestedFoldersView: View {
             }
             Spacer()
         }
-        .padding(.horizontal, 20)
+        .padding(.horizontal, Constants.margin)
         .navigationTitle(L10n.suggestedFoldersTitle)
         .onAppear {
             Analytics.track(.suggestedFoldersModalShow, properties: [:])

--- a/podcasts/SuggestedFoldersView.swift
+++ b/podcasts/SuggestedFoldersView.swift
@@ -47,13 +47,8 @@ struct SuggestedFoldersView: View {
                 .textStyle(SecondaryText())
             foldersView
                 .padding(.horizontal, -20)
-                // hack to allow the scroll indicators to be visible without overlapping the content
-                .safeAreaInset(edge: .trailing) {
-                    EmptyView().frame(width: 20)
-                }
-                .safeAreaInset(edge: .leading) {
-                    EmptyView().frame(width: 20)
-                }
+                // hack to allow the scroll indicator to be visible without overlapping the content
+                .customHorizontalMargin(margin: 20)
             Button {
                 Analytics.track(.suggestedFoldersModalUseTheseFoldersTapped, properties: [:])
                 dismissAction(nil)

--- a/podcasts/SwiftUI/CustomHorizontalMargin.swift
+++ b/podcasts/SwiftUI/CustomHorizontalMargin.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+struct CustomHorizontalMargin: ViewModifier {
+    let margin: CGFloat
+
+    func body(content: Content) -> some View {
+        if #available(iOS 17.0, *) {
+            content.contentMargins(.horizontal, margin, for: .scrollContent)
+        } else {
+            content
+                .safeAreaInset(edge: .trailing) {
+                    EmptyView().frame(width: margin)
+                }
+                .safeAreaInset(edge: .leading) {
+                    EmptyView().frame(width: margin)
+                }
+        }
+    }
+}
+
+extension View {
+    func customHorizontalMargin(margin: CGFloat)
+    -> some View {
+        modifier(CustomHorizontalMargin(margin: margin))
+  }
+}

--- a/podcasts/SwiftUI/NavigationContainer.swift
+++ b/podcasts/SwiftUI/NavigationContainer.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+struct NavigationContainer<Content: View>: View {
+    var content: () -> Content
+
+    init(@ViewBuilder content: @escaping () -> Content) {
+    self.content = content
+}
+
+    var body: some View {
+        if #available(iOS 16.0, *) {
+            NavigationStack {
+                content()
+            }
+        } else {
+            NavigationView {
+                content()
+            }
+        }
+    }
+}


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

This PR adds the new podcast list view for each folder. 
**The data being displayed is still mock data.**

It also fixes two bugs found on a previous review:
 - Scroll indicator overlapping content on the folder and podcast cells
 - Create Custom button was too small

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
| 1 | 2 |
| - | - |
| ![Simulator Screenshot - iPhone 16 Pro Max - 2025-02-24 at 15 16 30](https://github.com/user-attachments/assets/1e601d6f-829e-4abb-93e7-376013dedce7) |  ![Simulator Screenshot - iPhone 16 Pro Max - 2025-02-24 at 15 15 49](https://github.com/user-attachments/assets/816a42a7-b37b-49cb-ac5d-6dfb97d1990f) |

## To test

- Start the app and login with a Plus or Patron user
- Ensure that you have the Feature Flag enabled. Profile -> Settings -> Beta Features -> SuggestedFolders
- Go to Podcasts tab
- Tap on the Create Folder icon on the top
- Check if the suggested folder screen shows and you see a grid view like the above with the folder
- Scroll around in the folder to see if all is correct.
- Tap on one of the folders
- Check if the content is correct and the podcast images are shown.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
