### PR TITLE
[Suggested folders] Implement API call

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Private/API Tasks/SuggestedFolderTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Private/API Tasks/SuggestedFolderTask.swift
@@ -8,10 +8,12 @@ public struct SuggestedFoldersResponse {
 
 class SuggestedFoldersTask: ApiBaseTask, @unchecked Sendable {
     var uuids: [String]
+    var language: String
     var completion: ((SuggestedFoldersResponse?) -> Void)?
 
-    init(uuids: [String], completion: ((SuggestedFoldersResponse?) -> Void)?) {
+    init(uuids: [String], language: String, completion: ((SuggestedFoldersResponse?) -> Void)?) {
         self.uuids = uuids
+        self.language = language
         self.completion = completion
     }
 
@@ -19,7 +21,7 @@ class SuggestedFoldersTask: ApiBaseTask, @unchecked Sendable {
         let urlString = "\(ServerConstants.Urls.cache())podcast/suggest_folders"
 
         do {
-            guard let requestData = try? JSONSerialization.data(withJSONObject: ["language": "en", "uuids": uuids]) else {
+            guard let requestData = try? JSONSerialization.data(withJSONObject: ["language": language, "uuids": uuids]) else {
                 FileLog.shared.addMessage("Failed to encode uuids for suggested folders call")
                 completion?(nil)
                 return

--- a/Modules/Server/Sources/PocketCastsServer/Private/API Tasks/SuggestedFolderTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Private/API Tasks/SuggestedFolderTask.swift
@@ -1,0 +1,49 @@
+import Foundation
+import PocketCastsUtils
+import SwiftProtobuf
+
+public struct SuggestedFoldersResponse {
+    public let suggestions: [String: [String]]
+}
+
+class SuggestedFoldersTask: ApiBaseTask, @unchecked Sendable {
+    var uuids: [String]
+    var completion: ((SuggestedFoldersResponse?) -> Void)?
+
+    init(uuids: [String], completion: ((SuggestedFoldersResponse?) -> Void)?) {
+        self.uuids = uuids
+        self.completion = completion
+    }
+
+    override func apiTokenAcquired(token: String) {
+        let urlString = "\(ServerConstants.Urls.cache())podcast/suggest_folders"
+
+        do {
+            guard let requestData = try? JSONSerialization.data(withJSONObject: ["language": "en", "uuids": uuids]) else {
+                FileLog.shared.addMessage("Failed to encode uuids for suggested folders call")
+                completion?(nil)
+                return
+            }
+
+            let (data, statusCode) = super.performPostToServer(url: urlString, token: token, data: requestData)
+            guard let responseData = data,
+                  statusCode == ServerConstants.HttpConstants.ok
+            else {
+                FileLog.shared.addMessage("Failed to get suggested folders - server returned \(statusCode)")
+                completion?(nil)
+                return
+            }
+            let validationResponse = try JSONSerialization.jsonObject(with: responseData)
+            guard let jsonDictionary = validationResponse as? [String: [String]] else {
+                FileLog.shared.addMessage("Failed to parse Suggested Folders Response - not a dictionary")
+                completion?(nil)
+                return
+            }
+            let suggestions = SuggestedFoldersResponse(suggestions: jsonDictionary)
+            completion?(suggestions)
+        } catch {
+            FileLog.shared.addMessage("Failed to parse Suggested Folders Response \(error.localizedDescription)")
+            completion?(nil)
+        }
+    }
+}

--- a/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+Suggestions.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+Suggestions.swift
@@ -1,9 +1,9 @@
 import Foundation
 
 extension ApiServerHandler {
-    public func suggestedFolders(for uuids: [String]) async -> SuggestedFoldersResponse? {
+    public func suggestedFolders(for uuids: [String], language: String = Locale.current.languageCode ?? "en") async -> SuggestedFoldersResponse? {
         return await withCheckedContinuation { continuation in
-            let operation = SuggestedFoldersTask(uuids: uuids) { response in
+            let operation = SuggestedFoldersTask(uuids: uuids, language: language) { response in
                 continuation.resume(returning: response)
             }
             apiQueue.addOperation(operation)

--- a/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+Suggestions.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+Suggestions.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+extension ApiServerHandler {
+    public func suggestedFolders(for uuids: [String]) async -> SuggestedFoldersResponse? {
+        return await withCheckedContinuation { continuation in
+            let operation = SuggestedFoldersTask(uuids: uuids) { response in
+                continuation.resume(returning: response)
+            }
+            apiQueue.addOperation(operation)
+        }
+    }
+}

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1929,6 +1929,7 @@
 		FF0753882D6CB79600BE8B3B /* SuggestedFolderPodcastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0753872D6CB78D00BE8B3B /* SuggestedFolderPodcastView.swift */; };
 		FF07538A2D6CB7CA00BE8B3B /* PodcastImageViewWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0753892D6CB7C300BE8B3B /* PodcastImageViewWrapper.swift */; };
 		FF07538C2D6CC4FA00BE8B3B /* CustomHorizontalMargin.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF07538B2D6CC4F400BE8B3B /* CustomHorizontalMargin.swift */; };
+		FF07538E2D6E004D00BE8B3B /* SuggestedFoldersUpSellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF07538D2D6E004D00BE8B3B /* SuggestedFoldersUpSellView.swift */; };
 		FF09982E2CDA996D00C1647B /* MarqueeTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF09982D2CDA996D00C1647B /* MarqueeTextView.swift */; };
 		FF0998302CE79C8F00C1647B /* ManageDownloadsBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF09982F2CE79C7500C1647B /* ManageDownloadsBannerView.swift */; };
 		FF0998322CEC026D00C1647B /* ManageDownloadsModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0998312CEC026D00C1647B /* ManageDownloadsModalView.swift */; };
@@ -3957,6 +3958,7 @@
 		FF0753872D6CB78D00BE8B3B /* SuggestedFolderPodcastView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestedFolderPodcastView.swift; sourceTree = "<group>"; };
 		FF0753892D6CB7C300BE8B3B /* PodcastImageViewWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PodcastImageViewWrapper.swift; sourceTree = "<group>"; };
 		FF07538B2D6CC4F400BE8B3B /* CustomHorizontalMargin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomHorizontalMargin.swift; sourceTree = "<group>"; };
+		FF07538D2D6E004D00BE8B3B /* SuggestedFoldersUpSellView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SuggestedFoldersUpSellView.swift; sourceTree = "<group>"; };
 		FF09982D2CDA996D00C1647B /* MarqueeTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarqueeTextView.swift; sourceTree = "<group>"; };
 		FF09982F2CE79C7500C1647B /* ManageDownloadsBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManageDownloadsBannerView.swift; sourceTree = "<group>"; };
 		FF0998312CEC026D00C1647B /* ManageDownloadsModalView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ManageDownloadsModalView.swift; sourceTree = "<group>"; };
@@ -6955,6 +6957,7 @@
 			children = (
 				BD998AC927B2408500B38857 /* CreateFolderView.swift */,
 				FF146C2B2D674A5400D2FCCE /* SuggestedFoldersView.swift */,
+				FF07538D2D6E004D00BE8B3B /* SuggestedFoldersUpSellView.swift */,
 				FF0753872D6CB78D00BE8B3B /* SuggestedFolderPodcastView.swift */,
 				FF0753832D69087F00BE8B3B /* GridFoldersView.swift */,
 				FF0753892D6CB7C300BE8B3B /* PodcastImageViewWrapper.swift */,
@@ -10682,6 +10685,7 @@
 				C7C4F8832A71E1B7002139B2 /* BookmarkEpisodeListController.swift in Sources */,
 				408C088E23155B34008C9667 /* WhatsNewHelper.swift in Sources */,
 				463538A726E16CD100BA9D35 /* Strings+L10n.swift in Sources */,
+				FF07538E2D6E004D00BE8B3B /* SuggestedFoldersUpSellView.swift in Sources */,
 				40043F0B23FBC6B1004A9B57 /* SiriPodcastItem.swift in Sources */,
 				4084263E2138E2750076D82E /* FeaturedCollectionViewCell.swift in Sources */,
 				46CD3CA12715E3E600F5EB8F /* SupportConfig.swift in Sources */,

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -165,6 +165,9 @@ enum AnalyticsEvent: String {
     case suggestedFoldersModalDismissed
     case suggestedFoldersModalUseTheseFoldersTapped
     case suggestedFoldersModalCreateCustomFoldersTapped
+    case suggestedFoldersPaywallModalShown
+    case suggestedFoldersPaywallModalUseTheseFoldersTapped
+    case suggestedFoldersPaywallModalMaybeLaterTapped
 
     // MARK: - Tab Bar Items
 

--- a/podcasts/PodcastListViewController.swift
+++ b/podcasts/PodcastListViewController.swift
@@ -330,21 +330,7 @@ class PodcastListViewController: PCViewController, UIGestureRecognizerDelegate, 
             if !SyncManager.isUserLoggedIn() {
                 NavigationManager.sharedManager.showUpsellView(from: self, source: .folders)
             } else {
-                let upsellSuggestedFoldersView = SuggestedFoldersUpSellView()
-                let hostingController = PCHostingController(rootView: upsellSuggestedFoldersView.environmentObject(Theme.sharedTheme))
-                if UIDevice.current.userInterfaceIdiom == .phone {
-                    if #available(iOS 16.0, *) {
-                        hostingController.sheetPresentationController?.detents = [.custom(resolver: { context in
-                            return context.maximumDetentValue * 0.65
-                        })]
-                    } else {
-                        hostingController.sheetPresentationController?.detents = [.medium()]
-                    }
-                    hostingController.sheetPresentationController?.prefersGrabberVisible = true
-                } else {
-                    hostingController.modalPresentationStyle = .formSheet
-                }
-                present(hostingController, animated: true, completion: nil)
+                showUpSellSuggestedFolder()
             }
             return
         }
@@ -360,6 +346,25 @@ class PodcastListViewController: PCViewController, UIGestureRecognizerDelegate, 
         let hostingController = PCHostingController(rootView: suggestedFoldersView.environmentObject(Theme.sharedTheme))
         present(hostingController, animated: true, completion: nil)
         hostingController.sheetPresentationController?.delegate = self
+    }
+
+    private func showUpSellSuggestedFolder() {
+        let upsellSuggestedFoldersView = SuggestedFoldersUpSellView()
+        let hostingController = PCHostingController(rootView: upsellSuggestedFoldersView.environmentObject(Theme.sharedTheme))
+        if UIDevice.current.userInterfaceIdiom == .phone {
+            if #available(iOS 16.0, *) {
+                hostingController.sheetPresentationController?.detents = [.custom(resolver: { context in
+                    return context.maximumDetentValue * 0.65
+                })]
+            } else {
+                hostingController.sheetPresentationController?.detents = [.medium()]
+            }
+            hostingController.sheetPresentationController?.prefersGrabberVisible = true
+        } else {
+            hostingController.modalPresentationStyle = .formSheet
+        }
+        present(hostingController, animated: true, completion: nil)
+
     }
 
     @objc private func podcastOptionsTapped(_ sender: UIBarButtonItem) {

--- a/podcasts/PodcastListViewController.swift
+++ b/podcasts/PodcastListViewController.swift
@@ -349,7 +349,12 @@ class PodcastListViewController: PCViewController, UIGestureRecognizerDelegate, 
     }
 
     private func showUpSellSuggestedFolder() {
-        let upsellSuggestedFoldersView = SuggestedFoldersUpSellView()
+        let upsellSuggestedFoldersView = SuggestedFoldersUpSellView(model: SuggestedFoldersModel(failedToLoadAction: {[weak self] in
+            guard let self else { return }
+            self.dismiss(animated: false) {
+                NavigationManager.sharedManager.showUpsellView(from: self, source: .folders)
+            }
+        }))
         let hostingController = PCHostingController(rootView: upsellSuggestedFoldersView.environmentObject(Theme.sharedTheme))
         if UIDevice.current.userInterfaceIdiom == .phone {
             if #available(iOS 16.0, *) {

--- a/podcasts/PodcastListViewController.swift
+++ b/podcasts/PodcastListViewController.swift
@@ -333,7 +333,13 @@ class PodcastListViewController: PCViewController, UIGestureRecognizerDelegate, 
                 let upsellSuggestedFoldersView = SuggestedFoldersUpSellView()
                 let hostingController = PCHostingController(rootView: upsellSuggestedFoldersView.environmentObject(Theme.sharedTheme))
                 if UIDevice.current.userInterfaceIdiom == .phone {
-                    hostingController.sheetPresentationController?.detents = [.medium()]
+                    if #available(iOS 16.0, *) {
+                        hostingController.sheetPresentationController?.detents = [.custom(resolver: { context in
+                            return context.maximumDetentValue * 0.65
+                        })]
+                    } else {
+                        hostingController.sheetPresentationController?.detents = [.medium()]
+                    }
                     hostingController.sheetPresentationController?.prefersGrabberVisible = true
                 } else {
                     hostingController.modalPresentationStyle = .formSheet

--- a/podcasts/PodcastListViewController.swift
+++ b/podcasts/PodcastListViewController.swift
@@ -332,8 +332,12 @@ class PodcastListViewController: PCViewController, UIGestureRecognizerDelegate, 
             } else {
                 let upsellSuggestedFoldersView = SuggestedFoldersUpSellView()
                 let hostingController = PCHostingController(rootView: upsellSuggestedFoldersView.environmentObject(Theme.sharedTheme))
-                hostingController.sheetPresentationController?.detents = [.medium()]
-                hostingController.sheetPresentationController?.prefersGrabberVisible = true
+                if UIDevice.current.userInterfaceIdiom == .phone {
+                    hostingController.sheetPresentationController?.detents = [.medium()]
+                    hostingController.sheetPresentationController?.prefersGrabberVisible = true
+                } else {
+                    hostingController.modalPresentationStyle = .formSheet
+                }
                 present(hostingController, animated: true, completion: nil)
             }
             return

--- a/podcasts/PodcastListViewController.swift
+++ b/podcasts/PodcastListViewController.swift
@@ -327,7 +327,15 @@ class PodcastListViewController: PCViewController, UIGestureRecognizerDelegate, 
 
     private func newSuggestedFolderCreationFlow() {
         if !SubscriptionHelper.hasActiveSubscription() {
-            NavigationManager.sharedManager.showUpsellView(from: self, source: .folders)
+            if !SyncManager.isUserLoggedIn() {
+                NavigationManager.sharedManager.showUpsellView(from: self, source: .folders)
+            } else {
+                let upsellSuggestedFoldersView = SuggestedFoldersUpSellView()
+                let hostingController = PCHostingController(rootView: upsellSuggestedFoldersView.environmentObject(Theme.sharedTheme))
+                hostingController.sheetPresentationController?.detents = [.medium()]
+                hostingController.sheetPresentationController?.prefersGrabberVisible = true
+                present(hostingController, animated: true, completion: nil)
+            }
             return
         }
         let suggestedFoldersView = SuggestedFoldersView { [weak self] folderUuid in

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -3411,6 +3411,10 @@ internal enum L10n {
   internal static var suggestedFoldersDescription: String { return L10n.tr("Localizable", "suggested_folders_description") }
   /// Suggested Folders
   internal static var suggestedFoldersTitle: String { return L10n.tr("Localizable", "suggested_folders_title") }
+  /// We’ve pre-made folders for your podcasts. Unlock this and features like bookmarks, transcripts, and more with Pocket Casts Plus.
+  internal static var suggestedFoldersUpsellDescription: String { return L10n.tr("Localizable", "suggested_folders_upsell_description") }
+  /// Your podcasts, automatically organized
+  internal static var suggestedFoldersUpsellTitle: String { return L10n.tr("Localizable", "suggested_folders_upsell_title") }
   /// Use these folders
   internal static var suggestedFoldersUseSuggestedFolders: String { return L10n.tr("Localizable", "suggested_folders_use_suggested_folders") }
   /// If you're having issues with the Pocket Casts Watch app we can send your wearable logs to better assist you. In order to do so, please open Pocket Casts on your Watch.

--- a/podcasts/SuggestedFoldersUpSellView.swift
+++ b/podcasts/SuggestedFoldersUpSellView.swift
@@ -1,0 +1,59 @@
+import PocketCastsDataModel
+import SwiftUI
+
+struct SuggestedFoldersUpSellView: View {
+    @Environment(\.dismiss) var dismissAction
+    @EnvironmentObject var theme: Theme
+    @ObservedObject var model: SuggestedFoldersModel = SuggestedFoldersModel()
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Spacer()
+            foldersView
+            Text(L10n.suggestedFoldersUpsellTitle)
+                .font(.body)
+                .textStyle(PrimaryText())
+            Text(L10n.suggestedFoldersUpsellDescription)
+                .font(.caption)
+                .textStyle(SecondaryText())
+            Button {
+                Analytics.track(.suggestedFoldersPaywallModalUseTheseFoldersTapped, properties: [:])
+                dismissAction()
+            } label: {
+                Text(L10n.suggestedFoldersUseSuggestedFolders)
+                    .textStyle(RoundedButton())
+            }
+            Button {
+                Analytics.track(.suggestedFoldersPaywallModalMaybeLaterTapped, properties: [:])
+                dismissAction()
+            } label: {
+                Text(L10n.maybeLater)
+                    .textStyle(BorderButton())
+            }
+            Spacer().frame(height: 8)
+        }
+        .padding(.horizontal, 16)
+        .onAppear {
+            Analytics.track(.suggestedFoldersPaywallModalShown, properties: [:])
+        }
+        .applyDefaultThemeOptions()
+    }
+
+    var foldersView: some View {
+        LazyVGrid(columns: [GridItem(.adaptive(minimum: 110, maximum: 160))], alignment: .center, spacing: 6) {
+            ForEach(Array<SuggestedFolder>(model.folders.prefix(3))) { folder in
+                SuggestedFolderPreviewWrapper(folder: folder)
+                    .cornerRadius(4)
+                    .frame(minWidth: 110, maxWidth: 160)
+                    .aspectRatio(1, contentMode: .fit)
+            }
+        }
+    }
+}
+
+struct SuggestedFoldersUpSellView_Previews: PreviewProvider {
+    static var previews: some View {
+        SuggestedFoldersView(dismissAction: { _ in })
+            .environmentObject(Theme(previewTheme: .light))
+    }
+}

--- a/podcasts/SuggestedFoldersUpSellView.swift
+++ b/podcasts/SuggestedFoldersUpSellView.swift
@@ -7,15 +7,21 @@ struct SuggestedFoldersUpSellView: View {
     @ObservedObject var model: SuggestedFoldersModel = SuggestedFoldersModel()
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
+        VStack(alignment: .center, spacing: 16) {
             Spacer()
             foldersView
-            Text(L10n.suggestedFoldersUpsellTitle)
-                .font(.body)
-                .textStyle(PrimaryText())
-            Text(L10n.suggestedFoldersUpsellDescription)
-                .font(.caption)
-                .textStyle(SecondaryText())
+            Spacer()
+            Group {
+                Text(L10n.suggestedFoldersUpsellTitle)
+                    .font(.title2)
+                    .textStyle(PrimaryText())
+                    .fixedSize(horizontal: false, vertical: true)
+                Text(L10n.suggestedFoldersUpsellDescription)
+                    .font(.body)
+                    .textStyle(SecondaryText())
+                    .fixedSize(horizontal: false, vertical: true)
+            }.multilineTextAlignment(.center)
+            Spacer()
             Button {
                 Analytics.track(.suggestedFoldersPaywallModalUseTheseFoldersTapped, properties: [:])
                 dismissAction()
@@ -40,11 +46,11 @@ struct SuggestedFoldersUpSellView: View {
     }
 
     var foldersView: some View {
-        LazyVGrid(columns: [GridItem(.adaptive(minimum: 110, maximum: 160))], alignment: .center, spacing: 6) {
+        LazyHGrid(rows: [GridItem(.adaptive(minimum: 110, maximum: 160))], alignment: .center, spacing: 6) {
             ForEach(Array<SuggestedFolder>(model.folders.prefix(3))) { folder in
                 SuggestedFolderPreviewWrapper(folder: folder)
                     .cornerRadius(4)
-                    .frame(minWidth: 110, maxWidth: 160)
+                    .frame(width: 130, height: 130)
                     .aspectRatio(1, contentMode: .fit)
             }
         }

--- a/podcasts/SuggestedFoldersUpSellView.swift
+++ b/podcasts/SuggestedFoldersUpSellView.swift
@@ -4,16 +4,44 @@ import SwiftUI
 struct SuggestedFoldersUpSellView: View {
     @Environment(\.dismiss) var dismissAction
     @EnvironmentObject var theme: Theme
-    @ObservedObject var model: SuggestedFoldersModel = SuggestedFoldersModel()
+    @ObservedObject var model: SuggestedFoldersModel
+
+    init(model: SuggestedFoldersModel = SuggestedFoldersModel()) {
+        self.model = model
+    }
 
     var body: some View {
+        Group {
+            switch model.loadingState {
+            case .loaded:
+                mainBody
+            default:
+                loadingView
+            }
+        }
+        .task {
+            await model.load()
+        }
+        .applyDefaultThemeOptions()
+    }
+
+    var loadingView: some View {
+        VStack {
+            Spacer()
+            HStack {
+                Spacer()
+                LoadingView()
+                Spacer()
+            }
+            Spacer()
+        }
+        .applyDefaultThemeOptions()
+    }
+
+    var mainBody: some View {
         VStack(alignment: .center, spacing: 16) {
             Spacer()
-            if model.loadingState == .loaded {
-                foldersView
-            } else {
-                LoadingView()
-            }
+            foldersView
             Spacer()
             Group {
                 Text(L10n.suggestedFoldersUpsellTitle)
@@ -47,10 +75,6 @@ struct SuggestedFoldersUpSellView: View {
         .onAppear {
             Analytics.track(.suggestedFoldersPaywallModalShown, properties: [:])
         }
-        .task {
-            await model.load()
-        }
-        .applyDefaultThemeOptions()
     }
 
     var foldersView: some View {

--- a/podcasts/SuggestedFoldersUpSellView.swift
+++ b/podcasts/SuggestedFoldersUpSellView.swift
@@ -41,18 +41,20 @@ struct SuggestedFoldersUpSellView: View {
     var mainBody: some View {
         VStack(alignment: .center, spacing: 16) {
             Spacer()
+                .frame(minHeight: 16)
             foldersView
             Spacer()
             Group {
                 Text(L10n.suggestedFoldersUpsellTitle)
-                    .font(.title2)
+                    .font(.system(size: 18, weight: .semibold))
                     .textStyle(PrimaryText())
                     .fixedSize(horizontal: false, vertical: true)
                 Text(L10n.suggestedFoldersUpsellDescription)
-                    .font(.body)
+                    .font(.system(size: 15))
                     .textStyle(SecondaryText())
                     .fixedSize(horizontal: false, vertical: true)
-            }.multilineTextAlignment(.center)
+            }
+            .multilineTextAlignment(.center)
             Spacer()
             Button {
                 Analytics.track(.suggestedFoldersPaywallModalUseTheseFoldersTapped, properties: [:])
@@ -78,12 +80,12 @@ struct SuggestedFoldersUpSellView: View {
     }
 
     var foldersView: some View {
-        LazyHGrid(rows: [GridItem(.adaptive(minimum: 110, maximum: 130))], alignment: .center, spacing: 6) {
+        LazyHGrid(rows: [GridItem(.adaptive(minimum: 90, maximum: 130))], alignment: .center, spacing: 6) {
             ForEach(Array<SuggestedFolder>(model.folders.prefix(3))) { folder in
                 SuggestedFolderPreviewWrapper(folder: folder)
                     .cornerRadius(4)
                     .aspectRatio(1, contentMode: .fit)
-                    .frame(height: 130)
+                    .frame(minHeight: 90)
             }
         }
     }

--- a/podcasts/SuggestedFoldersUpSellView.swift
+++ b/podcasts/SuggestedFoldersUpSellView.swift
@@ -9,7 +9,11 @@ struct SuggestedFoldersUpSellView: View {
     var body: some View {
         VStack(alignment: .center, spacing: 16) {
             Spacer()
-            foldersView
+            if model.loadingState == .loaded {
+                foldersView
+            } else {
+                LoadingView()
+            }
             Spacer()
             Group {
                 Text(L10n.suggestedFoldersUpsellTitle)

--- a/podcasts/SuggestedFoldersUpSellView.swift
+++ b/podcasts/SuggestedFoldersUpSellView.swift
@@ -29,6 +29,7 @@ struct SuggestedFoldersUpSellView: View {
                 Text(L10n.suggestedFoldersUseSuggestedFolders)
                     .textStyle(RoundedButton())
             }
+            Spacer().frame(height: 8)
             Button {
                 Analytics.track(.suggestedFoldersPaywallModalMaybeLaterTapped, properties: [:])
                 dismissAction()
@@ -46,12 +47,12 @@ struct SuggestedFoldersUpSellView: View {
     }
 
     var foldersView: some View {
-        LazyHGrid(rows: [GridItem(.adaptive(minimum: 110, maximum: 160))], alignment: .center, spacing: 6) {
+        LazyHGrid(rows: [GridItem(.adaptive(minimum: 110, maximum: 130))], alignment: .center, spacing: 6) {
             ForEach(Array<SuggestedFolder>(model.folders.prefix(3))) { folder in
                 SuggestedFolderPreviewWrapper(folder: folder)
                     .cornerRadius(4)
-                    .frame(width: 130, height: 130)
                     .aspectRatio(1, contentMode: .fit)
+                    .frame(height: 130)
             }
         }
     }

--- a/podcasts/SuggestedFoldersUpSellView.swift
+++ b/podcasts/SuggestedFoldersUpSellView.swift
@@ -43,6 +43,9 @@ struct SuggestedFoldersUpSellView: View {
         .onAppear {
             Analytics.track(.suggestedFoldersPaywallModalShown, properties: [:])
         }
+        .task {
+            await model.load()
+        }
         .applyDefaultThemeOptions()
     }
 

--- a/podcasts/SuggestedFoldersView.swift
+++ b/podcasts/SuggestedFoldersView.swift
@@ -10,22 +10,27 @@ class SuggestedFoldersModel: ObservableObject {
         case start
         case loading
         case loaded
+        case failed
     }
 
     @Published var loadingState: State = .start
 
-    init() {
+    var failedToLoadAction: (() -> ())? = nil
 
+    init(failedToLoadAction: (() -> ())? = nil) {
+        self.failedToLoadAction = failedToLoadAction
     }
 
     func load() async {
-        if loadingState == .loading || loadingState == .loaded {
+        if loadingState != .start {
             return
         }
         Task { @MainActor in
             loadingState = .loading
             let uuids = DataManager.sharedManager.allPodcasts(includeUnsubscribed: false).map { $0.uuid }
             guard let suggestionsResponse = await ApiServerHandler.shared.suggestedFolders(for: uuids) else {
+                loadingState = .failed
+                failedToLoadAction?()
                 return
             }
             var folders = [SuggestedFolder]()
@@ -54,23 +59,48 @@ struct SuggestedFoldersView: View {
     var dismissAction: (String?) -> Void
 
     var body: some View {
-        NavigationContainer {
-            mainBody
-                .toolbar {
-                    ToolbarItem(placement: .navigationBarLeading) {
-                        Button {
-                            Analytics.track(.suggestedFoldersModalDismissed, properties: [:])
-                            dismissAction(nil)
-                        } label: {
-                            Image("close")
-                                .foregroundColor(ThemeColor.secondaryIcon01(for: theme.activeTheme).color)
+        Group {
+            switch model.loadingState {
+            case .start, .loading:
+                loadingView
+            case .loaded:
+                NavigationContainer {
+                    mainBody
+                        .toolbar {
+                            ToolbarItem(placement: .navigationBarLeading) {
+                                Button {
+                                    Analytics.track(.suggestedFoldersModalDismissed, properties: [:])
+                                    dismissAction(nil)
+                                } label: {
+                                    Image("close")
+                                        .foregroundColor(ThemeColor.secondaryIcon01(for: theme.activeTheme).color)
+                                }
+                                .accessibilityLabel(L10n.close)
+                            }
                         }
-                        .accessibilityLabel(L10n.close)
-                    }
                 }
+                .navigationViewStyle(.stack)
+                .tint(ThemeColor.secondaryIcon01(for: theme.activeTheme).color)
+            case .failed:
+                CreateFolderView(isInsideNavigation: false, dismissAction: dismissAction)
+            }
         }
-        .navigationViewStyle(.stack)
-        .tint(ThemeColor.secondaryIcon01(for: theme.activeTheme).color)
+        .task {
+            await model.load()
+        }
+    }
+
+    var loadingView: some View {
+        VStack {
+            Spacer()
+            HStack {
+                Spacer()
+                LoadingView()
+                Spacer()
+            }
+            Spacer()
+        }
+        .applyDefaultThemeOptions()
     }
 
     var mainBody: some View {
@@ -78,14 +108,10 @@ struct SuggestedFoldersView: View {
             Spacer().frame(height: 8)
             Text(L10n.suggestedFoldersDescription)
                 .textStyle(SecondaryText())
-            if model.loadingState == .loaded {
-                foldersView
-                    .padding(.horizontal, -Constants.margin)
-                    // hack to allow the scroll indicator to be visible without overlapping the content
-                    .customHorizontalMargin(margin: Constants.margin)
-            } else {
-                LoadingView()
-            }
+            foldersView
+                .padding(.horizontal, -Constants.margin)
+                // hack to allow the scroll indicator to be visible without overlapping the content
+                .customHorizontalMargin(margin: Constants.margin)
             Button {
                 Analytics.track(.suggestedFoldersModalUseTheseFoldersTapped, properties: [:])
                 dismissAction(nil)
@@ -105,9 +131,6 @@ struct SuggestedFoldersView: View {
         .navigationTitle(L10n.suggestedFoldersTitle)
         .onAppear {
             Analytics.track(.suggestedFoldersModalShow, properties: [:])
-        }
-        .task {
-            await model.load()
         }
         .onChange(of: createFolderActive) { newFolder in
             if newFolder {

--- a/podcasts/SuggestedFoldersView.swift
+++ b/podcasts/SuggestedFoldersView.swift
@@ -1,16 +1,45 @@
 import PocketCastsDataModel
 import SwiftUI
+import PocketCastsServer
 
 class SuggestedFoldersModel: ObservableObject {
 
     private static let somePodcastsUUIDs = ["e7abe050-6cc7-0130-f8c5-723c91aeae46", "ba993300-d71c-0137-1e26-0acc26574db2", "4eb5b260-c933-0134-10da-25324e2a541d", "71a77ab0-c8bf-0136-7b94-27f978dac4db", "467b49a0-c657-0138-e72e-0acc26574db2"]
 
-    var folders: [SuggestedFolder] = {
-        let result: [SuggestedFolder] = (0..<20).map { index in
-            SuggestedFolder(name: "Folder-\(index)", color: Int32(index), topPodcastUuids: somePodcastsUUIDs.shuffled())
+    @Published var folders: [SuggestedFolder] = []
+
+    enum State {
+        case start
+        case loading
+        case loaded
+    }
+
+    @Published var loadingState: State = .start
+
+    init() {
+
+    }
+
+    func load() async {
+        if loadingState == .loading {
+            return
         }
-        return result
-    }()
+        Task { @MainActor in
+            loadingState = .loading
+            guard let suggestionsResponse = await ApiServerHandler.shared.suggestedFolders(for: Self.somePodcastsUUIDs) else {
+                return
+            }
+            var folders = [SuggestedFolder]()
+            for suggestion in suggestionsResponse.suggestions.keys {
+                if let uuids = suggestionsResponse.suggestions[suggestion] {
+                    let folder = SuggestedFolder(name: suggestion, color: Int32.random(in: 0..<10), topPodcastUuids: uuids)
+                    folders.append(folder)
+                }
+            }
+            self.folders = folders
+            loadingState = .loaded
+        }
+    }
 }
 
 struct SuggestedFoldersView: View {
@@ -74,8 +103,8 @@ struct SuggestedFoldersView: View {
         .onAppear {
             Analytics.track(.suggestedFoldersModalShow, properties: [:])
         }
-        .onDisappear {
-
+        .task {
+            await model.load()
         }
         .onChange(of: createFolderActive) { newFolder in
             if newFolder {

--- a/podcasts/SuggestedFoldersView.swift
+++ b/podcasts/SuggestedFoldersView.swift
@@ -4,8 +4,6 @@ import PocketCastsServer
 
 class SuggestedFoldersModel: ObservableObject {
 
-    private static let somePodcastsUUIDs = ["e7abe050-6cc7-0130-f8c5-723c91aeae46", "ba993300-d71c-0137-1e26-0acc26574db2", "4eb5b260-c933-0134-10da-25324e2a541d", "71a77ab0-c8bf-0136-7b94-27f978dac4db", "467b49a0-c657-0138-e72e-0acc26574db2"]
-
     @Published var folders: [SuggestedFolder] = []
 
     enum State {
@@ -26,7 +24,8 @@ class SuggestedFoldersModel: ObservableObject {
         }
         Task { @MainActor in
             loadingState = .loading
-            guard let suggestionsResponse = await ApiServerHandler.shared.suggestedFolders(for: Self.somePodcastsUUIDs) else {
+            let uuids = DataManager.sharedManager.allPodcasts(includeUnsubscribed: false).map { $0.uuid }
+            guard let suggestionsResponse = await ApiServerHandler.shared.suggestedFolders(for: uuids) else {
                 return
             }
             var folders = [SuggestedFolder]()

--- a/podcasts/SuggestedFoldersView.swift
+++ b/podcasts/SuggestedFoldersView.swift
@@ -19,7 +19,7 @@ class SuggestedFoldersModel: ObservableObject {
     }
 
     func load() async {
-        if loadingState == .loading {
+        if loadingState == .loading || loadingState == .loaded {
             return
         }
         Task { @MainActor in

--- a/podcasts/SuggestedFoldersView.swift
+++ b/podcasts/SuggestedFoldersView.swift
@@ -25,8 +25,8 @@ class SuggestedFoldersModel: ObservableObject {
         if loadingState != .start {
             return
         }
+        loadingState = .loading
         Task { @MainActor in
-            loadingState = .loading
             let uuids = DataManager.sharedManager.allPodcasts(includeUnsubscribed: false).map { $0.uuid }
             guard let suggestionsResponse = await ApiServerHandler.shared.suggestedFolders(for: uuids) else {
                 loadingState = .failed

--- a/podcasts/SuggestedFoldersView.swift
+++ b/podcasts/SuggestedFoldersView.swift
@@ -78,10 +78,14 @@ struct SuggestedFoldersView: View {
             Spacer().frame(height: 8)
             Text(L10n.suggestedFoldersDescription)
                 .textStyle(SecondaryText())
-            foldersView
-                .padding(.horizontal, -Constants.margin)
-                // hack to allow the scroll indicator to be visible without overlapping the content
-                .customHorizontalMargin(margin: Constants.margin)
+            if model.loadingState == .loaded {
+                foldersView
+                    .padding(.horizontal, -Constants.margin)
+                    // hack to allow the scroll indicator to be visible without overlapping the content
+                    .customHorizontalMargin(margin: Constants.margin)
+            } else {
+                LoadingView()
+            }
             Button {
                 Analytics.track(.suggestedFoldersModalUseTheseFoldersTapped, properties: [:])
                 dismissAction(nil)

--- a/podcasts/SuggestedFoldersView.swift
+++ b/podcasts/SuggestedFoldersView.swift
@@ -29,7 +29,7 @@ class SuggestedFoldersModel: ObservableObject {
                 return
             }
             var folders = [SuggestedFolder]()
-            for suggestion in suggestionsResponse.suggestions.keys {
+            for suggestion in suggestionsResponse.suggestions.keys.sorted() {
                 if let uuids = suggestionsResponse.suggestions[suggestion] {
                     let folder = SuggestedFolder(name: suggestion, color: Int32.random(in: 0..<10), topPodcastUuids: uuids)
                     folders.append(folder)

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4777,3 +4777,9 @@
 /* Suggested Folders button title to create custom folders*/
 "suggested_folders_create_custom_folders" = "Create custom folders";
 
+/* Suggested Folder upsell title */
+"suggested_folders_upsell_title"  = "Your podcasts, automatically organized";
+
+/* Suggested Folder upsell detail */
+"suggested_folders_upsell_description"  = "We’ve pre-made folders for your podcasts. Unlock this and features like bookmarks, transcripts, and more with Pocket Casts Plus.";
+


### PR DESCRIPTION
| 📘 Part of: [#2788](https://github.com/orgs/Automattic/projects/1278/views/1)  |  <!-- project issue number, if applicable -->
|:---:|

Fixes #2788 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR implement the API call to get the suggested folders and integrates the call on the screens.
We are still not applying the results of the suggested folders to the user folders.

| 1 | 2 |
| - | - |
| ![Simulator Screenshot - iPhone 16 Pro Max - 2025-02-27 at 15 37 20](https://github.com/user-attachments/assets/add9adb9-2934-4d04-810b-df81f40d29be) | ![Simulator Screenshot - iPhone 16 Pro Max - 2025-02-27 at 15 37 07](https://github.com/user-attachments/assets/2a576e1a-528d-46f5-90ac-ffefb84c2940) |

## To test

- Start the app and login with a Plus or Patron user
- Ensure that you have the Feature Flag enabled. Profile -> Settings -> Beta Features -> SuggestedFolders
- Go to Podcasts tab
- Tap on the Create Folder icon on the top
- Check if the suggested folder screen shows and you see a grid view like the above with the suggested folders and you can tap on them and see the content.
- Scroll around to see if the contents make sense for your podcasts

Now test the upsell flow

- Go to Profile -> Settings -> Developer and tap on No Plus option
- Go to Podcasts tab
- Tap on the Create Folder icon on the top
- Check if the upsell suggested folder screen shows (screen 2) and you see a a max of three suggested folders on the top


## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
