### PR TITLE
[Suggested folders] Apply suggestions to the database

### DIFF
--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -168,6 +168,7 @@ enum AnalyticsEvent: String {
     case suggestedFoldersPaywallModalShown
     case suggestedFoldersPaywallModalUseTheseFoldersTapped
     case suggestedFoldersPaywallModalMaybeLaterTapped
+    case suggestedFoldersDetailModalShown
 
     // MARK: - Tab Bar Items
 

--- a/podcasts/FoldersCoordinator.swift
+++ b/podcasts/FoldersCoordinator.swift
@@ -6,7 +6,15 @@ import PocketCastsUtils
 
 class FoldersCoordinator: NSObject {
 
-    	func startFolderCreationFlow(from vc: UIViewController) {
+    private let navigationManager: NavigationManager
+    private let dataManager: DataManager
+
+    init(navigationManager: NavigationManager = .sharedManager, dataManager: DataManager = .sharedManager) {
+        self.navigationManager = navigationManager
+        self.dataManager = dataManager
+    }
+
+    func startFolderCreationFlow(from vc: UIViewController) {
         if FeatureFlag.suggestedFolders.enabled {
             newSuggestedFolderCreationFlow(from: vc)
         } else {
@@ -19,14 +27,14 @@ class FoldersCoordinator: NSObject {
 
     private func oldFolderCreationFlow(from vc: UIViewController) {
         if !SubscriptionHelper.hasActiveSubscription() {
-            NavigationManager.sharedManager.showUpsellView(from: vc, source: .folders)
+            navigationManager.showUpsellView(from: vc, source: .folders)
             return
         }
 
         let creatFolderView = CreateFolderView { [weak vc] folderUuid in
             if let folderUuid = folderUuid, let folder = DataManager.sharedManager.findFolder(uuid: folderUuid) {
-                vc?.dismiss(animated: true, completion: {
-                    NavigationManager.sharedManager.navigateTo(NavigationManager.folderPageKey, data: [NavigationManager.folderKey: folder])
+                vc?.dismiss(animated: true, completion: { [weak self] in
+                    self?.navigationManager.navigateTo(NavigationManager.folderPageKey, data: [NavigationManager.folderKey: folder])
                 })
             } else {
                 vc?.dismiss(animated: true, completion: nil)
@@ -40,26 +48,28 @@ class FoldersCoordinator: NSObject {
     private func newSuggestedFolderCreationFlow(from vc: UIViewController) {
         if !SubscriptionHelper.hasActiveSubscription() {
             if !SyncManager.isUserLoggedIn() {
-                NavigationManager.sharedManager.showUpsellView(from: vc, source: .folders)
+                navigationManager.showUpsellView(from: vc, source: .folders)
             } else {
                 showUpSellSuggestedFolder(from: vc)
             }
             return
         }
         let suggestedFoldersView = SuggestedFoldersView { [weak vc, weak self] result in
+            guard let self, let vc else { return }
+
             switch result {
             case .dismiss:
-                vc?.dismiss(animated: true, completion: nil)
+                vc.dismiss(animated: true, completion: nil)
             case .applySuggestedFolders(let folders):
-                vc?.dismiss(animated: true, completion: nil)
-                self?.applySuggestedFolders(folders)
+                vc.dismiss(animated: true, completion: nil)
+                applySuggestedFolders(folders)
             case .createdManualFolder(let folderUuid):
-                guard let folder = DataManager.sharedManager.findFolder(uuid: folderUuid) else {
-                    vc?.dismiss(animated: true, completion: nil)
+                guard let folder = dataManager.findFolder(uuid: folderUuid) else {
+                    vc.dismiss(animated: true, completion: nil)
                     return
                 }
-                vc?.dismiss(animated: true, completion: {
-                    NavigationManager.sharedManager.navigateTo(NavigationManager.folderPageKey, data: [NavigationManager.folderKey: folder])
+                vc.dismiss(animated: true, completion: { [weak self] in
+                    self?.navigationManager.navigateTo(NavigationManager.folderPageKey, data: [NavigationManager.folderKey: folder])
                 })
             }
         }
@@ -71,8 +81,8 @@ class FoldersCoordinator: NSObject {
     private func showUpSellSuggestedFolder(from vc: UIViewController) {
         let upsellSuggestedFoldersView = SuggestedFoldersUpSellView(model: SuggestedFoldersModel(failedToLoadAction: {[weak vc] in
             guard let vc else { return }
-            vc.dismiss(animated: false) {
-                NavigationManager.sharedManager.showUpsellView(from: vc, source: .folders)
+            vc.dismiss(animated: false) { [weak self] in
+                self?.navigationManager.showUpsellView(from: vc, source: .folders)
             }
         }))
         let hostingController = PCHostingController(rootView: upsellSuggestedFoldersView.environmentObject(Theme.sharedTheme))
@@ -96,7 +106,7 @@ class FoldersCoordinator: NSObject {
         DataManager.sharedManager.clearAllFolderInformation()
         for suggestedFolder in suggestedFolders {
             let folder = makeFolder(from: suggestedFolder)
-            DataManager.sharedManager.bulkSetFolderUuid(folderUuid: folder.uuid, podcastUuids: suggestedFolder.topPodcastUuids)
+            dataManager.bulkSetFolderUuid(folderUuid: folder.uuid, podcastUuids: suggestedFolder.topPodcastUuids)
         }
         NotificationCenter.postOnMainThread(notification: ServerNotifications.podcastsRefreshed, object: nil)
     }
@@ -111,7 +121,7 @@ class FoldersCoordinator: NSObject {
 
         // the sort type for newly created folders defaults to the same thing the home grid is set to
         folder.sortType = Int32(Settings.homeFolderSortOrder().old.rawValue)
-        DataManager.sharedManager.save(folder: folder)
+        dataManager.save(folder: folder)
         return folder
     }
 }

--- a/podcasts/FoldersCoordinator.swift
+++ b/podcasts/FoldersCoordinator.swift
@@ -46,13 +46,21 @@ class FoldersCoordinator: NSObject {
             }
             return
         }
-        let suggestedFoldersView = SuggestedFoldersView { [weak vc] folderUuid in
-            if let folderUuid = folderUuid, let folder = DataManager.sharedManager.findFolder(uuid: folderUuid) {
+        let suggestedFoldersView = SuggestedFoldersView { [weak vc, weak self] result in
+            switch result {
+            case .dismiss:
+                vc?.dismiss(animated: true, completion: nil)
+            case .applySuggestedFolders(let folders):
+                vc?.dismiss(animated: true, completion: nil)
+                self?.applySuggestedFolders(folders)
+            case .createdManualFolder(let folderUuid):
+                guard let folder = DataManager.sharedManager.findFolder(uuid: folderUuid) else {
+                    vc?.dismiss(animated: true, completion: nil)
+                    return
+                }
                 vc?.dismiss(animated: true, completion: {
                     NavigationManager.sharedManager.navigateTo(NavigationManager.folderPageKey, data: [NavigationManager.folderKey: folder])
                 })
-            } else {
-                vc?.dismiss(animated: true, completion: nil)
             }
         }
         let hostingController = PCHostingController(rootView: suggestedFoldersView.environmentObject(Theme.sharedTheme))
@@ -82,6 +90,29 @@ class FoldersCoordinator: NSObject {
         }
         vc.present(hostingController, animated: true, completion: nil)
 
+    }
+
+    private func applySuggestedFolders(_ suggestedFolders: [SuggestedFolder]) {
+        DataManager.sharedManager.clearAllFolderInformation()
+        for suggestedFolder in suggestedFolders {
+            let folder = makeFolder(from: suggestedFolder)
+            DataManager.sharedManager.bulkSetFolderUuid(folderUuid: folder.uuid, podcastUuids: suggestedFolder.topPodcastUuids)
+        }
+        NotificationCenter.postOnMainThread(notification: ServerNotifications.podcastsRefreshed, object: nil)
+    }
+
+    private func makeFolder(from suggestedFolder: SuggestedFolder) -> Folder {
+        let folder = Folder()
+        folder.name = suggestedFolder.name
+        folder.color = suggestedFolder.color
+        folder.addedDate = Date()
+        folder.syncModified = TimeFormatter.currentUTCTimeInMillis()
+        folder.sortOrder = ServerPodcastManager.shared.lowestSortOrderForHomeGrid() - 1
+
+        // the sort type for newly created folders defaults to the same thing the home grid is set to
+        folder.sortType = Int32(Settings.homeFolderSortOrder().old.rawValue)
+        DataManager.sharedManager.save(folder: folder)
+        return folder
     }
 }
 

--- a/podcasts/SuggestedFolderPodcastView.swift
+++ b/podcasts/SuggestedFolderPodcastView.swift
@@ -19,5 +19,8 @@ struct SuggestedFolderPodcastView: View {
         // hack to allow the scroll indicator to be visible without overlapping the content
         .customHorizontalMargin(margin: SuggestedFoldersView.Constants.margin)
         .applyDefaultThemeOptions()
+        .onAppear {
+            Analytics.track(.suggestedFoldersDetailModalShown, properties: [:])
+        }
     }
 }

--- a/podcasts/SuggestedFoldersModel.swift
+++ b/podcasts/SuggestedFoldersModel.swift
@@ -35,8 +35,8 @@ class SuggestedFoldersModel: ObservableObject {
         if loadingState != .start {
             return
         }
-        loadingState = .loading
         Task { @MainActor in
+            loadingState = .loading
             let uuids = DataManager.sharedManager.allPodcasts(includeUnsubscribed: false).map { $0.uuid }
             guard let suggestionsResponse = await ApiServerHandler.shared.suggestedFolders(for: uuids) else {
                 loadingState = .failed

--- a/podcasts/SuggestedFoldersUpSellView.swift
+++ b/podcasts/SuggestedFoldersUpSellView.swift
@@ -93,7 +93,7 @@ struct SuggestedFoldersUpSellView: View {
 
 struct SuggestedFoldersUpSellView_Previews: PreviewProvider {
     static var previews: some View {
-        SuggestedFoldersView(dismissAction: { _ in })
+        SuggestedFoldersUpSellView()
             .environmentObject(Theme(previewTheme: .light))
     }
 }

--- a/podcasts/SuggestedFoldersView.swift
+++ b/podcasts/SuggestedFoldersView.swift
@@ -1,5 +1,11 @@
 import SwiftUI
 
+enum SuggestedFoldersResult {
+    case dismiss
+    case applySuggestedFolders([SuggestedFolder])
+    case createdManualFolder(String)
+}
+
 struct SuggestedFoldersView: View {
 
     enum Constants {
@@ -10,7 +16,7 @@ struct SuggestedFoldersView: View {
     @State private var createFolderActive = false
     @ObservedObject var model: SuggestedFoldersModel = SuggestedFoldersModel()
 
-    var dismissAction: (String?) -> Void
+    var onCompletion: (SuggestedFoldersResult) -> Void
 
     var body: some View {
         Group {
@@ -24,7 +30,7 @@ struct SuggestedFoldersView: View {
                             ToolbarItem(placement: .navigationBarLeading) {
                                 Button {
                                     Analytics.track(.suggestedFoldersModalDismissed, properties: [:])
-                                    dismissAction(nil)
+                                    onCompletion(.dismiss)
                                 } label: {
                                     Image("close")
                                         .foregroundColor(ThemeColor.secondaryIcon01(for: theme.activeTheme).color)
@@ -36,7 +42,13 @@ struct SuggestedFoldersView: View {
                 .navigationViewStyle(.stack)
                 .tint(ThemeColor.secondaryIcon01(for: theme.activeTheme).color)
             case .failed:
-                CreateFolderView(isInsideNavigation: false, dismissAction: dismissAction)
+                CreateFolderView(isInsideNavigation: false) { uuid in
+                    if let uuid {
+                        onCompletion(.createdManualFolder(uuid))
+                    } else {
+                        onCompletion(.dismiss)
+                    }
+                }
             }
         }
         .task {
@@ -68,13 +80,17 @@ struct SuggestedFoldersView: View {
                 .customHorizontalMargin(margin: Constants.margin)
             Button {
                 Analytics.track(.suggestedFoldersModalUseTheseFoldersTapped, properties: [:])
-                dismissAction(nil)
+                onCompletion(.applySuggestedFolders(model.folders))
             } label: {
                 Text(L10n.suggestedFoldersUseSuggestedFolders)
                     .textStyle(RoundedButton())
             }
             NavigationLink(destination: CreateFolderView(isInsideNavigation: true) { uuid in
-                dismissAction(uuid)
+                if let uuid {
+                    onCompletion(.createdManualFolder(uuid))
+                } else {
+                    onCompletion(.dismiss)
+                }
             }, isActive: $createFolderActive) {
                 Text(L10n.suggestedFoldersCreateCustomFolders)
                     .textStyle(BorderButton())
@@ -101,7 +117,7 @@ struct SuggestedFoldersView: View {
 
 struct SuggestedFoldersView_Previews: PreviewProvider {
     static var previews: some View {
-        SuggestedFoldersView(dismissAction: { _ in })
+        SuggestedFoldersView(onCompletion: { _ in })
             .environmentObject(Theme(previewTheme: .light))
     }
 }


### PR DESCRIPTION
| 📘 Part of: #https://github.com/orgs/Automattic/projects/1278 |  <!-- project issue number, if applicable -->
|:---:|

Fixes #2793  <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR implements the code to apply the suggested folders to the user database.

## To test

- Start the app and login with a Plus or Patron user
- Ensure that you have the Feature Flag enabled. Profile -> Settings -> Beta Features -> SuggestedFolders
- Go to Podcasts tab
- Tap on the Create Folder icon on the top
- Check if the suggested folder screen shows and you see a grid view like the above with the suggested folders and you can tap on them and see the content.
- Scroll around to see if the contents make sense for your podcasts
- Tap on Use Suggested Folders
- Check if suggestions are applied and reflected on the Podcast tab.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
