### PR TITLE
[Revert] Dismiss episode detail when archiving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 7.84
 -----
-
+- Revert episode detail screen dismiss action when archiving [#2802](https://github.com/Automattic/pocket-casts-ios/pull/2802)
 
 7.83
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,9 @@
 7.85
 -----
-
+- Revert episode detail screen dismiss action when archiving [#2802](https://github.com/Automattic/pocket-casts-ios/pull/2802)
 
 7.84
 -----
-- Revert episode detail screen dismiss action when archiving [#2802](https://github.com/Automattic/pocket-casts-ios/pull/2802)
 
 7.83
 -----
@@ -15,7 +14,6 @@
 7.82.1
 -----
 - Fix analytics bug [#2769](https://github.com/Automattic/pocket-casts-ios/pull/2769)
-
 
 7.82
 -----

--- a/podcasts/EpisodeDetailViewController+Actions.swift
+++ b/podcasts/EpisodeDetailViewController+Actions.swift
@@ -41,6 +41,7 @@ extension EpisodeDetailViewController {
             EpisodeManager.unarchiveEpisode(episode: episode, fireNotification: true)
         } else {
             EpisodeManager.archiveEpisode(episode: episode, fireNotification: true)
+            dismiss(animated: true, completion: nil)
         }
     }
 


### PR DESCRIPTION
Revert #2687

This PR revert the last change and re-introduce the dismiss action when archiving an episode

https://github.com/user-attachments/assets/2b07276b-e4a4-4a56-ace9-8c4c47b2d394


## To test

- CI must be 🟢 
- Open an episode detail
- Tap on archive
- The view should dismiss

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
