### PR TITLE
[Suggested Folders] Fix for Suggested flow showing all the time.

### DIFF
--- a/podcasts/FoldersCoordinator.swift
+++ b/podcasts/FoldersCoordinator.swift
@@ -36,7 +36,6 @@ class FoldersCoordinator: NSObject {
     private weak var currentVC: UIViewController? = nil
 
     func startFolderCreationFlow(from vc: UIViewController) {
-        currentVC = vc
         if FeatureFlag.suggestedFolders.enabled {
             newSuggestedFolderCreationFlow(from: vc)
         } else {
@@ -47,7 +46,6 @@ class FoldersCoordinator: NSObject {
     }
 
     func showUpsellIfNeeded(from vc: UIViewController) {
-        currentVC = vc
         guard FeatureFlag.suggestedFolders.enabled,
               !SubscriptionHelper.hasActiveSubscription(),
               DateUtil.hasEnoughTimePassed(since: startingTime, time: Constants.intervalAfterStartup),
@@ -128,6 +126,7 @@ class FoldersCoordinator: NSObject {
                 return
             case .applySuggestedFolders:
                 //Show subscription/IAP flow
+                self?.currentVC = vc
                 vc.dismiss(animated: false) {
                     self?.navigationManager.showUpsellView(from: vc, source: .folders)
                 }


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

This PR fixes the issue of the suggested folders flow being show out of place. 
Only save VC var when showing upsell flow

## To test

- Start app and login with an user with a  subscription
- Navigate around the app
- Check that suggested folder flow is not show automatically in any screen

- Now start app with and login without a  subscription
- Navigate around the app
- Check that suggested folder flow is only show in the Podcasts tab and after you press Not now option it will not show again.
- Tap on Create Folder
- Tap on Use these folders
- Complete the IAP flow
- Check that suggested folder flow is show at end of a successfull purchase.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
