### PR TITLE
[Fix] Add logs and prevent shuffle tap if user is not logged in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 7.84
 -----
-
+- UpNext Shuffle: add logs and prevent tap if user is not logged in [#2806](https://github.com/Automattic/pocket-casts-ios/pull/2806)
 
 7.83
 -----

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -346,7 +346,7 @@ class Settings: NSObject {
     }
 
     class func upNextShuffleEnabled() -> Bool {
-        if !FeatureFlag.upNextShuffle.enabled || !SubscriptionHelper.hasActiveSubscription() {
+        if !FeatureFlag.upNextShuffle.enabled || !SubscriptionHelper.hasActiveSubscription() || !SyncManager.isUserLoggedIn() {
             return false
         }
         return UserDefaults.standard.bool(forKey: Settings.upNextShuffleKey)

--- a/podcasts/UpNextViewController.swift
+++ b/podcasts/UpNextViewController.swift
@@ -207,7 +207,9 @@ class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
     }
 
     @objc private func shuffleButtonTapped() {
-        if !SubscriptionHelper.hasActiveSubscription() {
+        FileLog.shared.addMessage("UpNext shuffleButtonTapped: user has active subscription: \(SubscriptionHelper.hasActiveSubscription()) and is logged in: \(SyncManager.isUserLoggedIn())")
+
+        if !SubscriptionHelper.hasActiveSubscription() || !SyncManager.isUserLoggedIn() {
             // Edge case where the UpNext is presented by the player container with a free user.
             // In this case we need to dismiss the UpNext to present the paywall
             if let mainTabBar = presentingViewController?.presentingViewController, presentingViewController is PlayerContainerViewController {
@@ -227,10 +229,13 @@ class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
         if upNextShuffleEnabled {
             Toast.show(L10n.upNextShuffleToastMessage, aboveMiniPlayer: self.showingInTab ? true : false)
         }
+        FileLog.shared.addMessage("UpNext shuffleButtonTapped: shuffle enabled: \(upNextShuffleEnabled)")
         track(.upNextShuffleEnabled, properties: ["value": upNextShuffleEnabled])
     }
 
     @objc private func themeDidChange() {
+        FileLog.shared.addMessage("UpNext themeDidChange: user has active subscription: \(SubscriptionHelper.hasActiveSubscription()) and is logged in: \(SyncManager.isUserLoggedIn())")
+
         if !SubscriptionHelper.hasActiveSubscription() || !SyncManager.isUserLoggedIn() {
             shuffleButton.setImage(UIImage(named: "shuffle-plus"), for: .normal)
             shuffleButton.isSelected = false
@@ -239,6 +244,7 @@ class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
             let selected = UIImage(named: "shuffle-enabled")?.withTintColor(AppTheme.colorForStyle(.primaryIcon01, themeOverride: themeOverride), renderingMode: .alwaysOriginal)
             shuffleButton.setImage(unselected, for: .normal)
             shuffleButton.setImage(selected, for: .selected)
+            updateShuffleButtonState()
         }
     }
 
@@ -247,6 +253,8 @@ class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
             guard let self = self else { return }
             if FeatureFlag.upNextShuffle.enabled {
                 // Update UI
+                FileLog.shared.addMessage("UpNext subscriptionStatusDidChange: user has active subscription: \(SubscriptionHelper.hasActiveSubscription()) and is logged in: \(SyncManager.isUserLoggedIn())")
+
                 setupActionButtonsIfNecessary()
                 themeDidChange()
                 updateNavBarButtons()
@@ -261,9 +269,6 @@ class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
             NotificationCenter.default.addObserver(self, selector: #selector(themeDidChange), name: Constants.Notifications.themeChanged, object: nil)
             NotificationCenter.default.addObserver(self, selector: #selector(subscriptionStatusDidChange), name: ServerNotifications.subscriptionStatusChanged, object: nil)
             themeDidChange()
-            if SubscriptionHelper.hasActiveSubscription() {
-                shuffleButton.isSelected = Settings.upNextShuffleEnabled()
-            }
             shuffleButton.addTarget(self, action: #selector(shuffleButtonTapped), for: .touchUpInside)
         } else {
             guard clearQueueButton.allTargets.isEmpty else { return }


### PR DESCRIPTION
Ref. p1739785627940699-slack-C02A333D8LQ

This PR adds few logs to report the subscription and log in session status. It also add the login status in few parts to prevent users from tapping the shuffle button in weird state, like an available subscription and logged out.

## To test

- Test the feature with a plus user
- Logged out and confirm the shuffle icon is gold and the tap shows the paywall
- Login with plus user and cancel the subscription and test it when the subscription expires
- Test it with a free user

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
