### PR TITLE
[Suggested folders]  Cache results

### DIFF
--- a/podcasts/FoldersCoordinator.swift
+++ b/podcasts/FoldersCoordinator.swift
@@ -52,7 +52,7 @@ class FoldersCoordinator: NSObject {
               DateUtil.hasEnoughTimePassed(since: startingTime, time: Constants.intervalAfterStartup),
               Settings.suggestedFoldersUpsellCount < Constants.maxUpsellDisplays,
               DateUtil.hasEnoughTimePassed(since: Settings.suggestedFoldersLastUpsellDate, time: Constants.intervalBetweenUpsell),
-              DataManager.sharedManager.allPodcasts(includeUnsubscribed: false, reloadFromDatabase: false).count > Constants.minimumNumberOfPodcasts
+              dataManager.allPodcasts(includeUnsubscribed: false, reloadFromDatabase: false).count > Constants.minimumNumberOfPodcasts
         else {
             return
         }
@@ -66,8 +66,9 @@ class FoldersCoordinator: NSObject {
             return
         }
 
-        let creatFolderView = CreateFolderView { [weak vc] folderUuid in
-            if let folderUuid = folderUuid, let folder = DataManager.sharedManager.findFolder(uuid: folderUuid) {
+        let creatFolderView = CreateFolderView { [weak vc, weak self] folderUuid in
+            guard let self = self else { return }
+            if let folderUuid = folderUuid, let folder = dataManager.findFolder(uuid: folderUuid) {
                 vc?.dismiss(animated: true, completion: { [weak self] in
                     self?.navigationManager.navigateTo(NavigationManager.folderPageKey, data: [NavigationManager.folderKey: folder])
                 })

--- a/podcasts/FoldersCoordinator.swift
+++ b/podcasts/FoldersCoordinator.swift
@@ -22,6 +22,7 @@ class FoldersCoordinator: NSObject {
 
     private let navigationManager: NavigationManager
     private let dataManager: DataManager
+    private let suggestedFoldersModel: SuggestedFoldersModel
 
     private enum Constants {
         static let minimumNumberOfPodcasts: Int = 7
@@ -33,7 +34,11 @@ class FoldersCoordinator: NSObject {
     init(navigationManager: NavigationManager = .sharedManager, dataManager: DataManager = .sharedManager) {
         self.navigationManager = navigationManager
         self.dataManager = dataManager
+        self.suggestedFoldersModel = SuggestedFoldersModel()
         super.init()
+        Task {
+            await suggestedFoldersModel.load()
+        }
     }
 
     func startFolderCreationFlow(from vc: UIViewController) {
@@ -87,7 +92,7 @@ class FoldersCoordinator: NSObject {
             showUpsellSuggestedFolder(from: vc, source: source)
             return
         }
-        let suggestedFoldersView = SuggestedFoldersView(source: source) { [weak vc, weak self] result in
+        let suggestedFoldersView = SuggestedFoldersView(model: suggestedFoldersModel, source: source) { [weak vc, weak self] result in
             guard let self, let vc else { return }
 
             switch result {
@@ -112,7 +117,7 @@ class FoldersCoordinator: NSObject {
     }
 
     private func showUpsellSuggestedFolder(from vc: UIViewController, fromUserAction: Bool = false, source: AnalyticsSource) {
-        let suggestedFoldersView = SuggestedFoldersView(source: source) { [weak vc, weak self] result in
+        let suggestedFoldersView = SuggestedFoldersView(model: suggestedFoldersModel, source: source) { [weak vc, weak self] result in
             guard let self, let vc else { return }
             switch result {
             case .dismiss:

--- a/podcasts/FoldersCoordinator.swift
+++ b/podcasts/FoldersCoordinator.swift
@@ -14,6 +14,10 @@ class FoldersCoordinator: NSObject {
     }
 
     private var currentUpsellFlow: UpsellFlow = .none
+    private weak var currentVC: UIViewController? = nil
+
+    private var currentSource: AnalyticsSource = .unknown
+
     private let startingTime: Date = Date.now
 
     private let navigationManager: NavigationManager
@@ -31,9 +35,6 @@ class FoldersCoordinator: NSObject {
         self.dataManager = dataManager
         super.init()
     }
-
-    private weak var currentVC: UIViewController? = nil
-    private var currentSource: AnalyticsSource = .unknown
 
     func startFolderCreationFlow(from vc: UIViewController) {
         if FeatureFlag.suggestedFolders.enabled {

--- a/podcasts/FoldersCoordinator.swift
+++ b/podcasts/FoldersCoordinator.swift
@@ -42,7 +42,7 @@ class FoldersCoordinator: NSObject {
     }
 
     func startFolderCreationFlow(from vc: UIViewController) {
-        if FeatureFlag.suggestedFolders.enabled {
+        if FeatureFlag.suggestedFolders.enabled, suggestedFoldersModel.loadingState == .loaded {
             suggestedFolderCreationFlow(from: vc, source: .podcastsList)
         } else {
             manualFolderCreationFlow(from: vc)
@@ -57,7 +57,8 @@ class FoldersCoordinator: NSObject {
               DateUtil.hasEnoughTimePassed(since: startingTime, time: Constants.intervalAfterStartup),
               Settings.suggestedFoldersUpsellCount < Constants.maxUpsellDisplays,
               DateUtil.hasEnoughTimePassed(since: Settings.suggestedFoldersLastUpsellDate, time: Constants.intervalBetweenUpsell),
-              dataManager.allPodcasts(includeUnsubscribed: false, reloadFromDatabase: false).count > Constants.minimumNumberOfPodcasts
+              dataManager.allPodcasts(includeUnsubscribed: false, reloadFromDatabase: false).count > Constants.minimumNumberOfPodcasts,
+              suggestedFoldersModel.loadingState == .loaded
         else {
             return
         }

--- a/podcasts/SuggestedFoldersModel.swift
+++ b/podcasts/SuggestedFoldersModel.swift
@@ -25,9 +25,12 @@ class SuggestedFoldersModel: ObservableObject {
 
     @Published var loadingState: State = .start
 
+    let dataManager: DataManager
+
     var failedToLoadAction: (() -> ())? = nil
 
-    init(failedToLoadAction: (() -> ())? = nil) {
+    init(dataManager: DataManager = DataManager.sharedManager, failedToLoadAction: (() -> ())? = nil) {
+        self.dataManager = dataManager
         self.failedToLoadAction = failedToLoadAction
     }
 
@@ -37,7 +40,7 @@ class SuggestedFoldersModel: ObservableObject {
         }
         Task { @MainActor in
             loadingState = .loading
-            let uuids = DataManager.sharedManager.allPodcasts(includeUnsubscribed: false).map { $0.uuid }
+            let uuids = dataManager.allPodcasts(includeUnsubscribed: false).map { $0.uuid }
             guard let suggestionsResponse = await ApiServerHandler.shared.suggestedFolders(for: uuids) else {
                 loadingState = .failed
                 failedToLoadAction?()
@@ -64,7 +67,7 @@ class SuggestedFoldersModel: ObservableObject {
     }
 
     var userHasExistingFolders: Bool {
-        return DataManager.sharedManager.allFolders().count > 0
+        return dataManager.allFolders().count > 0
     }
 
     var userIsSignedIn: Bool {

--- a/podcasts/SuggestedFoldersModel.swift
+++ b/podcasts/SuggestedFoldersModel.swift
@@ -29,6 +29,8 @@ class SuggestedFoldersModel: ObservableObject {
 
     var failedToLoadAction: (() -> ())? = nil
 
+    var previousUuids: [String] = []
+
     init(dataManager: DataManager = DataManager.sharedManager, failedToLoadAction: (() -> ())? = nil) {
         self.dataManager = dataManager
         self.failedToLoadAction = failedToLoadAction
@@ -40,7 +42,12 @@ class SuggestedFoldersModel: ObservableObject {
         }
         Task { @MainActor in
             loadingState = .loading
-            let uuids = dataManager.allPodcasts(includeUnsubscribed: false).map { $0.uuid }
+            let uuids = dataManager.allPodcastsOrderedByAddedDate().map { $0.uuid }
+            if areUuidsTheSame(previous: previousUuids, current: uuids) {
+                loadingState = .loaded
+                return
+            }
+            previousUuids = uuids
             guard let suggestionsResponse = await ApiServerHandler.shared.suggestedFolders(for: uuids) else {
                 loadingState = .failed
                 failedToLoadAction?()
@@ -56,6 +63,10 @@ class SuggestedFoldersModel: ObservableObject {
             self.folders = folders
             loadingState = .loaded
         }
+    }
+
+    private func areUuidsTheSame(previous: [String], current: [String]) -> Bool {
+        return previous == current
     }
 
     var userHasSubscription: Bool {

--- a/podcasts/SuggestedFoldersModel.swift
+++ b/podcasts/SuggestedFoldersModel.swift
@@ -100,7 +100,7 @@ class SuggestedFoldersModel: ObservableObject {
         return userType
     }
 
-    private func cacheLocation() -> URL {
+    private lazy var cacheLocation: URL = {
         let fileManager: FileManager = .default
         let name: String = "suggestedFolders"
 
@@ -111,10 +111,10 @@ class SuggestedFoldersModel: ObservableObject {
 
         let fileURL = folderURLs[0].appendingPathComponent(name + ".cache")
         return fileURL
-    }
+    }()
 
     private func saveToCache() {
-        let fileURL = cacheLocation()
+        let fileURL = cacheLocation
         guard let data = try? JSONEncoder().encode(folders) else {
             return
         }
@@ -122,7 +122,7 @@ class SuggestedFoldersModel: ObservableObject {
     }
 
     private func loadFromCache() {
-        let fileURL = cacheLocation()
+        let fileURL = cacheLocation
         guard let data = try? Data(contentsOf: fileURL),
               let folders = try? JSONDecoder().decode([SuggestedFolder].self, from: data) else {
             return

--- a/podcasts/SuggestedFoldersModel.swift
+++ b/podcasts/SuggestedFoldersModel.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import PocketCastsDataModel
 import PocketCastsServer
 
-struct SuggestedFolder: Identifiable {
+struct SuggestedFolder: Identifiable, Codable {
     var id: String {
         return name
     }
@@ -41,8 +41,11 @@ class SuggestedFoldersModel: ObservableObject {
             return
         }
         Task { @MainActor in
+            if loadingState == .start {
+                loadFromCache()
+            }
             loadingState = .loading
-            let uuids = dataManager.allPodcastsOrderedByAddedDate().map { $0.uuid }
+            let uuids = dataManager.allPodcastsOrderedByAddedDate().map { $0.uuid }.sorted()
             if areUuidsTheSame(previous: previousUuids, current: uuids) {
                 loadingState = .loaded
                 return
@@ -61,6 +64,7 @@ class SuggestedFoldersModel: ObservableObject {
                 }
             }
             self.folders = folders
+            saveToCache()
             loadingState = .loaded
         }
     }
@@ -94,5 +98,39 @@ class SuggestedFoldersModel: ObservableObject {
             userType = "paid"
         }
         return userType
+    }
+
+    private func cacheLocation() -> URL {
+        let fileManager: FileManager = .default
+        let name: String = "suggestedFolders"
+
+        let folderURLs = fileManager.urls(
+            for: .cachesDirectory,
+            in: .userDomainMask
+        )
+
+        let fileURL = folderURLs[0].appendingPathComponent(name + ".cache")
+        return fileURL
+    }
+
+    private func saveToCache() {
+        let fileURL = cacheLocation()
+        guard let data = try? JSONEncoder().encode(folders) else {
+            return
+        }
+        try? data.write(to: fileURL)
+    }
+
+    private func loadFromCache() {
+        let fileURL = cacheLocation()
+        guard let data = try? Data(contentsOf: fileURL),
+              let folders = try? JSONDecoder().decode([SuggestedFolder].self, from: data) else {
+            return
+        }
+        var previousUuids = folders.reduce(into: [String]()) { result, folder in
+            result.append(contentsOf: folder.podcastUuids)
+        }
+        self.folders = folders
+        self.previousUuids = previousUuids.sorted()
     }
 }

--- a/podcasts/SuggestedFoldersModel.swift
+++ b/podcasts/SuggestedFoldersModel.swift
@@ -35,7 +35,7 @@ class SuggestedFoldersModel: ObservableObject {
     }
 
     func load() async {
-        if loadingState != .start {
+        if loadingState == .loading {
             return
         }
         Task { @MainActor in

--- a/podcasts/SuggestedFoldersView.swift
+++ b/podcasts/SuggestedFoldersView.swift
@@ -24,6 +24,12 @@ struct SuggestedFoldersView: View {
 
     var onCompletion: (SuggestedFoldersResult) -> Void
 
+    init(model: SuggestedFoldersModel = SuggestedFoldersModel(), source: AnalyticsSource, onCompletion: @escaping (SuggestedFoldersResult) -> Void) {
+        self.model = model
+        self.source = source
+        self.onCompletion = onCompletion
+    }
+
     var body: some View {
         Group {
             switch model.loadingState {


### PR DESCRIPTION
| 📘 Part of: #https://github.com/orgs/Automattic/projects/1278 |  <!-- project issue number, if applicable -->
|:---:|

Fixes #2808 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR implement a cache mechanism for the suggested folder it works the following way:

- A record is kept of the uuids used on the last call
- Every time a call is made the uuids being used are compared with the last call made
- If the same use the cached value
- If not, do a new call and save results to memory and disk
- Next startup from the app the cache is pre-loaded with the disk information

## To test

- Clean install the app
- Ensure that you have the Feature Flag enabled. Profile -> Settings -> Beta Features -> SuggestedFolders
- Login with a Plus user
- Go to Podcasts tab
- Tap on Folder icon on the top left
- Check if the Suggested Folders show correctly
- Go back to Podcasts tab
- Delete one of the existing folders
- Tap on Folder icon on the top left
- Check if the Suggested Folders show correctly with the updated value

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
