### PR TITLE
[Generated Transcripts] Parse new pocket casts transcript parameter

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Episode.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Episode.swift
@@ -209,11 +209,19 @@ public class Episode: NSObject, BaseEpisode {
         }
 
         public let transcripts: [Transcript]
+        public let pocketCastsTranscripts: [Transcript]?
 
         public struct Transcript: Decodable {
             public let url: String
             public let type: String
             public let language: String?
+        }
+
+        public func hasGeneratedTranscripts() -> Bool {
+            guard let pocketCastsTranscripts else {
+                return false
+            }
+            return !pocketCastsTranscripts.isEmpty
         }
     }
 }

--- a/PocketCastsTests/Tests/Playback/Chapters/ChapterManagerTests.swift
+++ b/PocketCastsTests/Tests/Playback/Chapters/ChapterManagerTests.swift
@@ -119,8 +119,8 @@ private class ShowInfoCoordinatorMock: ShowInfoCoordinating {
         (nil, nil)
     }
 
-    func loadTranscriptsMetadata(podcastUuid: String, episodeUuid: String) async throws -> [Episode.Metadata.Transcript] {
-        return []
+    func loadTranscriptsMetadata(podcastUuid: String, episodeUuid: String) async throws -> EpisodeTranscriptData {
+        return (transcripts: [], hasGeneratedTranscripts: false)
     }
 }
 

--- a/PocketCastsTests/Tests/Player/Transcripts/TranscriptManagerTests.swift
+++ b/PocketCastsTests/Tests/Player/Transcripts/TranscriptManagerTests.swift
@@ -17,14 +17,13 @@ final class TranscriptManagerTests: XCTestCase {
             return (nil, nil)
         }
 
-        func loadTranscriptsMetadata(podcastUuid: String, episodeUuid: String) async throws -> [Episode.Metadata.Transcript] {
+        func loadTranscriptsMetadata(podcastUuid: String, episodeUuid: String) async throws -> EpisodeTranscriptData {
             guard let transcriptURL = Bundle(for: Self.self).url(forResource: "sample", withExtension: "vtt") else {
-                return []
+                return (transcripts: [], hasGeneratedTranscripts: false)
             }
             let transcript = Episode.Metadata.Transcript(url: transcriptURL.absoluteString, type: "text/vtt", language: nil)
-            return [transcript]
+            return (transcripts: [transcript], hasGeneratedTranscripts: false)
         }
-
     }
 
     func testLoadingTranscript() async throws {

--- a/podcasts/Episode Info Coordinator/ShowInfoCoordinating.swift
+++ b/podcasts/Episode Info Coordinator/ShowInfoCoordinating.swift
@@ -4,7 +4,7 @@ import PocketCastsServer
 
 protocol ShowInfoCoordinating {
     typealias EpisodeTranscriptData = (transcripts: [Episode.Metadata.Transcript], hasGeneratedTranscripts: Bool)
-    
+
     func loadShowNotes(
         podcastUuid: String,
         episodeUuid: String

--- a/podcasts/Episode Info Coordinator/ShowInfoCoordinating.swift
+++ b/podcasts/Episode Info Coordinator/ShowInfoCoordinating.swift
@@ -3,6 +3,8 @@ import PocketCastsDataModel
 import PocketCastsServer
 
 protocol ShowInfoCoordinating {
+    typealias EpisodeTranscriptData = (transcripts: [Episode.Metadata.Transcript], hasGeneratedTranscripts: Bool)
+    
     func loadShowNotes(
         podcastUuid: String,
         episodeUuid: String
@@ -21,5 +23,5 @@ protocol ShowInfoCoordinating {
     func loadTranscriptsMetadata(
         podcastUuid: String,
         episodeUuid: String
-    ) async throws -> [Episode.Metadata.Transcript]
+    ) async throws -> EpisodeTranscriptData
 }

--- a/podcasts/Episode Info Coordinator/ShowInfoCoordinator.swift
+++ b/podcasts/Episode Info Coordinator/ShowInfoCoordinator.swift
@@ -1,6 +1,7 @@
 import Foundation
 import PocketCastsDataModel
 import PocketCastsServer
+import PocketCastsUtils
 
 actor ShowInfoCoordinator: ShowInfoCoordinating {
     static let shared = ShowInfoCoordinator()
@@ -57,17 +58,23 @@ actor ShowInfoCoordinator: ShowInfoCoordinating {
         return (metadata?.chapters, nil)
     }
 
-    public func loadTranscriptsMetadata(podcastUuid: String, episodeUuid: String) async throws -> [Episode.Metadata.Transcript] {
+    public func loadTranscriptsMetadata(podcastUuid: String, episodeUuid: String) async throws -> EpisodeTranscriptData {
 #if os(watchOS)
-        return []
+        return (transcripts: [], hasGeneratedTranscripts: false)
 #else
         let metadata = try await loadShowInfo(podcastUuid: podcastUuid, episodeUuid: episodeUuid)
 
-        guard let transcripts = metadata?.transcripts else {
-            return []
+        if FeatureFlag.generatedTranscripts.enabled {
+            let externalTranscripts = metadata?.transcripts ?? []
+            let pocketCastsTranscripts = metadata?.pocketCastsTranscripts ?? []
+            let transcripts = externalTranscripts.isEmpty ? pocketCastsTranscripts : externalTranscripts
+            return (transcripts: transcripts, hasGeneratedTranscripts: !pocketCastsTranscripts.isEmpty)
         }
 
-        return transcripts
+        guard let transcripts = metadata?.transcripts else {
+            return (transcripts: [], hasGeneratedTranscripts: false)
+        }
+        return (transcripts: transcripts, hasGeneratedTranscripts: metadata?.hasGeneratedTranscripts() ?? false)
 #endif
     }
 

--- a/podcasts/Episode+Transcript.swift
+++ b/podcasts/Episode+Transcript.swift
@@ -3,9 +3,15 @@ import PocketCastsDataModel
 extension Episode {
     func checkTranscriptAvailability() {
         Task.init {
-            if let transcripts = try? await ShowInfoCoordinator.shared.loadTranscriptsMetadata(podcastUuid: parentIdentifier(), episodeUuid: uuid) {
-                let transcriptsAvailable = !transcripts.isEmpty
-                NotificationCenter.postOnMainThread(notification: Constants.Notifications.episodeTranscriptAvailabilityChanged, userInfo: ["episodeUuid": uuid, "isAvailable": transcriptsAvailable])
+            if let metadata = try? await ShowInfoCoordinator.shared.loadTranscriptsMetadata(podcastUuid: parentIdentifier(), episodeUuid: uuid) {
+                let transcriptsAvailable = !metadata.transcripts.isEmpty
+                let hasGeneratedTranscripts = metadata.hasGeneratedTranscripts
+                let userInfo = [
+                    "episodeUuid": uuid,
+                    "isAvailable": transcriptsAvailable,
+                    "hasGeneratedTranscripts": hasGeneratedTranscripts
+                ]
+                NotificationCenter.postOnMainThread(notification: Constants.Notifications.episodeTranscriptAvailabilityChanged, userInfo: userInfo)
             }
         }
     }

--- a/podcasts/NowPlayingPlayerItemViewController+Shelf.swift
+++ b/podcasts/NowPlayingPlayerItemViewController+Shelf.swift
@@ -395,7 +395,13 @@ extension NowPlayingPlayerItemViewController: NowPlayingActionsDelegate {
         }
         shelfButtonTapped(.transcript)
 
-        displayTranscript = true
+        if FeatureFlag.generatedTranscripts.enabled &&
+           transcriptButton.hasGeneratedTranscripts &&
+           (!SubscriptionHelper.hasActiveSubscription() || !SyncManager.isUserLoggedIn()) {
+            // Presented paywall
+        } else {
+            displayTranscript = true
+        }
         #endif
     }
 

--- a/podcasts/ShelfActionsViewController.swift
+++ b/podcasts/ShelfActionsViewController.swift
@@ -51,6 +51,7 @@ class ShelfActionsViewController: UIViewController, CheckTranscriptAvailability 
 
     private var sheetPresentationDismissalBlocker: ShelfActionsSheetDismissalBlocker?
 
+    var hasGeneratedTranscripts = false
     var isTranscriptEnabled = false {
         didSet {
             reloadActions()

--- a/podcasts/TranscriptManager.swift
+++ b/podcasts/TranscriptManager.swift
@@ -42,11 +42,11 @@ class TranscriptManager {
 
     public func loadTranscript() async throws -> TranscriptModel {
         guard
-            let transcripts = try? await showCoordinator.loadTranscriptsMetadata(podcastUuid: podcastUUID, episodeUuid: episodeUUID),
-            !transcripts.isEmpty else {
+            let metadata = try? await showCoordinator.loadTranscriptsMetadata(podcastUuid: podcastUUID, episodeUuid: episodeUUID),
+            !metadata.transcripts.isEmpty else {
             throw TranscriptError.notAvailable
         }
-        var transcriptsAvailable = transcripts
+        var transcriptsAvailable = metadata.transcripts
         while let transcript = TranscriptFormat.bestTranscript(from: transcriptsAvailable) {
             do {
                 let model = try await loadTranscript(transcript)

--- a/podcasts/TranscriptShelfButton.swift
+++ b/podcasts/TranscriptShelfButton.swift
@@ -2,6 +2,7 @@ import UIKit
 import PocketCastsDataModel
 
 class TranscriptShelfButton: UIButton, CheckTranscriptAvailability {
+    var hasGeneratedTranscripts: Bool = false
     var isTranscriptEnabled: Bool {
         didSet {
             imageView?.tintColor = isTranscriptEnabled ? ThemeColor.playerContrast02() : ThemeColor.playerContrast06()
@@ -26,6 +27,7 @@ class TranscriptShelfButton: UIButton, CheckTranscriptAvailability {
 
 protocol CheckTranscriptAvailability: AnyObject {
     var isTranscriptEnabled: Bool { get set }
+    var hasGeneratedTranscripts: Bool { get set }
 
     func addTranscriptObservers()
     func checkTranscriptAvailability()
@@ -36,11 +38,13 @@ extension CheckTranscriptAvailability {
         NotificationCenter.default.addObserver(forName: Constants.Notifications.episodeTranscriptAvailabilityChanged, object: nil, queue: .main) { [weak self] notification in
             guard let episodeUuid = notification.userInfo?["episodeUuid"] as? String,
                   let isAvailable = notification.userInfo?["isAvailable"] as? Bool,
+                  let hasGeneratedTranscripts = notification.userInfo?["hasGeneratedTranscripts"] as? Bool,
                   episodeUuid == PlaybackManager.shared.currentEpisode()?.uuid else {
                 return
             }
 
             self?.isTranscriptEnabled = isAvailable
+            self?.hasGeneratedTranscripts = hasGeneratedTranscripts
         }
 
         NotificationCenter.default.addObserver(forName: Constants.Notifications.playbackTrackChanged, object: nil, queue: .main) { [weak self] notification in
@@ -50,6 +54,7 @@ extension CheckTranscriptAvailability {
 
     func checkTranscriptAvailability() {
         isTranscriptEnabled = false
+        hasGeneratedTranscripts = false
         let currentEpisode = PlaybackManager.shared.currentEpisode() as? Episode
         currentEpisode?.checkTranscriptAvailability()
     }


### PR DESCRIPTION
| 📘 Part of: #2812
|:---:|

Fixes #2814

This PR maps the new `pocketCastsTranscripts` that contains the generated transcripts.
External transcripts have priority over generated.

## To test

• CI must be 🟢 

### New parameter
• Run staging on a new install to clear all the cache
• Make sure you have `generatedTranscripts` FF on
• Look for `Conan O’Brian Needs a Friend`, episode `This Is My Deal Here, Wade` and play it
• The transcript icon in shelf should be available
• Tap on it to see load the transcript
• Do the same test with `Cautionary Tales` to load the external transcript as before

### Smoke test
• Switch off the FF
• Make sure everything works as before

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
