### PR TITLE
Add feature flag for new podcast header design

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -147,6 +147,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// Enable the generated transcript
     case generatedTranscripts
 
+    /// Enable the new podcast view
+    case podcastViewChanges
+
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -245,6 +248,8 @@ public enum FeatureFlag: String, CaseIterable {
             false
         case .generatedTranscripts:
             false
+        case .podcastViewChanges:
+            false
         }
     }
 
@@ -266,6 +271,8 @@ public enum FeatureFlag: String, CaseIterable {
             "default_player_filter_callback_fix"
         case .usePodcastHTMLDescription:
             "use_podcast_html_description"
+        case .podcastViewChanges:
+            "podcast_view_changes_2025"
         default:
             rawValue.lowerSnakeCased()
         }

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1980,6 +1980,7 @@
 		FF7F89EF2C2AF7B600FC0ED5 /* SwiftSubtitles in Frameworks */ = {isa = PBXBuildFile; productRef = FF7F89EE2C2AF7B600FC0ED5 /* SwiftSubtitles */; };
 		FF7F89F12C2C0FD600FC0ED5 /* TranscriptModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF7F89F02C2C0FD600FC0ED5 /* TranscriptModel.swift */; };
 		FF8970762B5FFC5E004ADB23 /* SubscriptionPriceAndOfferView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF8970752B5FFC5E004ADB23 /* SubscriptionPriceAndOfferView.swift */; };
+		FF89C0962D807B4000BC5104 /* PodcastHeaderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF89C0952D807B2B00BC5104 /* PodcastHeaderCell.swift */; };
 		FF91A0F62B64159D002A0590 /* UIScreen+Sizes.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF91A0F52B64159D002A0590 /* UIScreen+Sizes.swift */; };
 		FF91A0F82B6BBF33002A0590 /* UpgradeRoundedSegmentedControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF91A0F72B6BBF33002A0590 /* UpgradeRoundedSegmentedControl.swift */; };
 		FF91A0FA2B6BBFD1002A0590 /* UpgradeCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF91A0F92B6BBFD1002A0590 /* UpgradeCard.swift */; };
@@ -4003,6 +4004,7 @@
 		FF7F89EC2C2AF6DE00FC0ED5 /* TranscriptManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptManager.swift; sourceTree = "<group>"; };
 		FF7F89F02C2C0FD600FC0ED5 /* TranscriptModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptModel.swift; sourceTree = "<group>"; };
 		FF8970752B5FFC5E004ADB23 /* SubscriptionPriceAndOfferView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionPriceAndOfferView.swift; sourceTree = "<group>"; };
+		FF89C0952D807B2B00BC5104 /* PodcastHeaderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PodcastHeaderCell.swift; sourceTree = "<group>"; };
 		FF91A0F52B64159D002A0590 /* UIScreen+Sizes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIScreen+Sizes.swift"; sourceTree = "<group>"; };
 		FF91A0F72B6BBF33002A0590 /* UpgradeRoundedSegmentedControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpgradeRoundedSegmentedControl.swift; sourceTree = "<group>"; };
 		FF91A0F92B6BBFD1002A0590 /* UpgradeCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpgradeCard.swift; sourceTree = "<group>"; };
@@ -6215,6 +6217,7 @@
 		BD6D417B200C555000CA8993 /* Cells */ = {
 			isa = PBXGroup;
 			children = (
+				FF89C0952D807B2B00BC5104 /* PodcastHeaderCell.swift */,
 				409C793522387C0500386495 /* AllArchivedCell.swift */,
 				409C793622387C0500386495 /* AllArchivedCell.xib */,
 				4086511923B1CE8400D7585A /* CreateSiriShortcutCell.swift */,
@@ -10274,6 +10277,7 @@
 				4007B060230E3A81008DDCF5 /* WhatsNewStructs.swift in Sources */,
 				4041FE8D218A7DA60089D4A1 /* SiriShortcutEnabledCell.swift in Sources */,
 				F57D8F162C66CBB80004C4DF /* UnsafeTransfer.swift in Sources */,
+				FF89C0962D807B4000BC5104 /* PodcastHeaderCell.swift in Sources */,
 				F52B4F8C2BB4A9CA00E87BE4 /* CategoriesSelectorViewController.swift in Sources */,
 				BD5C39541B5E0A2A00C3A499 /* ShiftyLoadingAlert.swift in Sources */,
 				FF40C0662C65175B003A9D93 /* TranscriptErrorView.swift in Sources */,

--- a/podcasts/PodcastHeaderCell.swift
+++ b/podcasts/PodcastHeaderCell.swift
@@ -1,0 +1,18 @@
+import Foundation
+import UIKit
+
+class PodcastHeaderCell: UITableViewCell {
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    required override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        commonSetup()
+    }
+
+    func commonSetup() {
+        self.backgroundColor = .purple
+    }
+}

--- a/podcasts/PodcastViewController+TableData.swift
+++ b/podcasts/PodcastViewController+TableData.swift
@@ -62,10 +62,15 @@ extension PodcastViewController: UITableViewDataSource, UITableViewDelegate {
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         if indexPath.section == PodcastViewController.headerSection {
-            let cell = podcastHeadingCell
-            cell.populateFrom(tintColor: podcast?.iconTintColor(), delegate: self, parentController: self)
-            cell.buttonsEnabled = !isMultiSelectEnabled
-            return cell
+            if FeatureFlag.podcastViewChanges.enabled {
+                let cell = PodcastHeaderCell(style: .default, reuseIdentifier: nil)
+                return cell
+            } else {
+                let cell = podcastHeadingCell
+                cell.populateFrom(tintColor: podcast?.iconTintColor(), delegate: self, parentController: self)
+                cell.buttonsEnabled = !isMultiSelectEnabled
+                return cell
+            }
         }
 
         guard let itemAtRow = episodeInfo[safe: indexPath.section]?.elements[safe: indexPath.row] as? ListItem else {


### PR DESCRIPTION
| 📘 Part of: #2825  |  <!-- project issue number, if applicable -->
|:---:|

Fixes #2829 

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
Add Feature Flag to control new Design for podcast header

## To test

1. Start the app
2. Go to Profile -> Settings -> Beta Features
3. Check if you can see the podcastView changes feature flag
4. Enable it
5. Go to Podcast
6. Open a Podcast
7. Check if you see a purple placeholder header
8. Disable the FF
9. Go back to podcast details and check if you see the regular header

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
