### PR TITLE
[Generated Transcripts] Add analytics events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 7.85
 -----
 - Revert episode detail screen dismiss action when archiving [#2802](https://github.com/Automattic/pocket-casts-ios/pull/2802)
+- Implement the possibility to display generated transcripts [#2812](https://github.com/Automattic/pocket-casts-ios/issues/2812)
 
 7.84
 -----

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -247,7 +247,7 @@ public enum FeatureFlag: String, CaseIterable {
         case .suggestedFolders:
             false
         case .generatedTranscripts:
-            false
+            true
         case .podcastViewChanges:
             false
         }

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -787,6 +787,9 @@ enum AnalyticsEvent: String {
     case transcriptSearchShown
     case transcriptSearchNextResult
     case transcriptSearchPreviousResult
+    case transcriptGeneratedPaywallShown
+    case transcriptGeneratedPaywallDismissed
+    case transcriptGeneratedPaywallSubscribeTapped
 
     // MARK: - Widgets
 

--- a/podcasts/GeneratedTranscriptsPremiumOverlay.swift
+++ b/podcasts/GeneratedTranscriptsPremiumOverlay.swift
@@ -5,6 +5,8 @@ class GeneratedTranscriptsPremiumOverlay: UIViewController {
     var dismissTranscript: (() -> Void)?
     var purchaseSuccessfull: (() -> Void)?
 
+    private let playbackManager: PlaybackManager
+
     private lazy var stackView: UIStackView = {
         let stackView = UIStackView()
         stackView.translatesAutoresizingMaskIntoConstraints = false
@@ -71,6 +73,15 @@ class GeneratedTranscriptsPremiumOverlay: UIViewController {
         return blurEffectView
     }()
 
+    init(playbackManager: PlaybackManager) {
+        self.playbackManager = playbackManager
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
         setupView()
@@ -78,10 +89,12 @@ class GeneratedTranscriptsPremiumOverlay: UIViewController {
 
     func didAppear() {
         NotificationCenter.default.addObserver(self, selector: #selector(subscriptionStatusDidChange), name: ServerNotifications.subscriptionStatusChanged, object: nil)
+        track(event: .transcriptGeneratedPaywallShown)
     }
 
     func didDisappear() {
         NotificationCenter.default.removeObserver(self)
+        track(event: .transcriptGeneratedPaywallDismissed)
     }
 
     private func setupView() {
@@ -132,6 +145,7 @@ class GeneratedTranscriptsPremiumOverlay: UIViewController {
     }
 
     @objc private func paywallButtonTapped() {
+        track(event: .transcriptGeneratedPaywallSubscribeTapped)
         NavigationManager.sharedManager.showUpsellView(from: self, source: .generatedTranscripts)
     }
 
@@ -141,5 +155,13 @@ class GeneratedTranscriptsPremiumOverlay: UIViewController {
                 self?.purchaseSuccessfull?()
             }
         }
+    }
+
+    private func track(event: AnalyticsEvent) {
+        guard let episode = playbackManager.currentEpisode(),
+              let podcast = playbackManager.currentPodcast else {
+            return
+        }
+        Analytics.track(event, properties: ["episode_uuid": episode.uuid, "podcast_uuid": podcast.uuid])
     }
 }

--- a/podcasts/PlayerContainerViewController.swift
+++ b/podcasts/PlayerContainerViewController.swift
@@ -83,7 +83,8 @@ class PlayerContainerViewController: SimpleNotificationsViewController, PlayerTa
     }()
 
     private lazy var generatedTranscriptsPremiumOverlay: GeneratedTranscriptsPremiumOverlay = {
-        let item = GeneratedTranscriptsPremiumOverlay()
+        let playbackManager = PlaybackManager.shared
+        let item = GeneratedTranscriptsPremiumOverlay(playbackManager: playbackManager)
         item.view.translatesAutoresizingMaskIntoConstraints = false
         item.dismissTranscript = { [weak self] in
             self?.dismissGeneratedTranscriptsPremiumOverlay(dismissTranscript: true)


### PR DESCRIPTION
| 📘 Part of: #2812
|:---:|

Fixes #2818

Adds new analytics events

## To test

- Start from a fresh install
- Run the app in prod
- Make sure you have the FF on
- Follow the following podcasts: `The Rest is History`
- Play the last episode
- Open the transcripts
- When the overlay appears confirm you see this event:
- `🔵 Tracked: transcript_generated_paywall_shown ["podcast_uuid": "UUID", "episode_uuid": "UUID"]`
- Tap on the bottom button to display the paywall
- Confirm you see `🔵 Tracked: transcript_generated_paywall_subscribe_tapped ["podcast_uuid": "UUID", "episode_uuid": "UUID"]`
- When the paywall appears confirm you see:
- `🔵 Tracked: plus_promotion_shown ["flow": "plus_upsell", "source": "generatedTranscripts"]`
- Dismiss the paywall
- Dismiss the overlay
- Confirm you see `🔵 Tracked: transcript_generated_paywall_dismissed ["podcast_uuid": "UUID", "episode_uuid": "UUID"]`

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
