### PR TITLE
[Generated Transcripts] Enable Feature Flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 7.85
 -----
 - Revert episode detail screen dismiss action when archiving [#2802](https://github.com/Automattic/pocket-casts-ios/pull/2802)
+- Implement the possibility to display generated transcripts [#2812](https://github.com/Automattic/pocket-casts-ios/issues/2812)
 
 7.84
 -----

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -247,7 +247,7 @@ public enum FeatureFlag: String, CaseIterable {
         case .suggestedFolders:
             false
         case .generatedTranscripts:
-            false
+            true
         case .podcastViewChanges:
             false
         }


### PR DESCRIPTION
| 📘 Part of: #2812 
|:---:|

Fixes #2848 

Enable Feature Flag

## To test

- Run the App with a free user
- Play the last episode of `The Rest is History`
- Open transcripts
- Confirm you see the overlay

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
