### PR TITLE
[Fix] Prevent to open share path if url is the base URL

### DIFF
--- a/podcasts/AppDelegate+SiriShortcuts.swift
+++ b/podcasts/AppDelegate+SiriShortcuts.swift
@@ -29,7 +29,7 @@ extension AppDelegate {
             else { return }
 
             //If path is just the base share URL let's return
-            if path.isEmpty, URL(string: ServerConstants.Urls.share())?.host == incomingURL.host {
+            if path.isEmpty || path == "/", URL(string: ServerConstants.Urls.share())?.host == incomingURL.host {
                 return
             }
 

--- a/podcasts/AppDelegate+SiriShortcuts.swift
+++ b/podcasts/AppDelegate+SiriShortcuts.swift
@@ -1,4 +1,5 @@
 import Foundation
+import PocketCastsServer
 import Intents
 import JLRoutes
 import PocketCastsDataModel
@@ -26,6 +27,11 @@ extension AppDelegate {
                 path != "/get",
                 path != "/get/"
             else { return }
+
+            //If path is just the base share URL let's return
+            if path.isEmpty, URL(string: ServerConstants.Urls.share())?.host == incomingURL.host {
+                return
+            }
 
             if path.startsWith(string: "/redeem") {
                 handleReferralsDeepLink(url: incomingURL)


### PR DESCRIPTION
Ref. p1741935356767609-slack-C029BMLUGRX

This PR prevents to open the share URL if a user taps on `https://pca.st/`

## To test

- Run or install this branch
- Add `https://pca.st/` to your notes app
- Tap on the link
- Observe the link opening the app without redirecting to Safari
- Test this branch with different share URLs to confirm they still work as expected

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
