### PR TITLE
[Podcast view changes] Follow button animation

### DIFF
--- a/podcasts/PodcastHeaderModel.swift
+++ b/podcasts/PodcastHeaderModel.swift
@@ -100,7 +100,7 @@ class PodcastHeaderViewModel: ObservableObject {
             delegate.unsubscribe()
         } else {
             delegate.subscribe()
-            isExpanded = false
+            //isExpanded = false
         }
     }
 

--- a/podcasts/PodcastHeaderModel.swift
+++ b/podcasts/PodcastHeaderModel.swift
@@ -14,10 +14,13 @@ class PodcastHeaderViewModel: ObservableObject {
     init(podcast: Podcast, delegate: PodcastActionsDelegate? = nil) {
         self.podcast = podcast
         self.delegate = delegate
+        self.isSubscribed = podcast.isSubscribed()
         addObservers()
     }
 
     @Published var isExpanded: Bool = true
+
+    @Published var isSubscribed: Bool = false
 
     private var cancellables = Set<AnyCancellable>()
     private func addObservers() {
@@ -30,8 +33,8 @@ class PodcastHeaderViewModel: ObservableObject {
             else {
                 return
             }
-
             self.podcast = podcast
+            self.isSubscribed = podcast.isSubscribed()
         }
         .store(in: &cancellables)
     }
@@ -100,7 +103,7 @@ class PodcastHeaderViewModel: ObservableObject {
             delegate.unsubscribe()
         } else {
             delegate.subscribe()
-            //isExpanded = false
+            isSubscribed = true
         }
     }
 

--- a/podcasts/PodcastHeaderModel.swift
+++ b/podcasts/PodcastHeaderModel.swift
@@ -101,8 +101,10 @@ class PodcastHeaderViewModel: ObservableObject {
 
         if podcast.isSubscribed() {
             delegate.unsubscribe()
+            // do not switch variable here because there is still a confimation screen
         } else {
             delegate.subscribe()
+            // switching state immediately so animation is triggered at press
             isSubscribed = true
         }
     }

--- a/podcasts/PoscastHeaderView.swift
+++ b/podcasts/PoscastHeaderView.swift
@@ -85,20 +85,34 @@ struct PodcastHeaderView: View {
 
     private var followButton: some View {
         Button() {
-            viewModel.subscribeButtonTapped()
+            withAnimation {
+                viewModel.subscribeButtonTapped()
+            }
         } label: {
-            Text(viewModel.podcast.subscribed != 0 ? L10n.unfollow : L10n.follow)
+            Text(viewModel.podcast.subscribed != 0 ? "" : L10n.follow)
                 .font(.body).bold()
                 .foregroundStyle(theme.primaryText01)
                 .padding()
-                .cornerRadius(8)
+                .cornerRadius(viewModel.podcast.subscribed == 0 ? 8 : 44)
+                .background {
+                    Image("discover_tick")
+                        .cornerRadius(44)
+                        .frame(width: 44, height: 44)
+                        .background {
+                            RoundedRectangle(cornerRadius: 44)
+                            .inset(by: 0.5)
+                            .stroke(theme.support02, lineWidth: 1)
+                            .background(theme.support02)
+                        }
+                        .opacity(viewModel.podcast.subscribed == 0 ? 0 : 1)
+                }
                 .overlay(
-                    RoundedRectangle(cornerRadius: 8)
+                    RoundedRectangle(cornerRadius: viewModel.podcast.subscribed == 0 ? 8 : 44)
                     .inset(by: 0.5)
                     .stroke(theme.primaryUi05, lineWidth: 1)
                 )
+
         }
-        .frame(width: 150, height: 40)
     }
 
     private var podcastActions: some View {

--- a/podcasts/PoscastHeaderView.swift
+++ b/podcasts/PoscastHeaderView.swift
@@ -120,7 +120,7 @@ struct PodcastHeaderView: View {
         HStack(spacing: 8) {
             Spacer()
             followButton
-            if viewModel.podcast.subscribed != 0 {
+            if viewModel.isSubscribed {
                 actionButton(title: L10n.folder, imageName: viewModel.folderImage) {
                     viewModel.delegate?.folderTapped()
                 }

--- a/podcasts/PoscastHeaderView.swift
+++ b/podcasts/PoscastHeaderView.swift
@@ -117,7 +117,7 @@ struct PodcastHeaderView: View {
     }
 
     private var podcastActions: some View {
-        HStack(spacing: 0) {
+        HStack(spacing: 8) {
             Spacer()
             followButton
             if viewModel.podcast.subscribed != 0 {

--- a/podcasts/PoscastHeaderView.swift
+++ b/podcasts/PoscastHeaderView.swift
@@ -89,28 +89,29 @@ struct PodcastHeaderView: View {
                 viewModel.subscribeButtonTapped()
             }
         } label: {
-            Text(viewModel.podcast.subscribed != 0 ? "" : L10n.follow)
+            Text(viewModel.isSubscribed ? "" : L10n.follow)
                 .font(.body).bold()
                 .foregroundStyle(theme.primaryText01)
                 .padding()
-                .cornerRadius(viewModel.podcast.subscribed == 0 ? 8 : 44)
+                .cornerRadius(viewModel.isSubscribed ? 8 : 32)
+                .frame(width: viewModel.isSubscribed ? 32 : nil, height: viewModel.isSubscribed ? 32 : 40)
                 .background {
                     Image("discover_tick")
-                        .cornerRadius(44)
-                        .frame(width: 44, height: 44)
-                        .background {
-                            RoundedRectangle(cornerRadius: 44)
-                            .inset(by: 0.5)
-                            .stroke(theme.support02, lineWidth: 1)
-                            .background(theme.support02)
-                        }
-                        .opacity(viewModel.podcast.subscribed == 0 ? 0 : 1)
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .background(theme.support02)
+                        .tint(theme.primaryUi01)
+                        .frame(width: 24, height: 24)
+                        .clipShape(Circle())
+                        .opacity(viewModel.isSubscribed ? 1 : 0)
                 }
                 .overlay(
-                    RoundedRectangle(cornerRadius: viewModel.podcast.subscribed == 0 ? 8 : 44)
+                    RoundedRectangle(cornerRadius: viewModel.isSubscribed ? 32 : 8)
                     .inset(by: 0.5)
                     .stroke(theme.primaryUi05, lineWidth: 1)
+                    .opacity(viewModel.isSubscribed ? 0 : 1)
                 )
+                .clipped()
 
         }
     }

--- a/podcasts/PoscastHeaderView.swift
+++ b/podcasts/PoscastHeaderView.swift
@@ -93,7 +93,7 @@ struct PodcastHeaderView: View {
                 .font(.body).bold()
                 .foregroundStyle(theme.primaryText01)
                 .padding()
-                .cornerRadius(viewModel.isSubscribed ? 8 : 32)                
+                .cornerRadius(viewModel.isSubscribed ? 8 : 32)
                 .frame(minWidth: viewModel.isSubscribed ? 32 : 150, maxWidth: viewModel.isSubscribed ? 32 : nil, minHeight: viewModel.isSubscribed ? 32 : 40, maxHeight: viewModel.isSubscribed ? 32 : 40)
                 .background {
                     Image("discover_tick")

--- a/podcasts/PoscastHeaderView.swift
+++ b/podcasts/PoscastHeaderView.swift
@@ -93,8 +93,8 @@ struct PodcastHeaderView: View {
                 .font(.body).bold()
                 .foregroundStyle(theme.primaryText01)
                 .padding()
-                .cornerRadius(viewModel.isSubscribed ? 8 : 32)
-                .frame(width: viewModel.isSubscribed ? 32 : nil, height: viewModel.isSubscribed ? 32 : 40)
+                .cornerRadius(viewModel.isSubscribed ? 8 : 32)                
+                .frame(minWidth: viewModel.isSubscribed ? 32 : 150, maxWidth: viewModel.isSubscribed ? 32 : nil, minHeight: viewModel.isSubscribed ? 32 : 40, maxHeight: viewModel.isSubscribed ? 32 : 40)
                 .background {
                     Image("discover_tick")
                         .resizable()


### PR DESCRIPTION
| 📘 Part of: #2825  |  <!-- project issue number, if applicable -->
|:---:|

Fixes #2862 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

https://github.com/user-attachments/assets/099ec4c1-af8d-44bd-b6fd-1ee9bf376eb8


## To test

1. Start the app
2. Ensure you have the podcastViewChanges FF enabled
3. Open a podcast that you don't Follow 
4. Tap on the follow button
5. Check if button animates correctly to the green checkmark status
6. Press on the green checkmark status and see if the unfollow confirmation sheet shows up

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
