### PR TITLE
[Generated Transcript] Update banner view when episode finishes

### DIFF
--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -76,9 +76,12 @@ class TranscriptViewController: PlayerItemViewController {
             transcriptViewTopConstraint?.constant = 80.0
             topGradientTopConstraint?.constant = 100.0
             topGradientHeightConstraint?.constant = 30.0
-
-            updateTextMargins()
+        } else {
+            transcriptViewTopConstraint?.constant = 0.0
+            topGradientTopConstraint?.constant = 0.0
+            topGradientHeightConstraint?.constant = Sizes.topGradientHeight
         }
+        updateTextMargins()
     }
 
     private func addGeneratedTranscriptsObservers() {
@@ -368,6 +371,9 @@ class TranscriptViewController: PlayerItemViewController {
         transcriptView.indicatorStyle = .white
         activityIndicatorView.color = ThemeColor.playerContrast02()
         updateGradientColors()
+        if FeatureFlag.generatedTranscripts.enabled {
+            bannerView.backgroundColor = PlayerColorHelper.playerBackgroundColor01()
+        }
     }
 
     private func updateGradientColors() {
@@ -423,16 +429,14 @@ class TranscriptViewController: PlayerItemViewController {
                 let transcript = try await transcriptManager.loadTranscript()
                 await track(.transcriptShown, properties: ["type": transcript.type, "show_as_webpage": transcript.hasJavascript])
                 let hasGeneratedTranscripts = FeatureFlag.generatedTranscripts.enabled && transcriptManager.hasGeneratedTranscripts
-                if hasGeneratedTranscripts {
-                    await MainActor.run {
-                        self.updateTextMargins()
-                        UIView.animate(withDuration: 0.25) {
-                            if self.shouldShowPremiumView {
-                                self.stackView.alpha = 0
-                                self.showGeneratedTranscriptsPremiumOverlay?()
-                            }
-                            self.bannerView.isHidden = false
+                await MainActor.run {
+                    self.setHasGeneratedTranscripts(hasGeneratedTranscripts)
+                    UIView.animate(withDuration: 0.25) {
+                        if hasGeneratedTranscripts, self.shouldShowPremiumView {
+                            self.stackView.alpha = 0
+                            self.showGeneratedTranscriptsPremiumOverlay?()
                         }
+                        self.bannerView.isHidden = !hasGeneratedTranscripts
                     }
                 }
                 await show(transcript: transcript, resetPosition: shouldResetPosition)


### PR DESCRIPTION
| 📘 Part of: #2812
|:---:|

Fixes #2866

This PR fixes the transcripts UI when an episode finishes and move to the next one

## To test

• **Use a plus user**

1. Play an episode with regular transcripts, such as one from `Stuff You Should Know`.
2. Add an episode with generated transcripts, like `Conan's show`, to the queue.
3. Add an episode with regular transcripts, like `Cautionary tales`, to the queue.
4. Open the transcript view.
5. Scrub to the end of the episode.
6. Observe that the transcripts and the header updates with the correct size and colors
7. Scrub to the end of the episode.
8. Observe the banner is now hidden and the  transcripts and the header updates with the correct size and colors

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
