### PR TITLE
[FIx] Fix Most Popular in Region Share URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Revert episode detail screen dismiss action when archiving [#2802](https://github.com/Automattic/pocket-casts-ios/pull/2802)
 - Implement the possibility to display generated transcripts [#2812](https://github.com/Automattic/pocket-casts-ios/issues/2812)
 - Add Suggested Folder feature [#2828](https://github.com/Automattic/pocket-casts-ios/issues/2828)
+- Fix Most popular in Region list URL when sharing [#2869](https://github.com/Automattic/pocket-casts-ios/issues/2869)
 
 7.84
 -----

--- a/podcasts/DiscoverCollectionViewController+DiscoverDelegate.swift
+++ b/podcasts/DiscoverCollectionViewController+DiscoverDelegate.swift
@@ -64,7 +64,8 @@ extension DiscoverCollectionViewController: DiscoverDelegate {
             collectionListVC.cellStyle = (item.expandedStyle == "descriptive_list") ? CollectionCellStyle.descriptive_list : CollectionCellStyle.grid
             navController()?.pushViewController(collectionListVC, animated: true)
         } else { // item == expandedStylw == "plain_list" || item.expandedStyle == "ranked_list"
-            let listView = PodcastHeaderListViewController(podcasts: podcasts, source: item.source)
+            let source = replaceRegionCode(string: item.source ?? "")
+            let listView = PodcastHeaderListViewController(podcasts: podcasts, source: source)
             listView.title = replaceRegionName(string: item.title?.localized ?? "")
             listView.showFeaturedCell = item.expandedStyle == "ranked_list"
             listView.showRankingNumber = item.expandedStyle == "ranked_list"

--- a/podcasts/DiscoverViewController+DiscoverDelegate.swift
+++ b/podcasts/DiscoverViewController+DiscoverDelegate.swift
@@ -52,7 +52,8 @@ extension DiscoverViewController: DiscoverDelegate {
             collectionListVC.cellStyle = (item.expandedStyle == "descriptive_list") ? CollectionCellStyle.descriptive_list : CollectionCellStyle.grid
             navController()?.pushViewController(collectionListVC, animated: true)
         } else { // item == expandedStylw == "plain_list" || item.expandedStyle == "ranked_list"
-            let listView = PodcastHeaderListViewController(podcasts: podcasts, source: item.source)
+            let source = replaceRegionCode(string: item.source ?? "")
+            let listView = PodcastHeaderListViewController(podcasts: podcasts, source: source)
             listView.title = replaceRegionName(string: item.title?.localized ?? "")
             listView.showFeaturedCell = item.expandedStyle == "ranked_list"
             listView.showRankingNumber = item.expandedStyle == "ranked_list"


### PR DESCRIPTION
Fixes #2869 

When adding the share button for the list, we missed to resolve the source by replacing the `[region]` with the correct code

## To test

- Open discovery
- Open one of the list and tap share
- Share to the Reminder app if you use the sim
- Confirm the list URL is correct
- Scroll to the bottom and open the `Popular in [Region]` list
- Share it and confirm the url is not `https://lists.pocketcasts.com/popular-%5BregionCode%5D` anymore but it uses the correct region code
- Do the same test by changing region from the discovery list
- Smoke test all other list URLs

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
