### PR TITLE
Ignore `.build`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ podcasts/Credentials/LocalApiCredentials.swift
 artifacts/*
 *.app.dSYM.zip
 *.ipa
+*.build


### PR DESCRIPTION
When using tools such as Cursor a lot of stuff is gonna be created by the IDE, this ignores it.