### PR TITLE
Fix podcast expand animation border display

### DIFF
--- a/podcasts/PodcastHeadingTableCell.swift
+++ b/podcasts/PodcastHeadingTableCell.swift
@@ -368,6 +368,7 @@ class PodcastHeadingTableCell: ThemeableCell, SubscribeButtonDelegate, Expandabl
 
         delegate.setSummaryExpanded(expanded: willBeExpanded)
         extraContentStackView.alpha = willBeExpanded ? 0 : 1
+        roundedBorder.alpha = willBeExpanded ? 0 : 1
 
         Analytics.track(.podcastScreenToggleSummary, properties: ["is_expanded": willBeExpanded])
 
@@ -375,6 +376,7 @@ class PodcastHeadingTableCell: ThemeableCell, SubscribeButtonDelegate, Expandabl
         if willBeExpanded {
             UIView.animate(withDuration: 0.2, delay: 0.10, options: [], animations: {
                 self.extraContentStackView.alpha = 1
+                self.roundedBorder.alpha = 1
             }, completion: nil)
 
             UIView.animate(withDuration: Constants.Animation.defaultAnimationTime) {
@@ -387,6 +389,7 @@ class PodcastHeadingTableCell: ThemeableCell, SubscribeButtonDelegate, Expandabl
         } else {
             UIView.animate(withDuration: Constants.Animation.defaultAnimationTime) {
                 self.extraContentStackView.alpha = 0
+                self.roundedBorder.alpha = 0
                 self.podcastImageHeightConstraint.constant = self.artworkSize()
                 self.updateLayout()
                 self.superview?.layoutIfNeeded()


### PR DESCRIPTION
| 📘 Part of: #2825 |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
When working on the new podcast view changes I noticed a small issue with the previous header animation.
When expanding the border of the podcast network was being show without animation. This PR fixes it

## Before ##
https://github.com/user-attachments/assets/bda31b1f-7312-4043-bd64-7b3d35c48dd0 

## After ##
https://github.com/user-attachments/assets/ab9a5f8a-7093-4dd0-9f27-1a33aab079ca

## To test

1. Start the app
2. Ensure that you *do not have* Podcast view changes FF enabled
3. Open a podcast
4. Tap on the arrow to expand/collapse description
5. Check that you do not see the network board while animating.


## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
