### PR TITLE
[Suggested Folders] - Fix upsell flow

### DIFF
--- a/podcasts/Onboarding/OnboardingFlow.swift
+++ b/podcasts/Onboarding/OnboardingFlow.swift
@@ -19,7 +19,7 @@ struct OnboardingFlow {
 
         let flowController: UIViewController
         switch flow {
-        case .plusUpsell, .endOfYearUpsell:
+        case .plusUpsell, .endOfYearUpsell, .suggestedFolderUpsell:
             // Only the upsell flow needs an unknown source
             self.source = source ?? "unknown"
             flowController = upgradeController(in: navigationController,


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
Ensure that suggested folders up sell show, shows purchase details screen before login


https://github.com/user-attachments/assets/be2d3eb4-02a8-44a4-a3b7-a2a8e1ad9247


## To test

1. Start the app with no logged in user
2. Go to podcasts tab
3. Tap on Folders
4. Check that you see the Suggested Folder screen
5. Tap on Replace Folders or Create Custom Folder
6. Check that you see the upsell folders screen instead of the login screen
7. Tap on Start Free Trial
8. Check that you see the login/signup screen

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
