### PR TITLE
[Suggested folders] Don't show suggested folders if podcasts didn't change since last application

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1977,6 +1977,7 @@
 		FF6BBCEE2C53E9D000604A01 /* TranscriptManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF6BBCED2C53E9D000604A01 /* TranscriptManagerTests.swift */; };
 		FF6BBCF02C53EA1F00604A01 /* sample.vtt in Resources */ = {isa = PBXBuildFile; fileRef = FF6BBCEF2C53EA1F00604A01 /* sample.vtt */; };
 		FF6BBCF22C578CE600604A01 /* TranscriptsDataRetriever.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF6BBCF12C578CE600604A01 /* TranscriptsDataRetriever.swift */; };
+		FF6C9DB02D916AA700BF2711 /* String+MD5.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF6C9DAF2D916AA000BF2711 /* String+MD5.swift */; };
 		FF7F89EA2C2979D900FC0ED5 /* TranscriptViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF7F89E92C2979D900FC0ED5 /* TranscriptViewController.swift */; };
 		FF7F89ED2C2AF6DE00FC0ED5 /* TranscriptManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF7F89EC2C2AF6DE00FC0ED5 /* TranscriptManager.swift */; };
 		FF7F89EF2C2AF7B600FC0ED5 /* SwiftSubtitles in Frameworks */ = {isa = PBXBuildFile; productRef = FF7F89EE2C2AF7B600FC0ED5 /* SwiftSubtitles */; };
@@ -4006,6 +4007,7 @@
 		FF6BBCED2C53E9D000604A01 /* TranscriptManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TranscriptManagerTests.swift; sourceTree = "<group>"; };
 		FF6BBCEF2C53EA1F00604A01 /* sample.vtt */ = {isa = PBXFileReference; lastKnownFileType = text; path = sample.vtt; sourceTree = "<group>"; };
 		FF6BBCF12C578CE600604A01 /* TranscriptsDataRetriever.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptsDataRetriever.swift; sourceTree = "<group>"; };
+		FF6C9DAF2D916AA000BF2711 /* String+MD5.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+MD5.swift"; sourceTree = "<group>"; };
 		FF7F89E92C2979D900FC0ED5 /* TranscriptViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptViewController.swift; sourceTree = "<group>"; };
 		FF7F89EC2C2AF6DE00FC0ED5 /* TranscriptManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptManager.swift; sourceTree = "<group>"; };
 		FF7F89F02C2C0FD600FC0ED5 /* TranscriptModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptModel.swift; sourceTree = "<group>"; };
@@ -7250,6 +7252,7 @@
 		BDF9DDDC1B8AE9B900E77B35 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				FF6C9DAF2D916AA000BF2711 /* String+MD5.swift */,
 				FF3DF62E2CA42F1B007CF697 /* UIView+Nib.swift */,
 				BDD5253920477E4400AAD211 /* NSObject+AppDelegate.swift */,
 				FF91A0F52B64159D002A0590 /* UIScreen+Sizes.swift */,
@@ -10237,6 +10240,7 @@
 				BD69EBBC1CD1D383007F273B /* SocialsHelper.swift in Sources */,
 				BDEDCF7124627F02005910C1 /* CustomSegmentedControl.swift in Sources */,
 				BD2F592A20468C6700AD3767 /* CustomObserver.swift in Sources */,
+				FF6C9DB02D916AA700BF2711 /* String+MD5.swift in Sources */,
 				C76ECAC42A67622900D9DB9E /* BookmarksEmptyStateView.swift in Sources */,
 				BDD62979200ECCBB00168DF7 /* EpisodeDetailViewController+ShowNotes.swift in Sources */,
 				BDD832AF214B8A8B0013D692 /* PCGoogleCastButton.swift in Sources */,

--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -215,6 +215,7 @@ struct Constants {
         enum suggestedFolders {
             static let lastUpsellDate = "suggestedFolders.lastUpsellDate"
             static let upsellCount = "suggestedFolders.upsellCount"
+            static let lastPodcastsUsed = "suggestedFolders.lastPodcastsUsed"
         }
     }
 

--- a/podcasts/FoldersCoordinator.swift
+++ b/podcasts/FoldersCoordinator.swift
@@ -42,7 +42,7 @@ class FoldersCoordinator: NSObject {
     }
 
     func startFolderCreationFlow(from vc: UIViewController) {
-        if FeatureFlag.suggestedFolders.enabled, suggestedFoldersModel.loadingState == .loaded {
+        if FeatureFlag.suggestedFolders.enabled, suggestedFoldersModel.loadingState == .loaded, didPodcastsChanged() {
             suggestedFolderCreationFlow(from: vc, source: .podcastsList)
         } else {
             manualFolderCreationFlow(from: vc)
@@ -142,12 +142,25 @@ class FoldersCoordinator: NSObject {
     }
 
     private func applySuggestedFolders(_ suggestedFolders: [SuggestedFolder]) {
+        saveLastUuidsUsed()
         DataManager.sharedManager.deleteAllFoldersAndMarkSync()
         for suggestedFolder in suggestedFolders {
             let folder = makeFolder(from: suggestedFolder)
             dataManager.bulkSetFolderUuid(folderUuid: folder.uuid, podcastUuids: suggestedFolder.podcastUuids)
         }
         NotificationCenter.postOnMainThread(notification: ServerNotifications.podcastsRefreshed, object: nil)
+    }
+
+    private func saveLastUuidsUsed() {
+        let uuids = dataManager.allPodcastsOrderedByAddedDate().map { $0.uuid }.sorted()
+        let md5 = String(uuids.joined(separator: "")).md5
+        Settings.suggestedFoldersLastPodcastsUsed = md5
+    }
+
+    private func didPodcastsChanged() -> Bool {
+        let uuids = dataManager.allPodcastsOrderedByAddedDate().map { $0.uuid }.sorted()
+        let md5 = String(uuids.joined(separator: "")).md5
+        return Settings.suggestedFoldersLastPodcastsUsed != md5
     }
 
     private func makeFolder(from suggestedFolder: SuggestedFolder) -> Folder {

--- a/podcasts/FoldersCoordinator.swift
+++ b/podcasts/FoldersCoordinator.swift
@@ -151,16 +151,18 @@ class FoldersCoordinator: NSObject {
         NotificationCenter.postOnMainThread(notification: ServerNotifications.podcastsRefreshed, object: nil)
     }
 
-    private func saveLastUuidsUsed() {
+    private var currentPodcastsHash: String {
         let uuids = dataManager.allPodcastsOrderedByAddedDate().map { $0.uuid }.sorted()
         let md5 = String(uuids.joined(separator: "")).md5
-        Settings.suggestedFoldersLastPodcastsUsed = md5
+        return md5
+    }
+
+    private func saveLastUuidsUsed() {
+        Settings.suggestedFoldersLastPodcastsUsed = currentPodcastsHash
     }
 
     private func didPodcastsChanged() -> Bool {
-        let uuids = dataManager.allPodcastsOrderedByAddedDate().map { $0.uuid }.sorted()
-        let md5 = String(uuids.joined(separator: "")).md5
-        return Settings.suggestedFoldersLastPodcastsUsed != md5
+        return Settings.suggestedFoldersLastPodcastsUsed != currentPodcastsHash
     }
 
     private func makeFolder(from suggestedFolder: SuggestedFolder) -> Folder {

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -1412,6 +1412,16 @@ class Settings: NSObject {
         }
     }
 
+    class var suggestedFoldersLastPodcastsUsed: String? {
+        set {
+            UserDefaults.standard.set(newValue, forKey: Constants.UserDefaults.suggestedFolders.lastPodcastsUsed)
+        }
+
+        get {
+            UserDefaults.standard.object(forKey: Constants.UserDefaults.suggestedFolders.lastPodcastsUsed) as? String
+        }
+    }
+
     // MARK: - Database (internal)
 
     class var upgradedIndexes: Bool {

--- a/podcasts/String+MD5.swift
+++ b/podcasts/String+MD5.swift
@@ -1,0 +1,10 @@
+import CryptoKit
+
+extension String {
+    var md5: String {
+        let hash = Insecure.MD5.hash(data: self.data(using: .utf8)!)
+            .map {String(format: "%02x", $0)}
+            .joined()
+        return hash
+    }
+}


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

This PR adds a mechanism to check if the podcast available changed since the last time suggested folders were applied

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

## To test

1. Start the app using a paid account
2. Got to the podcasts tab
3. Tap on the folders button
4. Check if suggestions are show and applied them, tap on Replace Folders
5. Check if results were applied
6. Tap on Folders again
7. Check if manual folder creation flow is show
8. Create a new folder
9. Unfollow some of the podcasts
10. Tap on Folders again
11. Check if suggested folders flow is show again

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
