### PR TITLE
[Podcast View Changes] Animations tweaks

### DIFF
--- a/podcasts/PodcastHeaderCell.swift
+++ b/podcasts/PodcastHeaderCell.swift
@@ -51,7 +51,7 @@ class PodcastHeaderCell: UITableViewCell {
         cell.contentView.backgroundColor = .clear
         cell.layoutIfNeeded()
         cell.selectionStyle = UITableViewCell.SelectionStyle.none
-
+        cell.contentView.clipsToBounds = true
         viewController.addChild(swiftUICellViewController)
         cell.contentView.addSubview(swiftUICellViewController.view)
         swiftUICellViewController.view.translatesAutoresizingMaskIntoConstraints = false

--- a/podcasts/PodcastHeaderCell.swift
+++ b/podcasts/PodcastHeaderCell.swift
@@ -13,8 +13,9 @@ class PodcastHeaderCell: UITableViewCell {
     }
 
     let podcast: Podcast
-    let viewController: PodcastViewController
+    weak var viewController: PodcastViewController?
     let viewModel: PodcastHeaderViewModel
+    var firstTime = true
     init(podcast: Podcast, vc: PodcastViewController) {
         self.podcast = podcast
         self.viewController = vc
@@ -30,16 +31,26 @@ class PodcastHeaderCell: UITableViewCell {
     }
 
     func commonSetup() {
+        guard let viewController = self.viewController else { return }
         self.backgroundColor = .clear
         self.selectionStyle = .none
-        configureCellFromSwiftUIView(cell: self, viewController: self.viewController, rootView: {
+        configureCellFromSwiftUIView(cell: self, viewController: viewController, rootView: {
             ContentSizeGeometryReader { proxy in
                 PodcastHeaderView(viewModel: self.viewModel)
                     .setupDefaultEnvironment()
                     .ignoresSafeArea()//Needs to be done in order to allow expansion of the view to navigation area when scrolling up
-            } contentSizeUpdated: { size in
-                self.calculatedHeight = size.height
-                self.viewController.reloadData()
+            } contentSizeUpdated: { [weak self] size in
+                guard let self = self else { return }
+                calculatedHeight = size.height
+                if firstTime {
+                    firstTime = false
+                    viewController.reloadData()
+                } else {
+                    // the following code allows the table to refresh the row height in a animated way
+                    viewController.tableView().beginUpdates()
+                    viewController.tableView().endUpdates()
+                }
+
             }
         })
     }

--- a/podcasts/PodcastHeaderView.swift
+++ b/podcasts/PodcastHeaderView.swift
@@ -172,7 +172,7 @@ struct PodcastHeaderView: View {
             }
         }
         .frame(height: contentHeight)
-        .animation(.snappy, value: contentHeight)
+        .animation(.easeInOut(duration: 0.1), value: contentHeight)
     }
 
     private var podcastDetails: some View {

--- a/podcasts/PodcastHeaderView.swift
+++ b/podcasts/PodcastHeaderView.swift
@@ -86,8 +86,10 @@ struct PodcastHeaderView: View {
                 .font(.title).bold()
                 .fixedSize(horizontal: false, vertical: true)
             Image(systemName: "chevron.up")
+                .frame(width: 24, height: 24)
                 .padding(.horizontal, 4)
                 .rotationEffect(.degrees(viewModel.isExpanded ? 0 : 180))
+                .contentShape(Rectangle())
         }
         .foregroundStyle(theme.primaryText01)
         .multilineTextAlignment(.center)

--- a/podcasts/PodcastHeaderView.swift
+++ b/podcasts/PodcastHeaderView.swift
@@ -39,13 +39,13 @@ struct PodcastHeaderView: View {
                     .frame(width: viewModel.isExpanded ? Constants.largeImageSize : Constants.smallImageSize, height: viewModel.isExpanded ? Constants.largeImageSize : Constants.smallImageSize)
                 Spacer()
             }
-            if viewModel.isExpanded {
-                VStack(spacing: 0) {
-                    Spacer().frame(height: 24)
-                    podcastCategory
-                }
-                .transition(.collapse.combined(with: .move(edge: .top)))
+            VStack(spacing: 0) {
+                Spacer().frame(height: 24)
+                podcastCategory
             }
+                .frame(maxHeight: viewModel.isExpanded ? .infinity : 0)
+                .opacity(viewModel.isExpanded ? 1 : 0)
+                .clipped()
             Spacer().frame(height: 16)
             podcastTitle
             Spacer().frame(height: 16)
@@ -56,19 +56,18 @@ struct PodcastHeaderView: View {
             Spacer().frame(height: 16)
             podcastActions
             Spacer().frame(height: 24)
-            if viewModel.isExpanded {
-                VStack {
-                    podcastDescription
-                    podcastDetails
-                    Spacer().frame(height: 24)
-                }
-                .transition(.collapse)
-                .transformEffect(.identity)
+            VStack {
+                podcastDescription
+                podcastDetails
+                Spacer().frame(height: 24)
             }
+                .frame(maxHeight: viewModel.isExpanded ? .infinity : 0)
+                .opacity(viewModel.isExpanded ? 1 : 0)
+                .clipped()
             EpisodeBookmarksTabsView(delegate: viewModel.delegate)
             Spacer()
                 .frame(height: 8)
-         }
+        }
         .padding()
     }
 

--- a/podcasts/PodcastHeaderView.swift
+++ b/podcasts/PodcastHeaderView.swift
@@ -50,8 +50,9 @@ struct PodcastHeaderView: View {
             Spacer().frame(height: 16)
             podcastTitle
             Spacer().frame(height: 16)
-            StarRatingView(viewModel: viewModel.podcastRatingViewModel, style: .short,
-                                      onRate: {
+            StarRatingView(viewModel: viewModel.podcastRatingViewModel,
+                           style: .short,
+                           onRate: {
                 viewModel.podcastRatingViewModel.update(podcast: viewModel.podcast, ignoringCache: true)
             })
             Spacer().frame(height: 16)

--- a/podcasts/PodcastHeaderView.swift
+++ b/podcasts/PodcastHeaderView.swift
@@ -37,6 +37,7 @@ struct PodcastHeaderView: View {
                 Spacer()
                 PodcastImageViewWrapper(podcastUUID: viewModel.podcast.uuid, size: .grid)
                     .frame(width: viewModel.isExpanded ? Constants.largeImageSize : Constants.smallImageSize, height: viewModel.isExpanded ? Constants.largeImageSize : Constants.smallImageSize)
+                    .animation(.bouncy, value: viewModel.isExpanded)
                 Spacer()
             }
             VStack(spacing: 0) {


### PR DESCRIPTION
| 📘 Part of: #2825  |  <!-- project issue number, if applicable -->
|:---:|

Fixes #2834  <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR improves the animation when collapsing and expanding the header. 

https://github.com/user-attachments/assets/5282bba1-dbed-42c9-86d8-1b59d1748c0b


## To test

- Start the app
- Ensure that you have the podcastViewChanges FF enabled
- Open a podcast that you follow
- Tap on the chevron or title on the tap to expand the podcast details
- Tap on the description to expand, check the animation
- Tap on the chevron again to see the collapse the animation, check the animation
 
## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
