### PR TITLE
[Podcast View Changes] show onboarding tooltip view

### DIFF
--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -42,6 +42,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
            appInstallState == .installed {
             //Never show the podcast feed reload tooltip for fresh install
             Settings.shouldShowPodcastFeeReloadTip = false
+            Settings.shouldShowPodcastViewChangesTip = false
         }
 
         let defaults = UserDefaults.standard

--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -217,6 +217,10 @@ struct Constants {
             static let upsellCount = "suggestedFolders.upsellCount"
             static let lastPodcastsUsed = "suggestedFolders.lastPodcastsUsed"
         }
+
+        enum podcastViewChanges {
+            static let showTip = "podcastViewChanges.showtip"
+        }
     }
 
     enum Values {

--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -1218,9 +1218,12 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
     private var viewChangesTipVC: UIViewController?
 
     private func showViewChangesTipIfNeeded() {
-        guard FeatureFlag.podcastViewChanges.enabled else {
+        guard FeatureFlag.podcastViewChanges.enabled,
+              Settings.shouldShowPodcastViewChangesTip
+        else {
             return
         }
+        Settings.shouldShowPodcastViewChangesTip = false
         viewChangesTipVC = showViewChangesTip()
     }
 

--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -443,6 +443,8 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
             showPodcastFeedReloadTipIfNeeded()
         }
         episodesTable.sendSubviewToBack(blurHeaderView)
+
+        showViewChangesTipIfNeeded()
     }
 
     override func viewWillDisappear(_ animated: Bool) {
@@ -1145,12 +1147,14 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
     }
 
     private func dismissPodcastFeedReloadTip() {
-        guard Settings.shouldShowPodcastFeeReloadTip else {
+        guard Settings.shouldShowPodcastFeeReloadTip,
+            let podcastFeedReloadTooltip
+        else {
             return
         }
         Analytics.track(.podcastRefreshEpisodeTooltipDismissed)
         Settings.shouldShowPodcastFeeReloadTip = false
-        podcastFeedReloadTooltip?.dismiss(animated: true) { [weak self] in
+        podcastFeedReloadTooltip.dismiss(animated: true) { [weak self] in
             self?.podcastFeedReloadTooltip = nil
         }
     }
@@ -1208,6 +1212,57 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
             popoverPresentationController.sourceRect = button.bounds
             popoverPresentationController.backgroundColor = ThemeColor.primaryUi01()
         }
+        return vc
+    }
+
+    private var viewChangesTipVC: UIViewController?
+
+    private func showViewChangesTipIfNeeded() {
+        guard FeatureFlag.podcastViewChanges.enabled else {
+            return
+        }
+        viewChangesTipVC = showViewChangesTip()
+    }
+
+    private func dismissViewChangesTip() {
+        guard let viewChangesTipVC else {
+            return
+        }
+        viewChangesTipVC.dismiss(animated: true)
+        self.viewChangesTipVC = nil
+    }
+
+    private func showViewChangesTip() -> UIViewController {
+        let sourceView = podcastHeaderCell
+
+        let vc = UIHostingController(rootView: AnyView (EmptyView()) )
+        let idealSize = CGSizeMake(290, 100)
+        let tipView = TipViewStatic(title: L10n.podcastViewChangesTipTitle,
+                                    message: L10n.podcastViewChangesTipDetails,
+                              onTap: { [weak self] in
+            self?.dismissViewChangesTip()
+        })
+            .frame(idealWidth: idealSize.width, minHeight: idealSize.height)
+            .setupDefaultEnvironment()
+        vc.rootView = AnyView(tipView)
+        vc.view.backgroundColor = .clear
+        vc.view.clipsToBounds = false
+        vc.modalPresentationStyle = .popover
+        if #available(iOS 16.0, *) {
+            vc.sizingOptions = [.preferredContentSize]
+        } else {
+            vc.preferredContentSize = idealSize
+        }
+        if let popoverPresentationController = vc.popoverPresentationController {
+            popoverPresentationController.delegate = self
+            popoverPresentationController.permittedArrowDirections = [.down]
+            popoverPresentationController.sourceView = sourceView
+            var point = sourceView.center
+            point.y = summaryExpanded ? 1.4 * PodcastHeaderView.Constants.largeImageSize : 1.4 * PodcastHeaderView.Constants.smallImageSize
+            popoverPresentationController.sourceRect = CGRect(origin: point, size: .zero)
+            popoverPresentationController.backgroundColor = ThemeColor.primaryUi01()
+        }
+        present(vc, animated: true)
         return vc
     }
 
@@ -1278,6 +1333,7 @@ extension PodcastViewController: UIPopoverPresentationControllerDelegate {
 
     func popoverPresentationControllerDidDismissPopover(_ popoverPresentationController: UIPopoverPresentationController) {
         dismissPodcastFeedReloadTip()
+        dismissViewChangesTip()
     }
 }
 

--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -1216,6 +1216,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
     }
 
     private var viewChangesTipVC: UIViewController?
+    private var dimmingView: UIView?
 
     private func showViewChangesTipIfNeeded() {
         guard FeatureFlag.podcastViewChanges.enabled,
@@ -1237,10 +1238,17 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
             return
         }
         viewChangesTipVC.dismiss(animated: true)
+        dimmingView?.removeFromSuperview()
         self.viewChangesTipVC = nil
     }
 
-    private func showTip(title: String, message: String, sourceView: UIView, sourceRect: CGRect = CGRectNull, action: @escaping () -> ()) -> UIViewController {
+    private func showTip(title: String, message: String, sourceView: UIView, sourceRect: CGRect = CGRectNull, dimBackground: Bool = true, action: @escaping () -> ()) -> UIViewController {
+        if dimBackground {
+            let dimmingView = UIView(frame: self.view.bounds)
+            dimmingView.backgroundColor = .black.withAlphaComponent(0.3)
+            self.tabBarController?.view.addSubview(dimmingView)
+            self.dimmingView = dimmingView
+        }
         let vc = UIHostingController(rootView: AnyView (EmptyView()) )
         let idealSize = CGSizeMake(290, 100)
         let tipView = TipViewStatic(title: title,

--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -1227,7 +1227,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
         Settings.shouldShowPodcastViewChangesTip = false
         var point = podcastHeaderCell.center
         point.y = summaryExpanded ? 1.4 * PodcastHeaderView.Constants.largeImageSize : 1.4 * PodcastHeaderView.Constants.smallImageSize
-        var rect = CGRect(origin: point, size: .zero)
+        let rect = CGRect(origin: point, size: .zero)
         viewChangesTipVC = showTip(title: L10n.podcastViewChangesTipTitle, message: L10n.podcastViewChangesTipDetails, sourceView: podcastHeaderCell, sourceRect: rect) { [weak self] in
             self?.dismissViewChangesTip()
         }
@@ -1253,6 +1253,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
         let idealSize = CGSizeMake(290, 100)
         let tipView = TipViewStatic(title: title,
                                     message: message,
+                                    showClose: true,
                               onTap: {
             action()
         })

--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -1224,7 +1224,12 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
             return
         }
         Settings.shouldShowPodcastViewChangesTip = false
-        viewChangesTipVC = showViewChangesTip()
+        var point = podcastHeaderCell.center
+        point.y = summaryExpanded ? 1.4 * PodcastHeaderView.Constants.largeImageSize : 1.4 * PodcastHeaderView.Constants.smallImageSize
+        var rect = CGRect(origin: point, size: .zero)
+        viewChangesTipVC = showTip(title: L10n.podcastViewChangesTipTitle, message: L10n.podcastViewChangesTipDetails, sourceView: podcastHeaderCell, sourceRect: rect) { [weak self] in
+            self?.dismissViewChangesTip()
+        }
     }
 
     private func dismissViewChangesTip() {
@@ -1235,15 +1240,13 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
         self.viewChangesTipVC = nil
     }
 
-    private func showViewChangesTip() -> UIViewController {
-        let sourceView = podcastHeaderCell
-
+    private func showTip(title: String, message: String, sourceView: UIView, sourceRect: CGRect = CGRectNull, action: @escaping () -> ()) -> UIViewController {
         let vc = UIHostingController(rootView: AnyView (EmptyView()) )
         let idealSize = CGSizeMake(290, 100)
-        let tipView = TipViewStatic(title: L10n.podcastViewChangesTipTitle,
-                                    message: L10n.podcastViewChangesTipDetails,
-                              onTap: { [weak self] in
-            self?.dismissViewChangesTip()
+        let tipView = TipViewStatic(title: title,
+                                    message: message,
+                              onTap: {
+            action()
         })
             .frame(idealWidth: idealSize.width, minHeight: idealSize.height)
             .setupDefaultEnvironment()
@@ -1260,9 +1263,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
             popoverPresentationController.delegate = self
             popoverPresentationController.permittedArrowDirections = [.down]
             popoverPresentationController.sourceView = sourceView
-            var point = sourceView.center
-            point.y = summaryExpanded ? 1.4 * PodcastHeaderView.Constants.largeImageSize : 1.4 * PodcastHeaderView.Constants.smallImageSize
-            popoverPresentationController.sourceRect = CGRect(origin: point, size: .zero)
+            popoverPresentationController.sourceRect = sourceRect
             popoverPresentationController.backgroundColor = ThemeColor.primaryUi01()
         }
         present(vc, animated: true)

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -1422,6 +1422,17 @@ class Settings: NSObject {
         }
     }
 
+    // MARK: - Podcast View Changes Tip
+
+    static var shouldShowPodcastViewChangesTip: Bool {
+        get {
+            UserDefaults.standard.value(forKey: Constants.UserDefaults.podcastViewChanges.showTip) as? Bool ?? true
+        }
+        set {
+            UserDefaults.standard.setValue(newValue, forKey: Constants.UserDefaults.podcastViewChanges.showTip)
+        }
+    }
+
     // MARK: - Database (internal)
 
     class var upgradedIndexes: Bool {

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -2400,6 +2400,10 @@ internal enum L10n {
   internal static func podcastUploading(_ p1: Any) -> String {
     return L10n.tr("Localizable", "podcast_uploading", String(describing: p1))
   }
+  /// Tap on the podcast title to collapse or expand its description and details
+  internal static var podcastViewChangesTipDetails: String { return L10n.tr("Localizable", "podcast_view_changes_tip_details") }
+  /// We've made some changes
+  internal static var podcastViewChangesTipTitle: String { return L10n.tr("Localizable", "podcast_view_changes_tip_title") }
   /// Waiting to upload
   internal static var podcastWaitingUpload: String { return L10n.tr("Localizable", "podcast_waiting_upload") }
   /// Yesterday

--- a/podcasts/TipView.swift
+++ b/podcasts/TipView.swift
@@ -24,7 +24,7 @@ struct TipViewStatic: View {
     let showClose: Bool
     let onTap: (()->())?
 
-    init(title: String, message: String?, showClose: Bool = false, onTap:  (() -> Void)?) {
+    init(title: String, message: String?, showClose: Bool = false, onTap: (() -> Void)?) {
         self.title = title
         self.message = message
         self.showClose = showClose

--- a/podcasts/TipView.swift
+++ b/podcasts/TipView.swift
@@ -21,7 +21,15 @@ struct TipView: View {
 struct TipViewStatic: View {
     let title: String
     let message: String?
+    let showClose: Bool
     let onTap: (()->())?
+
+    init(title: String, message: String?, showClose: Bool = false, onTap:  (() -> Void)?) {
+        self.title = title
+        self.message = message
+        self.showClose = showClose
+        self.onTap = onTap
+    }
 
     @EnvironmentObject var theme: Theme
 
@@ -51,6 +59,17 @@ struct TipViewStatic: View {
             .frame(maxHeight: .infinity)
             .onTapGesture {
                 onTap?()
+            }
+        }.overlay(alignment: .topTrailing) {
+            if showClose {
+                Button() {
+                    onTap?()
+                } label: {
+                    Image("close")
+                        .renderingMode(.template)
+                        .foregroundColor(theme.primaryText01)
+                        .padding(8)
+                }
             }
         }
     }

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4820,3 +4820,10 @@
 
 /* Description showed in the upsell overlay when a free user access the generated transcripts */
 "generated_transcripts_overlay_description" = "Subscribe to Plus to get access to it and other Premium features like bookmarks and folders.";
+
+/* Podcast View Changes tooltip title*/
+"podcast_view_changes_tip_title" = "We've made some changes";
+
+/* Podcast View Changes tooltip details of change*/
+"podcast_view_changes_tip_details" = "Tap on the podcast title to collapse or expand its description and details";
+


### PR DESCRIPTION
| 📘 Part of: #2825 |  <!-- project issue number, if applicable -->
|:---:|

Fixes #2832 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
Add displaying the onboarding tooltip

<img src="https://github.com/user-attachments/assets/26a8a847-5d82-4817-a520-f77b519a864d" width=320>

## To test

1. Start the app on top of a previous install that already has the `podcastViewChanges` flag enabled
2. Open a Podcast
3. Check that you see the tooltip on the screen
4. Tap anywhere on the screen to dismiss the tooltip
5. Reopen the podcast
6. Check that you don't see the tip again
7. Now do a fresh install
8. Start the app and enable the FF
9. Open a podcast
10. Check that you don't see the tooltip

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
