### PR TITLE
[Podcast View Changes] Navigation to category

### DIFF
--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -320,6 +320,7 @@ enum AnalyticsEvent: String {
     case podcastScreenPodcastDescriptionLinkTapped
     case podcastScreenNotificationsTapped
     case podcastScreenPodcastDetailsLinkTapped
+    case podcastScreenCategoryTapped
 
     // MARK: - App Store Review Request
 

--- a/podcasts/Categories/CategoriesSelectorViewController.swift
+++ b/podcasts/Categories/CategoriesSelectorViewController.swift
@@ -8,6 +8,7 @@ class CategoriesSelectorViewController: ThemedHostingController<CategoriesSelect
         @Published public var item: DiscoverItem?
         @Published public var selectedCategory: DiscoverCategory?
         @Published public var region: String?
+        private(set) var cachedCategories = [DiscoverCategory]()
 
         lazy var load: (() async -> (categories: [DiscoverCategory], popular: [DiscoverCategory])?) = { [weak self] in
             guard let source = self?.item?.source else { return nil }
@@ -16,7 +17,7 @@ class CategoriesSelectorViewController: ThemedHostingController<CategoriesSelect
                 guard let id = $0.id else { return false }
                 return self?.item?.popular?.contains(id) == true
             }
-
+            self?.cachedCategories = categories
             return (categories, popular)
         }
 
@@ -35,6 +36,14 @@ class CategoriesSelectorViewController: ThemedHostingController<CategoriesSelect
 
     func registerDiscoverDelegate(_ delegate: any DiscoverDelegate) {
         self.delegate = delegate
+    }
+
+    func setCategory(_ category: String) {
+        for categoryObject in observable.cachedCategories {
+            if categoryObject.name?.lowercased() == category {
+                observable.selectedCategory = categoryObject
+            }
+        }
     }
 
     func populateFrom(item: PocketCastsServer.DiscoverItem, region: String?, category: DiscoverCategory?) {
@@ -56,9 +65,20 @@ class CategoriesSelectorViewController: ThemedHostingController<CategoriesSelect
         self.observable.$selectedCategory
             .delay(for: .milliseconds(20), scheduler: DispatchQueue.main)
             .sink { [weak self] category in
-            guard let item = self?.observable.item else { return }
-            self?.delegate?.showExpanded(item: item, category: category)
-        }.store(in: &cancellables)
+                guard let item = self?.observable.item else { return }
+                self?.delegate?.showExpanded(item: item, category: category)
+            }
+            .store(in: &cancellables)
+
+        NotificationCenter.default.publisher(for: Constants.Notifications.discoverNavigateToCategory)
+            .receive(on: OperationQueue.main)
+            .sink { [unowned self] notification in
+                guard let category = notification.object as? String else {
+                    return
+                }
+                self.setCategory(category)
+            }
+            .store(in: &cancellables)
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -102,6 +102,8 @@ struct Constants {
 
         // Gravatar
         static let avatarNeedsRefreshing = NSNotification.Name(rawValue: "avatarNeedsRefreshing")
+
+        static let discoverNavigateToCategory = Notification.Name(rawValue: "DiscoverNavigateToCategory")
     }
 
     enum UserDefaults {

--- a/podcasts/DiscoverCellType.swift
+++ b/podcasts/DiscoverCellType.swift
@@ -46,7 +46,7 @@ enum DiscoverCellType: CaseIterable {
         }
     }
 
-    func createCellRegistration(delegate: DiscoverDelegate) -> UICollectionView.CellRegistration<UICollectionViewCell, ItemType> {
+    func createCellRegistration(parentViewController: UIViewController, delegate: DiscoverDelegate) -> UICollectionView.CellRegistration<UICollectionViewCell, ItemType> {
         return UICollectionView.CellRegistration<UICollectionViewCell, ItemType> { cell, indexPath, item in
 
             let existingViewController = (cell.contentConfiguration as? UIViewControllerContentConfiguration)?.viewController as? (UIViewController & DiscoverSummaryProtocol)
@@ -54,7 +54,7 @@ enum DiscoverCellType: CaseIterable {
             let vc = existingViewController ?? viewController(in: item.region)
 
             if existingViewController == nil {
-                cell.contentConfiguration = UIViewControllerContentConfiguration(viewController: vc)
+                cell.contentConfiguration = UIViewControllerContentConfiguration(parentViewController: parentViewController, viewController: vc)
             }
 
             vc.registerDiscoverDelegate(delegate)

--- a/podcasts/DiscoverCollectionViewController+DiscoverDelegate.swift
+++ b/podcasts/DiscoverCollectionViewController+DiscoverDelegate.swift
@@ -2,6 +2,18 @@ import PocketCastsServer
 import PocketCastsDataModel
 
 extension DiscoverCollectionViewController: DiscoverDelegate {
+
+    func navigateTo(category: String) {
+        if isViewLoaded {
+            NotificationCenter.default.post(name: Constants.Notifications.discoverNavigateToCategory, object: category)
+        } else {
+            loadViewIfNeeded()
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5.seconds) {
+                NotificationCenter.default.post(name: Constants.Notifications.discoverNavigateToCategory, object: category)
+            }
+        }
+    }
+
     func invalidate(item: PocketCastsServer.DiscoverItem) {
         let context = UICollectionViewLayoutInvalidationContext()
         let item = dataSource.snapshot().itemIdentifiers.first(where: {

--- a/podcasts/DiscoverCollectionViewController.swift
+++ b/podcasts/DiscoverCollectionViewController.swift
@@ -159,7 +159,7 @@ extension DiscoverCollectionViewController {
             countrySummary.discoverLayout = self.discoverLayout
             countrySummary.registerDiscoverDelegate(self)
 
-            supplementaryView.contentConfiguration = UIViewControllerContentConfiguration(viewController: countrySummary)
+            supplementaryView.contentConfiguration = UIViewControllerContentConfiguration(parentViewController: self, viewController: countrySummary)
         }
 
         let footerRegistrationEmpty = UICollectionView.SupplementaryRegistration<UICollectionViewListCell>(elementKind: UICollectionView.elementKindSectionFooter) { supplementaryView, elementKind, indexPath in
@@ -173,7 +173,7 @@ extension DiscoverCollectionViewController {
         }
 
         let registrations: [DiscoverCellType: UICollectionView.CellRegistration] = DiscoverCellType.allCases.reduce(into: [:]) { partialResult, cellType in
-            partialResult[cellType] = cellType.createCellRegistration(delegate: self)
+            partialResult[cellType] = cellType.createCellRegistration(parentViewController: self, delegate: self)
         }
 
         let nonItemRegistration = UICollectionView.CellRegistration<UICollectionViewCell, Item> { cell, indexPath, item in

--- a/podcasts/DiscoverSummaryProtocol.swift
+++ b/podcasts/DiscoverSummaryProtocol.swift
@@ -26,4 +26,6 @@ protocol DiscoverDelegate: AnyObject {
     func failedToLoadEpisode()
 
     func invalidate(item: DiscoverItem)
+
+    func navigateTo(category: String)
 }

--- a/podcasts/DiscoverViewController+DiscoverDelegate.swift
+++ b/podcasts/DiscoverViewController+DiscoverDelegate.swift
@@ -3,6 +3,18 @@ import PocketCastsDataModel
 import PocketCastsServer
 
 extension DiscoverViewController: DiscoverDelegate {
+
+    func navigateTo(category: String) {
+        if isViewLoaded {
+            NotificationCenter.default.post(name: Constants.Notifications.discoverNavigateToCategory, object: category)
+        } else {
+            loadViewIfNeeded()
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5.seconds) {
+                NotificationCenter.default.post(name: Constants.Notifications.discoverNavigateToCategory, object: category)
+            }
+        }
+    }
+
     func invalidate(item: PocketCastsServer.DiscoverItem) {
         // No-op for this older implementation.
     }

--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -315,6 +315,17 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
         switchToTab(.discover)
     }
 
+    func navigateToDiscover(category: String, animated: Bool) {
+        switchToTab(.discover)
+        if let index = pcTabs.firstIndex(of: .discover),
+           let navController = viewControllers?[safe: index] as? UINavigationController {
+            navController.popToRootViewController(animated: false)
+            if let discoverDelegate = navController.topViewController as? DiscoverDelegate {
+                discoverDelegate.navigateTo(category: category)
+            }
+        }
+    }
+
     func navigateToUpNext(_ animated: Bool) {
         switchToTab(.upNext)
     }

--- a/podcasts/NavigationManager.swift
+++ b/podcasts/NavigationManager.swift
@@ -17,6 +17,7 @@ class NavigationManager {
     private static let homePageKey = "homePage"
     static let podcastListPageKey = "podcastList"
     static let discoverPageKey = "discoverPage"
+    static let discoverCategoryKey = "discoverCategory"
 
     static let filterPageKey = "filterPage"
     static let filterUuidKey = "filterUuid"
@@ -136,7 +137,11 @@ class NavigationManager {
         } else if place == NavigationManager.podcastListPageKey {
             mainController?.navigateToPodcastList(animated)
         } else if place == NavigationManager.discoverPageKey {
-            mainController?.navigateToDiscover(animated)
+            guard let data = data, let category = data[NavigationManager.discoverCategoryKey] as? String else {
+                mainController?.navigateToDiscover(animated)
+                return
+            }
+            mainController?.navigateToDiscover(category: category, animated: animated)
         } else if place == NavigationManager.filterPageKey {
             if let data = data, let filterUuid = data[NavigationManager.filterUuidKey] as? String, let filter = DataManager.sharedManager.findFilter(uuid: filterUuid) {
                 mainController?.navigateToFilter(filter, animated: animated)

--- a/podcasts/NavigationProtocol.swift
+++ b/podcasts/NavigationProtocol.swift
@@ -14,6 +14,7 @@ protocol NavigationProtocol: AnyObject {
     func navigateToEpisode(_ episodeUuid: String, podcastUuid: String?, timestamp: TimeInterval?)
 
     func navigateToDiscover(_ animated: Bool)
+    func navigateToDiscover(category: String, animated: Bool)
 
     func navigateToProfile(_ animated: Bool)
 

--- a/podcasts/PodcastHeaderModel.swift
+++ b/podcasts/PodcastHeaderModel.swift
@@ -53,6 +53,15 @@ class PodcastHeaderViewModel: NSObject, ObservableObject {
         return folderImage
     }
 
+    var firstCategory: String {
+        guard let category = podcast.podcastCategory,
+              let substring = category.split(whereSeparator: \.isNewline).first
+        else {
+            return ""
+        }
+        return String(substring)
+    }
+
     var displayCategory: String {
         var result = podcast.podcastCategory?.localized(seperatingWith: \.isNewline) ?? ""
         if let author = podcast.author {
@@ -126,6 +135,10 @@ class PodcastHeaderViewModel: NSObject, ObservableObject {
 
     var htmlDescription: String {
         return podcast.podcastHTMLDescription ?? podcast.podcastDescription ?? ""
+    }
+
+    func categoryTapped() {
+        delegate?.categoryTapped(firstCategory)
     }
 }
 

--- a/podcasts/PodcastHeaderModel.swift
+++ b/podcasts/PodcastHeaderModel.swift
@@ -62,12 +62,13 @@ class PodcastHeaderViewModel: NSObject, ObservableObject {
         return String(substring).lowercased()
     }
 
-    var displayCategory: String {
-        var result = podcast.podcastCategory?.localized(seperatingWith: \.isNewline) ?? ""
+    var displayCategoryAndAuthor: AttributedString {
+        let category = podcast.podcastCategory?.localized(seperatingWith: \.isNewline) ?? ""
+        var markdown = "[\(category)](http://pocketcasts.com)"
         if let author = podcast.author {
-            result += " · \(author)"
+            markdown += " · \(author)"
         }
-        return result
+        return (try? AttributedString(markdown: markdown)) ?? AttributedString("")
     }
 
     var displayAuthor: String? {

--- a/podcasts/PodcastHeaderModel.swift
+++ b/podcasts/PodcastHeaderModel.swift
@@ -59,7 +59,7 @@ class PodcastHeaderViewModel: NSObject, ObservableObject {
         else {
             return ""
         }
-        return String(substring)
+        return String(substring).lowercased()
     }
 
     var displayCategory: String {

--- a/podcasts/PodcastHeaderView.swift
+++ b/podcasts/PodcastHeaderView.swift
@@ -75,13 +75,15 @@ struct PodcastHeaderView: View {
 
     private var podcastCategory: some View {
         VStack {
-            Text(viewModel.displayCategory)
+            Text(viewModel.displayCategoryAndAuthor)
                 .font(.callout)
                 .fixedSize(horizontal: false, vertical: true)
             .foregroundStyle(theme.primaryText02)
-            .onTapGesture {
+            .tint(theme.primaryText02)
+            .environment(\.openURL, OpenURLAction { url in
                 viewModel.categoryTapped()
-            }
+                return .handled
+            })
         }
     }
 

--- a/podcasts/PodcastHeaderView.swift
+++ b/podcasts/PodcastHeaderView.swift
@@ -79,6 +79,9 @@ struct PodcastHeaderView: View {
                 .font(.callout)
                 .fixedSize(horizontal: false, vertical: true)
             .foregroundStyle(theme.primaryText02)
+            .onTapGesture {
+                viewModel.categoryTapped()
+            }
         }
     }
 

--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -876,8 +876,8 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
         Analytics.track(.podcastScreenNotificationsTapped, properties: ["enabled": newValue])
     }
 
-    func categoryTapped(_ category: String) {        
-        NavigationManager.sharedManager.navigateTo(NavigationManager.discoverPageKey)
+    func categoryTapped(_ category: String) {
+        NavigationManager.sharedManager.navigateTo(NavigationManager.discoverPageKey, data: [NavigationManager.discoverCategoryKey: category])
         Analytics.track(.podcastScreenCategoryTapped, properties: ["category": category])
     }
 

--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -37,6 +37,7 @@ protocol PodcastActionsDelegate: AnyObject {
     func settingsTapped()
     func folderTapped()
     func notificationTapped()
+    func categoryTapped(_ category: String)
     func subscribe()
     func unsubscribe()
     func refreshArtwork(fromRect: CGRect, inView: UIView)
@@ -873,6 +874,11 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.podcastUpdated, object: podcast.uuid)
         Toast.show(newValue ? L10n.notificationsOn : L10n.notificationsOff)
         Analytics.track(.podcastScreenNotificationsTapped, properties: ["enabled": newValue])
+    }
+
+    func categoryTapped(_ category: String) {        
+        NavigationManager.sharedManager.navigateTo(NavigationManager.discoverPageKey)
+        Analytics.track(.podcastScreenCategoryTapped, properties: ["category": category])
     }
 
     func searchEpisodes(query: String) {

--- a/podcasts/UIViewControllerContentConfiguration.swift
+++ b/podcasts/UIViewControllerContentConfiguration.swift
@@ -1,7 +1,9 @@
 final class UIViewControllerContentConfiguration: UIContentConfiguration {
     let viewController: UIViewController
+    let parentViewController: UIViewController
 
-    init(viewController: UIViewController) {
+    init(parentViewController: UIViewController, viewController: UIViewController) {
+        self.parentViewController = parentViewController
         self.viewController = viewController
     }
 
@@ -45,6 +47,8 @@ class ViewControllerContainerContentView: UIView, UIContentView {
             viewController.view.trailingAnchor.constraint(equalTo: trailingAnchor),
             viewController.view.bottomAnchor.constraint(equalTo: bottomAnchor)
         ])
+
+        configuration.parentViewController.addChild(viewController)
     }
 
     override func systemLayoutSizeFitting(_ targetSize: CGSize, withHorizontalFittingPriority horizontalFittingPriority: UILayoutPriority, verticalFittingPriority: UILayoutPriority) -> CGSize {


### PR DESCRIPTION
| 📘 Part of: #2825  |  <!-- project issue number, if applicable -->
|:---:|

Fixes #2842  <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

https://github.com/user-attachments/assets/5027a543-a3e8-4d58-bb77-1a0a0a0368ac


## To test

1. Start the app and ensure you have the `podcastViewChanges` FF enabled
2. Open a podcast
3. Expand the header view if necessary
4. Tap on the Category bellow the podcast image
5. Check if Discover is open with that category selected
6. Go back to the Podcast view
7. Check if you tap the author bellow the image the category navigation is not opened

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
