### PR TITLE
[Newform AppsFlyer Integration] Add supported events list

### DIFF
--- a/PocketCastsTests/Tests/Analytics/AppsFlyerAdapterTests.swift
+++ b/PocketCastsTests/Tests/Analytics/AppsFlyerAdapterTests.swift
@@ -7,7 +7,7 @@ final class AppsFlyerAdapterTests: XCTestCase {
     func testAdapter() throws {
         let attController = AppTrackingTransparencyControllerMock()
         let adapter = AppsFlyerAdapterMock(appTrackingTransparencyProvider: attController)
-        adapter.track(name: "test 1", properties: nil)
+        adapter.track(name: "test_1", properties: nil)
 
         XCTAssertNil(adapter.trackedName)
         XCTAssertFalse(adapter.didAuthorize)
@@ -19,23 +19,38 @@ final class AppsFlyerAdapterTests: XCTestCase {
         XCTAssertTrue(adapter.didAuthorize)
         XCTAssertTrue(attController.userGaveConsent())
 
-        adapter.track(name: "test 2", properties: nil)
-        XCTAssertEqual(adapter.trackedName, "test 2")
+        adapter.track(name: "test_2", properties: nil)
+        XCTAssertEqual(adapter.trackedName, "test_2")
 
         attController.authState = .denied
 
-        adapter.track(name: "test 3", properties: nil)
+        adapter.track(name: "test_3", properties: nil)
+        XCTAssertNil(adapter.trackedName)
+
+        adapter.track(name: "non_supported_event", properties: nil)
         XCTAssertNil(adapter.trackedName)
     }
+}
+
+struct AppsFlyerDataProviderMock {
+    let supportedEvents: Set<String> = [
+        "test_1",
+        "test_2",
+        "test_3"
+    ]
 }
 
 fileprivate class AppsFlyerAdapterMock: AnalyticsAdapter {
     private(set) var trackedName: String?
     private(set) var didAuthorize = false
     private var appTrackingTransparencyProvider: AppTrackingTransparencyProvider
+    private let dataProvider: AppsFlyerDataProviderMock
 
     func track(name: String, properties: [AnyHashable: Any]?) {
-        guard appTrackingTransparencyProvider.userGaveConsent() else {
+        guard
+            appTrackingTransparencyProvider.userGaveConsent(),
+            dataProvider.supportedEvents.contains(name)
+        else {
             trackedName = nil
             return
         }
@@ -43,8 +58,10 @@ fileprivate class AppsFlyerAdapterMock: AnalyticsAdapter {
     }
 
     init(
+        dataProvider: AppsFlyerDataProviderMock = AppsFlyerDataProviderMock(),
         appTrackingTransparencyProvider: AppTrackingTransparencyProvider
     ) {
+        self.dataProvider = dataProvider
         self.appTrackingTransparencyProvider = appTrackingTransparencyProvider
         setup()
     }

--- a/podcasts/Analytics/Adapters/Newform AppsFlyer/AppsFlyerAdapter.swift
+++ b/podcasts/Analytics/Adapters/Newform AppsFlyer/AppsFlyerAdapter.swift
@@ -21,7 +21,8 @@ class AppsFlyerAdapter: AnalyticsAdapter {
     func track(name: String, properties: [AnyHashable: Any]?) {
         guard
             FeatureFlag.podcastNewformAppsFlyer.enabled,
-            appTrackingTransparencyProvider.userGaveConsent()
+            appTrackingTransparencyProvider.userGaveConsent(),
+            dataProvider.supportedEvents.contains(name)
         else {
             return
         }

--- a/podcasts/Analytics/Adapters/Newform AppsFlyer/AppsFlyerDataProvider.swift
+++ b/podcasts/Analytics/Adapters/Newform AppsFlyer/AppsFlyerDataProvider.swift
@@ -4,6 +4,40 @@ struct AppsFlyerDataProvider: AnonymousIdentifiable {
     let devKey = ApiCredentials.appsFlyerDevKey
     let appleAppID = "414834813"
     let userDefaults: UserDefaults
+    let supportedEvents: Set<String> = [
+        "user_signed_in",
+        "user_account_created",
+        "sso_started",
+        "purchase_successful",
+        "purchase_cancelled",
+        "setup_account_shown",
+        "setup_account_button_tapped",
+        "setup_account_dismissed",
+        "setup_account_link_tapped",
+        "signin_shown",
+        "signin_dismissed",
+        "select_account_type_shown",
+        "select_account_type_button_tapped",
+        "create_account_shown",
+        "create_account_dismissed",
+        "create_account_clicked",
+        "select_payment_frequency_shown",
+        "select_payment_frequency_dismissed",
+        "select_payment_frequency_next_button_tapped",
+        "select_payment_frequency_link_tapped",
+        "podcasts_list_shown",
+        "podcasts_tab_opened",
+        "filters_tab_opened",
+        "discover_tab_opened",
+        "profile_tab_opened",
+        "up_next_tab_opened",
+        "profile_shown",
+        "podcast_screen_shown",
+        "playback_play",
+        "filter_list_shown",
+        "discover_shown",
+        "podcast_subscribed"
+    ]
 
     var anonymousUUID: String {
         generateAnonymousUUID()


### PR DESCRIPTION
| 📘 Part of: #2850
|:---:|

Fixes #2893

Add supported events list

## To test

• CI must be 🟢
• Make sure you set true these 2 FF: `podcastNewformAppsFlyer` and `appsFlyerLogging`
• Run the app and accept the consent if needed
• You should see the event tracked only for the events in the list provided by the data provider (Original list in P2)

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
