### PR TITLE
[Podcast view changes] Activate FF and solve some issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 7.86
 -----
-
+- New podcast page design [#2825](https://github.com/Automattic/pocket-casts-ios/pull/2825)
 
 7.85
 -----

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -247,7 +247,7 @@ public enum FeatureFlag: String, CaseIterable {
         case .generatedTranscripts:
             true
         case .podcastViewChanges:
-            false
+            true
         case .podcastNewformAppsFlyer:
             false
         }

--- a/podcasts/PodcastHeaderModel.swift
+++ b/podcasts/PodcastHeaderModel.swift
@@ -141,6 +141,10 @@ class PodcastHeaderViewModel: NSObject, ObservableObject {
     func categoryTapped() {
         delegate?.categoryTapped(firstCategory)
     }
+
+    func podcastArtworkTapped() {
+        delegate?.refreshArtwork()
+    }
 }
 
 extension PodcastHeaderViewModel: ExpandableLabelDelegate {

--- a/podcasts/PodcastHeaderView.swift
+++ b/podcasts/PodcastHeaderView.swift
@@ -38,6 +38,9 @@ struct PodcastHeaderView: View {
                 PodcastImageViewWrapper(podcastUUID: viewModel.podcast.uuid, size: .grid)
                     .frame(width: viewModel.isExpanded ? Constants.largeImageSize : Constants.smallImageSize, height: viewModel.isExpanded ? Constants.largeImageSize : Constants.smallImageSize)
                     .animation(.bouncy, value: viewModel.isExpanded)
+                    .onLongPressGesture {
+                        viewModel.podcastArtworkTapped()
+                    }
                 Spacer()
             }
             VStack(spacing: 0) {

--- a/podcasts/PodcastHeadingTableCell.swift
+++ b/podcasts/PodcastHeadingTableCell.swift
@@ -227,7 +227,7 @@ class PodcastHeadingTableCell: ThemeableCell, SubscribeButtonDelegate, Expandabl
 
     @objc private func podcastImageLongPressed(_ sender: UILongPressGestureRecognizer) {
         if sender.state == .began {
-            delegate?.refreshArtwork(fromRect: podcastImageView.frame, inView: self)
+            delegate?.refreshArtwork()
         }
     }
 

--- a/podcasts/PodcastViewController+NetworkLoad.swift
+++ b/podcasts/PodcastViewController+NetworkLoad.swift
@@ -87,6 +87,9 @@ extension PodcastViewController {
                 if FeatureFlag.podcastFeedUpdate.enabled {
                     self.showPodcastFeedReloadTipIfNeeded()
                 }
+                if FeatureFlag.podcastViewChanges.enabled {
+                    self.showViewChangesTipIfNeeded()
+                }
             }
         }
     }

--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -40,7 +40,7 @@ protocol PodcastActionsDelegate: AnyObject {
     func categoryTapped(_ category: String)
     func subscribe()
     func unsubscribe()
-    func refreshArtwork(fromRect: CGRect, inView: UIView)
+    func refreshArtwork()
     func searchEpisodes(query: String)
     func clearSearch()
     func toggleShowArchived()
@@ -705,7 +705,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
 
     // MARK: - PodcastActionsDelegate
 
-    func refreshArtwork(fromRect: CGRect, inView: UIView) {
+    func refreshArtwork() {
         guard let podcast = podcast else { return }
 
         let optionsPicker = OptionsPicker(title: nil)

--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -1228,9 +1228,11 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
     private var viewChangesTipVC: UIViewController?
     private var dimmingView: UIView?
 
-    private func showViewChangesTipIfNeeded() {
+    func showViewChangesTipIfNeeded() {
         guard FeatureFlag.podcastViewChanges.enabled,
-              Settings.shouldShowPodcastViewChangesTip
+              Settings.shouldShowPodcastViewChangesTip,
+              self.podcast != nil,
+              viewChangesTipVC == nil
         else {
             return
         }

--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -506,7 +506,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
 
     func reloadData() {
         episodesTable.reloadData()
-        if FeatureFlag.podcastViewChanges.enabled {
+        if FeatureFlag.podcastViewChanges.enabled, viewIfLoaded != nil, viewIfLoaded?.window != nil {
             episodesTable.layoutIfNeeded()
             // This is being done here because after a relayout of table data we need to send the header back
             episodesTable.sendSubviewToBack(blurHeaderView)

--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -874,7 +874,11 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
         let newValue = !podcast.isPushEnabled
         PodcastManager.shared.setNotificationsEnabled(podcast: podcast, enabled: newValue)
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.podcastUpdated, object: podcast.uuid)
-        Toast.show(newValue ? L10n.notificationsOn : L10n.notificationsOff)
+        var message = newValue ? L10n.notificationsOn : L10n.notificationsOff
+        if let title = podcast.title, newValue {
+            message = L10n.notificationsOnForPodcast(title)
+        }
+        Toast.show(message)
         Analytics.track(.podcastScreenNotificationsTapped, properties: ["enabled": newValue])
     }
 

--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -443,7 +443,9 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
             refreshControl?.parentViewControllerDidAppear()
             showPodcastFeedReloadTipIfNeeded()
         }
-        episodesTable.sendSubviewToBack(blurHeaderView)
+        if FeatureFlag.podcastViewChanges.enabled {
+            episodesTable.sendSubviewToBack(blurHeaderView)
+        }
 
         showViewChangesTipIfNeeded()
     }
@@ -476,7 +478,9 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
         let miniPlayerOffset: CGFloat = PlaybackManager.shared.currentEpisode() == nil ? 0 : Constants.Values.miniPlayerOffset
         episodesTable.contentInset = UIEdgeInsets(top: navBarHeight(window: window), left: 0, bottom: miniPlayerOffset + multiSelectFooterOffset, right: 0)
         episodesTable.verticalScrollIndicatorInsets = episodesTable.contentInset
-        episodesTable.sendSubviewToBack(blurHeaderView)
+        if FeatureFlag.podcastViewChanges.enabled {
+            episodesTable.sendSubviewToBack(blurHeaderView)
+        }
     }
 
     override var preferredStatusBarStyle: UIStatusBarStyle {

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -1710,6 +1710,10 @@ internal enum L10n {
   internal static var notificationsOff: String { return L10n.tr("Localizable", "notifications_off") }
   /// Notifications On
   internal static var notificationsOn: String { return L10n.tr("Localizable", "notifications_on") }
+  /// We’ll notify you with new episodes of %1$@
+  internal static func notificationsOnForPodcast(_ p1: Any) -> String {
+    return L10n.tr("Localizable", "notifications_on_for_podcast", String(describing: p1))
+  }
   /// Play Now
   internal static var notificationsPlayNow: String { return L10n.tr("Localizable", "notifications_play_now") }
   /// Now Playing

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4806,6 +4806,7 @@
 
 /* Notifications Off*/
 "notifications_off" = "Notifications Off";
+
 /* Only on Unmetered Wifi */
 "only_on_unmetered_wifi" = "Only on Unmetered Wifi";
 
@@ -4827,3 +4828,5 @@
 /* Podcast View Changes tooltip details of change*/
 "podcast_view_changes_tip_details" = "Tap on the podcast title to collapse or expand its description and details";
 
+/* Toast message when notifications are enable for podcast. %1$@ argument is the name of the podcast*/
+"notifications_on_for_podcast" = "We’ll notify you with new episodes of %1$@";


### PR DESCRIPTION
| 📘 Part of: #2825 |  <!-- project issue number, if applicable -->
|:---:|

Fixes #2898 <!-- issue number, if applicable -->
Fixes #2899 <!-- issue number, if applicable -->

https://github.com/user-attachments/assets/b829131b-f073-47ce-91d7-fa51b8d57fbf

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR enables the FF by default and polish/fixes some things:
- Toast message when activating notifications on the podcast
- Fix a crash when showing tooltip but podcast still not loaded
- Sorts an warning regarding tableview being refresh without being on screen
- Add missing call to refresh artwork when long pressing on the podcast image

## To test

- Start the app from fresh
- Ensure that new podcast view design is active by default
- Open a podcast that you are following
- Tap on notifications icon to receive notifications
- Check if the toast message shows: `We’ll notify you with new episodes of XXXX`
- Long press the podcast image, check if a bottom sheet to refresh artwork is shown


## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
