### PR TITLE
Fix generated subtitles crash

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -13588,7 +13588,7 @@
 			repositoryURL = "https://github.com/dagronf/SwiftSubtitles";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.6.0;
+				minimumVersion = 1.8.2;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/podcasts.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/podcasts.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -258,8 +258,8 @@
         "repositoryURL": "https://github.com/dagronf/SwiftSubtitles",
         "state": {
           "branch": null,
-          "revision": "7cfb9cea6d7b85212de4f445dda17b8f5026c4ff",
-          "version": "1.7.0"
+          "revision": "aaa309326c2b8bfb52b7fdfabb1a43820c2e26b2",
+          "version": "1.8.2"
         }
       },
       {

--- a/podcasts/TranscriptManager.swift
+++ b/podcasts/TranscriptManager.swift
@@ -1,5 +1,6 @@
 import Foundation
 import PocketCastsDataModel
+import Sentry
 
 enum TranscriptError: Error {
     case notAvailable
@@ -76,6 +77,12 @@ class TranscriptManager {
         else {
             throw TranscriptError.failedToLoad
         }
+
+        let crumb = Breadcrumb()
+        crumb.level = SentryLevel.info
+        crumb.category = "transcript"
+        crumb.message = "Transcript file \(transcriptURL)"
+        SentrySDK.addBreadcrumb(crumb)
 
         guard let model = TranscriptModel.makeModel(from: transcriptText, format: transcriptFormat) else {
             throw TranscriptError.failedToParse


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR tries to address the crash that we are detecting on parsing generated transcripts by updating the SwiftSubtitle library.

## To test

1. Start the app
2. Login with a subscription user
3. Open a Podcast with generated transcripts. Ex: "VergeCast"
4. Play an episode ( you may need to open an older episode because of generation errors)
5. Open the mini-player
6. Open the transcript
7. Check that it works correctly

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
