### PR TITLE
Fix show suggested folder upsell with no podcasts

### DIFF
--- a/podcasts/FoldersCoordinator.swift
+++ b/podcasts/FoldersCoordinator.swift
@@ -42,7 +42,10 @@ class FoldersCoordinator: NSObject {
     }
 
     func startFolderCreationFlow(from vc: UIViewController) {
-        if FeatureFlag.suggestedFolders.enabled, suggestedFoldersModel.loadingState == .loaded, didPodcastsChanged() {
+        if FeatureFlag.suggestedFolders.enabled,
+           dataManager.allPodcasts(includeUnsubscribed: false, reloadFromDatabase: false).count > Constants.minimumNumberOfPodcasts,
+           suggestedFoldersModel.loadingState == .loaded,
+           didPodcastsChanged() {
             suggestedFolderCreationFlow(from: vc, source: .podcastsList)
         } else {
             manualFolderCreationFlow(from: vc)


### PR DESCRIPTION
| 📘 Part of: #2828  |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
Fixes the display of suggested folders when the user does not have enough podcasts.

## To test

1. Install the app from scratch without login in with an user
2. Go to podcast tab
3. Tap on the folder icon
4. Check that suggested folders upsell is not show, and just the standard upsell shows.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
