### PR TITLE
Update funding button color

### DIFF
--- a/podcasts/PodcastHeaderView.swift
+++ b/podcasts/PodcastHeaderView.swift
@@ -182,7 +182,7 @@ struct PodcastHeaderView: View {
             .resizable()
             .frame(width: width, height: height)
             .padding(padding)
-            .foregroundStyle(theme.primaryIcon02)
+            .foregroundStyle(theme.primaryIcon02Active)
     }
 
     private var podcastActions: some View {


### PR DESCRIPTION
| 📘 Part of: #2825  |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

Update the color of the fund button to match the other buttons colors.

<img src="https://github.com/user-attachments/assets/bdf69279-8fda-4fa0-804f-779c5ed33e84" width=320>

## To test

- Start the app
- Open The Changelog podcast
- Check if the color of the funding button as the same color as the other items.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
