### PR TITLE
Fix for action bar in new view changes

### DIFF
--- a/podcasts/PodcastHeaderModel.swift
+++ b/podcasts/PodcastHeaderModel.swift
@@ -114,7 +114,7 @@ class PodcastHeaderViewModel: NSObject, ObservableObject {
     func subscribeButtonTapped() {
         guard let delegate = delegate else { return }
 
-        if podcast.isSubscribed() {
+        if podcast.isSubscribed() || isSubscribed {
             delegate.unsubscribe()
             // do not switch variable here because there is still a confimation screen
         } else {

--- a/podcasts/PodcastHeaderView.swift
+++ b/podcasts/PodcastHeaderView.swift
@@ -190,6 +190,7 @@ struct PodcastHeaderView: View {
             Spacer()
             followButton
             if !viewModel.isSubscribed, let _ = viewModel.podcast.fundingURL {
+                Spacer().frame(width: 8)
                 fundingButton
             }
             if viewModel.isSubscribed {

--- a/podcasts/PodcastHeaderView.swift
+++ b/podcasts/PodcastHeaderView.swift
@@ -309,8 +309,31 @@ struct CollapseShape: Shape {
 }
 
 struct PodcastHeaderView_Previews: PreviewProvider {
+    struct PreviewContainerView: View {
+        @EnvironmentObject var theme: Theme
+
+        static func makePodcast() -> Podcast {
+            let podcast = Podcast()
+            podcast.title = "Test Podcast"
+            podcast.podcastCategory = "Test"
+            podcast.author = "Test Author"
+            podcast.estimatedNextEpisode = Date.now
+            podcast.podcastHTMLDescription = "<p>Test description</p>"
+            podcast.fundingURL = "https://www.pocketcasts.com"
+            return podcast
+        }
+
+        var body: some View {
+            VStack() {
+                PodcastHeaderView(viewModel: PodcastHeaderViewModel(podcast: Self.makePodcast()))
+                Spacer()
+            }
+            .background(theme.primaryUi01)
+            .frame(maxHeight: 400)
+        }
+    }
     static var previews: some View {
-        PodcastHeaderView(viewModel: PodcastHeaderViewModel(podcast: Podcast()))
+        PreviewContainerView()
             .previewWithAllThemes()
     }
 }

--- a/podcasts/PodcastHeaderView.swift
+++ b/podcasts/PodcastHeaderView.swift
@@ -182,7 +182,7 @@ struct PodcastHeaderView: View {
             .resizable()
             .frame(width: width, height: height)
             .padding(padding)
-            .foregroundStyle(theme.primaryIcon02Active)
+            .foregroundStyle(theme.primaryIcon03)
     }
 
     private var podcastActions: some View {
@@ -220,7 +220,7 @@ struct PodcastHeaderView: View {
                 .resizable()
                 .frame(width: 24, height: 24)
                 .padding(8)
-                .foregroundStyle(theme.primaryIcon02Active)
+                .foregroundStyle(theme.primaryIcon03)
         }
         .accessibilityLabel(title)
     }

--- a/podcasts/PodcastHeaderView.swift
+++ b/podcasts/PodcastHeaderView.swift
@@ -328,7 +328,7 @@ struct PodcastHeaderView_Previews: PreviewProvider {
                 PodcastHeaderView(viewModel: PodcastHeaderViewModel(podcast: Self.makePodcast()))
                 Spacer()
             }
-            .background(theme.primaryUi01)
+            .background(theme.primaryUi02)
             .frame(maxHeight: 400)
         }
     }


### PR DESCRIPTION
| 📘 Part of: #2895  |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR fixes three issues detected in tests:

- Podcast actions button colors was not visible in the Dark Contrast theme
- There was no spacing between the support button and follow button 
- If a user subscribed and unsubscribed quickly the UI was not updating

| 1 | 2 |
| - | - |
| ![Simulator Screenshot - iPhone 12 Pro - 2025-04-04 at 10 55 46](https://github.com/user-attachments/assets/ccfe5e15-04ce-4996-9ef2-7fa0c95e676f) | ![Simulator Screenshot - iPhone 12 Pro - 2025-04-04 at 10 55 19](https://github.com/user-attachments/assets/e640b038-1732-48e2-bee1-c7c29c680396) |

## To test

1. Start the app
2. Open a podcast you do not follow and has funding. Ex: Changelog
3. Select the Dark Contrast theme
4. Check if the support icon is spaced from follow and the image is visible
5. Tap on Follow
6. Check if the support icon is visible
7. Tap on the checkmark to unfollow and check if it works correctly

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
