### PR TITLE
Update downloading indicator color on up next to match the color on episode list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - New podcast page design [#2825](https://github.com/Automattic/pocket-casts-ios/pull/2825)
 - Add Creator Funding Support [#2913](https://github.com/Automattic/pocket-casts-ios/pull/2913)
 - Fix Watch app should pause play during announcements from other apps [#2245](https://github.com/Automattic/pocket-casts-ios/issues/2245)
+- Fix download indicator color in the up next list [#2941](https://github.com/Automattic/pocket-casts-ios/pull/2941)
 
 7.85
 -----

--- a/podcasts/PlayerCell.swift
+++ b/podcasts/PlayerCell.swift
@@ -233,7 +233,7 @@ class PlayerCell: ThemeableSwipeCell {
         selectView.backgroundColor = showTick ? AppTheme.colorForStyle(.primaryInteractive01, themeOverride: themeOverride) : AppTheme.colorForStyle(.primaryUi04, themeOverride: themeOverride)
         selectView.layer.borderWidth = showTick ? 0 : 2
         selectTickImageView.tintColor = AppTheme.colorForStyle(.primaryInteractive02, themeOverride: themeOverride)
-
+        downloadingIndicator.color = AppTheme.colorForStyle(.primaryIcon01, themeOverride: themeOverride)
         // Update the reorder control color
         let activeTheme = themeOverride ?? Theme.sharedTheme.activeTheme
         overrideUserInterfaceStyle = activeTheme.isDark ? .dark : .light


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
| 1 | 2 | 3 | 4 |
| - | - | - | - |
| ![Simulator Screenshot - iPhone 16 Pro Max - 2025-04-07 at 12 55 06](https://github.com/user-attachments/assets/4beac594-34b7-4cf9-b71a-369e0a8fea64) | ![Simulator Screenshot - iPhone 16 Pro Max - 2025-04-07 at 12 54 44](https://github.com/user-attachments/assets/324d2d80-95aa-43c0-8cb5-bf19a6c12156) | ![Simulator Screenshot - iPhone 16 Pro Max - 2025-04-07 at 12 54 18](https://github.com/user-attachments/assets/1176688f-7d8d-4203-b91c-54f68adac7da) |  ![Simulator Screenshot - iPhone 16 Pro Max - 2025-04-07 at 12 53 57](https://github.com/user-attachments/assets/6aadc686-3c9e-45da-8e54-01b6da07d02d) |
| ![Simulator Screenshot - iPhone 16 Pro Max - 2025-04-07 at 12 53 26](https://github.com/user-attachments/assets/a95af88c-8ebe-41e9-a071-7d4951a58543) |  ![Simulator Screenshot - iPhone 16 Pro Max - 2025-04-07 at 12 53 02](https://github.com/user-attachments/assets/016ff403-e4d8-4510-8b4d-30d449157fbb) |  ![Simulator Screenshot - iPhone 16 Pro Max - 2025-04-07 at 12 17 54](https://github.com/user-attachments/assets/e312c59d-61ec-4967-bc68-73974c576b0f) | ![Simulator Screenshot - iPhone 16 Pro Max - 2025-04-07 at 12 56 04](https://github.com/user-attachments/assets/7b671b1b-4523-40b2-9e17-d860bde4d337) |


## To test

1. Start the app and select the Light Theme
2. Add some items to UpNext
3. Select some of them and choose download
4. See if the download spinner is visible
5. Smoke test on other themes.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
