### PR TITLE
updated funding link to open in external browser

### DIFF
--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -830,7 +830,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
     func fundingTapped() {
         Analytics.track(.podcastScreenFundingTapped)
         guard let urlString = podcast?.fundingURL, let url = URL(string: urlString) else { return }
-        open(url: url)
+        UIApplication.shared.open(url, options: [:], completionHandler: nil)
     }
 
     func manageSubscriptionTapped() {


### PR DESCRIPTION
Related to https://github.com/Automattic/pocket-casts-ios/pull/2913

Open the funding url in an external browser to adhere to Apple policies. 

## To test

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
