### PR TITLE
Podcast view changes - tweak on layout and interaction

### DIFF
--- a/podcasts/PodcastHeaderDescriptionView.swift
+++ b/podcasts/PodcastHeaderDescriptionView.swift
@@ -6,8 +6,6 @@ struct PodcastHeaderDescriptionView: UIViewRepresentable {
     weak var delegate: ExpandableLabelDelegate?
     var heightChanged: (CGFloat) -> ()
 
-    static var cache: [String: RichExpandableLabel] = [:]
-
     init(htmlDescription: String, delegate: ExpandableLabelDelegate?, heightChanged: @escaping (CGFloat) -> ()) {
         _htmlDescription = .init(initialValue: htmlDescription)
         self.delegate = delegate
@@ -15,14 +13,7 @@ struct PodcastHeaderDescriptionView: UIViewRepresentable {
     }
 
     func makeUIView(context: Context) -> RichExpandableLabel {
-        let view: RichExpandableLabel
-        if let cachedView = Self.cache[htmlDescription], cachedView.superview == nil {
-            view = cachedView            
-        } else {
-            view = RichExpandableLabel()
-            Self.cache.removeAll()
-            Self.cache[htmlDescription] = view
-        }
+        let view = RichExpandableLabel()
         // we need this or else the webview will not expand to the width
         view.translatesAutoresizingMaskIntoConstraints = true
         view.delegate = self.delegate

--- a/podcasts/PodcastHeaderDescriptionView.swift
+++ b/podcasts/PodcastHeaderDescriptionView.swift
@@ -16,9 +16,8 @@ struct PodcastHeaderDescriptionView: UIViewRepresentable {
 
     func makeUIView(context: Context) -> RichExpandableLabel {
         let view: RichExpandableLabel
-        if let cachedView = Self.cache[htmlDescription] {
-            view = cachedView
-            view.removeFromSuperview()
+        if let cachedView = Self.cache[htmlDescription], cachedView.superview == nil {
+            view = cachedView            
         } else {
             view = RichExpandableLabel()
             Self.cache.removeAll()

--- a/podcasts/PodcastHeaderView.swift
+++ b/podcasts/PodcastHeaderView.swift
@@ -61,7 +61,7 @@ struct PodcastHeaderView: View {
             Spacer().frame(height: 16)
             podcastActions
             Spacer().frame(height: 24)
-            VStack {
+            VStack(spacing: 16) {
                 podcastDescription
                 podcastDetails
                 Spacer().frame(height: 24)

--- a/podcasts/PodcastHeaderView.swift
+++ b/podcasts/PodcastHeaderView.swift
@@ -38,6 +38,11 @@ struct PodcastHeaderView: View {
                 Spacer()
                 PodcastImageViewWrapper(podcastUUID: viewModel.podcast.uuid, size: .page)
                     .frame(width: viewModel.isExpanded ? Constants.largeImageSize : Constants.smallImageSize, height: viewModel.isExpanded ? Constants.largeImageSize : Constants.smallImageSize)
+                    .onTapGesture {
+                        withAnimation(.interpolatingSpring(stiffness: 100, damping: 15)) {
+                            viewModel.toggleExpanded()
+                        }
+                    }
                     .onLongPressGesture {
                         viewModel.podcastArtworkTapped()
                     }

--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -389,6 +389,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
         headerView.translatesAutoresizingMaskIntoConstraints = false
         headerView.backgroundColor = .clear
         headerView.layer.zPosition = -1000
+        headerView.isUserInteractionEnabled = false
         return headerView
     }()
 

--- a/podcasts/RichExpandableDescriptionView.swift
+++ b/podcasts/RichExpandableDescriptionView.swift
@@ -127,6 +127,10 @@ class RichExpandableLabel: WKWebView {
           -webkit-box-orient: vertical;
           overflow: hidden;
         }
+        p {
+            margin-top: 0;
+            margin-bottom: 0;
+        }
         a {
             color:\(linkColor.hexString());
         }
@@ -156,7 +160,8 @@ class RichExpandableLabel: WKWebView {
     }
 
     static func estimateHeightFor(maxLines: Int, lineHeightMultiple: CGFloat, font: UIFont) -> CGFloat {
-        return (font.lineHeight * lineHeightMultiple * CGFloat(maxLines)).rounded(.up)
+        //We don't take in account the extra space added by the line height multiple on the top and bottom lines
+        return ((font.lineHeight * lineHeightMultiple * CGFloat(maxLines-2)) + (2 * font.lineHeight)).rounded(.up)
     }
 
     private func update() {


### PR DESCRIPTION
| 📘 Part of: #2825  |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

This PR adds the following tweaks to podcast view changes:

- Allows tap on image to expand/collapse the description
- Fix margins on podcast description so it's always respected on collapsed and expanded state

| Before | After Collapsed | After Expanded |
| - | - | - |
| ![IMG_8299](https://github.com/user-attachments/assets/b5249b19-23de-4645-bd35-ca24cec21453) | ![Simulator Screenshot - iPhone 16 Pro Max - 2025-04-09 at 16 50 20](https://github.com/user-attachments/assets/7d804d85-15ec-4eb3-886c-f4a6399d1dfc) | ![Simulator Screenshot - iPhone 16 Pro Max - 2025-04-09 at 16 50 27](https://github.com/user-attachments/assets/7efa8711-80e5-4638-9c57-20f6f0b6bc12) |



## To test

- Start the app
- Open a podcast view 
- Tap on the podcast image to collapse and expand the image
- Check if the podcast description on the collapsed and expand state have the right margins on top and bottom.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
