### PR TITLE
Up Next Emptying: Debug info.txt file + Watch App Installed App Data

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1764,6 +1764,7 @@
 		F5BA5C9A2C7F701900BDA5B9 /* DiscoverCollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BA5C992C7F701900BDA5B9 /* DiscoverCollectionViewController.swift */; };
 		F5BA5C9C2C80F38200BDA5B9 /* UIViewControllerContentConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BA5C9B2C80F38200BDA5B9 /* UIViewControllerContentConfiguration.swift */; };
 		F5BA5C9E2C81254300BDA5B9 /* DiscoverCollectionViewController+DiscoverDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BA5C9D2C81254300BDA5B9 /* DiscoverCollectionViewController+DiscoverDelegate.swift */; };
+		F5BEAEC92DA73CE800541921 /* DebugInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BEAEC82DA73CE000541921 /* DebugInfo.swift */; };
 		F5BFF9892C6B0A9100A84561 /* Optional+ThrowOnNil.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BFF9882C6B0A9100A84561 /* Optional+ThrowOnNil.swift */; };
 		F5C1FA212D1283F5007CFDF2 /* AppIcon.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BD0D7AF31F6BC564006B673F /* AppIcon.xcassets */; };
 		F5CA25912CC9C30F0013DFF2 /* StoryFooter2024.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5CA25902CC9C30F0013DFF2 /* StoryFooter2024.swift */; };
@@ -3938,6 +3939,7 @@
 		F5BA5C992C7F701900BDA5B9 /* DiscoverCollectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverCollectionViewController.swift; sourceTree = "<group>"; };
 		F5BA5C9B2C80F38200BDA5B9 /* UIViewControllerContentConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewControllerContentConfiguration.swift; sourceTree = "<group>"; };
 		F5BA5C9D2C81254300BDA5B9 /* DiscoverCollectionViewController+DiscoverDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DiscoverCollectionViewController+DiscoverDelegate.swift"; sourceTree = "<group>"; };
+		F5BEAEC82DA73CE000541921 /* DebugInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugInfo.swift; sourceTree = "<group>"; };
 		F5BFF9882C6B0A9100A84561 /* Optional+ThrowOnNil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Optional+ThrowOnNil.swift"; sourceTree = "<group>"; };
 		F5CA25902CC9C30F0013DFF2 /* StoryFooter2024.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoryFooter2024.swift; sourceTree = "<group>"; };
 		F5CFDB612C6DA2D600DE57B2 /* AudioClipExporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AudioClipExporter.swift; sourceTree = "<group>"; };
@@ -5611,6 +5613,7 @@
 				C791418C294CE32D00F1852B /* StorageManager.swift */,
 				C701C25B2A8E82DC00AD9FAB /* PaidFeature.swift */,
 				32163E5F2B1EBDB6009BB16B /* DatabaseExport.swift */,
+				F5BEAEC82DA73CE000541921 /* DebugInfo.swift */,
 				F5E3DAA62BDD5567002BD4E4 /* PCBundleDoc.swift */,
 				F57D8F132C66CA230004C4DF /* UnsafeWait.swift */,
 				F57D8F152C66CBB80004C4DF /* UnsafeTransfer.swift */,
@@ -10743,6 +10746,7 @@
 				8B1C974628FE1C7E00BD5EB9 /* ImageView.swift in Sources */,
 				40484F0122F1507F007DBD55 /* ThemeableRoundedButton.swift in Sources */,
 				BDEBD3A91BA0108800AD038F /* BufferedAudio.swift in Sources */,
+				F5BEAEC92DA73CE800541921 /* DebugInfo.swift in Sources */,
 				402772D721B6105D00769811 /* PodcastManager+Delete.swift in Sources */,
 				403B5B02217D5F1500821A54 /* TitleViewWithCollapseButton.swift in Sources */,
 				F52ADE472BD9698B00AC647F /* ModalView.swift in Sources */,

--- a/podcasts/DatabaseExport.swift
+++ b/podcasts/DatabaseExport.swift
@@ -70,6 +70,9 @@ class DatabaseExport {
             let logsFile = exportDirectory.appendingPathComponent("logs.txt", isDirectory: false)
             try fileManager.copyItem(at: URL(fileURLWithPath: logFile), to: logsFile)
 
+            let debugInfoFile = exportDirectory.appendingPathComponent("info.txt", conformingTo: .text)
+            fileManager.createFile(atPath: debugInfoFile.absoluteString, contents: DebugInfo.string(optOut: UserDefaults.standard.debugOptedOut).data(using: .utf8))
+
             // Write the bundle document
             let exportFile = exportDirectory.appendingPathComponent("export", conformingTo: .pcasts)
             let wrapper = try PCBundleDoc().fileWrapper()

--- a/podcasts/DebugInfo.swift
+++ b/podcasts/DebugInfo.swift
@@ -19,7 +19,8 @@ struct DebugInfo {
         Device: \(DeviceUtil.identifier)
         OS: \(DeviceUtil.systemVersion ?? "Unknown")
         Local Time: \(localTime)
-        UTC Time: \(gmtTime)\n
+        UTC Time: \(gmtTime)
+        Watch App Installed: \(WatchManager.shared.isWatchAppInstalled ? "yes" : "no")\n
         """
 
         guard !optOut else { return debugString }

--- a/podcasts/DebugInfo.swift
+++ b/podcasts/DebugInfo.swift
@@ -1,0 +1,42 @@
+import PocketCastsServer
+import PocketCastsUtils
+
+struct DebugInfo {
+    static func string(optOut: Bool) -> String {
+        let syncEmail: String
+        if SyncManager.isUserLoggedIn(), let email = ServerSettings.syncingEmail() {
+            syncEmail = email
+        } else {
+            syncEmail = "Not logged in"
+        }
+
+        let now = Date()
+        let localTime = DateFormatHelper.sharedHelper.localTimeJsonDateFormatter.string(from: now)
+        let gmtTime = DateFormatHelper.sharedHelper.jsonFormat(now)
+
+        var debugString = """
+        App Version: \(Settings.appVersion())
+        Device: \(DeviceUtil.identifier)
+        OS: \(DeviceUtil.systemVersion ?? "Unknown")
+        Local Time: \(localTime)
+        UTC Time: \(gmtTime)\n
+        """
+
+        guard !optOut else { return debugString }
+        debugString += """
+        Sync Email: \(syncEmail)
+        App ID: \(Settings.uniqueAppId() ?? "Unknown")
+
+        Auto Download On: \(Settings.autoDownloadEnabled() ? "yes" : "no")
+        Auto Download Only on Wifi: \(Settings.autoDownloadMobileDataAllowed() ? "no" : "yes")
+        Warn Before Using Data: \(Settings.mobileDataAllowed() ? "no" : "yes")
+        Auto Download Up Next:  \(Settings.downloadUpNextEpisodes() ? "yes" : "no")
+        Auto Archive Played Episodes after: \(ArchiveHelper.archiveTimeToText(Settings.autoArchivePlayedAfter()))
+        Auto Archive Inactive Episodes after: \(ArchiveHelper.archiveTimeToText(Settings.autoArchiveInactiveAfter()))
+        Auto Archive Starred Episodes: \(Settings.archiveStarredEpisodes())
+        Uploaded Episode Count: \(ServerSettings.customStorageNumFiles())
+        """
+
+        return debugString
+    }
+}

--- a/podcasts/SupportConfig.swift
+++ b/podcasts/SupportConfig.swift
@@ -138,41 +138,7 @@ struct SupportConfig: ZDConfig {
     }
 
     private func appMetaData(optOut: Bool) -> ZDCustomField {
-        let syncEmail: String
-        if SyncManager.isUserLoggedIn(), let email = ServerSettings.syncingEmail() {
-            syncEmail = email
-        } else {
-            syncEmail = "Not logged in"
-        }
-
-        let now = Date()
-        let localTime = DateFormatHelper.sharedHelper.localTimeJsonDateFormatter.string(from: now)
-        let gmtTime = DateFormatHelper.sharedHelper.jsonFormat(now)
-
-        var debugString = """
-        App Version: \(Settings.appVersion())
-        Device: \(DeviceUtil.identifier)
-        OS: \(DeviceUtil.systemVersion ?? "Unknown")
-        Local Time: \(localTime)
-        UTC Time: \(gmtTime)\n
-        """
-
-        guard !optOut else { return ZDCustomField(.metaData, value: debugString) }
-        debugString += """
-        Sync Email: \(syncEmail)
-        App ID: \(Settings.uniqueAppId() ?? "Unknown")
-
-        Auto Download On: \(Settings.autoDownloadEnabled() ? "yes" : "no")
-        Auto Download Only on Wifi: \(Settings.autoDownloadMobileDataAllowed() ? "no" : "yes")
-        Warn Before Using Data: \(Settings.mobileDataAllowed() ? "no" : "yes")
-        Auto Download Up Next:  \(Settings.downloadUpNextEpisodes() ? "yes" : "no")
-        Auto Archive Played Episodes after: \(ArchiveHelper.archiveTimeToText(Settings.autoArchivePlayedAfter()))
-        Auto Archive Inactive Episodes after: \(ArchiveHelper.archiveTimeToText(Settings.autoArchiveInactiveAfter()))
-        Auto Archive Starred Episodes: \(Settings.archiveStarredEpisodes())
-        Uploaded Episode Count: \(ServerSettings.customStorageNumFiles())
-        """
-
-        return ZDCustomField(.metaData, value: debugString)
+        return ZDCustomField(.metaData, value: DebugInfo.string(optOut: optOut))
     }
 
     private var allPodcasts: ZDCustomField {

--- a/podcasts/WatchManager.swift
+++ b/podcasts/WatchManager.swift
@@ -12,6 +12,10 @@ class WatchManager: NSObject, WCSessionDelegate {
     // The last retrieved log is cached here for the duration of this session
     var cachedLog: String? = nil
 
+    var isWatchAppInstalled: Bool {
+        return WCSession.isSupported() && WCSession.default.isWatchAppInstalled
+    }
+
     func setup() {
         if !WCSession.isSupported() { return }
 


### PR DESCRIPTION
| 📘 Part of: #2945 |
|:---:|

Fixes #2953

* Adds an `info.txt` file to the database export containing the same information we send to Zendesk.
* Adds a "Watch App Installed" field to that debug info.

We often receive these database exports as follow up on tickets and it would be useful to have all of this information included along with the other logs.

## To test

**It's best to run this on device with an Apple Watch app attached to check the value**

### Info.txt file
* Navigate to Settings > Help & Feedback > ⋯
* Tap "Export Database"
* Save to Files
* Unzip and check that an `info.txt` file exists with the contents of the debug string

### Zendesk
* Go to Help & Feedback
* Scroll down to "Get in Touch"
* Tap "Leave Feedback"
* Fill out form & submit
* Check Zendesk Pocket Casts filter and sort by latest requested
* Verify that the PC App Data includes the "Watch App Installed" field

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
