### PR TITLE
Up Next Emptying: Apple Watch log export

### DIFF
--- a/podcasts/DatabaseExport.swift
+++ b/podcasts/DatabaseExport.swift
@@ -70,8 +70,8 @@ class DatabaseExport {
             let logsFile = exportDirectory.appendingPathComponent("logs.txt", isDirectory: false)
             try fileManager.copyItem(at: URL(fileURLWithPath: logFile), to: logsFile)
 
-            let debugInfoFile = exportDirectory.appendingPathComponent("info.txt", conformingTo: .text)
-            fileManager.createFile(atPath: debugInfoFile.absoluteString, contents: DebugInfo.string(optOut: UserDefaults.standard.debugOptedOut).data(using: .utf8))
+            let debugInfoFile = exportDirectory.appendingPathComponent("info.txt")
+            fileManager.createFile(atPath: debugInfoFile.path, contents: DebugInfo.string(optOut: UserDefaults.standard.debugOptedOut).data(using: .utf8))
 
             // Write the bundle document
             let exportFile = exportDirectory.appendingPathComponent("export", conformingTo: .pcasts)

--- a/podcasts/DatabaseExport.swift
+++ b/podcasts/DatabaseExport.swift
@@ -66,12 +66,16 @@ class DatabaseExport {
             try fileManager.createDirectory(at: exportDirectory, withIntermediateDirectories: true)
 
             FileLog.shared.forceFlush()
-            let logFile = try await FileLog.shared.logFileForUpload().awaitFirstValue(in: &cancellables)
-            let logsFile = exportDirectory.appendingPathComponent("logs.txt", isDirectory: false)
-            try fileManager.copyItem(at: URL(fileURLWithPath: logFile), to: logsFile)
+            let phoneLogFile = try await FileLog.shared.logFileForUpload().awaitFirstValue(in: &cancellables)
+            try moveFile(phoneLogFile, exportDirectory: exportDirectory, exportFileName: "ios-logs.txt")
 
             let debugInfoFile = exportDirectory.appendingPathComponent("info.txt")
             fileManager.createFile(atPath: debugInfoFile.path, contents: DebugInfo.string(optOut: UserDefaults.standard.debugOptedOut).data(using: .utf8))
+
+            let watchLogFile = await FileLog.shared.watchLogFileForUpload().awaitFirstValue(in: &cancellables)
+            if let watchLogFile {
+                try moveFile(watchLogFile, exportDirectory: exportDirectory, exportFileName: "watchos-logs.txt")
+            }
 
             // Write the bundle document
             let exportFile = exportDirectory.appendingPathComponent("export", conformingTo: .pcasts)
@@ -83,5 +87,10 @@ class DatabaseExport {
             FileLog.shared.addMessage("[Export] Prepare failed with error: \(error)")
             return nil
         }
+    }
+
+    private func moveFile(_ logFilePath: String, exportDirectory: URL, exportFileName: String) throws {
+        let exportFilePath = exportDirectory.appendingPathComponent(exportFileName, isDirectory: false)
+        try fileManager.copyItem(at: URL(fileURLWithPath: logFilePath), to: exportFilePath)
     }
 }

--- a/podcasts/Zendesk/FileLog+FileUpload.swift
+++ b/podcasts/Zendesk/FileLog+FileUpload.swift
@@ -42,7 +42,7 @@ extension FileLog: EventLoggingDelegate {
             .eraseToAnyPublisher()
     }
 
-    private func watchLogFileForUpload() -> AnyPublisher<String?, Never> {
+    func watchLogFileForUpload() -> AnyPublisher<String?, Never> {
         Future<String?, Error> { promise in
             WatchManager.shared.requestLogFile { watchLog in
                 guard let wearableLog = watchLog else {


### PR DESCRIPTION
| 📘 Part of: #2945 |
|:---:|

Fixes #2952

* Adds a `watchos-logs.txt` file to the database export
* Renames the `logs.txt` to `ios-logs.txt`
* Fixes an issue with the `info.txt` export which includes the same App Data we send to Zendesk. See #2953 

## To test

**I tested this using a watchOS and iOS simulator. These must be "paired" together by Xcode and I had them running at the same time.**

* Navigate to Settings > Help & Feedback > ⋯
* Tap "Export Database"
* Save to Files
* Unzip and check that `ios-logs.txt`, `watchos-logs.txt`, and `info.txt` exist in the export zip

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
