### PR TITLE
[Fix] Avoid to assign wrong frame position

### DIFF
--- a/podcasts/AudioReadTask.swift
+++ b/podcasts/AudioReadTask.swift
@@ -47,10 +47,10 @@ class AudioReadTask {
         if playPositionHint > 0 {
             currentFramePosition = framePositionForTime(playPositionHint).framePosition
             if currentFramePosition < audioFile.length {
-                FileLog.shared.addMessage("Setting framePosition to \(currentFramePosition) for file: \(audioFile.url.absoluteString)")
+                FileLog.shared.addMessage("Setting framePosition to \(currentFramePosition) for file: \(audioFile.url.lastPathComponent)")
                 audioFile.framePosition = currentFramePosition
             } else {
-                FileLog.shared.addMessage("Attempted to seek past EOF: \(currentFramePosition) >= \(audioFile.length), file: \(audioFile.url.absoluteString)")
+                FileLog.shared.addMessage("Attempted to seek past EOF: \(currentFramePosition) >= \(audioFile.length), file: \(audioFile.url.lastPathComponent)")
             }
         }
     }

--- a/podcasts/AudioReadTask.swift
+++ b/podcasts/AudioReadTask.swift
@@ -46,7 +46,12 @@ class AudioReadTask {
 
         if playPositionHint > 0 {
             currentFramePosition = framePositionForTime(playPositionHint).framePosition
-            audioFile.framePosition = currentFramePosition
+            if currentFramePosition < audioFile.length {
+                FileLog.shared.addMessage("Setting framePosition to \(currentFramePosition) for file: \(audioFile.url.absoluteString)")
+                audioFile.framePosition = currentFramePosition
+            } else {
+                FileLog.shared.addMessage("Attempted to seek past EOF: \(currentFramePosition) >= \(audioFile.length), file: \(audioFile.url.absoluteString)")
+            }
         }
     }
 


### PR DESCRIPTION
Fixes sentry-5543778228

This fix should avoid setting a wrong frame position which causes a crash

## To test

- Run the app
- Use the effect player
- Try to play different episodes
- The if statement should enter if you play with an episode already started
- Check the logs to see if it works
- The app shouldn't crash

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
