### PR TITLE
[Newform AppsFlyer Integration] Catch app installed event

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -174,7 +174,7 @@ public enum FeatureFlag: String, CaseIterable {
         case .firebaseLogging:
             false
         case .appsFlyerLogging:
-            true
+            false
         case .endOfYear:
             false
         case .errorLogoutHandling:

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -174,7 +174,7 @@ public enum FeatureFlag: String, CaseIterable {
         case .firebaseLogging:
             false
         case .appsFlyerLogging:
-            false
+            true
         case .endOfYear:
             false
         case .errorLogoutHandling:

--- a/podcasts/Analytics/Adapters/Newform AppsFlyer/AppsFlyerAdapter.swift
+++ b/podcasts/Analytics/Adapters/Newform AppsFlyer/AppsFlyerAdapter.swift
@@ -75,6 +75,7 @@ class AppsFlyerAdapter: AnalyticsAdapter {
     private func trackApplicationInstalledIfNeeded() {
         if dataProvider.isNewInstall {
             track(name: "application_installed", properties: nil)
+            track(name: "application_opened", properties: nil)
         }
     }
 }

--- a/podcasts/Analytics/Adapters/Newform AppsFlyer/AppsFlyerAdapter.swift
+++ b/podcasts/Analytics/Adapters/Newform AppsFlyer/AppsFlyerAdapter.swift
@@ -65,7 +65,16 @@ class AppsFlyerAdapter: AnalyticsAdapter {
                 FileLog.shared.addMessage("AppsFlyer start error: \(error)")
             } else {
                 FileLog.shared.addMessage("AppsFlyer start success: \(params ?? [:])")
+                DispatchQueue.main.async { [weak self] in
+                    self?.trackApplicationInstalledIfNeeded()
+                }
             }
+        }
+    }
+
+    private func trackApplicationInstalledIfNeeded() {
+        if dataProvider.isNewInstall {
+            track(name: "application_installed", properties: nil)
         }
     }
 }

--- a/podcasts/Analytics/Adapters/Newform AppsFlyer/AppsFlyerDataProvider.swift
+++ b/podcasts/Analytics/Adapters/Newform AppsFlyer/AppsFlyerDataProvider.swift
@@ -6,6 +6,7 @@ struct AppsFlyerDataProvider: AnonymousIdentifiable {
     let userDefaults: UserDefaults
     let supportedEvents: Set<String> = [
         "application_installed",
+        "application_opened",
         "user_signed_in",
         "user_account_created",
         "sso_started",

--- a/podcasts/Analytics/Adapters/Newform AppsFlyer/AppsFlyerDataProvider.swift
+++ b/podcasts/Analytics/Adapters/Newform AppsFlyer/AppsFlyerDataProvider.swift
@@ -5,6 +5,7 @@ struct AppsFlyerDataProvider: AnonymousIdentifiable {
     let appleAppID = "414834813"
     let userDefaults: UserDefaults
     let supportedEvents: Set<String> = [
+        "application_installed",
         "user_signed_in",
         "user_account_created",
         "sso_started",
@@ -47,5 +48,9 @@ struct AppsFlyerDataProvider: AnonymousIdentifiable {
         userDefaults: UserDefaults? = UserDefaults(suiteName: SharedConstants.GroupUserDefaults.groupContainerId)
     ) {
         self.userDefaults = userDefaults ?? .standard
+    }
+
+    var isNewInstall: Bool {
+        (UIApplication.shared.delegate as? AppDelegate)?.appInstallState == .installed
     }
 }

--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -25,6 +25,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     lazy var appLifecycleAnalytics = AppLifecycleAnalytics()
 
     private var backgroundSignOutListener: BackgroundSignOutListener?
+    private(set) var appInstallState: AppLifecycleAnalytics.AppInstallState?
 
     lazy var whatsNew: WhatsNew = WhatsNew()
 
@@ -38,8 +39,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         addAnalyticsObservers()
         setupAnalytics()
 
-        if let appInstallState = appLifecycleAnalytics.checkApplicationInstalledOrUpgraded(),
-           appInstallState == .installed {
+        appInstallState = appLifecycleAnalytics.checkApplicationInstalledOrUpgraded()
+
+        if let appInstallState, appInstallState == .installed {
             //Never show the podcast feed reload tooltip for fresh install
             Settings.shouldShowPodcastFeeReloadTip = false
             Settings.shouldShowPodcastViewChangesTip = false


### PR DESCRIPTION
| 📘 Part of: #2850 
|:---:|

This PR catches the app install event and force to fire it as soon the user accept the consent.

## To test

- Enable the AppsFlyer logger by code
- Run the app as fresh install
- Accept the ATT consent
- Confirm AppsFlyer logs `application_installed` & `application_opened`

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
