### PR TITLE
[Notifications Revamp] Onboarding notifications check task completion

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1984,6 +1984,7 @@
 		FF4A73D82C87694300587128 /* ReferralCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF4A73D72C87694300587128 /* ReferralCardView.swift */; };
 		FF4A73DA2C876D5E00587128 /* ReferralSendPassVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF4A73D92C876D5E00587128 /* ReferralSendPassVC.swift */; };
 		FF4B3E392C2D94F300F84DD6 /* TranscriptFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF4B3E382C2D94F300F84DD6 /* TranscriptFilter.swift */; };
+		FF4D65D02DA81B5B003DC1F0 /* NotificationsCoordinator+AnalyticsAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF4D65CF2DA81B4B003DC1F0 /* NotificationsCoordinator+AnalyticsAdapter.swift */; };
 		FF4E93122BDBF0D800F370AA /* MiniPlayerGradientView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF4E93112BDBF0D800F370AA /* MiniPlayerGradientView.swift */; };
 		FF5381A62C90A06400829525 /* ReferralsClaimBannerTableCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF5381A52C90A06400829525 /* ReferralsClaimBannerTableCell.swift */; };
 		FF5381AE2C90FF1500829525 /* ReferralCardMiniView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF5381AD2C90FF1500829525 /* ReferralCardMiniView.swift */; };
@@ -4030,6 +4031,7 @@
 		FF4A73D72C87694300587128 /* ReferralCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReferralCardView.swift; sourceTree = "<group>"; };
 		FF4A73D92C876D5E00587128 /* ReferralSendPassVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReferralSendPassVC.swift; sourceTree = "<group>"; };
 		FF4B3E382C2D94F300F84DD6 /* TranscriptFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptFilter.swift; sourceTree = "<group>"; };
+		FF4D65CF2DA81B4B003DC1F0 /* NotificationsCoordinator+AnalyticsAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NotificationsCoordinator+AnalyticsAdapter.swift"; sourceTree = "<group>"; };
 		FF4E93112BDBF0D800F370AA /* MiniPlayerGradientView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MiniPlayerGradientView.swift; sourceTree = "<group>"; };
 		FF5381A52C90A06400829525 /* ReferralsClaimBannerTableCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReferralsClaimBannerTableCell.swift; sourceTree = "<group>"; };
 		FF5381AD2C90FF1500829525 /* ReferralCardMiniView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReferralCardMiniView.swift; sourceTree = "<group>"; };
@@ -8512,6 +8514,7 @@
 		FFE794DB2DA443E8005E4D40 /* Notifications */ = {
 			isa = PBXGroup;
 			children = (
+				FF4D65CF2DA81B4B003DC1F0 /* NotificationsCoordinator+AnalyticsAdapter.swift */,
 				FFE794DC2DA443F8005E4D40 /* NotificationsCoordinator.swift */,
 			);
 			path = Notifications;
@@ -9711,9 +9714,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-podcasts/Pods-podcasts-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-podcasts/Pods-podcasts-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -9746,9 +9753,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-PocketCastsTests/Pods-PocketCastsTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-PocketCastsTests/Pods-PocketCastsTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -10812,6 +10823,7 @@
 				FF0753862D6CB70A00BE8B3B /* NavigationContainer.swift in Sources */,
 				BD74F1B621F0133B002EF774 /* MPFeedbackCommand+Title.swift in Sources */,
 				C72CED2D289DA14F0017883A /* AnalyticsEvent.swift in Sources */,
+				FF4D65D02DA81B5B003DC1F0 /* NotificationsCoordinator+AnalyticsAdapter.swift in Sources */,
 				BD874EF71C9A428B00F5B2A5 /* GeneralSettingsViewController.swift in Sources */,
 				C7A110F7291F65FB00887A90 /* WelcomeView.swift in Sources */,
 				BD98C54B1BA802AA00E85D3B /* DiscoverDisclosureCell.swift in Sources */,

--- a/podcasts/AppDelegate+Analytics.swift
+++ b/podcasts/AppDelegate+Analytics.swift
@@ -18,6 +18,11 @@ extension AppDelegate {
         if FeatureFlag.podcastNewformAppsFlyer.enabled {
             adapters.append(AppsFlyerAdapter(appTrackingTransparencyProvider: AppTrackingTransparencyController.shared))
         }
+
+        if FeatureFlag.notificationsRevamp.enabled {
+            adapters.append(NotificationsCoordinator.shared)
+        }
+
         Analytics.register(adapters: adapters)
         Analytics.add(analyticsAppThemeProvider: AnalyticsAppThemeProvider())
     }

--- a/podcasts/AppDelegate+UrlHandling.swift
+++ b/podcasts/AppDelegate+UrlHandling.swift
@@ -385,10 +385,7 @@ extension AppDelegate {
         setupOnboardingRoutes()
     }
 
-    func setupOnboardingRoutes() {
-        guard FeatureFlag.notificationsRevamp.enabled else {
-            return
-        }
+    func setupOnboardingRoutes() {        
         JLRoutes.global().addRoute("/settings/themes") {[weak self] parameters -> Bool in
             guard self != nil else { return false }
             NavigationManager.sharedManager.navigateTo(NavigationManager.settingsAppearanceKey, data: [NavigationManager.settingsAppearanceShowThemeKey: true])

--- a/podcasts/AppDelegate+UrlHandling.swift
+++ b/podcasts/AppDelegate+UrlHandling.swift
@@ -385,7 +385,7 @@ extension AppDelegate {
         setupOnboardingRoutes()
     }
 
-    func setupOnboardingRoutes() {        
+    func setupOnboardingRoutes() {
         JLRoutes.global().addRoute("/settings/themes") {[weak self] parameters -> Bool in
             guard self != nil else { return false }
             NavigationManager.sharedManager.navigateTo(NavigationManager.settingsAppearanceKey, data: [NavigationManager.settingsAppearanceShowThemeKey: true])

--- a/podcasts/DeveloperMenu.swift
+++ b/podcasts/DeveloperMenu.swift
@@ -289,7 +289,7 @@ struct DeveloperMenu: View {
 
             Section {
                 Button("Speed Up Notifications") {
-                    NotificationsCoordinator.shared.timeIntervalStep = 15.seconds
+                    NotificationsCoordinator.shared.timeIntervalStep = 60.seconds
                 }
             } header: {
                 Text("Notifications")

--- a/podcasts/DeveloperMenu.swift
+++ b/podcasts/DeveloperMenu.swift
@@ -289,7 +289,7 @@ struct DeveloperMenu: View {
 
             Section {
                 Button("Speed Up Notifications") {
-                    NotificationsCoordinator.shared.timeIntervalStep = 5.seconds
+                    NotificationsCoordinator.shared.timeIntervalStep = 15.seconds
                 }
             } header: {
                 Text("Notifications")

--- a/podcasts/Notifications/NotificationsCoordinator+AnalyticsAdapter.swift
+++ b/podcasts/Notifications/NotificationsCoordinator+AnalyticsAdapter.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+extension NotificationsCoordinator: AnalyticsAdapter {
+
+    func track(name: String, properties: [AnyHashable: Any]?) {
+        for notification in onboardingNotifications {
+            if notification.checkCancelConditionsForEvent(name: name) {
+                self.cancelNotification(notification)
+            }
+        }
+    }
+
+}
+
+extension NotificationType {
+
+    func checkCancelConditionsForEvent(name: String) -> Bool {
+        var possibleConditions: [AnalyticsEvent] = []
+        switch self {
+        case .onboardingSignUp:
+            possibleConditions = [.userSignedIn, .userAccountCreated]
+        case .onboardingImport:
+            possibleConditions = [.settingsImportShown, .onboardingImportShown]
+        case .onboardingThemes:
+            possibleConditions = [.settingsAppearanceThemeChanged]
+        case .onboardingUpNext:
+            possibleConditions = [.episodeAddedToUpNext, .episodeBulkAddToUpNext]
+        case .onboardingFilters:
+            possibleConditions = [.filterCreated]
+        case .onboardingUpsell:
+            possibleConditions  = [.plusPromotionShown]
+        }
+        return possibleConditions.contains {
+            $0.rawValue.toSnakeCaseFromCamelCase() == name
+        }
+    }
+}

--- a/podcasts/Notifications/NotificationsCoordinator+AnalyticsAdapter.swift
+++ b/podcasts/Notifications/NotificationsCoordinator+AnalyticsAdapter.swift
@@ -15,7 +15,8 @@ extension NotificationsCoordinator: AnalyticsAdapter {
 extension NotificationType {
 
     func checkCancelConditionsForEvent(name: String) -> Bool {
-        var possibleConditions: [AnalyticsEvent] = []
+        var possibleConditions: Set<AnalyticsEvent>
+
         switch self {
         case .onboardingSignUp:
             possibleConditions = [.userSignedIn, .userAccountCreated]

--- a/podcasts/Notifications/NotificationsCoordinator+AnalyticsAdapter.swift
+++ b/podcasts/Notifications/NotificationsCoordinator+AnalyticsAdapter.swift
@@ -28,7 +28,7 @@ extension NotificationType {
         case .onboardingFilters:
             possibleConditions = [.filterCreated]
         case .onboardingUpsell:
-            possibleConditions  = [.plusPromotionShown]
+            possibleConditions  = [.purchaseSuccessful]
         }
         return possibleConditions.contains {
             $0.rawValue.toSnakeCaseFromCamelCase() == name

--- a/podcasts/Notifications/NotificationsCoordinator.swift
+++ b/podcasts/Notifications/NotificationsCoordinator.swift
@@ -78,7 +78,7 @@ class NotificationsCoordinator {
         self.notificationCenter = notificationCenter
     }
 
-    private let onboardingNotifications: [NotificationType] = [.onboardingSignUp, .onboardingImport, .onboardingUpNext, .onboardingFilters, .onboardingThemes, .onboardingUpsell]
+    let onboardingNotifications: [NotificationType] = [.onboardingSignUp, .onboardingImport, .onboardingUpNext, .onboardingFilters, .onboardingThemes, .onboardingUpsell]
 
     func setupOnboardingNotifications() {
         Settings.notificationsOnboardingTips = true

--- a/podcasts/Notifications/NotificationsCoordinator.swift
+++ b/podcasts/Notifications/NotificationsCoordinator.swift
@@ -72,8 +72,10 @@ class NotificationsCoordinator {
 
     var timeIntervalStep: TimeInterval = 24.hours
 
-    private init() {
+    private let notificationCenter: UNUserNotificationCenter
 
+    private init(notificationCenter: UNUserNotificationCenter = .current()) {
+        self.notificationCenter = notificationCenter
     }
 
     private let onboardingNotifications: [NotificationType] = [.onboardingSignUp, .onboardingImport, .onboardingUpNext, .onboardingFilters, .onboardingThemes, .onboardingUpsell]
@@ -92,7 +94,6 @@ class NotificationsCoordinator {
 
     func cancelOnboardingNotifications() {
         Settings.notificationsOnboardingTips = false
-        let notificationCenter = UNUserNotificationCenter.current()
         notificationCenter.removePendingNotificationRequests(withIdentifiers: onboardingNotifications.map { $0.identifier })
     }
 
@@ -109,7 +110,6 @@ class NotificationsCoordinator {
 
         // Schedule the request with the system.
         Task {
-            let notificationCenter = UNUserNotificationCenter.current()
             do {
                 try await notificationCenter.add(request)
             } catch {
@@ -117,5 +117,9 @@ class NotificationsCoordinator {
                 FileLog.shared.addMessage("[Notifications Coordinator] Error adding notification: \(error)")
             }
         }
+    }
+
+    func cancelNotification(_ type: NotificationType) {
+        notificationCenter.removePendingNotificationRequests(withIdentifiers: [type.identifier])
     }
 }


### PR DESCRIPTION
| 📘 Part of: #2906  |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR adds checks to see if onboarding tasks were already done by the user

This PR implements the checks to see if an for onboarding notifications should still be sent/

## To test

1. Start the app with a non logged user
2. Ensure that you have the NotificationRevamp FF enabled
3. After restart in order to speed up notifications deliver go to Settings -> Developer Menu and tap on Speed Up Notifications in order to get them delivered in 70 seconds intervals. ( You may need to increase this value in order to have enough time to complete actions)
4. Go to Settings -> Notifications
6. Tap on Daily Reminders toggle to start sending onboarding notifications
7. Now you should try to complete the following actions and see if when done you don't see the corresponding notification
    - SignUp -> Login or Create an account
    - Import -> Open Profile -> Settings -> Import Podcasts
    - UpNext -> Add an item to UpNext queue
    - Filters -> Create a filter
    - Themes -> Select a theme on Appearance
    - Upsell -> Purchase a subscription ( you may want to use a Testflight account for this)

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
