### PR TITLE
Fix flashing when switching tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add Creator Funding Support [#2913](https://github.com/Automattic/pocket-casts-ios/pull/2913)
 - Fix Watch app should pause play during announcements from other apps [#2245](https://github.com/Automattic/pocket-casts-ios/issues/2245)
 - Fix download indicator color in the up next list [#2941](https://github.com/Automattic/pocket-casts-ios/pull/2941)
+- Fix flashing when switching tabs [#2964](https://github.com/Automattic/pocket-casts-ios/pull/2964)
 
 7.85
 -----

--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -643,6 +643,7 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
     // MARK: - End of Year
 
     private func updateTabBarColor() {
+        self.view.backgroundColor = AppTheme.viewBackgroundColor()
         let appearance = UITabBarAppearance()
         appearance.configureWithOpaqueBackground()
         appearance.backgroundColor = AppTheme.tabBarBackgroundColor()


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes #2932  <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR fixes the flashing issue when switching around tabs.
From my tests these flash happened when you have one of the following:
- Your device system theme was dark and the app was running a light theme
- Your device system theme was light and the app was running a dark theme

So by default the main tab controller was grabbing the system background color and then when switching tab this background color was bleeding in the UI

## To test

- Set your device system to a dark color
- Set your app theme to a light color
- Start the app
- Switching around tabs and check if you see a flash effect.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
