### PR TITLE
Up Next Emptying: Add device ID to up_next/sync call

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Private/Protobuffer/api.pb.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Private/Protobuffer/api.pb.swift
@@ -3217,6 +3217,18 @@ struct Api_UuidRequest: Sendable {
   init() {}
 }
 
+struct Api_UuidListResponse: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  var uuids: [String] = []
+
+  var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  init() {}
+}
+
 struct Api_KeywordRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
@@ -3618,6 +3630,8 @@ struct Api_UpNextSyncRequest: Sendable {
   mutating func clearUpNext() {self._upNext = nil}
 
   var showPlayStatus: Bool = false
+
+  var deviceID: String = String()
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -11229,6 +11243,38 @@ extension Api_UuidRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplemen
   }
 }
 
+extension Api_UuidListResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  static let protoMessageName: String = _protobuf_package + ".UuidListResponse"
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "uuids"),
+  ]
+
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeRepeatedStringField(value: &self.uuids) }()
+      default: break
+      }
+    }
+  }
+
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.uuids.isEmpty {
+      try visitor.visitRepeatedStringField(value: self.uuids, fieldNumber: 1)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  static func ==(lhs: Api_UuidListResponse, rhs: Api_UuidListResponse) -> Bool {
+    if lhs.uuids != rhs.uuids {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
 extension Api_KeywordRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".KeywordRequest"
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
@@ -12065,6 +12111,7 @@ extension Api_UpNextSyncRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageIm
     3: .same(proto: "model"),
     4: .standard(proto: "up_next"),
     5: .standard(proto: "show_play_status"),
+    6: .standard(proto: "device_id"),
   ]
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -12078,6 +12125,7 @@ extension Api_UpNextSyncRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageIm
       case 3: try { try decoder.decodeSingularStringField(value: &self.model) }()
       case 4: try { try decoder.decodeSingularMessageField(value: &self._upNext) }()
       case 5: try { try decoder.decodeSingularBoolField(value: &self.showPlayStatus) }()
+      case 6: try { try decoder.decodeSingularStringField(value: &self.deviceID) }()
       default: break
       }
     }
@@ -12103,6 +12151,9 @@ extension Api_UpNextSyncRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageIm
     if self.showPlayStatus != false {
       try visitor.visitSingularBoolField(value: self.showPlayStatus, fieldNumber: 5)
     }
+    if !self.deviceID.isEmpty {
+      try visitor.visitSingularStringField(value: self.deviceID, fieldNumber: 6)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -12112,6 +12163,7 @@ extension Api_UpNextSyncRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageIm
     if lhs.model != rhs.model {return false}
     if lhs._upNext != rhs._upNext {return false}
     if lhs.showPlayStatus != rhs.showPlayStatus {return false}
+    if lhs.deviceID != rhs.deviceID {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/UpNextSyncTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/UpNextSyncTask.swift
@@ -47,6 +47,7 @@ class UpNextSyncTask: ApiBaseTask {
         var syncRequest = Api_UpNextSyncRequest()
         syncRequest.deviceTime = TimeFormatter.currentUTCTimeInMillis()
         syncRequest.version = apiVersion
+        syncRequest.deviceID = ServerConfig.shared.syncDelegate?.uniqueAppId() ?? ""
         var upNextChanges = Api_UpNextChanges()
         var latestActionTime: Int64 = 0
         var changes = [Api_UpNextChanges.Change]()

--- a/scripts/update_proto.sh
+++ b/scripts/update_proto.sh
@@ -13,8 +13,12 @@ then
     exit 1
 fi
 
-brew upgrade protobuf
-brew upgrade swift-protobuf
+if command -v brew &> /dev/null; then
+    brew upgrade protobuf
+    brew upgrade swift-protobuf
+else
+    echo "Brew is not installed. Make sure protoc + protoc-gen-swift is installed."
+fi
 
 protoc --swift_out=./Modules/Server/Sources/PocketCastsServer/Private/Protobuffer --proto_path=$API_BASE_FOLDER/ $API_BASE_FOLDER/api.proto
 protoc --swift_out=./Modules/Server/Sources/PocketCastsServer/Private/Protobuffer --proto_path=$API_BASE_FOLDER/ $API_BASE_FOLDER/files.proto


### PR DESCRIPTION
| 📘 Part of: #2945 |
|:---:|

Fixes #2961

Adds the `deviceID` property to `up_next/sync` API requests.

## To test

* Start a proxy or set a breakpoint at `UpNextSyncTask:51` to see the device ID sent
* Make a change to your Up Next queue
* Verify that the device ID shows up in the `up_next/sync` request

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
