### PR TITLE
[Fix] Add Libro.fm URL

### DIFF
--- a/podcasts/Onboarding/Plus/Account Prompt/PlusAccountUpgradePrompt.swift
+++ b/podcasts/Onboarding/Plus/Account Prompt/PlusAccountUpgradePrompt.swift
@@ -131,7 +131,7 @@ struct PlusAccountUpgradePrompt: View {
 
     private static func libroFmFeature() -> Feature? {
         if FeatureFlag.libroFm.enabled {
-            return Feature(iconName: "plus-feature-librofm", title: L10n.plusFeatureLibrofm)
+            return Feature(iconName: "plus-feature-librofm", title: L10n.plusFeatureLibrofm.libroFmWithURL)
         }
         return nil
     }

--- a/podcasts/Onboarding/Plus/UpgradeCard.swift
+++ b/podcasts/Onboarding/Plus/UpgradeCard.swift
@@ -86,7 +86,7 @@ extension UpgradeTier {
 
     private static var libroFm: TierFeature? {
         if FeatureFlag.libroFm.enabled {
-            return TierFeature(iconName: "plus-feature-librofm", title: L10n.plusFeatureLibrofm)
+            return TierFeature(iconName: "plus-feature-librofm", title: L10n.plusFeatureLibrofm.libroFmWithURL)
         }
         return nil
     }

--- a/podcasts/Onboarding/Plus/UpgradeLandingView.swift
+++ b/podcasts/Onboarding/Plus/UpgradeLandingView.swift
@@ -235,4 +235,8 @@ extension String {
     var newSlumberStudiosWithUrl: String {
         self.replacingOccurrences(of: self, with: "[\(self)](https://slumberstudios.com)")
     }
+
+    var libroFmWithURL: String {
+        self.replacingOccurrences(of: "Libro.fm", with: "[Libro.fm](https://libro.fm)")
+    }
 }


### PR DESCRIPTION
Add Libro.fm URL

| Paywall | Card |
| -------- | ------- |
| ![Simulator Screenshot - iPhone 16 - 2025-04-14 at 16 06 19](https://github.com/user-attachments/assets/f2afeac4-fe21-4a96-8bf7-e0959788bd6b) | ![Simulator Screenshot - iPhone 16 - 2025-04-14 at 16 06 29](https://github.com/user-attachments/assets/8cebf619-d161-4441-9fe3-76c73a34a8c8) |


## To test

 • Run the app with a free user
• Enable the `libroFm` feature
• Tap on a premium feature
• Check the text with [Libro.fm](https://libro.fm) url
• Tap on it and confirm it opens the right url 
• Go to Profile -> Account
• Check the Profile plan card and confirm you see [Libro.fm](https://libro.fm) url
• Tap on it and confirm it opens the right url 

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
