### PR TITLE
Up Next Emptying: Save apple watch logs to file

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -165,6 +165,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// Enable the new notifications types and settings
     case notificationsRevamp
 
+    /// Any time watch data is sent, we refresh the watch logs and save them to a file for sending to Zendesk or exporting
+    case refreshAndSaveWatchLogsOnSend
+
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -275,6 +278,8 @@ public enum FeatureFlag: String, CaseIterable {
             false
         case .notificationsRevamp:
             false
+        case .refreshAndSaveWatchLogsOnSend:
+            true
         }
     }
 

--- a/Modules/Utils/Sources/PocketCastsUtils/Logging/FileRotating.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Logging/FileRotating.swift
@@ -5,21 +5,21 @@ protocol FileRotating {
     func rotateFile(ifSizeExceeds: Int)
 }
 
-struct FileRotator: FileRotating {
+public struct FileRotator: FileRotating {
 
     private let fileManager: FileManager
     private let targetFilePath: String
     private let backupFilePath: String
     private let logger: Logger?
 
-    init(fileManager: FileManager = .default, targetFilePath: String, backupFilePath: String, loggingTo logger: Logger? = nil) {
+    public init(fileManager: FileManager = .default, targetFilePath: String, backupFilePath: String, loggingTo logger: Logger? = nil) {
         self.fileManager = fileManager
         self.targetFilePath = targetFilePath
         self.backupFilePath = backupFilePath
         self.logger = logger
     }
 
-    func rotateFile(ifSizeExceeds maxFileSizeInBytes: Int) {
+    public func rotateFile(ifSizeExceeds maxFileSizeInBytes: Int) {
         guard fileManager.fileExists(atPath: targetFilePath) else {
             logger?.debug("Attempted to rotate file at <\(targetFilePath)> but no such file exists. Aborting.")
             return

--- a/podcasts/WatchManager+Send.swift
+++ b/podcasts/WatchManager+Send.swift
@@ -3,6 +3,8 @@ import WatchConnectivity
 import PocketCastsUtils
 
 extension WatchManager {
+    private static let watchLogFileName = "watch-logs.txt"
+
     /// Requests the Apple Watch log contents.
     /// If anything is returned, it is also saved in a cache so in case any
     /// subsequent call fails, it will return from the cache.
@@ -56,8 +58,14 @@ extension WatchManager {
         }
     }
 
+    func readLogFile() -> String? {
+        let filePath = FileManager.default.temporaryDirectory.appendingPathComponent(Self.watchLogFileName)
+        let contents = try? String(contentsOf: filePath, encoding: .utf8)
+        return contents
+    }
+
     private func saveLog(contents: String) {
-        let filePath = FileManager.default.temporaryDirectory.appendingPathComponent("watch-logs.txt")
+        let filePath = FileManager.default.temporaryDirectory.appendingPathComponent(Self.watchLogFileName)
         let backupPath = FileManager.default.temporaryDirectory.appendingPathComponent("watch-logs-backup.txt")
         let rotator = FileRotator(fileManager: FileManager.default, targetFilePath: filePath.path, backupFilePath: backupPath.path, loggingTo: nil)
         rotator.rotateFile(ifSizeExceeds: 100.kilobytes)

--- a/podcasts/WatchManager+Send.swift
+++ b/podcasts/WatchManager+Send.swift
@@ -1,5 +1,6 @@
 import Foundation
 import WatchConnectivity
+import PocketCastsUtils
 
 extension WatchManager {
     /// Requests the Apple Watch log contents.
@@ -39,6 +40,9 @@ extension WatchManager {
             self?.logFileRequestTimedAction.cancelTimer()
             if let logContents = response[WatchConstants.Messages.LogFileRequest.logContents] as? String {
                 self?.cachedLog = logContents
+                if FeatureFlag.refreshAndSaveWatchLogsOnSend.enabled {
+                    self?.saveLog(contents: logContents)
+                }
                 completion(logContents)
             } else {
                 completion(self?.cachedLog)
@@ -49,6 +53,18 @@ extension WatchManager {
             haveCalledCompletion = true
 
             completion(self?.cachedLog)
+        }
+    }
+
+    private func saveLog(contents: String) {
+        let filePath = FileManager.default.temporaryDirectory.appendingPathComponent("watch-logs.txt")
+        let backupPath = FileManager.default.temporaryDirectory.appendingPathComponent("watch-logs-backup.txt")
+        let rotator = FileRotator(fileManager: FileManager.default, targetFilePath: filePath.path, backupFilePath: backupPath.path, loggingTo: nil)
+        rotator.rotateFile(ifSizeExceeds: 100.kilobytes)
+        do {
+            try contents.write(to: filePath, atomically: false, encoding: .utf8)
+        } catch let error {
+            FileLog.shared.addMessage("Failed to save cached watch log file: \(error.localizedDescription)")
         }
     }
 }

--- a/podcasts/WatchManager.swift
+++ b/podcasts/WatchManager.swift
@@ -400,6 +400,13 @@ class WatchManager: NSObject, WCSessionDelegate {
         }
         DispatchQueue.global(qos: .background).async { [weak self] in
             self?.sendStateToWatch()
+            if FeatureFlag.refreshAndSaveWatchLogsOnSend.enabled {
+                FileLog.shared.addMessage("WatchManager: Start log request on send")
+                WatchManager.shared.requestLogFile(completion: { _ in
+                    // We don't do anything with the log, requesting it will cache and save the contents
+                    FileLog.shared.addMessage("WatchManager: Completed log request on send")
+                })
+            }
         }
     }
 

--- a/podcasts/WatchManager.swift
+++ b/podcasts/WatchManager.swift
@@ -38,6 +38,8 @@ class WatchManager: NSObject, WCSessionDelegate {
         NotificationCenter.default.addObserver(self, selector: #selector(autoDownloadChanged), name: Constants.Notifications.watchAutoDownloadSettingsChanged, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(playbackStateChanged), name: Constants.Notifications.podcastChapterChanged, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(playbackStateChanged), name: Constants.Notifications.podcastChaptersDidUpdate, object: nil)
+
+        cachedLog = WatchManager.shared.readLogFile()
     }
 
     deinit {


### PR DESCRIPTION
| 📘 Part of: #2945 |
|:---:|

Fixes #2951

When we collect logs for Zendesk or Database Export, those logs are requested directly from the watchOS app. As far as I can tell, this is the _only_ time we request the logs from the watchOS app, so we have no other method of retrieving the logs unless the user has both the watch and iOS app open simultaneously at that time.

Instead, this PR sends the log updates any time new data is passed between watch and iOS and saves this to a file on iOS for use any time we need the log and the watchOS app is not connected. This happens in the background _after_ other actions have taken place, but I've feature flagged this with `refresh_and_save_watch_logs_on_send` in case we see any performance degradation.

I also investigated using [`WCSession.transferFile`](https://developer.apple.com/documentation/watchconnectivity/wcsession/transferfile(_:metadata:)) but had trouble getting that method to work for now.

## To test

* Build and run the iOS and Apple Watch app. A simulator will work. 
* Perform several actions on the watch seek back and forward in Now Playing, play pause, and change the Up Next queue.
* Quit the watchOS app
* Navigate to Profile > Help & Feedback > ⋯ > Export Database
* Make sure the exported file contains a `watchos-logs.txt` log with recent log lines.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
