### PR TITLE
Fix switch to effects player 

### DIFF
--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -911,9 +911,7 @@ class PlaybackManager: ServerPlaybackDelegate {
 
     func silenceRemovalAvailable() -> Bool {
         #if APPCLIP
-        if let episode = currentEpisode() {
-            return !episode.videoPodcast()
-        }
+        return false
         #elseif !os(watchOS)
             if let episode = currentEpisode() {
                 return !episode.videoPodcast() && !GoogleCastManager.sharedManager.connectedOrConnectingToDevice()

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -2055,10 +2055,14 @@ class PlaybackManager: ServerPlaybackDelegate {
             // the current episode we were playing has downloaded, switch to playing the downloaded version
             let currentlyPlaying = playing()
             recordPlaybackPosition(sendToServerImmediately: false, fireNotifications: true)
-
+            #if APPCLIP
             if refreshedEpisode.uuid != currentEpisode()?.uuid {
                 load(episode: refreshedEpisode, autoPlay: currentlyPlaying, overrideUpNext: false, saveCurrentEpisode: false)
             }
+            #else
+            load(episode: refreshedEpisode, autoPlay: currentlyPlaying, overrideUpNext: false, saveCurrentEpisode: false)
+            #endif
+
             if refreshedEpisode.videoPodcast() {
                 NotificationCenter.postOnMainThread(notification: Constants.Notifications.videoPlaybackEngineSwitched)
             }


### PR DESCRIPTION
Fixes #2837

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR updates the code so that main app will switch between Defaults Player to Effects Player when a download finishes.
It also disables the UI for trim silence on App Clips, while the UI was there the App Clip was never trimming silences because it's only using the Default Player that does not support trim silence.

## To test

1. Start the main app
2. Play an episode that is not downloaded
3. Ensure that you activate trim silence in the effects for the episode
4. Check in the console if you see Using Default Player and after the download is finished you see Using Effects Player
5. Start the app clip demo app
6. See if the effect ui player has the Trim silence button disabled and you cannot enable the effect
7. Check if episode plays correctly

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
