### PR TITLE
Up Next Emptying: Logging Additions

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Private/UserDefaults+DataProtection.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Private/UserDefaults+DataProtection.swift
@@ -1,0 +1,14 @@
+import Foundation
+#if !os(watchOS)
+import UIKit
+#endif
+
+extension UserDefaults {
+    static func isProtectedDataAvailable() -> Bool? {
+        #if !os(watchOS)
+        return UIApplication.shared.isProtectedDataAvailable
+        #else
+        return nil
+        #endif
+    }
+}

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncManager.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncManager.swift
@@ -75,6 +75,9 @@ public extension SyncManager {
     enum SyncingReason: String {
         case accountCreated
         case login
+        case replace
+        case remove
+        case add
     }
 
     /// Defines a reason why a sync is being performed

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/UpNextSyncTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/UpNextSyncTask.swift
@@ -6,6 +6,11 @@ import SwiftProtobuf
 class UpNextSyncTask: ApiBaseTask {
     private static let processDataLock = NSObject()
 
+    override func main() {
+        logProtectedDataAvailable()
+        super.main()
+    }
+
     override func apiTokenAcquired(token: String) {
         let trace = TraceManager.shared.beginTracing(eventName: "SERVER_UP_NEXT_SYNC")
         defer { TraceManager.shared.endTracing(trace: trace) }
@@ -25,6 +30,20 @@ class UpNextSyncTask: ApiBaseTask {
             }
         } catch {
             FileLog.shared.addMessage("UpNextSyncTask: had issues encoding protobuf \(error.localizedDescription)")
+        }
+    }
+
+    private func logProtectedDataAvailable() {
+        DispatchQueue.main.async {
+            let protectedDataAvailable: String
+            switch UserDefaults.isProtectedDataAvailable() {
+            case .some(let value):
+                protectedDataAvailable = value ? "yes" : "no"
+            case .none:
+                protectedDataAvailable = "unknown"
+            }
+
+            FileLog.shared.addMessage("UpNextSyncTask: Protected data available: \(protectedDataAvailable)")
         }
     }
 

--- a/podcasts/AppDelegate+SiriShortcuts.swift
+++ b/podcasts/AppDelegate+SiriShortcuts.swift
@@ -105,6 +105,7 @@ extension AppDelegate {
 
     func application(_ application: UIApplication, handle: INIntent, completionHandler: (INIntentResponse) -> Void) {
         if let handle = handle as? INPlayMediaIntent {
+            FileLog.shared.addMessage("Handling Siri PlayMediaIntent: \(handle.identifier ?? "unknown")")
             let responseCode = handlePlayMediaIntent(intent: handle)
 
             let response = INPlayMediaIntentResponse(code: responseCode, userActivity: nil)

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -680,23 +680,6 @@ class PlaybackManager: ServerPlaybackDelegate {
         uuidOfPlayingList = filter.uuid
     }
 
-    func play(episodes: [BaseEpisode], startingAtEpisode: BaseEpisode) {
-        populateFromEpisodes(episodes, startingAtEpisode: startingAtEpisode)
-    }
-
-    func play(podcast: Podcast, startingAtEpisode: Episode) {
-        let episodeSortOrder = podcast.podcastSortOrder
-
-        let orderDirection = (episodeSortOrder == PodcastEpisodeSortOrder.newestToOldest) ? "DESC" : "ASC"
-        let episodes = DataManager.sharedManager.findEpisodesWhere(customWhere: "podcastUuid == ? AND archived = 0 AND (playingStatus == \(PlayingStatus.notPlayed.rawValue) OR playingStatus == \(PlayingStatus.inProgress.rawValue)) ORDER BY publishedDate \(orderDirection), addedDate \(orderDirection)", arguments: [podcast.uuid])
-
-        if episodes.count > 0 {
-            populateFromEpisodes(episodes, startingAtEpisode: startingAtEpisode)
-        } else {
-            load(episode: startingAtEpisode, autoPlay: true, overrideUpNext: true)
-        }
-    }
-
     func internalPlayerForVideoPlayback() -> AVPlayer? {
         if let episode = currentEpisode(), player == nil {
             load(episode: episode, autoPlay: false, overrideUpNext: false)

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -151,7 +151,7 @@ class PlaybackManager: ServerPlaybackDelegate {
     }
 
     func load(episode: BaseEpisode, autoPlay: Bool, overrideUpNext: Bool, saveCurrentEpisode: Bool = true, completion: (() -> Void)? = nil) {
-        FileLog.shared.addMessage("Loading \(episode.displayableTitle()) with UUID \(episode.uuid) autoPlay \(autoPlay)")
+        FileLog.shared.addMessage("Loading \(episode.displayableTitle()) with UUID \(episode.uuid) autoPlay \(autoPlay) overrideUpNext: \(overrideUpNext)")
 
         let episodeIsChanging = episode.uuid != currentEpisode()?.uuid
 

--- a/podcasts/PlaybackQueue.swift
+++ b/podcasts/PlaybackQueue.swift
@@ -19,6 +19,7 @@ class PlaybackQueue: NSObject {
         DataManager.sharedManager.delete(playlistEpisode: episodeToRemove)
         if SyncManager.isUserLoggedIn() {
             DataManager.sharedManager.saveUpNextRemove(episodeUuid: episode.uuid)
+            SyncManager.syncReason = .remove
             startSyncTimer()
         }
 
@@ -32,6 +33,7 @@ class PlaybackQueue: NSObject {
         DataManager.sharedManager.delete(playlistEpisode: episodeToRemove)
         if SyncManager.isUserLoggedIn() {
             DataManager.sharedManager.saveUpNextRemove(episodeUuid: uuid)
+            SyncManager.syncReason = .remove
             startSyncTimer()
         }
 
@@ -66,6 +68,7 @@ class PlaybackQueue: NSObject {
                 DataManager.sharedManager.saveUpNextAddToBottom(episodeUuid: episode.uuid)
             }
 
+            SyncManager.syncReason = .add
             startSyncTimer()
         }
 
@@ -369,6 +372,8 @@ class PlaybackQueue: NSObject {
         FileLog.shared.addMessage("PlaybackQueue: Saving replace of \(episodeUuids.count) episodes")
 
         DataManager.sharedManager.saveReplace(episodeList: episodeUuids)
+
+        SyncManager.syncReason = .replace
 
         startSyncTimer()
     }

--- a/podcasts/Up Next History/UpNextHistoryModel.swift
+++ b/podcasts/Up Next History/UpNextHistoryModel.swift
@@ -26,15 +26,6 @@ class UpNextHistoryModel: ObservableObject {
         }
     }
 
-    func replaceUpNext(entry: Date) {
-        Task {
-            PlaybackManager.shared.endPlayback()
-            dataManager.replaceUpNext(entry: entry)
-            PlaybackManager.shared.queue.bulkOperationDidComplete()
-            PlaybackManager.shared.queue.refreshList(checkForAutoDownload: false)
-        }
-    }
-
     func reAddMissingItems(entry: Date) {
         Task {
             let episodesUuid = dataManager.upNextHistoryEpisodes(entry: entry)


### PR DESCRIPTION
| 📘 Part of: #2945 |
|:---:|

Fixes #2949

* Adds additional logging for `overrideUpNext`, "Handling Siri PlayMediaIntent" (to determine if a track is being "autoplayed" as part of a media intent somehow)
* Adds new SyncReason values which are logged for Up Next Sync events
* Adds additional logging for `isProtectedDataAvailable` to determine if UserDefaults may be inaccessible (based on info from https://christianselig.com/2024/10/beware-userdefaults/)
* Removes unused code that I spotted while tracing this issue around the code.

## To test

* Ensure that Up Next queue updates continue to work

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
