### PR TITLE
[Notifications Revamp] Onboarding staff picks

### DIFF
--- a/podcasts/AppDelegate+UrlHandling.swift
+++ b/podcasts/AppDelegate+UrlHandling.swift
@@ -143,12 +143,16 @@ extension AppDelegate {
         }
 
         // Open to discover
-        JLRoutes.global().addRoute("/discover") { paramDict -> Bool in
+        JLRoutes.global().addRoute("/discover/*") { paramDict -> Bool in
             if let sourceString = paramDict["source"] as? String, sourceString == "widget" {
                 Analytics.track(.widgetInteraction, properties: ["action": "discover"])
             }
 
-            NavigationManager.sharedManager.navigateTo(NavigationManager.discoverPageKey, data: nil)
+            var data: NSDictionary?
+            if let pathComponents = paramDict[JLRouteWildcardComponentsKey] as? [String], let itemID = pathComponents.first {
+                data = [NavigationManager.discoverListKey: itemID]
+            }
+            NavigationManager.sharedManager.navigateTo(NavigationManager.discoverPageKey, data: data)
 
             return true
         }

--- a/podcasts/DeveloperMenu.swift
+++ b/podcasts/DeveloperMenu.swift
@@ -302,7 +302,7 @@ struct DeveloperMenu: View {
 
             Section {
                 Button("Speed Up Notifications") {
-                    NotificationsCoordinator.shared.timeIntervalStep = 60.seconds
+                    NotificationsCoordinator.shared.timeIntervalStep = 10.seconds
                 }
             } header: {
                 Text("Notifications")

--- a/podcasts/DiscoverCollectionViewController+DiscoverDelegate.swift
+++ b/podcasts/DiscoverCollectionViewController+DiscoverDelegate.swift
@@ -62,6 +62,29 @@ extension DiscoverCollectionViewController: DiscoverDelegate {
         navigationController?.pushViewController(podcastController, animated: true)
     }
 
+    func showItemWith(identifier: String) {
+        guard let items = discoverLayout?.layout, let item = items.first(where: { $0.id == identifier || $0.uuid == identifier}) else {
+            return
+        }
+
+        guard let source = item.source else { return }
+
+        DiscoverServerHandler.shared.discoverPodcastList(source: source, completion: { [weak self] podcastList in
+            guard let self, let discoverPodcast = podcastList?.podcasts else { return }
+
+            let podcasts: [DiscoverPodcast]
+            if let itemCount = item.summaryItemCount {
+                podcasts = Array(discoverPodcast[0..<itemCount])
+            } else {
+                podcasts = discoverPodcast
+            }
+
+            DispatchQueue.main.async {
+                self.showExpanded(item: item, podcasts: podcasts, podcastCollection: nil)
+            }
+        })
+    }
+    
     func showExpanded(item: DiscoverItem, podcasts: [DiscoverPodcast], podcastCollection: PodcastCollection?) {
         if let listId = item.uuid {
             AnalyticsHelper.listShowAllTapped(listId: listId)

--- a/podcasts/DiscoverCollectionViewController+DiscoverDelegate.swift
+++ b/podcasts/DiscoverCollectionViewController+DiscoverDelegate.swift
@@ -14,6 +14,10 @@ extension DiscoverCollectionViewController: DiscoverDelegate {
         }
     }
 
+    func navigateTo(listID: String) {
+        showItemWith(identifier: listID)
+    }
+
     func invalidate(item: PocketCastsServer.DiscoverItem) {
         let context = UICollectionViewLayoutInvalidationContext()
         let item = dataSource.snapshot().itemIdentifiers.first(where: {

--- a/podcasts/DiscoverCollectionViewController+DiscoverDelegate.swift
+++ b/podcasts/DiscoverCollectionViewController+DiscoverDelegate.swift
@@ -15,7 +15,13 @@ extension DiscoverCollectionViewController: DiscoverDelegate {
     }
 
     func navigateTo(listID: String) {
-        showItemWith(identifier: listID)
+        if isViewLoaded {
+            showItemWith(identifier: listID)
+        } else {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5.seconds) {[weak self] in
+                self?.showItemWith(identifier: listID)
+            }
+        }
     }
 
     func invalidate(item: PocketCastsServer.DiscoverItem) {
@@ -88,7 +94,7 @@ extension DiscoverCollectionViewController: DiscoverDelegate {
             }
         })
     }
-    
+
     func showExpanded(item: DiscoverItem, podcasts: [DiscoverPodcast], podcastCollection: PodcastCollection?) {
         if let listId = item.uuid {
             AnalyticsHelper.listShowAllTapped(listId: listId)

--- a/podcasts/DiscoverSummaryProtocol.swift
+++ b/podcasts/DiscoverSummaryProtocol.swift
@@ -28,4 +28,6 @@ protocol DiscoverDelegate: AnyObject {
     func invalidate(item: DiscoverItem)
 
     func navigateTo(category: String)
+
+    func navigateTo(listID: String)
 }

--- a/podcasts/DiscoverViewController+DiscoverDelegate.swift
+++ b/podcasts/DiscoverViewController+DiscoverDelegate.swift
@@ -16,7 +16,13 @@ extension DiscoverViewController: DiscoverDelegate {
     }
 
     func navigateTo(listID: String) {
-
+        if isViewLoaded {
+            showItemWith(identifier: listID)
+        } else {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5.seconds) {[weak self] in
+                self?.showItemWith(identifier: listID)
+            }
+        }
     }
 
     func invalidate(item: PocketCastsServer.DiscoverItem) {
@@ -52,6 +58,29 @@ extension DiscoverViewController: DiscoverDelegate {
     func show(podcast: Podcast) {
         let podcastController = PodcastViewController(podcast: podcast)
         navigationController?.pushViewController(podcastController, animated: true)
+    }
+
+    func showItemWith(identifier: String) {
+        guard let items = discoverLayout?.layout, let item = items.first(where: { $0.id == identifier || $0.uuid == identifier}) else {
+            return
+        }
+
+        guard let source = item.source else { return }
+
+        DiscoverServerHandler.shared.discoverPodcastList(source: source, completion: { [weak self] podcastList in
+            guard let self, let discoverPodcast = podcastList?.podcasts else { return }
+
+            let podcasts: [DiscoverPodcast]
+            if let itemCount = item.summaryItemCount {
+                podcasts = Array(discoverPodcast[0..<itemCount])
+            } else {
+                podcasts = discoverPodcast
+            }
+
+            DispatchQueue.main.async {
+                self.showExpanded(item: item, podcasts: podcasts, podcastCollection: nil)
+            }
+        })
     }
 
     func showExpanded(item: DiscoverItem, podcasts: [DiscoverPodcast], podcastCollection: PodcastCollection?) {

--- a/podcasts/DiscoverViewController+DiscoverDelegate.swift
+++ b/podcasts/DiscoverViewController+DiscoverDelegate.swift
@@ -15,6 +15,10 @@ extension DiscoverViewController: DiscoverDelegate {
         }
     }
 
+    func navigateTo(listID: String) {
+
+    }
+
     func invalidate(item: PocketCastsServer.DiscoverItem) {
         // No-op for this older implementation.
     }

--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -336,6 +336,17 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
         }
     }
 
+    func navigateToDiscover(listID: String, animated: Bool) {
+        switchToTab(.discover)
+        if let index = pcTabs.firstIndex(of: .discover),
+           let navController = viewControllers?[safe: index] as? UINavigationController {
+            navController.popToRootViewController(animated: false)
+            if let discoverDelegate = navController.topViewController as? DiscoverDelegate {
+                discoverDelegate.navigateTo(listID: listID)
+            }
+        }
+    }
+
     func navigateToUpNext(_ animated: Bool) {
         switchToTab(.upNext)
     }

--- a/podcasts/NavigationManager.swift
+++ b/podcasts/NavigationManager.swift
@@ -241,11 +241,20 @@ class NavigationManager {
     }
 
     func navigateToDiscover(data: NSDictionary?, animated: Bool) {
-        guard let data = data, let category = data[NavigationManager.discoverCategoryKey] as? String else {
+        guard let data = data else {
             mainController?.navigateToDiscover(animated)
             return
         }
-        mainController?.navigateToDiscover(category: category, animated: animated)
+
+        if let category = data[NavigationManager.discoverCategoryKey] as? String {
+            mainController?.navigateToDiscover(category: category, animated: animated)
+            return
+        }
+
+        if let listId = data[NavigationManager.discoverListKey] as? String {
+            mainController?.navigateToDiscover(listID: listId, animated: animated)
+            return
+        }
     }
 }
 

--- a/podcasts/NavigationManager.swift
+++ b/podcasts/NavigationManager.swift
@@ -18,6 +18,7 @@ class NavigationManager {
     static let podcastListPageKey = "podcastList"
     static let discoverPageKey = "discoverPage"
     static let discoverCategoryKey = "discoverCategory"
+    static let discoverListKey = "discoverList"
 
     static let filterPageKey = "filterPage"
     static let filterUuidKey = "filterUuid"

--- a/podcasts/NavigationManager.swift
+++ b/podcasts/NavigationManager.swift
@@ -145,11 +145,7 @@ class NavigationManager {
         } else if place == NavigationManager.podcastListPageKey {
             mainController?.navigateToPodcastList(animated)
         } else if place == NavigationManager.discoverPageKey {
-            guard let data = data, let category = data[NavigationManager.discoverCategoryKey] as? String else {
-                mainController?.navigateToDiscover(animated)
-                return
-            }
-            mainController?.navigateToDiscover(category: category, animated: animated)
+            navigateToDiscover(data: data, animated: animated)
         } else if place == NavigationManager.filterPageKey {
             if let data = data, let filterUuid = data[NavigationManager.filterUuidKey] as? String, let filter = DataManager.sharedManager.findFilter(uuid: filterUuid) {
                 mainController?.navigateToFilter(filter, animated: animated)
@@ -242,6 +238,14 @@ class NavigationManager {
             let row = data?[NavigationManager.settingsRowKey] as? SettingsViewController.TableRow
             mainController?.showSettings(row: row)
         }
+    }
+
+    func navigateToDiscover(data: NSDictionary?, animated: Bool) {
+        guard let data = data, let category = data[NavigationManager.discoverCategoryKey] as? String else {
+            mainController?.navigateToDiscover(animated)
+            return
+        }
+        mainController?.navigateToDiscover(category: category, animated: animated)
     }
 }
 

--- a/podcasts/NavigationProtocol.swift
+++ b/podcasts/NavigationProtocol.swift
@@ -15,6 +15,7 @@ protocol NavigationProtocol: AnyObject {
 
     func navigateToDiscover(_ animated: Bool)
     func navigateToDiscover(category: String, animated: Bool)
+    func navigateToDiscover(listID: String, animated: Bool)
 
     func navigateToProfile(_ animated: Bool)
 

--- a/podcasts/Notifications/NotificationsCoordinator+AnalyticsAdapter.swift
+++ b/podcasts/Notifications/NotificationsCoordinator+AnalyticsAdapter.swift
@@ -4,7 +4,7 @@ extension NotificationsCoordinator: AnalyticsAdapter {
 
     func track(name: String, properties: [AnyHashable: Any]?) {
         for notification in onboardingNotifications {
-            if notification.checkCancelConditionsForEvent(name: name) {
+            if notification.checkCancelConditionsForEvent(name: name, properties: properties) {
                 self.cancelNotification(notification)
             }
         }
@@ -14,7 +14,7 @@ extension NotificationsCoordinator: AnalyticsAdapter {
 
 extension NotificationType {
 
-    func checkCancelConditionsForEvent(name: String) -> Bool {
+    func checkCancelConditionsForEvent(name: String, properties: [AnyHashable: Any]?) -> Bool {
         var possibleConditions: Set<AnalyticsEvent>
 
         switch self {
@@ -30,9 +30,25 @@ extension NotificationType {
             possibleConditions = [.filterCreated]
         case .onboardingUpsell:
             possibleConditions  = [.purchaseSuccessful]
+        case .onboardingStaffPicks:
+            possibleConditions = [.discoverListShowAllTapped]
         }
-        return possibleConditions.contains {
+        let eventMatch = possibleConditions.contains {
             $0.rawValue.toSnakeCaseFromCamelCase() == name
+        }
+        guard eventMatch else {
+            return false
+        }
+
+        // check for properties
+        switch self {
+        case .onboardingStaffPicks:
+            guard let properties, let listID = properties["list_id"] as? String else {
+                return false
+            }
+            return listID == "staff-picks"
+        default:
+            return true
         }
     }
 }

--- a/podcasts/Notifications/NotificationsCoordinator.swift
+++ b/podcasts/Notifications/NotificationsCoordinator.swift
@@ -6,6 +6,7 @@ enum NotificationType: String {
     case onboardingSignUp
     case onboardingImport
     case onboardingThemes
+    case onboardingStaffPicks
     case onboardingUpNext
     case onboardingFilters
     case onboardingUpsell
@@ -24,6 +25,8 @@ enum NotificationType: String {
             return L10n.notificationsOnboardingFiltersTitle
         case .onboardingUpsell:
             return L10n.notificationsOnboardingUpsellTitle
+        case .onboardingStaffPicks:
+            return L10n.notificationsOnboardingStaffPicksTitle
         }
     }
 
@@ -41,6 +44,8 @@ enum NotificationType: String {
             return L10n.notificationsOnboardingFiltersBody
         case .onboardingUpsell:
             return L10n.notificationsOnboardingUpsellBody
+        case .onboardingStaffPicks:
+            return L10n.notificationsOnboardingStaffPicksBody
         }
     }
 
@@ -62,6 +67,8 @@ enum NotificationType: String {
             return "pktc://filters"
         case .onboardingUpsell:
             return "pktc://upsell"
+        case .onboardingStaffPicks:
+            return "pktc://discover/staff-picks"
         }
     }
 }
@@ -78,7 +85,7 @@ class NotificationsCoordinator {
         self.notificationCenter = notificationCenter
     }
 
-    let onboardingNotifications: [NotificationType] = [.onboardingSignUp, .onboardingImport, .onboardingUpNext, .onboardingFilters, .onboardingThemes, .onboardingUpsell]
+    let onboardingNotifications: [NotificationType] = [.onboardingSignUp, .onboardingImport, .onboardingUpNext, .onboardingFilters, .onboardingThemes, .onboardingStaffPicks, .onboardingUpsell]
 
     func setupOnboardingNotifications() {
         Settings.notificationsOnboardingTips = true

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -1759,11 +1759,11 @@ internal enum L10n {
   internal static func notificationsOnForPodcast(_ p1: Any) -> String {
     return L10n.tr("Localizable", "notifications_on_for_podcast", String(describing: p1))
   }
-  /// Organize your episodes
+  /// Create smart filters to organize your episodes.
   internal static var notificationsOnboardingFiltersBody: String { return L10n.tr("Localizable", "notifications_onboarding_filters_body") }
   /// Organize your episodes
   internal static var notificationsOnboardingFiltersTitle: String { return L10n.tr("Localizable", "notifications_onboarding_filters_title") }
-  /// Easily import your podcasts
+  /// Switching from another app? Bring all your favorite shows to Pocket Casts.
   internal static var notificationsOnboardingImportBody: String { return L10n.tr("Localizable", "notifications_onboarding_import_body") }
   /// Easily import your podcasts
   internal static var notificationsOnboardingImportTitle: String { return L10n.tr("Localizable", "notifications_onboarding_import_title") }
@@ -1771,15 +1771,19 @@ internal enum L10n {
   internal static var notificationsOnboardingSignupBody: String { return L10n.tr("Localizable", "notifications_onboarding_signup_body") }
   /// Your shows, on any device!
   internal static var notificationsOnboardingSignupTitle: String { return L10n.tr("Localizable", "notifications_onboarding_signup_title") }
-  /// Time for a new look
+  /// Perfectly ripe podcasts, picked just for you by real, podcast-loving humans.
+  internal static var notificationsOnboardingStaffPicksBody: String { return L10n.tr("Localizable", "notifications_onboarding_staff_picks_body") }
+  /// Explore our Staff Picks
+  internal static var notificationsOnboardingStaffPicksTitle: String { return L10n.tr("Localizable", "notifications_onboarding_staff_picks_title") }
+  /// Browse our themes and find the one that suits your style.
   internal static var notificationsOnboardingThemesBody: String { return L10n.tr("Localizable", "notifications_onboarding_themes_body") }
   /// Time for a new look
   internal static var notificationsOnboardingThemesTitle: String { return L10n.tr("Localizable", "notifications_onboarding_themes_title") }
-  /// Simplify your queue
+  /// Build a playback queue and say goodbye to jumping around between episodes.
   internal static var notificationsOnboardingUpnextBody: String { return L10n.tr("Localizable", "notifications_onboarding_upnext_body") }
   /// Simplify your queue
   internal static var notificationsOnboardingUpnextTitle: String { return L10n.tr("Localizable", "notifications_onboarding_upnext_title") }
-  /// Level up your podcast game
+  /// Unlock exclusive features like folders, bookmarks, and more with Plus!
   internal static var notificationsOnboardingUpsellBody: String { return L10n.tr("Localizable", "notifications_onboarding_upsell_body") }
   /// Level up your podcast game
   internal static var notificationsOnboardingUpsellTitle: String { return L10n.tr("Localizable", "notifications_onboarding_upsell_title") }

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4867,23 +4867,29 @@
 /* Notification title for upsell onboardingmessage */
 "notifications_onboarding_upsell_title" = "Level up your podcast game";
 
+/* Notification title for staff picks onboarding message */
+"notifications_onboarding_staff_picks_title" = "Explore our Staff Picks";
+
 /* Notification body for signup onboarding message */
 "notifications_onboarding_signup_body" = "Create a free account to sync your shows and listen anywhere.";
 
 /* Notification body for import onboarding message */
-"notifications_onboarding_import_body" = "Easily import your podcasts";
+"notifications_onboarding_import_body" = "Switching from another app? Bring all your favorite shows to Pocket Casts.";
 
 /* Notification body for themes onboarding message */
-"notifications_onboarding_themes_body" = "Time for a new look";
+"notifications_onboarding_themes_body" = "Browse our themes and find the one that suits your style.";
 
 /* Notification body for onboarding to upnext message */
-"notifications_onboarding_upnext_body" = "Simplify your queue";
+"notifications_onboarding_upnext_body" = "Build a playback queue and say goodbye to jumping around between episodes.";
 
 /* Notification body for onboarding to filters message */
-"notifications_onboarding_filters_body" = "Organize your episodes";
+"notifications_onboarding_filters_body" = "Create smart filters to organize your episodes.";
 
 /* Notification body for onboarding to upsell message */
-"notifications_onboarding_upsell_body" = "Level up your podcast game";
+"notifications_onboarding_upsell_body" = "Unlock exclusive features like folders, bookmarks, and more with Plus!";
+
+/* Notification body for onboarding to staff picks message */
+"notifications_onboarding_staff_picks_body" = "Perfectly ripe podcasts, picked just for you by real, podcast-loving humans.";
 
 /* Encourage Account Creation: modal title */
 "eac_informational_view_modal_title" = "We noticed you’re not logged in";

--- a/scripts/notifications/discover-staff-picks.apns
+++ b/scripts/notifications/discover-staff-picks.apns
@@ -1,0 +1,11 @@
+{
+  "Simulator Target Bundle": "au.com.shiftyjelly.podcasts",
+  "aps": {
+    "alert": {
+      "title": "Explore our Staff Picks",
+      "body": "Perfectly ripe podcasts, picked just for you by real, podcast-loving humans."
+    },
+    "category": "DEEP_LINK"
+  },
+  "destination_url": "pktc://discover/staff-picks"
+}


### PR DESCRIPTION
| 📘 Part of: #2906  |  <!-- project issue number, if applicable -->
|:---:|

Fixes #2909  <!-- issue number, if applicable -->

This PR adds the missing onboarding notification: Staff Picks.
This PR also update the notifications body to use the correct strings.

## To test

1. Start the app with a non logged user
2. Ensure that you have the NotificationRevamp FF enabled
3. After restart in order to speed up notifications deliver go to Settings -> Developer Menu and tap on Speed Up Notifications in order to get them delivered in 10 seconds intervals.
4. Go to Settings -> Notifications
5. Tap on Daily Reminders toggle to start sending onboarding notifications
6. Check that the Staff Picks notification shows up correctly
7. Tap on it and see if the Discover tab is opened and the Staff Picks list is pushed
8. Go to Settings -> Notifications
9. Tap on Daily Reminders toggle to start sending onboarding notifications
10. Go to Discover and open Staff Picks before the Staff Pick notification arrives
11. Check if the Staff Picks notification does not show up

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
