### PR TITLE
[Improve Podcast Sorting] Update sorting positions

### DIFF
--- a/podcasts/PodcastListViewController+Search.swift
+++ b/podcasts/PodcastListViewController+Search.swift
@@ -1,5 +1,6 @@
 import UIKit
 import PocketCastsDataModel
+import PocketCastsUtils
 
 extension PodcastListViewController: UIScrollViewDelegate, PCSearchBarDelegate {
     var searchControllerView: UIView? {
@@ -54,7 +55,6 @@ extension PodcastListViewController: UIScrollViewDelegate, PCSearchBarDelegate {
             strongSelf.refreshGridItems()
             Analytics.track(.podcastsListSortOrderChanged, properties: ["sort_by": LibrarySort.titleAtoZ])
         }
-        options.addAction(action: podcastNameAction)
 
         let releaseDateAction = OptionAction(label: LibrarySort.episodeDateNewestToOldest.description, selected: sortOption == .episodeDateNewestToOldest) { [weak self] in
             guard let strongSelf = self else { return }
@@ -63,7 +63,6 @@ extension PodcastListViewController: UIScrollViewDelegate, PCSearchBarDelegate {
             strongSelf.refreshGridItems()
             Analytics.track(.podcastsListSortOrderChanged, properties: ["sort_by": LibrarySort.episodeDateNewestToOldest])
         }
-        options.addAction(action: releaseDateAction)
 
         let subscribedOrder = OptionAction(label: LibrarySort.dateAddedNewestToOldest.description, selected: sortOption == .dateAddedNewestToOldest) { [weak self] in
             guard let strongSelf = self else { return }
@@ -72,7 +71,6 @@ extension PodcastListViewController: UIScrollViewDelegate, PCSearchBarDelegate {
             strongSelf.refreshGridItems()
             Analytics.track(.podcastsListSortOrderChanged, properties: ["sort_by": LibrarySort.dateAddedNewestToOldest])
         }
-        options.addAction(action: subscribedOrder)
 
         let dragAndDropAction = OptionAction(label: LibrarySort.custom.description, selected: sortOption == .custom) { [weak self] in
             guard let strongSelf = self else { return }
@@ -81,7 +79,19 @@ extension PodcastListViewController: UIScrollViewDelegate, PCSearchBarDelegate {
             strongSelf.refreshGridItems()
             Analytics.track(.podcastsListSortOrderChanged, properties: ["sort_by": LibrarySort.custom])
         }
-        options.addAction(action: dragAndDropAction)
+
+        if FeatureFlag.podcastsSortChanges.enabled {
+            options.addAction(action: subscribedOrder)
+            options.addAction(action: releaseDateAction)
+            // TODO: Add action for Recently Played
+            options.addAction(action: podcastNameAction)
+            options.addAction(action: dragAndDropAction)
+        } else {
+            options.addAction(action: podcastNameAction)
+            options.addAction(action: releaseDateAction)
+            options.addAction(action: subscribedOrder)
+            options.addAction(action: dragAndDropAction)
+        }
 
         options.show(statusBarStyle: preferredStatusBarStyle)
     }


### PR DESCRIPTION
| 📘 Part of: #2978
|:---:|

Fixes #2980

This PR updates the sorting options position

| Before | After |
| -------- | ------- |
| ![simulator_screenshot_FC88B96F-DA52-4270-ADE5-E46FB753C38C](https://github.com/user-attachments/assets/bf6e894f-11c6-4ca5-a7be-ee09b5742f7d) | ![simulator_screenshot_C6063753-D500-4975-B5DC-F976A1A85807](https://github.com/user-attachments/assets/9f75112a-57b5-41a4-b887-a668fa5df1d2) |

## To test

- Run this branch as fresh install and enable the `podcastsSortChanges` FF
- Add few podcasts
- Tap on toolbar more menu
- Tap on Sort by in the more options
- ✅ Notice that sort options are arranged as usual (Before screenshot)
- ✅ Notice that Date added is still the default option
- (Optional) Login with a Plus account having folders
- (Optional) Tap a folder in Podcasts tab
- (Optional) Open Sort by from more menu for folders
- (Optional) Notice that the sort options are arranged in the same order as for podcasts

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
