### PR TITLE
Up Next Emptying: Avoid replace action when switching Now Playing episodes

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -168,6 +168,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// Any time watch data is sent, we refresh the watch logs and save them to a file for sending to Zendesk or exporting
     case refreshAndSaveWatchLogsOnSend
 
+    /// Avoid replace actions for Up Next episode queue when swapping the currently playing episode
+    case avoidReplaceOnEpisodeSwap
+
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -279,6 +282,8 @@ public enum FeatureFlag: String, CaseIterable {
         case .notificationsRevamp:
             false
         case .refreshAndSaveWatchLogsOnSend:
+            true
+        case .avoidReplaceOnEpisodeSwap:
             true
         }
     }

--- a/podcasts/PlaybackQueue.swift
+++ b/podcasts/PlaybackQueue.swift
@@ -195,8 +195,16 @@ class PlaybackQueue: NSObject {
 
     func overrideAllEpisodesWith(episode: BaseEpisode) {
         FileLog.shared.addMessage("PlaybackQueue: overrideAllEpisodesWith with \(episode.title ?? "Untitled")")
+        if FeatureFlag.avoidReplaceOnEpisodeSwap.enabled {
+            if let episode = DataManager.sharedManager.allUpNextEpisodes().first {
+                remove(episode: episode, fireNotification: false)
+            }
+        }
+
         DataManager.sharedManager.deleteAllUpNextEpisodes()
-        saveReplaceIfRequired()
+        if !FeatureFlag.avoidReplaceOnEpisodeSwap.enabled {
+            saveReplaceIfRequired()
+        }
 
         pushNewCurrentlyPlaying(episode: episode)
     }

--- a/podcasts/PlaybackQueue.swift
+++ b/podcasts/PlaybackQueue.swift
@@ -195,14 +195,18 @@ class PlaybackQueue: NSObject {
 
     func overrideAllEpisodesWith(episode: BaseEpisode) {
         FileLog.shared.addMessage("PlaybackQueue: overrideAllEpisodesWith with \(episode.title ?? "Untitled")")
-        if FeatureFlag.avoidReplaceOnEpisodeSwap.enabled {
-            if let episode = DataManager.sharedManager.allUpNextEpisodes().first {
+
+        let upNext = DataManager.sharedManager.allUpNextEpisodes()
+        let shouldRemoveInsteadOfReplace = FeatureFlag.avoidReplaceOnEpisodeSwap.enabled && upNext.count == 1
+
+        if shouldRemoveInsteadOfReplace {
+            if let episode = upNext.first {
                 remove(episode: episode, fireNotification: false)
             }
         }
 
         DataManager.sharedManager.deleteAllUpNextEpisodes()
-        if !FeatureFlag.avoidReplaceOnEpisodeSwap.enabled {
+        if !shouldRemoveInsteadOfReplace {
             saveReplaceIfRequired()
         }
 


### PR DESCRIPTION
| 📘 Part of: #2945 |
|:---:|

Fixes #2994

This replaces one case where we add a "replace" action followed by "play now" with a "remove" action for the episode followed by "play now". After running it by @geekygecko, we think it might help to avoid Replace when possible (i.e. the user hasn't explicitly cleared the queue).

This is feature flagged behind `avoid_replace_on_episode_swap`.

### Before

Before, we were sending 5 (replace) + 1 (play now)

```
{
  "deviceTime": 1744676049020,
  "upNext": {
    "changes": [
      {
        "action": 5,
        "modified": 1744676044006
      },
      {
        "action": 1,
        "modified": 1744676044008,
        "podcast": "b2e89fd0-e4fc-013c-5d20-0acc26574db2",
        "published": "2025-04-14T23:00:00Z",
        "title": "79. Insider Trading in The White House?",
        "url": "https://pdst.fm/e/chrt.fm/track/A27C8C/traffic.megaphone.fm/GLT8114846099.mp3?updated=1744667024",
        "uuid": "75ecc2a1-6a47-4b7d-992a-e1d55a01f989"
      }
    ],
    "serverModified": 1744675850051
  },
  "version": 2
}
```

### After

After, we are sending 4 (remove) + 1 (play now)

```
{
  "deviceTime": 1744777761083,
  "upNext": {
    "changes": [
      {
        "action": 1,
        "modified": 1744777756076,
        "podcast": "3782b780-0bc5-012e-fb02-00163e1b201c",
        "published": "2025-04-13T22:00:00Z",
        "title": "How to Tell a Dumb American Story",
        "url": "https://pfx.vpixl.com/6qj4J/dts.podtrac.com/redirect.mp3/chrt.fm/track/138C95/pdst.fm/e/traffic.megaphone.fm/NPR2801319086.mp3",
        "uuid": "534dd020-b1e0-436a-ad1a-22cd309dee11"
      },
      {
        "action": 4,
        "modified": 1744777756072,
        "podcast": "f5b97290-0422-012e-f9a0-00163e1b201c",
        "published": "2025-04-11T14:00:00Z",
        "title": "Signal Hill: Caterpillar Roadshow",
        "url": "https://pscrb.fm/rss/p/mgln.ai/e/14/prfx.byspotify.com/e/dts.podtrac.com/pts/redirect.mp3/waaa.wnyc.org/758af4c0-a2c3-47ec-a2d8-05f41bfbde51/episodes/05db8445-4a85-4099-961e-03411d0ef01c/audio/128/default.mp3?aid=rss_feed&awCollectionId=758af4c0-a2c3-47ec-a2d8-05f41bfbde51&awEpisodeId=05db8445-4a85-4099-961e-03411d0ef01c&feed=EmVW7VGp",
        "uuid": "fd429a39-6eb2-4587-a10a-4b4b8b408dbe"
      }
    ],
    "serverModified": 1744777369348
  },
  "version": 2
}
```

The hope is that avoiding replace actions could prevent issues which might occur with two clients merging when one may end up between the replace action and play now, or cases where the `modified` date sent by the client may be invalid for whatever reason.

## To test

### Play Now functionality
* Empty your Up Next Queue
* Play an episode
* Play another episode
* Ensure that no episodes are added to your queue

### Up Next queue
* Add an episode to your Up Next Queue
* Play a different episode
* Play another episode
* Ensure that the 2nd episode is added to the Up Next queue

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
