### PR TITLE
[Enhancement] Improve AppsFlyer setup

### DIFF
--- a/podcasts/Analytics/Adapters/Newform AppsFlyer/AppsFlyerAdapter.swift
+++ b/podcasts/Analytics/Adapters/Newform AppsFlyer/AppsFlyerAdapter.swift
@@ -14,7 +14,8 @@ class AppsFlyerAdapter: AnalyticsAdapter {
     ) {
         self.dataProvider = dataProvider
         self.appTrackingTransparencyProvider = appTrackingTransparencyProvider
-        setup()
+        appsFlyerSetup()
+        checkUserConsent()
 #if DEBUG
         FileLog.shared.console("AppsFlyer anonymous UUID \(dataProvider.anonymousUUID)")
 #endif
@@ -31,20 +32,20 @@ class AppsFlyerAdapter: AnalyticsAdapter {
         appsFlyer.logEvent(name, withValues: properties)
     }
 
-    private func setup() {
-        guard FeatureFlag.podcastNewformAppsFlyer.enabled else {
-            return
-        }
-        if appTrackingTransparencyProvider.userDeniedConsent() {
-            FileLog.shared.addMessage("AppsFlyer setup not possible as ATT is denied")
-            return
-        }
+    private func appsFlyerSetup() {
         appsFlyer.appsFlyerDevKey = dataProvider.devKey
         appsFlyer.appleAppID = dataProvider.appleAppID
         appsFlyer.customerUserID = dataProvider.anonymousUUID
 #if DEBUG
         appsFlyer.isDebug = FeatureFlag.appsFlyerLogging.enabled
 #endif
+    }
+
+    private func checkUserConsent() {
+        if appTrackingTransparencyProvider.userDeniedConsent() {
+            FileLog.shared.addMessage("AppsFlyer setup not possible as ATT is denied")
+            return
+        }
         let shouldShowPrompt = appTrackingTransparencyProvider.shouldShowPrompt()
         if !shouldShowPrompt, appTrackingTransparencyProvider.userGaveConsent() {
             start()


### PR DESCRIPTION
Improve the AppsFlyer singleton setup, removing warning.

## To test

- Run this branch on a fresh install
- When the ATT showed up, decline the consent
- You should not see any system warning in the console log related to a Task calling an API with `kadsdkless` as domain
- Stop the run
- Delete the app
- In the `AppsFlyerAdapter` force to set `appsFlyer.isDebug` as `true`
- Run a fresh install
- This time accept the consent
- You should see the AppsFlyer debug logs

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
