### PR TITLE
Watch Log crash fix

### DIFF
--- a/podcasts/WatchManager+Send.swift
+++ b/podcasts/WatchManager+Send.swift
@@ -23,14 +23,17 @@ extension WatchManager {
             return
         }
 
+        // Hold a local reference so we don't potentially run into a deallocated `self` when the below blocks are run.
+        let cachedLog = self.cachedLog
+
         // since we don't know how long it takes for a send message to timeout, wait only 10 seconds for a watch response before giving up here
         var haveCalledCompletion = false
-        logFileRequestTimedAction.startTimer(for: 5.seconds) { [weak self] in
+        logFileRequestTimedAction.startTimer(for: 5.seconds) { [cachedLog] in
             if haveCalledCompletion { return }
 
             haveCalledCompletion = true
 
-            completion(self?.cachedLog)
+            completion(cachedLog)
         }
 
         // if we get here then it's likely we'll be able to ask the watch for a log file, so let's try
@@ -47,14 +50,14 @@ extension WatchManager {
                 }
                 completion(logContents)
             } else {
-                completion(self?.cachedLog)
+                completion(cachedLog)
             }
 
-        }) { [weak self] _ in
+        }) { _ in
             if haveCalledCompletion { return }
             haveCalledCompletion = true
 
-            completion(self?.cachedLog)
+            completion(cachedLog)
         }
     }
 

--- a/podcasts/WatchManager.swift
+++ b/podcasts/WatchManager.swift
@@ -399,10 +399,11 @@ class WatchManager: NSObject, WCSessionDelegate {
             return
         }
         DispatchQueue.global(qos: .background).async { [weak self] in
-            self?.sendStateToWatch()
+            guard let self else { return }
+            sendStateToWatch()
             if FeatureFlag.refreshAndSaveWatchLogsOnSend.enabled {
                 FileLog.shared.addMessage("WatchManager: Start log request on send")
-                WatchManager.shared.requestLogFile(completion: { _ in
+                requestLogFile(completion: { _ in
                     // We don't do anything with the log, requesting it will cache and save the contents
                     FileLog.shared.addMessage("WatchManager: Completed log request on send")
                 })


### PR DESCRIPTION
Fixes a crash with Watch Log fetching from the background.

`WatchManager` may be getting deallocated when this thread is called and we want to skip these calls in that case.

## To test

### Normal Functionality

- Build and run the iOS and Apple Watch app. A simulator will work.
- Perform several actions on the watch seek back and forward in Now Playing, play pause, and change the Up Next queue.
- Quit the watchOS app
- Navigate to Profile > Help & Feedback > ⋯ > Export Database
- Make sure the exported file contains a watchos-logs.txt log with recent log lines.

### The Crash

- Apply [this change](https://github.com/user-attachments/files/19797716/mutable-watchmanager.patch)
 to make the WatchManager singleton mutable:
```swift
    static var shared: WatchManager! = WatchManager()
```
- Add a breakpoint which executes: `expr WatchManager.shared = nil` as a debugger command. You can also check "Automatically continue" if you don't want to skip.
![CleanShot 2025-04-17 at 10 20 20@2x](https://github.com/user-attachments/assets/124de782-989a-4482-abc6-64886917f359)
- You should not see any crash after this change

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
