### PR TITLE
[Notifications Revamp] ReEngagement notifications

### DIFF
--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -226,7 +226,7 @@ struct Constants {
         }
 
         enum notifications {
-            static let onboardingTips = "notifications.onboardingTips"
+            static let dailyReminders = "notifications.dailyReminders"
             static let newFeaturesAndTips = "notifications.newFeaturesAndTips"
         }
     }

--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -227,6 +227,7 @@ struct Constants {
 
         enum notifications {
             static let onboardingTips = "notifications.onboardingTips"
+            static let newFeaturesAndTips = "notifications.newFeaturesAndTips"
         }
     }
 

--- a/podcasts/DeveloperMenu.swift
+++ b/podcasts/DeveloperMenu.swift
@@ -302,7 +302,8 @@ struct DeveloperMenu: View {
 
             Section {
                 Button("Speed Up Notifications") {
-                    NotificationsCoordinator.shared.timeIntervalStep = 10.seconds
+                    NotificationsCoordinator.shared.onboardingTimeIntervalStep = 10.seconds
+                    NotificationsCoordinator.shared.reEngagementTimeIntervalStep = 60.seconds
                 }
             } header: {
                 Text("Notifications")

--- a/podcasts/DeveloperMenu.swift
+++ b/podcasts/DeveloperMenu.swift
@@ -304,6 +304,7 @@ struct DeveloperMenu: View {
                 Button("Speed Up Notifications") {
                     NotificationsCoordinator.shared.onboardingTimeIntervalStep = 10.seconds
                     NotificationsCoordinator.shared.reEngagementTimeIntervalStep = 60.seconds
+                    NotificationsCoordinator.shared.ignoreScheduleHours = true
                 }
             } header: {
                 Text("Notifications")

--- a/podcasts/Notifications/NotificationsCoordinator+AnalyticsAdapter.swift
+++ b/podcasts/Notifications/NotificationsCoordinator+AnalyticsAdapter.swift
@@ -8,11 +8,19 @@ extension NotificationsCoordinator: AnalyticsAdapter {
                 self.cancelNotification(notification)
             }
         }
+        updateReEngagementNotifications(name: name, properties: properties)
+    }
+
+    func updateReEngagementNotifications(name: String, properties: [AnyHashable: Any]?) {
+        // Check if need to cancel an existing notification
         if NotificationType.reengagementWeekly.checkCancelConditionsForEvent(name: name, properties: properties) {
             self.cancelNotification(.reengagementWeekly)
         }
+        let event: AnalyticsEvent = .applicationClosed
+        if event.rawValue.toSnakeCaseFromCamelCase() == name {
+            self.updateReengamentNotifications()
+        }
     }
-
 }
 
 extension NotificationType {

--- a/podcasts/Notifications/NotificationsCoordinator+AnalyticsAdapter.swift
+++ b/podcasts/Notifications/NotificationsCoordinator+AnalyticsAdapter.swift
@@ -8,6 +8,9 @@ extension NotificationsCoordinator: AnalyticsAdapter {
                 self.cancelNotification(notification)
             }
         }
+        if NotificationType.reengagementWeekly.checkCancelConditionsForEvent(name: name, properties: properties) {
+            self.cancelNotification(.reengagementWeekly)
+        }
     }
 
 }
@@ -18,6 +21,8 @@ extension NotificationType {
         var possibleConditions: Set<AnalyticsEvent>
 
         switch self {
+        case .reengagementWeekly:
+            possibleConditions = [.applicationOpened]
         case .onboardingSignUp:
             possibleConditions = [.userSignedIn, .userAccountCreated]
         case .onboardingImport:

--- a/podcasts/Notifications/NotificationsCoordinator.swift
+++ b/podcasts/Notifications/NotificationsCoordinator.swift
@@ -30,7 +30,7 @@ enum NotificationType: String {
         case .onboardingStaffPicks:
             return L10n.notificationsOnboardingStaffPicksTitle
         case .reengagementWeekly:
-            return "We miss you!"
+            return L10n.notificationsReengagementWeeklyTitle
         }
     }
 
@@ -51,7 +51,7 @@ enum NotificationType: String {
         case .onboardingStaffPicks:
             return L10n.notificationsOnboardingStaffPicksBody
         case .reengagementWeekly:
-            return "It’s been awhile since you’ve listened. Jump back in and enjoy!"
+            return L10n.notificationsReengagementWeeklyBody
         }
     }
 

--- a/podcasts/Notifications/NotificationsCoordinator.swift
+++ b/podcasts/Notifications/NotificationsCoordinator.swift
@@ -88,6 +88,11 @@ class NotificationsCoordinator {
     var onboardingTimeIntervalStep: TimeInterval = 24.hours
     var reEngagementTimeIntervalStep: TimeInterval = 1.week
 
+    enum Constants {
+        static let onboardingScheduleHour: Int = 10
+        static let reengagementScheduleHour: Int = 16
+    }
+
     private let notificationCenter: UNUserNotificationCenter
 
     private init(notificationCenter: UNUserNotificationCenter = .current()) {
@@ -98,10 +103,10 @@ class NotificationsCoordinator {
 
     func setupOnboardingNotifications() {
         Settings.notificationsOnboardingTips = true
-        NotificationsHelper.shared.registerForPushNotifications { granted in
-            guard granted else { return }
-            var timeInterval: TimeInterval = self.onboardingTimeIntervalStep
-            self.onboardingNotifications.forEach { notification in
+        NotificationsHelper.shared.registerForPushNotifications { [weak self] granted in
+            guard let self, granted else { return }
+            var timeInterval: TimeInterval = calculateTimeIntervalToHour(Constants.onboardingScheduleHour) + onboardingTimeIntervalStep
+            onboardingNotifications.forEach { notification in
                 self.scheduleNotification(notification, timeInterval: timeInterval)
                 timeInterval += self.onboardingTimeIntervalStep
             }
@@ -128,7 +133,9 @@ class NotificationsCoordinator {
 
     func updateReengamentNotifications() {
         cancelNotification(.reengagementWeekly)
-        scheduleNotification(.reengagementWeekly, timeInterval: reEngagementTimeIntervalStep, repeats: true)
+        let initialInterval = calculateTimeIntervalToHour(Constants.reengagementScheduleHour) + reEngagementTimeIntervalStep
+        scheduleNotification(.reengagementWeekly, timeInterval: initialInterval, repeats: false)
+        scheduleNotification(.reengagementWeekly, timeInterval: initialInterval + reEngagementTimeIntervalStep, repeats: true)
     }
 
     func scheduleNotification(_ type: NotificationType, timeInterval: TimeInterval = 5.seconds, repeats: Bool = false) {
@@ -155,5 +162,12 @@ class NotificationsCoordinator {
 
     func cancelNotification(_ type: NotificationType) {
         notificationCenter.removePendingNotificationRequests(withIdentifiers: [type.identifier])
+    }
+
+    private func calculateTimeIntervalToHour(_ hour: Int) -> TimeInterval {
+        guard let date = Calendar.current.date(bySettingHour: hour, minute: 0, second: 0, of: Date.now, matchingPolicy: .nextTime) else {
+            return 0
+        }
+        return date.timeIntervalSince(Date.now)
     }
 }

--- a/podcasts/Notifications/NotificationsCoordinator.swift
+++ b/podcasts/Notifications/NotificationsCoordinator.swift
@@ -102,8 +102,8 @@ class NotificationsCoordinator {
 
     let onboardingNotifications: [NotificationType] = [.onboardingSignUp, .onboardingImport, .onboardingUpNext, .onboardingFilters, .onboardingThemes, .onboardingStaffPicks, .onboardingUpsell]
 
-    func setupOnboardingNotifications() {
-        Settings.notificationsOnboardingTips = true
+    func setupDailyRemindersNotifications() {
+        Settings.notificationsDailyReminders = true
         NotificationsHelper.shared.registerForPushNotifications { [weak self] granted in
             guard let self, granted else { return }
             let timeIntervalToSchedule: TimeInterval = calculateTimeIntervalToHour(Constants.onboardingScheduleHour)
@@ -115,8 +115,8 @@ class NotificationsCoordinator {
         }
     }
 
-    func cancelOnboardingNotifications() {
-        Settings.notificationsOnboardingTips = false
+    func cancelDailyRemainderNotifications() {
+        Settings.notificationsDailyReminders = false
         notificationCenter.removePendingNotificationRequests(withIdentifiers: onboardingNotifications.map { $0.identifier })
     }
 

--- a/podcasts/Notifications/NotificationsCoordinator.swift
+++ b/podcasts/Notifications/NotificationsCoordinator.swift
@@ -87,6 +87,7 @@ class NotificationsCoordinator {
 
     var onboardingTimeIntervalStep: TimeInterval = 24.hours
     var reEngagementTimeIntervalStep: TimeInterval = 1.week
+    var ignoreScheduleHours: Bool = false
 
     enum Constants {
         static let onboardingScheduleHour: Int = 10
@@ -105,7 +106,8 @@ class NotificationsCoordinator {
         Settings.notificationsOnboardingTips = true
         NotificationsHelper.shared.registerForPushNotifications { [weak self] granted in
             guard let self, granted else { return }
-            var timeInterval: TimeInterval = calculateTimeIntervalToHour(Constants.onboardingScheduleHour) + onboardingTimeIntervalStep
+            let timeIntervalToSchedule: TimeInterval = calculateTimeIntervalToHour(Constants.onboardingScheduleHour)
+            var timeInterval: TimeInterval = timeIntervalToSchedule + onboardingTimeIntervalStep
             onboardingNotifications.forEach { notification in
                 self.scheduleNotification(notification, timeInterval: timeInterval)
                 timeInterval += self.onboardingTimeIntervalStep
@@ -133,7 +135,8 @@ class NotificationsCoordinator {
 
     func updateReengamentNotifications() {
         cancelNotification(.reengagementWeekly)
-        let initialInterval = calculateTimeIntervalToHour(Constants.reengagementScheduleHour) + reEngagementTimeIntervalStep
+        let timeIntervalToSchedule: TimeInterval = calculateTimeIntervalToHour(Constants.reengagementScheduleHour)
+        let initialInterval = timeIntervalToSchedule + reEngagementTimeIntervalStep
         scheduleNotification(.reengagementWeekly, timeInterval: initialInterval, repeats: false)
         scheduleNotification(.reengagementWeekly, timeInterval: initialInterval + reEngagementTimeIntervalStep, repeats: true)
     }
@@ -165,6 +168,9 @@ class NotificationsCoordinator {
     }
 
     private func calculateTimeIntervalToHour(_ hour: Int) -> TimeInterval {
+        if ignoreScheduleHours {
+            return 1
+        }
         guard let date = Calendar.current.date(bySettingHour: hour, minute: 0, second: 0, of: Date.now, matchingPolicy: .nextTime) else {
             return 0
         }

--- a/podcasts/Notifications/NotificationsCoordinator.swift
+++ b/podcasts/Notifications/NotificationsCoordinator.swift
@@ -89,7 +89,7 @@ class NotificationsCoordinator {
     var reEngagementTimeIntervalStep: TimeInterval = 1.week
     var ignoreScheduleHours: Bool = false
 
-    enum Constants {
+    private enum Constants {
         static let onboardingScheduleHour: Int = 10
         static let reengagementScheduleHour: Int = 16
     }

--- a/podcasts/Notifications/NotificationsCoordinator.swift
+++ b/podcasts/Notifications/NotificationsCoordinator.swift
@@ -112,14 +112,32 @@ class NotificationsCoordinator {
         notificationCenter.removePendingNotificationRequests(withIdentifiers: onboardingNotifications.map { $0.identifier })
     }
 
-    func scheduleNotification(_ type: NotificationType, timeInterval: TimeInterval = 5.seconds) {
+    func setupNewFeaturesAndTipsNotifications() {
+        Settings.notificationsNewFeaturesAndTips = true
+        NotificationsHelper.shared.registerForPushNotifications { [weak self] granted in
+            guard granted else { return }
+            self?.updateReengamentNotifications()
+        }
+    }
+
+    func cancelNewFeaturesAndTipsNotifications() {
+        Settings.notificationsNewFeaturesAndTips = true
+        cancelNotification(.reengagementWeekly)
+    }
+
+    func updateReengamentNotifications() {
+        cancelNotification(.reengagementWeekly)
+        scheduleNotification(.reengagementWeekly, timeInterval: 1.week, repeats: true)
+    }
+
+    func scheduleNotification(_ type: NotificationType, timeInterval: TimeInterval = 5.seconds, repeats: Bool = false) {
         let content = UNMutableNotificationContent()
         content.title = type.title
         content.body = type.body
         content.categoryIdentifier = NotificationsHelper.NotificationsCategory.deepLink.rawValue
         content.userInfo = ["destination_url": type.link]
 
-        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: timeInterval, repeats: false)
+        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: timeInterval, repeats: repeats)
 
         let request = UNNotificationRequest(identifier: type.identifier, content: content, trigger: trigger)
 

--- a/podcasts/Notifications/NotificationsCoordinator.swift
+++ b/podcasts/Notifications/NotificationsCoordinator.swift
@@ -85,7 +85,8 @@ class NotificationsCoordinator {
 
     static let shared: NotificationsCoordinator = NotificationsCoordinator()
 
-    var timeIntervalStep: TimeInterval = 24.hours
+    var onboardingTimeIntervalStep: TimeInterval = 24.hours
+    var reEngagementTimeIntervalStep: TimeInterval = 1.week
 
     private let notificationCenter: UNUserNotificationCenter
 
@@ -99,10 +100,10 @@ class NotificationsCoordinator {
         Settings.notificationsOnboardingTips = true
         NotificationsHelper.shared.registerForPushNotifications { granted in
             guard granted else { return }
-            var timeInterval: TimeInterval = self.timeIntervalStep
+            var timeInterval: TimeInterval = self.onboardingTimeIntervalStep
             self.onboardingNotifications.forEach { notification in
                 self.scheduleNotification(notification, timeInterval: timeInterval)
-                timeInterval += self.timeIntervalStep
+                timeInterval += self.onboardingTimeIntervalStep
             }
         }
     }
@@ -121,13 +122,13 @@ class NotificationsCoordinator {
     }
 
     func cancelNewFeaturesAndTipsNotifications() {
-        Settings.notificationsNewFeaturesAndTips = true
+        Settings.notificationsNewFeaturesAndTips = false
         cancelNotification(.reengagementWeekly)
     }
 
     func updateReengamentNotifications() {
         cancelNotification(.reengagementWeekly)
-        scheduleNotification(.reengagementWeekly, timeInterval: 1.week, repeats: true)
+        scheduleNotification(.reengagementWeekly, timeInterval: reEngagementTimeIntervalStep, repeats: true)
     }
 
     func scheduleNotification(_ type: NotificationType, timeInterval: TimeInterval = 5.seconds, repeats: Bool = false) {

--- a/podcasts/Notifications/NotificationsCoordinator.swift
+++ b/podcasts/Notifications/NotificationsCoordinator.swift
@@ -11,6 +11,8 @@ enum NotificationType: String {
     case onboardingFilters
     case onboardingUpsell
 
+    case reengagementWeekly
+
     var title: String {
         switch self {
         case .onboardingSignUp:
@@ -27,6 +29,8 @@ enum NotificationType: String {
             return L10n.notificationsOnboardingUpsellTitle
         case .onboardingStaffPicks:
             return L10n.notificationsOnboardingStaffPicksTitle
+        case .reengagementWeekly:
+            return "We miss you!"
         }
     }
 
@@ -46,6 +50,8 @@ enum NotificationType: String {
             return L10n.notificationsOnboardingUpsellBody
         case .onboardingStaffPicks:
             return L10n.notificationsOnboardingStaffPicksBody
+        case .reengagementWeekly:
+            return "It’s been awhile since you’ve listened. Jump back in and enjoy!"
         }
     }
 
@@ -69,6 +75,8 @@ enum NotificationType: String {
             return "pktc://upsell"
         case .onboardingStaffPicks:
             return "pktc://discover/staff-picks"
+        case .reengagementWeekly:
+            return "pktc://open"
         }
     }
 }

--- a/podcasts/Notifications/NotificationsCoordinator.swift
+++ b/podcasts/Notifications/NotificationsCoordinator.swift
@@ -76,7 +76,7 @@ enum NotificationType: String {
         case .onboardingStaffPicks:
             return "pktc://discover/staff-picks"
         case .reengagementWeekly:
-            return "pktc://open"
+            return "pktc://discover"
         }
     }
 }

--- a/podcasts/NotificationsViewController.swift
+++ b/podcasts/NotificationsViewController.swift
@@ -269,6 +269,11 @@ class NotificationsViewController: PCViewController, UITableViewDataSource, UITa
         case .trendingRecommendations:
             Settings.trackValueToggled(.settingsNotificationsTrendingToggle, enabled: sender.isOn)
         case .newFeaturesAndTips:
+            if sender.isOn {
+                NotificationsCoordinator.shared.setupNewFeaturesAndTipsNotifications()
+            } else {
+                NotificationsCoordinator.shared.cancelNewFeaturesAndTipsNotifications()
+            }
             Settings.trackValueToggled(.settingsNotificationsNewFeaturesToggle, enabled: sender.isOn)
         case .pocketCastsOffers:
             Settings.trackValueToggled(.settingsNotificationsOffersToggle, enabled: sender.isOn)

--- a/podcasts/NotificationsViewController.swift
+++ b/podcasts/NotificationsViewController.swift
@@ -14,6 +14,10 @@ class NotificationsViewController: PCViewController, UITableViewDataSource, UITa
 
     private var notificationsDenied = false
 
+    private lazy var notificationsCoordinator: NotificationsCoordinator = {
+        return NotificationsCoordinator.shared
+    }()
+
     enum Section: Int {
         case episodes = 0
         case recommendationsAndReminders
@@ -53,7 +57,7 @@ class NotificationsViewController: PCViewController, UITableViewDataSource, UITa
         var value: Bool {
             switch self {
             case .dailyReminders:
-                return Settings.notificationsOnboardingTips
+                return Settings.notificationsDailyReminders
             case .newEpisodes:
                 return NotificationsHelper.shared.pushEnabled()
             case .newFeaturesAndTips:
@@ -262,18 +266,18 @@ class NotificationsViewController: PCViewController, UITableViewDataSource, UITa
                 episodePushToggled(sender)
         case .dailyReminders:
             if sender.isOn {
-                NotificationsCoordinator.shared.setupOnboardingNotifications()
+                notificationsCoordinator.setupDailyRemindersNotifications()
             } else {
-                NotificationsCoordinator.shared.cancelOnboardingNotifications()
+                notificationsCoordinator.cancelDailyRemainderNotifications()
             }
             Settings.trackValueToggled(.settingsNotificationsDailyRemindersToggle, enabled: sender.isOn)
         case .trendingRecommendations:
             Settings.trackValueToggled(.settingsNotificationsTrendingToggle, enabled: sender.isOn)
         case .newFeaturesAndTips:
             if sender.isOn {
-                NotificationsCoordinator.shared.setupNewFeaturesAndTipsNotifications()
+                notificationsCoordinator.setupNewFeaturesAndTipsNotifications()
             } else {
-                NotificationsCoordinator.shared.cancelNewFeaturesAndTipsNotifications()
+                notificationsCoordinator.cancelNewFeaturesAndTipsNotifications()
             }
             Settings.trackValueToggled(.settingsNotificationsNewFeaturesToggle, enabled: sender.isOn)
         case .pocketCastsOffers:

--- a/podcasts/NotificationsViewController.swift
+++ b/podcasts/NotificationsViewController.swift
@@ -56,10 +56,11 @@ class NotificationsViewController: PCViewController, UITableViewDataSource, UITa
                 return Settings.notificationsOnboardingTips
             case .newEpisodes:
                 return NotificationsHelper.shared.pushEnabled()
+            case .newFeaturesAndTips:
+                return Settings.notificationsNewFeaturesAndTips
             case .podcastsChosen,
                  .appBadges,
                  .trendingRecommendations,
-                 .newFeaturesAndTips,
                  .pocketCastsOffers:
                 return false
             }

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -1455,6 +1455,15 @@ class Settings: NSObject {
         }
     }
 
+    static var notificationsNewFeaturesAndTips: Bool {
+        get {
+            UserDefaults.standard.value(forKey: Constants.UserDefaults.notifications.newFeaturesAndTips) as? Bool ?? false
+        }
+        set {
+            UserDefaults.standard.setValue(newValue, forKey: Constants.UserDefaults.notifications.newFeaturesAndTips)
+        }
+    }
+
     // MARK: - Database (internal)
 
     class var upgradedIndexes: Bool {

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -1446,12 +1446,12 @@ class Settings: NSObject {
 
     // MARK: - Notifications
 
-    static var notificationsOnboardingTips: Bool {
+    static var notificationsDailyReminders: Bool {
         get {
-            UserDefaults.standard.value(forKey: Constants.UserDefaults.notifications.onboardingTips) as? Bool ?? false
+            UserDefaults.standard.value(forKey: Constants.UserDefaults.notifications.dailyReminders) as? Bool ?? false
         }
         set {
-            UserDefaults.standard.setValue(newValue, forKey: Constants.UserDefaults.notifications.onboardingTips)
+            UserDefaults.standard.setValue(newValue, forKey: Constants.UserDefaults.notifications.dailyReminders)
         }
     }
 

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -1791,6 +1791,10 @@ internal enum L10n {
   internal static var notificationsPlayNow: String { return L10n.tr("Localizable", "notifications_play_now") }
   /// Pocket Casts Offers
   internal static var notificationsPocketCastOffers: String { return L10n.tr("Localizable", "notifications_pocket_cast_offers") }
+  /// It’s been awhile since you’ve listened. Jump back in and enjoy!
+  internal static var notificationsReengagementWeeklyBody: String { return L10n.tr("Localizable", "notifications_reengagement_weekly_body") }
+  /// We miss you!
+  internal static var notificationsReengagementWeeklyTitle: String { return L10n.tr("Localizable", "notifications_reengagement_weekly_title") }
   /// Trending & Recommendations
   internal static var notificationsTrendingAndRecommendations: String { return L10n.tr("Localizable", "notifications_trending_and_recommendations") }
   /// Go to device settings

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4957,3 +4957,9 @@
 /* Notification permission banner action*/
 "notitifications_permission_banner_action" = "Go to device settings";
 
+/* Notification title for weekly reengagement message */
+"notifications_reengagement_weekly_title" = "We miss you!";
+
+/* Notification body for for weekly reengagement message */
+"notifications_reengagement_weekly_body" = "It’s been awhile since you’ve listened. Jump back in and enjoy!";
+

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4960,6 +4960,6 @@
 /* Notification title for weekly reengagement message */
 "notifications_reengagement_weekly_title" = "We miss you!";
 
-/* Notification body for for weekly reengagement message */
+/* Notification body for weekly reengagement message */
 "notifications_reengagement_weekly_body" = "It’s been awhile since you’ve listened. Jump back in and enjoy!";
 

--- a/scripts/notifications/reengagement_weekly.apns
+++ b/scripts/notifications/reengagement_weekly.apns
@@ -1,0 +1,11 @@
+{
+  "Simulator Target Bundle": "au.com.shiftyjelly.podcasts",
+  "aps": {
+    "alert": {
+      "title": "We miss you!",
+      "body": "It’s been awhile since you’ve listened. Jump back in and enjoy!"
+    },
+    "category": "DEEP_LINK"
+  },
+  "destination_url": "pktc://open"
+}

--- a/scripts/notifications/reengagement_weekly.apns
+++ b/scripts/notifications/reengagement_weekly.apns
@@ -7,5 +7,5 @@
     },
     "category": "DEEP_LINK"
   },
-  "destination_url": "pktc://open"
+  "destination_url": "pktc://discover"
 }


### PR DESCRIPTION
| 📘 Part of: #2906  |  <!-- project issue number, if applicable -->
|:---:|

Fixes #2912  <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

<img src="https://github.com/user-attachments/assets/bf1eedf6-534d-4818-9a98-7713c2f1e24d" width=320>

## To test

1. Start the app with a non logged user
2. Ensure that you have the NotificationRevamp FF enabled
3. After restart in order to speed up notifications deliver go to Settings -> Developer Menu and tap on Speed Up Notifications in order to get them delivered in 60 seconds intervals.
4. Go to Settings -> Notifications
5. Tap on New Features And tip toggle to start sending re-engagement notifications
6. Switch to another app
7. Wait for 60s and see if a notification shows up
8. Tap on the notification
9. Check if it opens the app
10. Now wait for more than 60s in the app, and check that no notification shows up while you are inside the app
11. Switch to another app
12. Wait for 60s and see if a notification shows up
13. Tap on the notification and see if app opens up


## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
