### PR TITLE
GRDB: fix crash on `BookmarkDataManager`

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Bookmarks/BookmarkDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Bookmarks/BookmarkDataManager.swift
@@ -158,7 +158,7 @@ public struct BookmarkDataManager {
         SET \(Column.syncStatus) = ?
         """
 
-        let result = await dbQueue.executeUpdate(query, values: [SyncStatus.synced])
+        let result = await dbQueue.executeUpdate(query, values: [SyncStatus.synced.rawValue])
         switch result {
         case .success:
             return true


### PR DESCRIPTION
| 📘 Part of: #2773 |
|:---:|

As mentioned by @SergioEstevao [here](https://github.com/Automattic/pocket-casts-ios/pull/2840#issuecomment-2792907135) there was a crash when dealing with Bookmarks.

## About the fix

There was two ways to fix that:

1. By using `rawValue` (as did in this PR)
2. By making `SyncStatus` to conform to `DatabaseValueConvertible`

I did (1) because:

1. This seems to be the only place where an enum was used directly 
2. By not using `DatabaseValueConvertible` we keep the `Enums` decoupled of the database framework. 

## To test

Enable `grdb` feature flag in `FeatureFlag.swift`

1. Do a clean install of the app
2. Login to an account with Bookmarks
3. ✅ The login should succeed

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
