### PR TITLE
GRDB: enable for `DEBUG` environment

### DIFF
--- a/Modules/DataModel/Tests/PocketCastsDataModelTests/DataManager+TestDatabase.swift
+++ b/Modules/DataModel/Tests/PocketCastsDataModelTests/DataManager+TestDatabase.swift
@@ -65,6 +65,10 @@ extension DatabasePool {
             throw TestError.dbFolderPathFailure
         }
 
+        if !FileManager.default.fileExists(atPath: dbFolderPath as String) {
+            try FileManager.default.createDirectory(atPath: dbFolderPath as String, withIntermediateDirectories: true)
+        }
+
         let dbPath = dbFolderPath.appendingPathComponent(databaseName ?? "podcast_testDB_GRDB.sqlite3")
         if databaseName == nil && FileManager.default.fileExists(atPath: dbPath) {
             try FileManager.default.removeItem(atPath: dbPath)

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -286,7 +286,11 @@ public enum FeatureFlag: String, CaseIterable {
         case .libroFm:
             false
         case .grdb:
+            #if DEBUG
+            true
+            #else
             false
+            #endif
         case .encourageAccountCreation:
             true
         case .notificationsRevamp:

--- a/PocketCastsTests/Extensions/FMDatabaseQueue+Test.swift
+++ b/PocketCastsTests/Extensions/FMDatabaseQueue+Test.swift
@@ -65,6 +65,10 @@ extension DatabasePool {
             throw TestError.dbFolderPathFailure
         }
 
+        if !FileManager.default.fileExists(atPath: dbFolderPath as String) {
+            try FileManager.default.createDirectory(atPath: dbFolderPath as String, withIntermediateDirectories: true)
+        }
+
         let dbPath = dbFolderPath.appendingPathComponent(databaseName ?? "podcast_testDB_GRDB.sqlite3")
         if databaseName == nil && FileManager.default.fileExists(atPath: dbPath) {
             try FileManager.default.removeItem(atPath: dbPath)

--- a/PocketCastsTests/Helpers/DBTestCase.swift
+++ b/PocketCastsTests/Helpers/DBTestCase.swift
@@ -4,7 +4,15 @@ import FMDB
 @testable import podcasts
 
 class DBTestCase: XCTestCase {
-    var dataManager: DataManager!
+    // We use a single DataManager instance for tests based on DBTestCase,
+    // since some tests interact with the download logic.
+    // Creating multiple DataManager instances cause the app delegate
+    // to reference an outdated one with a closed database.
+    // This issue is silently ignored when using FMDB, but GRDB surfaces an error.
+    static var dataManager: DataManager!
+    var dataManager: DataManager! {
+        Self.dataManager
+    }
     var downloadManager: DownloadManager!
     var podcast: Podcast!
     var episode: Episode!
@@ -19,7 +27,7 @@ class DBTestCase: XCTestCase {
     }
 
     private func setupData() throws {
-        let dataManager = try setupDatabase()
+        let dataManager = Self.dataManager == nil ? try setupDatabase() : Self.dataManager!
         let downloadManager = DownloadManager(dataManager: dataManager)
 
         let podcast = Podcast()
@@ -39,7 +47,7 @@ class DBTestCase: XCTestCase {
         episode.playingStatus = PlayingStatus.notPlayed.rawValue
 
         dataManager.save(episode: episode)
-        self.dataManager = dataManager
+        Self.dataManager = dataManager
         self.downloadManager = downloadManager
         self.episode = episode
         self.podcast = podcast
@@ -71,9 +79,5 @@ class DBTestCase: XCTestCase {
         XCTAssertEqual(task.state, URLSessionTask.State.running)
 
         return (podcastManager, task)
-    }
-
-    func cleanDownloadQueue() {
-        downloadManager.removeFromQueue(episode: episode, fireNotification: false, userInitiated: false)
     }
 }

--- a/PocketCastsTests/Tests/Utilities/DownloadManagerTests.swift
+++ b/PocketCastsTests/Tests/Utilities/DownloadManagerTests.swift
@@ -28,7 +28,5 @@ final class DownloadManagerTests: DBTestCase {
         let error = task.error as? NSError
         XCTAssertEqual(error?.domain, NSURLErrorDomain, "Task should be cancelled")
         XCTAssertEqual(error?.code, NSURLErrorCancelled, "Task should be cancelled")
-
-        cleanDownloadQueue()
     }
 }

--- a/PocketCastsTests/Tests/Utilities/PodcastManagerTests.swift
+++ b/PocketCastsTests/Tests/Utilities/PodcastManagerTests.swift
@@ -26,7 +26,5 @@ final class PodcastManagerTests: DBTestCase {
         let error = task.error as? NSError
         XCTAssertEqual(error?.domain, NSURLErrorDomain, "Task should be cancelled")
         XCTAssertEqual(error?.code, NSURLErrorCancelled, "Task should be cancelled")
-
-        cleanDownloadQueue()
     }
 }


### PR DESCRIPTION
| 📘 Part of: #2773 | 
|:---:|

As I suggested, this enables GRDB for the development environment — which is the first step in testing the GRDB integration to find issues we might not be aware of.

After I merged `trunk` to the GRDB code, tests started failing. I fixed them on this PR.

## To test

1. Run the app
2. Ensure `grdb` flag is`true`

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
