### PR TITLE
Recommendations: Authentication property handling

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/Discover/DiscoverServerHandler.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Discover/DiscoverServerHandler.swift
@@ -35,32 +35,32 @@ public class DiscoverServerHandler {
         } else {
             contentPath = "ios/content_v2.json"
         }
-        discoverRequest(path: ServerConstants.Urls.discover() + contentPath, type: DiscoverLayout.self) { discoverItems, cachedResponse in
+        discoverRequest(path: ServerConstants.Urls.discover() + contentPath, type: DiscoverLayout.self, authenticated: nil) { discoverItems, cachedResponse in
             completion(discoverItems, cachedResponse)
         }
     }
 
-    public func discoverNetworkList(source: String, completion: @escaping ([PodcastNetwork]?) -> Void) {
-        discoverRequest(path: source, type: [PodcastNetwork].self) { networkList, _ in
+    public func discoverNetworkList(source: String, authenticated: Bool?, completion: @escaping ([PodcastNetwork]?) -> Void) {
+        discoverRequest(path: source, type: [PodcastNetwork].self, authenticated: authenticated) { networkList, _ in
             completion(networkList)
         }
     }
 
-    public func discoverPodcastList(source: String, completion: @escaping (PodcastList?) -> Void) {
-        discoverRequest(path: source, type: PodcastList.self) { podcastList, _ in
+    public func discoverPodcastList(source: String, authenticated: Bool?, completion: @escaping (PodcastList?) -> Void) {
+        discoverRequest(path: source, type: PodcastList.self, authenticated: authenticated) { podcastList, _ in
             completion(podcastList)
         }
     }
 
-    public func discoverCategories(source: String, completion: @escaping ([DiscoverCategory]?) -> Void) {
-        discoverRequest(path: source, type: [DiscoverCategory].self) { categories, _ in
+    public func discoverCategories(source: String, authenticated: Bool?, completion: @escaping ([DiscoverCategory]?) -> Void) {
+        discoverRequest(path: source, type: [DiscoverCategory].self, authenticated: authenticated) { categories, _ in
             completion(categories)
         }
     }
 
-    public func discoverCategories(source: String) async -> [DiscoverCategory] {
+    public func discoverCategories(source: String, authenticated: Bool?) async -> [DiscoverCategory] {
         return await withCheckedContinuation { continuation in
-            DiscoverServerHandler.shared.discoverCategories(source: source, completion: { discoverCategories in
+            DiscoverServerHandler.shared.discoverCategories(source: source, authenticated: authenticated, completion: { discoverCategories in
                 DispatchQueue.main.async {
                     guard let discoverCategories = discoverCategories else {
                         continuation.resume(returning: [])
@@ -72,25 +72,25 @@ public class DiscoverServerHandler {
         }
     }
 
-    public func discoverCategoryDetails(source: String, completion: @escaping (DiscoverCategoryDetails?) -> Void) {
-        discoverRequest(path: source, type: DiscoverCategoryDetails.self) { categoryDetails, _ in
+    public func discoverCategoryDetails(source: String, authenticated: Bool?, completion: @escaping (DiscoverCategoryDetails?) -> Void) {
+        discoverRequest(path: source, type: DiscoverCategoryDetails.self, authenticated: authenticated) { categoryDetails, _ in
             completion(categoryDetails)
         }
     }
 
-    public func discoverPodcastCollection(source: String, completion: @escaping (PodcastCollection?) -> Void) {
-        discoverRequest(path: source, type: PodcastCollection.self) { podcastCollection, _ in
+    public func discoverPodcastCollection(source: String, authenticated: Bool?, completion: @escaping (PodcastCollection?) -> Void) {
+        discoverRequest(path: source, type: PodcastCollection.self, authenticated: authenticated) { podcastCollection, _ in
             completion(podcastCollection)
         }
     }
 
-    public func discoverItem<T>(_ source: String?, type: T.Type) -> AnyPublisher<T, Error> where T: Decodable {
+    public func discoverItem<T>(_ source: String?, authenticated: Bool, type: T.Type) -> AnyPublisher<T, Error> where T: Decodable {
         guard let source = source else {
             return Fail(error: DiscoverServerError.badRequest).eraseToAnyPublisher()
         }
 
         return Future { [unowned self] promise in
-            self.discoverRequest(path: source, type: type) { discoverList, didError in
+            self.discoverRequest(path: source, type: type, authenticated: authenticated) { discoverList, didError in
                 if !didError, let discoverList = discoverList {
                     promise(.success(discoverList))
                 } else {
@@ -101,7 +101,12 @@ public class DiscoverServerHandler {
         .eraseToAnyPublisher()
     }
 
-    private func discoverRequest<T>(path: String, type: T.Type, completion: @escaping (T?, Bool) -> Void) where T: Decodable {
+    private let tokenHelper = {
+        let connection = URLConnection(handler: URLSession.shared)
+        return TokenHelper(urlConnection: connection)
+    }()
+
+    private func discoverRequest<T>(path: String, type: T.Type, authenticated: Bool?, completion: @escaping (T?, Bool) -> Void) where T: Decodable {
         let url = ServerHelper.asUrl(path)
         let request = URLRequest(url: url)
 
@@ -118,7 +123,7 @@ public class DiscoverServerHandler {
             }
         }
 
-        URLSession.shared.dataTask(with: request) { [weak self] data, response, error in
+        let completion: (Data?, URLResponse?, Error?) -> Void = { [weak self] data, response, error in
             guard let data = data, let response = response, error == nil else {
                 completion(nil, false)
                 return
@@ -137,6 +142,14 @@ public class DiscoverServerHandler {
             } catch {
                 completion(nil, false)
             }
-        }.resume()
+        }
+
+        if FeatureFlag.recommendations.enabled && authenticated == true {
+            tokenHelper.callSecureUrl(request: request) { response, data, error in
+                completion(data, response, error)
+            }
+        } else {
+            URLSession.shared.dataTask(with: request, completionHandler: completion).resume()
+        }
     }
 }

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
@@ -265,6 +265,7 @@ public struct DiscoverItem: Decodable, Equatable {
     public var expandedStyle: String?
     public var summaryItemCount: Int?
     public var source: String?
+    public var authenticated: Bool?
     public var sponsoredPodcasts: [CarouselSponsoredPodcast]?
     public var expandedTopItemLabel: String?
     public var curated: Bool?
@@ -280,7 +281,7 @@ public struct DiscoverItem: Decodable, Equatable {
         case sponsoredPodcasts = "sponsored_podcasts"
         case expandedTopItemLabel = "expanded_top_item_label"
         case categoryID = "category_id"
-        case type, title, source, regions, curated, uuid, popular, id
+        case type, title, source, regions, curated, uuid, popular, id, authenticated
     }
 
     public init(
@@ -298,7 +299,8 @@ public struct DiscoverItem: Decodable, Equatable {
         regions: [String],
         isSponsored: Bool? = nil,
         popular: [Int]? = nil,
-        categoryID: Int? = nil
+        categoryID: Int? = nil,
+        authenticated: Bool? = nil
     ) {
         self.id = id
         self.uuid = uuid
@@ -315,6 +317,7 @@ public struct DiscoverItem: Decodable, Equatable {
         self.isSponsored = isSponsored
         self.popular = popular
         self.categoryID = categoryID
+        self.authenticated = authenticated
     }
 }
 

--- a/podcasts/Categories/CategoriesSelectorViewController.swift
+++ b/podcasts/Categories/CategoriesSelectorViewController.swift
@@ -12,7 +12,7 @@ class CategoriesSelectorViewController: ThemedHostingController<CategoriesSelect
 
         lazy var load: (() async -> (categories: [DiscoverCategory], popular: [DiscoverCategory])?) = { [weak self] in
             guard let source = self?.item?.source else { return nil }
-            let categories = await DiscoverServerHandler.shared.discoverCategories(source: source)
+            let categories = await DiscoverServerHandler.shared.discoverCategories(source: source, authenticated: self?.item?.authenticated)
             let popular = categories.filter {
                 guard let id = $0.id else { return false }
                 return self?.item?.popular?.contains(id) == true

--- a/podcasts/CategoryPodcastsViewController.swift
+++ b/podcasts/CategoryPodcastsViewController.swift
@@ -132,7 +132,7 @@ class CategoryPodcastsViewController: PCViewController, UITableViewDelegate, UIT
         noNetworkView.isHidden = true
         loadingIndicator.startAnimating()
 
-        DiscoverServerHandler.shared.discoverCategoryDetails(source: source, completion: { [weak self] categoryDetails in
+        DiscoverServerHandler.shared.discoverCategoryDetails(source: source, authenticated: nil, completion: { [weak self] categoryDetails in
             DispatchQueue.main.async {
                 guard let strongSelf = self, let podcasts = categoryDetails?.podcasts else {
                     return

--- a/podcasts/CategorySummaryViewController.swift
+++ b/podcasts/CategorySummaryViewController.swift
@@ -43,7 +43,7 @@ class CategorySummaryViewController: UIViewController, UITableViewDataSource, UI
     func populateFrom(item: DiscoverItem, region: String?, category: DiscoverCategory?) {
         guard let source = item.source else { return }
 
-        DiscoverServerHandler.shared.discoverCategories(source: source, completion: { [weak self] discoverCategories in
+        DiscoverServerHandler.shared.discoverCategories(source: source, authenticated: item.authenticated, completion: { [weak self] discoverCategories in
             DispatchQueue.main.async {
                 guard let strongSelf = self, let discoverCategories = discoverCategories else { return }
 

--- a/podcasts/CollectionSummaryViewController.swift
+++ b/podcasts/CollectionSummaryViewController.swift
@@ -80,7 +80,7 @@ class CollectionSummaryViewController: UIViewController, DiscoverSummaryProtocol
         guard let source = item.source else { return }
 
         self.item = item
-        DiscoverServerHandler.shared.discoverPodcastCollection(source: source, completion: { [weak self] podcastCollection in
+        DiscoverServerHandler.shared.discoverPodcastCollection(source: source, authenticated: item.authenticated, completion: { [weak self] podcastCollection in
             self?.podcastCollection = podcastCollection
             guard podcastCollection?.podcasts != nil || podcastCollection?.episodes != nil else { return }
 

--- a/podcasts/DiscoverCollectionViewController+Categories.swift
+++ b/podcasts/DiscoverCollectionViewController+Categories.swift
@@ -1,4 +1,5 @@
 import PocketCastsServer
+import PocketCastsUtils
 
 extension DiscoverCollectionViewController {
     private enum Constants {
@@ -18,8 +19,12 @@ extension DiscoverCollectionViewController {
             newLayout = discoverLayout
         }
 
-        populateFrom(discoverLayout: newLayout, selectedCategory: category, shouldInclude: {
-            ($0.categoryID == category?.id) || items.contains($0)
+        populateFrom(discoverLayout: newLayout, selectedCategory: category, shouldInclude: { item in
+
+            // Filter out items that don't match the selected category
+            let categoryFilter = (item.categoryID == category?.id) || items.contains(item)
+
+            return categoryFilter && item.shouldShowAuthenticated() // We don't currently have authenticated category items, but handle them just in case
         })
     }
 

--- a/podcasts/DiscoverCollectionViewController+DiscoverDelegate.swift
+++ b/podcasts/DiscoverCollectionViewController+DiscoverDelegate.swift
@@ -79,7 +79,7 @@ extension DiscoverCollectionViewController: DiscoverDelegate {
 
         guard let source = item.source else { return }
 
-        DiscoverServerHandler.shared.discoverPodcastList(source: source, completion: { [weak self] podcastList in
+        DiscoverServerHandler.shared.discoverPodcastList(source: source, authenticated: item.authenticated, completion: { [weak self] podcastList in
             guard let self, let discoverPodcast = podcastList?.podcasts else { return }
 
             let podcasts: [DiscoverPodcast]

--- a/podcasts/DiscoverCollectionViewController.swift
+++ b/podcasts/DiscoverCollectionViewController.swift
@@ -1,5 +1,6 @@
 import PocketCastsServer
 import SwiftUI
+import PocketCastsUtils
 
 class DiscoverCollectionViewController: PCViewController {
 
@@ -97,7 +98,7 @@ class DiscoverCollectionViewController: PCViewController {
         }
 
         let itemFilter = shouldInclude ?? { item in
-            item.categoryID == nil
+            item.categoryID == nil && item.shouldShowAuthenticated()
         }
 
         self.discoverLayout = discoverLayout

--- a/podcasts/DiscoverCollectionViewController.swift
+++ b/podcasts/DiscoverCollectionViewController.swift
@@ -55,6 +55,7 @@ class DiscoverCollectionViewController: PCViewController {
         reloadData()
 
         setupMiniPlayerObservers()
+        setupLoginObserver()
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -287,5 +288,15 @@ extension DiscoverCollectionViewController {
         let miniPlayerOffset: CGFloat = PlaybackManager.shared.currentEpisode() == nil ? 0 : Constants.Values.miniPlayerOffset
         collectionView.contentInset = UIEdgeInsets(top: PCSearchBarController.defaultHeight, left: 0, bottom: miniPlayerOffset, right: 0)
         collectionView.verticalScrollIndicatorInsets = UIEdgeInsets(top: 0, left: 0, bottom: miniPlayerOffset, right: 0)
+    }
+}
+
+// MARK: - Authentication Handling
+extension DiscoverCollectionViewController {
+    fileprivate func setupLoginObserver() {
+        // Add observer for login/logout notification
+        NotificationCenter.default.addObserver(forName: .userLoginDidChange, object: nil, queue: .main) { [weak self] _ in
+            self?.reloadData()
+        }
     }
 }

--- a/podcasts/DiscoverEpisodeViewModel.swift
+++ b/podcasts/DiscoverEpisodeViewModel.swift
@@ -38,7 +38,7 @@ class DiscoverEpisodeViewModel: ObservableObject {
         self.playbackManager = playbackManager
         $discoverItem
             .dropFirst()
-            .flatMap { DiscoverServerHandler.shared.discoverItem($0?.source, type: PodcastCollection?.self) }
+            .flatMap { DiscoverServerHandler.shared.discoverItem($0?.source, authenticated: $0?.authenticated ?? false, type: PodcastCollection?.self) }
             .replaceError(with: nil)
             .assign(to: &$discoverCollection)
 

--- a/podcasts/DiscoverItem+Helper.swift
+++ b/podcasts/DiscoverItem+Helper.swift
@@ -1,5 +1,6 @@
 import Foundation
 import PocketCastsServer
+import PocketCastsUtils
 
 extension DiscoverItem {
     /// Attempts to infer the list ID for a discover item
@@ -20,6 +21,19 @@ extension DiscoverItem {
             return "popular"
         default:
             return "none"
+        }
+    }
+
+    // Filter items for recommendations - authenticated items won't be included if logged out
+    func shouldShowAuthenticated() -> Bool {
+        if FeatureFlag.recommendations.enabled {
+            if SyncManager.isUserLoggedIn() {
+                return true
+            } else {
+                return authenticated != true // this handles both `false` and `nil` values
+            }
+        } else {
+            return true
         }
     }
 }

--- a/podcasts/DiscoverViewController+DiscoverDelegate.swift
+++ b/podcasts/DiscoverViewController+DiscoverDelegate.swift
@@ -67,7 +67,7 @@ extension DiscoverViewController: DiscoverDelegate {
 
         guard let source = item.source else { return }
 
-        DiscoverServerHandler.shared.discoverPodcastList(source: source, completion: { [weak self] podcastList in
+        DiscoverServerHandler.shared.discoverPodcastList(source: source, authenticated: item.authenticated, completion: { [weak self] podcastList in
             guard let self, let discoverPodcast = podcastList?.podcasts else { return }
 
             let podcasts: [DiscoverPodcast]

--- a/podcasts/FeaturedSummaryViewController.swift
+++ b/podcasts/FeaturedSummaryViewController.swift
@@ -178,7 +178,7 @@ class FeaturedSummaryViewController: SimpleNotificationsViewController, GridLayo
         var sponsoredPodcastsToAdd: [Int: DiscoverPodcast] = [:]
 
         dispatchGroup.enter()
-        DiscoverServerHandler.shared.discoverPodcastList(source: source, completion: { podcastList in
+        DiscoverServerHandler.shared.discoverPodcastList(source: source, authenticated: item.authenticated, completion: { podcastList in
             guard let discoverPodcast = podcastList?.podcasts else { return }
 
             podcastsToShow = discoverPodcast
@@ -190,7 +190,7 @@ class FeaturedSummaryViewController: SimpleNotificationsViewController, GridLayo
             for sponsored in sponsoredPodcasts {
                 if let source = sponsored.source, let position = sponsored.position {
                     dispatchGroup.enter()
-                    DiscoverServerHandler.shared.discoverPodcastCollection(source: source, completion: { [weak self] podcastList in
+                    DiscoverServerHandler.shared.discoverPodcastCollection(source: source, authenticated: item.authenticated, completion: { [weak self] podcastList in
                         guard let podcastList = podcastList, let discoverPodcast = podcastList.podcasts?.first else { return }
 
                         sponsoredPodcastsToAdd[position] = discoverPodcast

--- a/podcasts/LargeListSummaryViewController.swift
+++ b/podcasts/LargeListSummaryViewController.swift
@@ -158,7 +158,7 @@ class LargeListSummaryViewController: DiscoverPeekViewController, DiscoverSummar
         titleLabel.text = delegate?.replaceRegionName(string: title)
         titleLabel.sizeToFit()
         divider.isHidden = true
-        DiscoverServerHandler.shared.discoverPodcastList(source: source, completion: { [weak self] podcastList in
+        DiscoverServerHandler.shared.discoverPodcastList(source: source, authenticated: item.authenticated, completion: { [weak self] podcastList in
             guard let strongSelf = self, let discoverPodcast = podcastList?.podcasts else { return }
 
             let podcasts: [DiscoverPodcast]

--- a/podcasts/NetworkSummaryViewController.swift
+++ b/podcasts/NetworkSummaryViewController.swift
@@ -89,7 +89,7 @@ class NetworkSummaryViewController: DiscoverPeekViewController, DiscoverSummaryP
     func populateFrom(item: DiscoverItem, region: String?, category: DiscoverCategory?) {
         guard let source = item.source else { return }
 
-        DiscoverServerHandler.shared.discoverNetworkList(source: source) { [weak self] podcastNetworks in
+        DiscoverServerHandler.shared.discoverNetworkList(source: source, authenticated: item.authenticated) { [weak self] podcastNetworks in
             guard let strongSelf = self, let podcastNetworks = podcastNetworks else { return }
 
             strongSelf.networks = podcastNetworks

--- a/podcasts/NetworkViewController.swift
+++ b/podcasts/NetworkViewController.swift
@@ -168,7 +168,7 @@ class NetworkViewController: PCViewController, UITableViewDataSource, UITableVie
         if loadingIndicator.isAnimating || podcasts != nil { return }
 
         loadingIndicator.startAnimating()
-        DiscoverServerHandler.shared.discoverPodcastList(source: source) { [weak self] podcastList in
+        DiscoverServerHandler.shared.discoverPodcastList(source: source, authenticated: nil) { [weak self] podcastList in
             guard let strongSelf = self, let podcastList = podcastList else { return }
 
             DispatchQueue.main.async {

--- a/podcasts/SinglePodcastViewController.swift
+++ b/podcasts/SinglePodcastViewController.swift
@@ -75,7 +75,7 @@ class SinglePodcastViewController: UIViewController, DiscoverSummaryProtocol {
         self.item = item
         self.region = region
         self.category = category
-        DiscoverServerHandler.shared.discoverPodcastList(source: source, completion: { [weak self] podcastList in
+        DiscoverServerHandler.shared.discoverPodcastList(source: source, authenticated: item.authenticated, completion: { [weak self] podcastList in
             guard let discoverPodcast = podcastList?.podcasts else { return }
 
             self?.podcast = discoverPodcast.first

--- a/podcasts/SmallPagedListSummaryViewController.swift
+++ b/podcasts/SmallPagedListSummaryViewController.swift
@@ -167,7 +167,7 @@ class SmallPagedListSummaryViewController: DiscoverPeekViewController, GridLayou
         self.item = item
         titleLabel.text = delegate?.replaceRegionName(string: title)
 
-        DiscoverServerHandler.shared.discoverPodcastList(source: source, completion: { [weak self] podcastList in
+        DiscoverServerHandler.shared.discoverPodcastList(source: source, authenticated: item.authenticated, completion: { [weak self] podcastList in
             guard let strongSelf = self, let discoverPodcast = podcastList?.podcasts else { return }
             for podcast in discoverPodcast {
                 strongSelf.podcasts.append(podcast)

--- a/podcasts/SupporterContributionsViewController.swift
+++ b/podcasts/SupporterContributionsViewController.swift
@@ -167,7 +167,7 @@ class SupporterContributionsViewController: PCViewController, UITableViewDelegat
         guard let bundles = bundleSubscriptions else { return }
         for bundle in bundles {
             let bundleUrl = ServerHelper.bundleUrl(bundleUuid: bundle.bundleUuid)
-            DiscoverServerHandler.shared.discoverPodcastCollection(source: bundleUrl.absoluteString, completion: { podcastCollection in
+            DiscoverServerHandler.shared.discoverPodcastCollection(source: bundleUrl.absoluteString, authenticated: nil, completion: { podcastCollection in
 
                 guard let podcastCollection = podcastCollection else { return }
                 self.bundleInfo[bundle.bundleUuid] = podcastCollection

--- a/podcasts/SupporterGratitudeViewController.swift
+++ b/podcasts/SupporterGratitudeViewController.swift
@@ -87,7 +87,7 @@ class SupporterGratitudeViewController: PCViewController, SyncSigninDelegate {
 
     private func loadBundleCollection(uuid: String) {
         let bundleUrl = ServerHelper.bundleUrl(bundleUuid: uuid)
-        DiscoverServerHandler.shared.discoverPodcastCollection(source: bundleUrl.absoluteString, completion: { podcastCollection in
+        DiscoverServerHandler.shared.discoverPodcastCollection(source: bundleUrl.absoluteString, authenticated: nil, completion: { podcastCollection in
             guard let podcastCollection = podcastCollection else { return }
 
             DispatchQueue.main.async {

--- a/podcasts/SupporterPodcastViewController.swift
+++ b/podcasts/SupporterPodcastViewController.swift
@@ -490,7 +490,7 @@ class SupporterPodcastViewController: PCViewController, UITableViewDataSource, U
 
     private func loadBundleCollection(uuid: String) {
         let bundleUrl = ServerHelper.bundleUrl(bundleUuid: uuid)
-        DiscoverServerHandler.shared.discoverPodcastCollection(source: bundleUrl.absoluteString, completion: { podcastCollection in
+        DiscoverServerHandler.shared.discoverPodcastCollection(source: bundleUrl.absoluteString, authenticated: nil, completion: { podcastCollection in
             guard let podcastCollection = podcastCollection else { return }
             self.bundleCollection = podcastCollection
             DispatchQueue.main.async {


### PR DESCRIPTION
| 📘 Part of: #2989 |
|:---:|

Fixes #2991, #2993
Part of #2992

* Adds `Authorization` header for Discover `source` calls when `authenticated` property is `true`
* Filters Discover items based on `authenticated` property when the user is logged out
* Reloads Discover on Login change

### Loved by listeners of

<img src="https://github.com/user-attachments/assets/236d4602-e155-43e7-a415-342f038fe0ea" width=300>


### You Might Like

<img src="https://github.com/user-attachments/assets/998f9165-4cd5-4cf4-9e44-766e01433c52" width=300>

### If you Like



NOTE: This doesn't have the new header design quite yet.

## To test

* Log in with an account
* Enable the Recommendations feature flag
* Restart the app
* Navigate to Discover
* Verify that you see the sections "Similar Shows", "You Might Like", "If You Like" - NOTE: Not all users may have content in these. Hiding them when empty will come in a separate PR.
* Log out of your account
* Navigate back to Discover and verify that the sections have disappeared

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
