### PR TITLE
Remove watch log on send

### DIFF
--- a/podcasts/WatchManager.swift
+++ b/podcasts/WatchManager.swift
@@ -401,13 +401,6 @@ class WatchManager: NSObject, WCSessionDelegate {
         DispatchQueue.global(qos: .background).async { [weak self] in
             guard let self else { return }
             sendStateToWatch()
-            if FeatureFlag.refreshAndSaveWatchLogsOnSend.enabled {
-                FileLog.shared.addMessage("WatchManager: Start log request on send")
-                requestLogFile(completion: { _ in
-                    // We don't do anything with the log, requesting it will cache and save the contents
-                    FileLog.shared.addMessage("WatchManager: Completed log request on send")
-                })
-            }
         }
     }
 


### PR DESCRIPTION
| 📘 Part of: #2945 |
|:---:|

We ran into some background queue crashes with TimedActionHelper and we'd like to fix those up in 7.88 and leave the rest of the functionality for 7.87.

## To test

* Run the watch and iOS app as a pair
* Perform some actions on watch and ensure they work on iOS and vice versa.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
