### PR TITLE
[Recommendations] Authentication failure handling

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/Discover/DiscoverServerHandler.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Discover/DiscoverServerHandler.swift
@@ -10,6 +10,11 @@ public class DiscoverServerHandler {
 
     public static let shared = DiscoverServerHandler()
 
+    private let tokenHelper = {
+        let connection = URLConnection(handler: URLSession.shared)
+        return TokenHelper(urlConnection: connection)
+    }()
+
     public private(set) lazy var discoveryCache: URLCache = {
         let cache = URLCache(memoryCapacity: 1024 * 1024, diskCapacity: 5 * 1024 * 1024, diskPath: "discovery")
         return cache
@@ -101,47 +106,37 @@ public class DiscoverServerHandler {
         .eraseToAnyPublisher()
     }
 
-    private let tokenHelper = {
-        let connection = URLConnection(handler: URLSession.shared)
-        return TokenHelper(urlConnection: connection)
-    }()
+    /// A method to check whether the response from the source URL authenticated successfully.
+    /// - Parameters:
+    ///   - item: An item which is `authenticated == true`
+    /// - Returns: Whether or not the authentication succeeded
+    public func checkSourceAuthentication(for item: DiscoverItem) async -> Bool {
+        // If there's no source URL, consider authentication failed. This shouldn't happen.
+        guard item.authenticated == true, let source = item.source else {
+            return false
+        }
 
-    private func discoverRequest<T>(path: String, type: T.Type, authenticated: Bool?, completion: @escaping (T?, Bool) -> Void) where T: Decodable {
+        return await withCheckedContinuation { continuation in
+            performDiscoverRequest(path: source, authenticated: item.authenticated == true) { data, response, error in
+                let success = response?.extractStatusCode() == 200
+                continuation.resume(returning: success)
+            }
+        }
+    }
+
+    private func performDiscoverRequest(
+        path: String,
+        authenticated: Bool?,
+        completion: @escaping (Data?, URLResponse?, Error?) -> Void
+    ) {
         let url = ServerHelper.asUrl(path)
         let request = URLRequest(url: url)
 
-        if let cachedResponse = discoveryCache.cachedResponse(for: request) {
-            if let expiryDate = cachedResponse.response.cacheExpiryDate(), expiryDate.timeIntervalSinceNow > 0 {
-                do {
-                    let list = try JSONDecoder().decode(type, from: cachedResponse.data)
-                    completion(list, true)
-
-                    return
-                } catch {
-                    discoveryCache.removeCachedResponse(for: request)
-                }
-            }
-        }
-
-        let completion: (Data?, URLResponse?, Error?) -> Void = { [weak self] data, response, error in
-            guard let data = data, let response = response, error == nil else {
-                completion(nil, false)
-                return
-            }
-
-            do {
-                let decoder = JSONDecoder()
-                decoder.dateDecodingStrategy = .iso8601
-
-                let list = try decoder.decode(type, from: data)
-                completion(list, false)
-
-                // only cache successful responses
-                let responseToCache = CachedURLResponse(response: response, data: data)
-                self?.discoveryCache.storeCachedResponse(responseToCache, for: request)
-            } catch {
-                completion(nil, false)
-            }
+        if let cachedResponse = discoveryCache.cachedResponse(for: request),
+           let expiryDate = cachedResponse.response.cacheExpiryDate(),
+           expiryDate.timeIntervalSinceNow > 0 {
+            completion(cachedResponse.data, cachedResponse.response, nil)
+            return
         }
 
         if FeatureFlag.recommendations.enabled && authenticated == true {
@@ -150,6 +145,62 @@ public class DiscoverServerHandler {
             }
         } else {
             URLSession.shared.dataTask(with: request, completionHandler: completion).resume()
+        }
+    }
+
+    private func decodeDiscoverResponse<T>(
+        data: Data,
+        response: URLResponse,
+        cacheRequest: URLRequest,
+        useCache: Bool,
+        type: T.Type
+    ) -> T? where T: Decodable {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+
+        do {
+            let decoded = try decoder.decode(type, from: data)
+            if useCache {
+                let responseToCache = CachedURLResponse(response: response, data: data)
+                discoveryCache.storeCachedResponse(responseToCache, for: cacheRequest)
+            }
+            return decoded
+        } catch {
+            if useCache {
+                discoveryCache.removeCachedResponse(for: cacheRequest)
+            }
+            return nil
+        }
+    }
+
+    private func discoverRequest<T>(
+        path: String,
+        type: T.Type,
+        authenticated: Bool?,
+        completion: @escaping (T?, Bool) -> Void
+    ) where T: Decodable {
+        let url = ServerHelper.asUrl(path)
+        let request = URLRequest(url: url)
+
+        performDiscoverRequest(path: path, authenticated: authenticated) { [weak self] data, response, error in
+            guard
+                let self = self,
+                let data = data,
+                let response = response,
+                error == nil
+            else {
+                completion(nil, false)
+                return
+            }
+
+            let decoded = self.decodeDiscoverResponse(
+                data: data,
+                response: response,
+                cacheRequest: request,
+                useCache: true,
+                type: type
+            )
+            completion(decoded, false)
         }
     }
 }

--- a/Modules/Server/Sources/PocketCastsServer/Public/Discover/DiscoverServerHandler.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Discover/DiscoverServerHandler.swift
@@ -112,12 +112,12 @@ public class DiscoverServerHandler {
     /// - Returns: Whether or not the authentication succeeded
     public func checkSourceAuthentication(for item: DiscoverItem) async -> Bool {
         // If there's no source URL, consider authentication failed. This shouldn't happen.
-        guard item.authenticated == true, let source = item.source else {
+        guard item.isAuthenticated, let source = item.source else {
             return false
         }
 
         return await withCheckedContinuation { continuation in
-            performDiscoverRequest(path: source, authenticated: item.authenticated == true) { data, response, error in
+            performDiscoverRequest(path: source, authenticated: item.isAuthenticated) { data, response, error in
                 let success = response?.extractStatusCode() == 200
                 continuation.resume(returning: success)
             }

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
@@ -319,6 +319,10 @@ public struct DiscoverItem: Decodable, Equatable {
         self.categoryID = categoryID
         self.authenticated = authenticated
     }
+
+    public var isAuthenticated: Bool {
+        authenticated == true
+    }
 }
 
 public struct CarouselSponsoredPodcast: Decodable, Equatable {

--- a/podcasts/ContentUnavailableConfiguration.swift
+++ b/podcasts/ContentUnavailableConfiguration.swift
@@ -20,6 +20,12 @@ struct ContentUnavailableConfiguration {
             NoResultsView().environmentObject(Theme.sharedTheme)
         }
     }
+
+    static func empty() -> UIContentConfiguration {
+        UIHostingConfiguration {
+            EmptyView()
+        }
+    }
 }
 
 struct LoadingView: View {

--- a/podcasts/DeveloperMenu.swift
+++ b/podcasts/DeveloperMenu.swift
@@ -70,6 +70,7 @@ struct DeveloperMenu: View {
 
                 Button("Force Reload Discover") {
                     DiscoverServerHandler.shared.discoveryCache.removeAllCachedResponses()
+                    URLSession.shared.configuration.urlCache?.removeAllCachedResponses()
                     NotificationCenter.postOnMainThread(notification: Constants.Notifications.chartRegionChanged)
                 }
 

--- a/podcasts/DiscoverCellType.swift
+++ b/podcasts/DiscoverCellType.swift
@@ -18,6 +18,7 @@ enum DiscoverCellType: CaseIterable {
     case categorySummary
     case singleEpisode
     case categoryPodcasts
+    case largeListWithPodcast
 
     typealias ItemType = DiscoverCellModel
 
@@ -43,6 +44,8 @@ enum DiscoverCellType: CaseIterable {
             SingleEpisodeViewController()
         case .categoryPodcasts:
             CategoryPodcastsViewController(region: region)
+        case .largeListWithPodcast:
+            LargeListSummaryViewController()
         }
     }
 
@@ -87,6 +90,8 @@ extension DiscoverItem {
             return .collectionSummary
         case ("category_podcast_list", _, _):
             return .categoryPodcasts
+        case ("podcast_list", "large_list_with_podcast", _):
+            return .largeListWithPodcast
         default:
             FileLog.shared.addMessage("Unknown Discover Item: \(type ?? "unknown") \(summaryStyle ?? "unknown")")
             assertionFailure("Unknown Discover Item: \(type ?? "unknown") \(summaryStyle ?? "unknown")")

--- a/podcasts/DiscoverCollectionViewController.swift
+++ b/podcasts/DiscoverCollectionViewController.swift
@@ -5,9 +5,10 @@ import PocketCastsUtils
 class DiscoverCollectionViewController: PCViewController {
 
     enum CellType: Hashable {
-        case loading
+        case loading(String?)
         case noNetwork
         case noResults
+        case empty
         case item(DiscoverCellType.ItemType)
     }
 
@@ -23,6 +24,7 @@ class DiscoverCollectionViewController: PCViewController {
     private var loadingContent = false
     private(set) var discoverLayout: DiscoverLayout?
     fileprivate var selectedCategory: DiscoverCategory?
+    private var loadingTasks: [String: Task<Void, Never>] = [:]
 
     private(set) lazy var searchController: PCSearchBarController = {
         PCSearchBarController()
@@ -84,6 +86,10 @@ class DiscoverCollectionViewController: PCViewController {
         collectionView.reloadData()
     }
 
+    private func checkSourceAuthentication(for item: DiscoverItem) async -> Bool {
+        return await DiscoverServerHandler.shared.checkSourceAuthentication(for: item)
+    }
+
     func populateFrom(discoverLayout: DiscoverLayout?, selectedCategory: DiscoverCategory? = nil, shouldInclude: ((DiscoverItem) -> Bool)? = nil) {
         self.selectedCategory = selectedCategory
         loadingContent = false
@@ -105,8 +111,46 @@ class DiscoverCollectionViewController: PCViewController {
         self.discoverLayout = discoverLayout
 
         let currentRegion = Settings.discoverRegion(discoverLayout: discoverLayout)
-        let snapshot = discoverLayout.layout?.makeDataSourceSnapshot(region: currentRegion, selectedCategory: selectedCategory, itemFilter: itemFilter)
-        if let snapshot {
+        var snapshot = NSDiffableDataSourceSnapshot<Section, Item>()
+        snapshot.appendSections([0])
+
+        loadingTasks = [:]
+
+        for item in items {
+            if itemFilter(item) {
+                if item.authenticated == true, let uuid = item.uuid {
+                    snapshot.appendItems([.loading(uuid)])
+                    loadingTasks[uuid] = Task {
+                        let isAuthenticated = await checkSourceAuthentication(for: item)
+                        self.updateItemInSnapshot(item: item, isAuthenticated: isAuthenticated, region: currentRegion, selectedCategory: selectedCategory)
+                    }
+                } else {
+                    snapshot.appendItems([.item(.init(item: item, region: currentRegion, selectedCategory: selectedCategory))])
+                }
+            }
+        }
+
+        dataSource.apply(snapshot)
+    }
+
+    private func updateItemInSnapshot(item: DiscoverItem, isAuthenticated: Bool, region: String, selectedCategory: DiscoverCategory?) {
+        var snapshot = dataSource.snapshot()
+
+        // Find the loading placeholder for this specific item using its UUID
+        let items = snapshot.itemIdentifiers(inSection: 0)
+        if let loadingItem = items.first(where: {
+            if case .loading(let uuid) = $0, uuid == item.uuid { return true }
+            return false
+        }) {
+            // Replace the loading placeholder with either the authenticated item or empty
+            if isAuthenticated {
+                let newItem = CellType.item(.init(item: item, region: region, selectedCategory: selectedCategory))
+                snapshot.insertItems([newItem], beforeItem: loadingItem)
+            } else {
+                snapshot.insertItems([.empty], beforeItem: loadingItem)
+            }
+            snapshot.deleteItems([loadingItem])
+
             dataSource.apply(snapshot)
         }
     }
@@ -114,7 +158,7 @@ class DiscoverCollectionViewController: PCViewController {
     private func showPageLoading() {
         var snapshot = NSDiffableDataSourceSnapshot<Section, Item>()
         snapshot.appendSections([0])
-        snapshot.appendItems([CellType.loading])
+        snapshot.appendItems([CellType.loading(nil)])
         dataSource.apply(snapshot)
     }
 
@@ -190,6 +234,8 @@ extension DiscoverCollectionViewController {
                     }
                 case .noResults:
                     contentConfiguration = ContentUnavailableConfiguration.noResults()
+                case .empty:
+                    contentConfiguration = ContentUnavailableConfiguration.empty()
                 case .item:
                     ()
                     fatalError("Should never happen")
@@ -206,6 +252,8 @@ extension DiscoverCollectionViewController {
                     }
                 case .noResults:
                     view = NoResultsView()
+                case .empty:
+                    view = EmptyView()
                 case .item:
                     ()
                     fatalError("Should never happen")
@@ -218,7 +266,7 @@ extension DiscoverCollectionViewController {
 
         dataSource = UICollectionViewDiffableDataSource<Section, Item>(collectionView: collectionView) { collectionView, indexPath, item in
             switch item {
-            case .loading, .noResults, .noNetwork:
+            case .loading, .noResults, .noNetwork, .empty:
                 return collectionView.dequeueConfiguredReusableCell(using: nonItemRegistration, for: indexPath, item: item)
             case .item(let item):
                 guard let cellType = item.item.cellType() else { return UICollectionViewCell() }

--- a/podcasts/DiscoverCollectionViewController.swift
+++ b/podcasts/DiscoverCollectionViewController.swift
@@ -114,6 +114,7 @@ class DiscoverCollectionViewController: PCViewController {
         var snapshot = NSDiffableDataSourceSnapshot<Section, Item>()
         snapshot.appendSections([0])
 
+        loadingTasks.values.forEach { $0.cancel() }
         loadingTasks = [:]
 
         for item in items {
@@ -122,6 +123,7 @@ class DiscoverCollectionViewController: PCViewController {
                     snapshot.appendItems([.loading(uuid)])
                     loadingTasks[uuid] = Task {
                         let isAuthenticated = await checkSourceAuthentication(for: item)
+                        guard Task.isCancelled else { return }
                         self.updateItemInSnapshot(item: item, isAuthenticated: isAuthenticated, region: currentRegion, selectedCategory: selectedCategory)
                     }
                 } else {


### PR DESCRIPTION
| 📘 Part of: #2989 |
|:---:|

Part of #3016

Hides recommendations cells when the API returns anything but 200.

We expect to see:
* `404` if the response is missing
* `401` if authentication failed for some reason (although we shouldn't even make the call since we know whether the user is authenticated)

Here's an example showing only one of the filled out sections while others remain hidden:

https://github.com/user-attachments/assets/6c52c75b-a487-4480-926b-6aab90a45a3a

## To test

* Log in to an account with some listening history
* Enable the `recommendations` feature flag & restart the app
* Navigate to Discover
* You may need to force reload discover in the Developer menu
* ✅ Verify that you see one of the Recommendations sections
* Other sections should be missing and nothing should be completely empty
* If you have trouble verifying which sections should appear, use Proxyman to verify that the `api.pocketcasts.com/recommendations/<user, social, podcast>` API calls are returning a 200 for at least one. If not, reach out to me and I can try to help.

On many accounts I only see one of these endpoints successfully returning:

![CleanShot 2025-04-21 at 11 03 15@2x](https://github.com/user-attachments/assets/e0b6adcd-c8be-4c61-b85a-42c8d8d1a1ae)

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
