### PR TITLE
[Improving Sorting Option] Enable FF and Update Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 7.88
 -----
-
+- Add Recenlty Played sorting option for podcasts [#2978](https://github.com/Automattic/pocket-casts-ios/issues/2978)
 
 7.87
 -----

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -289,7 +289,7 @@ public enum FeatureFlag: String, CaseIterable {
         case .avoidReplaceOnEpisodeSwap:
             true
         case .podcastsSortChanges:
-            false
+            true
         }
     }
 


### PR DESCRIPTION
| 📘 Part of: #2978
|:---:|

Fixes #3025

This PR enable the FF by default and update the Changelog

## To test

- Run this branch
- Confirm the FF is on
- Confirm you see the new option in podcasts and Folder view

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
