### PR TITLE
Recommendations: Discover "Large list with podcast" display style

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
@@ -364,6 +364,7 @@ public struct PodcastCollection: Decodable {
     public var webUrl: String?
     public var collageImages: [CollageImage]?
     public let headerImage: String?
+    public let featureImage: String?
     public enum CodingKeys: String, CodingKey {
         case webUrl = "web_url"
         case webTitle = "web_title"
@@ -371,6 +372,7 @@ public struct PodcastCollection: Decodable {
         case collageImages = "collage_images"
         case headerImage = "header_image"
         case listId = "list_id"
+        case featureImage = "feature_image"
         case title, description, subtitle, colors, podcasts, author, episodes
     }
 }

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1741,6 +1741,7 @@
 		F565602F2B7ACD9B003E76D5 /* DataManager+Import.swift in Sources */ = {isa = PBXBuildFile; fileRef = F565602E2B7ACD9B003E76D5 /* DataManager+Import.swift */; };
 		F56ADE562B7FE37500ADFE31 /* SettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5AD75442B7FDC2800D65C55 /* SettingsTests.swift */; };
 		F56C030C2CCEEF7100E515FF /* NumberListened2024.swift in Sources */ = {isa = PBXBuildFile; fileRef = F56C030B2CCEEF6700E515FF /* NumberListened2024.swift */; };
+		F57498D12DB8430A00892BF0 /* LargeListSummaryCellHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F57498D02DB8430A00892BF0 /* LargeListSummaryCellHeaderView.swift */; };
 		F57626B62C8B56C7009C8225 /* String+SanitizedFileName.swift in Sources */ = {isa = PBXBuildFile; fileRef = F57626B52C8B56C7009C8225 /* String+SanitizedFileName.swift */; };
 		F57ABBFB2CECEBCD00CC50AF /* PodcastManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2E8ED21FB18A7C005E4B7C /* PodcastManager.swift */; };
 		F57ABBFC2CECEBD800CC50AF /* ArchiveHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD24E6F220E3474600A712E3 /* ArchiveHelper.swift */; };
@@ -3949,6 +3950,7 @@
 		F56295282C0FC14900C44E8A /* DBTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DBTestCase.swift; sourceTree = "<group>"; };
 		F565602E2B7ACD9B003E76D5 /* DataManager+Import.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DataManager+Import.swift"; sourceTree = "<group>"; };
 		F56C030B2CCEEF6700E515FF /* NumberListened2024.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberListened2024.swift; sourceTree = "<group>"; };
+		F57498D02DB8430A00892BF0 /* LargeListSummaryCellHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeListSummaryCellHeaderView.swift; sourceTree = "<group>"; };
 		F57626B52C8B56C7009C8225 /* String+SanitizedFileName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+SanitizedFileName.swift"; sourceTree = "<group>"; };
 		F57BAC662C00CD9C007B24BD /* URLSession+Episode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLSession+Episode.swift"; sourceTree = "<group>"; };
 		F57CD7D82C2624AD0035269A /* MediaTrimView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaTrimView.swift; sourceTree = "<group>"; };
@@ -4664,6 +4666,7 @@
 		40B23F95212537B7007EA6DE /* Large List */ = {
 			isa = PBXGroup;
 			children = (
+				F57498D02DB8430A00892BF0 /* LargeListSummaryCellHeaderView.swift */,
 				408426292134CBCD0076D82E /* LargeListCell.swift */,
 				408426262134CBCD0076D82E /* LargeListCell.xib */,
 				408426272134CBCD0076D82E /* LargeListSummaryViewController.swift */,
@@ -10525,6 +10528,7 @@
 				F5F8F3182CC314250071DD0E /* IntroStory2024.swift in Sources */,
 				C73CD7A82916E8A900EAE879 /* SwiftUI+Previews.swift in Sources */,
 				BDB002BF211A9E1B00224A55 /* ProgressLine.swift in Sources */,
+				F57498D12DB8430A00892BF0 /* LargeListSummaryCellHeaderView.swift in Sources */,
 				9A263EC12DA65CC900E895B6 /* InformationalProfileBannerCell.swift in Sources */,
 				C7A110FF2922971100887A90 /* LoginLandingHostingController.swift in Sources */,
 				C7FAFF5B294183AA00329B40 /* CancelConfirmationView.swift in Sources */,

--- a/podcasts/LargeListSummaryCellHeaderView.swift
+++ b/podcasts/LargeListSummaryCellHeaderView.swift
@@ -34,8 +34,7 @@ class LargeListSummaryCellHeaderView: UIView {
         let label = ThemeableLabel()
         label.textColor = ThemeColor.primaryText01()
         label.font = .systemFont(ofSize: 22, weight: .bold)
-        label.numberOfLines = 0
-        label.setContentCompressionResistancePriority(.defaultHigh, for: .vertical)
+        label.adjustsFontSizeToFitWidth = true
         return label
     }()
 

--- a/podcasts/LargeListSummaryCellHeaderView.swift
+++ b/podcasts/LargeListSummaryCellHeaderView.swift
@@ -76,12 +76,17 @@ class LargeListSummaryCellHeaderView: UIView {
         addSubview(horizontalStack)
         horizontalStack.translatesAutoresizingMaskIntoConstraints = false
 
+        // Allow this constraint to break if necessary.
+        // Sometimes, the cell height may fluctuate and cause this constraint to throw warnings
+        let imageWidthAnchor = imageView.widthAnchor.constraint(equalToConstant: 44)
+        imageWidthAnchor.priority = UILayoutPriority(rawValue: 999)
+
         NSLayoutConstraint.activate([
             horizontalStack.leadingAnchor.constraint(equalTo: leadingAnchor),
             horizontalStack.trailingAnchor.constraint(equalTo: trailingAnchor),
             horizontalStack.topAnchor.constraint(equalTo: topAnchor),
             horizontalStack.bottomAnchor.constraint(equalTo: bottomAnchor),
-            imageView.widthAnchor.constraint(equalToConstant: 44),
+            imageWidthAnchor,
             imageView.heightAnchor.constraint(equalTo: imageView.widthAnchor)
         ])
 

--- a/podcasts/LargeListSummaryCellHeaderView.swift
+++ b/podcasts/LargeListSummaryCellHeaderView.swift
@@ -1,0 +1,90 @@
+import PocketCastsDataModel
+
+class LargeListSummaryCellHeaderView: UIView {
+    private let horizontalStack: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .horizontal
+        stack.spacing = 12
+        stack.alignment = .center
+        return stack
+    }()
+
+    private let imageView: PodcastImageView = {
+        let imageView = PodcastImageView()
+        imageView.contentMode = .scaleAspectFit
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        return imageView
+    }()
+
+    private let verticalStack: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .vertical
+        stack.spacing = 0
+        return stack
+    }()
+
+    private let topLabel: ThemeableLabel = {
+        let label = ThemeableLabel()
+        label.font = .systemFont(ofSize: 15, weight: .medium)
+        label.textColor = ThemeColor.primaryText02()
+        return label
+    }()
+
+    private let bottomLabel: ThemeableLabel = {
+        let label = ThemeableLabel()
+        label.textColor = ThemeColor.primaryText01()
+        label.font = .systemFont(ofSize: 22, weight: .bold)
+        return label
+    }()
+
+    var topText: String? {
+        get { topLabel.text }
+        set { topLabel.text = newValue }
+    }
+
+    var bottomText: String? {
+        get { bottomLabel.text }
+        set { bottomLabel.text = newValue }
+    }
+
+    var podcastUUID: String? {
+        didSet {
+            if let uuid = podcastUUID {
+                imageView.setPodcast(uuid: uuid, size: .list)
+                if let podcast = DataManager.sharedManager.findPodcast(uuid: uuid) {
+                    bottomLabel.text = podcast.title
+                }
+            }
+        }
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setup()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setup()
+    }
+
+    private func setup() {
+        addSubview(horizontalStack)
+        horizontalStack.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+            horizontalStack.leadingAnchor.constraint(equalTo: leadingAnchor),
+            horizontalStack.trailingAnchor.constraint(equalTo: trailingAnchor),
+            horizontalStack.topAnchor.constraint(equalTo: topAnchor),
+            horizontalStack.bottomAnchor.constraint(equalTo: bottomAnchor),
+            imageView.widthAnchor.constraint(equalToConstant: 44),
+            imageView.heightAnchor.constraint(equalTo: imageView.widthAnchor)
+        ])
+
+        verticalStack.addArrangedSubview(topLabel)
+        verticalStack.addArrangedSubview(bottomLabel)
+
+        horizontalStack.addArrangedSubview(imageView)
+        horizontalStack.addArrangedSubview(verticalStack)
+    }
+}

--- a/podcasts/LargeListSummaryCellHeaderView.swift
+++ b/podcasts/LargeListSummaryCellHeaderView.swift
@@ -34,6 +34,7 @@ class LargeListSummaryCellHeaderView: UIView {
         let label = ThemeableLabel()
         label.textColor = ThemeColor.primaryText01()
         label.font = .systemFont(ofSize: 22, weight: .bold)
+        label.numberOfLines = 0
         return label
     }()
 
@@ -49,6 +50,7 @@ class LargeListSummaryCellHeaderView: UIView {
 
     var podcastUUID: String? {
         didSet {
+            toggleExtras(hidden: podcastUUID == nil)
             if let uuid = podcastUUID {
                 imageView.setPodcast(uuid: uuid, size: .list)
                 if let podcast = DataManager.sharedManager.findPodcast(uuid: uuid) {
@@ -56,6 +58,11 @@ class LargeListSummaryCellHeaderView: UIView {
                 }
             }
         }
+    }
+
+    func toggleExtras(hidden: Bool) {
+        topLabel.isHidden = hidden
+        imageView.isHidden = hidden
     }
 
     override init(frame: CGRect) {

--- a/podcasts/LargeListSummaryCellHeaderView.swift
+++ b/podcasts/LargeListSummaryCellHeaderView.swift
@@ -53,9 +53,6 @@ class LargeListSummaryCellHeaderView: UIView {
             toggleExtras(hidden: podcastUUID == nil)
             if let uuid = podcastUUID {
                 imageView.setPodcast(uuid: uuid, size: .list)
-                if let podcast = DataManager.sharedManager.findPodcast(uuid: uuid) {
-                    bottomLabel.text = podcast.title
-                }
             }
         }
     }

--- a/podcasts/LargeListSummaryCellHeaderView.swift
+++ b/podcasts/LargeListSummaryCellHeaderView.swift
@@ -35,6 +35,7 @@ class LargeListSummaryCellHeaderView: UIView {
         label.textColor = ThemeColor.primaryText01()
         label.font = .systemFont(ofSize: 22, weight: .bold)
         label.numberOfLines = 0
+        label.setContentCompressionResistancePriority(.defaultHigh, for: .vertical)
         return label
     }()
 

--- a/podcasts/LargeListSummaryViewController.swift
+++ b/podcasts/LargeListSummaryViewController.swift
@@ -6,7 +6,7 @@ class LargeListSummaryViewController: DiscoverPeekViewController, DiscoverSummar
 
     @IBOutlet weak var divider: ThemeDividerView!
     @IBOutlet weak var titleTopConstraint: NSLayoutConstraint!
-    @IBOutlet var titleLabel: ThemeableLabel!
+    @IBOutlet var podcastHeaderView: LargeListSummaryCellHeaderView?
     @IBOutlet var showAllBtn: UIButton! {
         didSet {
             showAllBtn.setTitle(L10n.discoverShowAll.localizedUppercase, for: .normal)
@@ -36,7 +36,6 @@ class LargeListSummaryViewController: DiscoverPeekViewController, DiscoverSummar
 
     private var relatedPodcastImageView: PodcastImageView?
     private var relatedPodcastLabel: UILabel?
-    private var podcastHeaderView: LargeListSummaryCellHeaderView?
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -95,18 +94,6 @@ class LargeListSummaryViewController: DiscoverPeekViewController, DiscoverSummar
         super.viewDidDisappear(animated)
         NotificationCenter.default.removeObserver(self, name: Constants.Notifications.podcastDeleted, object: nil)
         NotificationCenter.default.removeObserver(self, name: Constants.Notifications.podcastAdded, object: nil)
-    }
-
-    func replaceTitleWithStackView() {
-        let stackView = titleLabel.superview as? UIStackView
-        titleLabel.removeFromSuperview()
-
-        let headerView = LargeListSummaryCellHeaderView()
-        headerView.topText = item?.title
-        headerView.podcastUUID = relatedPodcastID
-        podcastHeaderView = headerView
-
-        stackView?.insertArrangedSubview(headerView, at: 0)
     }
 
     // MARK: - UICollectionView Methods
@@ -180,10 +167,11 @@ class LargeListSummaryViewController: DiscoverPeekViewController, DiscoverSummar
 
         switch item.cellType() {
         case .largeListWithPodcast:
-            replaceTitleWithStackView()
+            podcastHeaderView?.topText = item.title
+            podcastHeaderView?.podcastUUID = nil
         default:
-            titleLabel.text = delegate?.replaceRegionName(string: title)
-            titleLabel.sizeToFit()
+            podcastHeaderView?.bottomText = delegate?.replaceRegionName(string: title)
+            podcastHeaderView?.podcastUUID = nil
         }
 
         divider.isHidden = true

--- a/podcasts/LargeListSummaryViewController.swift
+++ b/podcasts/LargeListSummaryViewController.swift
@@ -1,5 +1,6 @@
 import PocketCastsServer
 import UIKit
+import PocketCastsDataModel
 
 class LargeListSummaryViewController: DiscoverPeekViewController, DiscoverSummaryProtocol, UICollectionViewDataSource, GridLayoutDelegate, UICollectionViewDelegateFlowLayout {
 
@@ -16,6 +17,15 @@ class LargeListSummaryViewController: DiscoverPeekViewController, DiscoverSummar
 
     private var lastLayedOutWidth = 0 as CGFloat
 
+    private var relatedPodcastID: String? {
+        didSet {
+            relatedPodcastImageView?.setPodcast(uuid: relatedPodcastID ?? "", size: .list)
+
+            if let podcast = DataManager.sharedManager.findPodcast(uuid: relatedPodcastID ?? "") {
+                relatedPodcastLabel?.text = podcast.title
+            }
+        }
+    }
     private var podcasts = [DiscoverPodcast]()
     private weak var delegate: DiscoverDelegate?
     private var item: DiscoverItem?
@@ -87,6 +97,55 @@ class LargeListSummaryViewController: DiscoverPeekViewController, DiscoverSummar
         NotificationCenter.default.removeObserver(self, name: Constants.Notifications.podcastAdded, object: nil)
     }
 
+    func replaceTitleWithStackView() {
+        let stackView = titleLabel.superview as? UIStackView
+        titleLabel.removeFromSuperview()
+
+        let horizontalStack = horizontalStack()
+        stackView?.insertArrangedSubview(horizontalStack, at: 0)
+    }
+
+    private var relatedPodcastImageView: PodcastImageView?
+    private var relatedPodcastLabel: UILabel?
+
+    func horizontalStack() -> UIStackView {
+        let horizontalStack = UIStackView()
+        horizontalStack.axis = .horizontal
+        horizontalStack.spacing = 12
+        horizontalStack.alignment = .center
+
+        let imageView = PodcastImageView()
+        imageView.contentMode = .scaleAspectFit
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            imageView.widthAnchor.constraint(equalToConstant: 44),
+            imageView.heightAnchor.constraint(equalTo: imageView.widthAnchor)
+        ])
+        relatedPodcastImageView = imageView
+
+        let verticalStack = UIStackView()
+        verticalStack.axis = .vertical
+        verticalStack.spacing = 0
+
+        let topLabel = ThemeableLabel()
+        topLabel.font = .systemFont(ofSize: 15, weight: .medium)
+        topLabel.textColor = ThemeColor.primaryText02()
+        topLabel.text = item?.title
+
+        let bottomLabel = ThemeableLabel()
+        bottomLabel.textColor = ThemeColor.primaryText01()
+        bottomLabel.font = .systemFont(ofSize: 22, weight: .bold)
+        relatedPodcastLabel = bottomLabel
+
+        verticalStack.addArrangedSubview(topLabel)
+        verticalStack.addArrangedSubview(bottomLabel)
+
+        horizontalStack.addArrangedSubview(imageView)
+        horizontalStack.addArrangedSubview(verticalStack)
+
+        return horizontalStack
+    }
+
     // MARK: - UICollectionView Methods
 
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
@@ -155,28 +214,60 @@ class LargeListSummaryViewController: DiscoverPeekViewController, DiscoverSummar
         showAllBtn.isHidden = item.expandedStyle == nil
 
         self.item = item
-        titleLabel.text = delegate?.replaceRegionName(string: title)
-        titleLabel.sizeToFit()
+
+        switch item.cellType() {
+        case .largeListWithPodcast:
+            replaceTitleWithStackView()
+        default:
+            titleLabel.text = delegate?.replaceRegionName(string: title)
+            titleLabel.sizeToFit()
+        }
+
         divider.isHidden = true
-        DiscoverServerHandler.shared.discoverPodcastList(source: source, authenticated: item.authenticated, completion: { [weak self] podcastList in
-            guard let strongSelf = self, let discoverPodcast = podcastList?.podcasts else { return }
 
-            let podcasts: [DiscoverPodcast]
-            if let itemCount = item.summaryItemCount {
-                podcasts = Array(discoverPodcast[0..<itemCount])
-            } else {
-                podcasts = discoverPodcast
-            }
+        switch item.cellType() {
+        case .largeListWithPodcast:
+            DiscoverServerHandler.shared.discoverPodcastCollection(source: source, authenticated: item.authenticated, completion: { [weak self] podcastCollection in
+                guard let strongSelf = self, let discoverPodcast = podcastCollection?.podcasts else { return }
 
-            for podcast in podcasts {
-                strongSelf.podcasts.append(podcast)
-            }
+                let podcasts: [DiscoverPodcast]
+                if let itemCount = item.summaryItemCount {
+                    podcasts = Array(discoverPodcast[0..<itemCount])
+                } else {
+                    podcasts = discoverPodcast
+                }
 
-            DispatchQueue.main.async {
-                strongSelf.divider.isHidden = false
-                strongSelf.collectionView.reloadData()
-            }
-        })
+                for podcast in podcasts {
+                    strongSelf.podcasts.append(podcast)
+                }
+
+                DispatchQueue.main.async {
+                    strongSelf.relatedPodcastID = podcastCollection?.featureImage
+                    strongSelf.divider.isHidden = false
+                    strongSelf.collectionView.reloadData()
+                }
+            })
+        default:
+            DiscoverServerHandler.shared.discoverPodcastList(source: source, authenticated: item.authenticated, completion: { [weak self] podcastList in
+                guard let strongSelf = self, let discoverPodcast = podcastList?.podcasts else { return }
+
+                let podcasts: [DiscoverPodcast]
+                if let itemCount = item.summaryItemCount {
+                    podcasts = Array(discoverPodcast[0..<itemCount])
+                } else {
+                    podcasts = discoverPodcast
+                }
+
+                for podcast in podcasts {
+                    strongSelf.podcasts.append(podcast)
+                }
+
+                DispatchQueue.main.async {
+                    strongSelf.divider.isHidden = false
+                    strongSelf.collectionView.reloadData()
+                }
+            })
+        }
     }
 
     // MARK: - IBActions

--- a/podcasts/LargeListSummaryViewController.swift
+++ b/podcasts/LargeListSummaryViewController.swift
@@ -19,11 +19,7 @@ class LargeListSummaryViewController: DiscoverPeekViewController, DiscoverSummar
 
     private var relatedPodcastID: String? {
         didSet {
-            relatedPodcastImageView?.setPodcast(uuid: relatedPodcastID ?? "", size: .list)
-
-            if let podcast = DataManager.sharedManager.findPodcast(uuid: relatedPodcastID ?? "") {
-                relatedPodcastLabel?.text = podcast.title
-            }
+            podcastHeaderView?.podcastUUID = relatedPodcastID
         }
     }
     private var podcasts = [DiscoverPodcast]()
@@ -37,6 +33,10 @@ class LargeListSummaryViewController: DiscoverPeekViewController, DiscoverSummar
             view.setNeedsLayout()
         }
     }
+
+    private var relatedPodcastImageView: PodcastImageView?
+    private var relatedPodcastLabel: UILabel?
+    private var podcastHeaderView: LargeListSummaryCellHeaderView?
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -101,49 +101,12 @@ class LargeListSummaryViewController: DiscoverPeekViewController, DiscoverSummar
         let stackView = titleLabel.superview as? UIStackView
         titleLabel.removeFromSuperview()
 
-        let horizontalStack = horizontalStack()
-        stackView?.insertArrangedSubview(horizontalStack, at: 0)
-    }
+        let headerView = LargeListSummaryCellHeaderView()
+        headerView.topText = item?.title
+        headerView.podcastUUID = relatedPodcastID
+        podcastHeaderView = headerView
 
-    private var relatedPodcastImageView: PodcastImageView?
-    private var relatedPodcastLabel: UILabel?
-
-    func horizontalStack() -> UIStackView {
-        let horizontalStack = UIStackView()
-        horizontalStack.axis = .horizontal
-        horizontalStack.spacing = 12
-        horizontalStack.alignment = .center
-
-        let imageView = PodcastImageView()
-        imageView.contentMode = .scaleAspectFit
-        imageView.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            imageView.widthAnchor.constraint(equalToConstant: 44),
-            imageView.heightAnchor.constraint(equalTo: imageView.widthAnchor)
-        ])
-        relatedPodcastImageView = imageView
-
-        let verticalStack = UIStackView()
-        verticalStack.axis = .vertical
-        verticalStack.spacing = 0
-
-        let topLabel = ThemeableLabel()
-        topLabel.font = .systemFont(ofSize: 15, weight: .medium)
-        topLabel.textColor = ThemeColor.primaryText02()
-        topLabel.text = item?.title
-
-        let bottomLabel = ThemeableLabel()
-        bottomLabel.textColor = ThemeColor.primaryText01()
-        bottomLabel.font = .systemFont(ofSize: 22, weight: .bold)
-        relatedPodcastLabel = bottomLabel
-
-        verticalStack.addArrangedSubview(topLabel)
-        verticalStack.addArrangedSubview(bottomLabel)
-
-        horizontalStack.addArrangedSubview(imageView)
-        horizontalStack.addArrangedSubview(verticalStack)
-
-        return horizontalStack
+        stackView?.insertArrangedSubview(headerView, at: 0)
     }
 
     // MARK: - UICollectionView Methods

--- a/podcasts/LargeListSummaryViewController.swift
+++ b/podcasts/LargeListSummaryViewController.swift
@@ -181,16 +181,7 @@ class LargeListSummaryViewController: DiscoverPeekViewController, DiscoverSummar
             DiscoverServerHandler.shared.discoverPodcastCollection(source: source, authenticated: item.authenticated, completion: { [weak self] podcastCollection in
                 guard let strongSelf = self, let discoverPodcast = podcastCollection?.podcasts else { return }
 
-                let podcasts: [DiscoverPodcast]
-                if let itemCount = item.summaryItemCount {
-                    podcasts = Array(discoverPodcast[0..<itemCount])
-                } else {
-                    podcasts = discoverPodcast
-                }
-
-                for podcast in podcasts {
-                    strongSelf.podcasts.append(podcast)
-                }
+                strongSelf.appendPodcasts(discoverPodcast, item: item)
 
                 DispatchQueue.main.async {
                     strongSelf.relatedPodcastID = podcastCollection?.featureImage
@@ -203,22 +194,26 @@ class LargeListSummaryViewController: DiscoverPeekViewController, DiscoverSummar
             DiscoverServerHandler.shared.discoverPodcastList(source: source, authenticated: item.authenticated, completion: { [weak self] podcastList in
                 guard let strongSelf = self, let discoverPodcast = podcastList?.podcasts else { return }
 
-                let podcasts: [DiscoverPodcast]
-                if let itemCount = item.summaryItemCount {
-                    podcasts = Array(discoverPodcast[0..<itemCount])
-                } else {
-                    podcasts = discoverPodcast
-                }
-
-                for podcast in podcasts {
-                    strongSelf.podcasts.append(podcast)
-                }
+                strongSelf.appendPodcasts(discoverPodcast, item: item)
 
                 DispatchQueue.main.async {
                     strongSelf.divider.isHidden = false
                     strongSelf.collectionView.reloadData()
                 }
             })
+        }
+    }
+
+    private func appendPodcasts(_ discoverPodcast: [DiscoverPodcast], item: DiscoverItem) {
+        let podcasts: [DiscoverPodcast]
+        if let itemCount = item.summaryItemCount {
+            podcasts = Array(discoverPodcast[0..<itemCount])
+        } else {
+            podcasts = discoverPodcast
+        }
+
+        for podcast in podcasts {
+            self.podcasts.append(podcast)
         }
     }
 

--- a/podcasts/LargeListSummaryViewController.swift
+++ b/podcasts/LargeListSummaryViewController.swift
@@ -194,6 +194,7 @@ class LargeListSummaryViewController: DiscoverPeekViewController, DiscoverSummar
 
                 DispatchQueue.main.async {
                     strongSelf.relatedPodcastID = podcastCollection?.featureImage
+                    strongSelf.podcastHeaderView?.bottomText = podcastCollection?.title
                     strongSelf.divider.isHidden = false
                     strongSelf.collectionView.reloadData()
                 }

--- a/podcasts/LargeListSummaryViewController.xib
+++ b/podcasts/LargeListSummaryViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23094" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23084"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -13,8 +13,8 @@
                 <outlet property="collectionView" destination="iJi-Yt-ez5" id="lqV-Pl-Ekp"/>
                 <outlet property="divider" destination="8lf-U1-Pgg" id="5tp-81-JYJ"/>
                 <outlet property="largeListCollectionViewHeight" destination="O9B-Ec-Krr" id="8nl-ey-dbz"/>
+                <outlet property="podcastHeaderView" destination="CeQ-tP-ch9" id="qZF-S8-GrF"/>
                 <outlet property="showAllBtn" destination="sF0-fo-tPV" id="NQp-Ou-W2d"/>
-                <outlet property="titleLabel" destination="0VX-rs-RFl" id="gRb-Ti-AKA"/>
                 <outlet property="titleTopConstraint" destination="iGU-3S-axn" id="MLu-4G-TLm"/>
                 <outlet property="view" destination="Fw0-IT-oEE" id="dU6-pd-YkH"/>
             </connections>
@@ -26,18 +26,16 @@
                 <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" alignment="lastBaseline" translatesAutoresizingMaskIntoConstraints="NO" id="X56-LC-Q5n">
                     <rect key="frame" x="16" y="30" width="338" height="20"/>
                     <subviews>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Featured" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0VX-rs-RFl" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
+                        <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="CeQ-tP-ch9" customClass="LargeListSummaryCellHeaderView" customModule="podcasts" customModuleProvider="target">
                             <rect key="frame" x="0.0" y="0.0" width="92" height="20"/>
-                            <fontDescription key="fontDescription" type="boldSystem" pointSize="22"/>
-                            <color key="textColor" red="0.30196078430000001" green="0.33725490200000002" blue="0.36078431370000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                            <nil key="highlightedColor"/>
-                        </label>
-                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dtr-d4-ivC">
+                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        </view>
+                        <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="dtr-d4-ivC">
                             <rect key="frame" x="92" y="0.0" width="176" height="20"/>
                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         </view>
                         <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" pointerInteraction="YES" translatesAutoresizingMaskIntoConstraints="NO" id="sF0-fo-tPV" customClass="ThemeableUIButton" customModule="podcasts" customModuleProvider="target">
-                            <rect key="frame" x="268" y="0.0" width="70" height="28"/>
+                            <rect key="frame" x="268" y="0.0" width="70" height="20"/>
                             <fontDescription key="fontDescription" type="boldSystem" pointSize="13"/>
                             <state key="normal" title="SHOW ALL">
                                 <color key="titleColor" red="0.035672488410000001" green="1" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>


### PR DESCRIPTION
| 📘 Part of: #2989 |
|:---:|

Fixes #2992

[Android PR](https://github.com/Automattic/pocket-casts-android/pull/3918)
Figma designs: It06RUexEgXSlFNOEbGOKR-fi-111_9633 

Adds the new updated header design with Podcast info for the `large_list_with_podcast` recommendations discover item type.

<img src="https://github.com/user-attachments/assets/c53f6d5e-55f5-4808-80c2-fc974c7eae2e" width=300>

### Code Changes

* Adds the `feature_image` property to our `PodcastCollection` response type.
* Adds a new `LargeListSummaryCellHeaderView` which replaces the old label used for the title. The views inside are hidden and shown as necessary in a stack view depending on the item type.
* An API change is made to decode the `PodcastCollection` type for the `large_list_with_podcast` discover item type.

## To test

* Log in to an account with some listening history
* Enable the `recommendations` feature flag & restart the app
* Navigate to Discover
* You may need to force reload discover in the Developer menu
* ✅ Check if the "Loved by listeners of" or "If you like" lists has recommendations and check that the header appears with the podcast's image and title.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
