### PR TITLE
Increase Log maximum file size by 10x

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Logging/FileLog.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Logging/FileLog.swift
@@ -28,9 +28,9 @@ actor LogBuffer {
     }
 
     #if os(watchOS)
-        private let maxFileSize = 25.kilobytes
+        private let maxFileSize = 250.kilobytes
     #else
-        private let maxFileSize = 100.kilobytes
+        private let maxFileSize = 1.megabytes
     #endif
 
     func append(_ message: String, date: Date) {


### PR DESCRIPTION
Fixes #2976

This increases the current maximum log file size by 10x.

| Platform | Before | After |
|--|--|--|
| iOS | 100 kilobytes | 1 megabyte |
| watchOS | 25 kilobytes | 250 kilobytes |

## To test

* Use the iOS app and ensure log messages are output to the console
* Go to Profile > Help & Feedback > ⋯ > Logs and make sure logs appear

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
