### PR TITLE
[Winback Updates] Update Available Plans

### DIFF
--- a/podcasts/Cancel Subscription/Cancel Subscription/Plans View/CancelSubscriptionPlanRow.swift
+++ b/podcasts/Cancel Subscription/Cancel Subscription/Plans View/CancelSubscriptionPlanRow.swift
@@ -12,7 +12,7 @@ struct CancelSubscriptionPlanRow: View {
             HStack {
                 Spacer()
                 Text(L10n.cancelSubscriptionAvailablePlansBestValueBadge)
-                    .font(size: 14.0, style: .body, weight: .regular)
+                    .font(size: 14.0, style: .body, weight: .medium)
                     .foregroundStyle(theme.primaryInteractive02)
                     .frame(height: 24.0)
                     .padding(.horizontal, 16.0)

--- a/podcasts/Cancel Subscription/Cancel Subscription/Plans View/CancelSubscriptionPlanRow.swift
+++ b/podcasts/Cancel Subscription/Cancel Subscription/Plans View/CancelSubscriptionPlanRow.swift
@@ -7,6 +7,49 @@ struct CancelSubscriptionPlanRow: View {
     var selected: Bool
     let onTap: (PlusPricingInfoModel.PlusProductPricingInfo) -> Void
 
+    var badge: some View {
+        VStack {
+            HStack {
+                Spacer()
+                Text(L10n.cancelSubscriptionAvailablePlansBestValueBadge)
+                    .font(size: 14.0, style: .body, weight: .regular)
+                    .foregroundStyle(theme.primaryInteractive02)
+                    .frame(height: 24.0)
+                    .padding(.horizontal, 16.0)
+                    .background(
+                        RoundedRectangle(
+                            cornerRadius: 12.0,
+                            style: .continuous
+                        )
+                        .fill(theme.primaryField03Active)
+                    )
+            }
+            .padding(.trailing, 12.0)
+            .padding(.top, -12.0)
+            Spacer()
+        }
+    }
+
+    @ViewBuilder
+    var tick: some View {
+        if selected {
+            ZStack {
+                Circle()
+                    .fill(theme.primaryField03Active)
+                Image("small-tick")
+                    .resizable()
+                    .foregroundColor(theme.primaryInteractive02)
+            }
+        } else {
+            Circle()
+                .fill(theme.primaryUi01Active)
+                .overlay(
+                        Circle()
+                            .stroke(theme.primaryInteractive03, lineWidth: 2)
+                    )
+        }
+    }
+
     var body: some View {
         ZStack {
             Rectangle()
@@ -14,39 +57,37 @@ struct CancelSubscriptionPlanRow: View {
                 .background(theme.primaryUi01Active)
                 .cornerRadius(8.0)
                 .frame(height: 64)
-            VStack(alignment: .leading, spacing: 0) {
-                HStack(spacing: 0) {
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8.0)
+                        .stroke(theme.primaryField03Active,
+                                lineWidth: selected ? 2 : 0)
+                )
+            HStack(spacing: 16.0) {
+                tick
+                    .frame(width: 24, height: 24)
+                VStack(alignment: .leading, spacing: 0) {
                     Text(product.planTitle)
                         .font(size: 18.0, style: .body, weight: .bold)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.5)
                         .foregroundStyle(theme.primaryText01)
-                    Spacer()
-                    if selected {
-                        ZStack {
-                            Circle()
-                                .fill(theme.primaryField03Active)
-                                .frame(width: 24, height: 24)
-                            Image("small-tick")
-                                .resizable()
-                                .frame(width: 24, height: 24)
-                                .foregroundColor(theme.primaryInteractive02)
-                        }
-                    }
-                }
-                HStack(spacing: 0) {
                     Text(product.frequencyPrice)
                         .font(size: 15.0, style: .body, weight: .regular)
-                        .foregroundStyle(theme.primaryText01)
-                    Spacer()
+                        .foregroundStyle(theme.primaryText02)
+                }
+                Spacer()
+                if let weeklyPrice = product.formattedWeeklyPrice {
+                    Text(weeklyPrice)
+                        .font(size: 15.0, style: .body, weight: .regular)
+                        .foregroundStyle(theme.primaryText02)
                 }
             }
-            .padding(.leading, 20.0)
-            .padding(.trailing, 10.0)
+            .padding(.horizontal, 16.0)
+            if product.isBestValue {
+                badge
+                    .frame(height: 64)
+            }
         }
-        .overlay(
-            RoundedRectangle(cornerRadius: 8.0)
-                .stroke(theme.primaryField03Active,
-                        lineWidth: selected ? 2 : 0)
-        )
         .padding(.horizontal, 20.0)
         .onTapGesture {
             onTap(product)
@@ -78,6 +119,24 @@ extension PlusPricingInfoModel.PlusProductPricingInfo {
             return L10n.plusMonthlyFrequencyPricingFormat(rawPrice)
         }
     }
+
+    fileprivate var formattedWeeklyPrice: String? {
+        switch identifier {
+        case .yearly, .yearlyReferral, .patronYearly:
+            return weeklyPrice.isEmpty ? nil : L10n.iapProductWeeklyPricingFormat(weeklyPrice)
+        case .monthly, .patronMonthly:
+            return nil
+        }
+    }
+
+    fileprivate var isBestValue: Bool {
+        switch identifier {
+        case .yearly:
+            return true
+        default:
+            return false
+        }
+    }
 }
 
 struct CancelSubscriptionPlanRow_Preview: PreviewProvider {
@@ -88,6 +147,7 @@ struct CancelSubscriptionPlanRow_Preview: PreviewProvider {
                     identifier: .yearly,
                     price: "",
                     rawPrice: "$39.99",
+                    weeklyPrice: "$0.70",
                     offer: nil),
                 selected: true
             ) { _ in }
@@ -97,12 +157,24 @@ struct CancelSubscriptionPlanRow_Preview: PreviewProvider {
                     identifier: .monthly,
                     price: "",
                     rawPrice: "$3.99",
+                    weeklyPrice: "",
+                    offer: nil),
+                selected: false
+            ) { _ in }
+                .environmentObject(Theme.sharedTheme)
+            CancelSubscriptionPlanRow(
+                product: .init(
+                    identifier: .yearlyReferral,
+                    price: "",
+                    rawPrice: "$39.99",
+                    weeklyPrice: "$0.70",
                     offer: nil),
                 selected: false
             ) { _ in }
                 .environmentObject(Theme.sharedTheme)
         }
         .background(.gray)
-        .previewLayout(.fixed(width: 393, height: 250))
+        .previewLayout(.fixed(width: 393, height: 300))
+        .padding(.vertical, 16.0)
     }
 }

--- a/podcasts/Cancel Subscription/Cancel Subscription/Plans View/CancelSubscriptionPlansView.swift
+++ b/podcasts/Cancel Subscription/Cancel Subscription/Plans View/CancelSubscriptionPlansView.swift
@@ -28,7 +28,7 @@ struct CancelSubscriptionPlansView: View {
                     .font(size: 28.0, style: .body, weight: .bold)
                     .foregroundStyle(theme.primaryText01)
                     .padding(.bottom, 28.0)
-                ForEach(viewModel.pricingInfo.products, id: \.id) { product in
+                ForEach(viewModel.getOrderedProducts(), id: \.id) { product in
                     CancelSubscriptionPlanRow(product: product,
                                               selected: product.identifier == viewModel.currentPricingProduct?.identifier) { selectedProduct in
                         viewModel.purchase(product: selectedProduct)
@@ -54,13 +54,13 @@ struct CancelSubscriptionPlansView: View {
                 .padding(.top, 240.0)
                 .padding(.bottom, 16.0)
             Text(L10n.cancelSubscriptionAvailablePlansRetryScreenText)
-                .font(size: 15.0, style: .body, weight: .regular)
+                .font(size: 15.0, style: .body, weight: .medium)
                 .multilineTextAlignment(.center)
                 .foregroundStyle(theme.primaryText01)
                 .padding(.bottom, 16.0)
             Button(action: loadProducts) {
                 Text(L10n.tryAgain)
-                    .font(size: 13.0, style: .body, weight: .medium)
+                    .font(size: 15.0, style: .body, weight: .regular)
                     .foregroundStyle(theme.primaryText01)
                     .frame(height: 28.0)
                     .padding(.horizontal, 16.0)

--- a/podcasts/Cancel Subscription/Cancel Subscription/Plans View/CancelSubscriptionPlansViewModel.swift
+++ b/podcasts/Cancel Subscription/Cancel Subscription/Plans View/CancelSubscriptionPlansViewModel.swift
@@ -40,6 +40,12 @@ class CancelSubscriptionPlansViewModel: CancelSubscriptionViewModel {
         Analytics.track(.winbackScreenDismissed, properties: ["screen": "available_plans"])
     }
 
+    func getOrderedProducts() -> [PlusPricingInfoModel.PlusProductPricingInfo] {
+        let order: [IAPProductID] = [.monthly, .patronMonthly, .yearly, .patronYearly, .yearlyReferral]
+        let productMap = Dictionary(uniqueKeysWithValues: pricingInfo.products.map { ($0.identifier, $0) })
+        return order.compactMap { productMap[$0] }
+    }
+
     func loadCurrentProduct() async {
         if currentProductAvailability == .loading { return }
 

--- a/podcasts/IAPHelper.swift
+++ b/podcasts/IAPHelper.swift
@@ -143,6 +143,18 @@ class IAPHelper: NSObject {
         return formattedPrice ?? ""
     }
 
+    public func getWeeklyPrice(for identifier: IAPProductID) -> String {
+        guard let product = getProduct(for: identifier) else { return "" }
+        let weekly = product.price.doubleValue / 52
+
+        let numberFormatter = NumberFormatter()
+        numberFormatter.formatterBehavior = .behavior10_4
+        numberFormatter.numberStyle = .currency
+        numberFormatter.locale = product.priceLocale
+        let formattedPrice = numberFormatter.string(from: NSNumber(value: weekly))
+        return formattedPrice ?? ""
+    }
+
     public func buyProduct(identifier: IAPProductID, discount: IAPDiscountInfo? = nil) -> Bool {
         guard settings.isLoggedIn, let product = getProduct(for: identifier) else {
             FileLog.shared.addMessage("IAPHelper Failed to initiate purchase of \(identifier)")

--- a/podcasts/Onboarding/Models/PlusPricingInfoModel.swift
+++ b/podcasts/Onboarding/Models/PlusPricingInfoModel.swift
@@ -28,6 +28,7 @@ class PlusPricingInfoModel: ObservableObject {
         for product in availableProductIds {
             let price = purchaseHandler.getPriceWithFrequency(for: product) ?? ""
             let rawPrice = purchaseHandler.getPrice(for: product)
+            let weeklyPrice = purchaseHandler.getWeeklyPrice(for: product)
             var offer: ProductOfferInfo?
             if purchaseHandler.isEligibleForOffer,
                let duration = purchaseHandler.localizedFreeTrialDuration(product),
@@ -40,6 +41,7 @@ class PlusPricingInfoModel: ObservableObject {
             let info = PlusProductPricingInfo(identifier: product,
                                               price: price,
                                               rawPrice: rawPrice,
+                                              weeklyPrice: weeklyPrice,
                                               offer: offer)
             pricing.append(info)
         }
@@ -62,6 +64,7 @@ class PlusPricingInfoModel: ObservableObject {
         let identifier: IAPProductID
         let price: String
         let rawPrice: String
+        let weeklyPrice: String
         let offer: ProductOfferInfo?
 
         var id: String { identifier.rawValue }

--- a/podcasts/Onboarding/Plus/SubscriptionPriceAndOfferView.swift
+++ b/podcasts/Onboarding/Plus/SubscriptionPriceAndOfferView.swift
@@ -106,5 +106,5 @@ private struct OfferStack<Content: View>: View {
 }
 
 #Preview {
-    SubscriptionPriceAndOfferView(product: PlusPricingInfoModel.PlusProductPricingInfo(identifier: .monthly, price: "9.99", rawPrice: "9.99", offer: nil), mainTextColor: .black, secondaryTextColor: .gray)
+    SubscriptionPriceAndOfferView(product: PlusPricingInfoModel.PlusProductPricingInfo(identifier: .monthly, price: "9.99", rawPrice: "9.99", weeklyPrice: "0.70", offer: nil), mainTextColor: .black, secondaryTextColor: .gray)
 }

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -392,6 +392,8 @@ internal enum L10n {
   internal static var cancelFailed: String { return L10n.tr("Localizable", "cancel_failed") }
   /// Cancel Subscription
   internal static var cancelSubscription: String { return L10n.tr("Localizable", "cancel_subscription") }
+  /// Best Value
+  internal static var cancelSubscriptionAvailablePlansBestValueBadge: String { return L10n.tr("Localizable", "cancel_subscription_available_plans_best_value_badge") }
   /// Your new plan will activate at the end of your current billing period.
   internal static var cancelSubscriptionAvailablePlansFooter: String { return L10n.tr("Localizable", "cancel_subscription_available_plans_footer") }
   /// Sorry, but something went wrong fetching your plans.
@@ -430,8 +432,8 @@ internal enum L10n {
   }
   /// Get your next month free
   internal static var cancelSubscriptionPromotionTitle: String { return L10n.tr("Localizable", "cancel_subscription_promotion_title") }
-  /// Before you cancel,
-  /// check out these offers
+  /// Thinking of leaving?
+  /// Let us help first
   internal static var cancelSubscriptionTitle: String { return L10n.tr("Localizable", "cancel_subscription_title") }
   /// Get 50%% off your next year
   internal static var cancelSubscriptionYearlyPromotionTitle: String { return L10n.tr("Localizable", "cancel_subscription_yearly_promotion_title") }
@@ -1473,6 +1475,10 @@ internal enum L10n {
   internal static var howToUploadSecondInstruction: String { return L10n.tr("Localizable", "how_to_upload_second_instruction") }
   /// That's it, you're done. Change any details you want, hit save and play!
   internal static var howToUploadSummary: String { return L10n.tr("Localizable", "how_to_upload_summary") }
+  /// %1$@/week
+  internal static func iapProductWeeklyPricingFormat(_ p1: Any) -> String {
+    return L10n.tr("Localizable", "iap_product_weekly_pricing_format", String(describing: p1))
+  }
   /// Import
   internal static var `import`: String { return L10n.tr("Localizable", "import") }
   /// We can import your podcasts from Apple Podcasts by using the built-in Shortcuts app.

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4685,7 +4685,7 @@
 "manage_downloads_action" = "Manage downloads";
 
 /* Title of the cancel subscription view, '\n' is a line break format to allow a clean wrapping of text */
-"cancel_subscription_title" = "Before you cancel,\ncheck out these offers";
+"cancel_subscription_title" = "Thinking of leaving?\nLet us help first";
 
 /* Title for the continue button */
 "cancel_subscription_continue_button" = "Continue to Cancellation";
@@ -4725,6 +4725,12 @@
 
 /* Footer of the Available Plans screen accessible from the Cancel Subscription view */
 "cancel_subscription_available_plans_footer" = "Your new plan will activate at the end of your current billing period.";
+
+/* Badge that appears over the best value plan in the available plans list */
+"cancel_subscription_available_plans_best_value_badge" = "Best Value";
+
+/* For yealry plans, we show the weekly price. %1$@ is the price. For example: $0.70/week */
+"iap_product_weekly_pricing_format" = "%1$@/week";
 
 /* Text displayed when the retry screen is visible */
 "cancel_subscription_available_plans_retry_screen_text" = "Sorry, but something went wrong fetching your plans.";


### PR DESCRIPTION
| 📘 Part of: #3029 
|:---:|

Fixes #3030 

This PR updates the Available Plans view. The tick is now on the left and there's a badge for the best value. Also, for the yearly plans we have the weekly price.

| 1 | 2 | 3 |
| :--------: | :-------: | :-------: |
| ![IMG_0100](https://github.com/user-attachments/assets/70cc5217-a5d8-42c3-96db-5c56d31d9142)  | ![IMG_0101](https://github.com/user-attachments/assets/fd21ce1c-36c9-4ddb-9ce6-2f10a0c95373) | ![IMG_0102](https://github.com/user-attachments/assets/3d47779c-f57a-4b67-babe-61355d6640d5) |
| ![IMG_0103](https://github.com/user-attachments/assets/72615aba-92e6-4a67-9065-925fd52caddb) | ![IMG_0104](https://github.com/user-attachments/assets/bc761d2e-65fe-4b8c-83e4-cad209104708) | ![IMG_0105](https://github.com/user-attachments/assets/ab535037-616a-4cfc-9433-85688324b029) |
| ![IMG_0106](https://github.com/user-attachments/assets/ab572466-9be9-4ef6-a5fc-a16378fa4d41) | ![IMG_0107](https://github.com/user-attachments/assets/f711383c-503c-4c9e-a2a3-f7de512863b8) | ![IMG_0108](https://github.com/user-attachments/assets/a43256e4-1f76-405b-8519-a31a38ac4c28) |
| ![IMG_0109](https://github.com/user-attachments/assets/e9e9dde6-e4d6-46e0-96f9-558355195f2e) |


## To test

- Login with a plus/patron user
- Go to account -> cancel subscription
- Tap on `Looking for a different plan`?
- Confirm you see the screen modified like the screenshot above

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
