### PR TITLE
[Fix] Disable email field if user is signed in

### DIFF
--- a/podcasts/PCMessageSupportViewModel.swift
+++ b/podcasts/PCMessageSupportViewModel.swift
@@ -2,12 +2,24 @@ import Foundation
 import PocketCastsServer
 
 class PCMessageSupportViewModel: MessageSupportViewModel {
-    // MARK: Init
+    private static var requesterEmail: String {
+        let syncEmail = ServerSettings.syncingEmail()
+        let storedEmail = UserDefaults.standard.string(forKey: Constants.UserDefaults.supportEmail)
 
+        let requesterEmail: String? = if SyncManager.isUserLoggedIn() {
+            syncEmail ?? storedEmail
+        } else {
+            storedEmail ?? syncEmail
+        }
+        return requesterEmail ?? ""
+    }
+
+    // MARK: Init
     init(config: SupportConfig) {
         super.init(config: config,
                    requesterName: UserDefaults.standard.string(forKey: Constants.UserDefaults.supportName) ?? "",
-                   requesterEmail: UserDefaults.standard.string(forKey: Constants.UserDefaults.supportEmail) ?? ServerSettings.syncingEmail() ?? "")
+                   requesterEmail: Self.requesterEmail,
+                   isUserSignedIn: SyncManager.isUserLoggedIn())
     }
 
     override func submitRequest(ignoreUnavailableWatchLogs: Bool = false) {

--- a/podcasts/Zendesk/MessageSupportView.swift
+++ b/podcasts/Zendesk/MessageSupportView.swift
@@ -23,6 +23,7 @@ struct MessageSupportView: View {
                 TextField(L10n.supportEmailPlaceholder, text: $viewModel.requesterEmail)
                     .autocapitalization(.none)
                     .keyboardType(.emailAddress)
+                    .disabled(viewModel.isUserSignedIn)
                     .requiredStyle(viewModel.requesterEmailErrored)
 
                 Text(L10n.supportCommentIndicator)
@@ -99,7 +100,7 @@ struct MessageSupportView_Previews: PreviewProvider {
     }
 
     static var previews: some View {
-        MessageSupportView(viewModel: MessageSupportViewModel(config: PreviewConfig()))
+        MessageSupportView(viewModel: MessageSupportViewModel(config: PreviewConfig(), isUserSignedIn: true))
             .environmentObject(Theme(previewTheme: .rosé))
     }
 }

--- a/podcasts/Zendesk/MessageSupportViewModel.swift
+++ b/podcasts/Zendesk/MessageSupportViewModel.swift
@@ -43,6 +43,7 @@ class MessageSupportViewModel: ObservableObject {
 
     let attachedLogsView: SupportLogsView
     let config: ZDConfig
+    let isUserSignedIn: Bool
 
     // MARK: Retry
 
@@ -96,11 +97,12 @@ class MessageSupportViewModel: ObservableObject {
 
     // MARK: Init
 
-    init(config: ZDConfig, requesterName: String = "", requesterEmail: String = "", comment: String = "", session: URLSession = URLSession.shared) {
+    init(config: ZDConfig, requesterName: String = "", requesterEmail: String = "", comment: String = "", session: URLSession = URLSession.shared, isUserSignedIn: Bool) {
         self.config = config
         self.requesterName = requesterName
         self.requesterEmail = requesterEmail
         self.comment = comment
+        self.isUserSignedIn = isUserSignedIn
         attachedLogsView = SupportLogsView(SupportLogsViewModel(config))
 
         supportService = ZendeskSupportService(config: config, session: session)


### PR DESCRIPTION
Fixes #3035 

This PR fixes the reported issue #3035 
• Disable the email field if the user is signed in
• Check for the sync email first if the user is signed in

## To test

1. Go to Profile and sign in
2. Tap Help & Feedback
3. Scroll all the way down
4. Tap Get in touch
5. Tap Get Support
6. Check you can not change the Email field
7. Log out
8. Do the same test but check you can modify the field

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
