### PR TITLE
Add Facebook SDK + isAdvertiserTrackingEnabled setting

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1944,6 +1944,7 @@
 		F5FE747D2C223A6E00DF2EAA /* PocketCastsLogoPill.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5FF61242BD0831200190711 /* PocketCastsLogoPill.swift */; };
 		F5FF61202BD076BA00190711 /* Sharing.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F5FF611F2BD076BA00190711 /* Sharing.xcassets */; };
 		F5FF61292BD6D88C00190711 /* SharingModal.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5FF61282BD6D88C00190711 /* SharingModal.swift */; };
+		F5FFC2352DBAF06D0091429C /* FacebookCore in Frameworks */ = {isa = PBXBuildFile; productRef = F5FFC2342DBAF06D0091429C /* FacebookCore */; };
 		FF03F7C42C0E331E00369572 /* SourceInterfaceModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF03F7C32C0E331E00369572 /* SourceInterfaceModel.swift */; };
 		FF05C98F2C0A0BF800E41EB3 /* FileManager+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF05C98E2C0A0BF800E41EB3 /* FileManager+Helper.swift */; };
 		FF05C9902C0A255600E41EB3 /* FileManager+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF05C98E2C0A0BF800E41EB3 /* FileManager+Helper.swift */; };
@@ -4181,6 +4182,7 @@
 				468F00D327CD575C00FFAAAA /* FirebasePerformance in Frameworks */,
 				BD11C41D2524741C00E308E6 /* CarPlay.framework in Frameworks */,
 				BD44F750267C850000810148 /* DifferenceKit in Frameworks */,
+				F5FFC2352DBAF06D0091429C /* FacebookCore in Frameworks */,
 				C72CED34289DA28B0017883A /* AutomatticTracks in Frameworks */,
 				BDD8AABF267C858D0013494D /* Fuse in Frameworks */,
 				46305CF0272B082C003AC87B /* AutomatticEncryptedLogs in Frameworks */,
@@ -8800,6 +8802,7 @@
 				8B1762792B684E7100F44450 /* Kingfisher */,
 				FF7F89EE2C2AF7B600FC0ED5 /* SwiftSubtitles */,
 				9A11FC922D91CBF300A1EF3E /* AppsFlyerLib-Dynamic */,
+				F5FFC2342DBAF06D0091429C /* FacebookCore */,
 			);
 			productName = podcasts;
 			productReference = BDBD53EC17019B2A0048C8C5 /* podcasts.app */;
@@ -8988,6 +8991,7 @@
 				8B1762782B684E7100F44450 /* XCRemoteSwiftPackageReference "Kingfisher" */,
 				FF7F89EB2C2AF53C00FC0ED5 /* XCRemoteSwiftPackageReference "SwiftSubtitles" */,
 				9A11FC912D91CBF300A1EF3E /* XCRemoteSwiftPackageReference "AppsFlyerFramework-Dynamic" */,
+				F5FFC2312DBAF0340091429C /* XCRemoteSwiftPackageReference "facebook-ios-sdk" */,
 			);
 			productRefGroup = BDBD53ED17019B2A0048C8C5 /* Products */;
 			projectDirPath = "";
@@ -13699,6 +13703,14 @@
 				minimumVersion = 7.1.0;
 			};
 		};
+		F5FFC2312DBAF0340091429C /* XCRemoteSwiftPackageReference "facebook-ios-sdk" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/facebook/facebook-ios-sdk";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 14.1.0;
+			};
+		};
 		FF7F89EB2C2AF53C00FC0ED5 /* XCRemoteSwiftPackageReference "SwiftSubtitles" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/dagronf/SwiftSubtitles";
@@ -13880,6 +13892,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = BDBEE72B267C845E00BA43FB /* XCRemoteSwiftPackageReference "lottie-ios" */;
 			productName = Lottie;
+		};
+		F5FFC2342DBAF06D0091429C /* FacebookCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F5FFC2312DBAF0340091429C /* XCRemoteSwiftPackageReference "facebook-ios-sdk" */;
+			productName = FacebookCore;
 		};
 		FF2CD57B2B9F4B2D009B58B5 /* PocketCastsDataModel */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -13708,7 +13708,7 @@
 			repositoryURL = "https://github.com/facebook/facebook-ios-sdk";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 14.1.0;
+				minimumVersion = 18.0.0;
 			};
 		};
 		FF7F89EB2C2AF53C00FC0ED5 /* XCRemoteSwiftPackageReference "SwiftSubtitles" */ = {

--- a/podcasts.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/podcasts.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -78,8 +78,8 @@
         "repositoryURL": "https://github.com/facebook/facebook-ios-sdk",
         "state": {
           "branch": null,
-          "revision": "c19607d535864533523d1f437c84035e5fb101cf",
-          "version": "14.1.0"
+          "revision": "b28dde427715b45a26ebebf697929f4a81b15e04",
+          "version": "18.0.0"
         }
       },
       {

--- a/podcasts.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/podcasts.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -74,6 +74,15 @@
         }
       },
       {
+        "package": "Facebook",
+        "repositoryURL": "https://github.com/facebook/facebook-ios-sdk",
+        "state": {
+          "branch": null,
+          "revision": "c19607d535864533523d1f437c84035e5fb101cf",
+          "version": "14.1.0"
+        }
+      },
+      {
         "package": "Firebase",
         "repositoryURL": "https://github.com/firebase/firebase-ios-sdk.git",
         "state": {

--- a/podcasts/Analytics/Adapters/Newform AppsFlyer/AppsFlyerAdapter.swift
+++ b/podcasts/Analytics/Adapters/Newform AppsFlyer/AppsFlyerAdapter.swift
@@ -31,6 +31,16 @@ class AppsFlyerAdapter: AnalyticsAdapter {
             return
         }
         appsFlyer.logEvent(name, withValues: properties)
+        let parameters: [AppEvents.ParameterName: Any]? = properties?.reduce([:]) { (dict, element) in
+            let (key, value) = element
+            var modDict = dict
+            if let keyString = key as? String {
+                let paramName = AppEvents.ParameterName(rawValue: keyString)
+                modDict[paramName] = value
+            }
+            return modDict
+        }
+        FacebookCore.AppEvents.shared.logEvent(AppEvents.Name(name), parameters: parameters ?? [:])
     }
 
     private func appsFlyerSetup() {

--- a/podcasts/Analytics/Adapters/Newform AppsFlyer/AppsFlyerAdapter.swift
+++ b/podcasts/Analytics/Adapters/Newform AppsFlyer/AppsFlyerAdapter.swift
@@ -50,6 +50,13 @@ class AppsFlyerAdapter: AnalyticsAdapter {
 #if DEBUG
         appsFlyer.isDebug = FeatureFlag.appsFlyerLogging.enabled
 #endif
+        // Facebook AEM Analytics
+        FacebookCore.Settings.shared.isAutoLogAppEventsEnabled = true
+        FacebookCore.Settings.shared.isAdvertiserIDCollectionEnabled = true
+        FacebookCore.Settings.shared.appID = "APPID_HERE"
+        FacebookCore.Settings.shared.displayName = "DISPLAY_NAME_HERE"
+        FacebookCore.Settings.shared.clientToken = "CLIENT_TOKEN_HERE"
+
         if #available(iOS 18.0, *) {
         } else {
             FacebookCore.Settings.shared.isAdvertiserTrackingEnabled = appTrackingTransparencyProvider.userGaveConsent()

--- a/podcasts/Analytics/Adapters/Newform AppsFlyer/AppsFlyerAdapter.swift
+++ b/podcasts/Analytics/Adapters/Newform AppsFlyer/AppsFlyerAdapter.swift
@@ -1,5 +1,6 @@
 import AppsFlyerLib
 import PocketCastsUtils
+import FacebookCore
 
 class AppsFlyerAdapter: AnalyticsAdapter {
     let isThirdPartyAdapter = true
@@ -48,11 +49,13 @@ class AppsFlyerAdapter: AnalyticsAdapter {
         }
         let shouldShowPrompt = appTrackingTransparencyProvider.shouldShowPrompt()
         if !shouldShowPrompt, appTrackingTransparencyProvider.userGaveConsent() {
+            FacebookCore.Settings.shared.isAdvertiserTrackingEnabled = true
             start()
         } else if shouldShowPrompt {
             FileLog.shared.addMessage("AppsFlyer ATT not determined: wait for user to give consent")
             appTrackingTransparencyProvider.authorizationStatusUpdated = { [weak self] authorized in
                 FileLog.shared.addMessage("AppsFlyer ATT auth state changed: authorized \(authorized)")
+                FacebookCore.Settings.shared.isAdvertiserTrackingEnabled = authorized
                 if authorized {
                     self?.start()
                 }

--- a/podcasts/Analytics/Adapters/Newform AppsFlyer/AppsFlyerAdapter.swift
+++ b/podcasts/Analytics/Adapters/Newform AppsFlyer/AppsFlyerAdapter.swift
@@ -50,6 +50,10 @@ class AppsFlyerAdapter: AnalyticsAdapter {
 #if DEBUG
         appsFlyer.isDebug = FeatureFlag.appsFlyerLogging.enabled
 #endif
+        if #available(iOS 18.0, *) {
+        } else {
+            FacebookCore.Settings.shared.isAdvertiserTrackingEnabled = appTrackingTransparencyProvider.userGaveConsent()
+        }
     }
 
     private func checkUserConsent() {
@@ -59,13 +63,11 @@ class AppsFlyerAdapter: AnalyticsAdapter {
         }
         let shouldShowPrompt = appTrackingTransparencyProvider.shouldShowPrompt()
         if !shouldShowPrompt, appTrackingTransparencyProvider.userGaveConsent() {
-            FacebookCore.Settings.shared.isAdvertiserTrackingEnabled = true
             start()
         } else if shouldShowPrompt {
             FileLog.shared.addMessage("AppsFlyer ATT not determined: wait for user to give consent")
             appTrackingTransparencyProvider.authorizationStatusUpdated = { [weak self] authorized in
                 FileLog.shared.addMessage("AppsFlyer ATT auth state changed: authorized \(authorized)")
-                FacebookCore.Settings.shared.isAdvertiserTrackingEnabled = authorized
                 if authorized {
                     self?.start()
                 }

--- a/podcasts/AppDelegate+SiriShortcuts.swift
+++ b/podcasts/AppDelegate+SiriShortcuts.swift
@@ -4,9 +4,12 @@ import Intents
 import JLRoutes
 import PocketCastsDataModel
 import PocketCastsUtils
+import FacebookCore
 
 extension AppDelegate {
     func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
+        ApplicationDelegate.shared.application(application, continue: userActivity)
+
         handleContinue(userActivity)
 
         return true

--- a/podcasts/AppDelegate+SiriShortcuts.swift
+++ b/podcasts/AppDelegate+SiriShortcuts.swift
@@ -8,7 +8,9 @@ import FacebookCore
 
 extension AppDelegate {
     func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
-        ApplicationDelegate.shared.application(application, continue: userActivity)
+        if FeatureFlag.podcastNewformAppsFlyer.enabled {
+            ApplicationDelegate.shared.application(application, continue: userActivity)
+        }
 
         handleContinue(userActivity)
 

--- a/podcasts/AppDelegate+UrlHandling.swift
+++ b/podcasts/AppDelegate+UrlHandling.swift
@@ -4,6 +4,7 @@ import JLRoutes
 import PocketCastsDataModel
 import PocketCastsServer
 import PocketCastsUtils
+import FacebookCore
 
 extension AppDelegate {
     func application(_ application: UIApplication, performActionFor shortcutItem: UIApplicationShortcutItem, completionHandler: @escaping (Bool) -> Void) {
@@ -17,6 +18,12 @@ extension AppDelegate {
     }
 
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
+        ApplicationDelegate.shared.application(
+            app,
+            open: url,
+            sourceApplication: options[UIApplication.OpenURLOptionsKey.sourceApplication] as? String,
+            annotation: options[UIApplication.OpenURLOptionsKey.annotation]
+        )
         guard let progressViewController = SceneHelper.rootViewController() else { return false }
         return handleOpenUrl(url: url, rootViewController: progressViewController)
     }

--- a/podcasts/AppDelegate+UrlHandling.swift
+++ b/podcasts/AppDelegate+UrlHandling.swift
@@ -18,12 +18,14 @@ extension AppDelegate {
     }
 
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
-        ApplicationDelegate.shared.application(
-            app,
-            open: url,
-            sourceApplication: options[UIApplication.OpenURLOptionsKey.sourceApplication] as? String,
-            annotation: options[UIApplication.OpenURLOptionsKey.annotation]
-        )
+        if FeatureFlag.podcastNewformAppsFlyer.enabled {
+            ApplicationDelegate.shared.application(
+                app,
+                open: url,
+                sourceApplication: options[UIApplication.OpenURLOptionsKey.sourceApplication] as? String,
+                annotation: options[UIApplication.OpenURLOptionsKey.annotation]
+            )
+        }
         guard let progressViewController = SceneHelper.rootViewController() else { return false }
         return handleOpenUrl(url: url, rootViewController: progressViewController)
     }

--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -36,10 +36,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         configureFirebase()
         TraceManager.shared.setup(handler: traceHandler)
 
-        // Facebook AEM Analytics
-        FacebookCore.Settings.shared.appID = ApiCredentials.instagramAppID
-        ApplicationDelegate.shared.application(application, didFinishLaunchingWithOptions: launchOptions)
-
         setupSecrets()
         addAnalyticsObservers()
         setupAnalytics()
@@ -104,6 +100,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         NotificationCenter.default.addObserver(self, selector: #selector(showOverlays), name: Constants.Notifications.closedNonOverlayableWindow, object: nil)
 
         setupSignOutListener()
+
+        if FeatureFlag.podcastNewformAppsFlyer.enabled {
+            ApplicationDelegate.shared.application(application, didFinishLaunchingWithOptions: launchOptions)
+        }
 
         return true
     }

--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -6,6 +6,7 @@ import PocketCastsDataModel
 import PocketCastsServer
 import PocketCastsUtils
 import Combine
+import FacebookCore
 
 class AppDelegate: UIResponder, UIApplicationDelegate {
     private static let initialRefreshDelay = 2.seconds
@@ -34,6 +35,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
         configureFirebase()
         TraceManager.shared.setup(handler: traceHandler)
+
+        // Facebook AEM Analytics
+        FacebookCore.Settings.shared.appID = ApiCredentials.instagramAppID
+        ApplicationDelegate.shared.application(application, didFinishLaunchingWithOptions: launchOptions)
 
         setupSecrets()
         addAnalyticsObservers()

--- a/podcasts/SceneDelegate.swift
+++ b/podcasts/SceneDelegate.swift
@@ -1,10 +1,16 @@
 import JLRoutes
 import UIKit
+import FacebookCore
 
 class SceneDelegate: UIResponder, UISceneDelegate, UIWindowSceneDelegate {
     var window: UIWindow?
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
+
+        if let userActivity = connectionOptions.userActivities.first,
+                userActivity.activityType == NSUserActivityTypeBrowsingWeb {
+            ApplicationDelegate.shared.application(.shared, continue: userActivity)
+        }
 
         let window = UIWindow(windowScene: windowScene)
         self.window = window
@@ -35,6 +41,7 @@ class SceneDelegate: UIResponder, UISceneDelegate, UIWindowSceneDelegate {
     }
 
     func scene(_ scene: UIScene, continue userActivity: NSUserActivity) {
+        ApplicationDelegate.shared.application(.shared, continue: userActivity)
         appDelegate()?.handleContinue(userActivity)
     }
 

--- a/podcasts/SceneDelegate.swift
+++ b/podcasts/SceneDelegate.swift
@@ -1,15 +1,18 @@
 import JLRoutes
 import UIKit
 import FacebookCore
+import PocketCastsUtils
 
 class SceneDelegate: UIResponder, UISceneDelegate, UIWindowSceneDelegate {
     var window: UIWindow?
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
 
-        if let userActivity = connectionOptions.userActivities.first,
-                userActivity.activityType == NSUserActivityTypeBrowsingWeb {
-            ApplicationDelegate.shared.application(.shared, continue: userActivity)
+        if FeatureFlag.podcastNewformAppsFlyer.enabled {
+            if let userActivity = connectionOptions.userActivities.first,
+               userActivity.activityType == NSUserActivityTypeBrowsingWeb {
+                ApplicationDelegate.shared.application(.shared, continue: userActivity)
+            }
         }
 
         let window = UIWindow(windowScene: windowScene)


### PR DESCRIPTION
Fixes an issue with the AppsFlyer SDK not receiving Facebook AEM events.

* Includes the Facebook Core SDK 
* Sets the `isAdvertiserTrackingEnabled` property on the Facebook SDK depending on ATT consent

## To test

* Run the app with the `podcastNewformAppsFlyer` feature flag enabled (should be enabled by default)
* Open the Facebook Event Manager page for the configured app
* ✅ Verify that events come through (there may be a delay of several hours on these because I think real time events require you to be logged in to the Facebook app with an account tied to the development App ID).

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
