### PR TITLE
GRDB: add `write` and `read` methods

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/DB/FMDB/FMDBDatabase.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/DB/FMDB/FMDBDatabase.swift
@@ -12,13 +12,13 @@ final class FMDBDatabase: PCDatabase {
         self.fmdbDatabase = fmdbDatabase
     }
 
-    func pragmaUserVersion() -> Int32 {
+    func pragmaUserVersion() -> Int32? {
         if let rs = try? fmdbDatabase.executeQuery("PRAGMA user_version", values: nil) {
             if rs.next() { return rs.int(forColumnIndex: 0) }
             rs.close()
         }
 
-        return 0
+        return nil
     }
 
     func executeQuery(_ sql: String, values: [Any]?) throws -> any PCDBResultSet {

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/DB/FMDB/FMDBDatabase.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/DB/FMDB/FMDBDatabase.swift
@@ -12,6 +12,15 @@ final class FMDBDatabase: PCDatabase {
         self.fmdbDatabase = fmdbDatabase
     }
 
+    func pragmaUserVersion() -> Int32 {
+        if let rs = try? fmdbDatabase.executeQuery("PRAGMA user_version", values: nil) {
+            if rs.next() { return rs.int(forColumnIndex: 0) }
+            rs.close()
+        }
+
+        return 0
+    }
+
     func executeQuery(_ sql: String, values: [Any]?) throws -> any PCDBResultSet {
         try fmdbDatabase.executeQuery(sql, values: values)
     }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/DB/FMDB/FMDBQueue.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/DB/FMDB/FMDBQueue.swift
@@ -26,6 +26,28 @@ final class FMDBQueue: PCDBQueue {
         }
     }
 
+    func read(_ block: (any PCDatabase) -> Void) {
+        // FMDB doesn't have the concept of read or write
+        // This is implemented so we conform to the protocol
+        withoutActuallyEscaping(block) { block in
+            fmdbQueue.inDatabase { db in
+                let dbWrapper = FMDBDatabase(fmdbDatabase: db)
+                block(dbWrapper)
+            }
+        }
+    }
+
+    func write(_ block: (any PCDatabase) -> Void) {
+        // FMDB doesn't have the concept of read or write
+        // This is implemented so we conform to the protocol
+        withoutActuallyEscaping(block) { block in
+            fmdbQueue.inDatabase { db in
+                let dbWrapper = FMDBDatabase(fmdbDatabase: db)
+                block(dbWrapper)
+            }
+        }
+    }
+
     func close() {
         fmdbQueue.close()
     }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/DB/GRDB/GRDBDatabase.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/DB/GRDB/GRDBDatabase.swift
@@ -12,6 +12,10 @@ class GRDBDatabase: PCDatabase {
         self.database = database
     }
 
+    func pragmaUserVersion() -> Int32 {
+        (try? Int32.fetchOne(database, sql: "PRAGMA user_version")) ?? 0
+    }
+
     func executeQuery(_ sql: String, values: [Any]?) throws -> any PCDBResultSet {
         // Invalid arguments will result in a crash in the application
         // TODO: when releasing GRDB discuss if we want to make this optional

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/DB/GRDB/GRDBDatabase.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/DB/GRDB/GRDBDatabase.swift
@@ -12,8 +12,8 @@ class GRDBDatabase: PCDatabase {
         self.database = database
     }
 
-    func pragmaUserVersion() -> Int32 {
-        (try? Int32.fetchOne(database, sql: "PRAGMA user_version")) ?? 0
+    func pragmaUserVersion() -> Int32? {
+        try? Int32.fetchOne(database, sql: "PRAGMA user_version")
     }
 
     func executeQuery(_ sql: String, values: [Any]?) throws -> any PCDBResultSet {

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/DB/GRDB/GRDBQueue.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/DB/GRDB/GRDBQueue.swift
@@ -38,6 +38,32 @@ class GRDBQueue: PCDBQueue {
         }
     }
 
+    func read(_ block: (any PCDatabase) -> Void) {
+        withoutActuallyEscaping(block) { block in
+            // This should be a try? to match FMDB behavior
+            // However, while we test GRDB internally we would like any error
+            // to be thrown helping us to discover issues.
+            // TODO: remove once GRDB has been tested.
+            try! dbPool.read { db in
+                let dbWrapper = GRDBDatabase(database: db)
+                block(dbWrapper)
+            }
+        }
+    }
+
+    func write(_ block: (any PCDatabase) -> Void) {
+        withoutActuallyEscaping(block) { block in
+            // This should be a try? to match FMDB behavior
+            // However, while we test GRDB internally we would like any error
+            // to be thrown helping us to discover issues.
+            // TODO: remove once GRDB has been tested.
+            try! dbPool.write { db in
+                let dbWrapper = GRDBDatabase(database: db)
+                block(dbWrapper)
+            }
+        }
+    }
+
     func close() {
         // This should be a try? to match FMDB behavior
         // However, while we test GRDB internally we would like any error

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/DB/PCDBQueue.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/DB/PCDBQueue.swift
@@ -5,5 +5,9 @@ public protocol PCDBQueue {
 
     func inTransaction(_ block: (PCDatabase, UnsafeMutablePointer<ObjCBool>) -> Void)
 
+    func read(_ block: (PCDatabase) -> Void)
+
+    func write(_ block: (PCDatabase) -> Void)
+
     func close()
 }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/DB/PCDatabase.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/DB/PCDatabase.swift
@@ -3,7 +3,7 @@ import Foundation
 public protocol PCDatabase {
     var changes: Int32 { get }
 
-    func pragmaUserVersion() -> Int32
+    func pragmaUserVersion() -> Int32?
 
     func executeQuery(_ sql: String, values: [Any]?) throws -> PCDBResultSet
 

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/DB/PCDatabase.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/DB/PCDatabase.swift
@@ -3,6 +3,8 @@ import Foundation
 public protocol PCDatabase {
     var changes: Int32 { get }
 
+    func pragmaUserVersion() -> Int32
+
     func executeQuery(_ sql: String, values: [Any]?) throws -> PCDBResultSet
 
     func executeUpdate(_ sql: String, values: [Any]?) throws

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseHelper.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseHelper.swift
@@ -4,22 +4,12 @@ import PocketCastsUtils
 
 class DatabaseHelper {
     class func setup(queue: PCDBQueue) {
-        var startingSchemaVersion: Int32 = 0
-
-        queue.read { db in
+        queue.write { db in
             do {
                 try db.executeQuery("PRAGMA busy_timeout = 10000", values: nil).close()
 
-                let rs = try db.executeQuery("PRAGMA user_version", values: nil)
-                if rs.next() { startingSchemaVersion = rs.int(forColumnIndex: 0) }
-                rs.close()
-            } catch {
-                FileLog.shared.addMessage("Failed to setup database \(db.lastErrorCode()): \(db.lastErrorMessage()) actual error: \(error)")
-            }
-        }
+                let startingSchemaVersion = db.pragmaUserVersion() ?? 0
 
-        queue.write { db in
-            do {
                 var newSchemaVersion = startingSchemaVersion
                 upgradeIfRequired(schemaVersion: &newSchemaVersion, db: db)
 

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseHelper.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseHelper.swift
@@ -6,7 +6,7 @@ class DatabaseHelper {
     class func setup(queue: PCDBQueue) {
         var startingSchemaVersion: Int32 = 0
 
-        queue.inDatabase { db in
+        queue.read { db in
             do {
                 try db.executeQuery("PRAGMA busy_timeout = 10000", values: nil).close()
 
@@ -18,7 +18,7 @@ class DatabaseHelper {
             }
         }
 
-        queue.inDatabase { db in
+        queue.write { db in
             do {
                 var newSchemaVersion = startingSchemaVersion
                 upgradeIfRequired(schemaVersion: &newSchemaVersion, db: db)
@@ -29,27 +29,6 @@ class DatabaseHelper {
             } catch {
                 FileLog.shared.addMessage("Failed to setup database \(db.lastErrorCode()): \(db.lastErrorMessage()) actual error: \(error)")
             }
-        }
-    }
-
-    class func setup(db: PCDatabase) {
-        do {
-            try db.executeQuery("PRAGMA busy_timeout = 10000", values: nil).close()
-
-            var startingSchemaVersion: Int32 = 0
-
-            let rs = try db.executeQuery("PRAGMA user_version", values: nil)
-            if rs.next() { startingSchemaVersion = rs.int(forColumnIndex: 0) }
-            rs.close()
-
-            var newSchemaVersion = startingSchemaVersion
-            upgradeIfRequired(schemaVersion: &newSchemaVersion, db: db)
-
-            if newSchemaVersion != startingSchemaVersion {
-                try db.executeUpdate("PRAGMA user_version = \(newSchemaVersion)", values: nil)
-            }
-        } catch {
-            FileLog.shared.addMessage("Failed to setup database \(db.lastErrorCode()): \(db.lastErrorMessage()) actual error: \(error)")
         }
     }
 


### PR DESCRIPTION
| 📘 Part of: #2773 | 
|:---:|

To unlock the power of concurrent reads, we need to use GRDB `write` and `read` methods. This is a first step in this direction.

Since there are many places that this needs to be changed, I'll raise one PR per data manager — this makes it easier to be reviewed.

## To test

1. ✅ Run the app form scratch and ensure the app works just fine
2. Subscribe to a few podcasts
3. Change `grdb` in `FeatureFlag.swift` to `false`
4. Re-run the app
5. ✅ Everything should be there

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
