### PR TITLE
Recommendations: Similar Shows tab

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Private/TokenHelper.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Private/TokenHelper.swift
@@ -22,6 +22,22 @@ class TokenHelper {
         }
     }
 
+    /// Makes an authentication URL request and returns the response and data asynchronously
+    /// - Parameter request: The URLRequest to execute using URLConnection
+    /// - Returns: A tuple containing the HTTPURLResponse and Data
+    /// - Throws: Any error returned from the URLConnection
+    func callSecureUrl(request: URLRequest) async throws -> (HTTPURLResponse?, Data?) {
+        try await withCheckedThrowingContinuation { continuation in
+            performCallSecureUrl(request: request, retryOnUnauthorized: true) { response, data, error in
+                if let error = error {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                continuation.resume(returning: (response, data))
+            }
+        }
+    }
+
     private func performCallSecureUrl(request: URLRequest, retryOnUnauthorized: Bool = true, completion: @escaping ((HTTPURLResponse?, Data?, Error?) -> Void)) {
         var mutableRequest = request
 

--- a/Modules/Server/Sources/PocketCastsServer/Public/ServerPodcastManager.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/ServerPodcastManager.swift
@@ -258,6 +258,7 @@ public class ServerPodcastManager: NSObject {
             tokenHelper.callSecureUrl(request: request) { response, data, error in
                 if let error {
                     continuation.resume(throwing: error)
+                    return
                 }
                 guard let data = data else {
                     continuation.resume(returning: nil)
@@ -266,6 +267,7 @@ public class ServerPodcastManager: NSObject {
 
                 if response?.statusCode == ServerConstants.HttpConstants.notModified {
                     continuation.resume(returning: nil)
+                    return
                 }
 
                 let decoder = JSONDecoder()
@@ -274,8 +276,11 @@ public class ServerPodcastManager: NSObject {
                 do {
                     let decoded = try decoder.decode(PodcastCollection.self, from: data)
                     continuation.resume(returning: decoded)
+                    return
                 } catch let error {
                     print("Failed to decode recommendations \(error.localizedDescription)")
+                    continuation.resume(throwing: error)
+                    return
                 }
             }
         }

--- a/Modules/Server/Sources/PocketCastsServer/Public/ServerPodcastManager.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/ServerPodcastManager.swift
@@ -284,22 +284,6 @@ public class ServerPodcastManager: NSObject {
                 }
             }
         }
-//        return withCheckedThrowingContinuation { continuation in
-//            do {
-//                try tokenHelper.callSecureUrl(request: request) { response, data, error in
-//                    guard let data = data else { continuation.resume(returning: nil) }
-//
-//                    if response?.statusCode == ServerConstants.HttpConstants.notModified {
-//                        continuation.resume(returning: nil)
-//                    }
-//                    if let jsonResponse = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] {
-//                        continuation.resume(returning: jsonResponse)
-//                    }
-//                }
-//            } catch error {
-//                continuation.resume(throwing: error)
-//            }
-//        }
     }
 
     private func loadFrom(url: String) -> [String: Any]? {

--- a/Modules/Server/Sources/PocketCastsServer/Public/ServerPodcastManager.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/ServerPodcastManager.swift
@@ -1,7 +1,7 @@
 import Foundation
 import PocketCastsDataModel
 
-public struct Recommendations: Decodable {
+public struct PodcastRecommendations: Decodable {
     public let uuids: [String]
 }
 

--- a/Modules/Server/Sources/PocketCastsServer/Public/ServerPodcastManager.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/ServerPodcastManager.swift
@@ -248,8 +248,7 @@ public class ServerPodcastManager: NSObject {
             throw URLError(.badURL)
         }
 
-        components.path += "/recommendations/podcast"
-        components.queryItems = [URLQueryItem(name: "podcast_uuid", value: podcastUUID)]
+        components.path += "/recommendations/podcast/\(podcastUUID)"
         guard let url = components.url else {
             assertionFailure("[ServerPodcastManager] Recommendations API construction failed")
             throw URLError(.badURL)
@@ -259,12 +258,9 @@ public class ServerPodcastManager: NSObject {
         request.httpMethod = "GET"
         request.addValue("application/json", forHTTPHeaderField: ServerConstants.HttpHeaders.accept)
         request.setValue("application/json; charset=UTF8", forHTTPHeaderField: ServerConstants.HttpHeaders.contentType)
+        let (data, response) = try await urlConnection.send(request: request)
 
-        let tokenHelper = TokenHelper(urlConnection: urlConnection)
-
-        let (response, data) = try await tokenHelper.callSecureUrl(request: request)
-
-        if response?.statusCode == ServerConstants.HttpConstants.notModified {
+        if (response as? HTTPURLResponse)?.statusCode == ServerConstants.HttpConstants.notModified {
             return nil
         }
 

--- a/Modules/Server/Sources/PocketCastsServer/Public/ServerPodcastManager.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/ServerPodcastManager.swift
@@ -241,16 +241,16 @@ public class ServerPodcastManager: NSObject {
     }
 
     public func loadRecommendations(for podcastUUID: String) async throws -> PodcastCollection? {
-        var comps = URLComponents(string: ServerConstants.Urls.api())
+        let components = URLComponents(string: ServerConstants.Urls.api())
 
-        guard var comps else {
+        guard var components else {
             assertionFailure("[ServerPodcastManager] Recommendations API URL failed")
             throw URLError(.badURL)
         }
 
-        comps.path += "/recommendations/podcast"
-        comps.queryItems = [URLQueryItem(name: "podcast_uuid", value: podcastUUID)]
-        guard let url = comps.url else {
+        components.path += "/recommendations/podcast"
+        components.queryItems = [URLQueryItem(name: "podcast_uuid", value: podcastUUID)]
+        guard let url = components.url else {
             assertionFailure("[ServerPodcastManager] Recommendations API construction failed")
             throw URLError(.badURL)
         }
@@ -262,35 +262,20 @@ public class ServerPodcastManager: NSObject {
 
         let tokenHelper = TokenHelper(urlConnection: urlConnection)
 
-        return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<PodcastCollection?, Error>) in
-            tokenHelper.callSecureUrl(request: request) { response, data, error in
-                if let error {
-                    continuation.resume(throwing: error)
-                    return
-                }
-                guard let data = data else {
-                    continuation.resume(returning: nil)
-                    return
-                }
+        let (response, data) = try await tokenHelper.callSecureUrl(request: request)
 
-                if response?.statusCode == ServerConstants.HttpConstants.notModified {
-                    continuation.resume(returning: nil)
-                    return
-                }
-
-                let decoder = JSONDecoder()
-                decoder.dateDecodingStrategy = .iso8601
-
-                do {
-                    let decoded = try decoder.decode(PodcastCollection.self, from: data)
-                    continuation.resume(returning: decoded)
-                    return
-                } catch let error {
-                    continuation.resume(throwing: error)
-                    return
-                }
-            }
+        if response?.statusCode == ServerConstants.HttpConstants.notModified {
+            return nil
         }
+
+        guard let data = data else {
+            return nil
+        }
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+
+        return try decoder.decode(PodcastCollection.self, from: data)
     }
 
     private func loadFrom(url: String) -> [String: Any]? {

--- a/Modules/Server/Sources/PocketCastsServer/Public/ServerPodcastManager.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/ServerPodcastManager.swift
@@ -1,10 +1,6 @@
 import Foundation
 import PocketCastsDataModel
 
-public struct PodcastRecommendations: Decodable {
-    public let uuids: [String]
-}
-
 public class ServerPodcastManager: NSObject {
     private static let maxAutoDownloadSeperationTime = 12.hours
 
@@ -244,10 +240,22 @@ public class ServerPodcastManager: NSObject {
         return episode
     }
 
-    public func loadRecommendations(for podcast: String) async throws -> PodcastCollection? {
-        let url = ServerConstants.Urls.api() + "recommendations/podcast?podcast_uuid=\(podcast)"
+    public func loadRecommendations(for podcastUUID: String) async throws -> PodcastCollection? {
+        var comps = URLComponents(string: ServerConstants.Urls.api())
 
-        var request = URLRequest(url: URL(string: url)!, cachePolicy: .reloadIgnoringLocalCacheData, timeoutInterval: 10)
+        guard var comps else {
+            assertionFailure("[ServerPodcastManager] Recommendations API URL failed")
+            throw URLError(.badURL)
+        }
+
+        comps.path += "/recommendations/podcast"
+        comps.queryItems = [URLQueryItem(name: "podcast_uuid", value: podcastUUID)]
+        guard let url = comps.url else {
+            assertionFailure("[ServerPodcastManager] Recommendations API construction failed")
+            throw URLError(.badURL)
+        }
+
+        var request = URLRequest(url: url, cachePolicy: .reloadIgnoringLocalCacheData, timeoutInterval: 10)
         request.httpMethod = "GET"
         request.addValue("application/json", forHTTPHeaderField: ServerConstants.HttpHeaders.accept)
         request.setValue("application/json; charset=UTF8", forHTTPHeaderField: ServerConstants.HttpHeaders.contentType)
@@ -278,7 +286,6 @@ public class ServerPodcastManager: NSObject {
                     continuation.resume(returning: decoded)
                     return
                 } catch let error {
-                    print("Failed to decode recommendations \(error.localizedDescription)")
                     continuation.resume(throwing: error)
                     return
                 }

--- a/Modules/Server/Sources/PocketCastsServer/Public/ServerPodcastManager.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/ServerPodcastManager.swift
@@ -1,6 +1,10 @@
 import Foundation
 import PocketCastsDataModel
 
+public struct Recommendations: Decodable {
+    public let uuids: [String]
+}
+
 public class ServerPodcastManager: NSObject {
     private static let maxAutoDownloadSeperationTime = 12.hours
 
@@ -238,6 +242,59 @@ public class ServerPodcastManager: NSObject {
         DataManager.sharedManager.save(episode: episode)
 
         return episode
+    }
+
+    public func loadRecommendations(for podcast: String) async throws -> PodcastCollection? {
+        let url = ServerConstants.Urls.api() + "recommendations/podcast?podcast_uuid=\(podcast)"
+
+        var request = URLRequest(url: URL(string: url)!, cachePolicy: .reloadIgnoringLocalCacheData, timeoutInterval: 10)
+        request.httpMethod = "GET"
+        request.addValue("application/json", forHTTPHeaderField: ServerConstants.HttpHeaders.accept)
+        request.setValue("application/json; charset=UTF8", forHTTPHeaderField: ServerConstants.HttpHeaders.contentType)
+
+        let tokenHelper = TokenHelper(urlConnection: urlConnection)
+
+        return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<PodcastCollection?, Error>) in
+            tokenHelper.callSecureUrl(request: request) { response, data, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                }
+                guard let data = data else {
+                    continuation.resume(returning: nil)
+                    return
+                }
+
+                if response?.statusCode == ServerConstants.HttpConstants.notModified {
+                    continuation.resume(returning: nil)
+                }
+
+                let decoder = JSONDecoder()
+                decoder.dateDecodingStrategy = .iso8601
+
+                do {
+                    let decoded = try decoder.decode(PodcastCollection.self, from: data)
+                    continuation.resume(returning: decoded)
+                } catch let error {
+                    print("Failed to decode recommendations \(error.localizedDescription)")
+                }
+            }
+        }
+//        return withCheckedThrowingContinuation { continuation in
+//            do {
+//                try tokenHelper.callSecureUrl(request: request) { response, data, error in
+//                    guard let data = data else { continuation.resume(returning: nil) }
+//
+//                    if response?.statusCode == ServerConstants.HttpConstants.notModified {
+//                        continuation.resume(returning: nil)
+//                    }
+//                    if let jsonResponse = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] {
+//                        continuation.resume(returning: jsonResponse)
+//                    }
+//                }
+//            } catch error {
+//                continuation.resume(throwing: error)
+//            }
+//        }
     }
 
     private func loadFrom(url: String) -> [String: Any]? {

--- a/Modules/Server/Sources/PocketCastsServer/Public/URLConnection.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/URLConnection.swift
@@ -45,4 +45,16 @@ public class URLConnection {
     public func send(request: URLRequest, completion: @escaping (Data?, URLResponse?, Error?) -> Void) {
         handler.send(request: request, completion: completion)
     }
+
+    public func send(request: URLRequest) async throws -> (Data?, URLResponse?) {
+        try await withCheckedThrowingContinuation { continuation in
+            send(request: request) { data, response, error in
+                if let error = error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume(returning: (data, response))
+                }
+            }
+        }
+    }
 }

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1780,6 +1780,7 @@
 		F5BA5C9A2C7F701900BDA5B9 /* DiscoverCollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BA5C992C7F701900BDA5B9 /* DiscoverCollectionViewController.swift */; };
 		F5BA5C9C2C80F38200BDA5B9 /* UIViewControllerContentConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BA5C9B2C80F38200BDA5B9 /* UIViewControllerContentConfiguration.swift */; };
 		F5BA5C9E2C81254300BDA5B9 /* DiscoverCollectionViewController+DiscoverDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BA5C9D2C81254300BDA5B9 /* DiscoverCollectionViewController+DiscoverDelegate.swift */; };
+		F5BDBF502DB9754900AD8DF1 /* PodcastTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BDBF4F2DB9754900AD8DF1 /* PodcastTableViewCell.swift */; };
 		F5BEAEC92DA73CE800541921 /* DebugInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BEAEC82DA73CE000541921 /* DebugInfo.swift */; };
 		F5BFF9892C6B0A9100A84561 /* Optional+ThrowOnNil.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BFF9882C6B0A9100A84561 /* Optional+ThrowOnNil.swift */; };
 		F5C1FA212D1283F5007CFDF2 /* AppIcon.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BD0D7AF31F6BC564006B673F /* AppIcon.xcassets */; };
@@ -3975,6 +3976,7 @@
 		F5BA5C992C7F701900BDA5B9 /* DiscoverCollectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverCollectionViewController.swift; sourceTree = "<group>"; };
 		F5BA5C9B2C80F38200BDA5B9 /* UIViewControllerContentConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewControllerContentConfiguration.swift; sourceTree = "<group>"; };
 		F5BA5C9D2C81254300BDA5B9 /* DiscoverCollectionViewController+DiscoverDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DiscoverCollectionViewController+DiscoverDelegate.swift"; sourceTree = "<group>"; };
+		F5BDBF4F2DB9754900AD8DF1 /* PodcastTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PodcastTableViewCell.swift; sourceTree = "<group>"; };
 		F5BEAEC82DA73CE000541921 /* DebugInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugInfo.swift; sourceTree = "<group>"; };
 		F5BFF9882C6B0A9100A84561 /* Optional+ThrowOnNil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Optional+ThrowOnNil.swift"; sourceTree = "<group>"; };
 		F5CA25902CC9C30F0013DFF2 /* StoryFooter2024.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoryFooter2024.swift; sourceTree = "<group>"; };
@@ -6362,6 +6364,7 @@
 		BD6D417B200C555000CA8993 /* Cells */ = {
 			isa = PBXGroup;
 			children = (
+				F5BDBF4F2DB9754900AD8DF1 /* PodcastTableViewCell.swift */,
 				FF89C0972D81A2C700BC5104 /* PodcastHeaderModel.swift */,
 				FFF3FCCF2D8B143E009BAF26 /* PodcastHeaderDescriptionView.swift */,
 				FF89C0992D81A31700BC5104 /* PodcastHeaderView.swift */,
@@ -10391,6 +10394,7 @@
 				408971AD2512EE1F00783253 /* PodcastBundleCountView.swift in Sources */,
 				8B205C8129E84B6B0069BAF9 /* PageIndicatorView.swift in Sources */,
 				BDD71CF81BA93A6D006D2CE3 /* PodcastGroupCell.swift in Sources */,
+				F5BDBF502DB9754900AD8DF1 /* PodcastTableViewCell.swift in Sources */,
 				BD340FC821AF8A0F00EAB091 /* PodcastArchiveViewController+Table.swift in Sources */,
 				BD21D4A222DED42100D5888B /* ThemeableView.swift in Sources */,
 				405553D7244AD7A70048FE7A /* WatchSettingsViewController.swift in Sources */,

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1758,6 +1758,8 @@
 		F57D8F142C66CA230004C4DF /* UnsafeWait.swift in Sources */ = {isa = PBXBuildFile; fileRef = F57D8F132C66CA230004C4DF /* UnsafeWait.swift */; };
 		F57D8F162C66CBB80004C4DF /* UnsafeTransfer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F57D8F152C66CBB80004C4DF /* UnsafeTransfer.swift */; };
 		F57D8F182C66CDF40004C4DF /* View+CVPixelBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F57D8F172C66CDF40004C4DF /* View+CVPixelBuffer.swift */; };
+		F58189C22DBC56A200B95199 /* PodcastInfo+DiscoverPodcast.swift in Sources */ = {isa = PBXBuildFile; fileRef = F58189C12DBC56A200B95199 /* PodcastInfo+DiscoverPodcast.swift */; };
+		F58189C32DBC56A200B95199 /* PodcastInfo+DiscoverPodcast.swift in Sources */ = {isa = PBXBuildFile; fileRef = F58189C12DBC56A200B95199 /* PodcastInfo+DiscoverPodcast.swift */; };
 		F581ED422CC6F1A200A19860 /* ListeningTime2024Story.swift in Sources */ = {isa = PBXBuildFile; fileRef = F581ED412CC6F19300A19860 /* ListeningTime2024Story.swift */; };
 		F581ED442CC6F3A900A19860 /* Top5Podcasts2024Story.swift in Sources */ = {isa = PBXBuildFile; fileRef = F581ED432CC6F3A400A19860 /* Top5Podcasts2024Story.swift */; };
 		F586959A2C04320100E0754A /* PodcastManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F58695992C04320100E0754A /* PodcastManagerTests.swift */; };
@@ -3962,6 +3964,7 @@
 		F57D8F132C66CA230004C4DF /* UnsafeWait.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnsafeWait.swift; sourceTree = "<group>"; };
 		F57D8F152C66CBB80004C4DF /* UnsafeTransfer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnsafeTransfer.swift; sourceTree = "<group>"; };
 		F57D8F172C66CDF40004C4DF /* View+CVPixelBuffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+CVPixelBuffer.swift"; sourceTree = "<group>"; };
+		F58189C12DBC56A200B95199 /* PodcastInfo+DiscoverPodcast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PodcastInfo+DiscoverPodcast.swift"; sourceTree = "<group>"; };
 		F581ED412CC6F19300A19860 /* ListeningTime2024Story.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListeningTime2024Story.swift; sourceTree = "<group>"; };
 		F581ED432CC6F3A400A19860 /* Top5Podcasts2024Story.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Top5Podcasts2024Story.swift; sourceTree = "<group>"; };
 		F58695992C04320100E0754A /* PodcastManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PodcastManagerTests.swift; sourceTree = "<group>"; };
@@ -6799,6 +6802,7 @@
 		BDBA214D27C467FE0081E58D /* Helpers */ = {
 			isa = PBXGroup;
 			children = (
+				F58189C12DBC56A200B95199 /* PodcastInfo+DiscoverPodcast.swift */,
 				BDD3579427BCD6DF0000D155 /* GridHelper.swift */,
 				BD74F15027F28E6600222785 /* HomeGridDataHelper.swift */,
 			);
@@ -10311,6 +10315,7 @@
 				BDD3018C1EFB94C9004A9972 /* WatchManager.swift in Sources */,
 				C7BF5E47290832FD00733C1E /* DiscoverCoordinator.swift in Sources */,
 				F5E431D62B50888500A71DB3 /* PlusLabel.swift in Sources */,
+				F58189C32DBC56A200B95199 /* PodcastInfo+DiscoverPodcast.swift in Sources */,
 				BDD40A181FA1ABF500A53AE1 /* PCNavigationController.swift in Sources */,
 				F5235EEE2C3DF95C00C98739 /* PlayButton.swift in Sources */,
 				40B1613822F3B66900759E41 /* ThemeableTextField.swift in Sources */,
@@ -11133,6 +11138,7 @@
 				C791418E294CE33700F1852B /* StorageManager.swift in Sources */,
 				46E905A727E285F20039558C /* UpNextViewModel.swift in Sources */,
 				46D88ABE27DFDB6E00F3BC43 /* FilesListViewModel.swift in Sources */,
+				F58189C22DBC56A200B95199 /* PodcastInfo+DiscoverPodcast.swift in Sources */,
 				BD0EE37F1EFCF15400F2A6DC /* WatchImageHelper.swift in Sources */,
 				40BF0B3D241B3B0F003E3ABD /* WatchSyncManager.swift in Sources */,
 				463D169E27CE7E5C008FA135 /* EpisodeDetailsViewModel.swift in Sources */,

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1713,6 +1713,7 @@
 		F53EFEE82CD405DA00F4561B /* YearOverYearCompareTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F53EFEE72CD405DA00F4561B /* YearOverYearCompareTests.swift */; };
 		F53EFEEA2CD42AE400F4561B /* Ratings2024Story.swift in Sources */ = {isa = PBXBuildFile; fileRef = F53EFEE92CD42ADF00F4561B /* Ratings2024Story.swift */; };
 		F543F6A42C0804FA00FEC8B6 /* AnyPublisher+Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = F543F6A32C0804FA00FEC8B6 /* AnyPublisher+Async.swift */; };
+		F549D3532DBBED7B00451246 /* PodcastTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F549D3522DBBED7B00451246 /* PodcastTableViewCell.swift */; };
 		F54E0F542CC764C0006D4DA2 /* PositionModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = F54E0F532CC764C0006D4DA2 /* PositionModifier.swift */; };
 		F54E72192CA722A000CD5C86 /* Array+DiscoverItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = F54E72182CA722A000CD5C86 /* Array+DiscoverItem.swift */; };
 		F54E721D2CA7359800CD5C86 /* DiscoverCellType.swift in Sources */ = {isa = PBXBuildFile; fileRef = F54E721C2CA7359800CD5C86 /* DiscoverCellType.swift */; };
@@ -1780,7 +1781,7 @@
 		F5BA5C9A2C7F701900BDA5B9 /* DiscoverCollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BA5C992C7F701900BDA5B9 /* DiscoverCollectionViewController.swift */; };
 		F5BA5C9C2C80F38200BDA5B9 /* UIViewControllerContentConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BA5C9B2C80F38200BDA5B9 /* UIViewControllerContentConfiguration.swift */; };
 		F5BA5C9E2C81254300BDA5B9 /* DiscoverCollectionViewController+DiscoverDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BA5C9D2C81254300BDA5B9 /* DiscoverCollectionViewController+DiscoverDelegate.swift */; };
-		F5BDBF502DB9754900AD8DF1 /* PodcastTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BDBF4F2DB9754900AD8DF1 /* PodcastTableViewCell.swift */; };
+		F5BDBF502DB9754900AD8DF1 /* PodcastTableCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BDBF4F2DB9754900AD8DF1 /* PodcastTableCellView.swift */; };
 		F5BEAEC92DA73CE800541921 /* DebugInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BEAEC82DA73CE000541921 /* DebugInfo.swift */; };
 		F5BFF9892C6B0A9100A84561 /* Optional+ThrowOnNil.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BFF9882C6B0A9100A84561 /* Optional+ThrowOnNil.swift */; };
 		F5C1FA212D1283F5007CFDF2 /* AppIcon.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BD0D7AF31F6BC564006B673F /* AppIcon.xcassets */; };
@@ -3939,6 +3940,7 @@
 		F53EFEE72CD405DA00F4561B /* YearOverYearCompareTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YearOverYearCompareTests.swift; sourceTree = "<group>"; };
 		F53EFEE92CD42ADF00F4561B /* Ratings2024Story.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Ratings2024Story.swift; sourceTree = "<group>"; };
 		F543F6A32C0804FA00FEC8B6 /* AnyPublisher+Async.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AnyPublisher+Async.swift"; sourceTree = "<group>"; };
+		F549D3522DBBED7B00451246 /* PodcastTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PodcastTableViewCell.swift; sourceTree = "<group>"; };
 		F54E0F532CC764C0006D4DA2 /* PositionModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PositionModifier.swift; sourceTree = "<group>"; };
 		F54E72182CA722A000CD5C86 /* Array+DiscoverItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+DiscoverItem.swift"; sourceTree = "<group>"; };
 		F54E721C2CA7359800CD5C86 /* DiscoverCellType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverCellType.swift; sourceTree = "<group>"; };
@@ -3976,7 +3978,7 @@
 		F5BA5C992C7F701900BDA5B9 /* DiscoverCollectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverCollectionViewController.swift; sourceTree = "<group>"; };
 		F5BA5C9B2C80F38200BDA5B9 /* UIViewControllerContentConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewControllerContentConfiguration.swift; sourceTree = "<group>"; };
 		F5BA5C9D2C81254300BDA5B9 /* DiscoverCollectionViewController+DiscoverDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DiscoverCollectionViewController+DiscoverDelegate.swift"; sourceTree = "<group>"; };
-		F5BDBF4F2DB9754900AD8DF1 /* PodcastTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PodcastTableViewCell.swift; sourceTree = "<group>"; };
+		F5BDBF4F2DB9754900AD8DF1 /* PodcastTableCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PodcastTableCellView.swift; sourceTree = "<group>"; };
 		F5BEAEC82DA73CE000541921 /* DebugInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugInfo.swift; sourceTree = "<group>"; };
 		F5BFF9882C6B0A9100A84561 /* Optional+ThrowOnNil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Optional+ThrowOnNil.swift"; sourceTree = "<group>"; };
 		F5CA25902CC9C30F0013DFF2 /* StoryFooter2024.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoryFooter2024.swift; sourceTree = "<group>"; };
@@ -6364,7 +6366,8 @@
 		BD6D417B200C555000CA8993 /* Cells */ = {
 			isa = PBXGroup;
 			children = (
-				F5BDBF4F2DB9754900AD8DF1 /* PodcastTableViewCell.swift */,
+				F549D3522DBBED7B00451246 /* PodcastTableViewCell.swift */,
+				F5BDBF4F2DB9754900AD8DF1 /* PodcastTableCellView.swift */,
 				FF89C0972D81A2C700BC5104 /* PodcastHeaderModel.swift */,
 				FFF3FCCF2D8B143E009BAF26 /* PodcastHeaderDescriptionView.swift */,
 				FF89C0992D81A31700BC5104 /* PodcastHeaderView.swift */,
@@ -10394,7 +10397,7 @@
 				408971AD2512EE1F00783253 /* PodcastBundleCountView.swift in Sources */,
 				8B205C8129E84B6B0069BAF9 /* PageIndicatorView.swift in Sources */,
 				BDD71CF81BA93A6D006D2CE3 /* PodcastGroupCell.swift in Sources */,
-				F5BDBF502DB9754900AD8DF1 /* PodcastTableViewCell.swift in Sources */,
+				F5BDBF502DB9754900AD8DF1 /* PodcastTableCellView.swift in Sources */,
 				BD340FC821AF8A0F00EAB091 /* PodcastArchiveViewController+Table.swift in Sources */,
 				BD21D4A222DED42100D5888B /* ThemeableView.swift in Sources */,
 				405553D7244AD7A70048FE7A /* WatchSettingsViewController.swift in Sources */,
@@ -10848,6 +10851,7 @@
 				461C46C7274D80990003D3A9 /* LocalizationHelpers.swift in Sources */,
 				32163E602B1EBDB6009BB16B /* DatabaseExport.swift in Sources */,
 				BD93134F1D795628007A70FC /* SharePodcastsViewController.swift in Sources */,
+				F549D3532DBBED7B00451246 /* PodcastTableViewCell.swift in Sources */,
 				F581ED422CC6F1A200A19860 /* ListeningTime2024Story.swift in Sources */,
 				404D74AD24809BC9009DF761 /* SupporterGratitudeViewController.swift in Sources */,
 				BDCF60EC22EFEDDC0051EDB3 /* ThemeableTable.swift in Sources */,

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1561,7 +1561,7 @@
 		C76ECAC22A67612F00D9DB9E /* EmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C76ECAC12A67612F00D9DB9E /* EmptyStateView.swift */; };
 		C76ECAC42A67622900D9DB9E /* BookmarksEmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C76ECAC32A67622900D9DB9E /* BookmarksEmptyStateView.swift */; };
 		C76ECACE2A685FB300D9DB9E /* BookmarksListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C76ECACD2A685FB300D9DB9E /* BookmarksListView.swift */; };
-		C76ECAD62A69518800D9DB9E /* EpisodeBookmarksTabsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C76ECAD52A69518800D9DB9E /* EpisodeBookmarksTabsView.swift */; };
+		C76ECAD62A69518800D9DB9E /* PodcastDetailsTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C76ECAD52A69518800D9DB9E /* PodcastDetailsTabView.swift */; };
 		C7811D832A90090700FC68B4 /* Settings+Unlockable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7811D822A90090700FC68B4 /* Settings+Unlockable.swift */; };
 		C7811D842A9009A800FC68B4 /* Settings+Unlockable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7811D822A90090700FC68B4 /* Settings+Unlockable.swift */; };
 		C7811D862A90247B00FC68B4 /* Unlockable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7811D852A90247B00FC68B4 /* Unlockable.swift */; };
@@ -3797,7 +3797,7 @@
 		C76ECAC12A67612F00D9DB9E /* EmptyStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyStateView.swift; sourceTree = "<group>"; };
 		C76ECAC32A67622900D9DB9E /* BookmarksEmptyStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksEmptyStateView.swift; sourceTree = "<group>"; };
 		C76ECACD2A685FB300D9DB9E /* BookmarksListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksListView.swift; sourceTree = "<group>"; };
-		C76ECAD52A69518800D9DB9E /* EpisodeBookmarksTabsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EpisodeBookmarksTabsView.swift; sourceTree = "<group>"; };
+		C76ECAD52A69518800D9DB9E /* PodcastDetailsTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PodcastDetailsTabView.swift; sourceTree = "<group>"; };
 		C7811D822A90090700FC68B4 /* Settings+Unlockable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Settings+Unlockable.swift"; sourceTree = "<group>"; };
 		C7811D852A90247B00FC68B4 /* Unlockable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Unlockable.swift; sourceTree = "<group>"; };
 		C7811D882A90334200FC68B4 /* Unlockable+Bookmarks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Unlockable+Bookmarks.swift"; sourceTree = "<group>"; };
@@ -6545,7 +6545,7 @@
 				BD3311A0202171EF00863A15 /* EpisodeListSearchController.xib */,
 				40AE73B321F00DFA00F77ACE /* SubscribeButton.swift */,
 				40AE73B121F00AFD00F77ACE /* SubscribeButton.xib */,
-				C76ECAD52A69518800D9DB9E /* EpisodeBookmarksTabsView.swift */,
+				C76ECAD52A69518800D9DB9E /* PodcastDetailsTabView.swift */,
 			);
 			name = "Podcast Page";
 			sourceTree = "<group>";
@@ -10677,7 +10677,7 @@
 				404BB868231361A6006FE8A9 /* WhatsNewLinkButton.swift in Sources */,
 				BDBA7F2C1DA51B440080EBAC /* NotificationsHelper.swift in Sources */,
 				BD907DA621533243004D7C02 /* PodcastEffectsViewController.swift in Sources */,
-				C76ECAD62A69518800D9DB9E /* EpisodeBookmarksTabsView.swift in Sources */,
+				C76ECAD62A69518800D9DB9E /* PodcastDetailsTabView.swift in Sources */,
 				8B3DF0CE2BE5683700EE4CA8 /* MainTabBarController+Alert.swift in Sources */,
 				BD44E36D20937D9C008BD7F0 /* PodcastChapterParser.swift in Sources */,
 				C7D5E7F12A8BF3150039F4A1 /* UIViewController+Presenting.swift in Sources */,

--- a/podcasts/Analytics/Helpers/AnalyticsCoordinator.swift
+++ b/podcasts/Analytics/Helpers/AnalyticsCoordinator.swift
@@ -35,6 +35,7 @@ enum AnalyticsSource: String, AnalyticsDescribable {
     case playerPlaybackEffects = "player_playback_effects"
     case playerSkipForwardLongPress = "player_skip_forward_long_press"
     case podcastScreen = "podcast_screen"
+    case podcastScreenSimilarShows = "podcast_screen_similar_shows"
     case podcastSettings = "podcast_settings"
     case podcastsList = "podcasts_list"
     case profile

--- a/podcasts/EpisodeBookmarksTabsView.swift
+++ b/podcasts/EpisodeBookmarksTabsView.swift
@@ -27,7 +27,6 @@ struct EpisodeBookmarksTabsView: View {
 
             Text(L10n.bookmarks)
                 .buttonize {
-                    selectedTab = .bookmarks
                     delegate?.showBookmarks()
                 } customize: { config in
                     config.label

--- a/podcasts/EpisodeBookmarksTabsView.swift
+++ b/podcasts/EpisodeBookmarksTabsView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import Combine
+import PocketCastsUtils
 
 /// Displays a fake set of tabs that allows the user to open the bookmarks view from the podcast list
 struct PodcastDetailsTabView: View {
@@ -16,6 +17,16 @@ struct PodcastDetailsTabView: View {
     }
 
     var body: some View {
+        if FeatureFlag.recommendations.enabled {
+            ScrollView(.horizontal, showsIndicators: false) {
+                tabs
+            }
+        } else {
+            tabs
+        }
+    }
+
+    @ViewBuilder var tabs: some View {
         HStack(spacing: 12) {
             Text(L10n.episodes)
                 .buttonize {

--- a/podcasts/EpisodeBookmarksTabsView.swift
+++ b/podcasts/EpisodeBookmarksTabsView.swift
@@ -3,29 +3,45 @@ import SwiftUI
 /// Displays a fake set of tabs that allows the user to open the bookmarks view from the podcast list
 struct EpisodeBookmarksTabsView: View {
     @EnvironmentObject var theme: Theme
+    @State private var selectedTab: Tab = .episodes
 
     weak var delegate: PodcastActionsDelegate?
+
+    enum Tab {
+        case episodes
+        case bookmarks
+        case similarShows
+    }
 
     var body: some View {
         HStack(spacing: 12) {
             Text(L10n.episodes)
-                .applyStyle(theme: theme, highlighted: true)
+                .buttonize {
+                    selectedTab = .episodes
+                    delegate?.showEpisodes()
+                } customize: { config in
+                    config.label
+                        .applyStyle(theme: theme, highlighted: selectedTab == .episodes)
+                        .applyButtonEffect(isPressed: config.isPressed)
+                }
 
             Text(L10n.bookmarks)
                 .buttonize {
+                    selectedTab = .bookmarks
                     delegate?.showBookmarks()
                 } customize: { config in
                     config.label
-                        .applyStyle(theme: theme)
+                        .applyStyle(theme: theme, highlighted: selectedTab == .bookmarks)
                         .applyButtonEffect(isPressed: config.isPressed)
                 }
 
             Text(L10n.similarShows)
                 .buttonize {
-                    print("Similar Shows")
+                    selectedTab = .similarShows
+                    delegate?.showSimilarShows()
                 } customize: { config in
                     config.label
-                        .applyStyle(theme: theme)
+                        .applyStyle(theme: theme, highlighted: selectedTab == .similarShows)
                         .applyButtonEffect(isPressed: config.isPressed)
                 }
 

--- a/podcasts/EpisodeBookmarksTabsView.swift
+++ b/podcasts/EpisodeBookmarksTabsView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import Combine
 
 /// Displays a fake set of tabs that allows the user to open the bookmarks view from the podcast list
-struct EpisodeBookmarksTabsView: View {
+struct PodcastDetailsTabView: View {
     @EnvironmentObject var theme: Theme
     @State private var selectedTab: Tab = .episodes
     @State private var hasSimilarShows = false
@@ -76,7 +76,7 @@ private extension View {
 
 struct EpisodeBookmarksTabsView_Previews: PreviewProvider {
     static var previews: some View {
-        EpisodeBookmarksTabsView()
+        PodcastDetailsTabView()
             .setupDefaultEnvironment()
     }
 }

--- a/podcasts/EpisodeBookmarksTabsView.swift
+++ b/podcasts/EpisodeBookmarksTabsView.swift
@@ -1,9 +1,11 @@
 import SwiftUI
+import Combine
 
 /// Displays a fake set of tabs that allows the user to open the bookmarks view from the podcast list
 struct EpisodeBookmarksTabsView: View {
     @EnvironmentObject var theme: Theme
     @State private var selectedTab: Tab = .episodes
+    @State private var hasSimilarShows = false
 
     weak var delegate: PodcastActionsDelegate?
 
@@ -34,20 +36,25 @@ struct EpisodeBookmarksTabsView: View {
                         .applyButtonEffect(isPressed: config.isPressed)
                 }
 
-            Text(L10n.similarShows)
-                .buttonize {
-                    selectedTab = .similarShows
-                    delegate?.showSimilarShows()
-                } customize: { config in
-                    config.label
-                        .applyStyle(theme: theme, highlighted: selectedTab == .similarShows)
-                        .applyButtonEffect(isPressed: config.isPressed)
-                }
+            if hasSimilarShows {
+                Text(L10n.similarShows)
+                    .buttonize {
+                        selectedTab = .similarShows
+                        delegate?.showSimilarShows()
+                    } customize: { config in
+                        config.label
+                            .applyStyle(theme: theme, highlighted: selectedTab == .similarShows)
+                            .applyButtonEffect(isPressed: config.isPressed)
+                    }
+            }
 
             Spacer()
         }
         .font(.subheadline.weight(.medium))
         .environment(\.dynamicTypeSize, .large)
+        .onReceive(delegate?.hasSimilarShowsPublisher ?? Just(false).eraseToAnyPublisher()) { hasShows in
+            hasSimilarShows = hasShows
+        }
     }
 }
 

--- a/podcasts/EpisodeBookmarksTabsView.swift
+++ b/podcasts/EpisodeBookmarksTabsView.swift
@@ -20,6 +20,15 @@ struct EpisodeBookmarksTabsView: View {
                         .applyButtonEffect(isPressed: config.isPressed)
                 }
 
+            Text(L10n.similarShows)
+                .buttonize {
+                    print("Similar Shows")
+                } customize: { config in
+                    config.label
+                        .applyStyle(theme: theme)
+                        .applyButtonEffect(isPressed: config.isPressed)
+                }
+
             Spacer()
         }
         .font(.subheadline.weight(.medium))

--- a/podcasts/PodcastDetailsTabView.swift
+++ b/podcasts/PodcastDetailsTabView.swift
@@ -85,7 +85,7 @@ private extension View {
 
 // MARK: - Previews
 
-struct EpisodeBookmarksTabsView_Previews: PreviewProvider {
+struct PodcastDetailsTabView_Previews: PreviewProvider {
     static var previews: some View {
         PodcastDetailsTabView()
             .setupDefaultEnvironment()

--- a/podcasts/PodcastHeaderView.swift
+++ b/podcasts/PodcastHeaderView.swift
@@ -74,7 +74,7 @@ struct PodcastHeaderView: View {
                 .frame(maxHeight: viewModel.isExpanded ? .infinity : 0)
                 .opacity(viewModel.isExpanded ? 1 : 0)
                 .clipped()
-            EpisodeBookmarksTabsView(delegate: viewModel.delegate)
+            PodcastDetailsTabView(delegate: viewModel.delegate)
         }
         .padding(.horizontal)
     }

--- a/podcasts/PodcastHeadingTableCell.swift
+++ b/podcasts/PodcastHeadingTableCell.swift
@@ -137,7 +137,7 @@ class PodcastHeadingTableCell: ThemeableCell, SubscribeButtonDelegate, Expandabl
     override func setHighlighted(_ highlighted: Bool, animated: Bool) {}
 
     @IBOutlet var bookmarkTabsView: UIStackView!
-    private var tabsViewController: ThemedHostingController<EpisodeBookmarksTabsView>? = nil
+    private var tabsViewController: ThemedHostingController<PodcastDetailsTabView>? = nil
 
     override func prepareForReuse() {
         super.prepareForReuse()
@@ -154,7 +154,7 @@ class PodcastHeadingTableCell: ThemeableCell, SubscribeButtonDelegate, Expandabl
         }
 
         bookmarkTabsView.removeAllSubviews()
-        let controller = ThemedHostingController(rootView: EpisodeBookmarksTabsView(delegate: delegate))
+        let controller = ThemedHostingController(rootView: PodcastDetailsTabView(delegate: delegate))
 
         bookmarkTabsView.addArrangedSubview(controller.view)
         parentController.addChild(controller)

--- a/podcasts/PodcastInfo+DiscoverPodcast.swift
+++ b/podcasts/PodcastInfo+DiscoverPodcast.swift
@@ -2,10 +2,9 @@ import PocketCastsServer
 
 extension PodcastInfo {
     init(_ podcast: DiscoverPodcast) {
-        var info = Self()
-        info.uuid = podcast.uuid
-        info.title = podcast.title
-        info.author = podcast.author
-        self = info
+        self.init()
+        self.uuid   = podcast.uuid
+        self.title  = podcast.title
+        self.author = podcast.author
     }
 }

--- a/podcasts/PodcastInfo+DiscoverPodcast.swift
+++ b/podcasts/PodcastInfo+DiscoverPodcast.swift
@@ -1,0 +1,11 @@
+import PocketCastsServer
+
+extension PodcastInfo {
+    init(_ podcast: DiscoverPodcast) {
+        var info = Self()
+        info.uuid = podcast.uuid
+        info.title = podcast.title
+        info.author = podcast.author
+        self = info
+    }
+}

--- a/podcasts/PodcastTableCellView.swift
+++ b/podcasts/PodcastTableCellView.swift
@@ -13,14 +13,14 @@ struct PodcastTableCellView: View {
                 .frame(width: 48, height: 48)
                 .clipShape(RoundedRectangle(cornerRadius: 4))
 
-            VStack(alignment: .leading) {
+            VStack(alignment: .leading, spacing: 3) {
                 Text(viewModel.title ?? "")
                     .lineLimit(1)
-                    .font(.system(size: 15, weight: .medium))
+                    .font(.system(size: 16, weight: .medium))
                     .foregroundStyle(theme.primaryText01)
                 Text(viewModel.author ?? "")
                     .lineLimit(1)
-                    .font(.system(size: 14, weight: .medium))
+                    .font(.system(size: 14, weight: .regular))
                     .foregroundStyle(theme.primaryText02)
             }
 

--- a/podcasts/PodcastTableCellView.swift
+++ b/podcasts/PodcastTableCellView.swift
@@ -1,0 +1,49 @@
+import UIKit
+import SwiftUI
+import PocketCastsDataModel
+import PocketCastsServer
+
+struct PodcastTableCellView: View {
+    @EnvironmentObject var theme: Theme
+    let viewModel: PodcastCellViewModel
+
+    var body: some View {
+        HStack(spacing: 8) {
+            PodcastImage(uuid: viewModel.uuid)
+                .frame(width: 48, height: 48)
+                .clipShape(RoundedRectangle(cornerRadius: 4))
+
+            VStack(alignment: .leading) {
+                Text(viewModel.title ?? "")
+                    .font(.system(size: 15, weight: .medium))
+                    .foregroundStyle(theme.primaryText01)
+                Text(viewModel.author ?? "")
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundStyle(theme.primaryText02)
+            }
+
+            Spacer()
+
+            //TODO: Change source to Similar Shows
+            SubscribeButtonView(podcastUuid: viewModel.uuid, source: .podcastScreen)
+        }
+    }
+}
+
+struct PodcastCellViewModel {
+    let uuid: String
+    let title: String?
+    let author: String?
+
+    init(podcast: Podcast) {
+        self.uuid = podcast.uuid
+        self.title = podcast.title
+        self.author = podcast.author
+    }
+
+    init(discoverPodcast: DiscoverPodcast) {
+        self.uuid = discoverPodcast.uuid ?? ""
+        self.title = discoverPodcast.title
+        self.author = discoverPodcast.author
+    }
+}

--- a/podcasts/PodcastTableCellView.swift
+++ b/podcasts/PodcastTableCellView.swift
@@ -24,8 +24,7 @@ struct PodcastTableCellView: View {
 
             Spacer()
 
-            //TODO: Change source to Similar Shows
-            SubscribeButtonView(podcastUuid: viewModel.uuid, source: .podcastScreen)
+            SubscribeButtonView(podcastUuid: viewModel.uuid, source: .podcastScreenSimilarShows)
         }
     }
 }

--- a/podcasts/PodcastTableCellView.swift
+++ b/podcasts/PodcastTableCellView.swift
@@ -15,9 +15,11 @@ struct PodcastTableCellView: View {
 
             VStack(alignment: .leading) {
                 Text(viewModel.title ?? "")
+                    .lineLimit(1)
                     .font(.system(size: 15, weight: .medium))
                     .foregroundStyle(theme.primaryText01)
                 Text(viewModel.author ?? "")
+                    .lineLimit(1)
                     .font(.system(size: 14, weight: .medium))
                     .foregroundStyle(theme.primaryText02)
             }

--- a/podcasts/PodcastTableViewCell.swift
+++ b/podcasts/PodcastTableViewCell.swift
@@ -1,0 +1,37 @@
+import UIKit
+import SwiftUI
+import PocketCastsDataModel
+
+struct PodcastTableCellView: View {
+    let podcast: Podcast
+
+    var body: some View {
+        PodcastImage(uuid: podcast.uuid)
+
+        Text(podcast.title ?? "")
+            .font(style: .body)
+    }
+}
+
+final class PodcastTableViewCell: UITableViewCell {
+
+    static var reuseIdentifier: String = "PodcastTableViewCell"
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+
+        contentConfiguration = nil
+    }
+
+    func configure(with podcast: Podcast) {
+        if #available(iOS 16.0, *) {
+            self.contentConfiguration = UIHostingConfiguration {
+                PodcastTableCellView(podcast: podcast)
+            }
+        } else {
+            let view = PodcastTableCellView(podcast: podcast)
+            let uiView = view.environmentObject(Theme.sharedTheme).uiView
+            contentView.addSubview(uiView)
+        }
+    }
+}

--- a/podcasts/PodcastTableViewCell.swift
+++ b/podcasts/PodcastTableViewCell.swift
@@ -26,6 +26,8 @@ final class PodcastTableViewCell: ThemeableCell {
                 PodcastTableCellView(viewModel: viewModel)
                     .environmentObject(Theme.sharedTheme)
             }
+            .margins(.horizontal, 16)
+            .margins(.vertical, 8)
         } else {
             let view = PodcastTableCellView(viewModel: viewModel)
             let uiView = view.environmentObject(Theme.sharedTheme).uiView

--- a/podcasts/PodcastTableViewCell.swift
+++ b/podcasts/PodcastTableViewCell.swift
@@ -1,4 +1,8 @@
-final class PodcastTableViewCell: UITableViewCell {
+import SwiftUI
+import PocketCastsServer
+import PocketCastsDataModel
+
+final class PodcastTableViewCell: ThemeableCell {
     static var reuseIdentifier: String = "PodcastTableViewCell"
     private var viewModel: PodcastCellViewModel?
 
@@ -9,6 +13,8 @@ final class PodcastTableViewCell: UITableViewCell {
     }
 
     func configure(with viewModel: PodcastCellViewModel) {
+        self.selectedStyle = .primaryUi02Active
+
         self.viewModel = viewModel
 
         if #available(iOS 16.0, *) {

--- a/podcasts/PodcastTableViewCell.swift
+++ b/podcasts/PodcastTableViewCell.swift
@@ -1,21 +1,32 @@
 import UIKit
 import SwiftUI
 import PocketCastsDataModel
+import PocketCastsServer
 
 struct PodcastTableCellView: View {
+    @EnvironmentObject var theme: Theme
+
     let podcast: Podcast
 
     var body: some View {
-        HStack {
+        HStack(spacing: 8) {
             PodcastImage(uuid: podcast.uuid)
                 .frame(width: 48, height: 48)
+                .clipShape(RoundedRectangle(cornerRadius: 4))
 
-            VStack {
+            VStack(alignment: .leading) {
                 Text(podcast.title ?? "")
-                    .font(style: .body)
+                    .font(.system(size: 15, weight: .medium))
+                    .foregroundStyle(theme.primaryText01)
                 Text(podcast.author ?? "")
-                    .font(style: .caption)
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundStyle(theme.primaryText02)
             }
+
+            Spacer()
+
+            //TODO: Change source to Similar Shows
+            SubscribeButtonView(podcastUuid: podcast.uuid, source: .podcastScreen)
         }
     }
 }
@@ -30,15 +41,43 @@ final class PodcastTableViewCell: UITableViewCell {
         contentConfiguration = nil
     }
 
-    func configure(with podcast: Podcast) {
-        if #available(iOS 16.0, *) {
-            self.contentConfiguration = UIHostingConfiguration {
-                PodcastTableCellView(podcast: podcast)
+    func configure(with uuid: String) {
+        //TODO: Add task to something
+        Task {
+            let podcast = try await load(podcast: uuid)
+
+            if #available(iOS 16.0, *) {
+                self.contentConfiguration = UIHostingConfiguration {
+                    PodcastTableCellView(podcast: podcast)
+                        .environmentObject(Theme.sharedTheme)
+                }
+            } else {
+                let view = PodcastTableCellView(podcast: podcast)
+                let uiView = view.environmentObject(Theme.sharedTheme).uiView
+                contentView.addSubview(uiView)
             }
-        } else {
-            let view = PodcastTableCellView(podcast: podcast)
-            let uiView = view.environmentObject(Theme.sharedTheme).uiView
-            contentView.addSubview(uiView)
+        }
+    }
+
+    private enum ClientError: Swift.Error {
+        case noPodcastUuid
+        case podcastNotFound
+        case episodeNotFound
+    }
+
+    func load(podcast: String) async throws -> Podcast {
+        if let existingPodcast = DataManager.sharedManager.findPodcast(uuid: podcast, includeUnsubscribed: true) {
+            return existingPodcast
+        }
+
+        return try await withCheckedThrowingContinuation { continuation in
+            ServerPodcastManager.shared.addFromUuid(podcastUuid: podcast, subscribe: false) { added in
+                if added, let existingPodcast = DataManager.sharedManager.findPodcast(uuid: podcast, includeUnsubscribed: true) {
+                    continuation.resume(returning: existingPodcast)
+                } else {
+                    continuation.resume(throwing: ClientError.podcastNotFound)
+                }
+            }
         }
     }
 }

--- a/podcasts/PodcastTableViewCell.swift
+++ b/podcasts/PodcastTableViewCell.swift
@@ -29,7 +29,15 @@ final class PodcastTableViewCell: ThemeableCell {
         } else {
             let view = PodcastTableCellView(viewModel: viewModel)
             let uiView = view.environmentObject(Theme.sharedTheme).uiView
+            uiView.translatesAutoresizingMaskIntoConstraints = false
+            uiView.backgroundColor = .clear
             contentView.addSubview(uiView)
+            NSLayoutConstraint.activate([
+                contentView.layoutMarginsGuide.leadingAnchor.constraint(equalTo: uiView.leadingAnchor),
+                contentView.layoutMarginsGuide.trailingAnchor.constraint(equalTo: uiView.trailingAnchor),
+                contentView.layoutMarginsGuide.bottomAnchor.constraint(equalTo: uiView.bottomAnchor),
+                contentView.layoutMarginsGuide.topAnchor.constraint(equalTo: uiView.topAnchor)
+            ])
         }
     }
 

--- a/podcasts/PodcastTableViewCell.swift
+++ b/podcasts/PodcastTableViewCell.swift
@@ -6,10 +6,17 @@ struct PodcastTableCellView: View {
     let podcast: Podcast
 
     var body: some View {
-        PodcastImage(uuid: podcast.uuid)
+        HStack {
+            PodcastImage(uuid: podcast.uuid)
+                .frame(width: 48, height: 48)
 
-        Text(podcast.title ?? "")
-            .font(style: .body)
+            VStack {
+                Text(podcast.title ?? "")
+                    .font(style: .body)
+                Text(podcast.author ?? "")
+                    .font(style: .caption)
+            }
+        }
     }
 }
 

--- a/podcasts/PodcastTableViewCell.swift
+++ b/podcasts/PodcastTableViewCell.swift
@@ -10,6 +10,10 @@ final class PodcastTableViewCell: ThemeableCell {
         super.prepareForReuse()
         contentConfiguration = nil
         viewModel = nil
+        if #available(iOS 16.0, *) {
+        } else {
+            contentView.subviews.forEach { $0.removeFromSuperview() }
+        }
     }
 
     func configure(with viewModel: PodcastCellViewModel) {

--- a/podcasts/PodcastTableViewCell.swift
+++ b/podcasts/PodcastTableViewCell.swift
@@ -37,8 +37,8 @@ final class PodcastTableViewCell: ThemeableCell {
             NSLayoutConstraint.activate([
                 contentView.layoutMarginsGuide.leadingAnchor.constraint(equalTo: uiView.leadingAnchor),
                 contentView.layoutMarginsGuide.trailingAnchor.constraint(equalTo: uiView.trailingAnchor),
-                contentView.layoutMarginsGuide.bottomAnchor.constraint(equalTo: uiView.bottomAnchor),
-                contentView.layoutMarginsGuide.topAnchor.constraint(equalTo: uiView.topAnchor)
+                contentView.bottomAnchor.constraint(equalTo: uiView.bottomAnchor),
+                contentView.topAnchor.constraint(equalTo: uiView.topAnchor)
             ])
         }
     }

--- a/podcasts/PodcastTableViewCell.swift
+++ b/podcasts/PodcastTableViewCell.swift
@@ -1,62 +1,30 @@
-import UIKit
-import SwiftUI
-import PocketCastsDataModel
-import PocketCastsServer
-
-struct PodcastTableCellView: View {
-    @EnvironmentObject var theme: Theme
-
-    let podcast: Podcast
-
-    var body: some View {
-        HStack(spacing: 8) {
-            PodcastImage(uuid: podcast.uuid)
-                .frame(width: 48, height: 48)
-                .clipShape(RoundedRectangle(cornerRadius: 4))
-
-            VStack(alignment: .leading) {
-                Text(podcast.title ?? "")
-                    .font(.system(size: 15, weight: .medium))
-                    .foregroundStyle(theme.primaryText01)
-                Text(podcast.author ?? "")
-                    .font(.system(size: 14, weight: .medium))
-                    .foregroundStyle(theme.primaryText02)
-            }
-
-            Spacer()
-
-            //TODO: Change source to Similar Shows
-            SubscribeButtonView(podcastUuid: podcast.uuid, source: .podcastScreen)
-        }
-    }
-}
-
 final class PodcastTableViewCell: UITableViewCell {
-
     static var reuseIdentifier: String = "PodcastTableViewCell"
+    private var viewModel: PodcastCellViewModel?
 
     override func prepareForReuse() {
         super.prepareForReuse()
-
         contentConfiguration = nil
+        viewModel = nil
     }
 
-    func configure(with uuid: String) {
-        //TODO: Add task to something
-        Task {
-            let podcast = try await load(podcast: uuid)
+    func configure(with viewModel: PodcastCellViewModel) {
+        self.viewModel = viewModel
 
-            if #available(iOS 16.0, *) {
-                self.contentConfiguration = UIHostingConfiguration {
-                    PodcastTableCellView(podcast: podcast)
-                        .environmentObject(Theme.sharedTheme)
-                }
-            } else {
-                let view = PodcastTableCellView(podcast: podcast)
-                let uiView = view.environmentObject(Theme.sharedTheme).uiView
-                contentView.addSubview(uiView)
+        if #available(iOS 16.0, *) {
+            self.contentConfiguration = UIHostingConfiguration {
+                PodcastTableCellView(viewModel: viewModel)
+                    .environmentObject(Theme.sharedTheme)
             }
+        } else {
+            let view = PodcastTableCellView(viewModel: viewModel)
+            let uiView = view.environmentObject(Theme.sharedTheme).uiView
+            contentView.addSubview(uiView)
         }
+    }
+
+    func configure(with discoverPodcast: DiscoverPodcast) {
+        configure(with: PodcastCellViewModel(discoverPodcast: discoverPodcast))
     }
 
     private enum ClientError: Swift.Error {

--- a/podcasts/PodcastViewController+TableData.swift
+++ b/podcasts/PodcastViewController+TableData.swift
@@ -235,7 +235,7 @@ extension PodcastViewController: UITableViewDataSource, UITableViewDelegate {
                 }
             } else {
                 let selectedPodcast = similarPodcasts[indexPath.row]
-                if let podcast = DataManager.sharedManager.findPodcast(uuid: selectedPodcast) {
+                if let uuid = selectedPodcast.uuid, let podcast = DataManager.sharedManager.findPodcast(uuid: uuid) {
                     let podcastController = PodcastViewController(podcast: podcast)
                     navigationController?.pushViewController(podcastController, animated: true)
                 }

--- a/podcasts/PodcastViewController+TableData.swift
+++ b/podcasts/PodcastViewController+TableData.swift
@@ -26,7 +26,7 @@ extension PodcastViewController: UITableViewDataSource, UITableViewDelegate {
     }
 
     @objc private func tableLongPressed(_ sender: UILongPressGestureRecognizer) {
-        if sender.state == .began {
+        if sender.state == .began && currentViewMode != .similarShows {
             let touchPoint = sender.location(in: episodesTable)
             guard let indexPath = episodesTable.indexPathForRow(at: touchPoint), episodeAtIndexPath(indexPath) != nil else { return }
 
@@ -300,7 +300,8 @@ extension PodcastViewController: UITableViewDataSource, UITableViewDelegate {
     // MARK: - Swipe Actions
 
     func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
-        indexPath.section == PodcastViewController.allEpisodesSection && episodeAtIndexPath(indexPath) != nil
+        guard currentViewMode != .similarShows else { return false }
+        return indexPath.section == PodcastViewController.allEpisodesSection && episodeAtIndexPath(indexPath) != nil
     }
 
     func episodeAtIndexPath(_ indexPath: IndexPath) -> Episode? {
@@ -312,7 +313,9 @@ extension PodcastViewController: UITableViewDataSource, UITableViewDelegate {
     // MARK: - multi select support
 
     func tableView(_ tableView: UITableView, shouldBeginMultipleSelectionInteractionAt indexPath: IndexPath) -> Bool {
-        guard indexPath.section == PodcastViewController.allEpisodesSection, episodeAtIndexPath(indexPath) != nil else { return false }
+        guard currentViewMode != .similarShows,
+              indexPath.section == PodcastViewController.allEpisodesSection,
+              episodeAtIndexPath(indexPath) != nil else { return false }
 
         return Settings.multiSelectGestureEnabled()
     }

--- a/podcasts/PodcastViewController+TableData.swift
+++ b/podcasts/PodcastViewController+TableData.swift
@@ -1,6 +1,7 @@
 import PocketCastsDataModel
 import PocketCastsUtils
 import UIKit
+import PocketCastsServer
 
 extension PodcastViewController: UITableViewDataSource, UITableViewDelegate {
     private static let episodeCellId = "EpisodeCell"
@@ -235,10 +236,9 @@ extension PodcastViewController: UITableViewDataSource, UITableViewDelegate {
                 }
             } else {
                 let selectedPodcast = similarPodcasts[indexPath.row]
-                if let uuid = selectedPodcast.uuid, let podcast = DataManager.sharedManager.findPodcast(uuid: uuid) {
-                    let podcastController = PodcastViewController(podcast: podcast)
-                    navigationController?.pushViewController(podcastController, animated: true)
-                }
+                let info = PodcastInfo(selectedPodcast)
+                let podcastController = PodcastViewController(podcastInfo: info, existingImage: nil)
+                navigationController?.pushViewController(podcastController, animated: true)
             }
         }
     }

--- a/podcasts/PodcastViewController+TableData.swift
+++ b/podcasts/PodcastViewController+TableData.swift
@@ -153,6 +153,7 @@ extension PodcastViewController: UITableViewDataSource, UITableViewDelegate {
                 let podcast = similarPodcasts[indexPath.row]
                 let cell = tableView.dequeueReusableCell(withIdentifier: PodcastTableViewCell.reuseIdentifier, for: indexPath) as! PodcastTableViewCell
                 cell.configure(with: podcast)
+                cell.separatorInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: .greatestFiniteMagnitude)
                 return cell
             }
         }
@@ -253,19 +254,38 @@ extension PodcastViewController: UITableViewDataSource, UITableViewDelegate {
     // MARK: - Table Config
 
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        PodcastViewController.allEpisodesSection == section ? UITableView.automaticDimension : CGFloat.leastNonzeroMagnitude
+        if currentViewMode == .similarShows {
+            return CGFloat.leastNonzeroMagnitude
+        }
+        return PodcastViewController.allEpisodesSection == section ? UITableView.automaticDimension : CGFloat.leastNonzeroMagnitude
     }
 
     func tableView(_ tableView: UITableView, estimatedHeightForHeaderInSection section: Int) -> CGFloat {
-        PodcastViewController.allEpisodesSection == section ? 100 : CGFloat.leastNonzeroMagnitude
+        if currentViewMode == .similarShows {
+            return CGFloat.leastNonzeroMagnitude
+        }
+        return PodcastViewController.allEpisodesSection == section ? 100 : CGFloat.leastNonzeroMagnitude
     }
 
     func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        CGFloat.leastNonzeroMagnitude
+        if currentViewMode == .similarShows && section == PodcastViewController.headerSection {
+            return 16
+        }
+        return CGFloat.leastNonzeroMagnitude
+    }
+
+    func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+        if currentViewMode == .similarShows && section == PodcastViewController.headerSection {
+            let footerView = UIView()
+            footerView.backgroundColor = .clear
+            return footerView
+        }
+        return nil
     }
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        PodcastViewController.allEpisodesSection == section ? searchController?.view : nil
+        guard PodcastViewController.allEpisodesSection == section else { return nil }
+        return currentViewMode == .episodes ? searchController?.view : nil
     }
 
     func tableView(_ tableView: UITableView, willDisplayFooterView view: UIView, forSection section: Int) {

--- a/podcasts/PodcastViewController+TableData.swift
+++ b/podcasts/PodcastViewController+TableData.swift
@@ -11,6 +11,7 @@ extension PodcastViewController: UITableViewDataSource, UITableViewDelegate {
     private static let groupHeadingCellId = "GroupHeading"
 
     func registerCells() {
+        episodesTable.register(PodcastTableViewCell.self, forCellReuseIdentifier: PodcastTableViewCell.reuseIdentifier)
         episodesTable.register(UINib(nibName: "EpisodeCell", bundle: nil), forCellReuseIdentifier: PodcastViewController.episodeCellId)
         episodesTable.register(UINib(nibName: "PodcastHeadingTableCell", bundle: nil), forCellReuseIdentifier: PodcastViewController.headerCellId)
         episodesTable.register(UINib(nibName: "EpisodeLimitCell", bundle: nil), forCellReuseIdentifier: PodcastViewController.limitCellId)

--- a/podcasts/PodcastViewController+TableData.swift
+++ b/podcasts/PodcastViewController+TableData.swift
@@ -235,8 +235,10 @@ extension PodcastViewController: UITableViewDataSource, UITableViewDelegate {
                 }
             } else {
                 let selectedPodcast = similarPodcasts[indexPath.row]
-                let podcastController = PodcastViewController(podcast: selectedPodcast)
-                navigationController?.pushViewController(podcastController, animated: true)
+                if let podcast = DataManager.sharedManager.findPodcast(uuid: selectedPodcast) {
+                    let podcastController = PodcastViewController(podcast: podcast)
+                    navigationController?.pushViewController(podcastController, animated: true)
+                }
             }
         }
     }

--- a/podcasts/PodcastViewController+TableData.swift
+++ b/podcasts/PodcastViewController+TableData.swift
@@ -52,65 +52,109 @@ extension PodcastViewController: UITableViewDataSource, UITableViewDelegate {
     // MARK: - Table Data
 
     func numberOfSections(in tableView: UITableView) -> Int {
-        loadingPodcastInfo ? 0 : 2
+        if loadingPodcastInfo { return 0 }
+
+        switch currentViewMode {
+        case .episodes:
+            return 2
+        case .bookmarks:
+            return 0 // Bookmarks are shown in a separate controller
+        case .similarShows:
+            return 2 // Keep the same number of sections as episodes
+        }
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         if loadingPodcastInfo { return 0 }
 
-        return episodeInfo[safe: section]?.elements.count ?? 0
+        switch currentViewMode {
+        case .episodes:
+            return episodeInfo[safe: section]?.elements.count ?? 0
+        case .bookmarks:
+            return 0
+        case .similarShows:
+            if section == PodcastViewController.headerSection {
+                return 1 // Keep the header
+            } else {
+                return similarPodcasts.count
+            }
+        }
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        if indexPath.section == PodcastViewController.headerSection {
-            if FeatureFlag.podcastViewChanges.enabled {
-                let cell = podcastHeaderCell
+        switch currentViewMode {
+        case .episodes:
+            if indexPath.section == PodcastViewController.headerSection {
+                if FeatureFlag.podcastViewChanges.enabled {
+                    let cell = podcastHeaderCell
+                    return cell
+                } else {
+                    let cell = podcastHeadingCell
+                    cell.populateFrom(tintColor: podcast?.iconTintColor(), delegate: self, parentController: self)
+                    cell.buttonsEnabled = !isMultiSelectEnabled
+                    return cell
+                }
+            }
+
+            guard let itemAtRow = episodeInfo[safe: indexPath.section]?.elements[safe: indexPath.row] as? ListItem else {
+                FileLog.shared.addMessage("EpisodeInfo missing ListItem in section \(indexPath.section), row \(indexPath.row)")
+                return UITableViewCell()
+            }
+            if let listEpisode = itemAtRow as? ListEpisode {
+                let cell = tableView.dequeueReusableCell(withIdentifier: PodcastViewController.episodeCellId, for: indexPath) as! EpisodeCell
+                cell.hidesArtwork = true
+
+                if let podcast {
+                    cell.playlist = .podcast(uuid: podcast.uuid)
+                }
+
+                cell.delegate = self
+                cell.populateFrom(episode: listEpisode.episode, tintColor: podcast?.iconTintColor(), podcastUuid: podcast?.uuid, listUuid: listUuid)
+                cell.shouldShowSelect = isMultiSelectEnabled
+                if isMultiSelectEnabled {
+                    cell.showTick = selectedEpisodesContains(uuid: listEpisode.episode.uuid)
+                }
+                return cell
+            } else if let limitPlaceholder = itemAtRow as? EpisodeLimitPlaceholder {
+                let cell = tableView.dequeueReusableCell(withIdentifier: PodcastViewController.limitCellId, for: indexPath) as! EpisodeLimitCell
+                cell.limitMessage.text = limitPlaceholder.message
+                return cell
+            } else if itemAtRow is NoSearchResultsPlaceholder {
+                let cell = tableView.dequeueReusableCell(withIdentifier: PodcastViewController.noSearchResultsCell, for: indexPath) as! NoSearchResultsCell
+                return cell
+            } else if let archivedPlaceholder = itemAtRow as? AllArchivedPlaceholder {
+                let cell = tableView.dequeueReusableCell(withIdentifier: PodcastViewController.allArchivedCellId, for: indexPath) as! AllArchivedCell
+                cell.episodesArchivedLabel.text = archivedPlaceholder.message
+                return cell
+            } else if let heading = itemAtRow as? ListHeader {
+                let cell = tableView.dequeueReusableCell(withIdentifier: PodcastViewController.groupHeadingCellId, for: indexPath) as! HeadingCell
+                cell.heading.text = heading.headerTitle
                 return cell
             } else {
-                let cell = podcastHeadingCell
-                cell.populateFrom(tintColor: podcast?.iconTintColor(), delegate: self, parentController: self)
-                cell.buttonsEnabled = !isMultiSelectEnabled
+                let cell = tableView.dequeueReusableCell(withIdentifier: PodcastViewController.limitCellId, for: indexPath) as! EpisodeLimitCell
                 return cell
             }
-        }
 
-        guard let itemAtRow = episodeInfo[safe: indexPath.section]?.elements[safe: indexPath.row] as? ListItem else {
-            FileLog.shared.addMessage("EpisodeInfo missing ListItem in section \(indexPath.section), row \(indexPath.row)")
+        case .bookmarks:
             return UITableViewCell()
-        }
-        if let listEpisode = itemAtRow as? ListEpisode {
-            let cell = tableView.dequeueReusableCell(withIdentifier: PodcastViewController.episodeCellId, for: indexPath) as! EpisodeCell
-            cell.hidesArtwork = true
 
-            if let podcast {
-                cell.playlist = .podcast(uuid: podcast.uuid)
+        case .similarShows:
+            if indexPath.section == PodcastViewController.headerSection {
+                if FeatureFlag.podcastViewChanges.enabled {
+                    let cell = podcastHeaderCell
+                    return cell
+                } else {
+                    let cell = podcastHeadingCell
+                    cell.populateFrom(tintColor: podcast?.iconTintColor(), delegate: self, parentController: self)
+                    cell.buttonsEnabled = !isMultiSelectEnabled
+                    return cell
+                }
+            } else {
+                let podcast = similarPodcasts[indexPath.row]
+                let cell = tableView.dequeueReusableCell(withIdentifier: PodcastTableViewCell.reuseIdentifier, for: indexPath) as! PodcastTableViewCell
+                cell.configure(with: podcast)
+                return cell
             }
-
-            cell.delegate = self
-            cell.populateFrom(episode: listEpisode.episode, tintColor: podcast?.iconTintColor(), podcastUuid: podcast?.uuid, listUuid: listUuid)
-            cell.shouldShowSelect = isMultiSelectEnabled
-            if isMultiSelectEnabled {
-                cell.showTick = selectedEpisodesContains(uuid: listEpisode.episode.uuid)
-            }
-            return cell
-        } else if let limitPlaceholder = itemAtRow as? EpisodeLimitPlaceholder {
-            let cell = tableView.dequeueReusableCell(withIdentifier: PodcastViewController.limitCellId, for: indexPath) as! EpisodeLimitCell
-            cell.limitMessage.text = limitPlaceholder.message
-            return cell
-        } else if itemAtRow is NoSearchResultsPlaceholder {
-            let cell = tableView.dequeueReusableCell(withIdentifier: PodcastViewController.noSearchResultsCell, for: indexPath) as! NoSearchResultsCell
-            return cell
-        } else if let archivedPlaceholder = itemAtRow as? AllArchivedPlaceholder {
-            let cell = tableView.dequeueReusableCell(withIdentifier: PodcastViewController.allArchivedCellId, for: indexPath) as! AllArchivedCell
-            cell.episodesArchivedLabel.text = archivedPlaceholder.message
-            return cell
-        } else if let heading = itemAtRow as? ListHeader {
-            let cell = tableView.dequeueReusableCell(withIdentifier: PodcastViewController.groupHeadingCellId, for: indexPath) as! HeadingCell
-            cell.heading.text = heading.headerTitle
-            return cell
-        } else {
-            let cell = tableView.dequeueReusableCell(withIdentifier: PodcastViewController.limitCellId, for: indexPath) as! EpisodeLimitCell
-            return cell
         }
     }
 
@@ -147,34 +191,51 @@ extension PodcastViewController: UITableViewDataSource, UITableViewDelegate {
     }
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        if isMultiSelectEnabled, indexPath.section == PodcastViewController.allEpisodesSection {
-            if let listEpisode = episodeInfo[indexPath.section].elements[indexPath.row] as? ListEpisode {
-                if !multiSelectGestureInProgress {
-                    // If the episode is already selected move to the end of the array
-                    selectedEpisodesRemove(uuid: listEpisode.episode.uuid)
-                }
+        switch currentViewMode {
+        case .episodes:
+            if isMultiSelectEnabled, indexPath.section == PodcastViewController.allEpisodesSection {
+                if let listEpisode = episodeInfo[indexPath.section].elements[indexPath.row] as? ListEpisode {
+                    if !multiSelectGestureInProgress {
+                        // If the episode is already selected move to the end of the array
+                        selectedEpisodesRemove(uuid: listEpisode.episode.uuid)
+                    }
 
-                if !multiSelectGestureInProgress || multiSelectGestureInProgress, !selectedEpisodesContains(uuid: listEpisode.episode.uuid) {
-                    selectedEpisodes.append(listEpisode)
-                    // the cell below is optional because cellForRow only returns a cell if it's visible, and we don't need to tick cells that don't exist
-                    if let cell = episodesTable.cellForRow(at: indexPath) as? EpisodeCell? {
-                        cell?.showTick = true
+                    if !multiSelectGestureInProgress || multiSelectGestureInProgress, !selectedEpisodesContains(uuid: listEpisode.episode.uuid) {
+                        selectedEpisodes.append(listEpisode)
+                        // the cell below is optional because cellForRow only returns a cell if it's visible, and we don't need to tick cells that don't exist
+                        if let cell = episodesTable.cellForRow(at: indexPath) as? EpisodeCell? {
+                            cell?.showTick = true
+                        }
                     }
                 }
-            }
-        } else {
-            tableView.deselectRow(at: indexPath, animated: true)
+            } else {
+                tableView.deselectRow(at: indexPath, animated: true)
 
+                if indexPath.section == PodcastViewController.headerSection {
+                    if let cell = tableView.cellForRow(at: indexPath) as? PodcastHeadingTableCell, !isMultiSelectEnabled {
+                        cell.toggleExpanded(delegate: self)
+                    }
+                } else if indexPath.section == PodcastViewController.allEpisodesSection {
+                    guard let podcast = podcast, let episode = episodeAtIndexPath(indexPath) else { return }
+
+                    let episodeController = EpisodeDetailViewController(episode: episode, podcast: podcast, source: .podcastScreen, playlist: .podcast(uuid: podcast.uuid))
+                    episodeController.modalPresentationStyle = .formSheet
+                    present(episodeController, animated: true, completion: nil)
+                }
+            }
+
+        case .bookmarks:
+            break
+
+        case .similarShows:
             if indexPath.section == PodcastViewController.headerSection {
                 if let cell = tableView.cellForRow(at: indexPath) as? PodcastHeadingTableCell, !isMultiSelectEnabled {
                     cell.toggleExpanded(delegate: self)
                 }
-            } else if indexPath.section == PodcastViewController.allEpisodesSection {
-                guard let podcast = podcast, let episode = episodeAtIndexPath(indexPath) else { return }
-
-                let episodeController = EpisodeDetailViewController(episode: episode, podcast: podcast, source: .podcastScreen, playlist: .podcast(uuid: podcast.uuid))
-                episodeController.modalPresentationStyle = .formSheet
-                present(episodeController, animated: true, completion: nil)
+            } else {
+                let selectedPodcast = similarPodcasts[indexPath.row]
+                let podcastController = PodcastViewController(podcast: selectedPodcast)
+                navigationController?.pushViewController(podcastController, animated: true)
             }
         }
     }

--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -80,7 +80,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
     var summaryExpanded = false
     var descriptionExpanded = false
     var currentViewMode: ViewMode = .episodes
-    var similarPodcasts: [String] = []
+    var similarPodcasts: [DiscoverPodcast] = []
     private var hasSimilarShows = CurrentValueSubject<Bool, Never>(false)
     var hasSimilarShowsPublisher: AnyPublisher<Bool, Never> {
         hasSimilarShows.eraseToAnyPublisher()
@@ -1149,7 +1149,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
         Analytics.track(.podcastsScreenTabTapped, properties: ["value": "similar_shows"])
 
         // Use the stored recommendations data
-        similarPodcasts = recommendations?.podcasts?.compactMap { $0.uuid } ?? []
+        similarPodcasts = recommendations?.podcasts ?? []
         reloadData()
     }
 

--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -91,6 +91,14 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
         case episodes
         case bookmarks
         case similarShows
+
+        var analyticsValue: String {
+            switch self {
+            case .episodes: return "episodes"
+            case .bookmarks: return "bookmarks"
+            case .similarShows: return "similar_shows"
+            }
+        }
     }
 
     var searchController: EpisodeListSearchController?
@@ -476,13 +484,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
 
         // Load recommendations when view appears
         Task {
-            if let podcast = podcast {
-                recommendations = try await ServerPodcastManager.shared.loadRecommendations(for: podcast.uuid)
-                DispatchQueue.main.async { [weak self] in
-                    guard let self else { return }
-                    hasSimilarShows.send(recommendations?.podcasts?.isEmpty == false)
-                }
-            }
+            await loadRecommendations()
         }
     }
 
@@ -1125,32 +1127,18 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
     }
 
     func showEpisodes() {
-        currentViewMode = .episodes
-        if let podcast = podcast {
-            loadLocalEpisodes(podcast: podcast, animated: true)
-        }
-        reloadData()
+        switchViewMode(to: .episodes)
     }
 
     func showBookmarks() {
-        currentViewMode = .bookmarks
         guard let podcast else { return }
-
-        Analytics.track(.podcastsScreenTabTapped, properties: ["value": "bookmarks"])
 
         let controller = BookmarksPodcastListController(podcast: podcast)
         present(controller, animated: true)
     }
 
     func showSimilarShows() {
-        currentViewMode = .similarShows
-        guard let podcast else { return }
-
-        Analytics.track(.podcastsScreenTabTapped, properties: ["value": "similar_shows"])
-
-        // Use the stored recommendations data
-        similarPodcasts = recommendations?.podcasts ?? []
-        reloadData()
+        switchViewMode(to: .similarShows)
     }
 
     // MARK: - Podcast Feed Reload
@@ -1392,6 +1380,19 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
     func signingProcessCompleted() {
         navigationController?.popToViewController(self, animated: true)
     }
+
+    @MainActor
+    private func loadRecommendations() async {
+        guard let podcast = podcast else { return }
+
+        do {
+            recommendations = try await ServerPodcastManager.shared.loadRecommendations(for: podcast.uuid)
+            hasSimilarShows.send(recommendations?.podcasts?.isEmpty == false)
+        } catch {
+            // We won't do anything in the interface here since the Similar Shows button is optional and hidden by default
+            FileLog.shared.addMessage("[PodcastViewController] Failed to load recommendations \(error)")
+        }
+    }
 }
 
 // MARK: - Analytics
@@ -1405,6 +1406,22 @@ extension PodcastViewController: AnalyticsSourceProvider {
 private extension PodcastViewController {
     var podcastUUID: String {
         podcast?.uuid ?? podcastInfo?.analyticsDescription ?? "unknown"
+    }
+
+    private func switchViewMode(to mode: ViewMode) {
+        currentViewMode = mode
+        switch mode {
+        case .episodes:
+            if let podcast = podcast {
+                loadLocalEpisodes(podcast: podcast, animated: true)
+            }
+        case .similarShows:
+            similarPodcasts = recommendations?.podcasts ?? []
+        case .bookmarks:
+            break // Handled separately
+        }
+        Analytics.track(.podcastsScreenTabTapped, properties: ["value": mode.analyticsValue])
+        reloadData()
     }
 }
 

--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -483,8 +483,10 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
         showViewChangesTipIfNeeded()
 
         // Load recommendations when view appears
-        Task {
-            await loadRecommendations()
+        if FeatureFlag.recommendations.enabled {
+            Task {
+                await loadRecommendations()
+            }
         }
     }
 

--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -79,7 +79,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
     var summaryExpanded = false
     var descriptionExpanded = false
     var currentViewMode: ViewMode = .episodes
-    var similarPodcasts: [Podcast] = []
+    var similarPodcasts: [String] = []
 
     enum ViewMode {
         case episodes
@@ -1133,8 +1133,8 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
 
         // Load similar podcasts
         Task {
-//            similarPodcasts = await PodcastManager.shared.fetchSimilarPodcasts(for: podcast)
-            similarPodcasts = PodcastManager.shared.allPodcastsSorted(in: .recentlyPlayed)
+            //TODO: Pass through Discover podcasts or something so that only the image needs to be loaded
+            similarPodcasts = try await ServerPodcastManager.shared.loadRecommendations(for: podcast.uuid)?.podcasts?.map { $0.uuid ?? "" } ?? []
             DispatchQueue.main.async { [weak self] in
                 self?.reloadData()
             }

--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -23,6 +23,7 @@ enum PodcastFeedReloadSource {
 }
 
 protocol PodcastActionsDelegate: AnyObject {
+    var hasSimilarShowsPublisher: AnyPublisher<Bool, Never> { get }
     func isSummaryExpanded() -> Bool
     func setSummaryExpanded(expanded: Bool)
     func isDescriptionExpanded() -> Bool
@@ -80,6 +81,10 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
     var descriptionExpanded = false
     var currentViewMode: ViewMode = .episodes
     var similarPodcasts: [String] = []
+    private var hasSimilarShows = CurrentValueSubject<Bool, Never>(false)
+    var hasSimilarShowsPublisher: AnyPublisher<Bool, Never> {
+        hasSimilarShows.eraseToAnyPublisher()
+    }
 
     enum ViewMode {
         case episodes
@@ -467,6 +472,16 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
             self.navigationController?.isNavigationBarHidden = true
         }
         showViewChangesTipIfNeeded()
+
+        // Load recommendations when view appears
+        Task {
+            if let podcast = podcast {
+                let recommendations = try await ServerPodcastManager.shared.loadRecommendations(for: podcast.uuid)
+                DispatchQueue.main.async { [weak self] in
+                    self?.hasSimilarShows.send(recommendations?.podcasts?.isEmpty == false)
+                }
+            }
+        }
     }
 
     override func viewWillDisappear(_ animated: Bool) {

--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -85,6 +85,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
     var hasSimilarShowsPublisher: AnyPublisher<Bool, Never> {
         hasSimilarShows.eraseToAnyPublisher()
     }
+    private var recommendations: PodcastCollection?
 
     enum ViewMode {
         case episodes
@@ -476,9 +477,10 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
         // Load recommendations when view appears
         Task {
             if let podcast = podcast {
-                let recommendations = try await ServerPodcastManager.shared.loadRecommendations(for: podcast.uuid)
+                recommendations = try await ServerPodcastManager.shared.loadRecommendations(for: podcast.uuid)
                 DispatchQueue.main.async { [weak self] in
-                    self?.hasSimilarShows.send(recommendations?.podcasts?.isEmpty == false)
+                    guard let self else { return }
+                    hasSimilarShows.send(recommendations?.podcasts?.isEmpty == false)
                 }
             }
         }
@@ -1146,14 +1148,9 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
 
         Analytics.track(.podcastsScreenTabTapped, properties: ["value": "similar_shows"])
 
-        // Load similar podcasts
-        Task {
-            //TODO: Pass through Discover podcasts or something so that only the image needs to be loaded
-            similarPodcasts = try await ServerPodcastManager.shared.loadRecommendations(for: podcast.uuid)?.podcasts?.map { $0.uuid ?? "" } ?? []
-            DispatchQueue.main.async { [weak self] in
-                self?.reloadData()
-            }
-        }
+        // Use the stored recommendations data
+        similarPodcasts = recommendations?.podcasts?.compactMap { $0.uuid } ?? []
+        reloadData()
     }
 
     // MARK: - Podcast Feed Reload

--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -60,6 +60,8 @@ protocol PodcastActionsDelegate: AnyObject {
     var ratingView: UIView { get }
 
     func showBookmarks()
+    func showEpisodes()
+    func showSimilarShows()
     func showLogin(message: String?)
 
     func shouldDisplayPodcastFeedReloadButton() -> Bool
@@ -76,6 +78,14 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
     var listUuid: String?
     var summaryExpanded = false
     var descriptionExpanded = false
+    var currentViewMode: ViewMode = .episodes
+    var similarPodcasts: [Podcast] = []
+
+    enum ViewMode {
+        case episodes
+        case bookmarks
+        case similarShows
+    }
 
     var searchController: EpisodeListSearchController?
 
@@ -1097,13 +1107,38 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
         present(hostingController, animated: true, completion: nil)
     }
 
+    func showEpisodes() {
+        currentViewMode = .episodes
+        if let podcast = podcast {
+            loadLocalEpisodes(podcast: podcast, animated: true)
+        }
+        reloadData()
+    }
+
     func showBookmarks() {
+        currentViewMode = .bookmarks
         guard let podcast else { return }
 
         Analytics.track(.podcastsScreenTabTapped, properties: ["value": "bookmarks"])
 
         let controller = BookmarksPodcastListController(podcast: podcast)
         present(controller, animated: true)
+    }
+
+    func showSimilarShows() {
+        currentViewMode = .similarShows
+        guard let podcast else { return }
+
+        Analytics.track(.podcastsScreenTabTapped, properties: ["value": "similar_shows"])
+
+        // Load similar podcasts
+        Task {
+//            similarPodcasts = await PodcastManager.shared.fetchSimilarPodcasts(for: podcast)
+            similarPodcasts = PodcastManager.shared.allPodcastsSorted(in: .recentlyPlayed)
+            DispatchQueue.main.async { [weak self] in
+                self?.reloadData()
+            }
+        }
     }
 
     // MARK: - Podcast Feed Reload

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -3352,6 +3352,8 @@ internal enum L10n {
   internal static var signedInAs: String { return L10n.tr("Localizable", "signed_in_as") }
   /// Not Signed In
   internal static var signedOut: String { return L10n.tr("Localizable", "signed_out") }
+  /// Similar Shows
+  internal static var similarShows: String { return L10n.tr("Localizable", "similar_shows") }
   /// 1 chapter
   internal static var singleChapter: String { return L10n.tr("Localizable", "single_chapter") }
   /// Set sleep timer to %1$@

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4036,6 +4036,9 @@
 /* Title for an action that allows a user to create a new bookmark */
 "add_bookmark" = "Add Bookmark";
 
+/* Title for the similar shows feature in a Podcast */
+"similar_shows" = "Similar Shows";
+
 /* Autoplay feature announcement title */
 "announcement_autoplay_title" = "Autoplay is here!";
 


### PR DESCRIPTION
| 📘 Part of: #2989 |
|:---:|

Fixes #2990

<img width=300 src="https://github.com/user-attachments/assets/d26a1bd2-eae6-45dd-9f5d-c4a678c35bb9">

## Code Changes

- Adds [an async version of `callSecureUrl`](https://github.com/Automattic/pocket-casts-ios/pull/3045/files#diff-85b6631ce8d9b102c1d5fd2f74848a48ce954aec8a8ea98679c9518bb801a92eR30) for use in loading the recommendations.
- Added [`loadRecommendations` API call](https://github.com/Automattic/pocket-casts-ios/pull/3045/files#diff-b865096c8320e9a2a3556cabc125e53dc132887886bc52864c70ddfbd9730a18R243) to ServerPodcastManager, allowing podcasts to fetch similar show recommendations.
- Introduced a **new tab** ("Similar Shows") on the Podcast detail page in `EpisodeBookmarksTabsView`, with full support for dynamic switching between tabs. The visibility of the tab [is controlled by](https://github.com/Automattic/pocket-casts-ios/pull/3045/files#diff-9417b206a4499b7e62f475a3cc84b76bf29b5d33f9ed5e2960cbb855e70d73caR55) the `hasSimilarShows` binding [added to the delegate](https://github.com/Automattic/pocket-casts-ios/pull/3045/files#diff-76da8ffcd403b13ae6945bccccae68c592f749b4822cd03bce557568eb38ec4eR26) and [updated](https://github.com/Automattic/pocket-casts-ios/pull/3045/files#diff-76da8ffcd403b13ae6945bccccae68c592f749b4822cd03bce557568eb38ec4eR1390) as a result of loading the recommendations when the Podcast detail page appears..
- Updates the PodcastsViewController table to support the podcast list. This required a good amount of switching in the `PodcastViewController+TableData` extension. It's not the cleanest but it doesn't diverge too much from what we're already doing.
- Created `PodcastTableViewCell` and `PodcastTableCellView` for SwiftUI-backed cells displaying recommended podcasts within "Similar Shows". We have a `PodcastListCell` but it is a collection view cell and I think this SwiftUI version can be useful going forward.
- Added [`PodcastInfo+DiscoverPodcast` extension](https://github.com/Automattic/pocket-casts-ios/pull/3045/files#diff-fddf20b2d01e338f66344081c0e7dfa94662617b0994001eb58bdf36c7426199R3) for easy model translation between Discover and main podcast types.
- Updated `AnalyticsSource` to track [the new "podcast_screen_similar_shows" tab as a source](https://github.com/Automattic/pocket-casts-ios/pull/3045/files#diff-d060e7d8399af3e36ae604cb2d070050963aa00f314b628a0939453ff9f5f8c6R38).

## To test

* Log in with an account
* Navigate to a Podcast page for a popular podcast (Hidden Brain, This American Life, etc.)
* ✅ Verify that the "Similar Shows" tab appears with some suggested podcasts
* ✅ Verify that tapping the podcast opens the Podcast detail page
* ✅ Verify that subscribing works for that podcast
* Change themes
* ✅ Verify that podcast cell adjusts to the selected theme

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
