### PR TITLE
[Winback Updates] Add loading button when loading offer

### DIFF
--- a/podcasts/Cancel Subscription/Cancel Subscription/Offer View/CancelSubscriptionWinbackOfferView.swift
+++ b/podcasts/Cancel Subscription/Cancel Subscription/Offer View/CancelSubscriptionWinbackOfferView.swift
@@ -27,6 +27,21 @@ struct CancelSubscriptionWinbackOfferView: View {
         }
     }
 
+    private var loadingButton: some View {
+        ZStack {
+            Rectangle()
+                .overlay(theme.primaryInteractive01)
+                .cornerRadius(ViewConstants.buttonCornerRadius)
+            ProgressView()
+                .progressViewStyle(
+                    CircularProgressViewStyle(tint: theme.primaryInteractive02)
+                )
+        }
+        .frame(height: 56.0)
+        .padding(.horizontal, 16.0)
+        .padding(.bottom, 16.0)
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             Image("cs-winback-offer")
@@ -46,6 +61,7 @@ struct CancelSubscriptionWinbackOfferView: View {
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, 24)
             Spacer()
+            let isLoading = viewModel.offerPurchasingState == .purchasing
             Button(action: viewModel.claimOffer) {
                 Text(L10n.cancelSubscriptionWinbackViewAcceptOfferButton)
             }
@@ -53,10 +69,16 @@ struct CancelSubscriptionWinbackOfferView: View {
             .frame(height: 56.0)
             .padding(.horizontal, 16.0)
             .padding(.bottom, 16.0)
+            .overlay {
+                if isLoading {
+                    loadingButton
+                }
+            }
             Button(action: showManageSubscriptions) {
                 Text(L10n.cancelSubscriptionWinbackViewContinueCancellationButton)
             }
             .buttonStyle(BasicButtonStyle(textColor: theme.primaryInteractive01, backgroundColor: theme.primaryUi01, borderColor: theme.primaryInteractive01))
+            .disabled(isLoading)
             .frame(height: 56.0)
             .padding(.horizontal, 16.0)
             .padding(.bottom, 2.0)


### PR DESCRIPTION
| 📘 Part of: #3049
|:---:|

Fixes #3029

Add loading state for when the user taps the offer accept

<video src="https://github.com/user-attachments/assets/fe40cf23-7cf8-4378-9199-1a13acdfacba" width=350></video>

## To test

- Clean your sandbox user history and current subscription
- Run the app on staging and create a user
- Purchase a plan (you will need to make one for each plan)
- Open the Cancel Subscription
- Tap on Continue To Cancellation
- Tap on Cancel my subscription
- Tap on Accept Offer
- Confirm you see the loading while waiting for the OS to present the IAP sheet
- Dismiss it and confirm the Loader is replaced bye the prev text

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
