### PR TITLE
[Notifications revamps] Offers notifications

### DIFF
--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -231,6 +231,7 @@ struct Constants {
             static let dailyReminders = "notifications.dailyReminders"
             static let newFeaturesAndTips = "notifications.newFeaturesAndTips"
             static let recommendations = "notifications.recommendations"
+            static let offers = "notifications.offers"
         }
     }
 

--- a/podcasts/Notifications/NotificationsCoordinator+AnalyticsAdapter.swift
+++ b/podcasts/Notifications/NotificationsCoordinator+AnalyticsAdapter.swift
@@ -58,7 +58,7 @@ extension NotificationType {
             possibleConditions = [.discoverListShowAllTapped]
         case .recommendationsTrending:
             possibleConditions = [.discoverListShowAllTapped]
-        case .offers:
+        case .upsell:
             possibleConditions  = [.purchaseSuccessful]
         }
         let eventMatch = possibleConditions.contains {

--- a/podcasts/Notifications/NotificationsCoordinator+AnalyticsAdapter.swift
+++ b/podcasts/Notifications/NotificationsCoordinator+AnalyticsAdapter.swift
@@ -58,6 +58,8 @@ extension NotificationType {
             possibleConditions = [.discoverListShowAllTapped]
         case .recommendationsTrending:
             possibleConditions = [.discoverListShowAllTapped]
+        case .offers:
+            possibleConditions  = [.purchaseSuccessful]
         }
         let eventMatch = possibleConditions.contains {
             $0.rawValue.toSnakeCaseFromCamelCase() == name

--- a/podcasts/Notifications/NotificationsCoordinator+AnalyticsAdapter.swift
+++ b/podcasts/Notifications/NotificationsCoordinator+AnalyticsAdapter.swift
@@ -59,7 +59,7 @@ extension NotificationType {
         case .recommendationsTrending:
             possibleConditions = [.discoverListShowAllTapped]
         case .upsell:
-            possibleConditions  = [.purchaseSuccessful]
+            possibleConditions = [.purchaseSuccessful]
         }
         let eventMatch = possibleConditions.contains {
             $0.rawValue.toSnakeCaseFromCamelCase() == name

--- a/podcasts/Notifications/NotificationsCoordinator.swift
+++ b/podcasts/Notifications/NotificationsCoordinator.swift
@@ -1,5 +1,6 @@
 import Foundation
 import PocketCastsUtils
+import PocketCastsServer
 
 enum NotificationType: String {
 
@@ -130,11 +131,11 @@ enum NotificationsGroup {
             case .dailyReminders:
                 return 10
             case .recommendations:
-                return 14
+                return 11
             case .newFeaturesAndTips:
                 return 16
             case .offers:
-                return 12
+                return 14
         }
     }
 
@@ -175,7 +176,7 @@ enum NotificationsGroup {
             case .newFeaturesAndTips:
                 return Self.speedUpNotifications ? 60.seconds: 1.week
             case .offers:
-                return Self.speedUpNotifications ? 60.seconds: 1.week
+                return Self.speedUpNotifications ? 120.seconds: 2.week
         }
     }
 

--- a/podcasts/Notifications/NotificationsCoordinator.swift
+++ b/podcasts/Notifications/NotificationsCoordinator.swift
@@ -16,7 +16,7 @@ enum NotificationType: String {
 
     case recommendationsTrending
 
-    case offers
+    case upsell
 
     var title: String {
         switch self {
@@ -38,7 +38,7 @@ enum NotificationType: String {
             return L10n.notificationsReengagementWeeklyTitle
         case .recommendationsTrending:
             return L10n.notificationsRecommendationsTrendingTitle
-        case .offers:
+        case .upsell:
             return L10n.notificationsOnboardingUpsellTitle
         }
     }
@@ -63,7 +63,7 @@ enum NotificationType: String {
             return L10n.notificationsReengagementWeeklyBody
         case .recommendationsTrending:
             return L10n.notificationsRecommendationsTrendingBody
-        case .offers:
+        case .upsell:
             return L10n.notificationsOnboardingUpsellBody
         }
     }
@@ -92,14 +92,14 @@ enum NotificationType: String {
             return "pktc://discover"
         case .recommendationsTrending:
             return "pktc://discover/trending"
-        case .offers:
+        case .upsell:
             return "pktc://upsell"
         }
     }
 
     var shouldSend: Bool {
         switch self {
-            case .onboardingUpsell, .offers:
+            case .onboardingUpsell, .upsell:
                 return !SubscriptionHelper.hasActiveSubscription()
             default:
                 return true
@@ -122,7 +122,7 @@ enum NotificationsGroup {
             case .newFeaturesAndTips:
                 return [.reengagementWeekly]
             case .offers:
-                return [.offers]
+                return [.upsell]
         }
     }
 

--- a/podcasts/Notifications/NotificationsCoordinator.swift
+++ b/podcasts/Notifications/NotificationsCoordinator.swift
@@ -15,6 +15,8 @@ enum NotificationType: String {
 
     case recommendationsTrending
 
+    case offers
+
     var title: String {
         switch self {
         case .onboardingSignUp:
@@ -35,6 +37,8 @@ enum NotificationType: String {
             return L10n.notificationsReengagementWeeklyTitle
         case .recommendationsTrending:
             return L10n.notificationsRecommendationsTrendingTitle
+        case .offers:
+            return L10n.notificationsOnboardingUpsellTitle
         }
     }
 
@@ -58,6 +62,8 @@ enum NotificationType: String {
             return L10n.notificationsReengagementWeeklyBody
         case .recommendationsTrending:
             return L10n.notificationsRecommendationsTrendingBody
+        case .offers:
+            return L10n.notificationsOnboardingUpsellBody
         }
     }
 
@@ -85,6 +91,8 @@ enum NotificationType: String {
             return "pktc://discover"
         case .recommendationsTrending:
             return "pktc://discover/trending"
+        case .offers:
+            return "pktc://upsell"
         }
     }
 }
@@ -93,6 +101,7 @@ enum NotificationsGroup {
     case dailyReminders
     case recommendations
     case newFeaturesAndTips
+    case offers
 
     var notifications: [NotificationType] {
         switch self {
@@ -102,6 +111,8 @@ enum NotificationsGroup {
                 return [.recommendationsTrending]
             case .newFeaturesAndTips:
                 return [.reengagementWeekly]
+            case .offers:
+                return [.offers]
         }
     }
 
@@ -113,6 +124,8 @@ enum NotificationsGroup {
                 return 14
             case .newFeaturesAndTips:
                 return 16
+            case .offers:
+                return 12
         }
     }
 
@@ -124,6 +137,8 @@ enum NotificationsGroup {
                 return Settings.notificationsRecommendations
             case .newFeaturesAndTips:
                 return Settings.notificationsNewFeaturesAndTips
+            case .offers:
+                return Settings.notificationsOffers
         }
     }
 
@@ -135,6 +150,8 @@ enum NotificationsGroup {
                 Settings.notificationsRecommendations = newValue
             case .newFeaturesAndTips:
                 Settings.notificationsNewFeaturesAndTips = newValue
+            case .offers:
+                Settings.notificationsOffers = newValue
         }
     }
 
@@ -148,6 +165,8 @@ enum NotificationsGroup {
                 return Self.speedUpNotifications ? 60.seconds: 3.days
             case .newFeaturesAndTips:
                 return Self.speedUpNotifications ? 60.seconds: 1.week
+            case .offers:
+                return Self.speedUpNotifications ? 60.seconds: 1.week
         }
     }
 
@@ -155,7 +174,7 @@ enum NotificationsGroup {
         switch self {
             case .dailyReminders:
                 return false
-            case .recommendations, .newFeaturesAndTips:
+            case .recommendations, .newFeaturesAndTips, .offers:
                 return true
         }
     }

--- a/podcasts/Notifications/NotificationsCoordinator.swift
+++ b/podcasts/Notifications/NotificationsCoordinator.swift
@@ -95,6 +95,15 @@ enum NotificationType: String {
             return "pktc://upsell"
         }
     }
+
+    var shouldSend: Bool {
+        switch self {
+            case .onboardingUpsell, .offers:
+                return !SubscriptionHelper.hasActiveSubscription()
+            default:
+                return true
+        }
+    }
 }
 
 enum NotificationsGroup {
@@ -206,6 +215,9 @@ class NotificationsCoordinator {
         let timeIntervalToSchedule: TimeInterval = calculateTimeIntervalToHour(group.scheduleHour)
         var timeInterval: TimeInterval = timeIntervalToSchedule + group.timeIntervalStep
         for notification in group.notifications {
+            guard notification.shouldSend else {
+                continue
+            }
             if group.areRepeatable {
                 scheduleNotification(notification, timeInterval: timeInterval, repeats: false)
                 scheduleNotification(notification, timeInterval: timeInterval + group.timeIntervalStep, repeats: true)

--- a/podcasts/Notifications/NotificationsCoordinator.swift
+++ b/podcasts/Notifications/NotificationsCoordinator.swift
@@ -39,7 +39,7 @@ enum NotificationType: String {
         case .recommendationsTrending:
             return L10n.notificationsRecommendationsTrendingTitle
         case .upsell:
-            return L10n.notificationsOnboardingUpsellTitle
+            return L10n.notificationsOffersUpsellTitle
         }
     }
 
@@ -64,7 +64,7 @@ enum NotificationType: String {
         case .recommendationsTrending:
             return L10n.notificationsRecommendationsTrendingBody
         case .upsell:
-            return L10n.notificationsOnboardingUpsellBody
+            return L10n.notificationsOffersUpsellBody
         }
     }
 

--- a/podcasts/NotificationsViewController.swift
+++ b/podcasts/NotificationsViewController.swift
@@ -105,7 +105,7 @@ class NotificationsViewController: PCViewController, UITableViewDataSource, UITa
                 case .appBadges:
                     return nil
                 case .pocketCastsOffers:
-                    return nil
+                    return .offers
             }
         }
     }

--- a/podcasts/NotificationsViewController.swift
+++ b/podcasts/NotificationsViewController.swift
@@ -64,9 +64,9 @@ class NotificationsViewController: PCViewController, UITableViewDataSource, UITa
                 return Settings.notificationsNewFeaturesAndTips
             case .trendingRecommendations:
                 return Settings.notificationsRecommendations
-            case .podcastsChosen,
-                 .appBadges,
-                 .pocketCastsOffers:
+            case .pocketCastsOffers:
+                return Settings.notificationsOffers
+            case .podcastsChosen, .appBadges:
                 return false
             }
         }

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -1484,6 +1484,15 @@ class Settings: NSObject {
         }
     }
 
+    static var notificationsOffers: Bool {
+        get {
+            UserDefaults.standard.value(forKey: Constants.UserDefaults.notifications.offers) as? Bool ?? false
+        }
+        set {
+            UserDefaults.standard.setValue(newValue, forKey: Constants.UserDefaults.notifications.offers)
+        }
+    }
+
     // MARK: - Database (internal)
 
     class var upgradedIndexes: Bool {

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -1759,6 +1759,10 @@ internal enum L10n {
   internal static var notificationsNewFeaturesTips: String { return L10n.tr("Localizable", "notifications_new_features_tips") }
   /// Notifications Off
   internal static var notificationsOff: String { return L10n.tr("Localizable", "notifications_off") }
+  /// Unlock exclusive features like folders, bookmarks, and more with Plus!
+  internal static var notificationsOffersUpsellBody: String { return L10n.tr("Localizable", "notifications_offers_upsell_body") }
+  /// Level up your podcast game
+  internal static var notificationsOffersUpsellTitle: String { return L10n.tr("Localizable", "notifications_offers_upsell_title") }
   /// Notifications On
   internal static var notificationsOn: String { return L10n.tr("Localizable", "notifications_on") }
   /// We’ll notify you with new episodes of %1$@

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4879,7 +4879,7 @@
 /* Notification title for filters onboarding message */
 "notifications_onboarding_filters_title" = "Organize your episodes";
 
-/* Notification title for upsell onboardingmessage */
+/* Notification title for upsell onboarding message */
 "notifications_onboarding_upsell_title" = "Level up your podcast game";
 
 /* Notification title for staff picks onboarding message */
@@ -4998,4 +4998,11 @@
 
 /* Notification body for recommendations trending message */
 "notifications_recommendations_trending_body" = "Check out what everyone else is listening this week.";
+
+/* Notification title for offer upsell message */
+"notifications_offers_upsell_title" = "Level up your podcast game";
+
+/* Notification body for offer upsell message */
+"notifications_offers_upsell_body" = "Unlock exclusive features like folders, bookmarks, and more with Plus!";
+
 


### PR DESCRIPTION
| 📘 Part of: #2906  |  <!-- project issue number, if applicable -->
|:---:|

Refs #2935 

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

## To test

1. Start the app with an user without subscription or no user
2. Ensure that you have Notifications Revamp FF active
3. Go to Profile -> Settings -> Developer -> Speed Up Notifications
4. Go to Profile -> Settings -> Notifications
5. Activate Pocket Cast Offers toggle
6. Wait for 2 minutes and see if the upsell notifications shows
7. Now Disable the Pocket Cast Offers toggle
8. Check that it does not show again after 2 minutes
9. Login with an user with a subscription
10. Go to Profile -> Settings -> Notifications
11. Activate Pocket Cast Offers toggle
12. Check that the notification does not show up because you already have a subscription.


## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
