### PR TITLE
Suggested Folders: Add new upgrade source

### DIFF
--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -403,6 +403,7 @@ enum PlusUpgradeViewSource: String {
     case upNextShuffle
     case generatedTranscripts
     case onboarding
+    case suggestedFolders = "suggested_folders"
 
     /// Converts the enum into a Firebase promotionId, this matches the values set on Android
     func promotionId() -> String {

--- a/podcasts/FoldersCoordinator.swift
+++ b/podcasts/FoldersCoordinator.swift
@@ -135,7 +135,7 @@ class FoldersCoordinator: NSObject {
                 return
             case .applySuggestedFolders, .createdManualFolder:
                 //Show upsell flow
-                startUpsellFlow(from: vc, source: source)
+                startUpsellFlow(from: vc, source: source, upgradeSource: .suggestedFolders)
                 return
             }
         }
@@ -183,12 +183,12 @@ class FoldersCoordinator: NSObject {
         return folder
     }
 
-    private func startUpsellFlow(from vc: UIViewController, source: AnalyticsSource) {
+    private func startUpsellFlow(from vc: UIViewController, source: AnalyticsSource, upgradeSource: PlusUpgradeViewSource) {
         currentVC = vc
         currentSource = source
         addObservers()
         vc.dismiss(animated: false) {
-            self.navigationManager.showUpsellView(from: vc, source: .folders, flow: .suggestedFolderUpsell)
+            self.navigationManager.showUpsellView(from: vc, source: upgradeSource, flow: .suggestedFolderUpsell)
         }
     }
 


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR updates the analytics source for the upgrade flows to have an option for suggested_folders

## To test

1. Start the app
2. Ensure that you have tracks logging enabled
3. Use a login without a paid subscription
4. Ensure that you are following at least 8 podcasts
5. Tap on the Folder icon on the Podcast list
6. Check that you see the suggested folders flow
7. Tap on Use these folders or Create Manual
8. Check that the upsell flow starts and you the related event with the source: "suggested_folders"

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
