### PR TITLE
GRDB: add `read`/`write` methods to `FolderDataManager`

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/FolderDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/FolderDataManager.swift
@@ -37,7 +37,7 @@ class FolderDataManager {
     }
 
     func save(folder: Folder, dbQueue: PCDBQueue) {
-        dbQueue.inDatabase { db in
+        dbQueue.write { db in
             do {
                 if folder.uuid.isEmpty {
                     folder.uuid = UUID().uuidString.lowercased()
@@ -67,7 +67,7 @@ class FolderDataManager {
     }
 
     func saveSortOrders(folders: [Folder], syncModified: Int64, dbQueue: PCDBQueue) {
-        dbQueue.inTransaction { db, _ in
+        dbQueue.write { db in
             do {
                 for folders in folders {
                     try db.executeUpdate("UPDATE \(DataManager.folderTableName) SET sortOrder = ?, syncModified = ? WHERE uuid = ?", values: [folders.sortOrder, syncModified, folders.uuid])
@@ -119,7 +119,7 @@ class FolderDataManager {
     }
 
     private func cacheFolders(dbQueue: PCDBQueue) {
-        dbQueue.inDatabase { db in
+        dbQueue.read { db in
             do {
                 let resultSet = try db.executeQuery("SELECT * from \(DataManager.folderTableName)", values: nil)
                 defer { resultSet.close() }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -32,11 +32,11 @@ public class DataManager {
     public static let sharedManager = DataManager()
 
     /// Creates a DataManager using a queue that is persisted to a local SQLIte file
-    public convenience init() {
+    public convenience init(grdbEnabled: Bool = FeatureFlag.grdb.enabled) {
         DataManager.ensureDbFolderExists()
 
         var dbQueue: PCDBQueue
-        if FeatureFlag.grdb.enabled {
+        if grdbEnabled {
             var config = Configuration()
             config.busyMode = .timeout(10)
             dbQueue = GRDBQueue(dbPool: try! DatabasePool(path: DataManager.pathToDb(), configuration: config))
@@ -72,17 +72,17 @@ public class DataManager {
             dbQueue = FMDBQueue(fmdbQueue: FMDatabaseQueue(path: dbPath, flags: flags)!)
         }
 
-        self.init(dbQueue: dbQueue)
+        self.init(dbQueue: dbQueue, grdbEnabled: grdbEnabled)
     }
 
     /// Creates a DataManager using the given `PCDBQueue`.
     /// If `shouldCloseQueueAfterSetup` is true, `dbQueue.close()` is called after the schema is created, otherwise the queue is left open.
-    public init(dbQueue: PCDBQueue, shouldCloseQueueAfterSetup: Bool = true) {
+    public init(dbQueue: PCDBQueue, shouldCloseQueueAfterSetup: Bool = true, grdbEnabled: Bool = FeatureFlag.grdb.enabled) {
         self.dbQueue = dbQueue
 
         DatabaseHelper.setup(queue: dbQueue)
 
-        if shouldCloseQueueAfterSetup && !FeatureFlag.grdb.enabled {
+        if shouldCloseQueueAfterSetup && !grdbEnabled {
             // "You don't need to close it during the app lifecycle, unless you modify the schema." Since the above method can modify the schema, we do that here as recommended by the author of FMDB
             dbQueue.close()
         }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -41,8 +41,35 @@ public class DataManager {
             config.busyMode = .timeout(10)
             dbQueue = GRDBQueue(dbPool: try! DatabasePool(path: DataManager.pathToDb(), configuration: config))
         } else {
+            let dbPath = DataManager.pathToDb()
+            let walPath = dbPath + "-wal"
+            let shmPath = dbPath + "-shm"
+
+            // Check if WAL files exist
+            let fileManager = FileManager.default
+            let hasWalFiles = fileManager.fileExists(atPath: walPath) || fileManager.fileExists(atPath: shmPath)
+
+            if hasWalFiles {
+                // First open in WAL mode to perform checkpoint
+                let walFlags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FILEPROTECTION_NONE | SQLITE_OPEN_WAL
+                let walQueue = FMDatabaseQueue(path: dbPath, flags: walFlags)!
+
+                // Perform checkpoint to consolidate WAL
+                walQueue.inDatabase { db in
+                    do {
+                        try db.executeUpdate("PRAGMA wal_checkpoint(FULL);", values: nil)
+                    } catch {
+                        FileLog.shared.addMessage("Failed to perform WAL checkpoint: \(error)")
+                    }
+                }
+
+                // Close WAL connection
+                walQueue.close()
+            }
+
+            // Now open in non-WAL mode
             let flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FILEPROTECTION_NONE
-            dbQueue = FMDBQueue(fmdbQueue: FMDatabaseQueue(path: DataManager.pathToDb(), flags: flags)!)
+            dbQueue = FMDBQueue(fmdbQueue: FMDatabaseQueue(path: dbPath, flags: flags)!)
         }
 
         self.init(dbQueue: dbQueue)

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -32,16 +32,16 @@ public class DataManager {
     public static let sharedManager = DataManager()
 
     /// Creates a DataManager using a queue that is persisted to a local SQLIte file
-    public convenience init(grdbEnabled: Bool = FeatureFlag.grdb.enabled) {
+    public convenience init(grdbEnabled: Bool = FeatureFlag.grdb.enabled, databaseFileName: String? = nil) {
         DataManager.ensureDbFolderExists()
 
         var dbQueue: PCDBQueue
         if grdbEnabled {
             var config = Configuration()
             config.busyMode = .timeout(10)
-            dbQueue = GRDBQueue(dbPool: try! DatabasePool(path: DataManager.pathToDb(), configuration: config))
+            dbQueue = GRDBQueue(dbPool: try! DatabasePool(path: DataManager.pathToDb(fileName: databaseFileName), configuration: config))
         } else {
-            let dbPath = DataManager.pathToDb()
+            let dbPath = DataManager.pathToDb(fileName: databaseFileName)
             let walPath = dbPath + "-wal"
             let shmPath = dbPath + "-shm"
 
@@ -49,26 +49,8 @@ public class DataManager {
             let fileManager = FileManager.default
             let hasWalFiles = fileManager.fileExists(atPath: walPath) || fileManager.fileExists(atPath: shmPath)
 
-            if hasWalFiles {
-                // First open in WAL mode to perform checkpoint
-                let walFlags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FILEPROTECTION_NONE | SQLITE_OPEN_WAL
-                let walQueue = FMDatabaseQueue(path: dbPath, flags: walFlags)!
-
-                // Perform checkpoint to consolidate WAL
-                walQueue.inDatabase { db in
-                    do {
-                        try db.executeUpdate("PRAGMA wal_checkpoint(FULL);", values: nil)
-                    } catch {
-                        FileLog.shared.addMessage("Failed to perform WAL checkpoint: \(error)")
-                    }
-                }
-
-                // Close WAL connection
-                walQueue.close()
-            }
-
             // Now open in non-WAL mode
-            let flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FILEPROTECTION_NONE
+            let flags = hasWalFiles ? SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FILEPROTECTION_NONE | SQLITE_OPEN_WAL : SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FILEPROTECTION_NONE
             dbQueue = FMDBQueue(fmdbQueue: FMDatabaseQueue(path: dbPath, flags: flags)!)
         }
 
@@ -156,6 +138,10 @@ public class DataManager {
         if let sizeString = databaseSize {
             FileLog.shared.addMessage("VACUUM -> Database end size: \(sizeString)")
         }
+    }
+
+    public func close() {
+        dbQueue.close()
     }
 
     // MARK: - Up Next
@@ -1038,10 +1024,10 @@ public class DataManager {
 
     // MARK: - Path Related
 
-    public static func pathToDb() -> String {
+    public static func pathToDb(fileName: String? = nil) -> String {
         let folderPath = pathToDbFolder() as NSString
 
-        return folderPath.appendingPathComponent("podcast_newDB.sqlite3")
+        return folderPath.appendingPathComponent(fileName ?? "podcast_newDB.sqlite3")
     }
 
     private static func pathToDbFolder() -> String {

--- a/Modules/DataModel/Tests/PocketCastsDataModelTests/DataManager+TestDatabase.swift
+++ b/Modules/DataModel/Tests/PocketCastsDataModelTests/DataManager+TestDatabase.swift
@@ -92,13 +92,27 @@ extension DatabasePool {
             try FileManager.default.createDirectory(atPath: dbFolderPath as String, withIntermediateDirectories: true)
         }
 
-        let dbPath = dbFolderPath.appendingPathComponent("podcast_testDB_GRDB.sqlite3")
-        if FileManager.default.fileExists(atPath: dbPath) {
-            if FileManager.default.fileExists(atPath: dbFolderPath.appendingPathComponent(toFile)) {
-                try FileManager.default.removeItem(atPath: dbFolderPath.appendingPathComponent(toFile))
-            }
+        let dbFileName = "podcast_testDB_GRDB.sqlite3"
+        let dbPath = dbFolderPath.appendingPathComponent(dbFileName)
 
-            try FileManager.default.copyItem(at: URL(fileURLWithPath: dbPath), to: URL(fileURLWithPath: dbFolderPath.appendingPathComponent(toFile)))
+        if FileManager.default.fileExists(atPath: dbPath) {
+            // List of file suffixes to copy ("" for main file, and WAL-related files)
+            let suffixes = ["", "-shm", "-wal"]
+
+            for suffix in suffixes {
+                let sourceFile = dbFileName + suffix
+                let destinationFile = toFile + suffix
+
+                let sourcePath = dbFolderPath.appendingPathComponent(sourceFile)
+                let destinationPath = dbFolderPath.appendingPathComponent(destinationFile)
+
+                if FileManager.default.fileExists(atPath: sourcePath) {
+                    if FileManager.default.fileExists(atPath: destinationPath) {
+                        try FileManager.default.removeItem(atPath: destinationPath)
+                    }
+                    try FileManager.default.copyItem(atPath: sourcePath, toPath: destinationPath)
+                }
+            }
         }
     }
 }

--- a/Modules/DataModel/Tests/PocketCastsDataModelTests/FmdbGrdbTests.swift
+++ b/Modules/DataModel/Tests/PocketCastsDataModelTests/FmdbGrdbTests.swift
@@ -6,9 +6,6 @@ import SQLite3
 @testable import PocketCastsDataModel
 
 final class FmdbGrdbTests: XCTestCase {
-    var dbQueue: FMDatabaseQueue!
-    var dbPool: DatabasePool!
-
     private let featureFlagMock = FeatureFlagMock()
 
     lazy var isoFormatter: ISO8601DateFormatter = {
@@ -17,13 +14,11 @@ final class FmdbGrdbTests: XCTestCase {
     }()
 
     private func setupDataManagerWithFMDB() throws -> DataManager {
-        dbQueue = try XCTUnwrap(FMDatabaseQueue.newTestDatabase())
-        return DataManager(dbQueue: FMDBQueue(fmdbQueue: dbQueue))
+        DataManager(grdbEnabled: false, databaseFileName: "podcast_testDB.sqlite3")
     }
 
     private func setupDataManagerWithGRDB() throws -> DataManager {
-        dbPool = try XCTUnwrap(DatabasePool.newTestDatabase())
-        return grdbDatabaManager(dbPool: dbPool)
+        DataManager(grdbEnabled: true, databaseFileName: "podcast_testDB_GRDB.sqlite3")
     }
 
     // We have a check inside DataManager where the queue is closed
@@ -82,16 +77,14 @@ final class FmdbGrdbTests: XCTestCase {
         // Then read the podcasts and episodes back from FMDB and GRDB and compare them.
         // This ensures that the databases are compatible with each other.
 
-        dbQueue.close()
-        try! dbPool.close()
+        fmdbDataManager.close()
+        grdbDataManager.close()
         try! DatabasePool.copyDatabase(toFile: "GRDB_copy.sqlite3")
         try! FMDatabaseQueue.copyDatabase(toFile: "FMDB_copy.sqlite3")
 
-        dbQueue = try XCTUnwrap(FMDatabaseQueue.newTestDatabase(databaseName: "GRDB_copy.sqlite3"))
-        let fmdbFromGrdbDataManager = DataManager(dbQueue: FMDBQueue(fmdbQueue: dbQueue))
+        let fmdbFromGrdbDataManager = DataManager(grdbEnabled: false, databaseFileName: "GRDB_copy.sqlite3")
 
-        dbPool = try XCTUnwrap(DatabasePool.newTestDatabase(databaseName: "FMDB_copy.sqlite3"))
-        let grdbFromFmdbDataManager = grdbDatabaManager(dbPool: dbPool)
+        let grdbFromFmdbDataManager = DataManager(grdbEnabled: true, databaseFileName: "FMDB_copy.sqlite3")
 
         let fmdbPodcastReadFromGrdb = fmdbFromGrdbDataManager.findPodcast(uuid: "b5363810-adfb-013d-1a6e-0acc26574db2")
         let grdbPodcastReadFromFmdb = grdbFromFmdbDataManager.findPodcast(uuid: "b5363810-adfb-013d-1a6e-0acc26574db2")

--- a/PocketCastsTests/Extensions/FMDatabaseQueue+Test.swift
+++ b/PocketCastsTests/Extensions/FMDatabaseQueue+Test.swift
@@ -92,13 +92,31 @@ extension DatabasePool {
             try FileManager.default.createDirectory(atPath: dbFolderPath as String, withIntermediateDirectories: true)
         }
 
-        let dbPath = dbFolderPath.appendingPathComponent("podcast_testDB_GRDB.sqlite3")
-        if FileManager.default.fileExists(atPath: dbPath) {
-            if FileManager.default.fileExists(atPath: dbFolderPath.appendingPathComponent(toFile)) {
-                try FileManager.default.removeItem(atPath: dbFolderPath.appendingPathComponent(toFile))
-            }
+        let dbBaseName = "podcast_testDB_GRDB.sqlite3"
+        let dbPath = dbFolderPath.appendingPathComponent(dbBaseName)
+        let destinationBase = (toFile as NSString).deletingPathExtension
+        let destinationExtension = (toFile as NSString).pathExtension
 
-            try FileManager.default.copyItem(at: URL(fileURLWithPath: dbPath), to: URL(fileURLWithPath: dbFolderPath.appendingPathComponent(toFile)))
+        if FileManager.default.fileExists(atPath: dbPath) {
+            let baseFiles = [
+                "",          // Main db file
+                "-shm",      // Shared memory file
+                "-wal"       // Write-ahead log file
+            ]
+
+            for suffix in baseFiles {
+                let sourcePath = dbPath + suffix
+                let destFileName = destinationBase + suffix + (suffix == "" ? ".\(destinationExtension)" : "")
+                let destPath = dbFolderPath.appendingPathComponent(destFileName)
+
+                if FileManager.default.fileExists(atPath: destPath) {
+                    try FileManager.default.removeItem(atPath: destPath)
+                }
+
+                if FileManager.default.fileExists(atPath: sourcePath) {
+                    try FileManager.default.copyItem(atPath: sourcePath, toPath: destPath)
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
| 📘 Part of: #2773 | 
|:---:|

Add `read`/`write` methods to `FolderDataManager`

## To test

**Thoroughly** review the code, ensuring that write database operations use `write` and read operations use `read`.

1. Run the app and login to an account with folders
2. ✅ Check that folders appear correctly
3. Change `grdb` flag in `FeatureFlag.swift` to false
4. Re-run the app
5. ✅ Your folders should still be there

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
