### PR TITLE
Recommendations: Add datetime + new events for Similar Shows on podcast page

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
@@ -350,6 +350,7 @@ public struct PodcastList: Decodable {
     public var title: String?
     public var description: String?
     public var podcasts: [DiscoverPodcast]?
+    public let datetime: String?
 }
 
 public struct PodcastCollection: Decodable {

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
@@ -273,6 +273,7 @@ public struct DiscoverItem: Decodable, Equatable {
     public var isSponsored: Bool?
     public var popular: [Int]?
     public var categoryID: Int?
+    public var dateTime: String?
 
     public enum CodingKeys: String, CodingKey {
         case summaryStyle = "summary_style"
@@ -281,6 +282,7 @@ public struct DiscoverItem: Decodable, Equatable {
         case sponsoredPodcasts = "sponsored_podcasts"
         case expandedTopItemLabel = "expanded_top_item_label"
         case categoryID = "category_id"
+        case dateTime = "datetime"
         case type, title, source, regions, curated, uuid, popular, id, authenticated
     }
 
@@ -366,6 +368,7 @@ public struct PodcastCollection: Decodable {
     public var collageImages: [CollageImage]?
     public let headerImage: String?
     public let featureImage: String?
+    public let datetime: String?
     public enum CodingKeys: String, CodingKey {
         case webUrl = "web_url"
         case webTitle = "web_title"
@@ -374,7 +377,7 @@ public struct PodcastCollection: Decodable {
         case headerImage = "header_image"
         case listId = "list_id"
         case featureImage = "feature_image"
-        case title, description, subtitle, colors, podcasts, author, episodes, podroll
+        case title, description, subtitle, colors, podcasts, author, episodes, podroll, datetime
     }
 }
 

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -325,6 +325,8 @@ enum AnalyticsEvent: String {
     case podcastScreenNotificationsTapped
     case podcastScreenPodcastDetailsLinkTapped
     case podcastScreenCategoryTapped
+    case podcastScreenSimilarShowTapped
+    case podcastScreenSimilarShowSubscribed
 
     // MARK: - App Store Review Request
 

--- a/podcasts/Analytics/Helpers/AnalyticsCoordinator.swift
+++ b/podcasts/Analytics/Helpers/AnalyticsCoordinator.swift
@@ -35,7 +35,6 @@ enum AnalyticsSource: String, AnalyticsDescribable {
     case playerPlaybackEffects = "player_playback_effects"
     case playerSkipForwardLongPress = "player_skip_forward_long_press"
     case podcastScreen = "podcast_screen"
-    case podcastScreenSimilarShows = "podcast_screen_similar_shows"
     case podcastSettings = "podcast_settings"
     case podcastsList = "podcasts_list"
     case profile

--- a/podcasts/AnalyticsHelper.swift
+++ b/podcasts/AnalyticsHelper.swift
@@ -107,14 +107,20 @@ class AnalyticsHelper {
         bumpStat("discover_list_episode_play", parameters: properties)
     }
 
-    class func podcastSubscribedFromList(listId: String, podcastUuid: String) {
-        let properties = ["list_id": listId, "podcast_uuid": podcastUuid]
+    class func podcastSubscribedFromList(listId: String, podcastUuid: String, listDateTime: String? = nil) {
+        var properties = ["list_id": listId, "podcast_uuid": podcastUuid]
+        if let listDateTime {
+            properties["list_datetime"] = listDateTime
+        }
         Analytics.track(.discoverListPodcastSubscribed, properties: properties)
         bumpStat("discover_list_podcast_subscribe", parameters: properties)
     }
 
-    class func podcastTappedFromList(listId: String, podcastUuid: String) {
-        let properties = ["list_id": listId, "podcast_uuid": podcastUuid]
+    class func podcastTappedFromList(listId: String, podcastUuid: String, listDateTime: String? = nil) {
+        var properties = ["list_id": listId, "podcast_uuid": podcastUuid]
+        if let listDateTime {
+            properties["list_datetime"] = listDateTime
+        }
         Analytics.track(.discoverListPodcastTapped, properties: properties)
         bumpStat("discover_list_podcast_tap", parameters: properties)
     }

--- a/podcasts/AnalyticsHelper.swift
+++ b/podcasts/AnalyticsHelper.swift
@@ -151,11 +151,8 @@ class AnalyticsHelper {
         bumpStat("discover_list_show_all", parameters: properties)
     }
 
-    class func listImpression(listId: String, dateTime: String? = nil) {
+    class func listImpression(listId: String) {
         var properties = ["list_id": listId]
-        if let dateTime {
-            properties["list_datetime"] = dateTime
-        }
         Analytics.track(.discoverListImpression, properties: properties)
         bumpStat("discover_list_impression", parameters: properties)
     }

--- a/podcasts/AnalyticsHelper.swift
+++ b/podcasts/AnalyticsHelper.swift
@@ -142,15 +142,22 @@ class AnalyticsHelper {
         bumpStat("discover_list_podcast_episode_tap", parameters: properties)
     }
 
-    class func listShowAllTapped(listId: String) {
-        let properties = ["list_id": listId]
+    class func listShowAllTapped(listId: String, dateTime: String? = nil) {
+        var properties = ["list_id": listId]
+        if let dateTime {
+            properties["list_datetime"] = dateTime
+        }
         Analytics.track(.discoverListShowAllTapped, properties: properties)
         bumpStat("discover_list_show_all", parameters: properties)
     }
 
-    class func listImpression(listId: String) {
-        Analytics.track(.discoverListImpression, properties: ["list_id": listId])
-        bumpStat("discover_list_impression", parameters: ["list_id": listId])
+    class func listImpression(listId: String, dateTime: String? = nil) {
+        var properties = ["list_id": listId]
+        if let dateTime {
+            properties["list_datetime"] = dateTime
+        }
+        Analytics.track(.discoverListImpression, properties: properties)
+        bumpStat("discover_list_impression", parameters: properties)
     }
 
     class func forceTouchPlay() {

--- a/podcasts/DiscoverCollectionViewController+DiscoverDelegate.swift
+++ b/podcasts/DiscoverCollectionViewController+DiscoverDelegate.swift
@@ -2,7 +2,6 @@ import PocketCastsServer
 import PocketCastsDataModel
 
 extension DiscoverCollectionViewController: DiscoverDelegate {
-
     func navigateTo(category: String) {
         if isViewLoaded {
             NotificationCenter.default.post(name: Constants.Notifications.discoverNavigateToCategory, object: category)
@@ -95,9 +94,13 @@ extension DiscoverCollectionViewController: DiscoverDelegate {
         })
     }
 
-    func showExpanded(item: DiscoverItem, podcasts: [DiscoverPodcast], podcastCollection: PodcastCollection?) {
+    func showExpanded(item: PocketCastsServer.DiscoverItem, podcasts: [PocketCastsServer.DiscoverPodcast], podcastCollection: PocketCastsServer.PodcastCollection?) {
+        showExpanded(item: item, podcasts: podcasts, podcastCollection: podcastCollection, datetime: nil)
+    }
+
+    func showExpanded(item: DiscoverItem, podcasts: [DiscoverPodcast], podcastCollection: PodcastCollection?, datetime: String? = nil) {
         if let listId = item.uuid {
-            AnalyticsHelper.listShowAllTapped(listId: listId)
+            AnalyticsHelper.listShowAllTapped(listId: listId, dateTime: datetime)
         } else {
             Analytics.track(.discoverShowAllTapped, properties: ["list_id": item.inferredListId])
         }
@@ -123,7 +126,7 @@ extension DiscoverCollectionViewController: DiscoverDelegate {
         guard let podcastCollection = podcastCollection else { return }
 
         if let listId = item.uuid {
-            AnalyticsHelper.listShowAllTapped(listId: listId)
+            AnalyticsHelper.listShowAllTapped(listId: listId, dateTime: podcastCollection.datetime)
         }
 
         let listView = ExpandedEpisodeListViewController(podcastCollection: podcastCollection)

--- a/podcasts/DiscoverSummaryProtocol.swift
+++ b/podcasts/DiscoverSummaryProtocol.swift
@@ -12,6 +12,7 @@ protocol DiscoverDelegate: AnyObject {
     func show(podcast: Podcast)
     func showExpanded(item: DiscoverItem, category: DiscoverCategory?)
     func showExpanded(item: DiscoverItem, podcasts: [DiscoverPodcast], podcastCollection: PodcastCollection?)
+    func showExpanded(item: DiscoverItem, podcasts: [DiscoverPodcast], podcastCollection: PodcastCollection?, datetime: String?)
     func showExpanded(item: DiscoverItem, episodes: [DiscoverEpisode], podcastCollection: PodcastCollection?)
     func replaceRegionCode(string: String?) -> String?
     func replaceRegionName(string: String) -> String

--- a/podcasts/DiscoverViewController+DiscoverDelegate.swift
+++ b/podcasts/DiscoverViewController+DiscoverDelegate.swift
@@ -83,9 +83,13 @@ extension DiscoverViewController: DiscoverDelegate {
         })
     }
 
-    func showExpanded(item: DiscoverItem, podcasts: [DiscoverPodcast], podcastCollection: PodcastCollection?) {
+    func showExpanded(item: PocketCastsServer.DiscoverItem, podcasts: [PocketCastsServer.DiscoverPodcast], podcastCollection: PocketCastsServer.PodcastCollection?) {
+        showExpanded(item: item, podcasts: podcasts, podcastCollection: podcastCollection, datetime: nil)
+    }
+
+    func showExpanded(item: DiscoverItem, podcasts: [DiscoverPodcast], podcastCollection: PodcastCollection?, datetime dateTime: String? = nil) {
         if let listId = item.uuid {
-            AnalyticsHelper.listShowAllTapped(listId: listId)
+            AnalyticsHelper.listShowAllTapped(listId: listId, dateTime: dateTime)
         } else {
             Analytics.track(.discoverShowAllTapped, properties: ["list_id": item.inferredListId])
         }
@@ -111,7 +115,7 @@ extension DiscoverViewController: DiscoverDelegate {
         guard let podcastCollection = podcastCollection else { return }
 
         if let listId = item.uuid {
-            AnalyticsHelper.listShowAllTapped(listId: listId)
+            AnalyticsHelper.listShowAllTapped(listId: listId, dateTime: podcastCollection.datetime ?? item.dateTime)
         }
 
         let listView = ExpandedEpisodeListViewController(podcastCollection: podcastCollection)

--- a/podcasts/LargeListSummaryViewController.swift
+++ b/podcasts/LargeListSummaryViewController.swift
@@ -23,6 +23,7 @@ class LargeListSummaryViewController: DiscoverPeekViewController, DiscoverSummar
         }
     }
     private var podcasts = [DiscoverPodcast]()
+    private var datetime: String? // Used to track the generation of recommendations
     private weak var delegate: DiscoverDelegate?
     private var item: DiscoverItem?
 
@@ -84,7 +85,7 @@ class LargeListSummaryViewController: DiscoverPeekViewController, DiscoverSummar
         super.viewDidAppear(animated)
 
         if let listId = item?.uuid {
-            AnalyticsHelper.listImpression(listId: listId)
+            AnalyticsHelper.listImpression(listId: listId, dateTime: datetime)
         }
         NotificationCenter.default.addObserver(self, selector: #selector(podcastStatusChanged), name: Constants.Notifications.podcastAdded, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(podcastStatusChanged), name: Constants.Notifications.podcastDeleted, object: nil)
@@ -105,7 +106,7 @@ class LargeListSummaryViewController: DiscoverPeekViewController, DiscoverSummar
             cell.populateFrom(thisPodcast, isSubscribed: delegate.isSubscribed(podcast: thisPodcast))
             cell.onSubscribe = { [weak self] in
                 if let listId = self?.item?.uuid, let podcastUuid = thisPodcast.uuid {
-                    AnalyticsHelper.podcastSubscribedFromList(listId: listId, podcastUuid: podcastUuid)
+                    AnalyticsHelper.podcastSubscribedFromList(listId: listId, podcastUuid: podcastUuid, listDateTime: self?.datetime)
                 }
                 delegate.subscribe(podcast: thisPodcast)
             }
@@ -126,7 +127,7 @@ class LargeListSummaryViewController: DiscoverPeekViewController, DiscoverSummar
         collectionView.deselectItem(at: indexPath, animated: true)
 
         if let listId = item.uuid, let podcastUuid = podcast.uuid {
-            AnalyticsHelper.podcastTappedFromList(listId: listId, podcastUuid: podcastUuid)
+            AnalyticsHelper.podcastTappedFromList(listId: listId, podcastUuid: podcastUuid, listDateTime: datetime)
         }
     }
 
@@ -186,6 +187,7 @@ class LargeListSummaryViewController: DiscoverPeekViewController, DiscoverSummar
                 DispatchQueue.main.async {
                     strongSelf.relatedPodcastID = podcastCollection?.featureImage
                     strongSelf.podcastHeaderView?.bottomText = podcastCollection?.title
+                    strongSelf.datetime = podcastCollection?.datetime
                     strongSelf.divider.isHidden = false
                     strongSelf.collectionView.reloadData()
                 }
@@ -222,7 +224,7 @@ class LargeListSummaryViewController: DiscoverPeekViewController, DiscoverSummar
     @IBAction func showAllTapped(_ sender: Any) {
         guard let delegate = delegate, let item = item else { return }
 
-        delegate.showExpanded(item: item, podcasts: podcasts, podcastCollection: nil)
+        delegate.showExpanded(item: item, podcasts: podcasts, podcastCollection: nil, datetime: datetime)
     }
 
     // MARK: - Page Changed

--- a/podcasts/LargeListSummaryViewController.swift
+++ b/podcasts/LargeListSummaryViewController.swift
@@ -85,7 +85,7 @@ class LargeListSummaryViewController: DiscoverPeekViewController, DiscoverSummar
         super.viewDidAppear(animated)
 
         if let listId = item?.uuid {
-            AnalyticsHelper.listImpression(listId: listId, dateTime: datetime)
+            AnalyticsHelper.listImpression(listId: listId)
         }
         NotificationCenter.default.addObserver(self, selector: #selector(podcastStatusChanged), name: Constants.Notifications.podcastAdded, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(podcastStatusChanged), name: Constants.Notifications.podcastDeleted, object: nil)

--- a/podcasts/LargeListSummaryViewController.swift
+++ b/podcasts/LargeListSummaryViewController.swift
@@ -183,11 +183,11 @@ class LargeListSummaryViewController: DiscoverPeekViewController, DiscoverSummar
                 guard let strongSelf = self, let discoverPodcast = podcastCollection?.podcasts else { return }
 
                 strongSelf.appendPodcasts(discoverPodcast, item: item)
+                strongSelf.datetime = podcastCollection?.datetime
 
                 DispatchQueue.main.async {
                     strongSelf.relatedPodcastID = podcastCollection?.featureImage
                     strongSelf.podcastHeaderView?.bottomText = podcastCollection?.title
-                    strongSelf.datetime = podcastCollection?.datetime
                     strongSelf.divider.isHidden = false
                     strongSelf.collectionView.reloadData()
                 }
@@ -197,6 +197,7 @@ class LargeListSummaryViewController: DiscoverPeekViewController, DiscoverSummar
                 guard let strongSelf = self, let discoverPodcast = podcastList?.podcasts else { return }
 
                 strongSelf.appendPodcasts(discoverPodcast, item: item)
+                strongSelf.datetime = podcastList?.datetime
 
                 DispatchQueue.main.async {
                     strongSelf.divider.isHidden = false

--- a/podcasts/New Search/Views/Results/RoundedSubscribeButtonView.swift
+++ b/podcasts/New Search/Views/Results/RoundedSubscribeButtonView.swift
@@ -6,8 +6,8 @@ import PocketCastsUtils
 struct RoundedSubscribeButtonView: View {
     @ObservedObject var model: SubscribeButtonModel
 
-    init(podcastUuid: String, source: AnalyticsSource) {
-        self.model = SubscribeButtonModel(podcastUuid: podcastUuid, source: source)
+    init(podcastUuid: String, source: AnalyticsSource, onSubscribe: (() -> Void)? = nil) {
+        self.model = SubscribeButtonModel(podcastUuid: podcastUuid, source: source, subscribeBlock: onSubscribe)
     }
 
     var body: some View {
@@ -37,8 +37,8 @@ struct SubscribeButtonView: View {
 
     @ObservedObject var model: SubscribeButtonModel
 
-    init(podcastUuid: String, source: AnalyticsSource) {
-        self.model = SubscribeButtonModel(podcastUuid: podcastUuid, source: source)
+    init(podcastUuid: String, source: AnalyticsSource, onSubscribe: (() -> Void)? = nil) {
+        self.model = SubscribeButtonModel(podcastUuid: podcastUuid, source: source, subscribeBlock: onSubscribe)
     }
 
     var body: some View {
@@ -74,15 +74,19 @@ class SubscribeButtonModel: ObservableObject {
     let podcastUuid: String
     let source: AnalyticsSource
 
-    init(podcastUuid: String, source: AnalyticsSource) {
+    let subscribeBlock: (() -> Void)?
+
+    init(podcastUuid: String, source: AnalyticsSource, subscribeBlock: (() -> Void)?) {
         self.podcastUuid = podcastUuid
         self.source = source
+        self.subscribeBlock = subscribeBlock
         isSubscribed = DataManager.sharedManager.findPodcast(uuid: podcastUuid) != nil
     }
 
     func subscribe() {
         ServerPodcastManager.shared.subscribe(to: podcastUuid, completion: nil)
         Analytics.track(.podcastSubscribed, properties: ["source": source, "uuid": podcastUuid])
+        subscribeBlock?()
     }
 
     func checkSubscriptionStatus() {

--- a/podcasts/PodcastTableCellView.swift
+++ b/podcasts/PodcastTableCellView.swift
@@ -26,7 +26,7 @@ struct PodcastTableCellView: View {
 
             Spacer()
 
-            SubscribeButtonView(podcastUuid: viewModel.uuid, source: .podcastScreenSimilarShows, onSubscribe: {
+            SubscribeButtonView(podcastUuid: viewModel.uuid, source: .podcastScreen, onSubscribe: {
                 var properties = ["podcast_uuid": viewModel.uuid]
                 properties["list_datetime"] = viewModel.datetime
                 Analytics.track(.podcastScreenSimilarShowSubscribed, properties: properties)

--- a/podcasts/PodcastTableCellView.swift
+++ b/podcasts/PodcastTableCellView.swift
@@ -26,25 +26,32 @@ struct PodcastTableCellView: View {
 
             Spacer()
 
-            SubscribeButtonView(podcastUuid: viewModel.uuid, source: .podcastScreenSimilarShows)
+            SubscribeButtonView(podcastUuid: viewModel.uuid, source: .podcastScreenSimilarShows, onSubscribe: {
+                var properties = ["podcast_uuid": viewModel.uuid]
+                properties["list_datetime"] = viewModel.datetime
+                Analytics.track(.podcastScreenSimilarShowSubscribed, properties: properties)
+            })
         }
     }
 }
 
 struct PodcastCellViewModel {
     let uuid: String
+    let datetime: String?
     let title: String?
     let author: String?
 
-    init(podcast: Podcast) {
+    init(podcast: Podcast, datetime: String?) {
         self.uuid = podcast.uuid
         self.title = podcast.title
         self.author = podcast.author
+        self.datetime = datetime
     }
 
-    init(discoverPodcast: DiscoverPodcast) {
+    init(discoverPodcast: DiscoverPodcast, datetime: String?) {
         self.uuid = discoverPodcast.uuid ?? ""
         self.title = discoverPodcast.title
         self.author = discoverPodcast.author
+        self.datetime = datetime
     }
 }

--- a/podcasts/PodcastTableViewCell.swift
+++ b/podcasts/PodcastTableViewCell.swift
@@ -43,8 +43,8 @@ final class PodcastTableViewCell: ThemeableCell {
         }
     }
 
-    func configure(with discoverPodcast: DiscoverPodcast) {
-        configure(with: PodcastCellViewModel(discoverPodcast: discoverPodcast))
+    func configure(with discoverPodcast: DiscoverPodcast, datetime: String?) {
+        configure(with: PodcastCellViewModel(discoverPodcast: discoverPodcast, datetime: datetime))
     }
 
     private enum ClientError: Swift.Error {

--- a/podcasts/PodcastViewController+TableData.swift
+++ b/podcasts/PodcastViewController+TableData.swift
@@ -185,7 +185,7 @@ extension PodcastViewController: UITableViewDataSource, UITableViewDelegate {
                     return UITableViewCell()
                 }
                 let cell = tableView.dequeueReusableCell(withIdentifier: PodcastTableViewCell.reuseIdentifier, for: indexPath) as! PodcastTableViewCell
-                cell.configure(with: podcast)
+                cell.configure(with: podcast, datetime: nil)
                 return cell
             case .podcasts:
                 guard let podcast = recommendations?.podcasts?[indexPath.row] else {
@@ -193,7 +193,8 @@ extension PodcastViewController: UITableViewDataSource, UITableViewDelegate {
                     return UITableViewCell()
                 }
                 let cell = tableView.dequeueReusableCell(withIdentifier: PodcastTableViewCell.reuseIdentifier, for: indexPath) as! PodcastTableViewCell
-                cell.configure(with: podcast)
+                cell.configure(with: podcast, datetime: recommendations?.datetime)
+                cell.separatorInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: .greatestFiniteMagnitude)
                 return cell
             }
         }
@@ -284,6 +285,14 @@ extension PodcastViewController: UITableViewDataSource, UITableViewDelegate {
                 navigationController?.pushViewController(podcastController, animated: true)
             case .podcasts:
                 guard let selectedPodcast = recommendations?.podcasts?[indexPath.row] else { return }
+                var properties: [String: Any] = [:]
+                if let datetime = recommendations?.datetime {
+                    properties["list_datetime"] = datetime
+                }
+                if let uuid = selectedPodcast.uuid {
+                    properties["podcast_uuid"] = selectedPodcast.uuid
+                }
+                Analytics.track(.podcastScreenSimilarShowTapped, properties: properties)
                 let info = PodcastInfo(selectedPodcast)
                 let podcastController = PodcastViewController(podcastInfo: info, existingImage: nil)
                 navigationController?.pushViewController(podcastController, animated: true)

--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -84,6 +84,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
     var hasSimilarShowsPublisher: AnyPublisher<Bool, Never> {
         hasSimilarShows.eraseToAnyPublisher()
     }
+
     var recommendations: PodcastCollection?
 
     enum ViewMode {


### PR DESCRIPTION
| 📘 Part of: #2989 | 
|:---:|

Adds tracks event updates for recommendations in Discover and Similar Shows tab and removes the `podcast_screen_similar_shows` source.

## To test

* Enable the `Recommendations` feature flag and tracks logging + Restart the app
* Log in with an account with some playback history
* Navigate to "Discover"
* Scroll down and verify that you see a Recommendation cell ("You Might Like", "Loved by listeners of", "If you like")
* ✅ Verify the `discover_list_impression` with `"list_id": "recommendations_user_podcast"`.

```
🔵 Tracked: discover_list_impression ["theme_selected": "default_light", "list_id": "recommendations_user", "theme_use_system_settings": false, "theme_light_preference": "default_light", "theme_dark_preference": "dark_contrast"]
```

* Tap on a podcast in the section
* ✅ Verify that `discover_list_podcast_tapped` with `"list_id": "recommendations_user_podcast"` + `"list_datetime": "2025-04-17T09:11:26Z"` + "podcast_uuid": "e6d1eff0-244e-012e-04d4-00163e1b201c"

```
🔵 Tracked: discover_list_podcast_tapped ["theme_use_system_settings": false, "list_datetime": "2025-04-17T09:11:26Z", "list_id": "recommendations_user_podcast", "podcast_uuid": "e6d1eff0-244e-012e-04d4-00163e1b201c", "theme_dark_preference": "dark_contrast", "theme_selected": "light_contrast", "theme_light_preference": "light_contrast"]
```

* Subscribe to a podcast in the section
* ✅ Verify that `discover_list_podcast_subscribed` with `"podcast_uuid": "467b49a0-c657-0138-e72e-0acc26574db2"` +  "list_datetime": "2025-04-17T09:11:26Z" + "list_id": "recommendations_user_podcast"

```
🔵 Tracked: discover_list_podcast_subscribed ["theme_use_system_settings": false, "theme_light_preference": "light_contrast", "list_datetime": "2025-04-17T09:11:26Z", "list_id": "recommendations_user_podcast", "theme_selected": "light_contrast", "theme_dark_preference": "dark_contrast", "podcast_uuid": "467b49a0-c657-0138-e72e-0acc26574db2"]
```

* Tap "Show All"
* ✅ Verify that `discover_list_show_all_tapped` with `"list_id": "recommendations_user_podcast"` + `"list_datetime": "2025-04-17T09:11:26Z"`

```
🔵 Tracked: discover_list_show_all_tapped ["theme_selected": "light_contrast", "theme_light_preference": "light_contrast", "theme_use_system_settings": false, "list_id": "recommendations_user_podcast", "theme_dark_preference": "dark_contrast", "list_datetime": "2025-04-17T09:11:26Z"]
```

## Podcast Page

* Navigate to a podcast page
* Tap the "Similar Shows" tab
* ✅ Verify `podcasts_screen_tab_tapped` is logged with `"value": "similar_shows"`

```
🔵 Tracked: podcasts_screen_tab_tapped ["theme_dark_preference": "dark_contrast", "value": "similar_shows", "theme_light_preference": "light_contrast", "theme_selected": "light_contrast", "theme_use_system_settings": false]
```

* Tap on a show in this tab
* ✅ Verify `podcast_screen_similar_show_tapped` is logged with `"list_datetime": "2025-04-17T09:11:26Z"` + `"podcast_uuid": "ed103d40-38b4-0133-b635-0d11918ab357"`

```
🔵 Tracked: podcast_screen_similar_show_tapped ["theme_light_preference": "light_contrast", "theme_selected": "light_contrast", "theme_use_system_settings": false, "list_datetime": "2025-04-17T09:11:26Z", "theme_dark_preference": "dark_contrast", "podcast_uuid": "ed103d40-38b4-0133-b635-0d11918ab357"]

🔵 Tracked: podcast_screen_shown ["theme_dark_preference": "dark_contrast", "theme_selected": "light_contrast", "theme_light_preference": "light_contrast", "uuid": "ed103d40-38b4-0133-b635-0d11918ab357", "theme_use_system_settings": false]
```

---

* Go back
* Subscribe to a show from the cell
* ✅ Verify `podcast_screen_similar_show_subscribed` is logged with `"podcast_uuid": "ed103d40-38b4-0133-b635-0d11918ab357"` + `"podcast_uuid": "ed103d40-38b4-0133-b635-0d11918ab357"`

```
🔵 Tracked: podcast_subscribed ["theme_dark_preference": "dark_contrast", "theme_use_system_settings": false, "source": "podcast_screen_similar_shows", "theme_selected": "light_contrast", "uuid": "ed103d40-38b4-0133-b635-0d11918ab357", "theme_light_preference": "light_contrast"]

🔵 Tracked: podcast_screen_similar_show_subscribed ["theme_use_system_settings": false, "theme_dark_preference": "dark_contrast", "podcast_uuid": "ed103d40-38b4-0133-b635-0d11918ab357", "theme_light_preference": "light_contrast", "theme_selected": "light_contrast", "list_datetime": "2025-04-17T09:11:26Z"]
```

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
