### PR TITLE
Adds podcast to funding tap analytics

### DIFF
--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -829,7 +829,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
     }
 
     func fundingTapped() {
-        Analytics.track(.podcastScreenFundingTapped, properties: ["uuid": podcast?.uuid ?? ""])
+        Analytics.track(.podcastScreenFundingTapped, properties: ["podcast_uuid": podcast?.uuid ?? ""])
         guard let urlString = podcast?.fundingURL, let url = URL(string: urlString) else { return }
         UIApplication.shared.open(url, options: [:], completionHandler: nil)
     }

--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -829,7 +829,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
     }
 
     func fundingTapped() {
-        Analytics.track(.podcastScreenFundingTapped)
+        Analytics.track(.podcastScreenFundingTapped, properties: ["uuid": podcast?.uuid ?? ""])
         guard let urlString = podcast?.fundingURL, let url = URL(string: urlString) else { return }
         UIApplication.shared.open(url, options: [:], completionHandler: nil)
     }


### PR DESCRIPTION
## Description

The analytics event to help us improve the funding button now includes the podcast.

## Testing Instructions
1. Open the podcast page for [The Changelog](https://pca.st/podcast/70d13d50-9efe-0130-1b90-723c91aeae46)
2. Tap the funding button
3. ✅ Verify the analytic event `podcast_screen_funding_tapped` includes the property `podcast_uuid`

Android PR for ref: https://github.com/Automattic/pocket-casts-android/pull/3949 

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
