### PR TITLE
[Notifications Revamp] refactor new episodes notifications setup

### DIFF
--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -228,6 +228,7 @@ struct Constants {
         }
 
         enum notifications {
+            static let newEpisodes = "notifications.newEpisodes"
             static let dailyReminders = "notifications.dailyReminders"
             static let newFeaturesAndTips = "notifications.newFeaturesAndTips"
             static let recommendations = "notifications.recommendations"

--- a/podcasts/Notifications/NotificationsCoordinator.swift
+++ b/podcasts/Notifications/NotificationsCoordinator.swift
@@ -108,6 +108,8 @@ enum NotificationType: String {
 }
 
 enum NotificationsGroup {
+
+    case newEpisodes
     case dailyReminders
     case recommendations
     case newFeaturesAndTips
@@ -115,6 +117,8 @@ enum NotificationsGroup {
 
     var notifications: [NotificationType] {
         switch self {
+            case .newEpisodes:
+                return [] // New Episodes are notifications sent by the server, so they don't need a local implementation
             case .dailyReminders:
                 return [.onboardingSignUp, .onboardingImport, .onboardingUpNext, .onboardingFilters, .onboardingThemes, .onboardingStaffPicks, .onboardingUpsell]
             case .recommendations:
@@ -141,6 +145,8 @@ enum NotificationsGroup {
 
     var isEnabled: Bool {
         switch self {
+            case .newEpisodes:
+                return Settings.notificationsNewEpisodes
             case .dailyReminders:
                 return Settings.notificationsDailyReminders
             case .recommendations:
@@ -154,6 +160,8 @@ enum NotificationsGroup {
 
     func setEnabled(_ newValue: Bool) {
         switch self {
+            case .newEpisodes:
+                return Settings.notificationsNewEpisodes = newValue
             case .dailyReminders:
                 Settings.notificationsDailyReminders = newValue
             case .recommendations:
@@ -169,6 +177,8 @@ enum NotificationsGroup {
 
     var timeIntervalStep: TimeInterval {
         switch self {
+            case .newEpisodes:
+                return 0
             case .dailyReminders:
                 return Self.speedUpNotifications ? 10.seconds: 24.hours
             case .recommendations:

--- a/podcasts/Notifications/NotificationsCoordinator.swift
+++ b/podcasts/Notifications/NotificationsCoordinator.swift
@@ -1,6 +1,7 @@
 import Foundation
 import PocketCastsUtils
 import PocketCastsServer
+import PocketCastsDataModel
 
 enum NotificationType: String {
 
@@ -107,7 +108,7 @@ enum NotificationType: String {
     }
 }
 
-enum NotificationsGroup {
+enum NotificationsGroup: CaseIterable {
 
     case newEpisodes
     case dailyReminders
@@ -132,6 +133,8 @@ enum NotificationsGroup {
 
     var scheduleHour: Int {
         switch self {
+            case .newEpisodes:
+                return 0 // This is determined by the server
             case .dailyReminders:
                 return 10
             case .recommendations:
@@ -161,7 +164,14 @@ enum NotificationsGroup {
     func setEnabled(_ newValue: Bool) {
         switch self {
             case .newEpisodes:
-                return Settings.notificationsNewEpisodes = newValue
+                if newValue {
+                    // the user has just turned on push, enable it for all their podcasts for simplicity
+                    DataManager.sharedManager.setPushForAllPodcasts(pushEnabled: true)
+                    NotificationsHelper.shared.registerForPushNotifications()
+                } else {
+                    RefreshManager.shared.refreshPodcasts(forceEvenIfRefreshedRecently: true)
+                }
+                Settings.notificationsNewEpisodes = newValue
             case .dailyReminders:
                 Settings.notificationsDailyReminders = newValue
             case .recommendations:
@@ -173,6 +183,7 @@ enum NotificationsGroup {
         }
     }
 
+    // Variable to be used only in debugging/testing to accelarate notifications schedule
     static var speedUpNotifications: Bool = false
 
     var timeIntervalStep: TimeInterval {
@@ -192,10 +203,16 @@ enum NotificationsGroup {
 
     var areRepeatable: Bool {
         switch self {
-            case .dailyReminders:
+            case .dailyReminders, .newEpisodes:
                 return false
             case .recommendations, .newFeaturesAndTips, .offers:
                 return true
+        }
+    }
+
+    static var allDisabled: Bool {
+        Self.allCases.allSatisfy() {
+            $0.isEnabled == false
         }
     }
 }
@@ -242,6 +259,9 @@ class NotificationsCoordinator {
     func disableNotifications(for group: NotificationsGroup) {
         group.setEnabled(false)
         cancelNotifications(for: group)
+        if NotificationsGroup.allDisabled {
+            NotificationsHelper.shared.disablePush()
+        }
     }
 
     func scheduleNotification(_ type: NotificationType, timeInterval: TimeInterval = 5.seconds, repeats: Bool = false) {

--- a/podcasts/NotificationsViewController.swift
+++ b/podcasts/NotificationsViewController.swift
@@ -59,7 +59,7 @@ class NotificationsViewController: PCViewController, UITableViewDataSource, UITa
             case .dailyReminders:
                 return Settings.notificationsDailyReminders
             case .newEpisodes:
-                return NotificationsHelper.shared.pushEnabled()
+                return Settings.notificationsNewEpisodes
             case .newFeaturesAndTips:
                 return Settings.notificationsNewFeaturesAndTips
             case .trendingRecommendations:
@@ -95,7 +95,7 @@ class NotificationsViewController: PCViewController, UITableViewDataSource, UITa
                 case .dailyReminders:
                     return .dailyReminders
                 case .newEpisodes:
-                    return nil
+                    return .newEpisodes
                 case .newFeaturesAndTips:
                     return .newFeaturesAndTips
                 case .trendingRecommendations:
@@ -147,7 +147,7 @@ class NotificationsViewController: PCViewController, UITableViewDataSource, UITa
         }
         switch sectionType {
         case .episodes:
-            return NotificationsHelper.shared.pushEnabled() ? 3 : 1
+            return NotificationsGroup.newEpisodes.isEnabled ? 3 : 1
         case .featuresAndOffers, .recommendationsAndReminders:
             return rows[section].count
         }
@@ -278,32 +278,12 @@ class NotificationsViewController: PCViewController, UITableViewDataSource, UITa
         Analytics.track(.settingsNotificationsPodcastsChanged, properties: ["number_selected": numberSelected])
     }
 
-    func episodePushToggled(_ sender: UISwitch) {
-        //  UserDefaults.standard.set(sender.isOn, forKey: Constants.UserDefaults.pushEnabled)
-
-        if sender.isOn {
-            NotificationsHelper.shared.enablePush()
-            // the user has just turned on push, enable it for all their podcasts for simplicity
-            DataManager.sharedManager.setPushForAllPodcasts(pushEnabled: true)
-            NotificationsHelper.shared.registerForPushNotifications()
-        } else {
-            NotificationsHelper.shared.disablePush()
-            RefreshManager.shared.refreshPodcasts(forceEvenIfRefreshedRecently: true)
-        }
-
-        Settings.trackValueToggled(.settingsNotificationsNewEpisodesToggled, enabled: sender.isOn)
-
-        settingsTable.reloadData()
-    }
-
     @objc private func notificationToggled(_ sender: UISwitch) {
         guard let row = Row(rawValue: sender.tag) else {
             return
         }
         switch row {
-        case .newEpisodes:
-                episodePushToggled(sender)
-        case .dailyReminders, .trendingRecommendations, .newFeaturesAndTips, .pocketCastsOffers:
+        case .dailyReminders, .trendingRecommendations, .newFeaturesAndTips, .pocketCastsOffers, .newEpisodes:
             guard let notificationGroup = row.notificationGroup else { return }
             if sender.isOn {
                 notificationsCoordinator.setupNotifications(for: notificationGroup)
@@ -311,6 +291,9 @@ class NotificationsViewController: PCViewController, UITableViewDataSource, UITa
                 notificationsCoordinator.disableNotifications(for: notificationGroup)
             }
             Settings.trackValueToggled(row.analyticsEvent, enabled: sender.isOn)
+            if row == .newEpisodes {
+                settingsTable.reloadData()
+            }
         default:
             return
         }

--- a/podcasts/PodcastManager.swift
+++ b/podcasts/PodcastManager.swift
@@ -40,7 +40,7 @@ class PodcastManager: NSObject {
     #if !os(watchOS) && !APPCLIP
         func setNotificationsEnabled(podcast: Podcast, enabled: Bool) {
             if enabled {
-                if !NotificationsHelper.shared.pushEnabled() {
+                if !NotificationsGroup.newEpisodes.isEnabled {
                     // this is the first podcast to enable push, to work around the fact that we defaulted that to on at the data layer, turn it off for every podcast
                     // this means it just ends up being on for this one podcast, not all of them
                     let podcasts = dataManager.allPodcasts(includeUnsubscribed: false)
@@ -55,8 +55,7 @@ class PodcastManager: NSObject {
                     if !foundPushOff {
                         dataManager.setPushForAllPodcasts(pushEnabled: false)
                     }
-
-                    NotificationsHelper.shared.enablePush()
+                    NotificationsCoordinator.shared.setupNotifications(for: .newEpisodes)
                 }
             }
 

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -1456,6 +1456,14 @@ class Settings: NSObject {
 #endif
 
     // MARK: - Notifications
+    static var notificationsNewEpisodes: Bool {
+        get {
+            UserDefaults.standard.value(forKey: Constants.UserDefaults.notifications.newEpisodes) as? Bool ?? false
+        }
+        set {
+            UserDefaults.standard.setValue(newValue, forKey: Constants.UserDefaults.notifications.newEpisodes)
+        }
+    }
 
     static var notificationsDailyReminders: Bool {
         get {


### PR DESCRIPTION
| 📘 Part of: #2906  |  <!-- project issue number, if applicable -->
|:---:|

Fixes #3061  <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR update the notifications setup so that disable new episodes notifications do not disable all the other notifications setup.

## To test

1. Start the app
2. Ensure that you have NotificationRevamp FF enabled
3. Open Profile -> Settings -> Notifications
4. Enable all notifications
5. Go back to Settings
6. Enter Notifications again and see if the settings are with the same values
7. Now disable only the new local notifications
8. Go back and renter the screen
9. Check that Episode notifications are still enabled
10. Now go to Settings -> Developer -> SpeedUp Notifications
11. Go to Settings -> Notifications
12. Enable the local notifications and disable the new episodes notifications
13. Exit the app
14. Check that local notifications still arive

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
