### PR TITLE
[Notifications revamp] Implement new feature notification

### DIFF
--- a/podcasts/AppDelegate+UrlHandling.swift
+++ b/podcasts/AppDelegate+UrlHandling.swift
@@ -387,6 +387,7 @@ extension AppDelegate {
         }
 
         setupOnboardingRoutes()
+        setupNewFeaturesRoutes()
     }
 
     func setupOnboardingRoutes() {
@@ -417,6 +418,19 @@ extension AppDelegate {
         JLRoutes.global().addRoute("/upsell") {[weak self] parameters -> Bool in
             guard self != nil else { return false }
             NavigationManager.sharedManager.navigateTo(NavigationManager.settingsPageKey, data: [NavigationManager.settingsRowKey: SettingsViewController.TableRow.pocketCastsPlus])
+            return true
+        }
+    }
+
+    func setupNewFeaturesRoutes() {
+        JLRoutes.global().addRoute("/features/*") {[weak self] parameters -> Bool in
+            guard self != nil,
+                  let pathComponents = parameters[JLRouteWildcardComponentsKey] as? [String],
+                  let feature = pathComponents.first
+            else {
+                return false
+            }
+            NavigationManager.sharedManager.navigateTo(NavigationManager.featurePageKey, data: [NavigationManager.featureKey: feature])
             return true
         }
     }

--- a/podcasts/FoldersCoordinator.swift
+++ b/podcasts/FoldersCoordinator.swift
@@ -54,6 +54,14 @@ class FoldersCoordinator: NSObject {
         Analytics.track(.podcastsListFolderButtonTapped)
     }
 
+    func showSuggestedFolders(from vc: UIViewController, source: AnalyticsSource = .notifications) {
+        guard FeatureFlag.suggestedFolders.enabled,
+              dataManager.allPodcasts(includeUnsubscribed: false, reloadFromDatabase: false).count > Constants.minimumNumberOfPodcasts else {
+            return
+        }
+        suggestedFolderCreationFlow(from: vc, source: source)
+    }
+
     func showUpsellIfNeeded(from vc: UIViewController) {
         guard FeatureFlag.suggestedFolders.enabled,
               vc.presentedViewController == nil,

--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -263,7 +263,7 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
         guard let podcastListController = navController.topViewController as? PodcastListViewController else {
             return
         }
-        
+
         podcastListController.showSuggestedFolders()
     }
 

--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -255,6 +255,18 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
         navController.pushViewController(folderController, animated: true)
     }
 
+    func navigateToSuggestedFolders() {
+        guard let navController = selectedViewController as? UINavigationController else { return }
+
+        navController.popToRootViewController(animated: false)
+
+        guard let podcastListController = navController.topViewController as? PodcastListViewController else {
+            return
+        }
+        
+        podcastListController.showSuggestedFolders()
+    }
+
     func navigateToPodcast(_ podcast: Podcast) {
         appDelegate()?.miniPlayer()?.closeUpNextAndFullPlayer(completion: { [weak self] in
 

--- a/podcasts/NavigationManager.swift
+++ b/podcasts/NavigationManager.swift
@@ -73,6 +73,9 @@ class NavigationManager {
     static let signUpPageKey = "signUpPage"
     static let importPageKey = "importPage"
 
+    static let featurePageKey = "featurePageKey"
+    static let featureKey = "featureKey"
+
     static let sharedManager = NavigationManager()
 
     private weak var mainController: NavigationProtocol?
@@ -237,6 +240,8 @@ class NavigationManager {
         } else if place == NavigationManager.settingsPageKey {
             let row = data?[NavigationManager.settingsRowKey] as? SettingsViewController.TableRow
             mainController?.showSettings(row: row)
+        } else if place == NavigationManager.featurePageKey {
+            navigateToFeature(data: data, animated: animated)
         }
     }
 
@@ -254,6 +259,15 @@ class NavigationManager {
         if let listId = data[NavigationManager.discoverListKey] as? String {
             mainController?.navigateToDiscover(listID: listId, animated: animated)
             return
+        }
+    }
+
+    func navigateToFeature(data: NSDictionary?, animated: Bool) {
+        guard let feature = data?[NavigationManager.featureKey] as? String else {
+            return
+        }
+        if feature == "suggestedFolders" {
+            mainController?.navigateToSuggestedFolders()
         }
     }
 }

--- a/podcasts/NavigationProtocol.swift
+++ b/podcasts/NavigationProtocol.swift
@@ -10,6 +10,7 @@ protocol NavigationProtocol: AnyObject {
     func navigateTo(podcast searchResult: PodcastFolderSearchResult)
 
     func navigateToFolder(_ folder: Folder, popToRootViewController: Bool)
+    func navigateToSuggestedFolders()
 
     func navigateToEpisode(_ episodeUuid: String, podcastUuid: String?, timestamp: TimeInterval?)
 
@@ -53,5 +54,5 @@ protocol NavigationProtocol: AnyObject {
 
     func showEndOfYearStories()
     func dismissPresentedViewController(completion: (() -> Void)?)
-    func showOnboardingFlow(flow: OnboardingFlow.Flow?)
+    func showOnboardingFlow(flow: OnboardingFlow.Flow?)    
 }

--- a/podcasts/NavigationProtocol.swift
+++ b/podcasts/NavigationProtocol.swift
@@ -54,5 +54,5 @@ protocol NavigationProtocol: AnyObject {
 
     func showEndOfYearStories()
     func dismissPresentedViewController(completion: (() -> Void)?)
-    func showOnboardingFlow(flow: OnboardingFlow.Flow?)    
+    func showOnboardingFlow(flow: OnboardingFlow.Flow?)
 }

--- a/podcasts/Notifications/NotificationsCoordinator+AnalyticsAdapter.swift
+++ b/podcasts/Notifications/NotificationsCoordinator+AnalyticsAdapter.swift
@@ -60,6 +60,8 @@ extension NotificationType {
             possibleConditions = [.discoverListShowAllTapped]
         case .upsell:
             possibleConditions = [.purchaseSuccessful]
+        case .newFeature:
+            possibleConditions = [.suggestedFoldersPageShow]
         }
         let eventMatch = possibleConditions.contains {
             $0.rawValue.toSnakeCaseFromCamelCase() == name

--- a/podcasts/Notifications/NotificationsCoordinator+AnalyticsAdapter.swift
+++ b/podcasts/Notifications/NotificationsCoordinator+AnalyticsAdapter.swift
@@ -60,7 +60,7 @@ extension NotificationType {
             possibleConditions = [.discoverListShowAllTapped]
         case .upsell:
             possibleConditions = [.purchaseSuccessful]
-        case .newFeature:
+        case .newFeatureSuggestedFolders:
             possibleConditions = [.suggestedFoldersPageShow]
         }
         let eventMatch = possibleConditions.contains {

--- a/podcasts/Notifications/NotificationsCoordinator.swift
+++ b/podcasts/Notifications/NotificationsCoordinator.swift
@@ -260,8 +260,8 @@ class NotificationsCoordinator {
                 scheduleNotification(notification, timeInterval: timeInterval + group.timeIntervalStep, repeats: true)
             } else {
                 scheduleNotification(notification, timeInterval: timeInterval, repeats: false)
-                timeInterval += group.timeIntervalStep
             }
+            timeInterval += group.timeIntervalStep
         }
     }
 

--- a/podcasts/Notifications/NotificationsCoordinator.swift
+++ b/podcasts/Notifications/NotificationsCoordinator.swift
@@ -110,11 +110,23 @@ enum NotificationType: String {
             case .onboardingUpsell, .upsell:
                 return !SubscriptionHelper.hasActiveSubscription()
             case .newFeatureSuggestedFolders:
-                return Settings.suggestedFoldersUpsellCount == 1 && Settings.appVersion() == "7.88"
+                return Settings.suggestedFoldersUpsellCount < 2 && Settings.appVersion() == "7.88"
             default:
                 return true
         }
     }
+
+    var isRepeatable: Bool {
+        switch self {
+            case .reengagementWeekly,
+                 .recommendationsTrending,
+                 .upsell:
+                return true
+            default:
+                return false
+        }
+    }
+
 }
 
 enum NotificationsGroup: CaseIterable {
@@ -210,15 +222,6 @@ enum NotificationsGroup: CaseIterable {
         }
     }
 
-    var areRepeatable: Bool {
-        switch self {
-            case .dailyReminders, .newEpisodes:
-                return false
-            case .recommendations, .newFeaturesAndTips, .offers:
-                return true
-        }
-    }
-
     static var allDisabled: Bool {
         Self.allCases.allSatisfy() {
             $0.isEnabled == false
@@ -255,7 +258,7 @@ class NotificationsCoordinator {
             guard notification.shouldSend else {
                 continue
             }
-            if group.areRepeatable {
+            if notification.isRepeatable {
                 scheduleNotification(notification, timeInterval: timeInterval, repeats: false)
                 scheduleNotification(notification, timeInterval: timeInterval + group.timeIntervalStep, repeats: true)
             } else {

--- a/podcasts/Notifications/NotificationsCoordinator.swift
+++ b/podcasts/Notifications/NotificationsCoordinator.swift
@@ -18,6 +18,7 @@ enum NotificationType: String {
     case recommendationsTrending
 
     case upsell
+    case newFeature
 
     var title: String {
         switch self {
@@ -41,6 +42,8 @@ enum NotificationType: String {
             return L10n.notificationsRecommendationsTrendingTitle
         case .upsell:
             return L10n.notificationsOffersUpsellTitle
+        case .newFeature:
+            return L10n.notificationsNewFeatureSuggestedFoldersTitle
         }
     }
 
@@ -66,6 +69,8 @@ enum NotificationType: String {
             return L10n.notificationsRecommendationsTrendingBody
         case .upsell:
             return L10n.notificationsOffersUpsellBody
+        case .newFeature:
+            return L10n.notificationsNewFeatureSuggestedFoldersBody
         }
     }
 
@@ -95,6 +100,8 @@ enum NotificationType: String {
             return "pktc://discover/trending"
         case .upsell:
             return "pktc://upsell"
+        case .newFeature:
+            return "pktc://suggestedFolders"
         }
     }
 
@@ -125,7 +132,7 @@ enum NotificationsGroup: CaseIterable {
             case .recommendations:
                 return [.recommendationsTrending]
             case .newFeaturesAndTips:
-                return [.reengagementWeekly]
+                return [.newFeature, .reengagementWeekly]
             case .offers:
                 return [.upsell]
         }

--- a/podcasts/Notifications/NotificationsCoordinator.swift
+++ b/podcasts/Notifications/NotificationsCoordinator.swift
@@ -18,7 +18,7 @@ enum NotificationType: String {
     case recommendationsTrending
 
     case upsell
-    case newFeature
+    case newFeatureSuggestedFolders
 
     var title: String {
         switch self {
@@ -42,7 +42,7 @@ enum NotificationType: String {
             return L10n.notificationsRecommendationsTrendingTitle
         case .upsell:
             return L10n.notificationsOffersUpsellTitle
-        case .newFeature:
+        case .newFeatureSuggestedFolders:
             return L10n.notificationsNewFeatureSuggestedFoldersTitle
         }
     }
@@ -69,7 +69,7 @@ enum NotificationType: String {
             return L10n.notificationsRecommendationsTrendingBody
         case .upsell:
             return L10n.notificationsOffersUpsellBody
-        case .newFeature:
+        case .newFeatureSuggestedFolders:
             return L10n.notificationsNewFeatureSuggestedFoldersBody
         }
     }
@@ -100,7 +100,7 @@ enum NotificationType: String {
             return "pktc://discover/trending"
         case .upsell:
             return "pktc://upsell"
-        case .newFeature:
+        case .newFeatureSuggestedFolders:
             return "pktc://features/suggestedFolders"
         }
     }
@@ -109,6 +109,8 @@ enum NotificationType: String {
         switch self {
             case .onboardingUpsell, .upsell:
                 return !SubscriptionHelper.hasActiveSubscription()
+            case .newFeatureSuggestedFolders:
+                return Settings.suggestedFoldersUpsellCount == 1
             default:
                 return true
         }
@@ -132,7 +134,7 @@ enum NotificationsGroup: CaseIterable {
             case .recommendations:
                 return [.recommendationsTrending]
             case .newFeaturesAndTips:
-                return [.newFeature, .reengagementWeekly]
+                return [.newFeatureSuggestedFolders, .reengagementWeekly]
             case .offers:
                 return [.upsell]
         }

--- a/podcasts/Notifications/NotificationsCoordinator.swift
+++ b/podcasts/Notifications/NotificationsCoordinator.swift
@@ -110,7 +110,7 @@ enum NotificationType: String {
             case .onboardingUpsell, .upsell:
                 return !SubscriptionHelper.hasActiveSubscription()
             case .newFeatureSuggestedFolders:
-                return Settings.suggestedFoldersUpsellCount == 1
+                return Settings.suggestedFoldersUpsellCount == 1 && Settings.appVersion() == "7.88"
             default:
                 return true
         }

--- a/podcasts/Notifications/NotificationsCoordinator.swift
+++ b/podcasts/Notifications/NotificationsCoordinator.swift
@@ -101,7 +101,7 @@ enum NotificationType: String {
         case .upsell:
             return "pktc://upsell"
         case .newFeature:
-            return "pktc://suggestedFolders"
+            return "pktc://features/suggestedFolders"
         }
     }
 

--- a/podcasts/PodcastListViewController.swift
+++ b/podcasts/PodcastListViewController.swift
@@ -311,6 +311,10 @@ class PodcastListViewController: PCViewController, UIGestureRecognizerDelegate, 
         return FoldersCoordinator()
     }()
 
+    func showSuggestedFolders() {
+        foldersCoordinator.showSuggestedFolders(from: self)
+    }
+
     @objc private func createFolderTapped(_ sender: UIBarButtonItem) {
         foldersCoordinator.startFolderCreationFlow(from: self)
     }

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -1755,6 +1755,10 @@ internal enum L10n {
   internal static var notOnWifi: String { return L10n.tr("Localizable", "not_on_wifi") }
   /// Daily Reminders
   internal static var notificationsDailyReminders: String { return L10n.tr("Localizable", "notifications_daily_reminders") }
+  /// Try Plus and automatically organize your shows with folders.
+  internal static var notificationsNewFeatureSuggestedFoldersBody: String { return L10n.tr("Localizable", "notifications_new_feature_suggested_folders_body") }
+  /// Your podcasts organized
+  internal static var notificationsNewFeatureSuggestedFoldersTitle: String { return L10n.tr("Localizable", "notifications_new_feature_suggested_folders_title") }
   /// New Features & Tips
   internal static var notificationsNewFeaturesTips: String { return L10n.tr("Localizable", "notifications_new_features_tips") }
   /// Notifications Off

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -5005,4 +5005,9 @@
 /* Notification body for offer upsell message */
 "notifications_offers_upsell_body" = "Unlock exclusive features like folders, bookmarks, and more with Plus!";
 
+/* Notification title for new feature Suggested folders */
+"notifications_new_feature_suggested_folders_title" = "Your podcasts organized";
+
+/* Notification body for new feature Suggested folders */
+"notifications_new_feature_suggested_folders_body" = "Try Plus and automatically organize your shows with folders.";
 

--- a/scripts/notifications/features-suggestedFolders.apns
+++ b/scripts/notifications/features-suggestedFolders.apns
@@ -1,0 +1,11 @@
+{
+  "Simulator Target Bundle": "au.com.shiftyjelly.podcasts",
+  "aps": {
+    "alert": {
+      "title": "Your podcasts organized",
+      "body": "Try Plus and automatically organize your shows with folders."
+    },
+    "category": "DEEP_LINK"
+  },
+  "destination_url": "pktc://features/suggestedFolders"
+}


### PR DESCRIPTION
| 📘 Part of: #2906  |  <!-- project issue number, if applicable -->
|:---:|

Fixes #2935  <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

## To test

1. Start the app and ensure that you have followed at least 8 podcasts and didn't saw the SuggestedFolders CTA more than 1 time. ( Better start with a fresh account)
2. Ensure that you have NotificationRevamp FF enabled
3. Go to Settings -> Developer -> SpeedUp Notifications
4. Open Profile -> Settings -> Notifications
5. Enable New Features and Tips notification
6. Wait to see the Suggested Folder notification
7. Tap on it and see if the Suggested Folders screen is shown

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
