### PR TITLE
Recommendations: Add Podroll section to Similar Shows

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
@@ -358,6 +358,7 @@ public struct PodcastCollection: Decodable {
     public var description: String?
     public var podcasts: [DiscoverPodcast]?
     public let episodes: [DiscoverEpisode]?
+    public var podroll: [DiscoverPodcast]?
     public var collectionImage: String?
     public var colors: PodcastCollectionColors?
     public var webTitle: String?
@@ -373,7 +374,7 @@ public struct PodcastCollection: Decodable {
         case headerImage = "header_image"
         case listId = "list_id"
         case featureImage = "feature_image"
-        case title, description, subtitle, colors, podcasts, author, episodes
+        case title, description, subtitle, colors, podcasts, author, episodes, podroll
     }
 }
 

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1692,6 +1692,7 @@
 		E3F37446291F0DD1005916ED /* Chapters.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3F37445291F0DD1005916ED /* Chapters.swift */; };
 		E3F37447291F0DD1005916ED /* Chapters.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3F37445291F0DD1005916ED /* Chapters.swift */; };
 		F508F0FB2C4F1EC000822159 /* ClipPlaybackManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F508F0FA2C4F1EC000822159 /* ClipPlaybackManager.swift */; };
+		F50DF4242DC5851E00E4A01E /* PodrollHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F50DF4232DC5851E00E4A01E /* PodrollHeaderView.swift */; };
 		F51656D82C816FE6009446B4 /* ClipsWhatsNewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F51656D72C816FE6009446B4 /* ClipsWhatsNewView.swift */; };
 		F5197A402B995A1E007C8D0A /* DownloadManager+Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5197A3F2B995A1E007C8D0A /* DownloadManager+Logging.swift */; };
 		F5197A412B995A1E007C8D0A /* DownloadManager+Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5197A3F2B995A1E007C8D0A /* DownloadManager+Logging.swift */; };
@@ -3924,6 +3925,7 @@
 		EF3DD428DC2C444C2D8CEC5A /* Pods-PocketCastsTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PocketCastsTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-PocketCastsTests/Pods-PocketCastsTests.debug.xcconfig"; sourceTree = "<group>"; };
 		EFBF99F57846D0E1AF8DE08D /* Pods-PocketCasts-PocketCastsTests.staging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PocketCasts-PocketCastsTests.staging.xcconfig"; path = "Pods/Target Support Files/Pods-PocketCasts-PocketCastsTests/Pods-PocketCasts-PocketCastsTests.staging.xcconfig"; sourceTree = "<group>"; };
 		F508F0FA2C4F1EC000822159 /* ClipPlaybackManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipPlaybackManager.swift; sourceTree = "<group>"; };
+		F50DF4232DC5851E00E4A01E /* PodrollHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PodrollHeaderView.swift; sourceTree = "<group>"; };
 		F51656D72C816FE6009446B4 /* ClipsWhatsNewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipsWhatsNewView.swift; sourceTree = "<group>"; };
 		F5197A3F2B995A1E007C8D0A /* DownloadManager+Logging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DownloadManager+Logging.swift"; sourceTree = "<group>"; };
 		F51D3A0B2CA62D3C000F3B78 /* DiscoverCollectionViewController+Search.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DiscoverCollectionViewController+Search.swift"; sourceTree = "<group>"; };
@@ -6539,6 +6541,7 @@
 				BD780AE620049BFF00B5A442 /* PodcastViewController.swift */,
 				9A4BB1F02D48F05400B68D94 /* PodcastFeedViewModel.swift */,
 				BD5AE6821FE0E9A20009B8A1 /* PodcastViewController+TableData.swift */,
+				F50DF4232DC5851E00E4A01E /* PodrollHeaderView.swift */,
 				BDDF8AA5240CE85D009BA263 /* PodcastViewController+Swipe.swift */,
 				BD6D4186200C802900CA8993 /* PodcastViewController+NetworkLoad.swift */,
 				BD01397E2022DBF8001EAF84 /* PodcastViewController+Search.swift */,
@@ -10205,6 +10208,7 @@
 				4030D4612496446000BEC7D9 /* MultiSelectActionController.swift in Sources */,
 				C713D4F92A04C90500A78468 /* SubscriptionProfileImage.swift in Sources */,
 				BDD40A1C1FA1B14900A53AE1 /* TintableImageButton.swift in Sources */,
+				F50DF4242DC5851E00E4A01E /* PodrollHeaderView.swift in Sources */,
 				40588AAC254131D1002BDCA6 /* LargeNavBarViewController.swift in Sources */,
 				F52ADE442BD8B0F300AC647F /* SharingView.swift in Sources */,
 				BD95ED6E1BAFA571004335B0 /* CountryCell.swift in Sources */,

--- a/podcasts/PodcastViewController+TableData.swift
+++ b/podcasts/PodcastViewController+TableData.swift
@@ -217,6 +217,9 @@ extension PodcastViewController: UITableViewDataSource, UITableViewDelegate {
     // MARK: - Selection
 
     func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {
+        // Special handling for episodes only to deal with multi gesture
+        guard currentViewMode == .episodes else { return indexPath }
+
         guard indexPath.section == PodcastViewController.allEpisodesSection, episodeAtIndexPath(indexPath) != nil else { return nil }
 
         guard episodesTable.isEditing, !multiSelectGestureInProgress else { return indexPath }

--- a/podcasts/PodcastViewController+TableData.swift
+++ b/podcasts/PodcastViewController+TableData.swift
@@ -11,6 +11,24 @@ extension PodcastViewController: UITableViewDataSource, UITableViewDelegate {
     private static let allArchivedCellId = "AllArchivedCell"
     private static let groupHeadingCellId = "GroupHeading"
 
+    private enum SimilarShowsSection {
+        case header
+        case podroll
+        case podcasts
+    }
+
+    private func similarShowsSectionType(for section: Int) -> SimilarShowsSection {
+        if section == PodcastViewController.headerSection {
+            return .header
+        }
+
+        if section == 1, (recommendations?.podroll?.count ?? 0) > 0 {
+            return .podroll
+        }
+
+        return .podcasts
+    }
+
     func registerCells() {
         episodesTable.register(PodcastTableViewCell.self, forCellReuseIdentifier: PodcastTableViewCell.reuseIdentifier)
         episodesTable.register(UINib(nibName: "EpisodeCell", bundle: nil), forCellReuseIdentifier: PodcastViewController.episodeCellId)
@@ -61,7 +79,14 @@ extension PodcastViewController: UITableViewDataSource, UITableViewDelegate {
         case .bookmarks:
             return 0 // Bookmarks are shown in a separate controller
         case .similarShows:
-            return 2 // Keep the same number of sections as episodes
+            var sectionCount = 1 // Always show header section
+            if (recommendations?.podroll?.count ?? 0) > 0 {
+                sectionCount += 1 // Add podroll section if it has content
+            }
+            if (recommendations?.podcasts?.count ?? 0) > 0 {
+                sectionCount += 1 // Add podcasts section if it has content
+            }
+            return sectionCount
         }
     }
 
@@ -74,10 +99,13 @@ extension PodcastViewController: UITableViewDataSource, UITableViewDelegate {
         case .bookmarks:
             return 0
         case .similarShows:
-            if section == PodcastViewController.headerSection {
-                return 1 // Keep the header
-            } else {
-                return similarPodcasts.count
+            switch similarShowsSectionType(for: section) {
+            case .header:
+                return 1
+            case .podroll:
+                return recommendations?.podroll?.count ?? 0
+            case .podcasts:
+                return recommendations?.podcasts?.count ?? 0
             }
         }
     }
@@ -140,7 +168,8 @@ extension PodcastViewController: UITableViewDataSource, UITableViewDelegate {
             return UITableViewCell()
 
         case .similarShows:
-            if indexPath.section == PodcastViewController.headerSection {
+            switch similarShowsSectionType(for: indexPath.section) {
+            case .header:
                 if FeatureFlag.podcastViewChanges.enabled {
                     let cell = podcastHeaderCell
                     return cell
@@ -150,11 +179,21 @@ extension PodcastViewController: UITableViewDataSource, UITableViewDelegate {
                     cell.buttonsEnabled = !isMultiSelectEnabled
                     return cell
                 }
-            } else {
-                let podcast = similarPodcasts[indexPath.row]
+            case .podroll:
+                guard let podcast = recommendations?.podroll?[indexPath.row] else {
+                    assertionFailure("[PodcastViewController] Similar Shows - Missing podcast")
+                    return UITableViewCell()
+                }
                 let cell = tableView.dequeueReusableCell(withIdentifier: PodcastTableViewCell.reuseIdentifier, for: indexPath) as! PodcastTableViewCell
                 cell.configure(with: podcast)
-                cell.separatorInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: .greatestFiniteMagnitude)
+                return cell
+            case .podcasts:
+                guard let podcast = recommendations?.podcasts?[indexPath.row] else {
+                    assertionFailure("[PodcastViewController] Similar Shows - Missing podcast")
+                    return UITableViewCell()
+                }
+                let cell = tableView.dequeueReusableCell(withIdentifier: PodcastTableViewCell.reuseIdentifier, for: indexPath) as! PodcastTableViewCell
+                cell.configure(with: podcast)
                 return cell
             }
         }
@@ -230,12 +269,18 @@ extension PodcastViewController: UITableViewDataSource, UITableViewDelegate {
             break
 
         case .similarShows:
-            if indexPath.section == PodcastViewController.headerSection {
+            switch similarShowsSectionType(for: indexPath.section) {
+            case .header:
                 if let cell = tableView.cellForRow(at: indexPath) as? PodcastHeadingTableCell, !isMultiSelectEnabled {
                     cell.toggleExpanded(delegate: self)
                 }
-            } else {
-                let selectedPodcast = similarPodcasts[indexPath.row]
+            case .podroll:
+                guard let selectedPodcast = recommendations?.podroll?[indexPath.row] else { return }
+                let info = PodcastInfo(selectedPodcast)
+                let podcastController = PodcastViewController(podcastInfo: info, existingImage: nil)
+                navigationController?.pushViewController(podcastController, animated: true)
+            case .podcasts:
+                guard let selectedPodcast = recommendations?.podcasts?[indexPath.row] else { return }
                 let info = PodcastInfo(selectedPodcast)
                 let podcastController = PodcastViewController(podcastInfo: info, existingImage: nil)
                 navigationController?.pushViewController(podcastController, animated: true)
@@ -257,7 +302,16 @@ extension PodcastViewController: UITableViewDataSource, UITableViewDelegate {
 
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
         if currentViewMode == .similarShows {
-            return CGFloat.leastNonzeroMagnitude
+            switch similarShowsSectionType(for: section) {
+            case .podcasts:
+                if similarShowsSectionType(for: section - 1) == .header {
+                    return 16 // Add additional spacing between header & podcasts
+                }
+            case .podroll:
+                return 40
+            default:
+                return CGFloat.leastNonzeroMagnitude
+            }
         }
         return PodcastViewController.allEpisodesSection == section ? UITableView.automaticDimension : CGFloat.leastNonzeroMagnitude
     }
@@ -270,24 +324,37 @@ extension PodcastViewController: UITableViewDataSource, UITableViewDelegate {
     }
 
     func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        if currentViewMode == .similarShows && section == PodcastViewController.headerSection {
-            return 16
+        if currentViewMode == .similarShows {
+            switch similarShowsSectionType(for: section) {
+            case .podroll:
+                return 24 // Divider between podroll and podcasts
+            default:
+                return CGFloat.leastNonzeroMagnitude
+            }
         }
         return CGFloat.leastNonzeroMagnitude
     }
 
     func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
-        if currentViewMode == .similarShows && section == PodcastViewController.headerSection {
-            let footerView = UIView()
-            footerView.backgroundColor = .clear
-            return footerView
+        guard currentViewMode == .similarShows else { return nil }
+
+        switch similarShowsSectionType(for: section) {
+        case .podroll:
+            return dividerView()
+        default:
+            return nil
         }
-        return nil
     }
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        guard PodcastViewController.allEpisodesSection == section else { return nil }
-        return currentViewMode == .episodes ? searchController?.view : nil
+        guard currentViewMode == .similarShows else { return nil }
+
+        switch similarShowsSectionType(for: section) {
+        case .podroll:
+            return PodrollHeaderView()
+        default:
+            return nil
+        }
     }
 
     func tableView(_ tableView: UITableView, willDisplayFooterView view: UIView, forSection section: Int) {
@@ -327,5 +394,23 @@ extension PodcastViewController: UITableViewDataSource, UITableViewDelegate {
 
     func tableViewDidEndMultipleSelectionInteraction(_ tableView: UITableView) {
         multiSelectGestureInProgress = false
+    }
+
+    private func dividerView() -> UIView {
+        let footerView = UIView()
+        footerView.backgroundColor = .clear
+
+        let divider = ThemeDividerView()
+        divider.translatesAutoresizingMaskIntoConstraints = false
+        footerView.addSubview(divider)
+
+        NSLayoutConstraint.activate([
+            divider.leadingAnchor.constraint(equalTo: footerView.leadingAnchor, constant: 15),
+            divider.trailingAnchor.constraint(equalTo: footerView.trailingAnchor, constant: -15),
+            divider.centerYAnchor.constraint(equalTo: footerView.centerYAnchor),
+            divider.heightAnchor.constraint(equalToConstant: 1)
+        ])
+
+        return footerView
     }
 }

--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -80,12 +80,11 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
     var summaryExpanded = false
     var descriptionExpanded = false
     var currentViewMode: ViewMode = .episodes
-    var similarPodcasts: [DiscoverPodcast] = []
     private var hasSimilarShows = CurrentValueSubject<Bool, Never>(false)
     var hasSimilarShowsPublisher: AnyPublisher<Bool, Never> {
         hasSimilarShows.eraseToAnyPublisher()
     }
-    private var recommendations: PodcastCollection?
+    var recommendations: PodcastCollection?
 
     enum ViewMode {
         case episodes
@@ -234,6 +233,8 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
 
     static let headerSection = 0
     static let allEpisodesSection = 1
+    static let podrollSection = 1
+    static let similarShowsSection = 2
 
     private var isSearching = false
     private var cancellables = Set<AnyCancellable>()
@@ -1418,7 +1419,7 @@ private extension PodcastViewController {
                 loadLocalEpisodes(podcast: podcast, animated: true)
             }
         case .similarShows:
-            similarPodcasts = recommendations?.podcasts ?? []
+            break
         case .bookmarks:
             break // Handled separately
         }

--- a/podcasts/PodcastViewController.xib
+++ b/podcasts/PodcastViewController.xib
@@ -69,9 +69,9 @@
                         <constraint firstItem="iLx-g1-Ro1" firstAttribute="top" secondItem="NiC-SX-rde" secondAttribute="bottom" constant="62" id="cBX-Dd-xJB"/>
                     </constraints>
                 </view>
-                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="vOg-9D-tbz" customClass="ThemeableTable" customModule="podcasts" customModuleProvider="target">
+                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="grouped" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="vOg-9D-tbz" customClass="ThemeableTable" customModule="podcasts" customModuleProvider="target">
                     <rect key="frame" x="0.0" y="0.0" width="1024" height="1346"/>
-                    <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     <inset key="separatorInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                     <connections>
                         <outlet property="dataSource" destination="-1" id="d9D-Ge-hXK"/>

--- a/podcasts/PodrollHeaderView.swift
+++ b/podcasts/PodrollHeaderView.swift
@@ -1,0 +1,56 @@
+import UIKit
+
+class PodrollHeaderView: UIView {
+    private let stackView: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .horizontal
+        stack.spacing = 8
+        stack.alignment = .center
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        return stack
+    }()
+
+    private let icon: UIImageView = {
+        let imageView = UIImageView(image: UIImage(systemName: "microphone")?.withConfiguration(UIImage.SymbolConfiguration(weight: .bold)))
+        imageView.tintColor = ThemeColor.primaryText02()
+        imageView.contentMode = .scaleAspectFit
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        return imageView
+    }()
+
+    private let label: UILabel = {
+        let label = UILabel()
+        label.text = L10n.podcastPodrollHeader
+        label.font = .systemFont(ofSize: 12, weight: .semibold)
+        label.textColor = ThemeColor.primaryText02()
+        return label
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setup()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setup()
+    }
+
+    private func setup() {
+        backgroundColor = .clear
+
+        addSubview(stackView)
+        stackView.addArrangedSubview(icon)
+        stackView.addArrangedSubview(label)
+
+        NSLayoutConstraint.activate([
+            icon.widthAnchor.constraint(equalToConstant: 16),
+            icon.heightAnchor.constraint(equalToConstant: 16),
+
+            stackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+            stackView.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: -16),
+            stackView.topAnchor.constraint(equalTo: topAnchor, constant: 8),
+            stackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -8)
+        ])
+    }
+}

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -2463,6 +2463,8 @@ internal enum L10n {
   internal static var podcastPauseDownload: String { return L10n.tr("Localizable", "podcast_pause_download") }
   /// Pause playback
   internal static var podcastPausePlayback: String { return L10n.tr("Localizable", "podcast_pause_playback") }
+  /// Recommended shows by the creator
+  internal static var podcastPodrollHeader: String { return L10n.tr("Localizable", "podcast_podroll_header") }
   /// Queued
   internal static var podcastQueued: String { return L10n.tr("Localizable", "podcast_queued") }
   /// Queued...

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4045,6 +4045,8 @@
 /* Title for the similar shows feature in a Podcast */
 "similar_shows" = "Similar Shows";
 
+"podcast_podroll_header" = "Recommended shows by the creator";
+
 /* Autoplay feature announcement title */
 "announcement_autoplay_title" = "Autoplay is here!";
 


### PR DESCRIPTION
| 📘 Part of: #2989 |
|:---:|

Adds a new Podroll section to the Similar Shows tab
||||
|--|--|--|
| <img src="https://github.com/user-attachments/assets/566f9581-6d06-40ca-af2b-51a926fc2450"> | <img src="https://github.com/user-attachments/assets/1870540d-4ddd-4768-a55d-2febba4f83bd"> | <img src="https://github.com/user-attachments/assets/4d846f5e-73d1-4542-b9dd-500335c0a025"> |

## Code Changes

- Added `podroll` to the `PodcastCollection` structure for the eventual API change.
- `PodrollHeaderView` to visually represent the podroll section header.
-  Updated `PodcastViewController` to handle podroll + podcasts sections:
	- Introduced a new enumeration, `SimilarShowsSection`, to differentiate between sections like header, podroll, and podcasts.
	- Adjusted table view delegate & data source methods to handle dynamic section counts based on available content in podroll and podcasts.
	- Updated cell registration and configuration to include podroll items in the table view.
- Changed `PodcastViewController` table view style to grouped in the xib to prevent the section header from pinning.

## Missing

* Analytics events
* Information modal when tapping on the Podroll section header

## To test

### Without Podroll

* Enabled the `recommendations` feature flag
* Navigate to a Podcast page for a popular podcast (Hidden Brain, This American Life, etc.)
* ✅ Verify that the "Similar Shows" tab appears with some suggested podcasts
* ✅ Verify that tapping the podcast opens the Podcast detail page
* ✅ Verify that subscribing works for that podcast
* Change themes
* ✅ Verify that podcast cell adjusts to the selected theme

### With Podroll

* Enabled the `recommendations` feature flag
* Apply [this patch](https://github.com/user-attachments/files/20019416/StaticRecommendationsChange.patch) to point to a static example since the API isn't ready yet.
* Navigate to a Podcast page for a popular podcast (Hidden Brain, This American Life, etc.)
* ✅ Verify that the "Similar Shows" tab appears with some suggested podcasts
* ✅ Verify that tapping the podcast opens the Podcast detail page
* ✅ Verify that subscribing works for that podcast
* Change themes
* ✅ Verify that podcast cell adjusts to the selected theme



## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
