### PR TITLE
[Transcripts ] Only send transcript show event if transcript is being actually show

### DIFF
--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -427,7 +427,6 @@ class TranscriptViewController: PlayerItemViewController {
 
             do {
                 let transcript = try await transcriptManager.loadTranscript()
-                await track(.transcriptShown, properties: ["type": transcript.type, "show_as_webpage": transcript.hasJavascript])
                 let hasGeneratedTranscripts = FeatureFlag.generatedTranscripts.enabled && transcriptManager.hasGeneratedTranscripts
                 await MainActor.run {
                     self.setHasGeneratedTranscripts(hasGeneratedTranscripts)
@@ -435,6 +434,8 @@ class TranscriptViewController: PlayerItemViewController {
                         if hasGeneratedTranscripts, self.shouldShowPremiumView {
                             self.stackView.alpha = 0
                             self.showGeneratedTranscriptsPremiumOverlay?()
+                        } else {
+                            self.track(.transcriptShown, properties: ["type": transcript.type, "show_as_webpage": transcript.hasJavascript])
                         }
                         self.bannerView.isHidden = !hasGeneratedTranscripts
                     }


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
Update the transcripts_show event to only be sent when no paywall view is in front.

## To test

1. Start the app with a non Premium user
2. Enable the FF for tracksLogging
3. Play an episode with a Creator transcript ( Cautionary Tales)
4. Open the player
5. Tap on the transcript action button
6. Check if transcript is show and you can see in the console the `transcript_shown` event
7. Now open an episode with a Generated Transcript ( The Last of Us podcast)
8. Play an episode
9. Open the player
10. Tap on the transcript action button
11. Check if you see Generated Transcript paywall view
12. Check in the console that you *don't* see the `transcript_show` event but you see the `transcript_generated_paywall_shown` event
13. No login with an user with a paid Subscription
14. Open the transcript for that last episode
15. Check if transcript is show and you can see in the console the `transcript_shown` event

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
