### PR TITLE
[Notifications Revamp] Add user recommendations notification

### DIFF
--- a/podcasts/Notifications/NotificationsCoordinator+AnalyticsAdapter.swift
+++ b/podcasts/Notifications/NotificationsCoordinator+AnalyticsAdapter.swift
@@ -27,8 +27,13 @@ extension NotificationsCoordinator: AnalyticsAdapter {
     }
 
     func updateRecommendationNotifications(name: String, properties: [AnyHashable: Any]?) {
-        // Check if need to cancel an existing notification
-        if NotificationType.recommendationsTrending.checkCancelConditionsForEvent(name: name, properties: properties) {
+        var shouldUpdateNotifications = false
+        for notification in NotificationsGroup.recommendations.notifications {
+            if notification.checkCancelConditionsForEvent(name: name, properties: properties) {
+                shouldUpdateNotifications = true
+            }
+        }
+        if shouldUpdateNotifications {
             updateNotifications(for: .recommendations)
         }
     }

--- a/podcasts/Notifications/NotificationsCoordinator+AnalyticsAdapter.swift
+++ b/podcasts/Notifications/NotificationsCoordinator+AnalyticsAdapter.swift
@@ -56,7 +56,7 @@ extension NotificationType {
             possibleConditions  = [.purchaseSuccessful]
         case .onboardingStaffPicks:
             possibleConditions = [.discoverListShowAllTapped]
-        case .recommendationsTrending:
+        case .recommendationsTrending, .recommendationsYouMightLike:
             possibleConditions = [.discoverListShowAllTapped]
         case .upsell:
             possibleConditions = [.purchaseSuccessful]
@@ -79,7 +79,12 @@ extension NotificationType {
                 guard let properties, let listID = properties["list_id"] as? String else {
                     return false
                 }
-                return listID == "featured"
+                return listID == "trending"
+        case .recommendationsYouMightLike:
+                guard let properties, let listID = properties["list_id"] as? String else {
+                    return false
+                }
+                return listID == "recommendations_user"
         default:
             return true
         }

--- a/podcasts/Notifications/NotificationsCoordinator.swift
+++ b/podcasts/Notifications/NotificationsCoordinator.swift
@@ -15,6 +15,7 @@ enum NotificationType: String {
     case reengagementWeekly
 
     case recommendationsTrending
+    case recommendationsYouMightLike
 
     case upsell
 
@@ -38,6 +39,8 @@ enum NotificationType: String {
             return L10n.notificationsReengagementWeeklyTitle
         case .recommendationsTrending:
             return L10n.notificationsRecommendationsTrendingTitle
+        case .recommendationsYouMightLike:
+            return L10n.notificationsRecommendationsYouMightLikeTitle
         case .upsell:
             return L10n.notificationsOffersUpsellTitle
         }
@@ -63,6 +66,8 @@ enum NotificationType: String {
             return L10n.notificationsReengagementWeeklyBody
         case .recommendationsTrending:
             return L10n.notificationsRecommendationsTrendingBody
+        case .recommendationsYouMightLike:
+            return L10n.notificationsRecommendationsYouMightLikeBody
         case .upsell:
             return L10n.notificationsOffersUpsellBody
         }
@@ -92,6 +97,8 @@ enum NotificationType: String {
             return "pktc://discover"
         case .recommendationsTrending:
             return "pktc://discover/trending"
+        case .recommendationsYouMightLike:
+            return "pktc://discover/recommendations_user"
         case .upsell:
             return "pktc://upsell"
         }
@@ -118,7 +125,7 @@ enum NotificationsGroup {
             case .dailyReminders:
                 return [.onboardingSignUp, .onboardingImport, .onboardingUpNext, .onboardingFilters, .onboardingThemes, .onboardingStaffPicks, .onboardingUpsell]
             case .recommendations:
-                return [.recommendationsTrending]
+                return [.recommendationsTrending, .recommendationsYouMightLike]
             case .newFeaturesAndTips:
                 return [.reengagementWeekly]
             case .offers:

--- a/podcasts/Notifications/NotificationsCoordinator.swift
+++ b/podcasts/Notifications/NotificationsCoordinator.swift
@@ -233,8 +233,8 @@ class NotificationsCoordinator {
                 scheduleNotification(notification, timeInterval: timeInterval + group.timeIntervalStep, repeats: true)
             } else {
                 scheduleNotification(notification, timeInterval: timeInterval, repeats: false)
-                timeInterval += group.timeIntervalStep
             }
+            timeInterval += group.timeIntervalStep
         }
     }
 

--- a/podcasts/Notifications/NotificationsCoordinator.swift
+++ b/podcasts/Notifications/NotificationsCoordinator.swift
@@ -108,6 +108,8 @@ enum NotificationType: String {
         switch self {
             case .onboardingUpsell, .upsell:
                 return !SubscriptionHelper.hasActiveSubscription()
+            case .recommendationsYouMightLike:
+                return SyncManager.isUserLoggedIn()
             default:
                 return true
         }

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -1827,6 +1827,10 @@ internal enum L10n {
   internal static var notificationsRecommendationsTrendingBody: String { return L10n.tr("Localizable", "notifications_recommendations_trending_body") }
   /// Trending this week
   internal static var notificationsRecommendationsTrendingTitle: String { return L10n.tr("Localizable", "notifications_recommendations_trending_title") }
+  /// Wondering what to listen to next? Check out these shows!
+  internal static var notificationsRecommendationsYouMightLikeBody: String { return L10n.tr("Localizable", "notifications_recommendations_you_might_like_body") }
+  /// New recommendations for you
+  internal static var notificationsRecommendationsYouMightLikeTitle: String { return L10n.tr("Localizable", "notifications_recommendations_you_might_like_title") }
   /// It’s been awhile since you’ve listened. Jump back in and enjoy!
   internal static var notificationsReengagementWeeklyBody: String { return L10n.tr("Localizable", "notifications_reengagement_weekly_body") }
   /// We miss you!

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -5032,4 +5032,11 @@
 /* Notification body for offer upsell message */
 "notifications_offers_upsell_body" = "Unlock exclusive features like folders, bookmarks, and more with Plus!";
 
+/* Notification title for recommendations you might like message */
+"notifications_recommendations_you_might_like_title" = "New recommendations for you";
+
+/* Notification body for recommendations you might like message */
+"notifications_recommendations_you_might_like_body" = "Wondering what to listen to next? Check out these shows!";
+
+
 

--- a/scripts/notifications/discover-you-might-like.apns
+++ b/scripts/notifications/discover-you-might-like.apns
@@ -1,0 +1,11 @@
+{
+  "Simulator Target Bundle": "au.com.shiftyjelly.podcasts",
+  "aps": {
+    "alert": {
+      "title": "New recommendations for you",
+      "body": "Wondering what to listen to next? Check out these shows!"
+    },
+    "category": "DEEP_LINK"
+  },
+  "destination_url": "pktc://discover/recommendations_user"
+}


### PR DESCRIPTION
| 📘 Part of: #2906  |  <!-- project issue number, if applicable -->
|:---:|

Fixes #3010  <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

## To test

1. Start the app and login with an user
2. Ensure that you have NotificationRevamp FF enabled and the Recommendations FF enabled
3. Go to Settings -> Developer -> SpeedUp Notifications
4. Open Profile -> Settings -> Notifications
5. Enable Trending & Recommendations
6. Wait to see the You Might Like notification
7. Tap on it and see if the You Might Like tab on the Discovery Tab

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
