### PR TITLE
Fix crash when long pressing Episode list cell

### DIFF
--- a/podcasts/PodcastViewController+TableData.swift
+++ b/podcasts/PodcastViewController+TableData.swift
@@ -350,7 +350,9 @@ extension PodcastViewController: UITableViewDataSource, UITableViewDelegate {
     }
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        guard currentViewMode == .similarShows else { return nil }
+        guard currentViewMode == .similarShows else {
+            return currentViewMode == .episodes ? searchController?.view : nil
+        }
 
         switch similarShowsSectionType(for: section) {
         case .podroll:


### PR DESCRIPTION
| 📘 Part of: #2989 |
|:---:|

Fixes a crash in the Podcast page when long pressing on an episode cell.

https://github.com/user-attachments/assets/87b55ac3-e453-4214-a143-45c5abfddc8f

## To test

* Navigate to a Podcast page
* Tap and hold an episode cell
* Verify that multi-select comes up and the app doesn't crash

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
