### PR TITLE
[Improve Podcast Sorting] Hide tip close button

### DIFF
--- a/podcasts/PodcastListViewController+Tip.swift
+++ b/podcasts/PodcastListViewController+Tip.swift
@@ -25,7 +25,6 @@ extension PodcastListViewController: UIPopoverPresentationControllerDelegate {
         let idealSize = CGSize(width: 300, height: 120)
         let tipView = TipViewStatic(title: L10n.podcastsLibrarySortEpisodeRecentlyPlayedTipTitle,
                                     message: L10n.podcastsLibrarySortEpisodeRecentlyPlayedTipDescription,
-                                    showClose: true,
                               onTap: { [weak self] in
             self?.dismissRecentlyPlayedSortingTip()
         })


### PR DESCRIPTION
Ref. p1746503812613759-slack-C08JTGC2MD1

This PR removes the close button from the tooltip

<img src="https://github.com/user-attachments/assets/df7c1cfa-6994-4681-b1fe-510bb1dc857e" width=350 />

## To test

- To quick test go to `PodcastListViewController+Tip`
- In `showRecentlyPlayedSortingTipIfNeeded` comment lines `6-12`
- Run the branch and you should see the tip prompted in Podcasts
- Test it get dismissed as before

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
