### PR TITLE
Fix pull to refresh UI component color

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Extensions/UI/UIImage+Contrast.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Extensions/UI/UIImage+Contrast.swift
@@ -1,0 +1,22 @@
+import UIKit
+
+extension UIImage {
+
+    public var isDark: Bool {
+        guard let cgImage = self.cgImage,
+              let data = cgImage.dataProvider?.data,
+              let ptr = CFDataGetBytePtr(data) else { return false }
+        let length = CFDataGetLength(data)
+        var totalLuminance = 0.0
+        let bytesPerPixel = 4
+        for i in stride(from: 0, to: length, by: bytesPerPixel) {
+            let r = Double(ptr[i])
+            let g = Double(ptr[i + 1])
+            let b = Double(ptr[i + 2])
+            totalLuminance += 0.299 * r + 0.587 * g + 0.114 * b
+        }
+        let pixelCount = length / bytesPerPixel
+        let avgLuminance = totalLuminance / Double(pixelCount)
+        return avgLuminance < 150
+    }
+}

--- a/podcasts/CustomRefreshControl.swift
+++ b/podcasts/CustomRefreshControl.swift
@@ -13,6 +13,13 @@ class CustomRefreshControl: UIRefreshControl {
     private var refreshLabel = UILabel()
     private var isAnimating = false
     private var didTriggerHaptic = true
+    var customTintColor: UIColor = UIColor(hex: "#B8C3C9") {
+        didSet {
+            refreshLabel.textColor = customTintColor
+            refreshInnerImage.tintColor = customTintColor
+            refreshOuterImage.tintColor = customTintColor
+        }
+    }
 
     override init() {
         super.init(frame: .zero)
@@ -52,13 +59,15 @@ class CustomRefreshControl: UIRefreshControl {
         refreshLabel.text = L10n.refreshControlPullToRefresh
         refreshLabel.textAlignment = NSTextAlignment.center
         refreshLabel.font = UIFont.systemFont(ofSize: 12, weight: UIFont.Weight.semibold)
-        refreshLabel.textColor = UIColor(hex: "#B8C3C9")
+        refreshLabel.textColor = customTintColor
         addSubview(refreshLabel)
 
-        refreshInnerImage.image = UIImage(named: "refresh_inner")
+        refreshInnerImage.image = UIImage(named: "refresh_inner")?.withRenderingMode(.alwaysTemplate)
+        refreshInnerImage.tintColor = customTintColor
         addSubview(refreshInnerImage)
 
-        refreshOuterImage.image = UIImage(named: "refresh_outer")
+        refreshOuterImage.image = UIImage(named: "refresh_outer")?.withRenderingMode(.alwaysTemplate)
+        refreshOuterImage.tintColor = customTintColor
         addSubview(refreshOuterImage)
 
         addTarget(self, action: #selector(beginRefreshing), for: .valueChanged)

--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -1111,11 +1111,19 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
     private func setupRefreshControl() {
         if shouldDisplayPodcastFeedReloadButton() {
             refreshControl = CustomRefreshControl()
+            refreshControl?.customTintColor = contrastColorForPodcastImage
             refreshControl?.perform = { [weak self] in
                 self?.reloadPodcastFeed(source: .refreshControl)
             }
             episodesTable.refreshControl = refreshControl
         }
+    }
+
+    var contrastColorForPodcastImage: UIColor {
+        guard let image = ImageManager.sharedManager.cachedImageFor(podcastUuid: self.podcastUUID, size: .grid) else {
+            return .white
+        }
+        return image.isDark ? .white : .black
     }
 
     func shouldDisplayPodcastFeedReloadButton() -> Bool {

--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -1111,7 +1111,9 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
     private func setupRefreshControl() {
         if shouldDisplayPodcastFeedReloadButton() {
             refreshControl = CustomRefreshControl()
-            refreshControl?.customTintColor = contrastColorForPodcastImage
+            if FeatureFlag.podcastViewChanges.enabled {
+                refreshControl?.customTintColor = contrastColorForPodcastImage
+            }
             refreshControl?.perform = { [weak self] in
                 self?.reloadPodcastFeed(source: .refreshControl)
             }
@@ -1119,7 +1121,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
         }
     }
 
-    var contrastColorForPodcastImage: UIColor {
+    private var contrastColorForPodcastImage: UIColor {
         guard let image = ImageManager.sharedManager.cachedImageFor(podcastUuid: self.podcastUUID, size: .grid) else {
             return .white
         }


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes #3064  <!-- issue number, if applicable -->
This PR updates the Pull to Refresh UI component color depending of the podcast image.
If it's a darker image it will use a white tint, if it's a lighter image it will use a black tint.

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
| 1 | 2 |
| - | - |
| ![Simulator Screenshot - iPhone 16 Pro Max - 2025-05-07 at 13 49 28](https://github.com/user-attachments/assets/e1175686-5346-471b-b3f4-3f0f04dcf491) | ![Simulator Screenshot - iPhone 16 Pro Max - 2025-05-07 at 13 48 02](https://github.com/user-attachments/assets/697d447d-bf2c-4e2b-9701-5df06fc274fb) |

## To test

1. Start the app
2. Open some podcasts with different contrast images. Ex: Lighter: Rework Podcast, Darker: Build your SaaS
3. Pull to refresh
4. Check if the Pull refresh component shows and has good visibility


## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
