### PR TITLE
Update suggested folders shown events

### DIFF
--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -161,7 +161,7 @@ enum AnalyticsEvent: String {
     case folderChooseRemovedFromFolder
     case folderPodcastModalOptionTapped
 
-    case suggestedFoldersPageShow
+    case suggestedFoldersPageShown
     case suggestedFoldersPageDismissed
     case suggestedFoldersUseSuggestedFoldersTapped
     case suggestedFoldersCreateCustomFolderTapped

--- a/podcasts/SuggestedFoldersView.swift
+++ b/podcasts/SuggestedFoldersView.swift
@@ -132,7 +132,7 @@ struct SuggestedFoldersView: View {
         .padding(.horizontal, Constants.margin)
         .navigationBarTitleDisplayMode(.inline)
         .onAppear {
-            track(.suggestedFoldersPageShow)
+            track(.suggestedFoldersPageShown)
         }
         .onChange(of: createFolderActive) { newFolder in
             if newFolder {


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
Just update the analytics event for SuggestedFolder shown event with the same name as Android

## To test

1. Start the app
2. Enable the tracksLogging FF
3. Ensure that you have followed at least 8 podcasts
4. Go to Podcasts tab
5. Tap on the folders icon on the top left
6. Check if the event `suggested_folders_page_shown`

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
