### PR TITLE
[Fix] Informational Modal presentation fix

### DIFF
--- a/PocketCastsTests/Tests/Analytics/AppLifecyleAnalyticsTests.swift
+++ b/PocketCastsTests/Tests/Analytics/AppLifecyleAnalyticsTests.swift
@@ -94,7 +94,7 @@ class AppLifecycleAnalyticsTests: XCTestCase {
 
         let applicationInstallState = try XCTUnwrap(checkApplicationInstalledOrUpgraded())
 
-        XCTAssertEqual(applicationInstallState, .updated)
+        XCTAssertEqual(applicationInstallState, .sameVersion)
 
         waitForExpectations(timeout: 1)
     }

--- a/podcasts/Analytics/AppLifecyleAnalytics.swift
+++ b/podcasts/Analytics/AppLifecyleAnalytics.swift
@@ -59,6 +59,7 @@ extension AppLifecycleAnalytics {
     enum AppInstallState {
         case installed
         case updated
+        case sameVersion
     }
 
     /// Checks whether we need to track an app install or app update
@@ -87,7 +88,7 @@ extension AppLifecycleAnalytics {
 
         // If the versions are not the same, then record this as an upgrade
         guard lastRunVersion != currentVersion else {
-            return .updated
+            return .sameVersion
         }
 
         analytics.track(.applicationUpdated, properties: ["previous_version": lastRunVersion])

--- a/podcasts/AppDelegate+Defaults.swift
+++ b/podcasts/AppDelegate+Defaults.swift
@@ -140,12 +140,6 @@ extension AppDelegate {
             }
         }
 
-        if FeatureFlag.encourageAccountCreation.enabled {
-            performUpdateIfRequired(updateKey: "EncourageAccountCreation") {
-                Settings.shouldShowInitialOnboardingFlow = true
-            }
-        }
-
         defaults.synchronize()
     }
 

--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -42,11 +42,20 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         appInstallState = appLifecycleAnalytics.checkApplicationInstalledOrUpgraded()
 
-        if let appInstallState, appInstallState == .installed {
-            //Never show the podcast feed reload tooltip for fresh install
-            Settings.shouldShowPodcastFeeReloadTip = false
-            Settings.shouldShowPodcastViewChangesTip = false
-            Settings.shouldShowRecentlyPlayedSortingTip = false
+        if let appInstallState {
+            switch appInstallState {
+            case .updated:
+                if FeatureFlag.encourageAccountCreation.enabled, !Settings.hasShownInformationalViewModal {
+                    Settings.shouldShowInitialOnboardingFlow = !SyncManager.isUserLoggedIn()
+                }
+            case .installed:
+                //Never show the podcast feed reload tooltip for fresh install
+                Settings.shouldShowPodcastFeeReloadTip = false
+                Settings.shouldShowPodcastViewChangesTip = false
+                Settings.shouldShowRecentlyPlayedSortingTip = false
+            case .sameVersion:
+                break
+            }
         }
 
         let defaults = UserDefaults.standard

--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -232,6 +232,10 @@ struct Constants {
             static let newFeaturesAndTips = "notifications.newFeaturesAndTips"
             static let recommendations = "notifications.recommendations"
         }
+
+        enum informationalModal {
+            static let hasShownViewModal = "hasShownViewModal"
+        }
     }
 
     enum Values {

--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -157,7 +157,9 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
             }
         }
 
-        if FeatureFlag.encourageAccountCreation.enabled {
+        if FeatureFlag.encourageAccountCreation.enabled,
+           !Settings.hasShownInformationalViewModal,
+           (UIApplication.shared.delegate as? AppDelegate)?.appInstallState == .updated {
             NavigationManager.sharedManager.navigateTo(NavigationManager.onboardingFlow, data: ["flow": OnboardingFlow.Flow.encourageAccountCreation])
         } else {
             NavigationManager.sharedManager.navigateTo(NavigationManager.onboardingFlow, data: ["flow": OnboardingFlow.Flow.initialOnboarding])

--- a/podcasts/Onboarding/Encourage Account Creation/Modal/InformationalModalViewModel.swift
+++ b/podcasts/Onboarding/Encourage Account Creation/Modal/InformationalModalViewModel.swift
@@ -81,6 +81,8 @@ fileprivate class InformationalModalHostingController<Content>: OnboardingHostin
         super.viewWillAppear(animated)
         guard let viewModel = viewModel as? InformationalModalViewModel else { return }
 
+        Settings.hasShownInformationalViewModal = true
+
         let imageView = ThemeableImageView(frame: .zero)
         imageView.imageNameFunc = AppTheme.pcLogoSmallHorizontalForBackgroundImageName
         imageView.accessibilityLabel = L10n.setupAccount

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -1484,6 +1484,17 @@ class Settings: NSObject {
         }
     }
 
+    // MARK: - Encourage Account Creation
+
+    static var hasShownInformationalViewModal: Bool {
+        get {
+            UserDefaults.standard.value(forKey: Constants.UserDefaults.informationalModal.hasShownViewModal) as? Bool ?? false
+        }
+        set {
+            UserDefaults.standard.setValue(newValue, forKey: Constants.UserDefaults.informationalModal.hasShownViewModal)
+        }
+    }
+
     // MARK: - Database (internal)
 
     class var upgradedIndexes: Bool {


### PR DESCRIPTION
Fixes the presentational modal logic. We should not present it for new users.

## To test

### New Users
- Run a fresh install of this branch
- Confirm you see the login screen fullscreen
- Close the app
- Re-run it and confirm you don't see the login screen or the informational modal
- Close the app and Xcode

### Not logged in users
- On the same branch bump the `Version.xcconfig` 
- Open Xcode and run the branch again over the previous installation
- Confirm you see the Informational modal
- Dismiss it and close the app
- Re-run it and confirm you don't see the login screen or the informational modal
- Close the app and Xcode
- On the same branch bump the `Version.xcconfig` 
- Open Xcode and run the branch again over the previous installation
- Re-run it and confirm you don't see the login screen or the informational modal

### Logged in users
- Run a fresh install and login
- Close the app and Xcode
- On the same branch bump the `Version.xcconfig` 
- Open Xcode and run the branch again over the previous installation
- Re-run it and confirm you don't see the login screen or the informational modal

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
