### PR TITLE
Fix category pill selection reloading

### DIFF
--- a/podcasts/DiscoverCollectionViewController.swift
+++ b/podcasts/DiscoverCollectionViewController.swift
@@ -111,30 +111,38 @@ class DiscoverCollectionViewController: PCViewController {
         self.discoverLayout = discoverLayout
 
         let currentRegion = Settings.discoverRegion(discoverLayout: discoverLayout)
-        var snapshot = NSDiffableDataSourceSnapshot<Section, Item>()
-        snapshot.appendSections([0])
 
-        loadingTasks.values.forEach { $0.cancel() }
-        loadingTasks = [:]
+        if FeatureFlag.recommendations.enabled {
+            var snapshot = NSDiffableDataSourceSnapshot<Section, Item>()
+            snapshot.appendSections([0])
 
-        for item in items {
-            let selectedCategory = item.cellType() != .categoriesSelector ? selectedCategory : nil
+            loadingTasks.values.forEach { $0.cancel() }
+            loadingTasks = [:]
 
-            if itemFilter(item) {
-                if item.authenticated == true, let uuid = item.uuid {
-                    snapshot.appendItems([.loading(uuid)])
-                    loadingTasks[uuid] = Task {
-                        let isAuthenticated = await checkSourceAuthentication(for: item)
-                        guard Task.isCancelled else { return }
-                        self.updateItemInSnapshot(item: item, isAuthenticated: isAuthenticated, region: currentRegion, selectedCategory: selectedCategory)
+            for item in items {
+                let selectedCategory = item.cellType() != .categoriesSelector ? selectedCategory : nil
+
+                if itemFilter(item) {
+                    if item.authenticated == true, let uuid = item.uuid {
+                        snapshot.appendItems([.loading(uuid)])
+                        loadingTasks[uuid] = Task {
+                            let isAuthenticated = await checkSourceAuthentication(for: item)
+                            guard Task.isCancelled else { return }
+                            self.updateItemInSnapshot(item: item, isAuthenticated: isAuthenticated, region: currentRegion, selectedCategory: selectedCategory)
+                        }
+                    } else {
+                        snapshot.appendItems([.item(.init(item: item, region: currentRegion, selectedCategory: selectedCategory))])
                     }
-                } else {
-                    snapshot.appendItems([.item(.init(item: item, region: currentRegion, selectedCategory: selectedCategory))])
                 }
             }
-        }
 
-        dataSource.apply(snapshot)
+            dataSource.apply(snapshot)
+        } else {
+            let snapshot = discoverLayout.layout?.makeDataSourceSnapshot(region: currentRegion, selectedCategory: selectedCategory, itemFilter: itemFilter)
+            if let snapshot {
+                dataSource.apply(snapshot)
+            }
+        }
     }
 
     private func updateItemInSnapshot(item: DiscoverItem, isAuthenticated: Bool, region: String, selectedCategory: DiscoverCategory?) {

--- a/podcasts/DiscoverCollectionViewController.swift
+++ b/podcasts/DiscoverCollectionViewController.swift
@@ -118,6 +118,8 @@ class DiscoverCollectionViewController: PCViewController {
         loadingTasks = [:]
 
         for item in items {
+            let selectedCategory = item.cellType() != .categoriesSelector ? selectedCategory : nil
+
             if itemFilter(item) {
                 if item.authenticated == true, let uuid = item.uuid {
                     snapshot.appendItems([.loading(uuid)])


### PR DESCRIPTION
| 📘 Part of: #2989 |
|:---:|

Fixes a bug with category selection on the Discover screen. This was introduced in e0762c48870a158fa638f374b22adb1f94811258.

I also added a feature flag around this snapshot code to ensure it's covered if we need to disable.

| Before | After |
|--|--|
| <video src="https://github.com/user-attachments/assets/74ffa783-a877-4cee-b424-4395d4876389"> | <video src="https://github.com/user-attachments/assets/b25469db-b233-4bf4-9cb6-6884eb7188f4"> |

## To test

### Feature Flag Disabled

* Ensure the `recommendations` feature flag is disabled (it should be if this is a fresh install)
* Navigate to the Discover section
* Tap Category pills
* Make sure they properly select and animate

### Feature Flag Enabled
* Enable the `recommendations` feature flag
* Restart the app
* Navigate to the Discover section
* Tap Category pills
* Make sure they properly select and animate

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
