### PR TITLE
[Winback] Survey Screen

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Private/API Tasks/SubscriptionStatusTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Private/API Tasks/SubscriptionStatusTask.swift
@@ -34,7 +34,7 @@ class SubscriptionStatusTask: ApiBaseTask {
                 if let expiryDate = SubscriptionHelper.subscriptionRenewalDate() {
                     expiryDateString = expiryDate.description
                 }
-                FileLog.shared.addMessage("Received subscription status paid : \(status.paid), platform : \(status.platform), frequency : \(status.frequency), giftDays : \(status.giftDays), expiryDate : \(expiryDateString)")
+                FileLog.shared.addMessage("Received subscription status paid : \(status.paid), platform : \(status.platform), frequency : \(status.frequency), giftDays : \(status.giftDays), expiryDate : \(expiryDateString), autoRenewing : \(status.autoRenewing)")
                 if originalSubscriptionStatus, !SubscriptionHelper.hasActiveSubscription() {
                     ServerConfig.shared.syncDelegate?.cleanupCloudOnlyFiles()
                 }

--- a/Modules/Server/Sources/PocketCastsServer/Private/API Tasks/SubscriptionStatusTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Private/API Tasks/SubscriptionStatusTask.swift
@@ -34,7 +34,7 @@ class SubscriptionStatusTask: ApiBaseTask {
                 if let expiryDate = SubscriptionHelper.subscriptionRenewalDate() {
                     expiryDateString = expiryDate.description
                 }
-                FileLog.shared.addMessage("Received subscription status paid : \(status.paid), platform : \(status.platform), frequency : \(status.frequency), giftDays : \(status.giftDays), expiryDate : \(expiryDateString), autoRenewing : \(status.autoRenewing)")
+                FileLog.shared.addMessage("Received subscription status paid : \(status.paid), platform : \(status.platform), frequency : \(status.frequency), giftDays : \(status.giftDays), expiryDate : \(expiryDateString), timeToSubscriptionExpiry: \(SubscriptionHelper.timeToSubscriptionExpiry() ?? 0), originalSubscriptionStatus: \(originalSubscriptionStatus)")
                 if originalSubscriptionStatus, !SubscriptionHelper.hasActiveSubscription() {
                     ServerConfig.shared.syncDelegate?.cleanupCloudOnlyFiles()
                 }

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -708,6 +708,9 @@
 		9A74B4D12D83113B00D10858 /* BlurEffectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A74B4D02D83113900D10858 /* BlurEffectView.swift */; };
 		9A821DCB2DA5498E0056D860 /* InformationalBannerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A821DCA2DA549830056D860 /* InformationalBannerViewModel.swift */; };
 		9A991F842DB1362300B39FB8 /* BannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A991F832DB1362000B39FB8 /* BannerView.swift */; };
+		9A9B83BA2DCA666A002CE179 /* CancelSubscriptionSurveyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A9B83B92DCA6661002CE179 /* CancelSubscriptionSurveyView.swift */; };
+		9A9B83BC2DCBC2A4002CE179 /* CancelSubscriptionSurveyViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A9B83BB2DCBC2A4002CE179 /* CancelSubscriptionSurveyViewModel.swift */; };
+		9A9B83C02DCBC36D002CE179 /* CancelSubscriptionSurveyRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A9B83BF2DCBC36D002CE179 /* CancelSubscriptionSurveyRow.swift */; };
 		9AA3B6312D27F0B600A0E30E /* CancelSubscriptionPlansViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AA3B6302D27F0B600A0E30E /* CancelSubscriptionPlansViewModel.swift */; };
 		9AB645182D5138B200A842C8 /* Pocket Casts App Clip.app in Embed App Clips */ = {isa = PBXBuildFile; fileRef = F5D5F7792CEBE769001F492D /* Pocket Casts App Clip.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		BD001B892174260B00504DD3 /* FilterManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD001B882174260B00504DD3 /* FilterManager.swift */; };
@@ -2944,6 +2947,9 @@
 		9A821DCA2DA549830056D860 /* InformationalBannerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InformationalBannerViewModel.swift; sourceTree = "<group>"; };
 		9A9517324EFFD2C905890193 /* Pods-podcasts.appstore.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-podcasts.appstore.xcconfig"; path = "Pods/Target Support Files/Pods-podcasts/Pods-podcasts.appstore.xcconfig"; sourceTree = "<group>"; };
 		9A991F832DB1362000B39FB8 /* BannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannerView.swift; sourceTree = "<group>"; };
+		9A9B83B92DCA6661002CE179 /* CancelSubscriptionSurveyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancelSubscriptionSurveyView.swift; sourceTree = "<group>"; };
+		9A9B83BB2DCBC2A4002CE179 /* CancelSubscriptionSurveyViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancelSubscriptionSurveyViewModel.swift; sourceTree = "<group>"; };
+		9A9B83BF2DCBC36D002CE179 /* CancelSubscriptionSurveyRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancelSubscriptionSurveyRow.swift; sourceTree = "<group>"; };
 		9AA3B6302D27F0B600A0E30E /* CancelSubscriptionPlansViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancelSubscriptionPlansViewModel.swift; sourceTree = "<group>"; };
 		9E6FEF10644B78313185D080 /* Pods-PocketCastsTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PocketCastsTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-PocketCastsTests/Pods-PocketCastsTests.release.xcconfig"; sourceTree = "<group>"; };
 		A251FE0E92E432C4EF0C8207 /* Pods-PocketCastsTests.staging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PocketCastsTests.staging.xcconfig"; path = "Pods/Target Support Files/Pods-PocketCastsTests/Pods-PocketCastsTests.staging.xcconfig"; sourceTree = "<group>"; };
@@ -5448,6 +5454,7 @@
 				102864A82CECEDB20098B2A9 /* CancelSubscriptionViewRow.swift */,
 				9A509DDE2D14604600E8CEB1 /* Offer View */,
 				9A156AAF2CF61025007BA8D9 /* Plans View */,
+				9A9B83B82DCA6649002CE179 /* Survey */,
 			);
 			path = "Cancel Subscription";
 			sourceTree = "<group>";
@@ -5499,6 +5506,16 @@
 				9A263EC02DA65CC600E895B6 /* InformationalProfileBannerCell.swift */,
 			);
 			path = Banner;
+			sourceTree = "<group>";
+		};
+		9A9B83B82DCA6649002CE179 /* Survey */ = {
+			isa = PBXGroup;
+			children = (
+				9A9B83B92DCA6661002CE179 /* CancelSubscriptionSurveyView.swift */,
+				9A9B83BF2DCBC36D002CE179 /* CancelSubscriptionSurveyRow.swift */,
+				9A9B83BB2DCBC2A4002CE179 /* CancelSubscriptionSurveyViewModel.swift */,
+			);
+			path = Survey;
 			sourceTree = "<group>";
 		};
 		BD03B383173A1D68000A419B /* Video Player */ = {
@@ -10030,6 +10047,7 @@
 				10A4F7562C5162C90084D783 /* KidsProfileBannerTableCell.swift in Sources */,
 				BDA0E29F22DDB2DC0029EBEB /* ThemeableLabel.swift in Sources */,
 				BD3FD738202A85E900A7F609 /* ListeningHistoryViewController+Table.swift in Sources */,
+				9A9B83C02DCBC36D002CE179 /* CancelSubscriptionSurveyRow.swift in Sources */,
 				BD2B50AD201076310099B79D /* PodcastSettingsViewController.swift in Sources */,
 				8B5AB48A29018A950018C637 /* EpilogueStory2023.swift in Sources */,
 				C70A444F2A097C3C00F4D77E /* Theme+Plus.swift in Sources */,
@@ -10760,6 +10778,7 @@
 				46AA2E032767EF92001D647A /* PlayPauseLabeledButton.swift in Sources */,
 				C713D4F42A04C90500A78468 /* ProfileDataViewModel.swift in Sources */,
 				BD6B1F011CE05159003CE958 /* AnalyticsHelper.swift in Sources */,
+				9A9B83BC2DCBC2A4002CE179 /* CancelSubscriptionSurveyViewModel.swift in Sources */,
 				FF7F89F12C2C0FD600FC0ED5 /* TranscriptModel.swift in Sources */,
 				C7B3C60E2919DD1700054145 /* ContentSizeReader.swift in Sources */,
 				BD583AF421AE5F9E0048D78D /* EpisodeDateHelper.swift in Sources */,
@@ -10835,6 +10854,7 @@
 				8B99197429A67A7100A5C81C /* SearchView.swift in Sources */,
 				C7318EB72A62D75E00EAFA9C /* BookmarksTheme.swift in Sources */,
 				8B14E3AE29B8E71D0069B6F2 /* RoundedSubscribeButtonView.swift in Sources */,
+				9A9B83BA2DCA666A002CE179 /* CancelSubscriptionSurveyView.swift in Sources */,
 				FF0753942D70F06800BE8B3B /* FoldersCoordinator.swift in Sources */,
 				BD6CABC927D18C0700C6D396 /* GridBadgeView.swift in Sources */,
 				BDF15A441B54E155000EC323 /* PlaybackProtocol.swift in Sources */,

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -846,7 +846,7 @@ enum AnalyticsEvent: String {
     case winbackAvailablePlansSelectPlan
     case winbackAvailablePlansNewPlanPurchaseSuccessful
     case winbackWinbackOfferCancelButtonTapped
-    
+
     // MARK: - Cancel Subscription Survey
     case cancelSubscriptionSurveyShown
     case cancelSubscriptionSurveyDismissed

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -846,6 +846,13 @@ enum AnalyticsEvent: String {
     case winbackAvailablePlansSelectPlan
     case winbackAvailablePlansNewPlanPurchaseSuccessful
     case winbackWinbackOfferCancelButtonTapped
+    
+    // MARK: - Cancel Subscription Survey
+    case cancelSubscriptionSurveyShown
+    case cancelSubscriptionSurveyDismissed
+    case cancelSubscriptionSurveySubmitButtonTapped
+    case cancelSubscriptionSurveyFeedbackSubmitSuccess
+    case cancelSubscriptionSurveyFeedbackSubmitError
 
     // MARK: - Champion Dialog
     case pocketCastsChampionDialogShown

--- a/podcasts/Cancel Subscription/Cancel Subscription/Survey/CancelSubscriptionSurveyRow.swift
+++ b/podcasts/Cancel Subscription/Cancel Subscription/Survey/CancelSubscriptionSurveyRow.swift
@@ -1,0 +1,59 @@
+import SwiftUI
+
+struct CancelSubscriptionSurveyRow: View {
+    @EnvironmentObject var theme: Theme
+
+    let reason: CancelSubscriptionSurveyViewModel.Reason
+    var selected: Bool = false
+    let onTap: (CancelSubscriptionSurveyViewModel.Reason) -> Void
+
+    @ViewBuilder
+    var tick: some View {
+        if selected {
+            ZStack {
+                Circle()
+                    .fill(theme.primaryField03Active)
+                Image("small-tick")
+                    .resizable()
+                    .foregroundColor(theme.primaryInteractive02)
+            }
+        } else {
+            Circle()
+                .fill(theme.primaryUi01Active)
+                .overlay(
+                        Circle()
+                            .stroke(theme.primaryInteractive03, lineWidth: 2)
+                    )
+        }
+    }
+
+    var body: some View {
+        ZStack {
+            Rectangle()
+                .foregroundStyle(.clear)
+                .background(theme.primaryUi01Active)
+                .cornerRadius(8.0)
+                .frame(height: 64)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8.0)
+                        .stroke(theme.primaryField03Active,
+                                lineWidth: selected ? 2 : 0)
+                )
+            HStack(spacing: 16.0) {
+                tick
+                    .frame(width: 24, height: 24)
+                Text(reason.description)
+                    .font(size: 18.0, style: .body, weight: .bold)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.5)
+                    .foregroundStyle(theme.primaryText01)
+                Spacer()
+            }
+            .padding(.horizontal, 16.0)
+        }
+        .padding(.horizontal, 20.0)
+        .onTapGesture {
+            onTap(reason)
+        }
+    }
+}

--- a/podcasts/Cancel Subscription/Cancel Subscription/Survey/CancelSubscriptionSurveyView.swift
+++ b/podcasts/Cancel Subscription/Cancel Subscription/Survey/CancelSubscriptionSurveyView.swift
@@ -1,0 +1,136 @@
+import SwiftUI
+
+struct CancelSubscriptionSurveyView: View {
+    @EnvironmentObject var theme: Theme
+    @ObservedObject var viewModel: CancelSubscriptionSurveyViewModel
+
+    @FocusState private var isFocused: Bool
+
+    init(viewModel: CancelSubscriptionSurveyViewModel) {
+        self.viewModel = viewModel
+    }
+
+    var body: some View {
+        GeometryReader { geometry in
+            ZStack {
+                ScrollViewReader { scrollProxy in
+                    ScrollView(showsIndicators: false) {
+                        VStack(spacing: 10) {
+                            header
+                                .padding(.horizontal, 16.0)
+                                .padding(.bottom, 16.0)
+                            ForEach(CancelSubscriptionSurveyViewModel.Reason.allCases, id: \.id) { reason in
+                                CancelSubscriptionSurveyRow(reason: reason, selected: reason == viewModel.selectedReason) { reason in
+                                    viewModel.selectedReason = reason
+                                    switch reason {
+                                    case .other:
+                                        viewModel.additionalText = ""
+                                        isFocused = true
+                                    default:
+                                        isFocused = false
+                                    }
+                                }
+                            }
+                            if viewModel.selectedReason == .other {
+                                TextEditor(text: $viewModel.additionalText)
+                                    .themedTextField(style: .primaryUi01)
+                                    .foregroundStyle(theme.primaryText01)
+                                    .focused($isFocused)
+                                    .frame(height: 80.0)
+                                    .padding(.horizontal, 18.0)
+                                Spacer(minLength: 100.0)
+                                    .id("bottom")
+                            } else {
+                                Spacer(minLength: 0)
+                            }
+                        }
+                        .frame(minHeight: geometry.size.height)
+                        .id("content")
+                    }
+                    .onChange(of: isFocused) { focused in
+                        withAnimation {
+                            scrollProxy.scrollTo(focused ? "bottom" : "content", anchor: focused ? .bottom : .top)
+                        }
+                    }
+                    .padding(.top, 48)
+                    .modify {
+                        if #available(iOS 16.4, *) {
+                            $0.scrollBounceBehavior(.basedOnSize)
+                        }
+                    }
+                }
+
+                VStack {
+                    HStack {
+                        Button {
+                            viewModel.dismiss()
+                        } label: {
+                            Image("close")
+                                .renderingMode(.template)
+                                .foregroundStyle(theme.primaryField03Active)
+                        }
+                        .frame(width: 32.0, height: 32.0)
+                        .padding(8.0)
+                        Spacer()
+                    }
+                    Spacer()
+                }
+
+                VStack(spacing: 0) {
+                    Spacer()
+                    Rectangle()
+                        .fill(
+                            LinearGradient(
+                                colors: [theme.primaryUi01.opacity(0), theme.primaryUi01],
+                                startPoint: .top,
+                                endPoint: .bottom
+                            )
+                        )
+                        .frame(height: 16)
+                    button
+                        .frame(height: 88.0)
+                }
+            }
+            .background(
+                AppTheme.color(for: .primaryUi01, theme: theme)
+                    .ignoresSafeArea()
+            )
+        }
+    }
+
+    private var header: some View {
+        VStack(spacing: 8.0) {
+            Text(L10n.cancelSubscriptionSurveyTitle)
+                .font(style: .title, weight: .bold, maxSizeCategory: .extraExtraExtraLarge)
+                .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
+                .foregroundColor(theme.primaryText01)
+            Text(L10n.cancelSubscriptionSurveyDescription)
+                .font(size: 15.0, style: .body, weight: .regular, maxSizeCategory: .extraExtraExtraLarge)
+                .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
+                .foregroundColor(theme.primaryText02)
+        }
+    }
+
+    private var button: some View {
+        ZStack {
+            Rectangle()
+                .fill(theme.primaryUi01)
+            Button(action: viewModel.sendFeedback) {
+                Text(L10n.cancelSubscriptionSurveySubmitFeedback)
+            }
+            .buttonStyle(BasicButtonStyle(textColor: theme.primaryInteractive02, backgroundColor: theme.primaryInteractive01))
+            .disabled(!viewModel.canSendFeedback)
+            .frame(height: 56)
+            .padding(.horizontal, 16)
+            .padding(.vertical, 16)
+            .opacity(viewModel.canSendFeedback ? 1.0 : 0.6)
+        }
+    }
+}
+
+#Preview {
+    CancelSubscriptionSurveyView(viewModel: CancelSubscriptionSurveyViewModel(navigationController: nil))
+        .environmentObject(Theme.sharedTheme)
+}

--- a/podcasts/Cancel Subscription/Cancel Subscription/Survey/CancelSubscriptionSurveyView.swift
+++ b/podcasts/Cancel Subscription/Cancel Subscription/Survey/CancelSubscriptionSurveyView.swift
@@ -21,6 +21,9 @@ struct CancelSubscriptionSurveyView: View {
                                 .padding(.bottom, 16.0)
                             ForEach(CancelSubscriptionSurveyViewModel.Reason.allCases, id: \.id) { reason in
                                 CancelSubscriptionSurveyRow(reason: reason, selected: reason == viewModel.selectedReason) { reason in
+                                    if viewModel.isLoading {
+                                        return
+                                    }
                                     viewModel.selectedReason = reason
                                     switch reason {
                                     case .other:
@@ -33,6 +36,7 @@ struct CancelSubscriptionSurveyView: View {
                             }
                             if viewModel.selectedReason == .other {
                                 TextEditor(text: $viewModel.additionalText)
+                                    .font(size: 15.0, style: .body, weight: .regular, maxSizeCategory: .extraExtraExtraLarge)
                                     .themedTextField(style: .primaryUi01)
                                     .foregroundStyle(theme.primaryText01)
                                     .focused($isFocused)
@@ -126,7 +130,27 @@ struct CancelSubscriptionSurveyView: View {
             .padding(.horizontal, 16)
             .padding(.vertical, 16)
             .opacity(viewModel.canSendFeedback ? 1.0 : 0.6)
+            .overlay {
+                if viewModel.isLoading {
+                    loadingButton
+                }
+            }
         }
+    }
+
+    private var loadingButton: some View {
+        ZStack {
+            Rectangle()
+                .overlay(theme.primaryInteractive01)
+                .cornerRadius(ViewConstants.buttonCornerRadius)
+            ProgressView()
+                .progressViewStyle(
+                    CircularProgressViewStyle(tint: theme.primaryInteractive02)
+                )
+        }
+        .frame(height: 56.0)
+        .padding(.horizontal, 16.0)
+        .padding(.vertical, 16)
     }
 }
 

--- a/podcasts/Cancel Subscription/Cancel Subscription/Survey/CancelSubscriptionSurveyView.swift
+++ b/podcasts/Cancel Subscription/Cancel Subscription/Survey/CancelSubscriptionSurveyView.swift
@@ -11,95 +11,92 @@ struct CancelSubscriptionSurveyView: View {
     }
 
     var body: some View {
-        GeometryReader { geometry in
-            ZStack {
-                ScrollViewReader { scrollProxy in
-                    ScrollView(showsIndicators: false) {
-                        VStack(spacing: 10) {
-                            header
-                                .padding(.horizontal, 16.0)
-                                .padding(.bottom, 16.0)
-                            ForEach(CancelSubscriptionSurveyViewModel.Reason.allCases, id: \.id) { reason in
-                                CancelSubscriptionSurveyRow(reason: reason, selected: reason == viewModel.selectedReason) { reason in
-                                    if viewModel.isLoading {
-                                        return
-                                    }
-                                    viewModel.selectedReason = reason
-                                    switch reason {
-                                    case .other:
-                                        viewModel.additionalText = ""
-                                        isFocused = true
-                                    default:
-                                        isFocused = false
-                                    }
+        ZStack {
+            ScrollViewReader { scrollProxy in
+                ScrollView(showsIndicators: false) {
+                    VStack(spacing: 10) {
+                        header
+                            .padding(.horizontal, 16.0)
+                            .padding(.bottom, 16.0)
+                        ForEach(CancelSubscriptionSurveyViewModel.Reason.allCases, id: \.id) { reason in
+                            CancelSubscriptionSurveyRow(reason: reason, selected: reason == viewModel.selectedReason) { reason in
+                                if viewModel.isLoading {
+                                    return
+                                }
+                                viewModel.selectedReason = reason
+                                switch reason {
+                                case .other:
+                                    viewModel.additionalText = ""
+                                    isFocused = true
+                                default:
+                                    isFocused = false
                                 }
                             }
-                            if viewModel.selectedReason == .other {
-                                TextEditor(text: $viewModel.additionalText)
-                                    .font(size: 15.0, style: .body, weight: .regular, maxSizeCategory: .extraExtraExtraLarge)
-                                    .themedTextField(style: .primaryUi01)
-                                    .foregroundStyle(theme.primaryText01)
-                                    .focused($isFocused)
-                                    .frame(height: 80.0)
-                                    .padding(.horizontal, 18.0)
-                                Spacer(minLength: 100.0)
-                                    .id("bottom")
-                            } else {
-                                Spacer(minLength: 0)
-                            }
                         }
-                        .frame(minHeight: geometry.size.height)
-                        .id("content")
-                    }
-                    .onChange(of: isFocused) { focused in
-                        withAnimation {
-                            scrollProxy.scrollTo(focused ? "bottom" : "content", anchor: focused ? .bottom : .top)
+                        if viewModel.selectedReason == .other {
+                            TextEditor(text: $viewModel.additionalText)
+                                .font(size: 15.0, style: .body, weight: .regular, maxSizeCategory: .extraExtraExtraLarge)
+                                .themedTextField(style: .primaryUi01)
+                                .foregroundStyle(theme.primaryText01)
+                                .focused($isFocused)
+                                .disabled(viewModel.isLoading)
+                                .frame(height: 80.0)
+                                .padding(.horizontal, 18.0)
                         }
-                    }
-                    .padding(.top, 48)
-                    .modify {
-                        if #available(iOS 16.4, *) {
-                            $0.scrollBounceBehavior(.basedOnSize)
-                        }
-                    }
-                }
-
-                VStack {
-                    HStack {
-                        Button {
-                            viewModel.dismiss()
-                        } label: {
-                            Image("close")
-                                .renderingMode(.template)
-                                .foregroundStyle(theme.primaryField03Active)
-                        }
-                        .frame(width: 32.0, height: 32.0)
-                        .padding(8.0)
                         Spacer()
+                            .frame(minHeight: 105)
+                            .id("bottom")
                     }
-                    Spacer()
+                    .id("content")
                 }
-
-                VStack(spacing: 0) {
-                    Spacer()
-                    Rectangle()
-                        .fill(
-                            LinearGradient(
-                                colors: [theme.primaryUi01.opacity(0), theme.primaryUi01],
-                                startPoint: .top,
-                                endPoint: .bottom
-                            )
-                        )
-                        .frame(height: 16)
-                    button
-                        .frame(height: 88.0)
+                .onChange(of: isFocused) { focused in
+                    withAnimation {
+                        scrollProxy.scrollTo(focused ? "bottom" : "content", anchor: focused ? .bottom : .top)
+                    }
+                }
+                .padding(.top, 48)
+                .modify {
+                    if #available(iOS 16.4, *) {
+                        $0.scrollBounceBehavior(.basedOnSize)
+                    }
                 }
             }
-            .background(
-                AppTheme.color(for: .primaryUi01, theme: theme)
-                    .ignoresSafeArea()
-            )
+
+            VStack {
+                HStack {
+                    Button {
+                        viewModel.dismiss()
+                    } label: {
+                        Image("close")
+                            .renderingMode(.template)
+                            .foregroundStyle(theme.primaryField03Active)
+                    }
+                    .frame(width: 32.0, height: 32.0)
+                    .padding(8.0)
+                    Spacer()
+                }
+                Spacer()
+            }
+
+            VStack(spacing: 0) {
+                Spacer()
+                Rectangle()
+                    .fill(
+                        LinearGradient(
+                            colors: [theme.primaryUi01.opacity(0), theme.primaryUi01],
+                            startPoint: .top,
+                            endPoint: .bottom
+                        )
+                    )
+                    .frame(height: 16)
+                button
+                    .frame(height: 88.0)
+            }
         }
+        .background(
+            AppTheme.color(for: .primaryUi01, theme: theme)
+                .ignoresSafeArea()
+        )
     }
 
     private var header: some View {
@@ -121,7 +118,10 @@ struct CancelSubscriptionSurveyView: View {
         ZStack {
             Rectangle()
                 .fill(theme.primaryUi01)
-            Button(action: viewModel.sendFeedback) {
+            Button {
+                viewModel.sendFeedback()
+                isFocused = false
+            } label: {
                 Text(L10n.cancelSubscriptionSurveySubmitFeedback)
             }
             .buttonStyle(BasicButtonStyle(textColor: theme.primaryInteractive02, backgroundColor: theme.primaryInteractive01))

--- a/podcasts/Cancel Subscription/Cancel Subscription/Survey/CancelSubscriptionSurveyViewModel.swift
+++ b/podcasts/Cancel Subscription/Cancel Subscription/Survey/CancelSubscriptionSurveyViewModel.swift
@@ -1,0 +1,85 @@
+import SwiftUI
+
+class CancelSubscriptionSurveyViewModel: ObservableObject, OnboardingModel {
+    enum Reason: String, CaseIterable, Identifiable {
+        case betterApp = "found_better_app"
+        case technical = "technical_issue"
+        case cost = "cost"
+        case notEnoughUse = "not_used_enough"
+        case other = "other"
+
+        var id: String { rawValue }
+
+        var description: String {
+            switch self {
+            case .betterApp:
+                L10n.cancelSubscriptionSurveyRowBetterApp
+            case .technical:
+                L10n.cancelSubscriptionSurveyRowTechnicalIssue
+            case .cost:
+                L10n.cancelSubscriptionSurveyRowCost
+            case .notEnoughUse:
+                L10n.cancelSubscriptionSurveyRowNotEnough
+            case .other:
+                L10n.cancelSubscriptionSurveyRowOther
+            }
+        }
+    }
+
+    @Published var selectedReason: Reason?
+    @Published var additionalText: String = ""
+
+    private weak var navigationController: UINavigationController?
+
+    init(navigationController: UINavigationController?) {
+        self.navigationController = navigationController
+    }
+
+    var canSendFeedback: Bool {
+        if let selectedReason {
+            if selectedReason == .other {
+                return !additionalText.isEmpty
+            }
+            return true
+        }
+        return false
+    }
+
+    func sendFeedback() {
+
+    }
+
+    func dismiss() {
+        navigationController?.dismiss(animated: true)
+    }
+
+    func didAppear() {
+
+    }
+
+    func didDismiss(type: OnboardingDismissType) {
+        guard type == .swipe else { return }
+    }
+}
+
+// Making vew controller
+extension CancelSubscriptionSurveyViewModel {
+    /// Make the view, and allow it to be shown by itself or within another navigation flow
+    static func make() -> UINavigationController {
+        // If we're not being presented within another nav controller then wrap ourselves in one
+        let navController = UINavigationController()
+        let viewModel = CancelSubscriptionSurveyViewModel(navigationController: navController)
+
+        // Wrap the SwiftUI view in the hosting view controller
+        let swiftUIView = CancelSubscriptionSurveyView(viewModel: viewModel).setupDefaultEnvironment()
+
+        // Configure the controller
+        let controller = OnboardingHostingViewController(rootView: swiftUIView)
+        controller.navBarIsHidden = true
+        controller.viewModel = viewModel
+
+        // Set the root view of the new nav controller
+        navController.setViewControllers([controller], animated: false)
+        return navController
+    }
+}

--- a/podcasts/Cancel Subscription/Cancel Subscription/Survey/CancelSubscriptionSurveyViewModel.swift
+++ b/podcasts/Cancel Subscription/Cancel Subscription/Survey/CancelSubscriptionSurveyViewModel.swift
@@ -26,8 +26,18 @@ class CancelSubscriptionSurveyViewModel: ObservableObject, OnboardingModel {
         }
     }
 
+    enum LoadingState {
+        case idle
+        case loading
+    }
+
     @Published var selectedReason: Reason?
     @Published var additionalText: String = ""
+    @Published var loadingState: LoadingState = .idle
+
+    var isLoading: Bool {
+        loadingState == .loading
+    }
 
     private weak var navigationController: UINavigationController?
 
@@ -46,19 +56,25 @@ class CancelSubscriptionSurveyViewModel: ObservableObject, OnboardingModel {
     }
 
     func sendFeedback() {
-
+        if loadingState == .loading {
+            return
+        }
+        loadingState = .loading
+        Analytics.track(.cancelSubscriptionSurveySubmitButtonTapped)
     }
 
     func dismiss() {
+        Analytics.track(.cancelSubscriptionSurveyDismissed)
         navigationController?.dismiss(animated: true)
     }
 
     func didAppear() {
-
+        Analytics.track(.cancelSubscriptionSurveyShown)
     }
 
     func didDismiss(type: OnboardingDismissType) {
         guard type == .swipe else { return }
+        Analytics.track(.cancelSubscriptionSurveyDismissed)
     }
 }
 

--- a/podcasts/DeveloperMenu.swift
+++ b/podcasts/DeveloperMenu.swift
@@ -7,6 +7,7 @@ struct DeveloperMenu: View {
     @State var showingImporter = false
     @State var showingExporter = false
     @State var showing = false
+    @State var showSurvey = false
 
     var body: some View {
         List {
@@ -310,6 +311,17 @@ struct DeveloperMenu: View {
                 }
             } header: {
                 Text("Notifications")
+            }
+
+            Section {
+                Button("Present Cancel Subscription Survey") {
+                    showSurvey = true
+                }
+                .sheet(isPresented: $showSurvey) {
+                    CancelSubscriptionSurveyView(viewModel: CancelSubscriptionSurveyViewModel(navigationController: nil))
+                }
+            } header: {
+                Text("Cancel Subscription Survey")
             }
 
             Section {

--- a/podcasts/ProfileViewController.swift
+++ b/podcasts/ProfileViewController.swift
@@ -139,8 +139,6 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
 
         whatsNewDismissed()
         showReferralsHintIfNeeded()
-        
-        present(CancelSubscriptionSurveyViewModel.make(), animated: true)
     }
 
     override func viewDidDisappear(_ animated: Bool) {

--- a/podcasts/ProfileViewController.swift
+++ b/podcasts/ProfileViewController.swift
@@ -139,6 +139,8 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
 
         whatsNewDismissed()
         showReferralsHintIfNeeded()
+        
+        present(CancelSubscriptionSurveyViewModel.make(), animated: true)
     }
 
     override func viewDidDisappear(_ animated: Bool) {

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -436,6 +436,23 @@ internal enum L10n {
   }
   /// Get your next month free
   internal static var cancelSubscriptionPromotionTitle: String { return L10n.tr("Localizable", "cancel_subscription_promotion_title") }
+  /// We'd love to know why you canceled. Your feedback helps us improve.
+  internal static var cancelSubscriptionSurveyDescription: String { return L10n.tr("Localizable", "cancel_subscription_survey_description") }
+  /// I found a better app
+  internal static var cancelSubscriptionSurveyRowBetterApp: String { return L10n.tr("Localizable", "cancel_subscription_survey_row_better_app") }
+  /// Cost-related reasons
+  internal static var cancelSubscriptionSurveyRowCost: String { return L10n.tr("Localizable", "cancel_subscription_survey_row_cost") }
+  /// I don’t use it enough
+  internal static var cancelSubscriptionSurveyRowNotEnough: String { return L10n.tr("Localizable", "cancel_subscription_survey_row_not_enough") }
+  /// Other
+  internal static var cancelSubscriptionSurveyRowOther: String { return L10n.tr("Localizable", "cancel_subscription_survey_row_other") }
+  /// Technical issues
+  internal static var cancelSubscriptionSurveyRowTechnicalIssue: String { return L10n.tr("Localizable", "cancel_subscription_survey_row_technical_issue") }
+  /// Submit feedback
+  internal static var cancelSubscriptionSurveySubmitFeedback: String { return L10n.tr("Localizable", "cancel_subscription_survey_submit_feedback") }
+  /// Thanks for trying
+  /// Pocket Casts Plus
+  internal static var cancelSubscriptionSurveyTitle: String { return L10n.tr("Localizable", "cancel_subscription_survey_title") }
   /// Thinking of leaving?
   /// Let us help first
   internal static var cancelSubscriptionTitle: String { return L10n.tr("Localizable", "cancel_subscription_title") }

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4762,6 +4762,30 @@
 /* Badge that appears over the best value plan in the available plans list */
 "cancel_subscription_available_plans_best_value_badge" = "Best Value";
 
+/* Title of the survey screen that appears when a user cancels the subscription. \n forces Pocket Casts to be on a new line */
+"cancel_subscription_survey_title" = "Thanks for trying\nPocket Casts Plus";
+
+/* Description of the survey screen that appears when a user cancels the subscription */
+"cancel_subscription_survey_description" = "We'd love to know why you canceled. Your feedback helps us improve.";
+
+/* Title of the Send Button in the survey screen that appears when a user cancels the subscription */
+"cancel_subscription_survey_submit_feedback" = "Submit feedback";
+
+/* Option in the in the survey screen that appears when a user cancels the subscription */
+"cancel_subscription_survey_row_better_app" = "I found a better app";
+
+/* Option in the in the survey screen that appears when a user cancels the subscription */
+"cancel_subscription_survey_row_technical_issue" = "Technical issues";
+
+/* Option in the in the survey screen that appears when a user cancels the subscription */
+"cancel_subscription_survey_row_cost" = "Cost-related reasons";
+
+/* Option in the in the survey screen that appears when a user cancels the subscription */
+"cancel_subscription_survey_row_not_enough" = "I don’t use it enough";
+
+/* Option in the in the survey screen that appears when a user cancels the subscription */
+"cancel_subscription_survey_row_other" = "Other";
+
 /* For yealry plans, we show the weekly price. %1$@ is the price. For example: $0.70/week */
 "iap_product_weekly_pricing_format" = "%1$@/week";
 


### PR DESCRIPTION
| 📘 Part of: #3029
|:---:|

Fixes #3032

This PR adds the Survey screen. As we are waiting for the backend to implement the API, the screen is available from the dev portal.

| 1 | 2 | 3 |
| -------- | ------- | ------- |
| ![IMG_0123](https://github.com/user-attachments/assets/b1aa93fa-5f4d-4541-8b68-48360cd2a864) | ![IMG_0124](https://github.com/user-attachments/assets/0ef5ff35-dce8-4c95-ae5f-3d2b32753bad) | <video src="https://github.com/user-attachments/assets/23a50acb-3aef-4b14-bb11-a5b1da5225e0" /> |

## To test

- Run this branch
- Goto the dev portal
- Tap on `Present Cancel Subscription Survey` to prompt the survey screen
- Few things to notice:
  - There is no API attached, so when you press the Send button it will just show the loader
  - The top left `X` button doesn't work as we don't use a nav controller to present it

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
