### PR TITLE
Add analytics to track interaction around notification events

### DIFF
--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -497,7 +497,7 @@ enum AnalyticsEvent: String {
     case notificationsOptInAllowed
     case notificationsOptInDenied
 
-    case notificationsPermissionsShow
+    case notificationsPermissionsShown
     case notificationsPermissionsAllowTapped
     case notificationsPermissionsNotNowTapped
     case notificationsPermissionsOpenSystemSettings

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -502,6 +502,8 @@ enum AnalyticsEvent: String {
     case notificationsPermissionsNotNowTapped
     case notificationsPermissionsOpenSystemSettings
 
+    case notificationOpened
+
     // MARK: - Podcast Settings
 
     case podcastSettingsFeedErrorTapped

--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -571,7 +571,7 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
         switchToTab(.podcasts)
         selectedViewController?.dismiss(animated: false)
         if let controller = view.window?.rootViewController {
-            showSubscriptionRequired(controller, source: .unknown, context: nil, flow: .initialOnboarding)
+            showSubscriptionRequired(controller, source: .unknown, context: nil, flow: .none)
         }
     }
 

--- a/podcasts/Notifications/NotificationsCoordinator.swift
+++ b/podcasts/Notifications/NotificationsCoordinator.swift
@@ -114,6 +114,8 @@ enum NotificationType: String {
 
     var shouldSend: Bool {
         switch self {
+            case .onboardingSignUp:
+                return !SyncManager.isUserLoggedIn()
             case .onboardingUpsell, .upsell:
                 return !SubscriptionHelper.hasActiveSubscription()
             case .recommendationsYouMightLike:

--- a/podcasts/Notifications/NotificationsPermissionsView.swift
+++ b/podcasts/Notifications/NotificationsPermissionsView.swift
@@ -63,7 +63,7 @@ struct NotificationsPermissionsView: View {
         .padding()
         .background(theme.primaryUi01)
         .onAppear() {
-            Analytics.track(.notificationsPermissionsShow)
+            Analytics.track(.notificationsPermissionsShown)
         }
     }
 }

--- a/podcasts/NotificationsHelper.swift
+++ b/podcasts/NotificationsHelper.swift
@@ -112,6 +112,13 @@ class NotificationsHelper: NSObject, UNUserNotificationCenterDelegate {
         let categoryIdentifier = response.notification.request.content.categoryIdentifier
         let category = NotificationsCategory(rawValue: categoryIdentifier)
 
+        var properties: [String: Any] = ["category": categoryIdentifier]
+        let identifier = response.notification.request.identifier
+        if let type = NotificationType(rawValue: identifier) {
+            properties["type"] = type.rawValue
+        }
+        Analytics.track(.notificationOpened, properties: properties)
+
         switch category {
         case .episodes, .podcasts, .none:
             handleEpisodeNotification(response: response, completionHandler: completionHandler)


### PR DESCRIPTION
| 📘 Part of: #2906  |  <!-- project issue number, if applicable -->
|:---:|

Fixes #3012  <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR adds analytics tracking for opening of  notifications

## To test

1. Start the app
2. Ensure that you have the `notificationsRevamp` FF active and `tracksLoggin` enabled
3. Open Profile -> Settings -> Developer
4. Tap on Speed Up Notifications
5. Go to Profile -> Settings -> Notifications
6. Enable all push notifications
7. Wait for them to start arriving
8. Tap on them and see if you see the following event being tracked: `notification_opened` with `category=DEEP_LINK` and type="notificationType". notificationType will be one of the following: `reengagementWeekly, onboardingSignUp, onboardingImport, onboardingThemes, onboardingUpNext, onboardingFilters, onboardingUpsell, onboardingStaffPicks, recommendationsTrending, recommendationsYouMightLike, upsell, newFeatureSuggestedFolders`

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
