### PR TITLE
Recommendations: Add country code for recommendations endpoint

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/ServerPodcastManager.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/ServerPodcastManager.swift
@@ -240,7 +240,7 @@ public class ServerPodcastManager: NSObject {
         return episode
     }
 
-    public func loadRecommendations(for podcastUUID: String) async throws -> PodcastCollection? {
+    public func loadRecommendations(for podcastUUID: String, in region: String?) async throws -> PodcastCollection? {
         let components = URLComponents(string: ServerConstants.Urls.api())
 
         guard var components else {
@@ -248,7 +248,14 @@ public class ServerPodcastManager: NSObject {
             throw URLError(.badURL)
         }
 
-        components.path += "/recommendations/podcast/\(podcastUUID)"
+        components.path += "recommendations/podcast/\(podcastUUID)"
+
+        if let region {
+            components.queryItems = [
+                URLQueryItem(name: "country", value: region)
+            ]
+        }
+
         guard let url = components.url else {
             assertionFailure("[ServerPodcastManager] Recommendations API construction failed")
             throw URLError(.badURL)

--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -1400,7 +1400,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
         guard let podcast = podcast else { return }
 
         do {
-            recommendations = try await ServerPodcastManager.shared.loadRecommendations(for: podcast.uuid)
+            recommendations = try await ServerPodcastManager.shared.loadRecommendations(for: podcast.uuid, in: Settings.userRegion())
             hasSimilarShows.send(recommendations?.podcasts?.isEmpty == false)
         } catch {
             // We won't do anything in the interface here since the You Might Like button is optional and hidden by default

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -356,14 +356,17 @@ class Settings: NSObject {
 
     private static let chartRegion = "SJChartRegion"
     class func discoverRegion(discoverLayout: DiscoverLayout) -> String {
+        return convertRegion(userRegion: userRegion(), discoverLayout: discoverLayout)
+    }
+
+    class func userRegion() -> String? {
         var userRegion: String?
         if let savedRegion = UserDefaults.standard.string(forKey: chartRegion) {
             userRegion = savedRegion.lowercased()
         } else if let region = (Locale.current as NSLocale).object(forKey: NSLocale.Key.countryCode) as? String {
             userRegion = region.lowercased()
         }
-
-        return convertRegion(userRegion: userRegion, discoverLayout: discoverLayout)
+        return userRegion
     }
 
     private class func convertRegion(userRegion: String?, discoverLayout: DiscoverLayout) -> String {


### PR DESCRIPTION
| 📘 Part of: #2989 |
|:---:|

This adds a `country` query parameter for the recommendations endpoint. This endpoint will return category suggestions and the country code will be used to localize those.

| Global | Australia |
|--|--|
| ![Simulator Screenshot - iPhone 16 - 2025-05-08 at 09 11 46](https://github.com/user-attachments/assets/c66e9fed-74cc-4e9e-933d-2376bc26f34d) | ![Simulator Screenshot - iPhone 16 - 2025-05-08 at 09 19 46](https://github.com/user-attachments/assets/c4da4e24-450f-481c-9d08-8e4255797192) |

## To test

* Build for staging - the category fallback isn't available in production yet
* Find the podcast "The Tennis"
* Make sure the "You might like" tab loads - before, this show had no similar shows
* Go to Discover and change your "Content Region" at the bottom
* Restart the app
* Revisit "The Tennis" and "You might like" tab and ensure the results have changed

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
