### PR TITLE
Notifications trigger dates updates

### DIFF
--- a/podcasts/DeveloperMenu.swift
+++ b/podcasts/DeveloperMenu.swift
@@ -304,7 +304,9 @@ struct DeveloperMenu: View {
             Section {
                 Button("Speed Up Notifications") {
                     NotificationsGroup.speedUpNotifications = true
-                    NotificationsCoordinator.shared.ignoreScheduleHours = true
+                }
+                Button("Log Schedule") {
+                    NotificationsCoordinator.shared.debugMode = true
                 }
             } header: {
                 Text("Notifications")

--- a/podcasts/Notifications/NotificationsCoordinator.swift
+++ b/podcasts/Notifications/NotificationsCoordinator.swift
@@ -246,7 +246,8 @@ enum NotificationsGroup: CaseIterable {
             case .newEpisodes:
                 return nil
             case .dailyReminders:
-                triggerWeekDay = ((todayWeekday + order) % maxWeekDays) + 1
+                let timeIntervalToSchedule: TimeInterval = calculateTimeIntervalToHour(scheduleHour)
+                return UNTimeIntervalNotificationTrigger(timeInterval: timeIntervalToSchedule + (Double(order + 1) * timeIntervalStep), repeats: notification.isRepeatable)
             case .recommendations:
                 triggerWeekDay = ((todayWeekday + (order*3)) % maxWeekDays) + 1
             case .newFeaturesAndTips:
@@ -262,6 +263,16 @@ enum NotificationsGroup: CaseIterable {
         Self.allCases.allSatisfy() {
             $0.isEnabled == false
         }
+    }
+
+    private func calculateTimeIntervalToHour(_ hour: Int) -> TimeInterval {
+        if Self.speedUpNotifications {
+            return 1
+        }
+        guard let date = Calendar.current.date(bySettingHour: hour, minute: 0, second: 0, of: Date.now, matchingPolicy: .nextTime) else {
+            return 0
+        }
+        return date.timeIntervalSince(Date.now)
     }
 }
 
@@ -315,6 +326,7 @@ class NotificationsCoordinator {
             scheduleNotification(notification, trigger: trigger)
             order += 1
         }
+        // Uncomment the line bellow if you need to debug the notification schedules
         printPendingNotifications()
     }
 
@@ -371,15 +383,5 @@ class NotificationsCoordinator {
 
     func cancelNotification(_ type: NotificationType) {
         notificationCenter.removePendingNotificationRequests(withIdentifiers: [type.identifier])
-    }
-
-    private func calculateTimeIntervalToHour(_ hour: Int) -> TimeInterval {
-        if ignoreScheduleHours {
-            return 1
-        }
-        guard let date = Calendar.current.date(bySettingHour: hour, minute: 0, second: 0, of: Date.now, matchingPolicy: .nextTime) else {
-            return 0
-        }
-        return date.timeIntervalSince(Date.now)
     }
 }

--- a/podcasts/Notifications/NotificationsCoordinator.swift
+++ b/podcasts/Notifications/NotificationsCoordinator.swift
@@ -234,6 +234,32 @@ enum NotificationsGroup: CaseIterable {
         }
     }
 
+    func trigger(order: Int) -> UNNotificationTrigger? {
+        let todayComponents = Calendar.current.dateComponents(in: .current, from: Date.now)
+        let todayWeekday: Int = todayComponents.weekday ?? 1
+
+        switch self {
+            case .newEpisodes:
+                return nil
+            case .dailyReminders:
+                let weekday = ((todayWeekday + order) % 8) + 1
+                let dateComponents = DateComponents(hour: scheduleHour)
+                return UNCalendarNotificationTrigger(dateMatching: dateComponents, repeats: false)
+            case .recommendations:
+                let weekday = ((todayWeekday + (order*3)) % 8) + 1
+                let dateComponents = DateComponents(hour: scheduleHour, weekday: weekday)
+                return UNCalendarNotificationTrigger(dateMatching: dateComponents, repeats: true)
+            case .newFeaturesAndTips:
+                let weekday = ((todayWeekday + (order)) % 8) + 1
+                let dateComponents = DateComponents(hour: scheduleHour)
+                return UNCalendarNotificationTrigger(dateMatching: dateComponents, repeats: true)
+            case .offers:
+                let weekday = ((todayWeekday + (order)) % 8) + 1
+                let dateComponents = DateComponents(hour: scheduleHour)
+                return UNCalendarNotificationTrigger(dateMatching: dateComponents, repeats: true)
+        }
+    }
+
     static var allDisabled: Bool {
         Self.allCases.allSatisfy() {
             $0.isEnabled == false

--- a/podcasts/Notifications/NotificationsCoordinator.swift
+++ b/podcasts/Notifications/NotificationsCoordinator.swift
@@ -238,7 +238,7 @@ enum NotificationsGroup: CaseIterable {
         if Self.speedUpNotifications {
             return UNTimeIntervalNotificationTrigger(timeInterval: Double(order + 1) * timeIntervalStep, repeats: notification.isRepeatable)
         }
-        let calendar = Calendar.current        
+        let calendar = Calendar.current
         let maxWeekDays: Int = calendar.weekdaySymbols.count
         switch self {
             case .newEpisodes:

--- a/podcasts/Notifications/NotificationsCoordinator.swift
+++ b/podcasts/Notifications/NotificationsCoordinator.swift
@@ -243,7 +243,7 @@ enum NotificationsGroup: CaseIterable {
                 return nil
             case .dailyReminders:
                 let weekday = ((todayWeekday + order) % 8) + 1
-                let dateComponents = DateComponents(hour: scheduleHour)
+                let dateComponents = DateComponents(hour: scheduleHour, weekday: weekday)
                 return UNCalendarNotificationTrigger(dateMatching: dateComponents, repeats: false)
             case .recommendations:
                 let weekday = ((todayWeekday + (order*3)) % 8) + 1
@@ -251,11 +251,11 @@ enum NotificationsGroup: CaseIterable {
                 return UNCalendarNotificationTrigger(dateMatching: dateComponents, repeats: true)
             case .newFeaturesAndTips:
                 let weekday = ((todayWeekday + (order)) % 8) + 1
-                let dateComponents = DateComponents(hour: scheduleHour)
+                let dateComponents = DateComponents(hour: scheduleHour, weekday: weekday)
                 return UNCalendarNotificationTrigger(dateMatching: dateComponents, repeats: true)
             case .offers:
                 let weekday = ((todayWeekday + (order)) % 8) + 1
-                let dateComponents = DateComponents(hour: scheduleHour)
+                let dateComponents = DateComponents(hour: scheduleHour, weekday: weekday)
                 return UNCalendarNotificationTrigger(dateMatching: dateComponents, repeats: true)
         }
     }
@@ -307,19 +307,15 @@ class NotificationsCoordinator {
 
     func updateNotifications(for group: NotificationsGroup) {
         cancelNotifications(for: group)
-        let timeIntervalToSchedule: TimeInterval = calculateTimeIntervalToHour(group.scheduleHour)
-        var timeInterval: TimeInterval = timeIntervalToSchedule + group.timeIntervalStep
+        var order = 0
         for notification in group.notifications {
-            guard notification.shouldSend else {
+            guard notification.shouldSend,
+                  let trigger = group.trigger(order: order)
+            else {
                 continue
             }
-            if notification.isRepeatable {
-                scheduleNotification(notification, timeInterval: timeInterval, repeats: false)
-                scheduleNotification(notification, timeInterval: timeInterval + group.timeIntervalStep, repeats: true)
-            } else {
-                scheduleNotification(notification, timeInterval: timeInterval, repeats: false)
-            }
-            timeInterval += group.timeIntervalStep
+            scheduleNotification(notification, trigger: trigger)
+            order += 1
         }
     }
 
@@ -331,14 +327,14 @@ class NotificationsCoordinator {
         }
     }
 
-    func scheduleNotification(_ type: NotificationType, timeInterval: TimeInterval = 5.seconds, repeats: Bool = false) {
+    func scheduleNotification(_ type: NotificationType, trigger: UNNotificationTrigger) {
         let content = UNMutableNotificationContent()
         content.title = type.title
         content.body = type.body
         content.categoryIdentifier = NotificationsHelper.NotificationsCategory.deepLink.rawValue
         content.userInfo = ["destination_url": type.link]
 
-        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: timeInterval, repeats: repeats)
+        //let trigger = UNTimeIntervalNotificationTrigger(timeInterval: timeInterval, repeats: repeats)
 
         let request = UNNotificationRequest(identifier: type.identifier, content: content, trigger: trigger)
 

--- a/podcasts/Notifications/NotificationsCoordinator.swift
+++ b/podcasts/Notifications/NotificationsCoordinator.swift
@@ -240,8 +240,7 @@ enum NotificationsGroup: CaseIterable {
         }
         let calendar = Calendar.current
         let todayWeekday = calendar.component(.weekday, from: Date.now)
-        let maxWeekDays: Int = calendar.weekdaySymbols.count
-        var triggerWeekDay = todayWeekday
+        let maxWeekDays: Int = calendar.weekdaySymbols.count        
         switch self {
             case .newEpisodes:
                 return nil
@@ -250,29 +249,32 @@ enum NotificationsGroup: CaseIterable {
                 return UNTimeIntervalNotificationTrigger(timeInterval: timeIntervalToSchedule + (Double(order) * timeIntervalStep), repeats: notification.isRepeatable)
             case .recommendations:
                 return makeTrigger(
-                    daysFromNow: (order + 1) * 3,
+                    days: (order + 1) * 3,
+                    from: .now,
                     calendar: calendar,
                     repeats: notification.isRepeatable
                 )
 
             case .newFeaturesAndTips:
                 return makeTrigger(
-                    daysFromNow: (order + 1) * 2,
+                    days: (order + 1) * 2,
+                    from: .now,
                     calendar: calendar,
                     repeats: notification.isRepeatable
                 )
 
             case .offers:
                 return makeTrigger(
-                    daysFromNow: (order + 1) * 7,
+                    days: maxWeekDays - order - 1,
+                    from: .now,
                     calendar: calendar,
                     repeats: notification.isRepeatable
                 )
         }
     }
 
-    private func makeTrigger(daysFromNow: Int, calendar: Calendar, repeats: Bool) -> UNCalendarNotificationTrigger? {
-        guard let fireDate = calendar.date(byAdding: .day, value: daysFromNow, to: Date()) else {
+    private func makeTrigger(days: Int, from date: Date = .now, calendar: Calendar, repeats: Bool) -> UNCalendarNotificationTrigger? {
+        guard let fireDate = calendar.date(byAdding: .day, value: days, to: date) else {
             return nil
         }
 

--- a/podcasts/Notifications/NotificationsCoordinator.swift
+++ b/podcasts/Notifications/NotificationsCoordinator.swift
@@ -238,8 +238,7 @@ enum NotificationsGroup: CaseIterable {
         if Self.speedUpNotifications {
             return UNTimeIntervalNotificationTrigger(timeInterval: Double(order + 1) * timeIntervalStep, repeats: notification.isRepeatable)
         }
-        let todayComponents = Calendar.current.dateComponents(in: .current, from: Date.now)
-        let todayWeekday: Int = todayComponents.weekday ?? 1
+        let todayWeekday = Calendar.current.component(.weekday, from: Date.now)
         let maxWeekDays: Int = Calendar.current.weekdaySymbols.count
         var triggerWeekDay = todayWeekday
         switch self {
@@ -249,21 +248,36 @@ enum NotificationsGroup: CaseIterable {
                 let timeIntervalToSchedule: TimeInterval = calculateTimeIntervalToHour(scheduleHour)
                 return UNTimeIntervalNotificationTrigger(timeInterval: timeIntervalToSchedule + (Double(order) * timeIntervalStep), repeats: notification.isRepeatable)
             case .recommendations:
-                // Follow three days
-                triggerWeekDay = ((todayWeekday + ((order+1)*3)) % maxWeekDays)
+                return makeTrigger(
+                    daysFromNow: (order + 1) * 3,
+                    calendar: calendar,
+                    repeats: notification.isRepeatable
+                )
+
             case .newFeaturesAndTips:
-                // Follow two days
-                triggerWeekDay = ((todayWeekday + ((order+1)*2)) % maxWeekDays)
+                return makeTrigger(
+                    daysFromNow: (order + 1) * 2,
+                    calendar: calendar,
+                    repeats: notification.isRepeatable
+                )
+
             case .offers:
-                // One week from now
-                triggerWeekDay = ((todayWeekday - order - 1) % maxWeekDays)
+                return makeTrigger(
+                    daysFromNow: (order + 1) * 7,
+                    calendar: calendar,
+                    repeats: notification.isRepeatable
+                )
+        }
+    }
+
+    private func makeTrigger(daysFromNow: Int, calendar: Calendar, repeats: Bool) -> UNCalendarNotificationTrigger? {
+        guard let fireDate = calendar.date(byAdding: .day, value: daysFromNow, to: Date()) else {
+            return nil
         }
 
-        if triggerWeekDay == 0 {
-            triggerWeekDay += 1
-        }
-        let dateComponents = DateComponents(hour: scheduleHour, weekday: triggerWeekDay)
-        return UNCalendarNotificationTrigger(dateMatching: dateComponents, repeats: notification.isRepeatable)
+        let weekday = calendar.component(.weekday, from: fireDate)
+        let components = DateComponents(hour: scheduleHour, weekday: weekday)
+        return UNCalendarNotificationTrigger(dateMatching: components, repeats: repeats)
     }
 
     static var allDisabled: Bool {

--- a/podcasts/Notifications/NotificationsCoordinator.swift
+++ b/podcasts/Notifications/NotificationsCoordinator.swift
@@ -289,7 +289,7 @@ class NotificationsCoordinator {
 
     static let shared: NotificationsCoordinator = NotificationsCoordinator()
 
-    var ignoreScheduleHours: Bool = false
+    var debugMode: Bool = false
 
     private let notificationCenter: UNUserNotificationCenter
 
@@ -335,11 +335,13 @@ class NotificationsCoordinator {
             scheduleNotification(notification, trigger: trigger)
             order += 1
         }
-        // Uncomment the line bellow if you need to debug the notification schedules
         printPendingNotifications()
     }
 
-    private func printPendingNotifications() {
+    private func printPendingNotifications() {        
+        guard debugMode else {
+            return
+        }
         Task {
             FileLog.shared.addMessage("\n---- Notification Schedule ----\n")
             let pendingNotifications = await self.notificationCenter.pendingNotificationRequests()
@@ -388,6 +390,7 @@ class NotificationsCoordinator {
 
     func cancelNotifications(for group: NotificationsGroup) {
         notificationCenter.removePendingNotificationRequests(withIdentifiers: group.notifications.map { $0.identifier })
+        printPendingNotifications()
     }
 
     func cancelNotification(_ type: NotificationType) {

--- a/podcasts/Notifications/NotificationsCoordinator.swift
+++ b/podcasts/Notifications/NotificationsCoordinator.swift
@@ -234,30 +234,28 @@ enum NotificationsGroup: CaseIterable {
         }
     }
 
-    func trigger(order: Int) -> UNNotificationTrigger? {
+    func trigger(order: Int, notification: NotificationType) -> UNNotificationTrigger? {
+        if Self.speedUpNotifications {
+            return UNTimeIntervalNotificationTrigger(timeInterval: Double(order + 1) * timeIntervalStep, repeats: notification.isRepeatable)
+        }
         let todayComponents = Calendar.current.dateComponents(in: .current, from: Date.now)
         let todayWeekday: Int = todayComponents.weekday ?? 1
-
+        let maxWeekDays: Int = Calendar.current.weekdaySymbols.count
+        var triggerWeekDay = todayWeekday
         switch self {
             case .newEpisodes:
                 return nil
             case .dailyReminders:
-                let weekday = ((todayWeekday + order) % 8) + 1
-                let dateComponents = DateComponents(hour: scheduleHour, weekday: weekday)
-                return UNCalendarNotificationTrigger(dateMatching: dateComponents, repeats: false)
+                triggerWeekDay = ((todayWeekday + order) % maxWeekDays) + 1
             case .recommendations:
-                let weekday = ((todayWeekday + (order*3)) % 8) + 1
-                let dateComponents = DateComponents(hour: scheduleHour, weekday: weekday)
-                return UNCalendarNotificationTrigger(dateMatching: dateComponents, repeats: true)
+                triggerWeekDay = ((todayWeekday + (order*3)) % maxWeekDays) + 1
             case .newFeaturesAndTips:
-                let weekday = ((todayWeekday + (order)) % 8) + 1
-                let dateComponents = DateComponents(hour: scheduleHour, weekday: weekday)
-                return UNCalendarNotificationTrigger(dateMatching: dateComponents, repeats: true)
+                triggerWeekDay = ((todayWeekday + (order*2)) % maxWeekDays) + 1
             case .offers:
-                let weekday = ((todayWeekday + (order)) % 8) + 1
-                let dateComponents = DateComponents(hour: scheduleHour, weekday: weekday)
-                return UNCalendarNotificationTrigger(dateMatching: dateComponents, repeats: true)
+                triggerWeekDay = ((todayWeekday + (order)) % maxWeekDays) + 1
         }
+        let dateComponents = DateComponents(hour: scheduleHour, weekday: triggerWeekDay)
+        return UNCalendarNotificationTrigger(dateMatching: dateComponents, repeats: notification.isRepeatable)
     }
 
     static var allDisabled: Bool {
@@ -310,12 +308,32 @@ class NotificationsCoordinator {
         var order = 0
         for notification in group.notifications {
             guard notification.shouldSend,
-                  let trigger = group.trigger(order: order)
+                  let trigger = group.trigger(order: order, notification: notification)
             else {
                 continue
             }
             scheduleNotification(notification, trigger: trigger)
             order += 1
+        }
+        printPendingNotifications()
+    }
+
+    private func printPendingNotifications() {
+        Task {
+            print("\n---- Notification Schedule ----\n")
+            let pendingNotifications = await self.notificationCenter.pendingNotificationRequests()
+            for notificationRequest in pendingNotifications {
+                if let calendarTrigger = notificationRequest.trigger as? UNCalendarNotificationTrigger {
+                    let date = calendarTrigger.nextTriggerDate() ?? Date()
+                    print("Notification: \(notificationRequest.identifier) - \(date)\n")
+                }
+                if let intervalTrigger = notificationRequest.trigger as? UNTimeIntervalNotificationTrigger {
+                    let date = intervalTrigger.nextTriggerDate() ?? Date()
+                    print("Notification: \(notificationRequest.identifier) - \(date)\n")
+                }
+
+            }
+            print("\n---- End ----\n")
         }
     }
 
@@ -333,8 +351,6 @@ class NotificationsCoordinator {
         content.body = type.body
         content.categoryIdentifier = NotificationsHelper.NotificationsCategory.deepLink.rawValue
         content.userInfo = ["destination_url": type.link]
-
-        //let trigger = UNTimeIntervalNotificationTrigger(timeInterval: timeInterval, repeats: repeats)
 
         let request = UNNotificationRequest(identifier: type.identifier, content: content, trigger: trigger)
 

--- a/podcasts/Notifications/NotificationsCoordinator.swift
+++ b/podcasts/Notifications/NotificationsCoordinator.swift
@@ -238,8 +238,7 @@ enum NotificationsGroup: CaseIterable {
         if Self.speedUpNotifications {
             return UNTimeIntervalNotificationTrigger(timeInterval: Double(order + 1) * timeIntervalStep, repeats: notification.isRepeatable)
         }
-        let calendar = Calendar.current
-        let todayWeekday = calendar.component(.weekday, from: Date.now)
+        let calendar = Calendar.current        
         let maxWeekDays: Int = calendar.weekdaySymbols.count
         switch self {
             case .newEpisodes:

--- a/podcasts/Notifications/NotificationsCoordinator.swift
+++ b/podcasts/Notifications/NotificationsCoordinator.swift
@@ -249,11 +249,18 @@ enum NotificationsGroup: CaseIterable {
                 let timeIntervalToSchedule: TimeInterval = calculateTimeIntervalToHour(scheduleHour)
                 return UNTimeIntervalNotificationTrigger(timeInterval: timeIntervalToSchedule + (Double(order) * timeIntervalStep), repeats: notification.isRepeatable)
             case .recommendations:
-                triggerWeekDay = ((todayWeekday + (order*3)) % maxWeekDays) + 1
+                // Follow three days
+                triggerWeekDay = ((todayWeekday + ((order+1)*3)) % maxWeekDays)
             case .newFeaturesAndTips:
-                triggerWeekDay = ((todayWeekday + (order*2)) % maxWeekDays) + 1
+                // Follow two days
+                triggerWeekDay = ((todayWeekday + ((order+1)*2)) % maxWeekDays)
             case .offers:
-                triggerWeekDay = ((todayWeekday + (order)) % maxWeekDays) + 1
+                // One week from now
+                triggerWeekDay = ((todayWeekday - order - 1) % maxWeekDays)
+        }
+        
+        if triggerWeekDay == 0 {
+            triggerWeekDay += 1
         }
         let dateComponents = DateComponents(hour: scheduleHour, weekday: triggerWeekDay)
         return UNCalendarNotificationTrigger(dateMatching: dateComponents, repeats: notification.isRepeatable)

--- a/podcasts/Notifications/NotificationsCoordinator.swift
+++ b/podcasts/Notifications/NotificationsCoordinator.swift
@@ -240,7 +240,7 @@ enum NotificationsGroup: CaseIterable {
         }
         let calendar = Calendar.current
         let todayWeekday = calendar.component(.weekday, from: Date.now)
-        let maxWeekDays: Int = calendar.weekdaySymbols.count        
+        let maxWeekDays: Int = calendar.weekdaySymbols.count
         switch self {
             case .newEpisodes:
                 return nil

--- a/podcasts/Notifications/NotificationsCoordinator.swift
+++ b/podcasts/Notifications/NotificationsCoordinator.swift
@@ -247,7 +247,7 @@ enum NotificationsGroup: CaseIterable {
                 return nil
             case .dailyReminders:
                 let timeIntervalToSchedule: TimeInterval = calculateTimeIntervalToHour(scheduleHour)
-                return UNTimeIntervalNotificationTrigger(timeInterval: timeIntervalToSchedule + (Double(order + 1) * timeIntervalStep), repeats: notification.isRepeatable)
+                return UNTimeIntervalNotificationTrigger(timeInterval: timeIntervalToSchedule + (Double(order) * timeIntervalStep), repeats: notification.isRepeatable)
             case .recommendations:
                 triggerWeekDay = ((todayWeekday + (order*3)) % maxWeekDays) + 1
             case .newFeaturesAndTips:
@@ -269,10 +269,12 @@ enum NotificationsGroup: CaseIterable {
         if Self.speedUpNotifications {
             return 1
         }
-        guard let date = Calendar.current.date(bySettingHour: hour, minute: 0, second: 0, of: Date.now, matchingPolicy: .nextTime) else {
+        guard let date = Calendar.current.date(bySettingHour: hour, minute: 0, second: 0, of: Date.now, matchingPolicy: .nextTime),
+              let nextDate = Calendar.current.date(byAdding: .day, value: 1, to: date)
+        else {
             return 0
         }
-        return date.timeIntervalSince(Date.now)
+        return nextDate.timeIntervalSince(Date.now)
     }
 }
 
@@ -332,20 +334,20 @@ class NotificationsCoordinator {
 
     private func printPendingNotifications() {
         Task {
-            print("\n---- Notification Schedule ----\n")
+            FileLog.shared.addMessage("\n---- Notification Schedule ----\n")
             let pendingNotifications = await self.notificationCenter.pendingNotificationRequests()
             for notificationRequest in pendingNotifications {
                 if let calendarTrigger = notificationRequest.trigger as? UNCalendarNotificationTrigger {
                     let date = calendarTrigger.nextTriggerDate() ?? Date()
-                    print("Notification: \(notificationRequest.identifier) - \(date)\n")
+                    FileLog.shared.addMessage("Notification: \(notificationRequest.identifier) - \(date.formatted())\n")
                 }
                 if let intervalTrigger = notificationRequest.trigger as? UNTimeIntervalNotificationTrigger {
                     let date = intervalTrigger.nextTriggerDate() ?? Date()
-                    print("Notification: \(notificationRequest.identifier) - \(date)\n")
+                    FileLog.shared.addMessage("Notification: \(notificationRequest.identifier) - \(date.formatted())\n")
                 }
 
             }
-            print("\n---- End ----\n")
+            FileLog.shared.addMessage("\n---- End ----\n")
         }
     }
 

--- a/podcasts/Notifications/NotificationsCoordinator.swift
+++ b/podcasts/Notifications/NotificationsCoordinator.swift
@@ -258,7 +258,7 @@ enum NotificationsGroup: CaseIterable {
                 // One week from now
                 triggerWeekDay = ((todayWeekday - order - 1) % maxWeekDays)
         }
-        
+
         if triggerWeekDay == 0 {
             triggerWeekDay += 1
         }
@@ -338,7 +338,7 @@ class NotificationsCoordinator {
         printPendingNotifications()
     }
 
-    private func printPendingNotifications() {        
+    private func printPendingNotifications() {
         guard debugMode else {
             return
         }

--- a/podcasts/Notifications/NotificationsCoordinator.swift
+++ b/podcasts/Notifications/NotificationsCoordinator.swift
@@ -238,8 +238,9 @@ enum NotificationsGroup: CaseIterable {
         if Self.speedUpNotifications {
             return UNTimeIntervalNotificationTrigger(timeInterval: Double(order + 1) * timeIntervalStep, repeats: notification.isRepeatable)
         }
-        let todayWeekday = Calendar.current.component(.weekday, from: Date.now)
-        let maxWeekDays: Int = Calendar.current.weekdaySymbols.count
+        let calendar = Calendar.current
+        let todayWeekday = calendar.component(.weekday, from: Date.now)
+        let maxWeekDays: Int = calendar.weekdaySymbols.count
         var triggerWeekDay = todayWeekday
         switch self {
             case .newEpisodes:


### PR DESCRIPTION
| 📘 Part of: #2906  |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR updates the way we are scheduling the Notifications so that they always fall at the same hours during the weekdays.
It also refactors the code a bit to allow better customisation of the trigger for the notifications and the scheduling moving forward.

## To test
Because we cannot speed up notifications, I implemented a method that prints the current schedule for notification every time there is an update so we can check the values being set. These dates are printed on the Xcode Console

1. Start the app
2. Ensure that you have notificationRevamp FF enabled
3. Go to Profile  -> Settings -> Developer Menu 
4. Tap on the button Log Schedule in the Notification section
5. Go to Profile -> Settings -> Notifications
6. Enable and Disable the notifications and check the schedule dates.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
