### PR TITLE
Notifications track one off notifications

### DIFF
--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -233,6 +233,7 @@ struct Constants {
             static let newFeaturesAndTips = "notifications.newFeaturesAndTips"
             static let recommendations = "notifications.recommendations"
             static let offers = "notifications.offers"
+            static let triggerDates = "notifications.triggerDates"
         }
 
         enum informationalModal {

--- a/podcasts/Notifications/NotificationsCoordinator+AnalyticsAdapter.swift
+++ b/podcasts/Notifications/NotificationsCoordinator+AnalyticsAdapter.swift
@@ -5,6 +5,7 @@ extension NotificationsCoordinator: AnalyticsAdapter {
     func track(name: String, properties: [AnyHashable: Any]?) {
         for notification in NotificationsGroup.dailyReminders.notifications {
             if notification.checkCancelConditionsForEvent(name: name, properties: properties) {
+                markNotification(notification)
                 self.cancelNotification(notification)
             }
         }

--- a/podcasts/Notifications/NotificationsCoordinator.swift
+++ b/podcasts/Notifications/NotificationsCoordinator.swift
@@ -113,6 +113,9 @@ enum NotificationType: String {
     }
 
     var shouldSend: Bool {
+        if NotificationsGroup.dailyReminders.notifications.contains(self), Settings.notificationsLastTriggerDate[self.rawValue] != nil {
+            return false
+        }
         switch self {
             case .onboardingSignUp:
                 return !SyncManager.isUserLoggedIn()
@@ -325,6 +328,12 @@ class NotificationsCoordinator {
                 FileLog.shared.addMessage("[Notifications Coordinator] Error adding notification: \(error)")
             }
         }
+    }
+
+    func markNotification(_ notification: NotificationType) {
+        var notificationDates = Settings.notificationsLastTriggerDate
+        notificationDates[notification.rawValue] = Date.now
+        Settings.notificationsLastTriggerDate = notificationDates
     }
 
     func cancelNotifications(for group: NotificationsGroup) {

--- a/podcasts/Notifications/NotificationsCoordinator.swift
+++ b/podcasts/Notifications/NotificationsCoordinator.swift
@@ -113,7 +113,7 @@ enum NotificationType: String {
     }
 
     var shouldSend: Bool {
-        if NotificationsGroup.dailyReminders.notifications.contains(self), Settings.notificationsLastTriggerDate[self.rawValue] != nil {
+        if !self.isRepeatable, Settings.notificationsLastTriggerDate[self.rawValue] != nil {
             return false
         }
         switch self {

--- a/podcasts/NotificationsHelper.swift
+++ b/podcasts/NotificationsHelper.swift
@@ -116,6 +116,7 @@ class NotificationsHelper: NSObject, UNUserNotificationCenterDelegate {
         let identifier = response.notification.request.identifier
         if let type = NotificationType(rawValue: identifier) {
             properties["type"] = type.rawValue
+            NotificationsCoordinator.shared.markNotification(type)
         }
         Analytics.track(.notificationOpened, properties: properties)
 

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -1501,6 +1501,15 @@ class Settings: NSObject {
         }
     }
 
+    static var notificationsLastTriggerDate: [String: Date] {
+        get {
+            UserDefaults.standard.value(forKey: Constants.UserDefaults.notifications.triggerDates) as? [String: Date] ?? [:]
+        }
+        set {
+            UserDefaults.standard.setValue(newValue, forKey: Constants.UserDefaults.notifications.triggerDates)
+        }
+    }
+
     // MARK: - Encourage Account Creation
 
     static var hasShownInformationalViewModal: Bool {


### PR DESCRIPTION
| 📘 Part of: #2906  |  <!-- project issue number, if applicable -->
|:---:|

Fixes #3093 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR tracks the interactions with notifications to avoid sending them again when re-enabled on settins

## To test

1. Start the app
2. Ensure you have notificationsRevamp FF enabled
3. Go to Profile -> Settings -> Developer
4. Tap on Speed Up Notifications
5. Go to Profile -> Settings -> Notifications
6. Enable Daily Reminders
7. For each notification that arrives tap on it
8. When all notification arrived and you have tapped on them
9. Go to Profile -> Settings -> Notifications and disable Daily Tips and enable it again
10. Check that none of the notifications you interact with does not arrive again

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
