### PR TITLE
App clip reminder notification

### DIFF
--- a/Pocket Casts App Clip/AppClipAppDelegate.swift
+++ b/Pocket Casts App Clip/AppClipAppDelegate.swift
@@ -4,7 +4,7 @@ import UserNotifications
 
 class AppClipAppDelegate: NSObject, UIApplicationDelegate, ObservableObject {
 
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
         // This is where we register this device to recieve push notifications from Apple
         // All this function does is register the device with APNs, it doesn't set up push notifications by itself
         application.registerForRemoteNotifications()

--- a/Pocket Casts App Clip/AppClipAppDelegate.swift
+++ b/Pocket Casts App Clip/AppClipAppDelegate.swift
@@ -4,6 +4,8 @@ import UserNotifications
 
 enum AppClipNotification {
     static let appStoreNotificationID = "au.com.shiftyjelly.podcasts.prototype.Clip.reminder"
+
+    static let appAppStoreURL = "itms-apps://itunes.apple.com/app/apple-store/id414834813?mt=8"
 }
 
 class AppClipAppDelegate: NSObject, UIApplicationDelegate, ObservableObject {
@@ -30,7 +32,7 @@ extension AppClipAppDelegate: UNUserNotificationCenterDelegate {
         guard response.notification.request.identifier == AppClipNotification.appStoreNotificationID else {
             return
         }
-        guard let url = URL(string: "itms-apps://itunes.apple.com/app/apple-store/id414834813?mt=8") else {
+        guard let url = URL(string: AppClipNotification.appAppStoreURL) else {
             return
         }
         UIApplication.shared.open(url, options: [:], completionHandler: nil)

--- a/Pocket Casts App Clip/AppClipAppDelegate.swift
+++ b/Pocket Casts App Clip/AppClipAppDelegate.swift
@@ -1,0 +1,36 @@
+import Foundation
+import SwiftUI
+import UserNotifications
+
+class AppClipAppDelegate: NSObject, UIApplicationDelegate, ObservableObject {
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
+        // This is where we register this device to recieve push notifications from Apple
+        // All this function does is register the device with APNs, it doesn't set up push notifications by itself
+        application.registerForRemoteNotifications()
+
+        // Setting the notification delegate
+        UNUserNotificationCenter.current().delegate = self
+
+        return true
+    }
+
+    func application(_ application: UIApplication,
+                     didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+
+    }
+}
+
+extension AppClipAppDelegate: UNUserNotificationCenterDelegate {
+    func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse) async {
+        guard let url = URL(string: "itms-apps://itunes.apple.com/app/apple-store/id414834813?mt=8") else {
+            return
+        }
+        UIApplication.shared.open(url, options: [:], completionHandler: nil)
+    }
+
+    // This function allows us to view notifications in the app even with it in the foreground
+    func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification) async -> UNNotificationPresentationOptions {
+        return [.badge, .banner, .list, .sound]
+    }
+}

--- a/Pocket Casts App Clip/AppClipAppDelegate.swift
+++ b/Pocket Casts App Clip/AppClipAppDelegate.swift
@@ -2,6 +2,10 @@ import Foundation
 import SwiftUI
 import UserNotifications
 
+enum AppClipNotification {
+    static let appStoreNotificationID = "au.com.shiftyjelly.podcasts.prototype.Clip.reminder"
+}
+
 class AppClipAppDelegate: NSObject, UIApplicationDelegate, ObservableObject {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
@@ -23,6 +27,9 @@ class AppClipAppDelegate: NSObject, UIApplicationDelegate, ObservableObject {
 
 extension AppClipAppDelegate: UNUserNotificationCenterDelegate {
     func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse) async {
+        guard response.notification.request.identifier == AppClipNotification.appStoreNotificationID else {
+            return
+        }
         guard let url = URL(string: "itms-apps://itunes.apple.com/app/apple-store/id414834813?mt=8") else {
             return
         }

--- a/Pocket Casts App Clip/Info.plist
+++ b/Pocket Casts App Clip/Info.plist
@@ -5,7 +5,7 @@
 	<key>NSAppClip</key>
 	<dict>
 		<key>NSAppClipRequestEphemeralUserNotification</key>
-		<false/>
+		<true/>
 		<key>NSAppClipRequestLocationConfirmation</key>
 		<false/>
 	</dict>

--- a/Pocket Casts App Clip/NowPlayingView.swift
+++ b/Pocket Casts App Clip/NowPlayingView.swift
@@ -169,10 +169,10 @@ struct NowPlayingView: View {
                     return
                 }
                 let content = UNMutableNotificationContent()
-                content.title = "Ready for more podcasts?"
-                content.body = "Install Pocket Casts to get the full experience with powerful playback and customization tools."
+                content.title = L10n.notificationsAppClipTitle
+                content.body = L10n.notificationsAppClipBody
                 let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 4.hours, repeats: false)
-                let request = UNNotificationRequest(identifier: "au.com.shiftyjelly.podcasts.prototype.Clip", content: content, trigger: trigger)
+                let request = UNNotificationRequest(identifier: "au.com.shiftyjelly.podcasts.prototype.Clip.reminder", content: content, trigger: trigger)
                 try await notificationCenter.add(request)
             } catch {
                 FileLog.shared.addMessage("App Clip: Notification Sending Error - \(error)")

--- a/Pocket Casts App Clip/NowPlayingView.swift
+++ b/Pocket Casts App Clip/NowPlayingView.swift
@@ -3,6 +3,7 @@ import PocketCastsDataModel
 import PocketCastsServer
 import StoreKit
 import PocketCastsUtils
+import UserNotifications
 
 struct NowPlayingView: View {
 
@@ -30,6 +31,7 @@ struct NowPlayingView: View {
                         DispatchQueue.main.asyncAfter(deadline: .now() + 10) {
                             presentAppStoreOverlay = true
                         }
+                        scheduleNotification()
                     }
             case .failed:
                 errorView
@@ -154,6 +156,28 @@ struct NowPlayingView: View {
                 }
             }
         })
+    }
+
+    private func scheduleNotification() {
+        let notificationCenter = UNUserNotificationCenter.current()
+        Task {
+            do {
+                let granted = try await notificationCenter.requestAuthorization(options: [.alert, .sound, .badge])
+                guard granted else {
+                    let settings = await notificationCenter.notificationSettings()
+                    FileLog.shared.addMessage("App Clip: Notification status: \(settings.authorizationStatus)")
+                    return
+                }
+                let content = UNMutableNotificationContent()
+                content.title = "Ready for more podcasts?"
+                content.body = "Install Pocket Casts to get the full experience with powerful playback and customization tools."
+                let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 4.hours, repeats: false)
+                let request = UNNotificationRequest(identifier: "au.com.shiftyjelly.podcasts.prototype.Clip", content: content, trigger: trigger)
+                try await notificationCenter.add(request)
+            } catch {
+                FileLog.shared.addMessage("App Clip: Notification Sending Error - \(error)")
+            }
+        }
     }
 }
 

--- a/Pocket Casts App Clip/NowPlayingView.swift
+++ b/Pocket Casts App Clip/NowPlayingView.swift
@@ -172,7 +172,7 @@ struct NowPlayingView: View {
                 content.title = L10n.notificationsAppClipTitle
                 content.body = L10n.notificationsAppClipBody
                 let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 4.hours, repeats: false)
-                let request = UNNotificationRequest(identifier: "au.com.shiftyjelly.podcasts.prototype.Clip.reminder", content: content, trigger: trigger)
+                let request = UNNotificationRequest(identifier: AppClipNotification.appStoreNotificationID, content: content, trigger: trigger)
                 try await notificationCenter.add(request)
             } catch {
                 FileLog.shared.addMessage("App Clip: Notification Sending Error - \(error)")

--- a/Pocket Casts App Clip/Pocket_Casts_App_ClipApp.swift
+++ b/Pocket Casts App Clip/Pocket_Casts_App_ClipApp.swift
@@ -4,6 +4,9 @@ import AutomatticTracks
 
 @main
 struct Pocket_Casts_App_ClipApp: App {
+
+    @UIApplicationDelegateAdaptor private var appDelegate: AppClipAppDelegate
+
     init() {
         ServerConfig.shared.syncDelegate = ServerSyncManager.shared
         ServerConfig.shared.playbackDelegate = PlaybackManager.shared

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -2043,6 +2043,7 @@
 		FFC293992B6173400059F3BB /* IAPTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFC293982B6173400059F3BB /* IAPTypes.swift */; };
 		FFD044192C4FE9F400CCB192 /* TranscriptModelFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFD044182C4FE9F400CCB192 /* TranscriptModelFilterTests.swift */; };
 		FFD3AB8C2BD15E8F00C562CB /* CircleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFD3AB8B2BD15E8F00C562CB /* CircleView.swift */; };
+		FFDE41A32DD201AE0065ADDE /* AppClipAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFDE41A22DD201A40065ADDE /* AppClipAppDelegate.swift */; };
 		FFE794DD2DA443FF005E4D40 /* NotificationsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFE794DC2DA443F8005E4D40 /* NotificationsCoordinator.swift */; };
 		FFF024CE2B62AC9400457373 /* IAPHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFF024CD2B62AC9400457373 /* IAPHelperTests.swift */; };
 		FFF024CF2B62B13A00457373 /* Pocket Casts Configuration.storekit in Resources */ = {isa = PBXBuildFile; fileRef = C7547F77286F571900DC1C9E /* Pocket Casts Configuration.storekit */; };
@@ -4113,6 +4114,7 @@
 		FFC293982B6173400059F3BB /* IAPTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IAPTypes.swift; sourceTree = "<group>"; };
 		FFD044182C4FE9F400CCB192 /* TranscriptModelFilterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TranscriptModelFilterTests.swift; sourceTree = "<group>"; };
 		FFD3AB8B2BD15E8F00C562CB /* CircleView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CircleView.swift; sourceTree = "<group>"; };
+		FFDE41A22DD201A40065ADDE /* AppClipAppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppClipAppDelegate.swift; sourceTree = "<group>"; };
 		FFE794DC2DA443F8005E4D40 /* NotificationsCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsCoordinator.swift; sourceTree = "<group>"; };
 		FFF024CD2B62AC9400457373 /* IAPHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IAPHelperTests.swift; sourceTree = "<group>"; };
 		FFF17EC32B97930700E116C8 /* BookmarksProfileListController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksProfileListController.swift; sourceTree = "<group>"; };
@@ -8440,6 +8442,7 @@
 		F5D5F7B72CEBE7CE001F492D /* Pocket Casts App Clip */ = {
 			isa = PBXGroup;
 			children = (
+				FFDE41A22DD201A40065ADDE /* AppClipAppDelegate.swift */,
 				F5F5092E2CEBEF59007D6E39 /* app-clip-Bridging-Header.h */,
 				F5D5F7B12CEBE7CE001F492D /* Preview Content */,
 				F5D5F7B22CEBE7CE001F492D /* Assets.xcassets */,
@@ -11335,6 +11338,7 @@
 				9A11FCB22D94171B00A1EF3E /* AnonymousIdentifiable.swift in Sources */,
 				F5F509122CEBEBD6007D6E39 /* AnalyticsPlaybackHelper.swift in Sources */,
 				F5F509452CEBF2E2007D6E39 /* ShelfLoadState.swift in Sources */,
+				FFDE41A32DD201AE0065ADDE /* AppClipAppDelegate.swift in Sources */,
 				F5F508F12CEBE955007D6E39 /* RegionCancellingScrollView.swift in Sources */,
 				F5F5091D2CEBECB2007D6E39 /* EpisodeManager.swift in Sources */,
 				F5F5091C2CEBEC99007D6E39 /* DefaultPlayer.swift in Sources */,

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -1798,6 +1798,10 @@ internal enum L10n {
   internal static var `none`: String { return L10n.tr("Localizable", "none") }
   /// You're not on WiFi
   internal static var notOnWifi: String { return L10n.tr("Localizable", "not_on_wifi") }
+  /// Install Pocket Casts to get the full experience with powerful playback and customization tools.
+  internal static var notificationsAppClipBody: String { return L10n.tr("Localizable", "notifications_app_clip_body") }
+  /// Ready for more podcasts?
+  internal static var notificationsAppClipTitle: String { return L10n.tr("Localizable", "notifications_app_clip_title") }
   /// Daily Reminders
   internal static var notificationsDailyReminders: String { return L10n.tr("Localizable", "notifications_daily_reminders") }
   /// Try Plus and automatically organize your shows with folders.

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -5070,7 +5070,11 @@
 /* Notification body for recommendations you might like message */
 "notifications_recommendations_you_might_like_body" = "Wondering what to listen to next? Check out these shows!";
 
+/* Notification title for App Clip reminder*/
+"notifications_app_clip_title" = "Ready for more podcasts?";
 
+/* Notification body for App Clip reminder*/
+"notifications_app_clip_body" = "Install Pocket Casts to get the full experience with powerful playback and customization tools.";
 
 /* Notifications permissions screen title text*/
 "notifications_permissions_title" = "Stay up to date!";


### PR DESCRIPTION
| 📘 Part of: #2906  |  <!-- project issue number, if applicable -->
|:---:|

Fixes #3069  <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR adds a notification sending for 4 hours after opening the app clip to remind the users to install the full app.

## To test

Before compiling [update the timing of the notification](https://github.com/Automattic/pocket-casts-ios/pull/3095#pullrequestreview-2832716985) to a shorter interval to make it easier to test.

1. Start the App Clip scheme on a real device
2. Wait for the time you see and see if the notification shows up
3. Tap on the notification
4. Check if the app store opens in the Pocket Casts page

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
