### PR TITLE
Fix loading for Recommendation items in Discover

### DIFF
--- a/podcasts/DiscoverCollectionViewController.swift
+++ b/podcasts/DiscoverCollectionViewController.swift
@@ -125,10 +125,12 @@ class DiscoverCollectionViewController: PCViewController {
                 if itemFilter(item) {
                     if item.authenticated == true, let uuid = item.uuid {
                         snapshot.appendItems([.loading(uuid)])
-                        loadingTasks[uuid] = Task {
-                            let isAuthenticated = await checkSourceAuthentication(for: item)
-                            guard Task.isCancelled else { return }
+                        loadingTasks[uuid] = Task { [weak self] in
+                            guard let self, !Task.isCancelled else { return }
+                            let isAuthenticated = await self.checkSourceAuthentication(for: item)
+                            guard !Task.isCancelled else { return }
                             self.updateItemInSnapshot(item: item, isAuthenticated: isAuthenticated, region: currentRegion, selectedCategory: selectedCategory)
+                            self.loadingTasks.removeValue(forKey: uuid)
                         }
                     } else {
                         snapshot.appendItems([.item(.init(item: item, region: currentRegion, selectedCategory: selectedCategory))])


### PR DESCRIPTION
| 📘 Part of: #2989 |
|:---:|

When switching between categories, the Recommendation items in Discover were getting stuck loading.

| Before | After |
|--|--|
| <video src="https://github.com/user-attachments/assets/e8a24106-9027-4fed-8a2b-11e31c9aaa5f"> | <video src="https://github.com/user-attachments/assets/c3f42546-d249-4da6-b461-fc3704aa2cac"> |

## To test

* Log in to an account with some playback history so recommendations work
* Visit the Discover page
* Scroll down until you see a Recommended section
* Scroll and switch categories
* Close the Category
* Scroll down and check the Recommended section again

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
