### PR TITLE
Add reengagement downloads notification

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -9830,13 +9830,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-podcasts/Pods-podcasts-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-podcasts/Pods-podcasts-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -9869,13 +9865,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-PocketCastsTests/Pods-PocketCastsTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-PocketCastsTests/Pods-PocketCastsTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/podcasts/AppDelegate+UrlHandling.swift
+++ b/podcasts/AppDelegate+UrlHandling.swift
@@ -446,12 +446,14 @@ extension AppDelegate {
     }
 
     func setupProfileRoutes() {
-        JLRoutes.global().addRoute("/profile/downloads") {[weak self] parameters -> Bool in
-            guard self != nil
+        JLRoutes.global().addRoute("/profile/*") {[weak self] parameters -> Bool in
+            guard self != nil,
+                  let pathComponents = parameters[JLRouteWildcardComponentsKey] as? [String],
+                  let row = pathComponents.first
             else {
                 return false
             }
-            NavigationManager.sharedManager.navigateTo(NavigationManager.settingsProfileKey, data: [:])
+            NavigationManager.sharedManager.navigateTo(NavigationManager.settingsProfileKey, data: [NavigationManager.profileRowKey: row])
             return true
         }
     }

--- a/podcasts/AppDelegate+UrlHandling.swift
+++ b/podcasts/AppDelegate+UrlHandling.swift
@@ -446,7 +446,7 @@ extension AppDelegate {
     }
 
     func setupProfileRoutes() {
-        JLRoutes.global().addRoute("/profile/*") {[weak self] parameters -> Bool in
+        JLRoutes.global().addRoute("/profile/*") { [weak self] parameters -> Bool in
             guard self != nil,
                   let pathComponents = parameters[JLRouteWildcardComponentsKey] as? [String],
                   let row = pathComponents.first

--- a/podcasts/AppDelegate+UrlHandling.swift
+++ b/podcasts/AppDelegate+UrlHandling.swift
@@ -397,6 +397,7 @@ extension AppDelegate {
 
         setupOnboardingRoutes()
         setupNewFeaturesRoutes()
+        setupProfileRoutes()
     }
 
     func setupOnboardingRoutes() {
@@ -440,6 +441,17 @@ extension AppDelegate {
                 return false
             }
             NavigationManager.sharedManager.navigateTo(NavigationManager.featurePageKey, data: [NavigationManager.featureKey: feature])
+            return true
+        }
+    }
+
+    func setupProfileRoutes() {
+        JLRoutes.global().addRoute("/profile/downloads") {[weak self] parameters -> Bool in
+            guard self != nil
+            else {
+                return false
+            }
+            NavigationManager.sharedManager.navigateTo(NavigationManager.settingsProfileKey, data: [:])
             return true
         }
     }

--- a/podcasts/MainTabBarController+shortcuts.swift
+++ b/podcasts/MainTabBarController+shortcuts.swift
@@ -77,7 +77,7 @@ extension MainTabBarController {
     }
 
     @objc private func handleProfile() {
-        navigateToProfile(true)
+        navigateToProfile(animated: true)
     }
 
     @objc private func handleDecreaseSpeed() {

--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -365,8 +365,17 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
         switchToTab(.upNext)
     }
 
-    func navigateToProfile(_ animated: Bool) {
+    func navigateToProfile(row: ProfileViewController.TableRow? = nil, animated: Bool) {
         switchToTab(.profile)
+        guard let navController = selectedViewController as? UINavigationController else {
+            return
+        }
+        navController.popToRootViewController(animated: animated)
+        guard let profileViewController = navController.topViewController as? ProfileViewController,
+            let row else {
+            return
+        }
+        profileViewController.navigateToRow(row)
     }
 
     func navigateToFilter(_ filter: EpisodeFilter?, animated: Bool) {

--- a/podcasts/NavigationManager.swift
+++ b/podcasts/NavigationManager.swift
@@ -60,6 +60,7 @@ class NavigationManager {
     static let settingsAppearanceKey = "appearancePage"
     static let settingsAppearanceShowThemeKey = "appearanceShowThemeKey"
     static let settingsProfileKey = "profilePage"
+    static let profileRowKey = "profileRow"
     static let settingsHeadphoneKey = "headphoneSettings"
     static let settingsRedeemGuestPassKey = "redeemGuestPassPage"
     static let redeemGuestPassURLKey = "redeemGuestPassURLKey"
@@ -190,7 +191,7 @@ class NavigationManager {
             }
             mainController?.showSettingsAppearance(showThemeSelection: showThemeSelection)
         } else if place == NavigationManager.settingsProfileKey {
-            mainController?.showProfilePage()
+            navigateToProfile(data: data, animated: animated)
         }
         else if place == NavigationManager.settingsHeadphoneKey {
             mainController?.showHeadphoneSettings()
@@ -269,6 +270,15 @@ class NavigationManager {
         }
         if feature == "suggestedFolders" {
             mainController?.navigateToSuggestedFolders()
+        }
+    }
+
+    func navigateToProfile(data: NSDictionary?, animated: Bool) {
+        guard let row = data?[NavigationManager.profileRowKey] as? String else {
+            return
+        }
+        if row == "downloads" {
+            mainController?.navigateToProfile(row: .downloaded, animated: animated)
         }
     }
 

--- a/podcasts/NavigationManager.swift
+++ b/podcasts/NavigationManager.swift
@@ -61,6 +61,7 @@ class NavigationManager {
     static let settingsAppearanceShowThemeKey = "appearanceShowThemeKey"
     static let settingsProfileKey = "profilePage"
     static let profileRowKey = "profileRow"
+    static let profileRowDownloadsKey = "downloads"
     static let settingsHeadphoneKey = "headphoneSettings"
     static let settingsRedeemGuestPassKey = "redeemGuestPassPage"
     static let redeemGuestPassURLKey = "redeemGuestPassURLKey"
@@ -277,7 +278,7 @@ class NavigationManager {
         guard let row = data?[NavigationManager.profileRowKey] as? String else {
             return
         }
-        if row == "downloads" {
+        if row == NavigationManager.profileRowDownloadsKey {
             mainController?.navigateToProfile(row: .downloaded, animated: animated)
         }
     }

--- a/podcasts/NavigationProtocol.swift
+++ b/podcasts/NavigationProtocol.swift
@@ -18,7 +18,7 @@ protocol NavigationProtocol: AnyObject {
     func navigateToDiscover(category: String, animated: Bool)
     func navigateToDiscover(listID: String, animated: Bool)
 
-    func navigateToProfile(_ animated: Bool)
+    func navigateToProfile(row: ProfileViewController.TableRow?, animated: Bool)
 
     func navigateToFilter(_ filter: EpisodeFilter?, animated: Bool)
     func navigateToEditFilter(_ filter: EpisodeFilter)

--- a/podcasts/Notifications/NotificationsCoordinator+AnalyticsAdapter.swift
+++ b/podcasts/Notifications/NotificationsCoordinator+AnalyticsAdapter.swift
@@ -3,14 +3,18 @@ import Foundation
 extension NotificationsCoordinator: AnalyticsAdapter {
 
     func track(name: String, properties: [AnyHashable: Any]?) {
+        updateDailyReminders(name: name, properties: properties)
+        updateReEngagementNotifications(name: name, properties: properties)
+        updateRecommendationNotifications(name: name, properties: properties)
+    }
+
+    func updateDailyReminders(name: String, properties: [AnyHashable: Any]?) {
         for notification in NotificationsGroup.dailyReminders.notifications {
             if notification.checkCancelConditionsForEvent(name: name, properties: properties) {
                 markNotification(notification)
                 self.cancelNotification(notification)
             }
         }
-        updateReEngagementNotifications(name: name, properties: properties)
-        updateRecommendationNotifications(name: name, properties: properties)
     }
 
     func updateReEngagementNotifications(name: String, properties: [AnyHashable: Any]?) {
@@ -18,9 +22,12 @@ extension NotificationsCoordinator: AnalyticsAdapter {
             return
         }
         // Check if need to cancel an existing notification
-        if NotificationType.reengagementWeekly.checkCancelConditionsForEvent(name: name, properties: properties) {
-            self.cancelNotification(.reengagementWeekly)
+        for notification in NotificationsGroup.newFeaturesAndTips.notifications {
+            if notification.checkCancelConditionsForEvent(name: name, properties: properties) {
+                cancelNotification(notification)
+            }
         }
+
         let event: AnalyticsEvent = .applicationClosed
         if event.rawValue.toSnakeCaseFromCamelCase() == name {
             updateNotifications(for: .newFeaturesAndTips)

--- a/podcasts/Notifications/NotificationsCoordinator+AnalyticsAdapter.swift
+++ b/podcasts/Notifications/NotificationsCoordinator+AnalyticsAdapter.swift
@@ -68,6 +68,8 @@ extension NotificationType {
             possibleConditions = [.purchaseSuccessful]
         case .newFeatureSuggestedFolders:
             possibleConditions = [.suggestedFoldersPageShown]
+        case .reengagementDownloads:
+            possibleConditions = [.downloadsShown]
         }
         let eventMatch = possibleConditions.contains {
             $0.rawValue.toSnakeCaseFromCamelCase() == name

--- a/podcasts/Notifications/NotificationsCoordinator.swift
+++ b/podcasts/Notifications/NotificationsCoordinator.swift
@@ -72,7 +72,7 @@ enum NotificationType: String {
         case .reengagementWeekly:
             return L10n.notificationsReengagementWeeklyBody
         case .reengagementDownloads:
-            return L10n.notificationsReengagementDownloadsTitle
+                return L10n.notificationsReengagementDownloadsBody(NotificationsCoordinator.shared.numberOfDownloadsAvailable())
         case .recommendationsTrending:
             return L10n.notificationsRecommendationsTrendingBody
         case .recommendationsYouMightLike:
@@ -132,6 +132,8 @@ enum NotificationType: String {
                 return SyncManager.isUserLoggedIn()
             case .newFeatureSuggestedFolders:
                 return Settings.suggestedFoldersUpsellCount < 2 && Settings.appVersion() == "7.88"
+            case .reengagementDownloads:
+                return NotificationsCoordinator.shared.numberOfDownloadsAvailable() > 0
             default:
                 return true
         }
@@ -140,6 +142,7 @@ enum NotificationType: String {
     var isRepeatable: Bool {
         switch self {
             case .reengagementWeekly,
+                 .reengagementDownloads,
                  .recommendationsTrending,
                  .recommendationsYouMightLike,
                  .upsell:
@@ -168,7 +171,7 @@ enum NotificationsGroup: CaseIterable {
             case .recommendations:
                 return [.recommendationsTrending, .recommendationsYouMightLike]
             case .newFeaturesAndTips:
-                return [.newFeatureSuggestedFolders, .reengagementWeekly]
+                return [.newFeatureSuggestedFolders, .reengagementWeekly, .reengagementDownloads]
             case .offers:
                 return [.upsell]
         }
@@ -359,5 +362,15 @@ class NotificationsCoordinator {
             return 0
         }
         return date.timeIntervalSince(Date.now)
+    }
+
+    private lazy var episodesDataManager: EpisodesDataManager = {
+        return EpisodesDataManager()
+    }()
+
+    func numberOfDownloadsAvailable() -> Int {
+        episodesDataManager.downloadedEpisodes().reduce(0) { partialResult, list in
+            return partialResult + list.elements.count
+        }
     }
 }

--- a/podcasts/Notifications/NotificationsCoordinator.swift
+++ b/podcasts/Notifications/NotificationsCoordinator.swift
@@ -14,6 +14,7 @@ enum NotificationType: String {
     case onboardingUpsell
 
     case reengagementWeekly
+    case reengagementDownloads
 
     case recommendationsTrending
     case recommendationsYouMightLike
@@ -39,6 +40,8 @@ enum NotificationType: String {
             return L10n.notificationsOnboardingStaffPicksTitle
         case .reengagementWeekly:
             return L10n.notificationsReengagementWeeklyTitle
+        case .reengagementDownloads:
+                return L10n.notificationsReengagementDownloadsTitle
         case .recommendationsTrending:
             return L10n.notificationsRecommendationsTrendingTitle
         case .recommendationsYouMightLike:
@@ -68,6 +71,8 @@ enum NotificationType: String {
             return L10n.notificationsOnboardingStaffPicksBody
         case .reengagementWeekly:
             return L10n.notificationsReengagementWeeklyBody
+        case .reengagementDownloads:
+            return L10n.notificationsReengagementDownloadsTitle
         case .recommendationsTrending:
             return L10n.notificationsRecommendationsTrendingBody
         case .recommendationsYouMightLike:
@@ -101,6 +106,8 @@ enum NotificationType: String {
             return "pktc://discover/staff-picks"
         case .reengagementWeekly:
             return "pktc://discover"
+        case .reengagementDownloads:
+            return "pktc://profile/downloads"
         case .recommendationsTrending:
             return "pktc://discover/trending"
         case .recommendationsYouMightLike:

--- a/podcasts/ProfileViewController.swift
+++ b/podcasts/ProfileViewController.swift
@@ -40,7 +40,7 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
     private let settingsCellId = "SettingsCell"
     private let endOfYearPromptCell = "EndOfYearPromptCell"
 
-    private enum TableRow { case informationalBanner, kidsProfile, referralsClaim, allStats, downloaded, starred, listeningHistory, help, uploadedFiles, endOfYearPrompt, bookmarks }
+    enum TableRow { case informationalBanner, kidsProfile, referralsClaim, allStats, downloaded, starred, listeningHistory, help, uploadedFiles, endOfYearPrompt, bookmarks }
 
     lazy private var informationalBannerCoordinator: InformationalBannerViewCoordinator = {
         let viewModel = InformationalBannerViewModel(bannerType: .profile)
@@ -371,13 +371,17 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
         tableView.deselectRow(at: indexPath, animated: true)
 
         let row = tableData[indexPath.section][indexPath.row]
+        navigateToRow(row)
+    }
+
+    func navigateToRow(_ row: TableRow) {
         switch row {
         case .kidsProfile, .informationalBanner:
             break
         case .referralsClaim:
             dismiss(animated: true)
-            ReferralsCoordinator.shared.startClaimFlow(from: self) {
-                tableView.reloadData()
+            ReferralsCoordinator.shared.startClaimFlow(from: self) { [weak self] in
+                self?.profileTable.reloadData()
             }
         case .allStats:
             let statsViewController = StatsViewController()

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -1864,6 +1864,12 @@ internal enum L10n {
   internal static var notificationsRecommendationsYouMightLikeBody: String { return L10n.tr("Localizable", "notifications_recommendations_you_might_like_body") }
   /// New recommendations for you
   internal static var notificationsRecommendationsYouMightLikeTitle: String { return L10n.tr("Localizable", "notifications_recommendations_you_might_like_title") }
+  /// You have %1$@ new episodes downloaded and ready to go!
+  internal static func notificationsReengagementDownloadsBody(_ p1: Any) -> String {
+    return L10n.tr("Localizable", "notifications_reengagement_downloads_body", String(describing: p1))
+  }
+  /// Catch up offline
+  internal static var notificationsReengagementDownloadsTitle: String { return L10n.tr("Localizable", "notifications_reengagement_downloads_title") }
   /// It’s been awhile since you’ve listened. Jump back in and enjoy!
   internal static var notificationsReengagementWeeklyBody: String { return L10n.tr("Localizable", "notifications_reengagement_weekly_body") }
   /// We miss you!

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -5089,3 +5089,9 @@
 
 /* Text used for the "Learn more" link in the modal explaining Creator Picks */
 "creator_pick_modal_learn_more" = "Learn more";
+
+/* Notification title for reengagement downloads */
+"notifications_reengagement_downloads_title" = "Catch up offline";
+
+/* Notification body for reengagement downloads. %1$@ argument is the numbers of episodes downloaded */
+"notifications_reengagement_downloads_body" = "You have %1$@ new episodes downloaded and ready to go!";

--- a/scripts/notifications/reengagement_downloads.apns
+++ b/scripts/notifications/reengagement_downloads.apns
@@ -1,0 +1,11 @@
+{
+  "Simulator Target Bundle": "au.com.shiftyjelly.podcasts",
+  "aps": {
+    "alert": {
+      "title": "Catch up offline",
+      "body": "You have 3 new episodes downloaded and ready to go!"
+    },
+    "category": "DEEP_LINK"
+  },
+  "destination_url": "pktc://profile/downloads"
+}


### PR DESCRIPTION
| 📘 Part of: #2906  |  <!-- project issue number, if applicable -->
|:---:|

Fixes #3013 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

## To test

1. Start the app
2. Ensure you have notificationsRevamp FF enabled
3. Check that you have at least 1 episode downloaded on Profile -> Downloads
4. Open Profile -> Settings -> Developer
5. Tap on Speed Up Notifications
6. Open Profile -> Settings -> Notifications
7. Toggle Off then On the New Features and Tips notifications
8. Exit the app
9. Wait for two minutes to see if you see the downloads notification show up
10. Tap on the notification
11. Check if the downloads page opens

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
