### PR TITLE
Add a gradient to the overlay

### DIFF
--- a/podcasts/GeneratedTranscriptsPremiumOverlay.swift
+++ b/podcasts/GeneratedTranscriptsPremiumOverlay.swift
@@ -1,4 +1,5 @@
 import UIKit
+import PocketCastsUtils
 import PocketCastsServer
 
 class GeneratedTranscriptsPremiumOverlay: UIViewController {
@@ -73,6 +74,13 @@ class GeneratedTranscriptsPremiumOverlay: UIViewController {
         return blurEffectView
     }()
 
+    private let gradientColor = PlayerColorHelper.playerBackgroundColor01()
+    private lazy var topGradient: GradientView = {
+        let gradientView = GradientView(firstColor: gradientColor, secondColor: gradientColor.withAlphaComponent(0))
+        gradientView.translatesAutoresizingMaskIntoConstraints = false
+        return gradientView
+    }()
+
     init(playbackManager: PlaybackManager) {
         self.playbackManager = playbackManager
         super.init(nibName: nil, bundle: nil)
@@ -101,6 +109,7 @@ class GeneratedTranscriptsPremiumOverlay: UIViewController {
         view.backgroundColor = PlayerColorHelper.playerBackgroundColor01().withAlphaComponent(0.45)
 
         view.addSubview(blurEffectView)
+        view.addSubview(topGradient)
 
         view.addSubview(stackView)
         view.addSubview(badge)
@@ -119,6 +128,10 @@ class GeneratedTranscriptsPremiumOverlay: UIViewController {
                 blurEffectView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
                 blurEffectView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
                 blurEffectView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+                topGradient.topAnchor.constraint(equalTo: view.topAnchor),
+                topGradient.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+                topGradient.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+                topGradient.bottomAnchor.constraint(equalTo: view.centerYAnchor, constant: 100.0),
                 stackView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
                 stackView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 12),
                 stackView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -16),


### PR DESCRIPTION
Ref # p1746810260506059-Slack-C029BMLUGRX

This PR adds a gradient to the overlay in the Generated Transcript view

| Before | After |
| -------- | ------- |
| ![IMG_0128](https://github.com/user-attachments/assets/a3c31aea-0cbb-41d9-8ca6-9ff8a47f1958) | ![IMG_0127](https://github.com/user-attachments/assets/32b844a1-6fe7-41ba-9d62-2b13cedfa652) |


## To test

- Run this branch with a non plus user
- Play an episode from a podcast with Generated transcript, for example The Rest is History
- Confirm there's the gradient

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
