### PR TITLE
Use StoreKit 2 to check eligibility

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -179,6 +179,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// Recommendations including discover v3 support
     case recommendations
 
+    /// Ignore server IAP check
+    case newOfferEligibilityCheck
+
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -302,6 +305,8 @@ public enum FeatureFlag: String, CaseIterable {
         case .podcastsSortChanges:
             true
         case .recommendations:
+            true
+        case .newOfferEligibilityCheck:
             true
         }
     }

--- a/podcasts/IAPHelper.swift
+++ b/podcasts/IAPHelper.swift
@@ -391,6 +391,7 @@ extension IAPHelper {
         guard
             isCheckingEligibility == false,
             let productID = getFirstFreeTrialProductId(),
+            SubscriptionHelper.hasActiveSubscription() == false || FeatureFlag.newOfferEligibilityCheck.enabled,
             let receiptUrl = Bundle.main.appStoreReceiptURL,
             let receiptString = try? Data(contentsOf: receiptUrl).base64EncodedString()
         else {
@@ -432,7 +433,9 @@ extension IAPHelper {
 extension IAPHelper: SKPaymentTransactionObserver {
     func purchaseWasSuccessful(_ productId: IAPProductID) {
         trackPaymentEvent(.purchaseSuccessful, productId: productId)
-        updateTrialEligibility()
+        if FeatureFlag.newOfferEligibilityCheck.enabled {
+            updateTrialEligibility()
+        }
     }
 
     func purchaseWasCancelled(_ productId: IAPProductID, error: NSError) {

--- a/podcasts/IAPHelper.swift
+++ b/podcasts/IAPHelper.swift
@@ -366,6 +366,21 @@ private extension IAPHelper {
         }
     }
 
+    private func checkTrialEligibility(for productID: IAPProductID) async -> Bool? {
+        guard let products = try? await Product.products(for: [productID.rawValue]) else {
+            return nil
+        }
+        guard let product = products.first, let renewableSubscription = product.subscription else {
+            // No renewable subscription is available for this product.
+            return false
+        }
+        if await renewableSubscription.isEligibleForIntroOffer {
+            // The product is eligible for an introductory offer.
+            return  true
+        }
+        return false
+    }
+
     /// Update the trial eligibility if:
     /// - We are not already performing a check
     /// - The feature flag is enabled
@@ -375,7 +390,7 @@ private extension IAPHelper {
     private func updateTrialEligibility() {
         guard
             isCheckingEligibility == false,
-            getFirstFreeTrialProductId() != nil,
+            let productID = getFirstFreeTrialProductId(),
             SubscriptionHelper.hasActiveSubscription() == false,
             let receiptUrl = Bundle.main.appStoreReceiptURL,
             let receiptString = try? Data(contentsOf: receiptUrl).base64EncodedString()
@@ -384,12 +399,22 @@ private extension IAPHelper {
         }
 
         isCheckingEligibility = true
-        networking.checkTrialEligibility(receiptString) { [weak self] isEligible in
-            let eligible = isEligible ?? Constants.Values.offerEligibilityDefaultValue
+        if FeatureFlag.newOfferEligibilityCheck.enabled {
+            Task {
+                let isEligible = await self.checkTrialEligibility(for: productID)
+                let eligible = isEligible ?? Constants.Values.offerEligibilityDefaultValue
+                FileLog.shared.addMessage("Refreshed Trial Eligibility: \(eligible ? "Yes" : "No")")
+                isEligibleForOffer = eligible
+                isCheckingEligibility = false
+            }
+        } else {
+            networking.checkTrialEligibility(receiptString) { [weak self] isEligible in
+                let eligible = isEligible ?? Constants.Values.offerEligibilityDefaultValue
 
-            FileLog.shared.addMessage("Refreshed Trial Eligibility: \(eligible ? "Yes" : "No")")
-            self?.isEligibleForOffer = eligible
-            self?.isCheckingEligibility = false
+                FileLog.shared.addMessage("Refreshed Trial Eligibility: \(eligible ? "Yes" : "No")")
+                self?.isEligibleForOffer = eligible
+                self?.isCheckingEligibility = false
+            }
         }
     }
 }

--- a/podcasts/IAPHelper.swift
+++ b/podcasts/IAPHelper.swift
@@ -391,7 +391,6 @@ extension IAPHelper {
         guard
             isCheckingEligibility == false,
             let productID = getFirstFreeTrialProductId(),
-            SubscriptionHelper.hasActiveSubscription() == false,
             let receiptUrl = Bundle.main.appStoreReceiptURL,
             let receiptString = try? Data(contentsOf: receiptUrl).base64EncodedString()
         else {

--- a/podcasts/IAPHelper.swift
+++ b/podcasts/IAPHelper.swift
@@ -357,7 +357,7 @@ extension IAPHelper {
 
 // MARK: - Trial Eligibility
 
-private extension IAPHelper {
+extension IAPHelper {
     /// Listens for subscription changes
     private func addSubscriptionNotifications() {
         NotificationCenter.default.addObserver(forName: ServerNotifications.subscriptionStatusChanged, object: nil, queue: .main) { [weak self] _ in
@@ -387,7 +387,7 @@ private extension IAPHelper {
     /// - A product has a free trial
     /// - The user doesn't have an active subscription
     /// - The receipt exists
-    private func updateTrialEligibility() {
+    func updateTrialEligibility(completion: (() -> ())? = nil) {
         guard
             isCheckingEligibility == false,
             let productID = getFirstFreeTrialProductId(),
@@ -395,6 +395,9 @@ private extension IAPHelper {
             let receiptUrl = Bundle.main.appStoreReceiptURL,
             let receiptString = try? Data(contentsOf: receiptUrl).base64EncodedString()
         else {
+            DispatchQueue.main.async {
+                completion?()
+            }
             return
         }
 
@@ -406,6 +409,9 @@ private extension IAPHelper {
                 FileLog.shared.addMessage("Refreshed Trial Eligibility: \(eligible ? "Yes" : "No")")
                 isEligibleForOffer = eligible
                 isCheckingEligibility = false
+                DispatchQueue.main.async {
+                    completion?()
+                }
             }
         } else {
             networking.checkTrialEligibility(receiptString) { [weak self] isEligible in
@@ -414,6 +420,9 @@ private extension IAPHelper {
                 FileLog.shared.addMessage("Refreshed Trial Eligibility: \(eligible ? "Yes" : "No")")
                 self?.isEligibleForOffer = eligible
                 self?.isCheckingEligibility = false
+                DispatchQueue.main.async {
+                    completion?()
+                }
             }
         }
     }
@@ -424,6 +433,7 @@ private extension IAPHelper {
 extension IAPHelper: SKPaymentTransactionObserver {
     func purchaseWasSuccessful(_ productId: IAPProductID) {
         trackPaymentEvent(.purchaseSuccessful, productId: productId)
+        updateTrialEligibility()
     }
 
     func purchaseWasCancelled(_ productId: IAPProductID, error: NSError) {

--- a/podcasts/Onboarding/Models/PlusPricingInfoModel.swift
+++ b/podcasts/Onboarding/Models/PlusPricingInfoModel.swift
@@ -1,5 +1,6 @@
 import UIKit
 import PocketCastsServer
+import PocketCastsUtils
 
 /// A parent model that allows a view to present pricing information
 class PlusPricingInfoModel: ObservableObject {
@@ -121,8 +122,13 @@ extension PlusPricingInfoModel {
     func loadPrices(_ completion: (() -> Void)? = nil) {
         if purchaseHandler.hasLoadedProducts {
             priceAvailability = .available
-            purchaseHandler.updateTrialEligibility() { [weak self] in
-                guard let self else { return }
+            if FeatureFlag.newOfferEligibilityCheck.enabled {
+                purchaseHandler.updateTrialEligibility() { [weak self] in
+                    guard let self else { return }
+                    self.pricingInfo = Self.getPricingInfo(from: purchaseHandler)
+                    completion?()
+                }
+            } else {
                 self.pricingInfo = Self.getPricingInfo(from: purchaseHandler)
                 completion?()
             }
@@ -135,8 +141,14 @@ extension PlusPricingInfoModel {
 
         notificationCenter.addObserver(forName: ServerNotifications.iapProductsUpdated, object: nil, queue: .main) { [weak self] _ in
             guard let self else { return }
-            purchaseHandler.updateTrialEligibility() { [weak self] in
-                guard let self else { return }
+            if FeatureFlag.newOfferEligibilityCheck.enabled {
+                purchaseHandler.updateTrialEligibility() { [weak self] in
+                    guard let self else { return }
+                    priceAvailability = .available
+                    pricingInfo = Self.getPricingInfo(from: purchaseHandler)
+                    completion?()
+                }
+            } else {
                 priceAvailability = .available
                 pricingInfo = Self.getPricingInfo(from: purchaseHandler)
                 completion?()

--- a/podcasts/Onboarding/Models/PlusPricingInfoModel.swift
+++ b/podcasts/Onboarding/Models/PlusPricingInfoModel.swift
@@ -121,8 +121,11 @@ extension PlusPricingInfoModel {
     func loadPrices(_ completion: (() -> Void)? = nil) {
         if purchaseHandler.hasLoadedProducts {
             priceAvailability = .available
-            pricingInfo = Self.getPricingInfo(from: self.purchaseHandler)
-            completion?()
+            purchaseHandler.updateTrialEligibility() { [weak self] in
+                guard let self else { return }
+                self.pricingInfo = Self.getPricingInfo(from: purchaseHandler)
+                completion?()
+            }
             return
         }
 
@@ -131,13 +134,13 @@ extension PlusPricingInfoModel {
         let notificationCenter = NotificationCenter.default
 
         notificationCenter.addObserver(forName: ServerNotifications.iapProductsUpdated, object: nil, queue: .main) { [weak self] _ in
-            guard let self else {
-                return
+            guard let self else { return }
+            purchaseHandler.updateTrialEligibility() { [weak self] in
+                guard let self else { return }
+                priceAvailability = .available
+                pricingInfo = Self.getPricingInfo(from: purchaseHandler)
+                completion?()
             }
-
-            self.priceAvailability = .available
-            self.pricingInfo = Self.getPricingInfo(from: self.purchaseHandler)
-            completion?()
         }
 
         notificationCenter.addObserver(forName: ServerNotifications.iapProductsFailed, object: nil, queue: .main) { _ in


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes #3110 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR updates the check for eligibility for a trial by using a StoreKit2 call instead of our custom code on the server.

Notes:
- Testing eligibility  with sandbox accounts can be a bit buggy because of Apple caches as explained here: https://stackoverflow.com/questions/73347283/storekits-iseligibleforintrooffer-returns-false
 
## To test

1. Start the app on a real device
2. Ensure you have you Sandbox TestFlight user reseted. You can do this on AppStore Connect web or in the device: Settings -> Developer -> Sandbox apple account). Tap on Reset Eligibility and Clear Purchase history
3. Login with a brand new user
4. Go to Profile -> Account 
5. Check if you see the pill saying 1 Month Free Trial and the Button for purchase says `Start Free Trial`
6. Press on Start Free Trial
7. Continue the IAP Flow and see if you see the system sheet with the 1 Month Free Trial shown
8. Purchase using you Sandbox account
9. Now go Profile -> Cancel Subscription -> Continue to Cancelation -> Cancel my subscription - > Cancel Free Trial
10. Now you need to wait around 2 minutes for the cancelation to happen
11. 4. Go to Profile -> Account 
5. Check if don't see the pill saying 1 Month Free Trial and the Button for purchase says `subscribe to plus`
6. Press on `Subscribe to Plus`
7. Check that the system IAP flow does not show the Free 1 Month
8. If you want to retest the process please ensure to repeat step 2
 

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
