### PR TITLE
Recommendations: Fix discover region filter

### DIFF
--- a/podcasts/Array+DiscoverItem.swift
+++ b/podcasts/Array+DiscoverItem.swift
@@ -4,7 +4,7 @@ extension Array<DiscoverItem> {
     func makeDataSourceSnapshot(region: String, selectedCategory: DiscoverCategory?, itemFilter: (DiscoverItem) -> Bool) -> NSDiffableDataSourceSnapshot<Int, DiscoverCollectionViewController.Item> {
         var snapshot = NSDiffableDataSourceSnapshot<Int, DiscoverCollectionViewController.Item>()
 
-        let items = filter({ (itemFilter($0)) && $0.regions.contains(region) })
+        let items = filter({ (itemFilter($0)) })
 
         let models = items.map { item in
             let selectedCategory = item.cellType() != .categoriesSelector ? selectedCategory : nil

--- a/podcasts/DiscoverCollectionViewController.swift
+++ b/podcasts/DiscoverCollectionViewController.swift
@@ -122,7 +122,7 @@ class DiscoverCollectionViewController: PCViewController {
             for item in items {
                 let selectedCategory = item.cellType() != .categoriesSelector ? selectedCategory : nil
 
-                if itemFilter(item) {
+                if itemFilter(item) && item.regions.contains(currentRegion) {
                     if item.authenticated == true, let uuid = item.uuid {
                         snapshot.appendItems([.loading(uuid)])
                         loadingTasks[uuid] = Task { [weak self] in


### PR DESCRIPTION
| 📘 Part of: #2989 |
|:---:|

Fixes filtering for Discover items to the selected region.

| Before | After |
|--|--|
| ![Simulator Screenshot - iPhone 16 - 2025-05-13 at 15 47 29](https://github.com/user-attachments/assets/3d63deeb-3ab0-45ad-be14-ab9f3fad858a) | ![Simulator Screenshot - iPhone 16 - 2025-05-13 at 15 51 08](https://github.com/user-attachments/assets/105ff595-aecb-4e85-9ddd-4ad9a7aac92e) |

## To test

* Open the Discover section
* Scroll down to the bottom of the section
* ✅ Verify that only one "Popular" section appears (it should be the one for your selected region)
* Change to the Worldwide region
* ✅ Verify that the "Popular" section appears with no region name

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
