### PR TITLE
Notifications permissions check on podcast settings

### DIFF
--- a/podcasts/Common SwiftUI/Toast/ToastTheme.swift
+++ b/podcasts/Common SwiftUI/Toast/ToastTheme.swift
@@ -32,7 +32,11 @@ extension ToastTheme where Self == ToastPlayerTheme {
 class ToastDefaultTheme: ThemeObserver, ToastTheme {
     var background: Color { theme.playerContrast01 }
     var title: Color { theme.playerBackground01 }
-    var button: Color { theme.playerHighlight01 }
+    var button: Color {
+        // If the contrast between the background and highlight color is too low, then we'll switch to interactive 02
+        let contrast = theme.primaryInteractive01.contrast(with: background)
+        return contrast > 2 ? theme.primaryInteractive01 : theme.primaryInteractive02
+    }
 }
 
 extension ToastTheme where Self == ToastDefaultTheme {

--- a/podcasts/PodcastSettingsViewController+Table.swift
+++ b/podcasts/PodcastSettingsViewController+Table.swift
@@ -362,9 +362,19 @@ extension PodcastSettingsViewController: UITableViewDataSource, UITableViewDeleg
     }
 
     @objc private func notificationChanged(_ sender: UISwitch) {
-        PodcastManager.shared.setNotificationsEnabled(podcast: podcast, enabled: sender.isOn)
-        NotificationCenter.postOnMainThread(notification: Constants.Notifications.podcastUpdated, object: podcast.uuid)
         Analytics.track(.podcastSettingsNotificationsToggled, properties: ["enabled": sender.isOn])
+        NotificationsHelper.shared.registerForPushNotifications() { [weak self] granted in
+            guard let self, granted || !sender.isOn else {
+                Toast.show(L10n.notificationsPermissionsNeedsAction, actions: [.init(title: L10n.notificationsPermissionsOpenSettings, action: {
+                    Analytics.track(.notificationsPermissionsOpenSystemSettings)
+                    UIApplication.shared.openNotificationSettings()
+                })])
+                sender.isOn = false
+                return
+            }
+            PodcastManager.shared.setNotificationsEnabled(podcast: self.podcast, enabled: sender.isOn)
+            NotificationCenter.postOnMainThread(notification: Constants.Notifications.podcastUpdated, object: podcast.uuid)
+        }
     }
 
     private func tableData() -> [[TableRow]] {

--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -917,14 +917,23 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
             return
         }
         let newValue = !podcast.isPushEnabled
-        PodcastManager.shared.setNotificationsEnabled(podcast: podcast, enabled: newValue)
-        NotificationCenter.postOnMainThread(notification: Constants.Notifications.podcastUpdated, object: podcast.uuid)
-        var message = newValue ? L10n.notificationsOn : L10n.notificationsOff
-        if let title = podcast.title, newValue {
-            message = L10n.notificationsOnForPodcast(title)
-        }
-        Toast.show(message)
         Analytics.track(.podcastScreenNotificationsTapped, properties: ["enabled": newValue])
+        NotificationsHelper.shared.registerForPushNotifications() { granted in
+            guard granted || !newValue else {
+                Toast.show(L10n.notificationsPermissionsNeedsAction, actions: [.init(title: L10n.notificationsPermissionsOpenSettings, action: {
+                    Analytics.track(.notificationsPermissionsOpenSystemSettings)
+                    UIApplication.shared.openNotificationSettings()
+                })])
+                return
+            }
+            PodcastManager.shared.setNotificationsEnabled(podcast: podcast, enabled: newValue)
+            NotificationCenter.postOnMainThread(notification: Constants.Notifications.podcastUpdated, object: podcast.uuid)
+            var message = newValue ? L10n.notificationsOn : L10n.notificationsOff
+            if let title = podcast.title, newValue {
+                message = L10n.notificationsOnForPodcast(title)
+            }
+            Toast.show(message)
+        }
     }
 
     func categoryTapped(_ category: String) {

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -1856,6 +1856,10 @@ internal enum L10n {
   internal static var notificationsPermissionsAction: String { return L10n.tr("Localizable", "notifications_permissions_action") }
   /// Notifications are the best way to keep track of new episodes, get recommendations of new shows and tips about Pocket Casts.
   internal static var notificationsPermissionsBody: String { return L10n.tr("Localizable", "notifications_permissions_body") }
+  /// Please allow notifications in your device settings
+  internal static var notificationsPermissionsNeedsAction: String { return L10n.tr("Localizable", "notifications_permissions_needs_action") }
+  /// Open Settings
+  internal static var notificationsPermissionsOpenSettings: String { return L10n.tr("Localizable", "notifications_permissions_open_settings") }
   /// Stay up to date!
   internal static var notificationsPermissionsTitle: String { return L10n.tr("Localizable", "notifications_permissions_title") }
   /// Play Now

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -5102,3 +5102,10 @@
 
 /* Notification body for reengagement downloads. %1$@ argument is the numbers of episodes downloaded */
 "notifications_reengagement_downloads_body" = "You have %1$@ new episodes downloaded and ready to go!";
+
+/* Notification message to indicate that notification permissions are needed*/
+"notifications_permissions_needs_action" = "Please allow notifications in your device settings";
+
+/* Notification button title to open device notification settings*/
+"notifications_permissions_open_settings" = "Open Settings";
+


### PR DESCRIPTION
| 📘 Part of: #2906  |  <!-- project issue number, if applicable -->
|:---:|

Fixes #3119 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

<img src="https://github.com/user-attachments/assets/9612b90c-8c06-4772-b8ea-2ab47dd45a8a" width=320>


## To test

1. Start the app from a fresh install
3. Open a podcast and follow it
4. Tap on the notification icon on the header ( bell icon on header)
5. On the system sheet tap on Don't Allow
6. Check if the Toast message says that `Please allow notifications in you device setting`
7. Tap on Open Settings in the toast
8. Check if Device Settings are open
9. Allow notifications for Pocket Casts
10. Go back to the app
11. Tap on the notication icon again
12. Check if Toast shows up that says that you will be notified on new episodes.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
