### PR TITLE
[EU Accessibility Act] Upgrade screen color changes

### DIFF
--- a/podcasts/Onboarding/Plus/UpgradeCard.swift
+++ b/podcasts/Onboarding/Plus/UpgradeCard.swift
@@ -124,11 +124,32 @@ struct UpgradeCard: View {
 
     let showPurchaseButton: Bool
 
+    private var subscriptionPriceSecondaryTextColor: Color {
+        if theme.activeTheme == .light {
+            return Color(hex: "#6F7580")
+        }
+        return theme.primaryText02
+    }
+
+    private var termsAndConditionsTextColor: Color {
+        if theme.activeTheme == .light {
+            return Color(hex: "#6F7580")
+        }
+        return theme.primaryText01
+    }
+
+    private var termsAndConditionsOpacity: CGFloat {
+        if theme.activeTheme == .light {
+            return 1.0
+        }
+        return 0.64
+    }
+
     var body: some View {
         VStack {
             VStack(alignment: .leading, spacing: 0) {
                 if let subscriptionInfo {
-                    SubscriptionPriceAndOfferView(product: subscriptionInfo, mainTextColor: theme.primaryText01, secondaryTextColor: theme.primaryText02)
+                    SubscriptionPriceAndOfferView(product: subscriptionInfo, mainTextColor: theme.primaryText01, secondaryTextColor: subscriptionPriceSecondaryTextColor)
                 } else {
                     SubscriptionBadge(tier: tier.tier)
                         .padding(.bottom, 12)
@@ -152,8 +173,8 @@ struct UpgradeCard: View {
 
                     termsAndConditions
                         .font(style: .footnote).fixedSize(horizontal: false, vertical: true)
-                        .tint(theme.primaryText01)
-                        .opacity(0.64)
+                        .tint(termsAndConditionsTextColor)
+                        .opacity(termsAndConditionsOpacity)
                     if showPurchaseButton {
                         purchaseButton
                     }
@@ -185,7 +206,7 @@ struct UpgradeCard: View {
             Text(purchaseTerms[safe: 2] ?? "") +
             Text(.init("[\(purchaseTerms[safe: 3] ?? "")](\(termsOfUse))")).underline()
         }
-        .foregroundColor(theme.primaryText01)
+        .foregroundColor(termsAndConditionsTextColor)
         .environment(\.openURL, OpenURLAction { url in
             switch url.absoluteString {
             case privacyPolicy:

--- a/podcasts/Onboarding/Plus/UpgradeCard.swift
+++ b/podcasts/Onboarding/Plus/UpgradeCard.swift
@@ -138,7 +138,7 @@ struct UpgradeCard: View {
         return theme.primaryText01
     }
 
-    private var termsAndConditionsOpacity: CGFloat {
+    private var termsAndConditionsOpacity: Double {
         if theme.activeTheme == .light {
             return 1.0
         }

--- a/podcasts/Onboarding/Plus/UpgradeRoundedSegmentedControl.swift
+++ b/podcasts/Onboarding/Plus/UpgradeRoundedSegmentedControl.swift
@@ -37,6 +37,16 @@ struct UpgradeSegmentedControlButtonStyle: ButtonStyle {
     let isSelected: Bool
     let theme: Theme
 
+    private var foregroundColor: Color {
+        if isSelected {
+            return theme.primaryText01
+        }
+        if theme.activeTheme == .light {
+            return Color(hex: "#292B2E")
+        }
+        return theme.primaryText02
+    }
+
     init(isSelected: Bool = true, theme: Theme) {
         self.isSelected = isSelected
         self.theme = theme
@@ -50,7 +60,7 @@ struct UpgradeSegmentedControlButtonStyle: ButtonStyle {
                 isSelected ? theme.primaryUi01 : configuration.isPressed ? theme.primaryUi01 : theme.primaryUi05
             )
             .font(style: .subheadline, weight: .medium)
-            .foregroundColor(isSelected ? theme.primaryText01 : theme.primaryText02)
+            .foregroundColor(foregroundColor)
             .cornerRadius(100)
             .contentShape(Rectangle())
     }


### PR DESCRIPTION
| 📘 Part of: EU Accessibility Act
|:---:|

Fixes #3041 

This PR updates the colors with the light theme to comply with the WCAG recommendations in terms of color contrast and clarity.

| Before | After |
| -------- | ------- |
| ![IMG_0130](https://github.com/user-attachments/assets/4a77c2c7-fa49-477c-9cab-2b1f0f49e720) | ![IMG_0129](https://github.com/user-attachments/assets/25b770a5-1440-4a48-b6be-7443f89f91a6) |


## To test

- Run this branch with a non plus user
- Goto Profile -> Settings -> Pocket Casts Plus
- Check the new colors as defined in #3041 

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
