### PR TITLE
Recommendations: Truncate Discover headers

### DIFF
--- a/podcasts/LargeListSummaryCellHeaderView.swift
+++ b/podcasts/LargeListSummaryCellHeaderView.swift
@@ -34,7 +34,7 @@ class LargeListSummaryCellHeaderView: UIView {
         let label = ThemeableLabel()
         label.textColor = ThemeColor.primaryText01()
         label.font = .systemFont(ofSize: 22, weight: .bold)
-        label.adjustsFontSizeToFitWidth = true
+        label.numberOfLines = 1
         return label
     }()
 

--- a/podcasts/LargeListSummaryViewController.xib
+++ b/podcasts/LargeListSummaryViewController.xib
@@ -23,7 +23,7 @@
         <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Fw0-IT-oEE" customClass="ThemeableView" customModule="podcasts" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="370" height="275"/>
             <subviews>
-                <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" alignment="lastBaseline" translatesAutoresizingMaskIntoConstraints="NO" id="X56-LC-Q5n">
+                <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" alignment="lastBaseline" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="X56-LC-Q5n">
                     <rect key="frame" x="16" y="30" width="338" height="20"/>
                     <subviews>
                         <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="CeQ-tP-ch9" customClass="LargeListSummaryCellHeaderView" customModule="podcasts" customModuleProvider="target">
@@ -31,11 +31,11 @@
                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         </view>
                         <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="dtr-d4-ivC">
-                            <rect key="frame" x="92" y="0.0" width="176" height="20"/>
+                            <rect key="frame" x="97" y="0.0" width="126" height="20"/>
                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         </view>
                         <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" pointerInteraction="YES" translatesAutoresizingMaskIntoConstraints="NO" id="sF0-fo-tPV" customClass="ThemeableUIButton" customModule="podcasts" customModuleProvider="target">
-                            <rect key="frame" x="268" y="0.0" width="70" height="20"/>
+                            <rect key="frame" x="228" y="0.0" width="110" height="20"/>
                             <fontDescription key="fontDescription" type="boldSystem" pointSize="13"/>
                             <state key="normal" title="SHOW ALL">
                                 <color key="titleColor" red="0.035672488410000001" green="1" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>


### PR DESCRIPTION
| 📘 Part of: #2989 |
|:---:|

Adds truncation and spacing to the Discover cell header view

| Before | After |
|--|--|
| ![Simulator Screenshot - iPhone 16 - 2025-05-14 at 11 09 10](https://github.com/user-attachments/assets/52fee235-a29c-4242-80d4-57be1892a981) | ![Simulator Screenshot - iPhone 16 - 2025-05-14 at 11 05 01](https://github.com/user-attachments/assets/8d6e2f80-6f9c-4040-8ba8-29fac70f68f4) |

| Before | After |
|--|--|
| ![Simulator Screenshot - iPhone 16 - 2025-05-14 at 11 09 15](https://github.com/user-attachments/assets/a6e6749d-d916-46bf-9127-9214899498fe) | ![Simulator Screenshot - iPhone 16 - 2025-05-14 at 11 05 04](https://github.com/user-attachments/assets/297717a7-92e5-40e8-92b8-e6d17afdae70) |

## To test

* Open the Discover page with an account with some listening history
* Scroll through the Discover page and check the sales for the following:
* ✅ Verify that the title is truncated if it is long

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
