### PR TITLE
[Tooling] Skip jobs if there are no relevant code changes

### DIFF
--- a/.buildkite/commands/build.sh
+++ b/.buildkite/commands/build.sh
@@ -1,5 +1,9 @@
 #!/bin/bash -u
 
+if .buildkite/commands/should-skip-job.sh --job-type build; then
+  exit 0
+fi
+
 "$(dirname "${BASH_SOURCE[0]}")/shared_setup.sh"
 
 echo "--- Build & Test"

--- a/.buildkite/commands/build.sh
+++ b/.buildkite/commands/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -u
 
-if .buildkite/commands/should-skip-job.sh --job-type build; then
+if "$(dirname "${BASH_SOURCE[0]}")/should-skip-job.sh" --job-type build; then
   exit 0
 fi
 

--- a/.buildkite/commands/prototype-build.sh
+++ b/.buildkite/commands/prototype-build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-if .buildkite/commands/should-skip-job.sh --job-type build; then
+if "$(dirname "${BASH_SOURCE[0]}")/should-skip-job.sh" --job-type build; then
   exit 0
 fi
 

--- a/.buildkite/commands/prototype-build.sh
+++ b/.buildkite/commands/prototype-build.sh
@@ -1,5 +1,9 @@
 #!/bin/bash -eu
 
+if .buildkite/commands/should-skip-job.sh --job-type build; then
+  exit 0
+fi
+
 # Sentry CLI needs to be up-to-date
 brew upgrade sentry-cli
 

--- a/.buildkite/commands/prototype-upload.sh
+++ b/.buildkite/commands/prototype-upload.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-if .buildkite/commands/should-skip-job.sh --job-type build; then
+if "$(dirname "${BASH_SOURCE[0]}")/should-skip-job.sh" --job-type build; then
   exit 0
 fi
 

--- a/.buildkite/commands/prototype-upload.sh
+++ b/.buildkite/commands/prototype-upload.sh
@@ -1,5 +1,9 @@
 #!/bin/bash -eu
 
+if .buildkite/commands/should-skip-job.sh --job-type build; then
+  exit 0
+fi
+
 # Sentry CLI needs to be up-to-date
 brew upgrade sentry-cli
 

--- a/.buildkite/commands/should-skip-job.sh
+++ b/.buildkite/commands/should-skip-job.sh
@@ -28,9 +28,13 @@ LOCALIZATION_PATTERNS=(
   "**/*.stringsdict"
 )
 
+# Define constants for job types
+BUILD="build"
+LOCALIZATION="localization"
+
 # Check if arguments are valid
 if [ -z "${1:-}" ] || [ "$1" != "--job-type" ] || [ -z "${2:-}" ]; then
-  echo "Error: Must specify --job-type [build|localization]"
+  echo "Error: Must specify --job-type [$BUILD|$LOCALIZATION]"
   buildkite-agent step cancel
   exit 15
 fi
@@ -38,7 +42,7 @@ fi
 # Function to display skip message and create annotation
 show_skip_message() {
   local job_type=$1
-  local message="Skipping ${BUILDKITE_LABEL:-Job} - no relevant files changed"
+  local message="Skipped ${BUILDKITE_LABEL:-Job} - no relevant files changed"
   local context="skip-$(echo "${BUILDKITE_LABEL:-$job_type}" | sed -E -e 's/[^[:alnum:]]+/-/g' | tr A-Z a-z)"
   
   echo "$message" | buildkite-agent annotate --style "info" --context "$context"
@@ -47,7 +51,7 @@ show_skip_message() {
 
 job_type="$2"
 case "$job_type" in
-  "localization")
+  $LOCALIZATION)
     # Check if any localization files have changed
     # Return true (skip) if NO localization files have changed
     if ! pr_changed_files --any-match "${LOCALIZATION_PATTERNS[@]}"; then
@@ -56,7 +60,7 @@ case "$job_type" in
     fi
     exit 1
     ;;
-  "build")
+  $BUILD)
     # We should skip if changes are limited to documentation, tooling, and non-code files
     # We'll let the job run (won't skip) if PR includes changes in localization files though
     PATTERNS=("${COMMON_PATTERNS[@]}")
@@ -67,7 +71,7 @@ case "$job_type" in
     exit 1
     ;;
   *)
-    echo "Error: Job type must be either 'build' or 'localization'"
+    echo "Error: Job type must be either '$BUILD' or '$LOCALIZATION'"
     buildkite-agent step cancel
     exit 15
     ;;

--- a/.buildkite/commands/should-skip-job.sh
+++ b/.buildkite/commands/should-skip-job.sh
@@ -1,0 +1,74 @@
+#!/bin/bash -eu
+
+# Usage: should-skip-job.sh --job-type [build|localization]
+# --job-type build: For jobs building an app binary, e.g. Build, Prototype Builds…
+#     Skip when changes are limited to documentation, tooling, and non-code files
+# --job-type localization: For jobs that only need to run when localization files have changed
+#     Skip when NO localization files have changed
+#
+# Return codes:
+# 0 - Job should be skipped (script also handles displaying the message and annotation)
+# 1 - Job should not be skipped
+# 15 - Error in script parameters
+
+COMMON_PATTERNS=(
+  "*.md"
+  "*.po"
+  "*.pot"
+  "*.txt"
+  ".gitignore"
+  "config/Version.xcconfig"
+  "fastlane/**"
+  "Gemfile"
+  "Gemfile.lock"
+)
+
+LOCALIZATION_PATTERNS=(
+  "**/*.strings"
+  "**/*.stringsdict"
+)
+
+# Check if arguments are valid
+if [ -z "${1:-}" ] || [ "$1" != "--job-type" ] || [ -z "${2:-}" ]; then
+  echo "Error: Must specify --job-type [build|localization]"
+  buildkite-agent step cancel
+  exit 15
+fi
+
+# Function to display skip message and create annotation
+show_skip_message() {
+  local job_type=$1
+  local message="Skipping ${BUILDKITE_LABEL:-Job} - no relevant files changed"
+  local context="skip-$(echo "${BUILDKITE_LABEL:-$job_type}" | sed -E -e 's/[^[:alnum:]]+/-/g' | tr A-Z a-z)"
+  
+  echo "$message" | buildkite-agent annotate --style "info" --context "$context"
+  echo "$message"
+}
+
+job_type="$2"
+case "$job_type" in
+  "localization")
+    # Check if any localization files have changed
+    # Return true (skip) if NO localization files have changed
+    if ! pr_changed_files --any-match "${LOCALIZATION_PATTERNS[@]}"; then
+      show_skip_message "$job_type"
+      exit 0
+    fi
+    exit 1
+    ;;
+  "build")
+    # We should skip if changes are limited to documentation, tooling, and non-code files
+    # We'll let the job run (won't skip) if PR includes changes in localization files though
+    PATTERNS=("${COMMON_PATTERNS[@]}")
+    if pr_changed_files --all-match "${PATTERNS[@]}"; then
+      show_skip_message "$job_type"
+      exit 0
+    fi
+    exit 1
+    ;;
+  *)
+    echo "Error: Job type must be either 'build' or 'localization'"
+    buildkite-agent step cancel
+    exit 15
+    ;;
+esac

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -34,7 +34,12 @@ steps:
           queue: "linter"
 
       - label: ":sleuth_or_spy: Lint Localized Strings Format"
-        command: lint_localized_strings_format
+        command: |
+          if .buildkite/commands/should-skip-job.sh --job-type localization; then
+            exit 0
+          fi
+
+          lint_localized_strings_format
         agents:
           queue: mac
         plugins: [$CI_TOOLKIT]

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -5,7 +5,7 @@
 
 # 🎗️ If you update the image to a newer Xcode version, don't forget to also update the badge in the README.md file accordingly for consistency
 XCODE_VERSION="16.2"
-CI_TOOLKIT_PLUGIN_VERSION="3.9.1"
+CI_TOOLKIT_PLUGIN_VERSION="5.3.1"
 
 export IMAGE_ID="xcode-$XCODE_VERSION-macos-14.7.1-v1"
 export CI_TOOLKIT="automattic/a8c-ci-toolkit#$CI_TOOLKIT_PLUGIN_VERSION"


### PR DESCRIPTION
Internal reference: paaHJt-7Ss-p2

The main goal of this PR is to optimize the wait time for PRs with minor, non-code related changes, specially the ones related to the release process.

There's a script to check in jobs if the changes in a PR is relevant to the said job.
The jobs are the time consuming ones running UI tests or building the app:
- `should-skip-job.sh --job-type build`: skips if the changes are limited to documentation, tooling, metadata, etc
- `should-skip-job.sh --job-type localization`: skips the job if the changes don't contain localization changes

## Testing
I've created the PR https://github.com/Automattic/pocket-casts-ios/pull/3137 to test a few scenarios skipping jobs:
- App version bump: https://buildkite.com/automattic/pocket-casts-ios/builds/10516
- ++ Localization update: https://buildkite.com/automattic/pocket-casts-ios/builds/10518
- Metadata update: https://buildkite.com/automattic/pocket-casts-ios/builds/10519