### PR TITLE
[Drop iOS 15] Update internal packages to iOS 16 + watchOS 9

### DIFF
--- a/Modules/DataModel/Package.resolved
+++ b/Modules/DataModel/Package.resolved
@@ -1,0 +1,23 @@
+{
+  "pins" : [
+    {
+      "identity" : "fmdb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ccgus/fmdb.git",
+      "state" : {
+        "revision" : "1227a3fa2b9916bfd75fe380eb45cd210e69e251",
+        "version" : "2.7.12"
+      }
+    },
+    {
+      "identity" : "grdb.swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/groue/GRDB.swift.git",
+      "state" : {
+        "revision" : "a5a1be26b4513dc7ec360eb56bc08a345bac6649",
+        "version" : "7.5.0"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Modules/DataModel/Package.swift
+++ b/Modules/DataModel/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.5
+// swift-tools-version: 5.7
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "PocketCastsDataModel",
     platforms: [
-        .iOS(.v15), .watchOS(.v8)
+        .iOS(.v16), .watchOS(.v9)
     ],
     products: [
         .library(

--- a/Modules/Server/Package.resolved
+++ b/Modules/Server/Package.resolved
@@ -1,43 +1,41 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "CryptoSwift",
-        "repositoryURL": "https://github.com/krzyzanowskim/CryptoSwift.git",
-        "state": {
-          "branch": null,
-          "revision": "5669f222e46c8134fb1f399c745fa6882b43532e",
-          "version": "1.3.8"
-        }
-      },
-      {
-        "package": "FMDB",
-        "repositoryURL": "https://github.com/ccgus/fmdb.git",
-        "state": {
-          "branch": null,
-          "revision": "61e51fde7f7aab6554f30ab061cc588b28a97d04",
-          "version": "2.7.7"
-        }
-      },
-      {
-        "package": "SwiftProtobuf",
-        "repositoryURL": "https://github.com/apple/swift-protobuf.git",
-        "state": {
-          "branch": null,
-          "revision": "e1904bf5a5f79cb7e0ff68a427a53a93b652fcd1",
-          "version": "1.15.0"
-        }
-      },
-      {
-        "package": "SwiftyJSON",
-        "repositoryURL": "https://github.com/SwiftyJSON/SwiftyJSON.git",
-        "state": {
-          "branch": null,
-          "revision": "2b6054efa051565954e1d2b9da831680026cd768",
-          "version": "5.0.0"
-        }
+  "pins" : [
+    {
+      "identity" : "fmdb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ccgus/fmdb.git",
+      "state" : {
+        "revision" : "61e51fde7f7aab6554f30ab061cc588b28a97d04",
+        "version" : "2.7.7"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "grdb.swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/groue/GRDB.swift.git",
+      "state" : {
+        "revision" : "a5a1be26b4513dc7ec360eb56bc08a345bac6649",
+        "version" : "7.5.0"
+      }
+    },
+    {
+      "identity" : "swift-protobuf",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-protobuf.git",
+      "state" : {
+        "revision" : "e1904bf5a5f79cb7e0ff68a427a53a93b652fcd1",
+        "version" : "1.15.0"
+      }
+    },
+    {
+      "identity" : "swime",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/danielebogo/Swime",
+      "state" : {
+        "branch" : "master",
+        "revision" : "6a507c6480de4603bc5b6f178d4b1855b9c05a8c"
+      }
+    }
+  ],
+  "version" : 2
 }

--- a/Modules/Server/Package.swift
+++ b/Modules/Server/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.5
+// swift-tools-version: 5.7
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "PocketCastsServer",
     platforms: [
-        .iOS(.v15), .watchOS(.v8)
+        .iOS(.v16), .watchOS(.v9)
     ], products: [
         .library(
             name: "PocketCastsServer",
@@ -16,7 +16,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.0.0"),
-        .package(url: "https://github.com/danielebogo/Swime", .branch("master")),
+        .package(url: "https://github.com/danielebogo/Swime", branch: "master"),
         .package(path: "../DataModel/"),
         .package(path: "../Utils/")
     ],

--- a/Modules/Utils/Package.swift
+++ b/Modules/Utils/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.5
+// swift-tools-version: 5.7
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "PocketCastsUtils",
     platforms: [
-        .iOS(.v15), .watchOS(.v8)
+        .iOS(.v16), .watchOS(.v9)
     ],
     products: [
         .library(

--- a/Modules/Utils/Sources/PocketCastsUtils/Formatting/TimeFormatter.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Formatting/TimeFormatter.swift
@@ -75,11 +75,7 @@ public class TimeFormatter {
         if showSeconds {
             return colonFormatterHours.string(from: time) ?? "0:00"
         } else {
-            if #available(iOS 16.0, watchOS 9.0, *) {
-                return Duration.seconds(time).formatted(.units(allowed: [.hours, .minutes], width: .narrow))
-            } else {
-                return shortTimeFormatter.string(from: time) ?? "0:00"
-            }
+            return Duration.seconds(time).formatted(.units(allowed: [.hours, .minutes], width: .narrow))
         }
     }
 

--- a/podcasts/EmptyStateCell.swift
+++ b/podcasts/EmptyStateCell.swift
@@ -14,36 +14,16 @@ class EmptyStateCell: UITableViewCell {
     }
 
     func configure(title: String, message: String? = nil, icon: (() -> Image)? = nil, actions: [EmptyStateAction] = []) {
-        if #available(iOS 16.0, *) {
-            self.contentConfiguration = UIHostingConfiguration {
-                EmptyStateView(
-                    title: title,
-                    message: message,
-                    icon: icon,
-                    actions: actions,
-                    style: .defaultStyle
-                )
-            }
-            .margins(.horizontal, 16)
-            .margins(.vertical, 8)
-        } else {
-            let view = EmptyStateView(
+        self.contentConfiguration = UIHostingConfiguration {
+            EmptyStateView(
                 title: title,
                 message: message,
                 icon: icon,
                 actions: actions,
                 style: .defaultStyle
             )
-            let uiView = view.uiView
-            uiView.translatesAutoresizingMaskIntoConstraints = false
-            uiView.backgroundColor = .clear
-            contentView.addSubview(uiView)
-            NSLayoutConstraint.activate([
-                contentView.layoutMarginsGuide.leadingAnchor.constraint(equalTo: uiView.leadingAnchor),
-                contentView.layoutMarginsGuide.trailingAnchor.constraint(equalTo: uiView.trailingAnchor),
-                contentView.bottomAnchor.constraint(equalTo: uiView.bottomAnchor),
-                contentView.topAnchor.constraint(equalTo: uiView.topAnchor)
-            ])
         }
+        .margins(.horizontal, 16)
+        .margins(.vertical, 8)
     }
 }

--- a/podcasts/LoadingCell.swift
+++ b/podcasts/LoadingCell.swift
@@ -8,47 +8,18 @@ class LoadingCell: UITableViewCell {
         selectionStyle = .none
         backgroundColor = .clear
 
-        if #available(iOS 16.0, *) {
-            self.contentConfiguration = UIHostingConfiguration {
-                VStack(spacing: 16) {
-                    ProgressView()
-                        .tint(Color(uiColor: ThemeColor.primaryIcon01()))
-                    Text(L10n.loading)
-                        .font(style: .subheadline)
-                        .foregroundStyle(Color(uiColor: ThemeColor.primaryText02()))
-                }
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 32)
+        self.contentConfiguration = UIHostingConfiguration {
+            VStack(spacing: 16) {
+                ProgressView()
+                    .tint(Color(uiColor: ThemeColor.primaryIcon01()))
+                Text(L10n.loading)
+                    .font(style: .subheadline)
+                    .foregroundStyle(Color(uiColor: ThemeColor.primaryText02()))
             }
-            .margins(.horizontal, 16)
-        } else {
-            let stackView = UIStackView()
-            stackView.axis = .vertical
-            stackView.spacing = 16
-            stackView.alignment = .center
-            stackView.translatesAutoresizingMaskIntoConstraints = false
-            contentView.addSubview(stackView)
-
-            let activityIndicator = UIActivityIndicatorView(style: .medium)
-            activityIndicator.color = ThemeColor.primaryIcon01()
-            activityIndicator.startAnimating()
-
-            let label = UILabel()
-            label.text = L10n.loading
-            label.font = .systemFont(ofSize: 15)
-            label.textColor = ThemeColor.primaryText02()
-
-            stackView.addArrangedSubview(activityIndicator)
-            stackView.addArrangedSubview(label)
-
-            NSLayoutConstraint.activate([
-                stackView.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
-                stackView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
-                stackView.leadingAnchor.constraint(greaterThanOrEqualTo: contentView.leadingAnchor, constant: 16),
-                stackView.trailingAnchor.constraint(lessThanOrEqualTo: contentView.trailingAnchor, constant: -16),
-                contentView.heightAnchor.constraint(greaterThanOrEqualToConstant: 100)
-            ])
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 32)
         }
+        .margins(.horizontal, 16)
     }
 
     required init?(coder: NSCoder) {


### PR DESCRIPTION
| 📘 Part of: #2858 |
|:---:|

* Sets minimum deployment target to iOS 16 and watchOS 9 for internal swift packages
* Removes one available macro

## To test


## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
