### PR TITLE
[Empty State] ContentUnavailableConfiguration + HostingConfiguration backfill

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1716,6 +1716,7 @@
 		F52B4F8E2BB4A9ED00E87BE4 /* CategoriesSelectorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F52B4F8D2BB4A9ED00E87BE4 /* CategoriesSelectorView.swift */; };
 		F533F19D2C24B8CB00EDE9AA /* ShareDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = F533F19C2C24B8CB00EDE9AA /* ShareDestination.swift */; };
 		F53C3E832CC73549004F3581 /* TopSpotStory2024.swift in Sources */ = {isa = PBXBuildFile; fileRef = F53C3E822CC73538004F3581 /* TopSpotStory2024.swift */; };
+		F53DDB682DD508CA00A1E890 /* HostingConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = F53DDB672DD508CA00A1E890 /* HostingConfiguration.swift */; };
 		F53EFEE82CD405DA00F4561B /* YearOverYearCompareTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F53EFEE72CD405DA00F4561B /* YearOverYearCompareTests.swift */; };
 		F53EFEEA2CD42AE400F4561B /* Ratings2024Story.swift in Sources */ = {isa = PBXBuildFile; fileRef = F53EFEE92CD42ADF00F4561B /* Ratings2024Story.swift */; };
 		F543F6A42C0804FA00FEC8B6 /* AnyPublisher+Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = F543F6A32C0804FA00FEC8B6 /* AnyPublisher+Async.swift */; };
@@ -1817,6 +1818,7 @@
 		F5EA21F22CC1CD040043C780 /* EndOfYearDeveloperMenuButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5EA21F12CC1CD040043C780 /* EndOfYearDeveloperMenuButton.swift */; };
 		F5EA21F42CC1DBFE0043C780 /* EndOfYear2023StoriesModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5EA21F32CC1DBFE0043C780 /* EndOfYear2023StoriesModel.swift */; };
 		F5EA21F82CC1DC370043C780 /* EndOfYear2024StoriesModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5EA21F72CC1DC370043C780 /* EndOfYear2024StoriesModel.swift */; };
+		F5EB4E6A2DD4525C00197384 /* UIViewController+ContentUnavailableConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5EB4E692DD4525C00197384 /* UIViewController+ContentUnavailableConfiguration.swift */; };
 		F5F0C9B02CCEA5BE003D295D /* SubscriptionBadge2024.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5F0C9AF2CCEA5B5003D295D /* SubscriptionBadge2024.swift */; };
 		F5F479A62C3EF8AB002B4475 /* PlayheadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5F479A52C3EF8AB002B4475 /* PlayheadView.swift */; };
 		F5F508F02CEBE94F007D6E39 /* Strings+Generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 467DF6E826E1093A00AC290C /* Strings+Generated.swift */; };
@@ -3957,6 +3959,7 @@
 		F52B4F8D2BB4A9ED00E87BE4 /* CategoriesSelectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoriesSelectorView.swift; sourceTree = "<group>"; };
 		F533F19C2C24B8CB00EDE9AA /* ShareDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareDestination.swift; sourceTree = "<group>"; };
 		F53C3E822CC73538004F3581 /* TopSpotStory2024.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopSpotStory2024.swift; sourceTree = "<group>"; };
+		F53DDB672DD508CA00A1E890 /* HostingConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostingConfiguration.swift; sourceTree = "<group>"; };
 		F53EFEE72CD405DA00F4561B /* YearOverYearCompareTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YearOverYearCompareTests.swift; sourceTree = "<group>"; };
 		F53EFEE92CD42ADF00F4561B /* Ratings2024Story.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Ratings2024Story.swift; sourceTree = "<group>"; };
 		F543F6A32C0804FA00FEC8B6 /* AnyPublisher+Async.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AnyPublisher+Async.swift"; sourceTree = "<group>"; };
@@ -4023,6 +4026,7 @@
 		F5EA21F12CC1CD040043C780 /* EndOfYearDeveloperMenuButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndOfYearDeveloperMenuButton.swift; sourceTree = "<group>"; };
 		F5EA21F32CC1DBFE0043C780 /* EndOfYear2023StoriesModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndOfYear2023StoriesModel.swift; sourceTree = "<group>"; };
 		F5EA21F72CC1DC370043C780 /* EndOfYear2024StoriesModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndOfYear2024StoriesModel.swift; sourceTree = "<group>"; };
+		F5EB4E692DD4525C00197384 /* UIViewController+ContentUnavailableConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+ContentUnavailableConfiguration.swift"; sourceTree = "<group>"; };
 		F5F0C9AF2CCEA5B5003D295D /* SubscriptionBadge2024.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionBadge2024.swift; sourceTree = "<group>"; };
 		F5F479A52C3EF8AB002B4475 /* PlayheadView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayheadView.swift; sourceTree = "<group>"; };
 		F5F5092E2CEBEF59007D6E39 /* app-clip-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "app-clip-Bridging-Header.h"; sourceTree = "<group>"; };
@@ -5714,6 +5718,8 @@
 				F56035122DCBDB1F00E6F238 /* LoadingCell.swift */,
 				FF0F40792D5E328B0036FFE9 /* ThreadSafeDictionary.swift */,
 				F5B6FDAC2CADFEF200356909 /* ContentUnavailableConfiguration.swift */,
+				F53DDB672DD508CA00A1E890 /* HostingConfiguration.swift */,
+				F5EB4E692DD4525C00197384 /* UIViewController+ContentUnavailableConfiguration.swift */,
 				10DFE9352C5A8D1300957D0A /* ABTest */,
 				C7811D812A9008F500FC68B4 /* Unlockable */,
 				C7BDECAC2A15311000BECF02 /* Haptics */,
@@ -10583,6 +10589,7 @@
 				BD585C1F2047887700AC842C /* AppDelegate+UrlHandling.swift in Sources */,
 				C713D4FF2A0519BE00A78468 /* ContentSizeGeometryReader.swift in Sources */,
 				F5F8F3182CC314250071DD0E /* IntroStory2024.swift in Sources */,
+				F5EB4E6A2DD4525C00197384 /* UIViewController+ContentUnavailableConfiguration.swift in Sources */,
 				C73CD7A82916E8A900EAE879 /* SwiftUI+Previews.swift in Sources */,
 				BDB002BF211A9E1B00224A55 /* ProgressLine.swift in Sources */,
 				F57498D12DB8430A00892BF0 /* LargeListSummaryCellHeaderView.swift in Sources */,
@@ -10795,6 +10802,7 @@
 				408ADBD022B87FF800E10AE6 /* TopShadowView.swift in Sources */,
 				FFF17EC62B979B5500E116C8 /* BookmarksProfileListView.swift in Sources */,
 				BDA2065B1BB3AF1B00D38389 /* DownloadProgressManager.swift in Sources */,
+				F53DDB682DD508CA00A1E890 /* HostingConfiguration.swift in Sources */,
 				BD27B8C52756F486007A0EA7 /* UIColor+SwiftUI.swift in Sources */,
 				40A0A90D24B57B1C00C29362 /* MultiSelectHelper.swift in Sources */,
 				F56035132DCBDB1F00E6F238 /* LoadingCell.swift in Sources */,

--- a/podcasts/Common SwiftUI/BookmarksEmptyStateView.swift
+++ b/podcasts/Common SwiftUI/BookmarksEmptyStateView.swift
@@ -30,16 +30,16 @@ class DefaultEmptyStateStyle: ThemeObserver, EmptyStateViewStyle {
     var background: Color { theme.primaryUi01Active }
     var title: Color { theme.primaryText01 }
     var message: Color { theme.primaryText02 }
-    var button: Color { theme.primaryInteractive01 }
     var icon: Color { theme.primaryIcon03 }
+    var button: Color { theme.primaryInteractive01 }
 }
 
 class PlayerEmptyStateStyle: ThemeObserver, EmptyStateViewStyle {
     var background: Color { theme.playerContrast06 }
     var title: Color { theme.playerContrast01 }
     var message: Color { theme.playerContrast02 }
-    var button: Color { theme.playerContrast01 }
     var icon: Color { theme.primaryIcon03 }
+    var button: Color { theme.playerContrast01 }
 }
 
 extension EmptyStateViewStyle where Self == PlayerEmptyStateStyle {

--- a/podcasts/ContentUnavailableConfiguration.swift
+++ b/podcasts/ContentUnavailableConfiguration.swift
@@ -1,29 +1,72 @@
 import SwiftUI
 
-@available(iOS 16, *)
 // Many of these can be replaced with UIContentUnavailableConfigurations in iOS 17
 struct ContentUnavailableConfiguration {
     static func loading() -> UIContentConfiguration {
-        UIHostingConfiguration {
-            LoadingView().environmentObject(Theme.sharedTheme)
+        if #available(iOS 16.0, *) {
+            return UIHostingConfiguration {
+                LoadingView().environmentObject(Theme.sharedTheme)
+            }
+        } else {
+            return HostingConfiguration {
+                LoadingView().environmentObject(Theme.sharedTheme)
+            }
         }
     }
 
     static func noNetwork(tryAgainHandler: @escaping () -> Void) -> UIContentConfiguration {
-        UIHostingConfiguration {
-            NoNetworkView(tryAgainHandler: tryAgainHandler).environmentObject(Theme.sharedTheme)
+        if #available(iOS 16.0, *) {
+            return UIHostingConfiguration {
+                NoNetworkView(tryAgainHandler: tryAgainHandler).environmentObject(Theme.sharedTheme)
+            }
+        } else {
+            return HostingConfiguration {
+                NoNetworkView(tryAgainHandler: tryAgainHandler).environmentObject(Theme.sharedTheme)
+            }
         }
     }
 
     static func noResults() -> UIContentConfiguration {
-        UIHostingConfiguration {
-            NoResultsView().environmentObject(Theme.sharedTheme)
+        if #available(iOS 16.0, *) {
+            return UIHostingConfiguration {
+                NoResultsView().environmentObject(Theme.sharedTheme)
+            }
+        } else {
+            return HostingConfiguration {
+                NoResultsView().environmentObject(Theme.sharedTheme)
+            }
         }
     }
 
     static func empty() -> UIContentConfiguration {
-        UIHostingConfiguration {
-            EmptyView()
+        if #available(iOS 16.0, *) {
+            return UIHostingConfiguration {
+                EmptyView()
+            }
+        } else {
+            return HostingConfiguration {
+                EmptyView()
+            }
+        }
+    }
+
+    static func emptyState<Style: EmptyStateViewStyle>(
+        title: String,
+        message: String?,
+        icon: (() -> Image)? = nil,
+        actions: [EmptyStateAction] = [],
+        style: Style = DefaultEmptyStateStyle.defaultStyle
+    ) -> UIContentConfiguration {
+        if #available(iOS 16.0, *) {
+            return UIHostingConfiguration {
+                EmptyStateView(title: title, message: message, icon: icon, actions: actions, style: style)
+                    .environmentObject(Theme.sharedTheme)
+            }
+        } else {
+            return HostingConfiguration {
+                EmptyStateView(title: title, message: message, icon: icon, actions: actions, style: style)
+                    .environmentObject(Theme.sharedTheme)
+            }
         }
     }
 }

--- a/podcasts/HostingConfiguration.swift
+++ b/podcasts/HostingConfiguration.swift
@@ -1,0 +1,53 @@
+import UIKit
+import SwiftUI
+
+struct HostingConfiguration<Content: View>: UIContentConfiguration {
+    fileprivate let content: Content
+
+    init(@ViewBuilder content: () -> Content) {
+        self.content = content()
+    }
+
+    func makeContentView() -> any UIView & UIContentView {
+        HostingView(configuration: self)
+    }
+
+    func updated(for state: any UIConfigurationState) -> HostingConfiguration {
+        self
+    }
+}
+
+fileprivate final class HostingView<Content: View>: UIView, UIContentView {
+    private let hostingController: UIHostingController<Content>
+    private var _configuration: HostingConfiguration<Content>
+
+    var configuration: any UIContentConfiguration {
+        get {
+            _configuration
+        }
+        set {
+            guard let newConfig = newValue as? HostingConfiguration<Content> else {
+                assertionFailure("Invalid configuration type")
+                return
+            }
+            _configuration = newConfig
+            hostingController.rootView = newConfig.content
+        }
+    }
+
+    init(configuration: HostingConfiguration<Content>) {
+        self._configuration = configuration
+        self.hostingController = UIHostingController(rootView: configuration.content)
+        super.init(frame: .zero)
+
+        let hostedView: UIView = hostingController.view
+        hostedView.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(hostedView)
+        hostedView.anchorToAllSidesOf(view: self)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/podcasts/StarredViewController.swift
+++ b/podcasts/StarredViewController.swift
@@ -19,7 +19,11 @@ class StarredViewController: PCViewController {
 
     @IBOutlet var loadingIndicator: UIActivityIndicatorView!
 
-    var episodes = [ListEpisode]()
+    var episodes = [ListEpisode]() {
+        didSet {
+            refreshContentUnavilable()
+        }
+    }
     private let refreshQueue = OperationQueue()
     var cellHeights: [IndexPath: CGFloat] = [:]
     var isMultiSelectEnabled: Bool = false {
@@ -66,16 +70,6 @@ class StarredViewController: PCViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        let title = L10n.profileStarredNoEpisodesTitle
-        let message = L10n.profileStarredNoEpisodesDesc
-        let config = ContentUnavailableConfiguration.emptyState(title: title, message: message, icon: { Image("star_empty") })
-
-        if #available(iOS 17.0, *) {
-            self.contentUnavailableConfiguration = config
-        } else {
-            self.setContentUnavailableConfiguration(config)
-        }
 
         refreshQueue.maxConcurrentOperationCount = 1
         self.title = L10n.statusStarred
@@ -174,6 +168,22 @@ class StarredViewController: PCViewController {
 
         navigationItem.leftBarButtonItem = isMultiSelectEnabled ? UIBarButtonItem(title: L10n.selectAll, style: .done, target: self, action: #selector(selectAllTapped)) : nil
         navigationItem.backBarButtonItem = isMultiSelectEnabled ? nil : UIBarButtonItem(title: "", style: .plain, target: nil, action: nil)
+    }
+
+    private func refreshContentUnavilable() {
+        var config: UIContentConfiguration?
+
+        if episodes.isEmpty {
+            let title = L10n.profileStarredNoEpisodesTitle
+            let message = L10n.profileStarredNoEpisodesDesc
+            config = ContentUnavailableConfiguration.emptyState(title: title, message: message, icon: { Image("star_empty") })
+        }
+
+        if #available(iOS 17.0, *) {
+            self.contentUnavailableConfiguration = config
+        } else {
+            self.setContentUnavailableConfiguration(config)
+        }
     }
 }
 

--- a/podcasts/StarredViewController.swift
+++ b/podcasts/StarredViewController.swift
@@ -21,7 +21,7 @@ class StarredViewController: PCViewController {
 
     var episodes = [ListEpisode]() {
         didSet {
-            refreshContentUnavilable()
+            refreshContentUnavailable()
         }
     }
     private let refreshQueue = OperationQueue()
@@ -170,7 +170,7 @@ class StarredViewController: PCViewController {
         navigationItem.backBarButtonItem = isMultiSelectEnabled ? nil : UIBarButtonItem(title: "", style: .plain, target: nil, action: nil)
     }
 
-    private func refreshContentUnavilable() {
+    private func refreshContentUnavailable() {
         var config: UIContentConfiguration?
 
         if episodes.isEmpty {

--- a/podcasts/StarredViewController.swift
+++ b/podcasts/StarredViewController.swift
@@ -1,4 +1,5 @@
 import DifferenceKit
+import SwiftUI
 import PocketCastsDataModel
 import PocketCastsServer
 import UIKit
@@ -13,25 +14,6 @@ class StarredViewController: PCViewController {
             starredTable.rowHeight = UITableView.automaticDimension
             starredTable.allowsMultipleSelectionDuringEditing = true
             registerLongPress()
-        }
-    }
-
-    @IBOutlet var noEpisodesIcon: UIImageView! {
-        didSet {
-            noEpisodesIcon.tintColor = ThemeColor.primaryIcon02()
-        }
-    }
-
-    @IBOutlet var noEpisodesTitle: ThemeableLabel! {
-        didSet {
-            noEpisodesTitle.text = L10n.profileStarredNoEpisodesTitle
-        }
-    }
-
-    @IBOutlet var noEpisodesDescription: ThemeableLabel! {
-        didSet {
-            noEpisodesDescription.style = .primaryText02
-            noEpisodesDescription.text = L10n.profileStarredNoEpisodesDesc
         }
     }
 
@@ -85,8 +67,18 @@ class StarredViewController: PCViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        let title = L10n.profileStarredNoEpisodesTitle
+        let message = L10n.profileStarredNoEpisodesDesc
+        let config = ContentUnavailableConfiguration.emptyState(title: title, message: message, icon: { Image("star_empty") })
+
+        if #available(iOS 17.0, *) {
+            self.contentUnavailableConfiguration = config
+        } else {
+            self.setContentUnavailableConfiguration(config)
+        }
+
         refreshQueue.maxConcurrentOperationCount = 1
-        title = L10n.statusStarred
+        self.title = L10n.statusStarred
         setupNavBar()
         insetAdjuster.setupInsetAdjustmentsForMiniPlayer(scrollView: starredTable)
         if SyncManager.isUserLoggedIn() {

--- a/podcasts/StarredViewController.xib
+++ b/podcasts/StarredViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -14,9 +14,6 @@
                 <outlet property="loadingIndicator" destination="McZ-bj-10f" id="q4Y-N3-Zmd"/>
                 <outlet property="multiSelectFooter" destination="Bza-mD-9MN" id="D1n-8b-Pv7"/>
                 <outlet property="multiSelectFooterBottomConstraint" destination="54K-lA-SC0" id="49E-Ca-yqk"/>
-                <outlet property="noEpisodesDescription" destination="W93-H6-Fou" id="zCB-ZO-3uj"/>
-                <outlet property="noEpisodesIcon" destination="LDn-E9-TQd" id="LLE-Fh-QYz"/>
-                <outlet property="noEpisodesTitle" destination="910-uU-m8w" id="v1N-nw-we6"/>
                 <outlet property="starredTable" destination="VQm-Vl-pZf" id="lAs-dW-Ok1"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
             </connections>
@@ -26,53 +23,6 @@
             <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="VFM-dG-gY7" userLabel="No Episodes View" customClass="ThemeableView" customModule="podcasts" customModuleProvider="target">
-                    <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                    <subviews>
-                        <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="nodownloads" translatesAutoresizingMaskIntoConstraints="NO" id="LDn-E9-TQd">
-                            <rect key="frame" x="125.5" y="181.5" width="124" height="124"/>
-                            <constraints>
-                                <constraint firstAttribute="width" constant="124" id="46B-BT-UzC"/>
-                                <constraint firstAttribute="height" constant="124" id="WZk-Ot-NUc"/>
-                            </constraints>
-                        </imageView>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Nothing Starred" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="910-uU-m8w" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                            <rect key="frame" x="123.5" y="371.5" width="128" height="22"/>
-                            <fontDescription key="fontDescription" type="system" pointSize="18"/>
-                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                            <nil key="highlightedColor"/>
-                        </label>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" usesAttributedText="YES" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="W93-H6-Fou" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                            <rect key="frame" x="30" y="408.5" width="315" height="17"/>
-                            <attributedString key="attributedText">
-                                <fragment content="You haven't starred any episodes yet.">
-                                    <attributes>
-                                        <color key="NSColor" red="0.66666666666666663" green="0.66666666666666663" blue="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                        <font key="NSFont" metaFont="label" size="14"/>
-                                        <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" lineSpacing="7" tighteningFactorForTruncation="0.0"/>
-                                    </attributes>
-                                </fragment>
-                            </attributedString>
-                            <nil key="highlightedColor"/>
-                        </label>
-                    </subviews>
-                    <viewLayoutGuide key="safeArea" id="UZT-UU-oZQ"/>
-                    <color key="backgroundColor" red="0.98823529409999999" green="0.98823529409999999" blue="0.98823529409999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                    <constraints>
-                        <constraint firstItem="W93-H6-Fou" firstAttribute="centerX" secondItem="VFM-dG-gY7" secondAttribute="centerX" id="1hL-14-7Bz"/>
-                        <constraint firstAttribute="trailing" secondItem="W93-H6-Fou" secondAttribute="trailing" constant="30" id="EZM-z5-DHs"/>
-                        <constraint firstItem="LDn-E9-TQd" firstAttribute="centerX" secondItem="VFM-dG-gY7" secondAttribute="centerX" id="Hhg-yO-uwO"/>
-                        <constraint firstItem="910-uU-m8w" firstAttribute="centerX" secondItem="VFM-dG-gY7" secondAttribute="centerX" id="WGQ-9c-Y5n"/>
-                        <constraint firstItem="W93-H6-Fou" firstAttribute="leading" secondItem="VFM-dG-gY7" secondAttribute="leading" constant="30" id="aeA-QU-wMc"/>
-                        <constraint firstItem="910-uU-m8w" firstAttribute="top" secondItem="LDn-E9-TQd" secondAttribute="bottom" constant="66" id="bcv-go-Rn4">
-                            <variation key="heightClass=compact" constant="30"/>
-                        </constraint>
-                        <constraint firstItem="W93-H6-Fou" firstAttribute="top" secondItem="910-uU-m8w" secondAttribute="bottom" constant="15" id="oNc-Pc-d90"/>
-                        <constraint firstItem="LDn-E9-TQd" firstAttribute="centerY" secondItem="VFM-dG-gY7" secondAttribute="centerY" constant="-90" id="uj9-Q0-qIh">
-                            <variation key="heightClass=compact" constant="-50"/>
-                        </constraint>
-                    </constraints>
-                </view>
                 <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="VQm-Vl-pZf" customClass="ThemeableTable" customModule="podcasts" customModuleProvider="target">
                     <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                     <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -83,7 +33,7 @@
                     </connections>
                 </tableView>
                 <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="white" translatesAutoresizingMaskIntoConstraints="NO" id="McZ-bj-10f" customClass="ThemeLoadingIndicator" customModule="podcasts" customModuleProvider="target">
-                    <rect key="frame" x="177.5" y="323.5" width="20" height="20"/>
+                    <rect key="frame" x="177.5" y="333.5" width="20" height="20"/>
                 </activityIndicatorView>
                 <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Bza-mD-9MN" customClass="MultiSelectFooterView" customModule="podcasts" customModuleProvider="target">
                     <rect key="frame" x="8" y="602" width="359" height="65"/>
@@ -102,11 +52,7 @@
                 <constraint firstItem="VQm-Vl-pZf" firstAttribute="bottom" secondItem="i5M-Pr-FkT" secondAttribute="bottom" id="Eyq-tm-PKJ"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="Bza-mD-9MN" secondAttribute="trailing" constant="8" id="FO4-o2-LLI"/>
                 <constraint firstItem="McZ-bj-10f" firstAttribute="centerX" secondItem="fnl-2z-Ty3" secondAttribute="centerX" id="Lkn-dY-d1s"/>
-                <constraint firstItem="VFM-dG-gY7" firstAttribute="bottom" secondItem="fnl-2z-Ty3" secondAttribute="bottom" id="TX8-FA-fG1"/>
-                <constraint firstItem="VFM-dG-gY7" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="b5q-Tg-IUE"/>
-                <constraint firstItem="VFM-dG-gY7" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="i6h-KR-pWs"/>
                 <constraint firstItem="VQm-Vl-pZf" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="i7v-Au-4hS"/>
-                <constraint firstItem="VFM-dG-gY7" firstAttribute="trailing" secondItem="fnl-2z-Ty3" secondAttribute="trailing" id="klU-o1-qTc"/>
                 <constraint firstItem="VQm-Vl-pZf" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="mwO-GN-bAe"/>
                 <constraint firstItem="McZ-bj-10f" firstAttribute="centerY" secondItem="fnl-2z-Ty3" secondAttribute="centerY" id="uXe-a6-25G"/>
             </constraints>
@@ -114,7 +60,6 @@
         </view>
     </objects>
     <resources>
-        <image name="nodownloads" width="124" height="124"/>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -2676,9 +2676,9 @@ internal enum L10n {
   internal static var profileSendingResetEmailFailed: String { return L10n.tr("Localizable", "profile_sending_reset_email_failed") }
   /// 1 File
   internal static var profileSingleFile: String { return L10n.tr("Localizable", "profile_single_file") }
-  /// You haven't starred any episodes yet.
+  /// Star episodes you love and come back to them at anytime.
   internal static var profileStarredNoEpisodesDesc: String { return L10n.tr("Localizable", "profile_starred_no_episodes_desc") }
-  /// Nothing Starred
+  /// Save your favorites
   internal static var profileStarredNoEpisodesTitle: String { return L10n.tr("Localizable", "profile_starred_no_episodes_title") }
   /// By continuing, you agree to our %1$@Privacy Policy%2$@ and %3$@Terms and Conditions%4$@
   internal static func purchaseTerms(_ p1: Any, _ p2: Any, _ p3: Any, _ p4: Any) -> String {

--- a/podcasts/SwiftUI/EmptyStateView.swift
+++ b/podcasts/SwiftUI/EmptyStateView.swift
@@ -3,8 +3,15 @@ import SwiftUI
 protocol EmptyStateViewStyle: ObservableObject {
     var title: Color { get }
     var message: Color { get }
-    var button: Color { get }
     var icon: Color { get }
+    var button: Color { get }
+}
+
+struct EmptyStateAction: Identifiable {
+    let title: String
+    let action: () -> Void
+
+    var id: String { title }
 }
 
 /// Displays an informative view when there are no items to display and can be customized to show a custom view instead
@@ -12,6 +19,9 @@ protocol EmptyStateViewStyle: ObservableObject {
 ///
 /// The colors can be customized using EmptyStateViewStyle
 struct EmptyStateView<Title: View, Style: EmptyStateViewStyle>: View {
+    @ScaledMetric(relativeTo: .headline)
+   private var iconSize = 30
+
     @ObservedObject var style: Style
     let icon: (() -> Image)?
     let title: () -> Title
@@ -39,17 +49,17 @@ struct EmptyStateView<Title: View, Style: EmptyStateViewStyle>: View {
                 icon()
                     .resizable()
                     .foregroundStyle(style.icon)
-                    .frame(width: 30, height: 30)
+                    .frame(width: iconSize, height: iconSize)
             }
 
             title()
-                .font(style: .subheadline, weight: .semibold)
+                .font(.headline)
                 .foregroundStyle(style.title)
 
             if let message {
                 Text(message)
                     .multilineTextAlignment(.center)
-                    .font(style: .body)
+                    .font(.subheadline)
                     .foregroundStyle(style.message)
             }
 
@@ -70,13 +80,6 @@ struct EmptyStateView<Title: View, Style: EmptyStateViewStyle>: View {
     }
 }
 
-struct EmptyStateAction: Identifiable {
-    let title: String
-    let action: () -> Void
-
-    var id: String { title }
-}
-
 private enum EmptyConstants {
     static let cornerRadius = 4.0
     static let padding = 16.0
@@ -88,11 +91,11 @@ extension EmptyStateView where Title == Text {
     init(title: String, message: String?, icon: (() -> Image)? = nil, actions: [EmptyStateAction], style: Style) {
         self.message = message
         self.actions = actions
+        self.icon = icon
         self.title = {
             Text(title)
         }
         self.style = style
-        self.icon = icon
     }
 }
 
@@ -109,7 +112,7 @@ struct EmptyStateView_Previews: PreviewProvider {
         var background: Color { .black }
         var title: Color { .white }
         var message: Color { .white.opacity(0.8) }
-        var button: Color { .red }
         var icon: Color { .primary }
+        var button: Color { .red }
     }
 }

--- a/podcasts/UIViewController+ContentUnavailableConfiguration.swift
+++ b/podcasts/UIViewController+ContentUnavailableConfiguration.swift
@@ -1,0 +1,29 @@
+private var contentUnavailableKey: UInt8 = 0
+
+extension UIViewController {
+    private var pc_contentUnavailableView: UIView? {
+        get { objc_getAssociatedObject(self, &contentUnavailableKey) as? UIView }
+        set { objc_setAssociatedObject(self, &contentUnavailableKey, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC) }
+    }
+
+    func setContentUnavailableConfiguration(_ configuration: UIContentConfiguration?) {
+        // Remove previous view if any
+        pc_contentUnavailableView?.removeFromSuperview()
+        pc_contentUnavailableView = nil
+
+        guard let configuration = configuration else { return }
+
+        let configView = configuration.makeContentView()
+        configView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(configView)
+
+        NSLayoutConstraint.activate([
+            configView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            configView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            configView.leadingAnchor.constraint(greaterThanOrEqualTo: view.leadingAnchor, constant: 20),
+            configView.trailingAnchor.constraint(lessThanOrEqualTo: view.trailingAnchor, constant: -20)
+        ])
+
+        pc_contentUnavailableView = configView
+    }
+}

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -1538,10 +1538,10 @@
 "playback_effects" = "Playback effects";
 
 /* Description for the empty state on screen where the user can review their starred (favorited) podcast episodes */
-"profile_starred_no_episodes_desc" = "You haven't starred any episodes yet.";
+"profile_starred_no_episodes_desc" = "Star episodes you love and come back to them at anytime.";
 
 /* Title for the empty state on screen where the user can review their starred (favorited) podcast episodes */
-"profile_starred_no_episodes_title" = "Nothing Starred";
+"profile_starred_no_episodes_title" = "Save your favorites";
 
 /* Used next to a setting for how fast audio will play */
 "speed" = "Speed";


### PR DESCRIPTION
| 📘 Part of: #3102 | 
|:---:|

Fixes #3106

* Implements a new `ContentUnavailableConfiguration.emptyState` method to use the `EmptyStateView` with `contentUnavailableConfiguration` (or other `UIContentConfiguration` spots like cells)
* Adds a [backfilled implementation of `setContentUnavailableConfiguration`](https://github.com/Automattic/pocket-casts-ios/pull/3129/files#diff-96a67eb826f97d869f73c6614c826d1d4a65691fd56d6e968dbc7980f8b279c2) for `UIViewController` on iOS 16
* Adds a backfilled implementation of `UIHostingConfiguration`[ with `HostingConfiguration`](https://github.com/Automattic/pocket-casts-ios/pull/3129/files#diff-d75225af3f4d1363f7a8fee5019e9d00a6940db4c5f1a06fd526399f06ffdbed) - this is hopefully temporary with iOS 15 being dropped in 7.91
* Adds the Starred page empty state

#### Themes

| | | |
|--|--|--|
| ![simulator_screenshot_06B7203E-F525-4CE8-ACA2-CB73C4CDB5AF](https://github.com/user-attachments/assets/077187b8-479e-4fd6-96fa-b57a79b83f34) | ![Simulator Screenshot - iPhone 16 - 2025-05-14 at 20 21 39](https://github.com/user-attachments/assets/1e77bd52-4328-4238-b636-b964a5ce76b8) | ![Simulator Screenshot - iPhone 16 - 2025-05-14 at 20 21 52](https://github.com/user-attachments/assets/3beedb91-fe43-49e5-a2e7-3d1729433a95) |

#### Dynamic Type

| | | |
|--|--|--|
| ![Simulator Screenshot - iPhone 16 - 2025-05-14 at 20 56 29](https://github.com/user-attachments/assets/120dadce-fd45-422a-b74b-8b03f1d301c3) | ![simulator_screenshot_06B7203E-F525-4CE8-ACA2-CB73C4CDB5AF](https://github.com/user-attachments/assets/077187b8-479e-4fd6-96fa-b57a79b83f34) | ![Simulator Screenshot - iPhone 16 - 2025-05-14 at 20 56 25](https://github.com/user-attachments/assets/42759ed9-cf20-403b-a02e-71613a5a709a) |


#### iOS Versions

| 15 | 16 | 18 |
|--|--|--|
![simulator_screenshot_82483ADC-7B72-46C4-B028-481ACF4293F8](https://github.com/user-attachments/assets/33860265-dc8d-4eea-96f1-9d1763e86643) | ![Simulator Screenshot - iPhone 14 - 2025-05-14 at 22 04 02](https://github.com/user-attachments/assets/fd302fb0-8802-40c1-a390-360ba4e20155) | ![Simulator Screenshot - iPhone 16 - 2025-05-14 at 22 03 38](https://github.com/user-attachments/assets/3c1babf6-fe3f-4395-a857-4820b059f0b6) |

#### iPad

| Portrait | Landscape |
|--|--|
| ![Simulator Screenshot - iPad Pro (9 7-inch) - 2025-05-15 at 10 03 45](https://github.com/user-attachments/assets/9a0a15a7-0842-4999-9a2f-64a745cdd30b) | ![Simulator Screenshot - iPad Pro (9 7-inch) - 2025-05-15 at 10 03 49](https://github.com/user-attachments/assets/a89c57e9-97a6-4a99-92f5-09efa27228b5) |

## To test

* Use a profile with no starred episodes
* Visit Profile > Starred
* ✅ Verify that the new empty state view appears

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
