### PR TITLE
Recommendations: Filter the current podcast out of Recommendations

### DIFF
--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -1404,7 +1404,9 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
         updateEmptyStateVisibility()
 
         do {
-            recommendations = try await ServerPodcastManager.shared.loadRecommendations(for: podcast.uuid, in: Settings.userRegion())
+            var originalRecommendations = try await ServerPodcastManager.shared.loadRecommendations(for: podcast.uuid, in: Settings.userRegion())
+            filterCurrentPodcast(from: &originalRecommendations)
+            recommendations = originalRecommendations
             guard !Task.isCancelled else { return }
             hasSimilarShows.send(recommendations?.podcasts?.isEmpty == false)
         } catch {
@@ -1416,6 +1418,13 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
 
         isLoadingRecommendations.send(false)
         updateEmptyStateVisibility()
+    }
+
+    private func filterCurrentPodcast(from collection: inout PodcastCollection?) {
+        if var podcasts = collection?.podcasts {
+            podcasts = podcasts.filter { $0.uuid != self.podcast?.uuid }
+            collection?.podcasts = podcasts
+        }
     }
 
     private func updateEmptyStateVisibility() {


### PR DESCRIPTION
| 📘 Part of: #2989 |
|:---:|

Fixes an issue where the current podcast may show up in the Category list, the fallback when no show recommendations are available.

| Before | After |
|--|--|
| ![Simulator Screenshot - iPhone 16 - 2025-05-14 at 22 31 24](https://github.com/user-attachments/assets/c3e10aa4-184d-45d4-a425-2ca9c5de774f) | ![Simulator Screenshot - iPhone 16 - 2025-05-14 at 22 34 19](https://github.com/user-attachments/assets/9095013f-b0ac-4e6c-88e0-82718a52aa8d) |

## To test

* Change region to Australia in Discover
* Search for the podcast: "Mushroom Case Daily"
* Switch to the "You might like" tab
* ✅ Verify that "Mushroom Case Daily" does not show

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
