### PR TITLE
Improved podcast image header contrast

### DIFF
--- a/podcasts/Enumerations.swift
+++ b/podcasts/Enumerations.swift
@@ -78,7 +78,7 @@ enum PodcastFinishedAction: Int {
 }
 
 enum PodcastThumbnailSize {
-    case list, grid, page
+    case list, grid, page, detail
 }
 
 enum PodcastLicensing: Int32 {

--- a/podcasts/ImageManager.swift
+++ b/podcasts/ImageManager.swift
@@ -469,7 +469,7 @@ class ImageManager {
         case .list:
             let name = Theme.isDarkTheme() ? "noartwork-list-dark" : "noartwork-list"
             return UIImage(named: name)
-        case .page:
+        case .page, .detail:
             let name = Theme.isDarkTheme() ? "noartwork-page-dark" : "noartwork-page"
             return UIImage(named: name)
         }
@@ -509,7 +509,7 @@ class ImageManager {
             let shortestSide = screenHeight > screenWidth ? screenWidth : screenHeight
 
             return Int(round(shortestSide * UIScreen.main.scale / 3.0))
-        case .page:
+        case .page, .detail:
             return Int(320.0 * UIScreen.main.scale)
         }
     }

--- a/podcasts/PodcastHeaderView.swift
+++ b/podcasts/PodcastHeaderView.swift
@@ -36,7 +36,7 @@ struct PodcastHeaderView: View {
             Spacer().frame(height: 16)
             HStack(alignment: .top) {
                 Spacer()
-                PodcastImageViewWrapper(podcastUUID: viewModel.podcast.uuid, size: .page)
+                PodcastImageViewWrapper(podcastUUID: viewModel.podcast.uuid, size: .detail)
                     .frame(width: viewModel.isExpanded ? Constants.largeImageSize : Constants.smallImageSize, height: viewModel.isExpanded ? Constants.largeImageSize : Constants.smallImageSize)
                     .onTapGesture {
                         withAnimation(.interpolatingSpring(stiffness: 100, damping: 15)) {

--- a/podcasts/PodcastImageView.swift
+++ b/podcasts/PodcastImageView.swift
@@ -51,7 +51,8 @@ class PodcastImageView: UIView {
     }
 
     func adjustForSize(_ size: PodcastThumbnailSize) {
-        if size == .page {
+        switch size {
+        case .page:
             shadowView?.layer.shadowColor = UIColor.black.cgColor
             shadowView?.layer.shadowOffset = CGSize(width: 0, height: 1)
             shadowView?.layer.shadowOpacity = 0.1
@@ -59,7 +60,15 @@ class PodcastImageView: UIView {
             shadowView?.layer.cornerRadius = 8
 
             imageView?.layer.cornerRadius = 8
-        } else {
+        case .detail:
+            shadowView?.layer.shadowColor = UIColor.black.withAlphaComponent(0.2).cgColor
+            shadowView?.layer.shadowOffset = CGSize(width: 0, height: 2)
+            shadowView?.layer.shadowOpacity = 1
+            shadowView?.layer.shadowRadius = 10
+            shadowView?.layer.cornerRadius = 8
+
+            imageView?.layer.cornerRadius = 8
+        default:
             shadowView?.layer.shadowColor = UIColor.black.cgColor
             shadowView?.layer.shadowOffset = CGSize(width: 0, height: 1)
             shadowView?.layer.shadowOpacity = 0.1


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
| 1 | 2 |
| - | - |
| ![simulator_screenshot_C7267605-5200-4B34-A91F-DD10FD49E3E8](https://github.com/user-attachments/assets/debf9049-aa41-4f3e-b693-be0a7e59e976) | ![simulator_screenshot_F3D4B54D-E3A4-40E4-8F68-DBB4D4B2EAD9](https://github.com/user-attachments/assets/77fecb6d-d7c8-416b-aa90-b436b2fac5c4) |

This PR tweak the shadow color and radius of the podcast image when used on the podcast header, so we can have better contrast between the image and the blurred background.

## To test

1. Start the podcast
2. Open a podcast with a image that can cause contrast issues, ex: `This American Life`
3. Check the podcast image on top on both small and larger size ( tap on the image to switch)

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
