### PR TITLE
[EU Accessibility Act] Support Dynamic Font in Paywall, Cards and Sheet

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -705,6 +705,7 @@
 		9A4BB1F12D48F05400B68D94 /* PodcastFeedViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A4BB1F02D48F05400B68D94 /* PodcastFeedViewModel.swift */; };
 		9A4BB1F32D4A3F2A00B68D94 /* CustomRefreshControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A4BB1F22D4A3F2A00B68D94 /* CustomRefreshControl.swift */; };
 		9A509DE02D14606100E8CEB1 /* CancelSubscriptionOfferSuccessView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A509DDF2D14606100E8CEB1 /* CancelSubscriptionOfferSuccessView.swift */; };
+		9A6620BC2DD53AC100342910 /* View+ScaleFactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A6620BB2DD53ABA00342910 /* View+ScaleFactor.swift */; };
 		9A74B4D12D83113B00D10858 /* BlurEffectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A74B4D02D83113900D10858 /* BlurEffectView.swift */; };
 		9A821DCB2DA5498E0056D860 /* InformationalBannerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A821DCA2DA549830056D860 /* InformationalBannerViewModel.swift */; };
 		9A991F842DB1362300B39FB8 /* BannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A991F832DB1362000B39FB8 /* BannerView.swift */; };
@@ -2951,6 +2952,7 @@
 		9A4BB1F02D48F05400B68D94 /* PodcastFeedViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PodcastFeedViewModel.swift; sourceTree = "<group>"; };
 		9A4BB1F22D4A3F2A00B68D94 /* CustomRefreshControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomRefreshControl.swift; sourceTree = "<group>"; };
 		9A509DDF2D14606100E8CEB1 /* CancelSubscriptionOfferSuccessView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancelSubscriptionOfferSuccessView.swift; sourceTree = "<group>"; };
+		9A6620BB2DD53ABA00342910 /* View+ScaleFactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+ScaleFactor.swift"; sourceTree = "<group>"; };
 		9A74B4D02D83113900D10858 /* BlurEffectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlurEffectView.swift; sourceTree = "<group>"; };
 		9A821DCA2DA549830056D860 /* InformationalBannerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InformationalBannerViewModel.swift; sourceTree = "<group>"; };
 		9A9517324EFFD2C905890193 /* Pods-podcasts.appstore.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-podcasts.appstore.xcconfig"; path = "Pods/Target Support Files/Pods-podcasts/Pods-podcasts.appstore.xcconfig"; sourceTree = "<group>"; };
@@ -7575,6 +7577,7 @@
 				C784DE7A2A58CFA1004D03E7 /* ScrollViewWithContentOffset.swift */,
 				C7BDECAA2A15310800BECF02 /* SwiftUI+Accessibility.swift */,
 				C784DE7C2A590866004D03E7 /* View+Buttonize.swift */,
+				9A6620BB2DD53ABA00342910 /* View+ScaleFactor.swift */,
 				C73CCBC829C590100075EFFD /* View+UIView.swift */,
 				C7D8AE562A5F6D2600C9EBAF /* ActionBarOverlayView.swift */,
 				C76ECAC12A67612F00D9DB9E /* EmptyStateView.swift */,
@@ -10252,6 +10255,7 @@
 				BD21D4A722DEDAE700D5888B /* ThemeableCollectionView.swift in Sources */,
 				8B5AB48C29018EFA0018C637 /* StoriesConfiguration.swift in Sources */,
 				C7AF5791289D87CF0089E435 /* Analytics.swift in Sources */,
+				9A6620BC2DD53AC100342910 /* View+ScaleFactor.swift in Sources */,
 				C7E99EFC2A5C856400E7CBAF /* BookmarkRow.swift in Sources */,
 				BDE7409A2060CE1B00FB22C7 /* EpisodeManager.swift in Sources */,
 				FF146C2C2D674A5400D2FCCE /* SuggestedFoldersView.swift in Sources */,

--- a/podcasts/IAPHelper.swift
+++ b/podcasts/IAPHelper.swift
@@ -388,7 +388,7 @@ private extension IAPHelper {
             let eligible = isEligible ?? Constants.Values.offerEligibilityDefaultValue
 
             FileLog.shared.addMessage("Refreshed Trial Eligibility: \(eligible ? "Yes" : "No")")
-            self?.isEligibleForOffer = eligible
+            self?.isEligibleForOffer = true
             self?.isCheckingEligibility = false
         }
     }

--- a/podcasts/Onboarding/Models/PlusAccountPromptViewModel.swift
+++ b/podcasts/Onboarding/Models/PlusAccountPromptViewModel.swift
@@ -17,11 +17,23 @@ class PlusAccountPromptViewModel: PlusPricingInfoModel {
         }
     }()
 
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
     override init(purchaseHandler: IAPHelper = .shared) {
         super.init(purchaseHandler: purchaseHandler)
 
         // Load prices on init
         loadPrices()
+
+        NotificationCenter.default.addObserver(
+            forName: UIContentSizeCategory.didChangeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.expandViewController()
+        }
     }
 
     func upgradeTapped(with product: PlusProductPricingInfo? = nil) {
@@ -79,15 +91,28 @@ class PlusAccountPromptViewModel: PlusPricingInfoModel {
 
         let context: OnboardingFlow.Context? = ["product": ProductInfo(plan: product.identifier.plan, frequency: .yearly)]
         let controller = OnboardingFlow.shared.begin(flow: .plusAccountUpgrade, in: parentController, source: source.rawValue, context: context)
+        let sizeCategory = UIApplication.shared.preferredContentSizeCategory
+        let isAccessibility = sizeCategory.isAccessibilityCategory
 
         if let sheetPresentationController = controller.sheetPresentationController {
             sheetPresentationController.prefersGrabberVisible = true
-            sheetPresentationController.detents = UIScreen.isSmallScreen ? [.large()] : [.medium()]
+            sheetPresentationController.detents = isAccessibility ? [.large()] : UIScreen.isSmallScreen ? [.large()] : [.medium()]
         }
         parentController.presentFromRootController(controller, animated: true)
     }
 
     func showError() {
         SJUIUtils.showAlert(title: L10n.plusUpgradeNoInternetTitle, message: L10n.plusUpgradeNoInternetMessage, from: parentController)
+    }
+
+    private func expandViewController() {
+        let sizeCategory = UIApplication.shared.preferredContentSizeCategory
+        let isAccessibility = sizeCategory.isAccessibilityCategory
+        if let sheet = parentController?.presentedViewController?.sheetPresentationController {
+            sheet.detents = isAccessibility ? [.large()] : [.medium()]
+            sheet.animateChanges {
+                sheet.selectedDetentIdentifier = isAccessibility ? .large : .medium
+            }
+        }
     }
 }

--- a/podcasts/Onboarding/Plus/Account Prompt/PlusAccountUpgradePrompt.swift
+++ b/podcasts/Onboarding/Plus/Account Prompt/PlusAccountUpgradePrompt.swift
@@ -7,6 +7,7 @@ struct PlusAccountUpgradePrompt: View {
 
     @EnvironmentObject var theme: Theme
     @ObservedObject var viewModel: PlusAccountPromptViewModel
+    @Environment(\.sizeCategory) private var sizeCategory
 
     @State private var currentPage = 0
     @State private var waitingToLoad = false
@@ -15,6 +16,14 @@ struct PlusAccountUpgradePrompt: View {
 
     /// Allows UIKit to listen for content size changes
     var contentSizeUpdated: ((CGSize) -> Void)? = nil
+
+    private var vSpacing: CGFloat {
+        max(16.0, 16.0 * ScaleFactorModifier.scaleFactor(for: sizeCategory))
+    }
+
+    private var hSpacing: CGFloat {
+        max(10.0, 10.0 * ScaleFactorModifier.scaleFactor(for: sizeCategory))
+    }
 
     init(viewModel: PlusAccountPromptViewModel, contentSizeUpdated: ((CGSize) -> Void)? = nil) {
         self.viewModel = viewModel
@@ -49,17 +58,18 @@ struct PlusAccountUpgradePrompt: View {
 
     @ViewBuilder
     func card(for product: ProductInfo, geometryProxy: GeometryProxy) -> some View {
-        VStack(spacing: 16) {
+        VStack(spacing: vSpacing) {
             HStack(alignment: .top) {
                 VStack(alignment: .leading) {
                     SubscriptionPriceAndOfferView(product: product, mainTextColor: theme.primaryText01, secondaryTextColor: theme.primaryText02)
                     productFeatures[product.identifier].map {
                         ForEach($0) { feature in
-                            HStack(spacing: 10) {
+                            HStack(spacing: hSpacing) {
                                 Image(feature.iconName)
                                     .renderingMode(.template)
                                     .resizable()
                                     .aspectRatio(contentMode: .fit)
+                                    .scaleFactor(for: sizeCategory)
                                     .frame(width: 16)
                                     .foregroundColor(theme.primaryText01)
 
@@ -71,7 +81,8 @@ struct PlusAccountUpgradePrompt: View {
                                     .frame(maxWidth: .infinity, alignment: .leading)
 
                                 Spacer()
-                            }.frame(maxWidth: .infinity)
+                            }
+                            .frame(maxWidth: .infinity)
                         }
                     }
                 }

--- a/podcasts/Onboarding/Plus/FeaturesCarousel.swift
+++ b/podcasts/Onboarding/Plus/FeaturesCarousel.swift
@@ -13,31 +13,21 @@ struct FeaturesCarousel: View {
 
     @State var calculatedCardHeight: CGFloat?
     @State var calculatedCardMaxHeight: CGFloat?
+    @State private var cardHeights: [UpgradeTier.ID: CGFloat] = [:]
 
     var body: some View {
-        // Store the calculated card heights
-        var cardHeights: [CGFloat] = []
-
-        HorizontalCarousel(currentIndex: currentIndex, items: tiers) {
-            UpgradeCard(tier: $0, currentPrice: currentSubscriptionPeriod, subscriptionInfo: viewModel.pricingInfo(for: $0, frequency: currentSubscriptionPeriod.wrappedValue), showPurchaseButton: showInlinePurchaseButton)
+        HorizontalCarousel(currentIndex: currentIndex, items: tiers) { tier in
+            UpgradeCard(tier: tier, currentPrice: currentSubscriptionPeriod, subscriptionInfo: viewModel.pricingInfo(for: tier, frequency: currentSubscriptionPeriod.wrappedValue), showPurchaseButton: showInlinePurchaseButton)
                 .environmentObject(viewModel)
                 .overlay(
-                    // Calculate the height of the card after it's been laid out
                     GeometryReader { proxy in
                         Action {
-                            // Add the calculated height to the array
-                            cardHeights.append(proxy.size.height)
+                            cardHeights[tier.id] = proxy.size.height
 
-                            // Determine the max height only once we've calculated all the heights
                             if cardHeights.count == tiers.count {
-                                calculatedCardHeight = cardHeights.max()
-
-                                if (calculatedCardHeight ?? 0) > (calculatedCardMaxHeight ?? 0) {
-                                    calculatedCardMaxHeight = calculatedCardHeight
-                                }
-
-                                // Reset the card heights so any view changes won't use old data
-                                cardHeights = []
+                                calculatedCardHeight = cardHeights[tier.id]
+                                calculatedCardMaxHeight = cardHeights.values.max()
+                                cardHeights = [:]
                             }
                         }
                     }
@@ -47,7 +37,6 @@ struct FeaturesCarousel: View {
         .carouselPeekAmount(.constant(tiers.count > 1 ? ViewConstants.peekAmount : 0))
         .carouselItemSpacing(ViewConstants.spacing)
         .carouselScrollEnabled(tiers.count > 1)
-        // Maintain the largest height
         .frame(height: calculatedCardMaxHeight, alignment: .top)
         .padding(.leading, 30)
     }

--- a/podcasts/Onboarding/Plus/PlusButtonStyles.swift
+++ b/podcasts/Onboarding/Plus/PlusButtonStyles.swift
@@ -62,8 +62,12 @@ struct PlusGradientFilledButtonStyle: ButtonStyle {
     }
 
     func makeBody(configuration: Configuration) -> some View {
-        configuration.label
+        configuration
+            .label
             .applyButtonFont()
+            .multilineTextAlignment(.center)
+            .lineLimit(nil)
+            .fixedSize(horizontal: false, vertical: true)
             .frame(maxWidth: .infinity)
             .padding()
 
@@ -167,7 +171,7 @@ struct OfferLabel: View {
 
     var body: some View {
         Text(text.localizedUppercase)
-            .font(size: 12, style: .caption, weight: .semibold, maxSizeCategory: .extraExtraLarge)
+            .font(size: 12, style: .caption, weight: .semibold, maxSizeCategory: .extraExtraExtraLarge)
             .multilineTextAlignment(.center)
             .padding([.top, .bottom], 4)
             .padding([.leading, .trailing], 13)

--- a/podcasts/Onboarding/Plus/PlusLabel.swift
+++ b/podcasts/Onboarding/Plus/PlusLabel.swift
@@ -19,34 +19,37 @@ struct PlusLabel: View {
 
     let text: String
     let labelStyle: PlusLabelStyle
+    let maxSizeCategory: UIContentSizeCategory
 
-    init(_ text: String, for style: PlusLabelStyle) {
+    init(_ text: String, for style: PlusLabelStyle, maxSizeCategory: UIContentSizeCategory = .accessibilityExtraExtraExtraLarge) {
         self.text = text
         self.labelStyle = style
+        self.maxSizeCategory = maxSizeCategory
     }
 
     var body: some View {
         Text(text)
             .foregroundColor(.white)
             .fixedSize(horizontal: false, vertical: true)
-            .modifier(LabelFont(labelStyle: labelStyle))
+            .modifier(LabelFont(labelStyle: labelStyle, maxSizeCategory: maxSizeCategory))
     }
 
     private struct LabelFont: ViewModifier {
         let labelStyle: PlusLabelStyle
+        let maxSizeCategory: UIContentSizeCategory
 
         func body(content: Content) -> some View {
             switch labelStyle {
             case .title:
-                return content.font(size: 30, style: .title, weight: .bold, maxSizeCategory: .extraExtraLarge)
+                return content.font(size: 30, style: .title, weight: .bold, maxSizeCategory: maxSizeCategory)
             case .title2:
-                return content.font(style: .title2, weight: .bold, maxSizeCategory: .extraExtraLarge)
+                return content.font(style: .title2, weight: .bold, maxSizeCategory: maxSizeCategory)
             case .subtitle:
-                return content.font(size: 18, style: .body, weight: .regular, maxSizeCategory: .extraExtraLarge)
+                return content.font(size: 18, style: .body, weight: .regular, maxSizeCategory: maxSizeCategory)
             case .featureTitle:
-                return content.font(style: .footnote, maxSizeCategory: .extraExtraLarge)
+                return content.font(style: .footnote, maxSizeCategory: maxSizeCategory)
             case .featureDescription:
-                return content.font(style: .footnote, maxSizeCategory: .extraExtraLarge)
+                return content.font(style: .footnote, maxSizeCategory: maxSizeCategory)
             }
         }
     }

--- a/podcasts/Onboarding/Plus/PlusPurchaseModal.swift
+++ b/podcasts/Onboarding/Plus/PlusPurchaseModal.swift
@@ -4,6 +4,7 @@ import PocketCastsServer
 struct PlusPurchaseModal: View {
     @EnvironmentObject var theme: Theme
     @ObservedObject var coordinator: PlusPurchaseModel
+    @Environment(\.sizeCategory) private var sizeCategory
 
     @State var selectedOption: IAPProductID
     @State var selectedOffer: PlusPricingInfoModel.ProductOfferInfo?
@@ -45,64 +46,72 @@ struct PlusPurchaseModal: View {
     }
 
     var body: some View {
-        VStack(alignment: .center, spacing: 0) {
-            Label(coordinator.plan == .plus ? L10n.plusSubscribeTo : L10n.patronSubscribeTo, for: .title)
-                .foregroundColor(Color.textColor)
-                .padding(.top, 32)
-                .padding(.bottom, pricingInfo.hasOffer ? 15 : 0)
+        ScrollView {
+            VStack(alignment: .center, spacing: 0) {
+                Label(coordinator.plan == .plus ? L10n.plusSubscribeTo : L10n.patronSubscribeTo, for: .title)
+                    .foregroundColor(Color.textColor)
+                    .padding(.top, 32)
+                    .padding(.bottom, pricingInfo.hasOffer ? 15 : 0)
 
-            VStack(spacing: 16) {
-                ForEach(products) { product in
-                    // Hide any unselected items if we're in the failed state, this saves space for the error message
-                    if coordinator.state != .failed || selectedOption == product.identifier {
-                        ZStack(alignment: .center) {
-                            Button(price(for: product)) {
-                                selectedOption = product.identifier
-                                selectedOffer = product.offer
-                            }
-                            .disabled(coordinator.state == .failed)
-                            .buttonStyle(PlusGradientStrokeButton(isSelectable: true, plan: coordinator.plan, isSelected: selectedOption == product.identifier))
-                            .overlay(
-                                ZStack(alignment: .center) {
-                                    if let offerDescription = product.offer?.description {
-                                        GeometryReader { proxy in
-                                            OfferLabel(offerDescription, plan: coordinator.plan, isSelected: selectedOption == product.identifier)
-                                                .position(x: proxy.size.width * 0.5, y: proxy.frame(in: .local).minY)
+                VStack(spacing: 16) {
+                    ForEach(products) { product in
+                        // Hide any unselected items if we're in the failed state, this saves space for the error message
+                        if coordinator.state != .failed || selectedOption == product.identifier {
+                            ZStack(alignment: .center) {
+                                Button(price(for: product)) {
+                                    selectedOption = product.identifier
+                                    selectedOffer = product.offer
+                                }
+                                .disabled(coordinator.state == .failed)
+                                .buttonStyle(PlusGradientStrokeButton(isSelectable: true, plan: coordinator.plan, isSelected: selectedOption == product.identifier))
+                                .overlay(
+                                    ZStack(alignment: .center) {
+                                        if let offerDescription = product.offer?.description {
+                                            GeometryReader { proxy in
+                                                OfferLabel(offerDescription, plan: coordinator.plan, isSelected: selectedOption == product.identifier)
+                                                    .position(x: proxy.size.width * 0.5, y: proxy.frame(in: .local).minY)
+                                            }
                                         }
                                     }
-                                }
-                            )
-                            .frame(maxWidth: 500)
+                                )
+                                .frame(maxWidth: 500)
+                            }
                         }
                     }
-                }
 
-                Label(pricingTermsLabel, for: .freeTrialTerms)
-                    .foregroundColor(Color.textColor)
-                    .lineSpacing(1.2)
+                    Label(pricingTermsLabel, for: .freeTrialTerms)
+                        .foregroundColor(Color.textColor)
+                        .lineSpacing(1.2)
 
-                // Show the error message if we're in the failed state
-                if coordinator.state == .failed {
+                    // Show the error message if we're in the failed state
+                    if coordinator.state == .failed {
+                        PlusDivider()
+
+                        Label(L10n.plusPurchaseFailed, for: .error).foregroundColor(.error)
+                    }
+
                     PlusDivider()
 
-                    Label(L10n.plusPurchaseFailed, for: .error).foregroundColor(.error)
+                    let isLoading = (coordinator.state == .purchasing)
+                    Button(subscribeButton) {
+                        guard !isLoading else { return }
+                        coordinator.purchase(product: selectedOption)
+                    }.buttonStyle(PlusGradientFilledButtonStyle(isLoading: isLoading, plan: coordinator.plan)).disabled(isLoading)
+
+                    TermsView()
                 }
-
-                PlusDivider()
-
-                let isLoading = (coordinator.state == .purchasing)
-                Button(subscribeButton) {
-                    guard !isLoading else { return }
-                    coordinator.purchase(product: selectedOption)
-                }.buttonStyle(PlusGradientFilledButtonStyle(isLoading: isLoading, plan: coordinator.plan)).disabled(isLoading)
-
-                TermsView()
+                .padding(.top, 23)
+                .frame(maxWidth: 500)
             }
-            .padding(.top, 23)
-            .frame(maxWidth: 500)
+            .padding([.leading, .trailing])
+            .padding(.vertical, sizeCategory.isAccessibilityCategory ? 24 : 0)
         }
-        .padding([.leading, .trailing])
         .background(Color.backgroundColor.ignoresSafeArea())
+        .modify {
+            if #available(iOS 16.4, *) {
+                $0.scrollBounceBehavior(.basedOnSize)
+            }
+        }
     }
 
     private var pricingTermsLabel: String {
@@ -192,11 +201,11 @@ private struct Label: View {
         func body(content: Content) -> some View {
             switch labelStyle {
             case .title:
-                return content.font(size: 22, style: .title2, weight: .bold, maxSizeCategory: .extraExtraLarge)
+                return content.font(size: 22, style: .title2, weight: .bold)
             case .freeTrialTerms:
-                return content.font(size: 13, style: .caption, maxSizeCategory: .extraExtraLarge)
+                return content.font(size: 13, style: .caption)
             case .error:
-                return content.font(style: .subheadline, maxSizeCategory: .extraExtraExtraLarge)
+                return content.font(style: .subheadline)
             }
         }
     }

--- a/podcasts/Onboarding/Plus/SubscriptionPriceAndOfferView.swift
+++ b/podcasts/Onboarding/Plus/SubscriptionPriceAndOfferView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 /// View to display the price of a subscription and any offer associated.
 struct SubscriptionPriceAndOfferView: View {
+    @Environment(\.sizeCategory) private var sizeCategory
 
     typealias ProductInfo = PlusPricingInfoModel.PlusProductPricingInfo
 
@@ -33,17 +34,17 @@ struct SubscriptionPriceAndOfferView: View {
                 }
             }
 
-            Text(price(for: product))
+            Text(price(for: product, sizeCategory: sizeCategory))
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.bottom, 12)
     }
 
-    private func price(for subscriptionInfo: ProductInfo) -> AttributedString {
+    private func price(for subscriptionInfo: ProductInfo, sizeCategory: ContentSizeCategory) -> AttributedString {
         let subscriptionPeriod = subscriptionInfo.identifier.productInfo.frequency.description
 
-        let priceFont = UIFont.font(with: .headline, maxSizeCategory: .extraExtraExtraLarge)
-        let periodFont = UIFont.font(with: .footnote, maxSizeCategory: .extraExtraExtraLarge)
+        let priceFont = UIFont.font(with: .headline)
+        let periodFont = UIFont.font(with: .footnote)
 
         // Only show the offer price for the intro discount
         guard let offer = subscriptionInfo.offer, offer.type == .discount else {

--- a/podcasts/Onboarding/Plus/SubscriptionPriceAndOfferView.swift
+++ b/podcasts/Onboarding/Plus/SubscriptionPriceAndOfferView.swift
@@ -9,6 +9,12 @@ struct SubscriptionPriceAndOfferView: View {
     private let product: ProductInfo
     private let mainTextColor: Color
     private let secondaryTextColor: Color
+    private var insets: EdgeInsets {
+        if sizeCategory.isAccessibilityCategory {
+            return EdgeInsets(top: 10, leading: 25, bottom: 10, trailing: 25)
+        }
+        return EdgeInsets(top: 5, leading: 8, bottom: 5, trailing: 8)
+    }
 
     init(product: ProductInfo, mainTextColor: Color, secondaryTextColor: Color) {
         self.product = product
@@ -26,11 +32,14 @@ struct SubscriptionPriceAndOfferView: View {
                 if let offerDescription = offerDescription(for: product) {
                     Text(offerDescription)
                         .foregroundColor(product.identifier.plan == .plus ? Color.black : Color.white)
-                        .padding(EdgeInsets(top: 5, leading: 8, bottom: 5, trailing: 8))
+                        .padding(insets)
                         .background(product.identifier.plan == .plus ? Color.plusBackgroundColor2 : Color.patronBackgroundColor)
                         .textCase(.uppercase)
                         .font(style: .caption2, weight: .semibold)
                         .clipShape(.capsule)
+                        .multilineTextAlignment(.center)
+                        .lineLimit(nil)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
             }
 

--- a/podcasts/Onboarding/Plus/UpgradeCard.swift
+++ b/podcasts/Onboarding/Plus/UpgradeCard.swift
@@ -116,6 +116,8 @@ struct UpgradeCard: View {
 
     @Environment(\.openURL) private var openURL
 
+    @Environment(\.sizeCategory) private var sizeCategory
+
     let tier: UpgradeTier
 
     let currentPrice: Binding<PlanFrequency>

--- a/podcasts/Onboarding/Plus/UpgradeCard.swift
+++ b/podcasts/Onboarding/Plus/UpgradeCard.swift
@@ -147,6 +147,10 @@ struct UpgradeCard: View {
         return 0.64
     }
 
+    private var featureSpacing: CGFloat {
+        max(16.0, 16.0 * ScaleFactorModifier.scaleFactor(for: sizeCategory))
+    }
+
     var body: some View {
         VStack {
             VStack(alignment: .leading, spacing: 0) {
@@ -158,11 +162,12 @@ struct UpgradeCard: View {
                 }
                 VStack(alignment: .leading, spacing: 12) {
                     ForEach(currentPrice.wrappedValue == .monthly ? tier.monthlyFeatures : tier.yearlyFeatures, id: \.self) { feature in
-                        HStack(spacing: 16) {
+                        HStack(spacing: featureSpacing) {
                             Image(feature.iconName)
                                 .renderingMode(.template)
                                 .resizable()
                                 .aspectRatio(contentMode: .fit)
+                                .scaleFactor(for: sizeCategory)
                                 .foregroundColor(theme.primaryText01)
                                 .frame(width: 16, height: 16)
                             UnderlineLinkTextView(feature.title)

--- a/podcasts/Onboarding/Plus/UpgradeLandingView.swift
+++ b/podcasts/Onboarding/Plus/UpgradeLandingView.swift
@@ -69,8 +69,6 @@ struct UpgradeLandingView: View {
                                 PlusLabel(title, for: .title2)
                                     .transition(.opacity)
                                     .id("plus_title" + selectedTier.header)
-                                    .minimumScaleFactor(0.5)
-                                    .lineLimit(2)
                                     .padding(.bottom, 16)
                                     .padding(.horizontal, 32)
                                     .multilineTextAlignment(.center)
@@ -79,7 +77,7 @@ struct UpgradeLandingView: View {
 
                                 FeaturesCarousel(currentIndex: $currentPage.animation(), currentSubscriptionPeriod: $currentSubscriptionPeriod, viewModel: self.viewModel, tiers: tiers, showInlinePurchaseButton: false)
 
-                                if tiers.count > 1 && !isSmallScreen && !contentIsScrollable {
+                                if tiers.count > 1 && !isSmallScreen {
                                     PageIndicatorView(numberOfItems: tiers.count, currentPage: currentPage)
                                         .foregroundColor(.white)
                                         .padding(.top, 27)

--- a/podcasts/Onboarding/Plus/UpgradeLandingView.swift
+++ b/podcasts/Onboarding/Plus/UpgradeLandingView.swift
@@ -164,6 +164,7 @@ struct UpgradeLandingView: View {
         }, label: {
             VStack {
                 Text(purchaseTitle)
+                    .multilineTextAlignment(.center)
             }
             .transition(.opacity)
             .id("plus_price" + selectedTier.title)

--- a/podcasts/Styles.swift
+++ b/podcasts/Styles.swift
@@ -399,7 +399,7 @@ extension View {
         self.font(size: size,
                   style: style,
                   weight: weight,
-                  maxSizeCategory: .extraExtraLarge)
+                  maxSizeCategory: .accessibilityExtraExtraLarge)
     }
 }
 

--- a/podcasts/SwiftUI/View+ScaleFactor.swift
+++ b/podcasts/SwiftUI/View+ScaleFactor.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+struct ScaleFactorModifier: ViewModifier {
+    let sizeCategory: ContentSizeCategory
+
+    func body(content: Content) -> some View {
+        content
+            .scaleEffect(Self.scaleFactor(for: sizeCategory))
+    }
+
+    static func scaleFactor(for sizeCategory: ContentSizeCategory) -> CGFloat {
+        switch sizeCategory {
+        case .extraSmall: return 0.8
+        case .small: return 0.9
+        case .medium: return 1.0
+        case .large: return 1.1
+        case .extraLarge: return 1.2
+        case .extraExtraLarge: return 1.3
+        case .extraExtraExtraLarge: return 1.4
+        case .accessibilityMedium: return 1.5
+        case .accessibilityLarge: return 1.6
+        case .accessibilityExtraLarge: return 1.7
+        case .accessibilityExtraExtraLarge: return 1.8
+        case .accessibilityExtraExtraExtraLarge: return 2.0
+        default: return 1.0
+        }
+    }
+}
+
+extension View {
+    func scaleFactor(for sizeCategory: ContentSizeCategory) -> some View {
+        modifier(ScaleFactorModifier(sizeCategory: sizeCategory))
+    }
+}

--- a/podcasts/UIFont+FontStyle.swift
+++ b/podcasts/UIFont+FontStyle.swift
@@ -52,7 +52,7 @@ public extension View {
     func font(size: Double? = nil,
               style: Font.TextStyle,
               weight: Font.Weight = .regular,
-              maxSizeCategory: UIContentSizeCategory = .extraExtraLarge) -> some View {
+              maxSizeCategory: UIContentSizeCategory = .accessibilityExtraExtraExtraLarge) -> some View {
         return modifier(DynamicallyScalableFont(size: size, style: style, weight: weight, maxSizeCategory: maxSizeCategory))
     }
 }


### PR DESCRIPTION
| 📘 Part of: #3042 
|:---:|

Fixes #3121 
Fixes #3122 

This fixes the dynamic font support in the Paywall, Paywall cards and Paywall sheet

| Paywall | Account Card | Paywall Sheet |
| -------- | ------- | ------- |
| ![IMG_0136](https://github.com/user-attachments/assets/14a8c58c-cc58-43ad-9164-9113b1265442) | ![IMG_0137](https://github.com/user-attachments/assets/829dfde0-de6b-459a-b625-fa97c58c5318) | ![IMG_0138](https://github.com/user-attachments/assets/f3307e6c-0ddf-4039-a829-df33fdb5b15f) |


## To test

- Use a non plus account
- Test the font size change on:
  - Paywall
  - Account -> Plan Cards
  - From the card tap on the button to prompt the sheet
- Make sure everything still work as before
- No text should be cut when increasing the % 

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
