### PR TITLE
[Fix] Don't skip if frame is equal or more than file length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 7.89
 -----
 - Add Recommendations feature to Discover and Podcast pages [#2989](https://github.com/Automattic/pocket-casts-ios/issues/2989)
+- Fix repeating the episode when skipping forward [#3138](https://github.com/Automattic/pocket-casts-ios/pull/3138)
 
 7.88
 -----

--- a/podcasts/AudioReadTask.swift
+++ b/podcasts/AudioReadTask.swift
@@ -46,11 +46,12 @@ class AudioReadTask {
 
         if playPositionHint > 0 {
             currentFramePosition = framePositionForTime(playPositionHint).framePosition
-            if currentFramePosition < audioFile.length {
+            if currentFramePosition <= audioFile.length {
                 FileLog.shared.addMessage("Setting framePosition to \(currentFramePosition) for file: \(audioFile.url.lastPathComponent)")
                 audioFile.framePosition = currentFramePosition
             } else {
                 FileLog.shared.addMessage("Attempted to seek past EOF: \(currentFramePosition) >= \(audioFile.length), file: \(audioFile.url.lastPathComponent)")
+                audioFile.framePosition = audioFile.length
             }
         }
     }


### PR DESCRIPTION
Ref C02A333D8LQ-Slack-p1747211200775189

This PR should fix the episode reload when skipping

## To test

- Make sure you have few episodes in the queue
- Play an episode
- Use Siri to skip forward over the time
- After Siri disappear the app should move to the next episode in the queue
- Do the same test but this time by using the skip forward buttons
- Do the same test with scrubbing till the end

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
