### PR TITLE
[Empty States] Add Downloads empty state

### DIFF
--- a/podcasts/Common SwiftUI/BookmarksEmptyStateView.swift
+++ b/podcasts/Common SwiftUI/BookmarksEmptyStateView.swift
@@ -27,7 +27,7 @@ struct BookmarksEmptyStateView<Style: EmptyStateViewStyle>: View {
 // MARK: - Styles
 
 class DefaultEmptyStateStyle: ThemeObserver, EmptyStateViewStyle {
-    var background: Color { theme.primaryUi01Active }
+    var background: Color { theme.primaryUi02 }
     var title: Color { theme.primaryText01 }
     var message: Color { theme.primaryText02 }
     var icon: Color { theme.primaryIcon03 }

--- a/podcasts/ContentUnavailableConfiguration.swift
+++ b/podcasts/ContentUnavailableConfiguration.swift
@@ -62,6 +62,7 @@ struct ContentUnavailableConfiguration {
                 EmptyStateView(title: title, message: message, icon: icon, actions: actions, style: style)
                     .environmentObject(Theme.sharedTheme)
             }
+            .background(style.background)
         } else {
             return HostingConfiguration {
                 EmptyStateView(title: title, message: message, icon: icon, actions: actions, style: style)

--- a/podcasts/DownloadsViewController.swift
+++ b/podcasts/DownloadsViewController.swift
@@ -1,11 +1,16 @@
 import DifferenceKit
+import SwiftUI
 import PocketCastsDataModel
 import PocketCastsServer
 import PocketCastsUtils
 import UIKit
 
 class DownloadsViewController: PCViewController {
-    var episodes = [ArraySection<String, ListEpisode>]()
+    var episodes = [ArraySection<String, ListEpisode>]() {
+        didSet {
+            refreshContentUnavailable()
+        }
+    }
     var cellHeights: [IndexPath: CGFloat] = [:]
 
     private let episodesDataManager = EpisodesDataManager()
@@ -16,36 +21,6 @@ class DownloadsViewController: PCViewController {
 
         return queue
     }()
-
-    @IBOutlet var noDownloadsTitle: ThemeableLabel! {
-        didSet {
-            noDownloadsTitle.text = L10n.downloadsNoDownloadsTitle
-        }
-    }
-
-    @IBOutlet var noDownloadsDescription: ThemeableLabel! {
-        didSet {
-            noDownloadsDescription.text = L10n.downloadsNoDownloadsDesc
-        }
-    }
-
-    @IBOutlet var noDownloadsView: ThemeableView! {
-        didSet {
-            noDownloadsView.style = .primaryUi02
-        }
-    }
-
-    @IBOutlet var noEpisodesIcon: UIImageView! {
-        didSet {
-            noEpisodesIcon.tintColor = ThemeColor.primaryIcon02()
-        }
-    }
-
-    @IBOutlet var noEpisodesDescription: ThemeableLabel! {
-        didSet {
-            noEpisodesDescription.style = .primaryText02
-        }
-    }
 
     @IBOutlet var downloadsTable: UITableView! {
         didSet {
@@ -189,8 +164,23 @@ class DownloadsViewController: PCViewController {
         reloadEpisodes()
     }
 
+    private func refreshContentUnavailable() {
+        var config: UIContentConfiguration?
+
+        if episodes.isEmpty {
+            let title = L10n.downloadsNoDownloadsTitle
+            let message = L10n.downloadsNoDownloadsDesc
+            config = ContentUnavailableConfiguration.emptyState(title: title, message: message, icon: { Image("filter_downloaded") })
+        }
+
+        if #available(iOS 17.0, *) {
+            self.contentUnavailableConfiguration = config
+        } else {
+            self.setContentUnavailableConfiguration(config)
+        }
+    }
+
     override func handleThemeChanged() {
-        noEpisodesIcon.tintColor = ThemeColor.primaryIcon02()
         downloadsTable.reloadData()
     }
 

--- a/podcasts/DownloadsViewController.swift
+++ b/podcasts/DownloadsViewController.swift
@@ -87,6 +87,7 @@ class DownloadsViewController: PCViewController {
         insetAdjuster.setupInsetAdjustmentsForMiniPlayer(scrollView: downloadsTable)
 
         title = L10n.downloads
+        view.backgroundColor = ThemeColor.primaryUi02()
 
         showManageDownloadsBanner()
 
@@ -182,6 +183,7 @@ class DownloadsViewController: PCViewController {
 
     override func handleThemeChanged() {
         downloadsTable.reloadData()
+        view.backgroundColor = ThemeColor.primaryUi02()
     }
 
     private func addEventObservers() {

--- a/podcasts/DownloadsViewController.xib
+++ b/podcasts/DownloadsViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -14,11 +14,6 @@
                 <outlet property="downloadsTable" destination="5W5-5i-nVt" id="ibc-qY-t0Q"/>
                 <outlet property="multiSelectFooter" destination="Iys-DQ-1tX" id="MOF-mX-BVm"/>
                 <outlet property="multiSelectFooterBottomConstraint" destination="wfz-i2-BaG" id="6sO-hO-s0l"/>
-                <outlet property="noDownloadsDescription" destination="U9d-CR-ZP6" id="X1c-6R-zch"/>
-                <outlet property="noDownloadsTitle" destination="spn-oM-SVV" id="8c0-JN-9ZV"/>
-                <outlet property="noDownloadsView" destination="7JB-Er-KH5" id="PRb-PH-H7e"/>
-                <outlet property="noEpisodesDescription" destination="U9d-CR-ZP6" id="tmY-Pj-JYN"/>
-                <outlet property="noEpisodesIcon" destination="TU6-kP-f7o" id="C5F-jX-bd5"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
             </connections>
         </placeholder>
@@ -27,48 +22,6 @@
             <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7JB-Er-KH5" userLabel="No Downloads View" customClass="ThemeableView" customModule="podcasts" customModuleProvider="target">
-                    <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                    <subviews>
-                        <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="nodownloads" translatesAutoresizingMaskIntoConstraints="NO" id="TU6-kP-f7o">
-                            <rect key="frame" x="125.5" y="181.5" width="124" height="124"/>
-                            <constraints>
-                                <constraint firstAttribute="height" constant="124" id="Dul-Kk-z9o"/>
-                                <constraint firstAttribute="width" constant="124" id="wlM-ye-ZN4"/>
-                            </constraints>
-                        </imageView>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="No Downloaded Episodes" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="spn-oM-SVV" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                            <rect key="frame" x="84.5" y="371.5" width="206" height="22"/>
-                            <fontDescription key="fontDescription" type="system" pointSize="18"/>
-                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                            <nil key="highlightedColor"/>
-                        </label>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" usesAttributedText="YES" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="U9d-CR-ZP6" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                            <rect key="frame" x="30" y="408.5" width="315" height="40.5"/>
-                            <attributedString key="attributedText">
-                                <fragment content="Oh no! You’re fresh out of downloads. Download some more and they’ll show up here.">
-                                    <attributes>
-                                        <color key="NSColor" red="0.66666666666666663" green="0.66666666666666663" blue="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                        <font key="NSFont" metaFont="label" size="14"/>
-                                        <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" lineSpacing="7" tighteningFactorForTruncation="0.0"/>
-                                    </attributes>
-                                </fragment>
-                            </attributedString>
-                            <nil key="highlightedColor"/>
-                        </label>
-                    </subviews>
-                    <color key="backgroundColor" red="0.9882352941176471" green="0.9882352941176471" blue="0.9882352941176471" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                    <constraints>
-                        <constraint firstItem="spn-oM-SVV" firstAttribute="top" secondItem="TU6-kP-f7o" secondAttribute="bottom" constant="66" id="Hkr-Dw-H0R"/>
-                        <constraint firstItem="U9d-CR-ZP6" firstAttribute="centerX" secondItem="7JB-Er-KH5" secondAttribute="centerX" id="IQ9-7P-jML"/>
-                        <constraint firstItem="U9d-CR-ZP6" firstAttribute="top" secondItem="spn-oM-SVV" secondAttribute="bottom" constant="15" id="UhZ-sb-q6G"/>
-                        <constraint firstItem="U9d-CR-ZP6" firstAttribute="leading" secondItem="7JB-Er-KH5" secondAttribute="leading" constant="30" id="UiT-4D-M0y"/>
-                        <constraint firstItem="TU6-kP-f7o" firstAttribute="centerY" secondItem="7JB-Er-KH5" secondAttribute="centerY" constant="-90" id="YbJ-iN-vy8"/>
-                        <constraint firstItem="TU6-kP-f7o" firstAttribute="centerX" secondItem="7JB-Er-KH5" secondAttribute="centerX" id="e2r-TI-UYW"/>
-                        <constraint firstAttribute="trailing" secondItem="U9d-CR-ZP6" secondAttribute="trailing" constant="30" id="frn-qn-enS"/>
-                        <constraint firstItem="spn-oM-SVV" firstAttribute="centerX" secondItem="7JB-Er-KH5" secondAttribute="centerX" id="vIt-Pi-SpB"/>
-                    </constraints>
-                </view>
                 <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="none" allowsSelectionDuringEditing="YES" allowsMultipleSelection="YES" allowsMultipleSelectionDuringEditing="YES" rowHeight="80" estimatedRowHeight="80" sectionHeaderHeight="45" estimatedSectionHeaderHeight="45" sectionFooterHeight="1" translatesAutoresizingMaskIntoConstraints="NO" id="5W5-5i-nVt" customClass="ThemeableTable" customModule="podcasts" customModuleProvider="target">
                     <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                     <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -91,14 +44,10 @@
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="Iys-DQ-1tX" firstAttribute="leading" secondItem="5W5-5i-nVt" secondAttribute="leading" constant="8" id="L26-ZW-SNP"/>
-                <constraint firstAttribute="trailing" secondItem="7JB-Er-KH5" secondAttribute="trailing" id="QcC-ja-ehS"/>
                 <constraint firstAttribute="bottom" secondItem="5W5-5i-nVt" secondAttribute="bottom" id="W8T-Eb-nNQ"/>
-                <constraint firstItem="7JB-Er-KH5" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="an1-zM-vgz"/>
                 <constraint firstItem="5W5-5i-nVt" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="fdb-mX-3vg"/>
-                <constraint firstAttribute="bottom" secondItem="7JB-Er-KH5" secondAttribute="bottom" id="h7L-HN-vUC"/>
                 <constraint firstItem="5W5-5i-nVt" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="iUx-It-szI"/>
                 <constraint firstItem="Iys-DQ-1tX" firstAttribute="trailing" secondItem="5W5-5i-nVt" secondAttribute="trailing" constant="-8" id="ilf-fW-fSq"/>
-                <constraint firstItem="7JB-Er-KH5" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="o9c-Ia-3Ck"/>
                 <constraint firstAttribute="trailing" secondItem="5W5-5i-nVt" secondAttribute="trailing" id="pOC-0a-GkD"/>
                 <constraint firstItem="9D4-c4-uHy" firstAttribute="bottom" secondItem="Iys-DQ-1tX" secondAttribute="bottom" id="wfz-i2-BaG"/>
             </constraints>
@@ -106,7 +55,6 @@
         </view>
     </objects>
     <resources>
-        <image name="nodownloads" width="124" height="124"/>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/podcasts/HostingConfiguration.swift
+++ b/podcasts/HostingConfiguration.swift
@@ -42,6 +42,7 @@ fileprivate final class HostingView<Content: View>: UIView, UIContentView {
 
         let hostedView: UIView = hostingController.view
         hostedView.translatesAutoresizingMaskIntoConstraints = false
+        hostedView.backgroundColor = .clear
         addSubview(hostedView)
         hostedView.anchorToAllSidesOf(view: self)
     }

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -902,9 +902,9 @@ internal enum L10n {
   internal static var downloads: String { return L10n.tr("Localizable", "downloads") }
   /// Auto Download Settings
   internal static var downloadsAutoDownload: String { return L10n.tr("Localizable", "downloads_auto_download") }
-  /// Oh no! You’re fresh out of downloads. Download some more and they’ll show up here.
+  /// Save episodes for offline listening and never miss a moment.
   internal static var downloadsNoDownloadsDesc: String { return L10n.tr("Localizable", "downloads_no_downloads_desc") }
-  /// No Downloaded Episodes
+  /// Enjoy offline listening
   internal static var downloadsNoDownloadsTitle: String { return L10n.tr("Localizable", "downloads_no_downloads_title") }
   /// Retry Failed Downloads
   internal static var downloadsRetryFailedDownloads: String { return L10n.tr("Localizable", "downloads_retry_failed_downloads") }

--- a/podcasts/SwiftUI/EmptyStateView.swift
+++ b/podcasts/SwiftUI/EmptyStateView.swift
@@ -5,6 +5,7 @@ protocol EmptyStateViewStyle: ObservableObject {
     var message: Color { get }
     var icon: Color { get }
     var button: Color { get }
+    var background: Color { get }
 }
 
 struct EmptyStateAction: Identifiable {
@@ -77,6 +78,7 @@ struct EmptyStateView<Title: View, Style: EmptyStateViewStyle>: View {
         .padding(.horizontal, EmptyConstants.padding)
         .padding(.vertical, EmptyConstants.verticalPadding)
         .padding(EmptyConstants.padding)
+        .background(style.background)
     }
 }
 

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -812,10 +812,10 @@
 "downloads_auto_download" = "Auto Download Settings";
 
 /* Title for the empty state when there are no downloads available */
-"downloads_no_downloads_title" = "No Downloaded Episodes";
+"downloads_no_downloads_title" = "Enjoy offline listening";
 
 /* The description for the empty state when there are no downloads available */
-"downloads_no_downloads_desc" = "Oh no! You’re fresh out of downloads. Download some more and they’ll show up here.";
+"downloads_no_downloads_desc" = "Save episodes for offline listening and never miss a moment.";
 
 /* Prompt to allow the user to retry failed downloads. */
 "downloads_retry_failed_downloads" = "Retry Failed Downloads";


### PR DESCRIPTION
| 📘 Part of: #3102 |
|:---:|

Fixes #3108

| | | |
|--|--|--|
| ![Simulator Screenshot - iPhone 16 Pro - 2025-05-15 at 21 08 42](https://github.com/user-attachments/assets/eb055b46-414a-48bb-b2c9-3654ea9db55c) | ![Simulator Screenshot - iPhone 16 Pro - 2025-05-15 at 21 08 21](https://github.com/user-attachments/assets/d32efb5d-2be0-496a-b7f5-3a74aeea5484) | ![Simulator Screenshot - iPhone 16 Pro - 2025-05-15 at 21 08 57](https://github.com/user-attachments/assets/4a522046-dbe8-4b67-9c8e-07d568cf85e2) |

## To test

* Use a fresh install or an account with no Downloads
* Visit Profile > Downloads
* ✅ Verify that the empty state appears
* Download an episode
* ✅ Verify that the empty state disappears

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
