### PR TITLE
Fix racing condition on enable push

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -294,7 +294,7 @@ public enum FeatureFlag: String, CaseIterable {
         case .encourageAccountCreation:
             true
         case .notificationsRevamp:
-            true
+            false
         case .refreshAndSaveWatchLogsOnSend:
             true
         case .avoidReplaceOnEpisodeSwap:

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -294,7 +294,7 @@ public enum FeatureFlag: String, CaseIterable {
         case .encourageAccountCreation:
             true
         case .notificationsRevamp:
-            false
+            true
         case .refreshAndSaveWatchLogsOnSend:
             true
         case .avoidReplaceOnEpisodeSwap:

--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -45,6 +45,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         if let appInstallState {
             switch appInstallState {
             case .updated:
+                if FeatureFlag.notificationsRevamp.enabled {
+                    Settings.notificationsNewEpisodes = UserDefaults.standard.bool(forKey: Constants.UserDefaults.pushEnabled)
+                }
                 if FeatureFlag.encourageAccountCreation.enabled, !Settings.hasShownInformationalViewModal {
                     Settings.shouldShowInitialOnboardingFlow = !SyncManager.isUserLoggedIn()
                 }

--- a/podcasts/NotificationsHelper.swift
+++ b/podcasts/NotificationsHelper.swift
@@ -41,7 +41,6 @@ class NotificationsHelper: NSObject, UNUserNotificationCenterDelegate {
             SettingsStore.appSettings.notifications = true
         }
         UserDefaults.standard.set(true, forKey: Constants.UserDefaults.pushEnabled)
-        registerForPushNotifications()
     }
 
     func disablePush() {

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -1461,7 +1461,7 @@ class Settings: NSObject {
     // MARK: - Notifications
     static var notificationsNewEpisodes: Bool {
         get {
-            UserDefaults.standard.value(forKey: Constants.UserDefaults.notifications.newEpisodes) as? Bool ?? UserDefaults.standard.bool(forKey: Constants.UserDefaults.pushEnabled)
+            UserDefaults.standard.value(forKey: Constants.UserDefaults.notifications.newEpisodes) as? Bool ?? false
         }
         set {
             UserDefaults.standard.setValue(newValue, forKey: Constants.UserDefaults.notifications.newEpisodes)


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

This PR fixes an issue where the user skipped notifications permissions on onboarding and then try to enable them on Notification Settings.
Before this fix when enabling for the first time notifications on the Notifications Settings those initial notification where not schedule at all.
Another fix introduced was that for new users enabling any of the new notifications was also enabling the new episode notifications.

## To test

1. Install the app from scratch
2. Skip the onboarding flow
3. Skip the notifications permissions flow ( Tap on Not Now)
4. Go to Profile -> Settings -> Notifications
5. Enable only the Daily Reminders notifications
6. Go back to Settings
7. Wait for 10 s and see if onboarding notifications are showing up
8. Go again to Profile -> Settings -> Notifications
9. Check that New Episodes notifications are not enabled

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
