### PR TITLE
[Empty States] Add new Empty State to Podcasts list

### DIFF
--- a/podcasts/PodcastListViewController.swift
+++ b/podcasts/PodcastListViewController.swift
@@ -20,20 +20,6 @@ class PodcastListViewController: PCViewController, UIGestureRecognizerDelegate, 
         }
     }
 
-    @IBOutlet var noPodcastsIcon: ThemeableImageView! {
-        didSet {
-            noPodcastsIcon.imageStyle = .primaryIcon01
-        }
-    }
-
-    @IBOutlet var noPodcastsView: UIView!
-    @IBOutlet var noPodcastsMessage: ThemeableLabel! {
-        didSet {
-            noPodcastsMessage.style = .primaryText02
-            noPodcastsMessage.text = L10n.podcastGridNoPodcastsMsg
-        }
-    }
-
     @IBOutlet var podcastsCollectionView: UICollectionView! {
         didSet {
             registerCells()
@@ -41,12 +27,6 @@ class PodcastListViewController: PCViewController, UIGestureRecognizerDelegate, 
             if let layout = podcastsCollectionView.collectionViewLayout as? UICollectionViewFlowLayout {
                 layout.sectionHeadersPinToVisibleBounds = true
             }
-        }
-    }
-
-    @IBOutlet var noPodcastsTitle: ThemeableLabel! {
-        didSet {
-            noPodcastsTitle.text = L10n.podcastGridNoPodcastsTitle
         }
     }
 
@@ -292,11 +272,34 @@ class PodcastListViewController: PCViewController, UIGestureRecognizerDelegate, 
                         strongSelf.gridItems = data
                     })
                 }
-                strongSelf.noPodcastsView.isHidden = newData.count != 0 || SyncManager.isFirstSyncInProgress()
+                let shouldHideEmpty = newData.count != 0 || SyncManager.isFirstSyncInProgress()
+                strongSelf.refreshContentUnavailable(shouldShow: !shouldHideEmpty)
                 strongSelf.foldersCoordinator.showUpsellIfNeeded(from: strongSelf)
             }
         }
     }
+
+    private func refreshContentUnavailable(shouldShow: Bool) {
+        var config: UIContentConfiguration?
+
+        if shouldShow {
+            let title = L10n.podcastGridNoPodcastsTitle
+            let message = L10n.podcastGridNoPodcastsMsg
+            config = ContentUnavailableConfiguration.emptyState(title: title, message: message, icon: { Image("podcastlist_smallgrid").renderingMode(.template) }, actions: [
+                .init(title: L10n.podcastGridDiscoverPodcasts, action: {
+                    Analytics.shared.track(.podcastsListDiscoverButtonTapped)
+                    NavigationManager.sharedManager.navigateTo(NavigationManager.discoverPageKey)
+                })
+            ])
+        }
+
+        if #available(iOS 17.0, *) {
+            self.contentUnavailableConfiguration = config
+        } else {
+            self.setContentUnavailableConfiguration(config)
+        }
+    }
+
 
     func showProfileController() {
         let profileViewController = ProfileViewController()

--- a/podcasts/PodcastListViewController.xib
+++ b/podcasts/PodcastListViewController.xib
@@ -1,20 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="PodcastListViewController" customModule="podcasts" customModuleProvider="target">
             <connections>
-                <outlet property="addPodcastBtn" destination="ldh-ty-HMK" id="Ri0-gU-4BD"/>
-                <outlet property="noPodcastsIcon" destination="veU-SP-Qa1" id="Q52-eF-J6J"/>
-                <outlet property="noPodcastsMessage" destination="pvg-OK-ETj" id="Jdx-Uk-S7E"/>
-                <outlet property="noPodcastsTitle" destination="fF8-gC-Sx6" id="wHj-zJ-MtS"/>
-                <outlet property="noPodcastsView" destination="qiQ-BF-0cD" id="wR6-If-LSW"/>
                 <outlet property="podcastsCollectionView" destination="4" id="hAI-hG-gPY"/>
                 <outlet property="view" destination="1" id="3"/>
             </connections>
@@ -34,88 +29,13 @@
                         <outlet property="delegate" destination="-1" id="10"/>
                     </connections>
                 </collectionView>
-                <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qiQ-BF-0cD" userLabel="No Podcasts View" customClass="ThemeableView" customModule="podcasts" customModuleProvider="target">
-                    <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                    <subviews>
-                        <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="grid-icon-large" translatesAutoresizingMaskIntoConstraints="NO" id="veU-SP-Qa1" customClass="ThemeableImageView" customModule="podcasts" customModuleProvider="target">
-                            <rect key="frame" x="168" y="194" width="39" height="39"/>
-                            <color key="tintColor" red="0.72156862745098038" green="0.76470588235294112" blue="0.78823529411764703" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                            <constraints>
-                                <constraint firstAttribute="width" constant="39" id="DV6-r9-Etc"/>
-                                <constraint firstAttribute="height" constant="39" id="MJX-YZ-jtt"/>
-                            </constraints>
-                        </imageView>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Time to add some Podcasts!" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fF8-gC-Sx6" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                            <rect key="frame" x="43.5" y="249" width="288.5" height="26.5"/>
-                            <fontDescription key="fontDescription" type="boldSystem" pointSize="22"/>
-                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                            <nil key="highlightedColor"/>
-                        </label>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pvg-OK-ETj" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                            <rect key="frame" x="20" y="291.5" width="335" height="84"/>
-                            <string key="text">Coming from another app? Import your podcasts via Profile &gt; Settings &gt; Import &amp; Export.
-
-
-If you're looking for inspiration try the Discover tab.</string>
-                            <fontDescription key="fontDescription" name=".AppleSystemUIFont" family=".AppleSystemUIFont" pointSize="14"/>
-                            <color key="textColor" red="0.52156862745098043" green="0.55294117647058827" blue="0.60392156862745094" alpha="1" colorSpace="calibratedRGB"/>
-                            <nil key="highlightedColor"/>
-                        </label>
-                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ldh-ty-HMK" customClass="ThemeableButton" customModule="podcasts" customModuleProvider="target">
-                            <rect key="frame" x="67.5" y="455.5" width="240" height="44"/>
-                            <accessibility key="accessibilityConfiguration" identifier="Discover Podcasts" label="Discover Podcasts">
-                                <accessibilityTraits key="traits" button="YES"/>
-                                <bool key="isElement" value="YES"/>
-                            </accessibility>
-                            <constraints>
-                                <constraint firstAttribute="width" constant="240" id="W8y-s8-klc"/>
-                                <constraint firstAttribute="height" constant="44" id="fGE-2p-yo1"/>
-                            </constraints>
-                            <userDefinedRuntimeAttributes>
-                                <userDefinedRuntimeAttribute type="string" keyPath="buttonTitle" value="Discover Podcasts"/>
-                                <userDefinedRuntimeAttribute type="boolean" keyPath="shouldFill" value="YES"/>
-                            </userDefinedRuntimeAttributes>
-                        </view>
-                    </subviews>
-                    <color key="backgroundColor" red="0.98823529409999999" green="0.98823529409999999" blue="0.98823529409999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                    <constraints>
-                        <constraint firstItem="pvg-OK-ETj" firstAttribute="top" secondItem="fF8-gC-Sx6" secondAttribute="bottom" constant="16" id="3Kd-0v-7SV"/>
-                        <constraint firstItem="ldh-ty-HMK" firstAttribute="top" secondItem="pvg-OK-ETj" secondAttribute="bottom" constant="80" id="6tp-zn-Z9o"/>
-                        <constraint firstItem="ldh-ty-HMK" firstAttribute="centerX" secondItem="qiQ-BF-0cD" secondAttribute="centerX" id="O05-q2-Miq"/>
-                        <constraint firstItem="pvg-OK-ETj" firstAttribute="leading" secondItem="qiQ-BF-0cD" secondAttribute="leading" constant="20" id="XTu-3t-OVm"/>
-                        <constraint firstItem="veU-SP-Qa1" firstAttribute="centerX" secondItem="qiQ-BF-0cD" secondAttribute="centerX" id="YT4-wS-rGd"/>
-                        <constraint firstAttribute="trailing" secondItem="pvg-OK-ETj" secondAttribute="trailing" constant="20" id="a6e-ee-oDS"/>
-                        <constraint firstItem="veU-SP-Qa1" firstAttribute="centerY" secondItem="qiQ-BF-0cD" secondAttribute="centerY" constant="-120" id="m77-ti-xg2"/>
-                        <constraint firstItem="fF8-gC-Sx6" firstAttribute="centerY" secondItem="qiQ-BF-0cD" secondAttribute="centerY" constant="-40" id="mfx-7H-mDy"/>
-                        <constraint firstItem="fF8-gC-Sx6" firstAttribute="top" secondItem="veU-SP-Qa1" secondAttribute="bottom" constant="16" id="uIT-tZ-vPc"/>
-                        <constraint firstItem="fF8-gC-Sx6" firstAttribute="centerX" secondItem="qiQ-BF-0cD" secondAttribute="centerX" id="whV-0i-r6O"/>
-                    </constraints>
-                    <variation key="default">
-                        <mask key="constraints">
-                            <exclude reference="mfx-7H-mDy"/>
-                        </mask>
-                    </variation>
-                    <variation key="heightClass=compact">
-                        <mask key="subviews">
-                            <exclude reference="veU-SP-Qa1"/>
-                        </mask>
-                        <mask key="constraints">
-                            <include reference="mfx-7H-mDy"/>
-                            <exclude reference="uIT-tZ-vPc"/>
-                        </mask>
-                    </variation>
-                </view>
             </subviews>
             <viewLayoutGuide key="safeArea" id="Za3-hf-MlM"/>
             <color key="backgroundColor" red="0.87843137250000003" green="0.90588235289999997" blue="0.90980392160000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
-                <constraint firstItem="qiQ-BF-0cD" firstAttribute="top" secondItem="1" secondAttribute="top" id="0lI-aD-hq6"/>
                 <constraint firstAttribute="bottom" secondItem="4" secondAttribute="bottom" id="BRV-dL-hXc"/>
                 <constraint firstItem="4" firstAttribute="trailing" secondItem="Za3-hf-MlM" secondAttribute="trailing" id="HYO-vk-n3Y"/>
-                <constraint firstItem="qiQ-BF-0cD" firstAttribute="leading" secondItem="1" secondAttribute="leading" id="RJg-Q6-FjA"/>
-                <constraint firstAttribute="trailing" secondItem="qiQ-BF-0cD" secondAttribute="trailing" id="V6l-qR-Jqv"/>
                 <constraint firstAttribute="top" secondItem="4" secondAttribute="top" id="a8I-6o-y0B"/>
-                <constraint firstAttribute="bottom" secondItem="qiQ-BF-0cD" secondAttribute="bottom" id="hb9-Ef-117"/>
                 <constraint firstItem="4" firstAttribute="leading" secondItem="Za3-hf-MlM" secondAttribute="leading" id="nkF-pm-2rk"/>
             </constraints>
             <simulatedStatusBarMetrics key="simulatedStatusBarMetrics"/>
@@ -123,7 +43,4 @@ If you're looking for inspiration try the Discover tab.</string>
             <point key="canvasLocation" x="-186.40000000000001" y="41.829085457271368"/>
         </view>
     </objects>
-    <resources>
-        <image name="grid-icon-large" width="39" height="39"/>
-    </resources>
 </document>


### PR DESCRIPTION
| 📘 Part of: #3102 |
|:---:|

Fixes #3149 

| | | |
|--|--|--|
| ![Simulator Screenshot - iPhone 16 Pro - 2025-05-16 at 19 41 18](https://github.com/user-attachments/assets/c6de4fe8-28c3-4413-b5be-b78d687f48f8) | ![Simulator Screenshot - iPhone 16 Pro - 2025-05-16 at 19 41 11](https://github.com/user-attachments/assets/ff02556f-e158-43cc-ba31-cd873e14b296) | ![Simulator Screenshot - iPhone 16 Pro - 2025-05-16 at 19 41 02](https://github.com/user-attachments/assets/3da210ac-29f6-4f55-985f-b858bbc5d241) |

## To test

### Empty State
* Use a new install or one without any listening history
* Go to Podcasts tab
* ✅ Verify the empty Listening History state

### Discover Button + Analytics
* Enable Tracks logging
* Tap the "Discover Podcasts" button
* ✅ Verify that `podcasts_list_discover_button_tapped` is tracked

### Replaced Empty State
* Subscribe to a podcast
* ✅ Verify that the podcast shows up and the empty state is hidden

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
