### PR TITLE
Add frequency, tier, and promo details for IAP events

### DIFF
--- a/podcasts/IAPHelper.swift
+++ b/podcasts/IAPHelper.swift
@@ -562,7 +562,7 @@ private extension IAPHelper {
         if let discount {
             if discount.contains(".\(IAPOfferType.winback.rawValue).") {
                 offerType = IAPOfferType.winback.rawValue
-            } else if discount == IAPPromotionID.referall {
+            } else if discount == IAPPromotionID.referall.rawValue {
                 offerType = IAPOfferType.referral.rawValue
             }
         }

--- a/podcasts/IAPHelper.swift
+++ b/podcasts/IAPHelper.swift
@@ -551,19 +551,19 @@ private extension IAPHelper {
         var offerType = "none"
         if isEligibleForOffer, let paymentMode = product?.introductoryPrice?.paymentMode {
             if paymentMode == .freeTrial {
-                offerType = "free_trial"
+                offerType = IAPOfferType.freeTrial.rawValue
             } else if paymentMode == .payUpFront {
-                offerType = "intro_offer"
+                offerType = IAPOfferType.introOffer.rawValue
             }
         }
         if productId == .yearlyReferral {
-            offerType = "referral"
+            offerType = IAPOfferType.referral.rawValue
         }
         if let discount {
-            if discount.contains(".winback.") {
-                offerType = "winback"
-            } else if discount == "com.pocketcasts.plus.yearly.referral.promo" {
-                offerType = "referral"
+            if discount.contains(".\(IAPOfferType.winback.rawValue).") {
+                offerType = IAPOfferType.winback.rawValue
+            } else if discount == IAPPromotionID.referall {
+                offerType = IAPOfferType.referral.rawValue
             }
         }
 

--- a/podcasts/IAPHelper.swift
+++ b/podcasts/IAPHelper.swift
@@ -397,16 +397,25 @@ private extension IAPHelper {
 // MARK: - SKPaymentTransactionObserver
 
 extension IAPHelper: SKPaymentTransactionObserver {
-    func purchaseWasSuccessful(_ productId: IAPProductID) {
-        trackPaymentEvent(.purchaseSuccessful, productId: productId)
+    fileprivate func purchaseWasSuccessful(_ payment: SKPayment) {
+        guard let productId = IAPProductID(rawValue: payment.productIdentifier) else {
+            return
+        }
+        trackPaymentEvent(.purchaseSuccessful, productId: productId, discount: payment.paymentDiscount?.identifier)
     }
 
-    func purchaseWasCancelled(_ productId: IAPProductID, error: NSError) {
-        trackPaymentEvent(.purchaseCancelled, productId: productId, error: error)
+    fileprivate func purchaseWasCancelled(_ payment: SKPayment, error: NSError) {
+        guard let productId = IAPProductID(rawValue: payment.productIdentifier) else {
+            return
+        }
+        trackPaymentEvent(.purchaseCancelled, productId: productId, discount: payment.paymentDiscount?.identifier, error: error)
     }
 
-    func purchaseFailed(_ productId: IAPProductID, error: NSError) {
-        trackPaymentEvent(.purchaseFailed, productId: productId, error: error)
+    fileprivate func purchaseFailed(_ payment: SKPayment, error: NSError) {
+        guard let productId = IAPProductID(rawValue: payment.productIdentifier) else {
+            return
+        }
+        trackPaymentEvent(.purchaseFailed, productId: productId, discount: payment.paymentDiscount?.identifier, error: error)
     }
 
     func paymentQueue(_ queue: SKPaymentQueue, updatedTransactions transactions: [SKPaymentTransaction]) {
@@ -427,6 +436,7 @@ extension IAPHelper: SKPaymentTransactionObserver {
                     hasNewPurchasedReceipt = true
                     queue.finishTransaction(transaction)
                     FileLog.shared.addMessage("IAPHelper Purchase successful for \(product) ")
+                    purchaseWasSuccessful(transaction.payment)
                 case .failed:
                     let e = transaction.error! as NSError
                     FileLog.shared.addMessage("IAPHelper Purchase FAILED for \(product), code=\(e.code) msg= \(e.localizedDescription)/")
@@ -434,10 +444,12 @@ extension IAPHelper: SKPaymentTransactionObserver {
 
                     let userInfo = ["error": e]
 
-                    if e.code == 0 || e.code == 2 { // app store couldn't be connected or user cancelled
+                    if e.code == SKError.Code.unknown.rawValue || e.code == SKError.Code.paymentCancelled.rawValue { // app store couldn't be connected or user cancelled
                         NotificationCenter.postOnMainThread(notification: ServerNotifications.iapPurchaseCancelled, userInfo: userInfo)
+                        purchaseWasCancelled(transaction.payment, error: e)
                     } else { // report error to user
                         NotificationCenter.postOnMainThread(notification: ServerNotifications.iapPurchaseFailed, userInfo: userInfo)
+                        purchaseFailed(transaction.payment, error: e)
                     }
                 case .deferred:
                     FileLog.shared.addMessage("IAPHelper Purchase deferred for \(product)")
@@ -534,7 +546,7 @@ private extension SKProductSubscriptionPeriod {
 }
 
 private extension IAPHelper {
-    func trackPaymentEvent(_ event: AnalyticsEvent, productId: IAPProductID, error: NSError? = nil) {
+    func trackPaymentEvent(_ event: AnalyticsEvent, productId: IAPProductID, discount: String?, error: NSError? = nil) {
         let product = getProduct(for: productId)
         var offerType = "none"
         if isEligibleForOffer, let paymentMode = product?.introductoryPrice?.paymentMode {
@@ -544,10 +556,21 @@ private extension IAPHelper {
                 offerType = "intro_offer"
             }
         }
+        if productId == .yearlyReferral {
+            offerType = "referral"
+        }
+        if let discount {
+            if discount.contains(".winback.") {
+                offerType = "winback"
+            } else if discount == "com.pocketcasts.plus.yearly.referral.promo" {
+                offerType = "referral"
+            }
+        }
 
         var properties: [AnyHashable: Any] = ["product": productId.rawValue,
-                                              "offer_type": offerType]
-
+                                              "offer_type": offerType,
+                                              "tier": productId.subscriptionTier.rawValue.lowercased(),
+                                              "frequency": productId.frequency.rawValue]
         if let source = OnboardingFlow.shared.source {
             properties["source"] = source
         }

--- a/podcasts/IAPTypes.swift
+++ b/podcasts/IAPTypes.swift
@@ -25,7 +25,7 @@ enum IAPOfferType: String {
     case freeTrial = "free_trial"
     case introOffer = "intro_offer"
     case referral = "referral"
-    case winback = "winback"    
+    case winback = "winback"
 }
 
 enum Plan {

--- a/podcasts/IAPTypes.swift
+++ b/podcasts/IAPTypes.swift
@@ -17,6 +17,17 @@ enum IAPProductID: String {
     }
 }
 
+enum IAPPromotionID: String {
+    case referall = "com.pocketcasts.plus.yearly.referral.promo"
+}
+
+enum IAPOfferType: String {
+    case freeTrial = "free_trial"
+    case introOffer = "intro_offer"
+    case referral = "referral"
+    case winback = "winback"    
+}
+
 enum Plan {
     case plus, patron
 

--- a/podcasts/Onboarding/Models/PlusPurchaseModel.swift
+++ b/podcasts/Onboarding/Models/PlusPurchaseModel.swift
@@ -214,8 +214,6 @@ private extension PlusPurchaseModel {
         Settings.setLoginDetailsUpdated()
         AnalyticsHelper.plusPlanPurchased()
 
-        purchaseHandler.purchaseWasSuccessful(purchasedProduct)
-
         handleNext()
     }
 
@@ -230,15 +228,10 @@ private extension PlusPurchaseModel {
             let purchasedProduct,
             let error = notification.userInfo?["error"] as? NSError
         else { return }
-
-        purchaseHandler.purchaseWasCancelled(purchasedProduct, error: error)
     }
 
     func handlePurchaseFailed(error: NSError?) {
-        defer { state = .failed }
-
-        guard let purchasedProduct else { return }
-        purchaseHandler.purchaseFailed(purchasedProduct, error: error ?? defaultError)
+        state = .failed
     }
 
     private var defaultError: NSError {


### PR DESCRIPTION


| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes #3177 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR refactors tracking of IAP events in order to be able to track promotions offer types, tiers and frequency

## To test

1. Start the app on a real device and create a new PC account
2. Enable the tracks logging FF
3. Use a Testflight AppStore sandbox account to test purchases
4. Start the purchase flow for each of the following levels
5. Check all the available tier levels: Patron Monthly, Patron Yearly, Plus Monthly, Plus Early
6. Go up in the purchase flow for each level until you get to IAP system sheet
7. Cancel on each one
8. Check if you see the event  `purchase_cancelled` with the following properties: `product`, `tier`, `offer_type` and `frequency` and they match with the option you choose.
9. Using a patron account in another device or web grab a referral link and open it on this device to activate a referral
10. Open Profile and tap on the `Claim your 2-Month Guest Pass` option in the banner
11. Tap on Activate my Pass
12. On the system IAP sheet tap on X to cancel
13. Check if you see the event  `purchase_cancelled` with the following properties: `product` = `com.pocketcasts.plus.yearly.referral`, `tier` = `plus`, `offer_type` = `referral` and `frequency`=`yearly`
14. Now restart the process with a new PC account  and reset the purchase history for the IAP sandbox account
15. This time complete the purchase
16. Check if you see the event  `purchase_successful` with the following properties: `product`, `tier`, `offer_type` and `frequency` and they match with the option you choose.
17. After the successful purchase wait for some minutes ( 10 should be enough) and try to do the cancelation flow in the app and check if you get a winback offer
18. Complete the purchase and see if you see the `offer_type` have the value `winback`
 

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
