### PR TITLE
[Empty State] Update Empty State when searching

### DIFF
--- a/podcasts/ListeningHistoryViewController.swift
+++ b/podcasts/ListeningHistoryViewController.swift
@@ -11,7 +11,11 @@ class ListeningHistoryViewController: PCViewController {
             refreshContentUnavailable()
         }
     }
-    var tempEpisodes = [ArraySection<String, ListEpisode>]()
+    var tempEpisodes = [ArraySection<String, ListEpisode>]() {
+        didSet {
+            refreshContentUnavailable()
+        }
+    }
     private let operationQueue = OperationQueue()
     var cellHeights: [IndexPath: CGFloat] = [:]
 
@@ -22,26 +26,6 @@ class ListeningHistoryViewController: PCViewController {
         let viewModel = InformationalBannerViewModel(bannerType: .listeningHistory)
         return InformationalBannerViewCoordinator(viewModel: viewModel)
     }()
-
-    @IBOutlet weak var emptyStateView: ThemeableView! {
-        didSet {
-            emptyStateView.isHidden = true
-        }
-    }
-
-    @IBOutlet weak var emptyStateTitle: ThemeableLabel! {
-        didSet {
-            emptyStateTitle.style = .primaryText01
-            emptyStateTitle.text = L10n.listeningHistorySearchNoEpisodesTitle
-        }
-    }
-
-    @IBOutlet weak var emptyStateText: ThemeableLabel! {
-        didSet {
-            emptyStateText.style = .primaryText02
-            emptyStateText.text = L10n.listeningHistorySearchNoEpisodesText
-        }
-    }
 
     @IBOutlet var listeningHistoryTable: UITableView! {
         didSet {
@@ -163,7 +147,7 @@ class ListeningHistoryViewController: PCViewController {
             let newData = self.episodesDataManager.listeningHistoryEpisodes()
 
             DispatchQueue.main.sync {
-                self.listeningHistoryTable.isHidden = (newData.count == 0)
+//                self.listeningHistoryTable.isHidden = (newData.count == 0)
                 if animated {
                     let changeSet = StagedChangeset(source: oldData, target: newData)
                     self.listeningHistoryTable.reload(using: changeSet, with: .none, setData: { data in
@@ -240,21 +224,37 @@ class ListeningHistoryViewController: PCViewController {
     private func refreshContentUnavailable() {
         var config: UIContentConfiguration?
 
-        if episodes.isEmpty {
-            let title = L10n.profileListeningHistoryEmptyTitle
-            let message = L10n.profileListeningHistoryEmptyDescription
-            config = ContentUnavailableConfiguration.emptyState(title: title, message: message, icon: { Image("options-history").renderingMode(.template) }, actions: [
-                .init(title: L10n.goToDiscover, action: {
-                    Analytics.shared.track(.listeningHistoryDiscoverButtonTapped)
-                    NavigationManager.sharedManager.navigateTo(NavigationManager.discoverPageKey)
-                })
-            ])
-        }
+        listeningHistoryTable.backgroundView = nil
 
-        if #available(iOS 17.0, *) {
-            self.contentUnavailableConfiguration = config
-        } else {
-            self.setContentUnavailableConfiguration(config)
+        if episodes.isEmpty {
+            if searchController?.searchTextField.text?.isEmpty == false {
+                // Empty State when searching
+                let title = L10n.listeningHistorySearchNoEpisodesTitle
+                let message = L10n.listeningHistorySearchNoEpisodesText
+                config = ContentUnavailableConfiguration.emptyState(
+                    title: title,
+                    message: message,
+                    icon: { Image("profile-download").renderingMode(.template) }
+                )
+
+                listeningHistoryTable.backgroundView = config?.makeContentView()
+            } else {
+                // Empty State when not searching
+                let title = L10n.profileListeningHistoryEmptyTitle
+                let message = L10n.profileListeningHistoryEmptyDescription
+                config = ContentUnavailableConfiguration.emptyState(title: title, message: message, icon: { Image("options-history").renderingMode(.template) }, actions: [
+                    .init(title: L10n.goToDiscover, action: {
+                        Analytics.shared.track(.listeningHistoryDiscoverButtonTapped)
+                        NavigationManager.sharedManager.navigateTo(NavigationManager.discoverPageKey)
+                    })
+                ])
+
+                if #available(iOS 17.0, *) {
+                    self.contentUnavailableConfiguration = config
+                } else {
+                    self.setContentUnavailableConfiguration(config)
+                }
+            }
         }
     }
 }
@@ -276,7 +276,6 @@ extension ListeningHistoryViewController: PCSearchBarDelegate {
 
     func searchDidEnd() {
         listeningHistoryTable.isHidden = tempEpisodes.isEmpty
-        emptyStateView.isHidden = true
         episodes = tempEpisodes
         listeningHistoryTable.reloadData()
         tempEpisodes.removeAll()
@@ -286,7 +285,6 @@ extension ListeningHistoryViewController: PCSearchBarDelegate {
         Analytics.track(.searchCleared, source: analyticsSource)
 
         listeningHistoryTable.isHidden = tempEpisodes.isEmpty
-        emptyStateView.isHidden = true
         episodes = tempEpisodes
         listeningHistoryTable.reloadData()
     }
@@ -299,8 +297,7 @@ extension ListeningHistoryViewController: PCSearchBarDelegate {
         let oldData = episodes
         let newData = episodesDataManager.searchEpisodes(for: searchTerm)
 
-        listeningHistoryTable.isHidden = newData.isEmpty
-        emptyStateView.isHidden = !newData.isEmpty
+//        listeningHistoryTable.isHidden = newData.isEmpty
 
         let changeSet = StagedChangeset(source: oldData, target: newData)
         self.listeningHistoryTable.reload(using: changeSet, with: .none, setData: { data in

--- a/podcasts/ListeningHistoryViewController.swift
+++ b/podcasts/ListeningHistoryViewController.swift
@@ -27,7 +27,7 @@ class ListeningHistoryViewController: PCViewController {
         return InformationalBannerViewCoordinator(viewModel: viewModel)
     }()
 
-    @IBOutlet var listeningHistoryTable: UITableView! {
+    @IBOutlet var listeningHistoryTable: ThemeableTable! {
         didSet {
             registerCells()
             listeningHistoryTable.estimatedRowHeight = 80
@@ -223,7 +223,8 @@ class ListeningHistoryViewController: PCViewController {
     private func refreshContentUnavailable() {
         var config: UIContentConfiguration?
 
-        listeningHistoryTable.backgroundView = nil
+        listeningHistoryTable.backgroundView = UIView()
+        listeningHistoryTable.themeStyle = .primaryUi04
 
         if episodes.isEmpty {
             if searchController?.searchTextField.text?.isEmpty == false {
@@ -236,6 +237,7 @@ class ListeningHistoryViewController: PCViewController {
                     icon: { Image("profile-download").renderingMode(.template) }
                 )
 
+                listeningHistoryTable.backgroundColor = UIColor(DefaultEmptyStateStyle.defaultStyle.background)
                 listeningHistoryTable.backgroundView = config?.makeContentView()
             } else {
                 // Empty State when not searching

--- a/podcasts/ListeningHistoryViewController.swift
+++ b/podcasts/ListeningHistoryViewController.swift
@@ -147,7 +147,6 @@ class ListeningHistoryViewController: PCViewController {
             let newData = self.episodesDataManager.listeningHistoryEpisodes()
 
             DispatchQueue.main.sync {
-//                self.listeningHistoryTable.isHidden = (newData.count == 0)
                 if animated {
                     let changeSet = StagedChangeset(source: oldData, target: newData)
                     self.listeningHistoryTable.reload(using: changeSet, with: .none, setData: { data in
@@ -296,8 +295,6 @@ extension ListeningHistoryViewController: PCSearchBarDelegate {
 
         let oldData = episodes
         let newData = episodesDataManager.searchEpisodes(for: searchTerm)
-
-//        listeningHistoryTable.isHidden = newData.isEmpty
 
         let changeSet = StagedChangeset(source: oldData, target: newData)
         self.listeningHistoryTable.reload(using: changeSet, with: .none, setData: { data in

--- a/podcasts/ListeningHistoryViewController.xib
+++ b/podcasts/ListeningHistoryViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23094" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23084"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -11,9 +11,6 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ListeningHistoryViewController" customModule="podcasts" customModuleProvider="target">
             <connections>
-                <outlet property="emptyStateText" destination="lM9-WS-Rr0" id="10P-21-GfP"/>
-                <outlet property="emptyStateTitle" destination="r4T-OR-jqf" id="bkD-cu-P81"/>
-                <outlet property="emptyStateView" destination="HOd-Ww-OXE" id="jHE-xg-ZNb"/>
                 <outlet property="listeningHistoryTable" destination="A8m-ib-xHF" id="Dhh-8A-WxM"/>
                 <outlet property="multiSelectFooter" destination="QnB-mS-nOl" id="igB-hs-H6a"/>
                 <outlet property="multiSelectFooterBottomConstraint" destination="5vw-fO-ZlE" id="8ao-4W-mKu"/>
@@ -25,32 +22,6 @@
             <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="HOd-Ww-OXE" userLabel="EmptyStateView" customClass="ThemeableView" customModule="podcasts" customModuleProvider="target">
-                    <rect key="frame" x="67" y="308.5" width="241" height="70"/>
-                    <subviews>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="No episodes found" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="r4T-OR-jqf" userLabel="Title" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                            <rect key="frame" x="0.0" y="0.0" width="241" height="21.5"/>
-                            <fontDescription key="fontDescription" type="system" pointSize="18"/>
-                            <nil key="textColor"/>
-                            <nil key="highlightedColor"/>
-                        </label>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="We couldn't find any episode for that search. Try another keyword." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lM9-WS-Rr0" userLabel="Text" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                            <rect key="frame" x="0.0" y="36.5" width="241" height="33.5"/>
-                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                            <nil key="textColor"/>
-                            <nil key="highlightedColor"/>
-                        </label>
-                    </subviews>
-                    <constraints>
-                        <constraint firstItem="lM9-WS-Rr0" firstAttribute="leading" secondItem="HOd-Ww-OXE" secondAttribute="leading" id="A1K-JB-KJ3"/>
-                        <constraint firstAttribute="bottom" secondItem="lM9-WS-Rr0" secondAttribute="bottom" id="LAJ-nK-5ws"/>
-                        <constraint firstItem="r4T-OR-jqf" firstAttribute="leading" secondItem="HOd-Ww-OXE" secondAttribute="leading" id="TmM-ZQ-hQl"/>
-                        <constraint firstAttribute="trailing" secondItem="r4T-OR-jqf" secondAttribute="trailing" id="eup-Vg-mGh"/>
-                        <constraint firstAttribute="trailing" secondItem="lM9-WS-Rr0" secondAttribute="trailing" id="ogv-YK-OX6"/>
-                        <constraint firstItem="lM9-WS-Rr0" firstAttribute="top" secondItem="r4T-OR-jqf" secondAttribute="bottom" constant="15" id="vap-oK-hm5"/>
-                        <constraint firstItem="r4T-OR-jqf" firstAttribute="top" secondItem="HOd-Ww-OXE" secondAttribute="top" id="zlr-on-IRM"/>
-                    </constraints>
-                </view>
                 <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" allowsSelectionDuringEditing="YES" allowsMultipleSelection="YES" allowsMultipleSelectionDuringEditing="YES" rowHeight="80" estimatedRowHeight="80" sectionHeaderHeight="45" estimatedSectionHeaderHeight="45" sectionFooterHeight="1" translatesAutoresizingMaskIntoConstraints="NO" id="A8m-ib-xHF" customClass="ThemeableTable" customModule="podcasts" customModuleProvider="target">
                     <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                     <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -75,10 +46,6 @@
                 <constraint firstItem="A8m-ib-xHF" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="4F5-oG-IJr"/>
                 <constraint firstItem="A8m-ib-xHF" firstAttribute="bottom" secondItem="QnB-mS-nOl" secondAttribute="bottom" id="5vw-fO-ZlE"/>
                 <constraint firstItem="A8m-ib-xHF" firstAttribute="bottom" secondItem="fnl-2z-Ty3" secondAttribute="bottom" id="6xF-nj-xUx"/>
-                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="HOd-Ww-OXE" secondAttribute="trailing" constant="67" id="VLb-ge-BND"/>
-                <constraint firstItem="HOd-Ww-OXE" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="67" id="gb8-mj-eks"/>
-                <constraint firstItem="HOd-Ww-OXE" firstAttribute="centerX" secondItem="fnl-2z-Ty3" secondAttribute="centerX" id="lUT-8O-vFx"/>
-                <constraint firstItem="HOd-Ww-OXE" firstAttribute="centerY" secondItem="fnl-2z-Ty3" secondAttribute="centerY" id="nYv-u1-sM2"/>
                 <constraint firstItem="QnB-mS-nOl" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" constant="8" id="uQa-1R-jHE"/>
                 <constraint firstItem="A8m-ib-xHF" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="z7n-3L-B2X"/>
                 <constraint firstAttribute="trailing" secondItem="QnB-mS-nOl" secondAttribute="trailing" constant="8" id="zdH-Yp-qq2"/>


### PR DESCRIPTION
| 📘 Part of: #3102 |
|:---:|

Fixes #3155

| | | |
|--|--|--|
| ![Simulator Screenshot - iPhone 16 - 2025-05-19 at 22 01 06](https://github.com/user-attachments/assets/9626a3a9-feca-4aab-81e8-1efef2b1dc0d) | ![Simulator Screenshot - iPhone 16 - 2025-05-19 at 22 01 25](https://github.com/user-attachments/assets/54258817-a1ab-464d-ae1a-c3fa09a6ac39) | ![Simulator Screenshot - iPhone 16 - 2025-05-19 at 22 01 41](https://github.com/user-attachments/assets/deaff2dc-961b-47f0-ad06-f2a2d8395c39) |

### Original Empty State

| | | |
|--|--|--|
| ![Simulator Screenshot - iPhone 16 - 2025-05-19 at 19 19 43](https://github.com/user-attachments/assets/9ff49497-e793-40d9-96c6-d44c100fbc6f) | ![Simulator Screenshot - iPhone 16 - 2025-05-19 at 19 19 51](https://github.com/user-attachments/assets/49ab10da-a143-4915-9677-692f01a00ac5) | ![Simulator Screenshot - iPhone 16 - 2025-05-19 at 19 19 31](https://github.com/user-attachments/assets/c315d1f6-ce78-4f1a-8ca5-02127075f56c) |

## To test

* Enable `tracksLogging` feature flag
* Open Profile > Listening History
* Clear listening history
* ✅ Verify that Empty State appears
* Listen to an episode
* ✅ Verify that the episode appears in Listening history
* Search for giberish
* ✅ Verify that empty state appears beneath the search bar
* Clear the search
* ✅ Verify that the empty state appears
* ✅ Tap the `Go to Discover` button
* ✅ Verify the `listening_history_discover_button_tapped` event is logged

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
