### PR TITLE
[Empty State] Add new filter tooltip

### DIFF
--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -283,6 +283,8 @@ enum AnalyticsEvent: String {
     case filterCreated
 
     case filterShown
+    case filterTooltipShown
+    case filterTooltipClosed
 
     case filterMultiSelectEntered
     case filterSelectAllButtonTapped

--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -179,6 +179,8 @@ struct Constants {
 
         static let shouldShowRecentlyPlayedSortingTip = "ShouldShowRecentlyPlayedSortingTip"
 
+        static let newFilterTip = "NewFilterTip"
+
         enum headphones {
             static let previousAction = SettingValue("headphones.previousAction",
                                                       defaultValue: HeadphoneControlAction.skipBack)

--- a/podcasts/PlaylistsViewController+Table.swift
+++ b/podcasts/PlaylistsViewController+Table.swift
@@ -1,5 +1,6 @@
 import PocketCastsDataModel
 import UIKit
+import SwiftUI
 
 extension PlaylistsViewController: UITableViewDelegate, UITableViewDataSource {
     private static let playlistCellId = "PlaylistCell"
@@ -97,5 +98,64 @@ extension PlaylistsViewController: UITableViewDelegate, UITableViewDataSource {
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.filterChanged)
 
         Analytics.track(.filterListReordered)
+    }
+}
+
+extension PlaylistsViewController {
+    func showNewFilterTip() {
+        let vc = UIHostingController(rootView: AnyView (EmptyView()) )
+        let idealSize = CGSizeMake(290, 100)
+        let tipView = TipViewStatic(title: L10n.filtersTipViewTitle,
+                                    message: L10n.filtersTipViewDescription,
+                              onTap: { [weak self] in
+            self?.dismissTipView()
+        })
+            .frame(idealWidth: idealSize.width, minHeight: idealSize.height)
+            .setupDefaultEnvironment()
+        vc.rootView = AnyView(tipView)
+        vc.view.backgroundColor = .clear
+        vc.view.clipsToBounds = false
+        vc.modalPresentationStyle = .popover
+        if #available(iOS 16.0, *) {
+            vc.sizingOptions = [.preferredContentSize]
+        } else {
+            vc.preferredContentSize = idealSize
+        }
+        if let popoverPresentationController = vc.popoverPresentationController {
+            popoverPresentationController.delegate = self
+            popoverPresentationController.permittedArrowDirections = [.up]
+            popoverPresentationController.sourceView = newFilterButton
+            popoverPresentationController.sourceRect = newFilterButton.bounds.offsetBy(dx: 0, dy: 10)
+            popoverPresentationController.backgroundColor = ThemeColor.primaryUi01()
+        }
+        newFilterTip = vc
+        Analytics.track(.filterTooltipShown)
+        present(vc, animated: true)
+    }
+
+    private func dismissTipView() {
+        dismiss(animated: true, completion: nil)
+        Analytics.track(.filterTooltipClosed)
+    }
+
+    func showNewFilterTipIfNeeded() {
+        guard
+            Settings.shouldShowNewFilterTip,
+            newFilterTip == nil
+        else {
+            return
+        }
+        showNewFilterTip()
+    }
+}
+
+extension PlaylistsViewController: UIPopoverPresentationControllerDelegate {
+    func adaptivePresentationStyle(for controller: UIPresentationController) -> UIModalPresentationStyle {
+        // Return no adaptive presentation style, use default presentation behaviour
+        return .none
+    }
+
+    func popoverPresentationControllerDidDismissPopover(_ popoverPresentationController: UIPopoverPresentationController) {
+        dismissTipView()
     }
 }

--- a/podcasts/PlaylistsViewController.swift
+++ b/podcasts/PlaylistsViewController.swift
@@ -32,6 +32,8 @@ class PlaylistsViewController: PCViewController, FilterCreatedDelegate {
         }
     }
 
+    var newFilterTip: UIViewController? = nil
+
     private var firstTimeLoading = true
 
     lazy private var informationalBannerCoordinator: InformationalBannerViewCoordinator = {
@@ -87,6 +89,8 @@ class PlaylistsViewController: PCViewController, FilterCreatedDelegate {
         addCustomObserver(Constants.Notifications.tappedOnSelectedTab, selector: #selector(checkForScrollTap(_:)))
 
         Analytics.track(.filterListShown, properties: ["filter_count": episodeFilters.count])
+
+        showNewFilterTipIfNeeded()
     }
 
     override func viewDidDisappear(_ animated: Bool) {

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -1447,6 +1447,17 @@ class Settings: NSObject {
         }
     }
 
+    // MARK: - New Filter Tip
+
+    static var shouldShowNewFilterTip: Bool {
+        get {
+            UserDefaults.standard.value(forKey: Constants.UserDefaults.newFilterTip) as? Bool ?? true
+        }
+        set {
+            UserDefaults.standard.setValue(newValue, forKey: Constants.UserDefaults.newFilterTip)
+        }
+    }
+
     // MARK: - Informational Banner
 #if !os(watchOS) && !APPCLIP
     static func dismissBanner(for type: InformationalBannerType) {

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -1342,6 +1342,10 @@ internal enum L10n {
   internal static var filtersDefaultNewReleases: String { return L10n.tr("Localizable", "filters_default_new_releases") }
   /// + New Filter
   internal static var filtersNewFilterButton: String { return L10n.tr("Localizable", "filters_new_filter_button") }
+  /// Create smart filters to organize your episodes. Filter by duration, release date, media type, and more.
+  internal static var filtersTipViewDescription: String { return L10n.tr("Localizable", "filters_tip_view_description") }
+  /// Organize your episodes
+  internal static var filtersTipViewTitle: String { return L10n.tr("Localizable", "filters_tip_view_title") }
   /// Folder
   internal static var folder: String { return L10n.tr("Localizable", "folder") }
   /// Add %1$@ Podcasts

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -1084,6 +1084,12 @@
 /* The title for the auto generated 'New Release' filter. */
 "filters_default_new_releases" = "New Releases";
 
+/* The title shown in a Tip View when the user hasn't yet added a filter */
+"filters_tip_view_title" = "Organize your episodes";
+
+/* The description shown in a Tip View when the user hasn't yet added a filter */
+"filters_tip_view_description" = "Create smart filters to organize your episodes. Filter by duration, release date, media type, and more.";
+
 /* Funny confirmation message accompanying several descriptive dialogs */
 "funny_conf_msg" = "It really matches your eyes ✨";
 


### PR DESCRIPTION
| 📘 Part of: #3102 |
|:---:|

Fixes #3109

| | | |
|--|--|--|
| ![Simulator Screenshot - iPhone 16 - 2025-05-20 at 14 23 21](https://github.com/user-attachments/assets/3df03168-3a8a-4797-b673-5091889e9056) | ![Simulator Screenshot - iPhone 16 - 2025-05-20 at 14 27 12](https://github.com/user-attachments/assets/4187fc04-033f-4b30-bcfa-ec60939b6425) | ![Simulator Screenshot - iPhone 16 - 2025-05-20 at 14 27 27](https://github.com/user-attachments/assets/ce79d9f1-cbc4-4eba-a6be-95c20a544f2c) |

## To test

* Fresh install of the app
* Enable the `tracksLogging` flag
* Open the Filters tab
* ✅ Verify that the tooltip appears
* ✅ Verify that `filter_tooltip_shown` event is logged
* Tap to close the tooltip
* ✅ Verify that `filter_tooltip_closed` event is logged

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
