### PR TITLE
Fix artwork aspect ratio during animation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 7.90
 -----
-
+- Fix UI glitch when expanding the player for podcasts with landscape artwork [#2086](https://github.com/Automattic/pocket-casts-ios/issues/2086)
 
 7.89
 -----

--- a/podcasts/MiniPlayerToFullPlayerAnimator.swift
+++ b/podcasts/MiniPlayerToFullPlayerAnimator.swift
@@ -141,6 +141,7 @@ class MiniPlayerToFullPlayerAnimator: NSObject, UIViewControllerAnimatedTransiti
 
             artwork = UIImageView()
             artwork?.image = fullPlayerArtwork.image
+            artwork?.contentMode = fullPlayerArtwork.contentMode
 
             containerView.addSubview(artwork ?? UIView())
             artwork?.frame = isPresenting ? miniPlayerArtworkFrame : fullPlayerArtworkFrame


### PR DESCRIPTION
Fixes #2086

Landscape podcast artwork is displayed as a square during player animation, but is displayed correctly as landscape at the end of the animation. This creates a weird effect at the animation end (see video in bug report).

The problem occurs because during the transition animation, a temporary `UIImageView` is created to smoothly animate between the mini-player and full-player. However, this temporary image view is not adopting the same content mode as the full-player image view, which is causing the weird animation effect where the image appears to change size or aspect ratio during the transition.


## To test

1. Find a podcast with landscape (rectangular) cover artwork (e.g. [this episode](https://pca.st/episode/70498efe-8055-44d1-b737-8ff4b71bb79b)) and press play to load landscape episode artwork
2. Tap the mini-player to expand to the full-player view
3. Observe the transition animation - the artwork appears to change aspect ratio at the end of the animation
4. When the full-player is fully open, the artwork displays correctly with proper aspect ratio

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
