### PR TITLE
Notification Revamp: Ensure that deep links to lists in Discovery are open after loading

### DIFF
--- a/podcasts/DiscoverCollectionViewController+DiscoverDelegate.swift
+++ b/podcasts/DiscoverCollectionViewController+DiscoverDelegate.swift
@@ -17,7 +17,8 @@ extension DiscoverCollectionViewController: DiscoverDelegate {
         if isViewLoaded {
             showItemWith(identifier: listID)
         } else {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5.seconds) {[weak self] in
+            loadViewIfNeeded()
+            reloadData { [weak self] in
                 self?.showItemWith(identifier: listID)
             }
         }
@@ -72,7 +73,9 @@ extension DiscoverCollectionViewController: DiscoverDelegate {
     }
 
     func showItemWith(identifier: String) {
-        guard let items = discoverLayout?.layout, let item = items.first(where: { $0.id == identifier || $0.uuid == identifier}) else {
+        guard let items = discoverLayout?.layout,
+              let item = items.first(where: { $0.id == identifier || $0.uuid == identifier})
+        else {
             return
         }
 


### PR DESCRIPTION
| 📘 Part of: #2906  |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

## To test

1. Start the app on the simulator
2. Ensure you have the notificationsRevamp FF enabled
3. Ensure that push notifications permissions are enable for the app. Go to Profile -> Settings -> Notifications and enable one type of the notifications
4. Kill the app
5. Drag and drop the file in `scripts/notifications/discover-trending.apns` to the simulator
6. Tap on the Push Notification banner
7. Check that the app opens on Discover inside the Trending list.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
