### PR TITLE
[Recommendations] Disable sharing for authenticated discover items

### DIFF
--- a/podcasts/DiscoverCollectionViewController+DiscoverDelegate.swift
+++ b/podcasts/DiscoverCollectionViewController+DiscoverDelegate.swift
@@ -113,7 +113,7 @@ extension DiscoverCollectionViewController: DiscoverDelegate {
             navController()?.pushViewController(collectionListVC, animated: true)
         } else { // item == expandedStylw == "plain_list" || item.expandedStyle == "ranked_list"
             let source = replaceRegionCode(string: item.source ?? "")
-            let listView = PodcastHeaderListViewController(podcasts: podcasts, source: source)
+            let listView = PodcastHeaderListViewController(podcasts: podcasts, source: source, isAuthenticated: item.isAuthenticated)
             listView.title = replaceRegionName(string: item.title?.localized ?? "")
             listView.showFeaturedCell = item.expandedStyle == "ranked_list"
             listView.showRankingNumber = item.expandedStyle == "ranked_list"

--- a/podcasts/DiscoverViewController+DiscoverDelegate.swift
+++ b/podcasts/DiscoverViewController+DiscoverDelegate.swift
@@ -102,7 +102,7 @@ extension DiscoverViewController: DiscoverDelegate {
             navController()?.pushViewController(collectionListVC, animated: true)
         } else { // item == expandedStylw == "plain_list" || item.expandedStyle == "ranked_list"
             let source = replaceRegionCode(string: item.source ?? "")
-            let listView = PodcastHeaderListViewController(podcasts: podcasts, source: source)
+            let listView = PodcastHeaderListViewController(podcasts: podcasts, source: source, isAuthenticated: item.isAuthenticated)
             listView.title = replaceRegionName(string: item.title?.localized ?? "")
             listView.showFeaturedCell = item.expandedStyle == "ranked_list"
             listView.showRankingNumber = item.expandedStyle == "ranked_list"

--- a/podcasts/ExpandedCollectionViewController.swift
+++ b/podcasts/ExpandedCollectionViewController.swift
@@ -61,7 +61,7 @@ class ExpandedCollectionViewController: PCViewController, CollectionHeaderLinkDe
             title = item.title?.localized.localizedCapitalized
         }
 
-        if item.source != nil {
+        if item.source != nil && item.isAuthenticated == false {
             customRightBtn = UIBarButtonItem(image: UIImage(named: "podcast-share"), style: .plain, target: self, action: #selector(handleShare))
         }
 

--- a/podcasts/PodcastHeaderListViewController.swift
+++ b/podcasts/PodcastHeaderListViewController.swift
@@ -14,12 +14,14 @@ class PodcastHeaderListViewController: PCViewController, UITableViewDataSource, 
     private static let cellId = "DiscoverCell"
     private static let featuredCellId = "FeaturedTableViewCell"
     private var source: URL?
+    private var isAuthenticated: Bool
 
-    init(podcasts: [DiscoverPodcast], source: String?) {
+    init(podcasts: [DiscoverPodcast], source: String?, isAuthenticated: Bool = false) {
         self.podcasts = podcasts
         if let source {
             self.source = URL(string: source)
         }
+        self.isAuthenticated = isAuthenticated
 
         super.init(nibName: "PodcastHeaderListViewController", bundle: nil)
     }
@@ -35,7 +37,7 @@ class PodcastHeaderListViewController: PCViewController, UITableViewDataSource, 
         chartsTable.register(UINib(nibName: "DiscoverPodcastTableCell", bundle: nil), forCellReuseIdentifier: PodcastHeaderListViewController.cellId)
         chartsTable.register(UINib(nibName: "FeaturedTableViewCell", bundle: nil), forCellReuseIdentifier: PodcastHeaderListViewController.featuredCellId)
 
-        if source != nil {
+        if source != nil && isAuthenticated == false {
             customRightBtn = UIBarButtonItem(image: UIImage(named: "podcast-share"), style: .plain, target: self, action: #selector(handleShare))
         }
 


### PR DESCRIPTION
| 📘 Part of: #2989 |
|:---:|

Disables sharing discover items which are authenticated. The shared source URL will not work in the browser.

| Before | After |
|--|--|
| ![Simulator Screenshot - iPhone 16 - 2025-05-21 at 11 21 39](https://github.com/user-attachments/assets/55e5be1b-e6c9-44bc-8b90-310547ee52b9) | ![Simulator Screenshot - iPhone 16 - 2025-05-21 at 11 20 03](https://github.com/user-attachments/assets/1763c5be-d335-452c-92c2-0852d1caf7cf) |

## To test

* Run the app with an account with some listening history
* Navigate to Discover
* Tap "Show all" on one of the recommendation items ("Loved by Listeners of", "If you like")
* ✅ Verify that the share button is hidden in the upper right

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
