### PR TITLE
[EU Accessibility Act] Inject view model

### DIFF
--- a/podcasts/AccountViewController+TableView.swift
+++ b/podcasts/AccountViewController+TableView.swift
@@ -44,7 +44,12 @@ extension AccountViewController: UITableViewDataSource, UITableViewDelegate {
 
         switch row {
         case .upgradeView:
-            let cell = tableView.dequeueReusableCell(withIdentifier: PlusAccountPromptTableCell.reuseIdentifier, for: indexPath) as! PlusAccountPromptTableCell
+            let cell: PlusAccountPromptTableCell
+            if let dequeuedCell = tableView.dequeueReusableCell(withIdentifier: PlusAccountPromptTableCell.reuseIdentifier) as? PlusAccountPromptTableCell {
+                cell = dequeuedCell
+            } else {
+                cell = PlusAccountPromptTableCell(reuseIdentifier: PlusAccountPromptTableCell.reuseIdentifier, model: model)
+            }
             cell.updateParent(self)
             cell.contentSizeUpdated = { [weak self] size in
                 self?.upgradePromptViewSize = size

--- a/podcasts/AccountViewController.swift
+++ b/podcasts/AccountViewController.swift
@@ -20,7 +20,6 @@ class AccountViewController: UIViewController, ChangeEmailDelegate {
             tableView.applyInsetForMiniPlayer()
             tableView.register(UINib(nibName: "NewsletterCell", bundle: nil), forCellReuseIdentifier: AccountViewController.newsletterCellId)
             tableView.register(UINib(nibName: "AccountActionCell", bundle: nil), forCellReuseIdentifier: AccountViewController.actionCellId)
-//            tableView.register(PlusAccountPromptTableCell.self, forCellReuseIdentifier: PlusAccountPromptTableCell.reuseIdentifier)
         }
     }
 

--- a/podcasts/AccountViewController.swift
+++ b/podcasts/AccountViewController.swift
@@ -9,6 +9,8 @@ class AccountViewController: UIViewController, ChangeEmailDelegate {
     static let newsletterCellId = "NewsletterCellId"
     static let actionCellId = "AccountActionCellId"
 
+    let model = PlusAccountPromptViewModel()
+
     private var isUsernamePasswordLogin: Bool {
         ServerSettings.syncingPassword() != nil
     }
@@ -18,7 +20,7 @@ class AccountViewController: UIViewController, ChangeEmailDelegate {
             tableView.applyInsetForMiniPlayer()
             tableView.register(UINib(nibName: "NewsletterCell", bundle: nil), forCellReuseIdentifier: AccountViewController.newsletterCellId)
             tableView.register(UINib(nibName: "AccountActionCell", bundle: nil), forCellReuseIdentifier: AccountViewController.actionCellId)
-            tableView.register(PlusAccountPromptTableCell.self, forCellReuseIdentifier: PlusAccountPromptTableCell.reuseIdentifier)
+//            tableView.register(PlusAccountPromptTableCell.self, forCellReuseIdentifier: PlusAccountPromptTableCell.reuseIdentifier)
         }
     }
 

--- a/podcasts/Onboarding/Plus/Account Prompt/PlusAccountPromptTableCell.swift
+++ b/podcasts/Onboarding/Plus/Account Prompt/PlusAccountPromptTableCell.swift
@@ -5,13 +5,15 @@ import PocketCastsUtils
 class PlusAccountPromptTableCell: ThemeableCell {
 //    static let reuseIdentifier: String = "PlusAccountPromptTableCell"
 
-    private let model = PlusAccountPromptViewModel()
+    private weak var model: PlusAccountPromptViewModel?
 
     /// Listen for size changes from the view so we can adjust the table size
     var contentSizeUpdated: ((CGSize) -> Void)? = nil
 
-    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
-        super.init(style: style, reuseIdentifier: reuseIdentifier)
+    init(reuseIdentifier: String?, model: PlusAccountPromptViewModel) {
+        self.model = model
+
+        super.init(style: .default, reuseIdentifier: reuseIdentifier)
 
         let view: UIView
         if FeatureFlag.newAccountUpgradePromptFlow.enabled {
@@ -43,8 +45,8 @@ class PlusAccountPromptTableCell: ThemeableCell {
 
     // Update the model's parent so we can present the modal
     func updateParent(_ controller: UIViewController) {
-        model.parentController = controller
-        model.source = .profile
+        model?.parentController = controller
+        model?.source = .profile
     }
 
     required init?(coder: NSCoder) {


### PR DESCRIPTION
| 📘 Part of: #3042
|:---:|

Fixes #3145 

This PR refactored a bit the `PlusAccountPromptTableCell` to receive the view model from the parent view controller.
This should avoid the vm to be deallocated when the dynamic font changes

## To test

- Run the app with a free user
- Open the account view controller
- Tap on Subscribe to Plus
- Change font size
- Observe the modal to adjust
- You should still be able to prompt the IAP sheet

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
