### PR TITLE
[Empty State] Update empty state for Folders

### DIFF
--- a/podcasts/FolderViewController.swift
+++ b/podcasts/FolderViewController.swift
@@ -1,30 +1,12 @@
 import PocketCastsDataModel
 import PocketCastsUtils
 import UIKit
+import SwiftUI
 
 class FolderViewController: PCViewController, UIGestureRecognizerDelegate {
     @IBOutlet var mainGrid: UICollectionView! {
         didSet {
             registerCells()
-        }
-    }
-
-    @IBOutlet var emptyFolderView: ThemeableView!
-    @IBOutlet var emptyFolderTitle: ThemeableLabel! {
-        didSet {
-            emptyFolderTitle.text = L10n.folderEmptyTitle
-        }
-    }
-
-    @IBOutlet var emptyFolderDescription: UILabel! {
-        didSet {
-            emptyFolderDescription.text = L10n.folderEmptyDescription
-        }
-    }
-
-    @IBOutlet var emptyFolderImage: ThemeableImageView! {
-        didSet {
-            emptyFolderImage.imageStyle = .primaryIcon01
         }
     }
 
@@ -274,6 +256,28 @@ class FolderViewController: PCViewController, UIGestureRecognizerDelegate {
         }
 
         mainGrid.reloadData()
-        emptyFolderView.isHidden = podcasts.count > 0
+
+        let shouldShowEmpty = podcasts.isEmpty
+        refreshContentUnavailable(shouldShow: shouldShowEmpty)
+    }
+
+    private func refreshContentUnavailable(shouldShow: Bool) {
+        var config: UIContentConfiguration?
+
+        if shouldShow {
+            let title = L10n.folderEmptyTitle
+            let message = L10n.folderEmptyDescription
+            config = ContentUnavailableConfiguration.emptyState(title: title, message: message, icon: { Image("folder-empty") }, actions: [
+                .init(title: L10n.folderEmptyButtonTitle, action: {
+                    self.addPodcastsTapped(self)
+                })
+            ])
+        }
+
+        if #available(iOS 17.0, *) {
+            self.contentUnavailableConfiguration = config
+        } else {
+            self.setContentUnavailableConfiguration(config)
+        }
     }
 }

--- a/podcasts/FolderViewController.xib
+++ b/podcasts/FolderViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -11,10 +11,6 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="FolderViewController" customModule="podcasts" customModuleProvider="target">
             <connections>
-                <outlet property="emptyFolderDescription" destination="0qP-lD-fjc" id="1jU-uy-758"/>
-                <outlet property="emptyFolderImage" destination="Bch-GE-a7s" id="vuj-zu-niv"/>
-                <outlet property="emptyFolderTitle" destination="HBF-An-d58" id="6Jz-MM-EHW"/>
-                <outlet property="emptyFolderView" destination="hy3-ku-I03" id="RFd-d3-x3R"/>
                 <outlet property="mainGrid" destination="47A-43-GRI" id="h9A-Gw-ZY7"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
             </connections>
@@ -25,7 +21,7 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="47A-43-GRI" customClass="ThemeableCollectionView" customModule="podcasts" customModuleProvider="target">
-                    <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                    <rect key="frame" x="0.0" y="48" width="414" height="814"/>
                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="SKr-CT-xsa" customClass="ReorderableFlowLayout" customModule="podcasts" customModuleProvider="target">
                         <size key="itemSize" width="128" height="128"/>
@@ -38,63 +34,19 @@
                         <outlet property="delegate" destination="-1" id="mnI-h5-aVN"/>
                     </connections>
                 </collectionView>
-                <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hy3-ku-I03" userLabel="Empty Folder View" customClass="ThemeableView" customModule="podcasts" customModuleProvider="target">
-                    <rect key="frame" x="0.0" y="44" width="414" height="818"/>
-                    <subviews>
-                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="empty-folder" translatesAutoresizingMaskIntoConstraints="NO" id="Bch-GE-a7s" customClass="ThemeableImageView" customModule="podcasts" customModuleProvider="target">
-                            <rect key="frame" x="127" y="216" width="160" height="160"/>
-                        </imageView>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Your folder is empty" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HBF-An-d58" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                            <rect key="frame" x="108" y="396" width="198.5" height="26.5"/>
-                            <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="22"/>
-                            <nil key="textColor"/>
-                            <nil key="highlightedColor"/>
-                        </label>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Add podcasts to your folder and they’ll appear here" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0qP-lD-fjc" customClass="SecondaryLabel" customModule="podcasts" customModuleProvider="target">
-                            <rect key="frame" x="60" y="442.5" width="294" height="41"/>
-                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                            <nil key="textColor"/>
-                            <nil key="highlightedColor"/>
-                        </label>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="oWd-ub-Y2P" customClass="ThemeableUIButton" customModule="podcasts" customModuleProvider="target">
-                            <rect key="frame" x="150" y="518" width="114" height="31"/>
-                            <state key="normal" title="Button"/>
-                            <buttonConfiguration key="configuration" style="plain" title="Add Podcasts"/>
-                            <connections>
-                                <action selector="addPodcastsTapped:" destination="-1" eventType="touchUpInside" id="R8t-y7-z95"/>
-                            </connections>
-                        </button>
-                    </subviews>
-                    <constraints>
-                        <constraint firstItem="Bch-GE-a7s" firstAttribute="centerX" secondItem="hy3-ku-I03" secondAttribute="centerX" id="24W-l5-9ra"/>
-                        <constraint firstItem="HBF-An-d58" firstAttribute="top" secondItem="Bch-GE-a7s" secondAttribute="bottom" constant="20" id="7eL-oJ-jjj"/>
-                        <constraint firstItem="HBF-An-d58" firstAttribute="centerX" secondItem="hy3-ku-I03" secondAttribute="centerX" id="BXr-pN-gbD"/>
-                        <constraint firstItem="0qP-lD-fjc" firstAttribute="top" secondItem="HBF-An-d58" secondAttribute="bottom" constant="20" id="LxK-iB-Ba7"/>
-                        <constraint firstItem="oWd-ub-Y2P" firstAttribute="centerX" secondItem="hy3-ku-I03" secondAttribute="centerX" id="f6x-yu-ewL"/>
-                        <constraint firstItem="0qP-lD-fjc" firstAttribute="leading" secondItem="hy3-ku-I03" secondAttribute="leading" constant="60" id="nJr-am-P3p"/>
-                        <constraint firstAttribute="trailing" secondItem="0qP-lD-fjc" secondAttribute="trailing" constant="60" id="v1y-fw-tN9"/>
-                        <constraint firstItem="HBF-An-d58" firstAttribute="centerY" secondItem="hy3-ku-I03" secondAttribute="centerY" id="wNh-Um-pB7"/>
-                        <constraint firstItem="oWd-ub-Y2P" firstAttribute="top" secondItem="0qP-lD-fjc" secondAttribute="bottom" constant="34.5" id="xQQ-Cf-xDO"/>
-                    </constraints>
-                </view>
             </subviews>
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
                 <constraint firstItem="47A-43-GRI" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="3Vn-s7-RuP"/>
-                <constraint firstItem="hy3-ku-I03" firstAttribute="bottom" secondItem="fnl-2z-Ty3" secondAttribute="bottom" id="PCs-Go-MbW"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="47A-43-GRI" secondAttribute="trailing" id="QQL-a4-Mvq"/>
-                <constraint firstItem="hy3-ku-I03" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="ThP-AH-vBO"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="47A-43-GRI" secondAttribute="bottom" id="ZO9-S6-sVk"/>
-                <constraint firstItem="hy3-ku-I03" firstAttribute="trailing" secondItem="fnl-2z-Ty3" secondAttribute="trailing" id="ks2-Gf-Ye5"/>
-                <constraint firstItem="hy3-ku-I03" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="oeW-Xb-cRE"/>
                 <constraint firstItem="47A-43-GRI" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="pDg-Yl-YRq"/>
             </constraints>
             <point key="canvasLocation" x="131.8840579710145" y="130.58035714285714"/>
         </view>
     </objects>
     <resources>
-        <image name="empty-folder" width="160" height="160"/>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -1379,6 +1379,8 @@ internal enum L10n {
   internal static var folderDeletePromptTitle: String { return L10n.tr("Localizable", "folder_delete_prompt_title") }
   /// Edit Folder
   internal static var folderEdit: String { return L10n.tr("Localizable", "folder_edit") }
+  /// Add podcasts
+  internal static var folderEmptyButtonTitle: String { return L10n.tr("Localizable", "folder_empty_button_title") }
   /// Add podcasts to your folder and they’ll appear here.
   internal static var folderEmptyDescription: String { return L10n.tr("Localizable", "folder_empty_description") }
   /// Your folder is empty

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -3542,6 +3542,9 @@
 /* Description shown under the title of an empty folder */
 "folder_empty_description" = "Add podcasts to your folder and they’ll appear here.";
 
+/* A button title for the empty folder state which will open the Add Podcasts screen */
+"folder_empty_button_title" = "Add podcasts";
+
 /* Upsell dialog title label when a free trial is active, %1$@ refers to the duration of the trial (1 month) */
 "free_trial_title_label" = "Try Plus with %1$@ free";
 


### PR DESCRIPTION
| 📘 Part of: #3102 |
|:---:|

Fixes #3172 

| Before | After |
|--|--|
| ![Simulator Screenshot - iPhone 16 - 2025-05-21 at 11 45 22](https://github.com/user-attachments/assets/ee6184ab-248b-462c-9ac8-82a25b5f15dd) | ![Simulator Screenshot - iPhone 16 - 2025-05-21 at 11 42 48](https://github.com/user-attachments/assets/c0afe805-1c5c-4d50-b258-f2e6cf73f76a) |

## To test

* Run the app with plus account or enable in the Developer menu
* Go to "Podcasts" tab
* Add a folder
* Add 0 podcasts
* Open the folder
* ✅ Verify that the new empty state appears
* Tap the "Add podcasts" button
* ✅ Verify that the empty state disappears
* Tap ⋯ to remove podcasts
* ✅ Verify that the empty state appears

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
