### PR TITLE
[Empty State] Update empty state for Discover search

### DIFF
--- a/podcasts/New Search/Views/Results/SearchResultsView.swift
+++ b/podcasts/New Search/Views/Results/SearchResultsView.swift
@@ -49,17 +49,9 @@ struct SearchResultsView: View {
                             SearchResultCell(episode: episode, result: nil, played: played)
                         }
                     } else if !searchResults.isShowingLocalResultsOnly {
-                        VStack(spacing: 2) {
-                            Text(L10n.discoverNoEpisodesFound)
-                                .font(style: .subheadline, weight: .medium)
-
-                            Text(L10n.discoverNoPodcastsFoundMsg)
-                                .font(size: 14, style: .subheadline, weight: .medium)
-                                .foregroundColor(AppTheme.color(for: .primaryText02, theme: theme))
-                                .multilineTextAlignment(.center)
-                        }
-                        .frame(maxWidth: .infinity)
-                        .padding(.all, 10)
+                        EmptyStateView(title: L10n.discoverNoEpisodesFound,
+                                       message: L10n.discoverNoPodcastsFoundMsg,
+                                       icon: { Image(systemName: "info.circle") })
                     }
                 }
             }

--- a/podcasts/SwiftUI/EmptyStateView.swift
+++ b/podcasts/SwiftUI/EmptyStateView.swift
@@ -106,7 +106,7 @@ private enum EmptyConstants {
 }
 
 extension EmptyStateView where Title == Text {
-    init(title: String, message: String?, icon: (() -> Image)? = nil, actions: [EmptyStateAction], style: Style) {
+    init(title: String, message: String?, icon: (() -> Image)? = nil, actions: [EmptyStateAction] = [], style: Style = .defaultStyle) {
         self.message = message
         self.actions = actions
         self.icon = icon


### PR DESCRIPTION
| 📘 Part of: #3102 |
|:---:|

Fixes #3154

| Before | After |
|--|--|
| ![Simulator Screenshot - iPhone 16 - 2025-05-21 at 14 57 30](https://github.com/user-attachments/assets/d7b1c69e-071f-456a-98aa-2ebd8427f734) | ![Simulator Screenshot - iPhone 16 - 2025-05-21 at 15 03 29](https://github.com/user-attachments/assets/f3b8de4d-ddc8-4816-8572-a2b2b2f54bd6) |

## To test

### Discover
* Navigate to Discover
* Type something into the search box
* ✅ Verify that the empty results state is shown
* Clear search
* ✅ Verify that the empty state disappears

### Episodes


## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
