### PR TITLE
Update CHANGELOG with Up Next Queue fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 -----
 - Add Recommendations feature to Discover and Podcast pages [#2989](https://github.com/Automattic/pocket-casts-ios/issues/2989)
 - Fix repeating the episode when skipping forward [#3138](https://github.com/Automattic/pocket-casts-ios/pull/3138)
+- Fix Up Next Queue syncing when an episode is replaced. This could lead to old episodes being added back to the queue. [#3159](https://github.com/Automattic/pocket-casts-ios/pull/3159)
 
 7.88
 -----


### PR DESCRIPTION
| 📘 Part of: #2945 |
|:---:|

A changelog entry for [the Up Next Queue fix](https://github.com/Automattic/pocket-casts-ios/pull/3159) added in the 7.89 release.

## To test

Nothing

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
