### PR TITLE
Enable FF for notifications revamp and add changelog entry.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 7.90
 -----
-
+ - New onboarding and content recommendations Notifications. [#2906](https://github.com/Automattic/pocket-casts-ios/issues/2906)
 
 7.89
 -----

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -303,7 +303,7 @@ public enum FeatureFlag: String, CaseIterable {
         case .encourageAccountCreation:
             true
         case .notificationsRevamp:
-            false
+            true
         case .refreshAndSaveWatchLogsOnSend:
             true
         case .avoidReplaceOnEpisodeSwap:

--- a/podcasts/Notifications/NotificationsCoordinator.swift
+++ b/podcasts/Notifications/NotificationsCoordinator.swift
@@ -131,7 +131,7 @@ enum NotificationType: String {
             case .recommendationsYouMightLike:
                 return SyncManager.isUserLoggedIn()
             case .newFeatureSuggestedFolders:
-                return Settings.suggestedFoldersUpsellCount < 2 && Settings.appVersion() == "7.88"
+                return Settings.suggestedFoldersUpsellCount < 2 && Settings.appVersion() == "7.90"
             case .reengagementDownloads:
                 return NotificationsCoordinator.shared.numberOfDownloadsAvailable() > 0
             default:


### PR DESCRIPTION
| 📘 Part of: #2906  |  <!-- project issue number, if applicable -->
|:---:|

Fixes #2906 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
Enable the notifications revamp for 7.90 version and add changelog entry

| 1 | 2 |
| - | - |
| ![Simulator Screenshot - iPhone 16 Pro Max - 2025-05-22 at 16 40 29](https://github.com/user-attachments/assets/e17801a8-d4d9-4cb8-9c06-d0f38a44e417) | ![Simulator Screenshot - iPhone 16 Pro Max - 2025-05-22 at 16 40 41](https://github.com/user-attachments/assets/80b99434-f917-4564-a374-084703c14e4c) |

## To test

1. Start the app
2. If you started from a clean install you should see a notification permission modal like the screenshot 1 above.
3. Go to Profile -> Settings -> Notifications
4. Check if you see the new notifications screen like the one in screenshot 2 above

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
