### PR TITLE
[Empty States] Persist filter tip shown setting

### DIFF
--- a/podcasts/PlaylistsViewController+Table.swift
+++ b/podcasts/PlaylistsViewController+Table.swift
@@ -130,7 +130,9 @@ extension PlaylistsViewController {
         }
         newFilterTip = vc
         Analytics.track(.filterTooltipShown)
-        present(vc, animated: true)
+        present(vc, animated: true) {
+            Settings.shouldShowNewFilterTip = false
+        }
     }
 
     private func dismissTipView() {


### PR DESCRIPTION
| 📘 Part of: #3102 |
|:---:|

Fixes an issue with the New Filter tooltip not disappearing.

<img src="https://github.com/user-attachments/assets/35f0ba1c-5900-49fc-8d87-bed3e977d067" alt="Simulator Screenshot - iPhone 16 - 2025-05-22 at 11 39 33" width="300">

## To test

* Open the Filters tab
* ✅ Verify that you see the tooltip for the New Filter button
* Close the app
* Open the Filters tab
* ✅ Verify that you **don't** see the tooltip for the New Filter button

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
