### PR TITLE
CI Run for #3166

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 7.90
 -----
-
+- Fix UI glitch when expanding the player for podcasts with landscape artwork [#2086](https://github.com/Automattic/pocket-casts-ios/issues/2086)
 
 7.89
 -----

--- a/podcasts/MiniPlayerToFullPlayerAnimator.swift
+++ b/podcasts/MiniPlayerToFullPlayerAnimator.swift
@@ -141,6 +141,7 @@ class MiniPlayerToFullPlayerAnimator: NSObject, UIViewControllerAnimatedTransiti
 
             artwork = UIImageView()
             artwork?.image = fullPlayerArtwork.image
+            artwork?.contentMode = fullPlayerArtwork.contentMode
 
             containerView.addSubview(artwork ?? UIView())
             artwork?.frame = isPresenting ? miniPlayerArtworkFrame : fullPlayerArtworkFrame


### PR DESCRIPTION


CI Run for #3166 

| Before | After |
|--|--|
| <video src="https://github.com/user-attachments/assets/e688be2e-0706-4ba6-8c19-4470494b61d9"></video> | <video src="https://github.com/user-attachments/assets/cd9b3b39-2485-457b-8cfe-569f764014e4"></video> |