### PR TITLE
[Empty States] Add empty state for search errors

### DIFF
--- a/podcasts/New Search/Model/SearchResultsModel.swift
+++ b/podcasts/New Search/Model/SearchResultsModel.swift
@@ -10,7 +10,9 @@ class SearchResultsModel: ObservableObject {
 
     @Published var isSearchingForPodcasts = false
     @Published var isSearchingForEpisodes = false
-    @Published var searchError: Error?
+
+    @Published var episodeSearchError: Error?
+    @Published var podcastSearchError: Error?
 
     @Published var podcasts: [PodcastFolderSearchResult] = []
     @Published var episodes: [EpisodeSearchResult] = []
@@ -42,7 +44,8 @@ class SearchResultsModel: ObservableObject {
     @MainActor
     func search(term: String) {
         currentSearchTerm = term
-        searchError = nil
+        episodeSearchError = nil
+        podcastSearchError = nil
 
         if !isShowingLocalResultsOnly {
             clearSearch()
@@ -54,6 +57,7 @@ class SearchResultsModel: ObservableObject {
                 let results = try await podcastSearch.search(term: term)
                 show(podcastResults: results)
             } catch {
+                podcastSearchError = error
                 analyticsHelper.trackFailed(error)
             }
 
@@ -69,7 +73,7 @@ class SearchResultsModel: ObservableObject {
                     playedEpisodesUUIDs = buildPlayedEpisodesUUIDs(results)
                     episodes = results
                 } catch {
-                    searchError = error
+                    episodeSearchError = error
                     analyticsHelper.trackFailed(error)
                 }
 

--- a/podcasts/New Search/Model/SearchResultsModel.swift
+++ b/podcasts/New Search/Model/SearchResultsModel.swift
@@ -10,6 +10,7 @@ class SearchResultsModel: ObservableObject {
 
     @Published var isSearchingForPodcasts = false
     @Published var isSearchingForEpisodes = false
+    @Published var searchError: Error?
 
     @Published var podcasts: [PodcastFolderSearchResult] = []
     @Published var episodes: [EpisodeSearchResult] = []
@@ -62,6 +63,7 @@ class SearchResultsModel: ObservableObject {
                     playedEpisodesUUIDs = buildPlayedEpisodesUUIDs(results)
                     episodes = results
                 } catch {
+                    searchError = error
                     analyticsHelper.trackFailed(error)
                 }
 

--- a/podcasts/New Search/Model/SearchResultsModel.swift
+++ b/podcasts/New Search/Model/SearchResultsModel.swift
@@ -20,6 +20,8 @@ class SearchResultsModel: ObservableObject {
 
     @Published var hideEpisodes = false
 
+    private(set) var currentSearchTerm: String = ""
+
     private(set) var playedEpisodesUUIDs = Set<String>()
     private let dataMangager: DataManager
 
@@ -34,10 +36,14 @@ class SearchResultsModel: ObservableObject {
         episodes = []
         playedEpisodesUUIDs = []
         resultsContainLocalPodcasts = false
+        currentSearchTerm = ""
     }
 
     @MainActor
     func search(term: String) {
+        currentSearchTerm = term
+        searchError = nil
+
         if !isShowingLocalResultsOnly {
             clearSearch()
         }

--- a/podcasts/New Search/Views/Results/PodcastCarouselView.swift
+++ b/podcasts/New Search/Views/Results/PodcastCarouselView.swift
@@ -43,7 +43,7 @@ struct PodcastsCarouselView: View {
                     message: L10n.discoverSearchFailedMsg,
                     icon: { Image(AppTheme.noConnectionImageName()).renderingMode(.template) },
                     actions: [
-                        .init(title: L10n.tryAgain) {
+                        .init(title: L10n.tryAgain, style: SimpleTextButtonStyle(theme: .sharedTheme)) {
                             searchResults.search(term: searchResults.currentSearchTerm)
                         }
                     ]

--- a/podcasts/New Search/Views/Results/PodcastCarouselView.swift
+++ b/podcasts/New Search/Views/Results/PodcastCarouselView.swift
@@ -37,7 +37,7 @@ struct PodcastsCarouselView: View {
 
     var body: some View {
         Group {
-            if let _ = searchResults.searchError {
+            if let _ = searchResults.podcastSearchError {
                 EmptyStateView(
                     title: L10n.discoverSearchFailed,
                     message: L10n.discoverSearchFailedMsg,

--- a/podcasts/New Search/Views/Results/PodcastCarouselView.swift
+++ b/podcasts/New Search/Views/Results/PodcastCarouselView.swift
@@ -95,16 +95,9 @@ struct PodcastsCarouselView: View {
                 .id(searchResults.podcasts.map { $0.id })
 
             } else if !searchResults.isShowingLocalResultsOnly {
-                VStack(spacing: 2) {
-                    Text(L10n.discoverNoPodcastsFound)
-                        .font(style: .subheadline, weight: .medium)
-
-                    Text(L10n.discoverNoPodcastsFoundMsg)
-                        .font(size: 14, style: .subheadline, weight: .medium)
-                        .foregroundColor(AppTheme.color(for: .primaryText02, theme: theme))
-                        .multilineTextAlignment(.center)
-                }
-                .padding(.all, 10)
+                EmptyStateView(title: L10n.discoverNoPodcastsFound,
+                               message: L10n.discoverNoPodcastsFoundMsg,
+                               icon: { Image(systemName: "info.circle") })
             }
 
             ThemedDivider()

--- a/podcasts/New Search/Views/Results/PodcastCarouselView.swift
+++ b/podcasts/New Search/Views/Results/PodcastCarouselView.swift
@@ -37,7 +37,12 @@ struct PodcastsCarouselView: View {
 
     var body: some View {
         Group {
-            if shouldShowLoadingActivity {
+            if let error = searchResults.searchError {
+                EmptyStateView(
+                    title: L10n.discoverSearchFailed,
+                    message: L10n.discoverSearchFailedMsg,
+                    icon: { Image(AppTheme.noConnectionImageName()) })
+            } else if shouldShowLoadingActivity {
                 ZStack(alignment: .center) {
                     ProgressView()
                         .tint(AppTheme.loadingActivityColor().color)

--- a/podcasts/New Search/Views/Results/PodcastCarouselView.swift
+++ b/podcasts/New Search/Views/Results/PodcastCarouselView.swift
@@ -41,9 +41,9 @@ struct PodcastsCarouselView: View {
                 EmptyStateView(
                     title: L10n.discoverSearchFailed,
                     message: L10n.discoverSearchFailedMsg,
-                    icon: { Image(AppTheme.noConnectionImageName()).renderingMode(.template) },
+                    icon: { Image("no-connection-grey").renderingMode(.template) },
                     actions: [
-                        .init(title: L10n.tryAgain, style: SimpleTextButtonStyle(theme: .sharedTheme)) {
+                        .init(title: L10n.tryAgain, style: SimpleTextButtonStyle(theme: .sharedTheme, textColor: .primaryInteractive01)) {
                             searchResults.search(term: searchResults.currentSearchTerm)
                         }
                     ]

--- a/podcasts/New Search/Views/Results/PodcastCarouselView.swift
+++ b/podcasts/New Search/Views/Results/PodcastCarouselView.swift
@@ -37,7 +37,7 @@ struct PodcastsCarouselView: View {
 
     var body: some View {
         Group {
-            if let error = searchResults.searchError {
+            if let _ = searchResults.searchError {
                 EmptyStateView(
                     title: L10n.discoverSearchFailed,
                     message: L10n.discoverSearchFailedMsg,

--- a/podcasts/New Search/Views/Results/PodcastCarouselView.swift
+++ b/podcasts/New Search/Views/Results/PodcastCarouselView.swift
@@ -41,7 +41,7 @@ struct PodcastsCarouselView: View {
                 EmptyStateView(
                     title: L10n.discoverSearchFailed,
                     message: L10n.discoverSearchFailedMsg,
-                    icon: { Image(AppTheme.noConnectionImageName()) },
+                    icon: { Image(AppTheme.noConnectionImageName()).renderingMode(.template) },
                     actions: [
                         .init(title: L10n.tryAgain) {
                             searchResults.search(term: searchResults.currentSearchTerm)

--- a/podcasts/New Search/Views/Results/PodcastCarouselView.swift
+++ b/podcasts/New Search/Views/Results/PodcastCarouselView.swift
@@ -41,7 +41,13 @@ struct PodcastsCarouselView: View {
                 EmptyStateView(
                     title: L10n.discoverSearchFailed,
                     message: L10n.discoverSearchFailedMsg,
-                    icon: { Image(AppTheme.noConnectionImageName()) })
+                    icon: { Image(AppTheme.noConnectionImageName()) },
+                    actions: [
+                        .init(title: L10n.tryAgain) {
+                            searchResults.search(term: searchResults.currentSearchTerm)
+                        }
+                    ]
+                )
             } else if shouldShowLoadingActivity {
                 ZStack(alignment: .center) {
                     ProgressView()

--- a/podcasts/New Search/Views/Results/SearchResultsView.swift
+++ b/podcasts/New Search/Views/Results/SearchResultsView.swift
@@ -43,7 +43,7 @@ struct SearchResultsView: View {
                         .onAppear {
                             identifier += 1
                         }
-                    } else if let error = searchResults.searchError {
+                    } else if let _ = searchResults.searchError {
                         EmptyStateView(
                             title: L10n.discoverSearchFailed,
                             message: L10n.discoverSearchFailedMsg,

--- a/podcasts/New Search/Views/Results/SearchResultsView.swift
+++ b/podcasts/New Search/Views/Results/SearchResultsView.swift
@@ -24,7 +24,7 @@ struct SearchResultsView: View {
                         message: L10n.discoverSearchFailedMsg,
                         icon: { Image(AppTheme.noConnectionImageName()).renderingMode(.template) },
                         actions: [
-                            .init(title: L10n.tryAgain) {
+                            .init(title: L10n.tryAgain, style: SimpleTextButtonStyle(theme: .sharedTheme)) {
                                 searchResults.search(term: searchResults.currentSearchTerm)
                             }
                         ]
@@ -70,7 +70,7 @@ struct SearchResultsView: View {
                     message: L10n.discoverSearchFailedMsg,
                     icon: { Image(AppTheme.noConnectionImageName()).renderingMode(.template) },
                     actions: [
-                        .init(title: L10n.tryAgain) {
+                        .init(title: L10n.tryAgain, style: SimpleTextButtonStyle(theme: .sharedTheme)) {
                             searchResults.search(term: searchResults.currentSearchTerm)
                         }
                     ]

--- a/podcasts/New Search/Views/Results/SearchResultsView.swift
+++ b/podcasts/New Search/Views/Results/SearchResultsView.swift
@@ -47,7 +47,13 @@ struct SearchResultsView: View {
                         EmptyStateView(
                             title: L10n.discoverSearchFailed,
                             message: L10n.discoverSearchFailedMsg,
-                            icon: { Image(AppTheme.noConnectionImageName()) })
+                            icon: { Image(AppTheme.noConnectionImageName()) },
+                            actions: [
+                                .init(title: L10n.tryAgain) {
+                                    searchResults.search(term: searchResults.currentSearchTerm)
+                                }
+                            ]
+                        )
                     } else if searchResults.episodes.count > 0 {
                         ForEach(searchResults.episodes.prefix(Constants.maxNumberOfEpisodes), id: \.self) { episode in
                             let played = searchResults.playedEpisodesUUIDs.contains(episode.uuid)

--- a/podcasts/New Search/Views/Results/SearchResultsView.swift
+++ b/podcasts/New Search/Views/Results/SearchResultsView.swift
@@ -17,54 +17,73 @@ struct SearchResultsView: View {
         Group {
             NavigationLink(destination: SearchResultsListView(displayMode: displayMode).setupDefaultEnvironment().environmentObject(searchAnalyticsHelper).environmentObject(searchResults).environmentObject(searchHistory), isActive: $showInlineResults) { EmptyView() }
 
-            SearchListView {
-                ThemeableListHeader(title: L10n.podcastsPlural, actionTitle: L10n.discoverShowAll) {
-                    displayMode = .podcasts
+            if searchResults.episodeSearchError != nil && searchResults.podcastSearchError != nil {
+                HStack(alignment: .center) {
+                    EmptyStateView(
+                        title: L10n.discoverSearchFailed,
+                        message: L10n.discoverSearchFailedMsg,
+                        icon: { Image(AppTheme.noConnectionImageName()) },
+                        actions: [
+                            .init(title: L10n.tryAgain) {
+                                searchResults.search(term: searchResults.currentSearchTerm)
+                            }
+                        ]
+                    )
+                }
+            } else {
+                SearchListView {
+                    ThemeableListHeader(title: L10n.podcastsPlural, actionTitle: L10n.discoverShowAll) {
+                        displayMode = .podcasts
+                        showInlineResults = true
+                    }
+
+                    PodcastsCarouselView()
+
+                    episodeList()
+                }
+            }
+        }
+    }
+
+    @ViewBuilder func episodeList() -> some View {
+        if !searchResults.hideEpisodes {
+            // If local results are being shown, we hide the episodes header
+            if !searchResults.isShowingLocalResultsOnly {
+                ThemeableListHeader(title: L10n.episodes, actionTitle: searchResults.episodes.count > 20 ? L10n.discoverShowAll : nil) {
+                    displayMode = .episodes
                     showInlineResults = true
                 }
+            }
 
-                PodcastsCarouselView()
-
-                if !searchResults.hideEpisodes {
-                    // If local results are being shown, we hide the episodes header
-                    if !searchResults.isShowingLocalResultsOnly {
-                        ThemeableListHeader(title: L10n.episodes, actionTitle: searchResults.episodes.count > 20 ? L10n.discoverShowAll : nil) {
-                            displayMode = .episodes
-                            showInlineResults = true
-                        }
-                    }
-
-                    if searchResults.isSearchingForEpisodes {
-                        ProgressView()
-                        .frame(maxWidth: .infinity)
-                        .tint(AppTheme.loadingActivityColor().color)
-                        // Force the list to re-render the ProgressView by changing it's id
-                        .id(identifier)
-                        .onAppear {
-                            identifier += 1
-                        }
-                    } else if let _ = searchResults.searchError {
-                        EmptyStateView(
-                            title: L10n.discoverSearchFailed,
-                            message: L10n.discoverSearchFailedMsg,
-                            icon: { Image(AppTheme.noConnectionImageName()) },
-                            actions: [
-                                .init(title: L10n.tryAgain) {
-                                    searchResults.search(term: searchResults.currentSearchTerm)
-                                }
-                            ]
-                        )
-                    } else if searchResults.episodes.count > 0 {
-                        ForEach(searchResults.episodes.prefix(Constants.maxNumberOfEpisodes), id: \.self) { episode in
-                            let played = searchResults.playedEpisodesUUIDs.contains(episode.uuid)
-                            SearchResultCell(episode: episode, result: nil, played: played)
-                        }
-                    } else if !searchResults.isShowingLocalResultsOnly {
-                        EmptyStateView(title: L10n.discoverNoEpisodesFound,
-                                       message: L10n.discoverNoPodcastsFoundMsg,
-                                       icon: { Image(systemName: "info.circle") })
-                    }
+            if searchResults.isSearchingForEpisodes {
+                ProgressView()
+                .frame(maxWidth: .infinity)
+                .tint(AppTheme.loadingActivityColor().color)
+                // Force the list to re-render the ProgressView by changing it's id
+                .id(identifier)
+                .onAppear {
+                    identifier += 1
                 }
+            } else if let _ = searchResults.episodeSearchError {
+                EmptyStateView(
+                    title: L10n.discoverSearchFailed,
+                    message: L10n.discoverSearchFailedMsg,
+                    icon: { Image(AppTheme.noConnectionImageName()) },
+                    actions: [
+                        .init(title: L10n.tryAgain) {
+                            searchResults.search(term: searchResults.currentSearchTerm)
+                        }
+                    ]
+                )
+            } else if searchResults.episodes.count > 0 {
+                ForEach(searchResults.episodes.prefix(Constants.maxNumberOfEpisodes), id: \.self) { episode in
+                    let played = searchResults.playedEpisodesUUIDs.contains(episode.uuid)
+                    SearchResultCell(episode: episode, result: nil, played: played)
+                }
+            } else if !searchResults.isShowingLocalResultsOnly {
+                EmptyStateView(title: L10n.discoverNoEpisodesFound,
+                               message: L10n.discoverNoPodcastsFoundMsg,
+                               icon: { Image(systemName: "info.circle") })
             }
         }
     }

--- a/podcasts/New Search/Views/Results/SearchResultsView.swift
+++ b/podcasts/New Search/Views/Results/SearchResultsView.swift
@@ -31,6 +31,7 @@ struct SearchResultsView: View {
                     )
                 }
                 .frame(maxHeight: .infinity)
+                .background(DefaultEmptyStateStyle.defaultStyle.background)
             } else {
                 SearchListView {
                     ThemeableListHeader(title: L10n.podcastsPlural, actionTitle: L10n.discoverShowAll) {

--- a/podcasts/New Search/Views/Results/SearchResultsView.swift
+++ b/podcasts/New Search/Views/Results/SearchResultsView.swift
@@ -43,6 +43,11 @@ struct SearchResultsView: View {
                         .onAppear {
                             identifier += 1
                         }
+                    } else if let error = searchResults.searchError {
+                        EmptyStateView(
+                            title: L10n.discoverSearchFailed,
+                            message: L10n.discoverSearchFailedMsg,
+                            icon: { Image(AppTheme.noConnectionImageName()) })
                     } else if searchResults.episodes.count > 0 {
                         ForEach(searchResults.episodes.prefix(Constants.maxNumberOfEpisodes), id: \.self) { episode in
                             let played = searchResults.playedEpisodesUUIDs.contains(episode.uuid)

--- a/podcasts/New Search/Views/Results/SearchResultsView.swift
+++ b/podcasts/New Search/Views/Results/SearchResultsView.swift
@@ -22,9 +22,9 @@ struct SearchResultsView: View {
                     EmptyStateView(
                         title: L10n.discoverSearchFailed,
                         message: L10n.discoverSearchFailedMsg,
-                        icon: { Image(AppTheme.noConnectionImageName()).renderingMode(.template) },
+                        icon: { Image("no-connection-grey").renderingMode(.template) },
                         actions: [
-                            .init(title: L10n.tryAgain, style: SimpleTextButtonStyle(theme: .sharedTheme)) {
+                            .init(title: L10n.tryAgain, style: SimpleTextButtonStyle(theme: .sharedTheme, textColor: .primaryInteractive01)) {
                                 searchResults.search(term: searchResults.currentSearchTerm)
                             }
                         ]
@@ -68,9 +68,9 @@ struct SearchResultsView: View {
                 EmptyStateView(
                     title: L10n.discoverSearchFailed,
                     message: L10n.discoverSearchFailedMsg,
-                    icon: { Image(AppTheme.noConnectionImageName()).renderingMode(.template) },
+                    icon: { Image("no-connection-grey").renderingMode(.template) },
                     actions: [
-                        .init(title: L10n.tryAgain, style: SimpleTextButtonStyle(theme: .sharedTheme)) {
+                        .init(title: L10n.tryAgain, style: SimpleTextButtonStyle(theme: .sharedTheme, textColor: .primaryInteractive01)) {
                             searchResults.search(term: searchResults.currentSearchTerm)
                         }
                     ]

--- a/podcasts/New Search/Views/Results/SearchResultsView.swift
+++ b/podcasts/New Search/Views/Results/SearchResultsView.swift
@@ -22,7 +22,7 @@ struct SearchResultsView: View {
                     EmptyStateView(
                         title: L10n.discoverSearchFailed,
                         message: L10n.discoverSearchFailedMsg,
-                        icon: { Image(AppTheme.noConnectionImageName()) },
+                        icon: { Image(AppTheme.noConnectionImageName()).renderingMode(.template) },
                         actions: [
                             .init(title: L10n.tryAgain) {
                                 searchResults.search(term: searchResults.currentSearchTerm)
@@ -68,7 +68,7 @@ struct SearchResultsView: View {
                 EmptyStateView(
                     title: L10n.discoverSearchFailed,
                     message: L10n.discoverSearchFailedMsg,
-                    icon: { Image(AppTheme.noConnectionImageName()) },
+                    icon: { Image(AppTheme.noConnectionImageName()).renderingMode(.template) },
                     actions: [
                         .init(title: L10n.tryAgain) {
                             searchResults.search(term: searchResults.currentSearchTerm)

--- a/podcasts/New Search/Views/Results/SearchResultsView.swift
+++ b/podcasts/New Search/Views/Results/SearchResultsView.swift
@@ -30,6 +30,7 @@ struct SearchResultsView: View {
                         ]
                     )
                 }
+                .frame(maxHeight: .infinity)
             } else {
                 SearchListView {
                     ThemeableListHeader(title: L10n.podcastsPlural, actionTitle: L10n.discoverShowAll) {

--- a/podcasts/SwiftUI/EmptyStateView.swift
+++ b/podcasts/SwiftUI/EmptyStateView.swift
@@ -12,15 +12,16 @@ struct EmptyStateAction: Identifiable {
     let id: String
     let view: AnyView
 
-    init(
+    init<Style: ButtonStyle>(
         title: String,
+        style: Style = RoundedButtonStyle(theme: .sharedTheme),
         action: @escaping () -> Void
     ) {
         self.id = title
         self.view = AnyView(
             Button(title) {
                 action()
-            }.buttonStyle(RoundedButtonStyle(theme: .sharedTheme))
+            }.buttonStyle(style)
         )
     }
 


### PR DESCRIPTION
| 📘 Part of: #3102 |
|:---:|

* Adds empty state for the Podcast section of search.
* Adds a separate failed state for any errors during search. This is to differentiate with an empty search result.
* Adds a Try Again button to retry the search calls

| Empty | Both Failed | One Fails |
|--|--|--|
| ![Simulator Screenshot - iPhone 16 - 2025-05-26 at 11 26 37](https://github.com/user-attachments/assets/021dccea-8607-4876-8df9-44b84d22ed08) | ![Simulator Screenshot - iPhone 16 - 2025-05-26 at 22 01 00](https://github.com/user-attachments/assets/4f9d28ce-6081-489d-ad5a-490c2e46638a) | ![Simulator Screenshot - iPhone 16 - 2025-05-26 at 22 00 29](https://github.com/user-attachments/assets/713346e4-e344-4c7f-a963-b27535590bb3) |

## To test

* Load [these scripts](https://github.com/user-attachments/files/20444449/search_state_proxyman_scripts.config.zip) into Proxyman from Tools > Import Settings > From Proxyman > Scripting
* Enable "Empty Podcast Search" and run a search
* ✅ Verify that the new Empty state appears
* Disable the "Empty Podcast Search" and Enable the "Failed Search"
* Run a new search
* ✅ Verify that the new Error states appear


## Checklist
- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
