### PR TITLE
GRDB: remove `try!` and log errors in Sentry

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/DB/GRDB/GRDBQueue.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/DB/GRDB/GRDBQueue.swift
@@ -12,65 +12,65 @@ class GRDBQueue: PCDBQueue {
 
     func inDatabase(_ block: (any PCDatabase) -> Void) {
         withoutActuallyEscaping(block) { block in
-            // This should be a try? to match FMDB behavior
-            // However, while we test GRDB internally we would like any error
-            // to be thrown helping us to discover issues.
-            // TODO: remove once GRDB has been tested.
-            try! dbPool.write { db in
-                let dbWrapper = GRDBDatabase(database: db)
-                block(dbWrapper)
+            do {
+                try dbPool.write { db in
+                    let dbWrapper = GRDBDatabase(database: db)
+                    block(dbWrapper)
+                }
+            } catch {
+                logger?.log(error: error, context: [:])
             }
         }
     }
 
     func inTransaction(_ block: (any PCDatabase, UnsafeMutablePointer<ObjCBool>) -> Void) {
         withoutActuallyEscaping(block) { block in
-            // This should be a try? to match FMDB behavior
-            // However, while we test GRDB internally we would like any error
-            // to be thrown helping us to discover issues.
-            // TODO: remove once GRDB has been tested.
-            try! dbPool.writeInTransaction { db in
-                let rollback = UnsafeMutablePointer<ObjCBool>.allocate(capacity: 1)
-                rollback.pointee = false
-                let dbWrapper = GRDBDatabase(database: db)
-                block(dbWrapper, rollback)
-                defer { rollback.deallocate() }
-                return rollback.pointee.boolValue ? .rollback : .commit
+            do {
+                try dbPool.writeInTransaction { db in
+                    let rollback = UnsafeMutablePointer<ObjCBool>.allocate(capacity: 1)
+                    rollback.pointee = false
+                    let dbWrapper = GRDBDatabase(database: db)
+                    block(dbWrapper, rollback)
+                    defer { rollback.deallocate() }
+                    return rollback.pointee.boolValue ? .rollback : .commit
+                }
+            } catch {
+                logger?.log(error: error, context: [:])
             }
         }
     }
 
     func read(_ block: (any PCDatabase) -> Void) {
         withoutActuallyEscaping(block) { block in
-            // This should be a try? to match FMDB behavior
-            // However, while we test GRDB internally we would like any error
-            // to be thrown helping us to discover issues.
-            // TODO: remove once GRDB has been tested.
-            try! dbPool.read { db in
-                let dbWrapper = GRDBDatabase(database: db)
-                block(dbWrapper)
+            do {
+                try dbPool.read { db in
+                    let dbWrapper = GRDBDatabase(database: db)
+                    block(dbWrapper)
+                }
+            } catch {
+                logger?.log(error: error, context: [:])
             }
         }
     }
 
     func write(_ block: (any PCDatabase) -> Void) {
         withoutActuallyEscaping(block) { block in
-            // This should be a try? to match FMDB behavior
-            // However, while we test GRDB internally we would like any error
-            // to be thrown helping us to discover issues.
-            // TODO: remove once GRDB has been tested.
-            try! dbPool.write { db in
-                let dbWrapper = GRDBDatabase(database: db)
-                block(dbWrapper)
+            do {
+                try dbPool.write { db in
+                    let dbWrapper = GRDBDatabase(database: db)
+                    block(dbWrapper)
+                }
+            } catch {
+                logger?.log(error: error, context: [:])
             }
         }
     }
 
     func close() {
-        // This should be a try? to match FMDB behavior
-        // However, while we test GRDB internally we would like any error
-        // to be thrown helping us to discover issues.
-        // TODO: remove once GRDB has been tested.
-        try! dbPool.close()
+        do {
+            try dbPool.close()
+        } catch {
+            logger?.log(error: error, context: [:])
+        }
     }
 }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/DB/GRDB/GRDBQueue.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/DB/GRDB/GRDBQueue.swift
@@ -3,9 +3,11 @@ import Foundation
 
 class GRDBQueue: PCDBQueue {
     private let dbPool: DatabasePool
+    private let logger: ErrorLogger?
 
-    init(dbPool: DatabasePool) {
+    init(dbPool: DatabasePool, logger: ErrorLogger? = nil) {
         self.dbPool = dbPool
+        self.logger = logger
     }
 
     func inDatabase(_ block: (any PCDatabase) -> Void) {

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -31,6 +31,8 @@ public class DataManager {
 
     public static internal(set) var sharedManager = DataManager()
 
+    public static var logger: ErrorLogger?
+
     /// Creates a DataManager using a queue that is persisted to a local SQLIte file
     public convenience init() {
         DataManager.ensureDbFolderExists()
@@ -39,7 +41,7 @@ public class DataManager {
         if FeatureFlag.grdb.enabled {
             var config = Configuration()
             config.busyMode = .timeout(10)
-            dbQueue = GRDBQueue(dbPool: try! DatabasePool(path: DataManager.pathToDb(), configuration: config))
+            dbQueue = GRDBQueue(dbPool: try! DatabasePool(path: DataManager.pathToDb(), configuration: config), logger: Self.logger)
         } else {
             let flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FILEPROTECTION_NONE
             dbQueue = FMDBQueue(fmdbQueue: FMDatabaseQueue(path: DataManager.pathToDb(), flags: flags)!)

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Logger/ErrorLogger.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Logger/ErrorLogger.swift
@@ -1,0 +1,3 @@
+public protocol ErrorLogger {
+    func log(error: Error, context: [String: Any]?)
+}

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Logger/ErrorLogger.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Logger/ErrorLogger.swift
@@ -1,3 +1,3 @@
 public protocol ErrorLogger {
-    func log(error: Error, context: [String: Any]?)
+    func log(error: Error, context: [String: String]?)
 }

--- a/podcasts/Analytics/Adapters/Crash Logging/CrashLoggingAdapter.swift
+++ b/podcasts/Analytics/Adapters/Crash Logging/CrashLoggingAdapter.swift
@@ -4,8 +4,11 @@ import AutomatticRemoteLogging
 class CrashLoggingAdapter: AnalyticsAdapter {
     let crashLogging: CrashLogging?
 
+    static var sharedManager: CrashLoggingAdapter?
+
     init() {
         self.crashLogging = try? CrashLogging(dataProvider: CrashLoggingDataProvider()).start()
+        Self.sharedManager = self
     }
 
     func track(name: String, properties: [AnyHashable: Any]?) { }

--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -1,4 +1,5 @@
 import BackgroundTasks
+import AutomatticRemoteLogging
 import Firebase
 import FirebasePerformance
 import Foundation
@@ -7,7 +8,6 @@ import PocketCastsServer
 import PocketCastsUtils
 import Combine
 import FacebookCore
-import Sentry
 
 class AppDelegate: UIResponder, UIApplicationDelegate {
     private static let initialRefreshDelay = 2.seconds
@@ -424,11 +424,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 }
 
 struct SentryLogger: ErrorLogger {
-    func log(error: Error, context: [String : Any]?) {
-        SentrySDK.capture(error: error) { scope in
-            context?.forEach { key, value in
-                scope.setExtra(value: "\(value)", key: key)
-            }
-        }
+    func log(error: Error, context: [String: String]?) {
+    #if os(iOS)
+    CrashLoggingAdapter.sharedManager?.crashLogging?.logError(error, tags: context ?? [:], level: .warning)
+    #endif
     }
 }

--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -7,6 +7,7 @@ import PocketCastsServer
 import PocketCastsUtils
 import Combine
 import FacebookCore
+import Sentry
 
 class AppDelegate: UIResponder, UIApplicationDelegate {
     private static let initialRefreshDelay = 2.seconds
@@ -39,6 +40,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         setupSecrets()
         addAnalyticsObservers()
         setupAnalytics()
+
+        DataManager.logger = SentryLogger()
 
         appInstallState = appLifecycleAnalytics.checkApplicationInstalledOrUpgraded()
 
@@ -417,5 +420,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
 
         backgroundSignOutListener = BackgroundSignOutListener(presentingViewController: SceneHelper.rootViewController())
+    }
+}
+
+struct SentryLogger: ErrorLogger {
+    func log(error: Error, context: [String : Any]?) {
+        SentrySDK.capture(error: error) { scope in
+            context?.forEach { key, value in
+                scope.setExtra(value: "\(value)", key: key)
+            }
+        }
     }
 }


### PR DESCRIPTION
| 📘 Part of: #2773 | 
|:---:|

Removes force unwraps and log errors to Sentry.

This basically does what FMDB does now, which is silently failing instead of crashing the app.

Ps.: we talked about `Breadcrumbs` but what (I believe) we want is to log the error even if it doesn't crash the app.

## Changes

1. Created an `ErrorLogger` protocol, since Sentry is not available on `DataModel` so we can inject it
2. Expose the `CrashLoggingAdapter` so we can send events to Sentry
3. Create `SentryLogger` conforming to `ErrorLogger`
4. Inject `SentryLogger` into `GRDBQueue`
5. Log to Sentry in case any issue is triggered

## To test

**Thoroughly** review the code, ensuring that write database operations use `write` and read operations use `read`.

1. In `GRDBQueue.swift` create an error enum (or just copy the code below), such as:
```swift
enum Test: Error {
    case fail
}
```
2. Then inside the `do` block in `inDatabase`, add:
```swift
UserDefaults.standard.set(true, forKey: "force-crash-logging")
                throw Test.fail
```
3. Run the app
4. Go to Sentry and filter for the latest events
5. ✅ You should see your event there

### `GRDBqueue.swift` code

To make it easier:

```swift
import GRDB
import Foundation

enum Test: Error {
    case fail
}

class GRDBQueue: PCDBQueue {
    private let dbPool: DatabasePool
    private let logger: ErrorLogger?

    init(dbPool: DatabasePool, logger: ErrorLogger? = nil) {
        self.dbPool = dbPool
        self.logger = logger
    }

    func inDatabase(_ block: (any PCDatabase) -> Void) {
        withoutActuallyEscaping(block) { block in
            do {
                UserDefaults.standard.set(true, forKey: "force-crash-logging")
                throw Test.fail
                try dbPool.write { db in
                    let dbWrapper = GRDBDatabase(database: db)
                    block(dbWrapper)
                }
            } catch {
                logger?.log(error: error, context: [:])
            }
        }
    }
```

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
