### PR TITLE
[Winback] Take in consideration gift days for survey display

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/SubscriptionHelper.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/SubscriptionHelper.swift
@@ -6,12 +6,14 @@ open class SubscriptionHelper: NSObject {
 
     public static var hasCancelledSubscription: Bool {
         let renewing = SubscriptionHelper.hasRenewingSubscription()
-        let timeToSubscriptionExpiry = SubscriptionHelper.timeToSubscriptionExpiry() ?? 0
+        let giftDays = SubscriptionHelper.subscriptionGiftDays()
 
-        if let expiryDate = SubscriptionHelper.subscriptionRenewalDate(), expiryDate > Date() {
+        if let expiryDate = SubscriptionHelper.subscriptionRenewalDate(), expiryDate > Date(), giftDays == 0 {
             return !renewing
         }
-        return !renewing && timeToSubscriptionExpiry < 0
+
+        let timeToSubscriptionExpiry = SubscriptionHelper.timeToSubscriptionExpiry() ?? 0
+        return !renewing && timeToSubscriptionExpiry < 0 && giftDays == 0
     }
 
     /// Returns the users active subscription tier or .none if they don't currently have one


### PR DESCRIPTION
| 📘 Part of: #3029 
|:---:|

Ref. p1748396313999369-Slack-PC-Beta-C0GKZ8J4A

For PC Champions and other users who have gifted days, the Survey got prompted as the auto renew is set to false.
We need to check the value of the Gift Days as well, like we do in `checkSubscriptionCancelledAcknowledgement`

## To test

- Use a user with no plus purchased but with gifted days
- Run a fresh install and login with that user
- Navigate to the Profile
- Confirm you don't see the survey

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
