### PR TITLE
[Empty States] Remove background color from the Empty State

### DIFF
--- a/podcasts/Bookmarks/BookmarksTheme.swift
+++ b/podcasts/Bookmarks/BookmarksTheme.swift
@@ -5,7 +5,6 @@ protocol BookmarksStyle: ObservableObject {
     associatedtype ActionStyle: ActionBarStyle
     associatedtype EmptyStyle: EmptyStateViewStyle
 
-    var background: Color { get }
     var primaryText: Color { get }
     var secondaryText: Color { get }
     var tertiaryText: Color { get }
@@ -78,7 +77,7 @@ class ThemedBookmarksStyle: ThemeObserver, BookmarksStyle {
     var playButtonBackground: Color? { theme.primaryUi01 }
     var playButtonStroke: Color? { theme.primaryText01 }
     var actionBarStyle = ThemedActionBarStyle()
-    var emptyStyle = DefaultEmptyStateStyle(background: .clear)
+    var emptyStyle = DefaultEmptyStateStyle()
 }
 
 // MARK: - Override Themed Style
@@ -120,7 +119,6 @@ class OverrideEmptyStateStyle: DefaultEmptyStateStyle {
         self.overrideTheme = overrideTheme
     }
 
-    override var background: Color { Color(ThemeColor.primaryUi01Active(for: overrideTheme)) }
     override var title: Color { Color(ThemeColor.primaryText01(for: overrideTheme)) }
     override var message: Color { Color(ThemeColor.primaryText02(for: overrideTheme)) }
     override var button: Color { Color(ThemeColor.primaryInteractive01(for: overrideTheme)) }

--- a/podcasts/Bookmarks/List/BookmarksListView.swift
+++ b/podcasts/Bookmarks/List/BookmarksListView.swift
@@ -42,7 +42,6 @@ struct BookmarksListView<ListStyle: BookmarksStyle>: View {
             }
         }
         .environmentObject(viewModel)
-        .background(style.background.ignoresSafeArea())
     }
 
     /// An empty state view that displays instructions

--- a/podcasts/Common SwiftUI/BookmarksEmptyStateView.swift
+++ b/podcasts/Common SwiftUI/BookmarksEmptyStateView.swift
@@ -27,13 +27,6 @@ struct BookmarksEmptyStateView<Style: EmptyStateViewStyle>: View {
 // MARK: - Styles
 
 class DefaultEmptyStateStyle: ThemeObserver, EmptyStateViewStyle {
-    private let customBackground: Color?
-
-    init(background: Color? = nil) {
-        self.customBackground = background
-    }
-
-    var background: Color { customBackground ?? theme.primaryUi02 }
     var title: Color { theme.primaryText01 }
     var message: Color { theme.primaryText02 }
     var icon: Color { theme.primaryIcon03 }
@@ -41,7 +34,6 @@ class DefaultEmptyStateStyle: ThemeObserver, EmptyStateViewStyle {
 }
 
 class PlayerEmptyStateStyle: ThemeObserver, EmptyStateViewStyle {
-    var background: Color { theme.playerContrast06 }
     var title: Color { theme.playerContrast01 }
     var message: Color { theme.playerContrast02 }
     var icon: Color { theme.primaryIcon03 }

--- a/podcasts/ContentUnavailableConfiguration.swift
+++ b/podcasts/ContentUnavailableConfiguration.swift
@@ -37,7 +37,6 @@ struct ContentUnavailableConfiguration {
             EmptyStateView(title: title, message: message, icon: icon, actions: actions, style: style)
                 .environmentObject(Theme.sharedTheme)
         }
-        .background(style.background)
     }
 }
 

--- a/podcasts/ListeningHistoryViewController.swift
+++ b/podcasts/ListeningHistoryViewController.swift
@@ -237,7 +237,7 @@ class ListeningHistoryViewController: PCViewController {
                     icon: { Image("profile-download").renderingMode(.template) }
                 )
 
-                listeningHistoryTable.backgroundColor = UIColor(DefaultEmptyStateStyle.defaultStyle.background)
+                listeningHistoryTable.backgroundColor = UIColor(Theme.sharedTheme.primaryUi02)
                 listeningHistoryTable.backgroundView = config?.makeContentView()
             } else {
                 // Empty State when not searching

--- a/podcasts/New Search/Views/Results/SearchResultsView.swift
+++ b/podcasts/New Search/Views/Results/SearchResultsView.swift
@@ -31,7 +31,7 @@ struct SearchResultsView: View {
                     )
                 }
                 .frame(maxHeight: .infinity)
-                .background(DefaultEmptyStateStyle.defaultStyle.background)
+                .background(Theme.sharedTheme.primaryUi02)
             } else {
                 SearchListView {
                     ThemeableListHeader(title: L10n.podcastsPlural, actionTitle: L10n.discoverShowAll) {

--- a/podcasts/SwiftUI/EmptyStateView.swift
+++ b/podcasts/SwiftUI/EmptyStateView.swift
@@ -5,7 +5,6 @@ protocol EmptyStateViewStyle: ObservableObject {
     var message: Color { get }
     var icon: Color { get }
     var button: Color { get }
-    var background: Color { get }
 }
 
 struct EmptyStateAction: Identifiable {
@@ -95,7 +94,6 @@ struct EmptyStateView<Title: View, Style: EmptyStateViewStyle>: View {
         .padding(.horizontal, EmptyConstants.padding)
         .padding(.vertical, EmptyConstants.verticalPadding)
         .padding(EmptyConstants.padding)
-        .background(style.background)
     }
 }
 
@@ -128,7 +126,6 @@ struct EmptyStateView_Previews: PreviewProvider {
     }
 
     private class PreviewStyle: EmptyStateViewStyle {
-        var background: Color { .black }
         var title: Color { .white }
         var message: Color { .white.opacity(0.8) }
         var icon: Color { .primary }

--- a/podcasts/UpNextViewController+Table.swift
+++ b/podcasts/UpNextViewController+Table.swift
@@ -84,11 +84,9 @@ extension UpNextViewController: UITableViewDelegate, UITableViewDataSource {
 
         if PlaybackManager.shared.queue.upNextCount() == 0 {
             let emptyCell = tableView.dequeueReusableCell(withIdentifier: UpNextViewController.emptyStateCell, for: indexPath) as! EmptyStateCell
-            let style: DefaultEmptyStateStyle = PlaybackManager.shared.currentEpisode() == nil ? .defaultStyle : .init(background: .clear)
             emptyCell.configure(title: L10n.upNextEmptyTitle,
                                 message: L10n.upNextEmptyDescription,
                                 icon: { Image("upnext") },
-                                style: style,
                 actions: [
                     .init(title: L10n.goToDiscover) {
                         Analytics.shared.track(.upNextDiscoverButtonTapped)
@@ -275,7 +273,7 @@ extension UpNextViewController: UITableViewDelegate, UITableViewDataSource {
             sections.insert(.nowPlayingSection, at: 0)
             upNextTable.themeStyle = .primaryUi04
         } else {
-            upNextTable.backgroundColor = UIColor(DefaultEmptyStateStyle.defaultStyle.background)
+            upNextTable.backgroundColor = UIColor(Theme.sharedTheme.primaryUi02)
         }
         tableData = sections
     }


### PR DESCRIPTION
| 📘 Part of: #3102 |
|:---:|

Removes the background from the empty state view. It should always be transparent and match the background as far as I can tell.

Fixes 2 issues:
* The background wasn't changing on theme changes in some cases
* The Bookmarks background wasn't correct

### Theme change background

| Before | After |
|--|--|
| <video src="https://github.com/user-attachments/assets/cfcefb17-b6ab-4a19-809b-52cdb69f3770"> | <video src="https://github.com/user-attachments/assets/bd22f09a-c930-41a4-bed5-96fcec013dff"> |

### Bookmarks background in player

| Before | After |
|--|--|
![Simulator Screenshot - iPhone 16 Pro - 2025-05-28 at 14 31 40](https://github.com/user-attachments/assets/7f6db05e-9b40-451e-a6e0-96f94db8e9d5) | ![Simulator Screenshot - iPhone 16 - 2025-05-28 at 14 31 41](https://github.com/user-attachments/assets/17af30a2-6fb1-4d11-bf30-2d4ccf0057c9) | 


## To test

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
