### PR TITLE
GRDB: remove `withoutActuallyEscaping` from the FMDB implementation

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/DB/FMDB/FMDBQueue.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/DB/FMDB/FMDBQueue.swift
@@ -1,4 +1,5 @@
 import Foundation
+import PocketCastsUtils
 import FMDB
 
 final class FMDBQueue: PCDBQueue {
@@ -9,7 +10,14 @@ final class FMDBQueue: PCDBQueue {
     }
 
     func inDatabase(_ block: (any PCDatabase) -> Void) {
-        withoutActuallyEscaping(block) { block in
+        if FeatureFlag.fmdbWithoutActuallyEscaping.enabled {
+            withoutActuallyEscaping(block) { block in
+                fmdbQueue.inDatabase { db in
+                    let dbWrapper = FMDBDatabase(fmdbDatabase: db)
+                    block(dbWrapper)
+                }
+            }
+        } else {
             fmdbQueue.inDatabase { db in
                 let dbWrapper = FMDBDatabase(fmdbDatabase: db)
                 block(dbWrapper)
@@ -18,7 +26,14 @@ final class FMDBQueue: PCDBQueue {
     }
 
     func inTransaction(_ block: (any PCDatabase, UnsafeMutablePointer<ObjCBool>) -> Void) {
-        withoutActuallyEscaping(block) { block in
+        if FeatureFlag.fmdbWithoutActuallyEscaping.enabled {
+            withoutActuallyEscaping(block) { block in
+                fmdbQueue.inTransaction { db, rollback in
+                    let dbWrapper = FMDBDatabase(fmdbDatabase: db)
+                    block(dbWrapper, rollback)
+                }
+            }
+        } else {
             fmdbQueue.inTransaction { db, rollback in
                 let dbWrapper = FMDBDatabase(fmdbDatabase: db)
                 block(dbWrapper, rollback)
@@ -29,10 +44,19 @@ final class FMDBQueue: PCDBQueue {
     func read(_ block: (any PCDatabase) -> Void) {
         // FMDB doesn't have the concept of read or write
         // This is implemented so we conform to the protocol
-        withoutActuallyEscaping(block) { block in
-            fmdbQueue.inDatabase { db in
-                let dbWrapper = FMDBDatabase(fmdbDatabase: db)
-                block(dbWrapper)
+        if FeatureFlag.fmdbWithoutActuallyEscaping.enabled {
+            withoutActuallyEscaping(block) { block in
+                fmdbQueue.inDatabase { db in
+                    let dbWrapper = FMDBDatabase(fmdbDatabase: db)
+                    block(dbWrapper)
+                }
+            }
+        } else {
+            withoutActuallyEscaping(block) { block in
+                fmdbQueue.inDatabase { db in
+                    let dbWrapper = FMDBDatabase(fmdbDatabase: db)
+                    block(dbWrapper)
+                }
             }
         }
     }
@@ -40,7 +64,14 @@ final class FMDBQueue: PCDBQueue {
     func write(_ block: (any PCDatabase) -> Void) {
         // FMDB doesn't have the concept of read or write
         // This is implemented so we conform to the protocol
-        withoutActuallyEscaping(block) { block in
+        if FeatureFlag.fmdbWithoutActuallyEscaping.enabled {
+            withoutActuallyEscaping(block) { block in
+                fmdbQueue.inDatabase { db in
+                    let dbWrapper = FMDBDatabase(fmdbDatabase: db)
+                    block(dbWrapper)
+                }
+            }
+        } else {
             fmdbQueue.inDatabase { db in
                 let dbWrapper = FMDBDatabase(fmdbDatabase: db)
                 block(dbWrapper)

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/DB/FMDB/FMDBQueue.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/DB/FMDB/FMDBQueue.swift
@@ -52,11 +52,9 @@ final class FMDBQueue: PCDBQueue {
                 }
             }
         } else {
-            withoutActuallyEscaping(block) { block in
-                fmdbQueue.inDatabase { db in
-                    let dbWrapper = FMDBDatabase(fmdbDatabase: db)
-                    block(dbWrapper)
-                }
+            fmdbQueue.inDatabase { db in
+                let dbWrapper = FMDBDatabase(fmdbDatabase: db)
+                block(dbWrapper)
             }
         }
     }

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -188,6 +188,8 @@ public enum FeatureFlag: String, CaseIterable {
     /// When replacing an episode list with a new one, use the provided episode instead of Up Next Queue
     case replaceSpecificEpisode
 
+    case fmdbWithoutActuallyEscaping
+
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -318,6 +320,8 @@ public enum FeatureFlag: String, CaseIterable {
             true
         case .replaceSpecificEpisode:
             true
+        case .fmdbWithoutActuallyEscaping:
+            false
         }
     }
 


### PR DESCRIPTION
| 📘 Part of: #2773 | 
|:---:|

@danielebogo shared with me some FMDB-related crashes that even though have a low volume, seems to be related to the new layer we added.

I think there is a high chance those issues might be related to the usage of `withoutActuallyEscaping`. So I'm removing the usage on the FMDB queue layer but keeping the `withoutActuallyEscaping` behind a feature flag, so we can re-enable if needed.

Ps.: this is targeting the frozen branch so we can test this in the next release.

## Changes

1. Add a new `fmdbWithoutActuallyEscaping` which default value is `false`
2. Change `FMDBQue` to use (or not) `withoutActuallyEscaping` based on the value of the flag

## To test

1. Change `grdb` to false
2. Run the app
3. ✅ Everything should work as always

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
