### PR TITLE
Add general sharing to Logs view + Disable Editing

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1811,6 +1811,7 @@
 		F5E16FE72CD47DE800C0372F /* SFSafariView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5E16FE62CD47DE800C0372F /* SFSafariView.swift */; };
 		F5E3DAA72BDD5567002BD4E4 /* PCBundleDoc.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5E3DAA62BDD5567002BD4E4 /* PCBundleDoc.swift */; };
 		F5E431D62B50888500A71DB3 /* PlusLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5E431D52B50888500A71DB3 /* PlusLabel.swift */; };
+		F5E63CAE2DEA0660000B9EBD /* NonEditableTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5E63CAD2DEA0660000B9EBD /* NonEditableTextView.swift */; };
 		F5E949DA2B61762E002DAFC3 /* TokenHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5E949D92B61762E002DAFC3 /* TokenHelperTests.swift */; };
 		F5EA21F22CC1CD040043C780 /* EndOfYearDeveloperMenuButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5EA21F12CC1CD040043C780 /* EndOfYearDeveloperMenuButton.swift */; };
 		F5EA21F42CC1DBFE0043C780 /* EndOfYear2023StoriesModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5EA21F32CC1DBFE0043C780 /* EndOfYear2023StoriesModel.swift */; };
@@ -4016,6 +4017,7 @@
 		F5E16FE62CD47DE800C0372F /* SFSafariView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SFSafariView.swift; sourceTree = "<group>"; };
 		F5E3DAA62BDD5567002BD4E4 /* PCBundleDoc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PCBundleDoc.swift; sourceTree = "<group>"; };
 		F5E431D52B50888500A71DB3 /* PlusLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlusLabel.swift; sourceTree = "<group>"; };
+		F5E63CAD2DEA0660000B9EBD /* NonEditableTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonEditableTextView.swift; sourceTree = "<group>"; };
 		F5E949D92B61762E002DAFC3 /* TokenHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenHelperTests.swift; sourceTree = "<group>"; };
 		F5EA21F12CC1CD040043C780 /* EndOfYearDeveloperMenuButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndOfYearDeveloperMenuButton.swift; sourceTree = "<group>"; };
 		F5EA21F32CC1DBFE0043C780 /* EndOfYear2023StoriesModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndOfYear2023StoriesModel.swift; sourceTree = "<group>"; };
@@ -8293,6 +8295,7 @@
 		C7E99F022A5E0F9600E7CBAF /* Common SwiftUI */ = {
 			isa = PBXGroup;
 			children = (
+				F5E63CAD2DEA0660000B9EBD /* NonEditableTextView.swift */,
 				9A991F832DB1362000B39FB8 /* BannerView.swift */,
 				FF4D65D12DAEE8F8003DC1F0 /* BannerView.swift */,
 				F52ADE462BD9698B00AC647F /* ModalView.swift */,
@@ -10679,6 +10682,7 @@
 				4030D4682498579D00BEC7D9 /* MultiSelectActionProtocol.swift in Sources */,
 				8B44446229785287007E0AA8 /* AppleSocialLogin.swift in Sources */,
 				FF5381AE2C90FF1500829525 /* ReferralCardMiniView.swift in Sources */,
+				F5E63CAE2DEA0660000B9EBD /* NonEditableTextView.swift in Sources */,
 				BD86D94F217EB81C0010FA1B /* FilterDownloadCell.swift in Sources */,
 				BD6B432A2755F516005E4017 /* AboutViewLogos.swift in Sources */,
 				C7AF7B992926B307002F0025 /* OnboardingHostingViewController.swift in Sources */,

--- a/podcasts/Common SwiftUI/NonEditableTextView.swift
+++ b/podcasts/Common SwiftUI/NonEditableTextView.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+import UIKit
+
+struct NonEditableTextView: UIViewRepresentable {
+    let text: String
+
+    func makeUIView(context: Context) -> UITextView {
+        let view = UITextView()
+        view.isEditable = false
+        view.isSelectable = true
+        view.isScrollEnabled = true
+        view.backgroundColor = .clear
+        view.textContainerInset = .zero
+        view.font = UIFont.preferredFont(forTextStyle: .body)
+        return view
+    }
+
+    func updateUIView(_ uiView: UITextView, context: Context) {
+        uiView.text = text
+    }
+}

--- a/podcasts/LogsView.swift
+++ b/podcasts/LogsView.swift
@@ -1,9 +1,10 @@
 import Foundation
 import SwiftUI
 import PocketCastsUtils
+import MessageUI
 import UniformTypeIdentifiers
 
-class LogsViewModel: NSObject, ObservableObject {
+class LogsViewModel: NSObject, ObservableObject, MFMailComposeViewControllerDelegate {
     @Published var logs = ""
     var presenter: UIViewController?
 
@@ -35,6 +36,28 @@ class LogsViewModel: NSObject, ObservableObject {
         try? data.write(to: tempURL)
         return tempURL
     }
+
+    func mailLogs() {
+        guard MFMailComposeViewController.canSendMail() else {
+            Toast.show(L10n.logsNoEmailAccountConfigured)
+            return
+        }
+        let mailVC = MFMailComposeViewController()
+        mailVC.mailComposeDelegate = self
+        mailVC.setSubject("iOS Logs \(Settings.appVersion())")
+        mailVC.setToRecipients(["support@pocketcasts.com"])
+        mailVC.setMessageBody("Please find attached my logs", isHTML: false)
+        if let data = logs.data(using: .utf8) {
+            mailVC.addAttachmentData(data, mimeType: UTType.plainText.preferredMIMEType ?? "plain/text", fileName: "logs.txt")
+        }
+        presenter?.present(mailVC, animated: true)
+    }
+
+    func mailComposeController(_ controller: MFMailComposeViewController,
+                                       didFinishWith result: MFMailComposeResult,
+                               error: Error?) {
+        presenter?.dismiss(animated: true)
+    }
 }
 
 struct LogsView: View {
@@ -48,16 +71,25 @@ struct LogsView: View {
             Spacer()
         }
         .navigationTitle(L10n.logs)
-        .toolbar(content: {
-            if let url = model.shareURL {
-                ToolbarItem(placement: .navigationBarTrailing) {
+        .toolbar {
+            ToolbarItemGroup(placement: .topBarTrailing) {
+                if MFMailComposeViewController.canSendMail() {
+                    Button(action: {
+                        model.mailLogs()
+                    }, label: {
+                        Image(systemName: "envelope")
+                            .bold()
+                    })
+                }
+                if let url = model.shareURL {
                     ShareLink(item: url, preview: SharePreview("logs.txt")) {
-                        Image(systemName: "square.and.arrow.up").bold()
+                        Image(systemName: "square.and.arrow.up")
+                            .bold()
                     }
-                    .foregroundStyle(theme.primaryIcon01)
                 }
             }
-        })
+        }
+        .foregroundStyle(theme.primaryIcon01)
         .applyDefaultThemeOptions()
         .ignoresSafeArea()
         .task {

--- a/podcasts/LogsView.swift
+++ b/podcasts/LogsView.swift
@@ -67,7 +67,7 @@ struct LogsView: View {
 
     var body: some View {
         VStack {
-            TextEditor(text: $model.logs.readOnly)
+            NonEditableTextView(text: $model.logs.wrappedValue)
             Spacer()
         }
         .navigationTitle(L10n.logs)

--- a/podcasts/LogsView.swift
+++ b/podcasts/LogsView.swift
@@ -1,9 +1,9 @@
 import Foundation
 import SwiftUI
 import PocketCastsUtils
-import MessageUI
+import UniformTypeIdentifiers
 
-class LogsViewModel: NSObject, ObservableObject, MFMailComposeViewControllerDelegate {
+class LogsViewModel: NSObject, ObservableObject {
     @Published var logs = ""
     var presenter: UIViewController?
 
@@ -18,29 +18,23 @@ class LogsViewModel: NSObject, ObservableObject, MFMailComposeViewControllerDele
         }
     }
 
-    func mailLogs() {
-        guard MFMailComposeViewController.canSendMail() else {
-            Toast.show(L10n.logsNoEmailAccountConfigured)
-            return
-        }
-        let mailVC = MFMailComposeViewController()
-        mailVC.mailComposeDelegate = self
+    var shareURL: URL? {
+        guard let data = logs.data(using: .utf8) else { return nil }
+        let date = Date()
+        let components = Calendar.current.dateComponents(in: .current, from: date)
 
-        mailVC.setSubject("iOS Logs \(Settings.appVersion())")
-        mailVC.setToRecipients(["support@pocketcasts.com"])
-        mailVC.setMessageBody("Please find attached my logs", isHTML: false)
-        if let data = logs.data(using: .utf8) {
-            mailVC.addAttachmentData(data, mimeType: UTType.plainText.preferredMIMEType ?? "plain/text", fileName: "logs.txt")
-        }
-        presenter?.present(mailVC, animated: true)
+        let dateString = String(format: "%04d-%02d-%02d-%02d-%02d-%02d",
+            components.year ?? 0,
+            components.month ?? 0,
+            components.day ?? 0,
+            components.hour ?? 0,
+            components.minute ?? 0,
+            components.second ?? 0
+        )
+        let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent("pocketcasts-logs-\(dateString).txt")
+        try? data.write(to: tempURL)
+        return tempURL
     }
-
-    func mailComposeController(_ controller: MFMailComposeViewController,
-                                       didFinishWith result: MFMailComposeResult,
-                               error: Error?) {
-        presenter?.dismiss(animated: true)
-    }
-
 }
 
 struct LogsView: View {
@@ -55,12 +49,13 @@ struct LogsView: View {
         }
         .navigationTitle(L10n.logs)
         .toolbar(content: {
-            ToolbarItem(placement: .navigationBarTrailing) {
-                Button(action: {
-                    model.mailLogs()
-                }, label: {
-                    Image("mail")
-                })
+            if let url = model.shareURL {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    ShareLink(item: url, preview: SharePreview("logs.txt")) {
+                        Image(systemName: "square.and.arrow.up").bold()
+                    }
+                    .foregroundStyle(theme.primaryIcon01)
+                }
             }
         })
         .applyDefaultThemeOptions()

--- a/podcasts/LogsView.swift
+++ b/podcasts/LogsView.swift
@@ -44,7 +44,7 @@ struct LogsView: View {
 
     var body: some View {
         VStack {
-            TextEditor(text: $model.logs)
+            TextEditor(text: $model.logs.readOnly)
             Spacer()
         }
         .navigationTitle(L10n.logs)
@@ -63,6 +63,12 @@ struct LogsView: View {
         .task {
             await model.load()
         }
+    }
+}
+
+fileprivate extension Binding {
+    var readOnly: Binding<Value> {
+        Binding(get: { self.wrappedValue }, set: { _ in })
     }
 }
 

--- a/podcasts/LogsView.swift
+++ b/podcasts/LogsView.swift
@@ -98,12 +98,6 @@ struct LogsView: View {
     }
 }
 
-fileprivate extension Binding {
-    var readOnly: Binding<Value> {
-        Binding(get: { self.wrappedValue }, set: { _ in })
-    }
-}
-
 #Preview {
     LogsView(model: LogsViewModel())
     .setupDefaultEnvironment()

--- a/podcasts/LogsView.swift
+++ b/podcasts/LogsView.swift
@@ -67,7 +67,7 @@ struct LogsView: View {
 
     var body: some View {
         VStack {
-            NonEditableTextView(text: $model.logs.wrappedValue)
+            NonEditableTextView(text: model.logs)
             Spacer()
         }
         .navigationTitle(L10n.logs)


### PR DESCRIPTION
* Add Share button
* Makes the logs non-editable

| | |
|--|--|
| ![Simulator Screenshot - iPhone 16 Pro - 2025-05-29 at 11 59 57](https://github.com/user-attachments/assets/dbdbe202-adeb-4a5b-ab51-7a1ee20309d6) | ![Simulator Screenshot - iPhone 16 Pro - 2025-05-29 at 12 00 01](https://github.com/user-attachments/assets/5f99de6a-3d8e-4b2a-bac7-ea45b7ab439b) |

## To test

* Open the logs view in Profile > Help & Feedback > ⋯
* ✅ Try editing logs
* ✅ Tap the Share button and test sharing to different places

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
