### PR TITLE
Feature Flag: fix a logic error that might prevent flag values to be applied

### DIFF
--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -314,31 +314,32 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func updateRemoteFeatureFlags() {
         guard BuildEnvironment.current != .debug else { return }
-        do {
-            if FeatureFlag.errorLogoutHandling.enabled != Settings.errorLogoutHandling {
-                ServerConfig.avoidLogoutOnError = FeatureFlag.errorLogoutHandling.enabled
-                try FeatureFlagOverrideStore().override(FeatureFlag.errorLogoutHandling, withValue: Settings.errorLogoutHandling)
+
+        if FeatureFlag.errorLogoutHandling.enabled != Settings.errorLogoutHandling {
+            ServerConfig.avoidLogoutOnError = FeatureFlag.errorLogoutHandling.enabled
+            try? FeatureFlagOverrideStore().override(FeatureFlag.errorLogoutHandling, withValue: Settings.errorLogoutHandling)
+        }
+
+        if FeatureFlag.newSettingsStorage.enabled != Settings.newSettingsStorage {
+            if FeatureFlag.newSettingsStorage.enabled {
+                SettingsStore.appSettings.importUserDefaults()
+                DataManager.sharedManager.importPodcastSettings()
             }
+        }
 
-            if FeatureFlag.newSettingsStorage.enabled != Settings.newSettingsStorage {
-                if FeatureFlag.newSettingsStorage.enabled {
-                    SettingsStore.appSettings.importUserDefaults()
-                    DataManager.sharedManager.importPodcastSettings()
-                }
-            }
+        try? FeatureFlagOverrideStore().override(FeatureFlag.slumber, withValue: Settings.slumberPromoCode?.isEmpty == false)
 
-            try FeatureFlagOverrideStore().override(FeatureFlag.slumber, withValue: Settings.slumberPromoCode?.isEmpty == false)
-
-            try FeatureFlag.allCases.forEach { flag in
-                if let remoteKey = flag.remoteKey {
-                    let remoteValue = RemoteConfig.remoteConfig().configValue(forKey: remoteKey)
-                    if remoteValue.source == .remote {
+        FeatureFlag.allCases.forEach { flag in
+            if let remoteKey = flag.remoteKey {
+                let remoteValue = RemoteConfig.remoteConfig().configValue(forKey: remoteKey)
+                if remoteValue.source == .remote {
+                    do {
                         try FeatureFlagOverrideStore().override(flag, withValue: remoteValue.boolValue)
+                    } catch {
+                        FileLog.shared.addMessage("Failed to set remote feature flag \(flag): \(error)")
                     }
                 }
             }
-        } catch {
-            FileLog.shared.addMessage("Failed to set remote feature flag: \(error)")
         }
     }
 


### PR DESCRIPTION
While working in the GRDB remote flag, I noticed that: the way the current logic is configured, if any flag cannot be override, it will thrown an error and skip ALL other flags to have the value applied.

If a flag cannot be override we want to keep iterating on the others because they can be.

This specific issue never happened before, but it might happen now because we'll make the `GRDB` flag to be overridable only in TestFlight.

## Reproducing the issue

1. Checkout `trunk`
2. [Comment this line](https://github.com/Automattic/pocket-casts-ios/blob/trunk/podcasts/AppDelegate.swift#L316)
3. [Change this bool value to](https://github.com/Automattic/pocket-casts-ios/blob/trunk/Modules/Utils/Sources/PocketCastsUtils/Feature%20Flags/FeatureFlag.swift#L366) `false`
4. Run a clean install of the app
5. 💥 You'll see that only one `Failed to set remote feature flag: cannotBeOverridden` is logged. Which means that all other flags were skipped.

## To test

1. Checkout this branch
2. [Comment this line](https://github.com/Automattic/pocket-casts-ios/blob/trunk/podcasts/AppDelegate.swift#L316)
3. [Change this bool value to](https://github.com/Automattic/pocket-casts-ios/blob/trunk/Modules/Utils/Sources/PocketCastsUtils/Feature%20Flags/FeatureFlag.swift#L366) `false`
4. Run a clean install of the app
5. ✅  You'll see many `Failed to set remote feature flag [flag name]: cannotBeOverridden` is logged. Which means that the app tried to apply all flags.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
