### PR TITLE
GRDB: add TestFlight feature flag

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -43,9 +43,11 @@ public class DataManager {
             config.busyMode = .timeout(10)
             dbQueue = GRDBQueue(dbPool: try! DatabasePool(path: DataManager.pathToDb(), configuration: config), logger: Self.logger)
             DataManager.setDatabaseFileProtectionToNone()
+            FileLog.shared.addMessage("[DataManager] Initialized using GRDB")
         } else {
             let flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FILEPROTECTION_NONE
             dbQueue = FMDBQueue(fmdbQueue: FMDatabaseQueue(path: DataManager.pathToDb(), flags: flags)!)
+            FileLog.shared.addMessage("[DataManager] Initialized using FMDB")
         }
 
         self.init(dbQueue: dbQueue)

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -355,7 +355,7 @@ public enum FeatureFlag: String, CaseIterable {
             // Never remove this line or change to "grdb" as it will enable it
             // in previous versions in which the work was in progress.
             // tl;dr: this flag can never be "grdb"
-            "grdb_testflight"
+            "grdb_pr_test"
         default:
             rawValue.lowerSnakeCased()
         }

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -351,6 +351,11 @@ public enum FeatureFlag: String, CaseIterable {
             "use_podcast_html_description"
         case .podcastViewChanges:
             "podcast_view_changes_2025"
+        case .grdb:
+            // Never remove this line or change to "grdb" as it will enable it
+            // in previous versions in which the work was in progress.
+            // tl;dr: this flag can never be "grdb"
+            "grdb_testflight"
         default:
             rawValue.lowerSnakeCased()
         }
@@ -363,7 +368,13 @@ extension FeatureFlag: OverrideableFlag {
     }
 
     public var canOverride: Bool {
-        true
+        switch self {
+        // GRDB can only change in TestFlight versions
+        case .grdb:
+            Self.isTestFlight
+        default:
+            true
+        }
     }
 
     private static let isTestFlight = Bundle.main.appStoreReceiptURL?.lastPathComponent == "sandboxReceipt"

--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -334,6 +334,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 let remoteValue = RemoteConfig.remoteConfig().configValue(forKey: remoteKey)
                 if remoteValue.source == .remote {
                     do {
+                        print("Overriding \(flag) to \(remoteValue.boolValue)")
                         try FeatureFlagOverrideStore().override(flag, withValue: remoteValue.boolValue)
                     } catch {
                         FileLog.shared.addMessage("Failed to set remote feature flag \(flag): \(error)")


### PR DESCRIPTION
| 📘 Part of: #2773 | 
|:---:|

This PR adds the remote feature flag value for enabling GRDB for TestFlight users **only**.

We will do a rollout, meaning not all users will have it enabled. We want to test that in a controlled way so we ensure everything goes smoothly.

## To test

1. [Comment this line](https://github.com/Automattic/pocket-casts-ios/blob/trunk/podcasts/AppDelegate.swift#L316) so the feature flag code runs in `DEBUG`
2. Do a clean install of the app
3. ✅ Search for `Overriding grdb to true`. This log might be or might not be there. Try a few times, each time deleting and running a clean install of the app. This way you can also test that the rollout is working as intended.
4. When you see the log, see that right below there's a `Failed to set remote feature flag grdb: cannotBeOverridden` because this is not TestFlight
5. [Change this](https://github.com/Automattic/pocket-casts-ios/blob/trunk/Modules/Utils/Sources/PocketCastsUtils/Feature%20Flags/FeatureFlag.swift#L369) to `true`
6. Delete the app, run it again until you see the `Overriding grdb to true`
7. ✅ This time there won't be a `Failed to set remote feature flag grdb: cannotBeOverridden` though
8. Re-run the app
9. ✅ You should see `[DataManager] Initialized using GRDB`

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
