### PR TITLE
Set navigation bar background to use view background and correct navigation bar color

### DIFF
--- a/podcasts/FoldersCoordinator.swift
+++ b/podcasts/FoldersCoordinator.swift
@@ -124,7 +124,7 @@ class FoldersCoordinator: NSObject {
                 })
             }
         }
-        let hostingController = PCHostingController(rootView: suggestedFoldersView.environmentObject(Theme.sharedTheme))
+        let hostingController = UIHostingController(rootView: suggestedFoldersView.environmentObject(Theme.sharedTheme))
         vc.present(hostingController, animated: true, completion: nil)
         hostingController.sheetPresentationController?.delegate = self
     }
@@ -147,7 +147,7 @@ class FoldersCoordinator: NSObject {
                 return
             }
         }
-        let hostingController = PCHostingController(rootView: suggestedFoldersView.environmentObject(Theme.sharedTheme))
+        let hostingController = UIHostingController(rootView: suggestedFoldersView.environmentObject(Theme.sharedTheme))
         vc.present(hostingController, animated: true, completion: nil)
         hostingController.sheetPresentationController?.delegate = self
 

--- a/podcasts/SuggestedFoldersView.swift
+++ b/podcasts/SuggestedFoldersView.swift
@@ -45,14 +45,14 @@ struct SuggestedFoldersView: View {
                                     onCompletion(.dismiss)
                                 } label: {
                                     Image("close")
-                                        .foregroundColor(ThemeColor.secondaryIcon01(for: theme.activeTheme).color)
+                                        .foregroundColor(ThemeColor.primaryInteractive01(for: theme.activeTheme).color)
                                 }
                                 .accessibilityLabel(L10n.close)
                             }
                         }
                 }
                 .navigationViewStyle(.stack)
-                .tint(ThemeColor.secondaryIcon01(for: theme.activeTheme).color)
+                .tint(ThemeColor.primaryInteractive01(for: theme.activeTheme).color)
             case .failed:
                 CreateFolderView(isInsideNavigation: false) { uuid in
                     if let uuid {


### PR DESCRIPTION

| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

Updates the Navigation Bar on Suggested folders to match the background color.

| 1 | 2 | 3 | 4 | 5 | 6|
| - | - | - | - | - | - |
|  ![Simulator Screenshot - iPhone 16 Pro Max - 2025-06-02 at 18 50 02](https://github.com/user-attachments/assets/0b9e2e0e-e848-4267-be07-f0f23a1c55e9) | ![Simulator Screenshot - iPhone 16 Pro Max - 2025-06-02 at 18 49 30](https://github.com/user-attachments/assets/53552a4c-c6c7-42e6-8890-7bddaafed110) | ![Simulator Screenshot - iPhone 16 Pro Max - 2025-06-02 at 18 49 20](https://github.com/user-attachments/assets/96c29381-56b2-4e21-bae7-3fb2750cf068) | ![Simulator Screenshot - iPhone 16 Pro Max - 2025-06-02 at 18 49 02](https://github.com/user-attachments/assets/ae042f0c-b912-48eb-b772-2db4b8e24bc1) | ![Simulator Screenshot - iPhone 16 Pro Max - 2025-06-02 at 18 48 46](https://github.com/user-attachments/assets/13e2b788-9bdf-46c6-90f5-2f11cc41fe16)| ![Simulator Screenshot - iPhone 16 Pro Max - 2025-06-02 at 18 48 18](https://github.com/user-attachments/assets/5d18dac2-0eb5-4153-8ad8-01b843320176) |

## To test

1. Start the app, ensure that that you have followed at least 8 podcasts, and if you already used Smart Folders and or remove a new podcast to your follow list
2. Switch to the podcasts tab 
3. Tap on the folders icon on the top
4. Check on different themes if the top navigation bar has a color that matches the background of the screen


## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
