### PR TITLE
[Banner Ads] Add Feature Flag

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -194,6 +194,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// Avoid using `withoutActuallyEscaping` for FMDB
     case fmdbWithoutActuallyEscaping
 
+    /// Include banner ads in the player and podcasts list. This is fetched from ths server so can be disabled from there as well.
+    case bannerAds
+
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -328,6 +331,8 @@ public enum FeatureFlag: String, CaseIterable {
             false
         case .fmdbWithoutActuallyEscaping:
             false
+        case .bannerAds:
+            true
         }
     }
 


### PR DESCRIPTION
| 📘 Part of: #3208 |
|:---:|

Adds `banner_ads` feature flag

## To test

* Navigate to the Developer settings section
* ✅ Verify that the `banner_ads` flag appears

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
