### PR TITLE
[Banner Ads] Podcast list

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -332,7 +332,7 @@ public enum FeatureFlag: String, CaseIterable {
         case .fmdbWithoutActuallyEscaping:
             false
         case .bannerAds:
-            true
+            false
         }
     }
 

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1713,6 +1713,8 @@
 		F52B4F8C2BB4A9CA00E87BE4 /* CategoriesSelectorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F52B4F8B2BB4A9CA00E87BE4 /* CategoriesSelectorViewController.swift */; };
 		F52B4F8E2BB4A9ED00E87BE4 /* CategoriesSelectorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F52B4F8D2BB4A9ED00E87BE4 /* CategoriesSelectorView.swift */; };
 		F533F19D2C24B8CB00EDE9AA /* ShareDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = F533F19C2C24B8CB00EDE9AA /* ShareDestination.swift */; };
+		F536B45A2DEA02330051A929 /* View+UIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73CCBC829C590100075EFFD /* View+UIView.swift */; };
+		F536B45B2DEA02830051A929 /* PCHostingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD6B432B27561EA8005E4017 /* PCHostingController.swift */; };
 		F53C3E832CC73549004F3581 /* TopSpotStory2024.swift in Sources */ = {isa = PBXBuildFile; fileRef = F53C3E822CC73538004F3581 /* TopSpotStory2024.swift */; };
 		F53DDB682DD508CA00A1E890 /* HostingConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = F53DDB672DD508CA00A1E890 /* HostingConfiguration.swift */; };
 		F53EFEE82CD405DA00F4561B /* YearOverYearCompareTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F53EFEE72CD405DA00F4561B /* YearOverYearCompareTests.swift */; };
@@ -1765,6 +1767,7 @@
 		F57D8F142C66CA230004C4DF /* UnsafeWait.swift in Sources */ = {isa = PBXBuildFile; fileRef = F57D8F132C66CA230004C4DF /* UnsafeWait.swift */; };
 		F57D8F162C66CBB80004C4DF /* UnsafeTransfer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F57D8F152C66CBB80004C4DF /* UnsafeTransfer.swift */; };
 		F57D8F182C66CDF40004C4DF /* View+CVPixelBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F57D8F172C66CDF40004C4DF /* View+CVPixelBuffer.swift */; };
+		F580777C2DEA032A005AFBA6 /* Theme+Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = C715EE0E2A0497DB0054A082 /* Theme+Color.swift */; };
 		F58189C22DBC56A200B95199 /* PodcastInfo+DiscoverPodcast.swift in Sources */ = {isa = PBXBuildFile; fileRef = F58189C12DBC56A200B95199 /* PodcastInfo+DiscoverPodcast.swift */; };
 		F58189C32DBC56A200B95199 /* PodcastInfo+DiscoverPodcast.swift in Sources */ = {isa = PBXBuildFile; fileRef = F58189C12DBC56A200B95199 /* PodcastInfo+DiscoverPodcast.swift */; };
 		F581ED422CC6F1A200A19860 /* ListeningTime2024Story.swift in Sources */ = {isa = PBXBuildFile; fileRef = F581ED412CC6F19300A19860 /* ListeningTime2024Story.swift */; };
@@ -1775,6 +1778,8 @@
 		F5952FCC2C05814100754BC3 /* DownloadManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5952FCB2C05814100754BC3 /* DownloadManagerTests.swift */; };
 		F5954D5E2C3F284D004A8C04 /* TrimSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5954D5D2C3F284D004A8C04 /* TrimSelectionView.swift */; };
 		F5954D602C3F2864004A8C04 /* TrimHandle.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5954D5F2C3F2864004A8C04 /* TrimHandle.swift */; };
+		F5A292162DE95F9000C49AC4 /* BannerAdView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5A292152DE95F8C00C49AC4 /* BannerAdView.swift */; };
+		F5A292172DE9638900C49AC4 /* BannerAdView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5A292152DE95F8C00C49AC4 /* BannerAdView.swift */; };
 		F5AD9C4D2C3C705200A01896 /* AudioWaveformView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5AD9C4C2C3C705200A01896 /* AudioWaveformView.swift */; };
 		F5ADE2F42CF52AF100F2CEA7 /* AnalyticsLoggingAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7C4CAEA28AB05A800CFC8CF /* AnalyticsLoggingAdapter.swift */; };
 		F5ADE2F52CF52AFA00F2CEA7 /* TracksAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C72CED31289DA1900017883A /* TracksAdapter.swift */; };
@@ -2011,7 +2016,6 @@
 		FF4A73DA2C876D5E00587128 /* ReferralSendPassVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF4A73D92C876D5E00587128 /* ReferralSendPassVC.swift */; };
 		FF4B3E392C2D94F300F84DD6 /* TranscriptFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF4B3E382C2D94F300F84DD6 /* TranscriptFilter.swift */; };
 		FF4D65D02DA81B5B003DC1F0 /* NotificationsCoordinator+AnalyticsAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF4D65CF2DA81B4B003DC1F0 /* NotificationsCoordinator+AnalyticsAdapter.swift */; };
-		FF4D65D22DAEE90D003DC1F0 /* BannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF4D65D12DAEE8F8003DC1F0 /* BannerView.swift */; };
 		FF4D65D42DAFF0D1003DC1F0 /* UIApplication+OpenStandardURLs.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF4D65D32DAFF0BC003DC1F0 /* UIApplication+OpenStandardURLs.swift */; };
 		FF4E93122BDBF0D800F370AA /* MiniPlayerGradientView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF4E93112BDBF0D800F370AA /* MiniPlayerGradientView.swift */; };
 		FF5381A62C90A06400829525 /* ReferralsClaimBannerTableCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF5381A52C90A06400829525 /* ReferralsClaimBannerTableCell.swift */; };
@@ -3993,6 +3997,7 @@
 		F5952FCB2C05814100754BC3 /* DownloadManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadManagerTests.swift; sourceTree = "<group>"; };
 		F5954D5D2C3F284D004A8C04 /* TrimSelectionView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrimSelectionView.swift; sourceTree = "<group>"; };
 		F5954D5F2C3F2864004A8C04 /* TrimHandle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrimHandle.swift; sourceTree = "<group>"; };
+		F5A292152DE95F8C00C49AC4 /* BannerAdView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannerAdView.swift; sourceTree = "<group>"; };
 		F5AD75442B7FDC2800D65C55 /* SettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsTests.swift; sourceTree = "<group>"; };
 		F5AD9C4C2C3C705200A01896 /* AudioWaveformView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioWaveformView.swift; sourceTree = "<group>"; };
 		F5B312B32BF5B6D400290696 /* FirebaseManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseManager.swift; sourceTree = "<group>"; };
@@ -4085,7 +4090,6 @@
 		FF4A73D92C876D5E00587128 /* ReferralSendPassVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReferralSendPassVC.swift; sourceTree = "<group>"; };
 		FF4B3E382C2D94F300F84DD6 /* TranscriptFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptFilter.swift; sourceTree = "<group>"; };
 		FF4D65CF2DA81B4B003DC1F0 /* NotificationsCoordinator+AnalyticsAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NotificationsCoordinator+AnalyticsAdapter.swift"; sourceTree = "<group>"; };
-		FF4D65D12DAEE8F8003DC1F0 /* BannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannerView.swift; sourceTree = "<group>"; };
 		FF4D65D32DAFF0BC003DC1F0 /* UIApplication+OpenStandardURLs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+OpenStandardURLs.swift"; sourceTree = "<group>"; };
 		FF4E93112BDBF0D800F370AA /* MiniPlayerGradientView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MiniPlayerGradientView.swift; sourceTree = "<group>"; };
 		FF5381A52C90A06400829525 /* ReferralsClaimBannerTableCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReferralsClaimBannerTableCell.swift; sourceTree = "<group>"; };
@@ -8298,8 +8302,8 @@
 			isa = PBXGroup;
 			children = (
 				F5E63CAD2DEA0660000B9EBD /* NonEditableTextView.swift */,
+				F5A292152DE95F8C00C49AC4 /* BannerAdView.swift */,
 				9A991F832DB1362000B39FB8 /* BannerView.swift */,
-				FF4D65D12DAEE8F8003DC1F0 /* BannerView.swift */,
 				F52ADE462BD9698B00AC647F /* ModalView.swift */,
 				C76ECAC32A67622900D9DB9E /* BookmarksEmptyStateView.swift */,
 				C7F4C6692A8FDC3000483C37 /* BookmarksLockedStateView.swift */,
@@ -10940,6 +10944,7 @@
 				BDCC55141CD0A448006BE239 /* AEXML.swift in Sources */,
 				9A74B4D12D83113B00D10858 /* BlurEffectView.swift in Sources */,
 				8B1C974628FE1C7E00BD5EB9 /* ImageView.swift in Sources */,
+				F5A292162DE95F9000C49AC4 /* BannerAdView.swift in Sources */,
 				40484F0122F1507F007DBD55 /* ThemeableRoundedButton.swift in Sources */,
 				BDEBD3A91BA0108800AD038F /* BufferedAudio.swift in Sources */,
 				F5BEAEC92DA73CE800541921 /* DebugInfo.swift in Sources */,
@@ -10971,7 +10976,6 @@
 				BD98C54B1BA802AA00E85D3B /* DiscoverDisclosureCell.swift in Sources */,
 				F5235EE02C3CCB1D00C98739 /* RoundedCorner.swift in Sources */,
 				4065143E2485EB8E00B7E789 /* LastSupporterPodcastCell.swift in Sources */,
-				FF4D65D22DAEE90D003DC1F0 /* BannerView.swift in Sources */,
 				BDD3579327BCD50D0000D155 /* FolderViewController+CollectionView.swift in Sources */,
 				BDE5B8D81E6401F80039B409 /* EpisodeFileSizeUpdater.swift in Sources */,
 				408971AF2512F57100783253 /* BundleImageView.swift in Sources */,
@@ -11279,6 +11283,7 @@
 				F5F509082CEBEAEF007D6E39 /* PlaybackProtocol.swift in Sources */,
 				F5F509242CEBEE90007D6E39 /* FileTypeUtil.swift in Sources */,
 				F57ABBFB2CECEBCD00CC50AF /* PodcastManager.swift in Sources */,
+				F536B45B2DEA02830051A929 /* PCHostingController.swift in Sources */,
 				F5F5093A2CEBF217007D6E39 /* PlayPauseButton.swift in Sources */,
 				F5F509152CEBEC00007D6E39 /* Chapters.swift in Sources */,
 				F5F5093D2CEBF248007D6E39 /* OptionAction.swift in Sources */,
@@ -11309,8 +11314,10 @@
 				F5F509632CEBF70E007D6E39 /* Queue.swift in Sources */,
 				F5F509302CEBEF95007D6E39 /* URLSession+Episode.swift in Sources */,
 				F5F509022CEBEA59007D6E39 /* String+Analytics.swift in Sources */,
+				F5A292172DE9638900C49AC4 /* BannerAdView.swift in Sources */,
 				F5F5094F2CEBF457007D6E39 /* MultipleActionView.swift in Sources */,
 				F5F5095D2CEBF697007D6E39 /* AudioUtils.swift in Sources */,
+				F580777C2DEA032A005AFBA6 /* Theme+Color.swift in Sources */,
 				F5F509402CEBF26F007D6E39 /* HapticsHelper.swift in Sources */,
 				F5F509652CEBF77A007D6E39 /* Unlockable.swift in Sources */,
 				F5F509592CEBF65E007D6E39 /* PlaybackItem.swift in Sources */,
@@ -11326,6 +11333,7 @@
 				F5F5091A2CEBEC60007D6E39 /* NowPlayingHelper.swift in Sources */,
 				F5F509142CEBEBF7007D6E39 /* ChapterInfo.swift in Sources */,
 				F5F5095E2CEBF69D007D6E39 /* BufferedAudio.swift in Sources */,
+				F536B45A2DEA02330051A929 /* View+UIView.swift in Sources */,
 				F5F509072CEBEA9D007D6E39 /* SleepTimerManager.swift in Sources */,
 				F5F509512CEBF49D007D6E39 /* ThemeableSwitch.swift in Sources */,
 				F5F509232CEBEE87007D6E39 /* BaseEpisode+Formatting.swift in Sources */,

--- a/podcasts/Common SwiftUI/BannerAdView.swift
+++ b/podcasts/Common SwiftUI/BannerAdView.swift
@@ -56,6 +56,7 @@ struct BannerAdView: View {
                 Text(model.adText)
                     .font(.subheadline.weight(.medium))
                     .foregroundColor(colors.adText)
+                    .fixedSize(horizontal: false, vertical: true)
                 HStack(spacing: 4) {
                     Text(model.adLabel)
                         .font(.caption2.weight(.semibold))

--- a/podcasts/Common SwiftUI/BannerAdView.swift
+++ b/podcasts/Common SwiftUI/BannerAdView.swift
@@ -1,0 +1,148 @@
+import SwiftUI
+
+class BannerAdModel: ObservableObject {
+    let adText: String
+    let imageURL: URL
+    let adLabel: String
+    let titleLabel: String
+    let onLinkTap: (() -> Void)?
+
+    init(adText: String, imageURL: URL, linkTitle: String, titleLabel: String = L10n.bannerAdsInfoLabel, onLinkTap: (() -> Void)? = nil) {
+        self.adText = adText
+        self.imageURL = imageURL
+        self.adLabel = titleLabel
+        self.titleLabel = linkTitle
+        self.onLinkTap = onLinkTap
+    }
+}
+
+struct BannerAdView: View {
+    struct Colors {
+        let background: Color
+        let adText: Color
+        let titleLabel: Color
+        let adLabelBackground: Color
+        let adLabel: Color
+        let icon: Color
+        let border: Color?
+
+        static func podcastList(_ theme: Theme) -> Self {
+            return Self(
+                background: theme.primaryUi06,
+                adText: theme.primaryText01,
+                titleLabel: theme.primaryInteractive01,
+                adLabelBackground: theme.primaryInteractive01,
+                adLabel: theme.primaryUi02Active,
+                icon: theme.primaryIcon02,
+                border: theme.primaryUi05
+            )
+        }
+    }
+
+    @ObservedObject var model: BannerAdModel
+    private let colors: Colors
+    @EnvironmentObject var theme: Theme
+    @Environment(\.sizeCategory) private var sizeCategory
+
+    init(model: BannerAdModel, colors: Colors) {
+        self.model = model
+        self.colors = colors
+    }
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 16) {
+            creative()
+            VStack(alignment: .leading, spacing: 8) {
+                Text(model.adText)
+                    .font(.subheadline.weight(.medium))
+                    .foregroundColor(colors.adText)
+                HStack(spacing: 4) {
+                    Text(model.adLabel)
+                        .font(.caption2.weight(.semibold))
+                        .foregroundColor(colors.adLabel)
+                        .padding(.horizontal, 4)
+                        .padding(.vertical, 2)
+                        .background(colors.adLabelBackground)
+                        .cornerRadius(4)
+                    Button(action: { model.onLinkTap?() }) {
+                        Text(model.titleLabel)
+                            .font(.footnote.weight(.semibold))
+                            .foregroundColor(colors.titleLabel)
+                    }
+                    .buttonStyle(PlainButtonStyle())
+                }
+            }
+            VStack {
+                Button(action: {
+                    //TODO: Add Ad reporting action in future PR
+                }, label: {
+                    Image(systemName: "ellipsis")
+                        .bold()
+                        .foregroundStyle(colors.icon)
+                })
+                .padding(10)
+                Spacer()
+            }
+        }
+        .padding(8)
+        .background(colors.background)
+        .modify {
+            if let border = colors.border {
+                $0.overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(border, lineWidth: 1)
+                )
+            }
+        }
+        .cornerRadius(8)
+        .padding(.vertical, 10)
+    }
+
+    @ViewBuilder func creative() -> some View {
+        AsyncImage(url: model.imageURL) { phase in
+            switch phase {
+            case .empty, .failure:
+                ProgressView()
+            case .success(let image):
+                image
+                    .resizable()
+                    .cornerRadius(4)
+            @unknown default:
+                ProgressView()
+                    .onAppear {
+                        assertionFailure("Unexpected AsyncImage phase: \(phase)")
+                    }
+            }
+        }
+        .aspectRatio(1, contentMode: .fit)
+        .frame(width: 86, height: 86)
+    }
+}
+
+#Preview("Light - Podcast List Theme") {
+    BannerAdView(
+        model: .init(
+            adText: "Listen to your favorite books while supporting your local indie bookstore",
+            imageURL: URL(string: "https://static.pocketcasts.com/discover/images/420/9349e8d0-a87f-013a-d8af-0acc26574db2.jpg")!,
+            linkTitle: "Libro.fm"
+        ),
+        colors: .podcastList(Theme(previewTheme: .light))
+    )
+    .environmentObject(Theme(previewTheme: .light))
+    .padding(16)
+    .frame(maxWidth: 400)
+}
+
+#Preview("Dark - Podcast List Theme") {
+    BannerAdView(
+        model: .init(
+            adText: "Listen to your favorite books while supporting your local indie bookstore",
+            imageURL: URL(string: "https://static.pocketcasts.com/discover/images/420/9349e8d0-a87f-013a-d8af-0acc26574db2.jpg")!,
+            linkTitle: "Libro.fm"
+        ),
+        colors: .podcastList(Theme(previewTheme: .light))
+    )
+    .environmentObject(Theme(previewTheme: .dark))
+    .padding(16)
+    .frame(maxWidth: 400)
+}

--- a/podcasts/Common SwiftUI/BannerAdView.swift
+++ b/podcasts/Common SwiftUI/BannerAdView.swift
@@ -50,7 +50,7 @@ struct BannerAdView: View {
     }
 
     var body: some View {
-        HStack(alignment: .center, spacing: 16) {
+        HStack(alignment: .top, spacing: 16) {
             creative()
             VStack(alignment: .leading, spacing: 8) {
                 Text(model.adText)

--- a/podcasts/PodcastListViewController+CollectionView.swift
+++ b/podcasts/PodcastListViewController+CollectionView.swift
@@ -1,18 +1,23 @@
 import PocketCastsDataModel
 import PocketCastsUtils
 import UIKit
+import SwiftUI
 
 extension PodcastListViewController: UICollectionViewDelegate, UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
     private static let podcastSquareCellId = "PodcastGridCell"
     private static let podcastListCellId = "PodcastListCell"
     private static let folderSquareCellId = "FolderGridCell"
     private static let folderListCellId = "FolderListCell"
+    private static let bannerAdHeaderId = "BannerAdHeader"
 
     func registerCells() {
         podcastsCollectionView.register(UINib(nibName: "PodcastGridCell", bundle: nil), forCellWithReuseIdentifier: PodcastListViewController.podcastSquareCellId)
         podcastsCollectionView.register(UINib(nibName: "PodcastListCell", bundle: nil), forCellWithReuseIdentifier: PodcastListViewController.podcastListCellId)
         podcastsCollectionView.register(UINib(nibName: "FolderGridCell", bundle: nil), forCellWithReuseIdentifier: PodcastListViewController.folderSquareCellId)
         podcastsCollectionView.register(UINib(nibName: "FolderListCell", bundle: nil), forCellWithReuseIdentifier: PodcastListViewController.folderListCellId)
+
+        // Register header view for banner ads
+        podcastsCollectionView.register(UICollectionReusableView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: PodcastListViewController.bannerAdHeaderId)
     }
 
     func numberOfSections(in collectionView: UICollectionView) -> Int {
@@ -125,5 +130,51 @@ extension PodcastListViewController: UICollectionViewDelegate, UICollectionViewD
         if let flowLayout = podcastsCollectionView.collectionViewLayout as? UICollectionViewFlowLayout {
             flowLayout.invalidateLayout() // force the elements to get laid out again with the new size
         }
+    }
+
+    // MARK: - Supplementary Views
+
+    func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
+        if kind == UICollectionView.elementKindSectionHeader {
+            let headerView = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: PodcastListViewController.bannerAdHeaderId, for: indexPath)
+
+            // Remove existing subviews
+            headerView.subviews.forEach { $0.removeFromSuperview() }
+
+            if let bannerAdModel = bannerAdModel {
+                let bannerAdView = BannerAdView(model: bannerAdModel, colors: .podcastList(Theme.sharedTheme))
+                let hostingController = PCHostingController(rootView: bannerAdView)
+                hostingController.view.translatesAutoresizingMaskIntoConstraints = false
+                hostingController.view.backgroundColor = .clear
+
+                headerView.addSubview(hostingController.view)
+                NSLayoutConstraint.activate([
+                    hostingController.view.topAnchor.constraint(equalTo: headerView.topAnchor),
+                    hostingController.view.leadingAnchor.constraint(equalTo: headerView.leadingAnchor),
+                    hostingController.view.trailingAnchor.constraint(equalTo: headerView.trailingAnchor),
+                    hostingController.view.bottomAnchor.constraint(equalTo: headerView.bottomAnchor)
+                ])
+            }
+
+            return headerView
+        }
+
+        return UICollectionReusableView()
+    }
+
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
+
+        guard let bannerAdModel else {
+            return .zero
+        }
+
+        // Use a separate view because fetching the view from UICollectionView isn't allowed until view is part of window hierarchy.
+        let sizingView = BannerAdView(model: bannerAdModel, colors: .podcastList(Theme.sharedTheme)).environmentObject(Theme.sharedTheme)
+
+        let hostingController = UIHostingController(rootView: sizingView)
+        let targetSize = CGSize(width: collectionView.bounds.width, height: UIView.layoutFittingCompressedSize.height)
+        let size = hostingController.sizeThatFits(in: targetSize)
+
+        return size
     }
 }

--- a/podcasts/PodcastListViewController.swift
+++ b/podcasts/PodcastListViewController.swift
@@ -9,6 +9,7 @@ import Kingfisher
 class PodcastListViewController: PCViewController, UIGestureRecognizerDelegate, ShareListDelegate {
     let gridHelper = GridHelper()
     var refreshControl: PCRefreshControl?
+    var bannerAdModel: BannerAdModel?
 
     @IBOutlet var addPodcastBtn: ThemeableButton! {
         didSet {
@@ -25,7 +26,7 @@ class PodcastListViewController: PCViewController, UIGestureRecognizerDelegate, 
             registerCells()
 
             if let layout = podcastsCollectionView.collectionViewLayout as? UICollectionViewFlowLayout {
-                layout.sectionHeadersPinToVisibleBounds = true
+                layout.sectionHeadersPinToVisibleBounds = false
             }
         }
     }
@@ -63,6 +64,10 @@ class PodcastListViewController: PCViewController, UIGestureRecognizerDelegate, 
         title = L10n.podcastsPlural
         setupSearchBar()
         setupRefreshControl()
+
+        if FeatureFlag.bannerAds.enabled {
+            setupBannerAd()
+        }
 
         let longPressGesture = UILongPressGestureRecognizer(target: self, action: #selector(handleLongPress(_:)))
         podcastsCollectionView.addGestureRecognizer(longPressGesture)
@@ -446,6 +451,15 @@ class PodcastListViewController: PCViewController, UIGestureRecognizerDelegate, 
     override func handleThemeChanged() {
         super.handleThemeChanged()
         podcastsCollectionView.reloadData()
+    }
+
+    private func setupBannerAd() {
+        // Example banner ad - in future implementation this will come from ad service
+        bannerAdModel = BannerAdModel(
+            adText: "Listen to your favorite books while supporting your local indie bookstore",
+            imageURL: URL(string: "https://static.pocketcasts.com/discover/images/420/9349e8d0-a87f-013a-d8af-0acc26574db2.jpg")!,
+            linkTitle: "Libro.fm"
+        )
     }
 }
 

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -314,6 +314,8 @@ internal enum L10n {
   internal static var autoRestartSleepTimerDescription: String { return L10n.tr("Localizable", "auto_restart_sleep_timer_description") }
   /// Back
   internal static var back: String { return L10n.tr("Localizable", "back") }
+  /// AD
+  internal static var bannerAdsInfoLabel: String { return L10n.tr("Localizable", "banner_ads_info_label") }
   /// Please download Pocket Casts from the App Store to purchase %1$@.
   internal static func betaPurchaseDisabled(_ p1: Any) -> String {
     return L10n.tr("Localizable", "beta_purchase_disabled", String(describing: p1))

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -5146,3 +5146,5 @@
 /* Notification button title to open device notification settings*/
 "notifications_permissions_open_settings" = "Open Settings";
 
+/* Banner Ads label. This needs to be an extremely short version of "advertisement" to indicate an ad in a tiny space. */
+"banner_ads_info_label" = "AD";


### PR DESCRIPTION
| 📘 Part of: #3208 |
|:---:|

Fixes #3210

* Adds the `BannerAdView` SwiftUI view
* Color themes for the podcast list - a different one will be used for the player
* Disables the `banner_ads` feature flag for now so we don't ship anything with the static banner ads.
* Ad fetching is still to come so the ad strings don't need to be localized or anything
* Analytics events will come in a future PR

| Classic | Dark Contrast | Default Dark |
|---|---|---|
| ![Classic](https://github.com/user-attachments/assets/e92cb782-e536-4258-98dc-d4662972a599) | ![Dark Contrast](https://github.com/user-attachments/assets/113cebe2-95b6-40bb-a566-74164881fae9) | ![Default Dark](https://github.com/user-attachments/assets/b8a9e4c5-9e00-4b95-ab81-1f0e78609d7f) |


| Default Light | Electricity | Extra Dark |
|---|---|---|
| ![Default Light](https://github.com/user-attachments/assets/fa28b72a-13c9-4c3e-ac83-7e2b80286827) | ![Electricity](https://github.com/user-attachments/assets/3b94ae4f-c681-47d4-bb28-d8230026ee75) | ![Extra Dark](https://github.com/user-attachments/assets/ba4a5a0c-a2db-4805-990b-dd5c2029fdcd) |


| Indigo | Light Contrast | Radioactive | Rose
|---|---|---|---|
| ![Indigo](https://github.com/user-attachments/assets/df0a8668-ccd1-43a8-86d2-73bd399828a4) | ![Light Contrast](https://github.com/user-attachments/assets/45211cad-46fa-4dde-a3ad-c91a2212d374) | ![Radioactive](https://github.com/user-attachments/assets/4bdcd55e-9362-43d6-b03d-11e0135a3c3c) | ![Rosé](https://github.com/user-attachments/assets/45436a7e-c806-4f4b-907c-a81349ee2890) |

## To test

* Enable the `bannerAds` feature flag
* Restart the app
* Navigate to the Podcasts screen
* ✅ Ensure that the banner ad shows at the top

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
