### PR TITLE
Fix crash on accessing DownloadManagers cache dictionaries

### DIFF
--- a/podcasts/DownloadManager.swift
+++ b/podcasts/DownloadManager.swift
@@ -19,6 +19,18 @@ extension Dictionary: DownloadManagerEpisodesCache where Self == Dictionary<Stri
 extension ThreadSafeDictionary: DownloadManagerEpisodesCache where ThreadSafeDictionary == ThreadSafeDictionary<String, BaseEpisode> {
 }
 
+protocol DownloadManagerStreamAndDownloadCache {
+    subscript(index: String) -> AVAssetResourceLoaderDelegate? { get set }
+
+    func contains(where predicate: ((key: String, value: AVAssetResourceLoaderDelegate)) throws -> Bool) rethrows -> Bool
+}
+
+extension Dictionary: DownloadManagerStreamAndDownloadCache where Self == Dictionary<String, AVAssetResourceLoaderDelegate> {
+}
+
+extension ThreadSafeDictionary: DownloadManagerStreamAndDownloadCache where ThreadSafeDictionary == ThreadSafeDictionary<String, AVAssetResourceLoaderDelegate> {
+}
+
 class DownloadManager: NSObject, FilePathProtocol {
 
     static let shared: DownloadManager = {
@@ -39,7 +51,13 @@ class DownloadManager: NSObject, FilePathProtocol {
         }
     }()
 
-    var downloadAndStreamEpisodes = [String: AVAssetResourceLoaderDelegate]()
+    lazy var downloadAndStreamEpisodes: DownloadManagerStreamAndDownloadCache = {
+        if FeatureFlag.downloadsThreadSafeCache.enabled {
+            ThreadSafeDictionary<String, AVAssetResourceLoaderDelegate>()
+        } else {
+            Dictionary<String, AVAssetResourceLoaderDelegate>()
+        }
+    }()
 
     var taskFailure: [String: FailureReason] = [:]
 
@@ -356,7 +374,7 @@ class DownloadManager: NSObject, FilePathProtocol {
             }
             downloadingEpisodesCache[downloadTaskUUID] = nil
             removeEpisodeFromCache(episode)
-            downloadAndStreamEpisodes.removeValue(forKey: downloadTaskUUID)
+            downloadAndStreamEpisodes[downloadTaskUUID] = nil
             guard let episode = dataManager.findBaseEpisode(uuid: downloadTaskUUID) else {
                 return
             }
@@ -444,7 +462,7 @@ class DownloadManager: NSObject, FilePathProtocol {
             let sessionToUse = useCellularSession ? cellularBackgroundSession : wifiOnlyBackgroundSession
         #endif
 
-        if FeatureFlag.streamAndCachePlayingEpisode.enabled, downloadAndStreamEpisodes.keys.contains(episode.uuid) {
+        if FeatureFlag.streamAndCachePlayingEpisode.enabled, downloadAndStreamEpisodes[episode.uuid] != nil {
             return
         }
 
@@ -505,7 +523,7 @@ class DownloadManager: NSObject, FilePathProtocol {
             saveRequired = true
         }
 
-        if FeatureFlag.streamAndCachePlayingEpisode.enabled, downloadAndStreamEpisodes.keys.contains(episode.uuid) {
+        if FeatureFlag.streamAndCachePlayingEpisode.enabled, downloadAndStreamEpisodes[episode.uuid] != nil {
             episode.downloadTaskId = episode.uuid
             episode.autoDownloadStatus = AutoDownloadStatus.playerDownloadedForStreaming.rawValue
             saveRequired = true

--- a/podcasts/ThreadSafeDictionary.swift
+++ b/podcasts/ThreadSafeDictionary.swift
@@ -9,15 +9,15 @@ class ThreadSafeDictionary<Key: Hashable, Value> {
 
     func value(forKey key: Key) -> Value? {
         var value: Value?
-        queue.sync {
-            value = table[key]
+        queue.sync { [weak self] in
+            value = self?.table[key]
         }
         return value
     }
 
     func updateValue(_ value: Value?, forKey key: Key) {
-        queue.async(flags: .barrier) {
-            self.table[key] = value
+        queue.async(flags: .barrier) { [weak self] in
+            self?.table[key] = value
         }
     }
 
@@ -36,8 +36,8 @@ class ThreadSafeDictionary<Key: Hashable, Value> {
 
     func contains(where predicate: ((key: Key, value: Value)) throws -> Bool) rethrows -> Bool {
         var result = false
-        try queue.sync {
-            result = try table.contains(where: predicate)
+        try queue.sync { [weak self] in
+            result = try self?.table.contains(where: predicate) ?? false
         }
         return result
     }


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes #3205 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

## To test

1. Start the app
2. Start multiple downloads of episodes
3. Start playing a different episode that is not downloaded while the downloads are ongoing
4. Start playing another episode
5. Check if no crashes are seen

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
