### PR TITLE
[Transcript in Episode View] Present Transcript view from Episode

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -714,6 +714,8 @@
 		9A9B83C02DCBC36D002CE179 /* CancelSubscriptionSurveyRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A9B83BF2DCBC36D002CE179 /* CancelSubscriptionSurveyRow.swift */; };
 		9AA3B6312D27F0B600A0E30E /* CancelSubscriptionPlansViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AA3B6302D27F0B600A0E30E /* CancelSubscriptionPlansViewModel.swift */; };
 		9AB645182D5138B200A842C8 /* Pocket Casts App Clip.app in Embed App Clips */ = {isa = PBXBuildFile; fileRef = F5D5F7792CEBE769001F492D /* Pocket Casts App Clip.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		9AE5043C2DEDF2030027A4AE /* TranscriptContainerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AE5043B2DEDF1F80027A4AE /* TranscriptContainerViewController.swift */; };
+		9AE5043E2DEDF5590027A4AE /* TranscriptPlaybackManaging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AE5043D2DEDF54F0027A4AE /* TranscriptPlaybackManaging.swift */; };
 		BD001B892174260B00504DD3 /* FilterManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD001B882174260B00504DD3 /* FilterManager.swift */; };
 		BD00CB2B24BD20CD00A10257 /* TimeStepperCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD00CB2924BD20CD00A10257 /* TimeStepperCell.swift */; };
 		BD00CB2C24BD20CD00A10257 /* TimeStepperCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = BD00CB2A24BD20CD00A10257 /* TimeStepperCell.xib */; };
@@ -2963,6 +2965,8 @@
 		9A9B83BB2DCBC2A4002CE179 /* CancelSubscriptionSurveyViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancelSubscriptionSurveyViewModel.swift; sourceTree = "<group>"; };
 		9A9B83BF2DCBC36D002CE179 /* CancelSubscriptionSurveyRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancelSubscriptionSurveyRow.swift; sourceTree = "<group>"; };
 		9AA3B6302D27F0B600A0E30E /* CancelSubscriptionPlansViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancelSubscriptionPlansViewModel.swift; sourceTree = "<group>"; };
+		9AE5043B2DEDF1F80027A4AE /* TranscriptContainerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptContainerViewController.swift; sourceTree = "<group>"; };
+		9AE5043D2DEDF54F0027A4AE /* TranscriptPlaybackManaging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptPlaybackManaging.swift; sourceTree = "<group>"; };
 		9E6FEF10644B78313185D080 /* Pods-PocketCastsTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PocketCastsTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-PocketCastsTests/Pods-PocketCastsTests.release.xcconfig"; sourceTree = "<group>"; };
 		A251FE0E92E432C4EF0C8207 /* Pods-PocketCastsTests.staging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PocketCastsTests.staging.xcconfig"; path = "Pods/Target Support Files/Pods-PocketCastsTests/Pods-PocketCastsTests.staging.xcconfig"; sourceTree = "<group>"; };
 		AA688FF113B87D7B363799D5 /* Pods-Pocket Casts App ClipTests.staging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Pocket Casts App ClipTests.staging.xcconfig"; path = "Pods/Target Support Files/Pods-Pocket Casts App ClipTests/Pods-Pocket Casts App ClipTests.staging.xcconfig"; sourceTree = "<group>"; };
@@ -8599,6 +8603,8 @@
 		FF7F89E82C2979C000FC0ED5 /* Transcripts */ = {
 			isa = PBXGroup;
 			children = (
+				9AE5043D2DEDF54F0027A4AE /* TranscriptPlaybackManaging.swift */,
+				9AE5043B2DEDF1F80027A4AE /* TranscriptContainerViewController.swift */,
 				9A86AB2C2DE8642300474E0F /* TranscriptExcerptView.swift */,
 				FF7F89E92C2979D900FC0ED5 /* TranscriptViewController.swift */,
 				9A0E6C652D822637008CFDF7 /* GeneratedTranscriptsPremiumOverlay.swift */,
@@ -10775,7 +10781,9 @@
 				BD35BB6C1CF697650018D63E /* AudioUtils.swift in Sources */,
 				C7B3C60A2919DCB700054145 /* ScrollViewIfNeeded.swift in Sources */,
 				C7252E142A71950500E7D3C0 /* EpisodeImage.swift in Sources */,
+				9AE5043E2DEDF5590027A4AE /* TranscriptPlaybackManaging.swift in Sources */,
 				FF9B6B772D0733670057A504 /* LogsView.swift in Sources */,
+				9AE5043C2DEDF2030027A4AE /* TranscriptContainerViewController.swift in Sources */,
 				BDA9668F2189805F00DF9370 /* UIScrollView+MiniPlayer.swift in Sources */,
 				BD48D5A6216DB26A00391F9E /* HapticsHelper.swift in Sources */,
 				F51656D82C816FE6009446B4 /* ClipsWhatsNewView.swift in Sources */,

--- a/podcasts/EpisodeDetailViewController+ShowNotes.swift
+++ b/podcasts/EpisodeDetailViewController+ShowNotes.swift
@@ -61,10 +61,14 @@ extension EpisodeDetailViewController: WKNavigationDelegate, SFSafariViewControl
             let showNotes = try? await ShowInfoCoordinator.shared.loadShowNotes(podcastUuid: parentIdentifier, episodeUuid: episodeUUID)
 
             if FeatureFlag.episodeDetailTranscript.enabled {
-                if let metadata = try? await ShowInfoCoordinator.shared.loadTranscriptsMetadata(podcastUuid: parentIdentifier, episodeUuid: episodeUUID) {
+                if let metadata = try? await ShowInfoCoordinator.shared.loadTranscriptsMetadata(podcastUuid: parentIdentifier, episodeUuid: episodeUUID), !metadata.transcripts.isEmpty {
                     await MainActor.run { [weak self] in
                         let viewModel = TranscriptExcerptViewModel(episodeUUID: episodeUUID, podcastUUID: parentIdentifier, isGeneratedTranscript: metadata.hasGeneratedTranscripts) {
-                            //TODO: add vc presentation here
+
+                            DispatchQueue.main.async {
+                                let playbackManager = TranscriptEpisodeInfoProvider(episodeUUID: episodeUUID, podcastUUID: parentIdentifier)
+                                self?.present(TranscriptContainerViewController(playbackManager: playbackManager), animated: true)
+                            }
                         }
                         let view = TranscriptExcerptView(viewModel: viewModel).themedUIView
                         view.translatesAutoresizingMaskIntoConstraints = false

--- a/podcasts/GeneratedTranscriptsPremiumOverlay.swift
+++ b/podcasts/GeneratedTranscriptsPremiumOverlay.swift
@@ -147,7 +147,7 @@ class GeneratedTranscriptsPremiumOverlay: UIViewController, AnalyticsSourceProvi
 
         let readableContentGuideMargin = 12.0
         let topMargin = showFromEpisode ? 24.0 : 0.0
-        
+
         NSLayoutConstraint.activate(
             [
                 blurEffectView.topAnchor.constraint(equalTo: view.topAnchor),

--- a/podcasts/GeneratedTranscriptsPremiumOverlay.swift
+++ b/podcasts/GeneratedTranscriptsPremiumOverlay.swift
@@ -21,7 +21,7 @@ class GeneratedTranscriptsPremiumOverlay: UIViewController, AnalyticsSourceProvi
         let closeButton = TintableImageButton()
         closeButton.translatesAutoresizingMaskIntoConstraints = false
         closeButton.setImage(UIImage(named: "close"), for: .normal)
-        closeButton.tintColor = ThemeColor.primaryIcon02()
+        closeButton.tintColor = closeButtonColor
         closeButton.addTarget(self, action: #selector(closeTapped), for: .touchUpInside)
         return closeButton
     }()
@@ -39,7 +39,7 @@ class GeneratedTranscriptsPremiumOverlay: UIViewController, AnalyticsSourceProvi
         title.text = L10n.generatedTranscriptsOverlayTitle
         title.numberOfLines = 0
         title.font = .systemFont(ofSize: 22, weight: .bold)
-        title.textColor = .white
+        title.textColor = titleColor
         title.backgroundColor = .clear
         title.textAlignment = .center
         return title
@@ -51,7 +51,7 @@ class GeneratedTranscriptsPremiumOverlay: UIViewController, AnalyticsSourceProvi
         description.text = L10n.generatedTranscriptsOverlayDescription
         description.numberOfLines = 0
         description.font = .systemFont(ofSize: 14, weight: .regular)
-        description.textColor = .white.withAlphaComponent(0.5)
+        description.textColor = descriptionColor
         description.backgroundColor = .clear
         description.textAlignment = .center
         return description
@@ -75,12 +75,35 @@ class GeneratedTranscriptsPremiumOverlay: UIViewController, AnalyticsSourceProvi
         return blurEffectView
     }()
 
-    private let gradientColor = PlayerColorHelper.playerBackgroundColor01()
+    private var gradientColor: UIColor {
+        showFromEpisode ? ThemeColor.primaryUi01(): PlayerColorHelper.playerBackgroundColor01()
+    }
+
+    private var titleColor: UIColor {
+        showFromEpisode ? ThemeColor.primaryText01(): .white
+    }
+
+    private var descriptionColor: UIColor {
+        showFromEpisode ? ThemeColor.primaryText02(): .white.withAlphaComponent(0.5)
+    }
+
+    private var backgroundColor: UIColor {
+        showFromEpisode ? ThemeColor.primaryUi01().withAlphaComponent(0.70) : PlayerColorHelper.playerBackgroundColor01().withAlphaComponent(0.45)
+    }
+
+    private var closeButtonColor: UIColor {
+        showFromEpisode ? ThemeColor.primaryText01() : ThemeColor.primaryIcon02()
+    }
+
     private lazy var topGradient: GradientView = {
         let gradientView = GradientView(firstColor: gradientColor, secondColor: gradientColor.withAlphaComponent(0))
         gradientView.translatesAutoresizingMaskIntoConstraints = false
         return gradientView
     }()
+
+    private var showFromEpisode: Bool {
+        analyticsSource == .episode
+    }
 
     init(playbackManager: PlaybackManager, analyticsSource: AnalyticsSource = .player) {
         self.playbackManager = playbackManager
@@ -108,7 +131,7 @@ class GeneratedTranscriptsPremiumOverlay: UIViewController, AnalyticsSourceProvi
     }
 
     private func setupView() {
-        view.backgroundColor = PlayerColorHelper.playerBackgroundColor01().withAlphaComponent(0.45)
+        view.backgroundColor = backgroundColor
 
         view.addSubview(blurEffectView)
         view.addSubview(topGradient)
@@ -123,7 +146,8 @@ class GeneratedTranscriptsPremiumOverlay: UIViewController, AnalyticsSourceProvi
         stackView.addArrangedSubview(UIView())
 
         let readableContentGuideMargin = 12.0
-
+        let topMargin = showFromEpisode ? 24.0 : 0.0
+        
         NSLayoutConstraint.activate(
             [
                 blurEffectView.topAnchor.constraint(equalTo: view.topAnchor),
@@ -134,7 +158,7 @@ class GeneratedTranscriptsPremiumOverlay: UIViewController, AnalyticsSourceProvi
                 topGradient.leadingAnchor.constraint(equalTo: view.leadingAnchor),
                 topGradient.trailingAnchor.constraint(equalTo: view.trailingAnchor),
                 topGradient.bottomAnchor.constraint(equalTo: view.centerYAnchor, constant: 100.0),
-                stackView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+                stackView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: topMargin),
                 stackView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 12),
                 stackView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -16),
                 closeButton.heightAnchor.constraint(equalToConstant: 44),
@@ -161,7 +185,12 @@ class GeneratedTranscriptsPremiumOverlay: UIViewController, AnalyticsSourceProvi
 
     @objc private func paywallButtonTapped() {
         track(event: .transcriptGeneratedPaywallSubscribeTapped)
-        NavigationManager.sharedManager.showUpsellView(from: self, source: .generatedTranscripts)
+        if analyticsSource == .player {
+            NavigationManager.sharedManager.showUpsellView(from: self, source: .generatedTranscripts)
+        } else {
+            let controller = OnboardingFlow.shared.begin(flow: .plusUpsell, source: PlusUpgradeViewSource.generatedTranscripts.rawValue, context: [:])
+            self.parent?.present(controller, animated: true, completion: nil)
+        }
     }
 
     @objc private func subscriptionStatusDidChange() {

--- a/podcasts/GeneratedTranscriptsPremiumOverlay.swift
+++ b/podcasts/GeneratedTranscriptsPremiumOverlay.swift
@@ -6,7 +6,7 @@ class GeneratedTranscriptsPremiumOverlay: UIViewController, AnalyticsSourceProvi
     var dismissTranscript: (() -> Void)?
     var purchaseSuccessfull: (() -> Void)?
 
-    private let playbackManager: PlaybackManager
+    private let playbackManager: TranscriptPlaybackManaging
     let analyticsSource: AnalyticsSource
 
     private lazy var stackView: UIStackView = {
@@ -105,7 +105,7 @@ class GeneratedTranscriptsPremiumOverlay: UIViewController, AnalyticsSourceProvi
         analyticsSource == .episode
     }
 
-    init(playbackManager: PlaybackManager, analyticsSource: AnalyticsSource = .player) {
+    init(playbackManager: TranscriptPlaybackManaging, analyticsSource: AnalyticsSource = .player) {
         self.playbackManager = playbackManager
         self.analyticsSource = analyticsSource
         super.init(nibName: nil, bundle: nil)
@@ -147,6 +147,7 @@ class GeneratedTranscriptsPremiumOverlay: UIViewController, AnalyticsSourceProvi
 
         let readableContentGuideMargin = 12.0
         let topMargin = showFromEpisode ? 24.0 : 0.0
+        let paywallButtonBottomMargin: CGFloat = showFromEpisode && view.safeAreaInsets.bottom == 0 ? -readableContentGuideMargin : 0.0
 
         NSLayoutConstraint.activate(
             [
@@ -171,7 +172,7 @@ class GeneratedTranscriptsPremiumOverlay: UIViewController, AnalyticsSourceProvi
                 descriptionLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 16),
                 descriptionLabel.leadingAnchor.constraint(equalTo: titleLabel.leadingAnchor),
                 descriptionLabel.trailingAnchor.constraint(equalTo: titleLabel.trailingAnchor),
-                paywallButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+                paywallButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: paywallButtonBottomMargin),
                 paywallButton.leadingAnchor.constraint(equalTo: titleLabel.leadingAnchor),
                 paywallButton.trailingAnchor.constraint(equalTo: titleLabel.trailingAnchor),
                 paywallButton.heightAnchor.constraint(equalToConstant: 56)
@@ -202,10 +203,10 @@ class GeneratedTranscriptsPremiumOverlay: UIViewController, AnalyticsSourceProvi
     }
 
     private func track(event: AnalyticsEvent) {
-        guard let episode = playbackManager.currentEpisode(),
-              let podcast = playbackManager.currentPodcast else {
+        guard let episodeUUID = playbackManager.episodeUUID,
+              let podcastUUID = playbackManager.podcastUUID else {
             return
         }
-        Analytics.track(event, properties: ["episode_uuid": episode.uuid, "podcast_uuid": podcast.uuid, "source": analyticsSource.rawValue])
+        Analytics.track(event, properties: ["episode_uuid": episodeUUID, "podcast_uuid": podcastUUID, "source": analyticsSource.rawValue])
     }
 }

--- a/podcasts/TranscriptContainerViewController.swift
+++ b/podcasts/TranscriptContainerViewController.swift
@@ -12,7 +12,6 @@ class TranscriptContainerViewController: UIViewController {
     }()
 
     private lazy var generatedTranscriptsPremiumOverlay: GeneratedTranscriptsPremiumOverlay = {
-        let playbackManager = PlaybackManager.shared
         let item = GeneratedTranscriptsPremiumOverlay(playbackManager: playbackManager, analyticsSource: .episode)
         item.view.translatesAutoresizingMaskIntoConstraints = false
         item.dismissTranscript = { [weak self] in

--- a/podcasts/TranscriptContainerViewController.swift
+++ b/podcasts/TranscriptContainerViewController.swift
@@ -2,11 +2,11 @@
 
 class TranscriptContainerViewController: UIViewController {
     private let playbackManager: TranscriptPlaybackManaging
+    private var generatedTranscriptsPremiumOverlayShown: Bool = false
 
     private lazy var transcriptsItem: TranscriptViewController = {
         let item = TranscriptViewController(playbackManager: playbackManager, source: .episode)
         item.view.translatesAutoresizingMaskIntoConstraints = false
-//        item.scrollViewHandler = self
         item.containerDelegate = self
         return item
     }()
@@ -40,6 +40,8 @@ class TranscriptContainerViewController: UIViewController {
     }
 
     func showTranscript() {
+        generatedTranscriptsPremiumOverlayShown = false
+
         Analytics.track(.episodeTranscriptShown)
 
         addChild(transcriptsItem)
@@ -56,6 +58,7 @@ class TranscriptContainerViewController: UIViewController {
     }
 
     private func showGeneratedTranscriptsPremiumOverlay() {
+        generatedTranscriptsPremiumOverlayShown = true
         generatedTranscriptsPremiumOverlay.didAppear()
         addChild(generatedTranscriptsPremiumOverlay)
         view.addSubview(generatedTranscriptsPremiumOverlay.view)
@@ -65,6 +68,7 @@ class TranscriptContainerViewController: UIViewController {
 
     private func dismissGeneratedTranscriptsPremiumOverlay(dismissTranscript: Bool) {
         UIView.animate(withDuration: 0.25) { [weak self] in
+            self?.generatedTranscriptsPremiumOverlayShown = false
             self?.generatedTranscriptsPremiumOverlay.didDisappear()
             self?.generatedTranscriptsPremiumOverlay.willMove(toParent: nil)
             self?.generatedTranscriptsPremiumOverlay.removeFromParent()
@@ -113,6 +117,10 @@ extension TranscriptContainerViewController: UIAdaptivePresentationControllerDel
     }
 
     func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
-        hideTranscript()
+        if generatedTranscriptsPremiumOverlay.view.superview != nil {
+            generatedTranscriptsPremiumOverlay.didDisappear()
+        } else {
+            hideTranscript()
+        }
     }
 }

--- a/podcasts/TranscriptContainerViewController.swift
+++ b/podcasts/TranscriptContainerViewController.swift
@@ -1,0 +1,101 @@
+
+
+class TranscriptContainerViewController: UIViewController {
+    private let playbackManager: TranscriptPlaybackManaging
+
+    private lazy var transcriptsItem: TranscriptViewController = {
+        let item = TranscriptViewController(playbackManager: playbackManager, source: .episode)
+        item.view.translatesAutoresizingMaskIntoConstraints = false
+//        item.scrollViewHandler = self
+        item.containerDelegate = self
+        return item
+    }()
+
+    private lazy var generatedTranscriptsPremiumOverlay: GeneratedTranscriptsPremiumOverlay = {
+        let playbackManager = PlaybackManager.shared
+        let item = GeneratedTranscriptsPremiumOverlay(playbackManager: playbackManager, analyticsSource: .episode)
+        item.view.translatesAutoresizingMaskIntoConstraints = false
+        item.dismissTranscript = { [weak self] in
+            self?.dismissGeneratedTranscriptsPremiumOverlay(dismissTranscript: true)
+        }
+        item.purchaseSuccessfull = { [weak self] in
+            self?.dismissGeneratedTranscriptsPremiumOverlay(dismissTranscript: false)
+        }
+        return item
+    }()
+
+    init(playbackManager: TranscriptPlaybackManaging) {
+        self.playbackManager = playbackManager
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        showTranscript()
+    }
+
+    func showTranscript() {
+        addChild(transcriptsItem)
+        view.addSubview(transcriptsItem.view)
+        transcriptsItem.view.anchorToAllSidesOf(view: view)
+        transcriptsItem.didMove(toParent: self)
+        transcriptsItem.willBeAddedToPlayer()
+        transcriptsItem.themeDidChange()
+        transcriptsItem.showGeneratedTranscriptsPremiumOverlay = { [weak self] in
+            UIView.animate(withDuration: 0.25) {
+                self?.showGeneratedTranscriptsPremiumOverlay()
+            }
+        }
+    }
+
+    private func showGeneratedTranscriptsPremiumOverlay() {
+        generatedTranscriptsPremiumOverlay.didAppear()
+        addChild(generatedTranscriptsPremiumOverlay)
+        view.addSubview(generatedTranscriptsPremiumOverlay.view)
+        generatedTranscriptsPremiumOverlay.view.anchorToAllSidesOf(view: view)
+        generatedTranscriptsPremiumOverlay.didMove(toParent: self)
+    }
+
+    private func dismissGeneratedTranscriptsPremiumOverlay(dismissTranscript: Bool) {
+        UIView.animate(withDuration: 0.25) { [weak self] in
+            self?.generatedTranscriptsPremiumOverlay.didDisappear()
+            self?.generatedTranscriptsPremiumOverlay.willMove(toParent: nil)
+            self?.generatedTranscriptsPremiumOverlay.removeFromParent()
+            self?.generatedTranscriptsPremiumOverlay.view.removeFromSuperview()
+        } completion: { [weak self] _ in
+            if dismissTranscript {
+                self?.dismissTranscript()
+            }
+        }
+    }
+
+    func hideTranscript() {
+        transcriptsItem.willBeRemovedFromPlayer()
+        transcriptsItem.willMove(toParent: nil)
+        transcriptsItem.removeFromParent()
+        transcriptsItem.view.removeFromSuperview()
+        transcriptsItem.didDisappear()
+    }
+
+    private func configureTranscriptView() {
+        view.backgroundColor = ThemeColor.primaryUi01()
+
+        view.addSubview(transcriptsItem.view)
+        transcriptsItem.view.anchorToAllSidesOf(view: view)
+    }
+}
+
+extension TranscriptContainerViewController: PlayerItemContainerDelegate {
+    func dismissTranscript() {
+        dismiss(animated: true)
+    }
+
+    func scrollToCurrentChapter() { }
+    func scrollToNowPlaying() { }
+    func scrollToBookmarks() { }
+    func navigateToPodcast() { }
+}

--- a/podcasts/TranscriptContainerViewController.swift
+++ b/podcasts/TranscriptContainerViewController.swift
@@ -36,6 +36,7 @@ class TranscriptContainerViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         showTranscript()
+        presentationController?.delegate = self
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -97,11 +98,25 @@ class TranscriptContainerViewController: UIViewController {
 
 extension TranscriptContainerViewController: PlayerItemContainerDelegate {
     func dismissTranscript() {
-        dismiss(animated: true)
+        dismiss(animated: true) { [weak self] in
+            self?.hideTranscript()
+        }
     }
 
     func scrollToCurrentChapter() { }
     func scrollToNowPlaying() { }
     func scrollToBookmarks() { }
     func navigateToPodcast() { }
+}
+
+extension TranscriptContainerViewController: UIAdaptivePresentationControllerDelegate {
+    func presentationControllerDidAttemptToDismiss(_ presentationController: UIPresentationController) { }
+
+    func presentationControllerShouldDismiss(_ presentationController: UIPresentationController) -> Bool {
+        return true
+    }
+
+    func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+        hideTranscript()
+    }
 }

--- a/podcasts/TranscriptContainerViewController.swift
+++ b/podcasts/TranscriptContainerViewController.swift
@@ -38,6 +38,12 @@ class TranscriptContainerViewController: UIViewController {
         showTranscript()
     }
 
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        Analytics.track(.episodeTranscriptShown)
+    }
+
     func showTranscript() {
         addChild(transcriptsItem)
         view.addSubview(transcriptsItem.view)

--- a/podcasts/TranscriptContainerViewController.swift
+++ b/podcasts/TranscriptContainerViewController.swift
@@ -39,13 +39,9 @@ class TranscriptContainerViewController: UIViewController {
         presentationController?.delegate = self
     }
 
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-
-        Analytics.track(.episodeTranscriptShown)
-    }
-
     func showTranscript() {
+        Analytics.track(.episodeTranscriptShown)
+
         addChild(transcriptsItem)
         view.addSubview(transcriptsItem.view)
         transcriptsItem.view.anchorToAllSidesOf(view: view)

--- a/podcasts/TranscriptErrorView.swift
+++ b/podcasts/TranscriptErrorView.swift
@@ -3,10 +3,16 @@ import UIKit
 import PocketCastsUtils
 
 class TranscriptErrorView: UIView {
+    enum ViewSource {
+        case player
+        case episode
+    }
 
     private var retryCallback: (() -> ())?
+    private let viewSource: ViewSource
 
-    init(retryCallback: (() -> ())?) {
+    init(source: ViewSource = .player, retryCallback: (() -> ())?) {
+        self.viewSource = source
         self.retryCallback = retryCallback
         super.init(frame: CGRect.zero)
         translatesAutoresizingMaskIntoConstraints = false
@@ -37,7 +43,8 @@ class TranscriptErrorView: UIView {
     }()
 
     private lazy var icon: UIImageView = {
-        let view = UIImageView(image: UIImage(named: "yield_scaled"))
+        let view = UIImageView(image: UIImage(named: "yield_scaled")?.withRenderingMode(.alwaysTemplate))
+        view.tintColor = viewSource == .episode ? ThemeColor.primaryIcon02() : .white
         view.translatesAutoresizingMaskIntoConstraints = false
         return view
     }()
@@ -50,8 +57,13 @@ class TranscriptErrorView: UIView {
         retryButton.setTitle(L10n.tryAgain, for: .normal)
         retryButton.addTarget(self, action: #selector(retryLoad), for: .touchUpInside)
 
-        retryButton.setTitleColor(.white, for: .normal)
-        retryButton.tintColor = .white.withAlphaComponent(0.2)
+        if viewSource == .episode {
+            retryButton.setTitleColor(ThemeColor.primaryText01(), for: .normal)
+            retryButton.tintColor = ThemeColor.primaryUi05()
+        } else {
+            retryButton.setTitleColor(.white, for: .normal)
+            retryButton.tintColor = .white.withAlphaComponent(0.2)
+        }
         retryButton.layer.masksToBounds = true
         retryButton.configuration = configuration
         retryButton.titleLabel?.font = UIFont.preferredFont(forTextStyle: .callout)
@@ -67,12 +79,20 @@ class TranscriptErrorView: UIView {
     }()
 
     func setMessage(_ message: String, attributes: [NSAttributedString.Key: Any]) {
-        label.attributedText = NSAttributedString(string: message, attributes: attributes)
+        var updatedAttributes = attributes
+        if viewSource == .episode {
+            updatedAttributes[.foregroundColor] = ThemeColor.primaryText01()
+        }
+        label.attributedText = NSAttributedString(string: message, attributes: updatedAttributes)
     }
 
     func setTextAttributes(_ attributes: [NSAttributedString.Key: Any]) {
         if let text = label.text {
-            label.attributedText = NSAttributedString(string: text, attributes: attributes)
+            var updatedAttributes = attributes
+            if viewSource == .episode {
+                updatedAttributes[.foregroundColor] = ThemeColor.primaryText01()
+            }
+            label.attributedText = NSAttributedString(string: text, attributes: updatedAttributes)
         }
     }
 

--- a/podcasts/TranscriptExcerptView.swift
+++ b/podcasts/TranscriptExcerptView.swift
@@ -64,7 +64,7 @@ class TranscriptExcerptViewModel: ObservableObject, TranscriptExcerptViewModelin
     }
 
     func excerptTapped() {
-        if case .loading = loadingState { return }
+        if loadingState != .success { return }
         tapAction()
         track(.episodeDetailTranscriptCardTapped)
     }

--- a/podcasts/TranscriptExcerptView.swift
+++ b/podcasts/TranscriptExcerptView.swift
@@ -64,7 +64,7 @@ class TranscriptExcerptViewModel: ObservableObject, TranscriptExcerptViewModelin
     }
 
     func excerptTapped() {
-        if loadingState != .success { return }
+        guard loadingState == .success else { return }
         tapAction()
         track(.episodeDetailTranscriptCardTapped)
     }

--- a/podcasts/TranscriptExcerptView.swift
+++ b/podcasts/TranscriptExcerptView.swift
@@ -96,7 +96,7 @@ struct TranscriptExcerptView<ViewModel: TranscriptExcerptViewModeling>: View {
         ZStack {
             Rectangle()
                 .foregroundStyle(.clear)
-                .background(theme.primaryUi04)
+                .background(theme.primaryUi02Active)
                 .cornerRadius(8.0)
                 .shadow(
                     color: .black.opacity(0.2),

--- a/podcasts/TranscriptPlaybackManaging.swift
+++ b/podcasts/TranscriptPlaybackManaging.swift
@@ -1,0 +1,39 @@
+protocol TranscriptPlaybackManaging {
+    var episodeUUID: String? { get }
+    var podcastUUID: String? { get }
+    var parentIdentifier: String? { get }
+
+    func currentTime() -> TimeInterval
+}
+
+extension PlaybackManager: TranscriptPlaybackManaging {
+    var episodeUUID: String? {
+        currentEpisode()?.uuid
+    }
+
+    var parentIdentifier: String? {
+        currentEpisode()?.parentIdentifier()
+    }
+
+    var podcastUUID: String? {
+        currentPodcast?.uuid
+    }
+}
+
+struct TranscriptEpisodeInfoProvider: TranscriptPlaybackManaging {
+    let episodeUUID: String?
+    let podcastUUID: String?
+
+    var parentIdentifier: String? {
+        podcastUUID
+    }
+
+    init(episodeUUID: String, podcastUUID: String) {
+        self.episodeUUID = episodeUUID
+        self.podcastUUID = podcastUUID
+    }
+
+    func currentTime() -> TimeInterval {
+        0
+    }
+}

--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -5,7 +5,7 @@ import PocketCastsUtils
 class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvider {
     let analyticsSource: AnalyticsSource
 
-    private let playbackManager: PlaybackManager
+    private let playbackManager: TranscriptPlaybackManaging
     private var transcript: TranscriptModel?
     private var previousRange: NSRange?
 
@@ -35,15 +35,13 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
 
     var showGeneratedTranscriptsPremiumOverlay: (() -> Void)?
 
-    init(playbackManager: PlaybackManager, source: AnalyticsSource = .player) {
-        self.playbackManager = playbackManager
-        self.analyticsSource = source
-        super.init()
+    private var showFromEpisode: Bool {
+        analyticsSource == .episode
     }
 
-    required override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
-        self.playbackManager = PlaybackManager.shared
-        self.analyticsSource = .player
+    init(playbackManager: TranscriptPlaybackManaging, source: AnalyticsSource = .player) {
+        self.playbackManager = playbackManager
+        self.analyticsSource = source
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -75,14 +73,16 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
     }
 
     func setHasGeneratedTranscripts(_ value: Bool) {
+        let topMargin = showFromEpisode ? 24.0 : 0.0
+
         if FeatureFlag.generatedTranscripts.enabled, value {
-            transcriptViewTopConstraint?.constant = 80.0
-            topGradientTopConstraint?.constant = 100.0
-            topGradientHeightConstraint?.constant = 30.0
+            transcriptViewTopConstraint?.constant = 80.0 + topMargin
+            topGradientTopConstraint?.constant = 100.0 + topMargin
+            topGradientHeightConstraint?.constant = 30.0 + topMargin
         } else {
-            transcriptViewTopConstraint?.constant = 0.0
-            topGradientTopConstraint?.constant = 0.0
-            topGradientHeightConstraint?.constant = Sizes.topGradientHeight
+            transcriptViewTopConstraint?.constant = 0.0 + topMargin
+            topGradientTopConstraint?.constant = 0.0 + topMargin
+            topGradientHeightConstraint?.constant = Sizes.topGradientHeight + topMargin
         }
         updateTextMargins()
     }
@@ -110,7 +110,7 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
         NSLayoutConstraint.activate(
             [
                 transcriptViewTopConstraint,
-                transcriptView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+                transcriptView.bottomAnchor.constraint(equalTo: showFromEpisode ? view.safeAreaLayoutGuide.bottomAnchor : view.bottomAnchor),
                 transcriptView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
                 transcriptView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
             ]
@@ -155,7 +155,7 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
         bottomGradient.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate(
             [
-                bottomGradient.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+                bottomGradient.bottomAnchor.constraint(equalTo: showFromEpisode ? view.safeAreaLayoutGuide.bottomAnchor : view.bottomAnchor),
                 bottomGradient.leadingAnchor.constraint(equalTo: view.leadingAnchor),
                 bottomGradient.trailingAnchor.constraint(equalTo: view.trailingAnchor),
                 bottomGradient.heightAnchor.constraint(equalToConstant: Sizes.bottomGradientHeight)
@@ -170,8 +170,9 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
 
         view.addSubview(stackView)
         stackView.translatesAutoresizingMaskIntoConstraints = false
+        let topMargin = showFromEpisode ? 24.0 : 0.0
         NSLayoutConstraint.activate([
-            stackView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            stackView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: topMargin),
             stackView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 12),
             stackView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -16)
         ])
@@ -245,13 +246,13 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
         label.text = L10n.generatedTranscriptsBanner
         label.numberOfLines = 2
         label.font = .systemFont(ofSize: 13, weight: .medium)
-        label.textColor = .white.withAlphaComponent(0.5)
+        label.textColor = showFromEpisode ? ThemeColor.primaryText01() : .white.withAlphaComponent(0.5)
         label.backgroundColor = .clear
         view.addSubview(label)
 
         let stroke = UIView()
         stroke.translatesAutoresizingMaskIntoConstraints = false
-        stroke.backgroundColor = .white.withAlphaComponent(0.5)
+        stroke.backgroundColor = showFromEpisode ? ThemeColor.primaryUi05() : .white.withAlphaComponent(0.5)
         view.addSubview(stroke)
 
         let bannerLabelLeadingConstraint = label.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 15.0)
@@ -300,20 +301,23 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
     private lazy var closeButton: TintableImageButton! = {
         let closeButton = TintableImageButton()
         closeButton.setImage(UIImage(named: "close"), for: .normal)
-        closeButton.tintColor = ThemeColor.primaryIcon02()
+        closeButton.tintColor = showFromEpisode ? ThemeColor.primaryText01() : ThemeColor.primaryIcon02()
         closeButton.addTarget(self, action: #selector(closeTapped), for: .touchUpInside)
         return closeButton
     }()
 
     private lazy var searchButton: RoundButton = {
+        let titleColor = showFromEpisode ? ThemeColor.primaryText01() : .white
+        let tintColor = showFromEpisode ? ThemeColor.primaryUi05() : .white.withAlphaComponent(0.2)
+
         var configuration = UIButton.Configuration.filled()
         configuration.contentInsets = .init(top: 4, leading: 12, bottom: 4, trailing: 12)
 
         let searchButton = RoundButton(type: .system)
         searchButton.setTitle(L10n.search, for: .normal)
         searchButton.addTarget(self, action: #selector(displaySearch), for: .touchUpInside)
-        searchButton.setTitleColor(.white, for: .normal)
-        searchButton.tintColor = .white.withAlphaComponent(0.2)
+        searchButton.setTitleColor(titleColor, for: .normal)
+        searchButton.tintColor = tintColor
         searchButton.layer.masksToBounds = true
         searchButton.configuration = configuration
         searchButton.titleLabel?.font = UIFont.preferredFont(forTextStyle: .callout)
@@ -362,20 +366,26 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
     }
 
     private func updateColors() {
-        view.backgroundColor = PlayerColorHelper.playerBackgroundColor01()
-        transcriptView.backgroundColor =  PlayerColorHelper.playerBackgroundColor01()
-        transcriptView.textColor = ThemeColor.playerContrast02()
-        transcriptView.indicatorStyle = .white
-        activityIndicatorView.color = ThemeColor.playerContrast02()
+//        let primaryColor =  showFromEpisode ? ThemeColor.primaryUi01() : PlayerColorHelper.playerBackgroundColor01()
+        let primaryColor =  PlayerColorHelper.playerBackgroundColor01()
+        let secondaryColor =  showFromEpisode ? ThemeColor.primaryText01() : ThemeColor.playerContrast02()
+        let activityIndicatorViewColor: UIScrollView.IndicatorStyle = showFromEpisode ? (Theme.sharedTheme.activeTheme.isDark ? .white : .black) : .white
+
+        view.backgroundColor = primaryColor
+        transcriptView.backgroundColor =  primaryColor
+        transcriptView.textColor = secondaryColor
+        transcriptView.indicatorStyle = activityIndicatorViewColor
+        activityIndicatorView.color = secondaryColor
         updateGradientColors()
         if FeatureFlag.generatedTranscripts.enabled {
-            bannerView.backgroundColor = PlayerColorHelper.playerBackgroundColor01()
+            bannerView.backgroundColor = primaryColor
         }
     }
 
     private func updateGradientColors() {
-        topGradient.updateColors(firstColor: Colors.gradientColor, secondColor: Colors.gradientColor.withAlphaComponent(0))
-        bottomGradient.updateColors(firstColor: Colors.gradientColor.withAlphaComponent(0), secondColor: Colors.gradientColor)
+        let gradientColor = showFromEpisode ? ThemeColor.primaryUi01() : Colors.gradientColor
+        topGradient.updateColors(firstColor: gradientColor, secondColor: gradientColor.withAlphaComponent(0))
+        bottomGradient.updateColors(firstColor: gradientColor.withAlphaComponent(0), secondColor: gradientColor)
     }
 
     @objc private func update() {
@@ -406,14 +416,14 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
     private var currentEpisodeUUID: String?
 
     private func loadTranscript() {
-        guard let episode = playbackManager.currentEpisode(), let podcast = playbackManager.currentPodcast else {
+        guard let episodeUUID = playbackManager.episodeUUID, let podcastUUID = playbackManager.podcastUUID else {
             return
         }
 
-        let shouldResetPosition = currentEpisodeUUID != episode.uuid
-        currentEpisodeUUID = episode.uuid
+        let shouldResetPosition = currentEpisodeUUID != episodeUUID
+        currentEpisodeUUID = episodeUUID
 
-        transcriptManager = TranscriptManager(episodeUUID: episode.uuid, podcastUUID: podcast.uuid)
+        transcriptManager = TranscriptManager(episodeUUID: episodeUUID, podcastUUID: podcastUUID)
 
         setupLoadingState()
 
@@ -544,11 +554,10 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
             standardFont =  UIFont(descriptor: descriptor, size: 0)
         }
 
-
         let normalStyle: [NSAttributedString.Key: Any] = [
             .paragraphStyle: paragraphStyle,
             .font: standardFont,
-            .foregroundColor: ThemeColor.playerContrast02()
+            .foregroundColor: showFromEpisode ? ThemeColor.primaryText01() : ThemeColor.playerContrast02()
         ]
 
         return normalStyle
@@ -559,7 +568,7 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
         formattedText.beginEditing()
         let normalStyle = makeStyle()
         var highlightStyle = normalStyle
-        highlightStyle[.foregroundColor] = ThemeColor.playerContrast01()
+        highlightStyle[.foregroundColor] = showFromEpisode ? ThemeColor.primaryText01() : ThemeColor.playerContrast01()
 
         let fullLength = NSRange(location: 0, length: formattedText.length)
         formattedText.addAttributes(normalStyle, range: fullLength)
@@ -581,9 +590,10 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
             let searchTermLength = searchTerm.count
             searchIndicesResult.enumerated().forEach { index, indice in
                 if indice + searchTermLength <= length {
+                    let backgroundColor = showFromEpisode ? ThemeColor.primaryText01().withAlphaComponent(index == currentSearchIndex ? 0.3 : 0.1) : .white.withAlphaComponent(index == currentSearchIndex ? 1 : 0.4)
                     let highlightStyle: [NSAttributedString.Key: Any] = [
-                        .backgroundColor: UIColor.white.withAlphaComponent(index == currentSearchIndex ? 1 : 0.4),
-                        .foregroundColor: index == currentSearchIndex ? UIColor.black : ThemeColor.playerContrast01()
+                        .backgroundColor: backgroundColor,
+                        .foregroundColor: showFromEpisode ? ThemeColor.primaryText01() : index == currentSearchIndex ? UIColor.black : ThemeColor.playerContrast01()
                     ]
 
                     formattedText.addAttributes(highlightStyle, range: NSRange(location: indice, length: searchTermLength))
@@ -728,9 +738,10 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
     func track(_ event: AnalyticsEvent, properties: [AnyHashable: Any] = [:]) {
         var properties = properties
 
-        if let episode = playbackManager.currentEpisode() {
-            properties["episode_uuid"] = episode.uuid
-            properties["podcast_uuid"] = episode.parentIdentifier()
+        if let episodeUUID = playbackManager.episodeUUID,
+           let parentIdentifier = playbackManager.parentIdentifier {
+            properties["episode_uuid"] = episodeUUID
+            properties["podcast_uuid"] = parentIdentifier
         }
 
         properties["source"] = analyticsSource.rawValue

--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -293,7 +293,8 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
     }()
 
     private lazy var errorView: TranscriptErrorView = {
-       TranscriptErrorView { [weak self] in
+        let source: TranscriptErrorView.ViewSource = analyticsSource == .episode ? .episode : .player
+        return TranscriptErrorView(source: source) { [weak self] in
             self?.retryLoad()
         }
     }()
@@ -368,13 +369,14 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
     private func updateColors() {
         let primaryColor =  showFromEpisode ? ThemeColor.primaryUi01() : PlayerColorHelper.playerBackgroundColor01()
         let secondaryColor =  showFromEpisode ? ThemeColor.primaryText01() : ThemeColor.playerContrast02()
-        let activityIndicatorViewColor: UIScrollView.IndicatorStyle = showFromEpisode ? (Theme.sharedTheme.activeTheme.isDark ? .white : .black) : .white
+        let activityIndicatorViewColor: UIColor = showFromEpisode ? ThemeColor.primaryIcon02() : ThemeColor.playerContrast02()
+        let activityIndicatorViewStyle: UIScrollView.IndicatorStyle = showFromEpisode ? (Theme.sharedTheme.activeTheme.isDark ? .white : .black) : .white
 
         view.backgroundColor = primaryColor
         transcriptView.backgroundColor =  primaryColor
         transcriptView.textColor = secondaryColor
-        transcriptView.indicatorStyle = activityIndicatorViewColor
-        activityIndicatorView.color = secondaryColor
+        transcriptView.indicatorStyle = activityIndicatorViewStyle
+        activityIndicatorView.color = activityIndicatorViewColor
         updateGradientColors()
         if FeatureFlag.generatedTranscripts.enabled {
             bannerView.backgroundColor = primaryColor
@@ -589,7 +591,7 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
             let searchTermLength = searchTerm.count
             searchIndicesResult.enumerated().forEach { index, indice in
                 if indice + searchTermLength <= length {
-                    let backgroundColor = showFromEpisode ? ThemeColor.primaryUi02Selected().withAlphaComponent(index == currentSearchIndex ? 1 : 0.4) : .white.withAlphaComponent(index == currentSearchIndex ? 1 : 0.4)
+                    let backgroundColor = showFromEpisode ? ThemeColor.primaryUi05().withAlphaComponent(index == currentSearchIndex ? 1 : 0.6) : .white.withAlphaComponent(index == currentSearchIndex ? 1 : 0.4)
                     let highlightStyle: [NSAttributedString.Key: Any] = [
                         .backgroundColor: backgroundColor,
                         .foregroundColor: showFromEpisode ? ThemeColor.primaryText01() : index == currentSearchIndex ? UIColor.black : ThemeColor.playerContrast01()

--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -78,11 +78,11 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
         if FeatureFlag.generatedTranscripts.enabled, value {
             transcriptViewTopConstraint?.constant = 80.0 + topMargin
             topGradientTopConstraint?.constant = 100.0 + topMargin
-            topGradientHeightConstraint?.constant = 30.0 + topMargin
+            topGradientHeightConstraint?.constant = 30.0
         } else {
             transcriptViewTopConstraint?.constant = 0.0 + topMargin
             topGradientTopConstraint?.constant = 0.0 + topMargin
-            topGradientHeightConstraint?.constant = Sizes.topGradientHeight + topMargin
+            topGradientHeightConstraint?.constant = Sizes.topGradientHeight
         }
         updateTextMargins()
     }

--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -366,8 +366,7 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
     }
 
     private func updateColors() {
-//        let primaryColor =  showFromEpisode ? ThemeColor.primaryUi01() : PlayerColorHelper.playerBackgroundColor01()
-        let primaryColor =  PlayerColorHelper.playerBackgroundColor01()
+        let primaryColor =  showFromEpisode ? ThemeColor.primaryUi01() : PlayerColorHelper.playerBackgroundColor01()
         let secondaryColor =  showFromEpisode ? ThemeColor.primaryText01() : ThemeColor.playerContrast02()
         let activityIndicatorViewColor: UIScrollView.IndicatorStyle = showFromEpisode ? (Theme.sharedTheme.activeTheme.isDark ? .white : .black) : .white
 
@@ -590,7 +589,7 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
             let searchTermLength = searchTerm.count
             searchIndicesResult.enumerated().forEach { index, indice in
                 if indice + searchTermLength <= length {
-                    let backgroundColor = showFromEpisode ? ThemeColor.primaryText01().withAlphaComponent(index == currentSearchIndex ? 0.3 : 0.1) : .white.withAlphaComponent(index == currentSearchIndex ? 1 : 0.4)
+                    let backgroundColor = showFromEpisode ? ThemeColor.primaryUi02Selected().withAlphaComponent(index == currentSearchIndex ? 1 : 0.4) : .white.withAlphaComponent(index == currentSearchIndex ? 1 : 0.4)
                     let highlightStyle: [NSAttributedString.Key: Any] = [
                         .backgroundColor: backgroundColor,
                         .foregroundColor: showFromEpisode ? ThemeColor.primaryText01() : index == currentSearchIndex ? UIColor.black : ThemeColor.playerContrast01()


### PR DESCRIPTION
| 📘 Part of: #3204
|:---:|

Fixes #3201

Adds the new transcript container to display the transcript and premium overlay from the episode view

| Overlay | Generated | Non Generated |
| -------- | ------- | ------- |
| ![IMG_0187](https://github.com/user-attachments/assets/4233a7dd-e93d-4f35-bd03-0516918d4575) | ![IMG_0189](https://github.com/user-attachments/assets/7baa480d-9321-4ae3-b4ab-1b7e0e3647a9) | ![IMG_0188](https://github.com/user-attachments/assets/55ff7222-e80e-4b03-b2dd-afe9dbcb9665) |



## To test

- Make sure you enable `episodeDetailTranscript`
- Make sure you have the tracks logger enabled
- Run it on a real device with a sandbox user
- Start using a free account
- Run the branch, enable the feature flag and navigate to a podcast with generated transcript
- Open an episode and tap on the transcript banner
- ✅ Confirm you see the event `episode_transcript_shown`
- ✅ Confirm you see the event `transcript_generated_paywall_shown` with the property `source: episode`
- Close the view
- ✅ Confirm you see the event `transcript_generated_paywall_dismissed`  with the property `source: episode`
- Reopen it and tap on the Subscribe button
- ✅ Confirm you see the event `transcript_generated_paywall_subscribe_tapped` with the property `source: episode`
- Purchase the plan and confirm you see the transcript with no overlay
- Use the search
- ✅ Confirm you see the event `transcript_search_shown`  with the property `source: episode`
- ✅ Confirm you see the event `transcript_search_next_result`  with the property `source: episode`
- ✅ Confirm you see the event `transcript_search_previous_result`  with the property `source: episode`
- Dismiss the transcript
- ✅ Confirm you see the event `transcript_dismissed`  with the property `source: episode`

### Smoke test
- Do a smoke test with the transcript from the mobile to confirm the colors and events are still working
- when checking for the events from the player, the source should be `source: player`

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
