### PR TITLE
[Banner Ads] Player view

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1779,7 +1779,6 @@
 		F5954D5E2C3F284D004A8C04 /* TrimSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5954D5D2C3F284D004A8C04 /* TrimSelectionView.swift */; };
 		F5954D602C3F2864004A8C04 /* TrimHandle.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5954D5F2C3F2864004A8C04 /* TrimHandle.swift */; };
 		F5A292162DE95F9000C49AC4 /* BannerAdView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5A292152DE95F8C00C49AC4 /* BannerAdView.swift */; };
-		F5A292172DE9638900C49AC4 /* BannerAdView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5A292152DE95F8C00C49AC4 /* BannerAdView.swift */; };
 		F5AD9C4D2C3C705200A01896 /* AudioWaveformView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5AD9C4C2C3C705200A01896 /* AudioWaveformView.swift */; };
 		F5ADE2F42CF52AF100F2CEA7 /* AnalyticsLoggingAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7C4CAEA28AB05A800CFC8CF /* AnalyticsLoggingAdapter.swift */; };
 		F5ADE2F52CF52AFA00F2CEA7 /* TracksAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C72CED31289DA1900017883A /* TracksAdapter.swift */; };
@@ -11314,7 +11313,6 @@
 				F5F509632CEBF70E007D6E39 /* Queue.swift in Sources */,
 				F5F509302CEBEF95007D6E39 /* URLSession+Episode.swift in Sources */,
 				F5F509022CEBEA59007D6E39 /* String+Analytics.swift in Sources */,
-				F5A292172DE9638900C49AC4 /* BannerAdView.swift in Sources */,
 				F5F5094F2CEBF457007D6E39 /* MultipleActionView.swift in Sources */,
 				F5F5095D2CEBF697007D6E39 /* AudioUtils.swift in Sources */,
 				F580777C2DEA032A005AFBA6 /* Theme+Color.swift in Sources */,

--- a/podcasts/Common SwiftUI/BannerAdView.swift
+++ b/podcasts/Common SwiftUI/BannerAdView.swift
@@ -26,6 +26,18 @@ struct BannerAdView: View {
         let icon: Color
         let border: Color?
 
+        static func playerColors(_ theme: Theme) -> Self {
+            return Self(
+                background: theme.playerContrast06,
+                adText: theme.playerContrast01,
+                titleLabel: theme.playerHighlight01,
+                adLabelBackground: theme.playerContrast06,
+                adLabel: theme.playerContrast01,
+                icon: theme.playerContrast02,
+                border: nil
+            )
+        }
+
         static func podcastList(_ theme: Theme) -> Self {
             return Self(
                 background: theme.primaryUi06,

--- a/podcasts/Common SwiftUI/BannerAdView.swift
+++ b/podcasts/Common SwiftUI/BannerAdView.swift
@@ -92,11 +92,12 @@ struct BannerAdView: View {
                 Button(action: {
                     //TODO: Add Ad reporting action in future PR
                 }, label: {
-                    Image(systemName: "ellipsis")
+                    Image(systemName: "xmark")
+                        .font(.system(size: 14))
                         .bold()
                         .foregroundStyle(colors.icon)
                 })
-                .padding(10)
+                .padding(2)
                 Spacer()
             }
         }

--- a/podcasts/Common SwiftUI/BannerAdView.swift
+++ b/podcasts/Common SwiftUI/BannerAdView.swift
@@ -56,6 +56,9 @@ struct BannerAdView: View {
     @EnvironmentObject var theme: Theme
     @Environment(\.sizeCategory) private var sizeCategory
 
+    // We override this because we don't want the ad getting _too_ large. In the player, especially, we run out of space.
+    let maxSizeCategory: UIContentSizeCategory = .accessibilityMedium
+
     init(model: BannerAdModel, colors: Colors) {
         self.model = model
         self.colors = colors
@@ -66,12 +69,12 @@ struct BannerAdView: View {
             creative()
             VStack(alignment: .leading, spacing: 8) {
                 Text(model.adText)
-                    .font(.subheadline.weight(.medium))
+                    .font(size: 14, style: .subheadline, weight: .medium, maxSizeCategory: maxSizeCategory)
                     .foregroundColor(colors.adText)
                     .fixedSize(horizontal: false, vertical: true)
                 HStack(spacing: 4) {
                     Text(model.adLabel)
-                        .font(.caption2.weight(.semibold))
+                        .font(size: 8, style: .caption2, weight: .semibold, maxSizeCategory: maxSizeCategory)
                         .foregroundColor(colors.adLabel)
                         .padding(.horizontal, 4)
                         .padding(.vertical, 2)
@@ -79,7 +82,7 @@ struct BannerAdView: View {
                         .cornerRadius(4)
                     Button(action: { model.onLinkTap?() }) {
                         Text(model.titleLabel)
-                            .font(.footnote.weight(.semibold))
+                            .font(size: 12, style: .footnote, weight: .semibold, maxSizeCategory: maxSizeCategory)
                             .foregroundColor(colors.titleLabel)
                     }
                     .buttonStyle(PlainButtonStyle())

--- a/podcasts/Common SwiftUI/BannerAdView.swift
+++ b/podcasts/Common SwiftUI/BannerAdView.swift
@@ -70,6 +70,7 @@ struct BannerAdView: View {
             VStack(alignment: .leading, spacing: 14) {
                 Text(model.adText)
                     .font(size: 14, style: .subheadline, weight: .medium, maxSizeCategory: maxSizeCategory)
+                    .lineSpacing(-1)
                     .foregroundColor(colors.adText)
                     .fixedSize(horizontal: false, vertical: true)
                 HStack(spacing: 4) {

--- a/podcasts/Common SwiftUI/BannerAdView.swift
+++ b/podcasts/Common SwiftUI/BannerAdView.swift
@@ -30,7 +30,7 @@ struct BannerAdView: View {
             return Self(
                 background: theme.playerContrast06,
                 adText: theme.playerContrast01,
-                titleLabel: theme.playerHighlight01,
+                titleLabel: PlayerColorHelper.playerHighlightColor01(for: .dark),
                 adLabelBackground: theme.playerContrast06,
                 adLabel: theme.playerContrast01,
                 icon: theme.playerContrast02,

--- a/podcasts/Common SwiftUI/BannerAdView.swift
+++ b/podcasts/Common SwiftUI/BannerAdView.swift
@@ -30,7 +30,7 @@ struct BannerAdView: View {
             return Self(
                 background: theme.playerContrast06,
                 adText: theme.playerContrast01,
-                titleLabel: PlayerColorHelper.playerHighlightColor01(for: .dark),
+                titleLabel: PlayerColorHelper.playerHighlightColor01(for: .dark).color,
                 adLabelBackground: theme.playerContrast06,
                 adLabel: theme.playerContrast01,
                 icon: theme.playerContrast02,
@@ -67,7 +67,7 @@ struct BannerAdView: View {
     var body: some View {
         HStack(alignment: .top, spacing: 16) {
             creative()
-            VStack(alignment: .leading, spacing: 8) {
+            VStack(alignment: .leading, spacing: 14) {
                 Text(model.adText)
                     .font(size: 14, style: .subheadline, weight: .medium, maxSizeCategory: maxSizeCategory)
                     .foregroundColor(colors.adText)
@@ -76,7 +76,7 @@ struct BannerAdView: View {
                     Text(model.adLabel)
                         .font(size: 8, style: .caption2, weight: .semibold, maxSizeCategory: maxSizeCategory)
                         .foregroundColor(colors.adLabel)
-                        .padding(.horizontal, 4)
+                        .padding(.horizontal, 3)
                         .padding(.vertical, 2)
                         .background(colors.adLabelBackground)
                         .cornerRadius(4)
@@ -93,7 +93,7 @@ struct BannerAdView: View {
                     //TODO: Add Ad reporting action in future PR
                 }, label: {
                     Image(systemName: "xmark")
-                        .font(.system(size: 14))
+                        .font(.system(size: 12))
                         .bold()
                         .foregroundStyle(colors.icon)
                 })

--- a/podcasts/NowPlayingPlayerItemViewController.swift
+++ b/podcasts/NowPlayingPlayerItemViewController.swift
@@ -210,58 +210,6 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
         #endif
     }
 
-#if !APPCLIP
-    func addAdBanner() {
-        removeBannerAd()
-
-        guard let stackView = episodeImage.superview as? UIStackView else { return }
-
-        let model = BannerAdModel(adText: "Listen to your favorite books while supporting your local indie bookstore",
-                                  imageURL: URL(string: "https://static.pocketcasts.com/discover/images/420/9349e8d0-a87f-013a-d8af-0acc26574db2.jpg")!,
-                                  linkTitle: "Libro.fm")
-        let adView = BannerAdView(model: model, colors: .playerColors(Theme.sharedTheme)).padding(8)
-        let hostingController = PCHostingController(rootView: AnyView(adView))
-
-        hostingController.view.translatesAutoresizingMaskIntoConstraints = false
-        hostingController.view.backgroundColor = .clear
-
-        let targetSize = CGSize(width: stackView.bounds.width, height: UIView.layoutFittingCompressedSize.height)
-        let size = hostingController.sizeThatFits(in: targetSize)
-
-        addChild(hostingController)
-        stackView.insertArrangedSubview(hostingController.view, at: 0)
-
-        let heightConstraint = hostingController.view.heightAnchor.constraint(equalToConstant: size.height)
-        NSLayoutConstraint.activate([heightConstraint])
-
-        hostingController.didMove(toParent: self)
-        bannerAdHostingController = hostingController
-        bannerAdHeightConstraint = heightConstraint
-    }
-#endif
-
-    private func removeBannerAd() {
-        guard let hostingController = bannerAdHostingController else { return }
-
-        hostingController.willMove(toParent: nil)
-        hostingController.view.removeFromSuperview()
-        hostingController.removeFromParent()
-        bannerAdHostingController = nil
-        bannerAdHeightConstraint = nil
-    }
-
-    private func updateBannerAdHeight() {
-        guard let hostingController = bannerAdHostingController,
-              let heightConstraint = bannerAdHeightConstraint,
-              let stackView = episodeImage.superview as? UIStackView else { return }
-
-        let targetSize = CGSize(width: stackView.bounds.width, height: UIView.layoutFittingCompressedSize.height)
-        let size = hostingController.sizeThatFits(in: targetSize)
-
-        heightConstraint.constant = size.height
-        view.layoutIfNeeded()
-    }
-
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
@@ -300,7 +248,12 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
         lastBoundsAdjustedFor = view.bounds
 
         resizeControls()
-        updateBannerAdHeight()
+
+        #if !APPCLIP
+        if FeatureFlag.bannerAds.enabled {
+            updateBannerAdHeight()
+        }
+        #endif
     }
 
     private func resizeControls() {
@@ -321,7 +274,12 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
 
     override func willBeRemovedFromPlayer() {
         removeAllCustomObservers()
-        removeBannerAd()
+
+        #if !APPCLIP
+        if FeatureFlag.bannerAds.enabled {
+            removeBannerAd()
+        }
+        #endif
     }
 
     override func themeDidChange() {
@@ -332,10 +290,14 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
 
-        // Update banner height when text size category changes
-        if traitCollection.preferredContentSizeCategory != previousTraitCollection?.preferredContentSizeCategory {
-            updateBannerAdHeight()
+        #if !APPCLIP
+        if FeatureFlag.bannerAds.enabled {
+            // Update banner height when text size category changes
+            if traitCollection.preferredContentSizeCategory != previousTraitCollection?.preferredContentSizeCategory {
+                updateBannerAdHeight()
+            }
         }
+        #endif
     }
 
     // MARK: - Interface Actions
@@ -514,5 +476,58 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
             skipFwdBtn.finishedTransition()
         })
     }
+
+    //MARK: Banner Ad
+
+    func addAdBanner() {
+        removeBannerAd()
+
+        guard let stackView = episodeImage.superview as? UIStackView else { return }
+
+        let model = BannerAdModel(adText: "Listen to your favorite books while supporting your local indie bookstore",
+                                  imageURL: URL(string: "https://static.pocketcasts.com/discover/images/420/9349e8d0-a87f-013a-d8af-0acc26574db2.jpg")!,
+                                  linkTitle: "Libro.fm")
+        let adView = BannerAdView(model: model, colors: .playerColors(Theme.sharedTheme)).padding(8)
+        let hostingController = PCHostingController(rootView: AnyView(adView))
+
+        hostingController.view.translatesAutoresizingMaskIntoConstraints = false
+        hostingController.view.backgroundColor = .clear
+
+        let targetSize = CGSize(width: stackView.bounds.width, height: UIView.layoutFittingCompressedSize.height)
+        let size = hostingController.sizeThatFits(in: targetSize)
+
+        addChild(hostingController)
+        stackView.insertArrangedSubview(hostingController.view, at: 0)
+
+        let heightConstraint = hostingController.view.heightAnchor.constraint(equalToConstant: size.height)
+        NSLayoutConstraint.activate([heightConstraint])
+
+        hostingController.didMove(toParent: self)
+        bannerAdHostingController = hostingController
+        bannerAdHeightConstraint = heightConstraint
+    }
+
+    private func removeBannerAd() {
+        guard let hostingController = bannerAdHostingController else { return }
+
+        hostingController.willMove(toParent: nil)
+        hostingController.view.removeFromSuperview()
+        hostingController.removeFromParent()
+        bannerAdHostingController = nil
+        bannerAdHeightConstraint = nil
+    }
+
+    private func updateBannerAdHeight() {
+        guard let hostingController = bannerAdHostingController,
+              let heightConstraint = bannerAdHeightConstraint,
+              let stackView = episodeImage.superview as? UIStackView else { return }
+
+        let targetSize = CGSize(width: stackView.bounds.width, height: UIView.layoutFittingCompressedSize.height)
+        let size = hostingController.sizeThatFits(in: targetSize)
+
+        heightConstraint.constant = size.height
+        view.layoutIfNeeded()
+    }
+
     #endif
 }

--- a/podcasts/NowPlayingPlayerItemViewController.swift
+++ b/podcasts/NowPlayingPlayerItemViewController.swift
@@ -477,7 +477,7 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
         })
     }
 
-    //MARK: Banner Ad
+    // MARK: Banner Ad
 
     func addAdBanner() {
         removeBannerAd()

--- a/podcasts/NowPlayingPlayerItemViewController.swift
+++ b/podcasts/NowPlayingPlayerItemViewController.swift
@@ -4,6 +4,7 @@ import Agrume
 import AVKit
 import SafariServices
 import UIKit
+import PocketCastsUtils
 
 class NowPlayingPlayerItemViewController: PlayerItemViewController {
     var showingCustomImage = false
@@ -199,6 +200,28 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
 
         routePicker.delegate = self
         #endif
+
+        if FeatureFlag.bannerAds.enabled {
+            addAdBanner()
+        }
+    }
+
+    func addAdBanner() {
+        if let stackView = episodeImage.superview as? UIStackView {
+            let model = BannerAdModel(adText: "Listen to your favorite books while supporting your local indie bookstore",
+                                      imageURL: URL(string: "https://static.pocketcasts.com/discover/images/420/9349e8d0-a87f-013a-d8af-0acc26574db2.jpg")!,
+                                      linkTitle: "Libro.fm")
+            let adView = BannerAdView(model: model, colors: .playerColors(Theme.sharedTheme)).environmentObject(Theme.sharedTheme).padding(4)
+            let adUiView = adView.uiView
+            adUiView.translatesAutoresizingMaskIntoConstraints = false
+            adUiView.backgroundColor = .clear
+            //TODO: Add child VC
+            stackView.insertArrangedSubview(adUiView, at: 0)
+            // Add a constraint for adUiView which sets height to 150
+            NSLayoutConstraint.activate([
+                adUiView.heightAnchor.constraint(equalToConstant: 150)
+            ])
+        }
     }
 
     override func viewDidAppear(_ animated: Bool) {

--- a/podcasts/NowPlayingPlayerItemViewController.swift
+++ b/podcasts/NowPlayingPlayerItemViewController.swift
@@ -184,8 +184,9 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
     #endif
 
     var lastShelfLoadState = ShelfLoadState()
-    
+
     private var bannerAdHostingController: PCHostingController<AnyView>?
+    private var bannerAdHeightConstraint: NSLayoutConstraint?
 
     private let analyticsPlaybackHelper = AnalyticsPlaybackHelper.shared
 
@@ -202,19 +203,19 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
         chromecastBtn.isPointerInteractionEnabled = true
 
         routePicker.delegate = self
-        #endif
 
         if FeatureFlag.bannerAds.enabled {
             addAdBanner()
         }
+        #endif
     }
 
+#if !APPCLIP
     func addAdBanner() {
-        // Remove existing banner if any
         removeBannerAd()
-        
+
         guard let stackView = episodeImage.superview as? UIStackView else { return }
-        
+
         let model = BannerAdModel(adText: "Listen to your favorite books while supporting your local indie bookstore",
                                   imageURL: URL(string: "https://static.pocketcasts.com/discover/images/420/9349e8d0-a87f-013a-d8af-0acc26574db2.jpg")!,
                                   linkTitle: "Libro.fm")
@@ -223,30 +224,42 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
 
         hostingController.view.translatesAutoresizingMaskIntoConstraints = false
         hostingController.view.backgroundColor = .clear
-        
-        // Calculate the proper size for the banner
+
         let targetSize = CGSize(width: stackView.bounds.width, height: UIView.layoutFittingCompressedSize.height)
         let size = hostingController.sizeThatFits(in: targetSize)
-        
+
         addChild(hostingController)
         stackView.insertArrangedSubview(hostingController.view, at: 0)
-        
-        // Add height constraint based on the calculated size
-        NSLayoutConstraint.activate([
-            hostingController.view.heightAnchor.constraint(equalToConstant: size.height)
-        ])
-        
+
+        let heightConstraint = hostingController.view.heightAnchor.constraint(equalToConstant: size.height)
+        NSLayoutConstraint.activate([heightConstraint])
+
         hostingController.didMove(toParent: self)
         bannerAdHostingController = hostingController
+        bannerAdHeightConstraint = heightConstraint
     }
-    
+#endif
+
     private func removeBannerAd() {
         guard let hostingController = bannerAdHostingController else { return }
-        
+
         hostingController.willMove(toParent: nil)
         hostingController.view.removeFromSuperview()
         hostingController.removeFromParent()
         bannerAdHostingController = nil
+        bannerAdHeightConstraint = nil
+    }
+
+    private func updateBannerAdHeight() {
+        guard let hostingController = bannerAdHostingController,
+              let heightConstraint = bannerAdHeightConstraint,
+              let stackView = episodeImage.superview as? UIStackView else { return }
+
+        let targetSize = CGSize(width: stackView.bounds.width, height: UIView.layoutFittingCompressedSize.height)
+        let size = hostingController.sizeThatFits(in: targetSize)
+
+        heightConstraint.constant = size.height
+        view.layoutIfNeeded()
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -287,6 +300,7 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
         lastBoundsAdjustedFor = view.bounds
 
         resizeControls()
+        updateBannerAdHeight()
     }
 
     private func resizeControls() {
@@ -313,6 +327,15 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
     override func themeDidChange() {
         lastShelfLoadState = ShelfLoadState()
         update()
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+
+        // Update banner height when text size category changes
+        if traitCollection.preferredContentSizeCategory != previousTraitCollection?.preferredContentSizeCategory {
+            updateBannerAdHeight()
+        }
     }
 
     // MARK: - Interface Actions

--- a/podcasts/NowPlayingPlayerItemViewController.swift
+++ b/podcasts/NowPlayingPlayerItemViewController.swift
@@ -5,6 +5,7 @@ import AVKit
 import SafariServices
 import UIKit
 import PocketCastsUtils
+import SwiftUI
 
 class NowPlayingPlayerItemViewController: PlayerItemViewController {
     var showingCustomImage = false
@@ -183,6 +184,8 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
     #endif
 
     var lastShelfLoadState = ShelfLoadState()
+    
+    private var bannerAdHostingController: PCHostingController<AnyView>?
 
     private let analyticsPlaybackHelper = AnalyticsPlaybackHelper.shared
 
@@ -207,21 +210,43 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
     }
 
     func addAdBanner() {
-        if let stackView = episodeImage.superview as? UIStackView {
-            let model = BannerAdModel(adText: "Listen to your favorite books while supporting your local indie bookstore",
-                                      imageURL: URL(string: "https://static.pocketcasts.com/discover/images/420/9349e8d0-a87f-013a-d8af-0acc26574db2.jpg")!,
-                                      linkTitle: "Libro.fm")
-            let adView = BannerAdView(model: model, colors: .playerColors(Theme.sharedTheme)).environmentObject(Theme.sharedTheme).padding(4)
-            let adUiView = adView.uiView
-            adUiView.translatesAutoresizingMaskIntoConstraints = false
-            adUiView.backgroundColor = .clear
-            //TODO: Add child VC
-            stackView.insertArrangedSubview(adUiView, at: 0)
-            // Add a constraint for adUiView which sets height to 150
-            NSLayoutConstraint.activate([
-                adUiView.heightAnchor.constraint(equalToConstant: 150)
-            ])
-        }
+        // Remove existing banner if any
+        removeBannerAd()
+        
+        guard let stackView = episodeImage.superview as? UIStackView else { return }
+        
+        let model = BannerAdModel(adText: "Listen to your favorite books while supporting your local indie bookstore",
+                                  imageURL: URL(string: "https://static.pocketcasts.com/discover/images/420/9349e8d0-a87f-013a-d8af-0acc26574db2.jpg")!,
+                                  linkTitle: "Libro.fm")
+        let adView = BannerAdView(model: model, colors: .playerColors(Theme.sharedTheme)).padding(4)
+        let hostingController = PCHostingController(rootView: AnyView(adView))
+
+        hostingController.view.translatesAutoresizingMaskIntoConstraints = false
+        hostingController.view.backgroundColor = .clear
+        
+        // Calculate the proper size for the banner
+        let targetSize = CGSize(width: stackView.bounds.width, height: UIView.layoutFittingCompressedSize.height)
+        let size = hostingController.sizeThatFits(in: targetSize)
+        
+        addChild(hostingController)
+        stackView.insertArrangedSubview(hostingController.view, at: 0)
+        
+        // Add height constraint based on the calculated size
+        NSLayoutConstraint.activate([
+            hostingController.view.heightAnchor.constraint(equalToConstant: size.height)
+        ])
+        
+        hostingController.didMove(toParent: self)
+        bannerAdHostingController = hostingController
+    }
+    
+    private func removeBannerAd() {
+        guard let hostingController = bannerAdHostingController else { return }
+        
+        hostingController.willMove(toParent: nil)
+        hostingController.view.removeFromSuperview()
+        hostingController.removeFromParent()
+        bannerAdHostingController = nil
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -282,6 +307,7 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
 
     override func willBeRemovedFromPlayer() {
         removeAllCustomObservers()
+        removeBannerAd()
     }
 
     override func themeDidChange() {

--- a/podcasts/NowPlayingPlayerItemViewController.swift
+++ b/podcasts/NowPlayingPlayerItemViewController.swift
@@ -219,7 +219,7 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
         let model = BannerAdModel(adText: "Listen to your favorite books while supporting your local indie bookstore",
                                   imageURL: URL(string: "https://static.pocketcasts.com/discover/images/420/9349e8d0-a87f-013a-d8af-0acc26574db2.jpg")!,
                                   linkTitle: "Libro.fm")
-        let adView = BannerAdView(model: model, colors: .playerColors(Theme.sharedTheme)).padding(4)
+        let adView = BannerAdView(model: model, colors: .playerColors(Theme.sharedTheme)).padding(8)
         let hostingController = PCHostingController(rootView: AnyView(adView))
 
         hostingController.view.translatesAutoresizingMaskIntoConstraints = false

--- a/podcasts/PlayerContainerViewController.xib
+++ b/podcasts/PlayerContainerViewController.xib
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23094" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23727" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23084"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23721"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -26,56 +25,61 @@
             <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="tuk-fS-Mph" userLabel="Header View">
+                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="cFq-QB-iNh">
                     <rect key="frame" x="0.0" y="0.0" width="414" height="60"/>
                     <subviews>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" pointerInteraction="YES" translatesAutoresizingMaskIntoConstraints="NO" id="n9H-5y-Rbm" userLabel="Close Button" customClass="ThemeableUIButton" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
-                            <rect key="frame" x="14" y="16" width="44" height="44"/>
-                            <accessibility key="accessibilityConfiguration" identifier="Close player" label="Close player"/>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="tuk-fS-Mph" userLabel="Header View">
+                            <rect key="frame" x="0.0" y="0.0" width="414" height="60"/>
+                            <subviews>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" pointerInteraction="YES" translatesAutoresizingMaskIntoConstraints="NO" id="n9H-5y-Rbm" userLabel="Close Button" customClass="ThemeableUIButton" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
+                                    <rect key="frame" x="14" y="16" width="44" height="44"/>
+                                    <accessibility key="accessibilityConfiguration" identifier="Close player" label="Close player"/>
+                                    <constraints>
+                                        <constraint firstAttribute="height" constant="44" id="YgN-8A-XLV"/>
+                                        <constraint firstAttribute="width" constant="44" id="tQf-4Q-6eX"/>
+                                    </constraints>
+                                    <state key="normal" image="episode-close"/>
+                                    <connections>
+                                        <action selector="closeTapped:" destination="-1" eventType="touchUpInside" id="oRk-so-QO5"/>
+                                    </connections>
+                                </button>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="DY8-o1-Oqt" customClass="PlayerTabsView" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
+                                    <rect key="frame" x="62" y="18" width="278" height="40"/>
+                                    <constraints>
+                                        <constraint firstAttribute="height" constant="40" placeholder="YES" id="fvZ-1o-n3k"/>
+                                    </constraints>
+                                </view>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" pointerInteraction="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HBu-bE-aeT" customClass="UpNextButton" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
+                                    <rect key="frame" x="360" y="14" width="44" height="44"/>
+                                    <accessibility key="accessibilityConfiguration" label="Up Next List"/>
+                                    <constraints>
+                                        <constraint firstAttribute="height" constant="44" id="Uoj-jj-poH"/>
+                                        <constraint firstAttribute="width" constant="44" id="iNo-lG-GYf"/>
+                                    </constraints>
+                                    <connections>
+                                        <action selector="upNextTapped:" destination="-1" eventType="touchUpInside" id="I6U-14-xLM"/>
+                                    </connections>
+                                </button>
+                            </subviews>
                             <constraints>
-                                <constraint firstAttribute="height" constant="44" id="YgN-8A-XLV"/>
-                                <constraint firstAttribute="width" constant="44" id="tQf-4Q-6eX"/>
-                            </constraints>
-                            <state key="normal" image="episode-close"/>
-                            <connections>
-                                <action selector="closeTapped:" destination="-1" eventType="touchUpInside" id="oRk-so-QO5"/>
-                            </connections>
-                        </button>
-                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="DY8-o1-Oqt" customClass="PlayerTabsView" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
-                            <rect key="frame" x="62" y="18" width="278" height="40"/>
-                            <constraints>
-                                <constraint firstAttribute="height" constant="40" placeholder="YES" id="fvZ-1o-n3k"/>
+                                <constraint firstAttribute="bottom" secondItem="n9H-5y-Rbm" secondAttribute="bottom" id="75X-MC-iuO"/>
+                                <constraint firstAttribute="trailing" secondItem="HBu-bE-aeT" secondAttribute="trailing" constant="10" id="A5g-u0-D5V"/>
+                                <constraint firstItem="DY8-o1-Oqt" firstAttribute="centerY" secondItem="HBu-bE-aeT" secondAttribute="centerY" constant="2" id="Igm-ry-DNo"/>
+                                <constraint firstItem="DY8-o1-Oqt" firstAttribute="leading" secondItem="n9H-5y-Rbm" secondAttribute="trailing" constant="4" id="LZm-RF-qiW"/>
+                                <constraint firstItem="HBu-bE-aeT" firstAttribute="leading" secondItem="DY8-o1-Oqt" secondAttribute="trailing" constant="20" id="OYA-T1-dGq"/>
+                                <constraint firstAttribute="bottom" secondItem="HBu-bE-aeT" secondAttribute="bottom" constant="2" id="QvH-py-N3Q"/>
+                                <constraint firstAttribute="height" constant="60" id="c5W-M4-Gcb"/>
+                                <constraint firstItem="n9H-5y-Rbm" firstAttribute="leading" secondItem="tuk-fS-Mph" secondAttribute="leading" constant="14" id="liR-iX-SIQ"/>
                             </constraints>
                         </view>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" pointerInteraction="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HBu-bE-aeT" customClass="UpNextButton" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
-                            <rect key="frame" x="360" y="14" width="44" height="44"/>
-                            <accessibility key="accessibilityConfiguration" label="Up Next List"/>
-                            <constraints>
-                                <constraint firstAttribute="height" constant="44" id="Uoj-jj-poH"/>
-                                <constraint firstAttribute="width" constant="44" id="iNo-lG-GYf"/>
-                            </constraints>
-                            <connections>
-                                <action selector="upNextTapped:" destination="-1" eventType="touchUpInside" id="I6U-14-xLM"/>
-                            </connections>
-                        </button>
                     </subviews>
-                    <constraints>
-                        <constraint firstAttribute="bottom" secondItem="n9H-5y-Rbm" secondAttribute="bottom" id="75X-MC-iuO"/>
-                        <constraint firstAttribute="trailing" secondItem="HBu-bE-aeT" secondAttribute="trailing" constant="10" id="A5g-u0-D5V"/>
-                        <constraint firstItem="DY8-o1-Oqt" firstAttribute="centerY" secondItem="HBu-bE-aeT" secondAttribute="centerY" constant="2" id="Igm-ry-DNo"/>
-                        <constraint firstItem="DY8-o1-Oqt" firstAttribute="leading" secondItem="n9H-5y-Rbm" secondAttribute="trailing" constant="4" id="LZm-RF-qiW"/>
-                        <constraint firstItem="HBu-bE-aeT" firstAttribute="leading" secondItem="DY8-o1-Oqt" secondAttribute="trailing" constant="20" id="OYA-T1-dGq"/>
-                        <constraint firstAttribute="bottom" secondItem="HBu-bE-aeT" secondAttribute="bottom" constant="2" id="QvH-py-N3Q"/>
-                        <constraint firstAttribute="height" constant="60" id="c5W-M4-Gcb"/>
-                        <constraint firstItem="n9H-5y-Rbm" firstAttribute="leading" secondItem="tuk-fS-Mph" secondAttribute="leading" constant="14" id="liR-iX-SIQ"/>
-                    </constraints>
-                </view>
+                </stackView>
                 <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" directionalLockEnabled="YES" pagingEnabled="YES" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jyM-S1-fQW" customClass="RegionCancellingScrollView" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
                     <rect key="frame" x="0.0" y="126" width="414" height="770"/>
                     <viewLayoutGuide key="contentLayoutGuide" id="Pc0-T1-vhz"/>
                     <viewLayoutGuide key="frameLayoutGuide" id="Phq-79-GHM"/>
                 </scrollView>
-                <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="wCD-j3-45q">
+                <view hidden="YES" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="wCD-j3-45q">
                     <rect key="frame" x="0.0" y="18" width="414" height="878"/>
                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                 </view>
@@ -83,16 +87,15 @@
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
+                <constraint firstItem="jyM-S1-fQW" firstAttribute="top" secondItem="cFq-QB-iNh" secondAttribute="bottom" id="8Us-Dp-0IV"/>
                 <constraint firstItem="jyM-S1-fQW" firstAttribute="trailing" secondItem="i5M-Pr-FkT" secondAttribute="trailing" id="Nab-fL-WgB"/>
                 <constraint firstItem="wCD-j3-45q" firstAttribute="width" secondItem="i5M-Pr-FkT" secondAttribute="width" id="NhE-5h-6lm"/>
-                <constraint firstItem="jyM-S1-fQW" firstAttribute="top" secondItem="tuk-fS-Mph" secondAttribute="bottom" constant="18" id="QNv-lA-xUW"/>
-                <constraint firstItem="wCD-j3-45q" firstAttribute="top" secondItem="DY8-o1-Oqt" secondAttribute="top" id="RD4-v4-Y6p"/>
+                <constraint firstItem="cFq-QB-iNh" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="RDF-xM-Rpa"/>
                 <constraint firstItem="wCD-j3-45q" firstAttribute="centerX" secondItem="fnl-2z-Ty3" secondAttribute="centerX" id="SFH-FR-Zml"/>
-                <constraint firstAttribute="top" secondItem="tuk-fS-Mph" secondAttribute="top" id="V0b-Ya-heu"/>
                 <constraint firstItem="jyM-S1-fQW" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="Vu0-o1-JuT"/>
-                <constraint firstItem="tuk-fS-Mph" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="ZVO-ed-MuN"/>
                 <constraint firstAttribute="bottom" secondItem="jyM-S1-fQW" secondAttribute="bottom" id="iHP-ln-ubZ"/>
-                <constraint firstAttribute="trailing" secondItem="tuk-fS-Mph" secondAttribute="trailing" id="jMd-Bl-UDQ"/>
+                <constraint firstAttribute="trailing" secondItem="cFq-QB-iNh" secondAttribute="trailing" id="jlq-GB-mk8"/>
+                <constraint firstItem="cFq-QB-iNh" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="liD-bk-2Ho"/>
                 <constraint firstItem="wCD-j3-45q" firstAttribute="bottom" secondItem="jyM-S1-fQW" secondAttribute="bottom" placeholder="YES" id="tMr-pU-IJP"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>


### PR DESCRIPTION
| 📘 Part of: #3208 |
|:---:|

Fixes #3209

* Adds a banner view to the player
* Adjusts player colors
* Changes the ellipsis button to an x

|||
|--|--|
| ![Simulator Screenshot - iPhone 16 - 2025-06-05 at 13 13 42](https://github.com/user-attachments/assets/4a683903-83b8-49a3-a52a-badc2f9e403b) | ![Simulator Screenshot - iPhone 16 - 2025-06-05 at 13 13 34](https://github.com/user-attachments/assets/589f1828-6d26-430b-9e39-aacdf343c632) |

## To test

* Enable the `banner_ads` feature flag
* Restart the app
* Play an episode
* ✅ Verify that the ad banner appears on top of the player

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
