### PR TITLE
Provision SwiftLint via SwiftPM

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,3 +1,103 @@
-swiftlint_version: 0.54.0
-parent_config: https://raw.githubusercontent.com/Automattic/swiftlint-config/0f8ab6388bd8d15a04391825ab125f80cfb90704/.swiftlint.yml
-remote_timeout: 10.0
+swiftlint_version: 0.58.2
+
+# Project configuration
+#
+excluded:
+  - BuildTools/.build
+  - DerivedData
+  - fastlane
+  # Enumerate without pattern because it makes SwiftLint resolved faster
+  - Modules/DataModel/.build
+  - Modules/Server/.build
+  - Modules/Utils/.build
+  - Pods
+  - Scripts
+  # Automattic's CI caching setup may generate this in the project folder
+  - Users/builder/Library/Caches/CocoaPods/Pods
+  - vendor
+
+# Rules – Opt-in only, so we can progressively introduce new ones
+#
+only_rules:
+  # Colons should be next to the identifier when specifying a type.
+  - colon
+
+  # There should be no space before and one after any comma.
+  - comma
+
+  # if,for,while,do statements shouldn't wrap their conditionals in parentheses.
+  - control_statement
+
+  # Arguments can be omitted when matching enums with associated types if they
+  # are not used.
+  - empty_enum_arguments
+
+  # Prefer `() -> ` over `Void -> `.
+  - empty_parameters
+
+  # MARK comment should be in valid format.
+  - mark
+
+  # Opening braces should be preceded by a single space and on the same line as
+  # the declaration.
+  - opening_brace
+
+  # Files should have a single trailing newline.
+  - trailing_newline
+
+  # Lines should not have trailing semicolons.
+  - trailing_semicolon
+
+  # Lines should not have trailing whitespace.
+  - trailing_whitespace
+
+  - custom_rules
+
+# Rules configuration
+#
+control_statement:
+  severity: error
+
+trailing_whitespace:
+  ignores_empty_lines: false
+  ignores_comments: false
+
+# Custom rules
+#
+custom_rules:
+  natural_content_alignment:
+    name: "Natural Content Alignment"
+    regex: '\.contentHorizontalAlignment(\s*)=(\s*)(\.left|\.right)'
+    message: "Forcing content alignment left or right can affect the Right-to-Left layout. Use naturalContentHorizontalAlignment instead."
+    severity: warning
+
+  natural_text_alignment:
+    name: "Natural Text Alignment"
+    regex: '\.textAlignment(\s*)=(\s*).left'
+    message: "Forcing text alignment to left can affect the Right-to-Left layout. Consider setting it to `natural`"
+    severity: warning
+
+  inverse_text_alignment:
+    name: "Inverse Text Alignment"
+    regex: '\.textAlignment(\s*)=(\s*).right'
+    message: "When forcing text alignment to the right, be sure to handle the Right-to-Left layout case properly, and then silence this warning with this line `// swiftlint:disable:next inverse_text_alignment`"
+    severity: warning
+
+  localization_comment:
+    name: "Localization Comment"
+    regex: 'NSLocalizedString([^,]+,\s+comment:\s*"")'
+    message: "Localized strings should include a description giving context for how the string is used."
+    severity: warning
+
+  string_interpolation_in_localized_string:
+    name: "String Interpolation in Localized String"
+    regex: 'NSLocalizedString\("[^"]*\\\(\S*\)'
+    message: "Localized strings must not use interpolated variables. Instead, use `String(format:`"
+    severity: error
+
+  swiftui_localization:
+    name: "SwiftUI Localization"
+    regex: 'LocalizedStringKey'
+    message: "Using `LocalizedStringKey` is incompatible with our tooling and doesn't allow you to provide a hint/context comment for translators either. Please use `NSLocalizedString` instead, even with SwiftUI code."
+    severity: error
+    excluded: '.*Widgets/.*'

--- a/BuildTools/Empty.swift
+++ b/BuildTools/Empty.swift
@@ -1,0 +1,2 @@
+// Here only to satisfy SwiftPM requirement.
+// See https://github.com/nicklockwood/SwiftFormat#1-create-a-buildtools-folder-and-packageswift

--- a/BuildTools/Package.resolved
+++ b/BuildTools/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "c6737edfd7078ad723024c817b128ee40ff5b15528bfa853fed61579c49e4882",
+  "pins" : [
+    {
+      "identity" : "swiftlintplugins",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SimplyDanny/SwiftLintPlugins",
+      "state" : {
+        "revision" : "7a3d77f3dd9f91d5cea138e52c20cfceabf352de",
+        "version" : "0.58.2"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/BuildTools/Package.swift
+++ b/BuildTools/Package.swift
@@ -1,0 +1,37 @@
+// swift-tools-version:6.0
+import Foundation
+import PackageDescription
+
+let package = Package(
+    name: "BuildTools",
+    platforms: [.macOS(.v10_13)],
+    dependencies: [
+        .package(url: "https://github.com/SimplyDanny/SwiftLintPlugins", exact: "0.58.2"),
+    ],
+    targets: [.target(name: "BuildTools", path: "")]
+)
+
+func loadSwiftLintVersion() -> Version {
+    let swiftLintConfigURL = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .appendingPathComponent("..")
+        .appendingPathComponent(".swiftlint.yml")
+
+    guard let yamlString = try? String(contentsOf: swiftLintConfigURL) else {
+        fatalError("Failed to read SwiftLint config file at \(swiftLintConfigURL).")
+    }
+
+    guard let versionLine = yamlString.components(separatedBy: .newlines)
+        .first(where: { $0.contains("swiftlint_version") }) else {
+        fatalError("SwiftLint version not found in YAML file.")
+    }
+
+    // Assumes the format `swiftlint_version: <version>`
+    guard let version = Version(versionLine.components(separatedBy: ":")
+        .last?
+        .trimmingCharacters(in: .whitespaces) ?? "") else {
+        fatalError("Failed to extract SwiftLint version.")
+    }
+
+    return version
+}

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,17 @@
 BUNDLE=rbenv exec bundle
 LANG_VAR=LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
 FASTLANE=$(LANG_VAR) $(BUNDLE) exec fastlane
-SWIFTLINT=./Pods/SwiftLint/swiftlint
+SWIFTLINT_FROM_BUILDTOOLS=swiftlint lint --working-directory .. --quiet
+
+define run_in_buildtools
+	@pushd BuildTools && \
+	export SDKROOT=$$(xcrun --sdk macosx --show-sdk-path) && \
+	swift package plugin \
+		--allow-writing-to-directory .. \
+		--allow-writing-to-package-directory \
+		$(1) && \
+	popd
+endef
 
 help: ## Show this list of commands
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
@@ -13,10 +23,10 @@ generate_colors: ## Generate colors and themes based on themes.csv
 	ruby scripts/themes/generate_themes.rb scripts/themes/theme.csv
 
 lint:
-	$(SWIFTLINT) lint --quiet
+	$(call run_in_buildtools,$(SWIFTLINT_FROM_BUILDTOOLS))
 
 format:
-	$(SWIFTLINT) lint --autocorrect --quiet
+	$(call run_in_buildtools,$(SWIFTLINT_FROM_BUILDTOOLS) --autocorrect)
 
 upload_dsyms: ## Upload dSYMs
 	./scripts/upload-symbols -gsp $(HOME)/.configure/pocketcasts-ios/secrets/GoogleService-Info.plist -p ios ./podcasts.app.dSYM.zip

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,9 @@ generate_colors: ## Generate colors and themes based on themes.csv
 lint:
 	$(call run_in_buildtools,$(SWIFTLINT_FROM_BUILDTOOLS))
 
+lint_lenient:
+	$(call run_in_buildtools,$(SWIFTLINT_FROM_BUILDTOOLS) --lenient)
+
 format:
 	$(call run_in_buildtools,$(SWIFTLINT_FROM_BUILDTOOLS) --autocorrect)
 

--- a/Podfile
+++ b/Podfile
@@ -12,12 +12,6 @@ def common_pods
   pod 'google-cast-sdk-no-bluetooth', git: 'https://github.com/Automattic/google-cast'
 end
 
-def swiftlint_version
-  require 'yaml'
-
-  YAML.load_file('.swiftlint.yml')['swiftlint_version']
-end
-
 target 'podcasts' do
   platform :ios, app_ios_deployment_target.version
   common_pods
@@ -32,7 +26,6 @@ abstract_target 'CI' do
   platform :ios, app_ios_deployment_target.version
 
   pod 'SwiftGen', '~> 6.0'
-  pod 'SwiftLint', swiftlint_version
 end
 
 post_install do |installer|

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,17 +1,14 @@
 PODS:
   - google-cast-sdk-no-bluetooth (1.2.0)
   - SwiftGen (6.5.1)
-  - SwiftLint (0.54.0)
 
 DEPENDENCIES:
   - google-cast-sdk-no-bluetooth (from `https://github.com/Automattic/google-cast`)
   - SwiftGen (~> 6.0)
-  - SwiftLint (= 0.54.0)
 
 SPEC REPOS:
   trunk:
     - SwiftGen
-    - SwiftLint
 
 EXTERNAL SOURCES:
   google-cast-sdk-no-bluetooth:
@@ -25,8 +22,7 @@ CHECKOUT OPTIONS:
 SPEC CHECKSUMS:
   google-cast-sdk-no-bluetooth: 97f3b1286fa2fa158ec47975b4bb758908a27b2d
   SwiftGen: a6d22010845f08fe18fbdf3a07a8e380fd22e0ea
-  SwiftLint: c1de071d9d08c8aba837545f6254315bc900e211
 
-PODFILE CHECKSUM: e8c602e42843a67ff3180450a699964354fdcbfa
+PODFILE CHECKSUM: b5d763d93ecf3bcd6096fe166c48315fe121b0fa
 
 COCOAPODS: 1.15.2

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -9722,7 +9722,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "[ $CI ] && exit 0\n./Pods/SwiftLint/swiftlint --lenient\n";
+			shellScript = "[ $CI ] && exit 0\nmake lint_lenient\n";
 		};
 		3F407FBC28EC30B800818E41 /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -9835,13 +9835,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-podcasts/Pods-podcasts-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-podcasts/Pods-podcasts-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -9874,13 +9870,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-PocketCastsTests/Pods-PocketCastsTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-PocketCastsTests/Pods-PocketCastsTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;


### PR DESCRIPTION
Updates how we fetch SwiftLint from using CocoaPods to SwiftPM. This brings us one step closer to no longer relying on CocoaPods, which is now in maintenance mode, and using a single dependency manager for all our Swift libraries and tools.

Closes https://linear.app/a8c/issue/AINFRA-449
<!-- Please include a summary of what this PR is changing and why these changes are needed. -->



## To test

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->
The SwiftLint set up in the repo does not run in CI. To verify this PR works, checkout locally and run a build.

![image](https://github.com/user-attachments/assets/31e3401e-e7fb-424d-b198-f93a713e088a)


## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary. – N.A.
- [x] I have considered adding unit tests for my changes. – N.A.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics. – N.A.
