### PR TITLE
Use SwiftPM to provision SwiftGen

### DIFF
--- a/.buildkite/commands/shared_setup.sh
+++ b/.buildkite/commands/shared_setup.sh
@@ -4,7 +4,7 @@ echo "--- :ruby: Setting up Ruby tools"
 install_gems
 
 echo "--- :cocoapods: Setting up Pods"
-install_cocoapods
+bundle exec pod install
 
 echo "--- :swift: Installing Swift Package Manager Dependencies"
 install_swiftpm_dependencies

--- a/BuildTools/Package.resolved
+++ b/BuildTools/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "c6737edfd7078ad723024c817b128ee40ff5b15528bfa853fed61579c49e4882",
+  "originHash" : "a1ab420392bfa8dc68f7cfaa50463766423701e5565674aec099d8dd3d3d85db",
   "pins" : [
+    {
+      "identity" : "swiftgenplugin",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SwiftGen/SwiftGenPlugin",
+      "state" : {
+        "revision" : "879b85a470cacd70c19e22eb7e11a3aed66f4068",
+        "version" : "6.6.2"
+      }
+    },
     {
       "identity" : "swiftlintplugins",
       "kind" : "remoteSourceControl",

--- a/BuildTools/Package.swift
+++ b/BuildTools/Package.swift
@@ -7,6 +7,7 @@ let package = Package(
     platforms: [.macOS(.v10_13)],
     dependencies: [
         .package(url: "https://github.com/SimplyDanny/SwiftLintPlugins", exact: "0.58.2"),
+        .package(url: "https://github.com/SwiftGen/SwiftGenPlugin", from: "6.5.1")
     ],
     targets: [.target(name: "BuildTools", path: "")]
 )

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,9 @@ swift_percentage: ## Swift and Obj-C percentage on the project
 generate_colors: ## Generate colors and themes based on themes.csv
 	ruby scripts/themes/generate_themes.rb scripts/themes/theme.csv
 
+generate_code:
+	$(call run_in_buildtools,generate-code-for-resources --config ../swiftgen.yml)
+
 lint:
 	$(call run_in_buildtools,$(SWIFTLINT_FROM_BUILDTOOLS))
 

--- a/Podfile
+++ b/Podfile
@@ -16,12 +16,6 @@ target 'PocketCastsTests' do
   platform :ios, app_ios_deployment_target.version
 end
 
-abstract_target 'CI' do
-  platform :ios, app_ios_deployment_target.version
-
-  pod 'SwiftGen', '~> 6.0'
-end
-
 post_install do |installer|
   installer.pods_project.targets.each do |target|
     target.build_configurations.each do |config|

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,16 +1,3 @@
-PODS:
-  - SwiftGen (6.6.3)
-
-DEPENDENCIES:
-  - SwiftGen (~> 6.0)
-
-SPEC REPOS:
-  trunk:
-    - SwiftGen
-
-SPEC CHECKSUMS:
-  SwiftGen: 4993cbf71cbc4886f775e26f8d5c3a1188ec9f99
-
-PODFILE CHECKSUM: 7b66b81aa404c914eb6fa8485d8904aa5068e586
+PODFILE CHECKSUM: 378b8ada09cc9cc169eaf11c7c47ddb152ea6d2f
 
 COCOAPODS: 1.15.2

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -9821,27 +9821,6 @@
 			shellPath = /bin/sh;
 			shellScript = "$SRCROOT/scripts/build-phases/post-build-update-plist.sh\n";
 		};
-		CD7B4456FFD51509B59727FB /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-podcasts/Pods-podcasts-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			inputPaths = (
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-podcasts/Pods-podcasts-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-podcasts/Pods-podcasts-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		DF03311AC9ED8455DC9169CD /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -9858,27 +9837,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		E28B605AF2A066CC36E6500E /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-PocketCastsTests/Pods-PocketCastsTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			inputPaths = (
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-PocketCastsTests/Pods-PocketCastsTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-PocketCastsTests/Pods-PocketCastsTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -9777,7 +9777,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [[ -f \"${PODS_ROOT}/SwiftGen/bin/swiftgen\" ]]; then\n  \"${SRCROOT}/Pods/SwiftGen/bin/swiftgen\" config run\nelse\n  echo \"warning: SwiftGen is not installed. Run 'pod install --repo-update' to install it.\"\nfi\n";
+			shellScript = "make generate_code\n";
 		};
 		923032459824EF8540A85F00 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
📘 Part of: https://linear.app/a8c/issue/AINFRA-443 .

By building on top of https://github.com/Automattic/pocket-casts-ios/pull/3238, this PR shows that switching from CocoaPods to SwiftPM works and does not change the generated output.

## To test

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->
Checkout locally and run a build, notice no changes in the generated files.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
Notice that running the new `make generate_code` does not change the
SwiftGen output compared to when it last run via binary sourced with
CocoaPods.