### PR TITLE
[Transcript in Episode View] Update CHANGELOG and enable FF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 7.91
 -----
-- Improve streaming downloads configuration. [#3143](https://github.com/Automattic/pocket-casts-ios/issues/3143)
+- Improve streaming downloads configuration [#3143](https://github.com/Automattic/pocket-casts-ios/issues/3143)
+- Enable transcript excerpt in the episode view [#3204](https://github.com/Automattic/pocket-casts-ios/issues/3204)
 
 7.90
 -----

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -331,7 +331,7 @@ public enum FeatureFlag: String, CaseIterable {
         case .replaceSpecificEpisode:
             true
         case .episodeDetailTranscript:
-            false
+            true
         case .fmdbWithoutActuallyEscaping:
             false
         case .bannerAds:


### PR DESCRIPTION
| 📘 Part of: #3204 
|:---:|

This PR enables the FF and updates the CHANGELOG

## To test

- Run a fresh install
- Open a podcast episode
- Confirm you see the transcript excerpt

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
