### PR TITLE
[Banner ads] Tracking

### DIFF
--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -903,4 +903,8 @@ enum AnalyticsEvent: String {
     case podcastScreenPodrollInformationModelShown
     case podcastScreenPodrollPodcastSubscribed
     case podcastScreenPodrollPodcastTapped
+
+    // MARK: - Banner Ads
+    case bannerAdImpression
+    case bannerAdTapped
 }

--- a/podcasts/AnalyticsHelper.swift
+++ b/podcasts/AnalyticsHelper.swift
@@ -157,6 +157,18 @@ class AnalyticsHelper {
         bumpStat("discover_list_impression", parameters: properties)
     }
 
+    class func bannerImpression(adID: String, source: String) {
+        let properties = ["id": adID, "promotion": source]
+        Analytics.track(.bannerAdImpression, properties: properties)
+        bumpStat("banner_ad_impression", parameters: properties)
+    }
+
+    class func bannerTapped(adID: String, source: String) {
+        let properties = ["id": adID, "promotion": source]
+        Analytics.track(.bannerAdTapped, properties: properties)
+        bumpStat("banner_ad_tapped", parameters: properties)
+    }
+
     class func forceTouchPlay() {
         logEvent("play_force_touch", parameters: nil)
     }

--- a/podcasts/Common SwiftUI/BannerAdView.swift
+++ b/podcasts/Common SwiftUI/BannerAdView.swift
@@ -5,14 +5,18 @@ class BannerAdModel: ObservableObject {
     let imageURL: URL
     let adLabel: String
     let titleLabel: String
+    let adID: String
+    let source: String
     let onLinkTap: (() -> Void)?
 
-    init(adText: String, imageURL: URL, linkTitle: String, titleLabel: String = L10n.bannerAdsInfoLabel, onLinkTap: (() -> Void)? = nil) {
+    init(adText: String, imageURL: URL, linkTitle: String, adID: String, source: String, titleLabel: String = L10n.bannerAdsInfoLabel, onLinkTap: (() -> Void)? = nil) {
         self.adText = adText
         self.imageURL = imageURL
         self.adLabel = titleLabel
         self.titleLabel = linkTitle
         self.onLinkTap = onLinkTap
+        self.adID = adID
+        self.source = source
     }
 }
 
@@ -111,7 +115,11 @@ struct BannerAdView: View {
         }
         .cornerRadius(8)
         .padding(.vertical, 10)
+        .onAppear {
+            AnalyticsHelper.bannerImpression(adID: model.adID, source: model.source)
+        }
         .onTapGesture {
+            AnalyticsHelper.bannerTapped(adID: model.adID, source: model.source)
             model.onLinkTap?()
         }
     }
@@ -142,7 +150,9 @@ struct BannerAdView: View {
         model: .init(
             adText: "Listen to your favorite books while supporting your local indie bookstore",
             imageURL: URL(string: "https://static.pocketcasts.com/discover/images/420/9349e8d0-a87f-013a-d8af-0acc26574db2.jpg")!,
-            linkTitle: "Libro.fm"
+            linkTitle: "Libro.fm",
+            adID: "test-ad-id",
+            source: "test"
         ),
         colors: .podcastList(Theme(previewTheme: .light))
     )
@@ -156,7 +166,9 @@ struct BannerAdView: View {
         model: .init(
             adText: "Listen to your favorite books while supporting your local indie bookstore",
             imageURL: URL(string: "https://static.pocketcasts.com/discover/images/420/9349e8d0-a87f-013a-d8af-0acc26574db2.jpg")!,
-            linkTitle: "Libro.fm"
+            linkTitle: "Libro.fm",
+            adID: "test-ad-id",
+            source: "test"
         ),
         colors: .podcastList(Theme(previewTheme: .light))
     )

--- a/podcasts/Common SwiftUI/BannerAdView.swift
+++ b/podcasts/Common SwiftUI/BannerAdView.swift
@@ -81,12 +81,9 @@ struct BannerAdView: View {
                         .padding(.vertical, 2)
                         .background(colors.adLabelBackground)
                         .cornerRadius(4)
-                    Button(action: { model.onLinkTap?() }) {
-                        Text(model.titleLabel)
-                            .font(size: 12, style: .footnote, weight: .semibold, maxSizeCategory: maxSizeCategory)
-                            .foregroundColor(colors.titleLabel)
-                    }
-                    .buttonStyle(PlainButtonStyle())
+                    Text(model.titleLabel)
+                        .font(size: 12, style: .footnote, weight: .semibold, maxSizeCategory: maxSizeCategory)
+                        .foregroundColor(colors.titleLabel)
                 }
             }
             VStack {
@@ -114,6 +111,9 @@ struct BannerAdView: View {
         }
         .cornerRadius(8)
         .padding(.vertical, 10)
+        .onTapGesture {
+            model.onLinkTap?()
+        }
     }
 
     @ViewBuilder func creative() -> some View {

--- a/podcasts/HomeGridListItem.swift
+++ b/podcasts/HomeGridListItem.swift
@@ -3,21 +3,21 @@ import Foundation
 import PocketCastsDataModel
 
 class HomeGridListItem: ListItem {
-    let gridItem: HomeGridItem
+    let gridItem: HomeGridItem?
 
     var podcast: Podcast? {
-        gridItem.podcast
+        gridItem?.podcast
     }
 
     var folder: Folder? {
-        gridItem.folder
+        gridItem?.folder
     }
 
     let theme: Theme.ThemeType
     let badgeType: BadgeType
     var frozenBadgeCount = -1 // used for comparisons only
 
-    init(gridItem: HomeGridItem, badgeType: BadgeType, theme: Theme.ThemeType) {
+    init(gridItem: HomeGridItem?, badgeType: BadgeType, theme: Theme.ThemeType) {
         self.gridItem = gridItem
         self.badgeType = badgeType
         self.theme = theme
@@ -25,8 +25,19 @@ class HomeGridListItem: ListItem {
         super.init()
     }
 
+    static let empty = HomeGridListItem(gridItem: nil, badgeType: .off, theme: Theme.sharedTheme.activeTheme)
+
     override var differenceIdentifier: String {
-        podcast?.uuid ?? folder?.uuid ?? ""
+        if let podcast = podcast {
+            return "podcast-\(podcast.uuid)"
+        } else if let folder = folder {
+            return "folder-\(folder.uuid)"
+        }
+        return "empty"
+    }
+
+    var isEmpty: Bool {
+        gridItem == nil
     }
 
     static func == (lhs: HomeGridListItem, rhs: HomeGridListItem) -> Bool {

--- a/podcasts/NowPlayingPlayerItemViewController.swift
+++ b/podcasts/NowPlayingPlayerItemViewController.swift
@@ -486,7 +486,15 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
 
         let model = BannerAdModel(adText: "Listen to your favorite books while supporting your local indie bookstore",
                                   imageURL: URL(string: "https://static.pocketcasts.com/discover/images/420/9349e8d0-a87f-013a-d8af-0acc26574db2.jpg")!,
-                                  linkTitle: "Libro.fm")
+                                  linkTitle: "Libro.fm",
+                                  adID: "1234",
+                                  source: "player") {
+            let url = URL(string: "https://libro.fm/")!
+            let safariViewController = SFSafariViewController(with: url)
+
+            NotificationCenter.postOnMainThread(notification: Constants.Notifications.openingNonOverlayableWindow)
+            SceneHelper.rootViewController()?.present(safariViewController, animated: true, completion: nil)
+        }
         let adView = BannerAdView(model: model, colors: .playerColors(Theme.sharedTheme)).padding(8)
         let hostingController = PCHostingController(rootView: AnyView(adView))
 

--- a/podcasts/PodcastListViewController+CollectionView.swift
+++ b/podcasts/PodcastListViewController+CollectionView.swift
@@ -2,6 +2,7 @@ import PocketCastsDataModel
 import PocketCastsUtils
 import UIKit
 import SwiftUI
+import PocketCastsServer
 
 extension PodcastListViewController: UICollectionViewDelegate, UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
     private static let podcastSquareCellId = "PodcastGridCell"
@@ -9,12 +10,14 @@ extension PodcastListViewController: UICollectionViewDelegate, UICollectionViewD
     private static let folderSquareCellId = "FolderGridCell"
     private static let folderListCellId = "FolderListCell"
     private static let bannerAdHeaderId = "BannerAdHeader"
+    private static let emptyStateCellId = "EmptyStateCell"
 
     func registerCells() {
         podcastsCollectionView.register(UINib(nibName: "PodcastGridCell", bundle: nil), forCellWithReuseIdentifier: PodcastListViewController.podcastSquareCellId)
         podcastsCollectionView.register(UINib(nibName: "PodcastListCell", bundle: nil), forCellWithReuseIdentifier: PodcastListViewController.podcastListCellId)
         podcastsCollectionView.register(UINib(nibName: "FolderGridCell", bundle: nil), forCellWithReuseIdentifier: PodcastListViewController.folderSquareCellId)
         podcastsCollectionView.register(UINib(nibName: "FolderListCell", bundle: nil), forCellWithReuseIdentifier: PodcastListViewController.folderListCellId)
+        podcastsCollectionView.register(UICollectionViewCell.self, forCellWithReuseIdentifier: PodcastListViewController.emptyStateCellId)
 
         // Register header view for banner ads
         podcastsCollectionView.register(UICollectionReusableView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: PodcastListViewController.bannerAdHeaderId)
@@ -28,9 +31,34 @@ extension PodcastListViewController: UICollectionViewDelegate, UICollectionViewD
         itemCount()
     }
 
+    private func makeEmptyStateView() -> EmptyStateView<Text, DefaultEmptyStateStyle> {
+        EmptyStateView(
+            title: L10n.podcastGridNoPodcastsTitle,
+            message: L10n.podcastGridNoPodcastsMsg,
+            icon: { Image("podcastlist_smallgrid").renderingMode(.template) },
+            actions: [
+                .init(title: L10n.podcastGridDiscoverPodcasts, action: {
+                    Analytics.shared.track(.podcastsListDiscoverButtonTapped)
+                    NavigationManager.sharedManager.navigateTo(NavigationManager.discoverPageKey)
+                })
+            ],
+            style: DefaultEmptyStateStyle.defaultStyle
+        )
+    }
+
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let libraryType = Settings.libraryType()
         let item = itemAt(indexPath: indexPath)
+
+        if item?.isEmpty == true {
+            let cell = collectionView.dequeueReusableCell(withReuseIdentifier: PodcastListViewController.emptyStateCellId, for: indexPath)
+            cell.contentConfiguration = UIHostingConfiguration {
+                makeEmptyStateView()
+            }
+            .margins(.horizontal, 16)
+            .margins(.vertical, 8)
+            return cell
+        }
 
         if libraryType == .list {
             if item?.podcast != nil {
@@ -75,6 +103,11 @@ extension PodcastListViewController: UICollectionViewDelegate, UICollectionViewD
         collectionView.deselectItem(at: indexPath, animated: true)
 
         let selectedItem = itemAt(indexPath: indexPath)
+
+        if selectedItem?.isEmpty == true {
+            return
+        }
+
         if let podcast = selectedItem?.podcast {
             Analytics.track(.podcastsListPodcastTapped)
             NavigationManager.sharedManager.navigateTo(NavigationManager.podcastPageKey, data: [NavigationManager.podcastKey: podcast])
@@ -123,7 +156,18 @@ extension PodcastListViewController: UICollectionViewDelegate, UICollectionViewD
     // MARK: - Row Sizing
 
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        gridHelper.collectionView(collectionView, sizeForItemAt: indexPath, itemCount: itemCount())
+        let item = itemAt(indexPath: indexPath)
+        if item?.isEmpty == true {
+            let sizingView = makeEmptyStateView()
+                .environmentObject(Theme.sharedTheme)
+
+            let hostingController = UIHostingController(rootView: sizingView)
+            let targetSize = CGSize(width: collectionView.bounds.width - 32, height: UIView.layoutFittingCompressedSize.height)
+            let size = hostingController.sizeThatFits(in: targetSize)
+
+            return CGSize(width: collectionView.bounds.width, height: size.height)
+        }
+        return gridHelper.collectionView(collectionView, sizeForItemAt: indexPath, itemCount: itemCount())
     }
 
     func updateFlowLayoutSize() {

--- a/podcasts/PodcastListViewController.swift
+++ b/podcasts/PodcastListViewController.swift
@@ -441,7 +441,7 @@ class PodcastListViewController: PCViewController, UIGestureRecognizerDelegate, 
             imageURL: URL(string: "https://static.pocketcasts.com/discover/images/420/9349e8d0-a87f-013a-d8af-0acc26574db2.jpg")!,
             linkTitle: "Libro.fm",
             adID: "12345",
-            source: "podcast-list"
+            source: "podcast_list"
         ) {
             let url = URL(string: "https://libro.fm/")!
             let safariViewController = SFSafariViewController(with: url)

--- a/podcasts/PodcastListViewController.swift
+++ b/podcasts/PodcastListViewController.swift
@@ -5,6 +5,7 @@ import PocketCastsServer
 import PocketCastsUtils
 import UIKit
 import Kingfisher
+import SafariServices
 
 class PodcastListViewController: PCViewController, UIGestureRecognizerDelegate, ShareListDelegate {
     let gridHelper = GridHelper()
@@ -458,8 +459,16 @@ class PodcastListViewController: PCViewController, UIGestureRecognizerDelegate, 
         bannerAdModel = BannerAdModel(
             adText: "Listen to your favorite books while supporting your local indie bookstore",
             imageURL: URL(string: "https://static.pocketcasts.com/discover/images/420/9349e8d0-a87f-013a-d8af-0acc26574db2.jpg")!,
-            linkTitle: "Libro.fm"
-        )
+            linkTitle: "Libro.fm",
+            adID: "12345",
+            source: "podcast-list"
+        ) {
+            let url = URL(string: "https://libro.fm/")!
+            let safariViewController = SFSafariViewController(with: url)
+
+            NotificationCenter.postOnMainThread(notification: Constants.Notifications.openingNonOverlayableWindow)
+            SceneHelper.rootViewController()?.present(safariViewController, animated: true, completion: nil)
+        }
     }
 }
 

--- a/podcasts/PodcastListViewController.swift
+++ b/podcasts/PodcastListViewController.swift
@@ -266,7 +266,11 @@ class PodcastListViewController: PCViewController, UIGestureRecognizerDelegate, 
             } else {
                 sortOption = Settings.homeFolderSortOrder()
             }
-            let newData = HomeGridDataHelper.gridListItems(orderedBy: sortOption, badgeType: Settings.podcastBadgeType())
+            var newData = HomeGridDataHelper.gridListItems(orderedBy: sortOption, badgeType: Settings.podcastBadgeType())
+
+            if newData.isEmpty {
+                newData = [HomeGridListItem.empty]
+            }
 
             DispatchQueue.main.sync {
                 if strongSelf.gridLayout != Settings.libraryType() {
@@ -278,34 +282,10 @@ class PodcastListViewController: PCViewController, UIGestureRecognizerDelegate, 
                         strongSelf.gridItems = data
                     })
                 }
-                let shouldHideEmpty = newData.count != 0 || SyncManager.isFirstSyncInProgress()
-                strongSelf.refreshContentUnavailable(shouldShow: !shouldHideEmpty)
                 strongSelf.foldersCoordinator.showUpsellIfNeeded(from: strongSelf)
             }
         }
     }
-
-    private func refreshContentUnavailable(shouldShow: Bool) {
-        var config: UIContentConfiguration?
-
-        if shouldShow {
-            let title = L10n.podcastGridNoPodcastsTitle
-            let message = L10n.podcastGridNoPodcastsMsg
-            config = ContentUnavailableConfiguration.emptyState(title: title, message: message, icon: { Image("podcastlist_smallgrid").renderingMode(.template) }, actions: [
-                .init(title: L10n.podcastGridDiscoverPodcasts, action: {
-                    Analytics.shared.track(.podcastsListDiscoverButtonTapped)
-                    NavigationManager.sharedManager.navigateTo(NavigationManager.discoverPageKey)
-                })
-            ])
-        }
-
-        if #available(iOS 17.0, *) {
-            self.contentUnavailableConfiguration = config
-        } else {
-            self.setContentUnavailableConfiguration(config)
-        }
-    }
-
 
     func showProfileController() {
         let profileViewController = ProfileViewController()


### PR DESCRIPTION
| 📘 Part of: #3208 |
|:---:|

* Adds tracking event `banner_ad_tapped` and `banner_ad_impression`
* Adds advertising stats `banner_ad_tapped` and `banner_ad_impression`
* Changes empty view in Podcast List to use Collection View - this was causing issues with tap handling + accessibility sizing

## To test

### Tracking Events

* Enable the `banner_ads` and `tracks_logging` feature flags
* Restart the app
* ✅ Verify that the banner appears and a `banner_ad_impression` event is logged with the `promotion` set to `podcast-list` and `id` set to `test-ad-id`
* Tap the banner
* ✅ Verify that the `banner_ad_tapped` event is logged with the `promotion` set to `podcast-list` and `id` set to `test-ad-id`
* ✅ Verify that the libro.fm web page is opened in Safari View Controller
* Open the player
* ✅ Verify that the banner appears and a `banner_ad_impression` event is logged with `promotion` set to `player` and and `id` set to `test-ad-id`
* Tap the banner
* ✅ Verify that the `banner_ad_tapped` event is logged with the `promotion` set to `player` and `id` set to `test-ad-id`
* ✅ Verify that the libro.fm web page is opened in Safari View Controller

### Empty State

* Unfollow all podcasts
* Ensure that the empty view appears below the banner view
*  ✅ Ensure tapping the banner still works and opens Safari View Controller
* Follow podcasts
*  ✅ Ensure empty view disappears and banner interactions till works

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
