### PR TITLE
GRDB: use `timeIntervalSince1970` for read queries

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/DB/GRDB/GRDBDatabase.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/DB/GRDB/GRDBDatabase.swift
@@ -17,9 +17,14 @@ class GRDBDatabase: PCDatabase {
     }
 
     func executeQuery(_ sql: String, values: [Any]?) throws -> any PCDBResultSet {
+        // We want GRDB to query `Date` the same way FMDB does: using `timeIntervalSince1970`
+        // In terms of raw performance changing that on the model layer would be much better.
+        // However, that's a large change that we want to avoid.
+        let filteredValues = values?.map { ($0 as? Date)?.timeIntervalSince1970 ?? $0 }
+
         // Invalid arguments will result in a crash in the application
         // TODO: when releasing GRDB discuss if we want to make this optional
-        let rowCursor = try Row.fetchCursor(database, sql: sql, arguments: StatementArguments(values != nil ? values! : [])!)
+        let rowCursor = try Row.fetchCursor(database, sql: sql, arguments: StatementArguments(values != nil ? filteredValues! : [])!)
         return GRDBResultSet(rowCursor: rowCursor)
     }
 

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/DB/GRDB/GRDBDatabase.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/DB/GRDB/GRDBDatabase.swift
@@ -24,7 +24,7 @@ class GRDBDatabase: PCDatabase {
 
         // Invalid arguments will result in a crash in the application
         // TODO: when releasing GRDB discuss if we want to make this optional
-        let rowCursor = try Row.fetchCursor(database, sql: sql, arguments: StatementArguments(values != nil ? filteredValues! : [])!)
+        let rowCursor = try Row.fetchCursor(database, sql: sql, arguments: StatementArguments(filteredValues != nil ? filteredValues! : [])!)
         return GRDBResultSet(rowCursor: rowCursor)
     }
 


### PR DESCRIPTION
Fixes #3235

We have updated GRDB `executeUpdate` to ensure using `timeIntervalSince1970`. However, `executeQuery` was missing. Which would cause issues with any queries using `Date`. 

## To test

I recommend reproducing the issue on `develop` so you can understand what was going on.

1. Ensure GRDB feature flag is enabled
2. Go to Profile > Settings > Auto Archive > set  "Played Episodes" to "After 24 hours"
3. Play episode to completion.
4. Note that episode is not deleted automatically
5. Perform a pull to refresh to initiate a sync (or wait for the next sync event)
6. ✅  Notice that the played episode is **NOT** archived, before 24 hours has passed

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
