### PR TITLE
[Banner Ads] Add "No Banner Ads" to upgrade screen

### DIFF
--- a/podcasts/Onboarding/Plus/Account Prompt/PlusAccountUpgradePrompt.swift
+++ b/podcasts/Onboarding/Plus/Account Prompt/PlusAccountUpgradePrompt.swift
@@ -115,6 +115,7 @@ struct PlusAccountUpgradePrompt: View {
 
     private let productFeatures: [IAPProductID: [Feature]] = [
         .yearly: ([
+            .init(iconName: "unsubscribe", title: L10n.plusMarketingNoBannerAds),
             .init(iconName: "plus-feature-folders", title: L10n.plusMarketingFoldersTitle),
             .init(iconName: "plus-feature-up-next-shuffle", title: L10n.plusMarketingUpNextShuffle),
             .init(iconName: "plus-feature-bookmarks", title: L10n.plusMarketingBookmarksTitle),

--- a/podcasts/Onboarding/Plus/UpgradeCard.swift
+++ b/podcasts/Onboarding/Plus/UpgradeCard.swift
@@ -29,6 +29,7 @@ struct UpgradeTier: Identifiable {
 extension UpgradeTier {
     static var plus: UpgradeTier {
         UpgradeTier(tier: .plus, iconName: "plusGold", title: "Plus", plan: .plus, header: L10n.plusMarketingTitle, description: L10n.accountDetailsPlusTitle, buttonLabel: L10n.plusSubscribeTo, buttonForegroundColor: Color.plusButtonFilledTextColor, monthlyFeatures: [
+            TierFeature(iconName: "unsubscribe", title: L10n.plusMarketingNoBannerAds),
             TierFeature(iconName: "plus-feature-folders", title: L10n.plusMarketingFoldersTitle),
             TierFeature(iconName: "plus-feature-up-next-shuffle", title: L10n.plusMarketingUpNextShuffle),
             TierFeature(iconName: "plus-feature-bookmarks", title: L10n.plusMarketingBookmarksTitle),
@@ -40,6 +41,7 @@ extension UpgradeTier {
             libroFm
         ].compactMap { $0 },
         yearlyFeatures: [
+            TierFeature(iconName: "unsubscribe", title: L10n.plusMarketingNoBannerAds),
             TierFeature(iconName: "plus-feature-folders", title: L10n.plusMarketingFoldersTitle),
             TierFeature(iconName: "plus-feature-up-next-shuffle", title: L10n.plusMarketingUpNextShuffle),
             TierFeature(iconName: "plus-feature-bookmarks", title: L10n.plusMarketingBookmarksTitle),

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -2309,6 +2309,8 @@ internal enum L10n {
   internal static var plusMarketingLearnMoreButton: String { return L10n.tr("Localizable", "plus_marketing_learn_more_button", fallback: "Learn more about Pocket Casts Plus") }
   /// Pocket Casts Plus marketing page, the main description of Pocket Casts Plus
   internal static var plusMarketingMainDescription: String { return L10n.tr("Localizable", "plus_marketing_main_description", fallback: "Get personal, and get distributed, all at once. Upload your personal audio files to our cloud servers, access your account via our web player, and make the app yours.") }
+  /// Pocket Casts Plus marketing page, description of removing banner ads
+  internal static var plusMarketingNoBannerAds: String { return L10n.tr("Localizable", "plus_marketing_no_banner_ads", fallback: "No Banner Ads") }
   /// Subtitle of the plus marketing view
   internal static var plusMarketingSubtitle: String { return L10n.tr("Localizable", "plus_marketing_subtitle", fallback: "Get access to exclusive features and customisation options") }
   /// Pocket Casts Plus marketing page, title of the Themes & Icons feature

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -1612,6 +1612,9 @@
 /* Message displayed when teh user tap "Pocket Casts Champion" button */
 "plus_champion_message" = "Thanks for being with Pocket Casts from the start. You're a real champion!";
 
+/* Pocket Casts Plus marketing page, description of removing banner ads */
+"plus_marketing_no_banner_ads" = "No Banner Ads";
+
 /* Pocket Casts Plus marketing page, description of the Cloud Storage feature */
 "plus_marketing_updated_cloud_storage_description" = "Upload your files to cloud storage and have it available everywhere";
 


### PR DESCRIPTION
| 📘 Part of: #3208 |
|:---:|

Fixes #3237

Adds the "No Banner Ads" feature to Plus upgrade screen.

| Before | After |
|--|--|
| ![Simulator Screenshot - iPhone 16 - 2025-06-09 at 17 37 54](https://github.com/user-attachments/assets/6e597eb2-cedc-42b1-93be-16642115088b) | ![Simulator Screenshot - iPhone 16 - 2025-06-09 at 17 33 56](https://github.com/user-attachments/assets/b5092a28-8eff-4768-99c2-d18a7f982dc3) |

## To test

* Visit the Plus upgrade screen
* ✅ Verify that "No Banner Ads" appears at the top

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
