### PR TITLE
Use `loadSwiftLintVersion()` in `Package.swift`

### DIFF
--- a/BuildTools/Package.swift
+++ b/BuildTools/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
     name: "BuildTools",
     platforms: [.macOS(.v10_13)],
     dependencies: [
-        .package(url: "https://github.com/SimplyDanny/SwiftLintPlugins", exact: "0.58.2"),
+        .package(url: "https://github.com/SimplyDanny/SwiftLintPlugins", exact: loadSwiftLintVersion()),
         .package(url: "https://github.com/SwiftGen/SwiftGenPlugin", from: "6.5.1")
     ],
     targets: [.target(name: "BuildTools", path: "")]


### PR DESCRIPTION
This way, the SwiftLint version to use will be read from `.swiftlint.yml` and be consistent with CI.

I used an hardcoded version to force a reload during the migration from CocoaPods and did not notice it when reviewing the code.

See https://linear.app/a8c/issue/AINFRA-699

## To test

If you feel like it, checkout this branch locally and run `make lint`. But notice that there has been no change to `Package.resolved` because, at runtime, the result of `loadSwiftLintVersion()` is the same as the previous `0.58.2` string literal.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
Notice that running the new `make generate_code` does not change the
SwiftGen output compared to when it last run via binary sourced with
CocoaPods.