### PR TITLE
Add logging when Network Monitor path updates

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Networking/NetworkUtils.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Networking/NetworkUtils.swift
@@ -6,6 +6,18 @@ public class NetworkUtils {
     private lazy var monitor = NWPathMonitor()
 
     private init() {
+        monitor.pathUpdateHandler = { path in
+            switch path.status {
+            case .satisfied:
+                FileLog.shared.addMessage("NetworkMonitor: Network is connected isExpensive: \(path.isExpensive)")
+            case .unsatisfied:
+                FileLog.shared.addMessage("NetworkMonitor: Network is disconnected")
+            case .requiresConnection:
+                FileLog.shared.addMessage("NetworkMonitor: Network requires connection")
+            @unknown default:
+                FileLog.shared.addMessage("NetworkMonitor: Unknown path status")
+            }
+        }
         monitor.start(queue: .main)
     }
 


### PR DESCRIPTION
Improves logging by logging path updates from `NetworkMonitor`. This will be useful to see network changes in the midst of logs when troubleshooting download errors.

See Slack for more info on this: p1749153729145199-slack-C02A333D8LQ

## To test

**Run on device**

* Disable network
* Check logs in Profile > Help & Feedback > Logs
* ✅ Verify you see `NetworkMonitor: Network is disconnected`
* Enable network
* Check logs in Profile > Help & Feedback > Logs
* ✅ Verify you see `NetworkMonitor: Network is connected isExpensive: (true or false depending on connection)`


## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.