### PR TITLE
Remove redundant rule in `gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 **/xcuserdata/
-podcasts.xcworkspace/xcuserdata/
 Pods/
 /.DS_Store
 /Themes.txt


### PR DESCRIPTION
`podcasts.xcworkspace/xcuserdata` is already covered by `**/xcuserdata`