### PR TITLE
[Bug] Fix description title tag

### DIFF
--- a/podcasts/EpisodeDetailViewController+ShowNotes.swift
+++ b/podcasts/EpisodeDetailViewController+ShowNotes.swift
@@ -158,7 +158,12 @@ extension EpisodeDetailViewController: WKNavigationDelegate, SFSafariViewControl
         } else {
             let currentTheme = themeOverride ?? Theme.sharedTheme.activeTheme
             lastThemeRenderedNotesIn = currentTheme
-            let formattedNotes = ShowNotesFormatter.formatInEpisode(customTitle: L10n.episodeDescriptionTitle, showNotes: showNotes, tintColor: linkTintColor(), convertTimesToLinks: false, bgColor: ThemeColor.primaryUi01(for: currentTheme), textColor: ThemeColor.primaryText01(for: currentTheme))
+            let formattedNotes: String
+            if FeatureFlag.episodeDetailTranscript.enabled {
+                formattedNotes = ShowNotesFormatter.formatInEpisode(customTitle: L10n.episodeDescriptionTitle, showNotes: showNotes, tintColor: linkTintColor(), convertTimesToLinks: false, bgColor: ThemeColor.primaryUi01(for: currentTheme), textColor: ThemeColor.primaryText01(for: currentTheme))
+            } else {
+                formattedNotes = ShowNotesFormatter.format(showNotes: showNotes, tintColor: linkTintColor(), convertTimesToLinks: false, bgColor: ThemeColor.primaryUi01(for: currentTheme), textColor: ThemeColor.primaryText01(for: currentTheme))
+            }
             showNotesWebView.loadHTMLString(formattedNotes, baseURL: URL(fileURLWithPath: Bundle.main.bundlePath))
         }
     }

--- a/podcasts/ShowNotesFormatter.swift
+++ b/podcasts/ShowNotesFormatter.swift
@@ -34,7 +34,7 @@ class ShowNotesFormatter {
         styledShowNotes = styledShowNotes + "</head><body>"
 
         if let customTitle {
-            styledShowNotes = styledShowNotes + "<customTitle>\(customTitle)</customTitle>"
+            styledShowNotes = styledShowNotes + "<p><customTitle>\(customTitle)</customTitle></p>"
         }
 
         styledShowNotes = styledShowNotes + "\(cleanedShowNotes)</body></html>"


### PR DESCRIPTION
Ref. [report](https://github.com/Automattic/pocket-casts-ios/issues/3265#issuecomment-2978805223)

This PR adds a `<p>` tag for the episode description title

## To test

- Run this branch
- Open this episode: https://pca.st/ervxr4dd
- Confirm you see the description below the `Episode Description` title

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
