### PR TITLE
GRDB: remove `withoutActuallyEscaping`

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/DB/FMDB/FMDBQueue.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/DB/FMDB/FMDBQueue.swift
@@ -10,70 +10,34 @@ final class FMDBQueue: PCDBQueue {
     }
 
     func inDatabase(_ block: (any PCDatabase) -> Void) {
-        if FeatureFlag.fmdbWithoutActuallyEscaping.enabled {
-            withoutActuallyEscaping(block) { block in
-                fmdbQueue.inDatabase { db in
-                    let dbWrapper = FMDBDatabase(fmdbDatabase: db)
-                    block(dbWrapper)
-                }
-            }
-        } else {
-            fmdbQueue.inDatabase { db in
-                let dbWrapper = FMDBDatabase(fmdbDatabase: db)
-                block(dbWrapper)
-            }
+        fmdbQueue.inDatabase { db in
+            let dbWrapper = FMDBDatabase(fmdbDatabase: db)
+            block(dbWrapper)
         }
     }
 
     func inTransaction(_ block: (any PCDatabase, UnsafeMutablePointer<ObjCBool>) -> Void) {
-        if FeatureFlag.fmdbWithoutActuallyEscaping.enabled {
-            withoutActuallyEscaping(block) { block in
-                fmdbQueue.inTransaction { db, rollback in
-                    let dbWrapper = FMDBDatabase(fmdbDatabase: db)
-                    block(dbWrapper, rollback)
-                }
-            }
-        } else {
-            fmdbQueue.inTransaction { db, rollback in
-                let dbWrapper = FMDBDatabase(fmdbDatabase: db)
-                block(dbWrapper, rollback)
-            }
+        fmdbQueue.inTransaction { db, rollback in
+            let dbWrapper = FMDBDatabase(fmdbDatabase: db)
+            block(dbWrapper, rollback)
         }
     }
 
     func read(_ block: (any PCDatabase) -> Void) {
         // FMDB doesn't have the concept of read or write
         // This is implemented so we conform to the protocol
-        if FeatureFlag.fmdbWithoutActuallyEscaping.enabled {
-            withoutActuallyEscaping(block) { block in
-                fmdbQueue.inDatabase { db in
-                    let dbWrapper = FMDBDatabase(fmdbDatabase: db)
-                    block(dbWrapper)
-                }
-            }
-        } else {
-            fmdbQueue.inDatabase { db in
-                let dbWrapper = FMDBDatabase(fmdbDatabase: db)
-                block(dbWrapper)
-            }
+        fmdbQueue.inDatabase { db in
+            let dbWrapper = FMDBDatabase(fmdbDatabase: db)
+            block(dbWrapper)
         }
     }
 
     func write(_ block: (any PCDatabase) -> Void) {
         // FMDB doesn't have the concept of read or write
         // This is implemented so we conform to the protocol
-        if FeatureFlag.fmdbWithoutActuallyEscaping.enabled {
-            withoutActuallyEscaping(block) { block in
-                fmdbQueue.inDatabase { db in
-                    let dbWrapper = FMDBDatabase(fmdbDatabase: db)
-                    block(dbWrapper)
-                }
-            }
-        } else {
-            fmdbQueue.inDatabase { db in
-                let dbWrapper = FMDBDatabase(fmdbDatabase: db)
-                block(dbWrapper)
-            }
+        fmdbQueue.inDatabase { db in
+            let dbWrapper = FMDBDatabase(fmdbDatabase: db)
+            block(dbWrapper)
         }
     }
 

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/DB/GRDB/GRDBQueue.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/DB/GRDB/GRDBQueue.swift
@@ -11,58 +11,50 @@ class GRDBQueue: PCDBQueue {
     }
 
     func inDatabase(_ block: (any PCDatabase) -> Void) {
-        withoutActuallyEscaping(block) { block in
-            do {
-                try dbPool.write { db in
-                    let dbWrapper = GRDBDatabase(database: db)
-                    block(dbWrapper)
-                }
-            } catch {
-                logger?.log(error: error, context: [:])
+        do {
+            try dbPool.write { db in
+                let dbWrapper = GRDBDatabase(database: db)
+                block(dbWrapper)
             }
+        } catch {
+            logger?.log(error: error, context: [:])
         }
     }
 
     func inTransaction(_ block: (any PCDatabase, UnsafeMutablePointer<ObjCBool>) -> Void) {
-        withoutActuallyEscaping(block) { block in
-            do {
-                try dbPool.writeInTransaction { db in
-                    let rollback = UnsafeMutablePointer<ObjCBool>.allocate(capacity: 1)
-                    rollback.pointee = false
-                    let dbWrapper = GRDBDatabase(database: db)
-                    block(dbWrapper, rollback)
-                    defer { rollback.deallocate() }
-                    return rollback.pointee.boolValue ? .rollback : .commit
-                }
-            } catch {
-                logger?.log(error: error, context: [:])
+        do {
+            try dbPool.writeInTransaction { db in
+                let rollback = UnsafeMutablePointer<ObjCBool>.allocate(capacity: 1)
+                rollback.pointee = false
+                let dbWrapper = GRDBDatabase(database: db)
+                block(dbWrapper, rollback)
+                defer { rollback.deallocate() }
+                return rollback.pointee.boolValue ? .rollback : .commit
             }
+        } catch {
+            logger?.log(error: error, context: [:])
         }
     }
 
     func read(_ block: (any PCDatabase) -> Void) {
-        withoutActuallyEscaping(block) { block in
-            do {
-                try dbPool.read { db in
-                    let dbWrapper = GRDBDatabase(database: db)
-                    block(dbWrapper)
-                }
-            } catch {
-                logger?.log(error: error, context: [:])
+        do {
+            try dbPool.read { db in
+                let dbWrapper = GRDBDatabase(database: db)
+                block(dbWrapper)
             }
+        } catch {
+            logger?.log(error: error, context: [:])
         }
     }
 
     func write(_ block: (any PCDatabase) -> Void) {
-        withoutActuallyEscaping(block) { block in
-            do {
-                try dbPool.write { db in
-                    let dbWrapper = GRDBDatabase(database: db)
-                    block(dbWrapper)
-                }
-            } catch {
-                logger?.log(error: error, context: [:])
+        do {
+            try dbPool.write { db in
+                let dbWrapper = GRDBDatabase(database: db)
+                block(dbWrapper)
             }
+        } catch {
+            logger?.log(error: error, context: [:])
         }
     }
 

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -188,9 +188,6 @@ public enum FeatureFlag: String, CaseIterable {
     /// Shows transcript excerpt in episode detail
     case episodeDetailTranscript
 
-    /// Avoid using `withoutActuallyEscaping` for FMDB
-    case fmdbWithoutActuallyEscaping
-
     /// Include banner ads in the player and podcasts list. This is fetched from ths server so can be disabled from there as well.
     case bannerAds
 
@@ -333,8 +330,6 @@ public enum FeatureFlag: String, CaseIterable {
             true
         case .episodeDetailTranscript:
             true
-        case .fmdbWithoutActuallyEscaping:
-            false
         case .bannerAds:
             false
         case .streamingCustomSessionConfiguration:


### PR DESCRIPTION
After #3206 number of crashes went down, so in this PR we remove `withoutActuallyEscaping` from the whole codebase.

## To test

1. Green CI and code review should be enough

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
