### PR TITLE
Add individual cell types for discover items

### DIFF
--- a/podcasts/Array+DiscoverItem.swift
+++ b/podcasts/Array+DiscoverItem.swift
@@ -6,9 +6,11 @@ extension Array<DiscoverItem> {
 
         let items = filter({ (itemFilter($0)) })
 
-        let models = items.map { item in
+        let models: [DiscoverCollectionViewController.Item] = items.compactMap { item in
             let selectedCategory = item.cellType() != .categoriesSelector ? selectedCategory : nil
-            return DiscoverCollectionViewController.Item.item(DiscoverCellModel(item: item, region: region, selectedCategory: selectedCategory))
+            let model = DiscoverCellModel(item: item, region: region, selectedCategory: selectedCategory)
+            guard let cellType = item.cellType() else { return nil }
+            return DiscoverCollectionViewController.Item.item(DiscoverCellType.ItemType(cellType: cellType, model: model))
         }
 
         snapshot.appendSections([0])

--- a/podcasts/DiscoverCellType.swift
+++ b/podcasts/DiscoverCellType.swift
@@ -20,7 +20,10 @@ enum DiscoverCellType: CaseIterable {
     case categoryPodcasts
     case largeListWithPodcast
 
-    typealias ItemType = DiscoverCellModel
+    struct ItemType: Hashable {
+        let cellType: DiscoverCellType
+        let model: DiscoverCellModel
+    }
 
     func viewController(in region: String) -> (UIViewController & DiscoverSummaryProtocol) {
         switch self {
@@ -58,7 +61,7 @@ enum DiscoverCellType: CaseIterable {
 
             let existingViewController = (cell.contentConfiguration as? UIViewControllerContentConfiguration)?.viewController as? (UIViewController & DiscoverSummaryProtocol)
 
-            let vc = existingViewController ?? viewController(in: item.region)
+            let vc = existingViewController ?? item.cellType.viewController(in: item.model.region)
 
             if existingViewController == nil {
                 cell.contentConfiguration = UIViewControllerContentConfiguration(parentViewController: parentViewController, viewController: vc)

--- a/podcasts/DiscoverCollectionViewController+Search.swift
+++ b/podcasts/DiscoverCollectionViewController+Search.swift
@@ -40,7 +40,7 @@ extension DiscoverCollectionViewController: UICollectionViewDelegate {
         switch item {
         case .item(let item):
             let viewController = (cell.contentConfiguration as? UIViewControllerContentConfiguration)?.viewController as? DiscoverSummaryProtocol & UIViewController
-            viewController?.populateFrom(item: item.item, region: item.region, category: item.selectedCategory)
+            viewController?.populateFrom(item: item.model.item, region: item.model.region, category: item.model.selectedCategory)
             viewController?.beginAppearanceTransition(true, animated: false)
             viewController?.endAppearanceTransition()
         default:

--- a/podcasts/DiscoverCollectionViewController.swift
+++ b/podcasts/DiscoverCollectionViewController.swift
@@ -238,30 +238,34 @@ extension DiscoverCollectionViewController {
             partialResult[cellType] = cellType.createCellRegistration(parentViewController: self, delegate: self)
         }
 
-        let nonItemRegistration = UICollectionView.CellRegistration<UICollectionViewCell, Item> { cell, indexPath, item in
-            let contentConfiguration: UIContentConfiguration
-            switch item {
-            case .loading:
-                contentConfiguration = ContentUnavailableConfiguration.loading()
-            case .noNetwork:
-                contentConfiguration = ContentUnavailableConfiguration.noNetwork { [weak self] in
-                    self?.reloadData()
-                }
-            case .noResults:
-                contentConfiguration = ContentUnavailableConfiguration.noResults()
-            case .empty:
-                contentConfiguration = ContentUnavailableConfiguration.empty()
-            case .item:
-                ()
-                fatalError("Should never happen")
+        let loadingRegistration = UICollectionView.CellRegistration<UICollectionViewCell, Item> { cell, indexPath, item in
+            cell.contentConfiguration = ContentUnavailableConfiguration.loading()
+        }
+
+        let noNetworkRegistration = UICollectionView.CellRegistration<UICollectionViewCell, Item> { cell, indexPath, item in
+            cell.contentConfiguration = ContentUnavailableConfiguration.noNetwork { [weak self] in
+                self?.reloadData()
             }
-            cell.contentConfiguration = contentConfiguration
+        }
+
+        let noResultsRegistration = UICollectionView.CellRegistration<UICollectionViewCell, Item> { cell, indexPath, item in
+            cell.contentConfiguration = ContentUnavailableConfiguration.noResults()
+        }
+
+        let emptyRegistration = UICollectionView.CellRegistration<UICollectionViewCell, Item> { cell, indexPath, item in
+            cell.contentConfiguration = ContentUnavailableConfiguration.empty()
         }
 
         dataSource = UICollectionViewDiffableDataSource<Section, Item>(collectionView: collectionView) { collectionView, indexPath, item in
             switch item {
-            case .loading, .noResults, .noNetwork, .empty:
-                return collectionView.dequeueConfiguredReusableCell(using: nonItemRegistration, for: indexPath, item: item)
+            case .loading:
+                return collectionView.dequeueConfiguredReusableCell(using: loadingRegistration, for: indexPath, item: item)
+            case .noNetwork:
+                return collectionView.dequeueConfiguredReusableCell(using: noNetworkRegistration, for: indexPath, item: item)
+            case .noResults:
+                return collectionView.dequeueConfiguredReusableCell(using: noResultsRegistration, for: indexPath, item: item)
+            case .empty:
+                return collectionView.dequeueConfiguredReusableCell(using: emptyRegistration, for: indexPath, item: item)
             case .item(let item):
                 let cellRegistration = registrations[item.cellType]!
                 return collectionView.dequeueConfiguredReusableCell(using: cellRegistration, for: indexPath, item: item)

--- a/podcasts/DiscoverCollectionViewController.swift
+++ b/podcasts/DiscoverCollectionViewController.swift
@@ -133,7 +133,10 @@ class DiscoverCollectionViewController: PCViewController {
                             self.loadingTasks.removeValue(forKey: uuid)
                         }
                     } else {
-                        snapshot.appendItems([.item(.init(item: item, region: currentRegion, selectedCategory: selectedCategory))])
+                        let model = DiscoverCellModel(item: item, region: currentRegion, selectedCategory: selectedCategory)
+                        if let cellType = item.cellType() {
+                            snapshot.appendItems([.item(DiscoverCellType.ItemType(cellType: cellType, model: model))])
+                        }
                     }
                 }
             }
@@ -158,8 +161,11 @@ class DiscoverCollectionViewController: PCViewController {
         }) {
             // Replace the loading placeholder with either the authenticated item or empty
             if isAuthenticated {
-                let newItem = CellType.item(.init(item: item, region: region, selectedCategory: selectedCategory))
-                snapshot.insertItems([newItem], beforeItem: loadingItem)
+                let model = DiscoverCellModel(item: item, region: region, selectedCategory: selectedCategory)
+                if let cellType = item.cellType() {
+                    let newItem = CellType.item(DiscoverCellType.ItemType(cellType: cellType, model: model))
+                    snapshot.insertItems([newItem], beforeItem: loadingItem)
+                }
             } else {
                 snapshot.insertItems([.empty], beforeItem: loadingItem)
             }
@@ -257,8 +263,7 @@ extension DiscoverCollectionViewController {
             case .loading, .noResults, .noNetwork, .empty:
                 return collectionView.dequeueConfiguredReusableCell(using: nonItemRegistration, for: indexPath, item: item)
             case .item(let item):
-                guard let cellType = item.item.cellType() else { return UICollectionViewCell() }
-                let cellRegistration = registrations[cellType]!
+                let cellRegistration = registrations[item.cellType]!
                 return collectionView.dequeueConfiguredReusableCell(using: cellRegistration, for: indexPath, item: item)
             }
         }


### PR DESCRIPTION
Fixes a warning when scrolling through Discover:

```
Warning: You are setting a new content configuration to a cell that has an existing content configuration, but the existing content view does not support the new configuration. This means the existing content view must be replaced with a new content view created from the new configuration, instead of updating the existing content view directly, which is expensive. Use separate registrations or reuse identifiers for different types of cells to avoid this. Make a symbolic breakpoint at UIContentConfigurationAlertForReplacedContentView to catch this in the debugger.
Cell: <UICollectionViewCell: 0x115cdf980; frame = (0 759.333; 393 100); layer = <CALayer: 0x115f4d2e0>>;
Existing content configuration: UIHostingConfiguration<ModifiedContent<LoadingView, _EnvironmentKeyWritingModifier<Optional<Theme>>>, EmptyView>(rootView: SwiftUI.ModifiedContent<podcasts.LoadingView, SwiftUI._EnvironmentKeyWritingModifier<Swift.Optional<podcasts.Theme>>>(content: podcasts.LoadingView(_theme: SwiftUI.EnvironmentObject<podcasts.Theme>(_store: nil, _seed: 0)), modifier: SwiftUI._EnvironmentKeyWritingModifier<Swift.Optional<podcasts.Theme>>(keyPath: \EnvironmentValues.<computed 0x00000002445948ec (Optional<Theme>)>, value: Optional(podcasts.Theme))), backgroundView: SwiftUI.EmptyView(), storage: SwiftUI.(unknown context at $188ccfa10).UIHostingConfigurationStorage(wantsBackground: false, margins: SwiftUI.OptionalEdgeInsets(top: nil, leading: nil, bottom: nil, trailing: nil), _minSize: (width: nil, height: nil), createsUIInteractions: true, disablesAnimatedSizeInvalidation: false, lastState: Optional(<UICellConfigurationState: 0x116141440; traitCollection = <UITraitCollection: 0x1077a4dc0; UserInterfaceIdiom = Phone, DisplayScale = 3, DisplayGamut = P3, HorizontalSizeClass = Compact, VerticalSizeClass = Regular, UserInterfaceStyle = Dark, UserInterfaceLayoutDirection = LTR, ForceTouchCapability = Unavailable, PreferredContentSizeCategory = L, AccessibilityContrast = Normal, UserInterfaceLevel = Base, ImageDynamicRange = 1, SceneCaptureState = 0>>), wantsPlatformItemList: false, delegate: nil));
New content configuration: UIHostingConfiguration<EmptyView, EmptyView>(rootView: SwiftUI.EmptyView(), backgroundView: SwiftUI.EmptyView(), storage: SwiftUI.(unknown context at $188ccfa10).UIHostingConfigurationStorage(wantsBackground: false, margins: SwiftUI.OptionalEdgeInsets(top: nil, leading: nil, bottom: nil, trailing: nil), _minSize: (width: nil, height: nil), createsUIInteractions: true, disablesAnimatedSizeInvalidation: false, lastState: Optional(<UICellConfigurationState: 0x11633fed0; traitCollection = <UITraitCollection: 0x115d4e580; UserInterfaceIdiom = Phone, DisplayScale = 3, DisplayGamut = P3, HorizontalSizeClass = Compact, VerticalSizeClass = Regular, UserInterfaceStyle = Dark, UserInterfaceLayoutDirection = LTR, ForceTouchCapability = Unavailable, PreferredContentSizeCategory = L, AccessibilityContrast = Normal, UserInterfaceLevel = Base, SceneCaptureState = 0, ImageDynamicRange = 1>>), wantsPlatformItemList: false, delegate: nil))
```

## Discover Cell Type Changes

### Before

All discover cell types shared the same `ItemType` so UICollectionView saw all cells as the same type (`DiscoverCellModel`) and tried to reuse a "categoriesSelector" cell for a "featuredSummary", causing content configuration conflicts.

```swift
enum DiscoverCellType {
    ...
    typealias ItemType = DiscoverCellModel  // ← All types used the same ItemType
}
```

### After
Each cell type now has a unique identifier:
```swift
enum DiscoverCellType {
    ...
    struct ItemType: Hashable {           // ← Now a struct that combines:
        let cellType: DiscoverCellType    // ← Which type of cell this is
        let model: DiscoverCellModel      // ← The data for the cell
    }
}
```

`UICollectionView` now sees `ItemType(cellType: .categoriesSelector, model: data)` and `ItemType(cellType: .featuredSummary, model: data)` as completely different types, allowing proper cell reuse.

## Non Item Registration

### Before

Used one nonItemRegistration that handled all non-item states:

```swift
let nonItemRegistration = UICollectionView.CellRegistration<UICollectionViewCell, Item> { cell, indexPath, item in
  let contentConfiguration: UIContentConfiguration
  switch item {
  case .loading:
	  contentConfiguration = ContentUnavailableConfiguration.loading()
  case .noNetwork:
	  contentConfiguration = ContentUnavailableConfiguration.noNetwork { [weak self] in
		  self?.reloadData()
	  }
  // ... more cases
  }
  cell.contentConfiguration = contentConfiguration
}
```

### After

Created separate registrations for each state:

```swift
let loadingRegistration = UICollectionView.CellRegistration<UICollectionViewCell, Item> { cell, indexPath, item in
  cell.contentConfiguration = ContentUnavailableConfiguration.loading()
}

let noNetworkRegistration = UICollectionView.CellRegistration<UICollectionViewCell, Item> { cell, indexPath, item in
  cell.contentConfiguration = ContentUnavailableConfiguration.noNetwork { [weak self] in
	  self?.reloadData()
  }
}
```

## To test

### Cell Reuse

* Visit Discover and scroll around
* ✅ Verify that sections load and there aren't any large gaps
* Visit various sections
* ✅ Ensure pushed sections load and Discover reloads when popping back

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
