### PR TITLE
GRDB: add new feature flag to enable for 20% of users in TestFlight

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -361,6 +361,8 @@ public enum FeatureFlag: String, CaseIterable {
             "use_podcast_html_description"
         case .podcastViewChanges:
             "podcast_view_changes_2025"
+        case .grdb:
+            "grdb_testflight"
         default:
             rawValue.lowerSnakeCased()
         }

--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -334,6 +334,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 let remoteValue = RemoteConfig.remoteConfig().configValue(forKey: remoteKey)
                 if remoteValue.source == .remote {
                     do {
+                        print("Overriding \(flag) to \(remoteValue.boolValue)")
                         try FeatureFlagOverrideStore().override(flag, withValue: remoteValue.boolValue)
                     } catch {
                         FileLog.shared.addMessage("Failed to set remote feature flag \(flag): \(error)")

--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -334,7 +334,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 let remoteValue = RemoteConfig.remoteConfig().configValue(forKey: remoteKey)
                 if remoteValue.source == .remote {
                     do {
-                        print("Overriding \(flag) to \(remoteValue.boolValue)")
                         try FeatureFlagOverrideStore().override(flag, withValue: remoteValue.boolValue)
                     } catch {
                         FileLog.shared.addMessage("Failed to set remote feature flag \(flag): \(error)")

--- a/podcasts/FirebaseManager.swift
+++ b/podcasts/FirebaseManager.swift
@@ -22,7 +22,7 @@ struct FirebaseManager {
         remoteConfig.setDefaults(remoteConfigDefaults)
 
         Task {
-            let isTestFlight = Bundle.main.appStoreReceiptURL?.lastPathComponent == "sandboxReceipt"
+            let isTestFlight = BuildEnvironment.current == .testFlight
 
             do {
                 try await remoteConfig.setCustomSignals(["isTestflight": "\(isTestFlight)"])


### PR DESCRIPTION
| 📘 Part of: #2773 | 
|:---:|

Add the new `grdb_testflight` feature flag. In Firebase, this is configured to:

1. Always return `false` if it's a non-TestFlight build
2. `true` for 20% of TestFlight users
3. `false` for the rest

## To test

### Functionality

It's quite tricky to test this one as it involves the backend settings the value.

1. [Comment this line ](https://github.com/Automattic/pocket-casts-ios/blob/trunk/podcasts/AppDelegate.swift#L316)
2. [Change](https://github.com/Automattic/pocket-casts-ios/blob/trunk/podcasts/FirebaseManager.swift#L5)`2.hour` to `1.second`
3. [Change](https://github.com/Automattic/pocket-casts-ios/blob/trunk/podcasts/FirebaseManager.swift#L25) `isTestflight` to `false`
4. Run the app multiple times (always doing a clean install)
5. ✅ You should **always** see a `Overriding grdb to false`
6. [Change](https://github.com/Automattic/pocket-casts-ios/blob/trunk/podcasts/FirebaseManager.swift#L25) `isTestflight` to `true`
7. Run the app multiple times
8. ✅ Eventually you should get `Overriding grdb to true` (the number of times until it returns `true` might vary, so you might need to do the clean reinstall for a few times)

### Flag

[Please review the rollout conditions](https://console.firebase.google.com/u/0/project/singular-vector-91401/config/env/firebase/rollout/rollout_9?app=1:910146533958:ios:cf844de2510aeece&dateRange=24h).

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
