### PR TITLE
Fix #2851: Folders History title

### DIFF
--- a/podcasts/Folder History/FolderHistoryView.swift
+++ b/podcasts/Folder History/FolderHistoryView.swift
@@ -38,7 +38,7 @@ struct FolderHistoryView: View {
         .onAppear {
             model.loadEntries()
         }
-        .navigationTitle(L10n.upNextHistory)
+        .navigationTitle(L10n.foldersHistory)
         .applyDefaultThemeOptions()
     }
 }


### PR DESCRIPTION
Fixes #2851 

Fixes the title on Folders History

<img src="https://github.com/user-attachments/assets/6b3339d0-05c6-499f-ad37-07cf47c44092" width=300>

## To test

* Open Settings > Folders History
* ✅ Verify navigation title is "Folders History"

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
