### PR TITLE
Activate new guest network redesign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 7.92
 -----
 - Add Play and Pause buttons to the transcript opened from the episode view [#3285](https://github.com/Automattic/pocket-casts-ios/pull/3285)
+- New UI for Guest Curator and Network highlights sections in Discovery [#3132](https://github.com/Automattic/pocket-casts-ios/issues/3132)
 
 7.91
 -----

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -335,7 +335,7 @@ public enum FeatureFlag: String, CaseIterable {
         case .streamingCustomSessionConfiguration:
             true
         case .guestListsNetworkHighlightsRedesign:
-            false
+            true
         case .smartCategories:
             false
         }


### PR DESCRIPTION
| 📘 Part of: #3132  |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
Activates the FF for network and guest list

## To test

1. Start the app on a clean install
2. Check that by default the new design for Network highlights and Guest Curator are active
3. Smoke test the new list interactions.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
