### PR TITLE
Fix the force reload of Feature Flag from developer panel

### DIFF
--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -312,8 +312,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
     }
 
-    func updateRemoteFeatureFlags() {
-        guard BuildEnvironment.current != .debug else { return }
+    func updateRemoteFeatureFlags(forceReload: Bool = false) {
+        if BuildEnvironment.current == .debug, !forceReload { return }
 
         if FeatureFlag.errorLogoutHandling.enabled != Settings.errorLogoutHandling {
             ServerConfig.avoidLogoutOnError = FeatureFlag.errorLogoutHandling.enabled
@@ -334,6 +334,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 let remoteValue = RemoteConfig.remoteConfig().configValue(forKey: remoteKey)
                 if remoteValue.source == .remote {
                     do {
+                        FileLog.shared.console("Override \(flag): \(remoteValue.boolValue)")
                         try FeatureFlagOverrideStore().override(flag, withValue: remoteValue.boolValue)
                     } catch {
                         FileLog.shared.addMessage("Failed to set remote feature flag \(flag): \(error)")

--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -313,7 +313,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func updateRemoteFeatureFlags(forceReload: Bool = false) {
-        if BuildEnvironment.current == .debug, !forceReload { return }
+        guard BuildEnvironment.current != .debug || forceReload else { return }
 
         if FeatureFlag.errorLogoutHandling.enabled != Settings.errorLogoutHandling {
             ServerConfig.avoidLogoutOnError = FeatureFlag.errorLogoutHandling.enabled

--- a/podcasts/DeveloperMenu.swift
+++ b/podcasts/DeveloperMenu.swift
@@ -89,7 +89,9 @@ struct DeveloperMenu: View {
 
                 Button("Force Reload Feature Flags") {
                     FirebaseManager.refreshRemoteConfig(expirationDuration: 0) { _ in
-                        (UIApplication.shared.delegate as? AppDelegate)?.updateRemoteFeatureFlags()
+                        DispatchQueue.main.async {
+                            (UIApplication.shared.delegate as? AppDelegate)?.updateRemoteFeatureFlags(forceReload: true)
+                        }
                     }
                 }
             }


### PR DESCRIPTION
While testing the Libro.fm FF remotely enabled, I discovered the force reload from the Dev panel didn't work:
- Xcode complained about the reload in background
- The force reload wasn't starting because of the debug environment 

This PR adds:
- Fix the background issue
- Add a force reload argument
- Add a debug log when the Firebase configuration overrides the local values

## To test

- Run this branch
- Confirm you don't see any any `Override \(flag): \(remoteValue.boolValue)`
- Open the dev panel and tap on `Force Reload Feature Flags`
- Confirm you see the override logs
- Stop the build
- Replace [this line](https://github.com/Automattic/pocket-casts-ios/blob/71d863874cb8e590ff902d91eaf73603d528f629/Modules/Utils/Sources/PocketCastsUtils/General/BuildEnvironment.swift#L24) with `.appStore`
- Start the build
- Confirm you see the override logs

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
