### PR TITLE
[Smart Categories] Category Visitation Tracking

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/Discover/DiscoverServerHandler.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Discover/DiscoverServerHandler.swift
@@ -4,7 +4,6 @@ import PocketCastsUtils
 
 public protocol DiscoverServerHandling {
     func discoverCategories(source: String, authenticated: Bool?) async -> [DiscoverCategory]
-    func discoverRecommendedCategories(source: String, authenticated: Bool?) async -> [Int]?
 }
 
 public class DiscoverServerHandler: DiscoverServerHandling {
@@ -65,14 +64,6 @@ public class DiscoverServerHandler: DiscoverServerHandling {
     public func discoverCategories(source: String, authenticated: Bool?, completion: @escaping ([DiscoverCategory]?) -> Void) {
         discoverRequest(path: source, type: [DiscoverCategory].self, authenticated: authenticated) { categories, _ in
             completion(categories)
-        }
-    }
-
-    public func discoverRecommendedCategories(source: String, authenticated: Bool?) async -> [Int]? {
-        return await withCheckedContinuation { continuation in
-            discoverRequest(path: source, type: [Int].self, authenticated: authenticated) { categories, _ in
-                continuation.resume(with: .success(categories))
-            }
         }
     }
 

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
@@ -272,7 +272,6 @@ public struct DiscoverItem: Decodable, Equatable {
     public var regions: [String]
     public var isSponsored: Bool?
     public var popular: [Int]?
-    public var recommendations: DiscoverSource?
     public var categoryID: Int?
     public var dateTime: String?
 
@@ -284,7 +283,7 @@ public struct DiscoverItem: Decodable, Equatable {
         case expandedTopItemLabel = "expanded_top_item_label"
         case categoryID = "category_id"
         case dateTime = "datetime"
-        case type, title, source, regions, curated, uuid, popular, id, authenticated, recommendations
+        case type, title, source, regions, curated, uuid, popular, id, authenticated
     }
 
     public init(
@@ -304,7 +303,6 @@ public struct DiscoverItem: Decodable, Equatable {
         popular: [Int]? = nil,
         categoryID: Int? = nil,
         authenticated: Bool? = nil,
-        recommendations: DiscoverSource? = nil
     ) {
         self.id = id
         self.uuid = uuid
@@ -322,7 +320,6 @@ public struct DiscoverItem: Decodable, Equatable {
         self.popular = popular
         self.categoryID = categoryID
         self.authenticated = authenticated
-        self.recommendations = recommendations
     }
 
     public var isAuthenticated: Bool {

--- a/PocketCastsTests/Tests/Discover/DiscoverItemObservableTests.swift
+++ b/PocketCastsTests/Tests/Discover/DiscoverItemObservableTests.swift
@@ -19,45 +19,13 @@ final class DiscoverItemObservableTests: XCTestCase {
                 DiscoverCategory(id: 3, name: "Science")
             ]
         }
-
-        func discoverRecommendedCategories(source: String, authenticated: Bool?) async -> [Int]? {
-            return [2, 3]
-        }
     }
 
-    func testRecommendedFiltering_appliesCorrectly() async {
-        FeatureFlagMock().set(.smartCategories, value: true)
-
-        // Given
-        let mockHandler = MockServerHandler()
-        let observable = CategoriesSelectorViewController.DiscoverItemObservable(serverHandler: mockHandler)
-        observable.item = DiscoverItem(
-            id: "item1",
-            title: "Test",
-            type: "categories",
-            source: "mockSource",
-            regions: [],
-            popular: [1, 2],
-            authenticated: true,
-            recommendations: DiscoverSource(source: "recSource", authenticated: true)
-        )
-
-        // When
-        let result = await observable.load()
-
-        // Then
-        XCTAssertEqual(result?.categories.count, 3)
-        XCTAssertEqual(result?.prioritized.map(\.id), [2, 3])
-    }
-
-    func testPopularFiltering_appliesWhenNoRecommendations() async {
-        class NoRecMock: MockServerHandler {
-            override func discoverRecommendedCategories(source: String, authenticated: Bool?) async -> [Int]? {
-                return nil
-            }
+    func testPopularFiltering() async {
+        class Mock: MockServerHandler {
         }
 
-        let observable = CategoriesSelectorViewController.DiscoverItemObservable(serverHandler: NoRecMock())
+        let observable = CategoriesSelectorViewController.DiscoverItemObservable(serverHandler: Mock())
         observable.item = DiscoverItem(
             id: "item2",
             title: "Test 2",

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1792,6 +1792,7 @@
 		F5BA5C9A2C7F701900BDA5B9 /* DiscoverCollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BA5C992C7F701900BDA5B9 /* DiscoverCollectionViewController.swift */; };
 		F5BA5C9C2C80F38200BDA5B9 /* UIViewControllerContentConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BA5C9B2C80F38200BDA5B9 /* UIViewControllerContentConfiguration.swift */; };
 		F5BA5C9E2C81254300BDA5B9 /* DiscoverCollectionViewController+DiscoverDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BA5C9D2C81254300BDA5B9 /* DiscoverCollectionViewController+DiscoverDelegate.swift */; };
+		F5BC940A2E0B7644000F9B64 /* UserDefaults+Tracking.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BC94092E0B7644000F9B64 /* UserDefaults+Tracking.swift */; };
 		F5BDBF502DB9754900AD8DF1 /* PodcastTableCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BDBF4F2DB9754900AD8DF1 /* PodcastTableCellView.swift */; };
 		F5BEAEC92DA73CE800541921 /* DebugInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BEAEC82DA73CE000541921 /* DebugInfo.swift */; };
 		F5BFF9892C6B0A9100A84561 /* Optional+ThrowOnNil.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BFF9882C6B0A9100A84561 /* Optional+ThrowOnNil.swift */; };
@@ -3974,6 +3975,7 @@
 		F5BA5C992C7F701900BDA5B9 /* DiscoverCollectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverCollectionViewController.swift; sourceTree = "<group>"; };
 		F5BA5C9B2C80F38200BDA5B9 /* UIViewControllerContentConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewControllerContentConfiguration.swift; sourceTree = "<group>"; };
 		F5BA5C9D2C81254300BDA5B9 /* DiscoverCollectionViewController+DiscoverDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DiscoverCollectionViewController+DiscoverDelegate.swift"; sourceTree = "<group>"; };
+		F5BC94092E0B7644000F9B64 /* UserDefaults+Tracking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+Tracking.swift"; sourceTree = "<group>"; };
 		F5BDBF4F2DB9754900AD8DF1 /* PodcastTableCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PodcastTableCellView.swift; sourceTree = "<group>"; };
 		F5BEAEC82DA73CE000541921 /* DebugInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugInfo.swift; sourceTree = "<group>"; };
 		F5BFF9882C6B0A9100A84561 /* Optional+ThrowOnNil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Optional+ThrowOnNil.swift"; sourceTree = "<group>"; };
@@ -5674,6 +5676,7 @@
 				4005F27422C057EA006BB8B8 /* AVFileUtil.swift */,
 				4004F56424EB51F900FBEBE1 /* SceneHelper.swift */,
 				46305CEC272AFA5F003AC87B /* UserDefaults+Helpers.swift */,
+				F5BC94092E0B7644000F9B64 /* UserDefaults+Tracking.swift */,
 				BD6275BE27D1C5370020A28C /* TraceHelper.swift */,
 				C7C4CAF228ABFD0900CFC8CF /* Notifications.swift */,
 				C7D6551328E5153200AD7174 /* Debounce.swift */,
@@ -10761,6 +10764,7 @@
 				FF0753942D70F06800BE8B3B /* FoldersCoordinator.swift in Sources */,
 				BD6CABC927D18C0700C6D396 /* GridBadgeView.swift in Sources */,
 				BDF15A441B54E155000EC323 /* PlaybackProtocol.swift in Sources */,
+				F5BC940A2E0B7644000F9B64 /* UserDefaults+Tracking.swift in Sources */,
 				BD9F2FD627549BA300070958 /* AboutView.swift in Sources */,
 				FF91A0FC2B6BC1D2002A0590 /* UpgradePrompt.swift in Sources */,
 				BDCCBC8824BC444F009B4D1D /* CustomTimeStepper.swift in Sources */,

--- a/podcasts/Categories/CategoriesSelectorView.swift
+++ b/podcasts/Categories/CategoriesSelectorView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import PocketCastsServer
+import PocketCastsUtils
 
 struct Category {
     let title: String
@@ -159,6 +160,9 @@ struct CategoryButton: View {
         Button(action: {
             selectedCategory = category
             Analytics.track(.discoverCategoriesPillTapped, properties: ["name": category.name ?? "none", "region": region ?? "none", "id": category.id ?? -1])
+            if FeatureFlag.smartCategories.enabled {
+                UserDefaults.standard.track(event: "category-visits")
+            }
         }, label: {
             Text(category.name ?? "")
         })

--- a/podcasts/Categories/CategoriesSelectorView.swift
+++ b/podcasts/Categories/CategoriesSelectorView.swift
@@ -161,7 +161,7 @@ struct CategoryButton: View {
             selectedCategory = category
             Analytics.track(.discoverCategoriesPillTapped, properties: ["name": category.name ?? "none", "region": region ?? "none", "id": category.id ?? -1])
             if FeatureFlag.smartCategories.enabled, let categoryID = category.id {
-                UserDefaults.standard.track(event: "category-visits", id: String(categoryID))
+                UserDefaults.standard.trackVisitation(event: .discoverCategory, id: String(categoryID))
             }
         }, label: {
             Text(category.name ?? "")

--- a/podcasts/Categories/CategoriesSelectorView.swift
+++ b/podcasts/Categories/CategoriesSelectorView.swift
@@ -160,8 +160,8 @@ struct CategoryButton: View {
         Button(action: {
             selectedCategory = category
             Analytics.track(.discoverCategoriesPillTapped, properties: ["name": category.name ?? "none", "region": region ?? "none", "id": category.id ?? -1])
-            if FeatureFlag.smartCategories.enabled {
-                UserDefaults.standard.track(event: "category-visits")
+            if FeatureFlag.smartCategories.enabled, let categoryID = category.id {
+                UserDefaults.standard.track(event: "category-visits", id: String(categoryID))
             }
         }, label: {
             Text(category.name ?? "")

--- a/podcasts/Categories/CategoriesSelectorViewController.swift
+++ b/podcasts/Categories/CategoriesSelectorViewController.swift
@@ -26,23 +26,27 @@ class CategoriesSelectorViewController: ThemedHostingController<CategoriesSelect
 
             // Filter and rank categories by recommendations
             if FeatureFlag.smartCategories.enabled,
-               let recommendedSource = item?.recommendations?.source,
-               let recommendedCategories = await self.serverHandler.discoverRecommendedCategories(source: recommendedSource, authenticated: item?.authenticated) {
-                filteredCategories = categories
-                    // Filter categories based on recommended IDs
-                    .compactMap { category -> DiscoverCategory? in
-                        guard let id = category.id, recommendedCategories.contains(id) else { return nil }
-                        return category
-                    }
-                    // Filter categories based on position in recommendedIDs
-                    .sorted { lhs, rhs in
-                        guard let lhsId = lhs.id, let rhsId = rhs.id,
-                              let lhsIndex = recommendedCategories.firstIndex(of: lhsId),
-                              let rhsIndex = recommendedCategories.firstIndex(of: rhsId) else {
-                            return false
-                        }
-                        return lhsIndex < rhsIndex
-                    }
+               let recommendations = UserDefaults.standard.tracks(for: "category-visits") {
+
+                let recommendedIDs = recommendations
+                    .sorted { $0.value > $1.value }
+                    .map { $0.key }
+
+                // Dictionary to speed up lookup and preserve original category objects
+                let categoriesByID = Dictionary(uniqueKeysWithValues: categories.compactMap { category -> (String, DiscoverCategory)? in
+                    guard let id = category.id else { return nil }
+                    return (String(id), category)
+                })
+
+                var sortedCategories: [DiscoverCategory] = recommendedIDs.compactMap { categoriesByID[$0] }
+
+                let remainingCategories = filteredCategories.filter { category in
+                    guard let id = category.id else { return false }
+                    return !recommendedIDs.contains(String(id))
+                }
+
+                sortedCategories.append(contentsOf: remainingCategories)
+                filteredCategories = sortedCategories
             }
 
             self.cachedCategories = categories

--- a/podcasts/Categories/CategoriesSelectorViewController.swift
+++ b/podcasts/Categories/CategoriesSelectorViewController.swift
@@ -26,7 +26,7 @@ class CategoriesSelectorViewController: ThemedHostingController<CategoriesSelect
 
             // Filter and rank categories by recommendations
             if FeatureFlag.smartCategories.enabled,
-               let recommendations = UserDefaults.standard.tracks(for: "category-visits") {
+               let recommendations = UserDefaults.standard.visitations(for: .discoverCategory) {
 
                 let recommendedIDs = recommendations
                     .sorted { $0.value > $1.value }

--- a/podcasts/UserDefaults+Tracking.swift
+++ b/podcasts/UserDefaults+Tracking.swift
@@ -1,12 +1,20 @@
 extension UserDefaults {
-    func track(event: String, id: String) {
-        var visits = UserDefaults.standard.dictionary(forKey: event) ?? [:]
-        let current = visits[id] as? Int ?? 0
-        visits[id] = current + 1
-        UserDefaults.standard.set(visits, forKey: event)
+    enum VisitationTrackEvent: String {
+        case discoverCategory
+
+        var key: String {
+            "visitation-\(rawValue)"
+        }
     }
 
-    func tracks(for event: String) -> [String: Int]? {
-        UserDefaults.standard.dictionary(forKey: event) as? [String: Int]
+    func trackVisitation(event: VisitationTrackEvent, id: String) {
+        var visits = UserDefaults.standard.dictionary(forKey: event.key) ?? [:]
+        let current = visits[id] as? Int ?? 0
+        visits[id] = current + 1
+        UserDefaults.standard.set(visits, forKey: event.key)
+    }
+
+    func visitations(for event: VisitationTrackEvent) -> [String: Int]? {
+        UserDefaults.standard.dictionary(forKey: event.key) as? [String: Int]
     }
 }

--- a/podcasts/UserDefaults+Tracking.swift
+++ b/podcasts/UserDefaults+Tracking.swift
@@ -1,0 +1,7 @@
+extension UserDefaults {
+    func track(event: String) {
+        let visits = UserDefaults.standard.dictionary(forKey: event) ?? [:]
+        visits[category.id] += 1
+        UserDefaults.standard.jsonObject(visits, forKey: event)
+    }
+}

--- a/podcasts/UserDefaults+Tracking.swift
+++ b/podcasts/UserDefaults+Tracking.swift
@@ -1,7 +1,12 @@
 extension UserDefaults {
-    func track(event: String) {
-        let visits = UserDefaults.standard.dictionary(forKey: event) ?? [:]
-        visits[category.id] += 1
-        UserDefaults.standard.jsonObject(visits, forKey: event)
+    func track(event: String, id: String) {
+        var visits = UserDefaults.standard.dictionary(forKey: event) ?? [:]
+        let current = visits[id] as? Int ?? 0
+        visits[id] = current + 1
+        UserDefaults.standard.set(visits, forKey: event)
+    }
+
+    func tracks(for event: String) -> [String: Int]? {
+        UserDefaults.standard.dictionary(forKey: event) as? [String: Int]
     }
 }


### PR DESCRIPTION
| 📘 Part of: [Smart Categories](https://linear.app/a8c/project/smart-categories-87cfb5eff13e/overview)
|:---:|

Closes #3289 and #3290

* Adds tracking of category views in UserDefaults
* Adds sorting to show most visited categories

## To test

* Enable the `smartCategories` feature flag
* Visit Discover
* Tap tabs later in the list
* Revisit Discover
* Restart the app
* Verify that the visited category is shown earlier in the list

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
