### PR TITLE
[Smart categories] Handle Sponsored categories

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
@@ -274,6 +274,7 @@ public struct DiscoverItem: Decodable, Equatable {
     public var popular: [Int]?
     public var categoryID: Int?
     public var dateTime: String?
+    public var sponsoredCategoryIDs: [Int]?
 
     public enum CodingKeys: String, CodingKey {
         case summaryStyle = "summary_style"
@@ -283,6 +284,7 @@ public struct DiscoverItem: Decodable, Equatable {
         case expandedTopItemLabel = "expanded_top_item_label"
         case categoryID = "category_id"
         case dateTime = "datetime"
+        case sponsoredCategoryIDs = "sponsored_ids"
         case type, title, source, regions, curated, uuid, popular, id, authenticated
     }
 
@@ -303,6 +305,7 @@ public struct DiscoverItem: Decodable, Equatable {
         popular: [Int]? = nil,
         categoryID: Int? = nil,
         authenticated: Bool? = nil,
+        sponsoredCategoryIDs: [Int]? = nil
     ) {
         self.id = id
         self.uuid = uuid
@@ -320,6 +323,7 @@ public struct DiscoverItem: Decodable, Equatable {
         self.popular = popular
         self.categoryID = categoryID
         self.authenticated = authenticated
+        self.sponsoredCategoryIDs = sponsoredCategoryIDs
     }
 
     public var isAuthenticated: Bool {

--- a/PocketCastsTests/Tests/Discover/DiscoverItemObservableTests.swift
+++ b/PocketCastsTests/Tests/Discover/DiscoverItemObservableTests.swift
@@ -47,16 +47,22 @@ final class DiscoverItemObservableTests: XCTestCase {
                     DiscoverCategory(id: 2, name: "News"),
                     DiscoverCategory(id: 3, name: "Science"),
                     DiscoverCategory(id: 4, name: "Sports"),
-                    DiscoverCategory(id: 5, name: "Music")
+                    DiscoverCategory(id: 5, name: "Music"),
+                    DiscoverCategory(id: 6, name: "Comedy"),
+                    DiscoverCategory(id: 7, name: "History")
                 ]
             }
         }
 
-        // Set up mock visitation data
+        // Set up mock visitation data - top 6 most visited
         UserDefaults.standard.set([
-            "3": 10, // Science - most visited
-            "1": 5,  // Tech - second most visited
-            "4": 2   // Sports - least visited
+            "3": 10, // Science - most visited (sponsored)
+            "1": 8,  // Tech - second most visited
+            "6": 7,  // Comedy - third most visited
+            "2": 6,  // News - fourth most visited (sponsored)
+            "4": 5,  // Sports - fifth most visited
+            "7": 4   // History - sixth most visited
+            // Music (id: 5) has no visits, so not in top 6
         ], forKey: UserDefaults.VisitationTrackEvent.discoverCategory.key)
 
         featureFlagMock.set(.smartCategories, value: true)
@@ -69,17 +75,18 @@ final class DiscoverItemObservableTests: XCTestCase {
             regions: [],
             popular: nil,
             authenticated: false,
-            sponsoredCategoryIDs: [2, 3]
+            sponsoredCategoryIDs: [2, 3] // Both in top 6
         )
 
         let result = await observable.load()
 
-        // Expected order: Science (sponsored + most visited), News (sponsored + unvisited), Tech (non-sponsored + visited), Sports (non-sponsored + visited), Music (non-sponsored + unvisited)
-        XCTAssertEqual(result?.prioritized.map(\.id), [3, 2, 1, 4, 5])
-        XCTAssertEqual(result?.categories.count, 5)
+        // Expected: Only top 6 categories, with sponsored from top 6 first, then rest by visit count
+        // Science (3) and News (2) are sponsored and in top 6, so they come first
+        XCTAssertEqual(result?.prioritized.map(\.id), [3, 2, 1, 6, 4, 7])
+        XCTAssertEqual(result?.prioritized.count, 6)
     }
 
-    func testSponsoredCategoriesAlwaysFirst() async {
+    func testSponsoredCategoriesOnlyPromotedIfInTop6() async {
         class Mock: MockServerHandler {
             override func discoverCategories(source: String, authenticated: Bool?) async -> [DiscoverCategory] {
                 return [
@@ -90,10 +97,10 @@ final class DiscoverItemObservableTests: XCTestCase {
             }
         }
 
-        // Set up visitation data where non-sponsored has more visits
+        // Set up visitation data where sponsored category is in top visits
         UserDefaults.standard.set([
             "1": 100, // Tech - most visited (non-sponsored)
-            "3": 5    // Science - less visited (sponsored)
+            "3": 50   // Science - second most visited (sponsored)
         ], forKey: UserDefaults.VisitationTrackEvent.discoverCategory.key)
 
         featureFlagMock.set(.smartCategories, value: true)
@@ -111,11 +118,11 @@ final class DiscoverItemObservableTests: XCTestCase {
 
         let result = await observable.load()
 
-        // Sponsored should come first despite having fewer visits
+        // Science is sponsored AND in top 6, so it gets promoted first
         XCTAssertEqual(result?.prioritized.map(\.id), [3, 1, 2])
     }
 
-    func testVisitedCategoriesWithinSponsoredGroup() async {
+    func testMultipleSponsoredCategoriesInTop6() async {
         class Mock: MockServerHandler {
             override func discoverCategories(source: String, authenticated: Bool?) async -> [DiscoverCategory] {
                 return [
@@ -129,8 +136,10 @@ final class DiscoverItemObservableTests: XCTestCase {
 
         // Multiple sponsored categories with different visit patterns
         UserDefaults.standard.set([
-            "2": 20, // News - more visited
-            "1": 10  // Tech - less visited
+            "2": 20, // News - most visited (sponsored)
+            "1": 15, // Tech - second most visited (sponsored)
+            "3": 10, // Science - third most visited
+            "4": 5   // Sports - fourth most visited (sponsored)
         ], forKey: UserDefaults.VisitationTrackEvent.discoverCategory.key)
 
         featureFlagMock.set(.smartCategories, value: true)
@@ -143,12 +152,12 @@ final class DiscoverItemObservableTests: XCTestCase {
             regions: [],
             popular: nil,
             authenticated: false,
-            sponsoredCategoryIDs: [1, 2, 4] // 1 and 2 visited, 4 unvisited
+            sponsoredCategoryIDs: [1, 2, 4] // All are in top 6
         )
 
         let result = await observable.load()
 
-        // Expected: visited sponsored (by visit count), unvisited sponsored, then non-sponsored
+        // Expected: sponsored categories from top 6 first (by visit count), then non-sponsored
         XCTAssertEqual(result?.prioritized.map(\.id), [2, 1, 4, 3])
     }
 
@@ -185,6 +194,53 @@ final class DiscoverItemObservableTests: XCTestCase {
 
         // Expected: visited categories by visit count, then unvisited in original order
         XCTAssertEqual(result?.prioritized.map(\.id), [3, 1, 2])
+    }
+
+    func testSponsoredCategoriesNotInTop6NotPromoted() async {
+        class Mock: MockServerHandler {
+            override func discoverCategories(source: String, authenticated: Bool?) async -> [DiscoverCategory] {
+                return [
+                    DiscoverCategory(id: 1, name: "Tech"),
+                    DiscoverCategory(id: 2, name: "News"),
+                    DiscoverCategory(id: 3, name: "Science"),
+                    DiscoverCategory(id: 4, name: "Sports"),
+                    DiscoverCategory(id: 5, name: "Music"),
+                    DiscoverCategory(id: 6, name: "Comedy"),
+                    DiscoverCategory(id: 7, name: "History"),
+                    DiscoverCategory(id: 8, name: "Religion")
+                ]
+            }
+        }
+
+        // Set up visitation data where sponsored category is NOT in top 6
+        UserDefaults.standard.set([
+            "1": 100, // Tech - most visited
+            "3": 90,  // Science - second most visited
+            "4": 80,  // Sports - third most visited
+            "5": 70,  // Music - fourth most visited
+            "6": 60,  // Comedy - fifth most visited
+            "7": 50   // History - sixth most visited
+            // Religion (id: 8, sponsored) and News (id: 2, sponsored) have no visits
+        ], forKey: UserDefaults.VisitationTrackEvent.discoverCategory.key)
+
+        featureFlagMock.set(.smartCategories, value: true)
+
+        let observable = CategoriesSelectorViewController.DiscoverItemObservable(serverHandler: Mock())
+        observable.item = DiscoverItem(
+            id: "item1",
+            title: "Test",
+            source: "mockSource",
+            regions: [],
+            popular: nil,
+            authenticated: false,
+            sponsoredCategoryIDs: [2, 8] // Neither in top 6
+        )
+
+        let result = await observable.load()
+
+        // Expected: Only top 6 categories by visit count, no sponsored promotion since none are in top 6
+        XCTAssertEqual(result?.prioritized.map(\.id), [1, 3, 4, 5, 6, 7])
+        XCTAssertEqual(result?.prioritized.count, 6)
     }
 
     func testSmartCategoriesDisabled() async {

--- a/PocketCastsTests/Tests/Discover/DiscoverItemObservableTests.swift
+++ b/PocketCastsTests/Tests/Discover/DiscoverItemObservableTests.swift
@@ -38,4 +38,44 @@ final class DiscoverItemObservableTests: XCTestCase {
         let result = await observable.load()
         XCTAssertEqual(result?.prioritized.map(\.id), [1])
     }
+
+    func testCategorySponsoredRanking() async {
+        class Mock: MockServerHandler {
+            override func discoverCategories(source: String, authenticated: Bool?) async -> [DiscoverCategory] {
+                return [
+                    DiscoverCategory(id: 1, name: "Tech"),
+                    DiscoverCategory(id: 2, name: "News"),
+                    DiscoverCategory(id: 3, name: "Science"),
+                    DiscoverCategory(id: 4, name: "Sports"),
+                    DiscoverCategory(id: 5, name: "Music")
+                ]
+            }
+        }
+
+        // Set up mock visitation data
+        UserDefaults.standard.set([
+            "3": 10, // Science - most visited
+            "1": 5,  // Tech - second most visited
+            "4": 2   // Sports - least visited
+        ], forKey: UserDefaults.VisitationTrackEvent.discoverCategory.key)
+
+        featureFlagMock.set(.smartCategories, value: true)
+
+        let observable = CategoriesSelectorViewController.DiscoverItemObservable(serverHandler: Mock())
+        observable.item = DiscoverItem(
+            id: "item1",
+            title: "Test Categories",
+            source: "mockSource",
+            regions: [],
+            popular: nil,
+            authenticated: false,
+            sponsoredCategoryIDs: [2, 3]
+        )
+
+        let result = await observable.load()
+
+        // Expected order: Science (sponsored + most visited), News (sponsored + unvisited), Tech (non-sponsored + visited), Sports (non-sponsored + visited), Music (non-sponsored + unvisited)
+        XCTAssertEqual(result?.prioritized.map(\.id), [3, 2, 1, 4, 5])
+        XCTAssertEqual(result?.categories.count, 5)
+    }
 }

--- a/PocketCastsTests/Tests/Discover/DiscoverItemObservableTests.swift
+++ b/PocketCastsTests/Tests/Discover/DiscoverItemObservableTests.swift
@@ -78,4 +78,147 @@ final class DiscoverItemObservableTests: XCTestCase {
         XCTAssertEqual(result?.prioritized.map(\.id), [3, 2, 1, 4, 5])
         XCTAssertEqual(result?.categories.count, 5)
     }
+
+    func testSponsoredCategoriesAlwaysFirst() async {
+        class Mock: MockServerHandler {
+            override func discoverCategories(source: String, authenticated: Bool?) async -> [DiscoverCategory] {
+                return [
+                    DiscoverCategory(id: 1, name: "Tech"),
+                    DiscoverCategory(id: 2, name: "News"),
+                    DiscoverCategory(id: 3, name: "Science")
+                ]
+            }
+        }
+
+        // Set up visitation data where non-sponsored has more visits
+        UserDefaults.standard.set([
+            "1": 100, // Tech - most visited (non-sponsored)
+            "3": 5    // Science - less visited (sponsored)
+        ], forKey: UserDefaults.VisitationTrackEvent.discoverCategory.key)
+
+        featureFlagMock.set(.smartCategories, value: true)
+
+        let observable = CategoriesSelectorViewController.DiscoverItemObservable(serverHandler: Mock())
+        observable.item = DiscoverItem(
+            id: "item1",
+            title: "Test",
+            source: "mockSource",
+            regions: [],
+            popular: nil,
+            authenticated: false,
+            sponsoredCategoryIDs: [3]
+        )
+
+        let result = await observable.load()
+
+        // Sponsored should come first despite having fewer visits
+        XCTAssertEqual(result?.prioritized.map(\.id), [3, 1, 2])
+    }
+
+    func testVisitedCategoriesWithinSponsoredGroup() async {
+        class Mock: MockServerHandler {
+            override func discoverCategories(source: String, authenticated: Bool?) async -> [DiscoverCategory] {
+                return [
+                    DiscoverCategory(id: 1, name: "Tech"),
+                    DiscoverCategory(id: 2, name: "News"),
+                    DiscoverCategory(id: 3, name: "Science"),
+                    DiscoverCategory(id: 4, name: "Sports")
+                ]
+            }
+        }
+
+        // Multiple sponsored categories with different visit patterns
+        UserDefaults.standard.set([
+            "2": 20, // News - more visited
+            "1": 10  // Tech - less visited
+        ], forKey: UserDefaults.VisitationTrackEvent.discoverCategory.key)
+
+        featureFlagMock.set(.smartCategories, value: true)
+
+        let observable = CategoriesSelectorViewController.DiscoverItemObservable(serverHandler: Mock())
+        observable.item = DiscoverItem(
+            id: "item1",
+            title: "Test",
+            source: "mockSource",
+            regions: [],
+            popular: nil,
+            authenticated: false,
+            sponsoredCategoryIDs: [1, 2, 4] // 1 and 2 visited, 4 unvisited
+        )
+
+        let result = await observable.load()
+
+        // Expected: visited sponsored (by visit count), unvisited sponsored, then non-sponsored
+        XCTAssertEqual(result?.prioritized.map(\.id), [2, 1, 4, 3])
+    }
+
+    func testNoSponsoredCategories() async {
+        class Mock: MockServerHandler {
+            override func discoverCategories(source: String, authenticated: Bool?) async -> [DiscoverCategory] {
+                return [
+                    DiscoverCategory(id: 1, name: "Tech"),
+                    DiscoverCategory(id: 2, name: "News"),
+                    DiscoverCategory(id: 3, name: "Science")
+                ]
+            }
+        }
+
+        UserDefaults.standard.set([
+            "3": 15,
+            "1": 10
+        ], forKey: UserDefaults.VisitationTrackEvent.discoverCategory.key)
+
+        featureFlagMock.set(.smartCategories, value: true)
+
+        let observable = CategoriesSelectorViewController.DiscoverItemObservable(serverHandler: Mock())
+        observable.item = DiscoverItem(
+            id: "item1",
+            title: "Test",
+            source: "mockSource",
+            regions: [],
+            popular: nil,
+            authenticated: false,
+            sponsoredCategoryIDs: nil
+        )
+
+        let result = await observable.load()
+
+        // Expected: visited categories by visit count, then unvisited in original order
+        XCTAssertEqual(result?.prioritized.map(\.id), [3, 1, 2])
+    }
+
+    func testSmartCategoriesDisabled() async {
+        class Mock: MockServerHandler {
+            override func discoverCategories(source: String, authenticated: Bool?) async -> [DiscoverCategory] {
+                return [
+                    DiscoverCategory(id: 1, name: "Tech"),
+                    DiscoverCategory(id: 2, name: "News"),
+                    DiscoverCategory(id: 3, name: "Science")
+                ]
+            }
+        }
+
+        UserDefaults.standard.set([
+            "3": 15,
+            "1": 10
+        ], forKey: UserDefaults.VisitationTrackEvent.discoverCategory.key)
+
+        featureFlagMock.set(.smartCategories, value: false)
+
+        let observable = CategoriesSelectorViewController.DiscoverItemObservable(serverHandler: Mock())
+        observable.item = DiscoverItem(
+            id: "item1",
+            title: "Test",
+            source: "mockSource",
+            regions: [],
+            popular: nil,
+            authenticated: false,
+            sponsoredCategoryIDs: [3]
+        )
+
+        let result = await observable.load()
+
+        // Should return original order when feature is disabled
+        XCTAssertEqual(result?.prioritized.map(\.id), [1, 2, 3])
+    }
 }

--- a/podcasts/Categories/CategoriesSelectorViewController.swift
+++ b/podcasts/Categories/CategoriesSelectorViewController.swift
@@ -18,34 +18,78 @@ class CategoriesSelectorViewController: ThemedHostingController<CategoriesSelect
 
             let categories = await self.serverHandler.discoverCategories(source: source, authenticated: self.item?.authenticated)
 
-            // Filter categories by popularity
-            var filteredCategories = categories.filter {
-                guard let id = $0.id else { return false }
-                return self.item?.popular?.contains(id) == true
+            // Determine which categories to work with
+            let workingCategories: [DiscoverCategory]
+            if let popular = self.item?.popular {
+                workingCategories = categories.filter {
+                    guard let id = $0.id else { return false }
+                    return popular.contains(id)
+                }
+            } else {
+                workingCategories = categories
             }
 
             // Filter and rank categories by recommendations
+            var filteredCategories = workingCategories
             if FeatureFlag.smartCategories.enabled,
                let recommendations = UserDefaults.standard.visitations(for: .discoverCategory) {
 
+                let categories = item?.sponsoredCategoryIDs
+                let sponsoredIDs = Set(item?.sponsoredCategoryIDs?.map { String($0) } ?? [])
                 let recommendedIDs = recommendations
                     .sorted { $0.value > $1.value }
                     .map { $0.key }
 
-                // Dictionary to speed up lookup and preserve original category objects
-                let categoriesByID = Dictionary(uniqueKeysWithValues: categories.compactMap { category -> (String, DiscoverCategory)? in
-                    guard let id = category.id else { return nil }
-                    return (String(id), category)
-                })
-
-                var sortedCategories: [DiscoverCategory] = recommendedIDs.compactMap { categoriesByID[$0] }
-
-                let remainingCategories = filteredCategories.filter { category in
-                    guard let id = category.id else { return false }
-                    return !recommendedIDs.contains(String(id))
+                // Separate sponsored and non-sponsored categories
+                let sponsoredCategories = workingCategories.filter { category in
+                    guard let id = category.id.map(String.init) else { return false }
+                    return sponsoredIDs.contains(id)
                 }
 
-                sortedCategories.append(contentsOf: remainingCategories)
+                let nonSponsoredCategories = workingCategories.filter { category in
+                    guard let id = category.id.map(String.init) else { return false }
+                    return !sponsoredIDs.contains(id)
+                }
+
+                var sortedCategories: [DiscoverCategory] = []
+
+                // 1. Add ALL sponsored categories first, sorted by visitation order
+                let sponsoredByVisitation = sponsoredCategories.sorted { lhs, rhs in
+                    guard let lhsID = lhs.id.map(String.init),
+                          let rhsID = rhs.id.map(String.init) else { return false }
+
+                    let lhsIndex = recommendedIDs.firstIndex(of: lhsID)
+                    let rhsIndex = recommendedIDs.firstIndex(of: rhsID)
+
+                    switch (lhsIndex, rhsIndex) {
+                    case (.some(let l), .some(let r)):
+                        return l < r  // Both visited - sort by visit order
+                    case (.some, .none):
+                        return true   // Visited comes before unvisited
+                    case (.none, .some):
+                        return false  // Unvisited comes after visited
+                    case (.none, .none):
+                        return false  // Both unvisited - keep original order
+                    }
+                }
+                sortedCategories.append(contentsOf: sponsoredByVisitation)
+
+                // 2. Add non-sponsored visited categories in visit order
+                for recommendedID in recommendedIDs {
+                    if let category = nonSponsoredCategories.first(where: { $0.id.map(String.init) == recommendedID }) {
+                        sortedCategories.append(category)
+                    }
+                }
+
+                // 3. Add remaining non-sponsored, non-visited categories in original order
+                let addedIDs = Set(sortedCategories.compactMap { $0.id.map(String.init) })
+                for category in nonSponsoredCategories {
+                    guard let id = category.id.map(String.init) else { continue }
+                    if !addedIDs.contains(id) {
+                        sortedCategories.append(category)
+                    }
+                }
+
                 filteredCategories = sortedCategories
             }
 

--- a/podcasts/Categories/CategoriesSelectorViewController.swift
+++ b/podcasts/Categories/CategoriesSelectorViewController.swift
@@ -35,36 +35,39 @@ class CategoriesSelectorViewController: ThemedHostingController<CategoriesSelect
                let recommendations = UserDefaults.standard.visitations(for: .discoverCategory) {
 
                 let sponsoredIDs = Set(item?.sponsoredCategoryIDs?.map { String($0) } ?? [])
-                let visitedIDs = Set(recommendations.keys)
 
-                filteredCategories = workingCategories.sorted { lhs, rhs in
+                // Get top 6 most visited categories by user
+                let sortedByVisits = workingCategories.sorted { lhs, rhs in
                     guard let lhsID = lhs.id.map(String.init),
                           let rhsID = rhs.id.map(String.init) else { return false }
 
-                    let lhsSponsored = sponsoredIDs.contains(lhsID)
-                    let rhsSponsored = sponsoredIDs.contains(rhsID)
-                    let lhsVisited = visitedIDs.contains(lhsID)
-                    let rhsVisited = visitedIDs.contains(rhsID)
+                    let lhsVisits = recommendations[lhsID] ?? 0
+                    let rhsVisits = recommendations[rhsID] ?? 0
+                    return lhsVisits > rhsVisits
+                }
 
-                    // Sponsored always comes first
+                let top6Categories = Array(sortedByVisits.prefix(6))
+                let top6IDs = Set(top6Categories.compactMap { $0.id.map(String.init) })
+
+                // Only promote sponsored categories that are in user's top 6
+                let promotableSponsored = sponsoredIDs.intersection(top6IDs)
+
+                filteredCategories = top6Categories.sorted { lhs, rhs in
+                    guard let lhsID = lhs.id.map(String.init),
+                          let rhsID = rhs.id.map(String.init) else { return false }
+
+                    let lhsSponsored = promotableSponsored.contains(lhsID)
+                    let rhsSponsored = promotableSponsored.contains(rhsID)
+
+                    // Sponsored categories from top 6 come first
                     if lhsSponsored != rhsSponsored {
                         return lhsSponsored
                     }
 
-                    // Within same sponsorship status, visited comes first
-                    if lhsVisited != rhsVisited {
-                        return lhsVisited
-                    }
-
-                    // Within same visited status, sort by visit order if both visited
-                    if lhsVisited && rhsVisited {
-                        let lhsVisits = recommendations[lhsID] ?? 0
-                        let rhsVisits = recommendations[rhsID] ?? 0
-                        return lhsVisits > rhsVisits
-                    }
-
-                    // Otherwise preserve original order
-                    return false
+                    // Within same sponsorship status, sort by visit count
+                    let lhsVisits = recommendations[lhsID] ?? 0
+                    let rhsVisits = recommendations[rhsID] ?? 0
+                    return lhsVisits > rhsVisits
                 }
             }
 

--- a/podcasts/Categories/CategoriesSelectorViewController.swift
+++ b/podcasts/Categories/CategoriesSelectorViewController.swift
@@ -34,63 +34,38 @@ class CategoriesSelectorViewController: ThemedHostingController<CategoriesSelect
             if FeatureFlag.smartCategories.enabled,
                let recommendations = UserDefaults.standard.visitations(for: .discoverCategory) {
 
-                let categories = item?.sponsoredCategoryIDs
                 let sponsoredIDs = Set(item?.sponsoredCategoryIDs?.map { String($0) } ?? [])
-                let recommendedIDs = recommendations
-                    .sorted { $0.value > $1.value }
-                    .map { $0.key }
-
-                // Separate sponsored and non-sponsored categories
-                let sponsoredCategories = workingCategories.filter { category in
-                    guard let id = category.id.map(String.init) else { return false }
-                    return sponsoredIDs.contains(id)
-                }
-
-                let nonSponsoredCategories = workingCategories.filter { category in
-                    guard let id = category.id.map(String.init) else { return false }
-                    return !sponsoredIDs.contains(id)
-                }
-
-                var sortedCategories: [DiscoverCategory] = []
-
-                // 1. Add ALL sponsored categories first, sorted by visitation order
-                let sponsoredByVisitation = sponsoredCategories.sorted { lhs, rhs in
+                let visitedIDs = Set(recommendations.keys)
+                
+                filteredCategories = workingCategories.sorted { lhs, rhs in
                     guard let lhsID = lhs.id.map(String.init),
                           let rhsID = rhs.id.map(String.init) else { return false }
-
-                    let lhsIndex = recommendedIDs.firstIndex(of: lhsID)
-                    let rhsIndex = recommendedIDs.firstIndex(of: rhsID)
-
-                    switch (lhsIndex, rhsIndex) {
-                    case (.some(let l), .some(let r)):
-                        return l < r  // Both visited - sort by visit order
-                    case (.some, .none):
-                        return true   // Visited comes before unvisited
-                    case (.none, .some):
-                        return false  // Unvisited comes after visited
-                    case (.none, .none):
-                        return false  // Both unvisited - keep original order
+                    
+                    let lhsSponsored = sponsoredIDs.contains(lhsID)
+                    let rhsSponsored = sponsoredIDs.contains(rhsID)
+                    let lhsVisited = visitedIDs.contains(lhsID)
+                    let rhsVisited = visitedIDs.contains(rhsID)
+                    
+                    // Sponsored always comes first
+                    if lhsSponsored != rhsSponsored {
+                        return lhsSponsored
                     }
-                }
-                sortedCategories.append(contentsOf: sponsoredByVisitation)
-
-                // 2. Add non-sponsored visited categories in visit order
-                for recommendedID in recommendedIDs {
-                    if let category = nonSponsoredCategories.first(where: { $0.id.map(String.init) == recommendedID }) {
-                        sortedCategories.append(category)
+                    
+                    // Within same sponsorship status, visited comes first
+                    if lhsVisited != rhsVisited {
+                        return lhsVisited
                     }
-                }
-
-                // 3. Add remaining non-sponsored, non-visited categories in original order
-                let addedIDs = Set(sortedCategories.compactMap { $0.id.map(String.init) })
-                for category in nonSponsoredCategories {
-                    guard let id = category.id.map(String.init) else { continue }
-                    if !addedIDs.contains(id) {
-                        sortedCategories.append(category)
+                    
+                    // Within same visited status, sort by visit order if both visited
+                    if lhsVisited && rhsVisited {
+                        let lhsVisits = recommendations[lhsID] ?? 0
+                        let rhsVisits = recommendations[rhsID] ?? 0
+                        return lhsVisits > rhsVisits
                     }
+                    
+                    // Otherwise preserve original order
+                    return false
                 }
-
-                filteredCategories = sortedCategories
             }
 
             self.cachedCategories = categories

--- a/podcasts/Categories/CategoriesSelectorViewController.swift
+++ b/podcasts/Categories/CategoriesSelectorViewController.swift
@@ -36,33 +36,33 @@ class CategoriesSelectorViewController: ThemedHostingController<CategoriesSelect
 
                 let sponsoredIDs = Set(item?.sponsoredCategoryIDs?.map { String($0) } ?? [])
                 let visitedIDs = Set(recommendations.keys)
-                
+
                 filteredCategories = workingCategories.sorted { lhs, rhs in
                     guard let lhsID = lhs.id.map(String.init),
                           let rhsID = rhs.id.map(String.init) else { return false }
-                    
+
                     let lhsSponsored = sponsoredIDs.contains(lhsID)
                     let rhsSponsored = sponsoredIDs.contains(rhsID)
                     let lhsVisited = visitedIDs.contains(lhsID)
                     let rhsVisited = visitedIDs.contains(rhsID)
-                    
+
                     // Sponsored always comes first
                     if lhsSponsored != rhsSponsored {
                         return lhsSponsored
                     }
-                    
+
                     // Within same sponsorship status, visited comes first
                     if lhsVisited != rhsVisited {
                         return lhsVisited
                     }
-                    
+
                     // Within same visited status, sort by visit order if both visited
                     if lhsVisited && rhsVisited {
                         let lhsVisits = recommendations[lhsID] ?? 0
                         let rhsVisits = recommendations[rhsID] ?? 0
                         return lhsVisits > rhsVisits
                     }
-                    
+
                     // Otherwise preserve original order
                     return false
                 }


### PR DESCRIPTION
| 📘 Part of: [Smart Categories](https://linear.app/a8c/project/smart-categories-87cfb5eff13e/overview)
|:---:|

Closes [PCIOS-8](https://linear.app/a8c/issue/PCIOS-8/add-sponsored-category-handling-and-sorting)

This ranks the most visited first, with sponsored posts bumped to the front if visited, then all others in their original server provided order.

## To test

* Ensure `smartCategories` feature flag is enabled
* Open the Discover page
* ✅ Verify that "Fiction" "Comedy" and "History" show up first (these are the sponsored tabs)
* Tap "History" several times and restart the app
* ✅ Verify that "History" is shown first in the list of categories or at least moves up in the ranking (depending on your previous visits)

I've added a number of unit tests with various permutations as well to test the specific sorting logic.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
