### PR TITLE
Add `podcast_uuid` to `episode_added_to_up_next`

### DIFF
--- a/podcasts/Analytics/Helpers/AnalyticsEpisodeHelper.swift
+++ b/podcasts/Analytics/Helpers/AnalyticsEpisodeHelper.swift
@@ -140,7 +140,7 @@ class AnalyticsEpisodeHelper: AnalyticsCoordinator {
     // MARK: - Up Next
 
     func episodeAddedToUpNext(episode: BaseEpisode, toTop: Bool) {
-        track(.episodeAddedToUpNext, properties: ["episode_uuid": episode.uuid, "to_top": toTop])
+        track(.episodeAddedToUpNext, properties: ["episode_uuid": episode.uuid, "podcast_uuid": episode.parentIdentifier(), "to_top": toTop])
     }
 
     func bulkAddToUpNext(count: Int, toTop: Bool) {


### PR DESCRIPTION
Adds `podcast_uuid` to the `episode_added_to_up_next` event.

Android counterpart: https://github.com/Automattic/pocket-casts-android/pull/4165

## To test

* Enable tracks logging in the Beta Features section
* Add an episode to the Up Next queue
* ✅ Verify that the `episode_added_to_up_next` event includes a `podcast_uuid`:
```
🔵 Tracked: episode_added_to_up_next ["source": "podcast_screen", "content_type": "audio", "theme_use_system_settings": true, "theme_dark_preference": "default_dark", "episode_uuid": "aff0faf3-7b25-4e15-a61f-fa422aed50ea", "theme_light_preference": "default_light", "podcast_uuid": "8b7a6d70-0f5a-013e-1b89-0acc26574db2", "to_top": true, "theme_selected": "default_light"]
```

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
