### PR TITLE
Enable 'Warn before using data' by default

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -200,6 +200,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// Adds Discover category user recommendations
     case smartCategories
 
+    /// Enabled the attributed text view in the Data Usage warning Sheet
+    case useDescriptiveActionAttributedTextView
+
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -338,6 +341,8 @@ public enum FeatureFlag: String, CaseIterable {
             false
         case .smartCategories:
             false
+        case .useDescriptiveActionAttributedTextView:
+            true
         }
     }
 

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -713,6 +713,8 @@
 		9A9B83C02DCBC36D002CE179 /* CancelSubscriptionSurveyRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A9B83BF2DCBC36D002CE179 /* CancelSubscriptionSurveyRow.swift */; };
 		9AA3B6312D27F0B600A0E30E /* CancelSubscriptionPlansViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AA3B6302D27F0B600A0E30E /* CancelSubscriptionPlansViewModel.swift */; };
 		9AB645182D5138B200A842C8 /* Pocket Casts App Clip.app in Embed App Clips */ = {isa = PBXBuildFile; fileRef = F5D5F7792CEBE769001F492D /* Pocket Casts App Clip.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		9ACB950B2E0D9199007238A7 /* DescriptiveActionAttributedTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ACB950A2E0D9199007238A7 /* DescriptiveActionAttributedTextView.swift */; };
+		9ACB950C2E0D9199007238A7 /* DescriptiveActionAttributedTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ACB950A2E0D9199007238A7 /* DescriptiveActionAttributedTextView.swift */; };
 		9AE5043C2DEDF2030027A4AE /* TranscriptContainerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AE5043B2DEDF1F80027A4AE /* TranscriptContainerViewController.swift */; };
 		9AE5043E2DEDF5590027A4AE /* TranscriptPlaybackManaging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AE5043D2DEDF54F0027A4AE /* TranscriptPlaybackManaging.swift */; };
 		BD001B892174260B00504DD3 /* FilterManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD001B882174260B00504DD3 /* FilterManager.swift */; };
@@ -2951,6 +2953,7 @@
 		9A9B83BB2DCBC2A4002CE179 /* CancelSubscriptionSurveyViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancelSubscriptionSurveyViewModel.swift; sourceTree = "<group>"; };
 		9A9B83BF2DCBC36D002CE179 /* CancelSubscriptionSurveyRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancelSubscriptionSurveyRow.swift; sourceTree = "<group>"; };
 		9AA3B6302D27F0B600A0E30E /* CancelSubscriptionPlansViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancelSubscriptionPlansViewModel.swift; sourceTree = "<group>"; };
+		9ACB950A2E0D9199007238A7 /* DescriptiveActionAttributedTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DescriptiveActionAttributedTextView.swift; sourceTree = "<group>"; };
 		9AE5043B2DEDF1F80027A4AE /* TranscriptContainerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptContainerViewController.swift; sourceTree = "<group>"; };
 		9AE5043D2DEDF54F0027A4AE /* TranscriptPlaybackManaging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptPlaybackManaging.swift; sourceTree = "<group>"; };
 		BD001B882174260B00504DD3 /* FilterManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterManager.swift; sourceTree = "<group>"; };
@@ -6764,6 +6767,7 @@
 				BD1A340E2044F269008A5061 /* SimpleActionView.swift */,
 				BDB5F0C6204504E900437669 /* MultipleActionView.swift */,
 				BD9086A6204E120C00C0C78D /* DescriptiveActionView.swift */,
+				9ACB950A2E0D9199007238A7 /* DescriptiveActionAttributedTextView.swift */,
 			);
 			name = "Action Views";
 			sourceTree = "<group>";
@@ -10035,6 +10039,7 @@
 				40AB3D23224C4E1000A4DC13 /* ProgressCircleView.swift in Sources */,
 				C7252E122A718AD600E7D3C0 /* BookmarkListRouter.swift in Sources */,
 				4053CDF7214B6B61001C92B1 /* EpisodeFilterOverlayController.swift in Sources */,
+				9ACB950C2E0D9199007238A7 /* DescriptiveActionAttributedTextView.swift in Sources */,
 				F5FE747B2C223A6100DF2EAA /* ShareImageView.swift in Sources */,
 				BD998AD327B3430700B38857 /* ColorPreviewFolderView.swift in Sources */,
 				BD7C1FFD237D16C600B3353B /* PCAlwaysVisibleCastBtn.swift in Sources */,
@@ -11217,6 +11222,7 @@
 				FFDE41A32DD201AE0065ADDE /* AppClipAppDelegate.swift in Sources */,
 				F5F508F12CEBE955007D6E39 /* RegionCancellingScrollView.swift in Sources */,
 				F5F5091D2CEBECB2007D6E39 /* EpisodeManager.swift in Sources */,
+				9ACB950B2E0D9199007238A7 /* DescriptiveActionAttributedTextView.swift in Sources */,
 				F5F5091C2CEBEC99007D6E39 /* DefaultPlayer.swift in Sources */,
 				F5F509392CEBF206007D6E39 /* ProgressCircleView.swift in Sources */,
 				F553A1642CECF997006581A1 /* EffectsViewController.swift in Sources */,

--- a/podcasts/AppDelegate+Defaults.swift
+++ b/podcasts/AppDelegate+Defaults.swift
@@ -140,6 +140,10 @@ extension AppDelegate {
             }
         }
 
+        performUpdateIfRequired(updateKey: "v7.93") {
+            Settings.setMobileDataAllowed(false)
+        }
+
         defaults.synchronize()
     }
 

--- a/podcasts/AppDelegate+Defaults.swift
+++ b/podcasts/AppDelegate+Defaults.swift
@@ -140,7 +140,7 @@ extension AppDelegate {
             }
         }
 
-        performUpdateIfRequired(updateKey: "v7.93") {
+        performUpdateIfRequired(updateKey: "ForceEnablingDataAllowedWarning") {
             Settings.setMobileDataAllowed(false)
         }
 

--- a/podcasts/AppDelegate+UrlHandling.swift
+++ b/podcasts/AppDelegate+UrlHandling.swift
@@ -419,6 +419,12 @@ extension AppDelegate {
             return true
         }
 
+        JLRoutes.global().addRoute("/settings/storage-and-data") {[weak self] parameters -> Bool in
+            guard self != nil else { return false }
+            NavigationManager.sharedManager.navigateTo(NavigationManager.settingsPageKey, data: [NavigationManager.settingsRowKey: SettingsViewController.TableRow.storageAndDataUse])
+            return true
+        }
+
         JLRoutes.global().addRoute("/filters") {[weak self] parameters -> Bool in
             guard self != nil else { return false }
             NavigationManager.sharedManager.navigateTo(NavigationManager.filterPageKey)

--- a/podcasts/DescriptiveActionAttributedTextView.swift
+++ b/podcasts/DescriptiveActionAttributedTextView.swift
@@ -5,12 +5,10 @@ struct DescriptiveActionAttributedTextView: View {
     @Environment(\.openURL) var openURL
 
     private let text: String
-    private let attributes: [String: URL]
     private let onLinkTap: (() -> Void)?
 
-    init(text: String, attributes: [String: URL], onLinkTap: (() -> Void)? = nil) {
+    init(text: String, onLinkTap: (() -> Void)? = nil) {
         self.text = text
-        self.attributes = attributes
         self.onLinkTap = onLinkTap
     }
 
@@ -26,12 +24,12 @@ struct DescriptiveActionAttributedTextView: View {
     }
 
     private func makeAttributedString() -> AttributedString {
-        var attributed = AttributedString(text)
+        var attributed = (try? AttributedString(markdown: text)) ?? AttributedString(text)
         attributed.font = .systemFont(ofSize: 15.0)
-        attributes.forEach { key, value in
-            if let range = attributed.range(of: key) {
-                attributed[range].foregroundColor = theme.secondaryInteractive01
-                attributed[range].link = value
+        for run in attributed.runs {
+            if let _ = run.link {
+                attributed[run.range].foregroundColor = theme.secondaryInteractive01
+                attributed[run.range].underlineStyle = .none
             }
         }
         return attributed
@@ -46,8 +44,7 @@ struct DescriptiveActionAttributedTextView: View {
 
 #Preview {
     DescriptiveActionAttributedTextView(
-        text: "This download will use mobile data. You can turn off this warning in Settings.",
-        attributes: ["Settings": URL(string: "pktc://settings/storage-and-data")!],
+        text: "This download will use mobile data. You can turn off this warning in [Settings](pktc://settings/storage-and-data).",
         onLinkTap: {}
     )
         .environmentObject(Theme(previewTheme: .light))

--- a/podcasts/DescriptiveActionAttributedTextView.swift
+++ b/podcasts/DescriptiveActionAttributedTextView.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+
+struct DescriptiveActionAttributedTextView: View {
+    @EnvironmentObject var theme: Theme
+    @Environment(\.openURL) var openURL
+
+    private let text: String
+    private let attributes: [String: URL]
+    private let onLinkTap: (() -> Void)?
+
+    init(text: String, attributes: [String: URL], onLinkTap: (() -> Void)? = nil) {
+        self.text = text
+        self.attributes = attributes
+        self.onLinkTap = onLinkTap
+    }
+
+    var body: some View {
+        Text(makeAttributedString())
+            .multilineTextAlignment(.center)
+            .foregroundColor(theme.primaryText01)
+            .environment(\.openURL, OpenURLAction { url in
+                onLinkTap?()
+                open(url: url)
+                return .handled
+            })
+    }
+
+    private func makeAttributedString() -> AttributedString {
+        var attributed = AttributedString(text)
+        attributed.font = .systemFont(ofSize: 15.0)
+        attributes.forEach { key, value in
+            if let range = attributed.range(of: key) {
+                attributed[range].foregroundColor = theme.secondaryInteractive01
+                attributed[range].link = value
+            }
+        }
+        return attributed
+    }
+
+    private func open(url: URL) {
+        if UIApplication.shared.canOpenURL(url) {
+            UIApplication.shared.open(url)
+        }
+    }
+}
+
+#Preview {
+    DescriptiveActionAttributedTextView(
+        text: "This download will use mobile data. You can turn off this warning in Settings.",
+        attributes: ["Settings": URL(string: "pktc://settings/storage-and-data")!],
+        onLinkTap: {}
+    )
+        .environmentObject(Theme(previewTheme: .light))
+}

--- a/podcasts/DescriptiveActionView.swift
+++ b/podcasts/DescriptiveActionView.swift
@@ -7,11 +7,12 @@ class DescriptiveActionView: UIView {
     private let actions: [OptionAction]
     private let themeOverride: Theme.ThemeType?
     private let iconTintStyle: ThemeStyle
-    private let attributedString: AttributedString?
+    private let attributes: [String: URL]?
+    private let onLinkTap: (() -> Void)?
 
     private weak var delegate: OptionsPickerRootController?
 
-    init(frame: CGRect, title: String, message: String?, attributedString: AttributedString? = nil, icon: String, actions: [OptionAction], delegate: OptionsPickerRootController, themeOverride: Theme.ThemeType? = nil, iconTintStyle: ThemeStyle = .primaryIcon01) {
+    init(frame: CGRect, title: String, message: String?, attributes: [String: URL]? = nil, icon: String, actions: [OptionAction], delegate: OptionsPickerRootController, themeOverride: Theme.ThemeType? = nil, iconTintStyle: ThemeStyle = .primaryIcon01, onLinkTap: (() -> Void)? = nil) {
         self.title = title
         self.message = message
         self.icon = icon
@@ -19,7 +20,8 @@ class DescriptiveActionView: UIView {
         self.delegate = delegate
         self.themeOverride = themeOverride
         self.iconTintStyle = iconTintStyle
-        self.attributedString = attributedString
+        self.attributes = attributes
+        self.onLinkTap = onLinkTap
         super.init(frame: frame)
     }
 
@@ -60,11 +62,15 @@ class DescriptiveActionView: UIView {
 
         // add message
         let messageBottomAnchor: NSLayoutYAxisAnchor
-        if let attributedString = attributedString {
-            let messageView = UIView()
+        if let attributes, let message {
+            let messageView = DescriptiveActionAttributedTextView(
+                text: message,
+                attributes: attributes,
+                onLinkTap: onLinkTap
+            ).themedUIView
             messageView.translatesAutoresizingMaskIntoConstraints = false
             addSubview(messageView)
-            
+
             NSLayoutConstraint.activate([
                 messageView.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 20),
                 messageView.centerXAnchor.constraint(equalTo: centerXAnchor),

--- a/podcasts/DescriptiveActionView.swift
+++ b/podcasts/DescriptiveActionView.swift
@@ -7,10 +7,11 @@ class DescriptiveActionView: UIView {
     private let actions: [OptionAction]
     private let themeOverride: Theme.ThemeType?
     private let iconTintStyle: ThemeStyle
+    private let attributedString: AttributedString?
 
     private weak var delegate: OptionsPickerRootController?
 
-    init(frame: CGRect, title: String, message: String?, icon: String, actions: [OptionAction], delegate: OptionsPickerRootController, themeOverride: Theme.ThemeType? = nil, iconTintStyle: ThemeStyle = .primaryIcon01) {
+    init(frame: CGRect, title: String, message: String?, attributedString: AttributedString? = nil, icon: String, actions: [OptionAction], delegate: OptionsPickerRootController, themeOverride: Theme.ThemeType? = nil, iconTintStyle: ThemeStyle = .primaryIcon01) {
         self.title = title
         self.message = message
         self.icon = icon
@@ -18,6 +19,7 @@ class DescriptiveActionView: UIView {
         self.delegate = delegate
         self.themeOverride = themeOverride
         self.iconTintStyle = iconTintStyle
+        self.attributedString = attributedString
         super.init(frame: frame)
     }
 
@@ -57,21 +59,37 @@ class DescriptiveActionView: UIView {
         ])
 
         // add message
-        let messageLabel = UILabel()
-        messageLabel.font = UIFont.systemFont(ofSize: 16, weight: .regular)
-        messageLabel.text = message
-        messageLabel.textColor = AppTheme.mainTextColor(for: themeOverride)
-        messageLabel.translatesAutoresizingMaskIntoConstraints = false
-        messageLabel.textAlignment = .center
-        messageLabel.numberOfLines = 0
-        addSubview(messageLabel)
+        let messageBottomAnchor: NSLayoutYAxisAnchor
+        if let attributedString = attributedString {
+            let messageView = UIView()
+            messageView.translatesAutoresizingMaskIntoConstraints = false
+            addSubview(messageView)
+            
+            NSLayoutConstraint.activate([
+                messageView.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 20),
+                messageView.centerXAnchor.constraint(equalTo: centerXAnchor),
+                messageView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 20),
+                trailingAnchor.constraint(equalTo: messageView.trailingAnchor, constant: 20)
+            ])
+            messageBottomAnchor = messageView.bottomAnchor
+        } else {
+            let messageLabel = UILabel()
+            messageLabel.font = UIFont.systemFont(ofSize: 16, weight: .regular)
+            messageLabel.text = message
+            messageLabel.textColor = AppTheme.mainTextColor(for: themeOverride)
+            messageLabel.translatesAutoresizingMaskIntoConstraints = false
+            messageLabel.textAlignment = .center
+            messageLabel.numberOfLines = 0
+            addSubview(messageLabel)
 
-        NSLayoutConstraint.activate([
-            messageLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 20),
-            messageLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
-            messageLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 20),
-            trailingAnchor.constraint(equalTo: messageLabel.trailingAnchor, constant: 20)
-        ])
+            NSLayoutConstraint.activate([
+                messageLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 20),
+                messageLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
+                messageLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 20),
+                trailingAnchor.constraint(equalTo: messageLabel.trailingAnchor, constant: 20)
+            ])
+            messageBottomAnchor = messageLabel.bottomAnchor
+        }
 
         var previousButton: ShiftyRoundButton?
         for (index, action) in actions.enumerated() {
@@ -95,7 +113,7 @@ class DescriptiveActionView: UIView {
             actionButton.translatesAutoresizingMaskIntoConstraints = false
             addSubview(actionButton)
 
-            let previousBottomAnchor = previousButton == nil ? messageLabel.bottomAnchor : previousButton!.bottomAnchor
+            let previousBottomAnchor = previousButton == nil ? messageBottomAnchor : previousButton!.bottomAnchor
             NSLayoutConstraint.activate([
                 actionButton.topAnchor.constraint(equalTo: previousBottomAnchor, constant: 20),
                 actionButton.centerXAnchor.constraint(equalTo: centerXAnchor),

--- a/podcasts/DescriptiveActionView.swift
+++ b/podcasts/DescriptiveActionView.swift
@@ -101,7 +101,7 @@ class DescriptiveActionView: UIView {
                 actionButton.centerXAnchor.constraint(equalTo: centerXAnchor),
                 actionButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 20),
                 trailingAnchor.constraint(equalTo: actionButton.trailingAnchor, constant: 20),
-                actionButton.heightAnchor.constraint(equalToConstant: 50)
+                actionButton.heightAnchor.constraint(equalToConstant: 56)
             ])
             previousButton = actionButton
         }

--- a/podcasts/DescriptiveActionView.swift
+++ b/podcasts/DescriptiveActionView.swift
@@ -1,4 +1,5 @@
 import UIKit
+import PocketCastsUtils
 
 class DescriptiveActionView: UIView {
     private let title: String
@@ -7,12 +8,11 @@ class DescriptiveActionView: UIView {
     private let actions: [OptionAction]
     private let themeOverride: Theme.ThemeType?
     private let iconTintStyle: ThemeStyle
-    private let attributes: [String: URL]?
     private let onLinkTap: (() -> Void)?
 
     private weak var delegate: OptionsPickerRootController?
 
-    init(frame: CGRect, title: String, message: String?, attributes: [String: URL]? = nil, icon: String, actions: [OptionAction], delegate: OptionsPickerRootController, themeOverride: Theme.ThemeType? = nil, iconTintStyle: ThemeStyle = .primaryIcon01, onLinkTap: (() -> Void)? = nil) {
+    init(frame: CGRect, title: String, message: String?, icon: String, actions: [OptionAction], delegate: OptionsPickerRootController, themeOverride: Theme.ThemeType? = nil, iconTintStyle: ThemeStyle = .primaryIcon01, onLinkTap: (() -> Void)? = nil) {
         self.title = title
         self.message = message
         self.icon = icon
@@ -20,7 +20,6 @@ class DescriptiveActionView: UIView {
         self.delegate = delegate
         self.themeOverride = themeOverride
         self.iconTintStyle = iconTintStyle
-        self.attributes = attributes
         self.onLinkTap = onLinkTap
         super.init(frame: frame)
     }
@@ -62,10 +61,9 @@ class DescriptiveActionView: UIView {
 
         // add message
         let messageBottomAnchor: NSLayoutYAxisAnchor
-        if let attributes, let message {
+        if FeatureFlag.useDescriptiveActionAttributedTextView.enabled, let message {
             let messageView = DescriptiveActionAttributedTextView(
                 text: message,
-                attributes: attributes,
                 onLinkTap: onLinkTap
             ).themedUIView
             messageView.translatesAutoresizingMaskIntoConstraints = false

--- a/podcasts/EpisodeListSearchController.swift
+++ b/podcasts/EpisodeListSearchController.swift
@@ -177,7 +177,7 @@ class EpisodeListSearchController: SimpleNotificationsViewController, UISearchBa
             let confirmPicker = OptionsPicker(title: nil)
             var warningMessage = downloadLimitExceeded ? L10n.bulkDownloadMax : ""
 
-            if !NetworkUtils.shared.isConnectedToUnexpensiveConnection() {
+            if NetworkUtils.shared.isConnectedToUnexpensiveConnection() {
                 confirmPicker.addDescriptiveActions(title: L10n.downloadAll, message: warningMessage, icon: "filter_downloaded", actions: [downloadAction])
             } else {
                 downloadAction.destructive = true

--- a/podcasts/EpisodeListSearchController.swift
+++ b/podcasts/EpisodeListSearchController.swift
@@ -188,9 +188,11 @@ class EpisodeListSearchController: SimpleNotificationsViewController, UISearchBa
                 queueAction.outline = true
 
                 if !Settings.mobileDataAllowed() {
-                    warningMessage = L10n.downloadDataWarning + "\n" + warningMessage
+                    warningMessage = L10n.downloadDataWarningWithSettingsLink + "\n" + warningMessage
                 }
-                confirmPicker.addDescriptiveActions(title: L10n.notOnWifi, message: warningMessage, icon: "option-alert", actions: [downloadAction, queueAction])
+                let attributes = [L10n.settings: URL(string: "pktc://settings/storage-and-data")!]
+
+                confirmPicker.addAttributedDescriptiveActions(title: L10n.notOnWifi, message: warningMessage, attributes: attributes, icon: "option-alert", actions: [downloadAction, queueAction])
             }
 
             confirmPicker.show(statusBarStyle: self?.preferredStatusBarStyle ?? .default)

--- a/podcasts/EpisodeListSearchController.swift
+++ b/podcasts/EpisodeListSearchController.swift
@@ -188,11 +188,9 @@ class EpisodeListSearchController: SimpleNotificationsViewController, UISearchBa
                 queueAction.outline = true
 
                 if !Settings.mobileDataAllowed() {
-                    warningMessage = L10n.downloadDataWarningWithSettingsLink + "\n" + warningMessage
+                    warningMessage = L10n.downloadDataWarningWithSettingsLink("pktc://settings/storage-and-data") + "\n" + warningMessage
                 }
-                let attributes = [L10n.settings: URL(string: "pktc://settings/storage-and-data")!]
-
-                confirmPicker.addAttributedDescriptiveActions(title: L10n.notOnWifi, message: warningMessage, attributes: attributes, icon: "option-alert", actions: [downloadAction, queueAction])
+                confirmPicker.addAttributedDescriptiveActions(title: L10n.notOnWifi, message: warningMessage, icon: "option-alert", actions: [downloadAction, queueAction])
             }
 
             confirmPicker.show(statusBarStyle: self?.preferredStatusBarStyle ?? .default)

--- a/podcasts/EpisodeListSearchController.swift
+++ b/podcasts/EpisodeListSearchController.swift
@@ -177,7 +177,7 @@ class EpisodeListSearchController: SimpleNotificationsViewController, UISearchBa
             let confirmPicker = OptionsPicker(title: nil)
             var warningMessage = downloadLimitExceeded ? L10n.bulkDownloadMax : ""
 
-            if NetworkUtils.shared.isConnectedToUnexpensiveConnection() {
+            if !NetworkUtils.shared.isConnectedToUnexpensiveConnection() {
                 confirmPicker.addDescriptiveActions(title: L10n.downloadAll, message: warningMessage, icon: "filter_downloaded", actions: [downloadAction])
             } else {
                 downloadAction.destructive = true
@@ -185,6 +185,7 @@ class EpisodeListSearchController: SimpleNotificationsViewController, UISearchBa
                 let queueAction = OptionAction(label: L10n.queueForLater, icon: nil) {
                     delegate.queueAllTapped()
                 }
+                queueAction.outline = true
 
                 if !Settings.mobileDataAllowed() {
                     warningMessage = L10n.downloadDataWarning + "\n" + warningMessage

--- a/podcasts/MultiSelectHelper.swift
+++ b/podcasts/MultiSelectHelper.swift
@@ -243,6 +243,7 @@ class MultiSelectHelper {
                 actionDelegate.multiSelectActionBegan(status: status)
                 queueEpisodes(downloadableEpisodes, actionDelegate: actionDelegate)
             }
+            queueAction.outline = true
 
             if !Settings.mobileDataAllowed() {
                 warningMessage = L10n.downloadDataWarning + "\n" + warningMessage

--- a/podcasts/MultiSelectHelper.swift
+++ b/podcasts/MultiSelectHelper.swift
@@ -246,12 +246,10 @@ class MultiSelectHelper {
             queueAction.outline = true
 
             if !Settings.mobileDataAllowed() {
-                warningMessage = L10n.downloadDataWarningWithSettingsLink + "\n" + warningMessage
+                warningMessage = L10n.downloadDataWarningWithSettingsLink("pktc://settings/storage-and-data") + "\n" + warningMessage
             }
 
-            let attributes = [L10n.settings: URL(string: "pktc://settings/storage-and-data")!]
-
-            confirmPicker.addAttributedDescriptiveActions(title: L10n.notOnWifi, message: warningMessage, attributes: attributes, icon: "option-alert", actions: [downloadAction, queueAction])
+            confirmPicker.addAttributedDescriptiveActions(title: L10n.notOnWifi, message: warningMessage, icon: "option-alert", actions: [downloadAction, queueAction])
         }
 
         confirmPicker.show(statusBarStyle: actionDelegate.multiSelectPreferredStatusBarStyle())

--- a/podcasts/MultiSelectHelper.swift
+++ b/podcasts/MultiSelectHelper.swift
@@ -246,10 +246,10 @@ class MultiSelectHelper {
             queueAction.outline = true
 
             if !Settings.mobileDataAllowed() {
-                warningMessage = "This download will use mobile data. You can turn off this warning in Settings." + "\n" + warningMessage
+                warningMessage = L10n.downloadDataWarningWithSettingsLink + "\n" + warningMessage
             }
 
-            let attributes = ["Settings": URL(string: "pktc://settings/storage-and-data")!]
+            let attributes = [L10n.settings: URL(string: "pktc://settings/storage-and-data")!]
 
             confirmPicker.addAttributedDescriptiveActions(title: L10n.notOnWifi, message: warningMessage, attributes: attributes, icon: "option-alert", actions: [downloadAction, queueAction])
         }

--- a/podcasts/MultiSelectHelper.swift
+++ b/podcasts/MultiSelectHelper.swift
@@ -246,9 +246,12 @@ class MultiSelectHelper {
             queueAction.outline = true
 
             if !Settings.mobileDataAllowed() {
-                warningMessage = L10n.downloadDataWarning + "\n" + warningMessage
+                warningMessage = "This download will use mobile data. You can turn off this warning in Settings." + "\n" + warningMessage
             }
-            confirmPicker.addDescriptiveActions(title: L10n.notOnWifi, message: warningMessage, icon: "option-alert", actions: [downloadAction, queueAction])
+
+            let attributes = ["Settings": URL(string: "pktc://settings/storage-and-data")!]
+
+            confirmPicker.addAttributedDescriptiveActions(title: L10n.notOnWifi, message: warningMessage, attributes: attributes, icon: "option-alert", actions: [downloadAction, queueAction])
         }
 
         confirmPicker.show(statusBarStyle: actionDelegate.multiSelectPreferredStatusBarStyle())

--- a/podcasts/NetworkUtils+Helpers.swift
+++ b/podcasts/NetworkUtils+Helpers.swift
@@ -68,6 +68,7 @@ extension NetworkUtils {
         let laterAction = OptionAction(label: L10n.queueForLater, icon: nil) {
             allowed?(true)
         }
+        laterAction.outline = true
         optionsPicker.addDescriptiveActions(title: L10n.notOnWifi, message: "", icon: "option-alert", actions: [uploadAction, laterAction])
 
         optionsPicker.setNoActionCallback {

--- a/podcasts/NetworkUtils+Helpers.swift
+++ b/podcasts/NetworkUtils+Helpers.swift
@@ -22,9 +22,7 @@ extension NetworkUtils {
         }
         laterAction.outline = true
 
-        let attributes = [L10n.settings: URL(string: "pktc://settings/storage-and-data")!]
-
-        optionsPicker.addAttributedDescriptiveActions(title: L10n.notOnWifi, message: L10n.downloadDataWarningWithSettingsLink, attributes: attributes, icon: "option-alert", actions: [downloadAction, laterAction])
+        optionsPicker.addAttributedDescriptiveActions(title: L10n.notOnWifi, message: L10n.downloadDataWarningWithSettingsLink("pktc://settings/storage-and-data"), icon: "option-alert", actions: [downloadAction, laterAction])
 
         optionsPicker.setNoActionCallback {
             disallowed?()

--- a/podcasts/NetworkUtils+Helpers.swift
+++ b/podcasts/NetworkUtils+Helpers.swift
@@ -21,7 +21,10 @@ extension NetworkUtils {
             allowed?(true)
         }
         laterAction.outline = true
-        optionsPicker.addDescriptiveActions(title: L10n.notOnWifi, message: L10n.downloadDataWarning, icon: "option-alert", actions: [downloadAction, laterAction])
+
+        let attributes = [L10n.settings: URL(string: "pktc://settings/storage-and-data")!]
+
+        optionsPicker.addAttributedDescriptiveActions(title: L10n.notOnWifi, message: L10n.downloadDataWarningWithSettingsLink, attributes: attributes, icon: "option-alert", actions: [downloadAction, laterAction])
 
         optionsPicker.setNoActionCallback {
             disallowed?()

--- a/podcasts/OptionsPicker.swift
+++ b/podcasts/OptionsPicker.swift
@@ -37,8 +37,8 @@ class OptionsPicker {
         optionsController?.addDescriptiveActions(title: title, message: message, icon: icon, actions: actions)
     }
 
-    func addAttributedDescriptiveActions(title: String, message: String, attributes: [String: URL], icon: String, actions: [OptionAction]) {
-        optionsController?.addAttributedDescriptiveActions(title: title, message: message, attributes: attributes, icon: icon, actions: actions)
+    func addAttributedDescriptiveActions(title: String, message: String, icon: String, actions: [OptionAction]) {
+        optionsController?.addAttributedDescriptiveActions(title: title, message: message, icon: icon, actions: actions)
     }
 
     func setNoActionCallback(_ callback: @escaping () -> Void) {

--- a/podcasts/OptionsPicker.swift
+++ b/podcasts/OptionsPicker.swift
@@ -37,6 +37,10 @@ class OptionsPicker {
         optionsController?.addDescriptiveActions(title: title, message: message, icon: icon, actions: actions)
     }
 
+    func addAttributedDescriptiveActions(title: String, message: String, attributes: [String: URL], icon: String, actions: [OptionAction]) {
+        optionsController?.addAttributedDescriptiveActions(title: title, message: message, attributes: attributes, icon: icon, actions: actions)
+    }
+
     func setNoActionCallback(_ callback: @escaping () -> Void) {
         noActionCallback = callback
     }

--- a/podcasts/OptionsPickerRootController.swift
+++ b/podcasts/OptionsPickerRootController.swift
@@ -137,6 +137,18 @@ class OptionsPickerRootController: UIViewController, UIGestureRecognizerDelegate
         actionsAdded += 1
     }
 
+    func addAttributedDescriptiveActions(title: String, attributedString: AttributedString, icon: String, actions: [OptionAction]) {
+        let actionView = DescriptiveActionView(frame: CGRect(x: 0, y: 0, width: view.bounds.width, height: actionHeight), title: title, message: nil, attributedString: attributedString, icon: icon, actions: actions, delegate: self, themeOverride: themeOverride, iconTintStyle: iconTintStyle)
+        stackView.addArrangedSubview(actionView)
+        NSLayoutConstraint.activate([
+            actionView.leadingAnchor.constraint(equalTo: stackView.leadingAnchor),
+            actionView.trailingAnchor.constraint(equalTo: stackView.trailingAnchor)
+        ])
+        actionView.actionWasAdded()
+
+        actionsAdded += 1
+    }
+
     func addSegmentedAction(name: String, icon: String?, actions: [OptionAction]) {
         if actionsAdded > 0 { addDivider() }
 

--- a/podcasts/OptionsPickerRootController.swift
+++ b/podcasts/OptionsPickerRootController.swift
@@ -137,8 +137,8 @@ class OptionsPickerRootController: UIViewController, UIGestureRecognizerDelegate
         actionsAdded += 1
     }
 
-    func addAttributedDescriptiveActions(title: String, message: String, attributes: [String: URL], icon: String, actions: [OptionAction]) {
-        let actionView = DescriptiveActionView(frame: CGRect(x: 0, y: 0, width: view.bounds.width, height: actionHeight), title: title, message: message, attributes: attributes, icon: icon, actions: actions, delegate: self, themeOverride: themeOverride, iconTintStyle: iconTintStyle) { [weak self] in
+    func addAttributedDescriptiveActions(title: String, message: String, icon: String, actions: [OptionAction]) {
+        let actionView = DescriptiveActionView(frame: CGRect(x: 0, y: 0, width: view.bounds.width, height: actionHeight), title: title, message: message, icon: icon, actions: actions, delegate: self, themeOverride: themeOverride, iconTintStyle: iconTintStyle) { [weak self] in
             self?.backgroundTapped()
         }
         stackView.addArrangedSubview(actionView)

--- a/podcasts/OptionsPickerRootController.swift
+++ b/podcasts/OptionsPickerRootController.swift
@@ -137,8 +137,10 @@ class OptionsPickerRootController: UIViewController, UIGestureRecognizerDelegate
         actionsAdded += 1
     }
 
-    func addAttributedDescriptiveActions(title: String, attributedString: AttributedString, icon: String, actions: [OptionAction]) {
-        let actionView = DescriptiveActionView(frame: CGRect(x: 0, y: 0, width: view.bounds.width, height: actionHeight), title: title, message: nil, attributedString: attributedString, icon: icon, actions: actions, delegate: self, themeOverride: themeOverride, iconTintStyle: iconTintStyle)
+    func addAttributedDescriptiveActions(title: String, message: String, attributes: [String: URL], icon: String, actions: [OptionAction]) {
+        let actionView = DescriptiveActionView(frame: CGRect(x: 0, y: 0, width: view.bounds.width, height: actionHeight), title: title, message: message, attributes: attributes, icon: icon, actions: actions, delegate: self, themeOverride: themeOverride, iconTintStyle: iconTintStyle) { [weak self] in
+            self?.backgroundTapped()
+        }
         stackView.addArrangedSubview(actionView)
         NSLayoutConstraint.activate([
             actionView.leadingAnchor.constraint(equalTo: stackView.leadingAnchor),

--- a/podcasts/PlaylistViewController.swift
+++ b/podcasts/PlaylistViewController.swift
@@ -362,12 +362,10 @@ class PlaylistViewController: PCViewController, TitleButtonDelegate {
                 }
 
                 if !Settings.mobileDataAllowed() {
-                    warningMessage = L10n.downloadDataWarningWithSettingsLink + "\n" + warningMessage
+                    warningMessage = L10n.downloadDataWarningWithSettingsLink("pktc://settings/storage-and-data") + "\n" + warningMessage
                 }
 
-                let attributes = [L10n.settings: URL(string: "pktc://settings/storage-and-data")!]
-
-                confirmPicker.addAttributedDescriptiveActions(title: L10n.notOnWifi, message: warningMessage, attributes: attributes, icon: "option-alert", actions: [downloadAction, queueAction])
+                confirmPicker.addAttributedDescriptiveActions(title: L10n.notOnWifi, message: warningMessage, icon: "option-alert", actions: [downloadAction, queueAction])
             }
             confirmPicker.show(statusBarStyle: AppTheme.defaultStatusBarStyle())
         }

--- a/podcasts/PlaylistViewController.swift
+++ b/podcasts/PlaylistViewController.swift
@@ -362,10 +362,12 @@ class PlaylistViewController: PCViewController, TitleButtonDelegate {
                 }
 
                 if !Settings.mobileDataAllowed() {
-                    warningMessage = L10n.downloadDataWarning + "\n" + warningMessage
+                    warningMessage = L10n.downloadDataWarningWithSettingsLink + "\n" + warningMessage
                 }
 
-                confirmPicker.addDescriptiveActions(title: L10n.notOnWifi, message: warningMessage, icon: "option-alert", actions: [downloadAction, queueAction])
+                let attributes = [L10n.settings: URL(string: "pktc://settings/storage-and-data")!]
+
+                confirmPicker.addAttributedDescriptiveActions(title: L10n.notOnWifi, message: warningMessage, attributes: attributes, icon: "option-alert", actions: [downloadAction, queueAction])
             }
             confirmPicker.show(statusBarStyle: AppTheme.defaultStatusBarStyle())
         }

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -878,8 +878,10 @@ internal enum L10n {
   internal static var downloadAll: String { return L10n.tr("Localizable", "download_all", fallback: "Download All") }
   /// A common string used throughout the app. Prompt to warn the user that continuing with the download will consume data. Used in tandem with a notice that the user is not on WiFi.
   internal static var downloadDataWarning: String { return L10n.tr("Localizable", "download_data_warning", fallback: "Downloading will use data.") }
-  /// A common string used throughout the app. Prompt to warn the user that continuing with the download will consume data. Used in tandem with a notice that the user is not on WiFi. The word Settings will be linked to an internal URL which redirects the user to the correct Settings.
-  internal static var downloadDataWarningWithSettingsLink: String { return L10n.tr("Localizable", "download_data_warning_with_settings_link", fallback: "This download will use mobile data. You can turn off this warning in Settings.") }
+  /// A common string used throughout the app. Prompt to warn the user that continuing with the download will consume data. Used in tandem with a notice that the user is not on WiFi. The word Settings will be linked to an internal URL which redirects the user to the correct Settings. The %@ is the placeholder for the URL
+  internal static func downloadDataWarningWithSettingsLink(_ p1: Any) -> String {
+    return L10n.tr("Localizable", "download_data_warning_with_settings_link", String(describing: p1), fallback: "This download will use mobile data. You can turn off this warning in [Settings](%@).")
+  }
   /// A common string used throughout the app. Prompts the user that they have selected multiple episodes to download. '%1$@' is a placeholder for the count of the selected items, will be more than one.
   internal static func downloadEpisodePluralFormat(_ p1: Any) -> String {
     return L10n.tr("Localizable", "download_episode_plural_format", String(describing: p1), fallback: "Download %1$@ Episodes")

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -878,6 +878,8 @@ internal enum L10n {
   internal static var downloadAll: String { return L10n.tr("Localizable", "download_all", fallback: "Download All") }
   /// A common string used throughout the app. Prompt to warn the user that continuing with the download will consume data. Used in tandem with a notice that the user is not on WiFi.
   internal static var downloadDataWarning: String { return L10n.tr("Localizable", "download_data_warning", fallback: "Downloading will use data.") }
+  /// A common string used throughout the app. Prompt to warn the user that continuing with the download will consume data. Used in tandem with a notice that the user is not on WiFi. The word Settings will be linked to an internal URL which redirects the user to the correct Settings.
+  internal static var downloadDataWarningWithSettingsLink: String { return L10n.tr("Localizable", "download_data_warning_with_settings_link", fallback: "This download will use mobile data. You can turn off this warning in Settings.") }
   /// A common string used throughout the app. Prompts the user that they have selected multiple episodes to download. '%1$@' is a placeholder for the count of the selected items, will be more than one.
   internal static func downloadEpisodePluralFormat(_ p1: Any) -> String {
     return L10n.tr("Localizable", "download_episode_plural_format", String(describing: p1), fallback: "Download %1$@ Episodes")

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -763,6 +763,9 @@
 /* A common string used throughout the app. Prompt to warn the user that continuing with the download will consume data. Used in tandem with a notice that the user is not on WiFi. */
 "download_data_warning" = "Downloading will use data.";
 
+/* A common string used throughout the app. Prompt to warn the user that continuing with the download will consume data. Used in tandem with a notice that the user is not on WiFi. The word Settings will be linked to an internal URL which redirects the user to the correct Settings. */
+"download_data_warning_with_settings_link" = "This download will use mobile data. You can turn off this warning in Settings.";
+
 /* A common string used throughout the app. Prompts the user that they have selected multiple episodes to download. '%1$@' is a placeholder for the count of the selected items, will be more than one. */
 "download_episode_plural_format" = "Download %1$@ Episodes";
 

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -763,8 +763,8 @@
 /* A common string used throughout the app. Prompt to warn the user that continuing with the download will consume data. Used in tandem with a notice that the user is not on WiFi. */
 "download_data_warning" = "Downloading will use data.";
 
-/* A common string used throughout the app. Prompt to warn the user that continuing with the download will consume data. Used in tandem with a notice that the user is not on WiFi. The word Settings will be linked to an internal URL which redirects the user to the correct Settings. */
-"download_data_warning_with_settings_link" = "This download will use mobile data. You can turn off this warning in Settings.";
+/* A common string used throughout the app. Prompt to warn the user that continuing with the download will consume data. Used in tandem with a notice that the user is not on WiFi. The word Settings will be linked to an internal URL which redirects the user to the correct Settings. The %@ is the placeholder for the URL */
+"download_data_warning_with_settings_link" = "This download will use mobile data. You can turn off this warning in [Settings](%@).";
 
 /* A common string used throughout the app. Prompts the user that they have selected multiple episodes to download. '%1$@' is a placeholder for the count of the selected items, will be more than one. */
 "download_episode_plural_format" = "Download %1$@ Episodes";


### PR DESCRIPTION
Fixes #3227

This PR enables by default the Warn User data usage option. It also updates the screen we show when the data usage toggle is on and the device is not connected, with a link to our settings.

| Settings | Sheet |
| -------- | ------- |
| ![IMG_0209](https://github.com/user-attachments/assets/faa9fce7-ac48-43ef-8cc8-4fb5ad05c4a8)  | ![IMG_3871](https://github.com/user-attachments/assets/d06d1ecf-c6ad-4d73-98a6-4c98cd4fbdf7) |

## To test

- Use a real device with a sim to switch between wifi and another connection
- Build this branch on top of current Production or beta
- Run the app and navigate to our `Settings -> Storage & Data Use`
- Confirm you see `Warn Before Using Data` on
- Go to a podcast and open it
- Select an episode and start the download
- You should not see any Sheet presented
- Switch off the Wifi and stay on your sim connection
- Try to download the another episode from the podcast view
- Confirm you see the Sheet (as the screen above)
- Tap on Settings in the text
- Confirm you are redirected to the `Storage & Data Use` settings page

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
