### PR TITLE
Add Swiftlint hook for claude code

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "FILE_PATH=$(jq -r '.tool_input.file_path'); if echo \"$FILE_PATH\" | grep -q '\\.swift$'; then echo \"Running SwiftLint on $FILE_PATH\"; swiftlint --fix \"$FILE_PATH\" && echo \"SwiftLint completed for $FILE_PATH\" || echo \"SwiftLint failed for $FILE_PATH\"; fi"
+            "command": "FILE_PATH=$(jq -r '.tool_input.file_path'); if echo \"$FILE_PATH\" | grep -q '\\.swift$'; then echo \"Running SwiftLint on $FILE_PATH\"; swift package --package-path BuildTools plugin --allow-writing-to-package-directory --allow-writing-to-directory . swiftlint --config ../.swiftlint.yml --fix \"$FILE_PATH\" && echo \"SwiftLint completed for $FILE_PATH\" || echo \"SwiftLint failed for $FILE_PATH\"; fi"
           }
         ]
       }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path' | grep '\\.swift$' && swiftlint --fix \"$(jq -r '.tool_input.file_path')\" || true"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "jq -r '.tool_input.file_path' | grep '\\.swift$' && swiftlint --fix \"$(jq -r '.tool_input.file_path')\" || true"
+            "command": "FILE_PATH=$(jq -r '.tool_input.file_path'); if echo \"$FILE_PATH\" | grep -q '\\.swift$'; then echo \"Running SwiftLint on $FILE_PATH\"; swiftlint --fix \"$FILE_PATH\" && echo \"SwiftLint completed for $FILE_PATH\" || echo \"SwiftLint failed for $FILE_PATH\"; fi"
           }
         ]
       }

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,4 +1,4 @@
-swiftlint_version: 0.58.2
+swiftlint_version: 0.59.0
 
 # Project configuration
 #

--- a/BuildTools/Package.resolved
+++ b/BuildTools/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "a1ab420392bfa8dc68f7cfaa50463766423701e5565674aec099d8dd3d3d85db",
+  "originHash" : "f624710ac764ff7618b0380b1735db9cf157dca25bc65c49aa651932f600e546",
   "pins" : [
     {
       "identity" : "swiftgenplugin",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SimplyDanny/SwiftLintPlugins",
       "state" : {
-        "revision" : "7a3d77f3dd9f91d5cea138e52c20cfceabf352de",
-        "version" : "0.58.2"
+        "revision" : "a60b5704f335fc18aa3aea3564c74774a338425f",
+        "version" : "0.59.0"
       }
     }
   ],


### PR DESCRIPTION
* Adds a [Claude Code Hook](https://docs.anthropic.com/en/docs/claude-code/hooks#posttooluse-input) to run `swiftlint --fix` on files that Claude edited. 
* Updates swiftlint to `0.59`


## To test

* Run [Claude Code](https://www.anthropic.com/claude-code) (the latest version `1.0.38`)
* Have it edit a file to add trailing whitespace (I just asked "Add trailing whitespace to a random line in @podcasts/DefaultPlayer.swift")
* ✅ Ensure that no change is made (whitespace removed) after the Claude command completes

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
