### PR TITLE
Increase size of tap area of X button in Search recent suggestions

### DIFF
--- a/podcasts/New Search/Views/History/SearchHistoryCell.swift
+++ b/podcasts/New Search/Views/History/SearchHistoryCell.swift
@@ -85,7 +85,8 @@ struct SearchHistoryCell: View {
                         ZStack {
                             Image("close")
                         }
-                        .frame(width: 48, height: 48)
+                        .frame(width: 56, height: 56)
+                        .background(.red)
                     }
                     .buttonStyle(SecondaryButtonStyle())
                 }

--- a/podcasts/New Search/Views/History/SearchHistoryCell.swift
+++ b/podcasts/New Search/Views/History/SearchHistoryCell.swift
@@ -86,7 +86,6 @@ struct SearchHistoryCell: View {
                             Image("close")
                         }
                         .frame(width: 56, height: 56)
-                        .background(.red)
                     }
                     .buttonStyle(SecondaryButtonStyle())
                 }


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes #3302 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

## To test

1. Start the app
2. Go to Discover
3. Tap on Search
4. Search for a term
5. Clear search result
6. Tap Search again
7. Check if the term search on possible options
8. Try to tap on the X button
9. Check if it's easy to tap on it

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
