### PR TITLE
Address Guest list UI issues

### DIFF
--- a/podcasts/HorizontalCollectionList.swift
+++ b/podcasts/HorizontalCollectionList.swift
@@ -42,6 +42,7 @@ struct HorizontalCollectionList: View {
             }
             .frame(width: 179, height: 210)
             VStack() {
+                Spacer().frame(height: 12)
                 Text(model.title)
                     .foregroundStyle(.white)
                     .font(size: 13, style: .footnote, weight: .bold)
@@ -62,7 +63,7 @@ struct HorizontalCollectionList: View {
             .background(
                 LinearGradient(
                     stops: [
-                        Gradient.Stop(color: Color(red: 0.16, green: 0.05, blue: 0.02).opacity(0.1), location: 0),
+                        Gradient.Stop(color: Color(red: 0.16, green: 0.05, blue: 0.02).opacity(0), location: 0),
                         Gradient.Stop(color: Color(red: 0.09, green: 0.05, blue: 0.03), location: 1),
                     ],
                     startPoint: UnitPoint(x: 0.5, y: 0),

--- a/podcasts/HorizontalCollectionList.swift
+++ b/podcasts/HorizontalCollectionList.swift
@@ -123,10 +123,9 @@ struct HorizontalCollectionList: View {
                         .foregroundStyle(.clear)
                 }
             }
+            .padding(.leading, 16)
             .frame(width: max(width - 24, 0), height: 210)
             .id(index + 1)
-            .padding(.leading, 16)
-
         }
     }
 


### PR DESCRIPTION
| 📘 Part of: #3132  |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

This PR addresses two issues found on the review of the guest list new UI feature:

- Fade gradient behind the poster view was ending in a abrupt way
- Scroll to last column was not correctly aligning
- The peek of the next column was not visible

| Before | After |
| - | - |
| ![Simulator Screenshot - iPhone 16 Pro Max - 2025-07-02 at 12 43 33](https://github.com/user-attachments/assets/d43e8690-a469-4b43-9378-71bb6153b065) | ![Simulator Screenshot - iPhone 16 Pro Max - 2025-07-02 at 12 26 47](https://github.com/user-attachments/assets/4d056d0d-7148-4ea1-9b7a-16fc5910b58e) |
| ![Simulator Screenshot - iPhone 16 Pro Max - 2025-07-02 at 12 43 47](https://github.com/user-attachments/assets/b22d25ab-7c28-427e-9809-4f35e32d79b5) | ![Simulator Screenshot - iPhone 16 Pro Max - 2025-07-02 at 12 05 03](https://github.com/user-attachments/assets/4c20c1b9-dc66-4862-9ca3-a9e5cad0bb67) | 
| ![Simulator Screenshot - iPhone 16 Pro Max - 2025-07-02 at 12 43 37](https://github.com/user-attachments/assets/749eb846-783c-4e0b-95a3-7231154c7a07) | ![Simulator Screenshot - iPhone 16 Pro Max - 2025-07-02 at 12 04 54](https://github.com/user-attachments/assets/4e8cddd8-0f15-4614-8757-d74b2a51366c) |


## To test

1. Start
2. Go to Discovery
3. Scroll to one of the new network or guest curator cells
4. Check that in the poster image at the start the gradient is correctly fading into the image without an abrupt end
5. Scroll to the last column and check that the image on the left is snap aligned at the right place.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
