### PR TITLE
[Transcript In Episode View] Transcript Excerpt redesign

### DIFF
--- a/podcasts/EpisodeDetailViewController+ShowNotes.swift
+++ b/podcasts/EpisodeDetailViewController+ShowNotes.swift
@@ -64,19 +64,23 @@ extension EpisodeDetailViewController: WKNavigationDelegate, SFSafariViewControl
             let showNotes = try? await ShowInfoCoordinator.shared.loadShowNotes(podcastUuid: parentIdentifier, episodeUuid: episodeUUID)
 
             if FeatureFlag.episodeDetailTranscript.enabled {
+                let hideExcerpt: (EpisodeDetailViewController?) -> Void = { vc in
+                    vc?.transcriptExcerpt?.isHidden = true
+                    vc?.showNotesHolderTopAnchor?.constant = 0.0
+                    vc?.showNotesWebViewTopConstraint?.constant = 20.0
+                }
                 if let metadata = try? await ShowInfoCoordinator.shared.loadTranscriptsMetadata(podcastUuid: parentIdentifier, episodeUuid: episodeUUID), !metadata.transcripts.isEmpty {
-                    await MainActor.run { [weak self] in
-                        let viewModel = TranscriptExcerptViewModel(episodeUUID: episodeUUID, podcastUUID: parentIdentifier, isGeneratedTranscript: metadata.hasGeneratedTranscripts) {
-
-                            DispatchQueue.main.async {
-                                let playbackManager = TranscriptEpisodeInfoProvider(episodeUUID: episodeUUID, podcastUUID: parentIdentifier)
-                                let controller = TranscriptContainerViewController(playbackManager: playbackManager)
-                                controller.playButtonTapped = { [weak self] playing in
-                                    self?.playPauseEpisode(isPlaying: playing)
-                                }
-                                self?.present(controller, animated: true)
+                    let viewModel = TranscriptExcerptViewModel(episodeUUID: episodeUUID, podcastUUID: parentIdentifier, isGeneratedTranscript: metadata.hasGeneratedTranscripts) {
+                        DispatchQueue.main.async { [weak self] in
+                            let playbackManager = TranscriptEpisodeInfoProvider(episodeUUID: episodeUUID, podcastUUID: parentIdentifier)
+                            let controller = TranscriptContainerViewController(playbackManager: playbackManager)
+                            controller.playButtonTapped = { [weak self] playing in
+                                self?.playPauseEpisode(isPlaying: playing)
                             }
+                            self?.present(controller, animated: true)
                         }
+                    }
+                    await MainActor.run { [weak self] in
                         let view = TranscriptExcerptView(viewModel: viewModel).themedUIView
                         view.translatesAutoresizingMaskIntoConstraints = false
                         self?.transcriptExcerpt?.addSubview(view)
@@ -87,9 +91,7 @@ extension EpisodeDetailViewController: WKNavigationDelegate, SFSafariViewControl
                     }
                 } else {
                     await MainActor.run { [weak self] in
-                        self?.transcriptExcerpt?.isHidden = true
-                        self?.showNotesHolderTopAnchor?.constant = 0.0
-                        self?.showNotesWebViewTopConstraint?.constant = 20.0
+                        hideExcerpt(self)
                     }
                 }
             }

--- a/podcasts/EpisodeDetailViewController+ShowNotes.swift
+++ b/podcasts/EpisodeDetailViewController+ShowNotes.swift
@@ -44,7 +44,7 @@ extension EpisodeDetailViewController: WKNavigationDelegate, SFSafariViewControl
             transcriptExcerpt.leadingAnchor.constraint(equalTo: mainScrollView.leadingAnchor),
             transcriptExcerpt.trailingAnchor.constraint(equalTo: mainScrollView.trailingAnchor),
             transcriptExcerpt.bottomAnchor.constraint(equalTo: showNotesHolderView.topAnchor),
-            transcriptExcerpt.heightAnchor.constraint(equalToConstant: 145)
+            transcriptExcerpt.heightAnchor.constraint(equalToConstant: 78)
         ])
 
         self.transcriptExcerpt = transcriptExcerpt
@@ -82,7 +82,7 @@ extension EpisodeDetailViewController: WKNavigationDelegate, SFSafariViewControl
                         self?.transcriptExcerpt?.addSubview(view)
                         view.anchorToAllSidesOf(view: self?.transcriptExcerpt)
                         self?.transcriptExcerpt?.isHidden = false
-                        self?.showNotesHolderTopAnchor?.constant = 145.0
+                        self?.showNotesHolderTopAnchor?.constant = 78.0
                         self?.showNotesWebViewTopConstraint?.constant = 0.0
                     }
                 } else {
@@ -162,12 +162,7 @@ extension EpisodeDetailViewController: WKNavigationDelegate, SFSafariViewControl
         } else {
             let currentTheme = themeOverride ?? Theme.sharedTheme.activeTheme
             lastThemeRenderedNotesIn = currentTheme
-            let formattedNotes: String
-            if FeatureFlag.episodeDetailTranscript.enabled {
-                formattedNotes = ShowNotesFormatter.formatInEpisode(customTitle: L10n.episodeDescriptionTitle, showNotes: showNotes, tintColor: linkTintColor(), convertTimesToLinks: false, bgColor: ThemeColor.primaryUi01(for: currentTheme), textColor: ThemeColor.primaryText01(for: currentTheme))
-            } else {
-                formattedNotes = ShowNotesFormatter.format(showNotes: showNotes, tintColor: linkTintColor(), convertTimesToLinks: false, bgColor: ThemeColor.primaryUi01(for: currentTheme), textColor: ThemeColor.primaryText01(for: currentTheme))
-            }
+            let formattedNotes = ShowNotesFormatter.format(showNotes: showNotes, tintColor: linkTintColor(), convertTimesToLinks: false, bgColor: ThemeColor.primaryUi01(for: currentTheme), textColor: ThemeColor.primaryText01(for: currentTheme))
             showNotesWebView.loadHTMLString(formattedNotes, baseURL: URL(fileURLWithPath: Bundle.main.bundlePath))
         }
     }

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -3825,6 +3825,8 @@ internal enum L10n {
   internal static var uploadSortLongestToShortest: String { return L10n.tr("Localizable", "upload_sort_longest_to_shortest", fallback: "Longest to shortest") }
   /// A duration (shortest to longest) sort option for uploaded files.
   internal static var uploadSortShortestToLongest: String { return L10n.tr("Localizable", "upload_sort_shortest_to_longest", fallback: "Shortest to longest") }
+  /// Title of the Transcript excerpt in Episode detail
+  internal static var viewTranscript: String { return L10n.tr("Localizable", "view_transcript", fallback: "View Transcript") }
   /// The Volume Boost feature. Makes voices louder.
   internal static var volumeBoost: String { return L10n.tr("Localizable", "volume_boost", fallback: "Volume Boost") }
   /// A short description of what the Volume Boost feature does

--- a/podcasts/TranscriptExcerptView.swift
+++ b/podcasts/TranscriptExcerptView.swift
@@ -102,38 +102,24 @@ struct TranscriptExcerptView<ViewModel: TranscriptExcerptViewModeling>: View {
                     color: .black.opacity(0.2),
                     radius: 3, x: 0, y: 1
                 )
-                .frame(minHeight: 115)
-            VStack(spacing: 9.0) {
-                HStack(spacing: 0) {
-                    Text(L10n.transcript)
-                        .font(size: 15.0, style: .body, weight: .medium)
-                        .foregroundStyle(theme.primaryText01)
-                        .redacted(if: viewModel.loadingState == .loading)
-                    Spacer()
-                    if viewModel.isGeneratedTranscript {
-                        Image("generated_transcript")
-                            .renderingMode(.template)
-                            .foregroundStyle(theme.primaryIcon02)
-                            .frame(width: 16, height: 16)
-                    }
+                .frame(minHeight: 48.0)
+            HStack(spacing: 12.0) {
+                if viewModel.isGeneratedTranscript {
+                    Image("generated_transcript")
+                        .renderingMode(.template)
+                        .foregroundStyle(theme.primaryIcon02)
+                        .frame(width: 16, height: 16)
                 }
-                .padding(.horizontal, 16.0)
-
-                HStack {
-                    Text(viewModel.message)
-                        .font(size: 14.0, style: .body, weight: .light, design: .serif)
-                        .multilineTextAlignment(.leading)
-                        .lineSpacing(5)
-                        .lineLimit(3)
-                        .truncationMode(.tail)
-                        .allowsTightening(false)
-                        .foregroundStyle(theme.primaryText01)
-                        .padding(.horizontal, 16)
-                        .redacted(if: viewModel.loadingState == .loading || viewModel.loadingState == .idle)
-                    Spacer()
-                }
+                Text(L10n.viewTranscript)
+                    .font(size: 15.0, style: .body, weight: .medium)
+                    .foregroundStyle(theme.primaryText01)
+                    .redacted(if: viewModel.loadingState == .loading)
+                Spacer()
+                Image("listview_arrow")
+                    .renderingMode(.template)
+                    .foregroundStyle(theme.primaryIcon02)
             }
-            .padding(.vertical, 12.0)
+            .padding(.horizontal, 16.0)
         }
         .padding(.horizontal, 16.0)
         .padding(.top, 16.0)
@@ -194,7 +180,7 @@ private class MockTranscriptExcerptViewModel: TranscriptExcerptViewModeling {
             isGeneratedTranscript: true)
     )
     .environmentObject(Theme(previewTheme: .light))
-    .frame(width: 375, height: 145)
+    .frame(width: 375, height: 78)
 }
 
 #Preview {
@@ -204,15 +190,15 @@ private class MockTranscriptExcerptViewModel: TranscriptExcerptViewModeling {
             isGeneratedTranscript: true)
     )
     .environmentObject(Theme(previewTheme: .light))
-    .frame(width: 375, height: 145)
+    .frame(width: 375, height: 78)
 }
 
 #Preview {
     TranscriptExcerptView(
         viewModel: MockTranscriptExcerptViewModel(
-            loadingState: .failure,
-            isGeneratedTranscript: true)
+            loadingState: .success,
+            isGeneratedTranscript: false)
     )
     .environmentObject(Theme(previewTheme: .light))
-    .frame(width: 375, height: 145)
+    .frame(width: 375, height: 78)
 }

--- a/podcasts/TranscriptExcerptView.swift
+++ b/podcasts/TranscriptExcerptView.swift
@@ -3,11 +3,10 @@ import SwiftUI
 protocol TranscriptExcerptViewModeling: ObservableObject {
     var loadingState: TranscriptExcerptLoadingState { get set }
     var isGeneratedTranscript: Bool { get }
-    var message: String { get set }
 
     init(episodeUUID: String, podcastUUID: String, isGeneratedTranscript: Bool, tapAction: @escaping () -> Void)
 
-    func loadTranscript() async
+    func loadExcerptTranscript() async
     func excerptTapped()
     func trackViewAppear()
 }
@@ -20,8 +19,7 @@ enum TranscriptExcerptLoadingState {
 }
 
 class TranscriptExcerptViewModel: ObservableObject, TranscriptExcerptViewModeling {
-    @Published var loadingState: TranscriptExcerptLoadingState = .idle
-    @Published var message: String = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam auctor quam id massa faucibus dignissim. Nullam eget metus id"
+    @Published var loadingState: TranscriptExcerptLoadingState = .success
 
     let isGeneratedTranscript: Bool
     private let manager: TranscriptManager
@@ -42,22 +40,20 @@ class TranscriptExcerptViewModel: ObservableObject, TranscriptExcerptViewModelin
         self.manager = TranscriptManager(episodeUUID: episodeUUID, podcastUUID: podcastUUID)
     }
 
-    func loadTranscript() async {
+    @discardableResult
+    func loadTranscript() async throws -> TranscriptModel {
+        try await manager.loadTranscript()
+    }
+
+    func loadExcerptTranscript() async {
         if case .loading = loadingState { return }
         Task { @MainActor [weak self] in
             guard let self else { return }
             loadingState = .loading
             do {
-                let transcript = try await manager.loadTranscript()
-                message = transcript.attributedText.string
-                    .replacingOccurrences(of: "\n", with: " ")
-                    .trimmingCharacters(in: .whitespaces)
+                try await loadTranscript()
                 loadingState = .success
             } catch {
-                message = L10n.transcriptErrorFailedToLoad
-                if let transcriptError = error as? TranscriptError {
-                    message = transcriptError.localizedDescription
-                }
                 loadingState = .failure
             }
         }
@@ -124,9 +120,6 @@ struct TranscriptExcerptView<ViewModel: TranscriptExcerptViewModeling>: View {
         .padding(.horizontal, 16.0)
         .padding(.top, 16.0)
         .padding(.bottom, 14.0)
-        .task {
-            await viewModel.loadTranscript()
-        }
         .onAppear {
             viewModel.trackViewAppear()
         }
@@ -138,7 +131,6 @@ struct TranscriptExcerptView<ViewModel: TranscriptExcerptViewModeling>: View {
 
 private class MockTranscriptExcerptViewModel: TranscriptExcerptViewModeling {
     @Published var loadingState: TranscriptExcerptLoadingState = .loading
-    @Published var message: String = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam auctor quam id massa faucibus dignissim. Nullam eget metus id nisl malesuada condimentum."
 
     let isGeneratedTranscript: Bool
 
@@ -153,17 +145,14 @@ private class MockTranscriptExcerptViewModel: TranscriptExcerptViewModeling {
         self.isGeneratedTranscript = isGeneratedTranscript
     }
 
-    func loadTranscript() async {
+    func loadExcerptTranscript() async {
         await MainActor.run {
             self.loadingState = _privateLoadingState
 
             switch self.loadingState {
             case .idle, .loading:
                 break
-            case .failure:
-                self.message = L10n.transcriptErrorFailedToLoad
-                break
-            case .success:
+            case .failure, .success:
                 break
             }
         }

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4495,6 +4495,9 @@
 /* Transcript error message when transcript is empty*/
 "transcript_error_empty" = "Sorry, but it looks this transcript is empty";
 
+/* Title of the Transcript excerpt in Episode detail */
+"view_transcript" = "View Transcript";
+
 /* Upgrade Experiment Paywall button title */
 "upgrade_experiment_paywall_button" = "Get Pocket Casts Plus";
 


### PR DESCRIPTION
Ref. p1751373862835639-Slack-C078746V6UX

Redesign of the Transcript excerpt in the Episode detail

| Generated | Non Generated | None |
| -------- | ------- | ------- |
| ![IMG_0213](https://github.com/user-attachments/assets/fccedf42-b110-4e40-8c98-6f8688be172f) | ![IMG_0215](https://github.com/user-attachments/assets/55c019de-c27c-4441-b6e4-84965765f771) | ![IMG_0214](https://github.com/user-attachments/assets/796c8441-7a7d-4ee2-9707-b3a9d34852fa) |

## To test

- Run this branch
- Open a podcast episode with generated transcript
- Confirm you see the same view as above
- Tap on it and confirm you open the transcript detail
- Do the same test with a podcast with non generated transcript and one with no podcast

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
