### PR TITLE
[New onboarding] Upgrade screen account entry

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -203,6 +203,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// Enabled the attributed text view in the Data Usage warning Sheet
     case useDescriptiveActionAttributedTextView
 
+    /// Use the new updgrade screens
+    case newOnboardingUpgrade
+
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -343,6 +346,8 @@ public enum FeatureFlag: String, CaseIterable {
             false
         case .useDescriptiveActionAttributedTextView:
             true
+        case .newOnboardingUpgrade:
+            false
         }
     }
 

--- a/Pocket Casts Configuration.storekit
+++ b/Pocket Casts Configuration.storekit
@@ -92,10 +92,10 @@
           "groupNumber" : 2,
           "internalID" : "C9B37131",
           "introductoryOffer" : {
-            "displayPrice" : "19.99",
+            "displayPrice" : "0.99",
             "internalID" : "20314E17",
-            "paymentMode" : "payUpFront",
-            "subscriptionPeriod" : "P1Y"
+            "paymentMode" : "free",
+            "subscriptionPeriod" : "P1M"
           },
           "localizations" : [
             {

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -4109,6 +4109,10 @@
 		FFFCD23E2C7768F900A345ED /* Referrals.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Referrals.xcassets; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		FF267F652E1586CD0004EF02 /* NewUpgrade */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = NewUpgrade; sourceTree = "<group>"; };
+/* End PBXFileSystemSynchronizedRootGroup section */
+
 /* Begin PBXFrameworksBuildPhase section */
 		2F9099082A4F88B00044FC55 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
@@ -7674,6 +7678,7 @@
 		C7B3C619291AD03A00054145 /* Plus */ = {
 			isa = PBXGroup;
 			children = (
+				FF267F652E1586CD0004EF02 /* NewUpgrade */,
 				C7DA8D282923DC5900C1B08B /* Account Prompt */,
 				C7FF76C1291B5F100082A464 /* PlusButtonStyles.swift */,
 				C7A110E5291EF2DF00887A90 /* PlusLandingViewModel.swift */,
@@ -8792,6 +8797,9 @@
 				8B0845922A66C86500742C2F /* PBXTargetDependency */,
 				8B0845952A66C86D00742C2F /* PBXTargetDependency */,
 				9AB645122D51368300A842C8 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				FF267F652E1586CD0004EF02 /* NewUpgrade */,
 			);
 			name = podcasts;
 			packageProductDependencies = (

--- a/podcasts/AccountViewController+TableView.swift
+++ b/podcasts/AccountViewController+TableView.swift
@@ -7,7 +7,10 @@ import UIKit
 extension AccountViewController: UITableViewDataSource, UITableViewDelegate {
 
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        UITableView.automaticDimension
+        if section == 0, FeatureFlag.newOnboardingUpgrade.enabled {
+            return 1
+        }
+        return UITableView.automaticDimension
     }
 
     func numberOfSections(in tableView: UITableView) -> Int {
@@ -279,5 +282,14 @@ extension AccountViewController: UITableViewDataSource, UITableViewDelegate {
         firstAlert.addAction(cancelAction)
 
         present(firstAlert, animated: true, completion: nil)
+    }
+
+    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        if section == 0, FeatureFlag.newOnboardingUpgrade.enabled {
+            let view = UIView(frame: CGRect(x: 0, y: 0, width: 100, height: 2))
+            view.backgroundColor = AppTheme.colorForStyle(.primaryUi03, themeOverride: nil)
+            return view
+        }
+        return nil
     }
 }

--- a/podcasts/AccountViewController.swift
+++ b/podcasts/AccountViewController.swift
@@ -44,7 +44,12 @@ class AccountViewController: UIViewController, ChangeEmailDelegate {
         let headerView = AccountHeaderView(viewModel: headerViewModel)
 
         let view = headerView.themedUIView
-        view.backgroundColor = .clear
+        if FeatureFlag.newOnboardingUpgrade.enabled {
+            view.backgroundColor = AppTheme.colorForStyle(.primaryUi03, themeOverride: nil)
+            self.tableView.themeStyle =  ThemeStyle.primaryUi03
+        } else {
+            view.backgroundColor = .clear
+        }
 
         return view
     }()

--- a/podcasts/Onboarding/Plus/Account Prompt/PlusAccountPromptTableCell.swift
+++ b/podcasts/Onboarding/Plus/Account Prompt/PlusAccountPromptTableCell.swift
@@ -16,7 +16,9 @@ class PlusAccountPromptTableCell: ThemeableCell {
         super.init(style: .default, reuseIdentifier: reuseIdentifier)
 
         let view: UIView
-        if FeatureFlag.newAccountUpgradePromptFlow.enabled {
+        if FeatureFlag.newOnboardingUpgrade.enabled {
+            view = UpgradeBannerView(viewModel: PlusLandingViewModel(source: .accountScreen, viewSource: .profile)).themedUIView
+        } else if FeatureFlag.newAccountUpgradePromptFlow.enabled {
             let _ = OnboardingFlow.shared.begin(flow: .plusAccountUpgrade, in: model.parentController, source: PlusAccountPromptViewModel.Source.profile.rawValue, context: nil)
             view = UpgradePrompt(viewModel: PlusLandingViewModel(source: .accountScreen, viewSource: .profile)) { [weak self] size in
                 self?.contentSizeUpdated?(size)

--- a/podcasts/Onboarding/Plus/Account Prompt/PlusAccountPromptTableCell.swift
+++ b/podcasts/Onboarding/Plus/Account Prompt/PlusAccountPromptTableCell.swift
@@ -43,6 +43,11 @@ class PlusAccountPromptTableCell: ThemeableCell {
         ])
 
         view.layoutIfNeeded()
+        if FeatureFlag.newOnboardingUpgrade.enabled {
+            self.separatorInset = UIEdgeInsets(top: 0, left: .greatestFiniteMagnitude, bottom: 0, right: 0)
+            self.style = .primaryUi03
+        }
+
     }
 
     // Update the model's parent so we can present the modal

--- a/podcasts/Onboarding/Plus/NewUpgrade/SubscriptionPurchaseButton.swift
+++ b/podcasts/Onboarding/Plus/NewUpgrade/SubscriptionPurchaseButton.swift
@@ -1,0 +1,49 @@
+import SwiftUI
+
+struct SubscriptionPurchaseButton: View {
+
+    let viewModel: PlusLandingViewModel
+    let tier: UpgradeTier = .plus
+    let frequency: PlanFrequency = .yearly
+
+    private var purchaseTitle: String {
+        guard let subscriptionInfo = viewModel.pricingInfo(for: tier, frequency: frequency) else {
+            return tier.buttonLabel
+        }
+
+        if subscriptionInfo.offer?.type == .freeTrial {
+            return L10n.freeTrialStartButton
+        }
+
+        return tier.buttonLabel
+    }
+
+    private var isLoading: Bool {
+        (viewModel.state == .purchasing) || (viewModel.priceAvailability == .loading)
+    }
+
+    var body: some View {
+        let hasError = Binding<Bool>(
+            get: { self.viewModel.state == .failed },
+            set: { _ in }
+        )
+        Button(action: {
+            viewModel.unlockTapped(.init(plan: tier.plan, frequency: frequency))
+        }, label: {
+            VStack {
+                Text(purchaseTitle)
+            }
+            .transition(.opacity)
+            .id("plus_price" + tier.title)
+        })
+        .buttonStyle(PlusOpaqueButtonStyle(isLoading: isLoading, plan: tier.plan, themeOverride: Theme.sharedTheme))
+        .alert(isPresented: hasError) {
+            Alert(
+                title: Text(L10n.plusPurchaseFailed),
+                dismissButton: .default(Text(L10n.ok)) {
+                    viewModel.reset()
+                }
+            )
+        }
+    }
+}

--- a/podcasts/Onboarding/Plus/NewUpgrade/SubscriptionPurchaseButton.swift
+++ b/podcasts/Onboarding/Plus/NewUpgrade/SubscriptionPurchaseButton.swift
@@ -3,8 +3,16 @@ import SwiftUI
 struct SubscriptionPurchaseButton: View {
 
     let viewModel: PlusLandingViewModel
-    let tier: UpgradeTier = .plus
-    let frequency: PlanFrequency = .yearly
+    let tier: UpgradeTier
+    let frequency: PlanFrequency
+    let action: (() -> Void)?
+
+    init(viewModel: PlusLandingViewModel, tier: UpgradeTier = .plus, frequency: PlanFrequency = .yearly, action: (() -> Void)? = nil) {
+        self.viewModel = viewModel
+        self.tier = tier
+        self.frequency = frequency
+        self.action = action
+    }
 
     private var purchaseTitle: String {
         guard let subscriptionInfo = viewModel.pricingInfo(for: tier, frequency: frequency) else {
@@ -28,7 +36,7 @@ struct SubscriptionPurchaseButton: View {
             set: { _ in }
         )
         Button(action: {
-            viewModel.unlockTapped(.init(plan: tier.plan, frequency: frequency))
+            action?()
         }, label: {
             VStack {
                 Text(purchaseTitle)

--- a/podcasts/Onboarding/Plus/NewUpgrade/UpgradeBannerView.swift
+++ b/podcasts/Onboarding/Plus/NewUpgrade/UpgradeBannerView.swift
@@ -7,16 +7,16 @@ struct UpgradeBannerView: View {
     var body: some View {
         VStack(spacing: 12) {
             SubscriptionBadge(tier: .plus)
-            Text("Superpowers for your podcasts")
+            Text(L10n.upgradeAccountTitle)
                 .foregroundStyle(theme.primaryText01)
                 .font(size: 18, style: .headline, weight: .bold)
                 .multilineTextAlignment(.center)
-            Text("Unlock all paid features like Folders, Shuffle, Bookmarks and many more")
+            Text(L10n.upgradeAccountInfo)
                 .foregroundStyle(theme.primaryText01)
                 .font(size: 13, style: .footnote, weight: .regular)
                 .multilineTextAlignment(.center)
             SubscriptionPurchaseButton(viewModel: viewModel) {
-                
+
             }
         }
         .padding(16)

--- a/podcasts/Onboarding/Plus/NewUpgrade/UpgradeBannerView.swift
+++ b/podcasts/Onboarding/Plus/NewUpgrade/UpgradeBannerView.swift
@@ -18,6 +18,7 @@ struct UpgradeBannerView: View {
             SubscriptionPurchaseButton(viewModel: viewModel) {
 
             }
+            .frame(maxWidth: 440)
         }
         .padding(16)
         .background(theme.primaryUi01)

--- a/podcasts/Onboarding/Plus/NewUpgrade/UpgradeBannerView.swift
+++ b/podcasts/Onboarding/Plus/NewUpgrade/UpgradeBannerView.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+struct UpgradeBannerView: View {
+    @EnvironmentObject var theme: Theme
+    @StateObject var viewModel: PlusLandingViewModel
+
+    var body: some View {
+        VStack(spacing: 12) {
+            SubscriptionBadge(tier: .plus)
+            Text("Superpowers for your podcasts")
+                .foregroundStyle(theme.primaryText02)
+                .font(size: 18, style: .headline, weight: .bold)
+                .multilineTextAlignment(.center)
+            Text("Unlock all paid features like Folders, Shuffle, Bookmarks and many more")
+                .foregroundStyle(theme.primaryText02)
+                .font(size: 13, style: .footnote, weight: .regular)
+                .multilineTextAlignment(.center)
+            SubscriptionPurchaseButton(viewModel: viewModel)
+        }
+        .padding(16)
+        .background(theme.primaryUi01)
+        .cornerRadius(8)
+        .shadow(color: .black.opacity(0.2), radius: 1.5, x: 0, y: 1)
+        .padding(16)
+    }
+}

--- a/podcasts/Onboarding/Plus/NewUpgrade/UpgradeBannerView.swift
+++ b/podcasts/Onboarding/Plus/NewUpgrade/UpgradeBannerView.swift
@@ -8,19 +8,22 @@ struct UpgradeBannerView: View {
         VStack(spacing: 12) {
             SubscriptionBadge(tier: .plus)
             Text("Superpowers for your podcasts")
-                .foregroundStyle(theme.primaryText02)
+                .foregroundStyle(theme.primaryText01)
                 .font(size: 18, style: .headline, weight: .bold)
                 .multilineTextAlignment(.center)
             Text("Unlock all paid features like Folders, Shuffle, Bookmarks and many more")
-                .foregroundStyle(theme.primaryText02)
+                .foregroundStyle(theme.primaryText01)
                 .font(size: 13, style: .footnote, weight: .regular)
                 .multilineTextAlignment(.center)
-            SubscriptionPurchaseButton(viewModel: viewModel)
+            SubscriptionPurchaseButton(viewModel: viewModel) {
+                
+            }
         }
         .padding(16)
         .background(theme.primaryUi01)
         .cornerRadius(8)
         .shadow(color: .black.opacity(0.2), radius: 1.5, x: 0, y: 1)
         .padding(16)
+        .background(theme.primaryUi03)
     }
 }

--- a/podcasts/Onboarding/Plus/PlusButtonStyles.swift
+++ b/podcasts/Onboarding/Plus/PlusButtonStyles.swift
@@ -3,18 +3,28 @@ import SwiftUI
 struct PlusOpaqueButtonStyle: ButtonStyle {
     let isLoading: Bool
     let plan: Plan
+    let themeOverride: Theme?
 
     private var background: Color {
-        plan == .plus ? Color.plusBackgroundColor2 : Color.patronBackgroundColor
+        if let themeOverride {
+            return themeOverride.primaryInteractive01
+        } else {
+            return plan == .plus ? Color.plusBackgroundColor2 : Color.patronBackgroundColor
+        }
     }
 
     private var foregroundColor: Color {
-        plan == .plus ? .plusButtonFilledTextColor : Color.patronButtonFilledTextColor
+        if let themeOverride {
+            return themeOverride.primaryInteractive02
+        } else {
+            return plan == .plus ? .plusButtonFilledTextColor : Color.patronButtonFilledTextColor
+        }
     }
 
-    init(isLoading: Bool = false, plan: Plan) {
+    init(isLoading: Bool = false, plan: Plan, themeOverride: Theme? = nil) {
         self.isLoading = isLoading
         self.plan = plan
+        self.themeOverride = themeOverride
     }
 
     func makeBody(configuration: Configuration) -> some View {

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -3777,6 +3777,10 @@ internal enum L10n {
   internal static var upNextShuffleToastMessage: String { return L10n.tr("Localizable", "up_next_shuffle_toast_message", fallback: "Shuffle is on. Episodes will play in random order.") }
   /// Label of a button that informs the user they can upgrade their account. .
   internal static var upgradeAccount: String { return L10n.tr("Localizable", "upgrade_account", fallback: "Upgrade Account") }
+  /// Upgrade account information for onboarding banner
+  internal static var upgradeAccountInfo: String { return L10n.tr("Localizable", "upgrade_account_info", fallback: "Unlock all paid features like Folders, Shuffle, Bookmarks and many more") }
+  /// Upgrade account Title for onboarding banner
+  internal static var upgradeAccountTitle: String { return L10n.tr("Localizable", "upgrade_account_title", fallback: "Superpowers for your podcasts") }
   /// Upgrade Experiment message informing the user that they have been granted 50% discount.
   internal static var upgradeExperimentDiscountYearlyMembership: String { return L10n.tr("Localizable", "upgrade_experiment_discount_yearly_membership", fallback: "Save 50%% off your first year") }
   /// Upgrade Experiment message informing the user that they have been granted a limited free membership. '%1$@' is a placeholder for a localized string for the free time period.

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -5190,4 +5190,9 @@
 /* Name for group of episodes that don't have a season defined when sorting in serial mode*/
 "podcast_extras" = "Extras";
 
+/* Upgrade account Title for onboarding banner*/
+"upgrade_account_title" = "Superpowers for your podcasts";
+
+/* Upgrade account information for onboarding banner*/
+"upgrade_account_info" = "Unlock all paid features like Folders, Shuffle, Bookmarks and many more";
 


### PR DESCRIPTION
| 📘 Part of: #[POC-47](https://linear.app/a8c/issue/POC-47/new-upgrade-screen) |  <!-- project issue number, if applicable -->
|:---:|

Fixes #[POC-66](https://linear.app/a8c/issue/POC-66/upgrade-screen-new-banner-on-account-profile) <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR updates the  upgrade banner in Account screen to show the new account flow.

| 1 | 2 | 3 | 4 | 5 |
| - | - | - | - | - |
| ![Simulator Screenshot - iPhone 16 Pro Max - 2025-07-02 at 23 52 43](https://github.com/user-attachments/assets/c57e53d7-a388-4fe2-9d77-f8ef89b8ee11) | ![Simulator Screenshot - iPhone 16 Pro Max - 2025-07-02 at 23 52 10](https://github.com/user-attachments/assets/13a0e246-8211-4b62-bf31-dee103a15089) | ![Simulator Screenshot - iPhone 16 Pro Max - 2025-07-02 at 23 51 59](https://github.com/user-attachments/assets/99fbe7ba-9189-4b3f-805d-f403bb76fe0f) | ![Simulator Screenshot - iPhone 16 Pro Max - 2025-07-02 at 23 51 45](https://github.com/user-attachments/assets/1ed049e3-7e2e-44bb-93b5-978dd4c6672a) | ![Simulator Screenshot - iPhone 16 Pro Max - 2025-07-02 at 23 51 33](https://github.com/user-attachments/assets/6144068b-dd2f-4444-a906-c9c705d5dc62) |

## To test

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->
1. Start the app
2. Ensure that you have the FF `NewOnboardingUpgrade` enabled
3. Login/Signup with a user without a paid subscription
4. Go to Profile tab
5. Open the account tab
6. Check if the new banner shows correctly in the top 

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
