### PR TITLE
[Smart Categories] Analytics updates

### DIFF
--- a/podcasts/AnalyticsHelper.swift
+++ b/podcasts/AnalyticsHelper.swift
@@ -151,8 +151,11 @@ class AnalyticsHelper {
         bumpStat("discover_list_show_all", parameters: properties)
     }
 
-    class func listImpression(listId: String) {
-        let properties = ["list_id": listId]
+    class func listImpression(listId: String, category: String?) {
+        var properties = ["list_id": listId]
+        if let category {
+            properties["category"] = category
+        }
         Analytics.track(.discoverListImpression, properties: properties)
         bumpStat("discover_list_impression", parameters: properties)
     }

--- a/podcasts/Categories/CategoriesModalPicker.swift
+++ b/podcasts/Categories/CategoriesModalPicker.swift
@@ -3,7 +3,7 @@ import PocketCastsServer
 import Kingfisher
 
 struct CategoriesModalPicker: View {
-    let categories: [DiscoverCategory]
+    let categories: [Category]
 
     @Binding var selectedCategory: DiscoverCategory?
 
@@ -43,7 +43,7 @@ struct CategoriesModalPicker: View {
             title
                 .padding(Constants.Padding.title)
             List {
-                ForEach(categories, id: \.self) { category in
+                ForEach(categories, id: \.category.id) { category in
                     cell(category)
                         .listRowInsets(EdgeInsets())
                         .listRowBackground(background)
@@ -68,7 +68,8 @@ struct CategoriesModalPicker: View {
             .foregroundStyle(titleForeground)
     }
 
-    @ViewBuilder func cell(_ category: DiscoverCategory) -> some View {
+    @ViewBuilder func cell(_ categoryWithMetadata: Category) -> some View {
+        let category = categoryWithMetadata.category
         HStack(spacing: Constants.cellSpacing) {
             if let icon = category.icon, let url = URL(string: icon) {
                 KFImage(url)
@@ -83,7 +84,7 @@ struct CategoriesModalPicker: View {
         .padding(Constants.Padding.cell)
         .buttonize {
             selectedCategory = category
-            Analytics.track(.discoverCategoriesPickerPick, properties: ["id": category.id ?? -1, "name": category.name ?? "all", "region": region ?? "none"])
+            Analytics.track(.discoverCategoriesPickerPick, properties: ["id": category.id ?? -1, "name": category.name ?? "all", "region": region ?? "none", "sponsored": categoryWithMetadata.isSponsored, "visits": categoryWithMetadata.visits])
         } customize: { config in
             config.label
                 .foregroundStyle(cellForeground)

--- a/podcasts/Categories/CategoriesSelectorView.swift
+++ b/podcasts/Categories/CategoriesSelectorView.swift
@@ -2,11 +2,6 @@ import SwiftUI
 import PocketCastsServer
 import PocketCastsUtils
 
-struct Category {
-    let title: String
-    let image: String
-}
-
 struct CategoriesSelectorView: View {
     @ObservedObject var discoverItemObservable: CategoriesSelectorViewController.DiscoverItemObservable
 
@@ -18,8 +13,14 @@ struct CategoriesSelectorView: View {
     var body: some View {
         Group {
             if let categories, let prioritized {
-                CategoriesPillsView(pillCategories: prioritized,
-                                    overflowCategories: categories,
+                let sponsoredCategoryIDs = discoverItemObservable.item?.sponsoredCategoryIDs
+                let recommendations = UserDefaults.standard.visitations(for: .discoverCategory)
+
+                let prioritizedCategories = Category.create(from: prioritized, sponsoredCategoryIDs: sponsoredCategoryIDs, recommendations: recommendations)
+                let overflowCategories = Category.create(from: categories, sponsoredCategoryIDs: sponsoredCategoryIDs, recommendations: recommendations)
+
+                CategoriesPillsView(categories: prioritizedCategories,
+                                    overflowCategories: overflowCategories,
                                     selectedCategory: $discoverItemObservable.selectedCategory.animation(.easeOut(duration: 0.25)),
                                     region: discoverItemObservable.region)
             } else {
@@ -53,9 +54,31 @@ struct PlaceholderPillsView: View {
     }
 }
 
+struct Category {
+    let category: DiscoverCategory
+    let isSponsored: Bool
+    let visits: Int
+
+    init(category: DiscoverCategory, sponsoredCategoryIDs: [Int]?, recommendations: [String: Int]?) {
+        self.category = category
+
+        let sponsoredIDs = Set(sponsoredCategoryIDs?.map { String($0) } ?? [])
+        let categoryID = category.id.map(String.init) ?? ""
+
+        self.isSponsored = sponsoredIDs.contains(categoryID)
+        self.visits = recommendations?[categoryID] ?? 0
+    }
+
+    static func create(from categories: [DiscoverCategory], sponsoredCategoryIDs: [Int]?, recommendations: [String: Int]?) -> [Category] {
+        return categories.map { category in
+            Category(category: category, sponsoredCategoryIDs: sponsoredCategoryIDs, recommendations: recommendations)
+        }
+    }
+}
+
 struct CategoriesPillsView: View {
-    let pillCategories: [DiscoverCategory]
-    let overflowCategories: [DiscoverCategory]
+    let categories: [Category]
+    let overflowCategories: [Category]
     @Binding var selectedCategory: DiscoverCategory?
 
     let region: String?
@@ -70,10 +93,10 @@ struct CategoriesPillsView: View {
 
     var body: some View {
         if let selectedCategory {
+            let selectedCategoryItem = categories.first { $0.category.id == selectedCategory.id }
             HStack {
                 CloseButton(selectedCategory: $selectedCategory)
-                CategoryButton(category: selectedCategory, selectedCategory: $selectedCategory, region: region)
-                    .matchedGeometryEffect(id: selectedCategory.id, in: animation)
+                CategoryButton(category: selectedCategory, selectedCategory: $selectedCategory, model: .init(region: region, index: 0, isSponsored: selectedCategoryItem?.isSponsored ?? false, visits: selectedCategoryItem?.visits ?? 0))
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(Constants.buttonInsets)
@@ -117,9 +140,9 @@ struct CategoriesPillsView: View {
     }
 
     @ViewBuilder private var categoryButtons: some View {
-        ForEach(pillCategories, id: \.id) { category in
-            CategoryButton(category: category, selectedCategory: $selectedCategory, region: region)
-                .matchedGeometryEffect(id: category.id, in: animation)
+        ForEach(Array(categories.enumerated()), id: \.element.category.id) { index, categoryItem in
+            CategoryButton(category: categoryItem.category, selectedCategory: $selectedCategory, model: .init(region: region, index: index, isSponsored: categoryItem.isSponsored, visits: categoryItem.visits))
+                .matchedGeometryEffect(id: categoryItem.category.id, in: animation)
         }
     }
 }
@@ -150,7 +173,14 @@ struct CategoryButton: View {
 
     @Binding var selectedCategory: DiscoverCategory?
 
-    let region: String?
+    struct Model {
+        let region: String?
+        let index: Int
+        let isSponsored: Bool
+        let visits: Int
+    }
+
+    let model: Model
 
     var isSelected: Bool {
         category.id == selectedCategory?.id
@@ -159,7 +189,7 @@ struct CategoryButton: View {
     var body: some View {
         Button(action: {
             selectedCategory = category
-            Analytics.track(.discoverCategoriesPillTapped, properties: ["name": category.name ?? "none", "region": region ?? "none", "id": category.id ?? -1])
+            Analytics.track(.discoverCategoriesPillTapped, properties: ["name": category.name ?? "none", "region": model.region ?? "none", "id": category.id ?? -1, "index": model.index, "sponsored": model.isSponsored, "visits": model.visits])
             if FeatureFlag.smartCategories.enabled, let categoryID = category.id {
                 UserDefaults.standard.trackVisitation(event: .discoverCategory, id: String(categoryID))
             }

--- a/podcasts/CategoryPodcastsViewController.swift
+++ b/podcasts/CategoryPodcastsViewController.swift
@@ -141,7 +141,8 @@ class CategoryPodcastsViewController: PCViewController, UITableViewDelegate, UIT
                 }
 
                 if let promotionUuid = categoryDetails?.promotion?.promotion_uuid {
-                    AnalyticsHelper.listImpression(listId: promotionUuid)
+                    let categoryId = strongSelf.category?.id.map(String.init)
+                    AnalyticsHelper.listImpression(listId: promotionUuid, category: categoryId)
                 }
             }
         })

--- a/podcasts/CollectionSummaryViewController.swift
+++ b/podcasts/CollectionSummaryViewController.swift
@@ -52,6 +52,7 @@ class CollectionSummaryViewController: UIViewController, DiscoverSummaryProtocol
 
     private weak var delegate: DiscoverDelegate?
     private var item: DiscoverItem?
+    private var category: DiscoverCategory?
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -65,7 +66,8 @@ class CollectionSummaryViewController: UIViewController, DiscoverSummaryProtocol
         super.viewDidAppear(animated)
 
         if let listId = item?.uuid {
-            AnalyticsHelper.listImpression(listId: listId)
+            let categoryId = category?.id.map(String.init)
+            AnalyticsHelper.listImpression(listId: listId, category: categoryId)
         }
     }
 
@@ -80,6 +82,7 @@ class CollectionSummaryViewController: UIViewController, DiscoverSummaryProtocol
         guard let source = item.source else { return }
 
         self.item = item
+        self.category = category
         DiscoverServerHandler.shared.discoverPodcastCollection(source: source, authenticated: item.authenticated, completion: { [weak self] podcastCollection in
             self?.podcastCollection = podcastCollection
             guard podcastCollection?.podcasts != nil || podcastCollection?.episodes != nil else { return }

--- a/podcasts/DiscoverEpisodeViewModel.swift
+++ b/podcasts/DiscoverEpisodeViewModel.swift
@@ -85,9 +85,9 @@ class DiscoverEpisodeViewModel: ObservableObject {
             .store(in: &cancellables)
     }
 
-    public func registerListImpression() {
+    public func registerListImpression(category: String?) {
         guard let listId = discoverItem?.uuid else { return }
-        AnalyticsHelper.listImpression(listId: listId)
+        AnalyticsHelper.listImpression(listId: listId, category: category)
     }
 
     public func didSelectPlayEpisode(from button: BasePlayPauseButton) {

--- a/podcasts/FeaturedSummaryViewController.swift
+++ b/podcasts/FeaturedSummaryViewController.swift
@@ -25,6 +25,7 @@ class FeaturedSummaryViewController: SimpleNotificationsViewController, GridLayo
     private var listIdImpressionTracked: [String] = []
 
     private weak var delegate: DiscoverDelegate?
+    private var category: DiscoverCategory?
     @IBOutlet var featuredCollectionViewHeight: NSLayoutConstraint!
     @IBOutlet var dividerHeightConstraint: NSLayoutConstraint! {
         didSet {
@@ -142,7 +143,8 @@ class FeaturedSummaryViewController: SimpleNotificationsViewController, GridLayo
             return
         }
 
-        AnalyticsHelper.listImpression(listId: listId)
+        let categoryId = category?.id.map(String.init)
+        AnalyticsHelper.listImpression(listId: listId, category: categoryId)
         listIdImpressionTracked.append(listId)
     }
 
@@ -170,6 +172,8 @@ class FeaturedSummaryViewController: SimpleNotificationsViewController, GridLayo
         if let delegate = delegate {
             listType = delegate.replaceRegionName(string: title)
         }
+
+        self.category = category
 
         let dispatchGroup = DispatchGroup()
 

--- a/podcasts/LargeListSummaryViewController.swift
+++ b/podcasts/LargeListSummaryViewController.swift
@@ -26,6 +26,7 @@ class LargeListSummaryViewController: DiscoverPeekViewController, DiscoverSummar
     private var datetime: String? // Used to track the generation of recommendations
     private weak var delegate: DiscoverDelegate?
     private var item: DiscoverItem?
+    private var category: DiscoverCategory?
 
     @IBOutlet var largeListCollectionViewHeight: NSLayoutConstraint!
 
@@ -85,7 +86,8 @@ class LargeListSummaryViewController: DiscoverPeekViewController, DiscoverSummar
         super.viewDidAppear(animated)
 
         if let listId = item?.uuid {
-            AnalyticsHelper.listImpression(listId: listId)
+            let categoryId = category?.id.map(String.init)
+            AnalyticsHelper.listImpression(listId: listId, category: categoryId)
         }
         NotificationCenter.default.addObserver(self, selector: #selector(podcastStatusChanged), name: Constants.Notifications.podcastAdded, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(podcastStatusChanged), name: Constants.Notifications.podcastDeleted, object: nil)
@@ -165,6 +167,7 @@ class LargeListSummaryViewController: DiscoverPeekViewController, DiscoverSummar
         showAllBtn.isHidden = item.expandedStyle == nil
 
         self.item = item
+        self.category = category
 
         switch item.cellType() {
         case .largeListWithPodcast:

--- a/podcasts/SingleEpisodeViewController.swift
+++ b/podcasts/SingleEpisodeViewController.swift
@@ -6,6 +6,7 @@ import UIKit
 class SingleEpisodeViewController: UIViewController {
     private let viewModel = DiscoverEpisodeViewModel()
     private var cancellables = Set<AnyCancellable>()
+    private var category: DiscoverCategory?
 
     @IBOutlet var episodeTitle: ThemeableLabel!
     @IBOutlet var podcastTitle: ThemeableLabel! {
@@ -38,7 +39,8 @@ class SingleEpisodeViewController: UIViewController {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        viewModel.registerListImpression()
+        let categoryId = category?.id.map(String.init)
+        viewModel.registerListImpression(category: categoryId)
     }
 
     func observeEpisodeChanges() {
@@ -112,6 +114,7 @@ extension SingleEpisodeViewController: DiscoverSummaryProtocol {
 
     func populateFrom(item: DiscoverItem, region: String?, category: DiscoverCategory?) {
         viewModel.discoverItem = item
+        self.category = category
 
         typeBadgeLabel.text = (item.title ?? L10n.discoverFeaturedEpisode).uppercased()
     }

--- a/podcasts/SinglePodcastViewController.swift
+++ b/podcasts/SinglePodcastViewController.swift
@@ -64,7 +64,8 @@ class SinglePodcastViewController: UIViewController, DiscoverSummaryProtocol {
 
         guard let listId = item?.uuid else { return }
 
-        AnalyticsHelper.listImpression(listId: listId)
+        let categoryId = category?.id.map(String.init)
+        AnalyticsHelper.listImpression(listId: listId, category: categoryId)
     }
 
     // MARK: DiscoverSummaryProtocol

--- a/podcasts/SmallPagedListSummaryViewController.swift
+++ b/podcasts/SmallPagedListSummaryViewController.swift
@@ -26,6 +26,7 @@ class SmallPagedListSummaryViewController: DiscoverPeekViewController, GridLayou
     private let maxFeaturedItems = 20
 
     private var item: DiscoverItem?
+    private var category: DiscoverCategory?
 
     private weak var delegate: DiscoverDelegate?
     @IBOutlet var smallPagedCollectionViewHeight: NSLayoutConstraint!
@@ -87,7 +88,8 @@ class SmallPagedListSummaryViewController: DiscoverPeekViewController, GridLayou
         super.viewDidAppear(animated)
 
         if let listId = item?.uuid {
-            AnalyticsHelper.listImpression(listId: listId)
+            let categoryId = category?.id.map(String.init)
+            AnalyticsHelper.listImpression(listId: listId, category: categoryId)
         }
         NotificationCenter.default.addObserver(self, selector: #selector(podcastStatusChanged), name: Constants.Notifications.podcastAdded, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(podcastStatusChanged), name: Constants.Notifications.podcastDeleted, object: nil)
@@ -165,6 +167,7 @@ class SmallPagedListSummaryViewController: DiscoverPeekViewController, GridLayou
         guard let source = delegate?.replaceRegionCode(string: item.source), let title = item.title?.localized else { return }
 
         self.item = item
+        self.category = category
         titleLabel.text = delegate?.replaceRegionName(string: title)
 
         DiscoverServerHandler.shared.discoverPodcastList(source: source, authenticated: item.authenticated, completion: { [weak self] podcastList in


### PR DESCRIPTION
| 📘 Part of: [Smart Categories](https://linear.app/a8c/project/smart-categories-87cfb5eff13e/overview)
|:---:|

Closes [PCIOS-14](https://linear.app/a8c/issue/PCIOS-14/update-analytics-events-for-smart-categories-success-metrics)

* `discover_categories_pill_tapped` new `index`, `sponsored`, `visits` properties

* `discover_categories_picker_pick` new `sponsored`, `visits` properties

* `discover_list_impression` new `category` id

## To test

* Visit Discover
* Scroll through list
* ✅ Verify `discover_list_impression` events with no category (since none is selected)
```
🔵 Tracked: discover_list_impression ["theme_selected": "default_light", "theme_light_preference": "default_light", "theme_dark_preference": "default_dark", "theme_use_system_settings": true, "list_id": "26287196-f403-41b6-9815-ac30d3fe2bdd"]
```
* Tap a category pill
* ✅ Verify `discover_categories_pill_tapped` is logged with `index`, `visits`, and `sponsored`
```
🔵 Tracked: discover_categories_pill_tapped ["visits": 4, "theme_dark_preference": "default_dark", "index": 0, "theme_use_system_settings": true, "sponsored": true, "name": "Society & Culture", "theme_selected": "default_light", "theme_light_preference": "default_light", "id": 13, "region": "us"]
```
* Verify that `discover_list_impression` event is logged with `category`
```
🔵 Tracked: discover_list_impression ["theme_dark_preference": "default_dark", "list_id": "cafa42f1-8345-4b8e-a4b9-798a47a9e4fe", "theme_use_system_settings": true, "category": "13", "theme_light_preference": "default_light", "theme_selected": "default_light"]
```
* Tap "All Categories" and select a category
* ✅ Verify `discover_categories_picker_pick` is logged with `sponsored` and `visits`
```
🔵 Tracked: discover_categories_picker_pick ["name": "Business", "theme_selected": "default_light", "id": 2, "region": "us", "theme_dark_preference": "default_dark", "sponsored": false, "theme_light_preference": "default_light", "visits": 0, "theme_use_system_settings": true]
```

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
