### PR TITLE
GRDB: enable only for TestFlight users

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -43,9 +43,11 @@ public class DataManager {
             config.busyMode = .timeout(10)
             dbQueue = GRDBQueue(dbPool: try! DatabasePool(path: DataManager.pathToDb(), configuration: config), logger: Self.logger)
             DataManager.setDatabaseFileProtectionToNone()
+            FileLog.shared.addMessage("[DataManager] Initialized using GRDB")
         } else {
             let flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FILEPROTECTION_NONE
             dbQueue = FMDBQueue(fmdbQueue: FMDatabaseQueue(path: DataManager.pathToDb(), flags: flags)!)
+            FileLog.shared.addMessage("[DataManager] Initialized using FMDB")
         }
 
         self.init(dbQueue: dbQueue)

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -367,7 +367,7 @@ public enum FeatureFlag: String, CaseIterable {
         case .podcastViewChanges:
             "podcast_view_changes_2025"
         case .grdb:
-            "grdb_testflight"
+            "grdb_testflight_793"
         default:
             rawValue.lowerSnakeCased()
         }
@@ -380,7 +380,13 @@ extension FeatureFlag: OverrideableFlag {
     }
 
     public var canOverride: Bool {
-        true
+        switch self {
+            // GRDB can only change in TestFlight versions
+            case .grdb:
+                Self.isTestFlight
+            default:
+                true
+        }
     }
 
     private static let isTestFlight = Bundle.main.appStoreReceiptURL?.lastPathComponent == "sandboxReceipt"


### PR DESCRIPTION
| 📘 Part of: #2773 | 
|:---:|

This PR adds the remote feature flag value for enabling GRDB for TestFlight users **only**. This is now done through the code since we downgraded Firebase due to crashes.

We will do a rollout, meaning not all users will have it enabled. We want to test that in a controlled way so we ensure everything goes smoothly.

## To test

1. [Comment this line](https://github.com/Automattic/pocket-casts-ios/blob/trunk/podcasts/AppDelegate.swift#L316) so the feature flag code runs in `DEBUG`
2. Change [isTestflight to `false`](https://github.com/Automattic/pocket-casts-ios/blob/trunk/Modules/Utils/Sources/PocketCastsUtils/Feature%20Flags/FeatureFlag.swift#L386)
3. Do a clean install of the app
4. ✅ Search for `Overriding grdb to true`. This log might be or might not be there. Try a few times, each time deleting and running a clean install of the app. This way you can also test that the rollout is working as intended.
6. ✅  You should should see a `Failed to set remote feature flag grdb: cannotBeOverridden` because this is not TestFlight
7. Change `isTestflight` to `true`
8. Delete the app, run it again until you see the `Overriding grdb to true`
9. ✅ This time there won't be a `Failed to set remote feature flag grdb: cannotBeOverridden` though
10. Re-run the app
11. ✅ You should see `[DataManager] Initialized using GRDB`

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
