### PR TITLE
GRDB: change feature flag to target only TestFlight users

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -367,7 +367,7 @@ public enum FeatureFlag: String, CaseIterable {
         case .podcastViewChanges:
             "podcast_view_changes_2025"
         case .grdb:
-            "grdb_testflight_793"
+            "grdb_testflight"
         default:
             rawValue.lowerSnakeCased()
         }


### PR DESCRIPTION
The previous remote feature flag was configured wrongly and it was being served for all users. That's not a problem — as the code for this flag is only in TestFlight, but then we can't guarantee the percentage we want to.

The issue has been fixed on Firebase Remote Config and here we just update the flag name.

## To test

1. [Check the rollout](https://console.firebase.google.com/u/0/project/singular-vector-91401/config/env/firebase/rollout/rollout_11?app=1:910146533958:ios:cf844de2510aeece&dateRange=24h)
2. Code review

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
