### PR TITLE
[New onboarding] Update patron features and use new design

### DIFF
--- a/Pocket Casts Configuration.storekit
+++ b/Pocket Casts Configuration.storekit
@@ -152,11 +152,7 @@
           "familyShareable" : false,
           "groupNumber" : 1,
           "internalID" : "FB9E06A9",
-          "introductoryOffer" : {
-            "internalID" : "3848A746",
-            "paymentMode" : "free",
-            "subscriptionPeriod" : "P1M"
-          },
+          "introductoryOffer" : null,
           "localizations" : [
             {
               "description" : "",

--- a/podcasts/AccountViewController+TableView.swift
+++ b/podcasts/AccountViewController+TableView.swift
@@ -178,10 +178,14 @@ extension AccountViewController: UITableViewDataSource, UITableViewDelegate {
         case .upgradeView:
             break
         case .upgradeAccount:
-            let controller = OnboardingFlow.shared.begin(flow: .patronAccountUpgrade, source: "account")
-            navigationController?.present(controller, animated: true)
-            break
-
+            if FeatureFlag.newOnboardingUpgrade.enabled {
+                let controller = ThemedHostingController(rootView: UpgradeAccountView(model: UpgradeAccountViewModel(upgradeTier: .patron, selectedProduct: .patronYearly)))
+                controller.modalPresentationStyle = .fullScreen
+                navigationController?.present(controller, animated: true)
+            } else {
+                let controller = OnboardingFlow.shared.begin(flow: .patronAccountUpgrade, source: "account")
+                navigationController?.present(controller, animated: true)
+            }
         case .supporterContributions:
             let supporterVC = SupporterContributionsViewController()
             navigationController?.pushViewController(supporterVC, animated: true)

--- a/podcasts/Onboarding/Plus/NewUpgrade/UpgradeAccountView.swift
+++ b/podcasts/Onboarding/Plus/NewUpgrade/UpgradeAccountView.swift
@@ -59,7 +59,7 @@ struct UpgradeAccountView: View {
 
     var header: some View {
         HStack() {
-            SubscriptionBadge(tier: model.upgradeTier.tier)
+            SubscriptionBadge(tier: model.upgradeTier.tier, displayMode: .plain)
             Spacer()
             Button() {
                 dismiss()

--- a/podcasts/Onboarding/Plus/NewUpgrade/UpgradeAccountViewModel.swift
+++ b/podcasts/Onboarding/Plus/NewUpgrade/UpgradeAccountViewModel.swift
@@ -6,7 +6,9 @@ class UpgradeAccountViewModel: PlusPricingInfoModel {
 
     @Published private(set) var selectedFrequency: PlanFrequency = .yearly
 
-    init() {
+    init(upgradeTier: UpgradeTier = .plus, selectedProduct: IAPProductID = .yearly) {
+        self.upgradeTier = upgradeTier
+        self.selectedProduct = selectedProduct
         super.init()
         loadPrices() {
             Task { @MainActor [weak self] in

--- a/podcasts/Onboarding/Plus/UpgradeTier.swift
+++ b/podcasts/Onboarding/Plus/UpgradeTier.swift
@@ -102,9 +102,9 @@ extension UpgradeTier {
 
     static var patronFeatures: [UpgradeTier.TierFeature] {
         [
-            TierFeature(iconName: "patron-everything", title: L10n.patronFeatureEverythingInPlus),
-            TierFeature(iconName: "patron-early-access", title: L10n.patronFeatureEarlyAccess),
-            TierFeature(iconName: "plus-feature-cloud", title: L10n.patronCloudStorageLimit),
+            TierFeature(iconName: "patron-everything", title: FeatureFlag.newOnboardingUpgrade.enabled ? L10n.featureMarketingAllPlusFeatures : L10n.patronFeatureEverythingInPlus),
+            TierFeature(iconName: "patron-early-access", title: FeatureFlag.newOnboardingUpgrade.enabled ? L10n.featureMarketingEarlyAccess : L10n.patronFeatureEarlyAccess),
+            TierFeature(iconName: "plus-feature-cloud", title: FeatureFlag.newOnboardingUpgrade.enabled ? L10n.featureMarketingCloudStorage(Settings.patronCloudStorageLimit.localized()) : L10n.patronCloudStorageLimit),
             TierFeature(iconName: "patron-badge", title: L10n.patronFeatureProfileBadge),
             TierFeature(iconName: "patron-icons", title: L10n.patronFeatureProfileIcons),
             TierFeature(iconName: "plus-feature-love", title: L10n.plusFeatureGratitude)

--- a/podcasts/Profile - SwiftUI/Common Views/SubscriptionBadge.swift
+++ b/podcasts/Profile - SwiftUI/Common Views/SubscriptionBadge.swift
@@ -3,10 +3,6 @@ import PocketCastsServer
 
 /// Displays a subscription badge view
 /// Example: SubscriptionBadge(type: .plus)
-///
-/// For an extra effect use:
-/// SubscriptionBadge(type: .patron, geometryProxy: geometryProxy)
-///
 struct SubscriptionBadge: View {
     let tier: SubscriptionTier
     var displayMode: DisplayMode = .black
@@ -66,6 +62,9 @@ struct SubscriptionBadge: View {
                 case .gradient:
                     background = Color.plusGradient
                     iconColor = .white
+                case .plain:
+                    background = .init(colors: [.black], startPoint: .top, endPoint: .bottom)
+                    iconColor = Color(hex: "FFD846")
                 }
 
             case .patron:
@@ -76,6 +75,9 @@ struct SubscriptionBadge: View {
                 case .gradient:
                     background = .init(colors: [.init(hex: "9583F8")], startPoint: .top, endPoint: .bottom)
                     iconColor = .white
+                case .plain:
+                    background = .init(colors: [.black], startPoint: .top, endPoint: .bottom)
+                    iconColor = Color(hex: "#7A64F6")
                 }
 
                 iconName = "patron-heart"
@@ -88,11 +90,14 @@ struct SubscriptionBadge: View {
     }
 
     enum DisplayMode {
-        /// Displays the badge using a black background and a white foreground
+        /// Displays the badge using a color background and a white foreground
         case black
 
         /// Displays the badge using a gradient background for each tier
         case gradient
+
+        /// Display the badge using a solid black background and tier color
+        case plain
     }
 }
 
@@ -111,6 +116,12 @@ struct SubscriptionBadge_Preview: PreviewProvider {
                     SubscriptionBadge(tier: .none, displayMode: .gradient) // Won't display
                     SubscriptionBadge(tier: .plus, displayMode: .gradient)
                     SubscriptionBadge(tier: .patron, displayMode: .gradient)
+                }
+
+                HStack {
+                    SubscriptionBadge(tier: .none, displayMode: .plain) // Won't display
+                    SubscriptionBadge(tier: .plus, displayMode: .plain)
+                    SubscriptionBadge(tier: .patron, displayMode: .plain)
                 }
             }
             .frame(maxWidth: .infinity)

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -1214,12 +1214,16 @@ internal enum L10n {
   internal static var exportingDatabase: String { return L10n.tr("Localizable", "exporting_database", fallback: "Exporting Database...") }
   /// Title shown when recommended podcasts can't be loaded
   internal static var failedRecommendations: String { return L10n.tr("Localizable", "failed_recommendations", fallback: "Couldn't load recommendations") }
+  /// Patron has all features of plus marketing message
+  internal static var featureMarketingAllPlusFeatures: String { return L10n.tr("Localizable", "feature_marketing_all_plus_features", fallback: "All the features in Plus") }
   /// Bookmarks feature marketing message
   internal static var featureMarketingBookmarks: String { return L10n.tr("Localizable", "feature_marketing_bookmarks", fallback: "Keep timestamps with Bookmarks") }
   /// Cloud Storage feature marketing message. The %1$@ argument is the amount of cloud disk space available. Ex: 20 GB Cloud Storage for your files
   internal static func featureMarketingCloudStorage(_ p1: Any) -> String {
     return L10n.tr("Localizable", "feature_marketing_cloud_storage", String(describing: p1), fallback: "%1$@ Cloud Storage for your files")
   }
+  /// Patron early access to new features marketing message
+  internal static var featureMarketingEarlyAccess: String { return L10n.tr("Localizable", "feature_marketing_early_access", fallback: "Early access to new features") }
   /// Extra Themes And App Icons feature marketing message
   internal static var featureMarketingExtraThemesIcons: String { return L10n.tr("Localizable", "feature_marketing_extra_themes_icons", fallback: "Extra Themes and App Icons") }
   /// Folders feature marketing message

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -5231,3 +5231,13 @@
 
 /* Slumber Studios feature marketing message */
 "feature_marketing_slumber" = "1 year of content from Slumber Studios";
+
+/* Patron has all features of plus marketing message*/
+"feature_marketing_all_plus_features" = "All the features in Plus";
+
+/* Patron early access to new features marketing message*/
+"feature_marketing_early_access" = "Early access to new features";
+
+/* Patron early access to new features marketing message*/
+"feature_marketing_early_access" = "Early access to new features";
+


### PR DESCRIPTION
| 📘 Part of: #[POC-47](https://linear.app/a8c/issue/POC-47/new-upgrade-screen) |  <!-- project issue number, if applicable -->
|:---:|

Fixes #[POC-67](https://linear.app/a8c/issue/POC-67/new-upgrade-screen-patron-variant) <!-- issue number, if applicable -->

| 1 | 2 |
| - | - |
|  ![Simulator Screenshot - iPhone 16 Pro Max - 2025-07-07 at 19 47 55](https://github.com/user-attachments/assets/d9440ff2-c682-4d0d-9272-457bed965d67) | ![Simulator Screenshot - iPhone 16 Pro Max - 2025-07-07 at 19 47 41](https://github.com/user-attachments/assets/8a674dea-61bc-473a-b278-bc310ba73368) |

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

## To test

1. Edit the podcasts scheme to use the test StoreKit scheme: `Pocket Casts Configuration.storekit`
2. Start the app
3. Ensure that you have the FF `NewOnboardingUpgrade` enabled. If you need to enable you will need to restart the app.
5. Login/Signup with a user **with** a paid Plus subscription
6. Go to Profile tab
7. Tap the account button
8. Tap on Upgrade Account
10. Check if the Patron Upgrade Screen is visible
11. Check if the features have the new copy
12. Check if switching between Monthly and Yearly work correctly

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
