### PR TITLE
Retry failed requests without user agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 7.94
 -----
-
+- Retry failed requests without user agent [#3323](https://github.com/Automattic/pocket-casts-ios/pull/3323)
 
 7.93
 -----

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -206,6 +206,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// Use the new updgrade screens
     case newOnboardingUpgrade
 
+    /// Retry failed downloads and stream without the user agent
+    case retryWithoutUserAgent
+
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -348,6 +351,8 @@ public enum FeatureFlag: String, CaseIterable {
             true
         case .newOnboardingUpgrade:
             false
+        case .retryWithoutUserAgent:
+            true
         }
     }
 

--- a/PocketCastsTests/Tests/Utilities/DownloadManagerRetryTests.swift
+++ b/PocketCastsTests/Tests/Utilities/DownloadManagerRetryTests.swift
@@ -1,0 +1,186 @@
+import XCTest
+import FMDB
+@testable import podcasts
+import PocketCastsDataModel
+
+final class DownloadManagerRetryTests: DBTestCase {
+
+    override func tearDown() {
+        super.tearDown()
+        cleanupDownloadManager()
+    }
+
+    // MARK: - Retry Without User-Agent Tests
+
+    func testRetryDownloadWithoutUserAgent_CallsPerformDownloadWithCorrectParameters() async throws {
+        // Create a mock episode with download URL
+        let mockEpisode = Episode()
+        mockEpisode.uuid = UUID().uuidString
+        mockEpisode.podcastUuid = podcast.uuid
+        mockEpisode.podcast_id = podcast.id
+        mockEpisode.downloadUrl = "https://example.com/episode.mp3"
+        mockEpisode.autoDownloadStatus = AutoDownloadStatus.autoDownloaded.rawValue
+        mockEpisode.addedDate = Date()
+        dataManager.save(episode: mockEpisode)
+
+        // Test the retry method
+        await downloadManager.retryDownloadWithoutUserAgent(episode: mockEpisode)
+
+        // Verify that a task was created
+        let tasks = await downloadManager.tasks(for: [mockEpisode])
+        XCTAssertEqual(tasks.count, 1, "Should create a retry task")
+
+        // Verify the retry state is tracked in the downloadAttempts dictionary
+        let task = try XCTUnwrap(tasks.first)
+        XCTAssertEqual(task.taskDescription, mockEpisode.uuid, "Task description should be clean (just episode UUID)")
+
+        // Check the new tracking system
+        if let attempt = downloadManager.getDownloadAttempt(for: task.taskIdentifier) {
+            XCTAssertTrue(attempt.hasRetriedWithoutUserAgent, "Should indicate retry without User-Agent in tracking system")
+            XCTAssertEqual(attempt.episodeUuid, mockEpisode.uuid, "Should track correct episode UUID")
+        } else {
+            XCTFail("Should have download attempt tracking data")
+        }
+    }
+
+    func testRetryDownloadWithoutUserAgent_DoesNothingWhenNoDownloadUrl() async throws {
+        // Create a mock episode without download URL
+        let mockEpisode = Episode()
+        mockEpisode.uuid = UUID().uuidString
+        mockEpisode.podcastUuid = podcast.uuid
+        mockEpisode.podcast_id = podcast.id
+        mockEpisode.downloadUrl = nil
+        mockEpisode.addedDate = Date()
+        dataManager.save(episode: mockEpisode)
+
+        // Test the retry method
+        await downloadManager.retryDownloadWithoutUserAgent(episode: mockEpisode)
+
+        // Verify that no task was created
+        let tasks = await downloadManager.tasks(for: [mockEpisode])
+        XCTAssertEqual(tasks.count, 0, "Should not create a task when there's no download URL")
+    }
+
+    // MARK: - Integration Tests
+
+    func testPerformDownload_WithRetryFlag_CreatesTaskWithRetryDescription() async throws {
+        await downloadManager.performDownload(
+            episode: episode,
+            url: episode.downloadUrl ?? "",
+            previousDownloadFailed: true,
+            fireNotification: false,
+            autoDownloadStatus: .notSpecified,
+            retryWithoutUserAgent: true
+        )
+
+        let tasks = await downloadManager.tasks(for: [episode])
+        let task = try XCTUnwrap(tasks.first)
+
+        // Check the new tracking system for retry state
+        if let attempt = downloadManager.getDownloadAttempt(for: task.taskIdentifier) {
+            XCTAssertTrue(attempt.hasRetriedWithoutUserAgent, "Should indicate retry without User-Agent in tracking system")
+        } else {
+            XCTFail("Should have download attempt tracking data")
+        }
+    }
+
+    func testPerformDownload_WithoutRetryFlag_CreatesNormalTaskDescription() async throws {
+        await downloadManager.performDownload(
+            episode: episode,
+            url: episode.downloadUrl ?? "",
+            previousDownloadFailed: false,
+            fireNotification: false,
+            autoDownloadStatus: .notSpecified,
+            retryWithoutUserAgent: false
+        )
+
+        let tasks = await downloadManager.tasks(for: [episode])
+        let task = try XCTUnwrap(tasks.first)
+
+        // Check the new tracking system for non-retry state
+        if let attempt = downloadManager.getDownloadAttempt(for: task.taskIdentifier) {
+            XCTAssertFalse(attempt.hasRetriedWithoutUserAgent, "Should not indicate retry for normal download in tracking system")
+        } else {
+            XCTFail("Should have download attempt tracking data")
+        }
+    }
+
+    private func cleanupDownloadManager() {
+        // Use runBlocking to wait for async cleanup to complete
+        let semaphore = DispatchSemaphore(value: 0)
+
+        Task {
+            await downloadManager.cancelAllTasks()
+            downloadManager.clearDownloadAttempts()
+            downloadManager.clearEpisodeCache()
+
+            semaphore.signal()
+        }
+
+        // Wait for cleanup to complete
+        _ = semaphore.wait(timeout: .now() + 5)
+    }
+}
+
+// MARK: - Extensions to expose private methods for testing
+
+extension DownloadManager {
+    func shouldRetryWithoutUserAgent(task: URLSessionDownloadTask) -> Bool {
+        guard let attempt = downloadAttempts[task.taskIdentifier] else { return false }
+        return !attempt.hasRetriedWithoutUserAgent
+    }
+
+    func retryDownloadWithoutUserAgent(episode: BaseEpisode) async {
+        guard let downloadUrl = episode.downloadUrl else {
+            return
+        }
+
+        let autoDownloadStatus = AutoDownloadStatus(rawValue: episode.autoDownloadStatus) ?? .notSpecified
+        await performDownload(episode: episode, url: downloadUrl, previousDownloadFailed: true, fireNotification: true, autoDownloadStatus: autoDownloadStatus, retryWithoutUserAgent: true)
+    }
+
+    func episodeForTask(_ task: URLSessionDownloadTask, forceReload: Bool) -> BaseEpisode? {
+        guard let taskDescription = task.taskDescription else { return nil }
+
+        if !forceReload {
+            if let episode = downloadingEpisodesCache[taskDescription] {
+                return episode
+            }
+        }
+
+        let episode = dataManager.findBaseEpisode(downloadTaskId: taskDescription)
+        if let episode = episode {
+            downloadingEpisodesCache[taskDescription] = episode
+        }
+
+        return episode
+    }
+
+    // Test helper to access download attempts tracking
+    func getDownloadAttempt(for taskIdentifier: Int) -> (episodeUuid: String, originalUrl: URL, hasRetriedWithoutUserAgent: Bool)? {
+        guard let attempt = downloadAttempts[taskIdentifier] else { return nil }
+        return (attempt.episodeUuid, attempt.originalUrl, attempt.hasRetriedWithoutUserAgent)
+    }
+
+    // Test cleanup methods
+    func cancelAllTasks() async {
+        let tasks = await allTasks()
+        for task in tasks {
+            downloadAttempts.removeValue(forKey: task.taskIdentifier)
+            task.cancel()
+        }
+    }
+
+    func clearDownloadAttempts() {
+        downloadAttempts.removeAll()
+    }
+
+    func clearEpisodeCache() {
+        // Clear downloadingEpisodesCache based on its type
+        if let cache = downloadingEpisodesCache as? ThreadSafeDictionary<String, BaseEpisode> {
+            cache.removeAll()
+        } else if var cache = downloadingEpisodesCache as? Dictionary<String, BaseEpisode> {
+            cache.removeAll()
+        }
+    }
+}

--- a/PocketCastsTests/Tests/Utilities/MediaExporterResourceLoaderDelegateRetryTests.swift
+++ b/PocketCastsTests/Tests/Utilities/MediaExporterResourceLoaderDelegateRetryTests.swift
@@ -1,0 +1,217 @@
+import XCTest
+import AVFoundation
+@testable import podcasts
+import PocketCastsDataModel
+import PocketCastsServer
+
+final class MediaExporterResourceLoaderDelegateRetryTests: XCTestCase {
+
+    var delegate: MediaExporterResourceLoaderDelegate!
+    var tempFilePath: String!
+    var testURL: URL!
+
+    override func setUp() {
+        super.setUp()
+
+        let tempDir = NSTemporaryDirectory()
+        tempFilePath = (tempDir as NSString).appendingPathComponent("test_media_export.mp3")
+
+        testURL = URL(string: "https://example.com/test.mp3")!
+
+        delegate = MediaExporterResourceLoaderDelegate(saveFilePath: tempFilePath) { status, contentType, downloaded, total in
+            // No-op for the mock callback
+        }
+    }
+
+    override func tearDown() {
+        delegate = nil
+
+        // Clean up temporary file
+        if let tempFilePath = tempFilePath {
+            try? FileManager.default.removeItem(atPath: tempFilePath)
+        }
+
+        super.tearDown()
+    }
+
+    // MARK: - Retry Logic Tests
+
+    func testShouldRetryWithoutUserAgent_ReturnsTrueForHTTPError() {
+        let httpError = NSError(domain: "Test", code: 403, userInfo: nil)
+        let result = delegate.shouldRetryWithoutUserAgent(error: httpError)
+        XCTAssertTrue(result, "Should retry for HTTP error 403 when haven't retried yet")
+    }
+
+    func testShouldRetryWithoutUserAgent_ReturnsFalseWhenAlreadyRetried() {
+        delegate.hasRetriedWithoutUserAgent = true
+        let httpError = NSError(domain: "Test", code: 403, userInfo: nil)
+        let result = delegate.shouldRetryWithoutUserAgent(error: httpError)
+        XCTAssertFalse(result, "Should not retry when already retried without User-Agent")
+    }
+
+    func testShouldRetryWithoutUserAgent_ReturnsFalseForNonHTTPError() {
+        let nonHTTPError = NSError(domain: "Test", code: 200, userInfo: nil)
+        let result = delegate.shouldRetryWithoutUserAgent(error: nonHTTPError)
+        XCTAssertFalse(result, "Should not retry for non-HTTP error status codes")
+    }
+
+    func testShouldRetryWithoutUserAgent_ReturnsFalseForNetworkError() {
+        let networkError = NSError(domain: NSURLErrorDomain, code: NSURLErrorNotConnectedToInternet, userInfo: nil)
+        let result = delegate.shouldRetryWithoutUserAgent(error: networkError)
+        XCTAssertFalse(result, "Should not retry for network connectivity errors")
+    }
+
+    // MARK: - User-Agent Header Tests
+
+    func testStartDataRequest_IncludesUserAgentByDefault() {
+        let expectation = XCTestExpectation(description: "Should create request with User-Agent")
+
+        var didCreateRequestWithUserAgent = false
+
+        let testDelegate = MediaExporterResourceLoaderDelegate(saveFilePath: tempFilePath) { _, _, _, _ in }
+
+        testDelegate.startDataRequest(with: testURL, retryWithoutUserAgent: false) { url, retryWithoutUserAgent in
+            didCreateRequestWithUserAgent = !retryWithoutUserAgent
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertTrue(didCreateRequestWithUserAgent, "Should create request with User-Agent header")
+    }
+
+    func testStartDataRequest_WithRetryFlag_ExcludesUserAgent() {
+        let expectation = XCTestExpectation(description: "Should create request without User-Agent")
+
+        // Create a test delegate that tracks request creation
+        var didCreateRequestWithUserAgent = false
+        let testDelegate = MediaExporterResourceLoaderDelegate(saveFilePath: tempFilePath) { _, _, _, _ in }
+
+        testDelegate.startDataRequest(with: testURL, retryWithoutUserAgent: true) { url, retryWithoutUserAgent in
+            // Simulate request creation and check for User-Agent header
+            if !retryWithoutUserAgent {
+                didCreateRequestWithUserAgent = true
+            } else {
+                didCreateRequestWithUserAgent = false
+                testDelegate.hasRetriedWithoutUserAgent = true
+            }
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertFalse(didCreateRequestWithUserAgent, "Should create request without User-Agent header")
+        XCTAssertTrue(testDelegate.hasRetriedWithoutUserAgent, "Should set retry flag")
+    }
+
+    // MARK: - URL Creation Tests
+
+    func testMakeCustomURL_CreatesCorrectURL() {
+        let originalURL = URL(string: "https://example.com/episode.mp3")!
+        let customURL = MediaExporterResourceLoaderDelegate.makeCustomURL(originalURL)
+
+        XCTAssertNotNil(customURL, "Should create custom URL")
+        XCTAssertTrue(customURL!.absoluteString.hasPrefix("custom-"), "Should prefix with 'custom-'")
+        XCTAssertTrue(customURL!.absoluteString.contains("https://example.com/episode.mp3"), "Should contain original URL")
+    }
+
+    func testResolveOriginalURL_ExtractsCorrectURL() {
+        let originalURL = URL(string: "https://example.com/episode.mp3")!
+        let customURL = MediaExporterResourceLoaderDelegate.makeCustomURL(originalURL)!
+        let resolvedURL = MediaExporterResourceLoaderDelegate.resolveOriginalURL(from: customURL)
+
+        XCTAssertEqual(resolvedURL, originalURL, "Should resolve back to original URL")
+    }
+
+    // MARK: - Error Response Tests
+
+    func testVerifyResponse_ReturnsErrorForHTTPError() {
+        let httpResponse = HTTPURLResponse(
+            url: testURL,
+            statusCode: 403,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+
+        delegate.response = httpResponse
+        let error = delegate.verifyResponse()
+
+        XCTAssertNotNil(error, "Should return error for HTTP 403")
+        XCTAssertEqual(error?.code, 403, "Error code should match HTTP status code")
+    }
+
+    func testVerifyResponse_ReturnsNilForSuccessfulResponse() {
+        let httpResponse = HTTPURLResponse(
+            url: testURL,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+
+        delegate.response = httpResponse
+        let error = delegate.verifyResponse()
+
+        XCTAssertNil(error, "Should not return error for HTTP 200")
+    }
+
+    // MARK: - Retry Integration Tests
+
+    func testRetryWithoutUserAgent_ResetsStateAndRetries() {
+        delegate.response = HTTPURLResponse(url: testURL, statusCode: 403, httpVersion: nil, headerFields: nil)
+        delegate.hasRetriedWithoutUserAgent = false
+
+        let expectation = XCTestExpectation(description: "Should retry without User-Agent")
+
+        // Override the startDataRequest method to verify retry
+        let testDelegate = MediaExporterResourceLoaderDelegate(saveFilePath: tempFilePath) { _, _, _, _ in }
+        testDelegate.response = HTTPURLResponse(url: testURL, statusCode: 403, httpVersion: nil, headerFields: nil)
+
+        testDelegate.retryWithoutUserAgent(originalURL: testURL)
+
+        // Wait briefly for the retry to be processed
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            XCTAssertTrue(testDelegate.hasRetriedWithoutUserAgent, "Should set retry flag")
+            XCTAssertNil(testDelegate.response, "Should reset response for retry")
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 1.0)
+    }
+}
+
+// MARK: - Extensions to expose private methods for testing
+
+extension MediaExporterResourceLoaderDelegate {
+    func shouldRetryWithoutUserAgent(error: NSError) -> Bool {
+        return !hasRetriedWithoutUserAgent && error.code >= 400
+    }
+
+    func retryWithoutUserAgent(originalURL: URL?) {
+        guard let originalURL = originalURL else { return }
+
+        invalidateAndCancelSession(shouldResetData: false)
+
+        response = nil
+        bufferData = Data()
+
+        startDataRequest(with: originalURL, retryWithoutUserAgent: true)
+    }
+
+    func verifyResponse() -> NSError? {
+        guard let response = response as? HTTPURLResponse else { return nil }
+
+        var error: NSError?
+
+        if response.statusCode >= 400 {
+            error = NSError(domain: "Failed downloading asset. Reason: response status code \(response.statusCode).", code: response.statusCode, userInfo: nil)
+        }
+
+        return error
+    }
+
+    func startDataRequest(with url: URL, retryWithoutUserAgent: Bool, mock: ((URL, Bool) -> Void)? = nil) {
+        if let mock {
+            mock(url, retryWithoutUserAgent)
+            return
+        }
+        self.startDataRequest(with: url, retryWithoutUserAgent: retryWithoutUserAgent)
+    }
+}

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1772,6 +1772,8 @@
 		F581ED422CC6F1A200A19860 /* ListeningTime2024Story.swift in Sources */ = {isa = PBXBuildFile; fileRef = F581ED412CC6F19300A19860 /* ListeningTime2024Story.swift */; };
 		F581ED442CC6F3A900A19860 /* Top5Podcasts2024Story.swift in Sources */ = {isa = PBXBuildFile; fileRef = F581ED432CC6F3A400A19860 /* Top5Podcasts2024Story.swift */; };
 		F586959A2C04320100E0754A /* PodcastManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F58695992C04320100E0754A /* PodcastManagerTests.swift */; };
+		F5869DE72E18AD9000DF75B7 /* DownloadManagerRetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5869DE32E18AD8F00DF75B7 /* DownloadManagerRetryTests.swift */; };
+		F5869DE82E18AD9000DF75B7 /* MediaExporterResourceLoaderDelegateRetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5869DE42E18AD8F00DF75B7 /* MediaExporterResourceLoaderDelegateRetryTests.swift */; };
 		F59503B42C93590A007FB3C8 /* ActivityItemSourceItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = F59503B32C93590A007FB3C8 /* ActivityItemSourceItem.swift */; };
 		F5952FCA2C057C6400754BC3 /* FMDatabaseQueue+Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5952FC92C057C6400754BC3 /* FMDatabaseQueue+Test.swift */; };
 		F5952FCC2C05814100754BC3 /* DownloadManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5952FCB2C05814100754BC3 /* DownloadManagerTests.swift */; };
@@ -3970,6 +3972,8 @@
 		F581ED412CC6F19300A19860 /* ListeningTime2024Story.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListeningTime2024Story.swift; sourceTree = "<group>"; };
 		F581ED432CC6F3A400A19860 /* Top5Podcasts2024Story.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Top5Podcasts2024Story.swift; sourceTree = "<group>"; };
 		F58695992C04320100E0754A /* PodcastManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PodcastManagerTests.swift; sourceTree = "<group>"; };
+		F5869DE32E18AD8F00DF75B7 /* DownloadManagerRetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadManagerRetryTests.swift; sourceTree = "<group>"; };
+		F5869DE42E18AD8F00DF75B7 /* MediaExporterResourceLoaderDelegateRetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaExporterResourceLoaderDelegateRetryTests.swift; sourceTree = "<group>"; };
 		F59503B32C93590A007FB3C8 /* ActivityItemSourceItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityItemSourceItem.swift; sourceTree = "<group>"; };
 		F5952FC92C057C6400754BC3 /* FMDatabaseQueue+Test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FMDatabaseQueue+Test.swift"; sourceTree = "<group>"; };
 		F5952FCB2C05814100754BC3 /* DownloadManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadManagerTests.swift; sourceTree = "<group>"; };
@@ -8283,6 +8287,8 @@
 		C7F4C6642A8EAB0A00483C37 /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				F5869DE32E18AD8F00DF75B7 /* DownloadManagerRetryTests.swift */,
+				F5869DE42E18AD8F00DF75B7 /* MediaExporterResourceLoaderDelegateRetryTests.swift */,
 				FF146C292D5F445B00D2FCCE /* ThreadSafeDictionaryTests.swift */,
 				C7F4C6672A8EAB2800483C37 /* PaidFeatureTests.swift */,
 				F5E949D92B61762E002DAFC3 /* TokenHelperTests.swift */,
@@ -9879,6 +9885,8 @@
 				9A263EC92DA6DEFB00E895B6 /* InformationalBannerViewCoordinatorTests.swift in Sources */,
 				9A4BB1ED2D3AB06700B68D94 /* AnalyticsAppThemeProviderTests.swift in Sources */,
 				8B484EFD28D2574D001AFA97 /* EpisodeBuilder.swift in Sources */,
+				F5869DE72E18AD9000DF75B7 /* DownloadManagerRetryTests.swift in Sources */,
+				F5869DE82E18AD9000DF75B7 /* MediaExporterResourceLoaderDelegateRetryTests.swift in Sources */,
 				F56ADE562B7FE37500ADFE31 /* SettingsTests.swift in Sources */,
 				8B484EFB28D25719001AFA97 /* Double+Ext.swift in Sources */,
 				8BF0BBD228918B49006BBECF /* HomeGridDataHelperTests.swift in Sources */,

--- a/podcasts/DownloadManager+SessionManagement.swift
+++ b/podcasts/DownloadManager+SessionManagement.swift
@@ -29,6 +29,9 @@ extension DownloadManager {
 
                 // cancel the foreground task, and transfer it to the background. Try to use the resume data if some is returned so it doesn't have to start again
                 foregroundTask.cancel { data in
+                    // Transfer tracking data from foreground to background task
+                    let oldAttempt = self.downloadAttempts.removeValue(forKey: foregroundTask.taskIdentifier)
+
                     let backgroundTask: URLSessionDownloadTask
                     if let data = data {
                         backgroundTask = self.cellularBackgroundSession.downloadTask(withResumeData: data)
@@ -36,6 +39,12 @@ extension DownloadManager {
                         backgroundTask = self.cellularBackgroundSession.downloadTask(with: request)
                     }
                     backgroundTask.taskDescription = savedTaskDescription
+
+                    // Transfer the tracking data to the new task
+                    if let attempt = oldAttempt {
+                        self.downloadAttempts[backgroundTask.taskIdentifier] = attempt
+                    }
+
                     backgroundTask.resume()
                 }
             }
@@ -53,8 +62,14 @@ extension DownloadManager {
         let tasks = await allTasks()
 
         tasks.forEach { task in
-            if let taskId = task.taskDescription, let episode = dataManager.findBaseEpisode(downloadTaskId: taskId), let index = episodeUuids.firstIndex(of: episode.uuid) {
-                episodeUuids.remove(at: index)
+            if let taskDescription = task.taskDescription {
+                if let episode = dataManager.findBaseEpisode(downloadTaskId: taskDescription), let index = episodeUuids.firstIndex(of: episode.uuid) {
+                    episodeUuids.remove(at: index)
+                } else {
+                    if FeatureFlag.downloadFixes.enabled {
+                        task.cancel()
+                    }
+                }
             } else {
                 if FeatureFlag.downloadFixes.enabled {
                     task.cancel()

--- a/podcasts/DownloadManager+URLSessionDelegate.swift
+++ b/podcasts/DownloadManager+URLSessionDelegate.swift
@@ -76,13 +76,19 @@ extension DownloadManager: URLSessionDelegate, URLSessionDownloadDelegate {
     }
 
     func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
-        guard let error = error as NSError?, let task = task as? URLSessionDownloadTask else {
-            // if there's no error then no need for us to do anything
+        guard let downloadTask = task as? URLSessionDownloadTask else { return }
+
+        guard let error = error as NSError? else {
+            downloadAttempts.removeValue(forKey: downloadTask.taskIdentifier)
             return
         }
 
-        // check for ones we cancelled
-        guard let episode = episodeForTask(task, forceReload: true) else { return } // we no longer have this episode
+        // Check for downloads that were cancelled
+        guard let episode = episodeForTask(downloadTask, forceReload: true) else {
+            downloadAttempts.removeValue(forKey: downloadTask.taskIdentifier)
+            return
+        }
+
         removeEpisodeFromCache(episode)
 
         switch error.code {
@@ -110,12 +116,16 @@ extension DownloadManager: URLSessionDelegate, URLSessionDownloadDelegate {
             ()
         }
 
+        downloadAttempts.removeValue(forKey: downloadTask.taskIdentifier)
+
         dataManager.saveEpisode(downloadStatus: .downloadFailed, downloadError: error.localizedDescription, downloadTaskId: nil, episode: episode)
 
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.episodeDownloadStatusChanged, object: episode.uuid)
     }
 
     func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {
+        downloadAttempts.removeValue(forKey: downloadTask.taskIdentifier)
+
         guard let episode = episodeForTask(downloadTask, forceReload: true) else { return }
 
         removeEpisodeFromCache(episode)
@@ -126,6 +136,14 @@ extension DownloadManager: URLSessionDelegate, URLSessionDownloadDelegate {
         }
 
         if response.statusCode >= 400, response.statusCode < 600 {
+            if shouldRetryWithoutUserAgent(task: downloadTask), FeatureFlag.retryWithoutUserAgent.enabled {
+                FileLog.shared.addMessage("DownloadManager: Retrying download without User-Agent for episode: \(episode.uuid), status code: \(response.statusCode)")
+                Task {
+                    await retryDownloadWithoutUserAgent(episode: episode)
+                }
+                return
+            }
+
             let message: String
             if response.statusCode == ServerConstants.HttpConstants.notFound {
                 message = L10n.downloadErrorContactAuthorVersion2
@@ -192,17 +210,17 @@ extension DownloadManager: URLSessionDelegate, URLSessionDownloadDelegate {
     }
 
     private func episodeForTask(_ task: URLSessionDownloadTask, forceReload: Bool) -> BaseEpisode? {
-        guard let downloadId = task.taskDescription else { return nil }
+        guard let taskDescription = task.taskDescription else { return nil }
 
         if !forceReload {
-            if let episode = downloadingEpisodesCache[downloadId] {
+            if let episode = downloadingEpisodesCache[taskDescription] {
                 return episode
             }
         }
 
-        let episode = dataManager.findBaseEpisode(downloadTaskId: downloadId)
+        let episode = dataManager.findBaseEpisode(downloadTaskId: taskDescription)
         if let episode = episode {
-            downloadingEpisodesCache[downloadId] = episode
+            downloadingEpisodesCache[taskDescription] = episode
         }
 
         return episode
@@ -256,5 +274,23 @@ extension DownloadManager: URLSessionDelegate, URLSessionDownloadDelegate {
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.episodeDownloadStatusChanged, object: episode.uuid)
 
         taskFailure[episode.uuid] = reason
+    }
+
+    private func shouldRetryWithoutUserAgent(task: URLSessionDownloadTask) -> Bool {
+        guard let attempt = downloadAttempts[task.taskIdentifier] else { return true }
+        return !attempt.hasRetriedWithoutUserAgent
+    }
+
+    private func retryDownloadWithoutUserAgent(episode: BaseEpisode) async {
+        guard let downloadUrl = episode.downloadUrl else {
+            FileLog.shared.addMessage("DownloadManager: Cannot retry download without User-Agent: no download URL for episode \(episode.uuid)")
+            return
+        }
+
+        FileLog.shared.addMessage("DownloadManager: Retrying download without User-Agent for episode: \(episode.uuid) at URL: \(downloadUrl)")
+
+        let autoDownloadStatus = AutoDownloadStatus(rawValue: episode.autoDownloadStatus) ?? .notSpecified
+
+        await performDownload(episode: episode, url: downloadUrl, previousDownloadFailed: true, fireNotification: true, autoDownloadStatus: autoDownloadStatus, retryWithoutUserAgent: true)
     }
 }

--- a/podcasts/DownloadManager.swift
+++ b/podcasts/DownloadManager.swift
@@ -61,6 +61,23 @@ class DownloadManager: NSObject, FilePathProtocol {
 
     var taskFailure: [String: FailureReason] = [:]
 
+    // MARK: - Download Retry Tracking
+    struct DownloadAttempt {
+        let episodeUuid: String
+        let originalUrl: URL
+        let hasRetriedWithoutUserAgent: Bool
+
+        func withRetryAttempt() -> DownloadAttempt {
+            return DownloadAttempt(
+                episodeUuid: episodeUuid,
+                originalUrl: originalUrl,
+                hasRetriedWithoutUserAgent: true
+            )
+        }
+    }
+
+    var downloadAttempts: [Int: DownloadAttempt] = [:]
+
     #if os(watchOS)
         var pendingWatchBackgroundTask: WKURLSessionRefreshBackgroundTask?
     #endif
@@ -428,6 +445,10 @@ class DownloadManager: NSObject, FilePathProtocol {
     }
 
     func performAddToQueue(episode: BaseEpisode, url: String, previousDownloadFailed: Bool, fireNotification: Bool, autoDownloadStatus: AutoDownloadStatus) async {
+        await performDownload(episode: episode, url: url, previousDownloadFailed: previousDownloadFailed, fireNotification: fireNotification, autoDownloadStatus: autoDownloadStatus, retryWithoutUserAgent: false)
+    }
+
+    func performDownload(episode: BaseEpisode, url: String, previousDownloadFailed: Bool, fireNotification: Bool, autoDownloadStatus: AutoDownloadStatus, retryWithoutUserAgent: Bool) async {
 
         var downloadUrl = URL(string: url)
         if downloadUrl == nil {
@@ -449,7 +470,9 @@ class DownloadManager: NSObject, FilePathProtocol {
         }
 
         var request = URLRequest(url: url)
-        request.addValue(ServerConstants.Values.appUserAgent, forHTTPHeaderField: ServerConstants.HttpHeaders.userAgent)
+        if !retryWithoutUserAgent {
+            request.addValue(ServerConstants.Values.appUserAgent, forHTTPHeaderField: ServerConstants.HttpHeaders.userAgent)
+        }
         request.timeoutInterval = 30.seconds
 
         let tempFilePath = tempPathForEpisode(episode)
@@ -473,8 +496,9 @@ class DownloadManager: NSObject, FilePathProtocol {
             }
         }
 
-        FileLog.shared.addMessage("Downloading episode \(episode.displayableTitle()), autoDownloadStatus: \(autoDownloadStatus), previousDownloadFailed: \(previousDownloadFailed)")
-        resumeDownload(tempFilePath: tempFilePath, session: sessionToUse, request: request, previousDownloadFailed: previousDownloadFailed, taskId: episode.uuid, estimatedBytes: episode.sizeInBytes)
+        let userAgentDescription = retryWithoutUserAgent ? "without User-Agent" : "with User-Agent"
+        FileLog.shared.addMessage("Downloading episode \(episode.displayableTitle()), autoDownloadStatus: \(autoDownloadStatus), previousDownloadFailed: \(previousDownloadFailed), \(userAgentDescription)")
+        resumeDownload(tempFilePath: tempFilePath, session: sessionToUse, request: request, previousDownloadFailed: previousDownloadFailed, taskId: episode.uuid, estimatedBytes: episode.sizeInBytes, retryWithoutUserAgent: retryWithoutUserAgent)
 
         if fireNotification { NotificationCenter.postOnMainThread(notification: Constants.Notifications.episodeDownloadStatusChanged, object: episode.uuid) }
     }
@@ -609,9 +633,8 @@ class DownloadManager: NSObject, FilePathProtocol {
             if downloadTasks.count == 0 { return }
 
             for task in downloadTasks {
-                if taskId == task.taskDescription {
+                if let taskDescription = task.taskDescription, taskId == taskDescription {
                     self?.cancelTask(task, for: episode)
-
                     return
                 }
             }
@@ -635,7 +658,7 @@ class DownloadManager: NSObject, FilePathProtocol {
 
     }
 
-    private func resumeDownload(tempFilePath: String, session: URLSession, request: URLRequest, previousDownloadFailed: Bool, taskId: String, estimatedBytes: Int64) {
+    private func resumeDownload(tempFilePath: String, session: URLSession, request: URLRequest, previousDownloadFailed: Bool, taskId: String, estimatedBytes: Int64, retryWithoutUserAgent: Bool = false) {
         let fileManager = FileManager.default
         var downloadTask: URLSessionDownloadTask?
         do {
@@ -667,6 +690,17 @@ class DownloadManager: NSObject, FilePathProtocol {
         }
 
         downloadTask?.taskDescription = taskId
+
+        // Store retry information in tracking dictionary
+        if let task = downloadTask, let url = request.url {
+            let attempt = DownloadAttempt(
+                episodeUuid: taskId,
+                originalUrl: url,
+                hasRetriedWithoutUserAgent: retryWithoutUserAgent
+            )
+            downloadAttempts[task.taskIdentifier] = attempt
+        }
+
         downloadTask?.resume()
     }
 
@@ -689,10 +723,12 @@ class DownloadManager: NSObject, FilePathProtocol {
 
     func tasks(for episodes: [BaseEpisode]) async -> [URLSessionTask] {
         let matchingTasks = await allTasks().filter { task in
-            let identifier = task.taskDescription
-            return episodes.contains { episode in
-                episode.downloadTaskId == identifier || episode.uuid == identifier
+            if let taskDescription = task.taskDescription {
+                return episodes.contains { episode in
+                    episode.downloadTaskId == taskDescription || episode.uuid == taskDescription
+                }
             }
+            return false
         }
 
         return matchingTasks

--- a/podcasts/MediaExporterResourceLoaderDelegate.swift
+++ b/podcasts/MediaExporterResourceLoaderDelegate.swift
@@ -27,17 +27,17 @@ fileprivate extension Int {
 }
 
 /// Responsible for downloading media data and providing the requested data parts.
-final class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelegate, URLSessionDelegate, URLSessionDataDelegate, URLSessionTaskDelegate {
+class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelegate, URLSessionDelegate, URLSessionDataDelegate, URLSessionTaskDelegate {
     private let lock = NSLock()
 
-    private var bufferData = Data()
+    var bufferData = Data()
     private let downloadBufferLimit = MediaExporterItemConfiguration.downloadBufferLimit
     private let readDataLimit = MediaExporterItemConfiguration.readDataLimit
 
-    private lazy var fileHandle = MediaFileHandle(filePath: saveFilePath)
+    private var fileHandle: MediaFileHandle
 
     private var session: URLSession?
-    private var response: URLResponse?
+    var response: URLResponse?
     private let queue = DispatchQueue(label: "com.pocketcasts.MediaExporterResourceLoaderDelegate", qos: .userInitiated, attributes: .concurrent)
     private var pendingRequests: Set<AVAssetResourceLoadingRequest> {
         get { queue.sync { return pendingRequestsValue } }
@@ -45,6 +45,7 @@ final class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoader
     }
     private var pendingRequestsValue = Set<AVAssetResourceLoadingRequest>()
     private var isDownloadComplete = false
+    var hasRetriedWithoutUserAgent = false
 
     private let saveFilePath: String
     private let callback: FileExporterProgressReport?
@@ -61,6 +62,7 @@ final class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoader
     init(saveFilePath: String, callback: FileExporterProgressReport?) {
         self.saveFilePath = saveFilePath
         self.callback = callback
+        self.fileHandle = MediaFileHandle(filePath: saveFilePath)
         super.init()
 
         NotificationCenter.default.addObserver(self, selector: #selector(handleAppWillTerminate), name: UIApplication.willTerminateNotification, object: nil)
@@ -145,6 +147,11 @@ final class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoader
         let error = verifyResponse()
 
         guard error == nil else {
+            if shouldRetryWithoutUserAgent(error: error!) {
+                retryWithoutUserAgent(originalURL: task.originalRequest?.url)
+                return
+            }
+
             downloadFailed(with: error!)
             return
         }
@@ -155,6 +162,10 @@ final class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoader
     // MARK: Internal methods
 
     func startDataRequest(with url: URL) {
+        startDataRequest(with: url, retryWithoutUserAgent: false)
+    }
+
+    @objc func startDataRequest(with url: URL, retryWithoutUserAgent: Bool) {
         guard session == nil else { return }
 
         let configuration = URLSessionConfiguration.default
@@ -170,7 +181,15 @@ final class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoader
         }
 
         var urlRequest = URLRequest(url: url)
-        urlRequest.setValue(ServerConstants.Values.appUserAgent, forHTTPHeaderField: ServerConstants.HttpHeaders.userAgent)
+        if !retryWithoutUserAgent {
+            urlRequest.setValue(ServerConstants.Values.appUserAgent, forHTTPHeaderField: ServerConstants.HttpHeaders.userAgent)
+        }
+
+        if retryWithoutUserAgent {
+            hasRetriedWithoutUserAgent = true
+            FileLog.shared.addMessage("MediaExporterResourceLoaderDelegate: Starting request without User-Agent header")
+        }
+
         session = URLSession(configuration: configuration, delegate: self, delegateQueue: nil)
         session?.dataTask(with: urlRequest).resume()
     }
@@ -280,6 +299,31 @@ final class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoader
         }
 
         return error
+    }
+
+    private func shouldRetryWithoutUserAgent(error: NSError) -> Bool {
+        // Only retry if we haven't already retried without User-Agent and the error is a status code >= 400
+        return !hasRetriedWithoutUserAgent && error.code >= 400
+    }
+
+    private func retryWithoutUserAgent(originalURL: URL?) {
+        guard let originalURL = originalURL else {
+            FileLog.shared.addMessage("MediaExporterResourceLoaderDelegate: Cannot retry without User-Agent - no original URL")
+            return
+        }
+
+        FileLog.shared.addMessage("MediaExporterResourceLoaderDelegate: Retrying without User-Agent header for URL: \(originalURL)")
+
+        fileHandle.close()
+
+        invalidateAndCancelSession(shouldResetData: false)
+
+        response = nil
+        bufferData = Data()
+
+        fileHandle = MediaFileHandle(filePath: saveFilePath)
+
+        startDataRequest(with: originalURL, retryWithoutUserAgent: true)
     }
 
     private func downloadFailed(with error: Error) {

--- a/podcasts/ThreadSafeDictionary.swift
+++ b/podcasts/ThreadSafeDictionary.swift
@@ -34,6 +34,12 @@ class ThreadSafeDictionary<Key: Hashable, Value> {
         updateValue(nil, forKey: key)
     }
 
+    func removeAll() {
+        queue.async(flags: .barrier) { [weak self] in
+            self?.table.removeAll()
+        }
+    }
+
     func contains(where predicate: ((key: Key, value: Value)) throws -> Bool) rethrows -> Bool {
         var result = false
         try queue.sync { [weak self] in


### PR DESCRIPTION
Fixes [PCIOS-11](https://linear.app/a8c/issue/PCIOS-11/retry-failed-downloads-and-streams-with-removed-user-agent-header)

* Adds a `retryWithoutUserAgent` Feature Flag
* Retries failed HTTP requests with a status code between 400 and 599 without the User Agent header

This is analogous to the Android change in https://github.com/Automattic/pocket-casts-android/pull/3180

## To test

* Attempt to play a podcast episode from `El sótano`
* ✅ Verify that the episode plays
* ✅ Verify that you see the following logs:
```
MediaExporterResourceLoaderDelegate: Retrying without User-Agent header for URL: https://ztnr.rtve.es/ztnr/16654690.mp3
MediaExporterResourceLoaderDelegate: Starting request without User-Agent header
```

* Attempt to download a podcast episode from `El sótano`
* Verify that the episode downloads
* ✅ Verify that you see the following logs (note the "Downloading episode ... without User-Agent"):
```
DownloadManager: Retrying download without User-Agent for episode: a2ff4eb5-f94d-4ad7-a700-ceb1339be534, status code: 403
DownloadManager: Retrying download without User-Agent for episode: a2ff4eb5-f94d-4ad7-a700-ceb1339be534 at URL: https://ztnr.rtve.es/ztnr/16652428.mp3
Downloading episode El sótano - Las valijas de New Rose Records (IV) - 04/07/25, autoDownloadStatus: notSpecified, previousDownloadFailed: true, without User-Agent
```

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
