### PR TITLE
[Improve App Rating] Add Survey Screen before rating alert

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(rg:*)",
+      "Bash(find:*)"
+    ],
+    "deny": []
+  }
+}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,9 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(rg:*)",
-      "Bash(find:*)"
-    ],
-    "deny": []
-  }
-}

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ artifacts/*
 *.app.dSYM.zip
 *.ipa
 *.build
+
+# Claude Code ignored personal preferences
+.claude/settings.local.json

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -209,6 +209,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// Retry failed downloads and stream without the user agent
     case retryWithoutUserAgent
 
+    /// Show a satisfaction survey before prompting to rate
+    case userSatisfactionSurvey
+
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -353,6 +356,8 @@ public enum FeatureFlag: String, CaseIterable {
             false
         case .retryWithoutUserAgent:
             true
+        case .userSatisfactionSurvey:
+            false
         }
     }
 

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1724,6 +1724,7 @@
 		F54E72192CA722A000CD5C86 /* Array+DiscoverItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = F54E72182CA722A000CD5C86 /* Array+DiscoverItem.swift */; };
 		F54E721D2CA7359800CD5C86 /* DiscoverCellType.swift in Sources */ = {isa = PBXBuildFile; fileRef = F54E721C2CA7359800CD5C86 /* DiscoverCellType.swift */; };
 		F54E721F2CA749AA00CD5C86 /* DiscoverCollectionViewController+Categories.swift in Sources */ = {isa = PBXBuildFile; fileRef = F54E721E2CA749AA00CD5C86 /* DiscoverCollectionViewController+Categories.swift */; };
+		F5516DBE2E1C9D82005DC201 /* UserSatisfactionSurveyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5516DBD2E1C9D82005DC201 /* UserSatisfactionSurveyView.swift */; };
 		F55275B82CB74E230012B705 /* EndOfYear2023Story.swift in Sources */ = {isa = PBXBuildFile; fileRef = F55275B72CB74E230012B705 /* EndOfYear2023Story.swift */; };
 		F55275BA2CB74EB60012B705 /* EndOfYear2024Story.swift in Sources */ = {isa = PBXBuildFile; fileRef = F55275B92CB74EB30012B705 /* EndOfYear2024Story.swift */; };
 		F553A15F2CECF953006581A1 /* EffectsButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD8032D22123EAD600BFBB03 /* EffectsButton.swift */; };
@@ -3949,6 +3950,7 @@
 		F54E72182CA722A000CD5C86 /* Array+DiscoverItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+DiscoverItem.swift"; sourceTree = "<group>"; };
 		F54E721C2CA7359800CD5C86 /* DiscoverCellType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverCellType.swift; sourceTree = "<group>"; };
 		F54E721E2CA749AA00CD5C86 /* DiscoverCollectionViewController+Categories.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DiscoverCollectionViewController+Categories.swift"; sourceTree = "<group>"; };
+		F5516DBD2E1C9D82005DC201 /* UserSatisfactionSurveyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSatisfactionSurveyView.swift; sourceTree = "<group>"; };
 		F55275B72CB74E230012B705 /* EndOfYear2023Story.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndOfYear2023Story.swift; sourceTree = "<group>"; };
 		F55275B92CB74EB30012B705 /* EndOfYear2024Story.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndOfYear2024Story.swift; sourceTree = "<group>"; };
 		F55449442B75935F00F68AE9 /* AppSettings+ImportUserDefaults.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AppSettings+ImportUserDefaults.swift"; sourceTree = "<group>"; };
@@ -6913,6 +6915,7 @@
 				BDED92FA251DC416000BF622 /* CarPlay */,
 				BD2A49EE1701AA8500C2F192 /* User Interface */,
 				BD585C1C204785EF00AC842C /* AppDelegate.swift */,
+				F5516DBD2E1C9D82005DC201 /* UserSatisfactionSurveyView.swift */,
 				C73CD7A72916E8A900EAE879 /* SwiftUI+Previews.swift */,
 				BD585C1E2047887700AC842C /* AppDelegate+UrlHandling.swift */,
 				BD585C242047C74D00AC842C /* AppDelegate+Defaults.swift */,
@@ -10008,6 +10011,7 @@
 				10C1D5502C737EEF009E1E98 /* PlusPaywallContainer.swift in Sources */,
 				BDC5F25027B3997300A85C93 /* FolderModel.swift in Sources */,
 				BDBD2AC7202D66B300E0A79E /* OptionsPickerRootController.swift in Sources */,
+				F5516DBE2E1C9D82005DC201 /* UserSatisfactionSurveyView.swift in Sources */,
 				FF07538A2D6CB7CA00BE8B3B /* PodcastImageViewWrapper.swift in Sources */,
 				4004F56524EB51F900FBEBE1 /* SceneHelper.swift in Sources */,
 				F5BA5C9E2C81254300BDA5B9 /* DiscoverCollectionViewController+DiscoverDelegate.swift in Sources */,

--- a/podcasts/Analytics/Helpers/AnalyticsCoordinator.swift
+++ b/podcasts/Analytics/Helpers/AnalyticsCoordinator.swift
@@ -56,6 +56,7 @@ enum AnalyticsSource: String, AnalyticsDescribable {
     case episodeSwipeAction = "episode_swipe_action"
     case handleUserActivity = "handle_user_activity"
     case suggestedFolderPopup = "popup"
+    case userSatisfactionSurvey = "user_satisfaction_survey"
     case unknown
 
     var analyticsDescription: String { rawValue }

--- a/podcasts/DeveloperMenu.swift
+++ b/podcasts/DeveloperMenu.swift
@@ -330,6 +330,17 @@ struct DeveloperMenu: View {
             }
 
             Section {
+                Button("Show User Satisfaction Survey") {
+                    (SceneHelper.rootViewController() as? MainTabBarController)?.showUserSatisfactionSurvey()
+                }
+                Button("Reset Review Requests") {
+                    Settings.resetReviewRequests()
+                }
+            } header: {
+                Text("Ratings")
+            }
+
+            Section {
                 Text(Bundle.main.identifier)
             } header: {
                 Text("Bundle ID")

--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -4,6 +4,7 @@ import SafariServices
 import UIKit
 import Combine
 import PocketCastsUtils
+import SwiftUI
 
 class MainTabBarController: UITabBarController, NavigationProtocol {
 
@@ -163,6 +164,35 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
 
         // Set the flag so the user won't see the on launch flow again
         Settings.shouldShowInitialOnboardingFlow = false
+    }
+
+    func showUserSatisfactionSurvey() {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+            let surveyView = UserSatisfactionSurveyView(presentSupportView: { [weak self] in
+                self?.presentSupportView()
+            })
+            let hostingController = UIHostingController(rootView: surveyView)
+
+            // Let the hosting controller size itself
+            hostingController.sizingOptions = .intrinsicContentSize
+
+            if let sheet = hostingController.sheetPresentationController {
+                sheet.detents = [
+                    .custom { context in
+                        let size = hostingController.sizeThatFits(in: CGSize(width: context.maximumDetentValue, height: .greatestFiniteMagnitude))
+                        return size.height
+                    }
+                ]
+                sheet.prefersGrabberVisible = true
+                sheet.preferredCornerRadius = 24
+            }
+
+            self.present(hostingController, animated: true)
+        }
+    }
+
+    private func presentSupportView() {
+        EmailHelper().presentSupportDialog(self, feedback: true)
     }
 
     private func fixTarBarTraitCollectionOnIpadForiOS18() {

--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -171,7 +171,7 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
             let surveyView = UserSatisfactionSurveyView(presentSupportView: { [weak self] in
                 self?.presentSupportView()
             })
-            let hostingController = ThemedHostingController(rootView: surveyView)
+            let hostingController = ThemedHostingController(rootView: surveyView, background: \.primaryUi01)
 
             // Let the hosting controller size itself
             hostingController.sizingOptions = .intrinsicContentSize

--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -171,7 +171,7 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
             let surveyView = UserSatisfactionSurveyView(presentSupportView: { [weak self] in
                 self?.presentSupportView()
             })
-            let hostingController = UIHostingController(rootView: surveyView)
+            let hostingController = ThemedHostingController(rootView: surveyView)
 
             // Let the hosting controller size itself
             hostingController.sizingOptions = .intrinsicContentSize

--- a/podcasts/PCHostingController.swift
+++ b/podcasts/PCHostingController.swift
@@ -35,13 +35,25 @@ class ModifedHostingController<Content: View, Modifier: ViewModifier>: UIHosting
 /// }
 class ThemedHostingController<Content>: ModifedHostingController<Content, ThemedEnvironment> where Content: View {
 
-    init(rootView: Content, theme: Theme = Theme.sharedTheme) {
+    private var background: KeyPath<Theme, Color>?
+
+    init(rootView: Content, theme: Theme = Theme.sharedTheme, background: KeyPath<Theme, Color>? = nil) {
+        self.background = background
         super.init(rootView: rootView, modifier: ThemedEnvironment(theme: theme))
     }
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .clear
+        themeDidChange()
+        NotificationCenter.default.addObserver(self, selector: #selector(themeDidChange), name: Constants.Notifications.themeChanged, object: nil)
+    }
+
+    @objc func themeDidChange() {
+        if let background {
+            view.backgroundColor = UIColor(Theme.sharedTheme[keyPath: background])
+        } else {
+            view.backgroundColor = .clear
+        }
     }
 
     @MainActor required dynamic init?(coder aDecoder: NSCoder) {
@@ -62,7 +74,7 @@ class PCHostingController<Content>: ThemedHostingController<Content> where Conte
         NotificationCenter.default.addObserver(self, selector: #selector(themeDidChange), name: Constants.Notifications.themeChanged, object: nil)
     }
 
-    @objc private func themeDidChange() {
+    @objc override func themeDidChange() {
         setupNavBar()
     }
 

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -986,6 +986,10 @@ class Settings: NSObject {
         UserDefaults.standard.array(forKey: Constants.UserDefaults.reviewRequestDates) as? [Date] ?? [Date]()
     }
 
+    class func resetReviewRequests() {
+        UserDefaults.standard.removeObject(forKey: Constants.UserDefaults.reviewRequestDates)
+    }
+
     // MARK: - Tracks
 
     class func setAnalytics(optOut: Bool) {

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -3869,6 +3869,14 @@ internal enum L10n {
   internal static var uploadSortLongestToShortest: String { return L10n.tr("Localizable", "upload_sort_longest_to_shortest", fallback: "Longest to shortest") }
   /// A duration (shortest to longest) sort option for uploaded files.
   internal static var uploadSortShortestToLongest: String { return L10n.tr("Localizable", "upload_sort_shortest_to_longest", fallback: "Shortest to longest") }
+  /// An option to say "no" when when asked if the user enjoys the app.
+  internal static var userSatisfactionSurveyNoResponse: String { return L10n.tr("Localizable", "user_satisfaction_survey_no_response", fallback: "Not really") }
+  /// A subtitle shown for the user satisfaction survey to ask whether a user enjoys the app
+  internal static var userSatisfactionSurveySubtitle: String { return L10n.tr("Localizable", "user_satisfaction_survey_subtitle", fallback: "Hi there! We'd love to know if you're enjoying our app.") }
+  /// A title shown for the user satisfaction survey to ask whether a user enjoys the app
+  internal static var userSatisfactionSurveyTitle: String { return L10n.tr("Localizable", "user_satisfaction_survey_title", fallback: "Enjoying Pocket Casts?") }
+  /// An option to say "yes" when when asked if the user enjoys the app.
+  internal static var userSatisfactionSurveyYesResponse: String { return L10n.tr("Localizable", "user_satisfaction_survey_yes_response", fallback: "Yes!") }
   /// Title of the Transcript excerpt in Episode detail
   internal static var viewTranscript: String { return L10n.tr("Localizable", "view_transcript", fallback: "View Transcript") }
   /// The Volume Boost feature. Makes voices louder.

--- a/podcasts/UserSatisfactionSurveyView.swift
+++ b/podcasts/UserSatisfactionSurveyView.swift
@@ -3,6 +3,7 @@ import StoreKit
 
 struct UserSatisfactionSurveyView: View {
     @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject var theme: Theme
 
     var presentSupportView: (() -> Void)?
 
@@ -11,11 +12,11 @@ struct UserSatisfactionSurveyView: View {
             VStack(spacing: 16) {
                 Text(L10n.userSatisfactionSurveyTitle)
                     .font(.headline)
-                    .foregroundColor(AppTheme.color(for: .primaryText01))
+                    .foregroundColor(theme.primaryText01)
 
                 Text(L10n.userSatisfactionSurveySubtitle)
                     .font(.callout)
-                    .foregroundColor(AppTheme.color(for: .secondaryText02))
+                    .foregroundColor(theme.primaryText02)
                     .multilineTextAlignment(.center)
                     .lineLimit(nil)
                     .fixedSize(horizontal: false, vertical: true)
@@ -36,7 +37,7 @@ struct UserSatisfactionSurveyView: View {
         }
         .padding(.top, 32)
         .padding(.bottom, 32)
-        .background(AppTheme.color(for: .primaryUi01))
+        .background(theme.primaryUi01)
     }
 
     private func handleYesResponse() {
@@ -63,12 +64,12 @@ struct UserSatisfactionSurveyView: View {
                 Text(text)
                     .font(.body)
                     .fontWeight(.medium)
-                    .foregroundColor(AppTheme.color(for: .primaryText01))
+                    .foregroundColor(theme.primaryText01)
             }
             .frame(maxWidth: .infinity)
             .padding(.vertical, 20)
             .if(UIAccessibility.buttonShapesEnabled) {
-                $0.background(AppTheme.color(for: .primaryUi05))
+                $0.background(theme.primaryUi05)
             }
             .cornerRadius(12)
         }

--- a/podcasts/UserSatisfactionSurveyView.swift
+++ b/podcasts/UserSatisfactionSurveyView.swift
@@ -1,0 +1,81 @@
+import SwiftUI
+import StoreKit
+
+struct UserSatisfactionSurveyView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    var presentSupportView: (() -> Void)?
+
+    var body: some View {
+        VStack(spacing: 32) {
+            VStack(spacing: 16) {
+                Text(L10n.userSatisfactionSurveyTitle)
+                    .font(.headline)
+                    .foregroundColor(AppTheme.color(for: .primaryText01))
+
+                Text(L10n.userSatisfactionSurveySubtitle)
+                    .font(.callout)
+                    .foregroundColor(AppTheme.color(for: .secondaryText02))
+                    .multilineTextAlignment(.center)
+                    .lineLimit(nil)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxWidth: .infinity)
+            }
+            .padding(.horizontal, 24)
+
+            HStack(spacing: 24) {
+                VStack(spacing: 12) {
+                    surveyResponseButton(emoji: "😔", text: L10n.userSatisfactionSurveyNoResponse, action: handleNotReallyResponse)
+                }
+
+                VStack(spacing: 12) {
+                    surveyResponseButton(emoji: "🥰", text: L10n.userSatisfactionSurveyYesResponse, action: handleYesResponse)
+                }
+            }
+            .padding(.horizontal, 24)
+        }
+        .padding(.top, 32)
+        .padding(.bottom, 32)
+        .background(AppTheme.color(for: .primaryUi01))
+    }
+
+    private func handleYesResponse() {
+        if let windowScene = UIApplication.shared.connectedScenes
+            .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene {
+            AppStore.requestReview(in: windowScene)
+            Settings.addReviewRequested()
+            Analytics.track(.appStoreReviewRequested, properties: ["source": AnalyticsSource.userSatisfactionSurvey])
+        }
+        dismiss()
+    }
+
+    private func handleNotReallyResponse() {
+        presentSupportView?()
+    }
+
+    @ViewBuilder
+    private func surveyResponseButton(emoji: String, text: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            VStack(spacing: 8) {
+                Text(emoji)
+                    .font(.system(size: 68))
+
+                Text(text)
+                    .font(.body)
+                    .fontWeight(.medium)
+                    .foregroundColor(AppTheme.color(for: .primaryText01))
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 20)
+            .if(UIAccessibility.buttonShapesEnabled) {
+                $0.background(AppTheme.color(for: .primaryUi05))
+            }
+            .cornerRadius(12)
+        }
+        .buttonStyle(PlainButtonStyle())
+    }
+}
+
+#Preview {
+    UserSatisfactionSurveyView()
+}

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -5244,3 +5244,14 @@
 /* Patron early access to new features marketing message*/
 "feature_marketing_early_access" = "Early access to new features";
 
+/* A title shown for the user satisfaction survey to ask whether a user enjoys the app */
+"user_satisfaction_survey_title" = "Enjoying Pocket Casts?";
+
+/* A subtitle shown for the user satisfaction survey to ask whether a user enjoys the app */
+"user_satisfaction_survey_subtitle" = "Hi there! We'd love to know if you're enjoying our app.";
+
+/* An option to say "no" when when asked if the user enjoys the app. */
+"user_satisfaction_survey_no_response" = "Not really";
+
+/* An option to say "yes" when when asked if the user enjoys the app. */
+"user_satisfaction_survey_yes_response" = "Yes!";


### PR DESCRIPTION
| 📘 Part of: [Improve App Rating](https://linear.app/a8c/project/improve-app-rating-6a17774dae82) |
|:---:|

Closes [PCIOS-18](https://linear.app/a8c/issue/PCIOS-18/add-rating-survey-prompt)

**NOTE**: This does not include the touchpoints to trigger the prompt or analytics events.

<video src="https://github.com/user-attachments/assets/73b97fd3-7778-4d3e-9c4a-d468dd253300"></video>

|   |   |   |   |
|---|---|---|---|
| ![image](https://github.com/user-attachments/assets/0e061829-c8dd-408a-8ce6-a11a9470ae68) | ![Simulator Screenshot - iPhone 16 Plus - 2025-07-09 at 21 51 01](https://github.com/user-attachments/assets/027409ce-a3df-4e7f-905e-a052b7cc8aae) | ![Simulator Screenshot - iPhone 16 Plus - 2025-07-09 at 21 51 15](https://github.com/user-attachments/assets/b2230694-6c54-4dc5-80dd-9d6e081c6e9a) | ![Simulator Screenshot - iPhone 16 Plus - 2025-07-09 at 21 51 34](https://github.com/user-attachments/assets/1c1ed0be-2fc6-463c-91dc-9c180f01550b) | ![Simulator Screenshot - iPhone 16 Plus - 2025-07-09 at 21 51 34](https://github.com/user-attachments/assets/b075e530-2b76-465f-90e7-9330caec9dcd) |


## To test

* Open the app
* Navigate to Profile > Developer > Show User Satisfaction Survey
* ✅ Verify that the survey prompt is shown when that button is pressed

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
