### PR TITLE
Add settings link in the Stream over cellular warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix iPad Login Text Field alignment when the keyboard is presented [#3283](https://github.com/Automattic/pocket-casts-ios/pull/3283)
 - Fix Player Shelf buttons when changing the size category on iPad or the Larger Text Display Zoom on iPhone [3309](https://github.com/Automattic/pocket-casts-ios/pull/3309)
 - Add Smart Categories sorting feature to show the user's most visited categories first [#3267](https://github.com/Automattic/pocket-casts-ios/pull/3267)
+- Enable "Warn Before Using Data" over cellular by default [#3301](https://github.com/Automattic/pocket-casts-ios/pull/3301)
 
 7.92
 -----

--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -492,6 +492,10 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
         switchToTab(.profile)
         guard let navController = selectedViewController as? UINavigationController else { return }
 
+        if navController.presentedViewController != nil {
+            navController.dismiss(animated: false)
+        }
+
         navController.popViewController(animated: false)
         let settingViewController = SettingsViewController()
         navController.pushViewController(settingViewController, animated: row == nil)

--- a/podcasts/NetworkUtils+Helpers.swift
+++ b/podcasts/NetworkUtils+Helpers.swift
@@ -42,7 +42,7 @@ extension NetworkUtils {
         let streamAction = OptionAction(label: L10n.podcastStreamConfirmation, icon: nil) {
             allowed?()
         }
-        optionsPicker.addDescriptiveActions(title: L10n.notOnWifi, message: L10n.podcastStreamDataWarning, icon: "option-alert", actions: [streamAction])
+        optionsPicker.addAttributedDescriptiveActions(title: L10n.notOnWifi, message: L10n.podcastStreamDataWarning("pktc://settings/storage-and-data"), icon: "option-alert", actions: [streamAction])
 
         optionsPicker.setNoActionCallback {
             disallowed?()

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -2576,7 +2576,9 @@ internal enum L10n {
   /// Confirmation option to stream the selected episode. Used in tandem with a notice that the user is not on WiFi.
   internal static var podcastStreamConfirmation: String { return L10n.tr("Localizable", "podcast_stream_confirmation", fallback: "Stream Anyway") }
   /// Prompt to warn the user that continuing with the option to stream will consume data. Used in tandem with a notice that the user is not on WiFi.
-  internal static var podcastStreamDataWarning: String { return L10n.tr("Localizable", "podcast_stream_data_warning", fallback: "Streaming this episode will use data") }
+  internal static func podcastStreamDataWarning(_ p1: Any) -> String {
+    return L10n.tr("Localizable", "podcast_stream_data_warning", String(describing: p1), fallback: "Streaming this episode will use data. You can turn off this warning in [Settings](%@).")
+  }
   /// Used to reference the episode was published this month.
   internal static var podcastThisMonth: String { return L10n.tr("Localizable", "podcast_this_month", fallback: "This Month") }
   /// Indicates the remaining amount of time left in the episode. '%1$@' is a placeholder for the remaining time.

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -1945,7 +1945,7 @@
 "podcast_stream_confirmation" = "Stream Anyway";
 
 /* Prompt to warn the user that continuing with the option to stream will consume data. Used in tandem with a notice that the user is not on WiFi. */
-"podcast_stream_data_warning" = "Streaming this episode will use data";
+"podcast_stream_data_warning" = "Streaming this episode will use data. You can turn off this warning in [Settings](%@).";
 
 /* Used to reference the episode was published this month. */
 "podcast_this_month" = "This Month";


### PR DESCRIPTION
| 📘 Part of: #https://github.com/Automattic/pocket-casts-ios/issues/3227 |
|:---:|

A continuation of #3301 to enable cellular warnings by default. We added the link to Settings for download but not streaming warnings.

* Adds the Settings link for the Streaming warning
* Adds the default change to the Changelog. I think this is probably worth including in the Release Notes.
* Pops off the episode page when navigating to Settings

| Before | After |
|--|--|
|  <img src="https://github.com/user-attachments/assets/0a35c61a-ca29-4da2-8043-31dc9e85f451" width=300>| <img src="https://github.com/user-attachments/assets/6254161e-e018-4aa3-91b1-f7ffd9b738b6" width=300> | 

| Before | After |
|--|--|
|  <video src="https://github.com/user-attachments/assets/856801fb-27c6-4568-a5e3-26f136689d6c" width=300> | <video src="https://github.com/user-attachments/assets/ee4f3e7a-6370-4147-94c9-460a5f21b4d4" width=300> | 

## To test

### Stream warning Settings link
* Stream an episode over cellular
* ✅ Verify that the warning appears with the link to Settings
* Tap the Settings link
* ✅ Verify that the Store & Data Usage screen appears

### Settings link in Download warning from Episode Page
* Navigate to the Episode page
* Download the episode over cellular
* Tap the "Settings" link in the warning
* ✅ Verify that the Episode page is dismissed and the user is navigated to Settings

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
