### PR TITLE
Readme improvements with Crash Log Symbolication + Logging and Exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,11 @@ Replace the `{API_PATH}` with the full path to the `pocketcasts-api/api/modules/
 ```
 make update_proto API_PATH={API_PATH}
 ```
+
+## Debugging
+
+### Crash Log Symbolication
+
+All [releases](https://github.com/Automattic/pocket-casts-ios/releases) include dSYMs inside of the `xcarchive` file.
+
+These can be used along with the [MacSymbolicator](https://github.com/inket/MacSymbolicator) app to symbolicate any crash logs.

--- a/README.md
+++ b/README.md
@@ -72,6 +72,24 @@ make update_proto API_PATH={API_PATH}
 
 ## Debugging
 
+### Logs
+
+Logs can be found in the app as a view and shared from there through the system sheet or mail:
+* Profile > Help & Feedback > ⋯ > Logs
+
+When debugging analytics, the `tracksLogging` feature flag will enable logging for these events.
+
+### Export Files
+
+An export can be created with the database, settings plist, and logs for debugging purposes:
+* Profile > Help & Feedback > ⋯ > Export Database - the export will include all log files and settings
+* Profile > Settings > Developer > Export Bundle
+
+These exports can also be imported to the app, replacing the database and settings with the ones from the file. This will prompt the user before replacement.
+* Open the file with Pocket Casts directly from Files
+* Drag and drop the file on the Simulator
+* Profile > Settings > Developer > Import Bundle
+
 ### Crash Log Symbolication
 
 All [releases](https://github.com/Automattic/pocket-casts-ios/releases) include dSYMs inside of the `xcarchive` file.


### PR DESCRIPTION
* Adds details about Crash Log symbolication with links to the relevant places
* Adds info about logging and database export files

## To test

* ✅ CI is green
* ✅ [Readme preview](https://github.com/Automattic/pocket-casts-ios/tree/bjtitus/readme-improvements#debugging) looks good

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
