### PR TITLE
GRDB: Enable

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -308,11 +308,7 @@ public enum FeatureFlag: String, CaseIterable {
         case .libroFm:
             false
         case .grdb:
-            #if DEBUG
             true
-            #else
-            false
-            #endif
         case .encourageAccountCreation:
             true
         case .notificationsRevamp:
@@ -366,8 +362,6 @@ public enum FeatureFlag: String, CaseIterable {
             "use_podcast_html_description"
         case .podcastViewChanges:
             "podcast_view_changes_2025"
-        case .grdb:
-            "grdb_testflight"
         default:
             rawValue.lowerSnakeCased()
         }
@@ -381,9 +375,9 @@ extension FeatureFlag: OverrideableFlag {
 
     public var canOverride: Bool {
         switch self {
-            // GRDB can only change in TestFlight versions
+            // GRDB can only change to `false` in non-TestFlight versions
             case .grdb:
-                Self.isTestFlight
+                !Self.isTestFlight
             default:
                 true
         }


### PR DESCRIPTION
| 📘 Part of: #2773 | 
|:---:|

Makes GRDB the default database framework.

## Changes

1. Makes `grdb` feature flag enabled by default
2. Makes `grdb` overridable only on NON-TestFlight versions ¶

¶ IMHO if we revert that in prod we would like to keep TestFlight in GRDB so we can fix and test issues. If if you think we should disable for everyone including TestFlight please let me know — not a strong feeling.

## To test

1. Run the app
2. ✅ `[DataManager] Initialized using GRDB` should be in the logs
3. Code review

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
