### PR TITLE
GRDB: disable Sentry warnings in `appStore` environment

### DIFF
--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -427,6 +427,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
 struct SentryLogger: ErrorLogger {
     func log(error: Error, context: [String: String]?) {
+        guard BuildEnvironment.current != .appStore else {
+            return
+        }
+
     #if os(iOS)
     CrashLoggingAdapter.sharedManager?.crashLogging?.logError(error, tags: context ?? [:], level: .warning)
     #endif

--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -8,6 +8,7 @@ import PocketCastsServer
 import PocketCastsUtils
 import Combine
 import FacebookCore
+import Sentry
 
 class AppDelegate: UIResponder, UIApplicationDelegate {
     private static let initialRefreshDelay = 2.seconds
@@ -427,7 +428,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
 struct SentryLogger: ErrorLogger {
     func log(error: Error, context: [String: String]?) {
-        guard BuildEnvironment.current != .appStore else {
+        if BuildEnvironment.current == .appStore {
+            let crumb = Breadcrumb()
+            crumb.level = SentryLevel.info
+            crumb.category = "grdb"
+            crumb.message = error.localizedDescription
+            SentrySDK.addBreadcrumb(crumb)
             return
         }
 


### PR DESCRIPTION
| 📘 Part of: #2773 | 
|:---:|

Do not track GRDB warnings to Sentry. Doing so in prod would hit our Sentry quotas pretty fast.

Instead, we add as a breadcrumb. If any crash happens, then we will have this info.

## To test

Code review.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
