### PR TITLE
Move cellular check into PlaybackManager

### DIFF
--- a/podcasts/PlaybackActionHelper.swift
+++ b/podcasts/PlaybackActionHelper.swift
@@ -14,13 +14,7 @@ class PlaybackActionHelper {
             return
         }
 
-        if !episode.downloaded(pathFinder: DownloadManager.shared) {
-            NetworkUtils.shared.streamEpisodeRequested({
-                performPlay(episode: episode, filterUuid: filterUuid, podcastUuid: podcastUuid)
-            }, disallowed: nil)
-        } else {
-            performPlay(episode: episode, filterUuid: filterUuid, podcastUuid: podcastUuid)
-        }
+        performPlay(episode: episode, filterUuid: filterUuid, podcastUuid: podcastUuid)
     }
 
     class func pause() {

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -211,8 +211,23 @@ class PlaybackManager: ServerPlaybackDelegate {
         }
     }
 
-    func play(completion: (() -> Void)? = nil, userInitiated: Bool = true) {
+    private var cellularAllowedEpisodeUUID: String?
+
+    func play(completion: (() -> Void)? = nil, userInitiated: Bool = true, allowed: Bool = false) {
         guard let currEpisode = currentEpisode() else { return }
+
+        if allowed {
+            cellularAllowedEpisodeUUID = currEpisode.uuid
+        }
+
+        #if !os(watchOS) && !APPCLIP
+        if !allowed && cellularAllowedEpisodeUUID != currEpisode.uuid && !currEpisode.downloaded(pathFinder: DownloadManager.shared) {
+            NetworkUtils.shared.streamEpisodeRequested({ [weak self] in
+                self?.play(completion: completion, userInitiated: userInitiated, allowed: true)
+            }, disallowed: nil)
+            return
+        }
+        #endif
 
         FileLog.shared.addMessage("PlaybackManager Play \(currentEpisode()?.title ?? "unknown episode") userInitiated: \(userInitiated)")
 


### PR DESCRIPTION
Fixes an issue where continuous playback ignores the check for cellular data.

## To test

1. Enable Settings > Storage & Data Use > Warn Before Using Data
2. Download a podcast in the Up Next queue
3. Don't download the very next episode in the Up Next queue
4. Play the downloaded episode back on cellular
5. Skip to the end
6. ✅ Verify that the cellular data warning appears before the non-downloaded episode is streamed

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
