### PR TITLE
[Improve App Ratings] Enable Feature Flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 7.94
 -----
 - Retry failed requests without user agent [#3323](https://github.com/Automattic/pocket-casts-ios/pull/3323)
+- Add Feedback Prompt before asking for App Review [#3331](https://github.com/Automattic/pocket-casts-ios/pull/3331)
 
 7.93
 -----

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -357,7 +357,7 @@ public enum FeatureFlag: String, CaseIterable {
         case .retryWithoutUserAgent:
             true
         case .userSatisfactionSurvey:
-            false
+            true
         }
     }
 


### PR DESCRIPTION
| 📘 Part of: [Improve App Ratings](https://linear.app/a8c/project/improve-app-rating-6a17774dae82) |
|:---:|

Enables the feature flag for `userSatisfactionSurvey`

## To test

This is mostly tested in https://github.com/Automattic/pocket-casts-ios/pull/3331

* Fresh install of the app
* Rate an episode by starring it
* Ensure the feedback prompt is shown

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
