### PR TITLE
[New Onboarding] Tweak scrolling and fades of content

### DIFF
--- a/podcasts/Onboarding/Plus/NewUpgrade/UpgradeAccountView.swift
+++ b/podcasts/Onboarding/Plus/NewUpgrade/UpgradeAccountView.swift
@@ -109,10 +109,10 @@ struct UpgradeAccountView: View {
                         }
                         if expand, model.isFreeTrialAvailable {
                             VStack {
-                                Spacer()
+                                Spacer().frame(height: 76)
                                 pageTwo
                                     .id(ScrollPosition.secondPage)
-                                Spacer()
+                                Spacer().frame(height: 62)
                             }
                         } else {
                             Spacer()

--- a/podcasts/Onboarding/Plus/NewUpgrade/UpgradeAccountView.swift
+++ b/podcasts/Onboarding/Plus/NewUpgrade/UpgradeAccountView.swift
@@ -21,8 +21,14 @@ struct UpgradeAccountView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             header
-            Spacer().frame(height: 24)
+            Spacer().frame(height: 8)
             scrollableContent
+                .overlay(alignment: .top) {
+                    gradient(up: true)
+                }
+                .overlay(alignment: .bottom) {
+                    gradient(up: false)
+                }
             UpgradeProductsView(model: model)
         }
         .padding(.horizontal, 24)
@@ -99,23 +105,21 @@ struct UpgradeAccountView: View {
                         }
                         if expand, model.isFreeTrialAvailable {
                             VStack {
+                                Spacer()
                                 pageTwo
+                                    .id(ScrollPosition.secondPage)
                                 Spacer()
                             }
-                            .id(ScrollPosition.secondPage)
-                            .frame(minHeight: sizeProxy.size.height)
                         } else {
                             Spacer()
                                 .id(ScrollPosition.secondPage)
                                 .frame(height: 8)
                         }
                     }
+                    .padding(.vertical, 16)
                 }
                 .scrollIndicators(.visible)
                 .withScrollFlashIndicator(trigger: flash)
-                .overlay(alignment: .bottom, content: {
-                    gradientSpacer
-                })
                 .onChange(of: model.selectedProduct) { _ in
                     if !model.isFreeTrialAvailable {
                         withAnimation {
@@ -138,14 +142,13 @@ struct UpgradeAccountView: View {
         }
     }
 
-    var gradientSpacer: some View {
-        HStack() {
-            Spacer()
-        }
-        .frame(height: 40)
-        .background(LinearGradient(colors: [
-            theme.primaryUi01.opacity(0),
-            theme.primaryUi01.opacity(1)
+    @ViewBuilder
+    func gradient(height: CGFloat = 16, up: Bool ) -> some View {
+        Rectangle()
+        .frame(height: height)
+        .foregroundStyle(LinearGradient(colors: [
+            theme.primaryUi01.opacity(up ? 1 : 0),
+            theme.primaryUi01.opacity(up ? 0 : 1)
         ], startPoint: UnitPoint.top, endPoint: UnitPoint.bottom))
         .allowsHitTesting(false)
     }

--- a/podcasts/Onboarding/Plus/NewUpgrade/UpgradeAccountView.swift
+++ b/podcasts/Onboarding/Plus/NewUpgrade/UpgradeAccountView.swift
@@ -18,16 +18,20 @@ struct UpgradeAccountView: View {
         case secondPage
     }
 
+    enum Constants {
+        static let gradientHeight: CGFloat = 24
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             header
             Spacer().frame(height: 8)
             scrollableContent
                 .overlay(alignment: .top) {
-                    gradient(up: true)
+                    gradient(height: Constants.gradientHeight, up: true)
                 }
                 .overlay(alignment: .bottom) {
-                    gradient(up: false)
+                    gradient(height: Constants.gradientHeight, up: false)
                 }
             UpgradeProductsView(model: model)
         }
@@ -116,7 +120,7 @@ struct UpgradeAccountView: View {
                                 .frame(height: 8)
                         }
                     }
-                    .padding(.vertical, 16)
+                    .padding(.vertical, Constants.gradientHeight)
                 }
                 .scrollIndicators(.visible)
                 .withScrollFlashIndicator(trigger: flash)

--- a/podcasts/Onboarding/Plus/NewUpgrade/UpgradeProductsView.swift
+++ b/podcasts/Onboarding/Plus/NewUpgrade/UpgradeProductsView.swift
@@ -126,8 +126,8 @@ extension L10n {
         let privacyPolicy = ServerConstants.Urls.privacyPolicy
         let termsOfUse = ServerConstants.Urls.termsOfUse
 
-        let privacyPolicyText = L10n.accountPrivacyPolicy
-        let termsOfUseText = L10n.termsOfUse
+        let privacyPolicyText = L10n.accountPrivacyPolicy.nonBreakingSpaces()
+        let termsOfUseText = L10n.termsOfUse.nonBreakingSpaces()
 
         // Create markdown formatted text with proper localization
         let termsMarkdown = L10n.purchaseTerms(

--- a/podcasts/Onboarding/Plus/NewUpgrade/UpgradeTimelineView.swift
+++ b/podcasts/Onboarding/Plus/NewUpgrade/UpgradeTimelineView.swift
@@ -85,7 +85,6 @@ struct UpgradeTimelineView: View {
                     .padding(.horizontal, 14)
                     Spacer()
                 }
-                //.offset(x: 0, y: 2)
                 .clipped()
             }
         }

--- a/podcasts/Onboarding/Plus/NewUpgrade/UpgradeTimelineView.swift
+++ b/podcasts/Onboarding/Plus/NewUpgrade/UpgradeTimelineView.swift
@@ -28,13 +28,6 @@ struct UpgradeTimelineView: View {
 
     let events: [TimelineEvent]
 
-    var circle: some View {
-        ZStack {
-            Circle()
-                .fill(theme.primaryInteractive01)
-        }
-    }
-
     private func opacityValueForIndex(_ index: Int) -> Double {
         guard events.isEmpty == false else {
             return 0
@@ -46,7 +39,9 @@ struct UpgradeTimelineView: View {
     func iconRow(iconName: String, index: Int) -> some View {
         ZStack(alignment: .top) {
             ZStack(alignment: .center) {
-                circle
+                Circle()
+                    .inset(by: index == 0 ? 0 : -0.2)
+                    .fill(theme.primaryInteractive01)
                     .opacity(opacityValueForIndex(index))
                     .frame(width: circleSize, height: circleSize)
                 Image(iconName)
@@ -60,10 +55,10 @@ struct UpgradeTimelineView: View {
                     ZStack {
                         Rectangle()
                             .frame(width: timelineBarWidth, height: timelineBarHeight)
-                            .offset(x: 0, y: (timelineBarHeight / 2.0) + (circleSize / 2.0))
+                            .offset(x: 0, y: (timelineBarHeight / 2.0) + (circleSize / 2.0) - (index == 0 ? 1 : 0))
                             .foregroundStyle(LinearGradient(colors: [
                                 theme.primaryInteractive01.opacity(opacityValueForIndex(index)),
-                                theme.primaryInteractive01.opacity(opacityValueForIndex(index+1))
+                                theme.primaryInteractive01.opacity(opacityValueForIndex(index+1)),
                             ], startPoint: UnitPoint.top, endPoint: UnitPoint.bottom))
                     }
                 }
@@ -86,10 +81,11 @@ struct UpgradeTimelineView: View {
                             .foregroundColor(theme.primaryText02)
                             .multilineTextAlignment(.leading)
                     }
-                    .padding(.bottom, index != events.count - 1 ? 32 : 0)
+                    .padding(.bottom, index != events.count - 1 ? 48 : 0)
                     .padding(.horizontal, 14)
                     Spacer()
                 }
+                //.offset(x: 0, y: 2)
                 .clipped()
             }
         }


### PR DESCRIPTION
| 📘 Part of: [POC-47](https://linear.app/a8c/issue/POC-47/new-upgrade-screen)
|:---:|

Fixes # <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
Change spacing on second page and add gradient on top and bottom of scrolling content


https://github.com/user-attachments/assets/56b896a8-f4fc-4b7e-beca-73371888d4a1

## To test

1. Start the app with an user without a subscription
2. Ensure that you have the `newOnboarding` FF active
3. Go to Profile -> Account -> Start Free Trial
4. Check if the content is displayed correctly
5. Tap on How Does the Free Trial Work
6. Check that only enough scroll is done to fit the extra content
7. Check there is fade/gradient on the top of the scrollable content 

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
