### PR TITLE
Fix missing event tracking

### DIFF
--- a/podcasts/DiscoverCollectionViewController+Search.swift
+++ b/podcasts/DiscoverCollectionViewController+Search.swift
@@ -79,6 +79,8 @@ extension DiscoverCollectionViewController: PCSearchBarDelegate {
         UIView.animate(withDuration: Constants.Animation.defaultAnimationTime) {
             searchView.alpha = 1
         }
+
+        searchResultsController.searchShown()
     }
 
     func searchDidEnd() {
@@ -91,7 +93,7 @@ extension DiscoverCollectionViewController: PCSearchBarDelegate {
             self.resultsControllerDelegate.clearSearch()
         }
 
-        Analytics.track(.searchDismissed, properties: ["source": AnalyticsSource.discover])
+        searchResultsController.searchDismissed()
     }
 
     func searchWasCleared() {

--- a/podcasts/New Search/Helpers/SearchAnalyticsHelper.swift
+++ b/podcasts/New Search/Helpers/SearchAnalyticsHelper.swift
@@ -14,6 +14,10 @@ class SearchAnalyticsHelper: ObservableObject {
         Analytics.track(.searchShown, properties: ["source": source])
     }
 
+    func trackDismissed() {
+        Analytics.track(.searchDismissed, properties: ["source": source])
+    }
+
     func trackSearchPerformed() {
         Analytics.track(.searchPerformed, properties: ["source": source])
     }

--- a/podcasts/New Search/SearchResultsViewController.swift
+++ b/podcasts/New Search/SearchResultsViewController.swift
@@ -34,6 +34,14 @@ class SearchResultsViewController: UIHostingController<AnyView> {
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+
+    func searchShown() {
+        searchAnalyticsHelper.trackShown()
+    }
+
+    func searchDismissed() {
+        searchAnalyticsHelper.trackDismissed()
+    }
 }
 
 extension SearchResultsViewController: SearchResultsDelegate {

--- a/podcasts/PodcastListViewController+Search.swift
+++ b/podcasts/PodcastListViewController+Search.swift
@@ -135,6 +135,8 @@ extension PodcastListViewController: UIScrollViewDelegate, PCSearchBarDelegate {
         UIView.animate(withDuration: Constants.Animation.defaultAnimationTime) {
             searchView.alpha = 1
         }
+
+        searchResultsController.searchShown()
     }
 
     func searchDidEnd() {
@@ -150,7 +152,7 @@ extension PodcastListViewController: UIScrollViewDelegate, PCSearchBarDelegate {
             self.searchResultsController.clearSearch()
         }
 
-        Analytics.track(.searchDismissed, properties: ["source": AnalyticsSource.podcastsList])
+        searchResultsController.searchDismissed()
     }
 
     func searchWasCleared() {


### PR DESCRIPTION
This PR fixes the missing `search_shown` event

## To test

- Run this branch and enable the tracks logger
- Go to Podcasts tab
- Tap the search bar
- Confirm you see `🔵 Tracked: search_shown [ "source": "podcasts_list"]`
- Close the search
- Confirm you see `🔵 Tracked: search_dismissed [ "source": "podcasts_list"]`
- Go to Discover
- Tap the search bar
- Confirm you see `🔵 Tracked: search_shown [ "source": "discover"]`
- Close the search
- Confirm you see `🔵 Tracked: search_dismissed [ "source": "discover"]`

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
