### PR TITLE
[New onboarding] pre select chapters contextual upgrade

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -2063,6 +2063,7 @@
 		FF9ED3552C86010F00B6E630 /* TipView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF9ED3542C86010F00B6E630 /* TipView.swift */; };
 		FFAA063E2C086DEA00FBC38F /* InsetAdjuster.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFAA063D2C086DEA00FBC38F /* InsetAdjuster.swift */; };
 		FFC293992B6173400059F3BB /* IAPTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFC293982B6173400059F3BB /* IAPTypes.swift */; };
+		FFCCF6C02E2E87FE00BFC9E5 /* PreSelectChaptersAnimationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFCCF6BF2E2E87ED00BFC9E5 /* PreSelectChaptersAnimationView.swift */; };
 		FFD044192C4FE9F400CCB192 /* TranscriptModelFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFD044182C4FE9F400CCB192 /* TranscriptModelFilterTests.swift */; };
 		FFD3AB8C2BD15E8F00C562CB /* CircleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFD3AB8B2BD15E8F00C562CB /* CircleView.swift */; };
 		FFDE41A32DD201AE0065ADDE /* AppClipAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFDE41A22DD201A40065ADDE /* AppClipAppDelegate.swift */; };
@@ -4120,6 +4121,7 @@
 		FF9ED3542C86010F00B6E630 /* TipView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TipView.swift; sourceTree = "<group>"; };
 		FFAA063D2C086DEA00FBC38F /* InsetAdjuster.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsetAdjuster.swift; sourceTree = "<group>"; };
 		FFC293982B6173400059F3BB /* IAPTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IAPTypes.swift; sourceTree = "<group>"; };
+		FFCCF6BF2E2E87ED00BFC9E5 /* PreSelectChaptersAnimationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreSelectChaptersAnimationView.swift; sourceTree = "<group>"; };
 		FFD044182C4FE9F400CCB192 /* TranscriptModelFilterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TranscriptModelFilterTests.swift; sourceTree = "<group>"; };
 		FFD3AB8B2BD15E8F00C562CB /* CircleView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CircleView.swift; sourceTree = "<group>"; };
 		FFDE41A22DD201A40065ADDE /* AppClipAppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppClipAppDelegate.swift; sourceTree = "<group>"; };
@@ -8525,6 +8527,7 @@
 		FF267FB52E16C8230004EF02 /* NewUpgrade */ = {
 			isa = PBXGroup;
 			children = (
+				FFCCF6BF2E2E87ED00BFC9E5 /* PreSelectChaptersAnimationView.swift */,
 				FF267FBD2E16FBD50004EF02 /* UpgradeAccountViewModel.swift */,
 				FF267FB32E16C8230004EF02 /* UpgradeAccountView.swift */,
 				FF267FB92E16E1890004EF02 /* UpgradeFeaturesView.swift */,
@@ -10056,6 +10059,7 @@
 				C7A654032991A7C900BB84C1 /* CarPlayListData.swift in Sources */,
 				8BC0600B2AB1FB8100A4FEC6 /* AppPlayEpisodeIntentExtension.swift in Sources */,
 				F5CFDB622C6DA2D600DE57B2 /* AudioClipExporter.swift in Sources */,
+				FFCCF6C02E2E87FE00BFC9E5 /* PreSelectChaptersAnimationView.swift in Sources */,
 				BD9FF6121B8EC90C009F075E /* ImageManager.swift in Sources */,
 				BD6B432C27561EA8005E4017 /* PCHostingController.swift in Sources */,
 				BDCA84F21C1FB7260022ED4D /* DownloadSettingsViewController.swift in Sources */,

--- a/podcasts/Onboarding/OnboardingFlow.swift
+++ b/podcasts/Onboarding/OnboardingFlow.swift
@@ -83,8 +83,7 @@ struct OnboardingFlow {
                                                 flowSource: .upsell,
                                                 viewSource: viewSource,
                                                 plan: product?.plan ?? .plus,
-                                                frequency: product?.frequency ?? .yearly,
-                                                customTitle: customTitle)
+                                                frequency: product?.frequency ?? .yearly)
         } else {
             return PlusLandingViewModel.make(in: controller,
                                              from: .upsell,

--- a/podcasts/Onboarding/Plus/NewUpgrade/PreSelectChaptersAnimationView.swift
+++ b/podcasts/Onboarding/Plus/NewUpgrade/PreSelectChaptersAnimationView.swift
@@ -16,6 +16,7 @@ struct ChapterRow: View {
 
     @State private var offset = 10.0
     @State private var opacity = 0.0
+    @State private var selected = true
 
     var body: some View {
         HStack(alignment: .center) {
@@ -29,7 +30,7 @@ struct ChapterRow: View {
                     .foregroundStyle(theme.primaryText01)
             }
             Spacer()
-            Image(chapter.selected ? "rounded-selected" : "rounded-deselected")
+            Image(selected ? "rounded-selected" : "rounded-deselected")
                 .renderingMode(.template)
                 .resizable()
                 .foregroundStyle(theme.primaryIcon02)
@@ -55,6 +56,7 @@ struct ChapterRow: View {
         }
         withAnimation(.easeInOut(duration: 0.6).delay(0.8 + (1 + (0.1 * index)) + (0.7 + (index * 0.1)))) {
             if !chapter.selected {
+                selected = false
                 offset = 0
                 opacity = 0.2
             }

--- a/podcasts/Onboarding/Plus/NewUpgrade/PreSelectChaptersAnimationView.swift
+++ b/podcasts/Onboarding/Plus/NewUpgrade/PreSelectChaptersAnimationView.swift
@@ -1,0 +1,50 @@
+import Foundation
+import SwiftUI
+
+struct PreSelectChaptersAnimationView: View {
+
+    struct Chapter {
+        let chapter: String
+        let title: String
+        let selected: Bool
+    }
+
+    let chapters: [Chapter] = [
+        Chapter(chapter: "CHAPTER 1", title: "Intro", selected: false),
+        Chapter(chapter: "CHAPTER 2", title: "A word from our sponsor", selected: true),
+        Chapter(chapter: "CHAPTER 3", title: "Who will win the Oscars", selected: true)
+    ]
+
+    @EnvironmentObject var theme: Theme
+
+    var body: some View {
+        VStack(spacing: 8) {
+            ForEach(chapters, id: \.chapter) { chapter in
+                HStack(alignment: .center) {
+                    VStack(alignment: .leading) {
+                        Text(chapter.chapter)
+                            .font(size: 12, style: .footnote, weight: .semibold)
+                            .kerning(0.36)
+                            .foregroundStyle(theme.primaryText02)
+                        Text(chapter.title)
+                            .font(size: 16, style: .title3, weight: .medium)
+                            .foregroundStyle(theme.primaryText01)
+                    }
+                    Spacer()
+                    Image(chapter.selected ? "rounded-selected" : "rounded-deselected")
+                        .renderingMode(.template)
+                        .resizable()
+                        .foregroundStyle(theme.primaryIcon02)
+                        .frame(width: 24, height: 24)
+                }
+                .padding(16)
+                .background(theme.primaryUi03)
+            }
+        }
+        .padding(24)
+    }
+}
+
+#Preview {
+    PreSelectChaptersAnimationView().setupDefaultEnvironment()
+}

--- a/podcasts/Onboarding/Plus/NewUpgrade/PreSelectChaptersAnimationView.swift
+++ b/podcasts/Onboarding/Plus/NewUpgrade/PreSelectChaptersAnimationView.swift
@@ -1,17 +1,76 @@
 import Foundation
 import SwiftUI
 
-struct PreSelectChaptersAnimationView: View {
+struct Chapter {
+    let chapter: String
+    let title: String
+    let selected: Bool
+}
 
-    struct Chapter {
-        let chapter: String
-        let title: String
-        let selected: Bool
+struct ChapterRow: View {
+
+    let chapter: Chapter
+    let index: Int
+
+    @EnvironmentObject var theme: Theme
+
+    @State private var offset = 10.0
+    @State private var opacity = 0.0
+
+    var body: some View {
+        HStack(alignment: .center) {
+            Image(chapter.selected ? "rounded-selected" : "rounded-deselected")
+                .renderingMode(.template)
+                .resizable()
+                .foregroundStyle(theme.primaryIcon02)
+                .frame(width: 24, height: 24)
+            Spacer().frame(width: 16)
+            VStack(alignment: .leading) {
+                Text(chapter.chapter)
+                    .font(size: 12, style: .footnote, weight: .semibold)
+                    .kerning(0.36)
+                    .foregroundStyle(theme.primaryText02)
+                Text(chapter.title)
+                    .font(size: 16, style: .title3, weight: .medium)
+                    .foregroundStyle(theme.primaryText01)
+            }
+            Spacer()
+        }
+        .padding(16)
+        .background(theme.primaryUi03)
+        .cornerRadius(4)
+        .shadow(color: .black.opacity(0.2), radius: 1.4, x: 0, y: 1)
+        .offset(y: offset)
+        .opacity(opacity)
+        .onAppear {
+            animate(Double(index))
+        }
+        .onTapGesture {
+            animate(Double(index))
+        }
     }
+
+    private func animate(_ index: Double) {
+        offset = 10
+        opacity = 0
+        withAnimation(.easeInOut(duration: 0.8).delay(1 + (0.05 * index))) {
+            offset = 0
+            opacity = 1
+        }
+        withAnimation(.easeInOut(duration: 0.6).delay(0.8 + (1 + (0.05 * index)) + (0.7 + (index * 0.05)))) {
+            if !chapter.selected {
+                offset = 0
+                opacity = 0.2
+            }
+        }
+    }
+}
+
+struct PreSelectChaptersAnimationView: View {
 
     let chapters: [Chapter] = [
         Chapter(chapter: "CHAPTER 1", title: "Intro", selected: false),
-        Chapter(chapter: "CHAPTER 2", title: "A word from our sponsor", selected: true),
+        Chapter(chapter: "CHAPTER 2", title: "A word from our sponsor", selected: false),
         Chapter(chapter: "CHAPTER 3", title: "Who will win the Oscars", selected: true)
     ]
 
@@ -19,30 +78,12 @@ struct PreSelectChaptersAnimationView: View {
 
     var body: some View {
         VStack(spacing: 8) {
-            ForEach(chapters, id: \.chapter) { chapter in
-                HStack(alignment: .center) {
-                    VStack(alignment: .leading) {
-                        Text(chapter.chapter)
-                            .font(size: 12, style: .footnote, weight: .semibold)
-                            .kerning(0.36)
-                            .foregroundStyle(theme.primaryText02)
-                        Text(chapter.title)
-                            .font(size: 16, style: .title3, weight: .medium)
-                            .foregroundStyle(theme.primaryText01)
-                    }
-                    Spacer()
-                    Image(chapter.selected ? "rounded-selected" : "rounded-deselected")
-                        .renderingMode(.template)
-                        .resizable()
-                        .foregroundStyle(theme.primaryIcon02)
-                        .frame(width: 24, height: 24)
-                }
-                .padding(16)
-                .background(theme.primaryUi03)
+            ForEach(Array(zip(chapters.indices, chapters)), id: \.0) { (index, chapter) in
+                ChapterRow(chapter: chapter, index: index)
             }
-        }
-        .padding(24)
+        }        
     }
+
 }
 
 #Preview {

--- a/podcasts/Onboarding/Plus/NewUpgrade/PreSelectChaptersAnimationView.swift
+++ b/podcasts/Onboarding/Plus/NewUpgrade/PreSelectChaptersAnimationView.swift
@@ -19,12 +19,6 @@ struct ChapterRow: View {
 
     var body: some View {
         HStack(alignment: .center) {
-            Image(chapter.selected ? "rounded-selected" : "rounded-deselected")
-                .renderingMode(.template)
-                .resizable()
-                .foregroundStyle(theme.primaryIcon02)
-                .frame(width: 24, height: 24)
-            Spacer().frame(width: 16)
             VStack(alignment: .leading) {
                 Text(chapter.chapter)
                     .font(size: 12, style: .footnote, weight: .semibold)
@@ -35,6 +29,11 @@ struct ChapterRow: View {
                     .foregroundStyle(theme.primaryText01)
             }
             Spacer()
+            Image(chapter.selected ? "rounded-selected" : "rounded-deselected")
+                .renderingMode(.template)
+                .resizable()
+                .foregroundStyle(theme.primaryIcon02)
+                .frame(width: 24, height: 24)
         }
         .padding(16)
         .background(theme.primaryUi03)
@@ -79,6 +78,7 @@ struct PreSelectChaptersAnimationView: View {
                 ChapterRow(chapter: chapter, index: index)
             }
         }
+        .padding(.horizontal, 16)
     }
 
 }

--- a/podcasts/Onboarding/Plus/NewUpgrade/PreSelectChaptersAnimationView.swift
+++ b/podcasts/Onboarding/Plus/NewUpgrade/PreSelectChaptersAnimationView.swift
@@ -53,11 +53,11 @@ struct ChapterRow: View {
     private func animate(_ index: Double) {
         offset = 10
         opacity = 0
-        withAnimation(.easeInOut(duration: 0.8).delay(1 + (0.05 * index))) {
+        withAnimation(.easeInOut(duration: 0.8).delay(1 + (0.1 * index))) {
             offset = 0
             opacity = 1
         }
-        withAnimation(.easeInOut(duration: 0.6).delay(0.8 + (1 + (0.05 * index)) + (0.7 + (index * 0.05)))) {
+        withAnimation(.easeInOut(duration: 0.6).delay(0.8 + (1 + (0.1 * index)) + (0.7 + (index * 0.1)))) {
             if !chapter.selected {
                 offset = 0
                 opacity = 0.2
@@ -81,7 +81,7 @@ struct PreSelectChaptersAnimationView: View {
             ForEach(Array(zip(chapters.indices, chapters)), id: \.0) { (index, chapter) in
                 ChapterRow(chapter: chapter, index: index)
             }
-        }        
+        }
     }
 
 }

--- a/podcasts/Onboarding/Plus/NewUpgrade/PreSelectChaptersAnimationView.swift
+++ b/podcasts/Onboarding/Plus/NewUpgrade/PreSelectChaptersAnimationView.swift
@@ -45,9 +45,6 @@ struct ChapterRow: View {
         .onAppear {
             animate(Double(index))
         }
-        .onTapGesture {
-            animate(Double(index))
-        }
     }
 
     private func animate(_ index: Double) {

--- a/podcasts/Onboarding/Plus/NewUpgrade/UpgradeAccountView.swift
+++ b/podcasts/Onboarding/Plus/NewUpgrade/UpgradeAccountView.swift
@@ -66,23 +66,40 @@ struct UpgradeAccountView: View {
         }
     }
 
+    var contextualAnimation: some View {
+        VStack {
+            Text("Animation")
+        }
+    }
+
     @ViewBuilder
     var pageOne: some View {
         VStack(spacing: 0) {
-            if FeatureFlag.newOnboardingVariant.enabled, model.isFreeTrialAvailable {
-                UpgradeTimelineView(events: model.timelineEvents)
-            } else {
-                UpgradeFeaturesView(features: model.features)
+            switch model.style {
+                case .generic:
+                    if FeatureFlag.newOnboardingVariant.enabled, model.isFreeTrialAvailable {
+                        UpgradeTimelineView(events: model.timelineEvents)
+                    } else {
+                        UpgradeFeaturesView(features: model.features)
+                    }
+                case .contextual:
+                    contextualAnimation
             }
+
         }
     }
 
     @ViewBuilder
     var pageTwo: some View {
-        if FeatureFlag.newOnboardingVariant.enabled, model.isFreeTrialAvailable {
-            UpgradeFeaturesView(features: model.features)
-        } else {
-            UpgradeTimelineView(events: model.timelineEvents)
+        switch model.style {
+            case .generic:
+                if FeatureFlag.newOnboardingVariant.enabled, model.isFreeTrialAvailable {
+                    UpgradeFeaturesView(features: model.features)
+                } else {
+                    UpgradeTimelineView(events: model.timelineEvents)
+                }
+            case .contextual:
+                UpgradeFeaturesView(features: model.features)
         }
     }
 
@@ -92,9 +109,24 @@ struct UpgradeAccountView: View {
                 ScrollView {
                     VStack(alignment: .leading, spacing: 0) {
                         title.id(ScrollPosition.firstPage)
-                        Spacer().frame(height: 24)
+                        switch model.style {
+                            case .generic:
+                                Spacer().frame(height: 24)
+                            case .contextual:
+                                Button {
+                                    expand = true
+                                    withAnimation {
+                                        proxy.scrollTo(ScrollPosition.secondPage, anchor: .top)
+                                    }
+                                } label: {
+                                    Text(L10n.subscriptionPlanFeaturesInfoLink)
+                                        .font(size: 15, style: .subheadline, weight: .medium)
+                                        .foregroundColor(theme.primaryInteractive01)
+                                }
+                                .padding(.vertical, 10)
+                        }
                         pageOne
-                        if model.isFreeTrialAvailable {
+                        if model.isFreeTrialAvailable && model.style == .generic {
                             Button {
                                 expand = true
                                 withAnimation {

--- a/podcasts/Onboarding/Plus/NewUpgrade/UpgradeAccountView.swift
+++ b/podcasts/Onboarding/Plus/NewUpgrade/UpgradeAccountView.swift
@@ -67,7 +67,7 @@ struct UpgradeAccountView: View {
     }
 
     var contextualAnimation: some View {
-        PreSelectChaptersAnimationView()
+        model.customAnimation
     }
 
     @ViewBuilder

--- a/podcasts/Onboarding/Plus/NewUpgrade/UpgradeAccountView.swift
+++ b/podcasts/Onboarding/Plus/NewUpgrade/UpgradeAccountView.swift
@@ -67,9 +67,7 @@ struct UpgradeAccountView: View {
     }
 
     var contextualAnimation: some View {
-        VStack {
-            Text("Animation")
-        }
+        PreSelectChaptersAnimationView()
     }
 
     @ViewBuilder

--- a/podcasts/Onboarding/Plus/NewUpgrade/UpgradeAccountViewModel.swift
+++ b/podcasts/Onboarding/Plus/NewUpgrade/UpgradeAccountViewModel.swift
@@ -23,14 +23,14 @@ class UpgradeAccountViewModel: PlusPurchaseModel {
 
     let flowSource: PlusLandingViewModel.Source
 
-    let type: UpgradeStyle
+    let style: UpgradeStyle
 
-    init(upgradeTier: UpgradeTier = .plus, selectedProduct: IAPProductID = .yearly, viewSource: PlusUpgradeViewSource = .unknown, flowSource: PlusLandingViewModel.Source, type: UpgradeStyle = .generic) {
+    init(upgradeTier: UpgradeTier = .plus, selectedProduct: IAPProductID = .yearly, viewSource: PlusUpgradeViewSource = .unknown, flowSource: PlusLandingViewModel.Source, style: UpgradeStyle = .generic) {
         self.upgradeTier = upgradeTier
         self.selectedProduct = selectedProduct
         self.viewSource = viewSource
         self.flowSource = flowSource
-        self.type = type
+        self.style = style
         super.init()
         loadPrices() {
             Task { @MainActor [weak self] in
@@ -178,7 +178,14 @@ extension UpgradeAccountViewModel {
                      viewSource: PlusUpgradeViewSource,
                      plan: Plan, frequency: PlanFrequency,
                      customTitle: String? = nil) -> UIViewController {
-        let viewModel = UpgradeAccountViewModel(upgradeTier: plan.tier, selectedProduct: product(for: plan, frequency: frequency), viewSource: viewSource, flowSource: flowSource)
+        var style = UpgradeStyle.generic
+        switch viewSource {
+            case .deselectChapters, .deselectChapterWhatsNew:
+                style = .contextual
+            default:
+                style = .generic
+        }
+        let viewModel = UpgradeAccountViewModel(upgradeTier: plan.tier, selectedProduct: product(for: plan, frequency: frequency), viewSource: viewSource, flowSource: flowSource, style: style)
 
         let view = UpgradeAccountView(model: viewModel)
         let controller = OnboardingHostingViewController(rootView: view.setupDefaultEnvironment())

--- a/podcasts/Onboarding/Plus/NewUpgrade/UpgradeAccountViewModel.swift
+++ b/podcasts/Onboarding/Plus/NewUpgrade/UpgradeAccountViewModel.swift
@@ -6,6 +6,11 @@ import PocketCastsUtils
 
 class UpgradeAccountViewModel: PlusPurchaseModel {
 
+    enum UpgradeStyle {
+        case generic
+        case contextual
+    }
+
     weak var navigationController: UINavigationController? = nil
 
     @Published var upgradeTier: UpgradeTier = .plus
@@ -18,11 +23,14 @@ class UpgradeAccountViewModel: PlusPurchaseModel {
 
     let flowSource: PlusLandingViewModel.Source
 
-    init(upgradeTier: UpgradeTier = .plus, selectedProduct: IAPProductID = .yearly, viewSource: PlusUpgradeViewSource = .unknown, flowSource: PlusLandingViewModel.Source) {
+    let type: UpgradeStyle
+
+    init(upgradeTier: UpgradeTier = .plus, selectedProduct: IAPProductID = .yearly, viewSource: PlusUpgradeViewSource = .unknown, flowSource: PlusLandingViewModel.Source, type: UpgradeStyle = .generic) {
         self.upgradeTier = upgradeTier
         self.selectedProduct = selectedProduct
         self.viewSource = viewSource
         self.flowSource = flowSource
+        self.type = type
         super.init()
         loadPrices() {
             Task { @MainActor [weak self] in

--- a/podcasts/Onboarding/Plus/NewUpgrade/UpgradeAccountViewModel.swift
+++ b/podcasts/Onboarding/Plus/NewUpgrade/UpgradeAccountViewModel.swift
@@ -6,7 +6,7 @@ import PocketCastsUtils
 
 class UpgradeAccountViewModel: PlusPurchaseModel {
 
-    enum UpgradeStyle {
+    enum PresentationStyle {
         case generic
         case contextual
     }
@@ -23,9 +23,9 @@ class UpgradeAccountViewModel: PlusPurchaseModel {
 
     let flowSource: PlusLandingViewModel.Source
 
-    let style: UpgradeStyle
+    let style: PresentationStyle
 
-    init(upgradeTier: UpgradeTier = .plus, selectedProduct: IAPProductID = .yearly, viewSource: PlusUpgradeViewSource = .unknown, flowSource: PlusLandingViewModel.Source, style: UpgradeStyle = .generic) {
+    init(upgradeTier: UpgradeTier = .plus, selectedProduct: IAPProductID = .yearly, viewSource: PlusUpgradeViewSource = .unknown, flowSource: PlusLandingViewModel.Source, style: PresentationStyle = .generic) {
         self.upgradeTier = upgradeTier
         self.selectedProduct = selectedProduct
         self.viewSource = viewSource
@@ -168,6 +168,12 @@ class UpgradeAccountViewModel: PlusPurchaseModel {
 
         OnboardingFlow.shared.track(.plusPromotionDismissed)
     }
+
+    // MARK: - custom animation
+
+    var customAnimation: some View {
+        viewSource.customAnimation
+    }
 }
 
 // MARK: - Factory methods
@@ -176,16 +182,9 @@ extension UpgradeAccountViewModel {
     static func make(in parentController: UIViewController? = nil,
                      flowSource: PlusLandingViewModel.Source,
                      viewSource: PlusUpgradeViewSource,
-                     plan: Plan, frequency: PlanFrequency,
-                     customTitle: String? = nil) -> UIViewController {
-        var style = UpgradeStyle.generic
-        switch viewSource {
-            case .deselectChapters, .deselectChapterWhatsNew:
-                style = .contextual
-            default:
-                style = .generic
-        }
-        let viewModel = UpgradeAccountViewModel(upgradeTier: plan.tier, selectedProduct: product(for: plan, frequency: frequency), viewSource: viewSource, flowSource: flowSource, style: style)
+                     plan: Plan, frequency: PlanFrequency) -> UIViewController {
+
+        let viewModel = UpgradeAccountViewModel(upgradeTier: plan.tier, selectedProduct: product(for: plan, frequency: frequency), viewSource: viewSource, flowSource: flowSource, style: viewSource.presentationStyle)
 
         let view = UpgradeAccountView(model: viewModel)
         let controller = OnboardingHostingViewController(rootView: view.setupDefaultEnvironment())
@@ -193,7 +192,7 @@ extension UpgradeAccountViewModel {
         controller.navBarIsHidden = true
         controller.viewModel = viewModel
 
-        viewModel.customTitle = customTitle
+        viewModel.customTitle = viewSource.customTitle
         viewModel.parentController = parentController
         viewModel.navigationController = parentController as? UINavigationController
 
@@ -237,6 +236,37 @@ extension Plan {
                 return .patron
             case .plus:
                 return .plus
+        }
+    }
+}
+
+private extension PlusUpgradeViewSource {
+
+    var presentationStyle: UpgradeAccountViewModel.PresentationStyle {
+        switch self {
+            case .deselectChapters, .deselectChapterWhatsNew:
+                return .contextual
+            default:
+                return .generic
+        }
+    }
+
+    var customTitle: String? {
+        switch self {
+            case .deselectChapters, .deselectChapterWhatsNew:
+                return L10n.subscriptionFeatureCustomTitlePreSelectedChapters
+            default:
+                return nil
+        }
+    }
+
+    @ViewBuilder
+    var customAnimation: some View {
+        switch self {
+            case .deselectChapters, .deselectChapterWhatsNew:
+                PreSelectChaptersAnimationView()
+            default:
+                EmptyView()
         }
     }
 }

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -3661,6 +3661,8 @@ internal enum L10n {
   internal static func subscriptionExpiresIn(_ p1: Any) -> String {
     return L10n.tr("Localizable", "subscription_expires_in", String(describing: p1), fallback: "Expires in %1$@")
   }
+  /// Subscription Plan title for custom upgrade screen for the preselected chapters feature
+  internal static var subscriptionFeatureCustomTitlePreSelectedChapters: String { return L10n.tr("Localizable", "subscription_feature_custom_title_pre_selected_chapters", fallback: "Preselect Chapters: cut to the good stuff") }
   /// Subscription pricing format, %1$@ is the price, %2$@ is the subscription period
   internal static func subscriptionFrequencyPricingFormat(_ p1: Any, _ p2: Any) -> String {
     return L10n.tr("Localizable", "subscription_frequency_pricing_format", String(describing: p1), String(describing: p2), fallback: "%1$@ per %2$@")

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -5271,3 +5271,6 @@
 /* Subscription Plan text linking to feaures information */
 "subscription_plan_features_info_link" = "See all Plus features";
 
+/* Subscription Plan title for custom upgrade screen for the preselected chapters feature */
+"subscription_feature_custom_title_pre_selected_chapters" = "Preselect Chapters: cut to the good stuff";
+


### PR DESCRIPTION
| 📘 Part of: [POC-47](https://linear.app/a8c/issue/POC-47/new-upgrade-screen) |  <!-- project issue number, if applicable -->
|:---:|

Fixes [POC-38](https://linear.app/a8c/issue/POC-38/upgrade-screen-context-preselect-chapters)

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR implements the contextual upgrade screen for pre-selected chapters.

https://github.com/user-attachments/assets/a7efd0fc-825a-4974-b67c-3f887fa87734


## To test

1. Start the application with an user without a Subscription
2. Ensure that you have `newOnboardingUpgrade` FF active
3. Play a podcast episode with chapters information. Ex: ATP
4. Open the player
5. Tap on the Chapters tab
6. tap on the preselect button on the top left
7. Check if a custom title for the upgrade screen is show
8. Check if a custom animation is show
9. Tap on See All Features button on the top
10. Check if the view scrolls to the features view
11. Check in different themes to see if the animation adapts correctly for the theme.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
