### PR TITLE
Disable purchases in TestFlight

### DIFF
--- a/podcasts/IAPHelper.swift
+++ b/podcasts/IAPHelper.swift
@@ -24,7 +24,7 @@ class IAPHelper: NSObject {
     private var isRequestingProducts = false
 
     /// Whether purchasing is allowed in the current environment or not
-    private(set) var canMakePurchases = true
+    private(set) var canMakePurchases = BuildEnvironment.current != .testFlight
 
     private var settings: IAPHelperSettings
     private var networking: IAPHelperNetworking


### PR DESCRIPTION
We mistakenly changed `canMakePurchases` to be always `true`. For TestFlight we don't want to allow that.

## To test

1. Launch the app
2. Sign into an account without plus or sign out if you're signed in
3. Go to the Podcasts tab
4. Tap the Folders icon
5. Tap the purchase button
6. ✅ Verify you see the purchase dialog
7. Open `BuildEnvironment.swift`
8. Change line 24 from `return .debug` to `return .testFlight`
9. Launch the app again
10. Repeat the steps above
11. ✅ Verify you see an alert instructing you to purchase on the App Store
12. Dismiss the view
13. Change the BuildEnvironment to `.appStore`
14. ✅ Verify you are able to purchase again

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
