### PR TITLE
Audio streaming fix stuttering

### DIFF
--- a/podcasts/MediaExporterResourceLoaderDelegate.swift
+++ b/podcasts/MediaExporterResourceLoaderDelegate.swift
@@ -8,7 +8,7 @@ import PocketCastsUtils
 /// MediaExporterItemConfiguration global configuration.
 private enum MediaExporterItemConfiguration {
     /// How much data is downloaded in memory before stored on a file.
-    public static var downloadBufferLimit: Int = 128.KB
+    public static var downloadBufferLimit: Int = 16.KB
 
     /// How much data is allowed to be read in memory at a time.
     public static var readDataLimit: Int = 10.MB

--- a/podcasts/MediaExporterResourceLoaderDelegate.swift
+++ b/podcasts/MediaExporterResourceLoaderDelegate.swift
@@ -190,7 +190,10 @@ class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
         }
 
         session = URLSession(configuration: configuration, delegate: self, delegateQueue: nil)
-        session?.dataTask(with: urlRequest).resume()
+        if let task = session?.dataTask(with: urlRequest) {
+            task.priority = URLSessionTask.highPriority
+            task.resume()
+        }
     }
 
     func invalidateAndCancelSession(shouldResetData: Bool = true, error: Error? = nil) {

--- a/podcasts/MediaExporterResourceLoaderDelegate.swift
+++ b/podcasts/MediaExporterResourceLoaderDelegate.swift
@@ -176,7 +176,7 @@ class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
             configuration.timeoutIntervalForRequest = 60 // seconds
             configuration.timeoutIntervalForResource = 3600 // seconds
             configuration.waitsForConnectivity = true
-            configuration.multipathServiceType = .handover // allows switching between celular/wifi            
+            configuration.multipathServiceType = .handover // allows switching between celular/wifi
         }
 
         var urlRequest = URLRequest(url: url)

--- a/podcasts/MediaExporterResourceLoaderDelegate.swift
+++ b/podcasts/MediaExporterResourceLoaderDelegate.swift
@@ -171,13 +171,12 @@ class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
         let configuration = URLSessionConfiguration.default
         configuration.requestCachePolicy = .reloadIgnoringLocalAndRemoteCacheData
         if FeatureFlag.streamingCustomSessionConfiguration.enabled {
-            configuration.networkServiceType = .avStreaming
+            configuration.networkServiceType = .responsiveData
             configuration.allowsCellularAccess = true
             configuration.timeoutIntervalForRequest = 60 // seconds
             configuration.timeoutIntervalForResource = 3600 // seconds
             configuration.waitsForConnectivity = true
-            configuration.multipathServiceType = .handover // allows switching between celular/wifi
-            configuration.httpMaximumConnectionsPerHost = 1
+            configuration.multipathServiceType = .handover // allows switching between celular/wifi            
         }
 
         var urlRequest = URLRequest(url: url)

--- a/podcasts/MediaExporterResourceLoaderDelegate.swift
+++ b/podcasts/MediaExporterResourceLoaderDelegate.swift
@@ -171,7 +171,7 @@ class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
         let configuration = URLSessionConfiguration.default
         configuration.requestCachePolicy = .reloadIgnoringLocalAndRemoteCacheData
         if FeatureFlag.streamingCustomSessionConfiguration.enabled {
-            configuration.networkServiceType = .responsiveData
+            configuration.networkServiceType = .avStreaming
             configuration.allowsCellularAccess = true
             configuration.timeoutIntervalForRequest = 60 // seconds
             configuration.timeoutIntervalForResource = 3600 // seconds


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes [POC-80](https://linear.app/a8c/issue/POC-80/playback-issues-on-short-podcast-episodes-reported-by-user)

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

Change session configuration for streaming and download to avoid very slow connections to stutter audio.

## To test

1. Start the app in a real device
2. Open this [podcast](https://pca.st/2253)
3. Play one of the episodes ( without downloading it before hand)
4. Check if there is stuttering of the audio
5. Tap on Download episode ( check the speed of the download if it's not too slow)

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
