### PR TITLE
Fix the trending notification message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 7.95
 -----
-
+- Fix the trending notification message [#3351](https://github.com/Automattic/pocket-casts-ios/pull/3351)
 
 7.94
 -----

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -1897,7 +1897,7 @@ internal enum L10n {
   /// Settings to control sending of pocket casts offers notifications
   internal static var notificationsPocketCastOffers: String { return L10n.tr("Localizable", "notifications_pocket_cast_offers", fallback: "Pocket Casts Offers") }
   /// Notification body for recommendations trending message
-  internal static var notificationsRecommendationsTrendingBody: String { return L10n.tr("Localizable", "notifications_recommendations_trending_body", fallback: "Check out what everyone else is listening this week.") }
+  internal static var notificationsRecommendationsTrendingBody: String { return L10n.tr("Localizable", "notifications_recommendations_trending_body", fallback: "Check out what everyone else is listening to this week.") }
   /// Notification title for recommendations trending message
   internal static var notificationsRecommendationsTrendingTitle: String { return L10n.tr("Localizable", "notifications_recommendations_trending_title", fallback: "Trending this week") }
   /// Notification body for recommendations you might like message

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -5108,7 +5108,7 @@
 "notifications_recommendations_trending_title" = "Trending this week";
 
 /* Notification body for recommendations trending message */
-"notifications_recommendations_trending_body" = "Check out what everyone else is listening this week.";
+"notifications_recommendations_trending_body" = "Check out what everyone else is listening to this week.";
 
 /* Notification title for offer upsell message */
 "notifications_offers_upsell_title" = "Level up your podcast game";


### PR DESCRIPTION
## Description

This change improves the "Trending this week" notification message.

## Testing Instructions

1. Start the app with a user that isn't logged in
2. In order to speed up notifications delivery go to Settings -> Developer Menu and tap on "Speed Up Notifications"
3. Go to Settings -> Notifications
4. Turn all the notifications off apart from the "Trending & Recommendation" 
5. Switch to another app
6. Wait for 60 seconds and see if a notification shows up
7. Tap on the notification
8. ✅ Verify the notification text looks correct

## Screenshot

<img width="1179" height="412" alt="Simulator Screenshot - iPhone 16 - 2025-07-24 at 14 13 09" src="https://github.com/user-attachments/assets/cff57ea3-faf8-42c0-aa00-25a72fe2299e" />

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
