### PR TITLE
[New Onboarding] Ensure that contextual animation is centered on the first page

### DIFF
--- a/podcasts/Onboarding/Plus/NewUpgrade/UpgradeAccountView.swift
+++ b/podcasts/Onboarding/Plus/NewUpgrade/UpgradeAccountView.swift
@@ -67,21 +67,59 @@ struct UpgradeAccountView: View {
     }
 
     var contextualAnimation: some View {
-        model.customAnimation
+        HStack {
+            Spacer()
+            VStack {
+                Spacer()
+                model.customAnimation
+                Spacer()
+            }
+            Spacer()
+        }
     }
 
     @ViewBuilder
-    var pageOne: some View {
-        VStack(spacing: 0) {
+    func pageOne(proxy: ScrollViewProxy) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            title.id(ScrollPosition.firstPage)
             switch model.style {
                 case .generic:
-                    if FeatureFlag.newOnboardingVariant.enabled, model.isFreeTrialAvailable {
-                        UpgradeTimelineView(events: model.timelineEvents)
-                    } else {
-                        UpgradeFeaturesView(features: model.features)
+                    VStack(alignment: .leading) {
+                        Spacer().frame(height: 24)
+                        if FeatureFlag.newOnboardingVariant.enabled, model.isFreeTrialAvailable {
+                            UpgradeTimelineView(events: model.timelineEvents)
+                        } else {
+                            UpgradeFeaturesView(features: model.features)
+                        }
+                        if model.isFreeTrialAvailable {
+                            Button {
+                                expand = true
+                                withAnimation {
+                                    proxy.scrollTo(ScrollPosition.secondPage, anchor: .top)
+                                }
+                            } label: {
+                                Text(FeatureFlag.newOnboardingVariant.enabled ? L10n.subscriptionPlanFeaturesInfoLink : L10n.subscriptionPlanFreeTrialInfoLink)
+                                    .font(size: 15, style: .subheadline, weight: .medium)
+                                    .foregroundColor(theme.primaryInteractive01)
+                            }
+                            .padding(.vertical, 24)
+                        }
                     }
                 case .contextual:
-                    contextualAnimation
+                    VStack(alignment: .leading) {
+                        Button {
+                            expand = true
+                            withAnimation {
+                                proxy.scrollTo(ScrollPosition.secondPage, anchor: .top)
+                            }
+                        } label: {
+                            Text(L10n.subscriptionPlanFeaturesInfoLink)
+                                .font(size: 15, style: .subheadline, weight: .medium)
+                                .foregroundColor(theme.primaryInteractive01)
+                        }
+                        .padding(.vertical, 10)
+                        contextualAnimation
+                    }
             }
 
         }
@@ -106,37 +144,8 @@ struct UpgradeAccountView: View {
             ScrollViewReader { proxy in
                 ScrollView {
                     VStack(alignment: .leading, spacing: 0) {
-                        title.id(ScrollPosition.firstPage)
-                        switch model.style {
-                            case .generic:
-                                Spacer().frame(height: 24)
-                            case .contextual:
-                                Button {
-                                    expand = true
-                                    withAnimation {
-                                        proxy.scrollTo(ScrollPosition.secondPage, anchor: .top)
-                                    }
-                                } label: {
-                                    Text(L10n.subscriptionPlanFeaturesInfoLink)
-                                        .font(size: 15, style: .subheadline, weight: .medium)
-                                        .foregroundColor(theme.primaryInteractive01)
-                                }
-                                .padding(.vertical, 10)
-                        }
-                        pageOne
-                        if model.isFreeTrialAvailable && model.style == .generic {
-                            Button {
-                                expand = true
-                                withAnimation {
-                                    proxy.scrollTo(ScrollPosition.secondPage, anchor: .top)
-                                }
-                            } label: {
-                                Text(FeatureFlag.newOnboardingVariant.enabled ? L10n.subscriptionPlanFeaturesInfoLink : L10n.subscriptionPlanFreeTrialInfoLink)
-                                    .font(size: 15, style: .subheadline, weight: .medium)
-                                    .foregroundColor(theme.primaryInteractive01)
-                            }
-                            .padding(.vertical, 24)
-                        }
+                        pageOne(proxy: proxy)
+                            .frame(height: model.style == .generic ? nil : sizeProxy.size.height - (Constants.gradientHeight * 2))
                         if expand, model.isFreeTrialAvailable {
                             VStack {
                                 Spacer().frame(height: 76)


### PR DESCRIPTION
| 📘 Part of: [POC-46](https://linear.app/a8c/issue/POC-47/new-upgrade-screen) |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR ensures that the contextual animations for upgrades are centered on the available space of the screen

| Before | After |
| - | - |
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-07-24 at 15 57 02" src="https://github.com/user-attachments/assets/6bde5e02-4f89-40b8-9722-9c93d5d475e4" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-07-24 at 15 41 16" src="https://github.com/user-attachments/assets/ec04dc81-0f1f-45a9-b1df-9fd04a50a786" /> |

## To test

1. Start the application with an user without a Subscription
2. Ensure that you have `newOnboardingUpgrade` FF active
3. Play a podcast episode with chapters information. Ex: ATP
4. Open the player
5. Tap on the Chapters tab
6. Tap on the preselect button on the top left
7. Check the animation is centered on the available space on the scrollable part
8. Check if a custom animation is show
9. Tap on See All Features button on the top
10. Smoke test the default generic style of the upgrade by going to Profile -> Settings -> Pocket Cast Plus

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
