### PR TITLE
Scroll LogsView to bottom

### DIFF
--- a/podcasts/Common SwiftUI/NonEditableTextView.swift
+++ b/podcasts/Common SwiftUI/NonEditableTextView.swift
@@ -3,6 +3,12 @@ import UIKit
 
 struct NonEditableTextView: UIViewRepresentable {
     let text: String
+    let scrolledToBottom: Bool
+
+    init(text: String, scrolledToBottom: Bool = false) {
+        self.text = text
+        self.scrolledToBottom = scrolledToBottom
+    }
 
     func makeUIView(context: Context) -> UITextView {
         let view = UITextView()
@@ -17,5 +23,13 @@ struct NonEditableTextView: UIViewRepresentable {
 
     func updateUIView(_ uiView: UITextView, context: Context) {
         uiView.text = text
+
+        if scrolledToBottom {
+            let bottomOffset = CGPoint(
+                x: 0,
+                y: max(0, uiView.contentSize.height - uiView.bounds.height + uiView.contentInset.bottom)
+            )
+            uiView.setContentOffset(bottomOffset, animated: false)
+        }
     }
 }

--- a/podcasts/LogsView.swift
+++ b/podcasts/LogsView.swift
@@ -67,7 +67,7 @@ struct LogsView: View {
 
     var body: some View {
         VStack {
-            NonEditableTextView(text: model.logs)
+            NonEditableTextView(text: model.logs, scrolledToBottom: true)
             Spacer()
         }
         .navigationTitle(L10n.logs)


### PR DESCRIPTION
Scrolls the Logs view to the bottom. Scrolling this view to find the most recent logs can be nearly impossible.

## To test

* Profile > Help & Feedback > ⋯ > Logs
* ✅ Verify that the logs are scrolled to the bottom, showing the most recent.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
