### PR TITLE
[Playlists] Address color updates and gesture

### DIFF
--- a/podcasts/Onboarding/Encourage Account Creation/Banner/InformationalBannerViewModel.swift
+++ b/podcasts/Onboarding/Encourage Account Creation/Banner/InformationalBannerViewModel.swift
@@ -25,14 +25,14 @@ class InformationalBannerViewModel: BannerModel, InformationalBannerPresenting {
     var onCloseBannerTap: (() -> Void)? = nil
     var onCreateFreeAccountTap: (() -> Void)? = nil
 
-    init(bannerType: InformationalBannerType) {
+    init(bannerType: InformationalBannerType, invertedColor: Bool? = nil) {
         self.bannerType = bannerType
         super.init(
             title: bannerType.title,
             message: bannerType.description,
             action: L10n.eacInformationalBannerCreateAccount,
             iconName: bannerType.iconName,
-            invertedColor: bannerType == .profile)
+            invertedColor: invertedColor ?? (bannerType == .profile))
         setupBinding()
     }
 

--- a/podcasts/PlaylistCell.swift
+++ b/podcasts/PlaylistCell.swift
@@ -11,6 +11,7 @@ class PlaylistCell: ThemeableCell {
 
         accessoryType = .disclosureIndicator
 
+        self.style = .primaryUi01
         iconStyle = .primaryIcon02
 
         updateColor()

--- a/podcasts/PlaylistsViewController+Table.swift
+++ b/podcasts/PlaylistsViewController+Table.swift
@@ -174,3 +174,26 @@ extension PlaylistsViewController: UIPopoverPresentationControllerDelegate {
         dismissTipView()
     }
 }
+
+extension PlaylistsViewController: UITableViewDragDelegate, UITableViewDropDelegate {
+    func tableView(_ tableView: UITableView, itemsForBeginning session: UIDragSession, at indexPath: IndexPath) -> [UIDragItem] {
+        let movedObject = playlists[indexPath.row]
+        let itemProvider = NSItemProvider(object: "\(movedObject.id)" as NSString)
+        return [UIDragItem(itemProvider: itemProvider)]
+    }
+
+    func tableView(_ tableView: UITableView, performDropWith coordinator: UITableViewDropCoordinator) {
+        guard let destinationIndexPath = coordinator.destinationIndexPath else { return }
+
+        coordinator.items.forEach { item in
+            if let sourceIndexPath = item.sourceIndexPath {
+                tableView.performBatchUpdates {
+                    let movedItem = playlists.remove(at: sourceIndexPath.row)
+                    playlists.insert(movedItem, at: destinationIndexPath.row)
+                    tableView.moveRow(at: sourceIndexPath, to: destinationIndexPath)
+                }
+                coordinator.drop(item.dragItem, toRowAt: destinationIndexPath)
+            }
+        }
+    }
+}

--- a/podcasts/PlaylistsViewController+Table.swift
+++ b/podcasts/PlaylistsViewController+Table.swift
@@ -195,5 +195,13 @@ extension PlaylistsViewController: UITableViewDragDelegate, UITableViewDropDeleg
                 coordinator.drop(item.dragItem, toRowAt: destinationIndexPath)
             }
         }
+
+        for (index, playlist) in playlists.enumerated() {
+            DataManager.sharedManager.updatePosition(filter: playlist, newPosition: Int32(index))
+        }
+
+        NotificationCenter.postOnMainThread(notification: Constants.Notifications.filterChanged)
+
+        Analytics.track(.filterListReordered)
     }
 }

--- a/podcasts/PlaylistsViewController.swift
+++ b/podcasts/PlaylistsViewController.swift
@@ -3,9 +3,18 @@ import PocketCastsUtils
 import UIKit
 
 class PlaylistsViewController: PCViewController, FilterCreatedDelegate {
-    @IBOutlet var filtersTable: UITableView! {
+    @IBOutlet var filtersTable: ThemeableTable! {
         didSet {
             registerCells()
+            if FeatureFlag.playlistsRebranding.enabled {
+                filtersTable.themeStyle = .primaryUi01
+                filtersTable.dragDelegate = self
+                filtersTable.dropDelegate = self
+            } else {
+                filtersTable.themeStyle = .primaryUi04
+                filtersTable.dragDelegate = nil
+                filtersTable.dropDelegate = nil
+            }
         }
     }
 
@@ -39,7 +48,8 @@ class PlaylistsViewController: PCViewController, FilterCreatedDelegate {
 
     lazy private var informationalBannerCoordinator: InformationalBannerViewCoordinator = {
         let bannerType: InformationalBannerType = FeatureFlag.playlistsRebranding.enabled ? .playlists : .filters
-        let viewModel = InformationalBannerViewModel(bannerType: bannerType)
+        let invertedColor: Bool? = FeatureFlag.playlistsRebranding.enabled ? true : nil
+        let viewModel = InformationalBannerViewModel(bannerType: bannerType, invertedColor: invertedColor)
         return InformationalBannerViewCoordinator(viewModel: viewModel)
     }()
 
@@ -47,7 +57,7 @@ class PlaylistsViewController: PCViewController, FilterCreatedDelegate {
         super.viewDidLoad()
 
         if FeatureFlag.playlistsRebranding.enabled {
-            setRighBarButtons()
+            customRightBtn = UIBarButtonItem(barButtonSystemItem: .add, target: self, action: #selector(addNewFilter))
         } else {
             customRightBtn = UIBarButtonItem(barButtonSystemItem: .edit, target: self, action: #selector(editTapped))
         }
@@ -107,34 +117,6 @@ class PlaylistsViewController: PCViewController, FilterCreatedDelegate {
         super.viewDidDisappear(animated)
         removeAllCustomObservers()
         navigationController?.navigationBar.shadowImage = nil
-    }
-
-    private func setRighBarButtons() {
-        let plusButton = UIButton(type: .system)
-        plusButton.setImage(UIImage(named: "add-playlist"), for: .normal)
-        plusButton.addTarget(self, action: #selector(addNewFilter), for: .touchUpInside)
-
-        let settingsButton = UIButton(type: .custom)
-        settingsButton.setImage(UIImage(named: "more"), for: .normal)
-        settingsButton.addTarget(self, action: #selector(editTapped), for: .touchUpInside)
-
-        let stackView = UIStackView(arrangedSubviews: [plusButton, settingsButton])
-        stackView.axis = .horizontal
-        stackView.spacing = 16
-        stackView.distribution = .equalSpacing
-        stackView.alignment = .center
-
-        let container = UIView()
-        container.addSubview(stackView)
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            stackView.leadingAnchor.constraint(equalTo: container.leadingAnchor),
-            stackView.trailingAnchor.constraint(equalTo: container.trailingAnchor),
-            stackView.topAnchor.constraint(equalTo: container.topAnchor),
-            stackView.bottomAnchor.constraint(equalTo: container.bottomAnchor)
-        ])
-
-        customRightBtn = UIBarButtonItem(customView: container)
     }
 
     @objc private func editTapped() {


### PR DESCRIPTION
| 📘 Part of: [Playlists](https://linear.app/a8c/project/playlists-b287949437df/overview)
|:---:|

Fixes PCIOS-39

This PR adds:
• Changes the background color of the table and rows
• Leave only the `+` navigation button and allow always the drag and drop gesture to reorder

| Before | After |
| :-------: | :-------: |
| <img width="1179" height="2556" alt="IMG_0271" src="https://github.com/user-attachments/assets/aa97e4b3-2240-4c27-bf92-ae4cb13d551c" /> | <img width="1179" height="2556" alt="IMG_0270" src="https://github.com/user-attachments/assets/962cb084-e38e-447d-99ec-0228930b27ea" /> |

## To test

- Run this branch and enable the `playlistRebranding` feature
- Restart the branch and navigate to Playlists
- Confirm the rows and background have the same bg color
- Confirm the drag and drop updates the position
- Confirm the + button opens the add filter panel
- Switch off the FF and restart
- Make sure everything works as expected

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
