### PR TITLE
GRDB: remove episode and podcast invalid entries

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseHelper.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseHelper.swift
@@ -812,6 +812,19 @@ class DatabaseHelper {
                 return
             }
         }
+
+        if schemaVersion < 57 {
+            do {
+                // During the FMDB to GRDB migration, we found some users had corrupted episodes
+                // with all columns set to NULL. This cleanup prevents crashes caused by those entries.
+                try db.executeUpdate("DELETE FROM SJEpisode WHERE id IS NULL", values: nil)
+                try db.executeUpdate("DELETE FROM SJPodcast WHERE id IS NULL", values: nil)
+                schemaVersion = 57
+            } catch {
+                failedAt(57)
+                return
+            }
+        }
         db.commit()
     }
 }


### PR DESCRIPTION
We have a crash happening with very few users causing a lot of events to be pushed to Sentry. Basically, those users have a database where there are episode entries with all values set to `NULL`. Eg.: 

```
EXC_BREAKPOINT
GRDB/Row.swift:492: Fatal error: 'try!' expression unexpectedly raised an error: could not decode Int64 from database value NULL - column: "id", column index: 0, row: [id:NULL addedDate:NULL detailedDescription:NULL downloadErrorDetails:NULL downloadTaskId:NULL downloadUrl:NULL duration:NULL episodeDescription:NULL episodeStatus:NULL fileType:NULL keepEpisode:NULL playedUpTo:NULL playingStatus:NULL publishedDate:NULL showNotes:NULL sizeInBytes:NULL title:NULL uuid:NULL podcastUuid:NULL wasDeleted:NULL podcast_id:NULL playingStatusModified:NULL playedUpToModified:NULL durationModified:NULL wasDeletedModified:NULL keepEpisodeModified:NULL lastDownloadAttemptDate:NULL autoDownloadStatus:NULL playbackErrorDetails:NULL cachedFrameCount:NULL lastPlaybackInteractionDate:NULL episodeNumber:NULL seasonNumber:NULL episodeType:NULL lastPlaybackInteractionSyncStatus:NULL archived:NULL archivedModified:NULL lastArchiveInteractionDate:NULL excludeFromEpisodeLimit:NULL starredModified:NULL deselectedChapters:NULL deselectedChaptersModified:NULL contentType:NULL], sql: `SELECT * from SJEpisode WHERE playingStatusModified > 0 OR playedUpToModified > 0 OR durationModified > 0 OR keepEpisodeModified > 0 OR archivedModified > 0 ORDER BY publishedDate DESC, addedDate DESC LIMIT 2000`, arguments: []
```

This PR adds a migration to remove any episode or podcast entry with a `NULL`  `id`.

## To test

1. Add a breakpoint in `DatabaseHelper` line `820`
2. Run the app
3. ✅ The breakpoint should hit
4. Re-run the app
5. ✅ The breakpoint should not hit

Ps.: you can simulate this crash by manually opening the database and changing the schema so you can set an `id` to `NULL`. 

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
