### PR TITLE
Switch allowsCellularAccess to allowsExpensiveNetworkAccess

### DIFF
--- a/podcasts/DownloadManager.swift
+++ b/podcasts/DownloadManager.swift
@@ -90,7 +90,7 @@ class DownloadManager: NSObject, FilePathProtocol {
 
     lazy var wifiOnlyBackgroundSession: URLSession = {
         var config = URLSessionConfiguration.background(withIdentifier: "au.com.shiftyjelly.PCBackgroundSession")
-        config.allowsCellularAccess = false
+        config.allowsExpensiveNetworkAccess = false
         addStandardConfig(to: &config)
 
         let session = URLSession(configuration: config, delegate: self, delegateQueue: nil)
@@ -99,7 +99,7 @@ class DownloadManager: NSObject, FilePathProtocol {
 
     lazy var cellularBackgroundSession: URLSession = {
         var config = URLSessionConfiguration.background(withIdentifier: DownloadManager.cellBackgroundSessionId)
-        config.allowsCellularAccess = true
+        config.allowsExpensiveNetworkAccess = true
         addStandardConfig(to: &config)
 
         let session = URLSession(configuration: config, delegate: self, delegateQueue: nil)


### PR DESCRIPTION
Related to [PCIOS-40](https://linear.app/a8c/issue/PCIOS-40/bug-downloading-episodes-via-mobile-data-not-working-as-expected) but it probably doesn't fix it. `allowsCellularAccess` typically mimics `allowsExpensiveNetworkAccess` but there may be cases where it does not.

Since we're [checking](https://github.com/Automattic/pocket-casts-ios/blob/51d67cda29f7a5b741d057977a3a9de2a2007f9a/Modules/Utils/Sources/PocketCastsUtils/Networking/NetworkUtils.swift#L33) `NWPath.isExpensive` we should use the same when configuring our URLSessions or there may be situations where the prompt isn't shown but requests don't go out.

## To test

* Enable "Warn Before Using Data" setting
* Switch to cellular data
* Download an episode
* Approve the download from the warning
* Make sure the episode downloads

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
